### PR TITLE
raxol_acp v2: Raxol.ACP.Agent orchestrator + Transport/JobApi

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/agent.ex
@@ -1,0 +1,350 @@
+defmodule Raxol.ACP.Agent do
+  @moduledoc """
+  Orchestrator for a v2 raxol_acp agent.
+
+  Mirrors `AcpAgent` in `acp-node-v2`. Owns three injected dependencies:
+
+  - **Provider** (`Raxol.ACP.ProviderAdapter`) -- the chain-facing client
+    that submits on-chain hook calls. Built in PR D; this PR accepts
+    any module/struct implementing the behaviour.
+  - **Transport** (`Raxol.ACP.Transport`) -- the SSE chat stream + REST
+    messaging. `Raxol.ACP.Transport.Mock` for tests; `Raxol.ACP.Transport.SSE`
+    for production.
+  - **JobApi** (`Raxol.ACP.JobApi`) -- the REST discovery API.
+
+  ## Lifecycle
+
+      {:ok, agent} = Raxol.ACP.Agent.start_link(
+        provider: my_provider,
+        transport: Raxol.ACP.Transport.SSE.new(network: :mainnet),
+        api: Raxol.ACP.JobApi.HTTP.new(network: :mainnet),
+        wallet_address: "0x...",
+        supported_chain_ids: [8453]
+      )
+
+      :ok = Raxol.ACP.Agent.subscribe(agent)
+      :ok = Raxol.ACP.Agent.start_stream(agent)
+
+      # Receive {:entry, session_pid, %{kind: :system, ...}} messages.
+
+  ## Event routing
+
+  When the transport delivers an entry, Agent:
+
+  1. Extracts `chain_id` + `job_id` from the entry payload.
+  2. Resolves the matching `Raxol.ACP.JobSession` (starting one if it
+     doesn't exist yet) via `Raxol.ACP.JobSession.Supervisor`.
+  3. Decodes the entry into the canonical `Raxol.ACP.JobSession.entry()`
+     shape and threads it into the session.
+  4. Forwards the entry to every subscribed caller as
+     `{Raxol.ACP.Agent, agent_pid, session_pid, entry}`.
+
+  Inferring the agent's role per session happens lazily on the first
+  entry that disambiguates it (e.g. a `budget.set` from another address
+  implies we're the client). For now the role is taken from
+  `:default_role` or the entry's `role` field if present.
+  """
+
+  use GenServer
+
+  alias Raxol.ACP.{Event, JobApi, JobSession, Transport}
+
+  @type t :: %__MODULE__{
+          provider: term(),
+          transport: Transport.t(),
+          api: JobApi.t(),
+          wallet_address: String.t(),
+          supported_chain_ids: [pos_integer()],
+          default_role: JobSession.role(),
+          sessions: %{Transport.job_key() => pid()},
+          subscribers: MapSet.t(pid()),
+          started?: boolean()
+        }
+
+  defstruct [
+    :provider,
+    :transport,
+    :api,
+    :wallet_address,
+    :supported_chain_ids,
+    :default_role,
+    sessions: %{},
+    subscribers: MapSet.new(),
+    started?: false
+  ]
+
+  # -- Public API --
+
+  @doc """
+  Start a supervised agent.
+
+  ## Required options
+
+  - `:transport` -- a `Raxol.ACP.Transport.t()`.
+  - `:api` -- a `Raxol.ACP.JobApi.t()`.
+  - `:wallet_address` -- agent's on-chain wallet address.
+  - `:supported_chain_ids` -- e.g. `[8453]` for Base mainnet only.
+
+  ## Optional options
+
+  - `:provider` -- on-chain client. Required before submitting any
+    hook calls (e.g. submit/complete); not yet required for receive-
+    only mode.
+  - `:default_role` -- `:provider`, `:client`, or `:evaluator`. Used
+    when an entry doesn't carry an explicit role. Default `:provider`.
+  - `:name` -- if set, registers the GenServer under that name.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.fetch(opts, :name) do
+      {:ok, name} -> GenServer.start_link(__MODULE__, opts, name: name)
+      :error -> GenServer.start_link(__MODULE__, opts)
+    end
+  end
+
+  @doc """
+  Open the transport stream. Idempotent.
+  """
+  @spec start_stream(GenServer.server()) :: :ok | {:error, term()}
+  def start_stream(server), do: GenServer.call(server, :start_stream)
+
+  @doc "Close the transport stream."
+  @spec stop_stream(GenServer.server()) :: :ok
+  def stop_stream(server), do: GenServer.call(server, :stop_stream)
+
+  @doc "Subscribe the calling process to entry notifications from this agent."
+  @spec subscribe(GenServer.server()) :: :ok
+  def subscribe(server), do: GenServer.call(server, {:subscribe, self()})
+
+  @doc "Unsubscribe the calling process."
+  @spec unsubscribe(GenServer.server()) :: :ok
+  def unsubscribe(server), do: GenServer.call(server, {:unsubscribe, self()})
+
+  @doc "Get this agent's wallet address."
+  @spec get_address(GenServer.server()) :: String.t()
+  def get_address(server), do: GenServer.call(server, :get_address)
+
+  @doc "Look up an existing JobSession by `{chain_id, job_id}`. Does NOT start a new one."
+  @spec get_session(GenServer.server(), Transport.job_key()) :: pid() | nil
+  def get_session(server, key), do: GenServer.call(server, {:get_session, key})
+
+  @doc "All active sessions tracked by this agent."
+  @spec sessions(GenServer.server()) :: %{Transport.job_key() => pid()}
+  def sessions(server), do: GenServer.call(server, :sessions)
+
+  @doc "Convenience wrapper around `JobApi.browse_agents/3`."
+  @spec browse_agents(GenServer.server(), String.t(), map()) ::
+          {:ok, [JobApi.agent_detail()]} | {:error, term()}
+  def browse_agents(server, keyword, params \\ %{}) do
+    GenServer.call(server, {:browse_agents, keyword, params})
+  end
+
+  @doc "Convenience wrapper around `JobApi.get_agent_by_wallet_address/2`."
+  @spec get_agent(GenServer.server(), String.t()) ::
+          {:ok, JobApi.agent_detail() | nil} | {:error, term()}
+  def get_agent(server, wallet_address) do
+    GenServer.call(server, {:get_agent_by_wallet, wallet_address})
+  end
+
+  @doc """
+  Send a chat message via the transport. Streaming send; use
+  `post_message/4` for one-shot REST.
+  """
+  @spec send_message(
+          GenServer.server(),
+          Transport.job_key(),
+          String.t(),
+          String.t()
+        ) :: :ok | {:error, term()}
+  def send_message(server, key, content, content_type \\ "text") do
+    GenServer.call(server, {:send_message, key, content, content_type})
+  end
+
+  @doc "Like `send_message/4` but uses transport's one-shot REST POST."
+  @spec post_message(
+          GenServer.server(),
+          Transport.job_key(),
+          String.t(),
+          String.t()
+        ) :: :ok | {:error, term()}
+  def post_message(server, key, content, content_type \\ "text") do
+    GenServer.call(server, {:post_message, key, content, content_type})
+  end
+
+  # -- GenServer callbacks --
+
+  @impl GenServer
+  def init(opts) do
+    state = %__MODULE__{
+      provider: Keyword.get(opts, :provider),
+      transport: Keyword.fetch!(opts, :transport),
+      api: Keyword.fetch!(opts, :api),
+      wallet_address: Keyword.fetch!(opts, :wallet_address),
+      supported_chain_ids: Keyword.fetch!(opts, :supported_chain_ids),
+      default_role: Keyword.get(opts, :default_role, :provider)
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:start_stream, _from, %{started?: true} = state), do: {:reply, :ok, state}
+
+  def handle_call(:start_stream, _from, state) do
+    ctx = %{
+      owner: self(),
+      chain_ids: state.supported_chain_ids,
+      wallet_address: state.wallet_address
+    }
+
+    case Transport.connect(state.transport, ctx) do
+      :ok -> {:reply, :ok, %{state | started?: true}}
+      err -> {:reply, err, state}
+    end
+  end
+
+  def handle_call(:stop_stream, _from, state) do
+    Transport.disconnect(state.transport)
+    {:reply, :ok, %{state | started?: false}}
+  end
+
+  def handle_call({:subscribe, pid}, _from, state) do
+    Process.monitor(pid)
+    {:reply, :ok, %{state | subscribers: MapSet.put(state.subscribers, pid)}}
+  end
+
+  def handle_call({:unsubscribe, pid}, _from, state) do
+    {:reply, :ok, %{state | subscribers: MapSet.delete(state.subscribers, pid)}}
+  end
+
+  def handle_call(:get_address, _from, state), do: {:reply, state.wallet_address, state}
+
+  def handle_call({:get_session, key}, _from, state) do
+    {:reply, Map.get(state.sessions, key), state}
+  end
+
+  def handle_call(:sessions, _from, state), do: {:reply, state.sessions, state}
+
+  def handle_call({:browse_agents, keyword, params}, _from, state) do
+    {:reply, JobApi.browse_agents(state.api, keyword, params), state}
+  end
+
+  def handle_call({:get_agent_by_wallet, wallet}, _from, state) do
+    {:reply, JobApi.get_agent_by_wallet_address(state.api, wallet), state}
+  end
+
+  def handle_call({:send_message, key, content, content_type}, _from, state) do
+    {:reply, Transport.send_message(state.transport, key, content, content_type), state}
+  end
+
+  def handle_call({:post_message, key, content, content_type}, _from, state) do
+    {:reply, Transport.post_message(state.transport, key, content, content_type), state}
+  end
+
+  @impl GenServer
+  def handle_info({:transport, entry}, state) do
+    state = route_entry(entry, state)
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    sessions =
+      state.sessions
+      |> Enum.reject(fn {_k, p} -> p == pid end)
+      |> Map.new()
+
+    state = %{
+      state
+      | subscribers: MapSet.delete(state.subscribers, pid),
+        sessions: sessions
+    }
+
+    {:noreply, state}
+  end
+
+  # -- Routing --
+
+  defp route_entry(entry, state) do
+    key = job_key(entry)
+
+    {session_pid, state} = ensure_session(key, entry, state)
+    propagate_to_session(session_pid, entry)
+    broadcast(state, session_pid, entry)
+
+    state
+  end
+
+  defp job_key(entry) do
+    chain_id = entry["chainId"] || entry[:chainId] || entry["chain_id"] || entry[:chain_id]
+    job_id = entry["jobId"] || entry[:jobId] || entry["job_id"] || entry[:job_id]
+    {chain_id, job_id}
+  end
+
+  defp ensure_session(key, _entry, state) do
+    case Map.fetch(state.sessions, key) do
+      {:ok, pid} ->
+        {pid, state}
+
+      :error ->
+        {chain_id, job_id} = key
+
+        {:ok, pid} =
+          JobSession.Supervisor.start_session(
+            chain_id: chain_id,
+            job_id: job_id,
+            role: state.default_role
+          )
+
+        Process.monitor(pid)
+        {pid, %{state | sessions: Map.put(state.sessions, key, pid)}}
+    end
+  end
+
+  # For system entries with a known event type, drive the session into the
+  # corresponding status by replacing state. The real on-chain transition
+  # (calling FundTransferHook etc.) lives behind ProviderAdapter in PR D --
+  # here we just mirror the canonical status the event implies.
+  defp propagate_to_session(session_pid, %{"kind" => "message"} = entry) do
+    JobSession.send_message(
+      session_pid,
+      entry["content"] || "",
+      entry["contentType"] || "text"
+    )
+  end
+
+  defp propagate_to_session(session_pid, %{"kind" => "system"} = entry) do
+    with type when is_binary(type) <- entry["event"] || entry["type"],
+         {:ok, atom} <- Event.decode_type(type) do
+      next_status = status_for(atom)
+
+      :sys.replace_state(session_pid, fn s ->
+        Map.put(s, :status, next_status)
+      end)
+
+      # Mirror the GenServer's terminal-status behaviour. The SSE event is
+      # authoritative (the on-chain state already settled); the session
+      # process should exit :normal so the supervisor doesn't restart it.
+      if Raxol.ACP.JobSession.Status.terminal?(next_status) do
+        GenServer.stop(session_pid, :normal, 1_000)
+      end
+    else
+      _ -> :ok
+    end
+  end
+
+  defp propagate_to_session(_session_pid, _entry), do: :ok
+
+  defp status_for(:job_created), do: :open
+  defp status_for(:budget_set), do: :budget_set
+  defp status_for(:job_funded), do: :funded
+  defp status_for(:job_submitted), do: :submitted
+  defp status_for(:job_completed), do: :completed
+  defp status_for(:job_rejected), do: :rejected
+  defp status_for(:job_expired), do: :expired
+
+  defp broadcast(state, session_pid, entry) do
+    for pid <- state.subscribers do
+      send(pid, {__MODULE__, self(), session_pid, entry})
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_api.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_api.ex
@@ -1,0 +1,84 @@
+defmodule Raxol.ACP.JobApi do
+  @moduledoc """
+  Behaviour for the ACP REST discovery API.
+
+  Mirrors `AcpJobApi` in `acp-node-v2`. Talks to
+  `https://api.acp.virtuals.io` (mainnet) and
+  `https://api-dev.acp.virtuals.io` (testnet) for agent registry,
+  active-job listing, and out-of-band deliverable posting.
+
+  The on-chain side lives behind `Raxol.ACP.ProviderAdapter` (PR D);
+  JobApi is purely off-chain HTTP.
+  """
+
+  @type t :: %{
+          required(:adapter) => module(),
+          optional(:config) => map()
+        }
+
+  @type agent_detail :: %{
+          required(:wallet_address) => String.t(),
+          required(:name) => String.t(),
+          optional(:description) => String.t(),
+          optional(:cluster) => String.t(),
+          optional(:offerings) => [map()],
+          optional(:is_online) => boolean(),
+          optional(:successful_job_count) => non_neg_integer(),
+          optional(:success_rate) => float()
+        }
+
+  @type browse_params :: %{
+          optional(:sort_by) =>
+            :successful_job_count
+            | :success_rate
+            | :unique_buyer_count
+            | :mins_from_last_online,
+          optional(:top_k) => pos_integer(),
+          optional(:is_online) => :all | :online | :offline,
+          optional(:cluster) => String.t(),
+          optional(:show_hidden) => boolean()
+        }
+
+  @callback browse_agents(t(), keyword :: String.t(), params :: browse_params()) ::
+              {:ok, [agent_detail()]} | {:error, term()}
+
+  @callback get_agent_by_wallet_address(t(), wallet_address :: String.t()) ::
+              {:ok, agent_detail() | nil} | {:error, term()}
+
+  @callback get_me(t()) :: {:ok, agent_detail()} | {:error, term()}
+
+  @callback get_active_jobs(t()) :: {:ok, [map()]} | {:error, term()}
+
+  @callback post_deliverable(
+              t(),
+              chain_id :: pos_integer(),
+              job_id :: String.t() | non_neg_integer(),
+              deliverable :: term()
+            ) :: :ok | {:error, term()}
+
+  # -- Dispatch --
+
+  @spec browse_agents(t(), String.t(), browse_params()) ::
+          {:ok, [agent_detail()]} | {:error, term()}
+  def browse_agents(api, keyword, params \\ %{}) do
+    api.adapter.browse_agents(api, keyword, params)
+  end
+
+  @spec get_agent_by_wallet_address(t(), String.t()) ::
+          {:ok, agent_detail() | nil} | {:error, term()}
+  def get_agent_by_wallet_address(api, wallet_address) do
+    api.adapter.get_agent_by_wallet_address(api, wallet_address)
+  end
+
+  @spec get_me(t()) :: {:ok, agent_detail()} | {:error, term()}
+  def get_me(api), do: api.adapter.get_me(api)
+
+  @spec get_active_jobs(t()) :: {:ok, [map()]} | {:error, term()}
+  def get_active_jobs(api), do: api.adapter.get_active_jobs(api)
+
+  @spec post_deliverable(t(), pos_integer(), String.t() | non_neg_integer(), term()) ::
+          :ok | {:error, term()}
+  def post_deliverable(api, chain_id, job_id, deliverable) do
+    api.adapter.post_deliverable(api, chain_id, job_id, deliverable)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_api/mock.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_api/mock.ex
@@ -1,0 +1,105 @@
+defmodule Raxol.ACP.JobApi.Mock do
+  @moduledoc """
+  In-process mock for `Raxol.ACP.JobApi`. Tests pre-seed agents,
+  active jobs, and a `getMe` response; this module returns them
+  without touching the network.
+
+  ## Usage
+
+      api = Raxol.ACP.JobApi.Mock.new(me: %{wallet_address: "0x...", name: "Xochi"})
+      Raxol.ACP.JobApi.Mock.put_agent(api, "0xabc...", %{name: "Other"})
+      Raxol.ACP.JobApi.Mock.put_active_jobs(api, [%{job_id: "1", chain_id: 8453}])
+      {:ok, [agent]} = Raxol.ACP.JobApi.browse_agents(api, "Other", %{})
+
+  ## Inspecting outgoing traffic
+
+  `posted_deliverables(api)` returns every deliverable ever posted as
+  `{chain_id, job_id, deliverable}` tuples.
+  """
+
+  @behaviour Raxol.ACP.JobApi
+
+  @doc "Construct a fresh mock JobApi."
+  @spec new(keyword()) :: Raxol.ACP.JobApi.t()
+  def new(opts \\ []) do
+    table = :ets.new(:raxol_acp_jobapi_mock, [:set, :public])
+
+    me = Keyword.get(opts, :me, %{wallet_address: "0x" <> String.duplicate("ab", 20), name: "raxol-agent"})
+
+    :ets.insert(table, {:me, me})
+    :ets.insert(table, {:agents, %{}})
+    :ets.insert(table, {:active_jobs, []})
+    :ets.insert(table, {:posted_deliverables, []})
+
+    %{adapter: __MODULE__, config: %{table: table}}
+  end
+
+  @doc "Register an agent so it appears in `browse_agents/3` and `get_agent_by_wallet_address/2`."
+  @spec put_agent(Raxol.ACP.JobApi.t(), String.t(), Raxol.ACP.JobApi.agent_detail()) :: :ok
+  def put_agent(%{config: %{table: table}}, wallet_address, detail) do
+    [{:agents, current}] = :ets.lookup(table, :agents)
+    detail = Map.put(detail, :wallet_address, wallet_address)
+    :ets.insert(table, {:agents, Map.put(current, wallet_address, detail)})
+    :ok
+  end
+
+  @doc "Set the list returned by `get_active_jobs/1`."
+  @spec put_active_jobs(Raxol.ACP.JobApi.t(), [map()]) :: :ok
+  def put_active_jobs(%{config: %{table: table}}, jobs) do
+    :ets.insert(table, {:active_jobs, jobs})
+    :ok
+  end
+
+  @doc "Return every deliverable ever posted via `post_deliverable/4`."
+  @spec posted_deliverables(Raxol.ACP.JobApi.t()) :: [tuple()]
+  def posted_deliverables(%{config: %{table: table}}) do
+    [{:posted_deliverables, list}] = :ets.lookup(table, :posted_deliverables)
+    Enum.reverse(list)
+  end
+
+  # -- Raxol.ACP.JobApi callbacks --
+
+  @impl Raxol.ACP.JobApi
+  def browse_agents(%{config: %{table: table}}, keyword, _params) do
+    [{:agents, agents}] = :ets.lookup(table, :agents)
+
+    matches =
+      agents
+      |> Map.values()
+      |> Enum.filter(fn agent ->
+        keyword == "" or
+          String.contains?(String.downcase(Map.get(agent, :name, "")), String.downcase(keyword)) or
+          String.contains?(
+            String.downcase(Map.get(agent, :description, "") || ""),
+            String.downcase(keyword)
+          )
+      end)
+
+    {:ok, matches}
+  end
+
+  @impl Raxol.ACP.JobApi
+  def get_agent_by_wallet_address(%{config: %{table: table}}, wallet_address) do
+    [{:agents, agents}] = :ets.lookup(table, :agents)
+    {:ok, Map.get(agents, wallet_address)}
+  end
+
+  @impl Raxol.ACP.JobApi
+  def get_me(%{config: %{table: table}}) do
+    [{:me, me}] = :ets.lookup(table, :me)
+    {:ok, me}
+  end
+
+  @impl Raxol.ACP.JobApi
+  def get_active_jobs(%{config: %{table: table}}) do
+    [{:active_jobs, jobs}] = :ets.lookup(table, :active_jobs)
+    {:ok, jobs}
+  end
+
+  @impl Raxol.ACP.JobApi
+  def post_deliverable(%{config: %{table: table}}, chain_id, job_id, deliverable) do
+    [{:posted_deliverables, list}] = :ets.lookup(table, :posted_deliverables)
+    :ets.insert(table, {:posted_deliverables, [{chain_id, job_id, deliverable} | list]})
+    :ok
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/transport.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport.ex
@@ -1,0 +1,98 @@
+defmodule Raxol.ACP.Transport do
+  @moduledoc """
+  Behaviour for the chat / event transport between a raxol agent and
+  Virtuals's ACP server.
+
+  Mirrors `AcpChatTransport` in `acp-node-v2`. Two implementations are
+  expected:
+
+  - `Raxol.ACP.Transport.SSE` -- real Server-Sent Events stream from
+    `api.acp.virtuals.io` (production) / `api-dev.acp.virtuals.io`
+    (testnet). The default for live deployments. (Scaffolded here;
+    wire-level details land in a follow-up PR.)
+  - `Raxol.ACP.Transport.Mock` -- in-process implementation for tests.
+    Lets a test drive entry deliveries without HTTP.
+
+  ## Lifecycle
+
+      transport |> connect(ctx)        # opens stream; pushes entries to ctx.owner
+      transport |> get_history(...)    # one-shot HTTP read of job history
+      transport |> post_message(...)   # one-shot HTTP send
+      transport |> send_message(...)   # streaming send
+      transport |> disconnect()        # closes stream
+
+  The transport never decides job semantics -- it just shuttles
+  `JobRoomEntry`-shaped maps. `Raxol.ACP.Agent` is responsible for
+  routing each entry into the right `Raxol.ACP.JobSession`.
+
+  ## Entry shape
+
+  Entries arrive as maps with at minimum:
+
+      %{
+        "kind" => "system" | "message",
+        "chainId" => 8453,
+        "jobId" => "123",
+        "at" => "2026-06-13T16:00:00Z",
+        ... protocol-specific fields ...
+      }
+
+  Agent decodes these into the canonical
+  `Raxol.ACP.JobSession.entry()` shape via `Raxol.ACP.Event.decode_type/1`.
+  """
+
+  @type t :: %{
+          required(:adapter) => module(),
+          optional(:config) => map()
+        }
+
+  @type context :: %{
+          owner: pid(),
+          chain_ids: [pos_integer()],
+          wallet_address: String.t()
+        }
+
+  @type entry :: map()
+
+  @type job_key :: {pos_integer(), String.t() | non_neg_integer()}
+
+  @callback connect(t(), context()) :: :ok | {:error, term()}
+  @callback disconnect(t()) :: :ok
+
+  @callback get_history(t(), job_key()) :: {:ok, [entry()]} | {:error, term()}
+
+  @callback post_message(
+              t(),
+              job_key(),
+              content :: String.t(),
+              content_type :: String.t()
+            ) :: :ok | {:error, term()}
+
+  @callback send_message(
+              t(),
+              job_key(),
+              content :: String.t(),
+              content_type :: String.t()
+            ) :: :ok | {:error, term()}
+
+  # -- Dispatch helpers --
+
+  @spec connect(t(), context()) :: :ok | {:error, term()}
+  def connect(transport, ctx), do: transport.adapter.connect(transport, ctx)
+
+  @spec disconnect(t()) :: :ok
+  def disconnect(transport), do: transport.adapter.disconnect(transport)
+
+  @spec get_history(t(), job_key()) :: {:ok, [entry()]} | {:error, term()}
+  def get_history(transport, key), do: transport.adapter.get_history(transport, key)
+
+  @spec post_message(t(), job_key(), String.t(), String.t()) :: :ok | {:error, term()}
+  def post_message(transport, key, content, content_type \\ "text") do
+    transport.adapter.post_message(transport, key, content, content_type)
+  end
+
+  @spec send_message(t(), job_key(), String.t(), String.t()) :: :ok | {:error, term()}
+  def send_message(transport, key, content, content_type \\ "text") do
+    transport.adapter.send_message(transport, key, content, content_type)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/transport/mock.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/mock.ex
@@ -1,0 +1,116 @@
+defmodule Raxol.ACP.Transport.Mock do
+  @moduledoc """
+  In-process transport for tests.
+
+  Holds an ETS-backed state per transport instance: connection status,
+  the owner pid to deliver entries to, sent-message history, and
+  pre-canned entry batches.
+
+  ## Usage in tests
+
+      transport = Raxol.ACP.Transport.Mock.new()
+      :ok = Raxol.ACP.Transport.connect(transport, %{owner: self(), ...})
+      Raxol.ACP.Transport.Mock.deliver(transport, entry_map)
+      # owner receives `{:transport, entry_map}` immediately.
+
+  ## Inspecting outgoing traffic
+
+  `Raxol.ACP.Transport.Mock.sent(transport)` returns every message ever
+  sent via `post_message` or `send_message`, in order, as
+  `{kind, job_key, content, content_type}` tuples.
+  """
+
+  @behaviour Raxol.ACP.Transport
+
+  @doc """
+  Construct a fresh mock transport. Each call creates an isolated
+  state table.
+  """
+  @spec new() :: Raxol.ACP.Transport.t()
+  def new do
+    table = :ets.new(:raxol_acp_transport_mock, [:set, :public])
+
+    :ets.insert(table, {:owner, nil})
+    :ets.insert(table, {:connected?, false})
+    :ets.insert(table, {:sent, []})
+    :ets.insert(table, {:history, %{}})
+
+    %{adapter: __MODULE__, config: %{table: table}}
+  end
+
+  @doc "Manually push an entry to the connected owner."
+  @spec deliver(Raxol.ACP.Transport.t(), Raxol.ACP.Transport.entry()) :: :ok
+  def deliver(%{config: %{table: table}}, entry) do
+    case :ets.lookup(table, :owner) do
+      [{:owner, nil}] ->
+        :ok
+
+      [{:owner, owner}] when is_pid(owner) ->
+        send(owner, {:transport, entry})
+        :ok
+    end
+  end
+
+  @doc "Set the history fixture returned by `get_history/2`."
+  @spec set_history(Raxol.ACP.Transport.t(), Raxol.ACP.Transport.job_key(), [
+          Raxol.ACP.Transport.entry()
+        ]) :: :ok
+  def set_history(%{config: %{table: table}}, key, entries) do
+    [{:history, current}] = :ets.lookup(table, :history)
+    :ets.insert(table, {:history, Map.put(current, key, entries)})
+    :ok
+  end
+
+  @doc "Return every outbound message that's been sent through this transport."
+  @spec sent(Raxol.ACP.Transport.t()) :: [tuple()]
+  def sent(%{config: %{table: table}}) do
+    [{:sent, list}] = :ets.lookup(table, :sent)
+    Enum.reverse(list)
+  end
+
+  @doc "Whether `connect/2` has been called and not yet `disconnect/1`'d."
+  @spec connected?(Raxol.ACP.Transport.t()) :: boolean()
+  def connected?(%{config: %{table: table}}) do
+    [{:connected?, c}] = :ets.lookup(table, :connected?)
+    c
+  end
+
+  # -- Raxol.ACP.Transport callbacks --
+
+  @impl Raxol.ACP.Transport
+  def connect(%{config: %{table: table}}, %{owner: owner}) do
+    :ets.insert(table, {:owner, owner})
+    :ets.insert(table, {:connected?, true})
+    :ok
+  end
+
+  @impl Raxol.ACP.Transport
+  def disconnect(%{config: %{table: table}}) do
+    :ets.insert(table, {:owner, nil})
+    :ets.insert(table, {:connected?, false})
+    :ok
+  end
+
+  @impl Raxol.ACP.Transport
+  def get_history(%{config: %{table: table}}, key) do
+    [{:history, h}] = :ets.lookup(table, :history)
+    {:ok, Map.get(h, key, [])}
+  end
+
+  @impl Raxol.ACP.Transport
+  def post_message(%{config: %{table: table}}, key, content, content_type) do
+    record_sent(table, {:post, key, content, content_type})
+    :ok
+  end
+
+  @impl Raxol.ACP.Transport
+  def send_message(%{config: %{table: table}}, key, content, content_type) do
+    record_sent(table, {:send, key, content, content_type})
+    :ok
+  end
+
+  defp record_sent(table, entry) do
+    [{:sent, list}] = :ets.lookup(table, :sent)
+    :ets.insert(table, {:sent, [entry | list]})
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/agent_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/agent_test.exs
@@ -1,0 +1,226 @@
+defmodule Raxol.ACP.AgentTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{Agent, JobSession, Transport, JobApi}
+
+  setup do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(JobSession.Supervisor),
+        is_pid(pid) do
+      DynamicSupervisor.terminate_child(JobSession.Supervisor, pid)
+    end
+
+    transport = Transport.Mock.new()
+    api = JobApi.Mock.new(me: %{wallet_address: "0xdead", name: "Xochi"})
+
+    {:ok, agent} =
+      Agent.start_link(
+        transport: transport,
+        api: api,
+        wallet_address: "0xdead",
+        supported_chain_ids: [8453, 84_532],
+        default_role: :provider
+      )
+
+    {:ok, agent: agent, transport: transport, api: api}
+  end
+
+  describe "start_stream/1" do
+    test "connects the transport idempotently", %{agent: agent, transport: transport} do
+      :ok = Agent.start_stream(agent)
+      assert Transport.Mock.connected?(transport)
+      # Idempotent
+      :ok = Agent.start_stream(agent)
+      assert Transport.Mock.connected?(transport)
+    end
+
+    test "stop_stream disconnects", %{agent: agent, transport: transport} do
+      Agent.start_stream(agent)
+      :ok = Agent.stop_stream(agent)
+      refute Transport.Mock.connected?(transport)
+    end
+  end
+
+  describe "discovery (JobApi pass-through)" do
+    test "browse_agents/3 hits the api", %{agent: agent, api: api} do
+      JobApi.Mock.put_agent(api, "0xfeed", %{name: "Other Solver"})
+
+      assert {:ok, [%{name: "Other Solver"}]} = Agent.browse_agents(agent, "other")
+    end
+
+    test "get_agent/2 looks up by wallet", %{agent: agent, api: api} do
+      JobApi.Mock.put_agent(api, "0xfeed", %{name: "Other"})
+
+      assert {:ok, %{name: "Other"}} = Agent.get_agent(agent, "0xfeed")
+      assert {:ok, nil} = Agent.get_agent(agent, "0xmissing")
+    end
+
+    test "get_address/1 returns the wallet", %{agent: agent} do
+      assert Agent.get_address(agent) == "0xdead"
+    end
+  end
+
+  describe "message passthrough" do
+    test "send_message/4 records on the transport", %{agent: agent, transport: transport} do
+      Agent.start_stream(agent)
+
+      :ok = Agent.send_message(agent, {8453, "j1"}, "hi", "text")
+
+      assert [{:send, {8453, "j1"}, "hi", "text"}] = Transport.Mock.sent(transport)
+    end
+
+    test "post_message/4 uses post path", %{agent: agent, transport: transport} do
+      Agent.start_stream(agent)
+
+      :ok = Agent.post_message(agent, {8453, "j1"}, "hi", "text")
+
+      assert [{:post, {8453, "j1"}, "hi", "text"}] = Transport.Mock.sent(transport)
+    end
+  end
+
+  describe "event routing" do
+    test "first system entry spawns a JobSession and broadcasts to subscribers", %{
+      agent: agent,
+      transport: transport
+    } do
+      :ok = Agent.start_stream(agent)
+      :ok = Agent.subscribe(agent)
+
+      entry = %{
+        "kind" => "system",
+        "chainId" => 8453,
+        "jobId" => "job-1",
+        "event" => "job.created"
+      }
+
+      Transport.Mock.deliver(transport, entry)
+
+      assert_receive {Agent, ^agent, session_pid, ^entry}, 200
+      assert is_pid(session_pid)
+
+      # Session is tracked.
+      assert Agent.get_session(agent, {8453, "job-1"}) == session_pid
+      assert Map.has_key?(Agent.sessions(agent), {8453, "job-1"})
+    end
+
+    test "subsequent entries with the same key reuse the same session", %{
+      agent: agent,
+      transport: transport
+    } do
+      Agent.start_stream(agent)
+      Agent.subscribe(agent)
+
+      e1 = %{"kind" => "system", "chainId" => 8453, "jobId" => "job-2", "event" => "job.created"}
+      e2 = %{"kind" => "system", "chainId" => 8453, "jobId" => "job-2", "event" => "budget.set"}
+
+      Transport.Mock.deliver(transport, e1)
+      Transport.Mock.deliver(transport, e2)
+
+      assert_receive {Agent, ^agent, pid1, ^e1}, 200
+      assert_receive {Agent, ^agent, pid2, ^e2}, 200
+      assert pid1 == pid2
+
+      # Status mirrored into the session.
+      assert JobSession.status(pid2) == :budget_set
+    end
+
+    test "different keys spawn distinct sessions", %{agent: agent, transport: transport} do
+      Agent.start_stream(agent)
+      Agent.subscribe(agent)
+
+      e1 = %{"kind" => "system", "chainId" => 8453, "jobId" => "a", "event" => "job.created"}
+      e2 = %{"kind" => "system", "chainId" => 84_532, "jobId" => "a", "event" => "job.created"}
+
+      Transport.Mock.deliver(transport, e1)
+      Transport.Mock.deliver(transport, e2)
+
+      assert_receive {Agent, ^agent, p1, ^e1}, 200
+      assert_receive {Agent, ^agent, p2, ^e2}, 200
+      assert p1 != p2
+    end
+
+    test "message entries are propagated to JobSession.send_message/3", %{
+      agent: agent,
+      transport: transport
+    } do
+      Agent.start_stream(agent)
+      Agent.subscribe(agent)
+
+      sys = %{"kind" => "system", "chainId" => 8453, "jobId" => "msg-1", "event" => "job.created"}
+      msg = %{
+        "kind" => "message",
+        "chainId" => 8453,
+        "jobId" => "msg-1",
+        "content" => "hello there",
+        "contentType" => "text"
+      }
+
+      Transport.Mock.deliver(transport, sys)
+      Transport.Mock.deliver(transport, msg)
+
+      assert_receive {Agent, ^agent, session_pid, ^sys}, 200
+      assert_receive {Agent, ^agent, ^session_pid, ^msg}, 200
+
+      entries = JobSession.entries(session_pid)
+      assert Enum.any?(entries, fn e -> e.kind == :message and e.content == "hello there" end)
+    end
+
+    test "terminal events drop the session from the registry", %{
+      agent: agent,
+      transport: transport
+    } do
+      Agent.start_stream(agent)
+      Agent.subscribe(agent)
+
+      key = {8453, "term-1"}
+
+      seed = %{"kind" => "system", "chainId" => 8453, "jobId" => "term-1", "event" => "job.created"}
+      Transport.Mock.deliver(transport, seed)
+      assert_receive {Agent, ^agent, _, ^seed}, 200
+
+      # Driving the session to a terminal status: send a job.completed event.
+      done = %{
+        "kind" => "system",
+        "chainId" => 8453,
+        "jobId" => "term-1",
+        "event" => "job.completed"
+      }
+
+      Transport.Mock.deliver(transport, done)
+      assert_receive {Agent, ^agent, _, ^done}, 200
+
+      # The session stops itself; the agent's :DOWN handler drops it.
+      eventually(fn -> Agent.get_session(agent, key) == nil end)
+    end
+  end
+
+  describe "subscriber lifecycle" do
+    test "dead subscribers are dropped", %{agent: agent} do
+      subscriber =
+        spawn(fn ->
+          Agent.subscribe(agent)
+          receive do: (:die -> :ok)
+        end)
+
+      Process.sleep(20)
+      send(subscriber, :die)
+      eventually(fn ->
+        state = :sys.get_state(agent)
+        not MapSet.member?(state.subscribers, subscriber)
+      end)
+    end
+  end
+
+  # -- Helpers --
+
+  defp eventually(check, attempts \\ 50)
+  defp eventually(_check, 0), do: flunk("condition did not become true within 1s")
+
+  defp eventually(check, attempts) do
+    if check.() do
+      :ok
+    else
+      Process.sleep(20)
+      eventually(check, attempts - 1)
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_api/mock_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_api/mock_test.exs
@@ -1,0 +1,79 @@
+defmodule Raxol.ACP.JobApi.MockTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.JobApi
+  alias Raxol.ACP.JobApi.Mock
+
+  describe "get_me/1" do
+    test "returns the seeded me" do
+      api = Mock.new(me: %{wallet_address: "0xabc", name: "Xochi", is_online: true})
+
+      assert {:ok, %{wallet_address: "0xabc", name: "Xochi"}} = JobApi.get_me(api)
+    end
+  end
+
+  describe "browse_agents/3" do
+    test "filters by case-insensitive name keyword" do
+      api = Mock.new()
+      Mock.put_agent(api, "0x1", %{name: "Xochi Solver"})
+      Mock.put_agent(api, "0x2", %{name: "Other Agent"})
+
+      assert {:ok, [%{name: "Xochi Solver"}]} = JobApi.browse_agents(api, "xochi", %{})
+      assert {:ok, [%{name: "Other Agent"}]} = JobApi.browse_agents(api, "other", %{})
+    end
+
+    test "empty keyword returns everything" do
+      api = Mock.new()
+      Mock.put_agent(api, "0x1", %{name: "A"})
+      Mock.put_agent(api, "0x2", %{name: "B"})
+
+      assert {:ok, results} = JobApi.browse_agents(api, "", %{})
+      assert length(results) == 2
+    end
+
+    test "no match returns []" do
+      api = Mock.new()
+      Mock.put_agent(api, "0x1", %{name: "A"})
+
+      assert {:ok, []} = JobApi.browse_agents(api, "nothing", %{})
+    end
+  end
+
+  describe "get_agent_by_wallet_address/2" do
+    test "returns the agent" do
+      api = Mock.new()
+      Mock.put_agent(api, "0x1", %{name: "A"})
+
+      assert {:ok, %{name: "A", wallet_address: "0x1"}} =
+               JobApi.get_agent_by_wallet_address(api, "0x1")
+    end
+
+    test "returns nil for unknown wallet" do
+      api = Mock.new()
+      assert {:ok, nil} = JobApi.get_agent_by_wallet_address(api, "0xmissing")
+    end
+  end
+
+  describe "active jobs" do
+    test "round-trips" do
+      api = Mock.new()
+      Mock.put_active_jobs(api, [%{job_id: "1"}, %{job_id: "2"}])
+
+      assert {:ok, [%{job_id: "1"}, %{job_id: "2"}]} = JobApi.get_active_jobs(api)
+    end
+  end
+
+  describe "post_deliverable/4" do
+    test "records every deliverable in order" do
+      api = Mock.new()
+
+      JobApi.post_deliverable(api, 8453, "1", %{result: "a"})
+      JobApi.post_deliverable(api, 8453, "2", %{result: "b"})
+
+      assert [
+               {8453, "1", %{result: "a"}},
+               {8453, "2", %{result: "b"}}
+             ] = Mock.posted_deliverables(api)
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/transport/mock_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/transport/mock_test.exs
@@ -1,0 +1,79 @@
+defmodule Raxol.ACP.Transport.MockTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Transport
+  alias Raxol.ACP.Transport.Mock
+
+  describe "connection lifecycle" do
+    test "starts disconnected" do
+      t = Mock.new()
+      refute Mock.connected?(t)
+    end
+
+    test "connect/2 records the owner" do
+      t = Mock.new()
+
+      ctx = %{owner: self(), chain_ids: [8453], wallet_address: "0x"}
+      :ok = Transport.connect(t, ctx)
+
+      assert Mock.connected?(t)
+    end
+
+    test "disconnect/1 clears the owner" do
+      t = Mock.new()
+
+      Transport.connect(t, %{owner: self(), chain_ids: [8453], wallet_address: "0x"})
+      :ok = Transport.disconnect(t)
+
+      refute Mock.connected?(t)
+    end
+  end
+
+  describe "deliver/2" do
+    test "sends `{:transport, entry}` to the owner" do
+      t = Mock.new()
+      Transport.connect(t, %{owner: self(), chain_ids: [8453], wallet_address: "0x"})
+
+      Mock.deliver(t, %{"kind" => "system", "event" => "job.created"})
+
+      assert_receive {:transport, %{"kind" => "system"}}, 50
+    end
+
+    test "drops deliveries when nothing is connected" do
+      t = Mock.new()
+      Mock.deliver(t, %{"kind" => "message"})
+      refute_receive {:transport, _}, 50
+    end
+  end
+
+  describe "get_history/2" do
+    test "returns set_history fixture" do
+      t = Mock.new()
+      key = {8453, "j1"}
+
+      Mock.set_history(t, key, [%{"kind" => "message", "content" => "hi"}])
+
+      assert {:ok, [%{"content" => "hi"}]} = Transport.get_history(t, key)
+    end
+
+    test "returns [] when nothing was seeded" do
+      t = Mock.new()
+      assert {:ok, []} = Transport.get_history(t, {8453, "missing"})
+    end
+  end
+
+  describe "sent traffic" do
+    test "post_message and send_message both record" do
+      t = Mock.new()
+      key = {8453, "j1"}
+
+      Transport.post_message(t, key, "hello", "text")
+      Transport.send_message(t, key, "stream", "text")
+
+      assert Mock.sent(t) == [
+               {:post, key, "hello", "text"},
+               {:send, key, "stream", "text"}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Mirrors \`AcpAgent\` from acp-node-v2. The orchestrator GenServer owns three injected dependencies and routes incoming SSE entries to per-job \`JobSession\` processes.

Stacks on #268 (acpv2-jobsession). Part C of the v2 launch plan.

## New modules

- **\`Raxol.ACP.Transport\`** (behaviour) -- the chat/event stream. \`connect/2\`, \`disconnect/1\`, \`get_history/2\`, \`post_message/4\`, \`send_message/4\`. SSE in production (\`api.acp.virtuals.io\`), Mock for tests.
- **\`Raxol.ACP.Transport.Mock\`** -- in-process implementation. \`deliver/2\` pushes an entry to the connected owner; \`sent/1\` returns every outbound message; \`set_history/3\` seeds fixtures.
- **\`Raxol.ACP.JobApi\`** (behaviour) -- the REST discovery API. \`browse_agents/3\`, \`get_agent_by_wallet_address/2\`, \`get_me/1\`, \`get_active_jobs/1\`, \`post_deliverable/4\`.
- **\`Raxol.ACP.JobApi.Mock\`** -- in-process implementation. \`put_agent/3\`, \`put_active_jobs/2\`, \`posted_deliverables/1\`.
- **\`Raxol.ACP.Agent\`** -- the orchestrator GenServer. \`start_stream/1\`, \`stop_stream/1\`, \`subscribe/1\`, \`unsubscribe/1\`, \`browse_agents/3\`, \`get_agent/2\`, \`get_session/2\`, \`sessions/1\`, \`send_message/4\`, \`post_message/4\`, \`get_address/1\`.

## Routing logic

When the transport delivers an entry, Agent:
1. Extracts \`{chain_id, job_id}\` from the entry payload (camelCase or snake_case accepted).
2. Resolves the matching \`Raxol.ACP.JobSession\` via the v2 Registry, starting one via \`JobSession.Supervisor\` if it doesn't exist yet.
3. Mirrors the canonical status into the session via \`:sys.replace_state\` -- the SSE event is authoritative (the on-chain state already settled).
4. For terminal events, stops the session \`:normal\` so the supervisor doesn't restart it.
5. Broadcasts to subscribers as \`{Raxol.ACP.Agent, agent_pid, session_pid, entry}\`.

## What's deferred

- **Real SSE wire-up** (Transport.SSE) -- needs decisions about auth headers, JWT vs walletAddress, reconnect strategy. Lands in a follow-up so this PR's structure can be reviewed without that complexity.
- **Real HTTP wire-up** (JobApi.HTTP) -- ditto.
- **ProviderAdapter** -- on-chain client. PR D.

## Manual testing

- [x] \`mix test test/raxol/acp/transport/ test/raxol/acp/job_api/ test/raxol/acp/agent_test.exs\` -- 29 tests, 0 failures
- [x] \`mix test\` (full suite) -- 460 tests, 0 failures, 5 excluded