### PR TITLE
Fix SCA install_session_key: don't wrap in execute()

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/wallet/sca/provisioning.ex
+++ b/packages/raxol_acp/lib/raxol/acp/wallet/sca/provisioning.ex
@@ -35,9 +35,16 @@ defmodule Raxol.ACP.Wallet.SCA.Provisioning do
 
   `install_session_key_calldata/3` builds the `installValidation` call
   that registers a session key on the single-signer validation module
-  as a new entity. Wrap it in the account's `execute(...)` and send it
-  as a UserOp signed by the owner. In production Virtuals' `acp setup`
-  usually does this; the helper exists for self-provisioning.
+  as a new entity. Use the result **directly** as `UserOp.call_data` --
+  the EntryPoint calls `sender.<call_data>`, which is exactly
+  `account.installValidation(...)`.
+
+  **Do NOT wrap it in `ModularAccount.execute_calldata(account, 0, ...)`.**
+  MAv2 SMA forbids self-calls (`execute(self, 0, ...)`) and reverts with
+  `SelfCallRecursionDepthExceeded()` during validation -- the bundler
+  surfaces this as "AA23 reverted" with selector `0x54ff929d`. In
+  production Virtuals' `acp setup` usually does this; the helper exists
+  for self-provisioning.
 
   ## Provisioning vs. raxol
 
@@ -114,8 +121,12 @@ defmodule Raxol.ACP.Wallet.SCA.Provisioning do
       installValidation(bytes25 validationConfig, bytes4[] selectors,
                         bytes installData, bytes[] hooks)
 
-  Wrap the result in the account's `execute(account, 0, calldata)` and
-  send it as a UserOp signed by the owner.
+  Use the result directly as `UserOp.call_data` and send it as a UserOp
+  signed by the owner. Do NOT wrap it in `execute(account, 0, calldata)`
+  -- MAv2 rejects self-calls with `SelfCallRecursionDepthExceeded()`
+  (AA23 / selector 0x54ff929d). The EntryPoint dispatches the userOp's
+  call_data directly to the sender, so `installValidation` is invoked
+  on the account itself without any wrapper.
 
   `validationConfig` packs `moduleAddress(20) || entityId(uint32) ||
   flags(1)`, where flags = userOp(1) | signature(2) | global(4).

--- a/packages/raxol_acp/test/raxol/acp/wallet/sca/bundler_harness_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/wallet/sca/bundler_harness_test.exs
@@ -166,11 +166,16 @@ defmodule Raxol.ACP.Wallet.SCA.BundlerHarnessTest do
 
     nonce0 = nonce_hex |> String.split() |> hd() |> String.to_integer()
 
+    # call_data is the installValidation calldata directly -- NOT wrapped
+    # in execute(sca, 0, ...). MAv2 SMA rejects self-calls with
+    # SelfCallRecursionDepthExceeded() (AA23 / selector 0x54ff929d). The
+    # EntryPoint dispatches userOp.call_data straight to sender, so the
+    # SCA's installValidation runs on itself without any wrapper.
     deploy_op = %UserOp{
       sender: sca,
       nonce: nonce0,
       init_code: Provisioning.deploy_init_code(@owner, 1),
-      call_data: ModularAccount.execute_calldata(sca, 0, install_data),
+      call_data: install_data,
       call_gas_limit: 800_000,
       verification_gas_limit: 1_500_000,
       pre_verification_gas: 200_000,


### PR DESCRIPTION
## Summary

MAv2 SMA rejects \`execute(self, 0, ...)\` self-calls with \`SelfCallRecursionDepthExceeded()\` (selector \`0x54ff929d\`). The EntryPoint surfaces this as 'AA23 reverted'.

The user-op \`call_data\` should be the \`installValidation\` calldata directly. The EntryPoint dispatches it straight to \`sender\`, so the SCA's \`installValidation\` runs on itself without any wrapper.

Both the \`install_session_key_calldata/3\` docstring and the \`BundlerHarnessTest\` session-key test incorrectly instructed wrapping in \`execute\`. **Production code never called it that way** -- only tests and docs did -- so no runtime fallout, but the docstring would have led the next caller into the same trap.

## Context

Found while preparing the Xochi launch on Virtuals's ACP marketplace. The v1 SCA provisioning path needs to work for our Elixir-native ProviderAdapter (we're not adopting Privy). v2 SCA provisioning should not carry the v1 \"wrap in execute\" pattern forward -- the docstring update flags this explicitly.

## Manual testing

- [x] \`mix test test/raxol/acp/wallet/sca/bundler_harness_test.exs --include live_bundler\` -- 2/2 pass (was 1/2)
- [x] \`mix test\` -- 371 tests, 0 failures, 5 excluded