### PR TITLE
fix runtime: allow concurrent :ssh Lifecycles (#228)

### DIFF
--- a/lib/raxol/core/runtime/lifecycle/initializer.ex
+++ b/lib/raxol/core/runtime/lifecycle/initializer.ex
@@ -207,8 +207,14 @@ defmodule Raxol.Core.Runtime.Lifecycle.Initializer do
 
     environment = Keyword.get(options, :environment, :terminal)
 
+    # :ssh is multi-instance (one Lifecycle per channel). Without [name: nil]
+    # the second concurrent SSH session collides on the registered Dispatcher
+    # name. Callers always reach the Dispatcher via state.dispatcher_pid, so
+    # dropping the registered name is safe.
     dispatcher_opts =
-      if environment in [:agent, :liveview], do: [name: nil], else: []
+      if environment in [:agent, :liveview, :ssh],
+        do: [name: nil],
+        else: []
 
     case Dispatcher.start_link(
            self(),

--- a/test/property/concurrent_ssh_lifecycle_test.exs
+++ b/test/property/concurrent_ssh_lifecycle_test.exs
@@ -1,0 +1,104 @@
+defmodule Raxol.Property.ConcurrentSshLifecycleTest do
+  @moduledoc """
+  Regression: issue #228.
+
+  `Raxol.Core.Runtime.Lifecycle.Initializer.start_dispatcher/5` registered the
+  Dispatcher with `name: __MODULE__` for every environment except `:agent` and
+  `:liveview`. The `:ssh` env was missed, so a second concurrent SSH session
+  failed with `{:error, {:already_started, _}}`.
+
+  Two regressions guard against this returning:
+
+    1. Behavioural: starting N Dispatchers with `[name: nil]` succeeds and
+       yields N distinct pids. Proves the underlying mechanism is sound.
+
+    2. Source guard: the initializer's env list contains `:ssh`. Proves the
+       wire-up that uses [name: nil] for the SSH env stays in place.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Core.Runtime.Events.Dispatcher
+
+  defmodule TestApp do
+    @moduledoc false
+    def init(_), do: {:ok, %{}}
+    def update(_, model), do: {model, []}
+    def view(_), do: %{type: :text, content: ""}
+  end
+
+  defp dispatcher_initial_state do
+    %{
+      app_module: TestApp,
+      model: %{},
+      width: 80,
+      height: 24,
+      debug_mode: false,
+      plugin_manager: nil,
+      command_registry_table: nil,
+      time_travel: nil,
+      cycle_profiler: nil
+    }
+  end
+
+  defp start_unnamed do
+    {:ok, pid} =
+      Dispatcher.start_link(self(), dispatcher_initial_state(), name: nil)
+
+    Process.unlink(pid)
+    pid
+  end
+
+  defp stop_all(pids) do
+    refs = Enum.map(pids, fn pid -> {pid, Process.monitor(pid)} end)
+    Enum.each(pids, &Process.exit(&1, :shutdown))
+
+    Enum.each(refs, fn {_pid, ref} ->
+      receive do
+        {:DOWN, ^ref, :process, _, _} -> :ok
+      after
+        500 -> :ok
+      end
+    end)
+  end
+
+  defp drain_mailbox do
+    receive do
+      _ -> drain_mailbox()
+    after
+      0 -> :ok
+    end
+  end
+
+  describe "concurrent dispatchers (regression for #228)" do
+    test "four dispatchers with [name: nil] start with distinct pids" do
+      pids = for _ <- 1..4, do: start_unnamed()
+
+      assert length(pids) == 4
+
+      assert length(Enum.uniq(pids)) == 4,
+             "all dispatcher pids must be distinct"
+
+      assert Enum.all?(pids, &Process.alive?/1)
+
+      drain_mailbox()
+      stop_all(pids)
+    end
+  end
+
+  describe "source guard for #228" do
+    @initializer_path Path.join([
+                        __DIR__,
+                        "../..",
+                        "lib/raxol/core/runtime/lifecycle/initializer.ex"
+                      ])
+
+    test "Initializer dispatcher_opts list includes :ssh" do
+      source = File.read!(@initializer_path)
+
+      assert source =~ ~r/environment in \[:agent, :liveview, :ssh\]/,
+             "initializer.ex must keep :ssh in the Dispatcher [name: nil] list. " <>
+               "Without it, concurrent :ssh Lifecycles collide on the registered " <>
+               "Dispatcher name (regression of #228)."
+    end
+  end
+end


### PR DESCRIPTION
## What went wrong

`Raxol.Core.Runtime.Lifecycle.Initializer.start_dispatcher/5` registered the
Dispatcher with `name: __MODULE__` for every environment except `:agent` and
`:liveview`. The `:ssh` env was added elsewhere in the runtime (`dispatcher.ex`,
`engine.ex`, `lifecycle.ex` all special-case `:ssh`) but this branch wasn't
updated, so the Dispatcher still registered globally and a second concurrent
`:ssh` Lifecycle failed with `{:error, {:already_started, _}}` -- only one SSH
session could connect at a time.

## Remediation

Add `:ssh` to the env list at `lib/raxol/core/runtime/lifecycle/initializer.ex`.
Every callsite of the Dispatcher in the runtime addresses it by the pid stored
in another process's state (`state.dispatcher_pid`), so the `__MODULE__`
registration isn't actually used in the hot path -- removing it for `:ssh` is
safe.

## Regression coverage

`test/property/concurrent_ssh_lifecycle_test.exs`:
- behavioural test: four dispatchers with `[name: nil]` start with distinct pids
- source guard: initializer.ex retains `:ssh` in the dispatcher_opts list

## Manual testing

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [ ] CI: full test suite + regression test pass

Closes #228.
