### PR TITLE
chore ci: fail fast on mix.lock drift

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -114,7 +114,11 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.clean --unused
-          mix deps.get
+          # --check-locked fails fast if mix.exs was edited without committing
+          # an updated mix.lock. Catches the failure mode where new deps land
+          # without their lockfile entries and surface as confusing compile
+          # errors downstream.
+          mix deps.get --check-locked
           mix deps.compile
 
   # ========================================
@@ -487,7 +491,11 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.clean --unused
-          mix deps.get
+          # --check-locked fails fast if mix.exs was edited without committing
+          # an updated mix.lock. Catches the failure mode where new deps land
+          # without their lockfile entries and surface as confusing compile
+          # errors downstream.
+          mix deps.get --check-locked
           mix deps.compile
 
       - name: Run tests (Unix)

--- a/mix.exs
+++ b/mix.exs
@@ -342,6 +342,11 @@ defmodule Raxol.MixProject do
       ],
       "explain.credo": ["run scripts/explain_credo_warning.exs"],
       lint: ["credo"],
+      # Verifies mix.lock is consistent with mix.exs without fetching new deps.
+      # Run after editing mix.exs to confirm the lockfile is committed too.
+      # This is the same check CI runs to prevent the failure mode where a new
+      # dep was added but mix.lock was forgotten.
+      "lockfile.check": ["deps.get --check-locked"],
       # Dialyzer commands
       "dialyzer.setup": ["dialyzer --plt"],
       "dialyzer.check": ["dialyzer --format dialyxir"],


### PR DESCRIPTION
## What this catches

When a contributor edits `mix.exs` (adds, removes, or changes a dep) but
forgets to run `mix deps.get` and commit the updated `mix.lock`, CI today
fails 30+ seconds in with a confusing compile error like:

```
* plug_cowboy (Hex package)
  lock mismatch: the dependency is out of date.
** (Mix) Can't continue due to errors on dependencies
```

This is exactly what broke master after `dfa07d3b Feat: Add codex
raxol_symphony` -- the new path dep was added to root `mix.exs` without
updating root `mix.lock`. Several downstream PR runs (and the four PRs
opened today) inherited the failure.

## Remediation

`mix deps.get --check-locked` raises immediately if `mix.lock` doesn't
match `mix.exs`. Replacing `mix deps.get` with this in CI fails fast with
a clear message before compile even starts.

Also added a Mix alias `mix lockfile.check` so contributors can run the
same check locally before pushing.

## Manual testing

- [x] `mix lockfile.check` passes on master
- [x] `mix format --check-formatted` clean
- [ ] CI runs the new check on this PR

Independent of #232 / #233 / #234 / #235.
