### PR TITLE
fix runtime: adopt existing PluginManager on already_started (#229)

### DIFF
--- a/lib/raxol/core/runtime/lifecycle/initializer.ex
+++ b/lib/raxol/core/runtime/lifecycle/initializer.ex
@@ -126,6 +126,14 @@ defmodule Raxol.Core.Runtime.Lifecycle.Initializer do
 
         {:ok, pm_pid}
 
+      # PluginLifecycle is registered as a VM singleton (name: __MODULE__) and
+      # all client calls go through the registered name, so concurrent Raxol
+      # Lifecycles share one plugin manager. PluginRegistry is ETS-backed and
+      # StateManager namespaces by plugin_id, so this is safe -- adopt the
+      # existing pid rather than failing init.
+      {:error, {:already_started, pm_pid}} ->
+        {:ok, pm_pid}
+
       {:error, reason} ->
         {:error, {:plugin_manager_start_failed, reason}, fn -> :ok end}
     end

--- a/lib/raxol/core/runtime/lifecycle/initializer.ex
+++ b/lib/raxol/core/runtime/lifecycle/initializer.ex
@@ -207,8 +207,14 @@ defmodule Raxol.Core.Runtime.Lifecycle.Initializer do
 
     environment = Keyword.get(options, :environment, :terminal)
 
+    # :ssh is multi-instance (one Lifecycle per channel). Without [name: nil]
+    # the second concurrent SSH session collides on the registered Dispatcher
+    # name. Callers always reach the Dispatcher via state.dispatcher_pid, so
+    # dropping the registered name is safe.
     dispatcher_opts =
-      if environment in [:agent, :liveview], do: [name: nil], else: []
+      if environment in [:agent, :liveview, :ssh],
+        do: [name: nil],
+        else: []
 
     case Dispatcher.start_link(
            self(),

--- a/test/property/concurrent_plugin_manager_test.exs
+++ b/test/property/concurrent_plugin_manager_test.exs
@@ -1,0 +1,67 @@
+defmodule Raxol.Property.ConcurrentPluginManagerTest do
+  @moduledoc """
+  Regression: issue #229.
+
+  `Raxol.Core.Runtime.Plugins.PluginLifecycle` registers as `name: __MODULE__`
+  and all client functions call `GenServer.call(__MODULE__, ...)`. By design
+  it's a VM-shared service -- `PluginRegistry` is ETS-backed and `StateManager`
+  namespaces by `plugin_id`. The bug was that
+  `Lifecycle.Initializer.start_plugin_manager/2` did not handle
+  `{:error, {:already_started, _}}` from `Manager.start_link/1`, so a second
+  concurrent `Raxol.Core.Runtime.Lifecycle` aborted during init. After fix,
+  the second caller adopts the existing pid and reuses it.
+
+  Two layers of protection:
+
+    1. Behavioural: N sequential `Manager.start_link/1` calls in one VM all
+       return `{:ok, pid}` and the pid is stable (same one across calls).
+
+    2. Source guard: `start_plugin_manager/2` retains the
+       `{:error, {:already_started, _}}` adoption arm. If a refactor removes
+       it, this test fails loudly.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Core.Runtime.Plugins.PluginManager, as: Manager
+
+  describe "concurrent plugin manager starts (regression for #229)" do
+    test "N sequential Manager.start_link calls all return the same pid" do
+      n = 6
+
+      results =
+        for _ <- 1..n do
+          case Manager.start_link([]) do
+            {:ok, pid} -> {:ok, pid}
+            {:error, {:already_started, pid}} -> {:ok, pid}
+            other -> other
+          end
+        end
+
+      pids = Enum.map(results, fn {:ok, pid} -> pid end)
+      assert length(pids) == n
+
+      assert length(Enum.uniq(pids)) == 1,
+             "all PluginManager start_link calls must converge on the same " <>
+               "pid (the singleton). Got: #{inspect(pids)}"
+
+      assert Process.alive?(hd(pids))
+    end
+  end
+
+  describe "source guard for #229" do
+    @initializer_path Path.join([
+                        __DIR__,
+                        "../..",
+                        "lib/raxol/core/runtime/lifecycle/initializer.ex"
+                      ])
+
+    test "start_plugin_manager retains the :already_started adoption arm" do
+      source = File.read!(@initializer_path)
+
+      assert source =~ ~r/\{:error,\s*\{:already_started,\s*pm_pid\}\}\s*->/,
+             "initializer.ex must keep the {:error, {:already_started, _}} -> " <>
+               "{:ok, pid} adoption arm in start_plugin_manager/2. Without it, " <>
+               "concurrent Lifecycles abort on the second call (regression of #229)."
+    end
+  end
+end

--- a/test/property/concurrent_ssh_lifecycle_test.exs
+++ b/test/property/concurrent_ssh_lifecycle_test.exs
@@ -1,0 +1,104 @@
+defmodule Raxol.Property.ConcurrentSshLifecycleTest do
+  @moduledoc """
+  Regression: issue #228.
+
+  `Raxol.Core.Runtime.Lifecycle.Initializer.start_dispatcher/5` registered the
+  Dispatcher with `name: __MODULE__` for every environment except `:agent` and
+  `:liveview`. The `:ssh` env was missed, so a second concurrent SSH session
+  failed with `{:error, {:already_started, _}}`.
+
+  Two regressions guard against this returning:
+
+    1. Behavioural: starting N Dispatchers with `[name: nil]` succeeds and
+       yields N distinct pids. Proves the underlying mechanism is sound.
+
+    2. Source guard: the initializer's env list contains `:ssh`. Proves the
+       wire-up that uses [name: nil] for the SSH env stays in place.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Core.Runtime.Events.Dispatcher
+
+  defmodule TestApp do
+    @moduledoc false
+    def init(_), do: {:ok, %{}}
+    def update(_, model), do: {model, []}
+    def view(_), do: %{type: :text, content: ""}
+  end
+
+  defp dispatcher_initial_state do
+    %{
+      app_module: TestApp,
+      model: %{},
+      width: 80,
+      height: 24,
+      debug_mode: false,
+      plugin_manager: nil,
+      command_registry_table: nil,
+      time_travel: nil,
+      cycle_profiler: nil
+    }
+  end
+
+  defp start_unnamed do
+    {:ok, pid} =
+      Dispatcher.start_link(self(), dispatcher_initial_state(), name: nil)
+
+    Process.unlink(pid)
+    pid
+  end
+
+  defp stop_all(pids) do
+    refs = Enum.map(pids, fn pid -> {pid, Process.monitor(pid)} end)
+    Enum.each(pids, &Process.exit(&1, :shutdown))
+
+    Enum.each(refs, fn {_pid, ref} ->
+      receive do
+        {:DOWN, ^ref, :process, _, _} -> :ok
+      after
+        500 -> :ok
+      end
+    end)
+  end
+
+  defp drain_mailbox do
+    receive do
+      _ -> drain_mailbox()
+    after
+      0 -> :ok
+    end
+  end
+
+  describe "concurrent dispatchers (regression for #228)" do
+    test "four dispatchers with [name: nil] start with distinct pids" do
+      pids = for _ <- 1..4, do: start_unnamed()
+
+      assert length(pids) == 4
+
+      assert length(Enum.uniq(pids)) == 4,
+             "all dispatcher pids must be distinct"
+
+      assert Enum.all?(pids, &Process.alive?/1)
+
+      drain_mailbox()
+      stop_all(pids)
+    end
+  end
+
+  describe "source guard for #228" do
+    @initializer_path Path.join([
+                        __DIR__,
+                        "../..",
+                        "lib/raxol/core/runtime/lifecycle/initializer.ex"
+                      ])
+
+    test "Initializer dispatcher_opts list includes :ssh" do
+      source = File.read!(@initializer_path)
+
+      assert source =~ ~r/environment in \[:agent, :liveview, :ssh\]/,
+             "initializer.ex must keep :ssh in the Dispatcher [name: nil] list. " <>
+               "Without it, concurrent :ssh Lifecycles collide on the registered " <>
+               "Dispatcher name (regression of #228)."
+    end
+  end
+end


### PR DESCRIPTION
## What went wrong

`Raxol.Core.Runtime.Plugins.PluginLifecycle` registers as `name: __MODULE__`
and all 15 client functions call `GenServer.call(__MODULE__, ...)`. By design
it's a VM-shared service: `PluginRegistry` is ETS-backed and `StateManager`
namespaces by `plugin_id`. The bug was on the caller side --
`Lifecycle.Initializer.start_plugin_manager/2` did not handle
`{:error, {:already_started, _}}` from `Manager.start_link/1`, so a second
concurrent `Raxol.Core.Runtime.Lifecycle` aborted with
`{:plugin_manager_start_failed, _}` and refused to init. Together with #228
this blocked any concurrent SSH deployment.

## Remediation

Add an `{:error, {:already_started, pm_pid}} -> {:ok, pm_pid}` arm in
`start_plugin_manager/2`. No PluginLifecycle API changes; same adoption
pattern already used in `packages/raxol_core/test/raxol/core/events/manager_test.exs`.

## Regression coverage

`test/property/concurrent_plugin_manager_test.exs`:
- behavioural test: N sequential `Manager.start_link/1` calls all return the
  same pid (singleton converged)
- source guard: initializer.ex retains the `:already_started` adoption arm

## Manual testing

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [ ] CI: full test suite + regression test pass

Stacked on #232. Closes #229.
