### PR TITLE
test: source guards for ANSI-in-DSL and fprof.apply patterns

### DIFF
--- a/test/property/code_invariants_test.exs
+++ b/test/property/code_invariants_test.exs
@@ -1,0 +1,96 @@
+defmodule Raxol.Property.CodeInvariantsTest do
+  @moduledoc """
+  Source-level invariants enforced by grep. Each `describe` block guards a
+  past fix from regressing -- if someone reintroduces the old pattern, the
+  test fails with a pointer to the original commit.
+
+  This file is the home for source guards that don't fit any individual
+  module's test file. Add new entries when fixing a class of bug that's
+  prone to silent reintroduction.
+  """
+  use ExUnit.Case, async: true
+
+  @repo_root Path.expand("../..", __DIR__)
+
+  defp source_files(globs) when is_list(globs) do
+    globs
+    |> Enum.flat_map(&Path.wildcard(Path.join(@repo_root, &1)))
+    |> Enum.reject(&String.contains?(&1, "_build/"))
+    |> Enum.reject(&String.contains?(&1, "deps/"))
+    |> Enum.uniq()
+  end
+
+  describe "no raw ANSI in View DSL components (regression for 506c1b9c)" do
+    @moduledoc """
+    Components must use the View DSL's style attributes (`fg:`, `bg:`,
+    `style: [:bold]`, ...) instead of embedding ANSI escape codes directly
+    in strings. Raw ANSI bypasses the renderer's color resolution, breaks
+    LiveView/MCP backends, and prevents theming.
+    """
+
+    @view_dsl_globs [
+      "lib/raxol/ui/components/**/*.ex"
+    ]
+
+    # Patterns that indicate a raw ANSI escape sequence inside an Elixir string.
+    @ansi_patterns [
+      ~r/"\\e\[/,
+      ~r/"\\x1b\[/,
+      ~r/"\\033\[/
+    ]
+
+    test "no escape-prefixed strings in components/" do
+      files = source_files(@view_dsl_globs)
+      assert files != [], "expected to find component source files"
+
+      offenders =
+        for file <- files,
+            content = File.read!(file),
+            pattern <- @ansi_patterns,
+            String.match?(content, pattern) do
+          Path.relative_to(file, @repo_root)
+        end
+        |> Enum.uniq()
+
+      assert offenders == [],
+             "View DSL components must not embed raw ANSI escape codes. " <>
+               "Use style attrs instead. Offenders:\n  " <>
+               Enum.join(offenders, "\n  ") <>
+               "\n(Original fix: 506c1b9c -- remove raw ANSI from focus_ring, hint, select.)"
+    end
+  end
+
+  describe "fprof access goes through apply/3 (regression for f435e5e1)" do
+    @moduledoc """
+    `:fprof` lives in OTP's `:tools` application, which isn't loaded at
+    compile time. Direct `:fprof.<function>(...)` calls produce
+    "undefined module" warnings (failing CI under `--warnings-as-errors`).
+    Using `apply(:fprof, :fun, args)` defers resolution to runtime where
+    `:tools` is available.
+    """
+
+    @profiler_globs [
+      "lib/raxol/performance/**/*.ex",
+      "lib/raxol/dev/**/*.ex",
+      "lib/mix/tasks/**/*.ex"
+    ]
+
+    test "no direct :fprof. calls in profilers" do
+      files = source_files(@profiler_globs)
+
+      offenders =
+        for file <- files,
+            content = File.read!(file),
+            String.match?(content, ~r/(?<!apply\()\s*:fprof\.[a-z_]+\(/) do
+          Path.relative_to(file, @repo_root)
+        end
+        |> Enum.uniq()
+
+      assert offenders == [],
+             "Use apply(:fprof, :fun, args) instead of direct :fprof.fun(args) " <>
+               "calls -- :fprof is not loaded at compile time. Offenders:\n  " <>
+               Enum.join(offenders, "\n  ") <>
+               "\n(Original fix: f435e5e1 -- eliminate fprof compile warnings via apply/3.)"
+    end
+  end
+end


### PR DESCRIPTION
## Why

The four PRs we've shipped this session each pair their fix with a
property/source-guard test, so the specific class of bug can't return
silently. Past fixes don't have that protection. This PR backfills two
high-leverage source guards as a starting point and establishes the
`test/property/code_invariants_test.exs` file as the home for further
backfills.

## What this guards

Two regressions, picked because they're prone to silent reintroduction
(grep doesn't catch them; nothing else in the test suite does):

### 1. No raw ANSI escape codes in View DSL components

`Raxol.UI.Components.*` must use `text("foo", fg: :cyan, style: [:bold])`,
not `text("\\e[36mfoo\\e[0m")`. Raw ANSI bypasses theming, breaks the
LiveView and MCP rendering backends, and was the bug fixed by 506c1b9c.

The guard greps `lib/raxol/ui/components/**/*.ex` for escape-prefixed
string literals (`"\\e[`, `"\\x1b[`, `"\\033[`). Failure points at the
original commit so a future contributor can read the context.

### 2. `:fprof` access through `apply/3`

`:fprof` is in OTP's `:tools` app, not loaded at compile time. Direct
`:fprof.foo(...)` calls produce undefined-module warnings that fail
`mix compile --warnings-as-errors`. Fixed by f435e5e1 by routing the 25
call sites through `apply/3`.

The guard greps profiler/dev/Mix-task source for `:fprof.<fun>(...)`
calls outside `apply(...)`.

## Why source guards (not behavioural property tests)

Both bugs are about *patterns in source code*, not runtime behaviour.
Behavioural tests would need to compile a deliberately-broken module to
detect, which is fragile. Source greps are O(files) and run in
milliseconds. The cost of false negatives is low: if someone routes
around the grep, code review catches it.

## Manual testing

- [x] `mix format --check-formatted` clean
- [ ] CI: `mix test test/property/code_invariants_test.exs` passes

Independent of #232 / #233 / #234 / #235 / #236 / #237 / #238 / #239.
