### PR TITLE
chore test: emit boot-budget telemetry as artifact

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -213,12 +213,20 @@ jobs:
           mix test --exclude integration --exclude property --exclude slow --exclude skip_on_ci
         env:
           MIX_TEST_PARTITION: 1
-      
+
       - name: Upload coverage
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-unit
           path: cover/unit.coverdata
+
+      - name: Upload boot metrics
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: boot-metrics-unit
+          path: _build/test/boot_metrics.json
+          if-no-files-found: ignore
 
   test-integration:
     name: Integration Tests

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,8 @@
 IO.puts("[TestHelper] === TEST HELPER STARTING ===")
 
+# Capture boot start time for the boot-budget telemetry below.
+boot_start_us = System.monotonic_time(:microsecond)
+
 # Start Mox - wrapped in try/catch for safety
 try do
   {:ok, _} = Application.ensure_all_started(:mox)
@@ -269,3 +272,54 @@ Raxol.Test.IsolationHelper.reset_global_state()
 IO.puts("[TestHelper] Global state reset for test isolation")
 
 IO.puts("[TestHelper] Test helper setup complete!")
+
+# Boot-budget telemetry. Captures elapsed time and resident memory after
+# the test_helper finishes. Written to _build/test/boot_metrics.json for
+# CI artifact upload, also printed to stderr in JSON for easy log scrape.
+#
+# Today this is informational. When we have a stable baseline, add a CI
+# step that fails if either metric exceeds budget so memory regressions
+# (the kind that triggered the runner OOMs in late April 2026) are caught
+# at the moment they're introduced rather than when they cascade.
+defmodule Raxol.Test.BootMetrics do
+  @moduledoc false
+
+  def emit(start_us) do
+    elapsed_ms = div(System.monotonic_time(:microsecond) - start_us, 1000)
+    mem_total = :erlang.memory(:total)
+    mem_processes = :erlang.memory(:processes)
+    mem_binary = :erlang.memory(:binary)
+    mem_ets = :erlang.memory(:ets)
+    proc_count = :erlang.system_info(:process_count)
+
+    payload = %{
+      kind: "raxol.test.boot_budget",
+      elapsed_ms: elapsed_ms,
+      memory_total_mb: div(mem_total, 1_048_576),
+      memory_processes_mb: div(mem_processes, 1_048_576),
+      memory_binary_mb: div(mem_binary, 1_048_576),
+      memory_ets_mb: div(mem_ets, 1_048_576),
+      process_count: proc_count,
+      ci: System.get_env("CI") == "true",
+      mix_env: to_string(Mix.env())
+    }
+
+    IO.puts(:stderr, "[TestHelper.boot_budget] #{Jason.encode!(payload)}")
+
+    out_dir = Path.join([Mix.Project.build_path(), "test"])
+    File.mkdir_p!(out_dir)
+
+    File.write!(
+      Path.join(out_dir, "boot_metrics.json"),
+      Jason.encode_to_iodata!(payload)
+    )
+  rescue
+    e ->
+      IO.puts(
+        :stderr,
+        "[TestHelper.boot_budget] failed to emit metrics: #{inspect(e)}"
+      )
+  end
+end
+
+Raxol.Test.BootMetrics.emit(boot_start_us)


### PR DESCRIPTION
## Why

The runner OOMs that have been killing CI for hours don't tell us what
exactly grew. Was it module loading? GenServer state? ETS tables? Today
nothing measures it. Adding a tiny boot-time + memory snapshot at the end
of `test_helper.exs` gives us the data we need to tighten budgets later.

## What this adds

A `Raxol.Test.BootMetrics.emit/1` helper at the bottom of
`test/test_helper.exs` captures:

- `elapsed_ms` -- time from "test helper starting" to "setup complete"
- `memory_total_mb`, `memory_processes_mb`, `memory_binary_mb`,
  `memory_ets_mb` -- the four BEAM memory categories
- `process_count` -- raw process count
- `ci`, `mix_env` -- run context

Two outputs:

- printed to stderr as one JSON line for log scrape
- written to `_build/test/boot_metrics.json` for CI artifact upload

The Unit Tests CI job now uploads the file as the `boot-metrics-unit`
artifact (`if: always()`, so it gets captured even on failure).

This is **informational only** for now. Once we have a stable baseline
(say, two weeks of green runs), add a follow-up CI step that fails if
either metric exceeds budget. The point is to catch the next memory
regression at the moment it lands rather than when it cascades into a
runner OOM as it did in late April 2026.

## Manual testing

- [x] `mix format --check-formatted` clean
- [ ] CI: artifact appears under `boot-metrics-unit`

Independent of #232 / #233 / #234 / #235 / #236 / #237 / #238.
