### PR TITLE
raxol_acp v2: Raxol.ACP.JobSession event-driven GenServer

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/job_session.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session.ex
@@ -1,0 +1,373 @@
+defmodule Raxol.ACP.JobSession do
+  @moduledoc """
+  Event-driven session for a single ACP v2 job.
+
+  Replaces v1's `Raxol.ACP.Job.Server` for the v2 model. One GenServer
+  per active job, registered under `Raxol.ACP.JobSession.Registry` by
+  `{chain_id, job_id}`. The session tracks role-aware status, maintains
+  a chronological entry log (events + messages), and notifies
+  subscribers via process messages of the shape
+  `{Raxol.ACP.JobSession, {chain_id, job_id}, entry}`.
+
+  ## Lifecycle
+
+      {:ok, _pid} = Raxol.ACP.JobSession.start_link(
+        chain_id: 8453,
+        job_id: "job-42",
+        role: :provider
+      )
+
+      :ok = Raxol.ACP.JobSession.subscribe(server)
+
+      {:ok, :budget_set} = Raxol.ACP.JobSession.set_budget(server, asset_token)
+      # ... time passes; client funds ...
+      {:ok, :submitted} = Raxol.ACP.JobSession.submit(server, deliverable)
+      # evaluator's process:
+      {:ok, :completed} = Raxol.ACP.JobSession.complete(server, "looks good")
+
+  Terminal statuses (`:completed`, `:rejected`, `:expired`) stop the
+  GenServer with `:normal` so transient supervisors do not resurrect
+  finished jobs.
+
+  ## Role gating
+
+  Actions are gated through `Raxol.ACP.JobSession.Tools.allowed?/3`.
+  Calling `complete/2` as a `:client` returns
+  `{:error, {:not_allowed_for_role, :client, :complete, status}}` instead
+  of executing.
+
+  ## On-chain side
+
+  This module is intentionally pure -- it records intent and notifies
+  listeners. Actually submitting hook calls to ACP v2's
+  `FundTransferHook` etc. lives behind `Raxol.ACP.ProviderAdapter`
+  (PR D). For now, transitions are local; a follow-up adapter wires
+  them to JSON-RPC.
+
+  ## Entries
+
+  The session stores a list of `entry()` maps in submission order:
+
+      %{kind: :system, event: :budget_set, payload: %{budget: ...}, at: dt}
+      %{kind: :message, from: role, content: "...", content_type: "text", at: dt}
+  """
+
+  use GenServer
+
+  alias Raxol.ACP.AssetToken
+  alias Raxol.ACP.JobSession.{Registry, Status, Tools}
+
+  @type role :: :client | :provider | :evaluator
+  @type job_key :: {pos_integer(), String.t() | non_neg_integer()}
+
+  @type entry :: %{
+          required(:kind) => :system | :message,
+          required(:at) => DateTime.t(),
+          optional(:event) => atom(),
+          optional(:payload) => map(),
+          optional(:from) => role(),
+          optional(:content) => String.t(),
+          optional(:content_type) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          job_id: String.t() | non_neg_integer(),
+          chain_id: pos_integer(),
+          role: role(),
+          status: Status.t(),
+          entries: [entry()],
+          subscribers: MapSet.t(pid()),
+          description: String.t() | nil
+        }
+
+  defstruct [
+    :job_id,
+    :chain_id,
+    :role,
+    :status,
+    entries: [],
+    subscribers: MapSet.new(),
+    description: nil
+  ]
+
+  # -- Public API --
+
+  @doc """
+  Start a JobSession registered under `Registry`.
+
+  ## Required options
+
+  - `:chain_id` -- the chain on which the ACP v2 job lives (e.g. 8453).
+  - `:job_id` -- the v2 job id (string or integer).
+  - `:role` -- `:client`, `:provider`, or `:evaluator`.
+
+  ## Optional
+
+  - `:initial_status` (default `:open`)
+  - `:description` -- short human-readable label for the job, mirrored
+    on `session.job.description` in acp-node-v2.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    chain_id = Keyword.fetch!(opts, :chain_id)
+    job_id = Keyword.fetch!(opts, :job_id)
+    GenServer.start_link(__MODULE__, opts, name: Registry.via({chain_id, job_id}))
+  end
+
+  @doc "Subscribe the calling process to entry notifications for `server`."
+  @spec subscribe(GenServer.server() | job_key()) :: :ok
+  def subscribe(server), do: GenServer.call(resolve(server), {:subscribe, self()})
+
+  @doc "Unsubscribe the calling process."
+  @spec unsubscribe(GenServer.server() | job_key()) :: :ok
+  def unsubscribe(server), do: GenServer.call(resolve(server), {:unsubscribe, self()})
+
+  @doc "Append a chat message to the session entry log. Always allowed."
+  @spec send_message(GenServer.server() | job_key(), String.t(), String.t()) :: :ok
+  def send_message(server, content, content_type \\ "text") do
+    GenServer.call(resolve(server), {:send_message, content, content_type})
+  end
+
+  @doc """
+  Provider action: set or update the budget (open -> budget_set, or
+  re-budget within budget_set).
+  """
+  @spec set_budget(GenServer.server() | job_key(), AssetToken.t()) ::
+          {:ok, Status.t()} | {:error, term()}
+  def set_budget(server, %AssetToken{} = budget) do
+    transition(server, :set_budget, %{budget: budget})
+  end
+
+  @doc """
+  Provider action: set budget and signal the fund-transfer flow. The
+  client funds `budget + transfer_amount` USDC; on submit the
+  FundTransferHook routes `transfer_amount` to `destination` and the
+  rest (the service fee) stays with the provider.
+  """
+  @spec set_budget_with_fund_request(
+          GenServer.server() | job_key(),
+          AssetToken.t(),
+          AssetToken.t(),
+          String.t()
+        ) :: {:ok, Status.t()} | {:error, term()}
+  def set_budget_with_fund_request(server, %AssetToken{} = budget, %AssetToken{} = transfer_amount, destination)
+      when is_binary(destination) do
+    transition(server, :set_budget_with_fund_request, %{
+      budget: budget,
+      transfer_amount: transfer_amount,
+      destination: destination
+    })
+  end
+
+  @doc "Client action: fund the escrow (budget_set -> funded)."
+  @spec fund(GenServer.server() | job_key(), AssetToken.t() | nil) ::
+          {:ok, Status.t()} | {:error, term()}
+  def fund(server, transfer_amount \\ nil) do
+    payload = if transfer_amount, do: %{transfer_amount: transfer_amount}, else: %{}
+    transition(server, :fund, payload)
+  end
+
+  @doc "Provider action: submit a deliverable (funded -> submitted)."
+  @spec submit(GenServer.server() | job_key(), term(), AssetToken.t() | nil) ::
+          {:ok, Status.t()} | {:error, term()}
+  def submit(server, deliverable, transfer_amount \\ nil) do
+    payload =
+      %{deliverable: deliverable}
+      |> maybe_put(:transfer_amount, transfer_amount)
+
+    transition(server, :submit, payload)
+  end
+
+  @doc "Evaluator action: approve the deliverable (submitted -> completed)."
+  @spec complete(GenServer.server() | job_key(), String.t()) ::
+          {:ok, Status.t()} | {:error, term()}
+  def complete(server, reason) when is_binary(reason) do
+    transition(server, :complete, %{reason: reason})
+  end
+
+  @doc "Evaluator action: reject the deliverable (submitted -> rejected)."
+  @spec reject(GenServer.server() | job_key(), String.t()) ::
+          {:ok, Status.t()} | {:error, term()}
+  def reject(server, reason) when is_binary(reason) do
+    transition(server, :reject, %{reason: reason})
+  end
+
+  @doc "Expire the job from any non-terminal status."
+  @spec expire(GenServer.server() | job_key(), String.t()) ::
+          {:ok, Status.t()} | {:error, term()}
+  def expire(server, reason) when is_binary(reason) do
+    transition(server, :expire, %{reason: reason})
+  end
+
+  # -- Read API --
+
+  @doc "Current status."
+  @spec status(GenServer.server() | job_key()) :: Status.t()
+  def status(server), do: GenServer.call(resolve(server), :status)
+
+  @doc "Role this session was started with."
+  @spec role(GenServer.server() | job_key()) :: role()
+  def role(server), do: GenServer.call(resolve(server), :role)
+
+  @doc "Full chronological entry log."
+  @spec entries(GenServer.server() | job_key()) :: [entry()]
+  def entries(server), do: GenServer.call(resolve(server), :entries)
+
+  @doc "Action atoms the LLM tool loop may call right now."
+  @spec available_tools(GenServer.server() | job_key()) :: [Tools.tool()]
+  def available_tools(server), do: GenServer.call(resolve(server), :available_tools)
+
+  @doc "Full struct (for tests / inspection)."
+  @spec get_state(GenServer.server() | job_key()) :: t()
+  def get_state(server), do: GenServer.call(resolve(server), :get_state)
+
+  # -- Internal --
+
+  defp transition(server, action, payload) do
+    GenServer.call(resolve(server), {:transition, action, payload})
+  end
+
+  defp resolve(pid) when is_pid(pid), do: pid
+  defp resolve(name) when is_atom(name), do: name
+  defp resolve({chain_id, job_id}) when is_integer(chain_id), do: Registry.via({chain_id, job_id})
+  defp resolve({:via, _, _} = via), do: via
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  # -- GenServer callbacks --
+
+  @impl GenServer
+  def init(opts) do
+    state = %__MODULE__{
+      job_id: Keyword.fetch!(opts, :job_id),
+      chain_id: Keyword.fetch!(opts, :chain_id),
+      role: Keyword.fetch!(opts, :role),
+      status: Keyword.get(opts, :initial_status, Status.initial()),
+      description: Keyword.get(opts, :description)
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:subscribe, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, :ok, %{state | subscribers: MapSet.put(state.subscribers, pid)}}
+  end
+
+  def handle_call({:unsubscribe, pid}, _from, state) do
+    {:reply, :ok, %{state | subscribers: MapSet.delete(state.subscribers, pid)}}
+  end
+
+  def handle_call({:send_message, content, content_type}, _from, state) do
+    entry = %{
+      kind: :message,
+      from: state.role,
+      content: content,
+      content_type: content_type,
+      at: DateTime.utc_now()
+    }
+
+    state = %{state | entries: state.entries ++ [entry]}
+    broadcast(state, entry)
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:transition, action, payload}, _from, state) do
+    from_status = state.status
+
+    with :ok <- check_role(state.role, from_status, action),
+         {:ok, next_status} <- resolve_next_status(action),
+         :ok <- Status.validate(from_status, next_status) do
+      entry = %{
+        kind: :system,
+        event: next_status,
+        payload: payload,
+        at: DateTime.utc_now()
+      }
+
+      state = %{state | status: next_status, entries: state.entries ++ [entry]}
+      broadcast(state, entry)
+      emit_telemetry(state, action, from_status, next_status)
+
+      if Status.terminal?(next_status) do
+        {:stop, :normal, {:ok, next_status}, state}
+      else
+        {:reply, {:ok, next_status}, state}
+      end
+    else
+      {:error, _reason} = err -> {:reply, err, state}
+    end
+  end
+
+  def handle_call(:status, _from, state), do: {:reply, state.status, state}
+  def handle_call(:role, _from, state), do: {:reply, state.role, state}
+  def handle_call(:entries, _from, state), do: {:reply, state.entries, state}
+  def handle_call(:available_tools, _from, state),
+    do: {:reply, Tools.available(state.role, state.status), state}
+
+  def handle_call(:get_state, _from, state), do: {:reply, state, state}
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | subscribers: MapSet.delete(state.subscribers, pid)}}
+  end
+
+  # -- Helpers --
+
+  defp check_role(role, status, action) do
+    # :expire bypasses role gating (timer or supervisor invokes it)
+    if action == :expire do
+      :ok
+    else
+      tool = action_to_tool(action)
+
+      if Tools.allowed?(role, status, tool) do
+        :ok
+      else
+        {:error, {:not_allowed_for_role, role, action, status}}
+      end
+    end
+  end
+
+  defp action_to_tool(:set_budget), do: :set_budget
+  defp action_to_tool(:set_budget_with_fund_request), do: :set_budget
+  defp action_to_tool(:set_budget_with_subscription), do: :set_budget
+  defp action_to_tool(:fund), do: :fund
+  defp action_to_tool(:submit), do: :submit
+  defp action_to_tool(:complete), do: :complete
+  defp action_to_tool(:reject), do: :reject
+  defp action_to_tool(:expire), do: nil
+
+  defp resolve_next_status(action) do
+    case Status.target_status(action) do
+      nil -> {:error, {:unknown_action, action}}
+      status -> {:ok, status}
+    end
+  end
+
+  defp broadcast(%{subscribers: subs} = state, entry) do
+    key = {state.chain_id, state.job_id}
+
+    for pid <- subs do
+      send(pid, {__MODULE__, key, entry})
+    end
+  end
+
+  defp emit_telemetry(state, action, from_status, next_status) do
+    :telemetry.execute(
+      [:raxol, :acp, :job_session, :transition],
+      %{},
+      %{
+        chain_id: state.chain_id,
+        job_id: state.job_id,
+        role: state.role,
+        action: action,
+        from: from_status,
+        to: next_status
+      }
+    )
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_session/registry.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/registry.ex
@@ -1,0 +1,47 @@
+defmodule Raxol.ACP.JobSession.Registry do
+  @moduledoc """
+  Process registry for active v2 ACP job sessions.
+
+  Wraps `Registry` (`keys: :unique`) so that each `Raxol.ACP.JobSession`
+  is addressable by `{chain_id, job_id}`. v2 jobs can run on multiple
+  chains, so the key carries the chain id alongside the job id (v1's
+  `Raxol.ACP.Job.Registry` keys by job_id alone because v1 was Base
+  mainnet only).
+
+  ## Usage
+
+      # JobSession registers itself via:
+      GenServer.start_link(JobSession, opts,
+        name: Raxol.ACP.JobSession.Registry.via({8453, "job-123"})
+      )
+
+      # Anywhere else can resolve the pid:
+      case Raxol.ACP.JobSession.Registry.whereis({8453, "job-123"}) do
+        :undefined -> :no_such_session
+        pid when is_pid(pid) -> pid
+      end
+  """
+
+  @type job_key :: {pos_integer(), String.t() | non_neg_integer()}
+
+  @doc "Build a `:via` tuple for registering or addressing a session."
+  @spec via(job_key()) :: {:via, module(), {module(), job_key()}}
+  def via({chain_id, job_id} = key) when is_integer(chain_id) and (is_binary(job_id) or is_integer(job_id)) do
+    {:via, Registry, {__MODULE__, key}}
+  end
+
+  @doc "Look up the pid of a session by `{chain_id, job_id}`."
+  @spec whereis(job_key()) :: pid() | :undefined
+  def whereis({chain_id, job_id} = key) when is_integer(chain_id) and (is_binary(job_id) or is_integer(job_id)) do
+    case Registry.lookup(__MODULE__, key) do
+      [{pid, _}] -> pid
+      [] -> :undefined
+    end
+  end
+
+  @doc "Child spec for use under a supervisor."
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(_opts) do
+    Registry.child_spec(keys: :unique, name: __MODULE__)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_session/status.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/status.ex
@@ -1,0 +1,86 @@
+defmodule Raxol.ACP.JobSession.Status do
+  @moduledoc """
+  Status enum for a v2 ACP job session and the legal transition graph.
+
+  Replaces v1's `Raxol.ACP.Job.StateMachine` phase enum. Statuses mirror
+  `JobSession.status` in `acp-node-v2`:
+
+      open -> budget_set -> funded -> submitted -> completed
+                                                \\-> rejected
+      (any) -> expired
+
+  `:expired` can fire from any non-terminal status. `:completed`,
+  `:rejected`, and `:expired` are terminal -- the JobSession process
+  terminates with `:normal` after one of these.
+  """
+
+  @type t ::
+          :open
+          | :budget_set
+          | :funded
+          | :submitted
+          | :completed
+          | :rejected
+          | :expired
+
+  @valid_transitions %{
+    open: [:budget_set, :expired],
+    # Allow re-budgeting before the client funds.
+    budget_set: [:budget_set, :funded, :expired],
+    funded: [:submitted, :expired],
+    submitted: [:completed, :rejected, :expired],
+    completed: [],
+    rejected: [],
+    expired: []
+  }
+
+  @terminal MapSet.new([:completed, :rejected, :expired])
+
+  @doc "Initial status of a freshly created job."
+  @spec initial() :: t()
+  def initial, do: :open
+
+  @doc "List every valid status."
+  @spec all() :: [t()]
+  def all, do: Map.keys(@valid_transitions)
+
+  @doc "Statuses from which no further transition is possible."
+  @spec terminal?(t()) :: boolean()
+  def terminal?(status), do: MapSet.member?(@terminal, status)
+
+  @doc """
+  Validate a transition from `from` to `to`.
+
+  Returns `:ok` for legal transitions, `{:error, {:invalid_transition,
+  from, to}}` otherwise.
+  """
+  @spec validate(t(), t()) :: :ok | {:error, {:invalid_transition, t(), t()}}
+  def validate(from, to) do
+    if to in Map.get(@valid_transitions, from, []) do
+      :ok
+    else
+      {:error, {:invalid_transition, from, to}}
+    end
+  end
+
+  @doc """
+  Map an action atom (`:set_budget`, `:fund`, etc.) to the status the
+  action transitions into. Returns `nil` for unknown actions.
+
+      iex> Raxol.ACP.JobSession.Status.target_status(:set_budget)
+      :budget_set
+
+      iex> Raxol.ACP.JobSession.Status.target_status(:reject)
+      :rejected
+  """
+  @spec target_status(atom()) :: t() | nil
+  def target_status(:set_budget), do: :budget_set
+  def target_status(:set_budget_with_fund_request), do: :budget_set
+  def target_status(:set_budget_with_subscription), do: :budget_set
+  def target_status(:fund), do: :funded
+  def target_status(:submit), do: :submitted
+  def target_status(:complete), do: :completed
+  def target_status(:reject), do: :rejected
+  def target_status(:expire), do: :expired
+  def target_status(_), do: nil
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_session/supervisor.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/supervisor.ex
@@ -1,0 +1,39 @@
+defmodule Raxol.ACP.JobSession.Supervisor do
+  @moduledoc """
+  DynamicSupervisor for `Raxol.ACP.JobSession` processes.
+
+  Sessions are transient -- a clean `:normal` exit (which happens on
+  terminal status) means the supervisor does NOT restart the session.
+  Crashes will be retried per the supervisor's restart policy.
+  """
+
+  use DynamicSupervisor
+
+  alias Raxol.ACP.JobSession
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Spawn a new JobSession process. `opts` are forwarded to
+  `Raxol.ACP.JobSession.start_link/1`.
+  """
+  @spec start_session(keyword()) :: DynamicSupervisor.on_start_child()
+  def start_session(opts) do
+    spec = %{
+      id: JobSession,
+      start: {JobSession, :start_link, [opts]},
+      restart: :transient,
+      type: :worker
+    }
+
+    DynamicSupervisor.start_child(__MODULE__, spec)
+  end
+
+  @impl DynamicSupervisor
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_session/tools.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/tools.ex
@@ -1,0 +1,58 @@
+defmodule Raxol.ACP.JobSession.Tools do
+  @moduledoc """
+  Role + status -> allowed actions for v2 LLM-driven JobSessions.
+
+  Mirrors the tool-availability matrix documented in the acp-node-v2
+  README ("Tool Availability by Role & Status"). The list returned by
+  `available/2` is the set of action atoms an agent (or LLM tool-calling
+  loop) may legitimately invoke at that point.
+
+  | Role      | Status     | Tools                          |
+  |-----------|------------|---------------------------------|
+  | provider  | open       | set_budget, send_message, wait |
+  | provider  | budget_set | set_budget                     |
+  | provider  | funded     | submit                         |
+  | client    | open       | send_message, wait             |
+  | client    | budget_set | send_message, fund, wait       |
+  | evaluator | submitted  | complete, reject               |
+
+  Any combination not listed yields `[]`. `:send_message` is always
+  available to the provider and client in pre-submission statuses, and
+  to all roles before a terminal status -- the table above is the
+  *minimum* gated set; raxol may surface `:send_message` more liberally
+  via `extra_tools/2`.
+  """
+
+  alias Raxol.ACP.JobSession.Status
+
+  @type role :: :client | :provider | :evaluator
+  @type tool :: :set_budget | :fund | :submit | :complete | :reject | :send_message | :wait
+
+  @doc """
+  Tools available to `role` at `status`. Returns an empty list when
+  no actions are legal (e.g. an evaluator before submission, or any
+  role in a terminal status).
+  """
+  @spec available(role(), Status.t()) :: [tool()]
+  def available(:provider, :open), do: [:set_budget, :send_message, :wait]
+  def available(:provider, :budget_set), do: [:set_budget]
+  def available(:provider, :funded), do: [:submit]
+  def available(:client, :open), do: [:send_message, :wait]
+  def available(:client, :budget_set), do: [:send_message, :fund, :wait]
+  def available(:evaluator, :submitted), do: [:complete, :reject]
+  def available(_role, _status), do: []
+
+  @doc """
+  Check whether the role may invoke this action at this status.
+
+      iex> Raxol.ACP.JobSession.Tools.allowed?(:provider, :funded, :submit)
+      true
+
+      iex> Raxol.ACP.JobSession.Tools.allowed?(:client, :submitted, :complete)
+      false
+  """
+  @spec allowed?(role(), Status.t(), tool()) :: boolean()
+  def allowed?(role, status, tool) do
+    tool in available(role, status)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/supervisor.ex
+++ b/packages/raxol_acp/lib/raxol/acp/supervisor.ex
@@ -13,15 +13,17 @@ defmodule Raxol.ACP.Supervisor do
   - The seller WebSocket can crash and restart independently of jobs in
     flight.
 
-  ## Children (v0.1)
+  ## Children (v0.2)
 
-  - `Raxol.ACP.Job.Registry` -- per-job process lookup
+  - `Raxol.ACP.Job.Registry` -- per-job process lookup (v1)
+  - `Raxol.ACP.JobSession.Registry` -- per-`{chain_id, job_id}` lookup (v2)
   - `Raxol.ACP.Wallet.NonceServer` -- serializes EVM nonce assignment for
     the umbrella seller wallet (default-named instance)
   - `Raxol.ACP.Offering.Registry` -- declared offerings (ETS-backed)
-  - `Raxol.ACP.Job.Store` -- ETS-backed memo persistence (jobs hydrate
-    from here on transient restart)
-  - `Raxol.ACP.Job.Supervisor` -- DynamicSupervisor for per-job processes
+  - `Raxol.ACP.Job.Store` -- ETS-backed memo persistence (v1 jobs
+    hydrate from here on transient restart)
+  - `Raxol.ACP.Job.Supervisor` -- DynamicSupervisor for v1 per-job processes
+  - `Raxol.ACP.JobSession.Supervisor` -- DynamicSupervisor for v2 sessions
   - `Raxol.ACP.Seller.Supervisor` -- only when
     `config :raxol_acp, seller_enabled: true`. Owns the Backend, the
     Queue, and the Runtime. Buyer-only deployments leave it off.
@@ -40,10 +42,12 @@ defmodule Raxol.ACP.Supervisor do
 
     base = [
       Raxol.ACP.Job.Registry,
+      Raxol.ACP.JobSession.Registry,
       {Raxol.ACP.Wallet.NonceServer, [initial_nonce: initial_nonce]},
       Raxol.ACP.Offering.Registry,
       Raxol.ACP.Job.Store,
-      Raxol.ACP.Job.Supervisor
+      Raxol.ACP.Job.Supervisor,
+      Raxol.ACP.JobSession.Supervisor
     ]
 
     children =

--- a/packages/raxol_acp/test/raxol/acp/job_session/status_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/status_test.exs
@@ -1,0 +1,87 @@
+defmodule Raxol.ACP.JobSession.StatusTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.JobSession.Status
+
+  describe "initial/0 + all/0" do
+    test "initial is :open" do
+      assert Status.initial() == :open
+    end
+
+    test "all/0 lists every status" do
+      assert MapSet.equal?(
+               MapSet.new(Status.all()),
+               MapSet.new([:open, :budget_set, :funded, :submitted, :completed, :rejected, :expired])
+             )
+    end
+  end
+
+  describe "terminal?/1" do
+    test ":completed, :rejected, :expired are terminal" do
+      assert Status.terminal?(:completed)
+      assert Status.terminal?(:rejected)
+      assert Status.terminal?(:expired)
+    end
+
+    test "in-flight statuses are not terminal" do
+      refute Status.terminal?(:open)
+      refute Status.terminal?(:budget_set)
+      refute Status.terminal?(:funded)
+      refute Status.terminal?(:submitted)
+    end
+  end
+
+  describe "validate/2" do
+    test "happy path: open -> budget_set -> funded -> submitted -> completed" do
+      assert :ok = Status.validate(:open, :budget_set)
+      assert :ok = Status.validate(:budget_set, :funded)
+      assert :ok = Status.validate(:funded, :submitted)
+      assert :ok = Status.validate(:submitted, :completed)
+    end
+
+    test "alternative: submitted -> rejected" do
+      assert :ok = Status.validate(:submitted, :rejected)
+    end
+
+    test "re-budget within :budget_set is allowed" do
+      assert :ok = Status.validate(:budget_set, :budget_set)
+    end
+
+    test "expire is reachable from every non-terminal status" do
+      for from <- [:open, :budget_set, :funded, :submitted] do
+        assert :ok = Status.validate(from, :expired), "from #{from}"
+      end
+    end
+
+    test "terminal statuses cannot transition further" do
+      for from <- [:completed, :rejected, :expired],
+          to <- Status.all() do
+        assert {:error, {:invalid_transition, ^from, ^to}} = Status.validate(from, to)
+      end
+    end
+
+    test "illegal jumps rejected" do
+      assert {:error, _} = Status.validate(:open, :funded)
+      assert {:error, _} = Status.validate(:open, :submitted)
+      assert {:error, _} = Status.validate(:budget_set, :submitted)
+      assert {:error, _} = Status.validate(:funded, :completed)
+    end
+  end
+
+  describe "target_status/1" do
+    test "maps actions to target statuses" do
+      assert Status.target_status(:set_budget) == :budget_set
+      assert Status.target_status(:set_budget_with_fund_request) == :budget_set
+      assert Status.target_status(:set_budget_with_subscription) == :budget_set
+      assert Status.target_status(:fund) == :funded
+      assert Status.target_status(:submit) == :submitted
+      assert Status.target_status(:complete) == :completed
+      assert Status.target_status(:reject) == :rejected
+      assert Status.target_status(:expire) == :expired
+    end
+
+    test "unknown action returns nil" do
+      assert Status.target_status(:wat) == nil
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_session/tools_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/tools_test.exs
@@ -1,0 +1,69 @@
+defmodule Raxol.ACP.JobSession.ToolsTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.JobSession.Tools
+
+  describe "available/2 matrix from acp-node-v2 README" do
+    test "provider × :open" do
+      assert MapSet.equal?(
+               MapSet.new(Tools.available(:provider, :open)),
+               MapSet.new([:set_budget, :send_message, :wait])
+             )
+    end
+
+    test "provider × :budget_set (can re-budget only)" do
+      assert Tools.available(:provider, :budget_set) == [:set_budget]
+    end
+
+    test "provider × :funded" do
+      assert Tools.available(:provider, :funded) == [:submit]
+    end
+
+    test "client × :open" do
+      assert MapSet.equal?(
+               MapSet.new(Tools.available(:client, :open)),
+               MapSet.new([:send_message, :wait])
+             )
+    end
+
+    test "client × :budget_set" do
+      assert MapSet.equal?(
+               MapSet.new(Tools.available(:client, :budget_set)),
+               MapSet.new([:send_message, :fund, :wait])
+             )
+    end
+
+    test "evaluator × :submitted" do
+      assert MapSet.equal?(
+               MapSet.new(Tools.available(:evaluator, :submitted)),
+               MapSet.new([:complete, :reject])
+             )
+    end
+
+    test "any role × terminal status -> no tools" do
+      for role <- [:provider, :client, :evaluator],
+          status <- [:completed, :rejected, :expired] do
+        assert Tools.available(role, status) == []
+      end
+    end
+
+    test "client cannot submit, complete, reject, set_budget" do
+      refute Tools.allowed?(:client, :funded, :submit)
+      refute Tools.allowed?(:client, :submitted, :complete)
+      refute Tools.allowed?(:client, :submitted, :reject)
+      refute Tools.allowed?(:client, :open, :set_budget)
+    end
+
+    test "provider cannot complete, reject, fund" do
+      refute Tools.allowed?(:provider, :submitted, :complete)
+      refute Tools.allowed?(:provider, :submitted, :reject)
+      refute Tools.allowed?(:provider, :budget_set, :fund)
+    end
+
+    test "evaluator cannot act before :submitted" do
+      for status <- [:open, :budget_set, :funded] do
+        assert Tools.available(:evaluator, status) == []
+      end
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_session_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session_test.exs
@@ -1,0 +1,227 @@
+defmodule Raxol.ACP.JobSessionTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{AssetToken, JobSession}
+  alias Raxol.ACP.JobSession.Registry
+
+  setup do
+    # Terminate any leftover JobSession children from prior tests so the
+    # registry doesn't carry stale {chain_id, job_id} entries.
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(JobSession.Supervisor),
+        is_pid(pid) do
+      DynamicSupervisor.terminate_child(JobSession.Supervisor, pid)
+    end
+
+    :ok
+  end
+
+  defp start_session(opts) do
+    opts =
+      [chain_id: 8453, job_id: "job-#{System.unique_integer([:positive])}"]
+      |> Keyword.merge(opts)
+
+    {:ok, pid} = JobSession.Supervisor.start_session(opts)
+    {pid, Keyword.fetch!(opts, :job_id)}
+  end
+
+  describe "start_link + registration" do
+    test "registers under {chain_id, job_id}" do
+      {pid, job_id} = start_session(role: :provider)
+
+      assert Registry.whereis({8453, job_id}) == pid
+      assert JobSession.status({8453, job_id}) == :open
+      assert JobSession.role({8453, job_id}) == :provider
+    end
+
+    test "respects :initial_status" do
+      {_pid, job_id} = start_session(role: :provider, initial_status: :budget_set)
+      assert JobSession.status({8453, job_id}) == :budget_set
+    end
+  end
+
+  describe "happy-path lifecycle" do
+    test "provider sets budget; client funds; provider submits; evaluator completes" do
+      {provider, job_id} = start_session(role: :provider)
+      ref = Process.monitor(provider)
+      budget = AssetToken.usdc(0.1, 8453)
+
+      assert {:ok, :budget_set} = JobSession.set_budget(provider, budget)
+      assert JobSession.status(provider) == :budget_set
+
+      # Spawn a separate session as :client to fund.
+      {:ok, client} =
+        JobSession.Supervisor.start_session(
+          chain_id: 8453,
+          job_id: "client-#{job_id}",
+          role: :client,
+          initial_status: :budget_set
+        )
+
+      assert {:ok, :funded} = JobSession.fund(client)
+
+      # Provider's session must also reach :funded for submit to work.
+      # In real life the SSE transport propagates this; here we drive it.
+      {:ok, :funded} = drive_to(provider, :funded)
+      assert {:ok, :submitted} = JobSession.submit(provider, %{result: "done"})
+
+      {:ok, evaluator} =
+        JobSession.Supervisor.start_session(
+          chain_id: 8453,
+          job_id: "eval-#{job_id}",
+          role: :evaluator,
+          initial_status: :submitted
+        )
+
+      eval_ref = Process.monitor(evaluator)
+      assert {:ok, :completed} = JobSession.complete(evaluator, "ok")
+
+      # Both terminal sessions exit :normal.
+      assert_receive {:DOWN, ^eval_ref, :process, ^evaluator, :normal}, 500
+      _ = ref
+    end
+
+    test "rejection path: submitted -> rejected stops the session" do
+      {evaluator, _job_id} = start_session(role: :evaluator, initial_status: :submitted)
+      ref = Process.monitor(evaluator)
+
+      assert {:ok, :rejected} = JobSession.reject(evaluator, "bad output")
+      assert_receive {:DOWN, ^ref, :process, ^evaluator, :normal}, 500
+    end
+  end
+
+  describe "role gating" do
+    test "client cannot set_budget" do
+      {client, _} = start_session(role: :client)
+      budget = AssetToken.usdc(0.1, 8453)
+
+      assert {:error, {:not_allowed_for_role, :client, :set_budget, :open}} =
+               JobSession.set_budget(client, budget)
+    end
+
+    test "client cannot submit" do
+      {client, _} = start_session(role: :client, initial_status: :funded)
+
+      assert {:error, {:not_allowed_for_role, :client, :submit, :funded}} =
+               JobSession.submit(client, %{})
+    end
+
+    test "provider cannot complete" do
+      {provider, _} = start_session(role: :provider, initial_status: :submitted)
+
+      assert {:error, {:not_allowed_for_role, :provider, :complete, :submitted}} =
+               JobSession.complete(provider, "ok")
+    end
+
+    test "evaluator cannot fund" do
+      {evaluator, _} = start_session(role: :evaluator, initial_status: :budget_set)
+
+      assert {:error, {:not_allowed_for_role, :evaluator, :fund, :budget_set}} =
+               JobSession.fund(evaluator)
+    end
+  end
+
+  describe "set_budget_with_fund_request" do
+    test "transitions to :budget_set and records destination" do
+      {provider, _} = start_session(role: :provider)
+      budget = AssetToken.usdc(0.1, 8453)
+      transfer = AssetToken.usdc(1, 8453)
+      destination = "0x" <> String.duplicate("ab", 20)
+
+      assert {:ok, :budget_set} =
+               JobSession.set_budget_with_fund_request(provider, budget, transfer, destination)
+
+      [entry] = Enum.filter(JobSession.entries(provider), &(&1.kind == :system))
+      assert entry.event == :budget_set
+      assert entry.payload.budget == budget
+      assert entry.payload.transfer_amount == transfer
+      assert entry.payload.destination == destination
+    end
+  end
+
+  describe "send_message + subscriptions" do
+    test "subscribers receive entries for messages and transitions" do
+      {provider, job_id} = start_session(role: :provider)
+      :ok = JobSession.subscribe(provider)
+
+      :ok = JobSession.send_message(provider, "hello", "text")
+
+      assert_receive {JobSession, {8453, ^job_id}, %{kind: :message, content: "hello"}}, 100
+
+      budget = AssetToken.usdc(0.1, 8453)
+      {:ok, :budget_set} = JobSession.set_budget(provider, budget)
+
+      assert_receive {JobSession, {8453, ^job_id}, %{kind: :system, event: :budget_set}}, 100
+    end
+
+    test "monitors subscribers and drops dead pids" do
+      {provider, _} = start_session(role: :provider)
+
+      subscriber =
+        spawn(fn ->
+          :ok = JobSession.subscribe(provider)
+          receive do: (:die -> :ok)
+        end)
+
+      # Let the subscribe call land
+      Process.sleep(20)
+      send(subscriber, :die)
+      Process.sleep(20)
+
+      state = JobSession.get_state(provider)
+      refute MapSet.member?(state.subscribers, subscriber)
+    end
+  end
+
+  describe "available_tools/1" do
+    test "tracks role and status" do
+      {provider, _} = start_session(role: :provider)
+
+      assert MapSet.equal?(
+               MapSet.new(JobSession.available_tools(provider)),
+               MapSet.new([:set_budget, :send_message, :wait])
+             )
+
+      budget = AssetToken.usdc(0.1, 8453)
+      {:ok, :budget_set} = JobSession.set_budget(provider, budget)
+
+      assert JobSession.available_tools(provider) == [:set_budget]
+    end
+  end
+
+  describe "expire/2" do
+    test "from any non-terminal status; bypasses role gating" do
+      {client, _} = start_session(role: :client, initial_status: :budget_set)
+      ref = Process.monitor(client)
+
+      assert {:ok, :expired} = JobSession.expire(client, "sla exceeded")
+      assert_receive {:DOWN, ^ref, :process, ^client, :normal}, 500
+    end
+  end
+
+  # -- Helpers --
+
+  # Drive a session through valid statuses to a target. Used to set up
+  # mid-lifecycle test states without spinning up the full transport.
+  defp drive_to(_pid, :open), do: {:ok, :open}
+
+  defp drive_to(pid, :budget_set) do
+    JobSession.set_budget(pid, AssetToken.usdc(0.1, 8453))
+  end
+
+  defp drive_to(pid, :funded) do
+    case JobSession.status(pid) do
+      :open ->
+        {:ok, :budget_set} = drive_to(pid, :budget_set)
+        # provider can't fund -- elevate test state directly via initial_status
+        :sys.replace_state(pid, &Map.put(&1, :status, :funded))
+        {:ok, :funded}
+
+      :budget_set ->
+        :sys.replace_state(pid, &Map.put(&1, :status, :funded))
+        {:ok, :funded}
+
+      status ->
+        {:error, {:cannot_drive_to_funded, status}}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

One GenServer per active v2 ACP job, registered by \`{chain_id, job_id}\` (v2 is multi-chain, so v1's \`job_id\`-only key is insufficient). Replaces v1's \`Raxol.ACP.Job.Server\` for the v2 model.

Stacks on #267 (acpv2-scaffold). Part B of the v2 launch plan.

## New modules

- **\`Raxol.ACP.JobSession.Status\`** -- 7-status enum (\`open / budget_set / funded / submitted / completed / rejected / expired\`) and transition graph. Re-budget within \`budget_set\` allowed; \`expire\` reachable from any non-terminal status; terminal statuses cannot transition further. Matches the canonical lifecycle in acp-node-v2.
- **\`Raxol.ACP.JobSession.Tools\`** -- role × status → allowed-action atoms matching the acp-node-v2 README's tool availability matrix:
  | Role | Status | Tools |
  |---|---|---|
  | provider | open | set_budget, send_message, wait |
  | provider | budget_set | set_budget (re-budget) |
  | provider | funded | submit |
  | client | open | send_message, wait |
  | client | budget_set | send_message, fund, wait |
  | evaluator | submitted | complete, reject |
- **\`Raxol.ACP.JobSession.Registry\`** -- \`{chain_id, job_id}\`-keyed Elixir Registry (\`:via\` tuple + \`whereis/1\`).
- **\`Raxol.ACP.JobSession.Supervisor\`** -- DynamicSupervisor with \`:transient\` restart so a clean \`:normal\` exit (terminal status) doesn't resurrect the session.
- **\`Raxol.ACP.JobSession\`** -- the GenServer. Action API: \`set_budget/2\`, \`set_budget_with_fund_request/4\`, \`fund/2\`, \`submit/3\`, \`complete/2\`, \`reject/2\`, \`expire/2\`, \`send_message/3\`. Subscriber API: \`subscribe/1\`, \`unsubscribe/1\`. Read API: \`status/1\`, \`role/1\`, \`entries/1\`, \`available_tools/1\`, \`get_state/1\`.

Pure: records transitions, gates by role, emits \`[:raxol, :acp, :job_session, :transition]\` telemetry, and notifies subscribers via \`{Raxol.ACP.JobSession, {chain_id, job_id}, entry}\` process messages. Does NOT yet make on-chain hook calls -- that's PR D (\`Raxol.ACP.ProviderAdapter\`).

Wired into \`Raxol.ACP.Supervisor\` alongside the v1 supervision tree -- both coexist during the transition.

## Manual testing

- [x] \`mix test test/raxol/acp/job_session/ test/raxol/acp/job_session_test.exs\` -- 35 tests, 0 failures
- [x] \`mix test\` (full suite) -- 431 tests, 0 failures, 5 excluded