### PR TITLE
audit: document VM-singletons + add CI allowlist guard

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Check formatting
         run: mix format --check-formatted
 
+      - name: Check singleton allowlist
+        run: bash scripts/check_singletons.sh
+
   compile:
     name: Compilation Check
     needs: setup

--- a/docs/core/SINGLETONS.md
+++ b/docs/core/SINGLETONS.md
@@ -1,0 +1,110 @@
+# VM-Singleton GenServer Audit
+
+This document catalogs every named-singleton (`name: __MODULE__`) process in
+the Raxol codebase, classifies each as **intentional** or **questionable**,
+and records the reasoning. Issues #228 and #229 surfaced because the runtime
+had *latent* singletons -- modules registered as VM-wide names that were
+actually meant to support multiple concurrent instances. This audit makes
+the contract explicit so the same class of bug can't repeat without a
+deliberate decision.
+
+## Why this matters
+
+`GenServer.start_link(name: __MODULE__)` collides on the second call from
+the same VM with `{:error, {:already_started, _}}`. For a process designed
+to be VM-wide (one config store, one rate limiter), that's correct. For a
+process designed to be per-instance (one Dispatcher per Raxol Lifecycle,
+one PluginManager per app), it's a latent multi-tenancy bug that surfaces
+the moment two SSH sessions, two LiveView mounts, or two agents run
+concurrently in the same node.
+
+Raxol explicitly supports concurrent SSH (`Raxol.SSH.Session` per channel),
+agent fan-out (`Raxol.Agent.Team`), and multi-mount LiveView. Every named
+singleton is a constraint on that surface.
+
+## Policy
+
+1. **Supervisors** may use `name: __MODULE__` -- canonical and harmless.
+2. **VM-wide services** (config, registries, accessibility queues, rate
+   limiters, dev tools) may use `name: __MODULE__`. Document the "why this
+   is one-per-VM" reasoning here.
+3. **Per-instance processes** (Dispatcher, Lifecycle, anything spawned per
+   app/session/channel) MUST accept `[name: nil]` and be addressable by pid
+   from the parent's state. Hardcoding `name: __MODULE__` for these is a
+   bug.
+4. New `name: __MODULE__` registrations must update this file.
+
+A CI grep guard at `scripts/check_singletons.sh` enforces (4) by failing
+when the set of singleton-registering call sites diverges from the
+allowlist below.
+
+## Allowlist
+
+### Supervisors (canonical)
+
+| Module | Path |
+|--------|------|
+| `Raxol.Core.CoreSupervisor` | `lib/raxol/core/core_supervisor.ex` |
+| `Raxol.Core.Runtime.RuntimeSupervisor` | `lib/raxol/core/runtime/runtime_supervisor.ex` |
+| `Raxol.Core.ServerRegistry` | `lib/raxol/core/server_registry.ex` |
+| `Raxol.DynamicSupervisor` | `lib/raxol/dynamic_supervisor.ex` |
+| `Raxol.Terminal.Supervisor` | `packages/raxol_terminal/lib/raxol/terminal/terminal_supervisor.ex` |
+| `Raxol.Core.Runtime.Plugins.PluginSupervisor` | `packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_supervisor.ex` |
+| `Raxol.Agent.Supervisor` | `packages/raxol_agent/lib/raxol/agent/supervisor.ex` |
+| `Raxol.MCP.Supervisor` | `packages/raxol_mcp/lib/raxol/mcp/supervisor.ex` |
+| `Raxol.Speech.Supervisor` | `packages/raxol_speech/lib/raxol/speech/supervisor.ex` |
+| `Raxol.Telegram.Supervisor` | `packages/raxol_telegram/lib/raxol/telegram/supervisor.ex` |
+| `Raxol.Watch.Supervisor` | `packages/raxol_watch/lib/raxol/watch/supervisor.ex` |
+
+### VM-wide services (intentional)
+
+| Module | Why one-per-VM |
+|--------|----------------|
+| `Raxol.RBAC` | One role/permission set per node |
+| `Raxol.RateLimit` | VM-wide rate limiting Agent |
+| `Raxol.Dev.CodeReloader` | One reloader watches the VM in dev |
+| `Raxol.Core.Runtime.ProcessStore` | Explicit Process-dictionary replacement; VM-wide by design |
+| `Raxol.Core.Config.ConfigStore` | VM-wide config |
+| `Raxol.Core.Accessibility.Announcements` | One global accessibility queue |
+| `Raxol.Core.Runtime.Plugins.PluginLifecycle` | Plugins shared across Lifecycles; ETS-backed Registry, plugin_id-namespaced state. Confirmed by #229. |
+| `Raxol.Core.Runtime.Plugins.ResourceBudget` | One budget shared across plugins |
+| `Raxol.Speech.Recognizer` | One Whisper model per VM |
+| `Raxol.Speech.Listener` | One microphone per host |
+| `Raxol.Speech.Speaker` | One TTS pipeline per VM |
+| `Raxol.Speech.TTS.OsSay` | OS process owns audio device |
+| `Raxol.Speech.TTS.Noop` | Test stub |
+| `Raxol.Telegram.SessionRouter` | One bot router per VM (re-evaluate if multi-bot needed) |
+| `Raxol.Watch.Notifier` | Push fan-out via DeviceRegistry; only one notifier needed |
+| `Raxol.Watch.DeviceRegistry` | ETS-backed device list |
+| `Raxol.Watch.Push.Noop` | Test stub |
+| `Raxol.Symphony.Runners.Noop` | Test stub |
+
+### Questionable (re-evaluate when next touched)
+
+| Module | Concern |
+|--------|---------|
+| `Raxol.Demo.SessionManager` | Manages demo sessions, but registered VM-wide. Two demo apps would collide. Likely OK in practice, but confirm. |
+| `Raxol.Core.Metrics.MetricsCollector` | Metrics collector is VM-wide -- intentional, but per-Lifecycle metric isolation may be wanted. |
+| `Raxol.Recording.Recorder` | Singleton recorder; multi-session recording would interleave. Investigate before exposing recording over SSH. |
+| `Raxol.Terminal.Buffer.SafeManager` | Registered as `__MODULE__` but the underlying module is `ScreenBuffer.Manager`. Buffer-per-emulator scenarios may want per-instance. |
+
+## CI guard
+
+`scripts/check_singletons.sh` greps the first-party tree for
+`GenServer\|Agent\|Supervisor\|DynamicSupervisor\.start_link.*name: __MODULE__`
+and diffs the result against `scripts/.singletons-allowlist`. To add a new
+singleton:
+
+1. Implement the registration.
+2. Add the file path to `scripts/.singletons-allowlist`.
+3. Document the reasoning in this file under "Allowlist" above.
+
+If you're tempted to add a registration but the process is per-instance,
+follow the `:agent`/`:liveview`/`:ssh` pattern in
+`Raxol.Core.Runtime.Lifecycle.Initializer.start_dispatcher/5`: accept
+`[name: nil]` from the caller and skip name registration in those envs.
+
+## Related
+
+- #228 -- Dispatcher singleton blocked concurrent SSH (fixed in #232)
+- #229 -- PluginManager `already_started` adoption (fixed in #233)

--- a/scripts/.singletons-allowlist
+++ b/scripts/.singletons-allowlist
@@ -1,0 +1,47 @@
+# Allowlist of files registering `name: __MODULE__` GenServer/Agent/Supervisor.
+# One file path per line. Lines starting with # are comments.
+#
+# Adding to this file is OK for supervisors and explicit VM-wide services.
+# For per-instance processes, follow the [name: nil] pattern in
+# `Raxol.Core.Runtime.Lifecycle.Initializer.start_dispatcher/5` instead.
+#
+# Document the reasoning for every entry in `docs/core/SINGLETONS.md`.
+
+# Supervisors -- canonical, harmless
+lib/raxol/core/core_supervisor.ex
+lib/raxol/core/runtime/runtime_supervisor.ex
+lib/raxol/core/server_registry.ex
+lib/raxol/dynamic_supervisor.ex
+packages/raxol_terminal/lib/raxol/terminal/terminal_supervisor.ex
+packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_supervisor.ex
+packages/raxol_agent/lib/raxol/agent/supervisor.ex
+packages/raxol_mcp/lib/raxol/mcp/supervisor.ex
+packages/raxol_speech/lib/raxol/speech/supervisor.ex
+packages/raxol_telegram/lib/raxol/telegram/supervisor.ex
+packages/raxol_watch/lib/raxol/watch/supervisor.ex
+
+# Intentional VM-wide services
+lib/raxol/rbac.ex
+lib/raxol/rate_limit.ex
+lib/raxol/dev/code_reloader.ex
+packages/raxol_core/lib/raxol/core/runtime/process_store.ex
+packages/raxol_core/lib/raxol/core/config/config_store.ex
+packages/raxol_core/lib/raxol/core/accessibility/announcements.ex
+packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_lifecycle.ex
+packages/raxol_core/lib/raxol/core/runtime/plugins/resource_budget.ex
+packages/raxol_speech/lib/raxol/speech/recognizer.ex
+packages/raxol_speech/lib/raxol/speech/listener.ex
+packages/raxol_speech/lib/raxol/speech/speaker.ex
+packages/raxol_speech/lib/raxol/speech/tts/os_say.ex
+packages/raxol_speech/lib/raxol/speech/tts/noop.ex
+packages/raxol_telegram/lib/raxol/telegram/session_router.ex
+packages/raxol_watch/lib/raxol/watch/notifier.ex
+packages/raxol_watch/lib/raxol/watch/device_registry.ex
+packages/raxol_watch/lib/raxol/watch/push/noop.ex
+packages/raxol_symphony/lib/raxol/symphony/runners/noop.ex
+
+# Re-evaluate when next touched (see docs/core/SINGLETONS.md)
+lib/raxol/demo/session_manager.ex
+lib/raxol/core/metrics/metrics_collector.ex
+lib/raxol/recording/recorder.ex
+packages/raxol_terminal/lib/raxol/terminal/buffer/safe_manager.ex

--- a/scripts/check_singletons.sh
+++ b/scripts/check_singletons.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# CI guard: fail if any new file registers `name: __MODULE__` for a
+# GenServer/Agent/Supervisor without being in the allowlist.
+#
+# See docs/core/SINGLETONS.md for the policy.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ALLOWLIST="$REPO_ROOT/scripts/.singletons-allowlist"
+
+if [[ ! -f "$ALLOWLIST" ]]; then
+  printf 'allowlist not found at %s\n' "$ALLOWLIST" >&2
+  exit 2
+fi
+
+# Match real start_link calls (require start_link at line start modulo
+# whitespace) -- this skips comment lines like "# Usage: ... start_link(name: __MODULE__)".
+pattern='^[[:space:]]*(GenServer|Agent|Supervisor|DynamicSupervisor)\.start_link.*name: __MODULE__'
+
+# First-party paths only -- skip vendored deps and _build.
+roots=(
+  lib
+  packages/raxol_core/lib
+  packages/raxol_terminal/lib
+  packages/raxol_agent/lib
+  packages/raxol_mcp/lib
+  packages/raxol_liveview/lib
+  packages/raxol_plugin/lib
+  packages/raxol_speech/lib
+  packages/raxol_telegram/lib
+  packages/raxol_watch/lib
+  packages/raxol_payments/lib
+  packages/raxol_sensor/lib
+  packages/raxol_symphony/lib
+)
+
+# Discover current registrations (file paths, deduped, sorted) into a tmpfile.
+found_file=$(mktemp)
+allowed_file=$(mktemp)
+trap 'rm -f "$found_file" "$allowed_file"' EXIT
+
+cd "$REPO_ROOT"
+for root in "${roots[@]}"; do
+  [[ -d "$root" ]] || continue
+  grep -rlE "$pattern" "$root" 2>/dev/null || true
+done | sort -u >"$found_file"
+
+grep -vE '^\s*(#|$)' "$ALLOWLIST" | sort -u >"$allowed_file"
+
+# Lines in found not in allowed -- new unauthorized registrations.
+unexpected=$(comm -23 "$found_file" "$allowed_file")
+
+if [[ -n "$unexpected" ]]; then
+  printf 'ERROR: new singleton-registering files not in allowlist:\n\n' >&2
+  printf '%s\n' "$unexpected" >&2
+  printf '\nIf intentional, add the path to %s and document the reasoning\n' "$ALLOWLIST" >&2
+  printf 'in docs/core/SINGLETONS.md. If the process is per-instance, accept\n' >&2
+  printf '[name: nil] from the caller instead of hardcoding name: __MODULE__.\n' >&2
+  exit 1
+fi
+
+# Lines in allowed not in found -- stale entries (file deleted/renamed).
+stale=$(comm -13 "$found_file" "$allowed_file")
+
+if [[ -n "$stale" ]]; then
+  printf 'WARNING: allowlist entries no longer match any source file:\n\n' >&2
+  printf '%s\n' "$stale" >&2
+  printf '\nRemove these from %s and update docs/core/SINGLETONS.md.\n' "$ALLOWLIST" >&2
+  exit 1
+fi
+
+count=$(wc -l <"$found_file" | tr -d ' ')
+printf 'singletons: %s allowed registrations, all accounted for.\n' "$count"


### PR DESCRIPTION
## Why

Issues #228 and #229 surfaced because the runtime had **latent**
singletons: modules registered as `name: __MODULE__` that were actually
designed to support multiple concurrent instances (one Dispatcher per SSH
session, one PluginManager per Lifecycle). The bug was invisible until two
SSH sessions tried to start. This PR makes the contract explicit so the
class of bug can't repeat without a deliberate decision.

## What this adds

- `docs/core/SINGLETONS.md` -- audit of every `name: __MODULE__`
  registration in first-party code, classified as **supervisor**,
  **intentional VM-wide**, or **questionable (re-evaluate)**. Documents
  the policy: per-instance processes must accept `[name: nil]` and be
  addressable by pid.
- `scripts/.singletons-allowlist` -- the 33 currently-allowed file paths.
- `scripts/check_singletons.sh` -- CI guard that diffs current
  registrations against the allowlist. Adding a new singleton requires
  updating both files, which forces a conscious decision and a doc entry.
- New CI step in `Format Check` runs the guard.

## Findings

33 first-party `name: __MODULE__` registrations. All currently classified
as supervisors or intentional VM-wide services (RBAC, RateLimit, ProcessStore,
ConfigStore, Accessibility queue, PluginLifecycle (#229 confirmed by
design), TTS/STT pipelines, push notifier, device registry).

Four flagged for re-evaluation when next touched (no urgent action):

- `Raxol.Demo.SessionManager` -- two demo apps would collide.
- `Raxol.Core.Metrics.MetricsCollector` -- per-Lifecycle isolation may be wanted.
- `Raxol.Recording.Recorder` -- multi-session recording would interleave.
- `Raxol.Terminal.Buffer.SafeManager` -- buffer-per-emulator scenarios.

## Manual testing

- [x] `bash scripts/check_singletons.sh` -- passes, 33 registrations accounted for
- [x] `mix format --check-formatted` clean
- [ ] CI: guard runs in Format Check job

Related: #232 (#228), #233 (#229).
