### PR TITLE
test: integration test for concurrent :ssh Lifecycles

### DIFF
--- a/test/property/concurrent_lifecycle_integration_test.exs
+++ b/test/property/concurrent_lifecycle_integration_test.exs
@@ -1,0 +1,120 @@
+defmodule Raxol.Property.ConcurrentLifecycleIntegrationTest do
+  @moduledoc """
+  Whole-stack regression: starts N concurrent `:ssh` Lifecycles end-to-end
+  and asserts they all init cleanly with distinct dispatcher pids and a
+  shared plugin manager pid.
+
+  This is the integration test for the singleton class of bugs surfaced
+  by #228 and #229. The granular tests (`concurrent_ssh_lifecycle_test`
+  and `concurrent_plugin_manager_test`) cover the Dispatcher and
+  PluginManager layers individually. This test exercises both fixes
+  together through `Raxol.Core.Runtime.Lifecycle.start_link/2`, which is
+  the actual API SSH sessions use.
+
+  If either fix regresses, this test fails immediately with a clear
+  pointer to which singleton collision happened.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Core.Runtime.Lifecycle
+
+  defmodule TestApp do
+    @moduledoc false
+    def init(_), do: {:ok, %{counter: 0}}
+    def update(_, model), do: {model, []}
+    def view(_), do: %{type: :text, content: "ok"}
+  end
+
+  defp ssh_opts(idx) do
+    [
+      environment: :ssh,
+      width: 80,
+      height: 24,
+      io_writer: fn _ -> :ok end,
+      name: :"test_ssh_session_#{idx}_#{System.unique_integer([:positive])}"
+    ]
+  end
+
+  defp start_one(idx) do
+    case Lifecycle.start_link(TestApp, ssh_opts(idx)) do
+      {:ok, pid} ->
+        Process.unlink(pid)
+        {:ok, pid}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp stop_all(pids) do
+    Enum.each(pids, fn pid ->
+      try do
+        Lifecycle.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+  end
+
+  defp dispatcher_pid(lifecycle_pid) do
+    state = :sys.get_state(lifecycle_pid, 5_000)
+    state.dispatcher_pid
+  rescue
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+
+  defp plugin_manager_pid(lifecycle_pid) do
+    state = :sys.get_state(lifecycle_pid, 5_000)
+    state.plugin_manager
+  rescue
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+
+  describe "concurrent :ssh Lifecycles (regression for #228 + #229)" do
+    test "four concurrent Lifecycles all init successfully" do
+      results = for i <- 1..4, do: start_one(i)
+
+      pids =
+        for {:ok, pid} <- results, do: pid
+
+      errors =
+        for {:error, reason} <- results, do: reason
+
+      assert errors == [],
+             "all four Lifecycles should init successfully. " <>
+               "Errors: #{inspect(errors)}\n" <>
+               "If this fails with {:already_started, _} or " <>
+               ":dispatcher_start_failed, regression of #228. " <>
+               "If with :plugin_manager_start_failed, regression of #229."
+
+      assert length(pids) == 4
+
+      try do
+        dispatchers =
+          Enum.map(pids, &dispatcher_pid/1) |> Enum.reject(&is_nil/1)
+
+        assert length(dispatchers) == 4,
+               "every Lifecycle should expose a dispatcher pid"
+
+        assert length(Enum.uniq(dispatchers)) == 4,
+               "dispatcher pids must be distinct (regression of #228)"
+
+        managers =
+          Enum.map(pids, &plugin_manager_pid/1) |> Enum.reject(&is_nil/1)
+
+        assert length(managers) == 4
+
+        assert length(Enum.uniq(managers)) == 1,
+               "PluginManager is VM-singleton; all Lifecycles must share " <>
+                 "the same pid (regression of #229 if not). Got: " <>
+                 inspect(Enum.uniq(managers))
+      after
+        stop_all(pids)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this catches

The granular tests in #232 (`concurrent_ssh_lifecycle_test`) and #233
(`concurrent_plugin_manager_test`) cover the Dispatcher and PluginManager
collisions individually. This is the **whole-stack** integration test:
four `:ssh` Lifecycles started end-to-end via
`Raxol.Core.Runtime.Lifecycle.start_link/2` (the actual API SSH sessions
use), with assertions on both layers in one shot.

If either fix regresses, the test fails immediately with an error message
that points at the responsible issue (#228 vs #229).

## Asserts

1. All four Lifecycles return `{:ok, pid}` -- not
   `{:error, {:already_started, _}}` (regression of #228 if so).
2. Their `dispatcher_pid` values are all distinct (regression of #228 if
   not).
3. Their `plugin_manager` pids are all the same -- PluginManager is a
   VM-singleton by design, confirmed by #229 (regression of #229 if not).

## Stacking

This PR is **stacked on #233** (which is stacked on #232). It can't pass
on master alone -- it requires both fixes. Merge order:

1. #232 first
2. then #233
3. then this PR (#241)

After #232/#233 merge, this branch should be rebased onto master and
should pass on its own.

## Manual testing

- [x] `mix format --check-formatted` clean
- [ ] CI: passes after #232 and #233 merge

Closes the singleton class of bugs surfaced by #228 / #229.
