### PR TITLE
raxol_acp v2: ProviderAdapter + HookClient

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/hook_client.ex
+++ b/packages/raxol_acp/lib/raxol/acp/hook_client.ex
@@ -1,0 +1,205 @@
+defmodule Raxol.ACP.HookClient do
+  @moduledoc """
+  High-level wrapper around `Raxol.ACP.ProviderAdapter` for the v2 ACP
+  Core hook calls.
+
+  The acp-node-v2 selectors (verified against
+  https://github.com/Virtual-Protocol/acp-node-v2/blob/main/src/core/constants.ts):
+
+      setBudget(uint256, uint256, bytes)
+      fund(uint256, uint256, bytes)
+      submit(uint256, bytes32, bytes)
+      complete(uint256, bytes32, bytes)
+      reject(uint256, bytes32, bytes)
+
+  Plus `createJob`, which targets ACP Core but takes the offering /
+  hook configuration as parameters.
+
+  All of these route through whichever `Raxol.ACP.ProviderAdapter` the
+  caller supplies, so this module doesn't care whether the underlying
+  signer is our Elixir-native SCA or something else.
+
+  ## On the `bytes data` parameter
+
+  ACP Core's hook functions take a trailing `bytes data` arg whose
+  contents are interpreted by the configured hook contract. For
+  `FundTransferHook`, `setBudget(jobId, amount, data)` encodes
+  `(transferAmount, destination)` in `data`. For
+  `SubscriptionHook`, `data` carries `packageId`. Callers pass the
+  pre-encoded bytes; this module doesn't try to abstract over the
+  variants -- that's the offering's job.
+  """
+
+  alias Raxol.ACP.ProviderAdapter
+
+  @type chain_id :: pos_integer()
+  @type job_id :: non_neg_integer()
+  @type token_amount :: non_neg_integer()
+  @type bytes32 :: binary()
+  @type tx_hash :: String.t()
+
+  # -- Action functions --
+
+  @doc """
+  Submit `setBudget(jobId, amount, data)` to the ACP Core contract on
+  `chain_id`. `acp_core_address` is the deployed ACP Core address;
+  caller usually reads it from `Raxol.ACP.Chain.mainnet/0`.
+  """
+  @spec set_budget(
+          ProviderAdapter.adapter(),
+          chain_id(),
+          String.t(),
+          job_id(),
+          token_amount(),
+          binary()
+        ) :: {:ok, tx_hash()} | {:error, term()}
+  def set_budget(adapter, chain_id, acp_core_address, job_id, amount, data \\ <<>>) do
+    submit_single(adapter, chain_id, acp_core_address, "setBudget(uint256,uint256,bytes)", [
+      {"uint256", job_id},
+      {"uint256", amount},
+      {"bytes", data}
+    ])
+  end
+
+  @doc "Submit `fund(jobId, amount, data)`."
+  @spec fund(
+          ProviderAdapter.adapter(),
+          chain_id(),
+          String.t(),
+          job_id(),
+          token_amount(),
+          binary()
+        ) :: {:ok, tx_hash()} | {:error, term()}
+  def fund(adapter, chain_id, acp_core_address, job_id, amount, data \\ <<>>) do
+    submit_single(adapter, chain_id, acp_core_address, "fund(uint256,uint256,bytes)", [
+      {"uint256", job_id},
+      {"uint256", amount},
+      {"bytes", data}
+    ])
+  end
+
+  @doc """
+  Submit `submit(jobId, deliverableHash, data)`.
+
+  `deliverable_hash` is a 32-byte commitment to the deliverable
+  payload. By convention this is `keccak256(canonical_json(deliverable))`.
+  """
+  @spec submit(
+          ProviderAdapter.adapter(),
+          chain_id(),
+          String.t(),
+          job_id(),
+          bytes32(),
+          binary()
+        ) :: {:ok, tx_hash()} | {:error, term()}
+  def submit(adapter, chain_id, acp_core_address, job_id, deliverable_hash, data \\ <<>>) do
+    submit_single(adapter, chain_id, acp_core_address, "submit(uint256,bytes32,bytes)", [
+      {"uint256", job_id},
+      {"bytes32", encode_bytes32(deliverable_hash)},
+      {"bytes", data}
+    ])
+  end
+
+  @doc "Submit `complete(jobId, deliverableHash, data)`."
+  @spec complete(
+          ProviderAdapter.adapter(),
+          chain_id(),
+          String.t(),
+          job_id(),
+          bytes32(),
+          binary()
+        ) :: {:ok, tx_hash()} | {:error, term()}
+  def complete(adapter, chain_id, acp_core_address, job_id, deliverable_hash, data \\ <<>>) do
+    submit_single(adapter, chain_id, acp_core_address, "complete(uint256,bytes32,bytes)", [
+      {"uint256", job_id},
+      {"bytes32", encode_bytes32(deliverable_hash)},
+      {"bytes", data}
+    ])
+  end
+
+  @doc "Submit `reject(jobId, deliverableHash, data)`."
+  @spec reject(
+          ProviderAdapter.adapter(),
+          chain_id(),
+          String.t(),
+          job_id(),
+          bytes32(),
+          binary()
+        ) :: {:ok, tx_hash()} | {:error, term()}
+  def reject(adapter, chain_id, acp_core_address, job_id, deliverable_hash, data \\ <<>>) do
+    submit_single(adapter, chain_id, acp_core_address, "reject(uint256,bytes32,bytes)", [
+      {"uint256", job_id},
+      {"bytes32", encode_bytes32(deliverable_hash)},
+      {"bytes", data}
+    ])
+  end
+
+  @doc """
+  Submit `createJob(...)` on ACP Core.
+
+  v2's createJob signature (from acp-node-v2 source):
+
+      createJob(address provider, address evaluator, uint256 expiredAt,
+                address hookAddress, bytes hookData)
+
+  Returns the assigned jobId via a separate `getJobIdFromTxHash` call
+  in the SDK; this function returns the tx hash and lets the caller
+  resolve the jobId.
+  """
+  @spec create_job(
+          ProviderAdapter.adapter(),
+          chain_id(),
+          String.t(),
+          %{
+            provider: String.t(),
+            evaluator: String.t(),
+            expired_at: non_neg_integer(),
+            hook_address: String.t(),
+            hook_data: binary()
+          }
+        ) :: {:ok, tx_hash()} | {:error, term()}
+  def create_job(adapter, chain_id, acp_core_address, %{
+        provider: provider,
+        evaluator: evaluator,
+        expired_at: expired_at,
+        hook_address: hook_address,
+        hook_data: hook_data
+      }) do
+    submit_single(adapter, chain_id, acp_core_address, "createJob(address,address,uint256,address,bytes)", [
+      {"address", provider},
+      {"address", evaluator},
+      {"uint256", expired_at},
+      {"address", hook_address},
+      {"bytes", hook_data}
+    ])
+  end
+
+  # -- Internals --
+
+  defp submit_single(adapter, chain_id, to, signature, args) do
+    data = Raxol.ACP.ABI.encode_call(signature, args)
+
+    call = %{
+      to: to,
+      data: data,
+      value: 0
+    }
+
+    case ProviderAdapter.send_calls(adapter, chain_id, [call]) do
+      {:ok, [tx_hash]} -> {:ok, tx_hash}
+      {:ok, [tx_hash | _]} -> {:ok, tx_hash}
+      {:ok, []} -> {:error, :no_tx_hash_returned}
+      err -> err
+    end
+  end
+
+  # `Raxol.ACP.ABI.encode_bytes32` accepts hex (with or without 0x);
+  # normalize raw 32-byte binaries to hex so both representations work.
+  defp encode_bytes32(<<_::binary-size(32)>> = bytes),
+    do: "0x" <> Base.encode16(bytes, case: :lower)
+
+  defp encode_bytes32("0x" <> hex = full) when byte_size(hex) == 64, do: full
+
+  defp encode_bytes32(other),
+    do: raise(ArgumentError, "bytes32 value must be 32 raw bytes or 66-char hex, got: #{inspect(other)}")
+end

--- a/packages/raxol_acp/lib/raxol/acp/provider_adapter.ex
+++ b/packages/raxol_acp/lib/raxol/acp/provider_adapter.ex
@@ -1,0 +1,127 @@
+defmodule Raxol.ACP.ProviderAdapter do
+  @moduledoc """
+  Low-level EVM provider behaviour. Mirrors `IEvmProviderAdapter` in
+  `acp-node-v2`:
+
+      sendCalls(chainId, calls)           # submit a batch of transactions
+      signMessage(chainId, message)       # personal_sign / EIP-191
+      signTypedData(chainId, typedData)   # EIP-712
+      getTransactionReceipt(chainId, hash)
+      readContract(chainId, params)
+      getLogs(chainId, params)
+
+  Two concrete implementations:
+
+  - `Raxol.ACP.ProviderAdapter.Mock` (this PR) -- in-process; records
+    every call and returns canned responses. Used by `Raxol.ACP.Agent`
+    and `Raxol.ACP.HookClient` tests so the full v2 lifecycle can be
+    exercised without an RPC or a wallet.
+  - `Raxol.ACP.ProviderAdapter.SCA` (follow-up PR) -- production:
+    wraps `Raxol.ACP.Wallet.SCA` so calls flow through our
+    Elixir-native MAv2 wallet + Alchemy paymaster + session key. No
+    Privy dependency.
+
+  ## Adapter shape
+
+  An adapter is a map carrying the implementing module and its config:
+
+      %{adapter: Raxol.ACP.ProviderAdapter.Mock, config: %{table: ...}}
+
+  All callbacks take the adapter map as the first argument so that the
+  implementation can stash whatever state it needs in `config`. This
+  matches the pattern used by `Raxol.ACP.Transport` and
+  `Raxol.ACP.JobApi`.
+
+  ## Call shape
+
+  `sendCalls` accepts a list of `call()` maps. Each carries the target
+  address, value (wei), data (ABI calldata), and an optional gas hint.
+  Returning a list of tx hashes (one per call) preserves the SDK's
+  batch semantics: a single bundled UserOp will return one hash array;
+  individual EOA calls return per-call hashes.
+  """
+
+  @type adapter :: %{required(:adapter) => module(), optional(:config) => map()}
+
+  @type call :: %{
+          required(:to) => String.t(),
+          required(:data) => binary() | String.t(),
+          optional(:value) => non_neg_integer(),
+          optional(:gas) => non_neg_integer()
+        }
+
+  @type chain_id :: pos_integer()
+
+  @type typed_data :: %{
+          required(:domain) => map(),
+          required(:types) => map(),
+          required(:message) => map()
+        }
+
+  @type read_params :: %{
+          required(:address) => String.t(),
+          required(:signature) => String.t(),
+          required(:args) => [{String.t(), term()}]
+        }
+
+  @type log_filter :: %{
+          optional(:address) => String.t() | [String.t()],
+          optional(:topics) => [String.t() | nil | [String.t()]],
+          optional(:from_block) => non_neg_integer() | String.t(),
+          optional(:to_block) => non_neg_integer() | String.t()
+        }
+
+  @callback send_calls(adapter(), chain_id(), [call()]) ::
+              {:ok, [String.t()]} | {:error, term()}
+
+  @callback sign_message(adapter(), chain_id(), binary()) ::
+              {:ok, binary()} | {:error, term()}
+
+  @callback sign_typed_data(adapter(), chain_id(), typed_data()) ::
+              {:ok, binary()} | {:error, term()}
+
+  @callback get_transaction_receipt(adapter(), chain_id(), String.t()) ::
+              {:ok, map() | nil} | {:error, term()}
+
+  @callback read_contract(adapter(), chain_id(), read_params()) ::
+              {:ok, term()} | {:error, term()}
+
+  @callback get_logs(adapter(), chain_id(), log_filter()) ::
+              {:ok, [map()]} | {:error, term()}
+
+  @callback get_address(adapter()) :: String.t()
+
+  @callback supported_chain_ids(adapter()) :: [chain_id()]
+
+  # -- Dispatch helpers --
+
+  @spec send_calls(adapter(), chain_id(), [call()]) :: {:ok, [String.t()]} | {:error, term()}
+  def send_calls(adapter, chain_id, calls),
+    do: adapter.adapter.send_calls(adapter, chain_id, calls)
+
+  @spec sign_message(adapter(), chain_id(), binary()) :: {:ok, binary()} | {:error, term()}
+  def sign_message(adapter, chain_id, message),
+    do: adapter.adapter.sign_message(adapter, chain_id, message)
+
+  @spec sign_typed_data(adapter(), chain_id(), typed_data()) :: {:ok, binary()} | {:error, term()}
+  def sign_typed_data(adapter, chain_id, typed_data),
+    do: adapter.adapter.sign_typed_data(adapter, chain_id, typed_data)
+
+  @spec get_transaction_receipt(adapter(), chain_id(), String.t()) :: {:ok, map() | nil} | {:error, term()}
+  def get_transaction_receipt(adapter, chain_id, hash),
+    do: adapter.adapter.get_transaction_receipt(adapter, chain_id, hash)
+
+  @spec read_contract(adapter(), chain_id(), read_params()) :: {:ok, term()} | {:error, term()}
+  def read_contract(adapter, chain_id, params),
+    do: adapter.adapter.read_contract(adapter, chain_id, params)
+
+  @spec get_logs(adapter(), chain_id(), log_filter()) :: {:ok, [map()]} | {:error, term()}
+  def get_logs(adapter, chain_id, filter),
+    do: adapter.adapter.get_logs(adapter, chain_id, filter)
+
+  @spec get_address(adapter()) :: String.t()
+  def get_address(adapter), do: adapter.adapter.get_address(adapter)
+
+  @spec supported_chain_ids(adapter()) :: [chain_id()]
+  def supported_chain_ids(adapter), do: adapter.adapter.supported_chain_ids(adapter)
+end

--- a/packages/raxol_acp/lib/raxol/acp/provider_adapter/mock.ex
+++ b/packages/raxol_acp/lib/raxol/acp/provider_adapter/mock.ex
@@ -1,0 +1,147 @@
+defmodule Raxol.ACP.ProviderAdapter.Mock do
+  @moduledoc """
+  In-process mock for `Raxol.ACP.ProviderAdapter`.
+
+  Records every call and lets tests pre-canned return values.
+
+  ## Usage
+
+      adapter =
+        Raxol.ACP.ProviderAdapter.Mock.new(
+          address: "0xabc...",
+          supported_chain_ids: [8453]
+        )
+
+      Raxol.ACP.ProviderAdapter.Mock.set_receipt(adapter, "0xtx", %{status: 1})
+      {:ok, ["0xtx1"]} = Raxol.ACP.ProviderAdapter.send_calls(adapter, 8453, [call])
+
+      Raxol.ACP.ProviderAdapter.Mock.sent_calls(adapter)
+      # => [{8453, [call]}]
+  """
+
+  @behaviour Raxol.ACP.ProviderAdapter
+
+  @doc "Construct a fresh mock adapter."
+  @spec new(keyword()) :: Raxol.ACP.ProviderAdapter.adapter()
+  def new(opts \\ []) do
+    table = :ets.new(:raxol_acp_provider_mock, [:set, :public])
+
+    :ets.insert(table, {:address, Keyword.get(opts, :address, "0x" <> String.duplicate("ab", 20))})
+    :ets.insert(table, {:supported_chain_ids, Keyword.get(opts, :supported_chain_ids, [8453])})
+    :ets.insert(table, {:sent_calls, []})
+    :ets.insert(table, {:sent_signatures, []})
+    :ets.insert(table, {:tx_counter, 0})
+    :ets.insert(table, {:receipts, %{}})
+    :ets.insert(table, {:contract_reads, %{}})
+    :ets.insert(table, {:logs, []})
+
+    %{adapter: __MODULE__, config: %{table: table}}
+  end
+
+  @doc "Set the receipt returned by `get_transaction_receipt/3`."
+  @spec set_receipt(Raxol.ACP.ProviderAdapter.adapter(), String.t(), map()) :: :ok
+  def set_receipt(%{config: %{table: table}}, tx_hash, receipt) do
+    [{:receipts, current}] = :ets.lookup(table, :receipts)
+    :ets.insert(table, {:receipts, Map.put(current, tx_hash, receipt)})
+    :ok
+  end
+
+  @doc "Set the value returned by `read_contract/3` for a given `{address, signature}`."
+  @spec set_contract_read(Raxol.ACP.ProviderAdapter.adapter(), String.t(), String.t(), term()) :: :ok
+  def set_contract_read(%{config: %{table: table}}, contract_address, signature, return_value) do
+    [{:contract_reads, current}] = :ets.lookup(table, :contract_reads)
+    key = {String.downcase(contract_address), signature}
+    :ets.insert(table, {:contract_reads, Map.put(current, key, return_value)})
+    :ok
+  end
+
+  @doc "Seed event logs returned by `get_logs/3`."
+  @spec set_logs(Raxol.ACP.ProviderAdapter.adapter(), [map()]) :: :ok
+  def set_logs(%{config: %{table: table}}, logs) do
+    :ets.insert(table, {:logs, logs})
+    :ok
+  end
+
+  @doc "All `send_calls/3` invocations in order: `[{chain_id, calls}, ...]`."
+  @spec sent_calls(Raxol.ACP.ProviderAdapter.adapter()) :: [{pos_integer(), [map()]}]
+  def sent_calls(%{config: %{table: table}}) do
+    [{:sent_calls, list}] = :ets.lookup(table, :sent_calls)
+    Enum.reverse(list)
+  end
+
+  @doc "All signature requests, in order. Useful to assert on EIP-712 payloads."
+  @spec sent_signatures(Raxol.ACP.ProviderAdapter.adapter()) :: [tuple()]
+  def sent_signatures(%{config: %{table: table}}) do
+    [{:sent_signatures, list}] = :ets.lookup(table, :sent_signatures)
+    Enum.reverse(list)
+  end
+
+  # -- Behaviour callbacks --
+
+  @impl Raxol.ACP.ProviderAdapter
+  def send_calls(%{config: %{table: table}}, chain_id, calls) do
+    record(table, :sent_calls, {chain_id, calls})
+    hashes = Enum.map(calls, fn _ -> mint_tx_hash(table) end)
+    {:ok, hashes}
+  end
+
+  @impl Raxol.ACP.ProviderAdapter
+  def sign_message(%{config: %{table: table}}, chain_id, message) do
+    record(table, :sent_signatures, {:message, chain_id, message})
+    {:ok, <<0xDE, 0xAD>>}
+  end
+
+  @impl Raxol.ACP.ProviderAdapter
+  def sign_typed_data(%{config: %{table: table}}, chain_id, typed_data) do
+    record(table, :sent_signatures, {:typed_data, chain_id, typed_data})
+    {:ok, <<0xBE, 0xEF>>}
+  end
+
+  @impl Raxol.ACP.ProviderAdapter
+  def get_transaction_receipt(%{config: %{table: table}}, _chain_id, tx_hash) do
+    [{:receipts, r}] = :ets.lookup(table, :receipts)
+    {:ok, Map.get(r, tx_hash)}
+  end
+
+  @impl Raxol.ACP.ProviderAdapter
+  def read_contract(%{config: %{table: table}}, _chain_id, %{address: addr, signature: sig}) do
+    [{:contract_reads, r}] = :ets.lookup(table, :contract_reads)
+    key = {String.downcase(addr), sig}
+
+    case Map.fetch(r, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, {:no_canned_read, addr, sig}}
+    end
+  end
+
+  @impl Raxol.ACP.ProviderAdapter
+  def get_logs(%{config: %{table: table}}, _chain_id, _filter) do
+    [{:logs, logs}] = :ets.lookup(table, :logs)
+    {:ok, logs}
+  end
+
+  @impl Raxol.ACP.ProviderAdapter
+  def get_address(%{config: %{table: table}}) do
+    [{:address, a}] = :ets.lookup(table, :address)
+    a
+  end
+
+  @impl Raxol.ACP.ProviderAdapter
+  def supported_chain_ids(%{config: %{table: table}}) do
+    [{:supported_chain_ids, ids}] = :ets.lookup(table, :supported_chain_ids)
+    ids
+  end
+
+  # -- Internal --
+
+  defp record(table, key, entry) do
+    [{^key, list}] = :ets.lookup(table, key)
+    :ets.insert(table, {key, [entry | list]})
+  end
+
+  defp mint_tx_hash(table) do
+    [{:tx_counter, n}] = :ets.lookup(table, :tx_counter)
+    :ets.insert(table, {:tx_counter, n + 1})
+    "0x" <> String.pad_leading(Integer.to_string(n + 1, 16), 64, "0")
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/hook_client_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/hook_client_test.exs
@@ -1,0 +1,134 @@
+defmodule Raxol.ACP.HookClientTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.{ABI, HookClient, ProviderAdapter}
+  alias Raxol.ACP.ProviderAdapter.Mock
+
+  @core "0x238E541BfefD82238730D00a2208E5497F1832E0"
+  @bytes32_a Base.decode16!(String.duplicate("a", 64), case: :mixed)
+  @bytes32_hex "0x" <> String.duplicate("ab", 32)
+
+  setup do
+    {:ok, adapter: Mock.new(address: "0xfeed", supported_chain_ids: [8453])}
+  end
+
+  describe "set_budget/6" do
+    test "encodes setBudget(jobId, amount, data) and submits via ProviderAdapter", %{adapter: a} do
+      assert {:ok, tx} = HookClient.set_budget(a, 8453, @core, 42, 1_000_000)
+      assert String.starts_with?(tx, "0x")
+
+      assert [{8453, [call]}] = Mock.sent_calls(a)
+      assert call.to == @core
+      assert call.value == 0
+
+      expected_selector = ABI.function_selector("setBudget(uint256,uint256,bytes)")
+      assert <<^expected_selector::binary-size(4), _rest::binary>> = call.data
+    end
+
+    test "passes the optional bytes data through verbatim", %{adapter: a} do
+      data = <<0xCA, 0xFE, 0xBA, 0xBE>>
+      assert {:ok, _} = HookClient.set_budget(a, 8453, @core, 1, 100, data)
+
+      [{8453, [call]}] = Mock.sent_calls(a)
+      # The dynamic `bytes` argument is at the end of the calldata; the last
+      # 32 bytes carry the length, and the following bytes carry the data
+      # (zero-padded to a 32-byte boundary).
+      <<_::binary-size(4), _head::binary-size(96), 4::unsigned-big-256, payload::binary>> =
+        call.data
+
+      assert binary_part(payload, 0, 4) == data
+    end
+  end
+
+  describe "fund/6" do
+    test "encodes fund(jobId, amount, data)", %{adapter: a} do
+      assert {:ok, _} = HookClient.fund(a, 8453, @core, 7, 500_000)
+
+      [{8453, [call]}] = Mock.sent_calls(a)
+      expected_selector = ABI.function_selector("fund(uint256,uint256,bytes)")
+      assert <<^expected_selector::binary-size(4), _rest::binary>> = call.data
+    end
+  end
+
+  describe "submit/6" do
+    test "accepts raw 32-byte deliverable hash", %{adapter: a} do
+      assert {:ok, _} = HookClient.submit(a, 8453, @core, 9, @bytes32_a)
+
+      [{8453, [call]}] = Mock.sent_calls(a)
+      expected_selector = ABI.function_selector("submit(uint256,bytes32,bytes)")
+      assert <<^expected_selector::binary-size(4), _rest::binary>> = call.data
+    end
+
+    test "accepts 0x-prefixed hex deliverable hash", %{adapter: a} do
+      assert {:ok, _} = HookClient.submit(a, 8453, @core, 9, @bytes32_hex)
+    end
+
+    test "rejects malformed bytes32", %{adapter: a} do
+      assert_raise ArgumentError, ~r/bytes32/, fn ->
+        HookClient.submit(a, 8453, @core, 9, "0xshort")
+      end
+    end
+  end
+
+  describe "complete/6 + reject/6" do
+    test "complete uses complete(uint256,bytes32,bytes) selector", %{adapter: a} do
+      assert {:ok, _} = HookClient.complete(a, 8453, @core, 1, @bytes32_a)
+
+      [{8453, [call]}] = Mock.sent_calls(a)
+      expected_selector = ABI.function_selector("complete(uint256,bytes32,bytes)")
+      assert <<^expected_selector::binary-size(4), _rest::binary>> = call.data
+    end
+
+    test "reject uses reject(uint256,bytes32,bytes) selector", %{adapter: a} do
+      assert {:ok, _} = HookClient.reject(a, 8453, @core, 1, @bytes32_a)
+
+      [{8453, [call]}] = Mock.sent_calls(a)
+      expected_selector = ABI.function_selector("reject(uint256,bytes32,bytes)")
+      assert <<^expected_selector::binary-size(4), _rest::binary>> = call.data
+    end
+  end
+
+  describe "create_job/4" do
+    test "encodes createJob(address,address,uint256,address,bytes)", %{adapter: a} do
+      params = %{
+        provider: "0x" <> String.duplicate("ab", 20),
+        evaluator: "0x" <> String.duplicate("cd", 20),
+        expired_at: 1_900_000_000,
+        hook_address: "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B",
+        hook_data: <<>>
+      }
+
+      assert {:ok, _tx} = HookClient.create_job(a, 8453, @core, params)
+
+      [{8453, [call]}] = Mock.sent_calls(a)
+      assert call.to == @core
+
+      expected_selector =
+        ABI.function_selector("createJob(address,address,uint256,address,bytes)")
+
+      assert <<^expected_selector::binary-size(4), _rest::binary>> = call.data
+    end
+  end
+
+  describe "error propagation" do
+    defmodule FailingAdapter do
+      @behaviour Raxol.ACP.ProviderAdapter
+      def send_calls(_, _, _), do: {:error, :network_down}
+      def sign_message(_, _, _), do: {:error, :nope}
+      def sign_typed_data(_, _, _), do: {:error, :nope}
+      def get_transaction_receipt(_, _, _), do: {:ok, nil}
+      def read_contract(_, _, _), do: {:error, :nope}
+      def get_logs(_, _, _), do: {:ok, []}
+      def get_address(_), do: "0x0"
+      def supported_chain_ids(_), do: []
+    end
+
+    test "propagates errors from the underlying adapter" do
+      bad_adapter = %{adapter: FailingAdapter, config: %{}}
+
+      assert {:error, :network_down} = HookClient.set_budget(bad_adapter, 8453, @core, 1, 100)
+      assert {:error, :network_down} = HookClient.fund(bad_adapter, 8453, @core, 1, 100)
+      assert {:error, :network_down} = HookClient.submit(bad_adapter, 8453, @core, 1, @bytes32_a)
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/provider_adapter/mock_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/provider_adapter/mock_test.exs
@@ -1,0 +1,123 @@
+defmodule Raxol.ACP.ProviderAdapter.MockTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.ProviderAdapter
+  alias Raxol.ACP.ProviderAdapter.Mock
+
+  describe "identity / config" do
+    test "get_address/1 returns the seeded address" do
+      adapter = Mock.new(address: "0xfeed")
+      assert ProviderAdapter.get_address(adapter) == "0xfeed"
+    end
+
+    test "supported_chain_ids/1 returns the seeded list" do
+      adapter = Mock.new(supported_chain_ids: [8453, 84_532])
+      assert ProviderAdapter.supported_chain_ids(adapter) == [8453, 84_532]
+    end
+
+    test "defaults are reasonable" do
+      adapter = Mock.new()
+      assert is_binary(ProviderAdapter.get_address(adapter))
+      assert [8453] == ProviderAdapter.supported_chain_ids(adapter)
+    end
+  end
+
+  describe "send_calls/3" do
+    test "records the call and returns one tx hash per call" do
+      adapter = Mock.new()
+
+      call_a = %{to: "0xabc", data: <<1, 2, 3>>, value: 0}
+      call_b = %{to: "0xdef", data: <<4, 5, 6>>, value: 0}
+
+      assert {:ok, [hash1, hash2]} = ProviderAdapter.send_calls(adapter, 8453, [call_a, call_b])
+      assert hash1 != hash2
+      assert String.starts_with?(hash1, "0x")
+      assert byte_size(hash1) == 66
+
+      assert [{8453, [^call_a, ^call_b]}] = Mock.sent_calls(adapter)
+    end
+
+    test "monotonic tx hashes across multiple calls" do
+      adapter = Mock.new()
+
+      {:ok, [h1]} = ProviderAdapter.send_calls(adapter, 8453, [%{to: "0x1", data: <<>>}])
+      {:ok, [h2]} = ProviderAdapter.send_calls(adapter, 8453, [%{to: "0x2", data: <<>>}])
+
+      assert h1 != h2
+    end
+  end
+
+  describe "signing" do
+    test "sign_message/3 records the request and returns a placeholder sig" do
+      adapter = Mock.new()
+
+      assert {:ok, <<0xDE, 0xAD>>} = ProviderAdapter.sign_message(adapter, 8453, "hello")
+      assert [{:message, 8453, "hello"}] = Mock.sent_signatures(adapter)
+    end
+
+    test "sign_typed_data/3 records the typed payload" do
+      adapter = Mock.new()
+      typed = %{domain: %{name: "X"}, types: %{}, message: %{}}
+
+      assert {:ok, <<0xBE, 0xEF>>} = ProviderAdapter.sign_typed_data(adapter, 8453, typed)
+      assert [{:typed_data, 8453, ^typed}] = Mock.sent_signatures(adapter)
+    end
+  end
+
+  describe "get_transaction_receipt/3" do
+    test "returns the seeded receipt; nil for unknown hash" do
+      adapter = Mock.new()
+      Mock.set_receipt(adapter, "0xab", %{status: 1, gas_used: 21_000})
+
+      assert {:ok, %{status: 1}} = ProviderAdapter.get_transaction_receipt(adapter, 8453, "0xab")
+      assert {:ok, nil} = ProviderAdapter.get_transaction_receipt(adapter, 8453, "0xmissing")
+    end
+  end
+
+  describe "read_contract/3" do
+    test "returns the seeded value" do
+      adapter = Mock.new()
+      Mock.set_contract_read(adapter, "0xABC", "name()", "USD Coin")
+
+      assert {:ok, "USD Coin"} =
+               ProviderAdapter.read_contract(adapter, 8453, %{
+                 address: "0xabc",
+                 signature: "name()",
+                 args: []
+               })
+    end
+
+    test "errors when no value was seeded" do
+      adapter = Mock.new()
+
+      assert {:error, {:no_canned_read, _, _}} =
+               ProviderAdapter.read_contract(adapter, 8453, %{
+                 address: "0xabc",
+                 signature: "missing()",
+                 args: []
+               })
+    end
+
+    test "address lookup is case-insensitive" do
+      adapter = Mock.new()
+      Mock.set_contract_read(adapter, "0xABCDEF", "x()", 1)
+
+      assert {:ok, 1} =
+               ProviderAdapter.read_contract(adapter, 8453, %{
+                 address: "0xabcdef",
+                 signature: "x()",
+                 args: []
+               })
+    end
+  end
+
+  describe "get_logs/3" do
+    test "returns the seeded logs" do
+      adapter = Mock.new()
+      Mock.set_logs(adapter, [%{topics: [<<0xAA>>]}, %{topics: [<<0xBB>>]}])
+
+      assert {:ok, [%{topics: [<<0xAA>>]}, %{topics: [<<0xBB>>]}]} =
+               ProviderAdapter.get_logs(adapter, 8453, %{})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The on-chain side of the v2 stack. Mirrors acp-node-v2's split between the low-level EVM \`IEvmProviderAdapter\` and the higher-level ACP Core hook calls.

Stacks on #269 (acpv2-agent). Part D of the v2 launch plan.

## New modules

**\`Raxol.ACP.ProviderAdapter\`** (behaviour) -- low-level EVM operations matching the acp-node-v2 interface:
- \`send_calls/3\` -- submit a batch of transactions
- \`sign_message/3\` -- personal_sign / EIP-191
- \`sign_typed_data/3\` -- EIP-712
- \`get_transaction_receipt/3\`
- \`read_contract/3\`
- \`get_logs/3\`
- \`get_address/1\`, \`supported_chain_ids/1\`

**\`Raxol.ACP.ProviderAdapter.Mock\`** -- in-process implementation. Records every call; lets tests pre-can receipts (\`set_receipt/3\`), contract reads (\`set_contract_read/4\`), and logs (\`set_logs/2\`); auto-mints monotonic tx hashes. Lives in \`lib/\` rather than \`test/support\` so other tests can compose against it.

**\`Raxol.ACP.HookClient\`** -- high-level wrapper for the ACP Core hook calls. Selectors verified against [acp-node-v2 constants.ts](https://github.com/Virtual-Protocol/acp-node-v2/blob/main/src/core/constants.ts):

| Function | Signature |
|---|---|
| \`create_job/4\` | \`createJob(address,address,uint256,address,bytes)\` |
| \`set_budget/6\` | \`setBudget(uint256,uint256,bytes)\` |
| \`fund/6\` | \`fund(uint256,uint256,bytes)\` |
| \`submit/6\` | \`submit(uint256,bytes32,bytes)\` |
| \`complete/6\` | \`complete(uint256,bytes32,bytes)\` |
| \`reject/6\` | \`reject(uint256,bytes32,bytes)\` |

The trailing \`bytes data\` argument passes through verbatim so offering-specific hooks (FundTransferHook's \`transferAmount+destination\`, SubscriptionHook's \`packageId\`) work without HookClient needing to know about them. Reuses the existing \`Raxol.ACP.ABI\` encoder.

## What's deferred

- **JobSession integration** -- the cleanest seam is a separate concern; JobSession stays pure in this PR. A follow-up adds optional \`:provider\` config that drives HookClient on transitions.
- **Real SCA-backed adapter** -- \`ProviderAdapter.SCA\` builds on \`Raxol.ACP.Wallet.SCA\` (post-#266). Lands in a follow-up so this PR can be reviewed in isolation.

## Manual testing

- [x] \`mix test test/raxol/acp/provider_adapter/ test/raxol/acp/hook_client_test.exs\` -- 22 tests, 0 failures
- [x] \`mix test\` (full suite) -- 482 tests, 0 failures, 5 excluded