### PR TITLE
raxol_acp 0.2.0-pre.0: scaffold ACP v2 + Xochi offering

### DIFF
--- a/packages/raxol_acp/MIGRATION_V2.md
+++ b/packages/raxol_acp/MIGRATION_V2.md
@@ -1,0 +1,45 @@
+# Migrating raxol_acp from v1 to v2
+
+`raxol_acp` was originally written against `@virtuals-protocol/acp-node@0.3.0-beta.40`. Virtuals deprecated that SDK on **2026-06-01** in favor of [`@virtuals-protocol/acp-node-v2`](https://github.com/Virtual-Protocol/acp-node-v2). The protocol layer changed substantially:
+
+- Memo-based job model → **hook-based** model (`FundTransferHook`, `SubscriptionHook`, `MultiHookRouter`).
+- Phase-callback API (`onNewTask`, `onEvaluate`) → **event-driven** API (`on("entry", handler)`).
+- Phase enum `request/negotiation/transaction/evaluation/completed` → `open/budget_set/funded/submitted/completed/rejected/expired`.
+- Socket.IO transport → **SSE** primary (`api.acp.virtuals.io`), Socket.IO legacy.
+- `Fare`/`FareAmount` token type → **`AssetToken`**.
+- Implicit settlement on phase transition → **explicit `complete()` / `reject()`**.
+- Raw private keys → **Privy + Alchemy ERC-4337**.
+- Compliance with **ERC-8183 (Agentic Commerce)**.
+
+`raxol_acp` 0.2.0 ships the v2 surface alongside the v1 surface so existing solver code keeps working during the transition. This document tracks what's landed and what's still pending.
+
+## Status — 2026-06-13
+
+| Area | v1 (existing) | v2 (scaffolded this PR) | v2 (TODO) |
+|------|---------------|-------------------------|-----------|
+| Chain config | `Raxol.ACP.Chain` (mainnet, sepolia, `acp_contract_address`, `acp_router_address`) | adds `acp_core_address`, `fund_transfer_hook_address`, `multi_hook_router_address`, `subscription_hook_address`, `subscription_state_address`, `acp_server_url` | — |
+| Token amounts | `Fare`/`FareAmount` (Decimal-based) | `Raxol.ACP.AssetToken` (raw integer + decimals + chain-aware) | — |
+| Event model | `onNewTask`/`onEvaluate` via Socket.IO | `Raxol.ACP.Event` type union + helpers | SSE transport, `Raxol.ACP.Agent` event dispatch |
+| Job session | `Raxol.ACP.Job.Server` (state machine) | — | `Raxol.ACP.JobSession` GenServer with `set_budget`/`fund`/`submit`/`complete`/`reject` |
+| Provider adapter | `Raxol.ACP.ContractClient.Onchain` (direct JSON-RPC) | — | `Raxol.ACP.ProviderAdapter.SCA` (Elixir-native, reuses `Raxol.ACP.Wallet.SCA`) |
+| Hook integration | (no first-class hooks) | — | `Raxol.ACP.Hooks.FundTransfer` for Xochi |
+| Xochi offering | (none) | `Raxol.ACP.Xochi.Offering` (request/deliverable schemas) | `Raxol.ACP.Xochi.SolverAgent` runtime |
+| Wallet/signer | `Raxol.ACP.Wallet.SCA` (MAv2 + session keys; `SelfCallRecursionDepthExceeded` fix in #266) | — | v2 SCA provisioning (deploy + install in two userOps, not one) |
+| Marketplace registration | — | — | `mix acp.register_offering` task |
+
+## Strategy
+
+We're replacing v1 in place inside this single package, NOT spinning up `raxol_acp_v2`. The v1 modules stay reachable under their original names (`Raxol.ACP.Job.Server`, etc.) while v2 modules go live under the new names (`Raxol.ACP.AssetToken`, `Raxol.ACP.JobSession`, `Raxol.ACP.Agent`). As each v2 module reaches parity with its v1 counterpart, we remove the v1 module in a follow-up PR.
+
+The mix version reflects the in-progress state: `0.2.0-pre.0` while scaffolding, `0.2.0-rc.N` when the v2 surface is feature-complete, `0.2.0` when v1 is removed.
+
+## Why not Privy?
+
+`acp-node-v2` standardizes on `PrivyAlchemyEvmProviderAdapter` for non-custodial key storage (P256 keys in OS keychain). Adopting Privy in Elixir would require either (a) calling a Privy HTTP wrapper from BEAM, or (b) reimplementing Privy's signing protocol natively. Neither is justified for our use case: we already run a BEAM-native MAv2 SCA wallet with Alchemy paymaster + session keys, and the Xochi solver agent is server-side (not a user-facing app where OS keychain matters). The Elixir-native `ProviderAdapter.SCA` keeps everything in process and avoids a third-party runtime dep.
+
+## References
+
+- [acp-node-v2 README](https://github.com/Virtual-Protocol/acp-node-v2/blob/main/README.md)
+- [acp-node-v2 migration guide](https://github.com/Virtual-Protocol/acp-node-v2/blob/main/migration.md)
+- [Virtuals whitepaper, ACP v2 section](https://whitepaper.virtuals.io/llms-full.txt)
+- [ERC-8183 Agentic Commerce](https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902)

--- a/packages/raxol_acp/lib/raxol/acp/asset_token.ex
+++ b/packages/raxol_acp/lib/raxol/acp/asset_token.ex
@@ -1,0 +1,146 @@
+defmodule Raxol.ACP.AssetToken do
+  @moduledoc """
+  Token-amount value object used throughout v2 budget / fund / submit
+  flows.
+
+  Replaces the v1 `Fare` / `FareAmount` pair. An `AssetToken` carries
+  the address, symbol, decimal precision, and raw amount so a single
+  value can travel through `set_budget/fund/submit` calls without
+  needing chain-specific lookup tables at every step.
+
+  ## Construction
+
+      Raxol.ACP.AssetToken.usdc(0.1, 8453)           # 100_000 raw (6 dp)
+      Raxol.ACP.AssetToken.usdc_from_raw(100_000, 8453)
+      Raxol.ACP.AssetToken.create(
+        address: "0x...",
+        symbol: "WETH",
+        decimals: 18,
+        amount: Decimal.new("1.5")
+      )
+
+  ## Equivalence with the SDK
+
+  Mirrors `AssetToken.usdc(amount, chainId)` and
+  `AssetToken.usdcFromRaw(rawAmount, chainId)` in `acp-node-v2`
+  (`src/core/assetToken.ts`). The shape is intentionally identical so
+  on-the-wire payloads round-trip.
+  """
+
+  alias Raxol.ACP.Chain
+
+  @type t :: %__MODULE__{
+          address: String.t(),
+          symbol: String.t(),
+          decimals: pos_integer(),
+          raw_amount: non_neg_integer(),
+          chain_id: pos_integer()
+        }
+
+  defstruct [:address, :symbol, :decimals, :raw_amount, :chain_id]
+
+  @doc """
+  Build a USDC token amount for the given chain. `amount` is in
+  human-readable units (e.g. `0.1` for 0.1 USDC). The chain must be a
+  known ACP chain (`Chain.mainnet/0` or `Chain.sepolia/0`).
+  """
+  @spec usdc(number() | Decimal.t(), pos_integer()) :: t()
+  def usdc(amount, chain_id) when is_integer(chain_id) do
+    config = chain_config_by_id!(chain_id)
+    decimals = 6
+    raw = to_raw(amount, decimals)
+
+    %__MODULE__{
+      address: config.usdc_address,
+      symbol: "USDC",
+      decimals: decimals,
+      raw_amount: raw,
+      chain_id: chain_id
+    }
+  end
+
+  @doc "Build a USDC token amount from a raw integer (e.g. `100_000` = 0.1 USDC)."
+  @spec usdc_from_raw(non_neg_integer(), pos_integer()) :: t()
+  def usdc_from_raw(raw_amount, chain_id)
+      when is_integer(raw_amount) and raw_amount >= 0 and is_integer(chain_id) do
+    config = chain_config_by_id!(chain_id)
+
+    %__MODULE__{
+      address: config.usdc_address,
+      symbol: "USDC",
+      decimals: 6,
+      raw_amount: raw_amount,
+      chain_id: chain_id
+    }
+  end
+
+  @doc """
+  Build a token amount for an arbitrary ERC-20. All fields required.
+
+      AssetToken.create(
+        address: "0x...",
+        symbol: "WETH",
+        decimals: 18,
+        amount: Decimal.new("1.5"),
+        chain_id: 8453
+      )
+  """
+  @spec create(keyword()) :: t()
+  def create(opts) do
+    address = Keyword.fetch!(opts, :address)
+    symbol = Keyword.fetch!(opts, :symbol)
+    decimals = Keyword.fetch!(opts, :decimals)
+    chain_id = Keyword.fetch!(opts, :chain_id)
+
+    raw =
+      case Keyword.fetch(opts, :raw_amount) do
+        {:ok, raw} when is_integer(raw) and raw >= 0 ->
+          raw
+
+        :error ->
+          opts |> Keyword.fetch!(:amount) |> to_raw(decimals)
+      end
+
+    %__MODULE__{
+      address: address,
+      symbol: symbol,
+      decimals: decimals,
+      raw_amount: raw,
+      chain_id: chain_id
+    }
+  end
+
+  @doc "Return the human-readable amount as a `Decimal`."
+  @spec to_human(t()) :: Decimal.t()
+  def to_human(%__MODULE__{raw_amount: raw, decimals: dp}) do
+    Decimal.div(Decimal.new(raw), Decimal.new(Integer.pow(10, dp)))
+  end
+
+  # -- Internal --
+
+  defp to_raw(%Decimal{} = amount, decimals) do
+    amount
+    |> Decimal.mult(Decimal.new(Integer.pow(10, decimals)))
+    |> Decimal.round(0, :down)
+    |> Decimal.to_integer()
+  end
+
+  defp to_raw(amount, decimals) when is_integer(amount) do
+    amount * Integer.pow(10, decimals)
+  end
+
+  defp to_raw(amount, decimals) when is_float(amount) do
+    amount
+    |> Decimal.from_float()
+    |> to_raw(decimals)
+  end
+
+  defp chain_config_by_id!(8453), do: Chain.mainnet()
+  defp chain_config_by_id!(84_532), do: Chain.sepolia()
+
+  defp chain_config_by_id!(other) do
+    raise ArgumentError,
+          "AssetToken: unknown chain_id #{inspect(other)}. " <>
+            "ACP v2 currently supports Base Mainnet (8453) and Base Sepolia (84532)."
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/chain.ex
+++ b/packages/raxol_acp/lib/raxol/acp/chain.ex
@@ -16,15 +16,22 @@ defmodule Raxol.ACP.Chain do
 
   ## Contract version (V1 vs V2)
 
-  `acp_contract_address` points at the **V1 `ACPSimple`** proxy and
-  `acp_router_address` at the newer **V2 `ACPRouter`**. Callers should
-  not pick the address directly; `Raxol.ACP.ContractClient.Onchain`
-  resolves the right one from `Application.get_env(:raxol_acp,
-  :acp_version, :v1)` so flipping the version is a single switch.
+  Three contract families coexist here during the v1 -> v2 transition:
 
-  V2 sepolia address is currently `nil` (no confirmed deployment
-  vendored). Setting `acp_version: :v2` with `chain: :sepolia` raises
-  unless `chain_overrides` supplies an `acp_router_address`.
+  - **`acp_contract_address`** -- V1 `ACPSimple` proxy. Sunsetted upstream
+    on 2026-06-01 but kept here while raxol_acp's v1 modules still call
+    into it. Set `acp_version: :v1` to use this path.
+  - **`acp_router_address`** -- the legacy "v2 ACPRouter" hop (Base
+    mainnet only). Obsolete; do not use for new work. The address stays
+    so existing dashboards / event indexers don't break.
+  - **`acp_core_address`** -- the real v2 ACP Core contract, paired with
+    `fund_transfer_hook_address`, `multi_hook_router_address`,
+    `subscription_hook_address`, and `subscription_state_address`. Use
+    this with `acp_version: :v2` (the future default).
+
+  Callers should not pick the address directly;
+  `Raxol.ACP.ContractClient.Onchain` resolves the right one from
+  `Application.get_env(:raxol_acp, :acp_version, :v1)`.
   """
 
   @type network :: :mainnet | :sepolia
@@ -35,7 +42,13 @@ defmodule Raxol.ACP.Chain do
           usdc_address: String.t(),
           acp_contract_address: String.t() | nil,
           acp_router_address: String.t() | nil,
+          acp_core_address: String.t() | nil,
+          fund_transfer_hook_address: String.t() | nil,
+          multi_hook_router_address: String.t() | nil,
+          subscription_hook_address: String.t() | nil,
+          subscription_state_address: String.t() | nil,
           acp_socket_url: String.t() | nil,
+          acp_server_url: String.t() | nil,
           x402_facilitator_url: String.t() | nil
         }
 
@@ -43,14 +56,23 @@ defmodule Raxol.ACP.Chain do
     chain_id: 8453,
     name: "Base Mainnet",
     rpc_url: "https://mainnet.base.org",
-    # USDC on Base mainnet
+    # USDC on Base mainnet (canonical Circle deployment)
     usdc_address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-    # V1 ACPSimple proxy (impl 0x48c15725...); verified on Basescan
+    # V1 ACPSimple proxy (impl 0x48c15725...). Sunsetted in v2; kept for
+    # back-compat during the transition.
     acp_contract_address: "0x6a1FE26D54ab0d3E1e3168f2e0c0cDa5cC0A0A4A",
-    # V2 ACPRouter on Base mainnet
+    # Legacy v1 ACPRouter -- interim hop, obsolete in true v2.
     acp_router_address: "0xa6C9BA866992cfD7fd6460ba912bfa405adA9df0",
-    # Virtuals ACP Socket.IO endpoint
+    # ACP v2 core contract -- verified against
+    # https://github.com/Virtual-Protocol/acp-node-v2/blob/main/src/core/constants.ts
+    acp_core_address: "0x238E541BfefD82238730D00a2208E5497F1832E0",
+    fund_transfer_hook_address: "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B",
+    multi_hook_router_address: "0x77F67252a8d3A6b049f4383FD50Fb9Bf784D29D1",
+    subscription_hook_address: "0xD087363615f36F2b0265Bb4AC78Cd730C6C0cc1D",
+    subscription_state_address: "0x52c2C68f4f7fF3C70760E3D0B9b2FA91CFE443Ad",
+    # Legacy Socket.IO endpoint (v1). v2 uses SSE via acp_server_url.
     acp_socket_url: "https://acpx.virtuals.io",
+    acp_server_url: "https://api.acp.virtuals.io",
     x402_facilitator_url: "https://acp-x402.virtuals.io"
   }
 
@@ -58,13 +80,20 @@ defmodule Raxol.ACP.Chain do
     chain_id: 84_532,
     name: "Base Sepolia",
     rpc_url: "https://sepolia.base.org",
-    # USDC on Base Sepolia
+    # Canonical Circle Sepolia USDC. Note: the Virtuals v2 SDK uses a
+    # Virtuals-specific test USDC (0xECc22a8F...) -- override via
+    # :chain_overrides if you need the Virtuals test deployment.
     usdc_address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-    # V1 ACPSimple proxy (impl 0xF9663D54...); verified on Basescan
     acp_contract_address: "0x8Db6B1c839Fc8f6bd35777E194677B67b4D51928",
-    # No verified V2 deployment on sepolia at time of writing.
     acp_router_address: nil,
+    # ACP v2 contracts on Base Sepolia (verified against acp-node-v2 source).
+    acp_core_address: "0x0b93793923CD5De81850aF8604a233f3f24d461e",
+    fund_transfer_hook_address: "0xbbeC2c985F9483473B9e0Da0704395943034266B",
+    multi_hook_router_address: "0x5Af0589bD265d2B5Abb617570Ceef8f34Ac6BcdD",
+    subscription_hook_address: "0x6eA4c9C6dA120B193e3C2249CCA81ead3Cfb318f",
+    subscription_state_address: "0x6f254046aA8A9c253f839eb64Da1FE284930100F",
     acp_socket_url: "https://acpx.virtuals.gg",
+    acp_server_url: "https://api-dev.acp.virtuals.io",
     x402_facilitator_url: "https://dev-acp-x402.virtuals.io"
   }
 

--- a/packages/raxol_acp/lib/raxol/acp/event.ex
+++ b/packages/raxol_acp/lib/raxol/acp/event.ex
@@ -1,0 +1,94 @@
+defmodule Raxol.ACP.Event do
+  @moduledoc """
+  Event-type union for the v2 event-driven model.
+
+  In v1 the seller agent registered two callbacks (`onNewTask`,
+  `onEvaluate`); v2 collapses this into a single
+  `on("entry", handler)` with role-aware semantics. This module defines
+  the canonical event-type strings the v2 SDK emits and the payload
+  shapes for each.
+
+  Canonical event-type strings (mirroring `acp-node-v2`):
+
+      "job.created" | "budget.set" | "job.funded"
+      "job.submitted" | "job.completed" | "job.rejected" | "job.expired"
+
+  Phase-to-event mapping vs v1:
+
+  | v1 phase     | v2 event       |
+  |--------------|----------------|
+  | REQUEST      | job.created    |
+  | NEGOTIATION  | budget.set     |
+  | TRANSACTION  | job.funded     |
+  | EVALUATION   | job.submitted  |
+  | COMPLETED    | job.completed  |
+  | REJECTED     | job.rejected   |
+  | (expired)    | job.expired    |
+  """
+
+  @type t ::
+          {:job_created, payload()}
+          | {:budget_set, payload()}
+          | {:job_funded, payload()}
+          | {:job_submitted, payload()}
+          | {:job_completed, payload()}
+          | {:job_rejected, payload()}
+          | {:job_expired, payload()}
+
+  @type payload :: %{
+          required(:job_id) => String.t() | non_neg_integer(),
+          required(:chain_id) => pos_integer(),
+          required(:actor) => String.t(),
+          required(:timestamp_ms) => non_neg_integer(),
+          optional(:budget) => Raxol.ACP.AssetToken.t(),
+          optional(:transfer_amount) => Raxol.ACP.AssetToken.t(),
+          optional(:destination) => String.t(),
+          optional(:deliverable) => term(),
+          optional(:reason) => String.t(),
+          optional(:tx_hash) => String.t(),
+          optional(:client) => String.t(),
+          optional(:provider) => String.t(),
+          optional(:evaluator) => String.t()
+        }
+
+  @event_types ~w(job.created budget.set job.funded job.submitted job.completed job.rejected job.expired)
+
+  @doc """
+  Decode a wire-format event-type string into the matching atom tuple
+  key.
+
+      iex> Raxol.ACP.Event.decode_type("job.created")
+      {:ok, :job_created}
+
+      iex> Raxol.ACP.Event.decode_type("nope")
+      {:error, :unknown_event_type}
+  """
+  @spec decode_type(String.t()) :: {:ok, atom()} | {:error, :unknown_event_type}
+  def decode_type(string) when is_binary(string) do
+    if string in @event_types do
+      atom = string |> String.replace(".", "_") |> String.to_atom()
+      {:ok, atom}
+    else
+      {:error, :unknown_event_type}
+    end
+  end
+
+  @doc "Inverse of `decode_type/1`: render an atom back to its wire string."
+  @spec encode_type(atom()) :: String.t()
+  def encode_type(:job_created), do: "job.created"
+  def encode_type(:budget_set), do: "budget.set"
+  def encode_type(:job_funded), do: "job.funded"
+  def encode_type(:job_submitted), do: "job.submitted"
+  def encode_type(:job_completed), do: "job.completed"
+  def encode_type(:job_rejected), do: "job.rejected"
+  def encode_type(:job_expired), do: "job.expired"
+
+  @doc "Terminal event types -- the session is done after one of these."
+  @spec terminal?(atom()) :: boolean()
+  def terminal?(type) when type in [:job_completed, :job_rejected, :job_expired], do: true
+  def terminal?(_), do: false
+
+  @doc "All canonical event-type strings, in lifecycle order."
+  @spec all_types() :: [String.t()]
+  def all_types, do: @event_types
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -1,0 +1,199 @@
+defmodule Raxol.ACP.Xochi.Offering do
+  @moduledoc """
+  Draft Xochi cross-chain intent offering schema for the Virtuals ACP
+  marketplace.
+
+  Xochi launches as a **fund-transfer agent**: the buyer creates a job
+  whose hookAddress is the v2 `FundTransferHook`, escrows funds, and
+  the Xochi solver agent uses `setBudgetWithFundRequest(budget,
+  transferAmount, destination)` to (a) take its service fee from the
+  escrow and (b) route the rest through Xochi's quote+execute flow to
+  the buyer-specified destination on a different chain.
+
+  This module defines the offering's JSON schema (for marketplace
+  registration), the canonical request shape, and the deliverable
+  shape Xochi returns when the intent settles.
+
+  ## Lifecycle
+
+      job.created      -> buyer initiated, awaiting provider acceptance
+      budget.set       -> Xochi quoted; budget = service fee in USDC
+      job.funded       -> buyer escrowed the full transfer + fee
+      job.submitted    -> Xochi.execute returned an intent_id; solver
+                          fills cross-chain; deliverable = { intent_id,
+                          src_tx_hash, dst_tx_hash, status }
+      job.completed    -> buyer verifies dst_tx; FundTransferHook
+                          releases escrow
+
+  The deliverable surfaces both src and dst transaction hashes so the
+  buyer (or an evaluator agent) can verify the cross-chain settlement
+  on-chain before approving.
+
+  ## Marketplace registration
+
+  When registering the offering at https://app.virtuals.io/acp/new, the
+  `requirement_schema/0` and `deliverable_schema/0` JSON Schemas below
+  go into the `Job Offering` form. `request_schema/0` is what buyers
+  fill out when creating a job.
+  """
+
+  @doc """
+  Offering metadata payload for Virtuals's marketplace API.
+
+  Returns a map that can be JSON-encoded for `POST /offerings`. The
+  shape mirrors the `Offering` type in acp-node-v2.
+  """
+  @spec offering_metadata() :: map()
+  def offering_metadata do
+    %{
+      name: "xochi_cross_chain_transfer",
+      display_name: "Xochi Cross-Chain Transfer",
+      description:
+        "Atomic cross-chain stablecoin transfer via Xochi intents. " <>
+          "Buyer escrows USDC on src chain, Xochi delivers to a recipient " <>
+          "on the dst chain, FundTransferHook releases service fee on settle.",
+      required_funds: true,
+      hook_kind: "fund_transfer",
+      sla_minutes: 10,
+      requirement_schema: requirement_schema(),
+      deliverable_schema: deliverable_schema(),
+      tags: ["payments", "cross-chain", "stablecoin", "xochi"]
+    }
+  end
+
+  @doc "JSON Schema for what the buyer must send when initiating a job."
+  @spec requirement_schema() :: map()
+  def requirement_schema do
+    %{
+      "$schema" => "https://json-schema.org/draft/2020-12/schema",
+      "type" => "object",
+      "required" => [
+        "src_chain_id",
+        "dst_chain_id",
+        "src_token",
+        "dst_token",
+        "amount_atomic",
+        "destination",
+        "slippage_bps"
+      ],
+      "additionalProperties" => false,
+      "properties" => %{
+        "src_chain_id" => %{
+          "type" => "integer",
+          "description" => "Source chain ID (e.g. 8453 for Base mainnet)."
+        },
+        "dst_chain_id" => %{
+          "type" => "integer",
+          "description" => "Destination chain ID."
+        },
+        "src_token" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]{40}$",
+          "description" => "ERC-20 address being sent on src_chain_id."
+        },
+        "dst_token" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]{40}$",
+          "description" => "ERC-20 address to be received on dst_chain_id."
+        },
+        "amount_atomic" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" => "Source amount in token base units (USDC: 1 USDC = 1_000_000)."
+        },
+        "destination" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]{40}$",
+          "description" => "Recipient address on dst_chain_id."
+        },
+        "slippage_bps" => %{
+          "type" => "integer",
+          "minimum" => 0,
+          "maximum" => 1000,
+          "default" => 50,
+          "description" => "Acceptable slippage in basis points (50 = 0.5%)."
+        },
+        "settlement_preference" => %{
+          "type" => "string",
+          "enum" => ["public", "private"],
+          "default" => "public",
+          "description" =>
+            "Settlement privacy. 'private' uses Xochi's dark pool path; 'public' uses standard solver routing."
+        },
+        "stealth_spending_pub_key" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]+$",
+          "description" => "Optional stealth-address spending pubkey for shielded settlement."
+        },
+        "stealth_viewing_pub_key" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]+$",
+          "description" => "Optional stealth-address viewing pubkey."
+        }
+      }
+    }
+  end
+
+  @doc "JSON Schema for what Xochi returns in `submit(deliverable)`."
+  @spec deliverable_schema() :: map()
+  def deliverable_schema do
+    %{
+      "$schema" => "https://json-schema.org/draft/2020-12/schema",
+      "type" => "object",
+      "required" => ["intent_id", "src_tx_hash", "status"],
+      "additionalProperties" => false,
+      "properties" => %{
+        "intent_id" => %{
+          "type" => "string",
+          "description" => "Xochi intent identifier returned by POST /xochi/quote."
+        },
+        "quote_id" => %{
+          "type" => "string",
+          "description" => "Xochi quote identifier (audit trail)."
+        },
+        "src_tx_hash" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]{64}$",
+          "description" => "Transaction hash on src_chain_id (intent lock)."
+        },
+        "dst_tx_hash" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]{64}$",
+          "description" => "Transaction hash on dst_chain_id (intent fill). Absent until settled."
+        },
+        "status" => %{
+          "type" => "string",
+          "enum" => ["pending", "settled", "failed", "refunded"],
+          "description" => "Lifecycle state of the Xochi intent."
+        },
+        "fee_atomic" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" => "Xochi service fee charged in USDC base units."
+        },
+        "dst_amount_atomic" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" => "Amount actually received on dst_chain_id (post-slippage)."
+        }
+      }
+    }
+  end
+
+  @doc "Default SLA in minutes -- max time from `job.funded` to `job.submitted`."
+  @spec sla_minutes() :: pos_integer()
+  def sla_minutes, do: 10
+
+  @doc """
+  Whether a given requirement payload is well-formed enough to start
+  signing a Xochi quote. Cheap shape check only -- does not call
+  Riddler.
+  """
+  @spec valid_requirement?(map()) :: boolean()
+  def valid_requirement?(req) when is_map(req) do
+    required = ~w(src_chain_id dst_chain_id src_token dst_token amount_atomic destination slippage_bps)
+    Enum.all?(required, &Map.has_key?(req, &1))
+  end
+
+  def valid_requirement?(_), do: false
+end

--- a/packages/raxol_acp/mix.exs
+++ b/packages/raxol_acp/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolAcp.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0-pre.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_acp/test/raxol/acp/asset_token_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/asset_token_test.exs
@@ -1,0 +1,69 @@
+defmodule Raxol.ACP.AssetTokenTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.AssetToken
+
+  describe "usdc/2" do
+    test "Base mainnet: 0.1 USDC -> 100_000 raw" do
+      token = AssetToken.usdc(0.1, 8453)
+      assert token.symbol == "USDC"
+      assert token.decimals == 6
+      assert token.raw_amount == 100_000
+      assert token.chain_id == 8453
+      assert token.address == "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    end
+
+    test "Base Sepolia: 1 USDC -> 1_000_000 raw" do
+      token = AssetToken.usdc(1, 84_532)
+      assert token.raw_amount == 1_000_000
+      assert token.chain_id == 84_532
+    end
+
+    test "Decimal input accepted" do
+      token = AssetToken.usdc(Decimal.new("0.25"), 8453)
+      assert token.raw_amount == 250_000
+    end
+
+    test "unknown chain raises" do
+      assert_raise ArgumentError, ~r/unknown chain_id/, fn ->
+        AssetToken.usdc(1, 12345)
+      end
+    end
+  end
+
+  describe "usdc_from_raw/2" do
+    test "round-trips with to_human/1" do
+      token = AssetToken.usdc_from_raw(2_500_000, 8453)
+      assert Decimal.equal?(AssetToken.to_human(token), Decimal.new("2.5"))
+    end
+  end
+
+  describe "create/1" do
+    test "WETH on Base mainnet" do
+      token =
+        AssetToken.create(
+          address: "0x4200000000000000000000000000000000000006",
+          symbol: "WETH",
+          decimals: 18,
+          amount: Decimal.new("1.5"),
+          chain_id: 8453
+        )
+
+      assert token.raw_amount == 1_500_000_000_000_000_000
+      assert token.symbol == "WETH"
+    end
+
+    test "raw_amount overrides amount when both could be provided" do
+      token =
+        AssetToken.create(
+          address: "0x" <> String.duplicate("ab", 20),
+          symbol: "FOO",
+          decimals: 8,
+          raw_amount: 12_345,
+          chain_id: 8453
+        )
+
+      assert token.raw_amount == 12_345
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/chain_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/chain_test.exs
@@ -44,6 +44,49 @@ defmodule Raxol.ACP.ChainTest do
     end
   end
 
+  describe "v2 contract addresses" do
+    # Values verified against
+    # https://github.com/Virtual-Protocol/acp-node-v2/blob/main/src/core/constants.ts
+    test "mainnet v2 contract addresses match acp-node-v2 source" do
+      config = Chain.mainnet()
+
+      assert config.acp_core_address == "0x238E541BfefD82238730D00a2208E5497F1832E0"
+      assert config.fund_transfer_hook_address == "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B"
+      assert config.multi_hook_router_address == "0x77F67252a8d3A6b049f4383FD50Fb9Bf784D29D1"
+      assert config.subscription_hook_address == "0xD087363615f36F2b0265Bb4AC78Cd730C6C0cc1D"
+      assert config.subscription_state_address == "0x52c2C68f4f7fF3C70760E3D0B9b2FA91CFE443Ad"
+      assert config.acp_server_url == "https://api.acp.virtuals.io"
+    end
+
+    test "sepolia v2 contract addresses match acp-node-v2 source" do
+      config = Chain.sepolia()
+
+      assert config.acp_core_address == "0x0b93793923CD5De81850aF8604a233f3f24d461e"
+      assert config.fund_transfer_hook_address == "0xbbeC2c985F9483473B9e0Da0704395943034266B"
+      assert config.multi_hook_router_address == "0x5Af0589bD265d2B5Abb617570Ceef8f34Ac6BcdD"
+      assert config.subscription_hook_address == "0x6eA4c9C6dA120B193e3C2249CCA81ead3Cfb318f"
+      assert config.subscription_state_address == "0x6f254046aA8A9c253f839eb64Da1FE284930100F"
+      assert config.acp_server_url == "https://api-dev.acp.virtuals.io"
+    end
+
+    test "v2 contract addresses are distinct between networks" do
+      mainnet = Chain.mainnet()
+      sepolia = Chain.sepolia()
+
+      for field <- [
+            :acp_core_address,
+            :fund_transfer_hook_address,
+            :multi_hook_router_address,
+            :subscription_hook_address,
+            :subscription_state_address,
+            :acp_server_url
+          ] do
+        assert Map.fetch!(mainnet, field) != Map.fetch!(sepolia, field),
+               "Expected mainnet and sepolia #{field} to differ"
+      end
+    end
+  end
+
   describe "get/1" do
     test "resolves :mainnet" do
       assert {:ok, config} = Chain.get(:mainnet)

--- a/packages/raxol_acp/test/raxol/acp/event_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/event_test.exs
@@ -1,0 +1,48 @@
+defmodule Raxol.ACP.EventTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Event
+
+  describe "decode_type/1" do
+    test "round-trips every canonical type" do
+      for str <- Event.all_types() do
+        assert {:ok, atom} = Event.decode_type(str)
+        assert Event.encode_type(atom) == str
+      end
+    end
+
+    test "rejects unknown strings" do
+      assert {:error, :unknown_event_type} = Event.decode_type("nope")
+      assert {:error, :unknown_event_type} = Event.decode_type("")
+    end
+  end
+
+  describe "terminal?/1" do
+    test "completed, rejected, expired are terminal" do
+      assert Event.terminal?(:job_completed)
+      assert Event.terminal?(:job_rejected)
+      assert Event.terminal?(:job_expired)
+    end
+
+    test "lifecycle events are not terminal" do
+      refute Event.terminal?(:job_created)
+      refute Event.terminal?(:budget_set)
+      refute Event.terminal?(:job_funded)
+      refute Event.terminal?(:job_submitted)
+    end
+  end
+
+  describe "all_types/0" do
+    test "returns the canonical 7 event types" do
+      assert Event.all_types() == [
+               "job.created",
+               "budget.set",
+               "job.funded",
+               "job.submitted",
+               "job.completed",
+               "job.rejected",
+               "job.expired"
+             ]
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
@@ -1,0 +1,98 @@
+defmodule Raxol.ACP.Xochi.OfferingTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Xochi.Offering
+
+  describe "offering_metadata/0" do
+    test "is a fund-transfer offering with USDC settlement" do
+      meta = Offering.offering_metadata()
+
+      assert meta.name == "xochi_cross_chain_transfer"
+      assert meta.required_funds == true
+      assert meta.hook_kind == "fund_transfer"
+      assert meta.sla_minutes == 10
+      assert "payments" in meta.tags
+    end
+
+    test "requirement and deliverable schemas are JSON-Schema 2020-12" do
+      meta = Offering.offering_metadata()
+
+      assert meta.requirement_schema["$schema"] ==
+               "https://json-schema.org/draft/2020-12/schema"
+
+      assert meta.deliverable_schema["$schema"] ==
+               "https://json-schema.org/draft/2020-12/schema"
+    end
+  end
+
+  describe "requirement_schema/0" do
+    test "rejects extra properties so buyers can't smuggle fields" do
+      schema = Offering.requirement_schema()
+      assert schema["additionalProperties"] == false
+    end
+
+    test "marks the 7 essential fields as required" do
+      schema = Offering.requirement_schema()
+      required = MapSet.new(schema["required"])
+
+      assert MapSet.equal?(
+               required,
+               MapSet.new([
+                 "src_chain_id",
+                 "dst_chain_id",
+                 "src_token",
+                 "dst_token",
+                 "amount_atomic",
+                 "destination",
+                 "slippage_bps"
+               ])
+             )
+    end
+
+    test "settlement_preference is optional and bounded" do
+      schema = Offering.requirement_schema()
+      prop = schema["properties"]["settlement_preference"]
+      assert prop["enum"] == ["public", "private"]
+      assert prop["default"] == "public"
+    end
+  end
+
+  describe "valid_requirement?/1" do
+    test "accepts a minimal valid request" do
+      req = %{
+        "src_chain_id" => 8453,
+        "dst_chain_id" => 10,
+        "src_token" => "0x" <> String.duplicate("ab", 20),
+        "dst_token" => "0x" <> String.duplicate("cd", 20),
+        "amount_atomic" => "1000000",
+        "destination" => "0x" <> String.duplicate("ef", 20),
+        "slippage_bps" => 50
+      }
+
+      assert Offering.valid_requirement?(req)
+    end
+
+    test "rejects requests missing a required field" do
+      refute Offering.valid_requirement?(%{"src_chain_id" => 8453})
+      refute Offering.valid_requirement?(%{})
+    end
+
+    test "rejects non-map input" do
+      refute Offering.valid_requirement?(nil)
+      refute Offering.valid_requirement?("string")
+    end
+  end
+
+  describe "deliverable_schema/0" do
+    test "intent_id, src_tx_hash, status are required" do
+      schema = Offering.deliverable_schema()
+      required = MapSet.new(schema["required"])
+      assert MapSet.equal?(required, MapSet.new(["intent_id", "src_tx_hash", "status"]))
+    end
+
+    test "status is bounded" do
+      schema = Offering.deliverable_schema()
+      assert schema["properties"]["status"]["enum"] == ["pending", "settled", "failed", "refunded"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Virtuals deprecated \`@virtuals-protocol/acp-node\` v1 on **2026-06-01** in favor of [acp-node-v2](https://github.com/Virtual-Protocol/acp-node-v2). This PR scaffolds the v2 surface inside raxol_acp so the Xochi launch ships against current Virtuals contracts.

**Key strategic decisions** (per discussion with @droo):
- Replace v1 in place inside this package (no new \`raxol_acp_v2\` package).
- Build alongside v1 first, sunset v1 module-by-module in follow-up PRs.
- Stay BEAM-native: build our own \`ProviderAdapter\` using the existing \`Raxol.ACP.Wallet.SCA\` (with #266 fix). No Privy dep.
- Xochi launches as a fund-transfer agent against v2's \`FundTransferHook\`.

## What's in this PR

**Chain config** (\`Raxol.ACP.Chain\`):
Adds \`acp_core_address\`, \`fund_transfer_hook_address\`, \`multi_hook_router_address\`, \`subscription_hook_address\`, \`subscription_state_address\`, \`acp_server_url\` for both Base mainnet and Base Sepolia. Addresses verified against [acp-node-v2 constants.ts](https://github.com/Virtual-Protocol/acp-node-v2/blob/main/src/core/constants.ts) -- note the whitepaper \`llms-full.txt\` export had a wrong \`FundTransferHook\` address; the SDK source is canonical.

**New modules:**
- \`Raxol.ACP.AssetToken\` -- chain-aware token amount; replaces v1 \`Fare\`/\`FareAmount\`. \`usdc/2\`, \`usdc_from_raw/2\`, \`create/1\`.
- \`Raxol.ACP.Event\` -- canonical 7-event union with \`decode_type/1\` / \`encode_type/1\` / \`terminal?/1\`.
- \`Raxol.ACP.Xochi.Offering\` -- draft marketplace metadata + request/deliverable JSON-Schema 2020-12 for the Xochi cross-chain transfer offering. Fund-transfer hook, 10-min SLA.

**Docs:** \`MIGRATION_V2.md\` tracks landed vs pending per area and explains the Privy non-decision.

**Version bump:** \`mix.exs\` to \`0.2.0-pre.0\` to signal in-progress v2 work.

## Status of the v2 punch list

| Area | This PR | Next |
|------|---------|------|
| Chain config | done | -- |
| AssetToken | done | -- |
| Event union | done | wire into JobSession |
| Offering schema | draft | refine after first job lifecycle test |
| JobSession GenServer | -- | PR B |
| AcpAgent / SSE transport | -- | PR C |
| ProviderAdapter.SCA | -- | PR D |
| FundTransferHook + Xochi handoff | -- | PR E |
| Marketplace registration | -- | PR F |

## Manual testing

- [x] \`mix test test/raxol/acp/chain_test.exs test/raxol/acp/asset_token_test.exs test/raxol/acp/event_test.exs test/raxol/acp/xochi/offering_test.exs\` -- 35 tests, 0 failures
- [x] \`mix test\` (full suite) -- 396 tests, 0 failures, 5 excluded