### PR TITLE
x402: per-chain USDC EIP-712 domain table

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/assets/usdc_domains.ex
+++ b/packages/raxol_payments/lib/raxol/payments/assets/usdc_domains.ex
@@ -1,0 +1,53 @@
+defmodule Raxol.Payments.Assets.UsdcDomains do
+  @moduledoc """
+  Per-chain USDC EIP-712 domain `name` and `version` values.
+
+  USDC's EIP-712 domain `name` is not uniform across chains: mainnet
+  deployments report `"USD Coin"`, but Ethereum/Base/OP Sepolia report
+  `"USDC"`. Signing with the wrong name produces a digest USDC's
+  `transferWithAuthorization` will reject.
+
+  Values were verified on-chain via Blockscout. Source of truth for
+  cross-checking: `riddler-permit2-erc3009/src/config.js` (`usdcName`
+  and `usdcVersion` per chain).
+
+  ## Example
+
+      iex> Raxol.Payments.Assets.UsdcDomains.lookup(8453)
+      %{name: "USD Coin", version: "2"}
+
+      iex> Raxol.Payments.Assets.UsdcDomains.lookup(11_155_111)
+      %{name: "USDC", version: "2"}
+  """
+
+  @default %{name: "USD Coin", version: "2"}
+
+  @domains %{
+    # Mainnets
+    1 => %{name: "USD Coin", version: "2"},
+    10 => %{name: "USD Coin", version: "2"},
+    137 => %{name: "USD Coin", version: "2"},
+    8453 => %{name: "USD Coin", version: "2"},
+    42_161 => %{name: "USD Coin", version: "2"},
+    # Testnets -- Sepolias use "USDC" except Arbitrum Sepolia
+    11_155_111 => %{name: "USDC", version: "2"},
+    11_155_420 => %{name: "USDC", version: "2"},
+    84_532 => %{name: "USDC", version: "2"},
+    421_614 => %{name: "USD Coin", version: "2"}
+  }
+
+  @doc """
+  Return `%{name, version}` for the given chain ID.
+
+  Falls back to `%{name: "USD Coin", version: "2"}` (the mainnet default)
+  for unknown chain IDs so legacy callers continue to work.
+  """
+  @spec lookup(pos_integer()) :: %{name: String.t(), version: String.t()}
+  def lookup(chain_id) when is_integer(chain_id) do
+    Map.get(@domains, chain_id, @default)
+  end
+
+  @doc "Return the set of chain IDs with explicit overrides."
+  @spec known_chain_ids() :: [pos_integer()]
+  def known_chain_ids, do: Map.keys(@domains)
+end

--- a/packages/raxol_payments/lib/raxol/payments/protocols/x402.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/x402.ex
@@ -64,10 +64,13 @@ defmodule Raxol.Payments.Protocols.X402 do
   @spec build_payment(map(), module()) ::
           {:ok, Headers.headers()} | {:error, term()}
   def build_payment(challenge, wallet) do
+    chain_id = chain_id_from_network(challenge.network)
+    %{name: name, version: version} = Raxol.Payments.Assets.UsdcDomains.lookup(chain_id)
+
     domain = %{
-      name: "USD Coin",
-      version: "2",
-      chainId: chain_id_from_network(challenge.network),
+      name: name,
+      version: version,
+      chainId: chain_id,
       verifyingContract: challenge.currency
     }
 

--- a/packages/raxol_payments/test/raxol/payments/assets/usdc_domains_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/assets/usdc_domains_test.exs
@@ -1,0 +1,50 @@
+defmodule Raxol.Payments.Assets.UsdcDomainsTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.Assets.UsdcDomains
+
+  describe "lookup/1" do
+    test "mainnet USDC deployments resolve to 'USD Coin'" do
+      for chain_id <- [1, 10, 137, 8453, 42_161] do
+        assert UsdcDomains.lookup(chain_id) == %{name: "USD Coin", version: "2"},
+               "chain #{chain_id} expected USD Coin"
+      end
+    end
+
+    test "Eth/OP/Base Sepolia USDC deployments resolve to 'USDC'" do
+      for chain_id <- [11_155_111, 11_155_420, 84_532] do
+        assert UsdcDomains.lookup(chain_id) == %{name: "USDC", version: "2"},
+               "chain #{chain_id} expected USDC"
+      end
+    end
+
+    test "Arbitrum Sepolia USDC resolves to 'USD Coin' (verified on-chain)" do
+      assert UsdcDomains.lookup(421_614) == %{name: "USD Coin", version: "2"}
+    end
+
+    test "unknown chain id falls back to mainnet default" do
+      assert UsdcDomains.lookup(999_999) == %{name: "USD Coin", version: "2"}
+    end
+  end
+
+  describe "known_chain_ids/0" do
+    test "covers every chain in the riddler-permit2-erc3009 matrix" do
+      ids = UsdcDomains.known_chain_ids() |> MapSet.new()
+
+      expected =
+        MapSet.new([
+          1,
+          10,
+          137,
+          8453,
+          42_161,
+          11_155_111,
+          11_155_420,
+          84_532,
+          421_614
+        ])
+
+      assert MapSet.equal?(ids, expected)
+    end
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/protocols/x402_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/x402_test.exs
@@ -129,4 +129,99 @@ defmodule Raxol.Payments.Protocols.X402Test do
       assert {:error, :no_receipt} = X402.parse_receipt([])
     end
   end
+
+  describe "build_payment/2 USDC domain resolution" do
+    # Captures the domain passed to sign_typed_data so we can assert that
+    # build_payment looks up the per-chain USDC name/version rather than
+    # using a hardcoded "USD Coin".
+    defmodule CaptureWallet do
+      @moduledoc false
+      @behaviour Raxol.Payments.Wallet
+      @impl true
+      def address, do: "0x" <> String.duplicate("ab", 20)
+      @impl true
+      def chain_id, do: 8453
+      @impl true
+      def sign_message(_msg), do: {:ok, <<0::512>>}
+      @impl true
+      def sign_typed_data(domain, _types, _message) do
+        Process.put(:captured_domain, domain)
+        {:ok, <<0::512>>}
+      end
+
+      @impl true
+      def sign_hash(_digest), do: {:ok, <<0::520>>}
+    end
+
+    defp challenge_for(chain_id, currency) do
+      %{
+        price: 1_000_000,
+        currency: currency,
+        network: "eip155:#{chain_id}",
+        pay_to: "0x" <> String.duplicate("cd", 20),
+        nonce: "0x" <> String.duplicate("12", 32),
+        valid_after: 0,
+        valid_before: 9_999_999_999,
+        extra: %{}
+      }
+    end
+
+    test "Base mainnet (8453) resolves to 'USD Coin'" do
+      challenge =
+        challenge_for(8453, "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+
+      assert {:ok, _} = X402.build_payment(challenge, CaptureWallet)
+
+      assert %{
+               name: "USD Coin",
+               version: "2",
+               chainId: 8453,
+               verifyingContract: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+             } = Process.get(:captured_domain)
+    end
+
+    test "Base Sepolia (84532) resolves to 'USDC' instead of hardcoded 'USD Coin'" do
+      challenge =
+        challenge_for(84_532, "0x036CbD53842c5426634e7929541eC2318f3dCF7e")
+
+      assert {:ok, _} = X402.build_payment(challenge, CaptureWallet)
+
+      assert %{
+               name: "USDC",
+               version: "2",
+               chainId: 84_532,
+               verifyingContract: "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+             } = Process.get(:captured_domain)
+    end
+
+    test "Ethereum Sepolia (11155111) resolves to 'USDC'" do
+      challenge =
+        challenge_for(11_155_111, "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238")
+
+      assert {:ok, _} = X402.build_payment(challenge, CaptureWallet)
+
+      assert %{name: "USDC", version: "2", chainId: 11_155_111} =
+               Process.get(:captured_domain)
+    end
+
+    test "Optimism Sepolia (11155420) resolves to 'USDC'" do
+      challenge =
+        challenge_for(11_155_420, "0x5fd84259d66Cd46123540766Be93DFE6D43130D7")
+
+      assert {:ok, _} = X402.build_payment(challenge, CaptureWallet)
+
+      assert %{name: "USDC", version: "2", chainId: 11_155_420} =
+               Process.get(:captured_domain)
+    end
+
+    test "Arbitrum Sepolia (421614) resolves to 'USD Coin' (verified on-chain)" do
+      challenge =
+        challenge_for(421_614, "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d")
+
+      assert {:ok, _} = X402.build_payment(challenge, CaptureWallet)
+
+      assert %{name: "USD Coin", version: "2", chainId: 421_614} =
+               Process.get(:captured_domain)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Raxol.Payments.Protocols.X402.build_payment/2` hardcoded `name: "USD Coin", version: "2"` in the EIP-712 domain. Verified on-chain via Blockscout:

| Chain | `name()` | `version()` |
|---|---|---|
| Ethereum / Base / OP / Arbitrum / Polygon mainnet USDC | `"USD Coin"` | `"2"` |
| Eth / Base / OP Sepolia USDC | `"USDC"` | `"2"` |
| Arbitrum Sepolia USDC | `"USD Coin"` | `"2"` |

Testnet x402 ERC-3009 signatures were therefore producing the wrong digest. This is part 5 of 6 of the broader plan to test raxol agent payment paths.

New `Raxol.Payments.Assets.UsdcDomains.lookup/1` is the per-chain table. Unknown chain IDs fall back to the mainnet `%{name: "USD Coin", version: "2"}` so legacy callers keep working. Cross-check against `riddler-permit2-erc3009/src/config.js` `usdcName`/`usdcVersion`.

## Manual testing

- [x] `mix test test/raxol/payments/assets/usdc_domains_test.exs test/raxol/payments/protocols/x402_test.exs` -- 23 tests pass
- [x] `mix test` (full raxol_payments suite) -- 31 properties + 506 tests, 0 failures
- [x] Arbitrum Sepolia USDC `name()` verified on-chain (Blockscout chain 421614, contract 0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d)