### PR TITLE
raxol_acp v2: FundTransferHook + Xochi SolverAgent runtime

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/abi.ex
+++ b/packages/raxol_acp/lib/raxol/acp/abi.ex
@@ -56,6 +56,19 @@ defmodule Raxol.ACP.ABI do
     function_selector(signature) <> encode_args(args)
   end
 
+  @doc """
+  ABI-encode argument tuples without a leading function selector.
+
+  Useful for encoding the trailing `bytes data` parameter of ACP hook
+  calls (e.g. `FundTransferHook` uses
+  `abi.encode(uint256 transferAmount, address destination)` as its
+  `setBudget` data).
+
+  Accepts the same `[{type, value}]` shape as `encode_call/2`.
+  """
+  @spec encode_args([{String.t(), term()}]) :: binary()
+  def encode_args(args) when is_list(args), do: do_encode_args(args)
+
   # -- Internal --
 
   # Solidity ABI head/tail encoding:
@@ -63,7 +76,7 @@ defmodule Raxol.ACP.ABI do
   #     offset placeholders for dynamic types)
   #   for each arg: emit a static word into head OR an offset word that
   #     points into the tail; dynamic payloads are appended to tail.
-  defp encode_args(args) do
+  defp do_encode_args(args) do
     head_size = length(args) * @word_size
 
     {heads, tails, _final_offset} =

--- a/packages/raxol_acp/lib/raxol/acp/hooks/fund_transfer.ex
+++ b/packages/raxol_acp/lib/raxol/acp/hooks/fund_transfer.ex
@@ -1,0 +1,74 @@
+defmodule Raxol.ACP.Hooks.FundTransfer do
+  @moduledoc """
+  Encoders / decoders for the `bytes data` parameter on ACP v2's
+  `FundTransferHook`.
+
+  The FundTransferHook intercepts ACP Core lifecycle calls
+  (`setBudget`, `fund`, etc.) and routes a portion of the escrowed
+  funds to a buyer-specified destination on completion. For the data
+  bytes that travel through `setBudget(jobId, amount, data)`:
+
+      abi.encode(uint256 transferAmount, address destination)
+
+  - `transferAmount` is the fraction of the escrow the buyer wants
+    delivered to `destination`. The remainder is the provider's
+    service fee.
+  - `destination` is the recipient EOA / contract that should receive
+    `transferAmount` on completion.
+
+  The `data` arg on `fund` is currently unused for the basic
+  FundTransfer flow (the hook reads its config from the prior
+  `setBudget`). We encode it as `<<>>` and accept anything that's the
+  empty binary on decode.
+
+  Verified shape against
+  https://github.com/Virtual-Protocol/acp-node-v2/blob/main/src/core/fundTransferHookAbi.ts
+  """
+
+  alias Raxol.ACP.ABI
+
+  @type transfer_amount :: non_neg_integer()
+  @type address :: String.t()
+
+  @doc """
+  Encode the `bytes data` for `setBudget` against the FundTransferHook.
+
+      abi.encode(uint256 transferAmount, address destination)
+  """
+  @spec encode_set_budget_data(transfer_amount(), address()) :: binary()
+  def encode_set_budget_data(transfer_amount, destination)
+      when is_integer(transfer_amount) and transfer_amount >= 0 and is_binary(destination) do
+    # Both args are static -- no offset prefix, just two 32-byte slots.
+    ABI.encode_args([
+      {"uint256", transfer_amount},
+      {"address", destination}
+    ])
+  end
+
+  @doc """
+  Decode previously-encoded `setBudget` data. Returns
+  `{:ok, %{transfer_amount, destination}}` or `{:error, reason}`.
+  """
+  @spec decode_set_budget_data(binary()) ::
+          {:ok, %{transfer_amount: transfer_amount(), destination: address()}} | {:error, term()}
+  def decode_set_budget_data(<<transfer_amount::unsigned-big-256, addr_word::binary-size(32)>>) do
+    # address is right-aligned in the 32-byte word
+    <<_padding::binary-size(12), addr_bytes::binary-size(20)>> = addr_word
+    {:ok, %{transfer_amount: transfer_amount, destination: "0x" <> Base.encode16(addr_bytes, case: :lower)}}
+  end
+
+  def decode_set_budget_data(other) do
+    {:error, {:invalid_set_budget_data, byte_size(other)}}
+  end
+
+  @doc "Encode the `bytes data` for `fund`. Empty for the basic flow."
+  @spec encode_fund_data() :: binary()
+  def encode_fund_data, do: <<>>
+
+  @doc """
+  Encode the `bytes data` for `submit`. Reserved for future use; for
+  now the deliverable is the bytes32 hash arg, and `data` is empty.
+  """
+  @spec encode_submit_data() :: binary()
+  def encode_submit_data, do: <<>>
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
@@ -1,0 +1,463 @@
+defmodule Raxol.ACP.Xochi.SolverAgent do
+  @moduledoc """
+  Runtime that drives a Xochi cross-chain transfer ACP job from
+  acceptance through settlement.
+
+  Subscribes to a `Raxol.ACP.Agent`, filters for v2 FundTransfer jobs
+  whose `provider` is this solver's wallet address, and runs the
+  lifecycle:
+
+  1. **`job.created`** -- record the job, wait for the buyer's
+     requirement message.
+  2. **`message` (contentType "requirement")** -- parse the
+     requirement JSON against
+     `Raxol.ACP.Xochi.Offering.requirement_schema/0`, compute the
+     service fee (default 50 bps via `:fee_bps`), and propose the
+     budget on-chain by calling
+     `Raxol.ACP.HookClient.set_budget/6` with FundTransfer hook
+     data (transferAmount, destination).
+  3. **`budget.set`** (echoed back via SSE) -- no-op for the solver;
+     just observe.
+  4. **`job.funded`** -- run `settle_fn` (default:
+     `Raxol.Payments.Protocols.Xochi.transfer/4`) and on success
+     submit the deliverable on-chain.
+  5. **`job.completed`** -- escrow released. Cleanup local state.
+
+  ## Configuration
+
+      Raxol.ACP.Xochi.SolverAgent.start_link(
+        agent: my_acp_agent,
+        provider: my_provider_adapter,
+        wallet_address: "0xfeed...",
+        evaluator_address: "0xevaluator...",
+        chain_id: 8453,
+        acp_core_address: "0x238E541BfefD82238730D00a2208E5497F1832E0",
+        fund_transfer_hook_address: "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B",
+        fee_bps: 50,
+        settle_fn: &Raxol.Payments.Protocols.Xochi.transfer/4,
+        xochi_config: %{base_url: "...", auth_token: "..."},
+        xochi_wallet: MySigner
+      )
+
+  ## Sessions
+
+  One internal `session_state()` per active job. Stored in process
+  state keyed by `{chain_id, job_id}`. State machine:
+
+      :awaiting_requirement -> :budget_proposed -> :awaiting_fund
+        -> :settling -> :submitted -> :completed
+
+  ## Telemetry
+
+  Emits `[:raxol, :acp, :xochi, :solver, :event]` on every entry it
+  acts on, with metadata `%{chain_id, job_id, event, action}`.
+  """
+
+  use GenServer
+
+  alias Raxol.ACP.{Agent, HookClient}
+  alias Raxol.ACP.Hooks.FundTransfer
+  alias Raxol.ACP.Xochi.Offering
+
+  @type session_status ::
+          :awaiting_requirement
+          | :budget_proposed
+          | :awaiting_fund
+          | :settling
+          | :submitted
+          | :completed
+          | :rejected
+          | :failed
+
+  @type session_state :: %{
+          required(:job_id) => String.t() | non_neg_integer(),
+          required(:chain_id) => pos_integer(),
+          required(:status) => session_status(),
+          required(:job_id_uint) => non_neg_integer(),
+          optional(:requirement) => map(),
+          optional(:budget_atomic) => non_neg_integer(),
+          optional(:transfer_amount_atomic) => non_neg_integer(),
+          optional(:destination) => String.t(),
+          optional(:deliverable) => map(),
+          optional(:settle_tx_hashes) => map()
+        }
+
+  @type t :: %__MODULE__{
+          agent: pid() | atom(),
+          provider: Raxol.ACP.ProviderAdapter.adapter(),
+          wallet_address: String.t(),
+          evaluator_address: String.t(),
+          chain_id: pos_integer(),
+          acp_core_address: String.t(),
+          fund_transfer_hook_address: String.t(),
+          fee_bps: non_neg_integer(),
+          settle_fn: fun(),
+          xochi_config: map(),
+          xochi_wallet: module() | nil,
+          sessions: %{Raxol.ACP.Transport.job_key() => session_state()}
+        }
+
+  defstruct [
+    :agent,
+    :provider,
+    :wallet_address,
+    :evaluator_address,
+    :chain_id,
+    :acp_core_address,
+    :fund_transfer_hook_address,
+    :xochi_config,
+    :xochi_wallet,
+    settle_fn: nil,
+    fee_bps: 50,
+    sessions: %{}
+  ]
+
+  # -- Public API --
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.get(opts, :name)
+
+    if name do
+      GenServer.start_link(__MODULE__, opts, name: name)
+    else
+      GenServer.start_link(__MODULE__, opts)
+    end
+  end
+
+  @doc "Return the current per-session state map."
+  @spec sessions(GenServer.server()) :: map()
+  def sessions(server), do: GenServer.call(server, :sessions)
+
+  @doc "Return the state for a specific `{chain_id, job_id}` key, or nil."
+  @spec session(GenServer.server(), Raxol.ACP.Transport.job_key()) ::
+          session_state() | nil
+  def session(server, key), do: GenServer.call(server, {:session, key})
+
+  # -- GenServer callbacks --
+
+  @impl GenServer
+  def init(opts) do
+    state = %__MODULE__{
+      agent: Keyword.fetch!(opts, :agent),
+      provider: Keyword.fetch!(opts, :provider),
+      wallet_address: normalize_address(Keyword.fetch!(opts, :wallet_address)),
+      evaluator_address: Keyword.fetch!(opts, :evaluator_address),
+      chain_id: Keyword.fetch!(opts, :chain_id),
+      acp_core_address: Keyword.fetch!(opts, :acp_core_address),
+      fund_transfer_hook_address: Keyword.fetch!(opts, :fund_transfer_hook_address),
+      fee_bps: Keyword.get(opts, :fee_bps, 50),
+      settle_fn: Keyword.get(opts, :settle_fn, &default_settle/1),
+      xochi_config: Keyword.get(opts, :xochi_config, %{}),
+      xochi_wallet: Keyword.get(opts, :xochi_wallet)
+    }
+
+    :ok = Agent.subscribe(state.agent)
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:sessions, _from, state), do: {:reply, state.sessions, state}
+
+  def handle_call({:session, key}, _from, state) do
+    {:reply, Map.get(state.sessions, key), state}
+  end
+
+  @impl GenServer
+  def handle_info({Raxol.ACP.Agent, _agent_pid, session_pid, entry}, state) do
+    {:noreply, dispatch(entry, session_pid, state)}
+  end
+
+  # Ignore anything we don't recognise.
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- Dispatch --
+
+  defp dispatch(%{"kind" => "system", "event" => "job.created"} = entry, _session, state) do
+    handle_job_created(entry, state)
+  end
+
+  defp dispatch(%{"kind" => "system", "event" => "job.funded"} = entry, _session, state) do
+    handle_job_funded(entry, state)
+  end
+
+  defp dispatch(
+         %{"kind" => "system", "event" => "job.completed"} = entry,
+         _session,
+         state
+       ) do
+    handle_job_completed(entry, state)
+  end
+
+  defp dispatch(
+         %{"kind" => "system", "event" => "job.rejected"} = entry,
+         _session,
+         state
+       ) do
+    finalize(entry, :rejected, state)
+  end
+
+  defp dispatch(
+         %{"kind" => "system", "event" => "job.expired"} = entry,
+         _session,
+         state
+       ) do
+    finalize(entry, :failed, state)
+  end
+
+  defp dispatch(%{"kind" => "message", "contentType" => "requirement"} = entry, _session, state) do
+    handle_requirement(entry, state)
+  end
+
+  defp dispatch(_entry, _session, state), do: state
+
+  # -- Handlers --
+
+  defp handle_job_created(entry, state) do
+    key = job_key(entry)
+    job_id_uint = parse_job_id(entry["jobId"])
+
+    # Filter: only act on jobs where we're the provider.
+    if interested?(entry, state) do
+      session = %{
+        job_id: entry["jobId"],
+        chain_id: entry["chainId"],
+        job_id_uint: job_id_uint,
+        status: :awaiting_requirement
+      }
+
+      emit(state, key, :job_created, :await_requirement)
+      put_session(state, key, session)
+    else
+      state
+    end
+  end
+
+  defp handle_requirement(entry, state) do
+    key = job_key(entry)
+
+    case Map.fetch(state.sessions, key) do
+      {:ok, %{status: :awaiting_requirement} = session} ->
+        case decode_requirement(entry["content"]) do
+          {:ok, req} ->
+            propose_budget(state, key, session, req)
+
+          {:error, reason} ->
+            emit(state, key, :requirement_error, reason)
+            put_session(state, key, %{session | status: :failed})
+        end
+
+      _ ->
+        state
+    end
+  end
+
+  defp handle_job_funded(_entry, state) do
+    # Find a session in :budget_proposed or :awaiting_fund and settle.
+    Enum.reduce(state.sessions, state, fn
+      {key, %{status: status} = s}, acc
+      when status in [:budget_proposed, :awaiting_fund] ->
+        settle(acc, key, s)
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp handle_job_completed(entry, state) do
+    key = job_key(entry)
+
+    case Map.fetch(state.sessions, key) do
+      {:ok, session} ->
+        emit(state, key, :job_completed, :ok)
+        put_session(state, key, %{session | status: :completed})
+
+      :error ->
+        state
+    end
+  end
+
+  defp finalize(entry, status, state) do
+    key = job_key(entry)
+
+    case Map.fetch(state.sessions, key) do
+      {:ok, session} ->
+        emit(state, key, status, :ok)
+        put_session(state, key, %{session | status: status})
+
+      :error ->
+        state
+    end
+  end
+
+  # -- Budget proposal --
+
+  defp propose_budget(state, key, session, requirement) do
+    transfer_atomic = String.to_integer(requirement["amount_atomic"])
+    budget_atomic = max(div(transfer_atomic * state.fee_bps, 10_000), 1)
+    destination = requirement["destination"]
+
+    hook_data = FundTransfer.encode_set_budget_data(transfer_atomic, destination)
+
+    case HookClient.set_budget(
+           state.provider,
+           state.chain_id,
+           state.acp_core_address,
+           session.job_id_uint,
+           budget_atomic,
+           hook_data
+         ) do
+      {:ok, tx_hash} ->
+        emit(state, key, :budget_proposed, %{tx_hash: tx_hash, budget_atomic: budget_atomic})
+
+        updated = %{
+          session
+          | status: :budget_proposed
+        }
+
+        updated =
+          updated
+          |> Map.put(:requirement, requirement)
+          |> Map.put(:budget_atomic, budget_atomic)
+          |> Map.put(:transfer_amount_atomic, transfer_atomic)
+          |> Map.put(:destination, destination)
+
+        put_session(state, key, updated)
+
+      {:error, reason} ->
+        emit(state, key, :budget_error, reason)
+        put_session(state, key, %{session | status: :failed})
+    end
+  end
+
+  # -- Settlement --
+
+  defp settle(state, key, session) do
+    session = %{session | status: :settling}
+    state = put_session(state, key, session)
+    emit(state, key, :settling, :start)
+
+    case state.settle_fn.(%{
+           requirement: session.requirement,
+           transfer_amount_atomic: session.transfer_amount_atomic,
+           destination: session.destination,
+           xochi_config: state.xochi_config,
+           xochi_wallet: state.xochi_wallet
+         }) do
+      {:ok, %{intent_id: intent_id} = deliverable} ->
+        submit_deliverable(state, key, session, deliverable, intent_id)
+
+      {:error, reason} ->
+        emit(state, key, :settle_error, reason)
+        put_session(state, key, %{session | status: :failed})
+    end
+  end
+
+  defp submit_deliverable(state, key, session, deliverable, intent_id) do
+    deliverable_hash = compute_deliverable_hash(deliverable)
+
+    case HookClient.submit(
+           state.provider,
+           state.chain_id,
+           state.acp_core_address,
+           session.job_id_uint,
+           deliverable_hash
+         ) do
+      {:ok, tx_hash} ->
+        emit(state, key, :submitted, %{tx_hash: tx_hash, intent_id: intent_id})
+
+        session =
+          session
+          |> Map.put(:status, :submitted)
+          |> Map.put(:deliverable, deliverable)
+          |> Map.put(:settle_tx_hashes, %{
+            submit: tx_hash,
+            intent_id: intent_id
+          })
+
+        put_session(state, key, session)
+
+      {:error, reason} ->
+        emit(state, key, :submit_error, reason)
+        put_session(state, key, %{session | status: :failed})
+    end
+  end
+
+  # -- Default settle (test-only) --
+
+  # In production, callers pass &Raxol.Payments.Protocols.Xochi.transfer/4
+  # via :settle_fn. The default below produces a deterministic stub so
+  # the SolverAgent can be exercised in tests without a live Xochi server.
+  defp default_settle(%{requirement: req, transfer_amount_atomic: _}) do
+    {:ok,
+     %{
+       intent_id: "stub-intent-" <> :erlang.unique_integer([:positive]) |> to_string(),
+       quote_id: "stub-quote",
+       src_tx_hash: "0x" <> String.duplicate("a", 64),
+       dst_tx_hash: "0x" <> String.duplicate("b", 64),
+       status: "settled",
+       fee_atomic: "0",
+       dst_amount_atomic: req["amount_atomic"]
+     }}
+  end
+
+  # -- Helpers --
+
+  defp interested?(entry, state) do
+    job_provider =
+      entry["provider"] ||
+        get_in(entry, ["payload", "provider"]) ||
+        get_in(entry, ["data", "provider"])
+
+    case job_provider do
+      nil -> false
+      addr -> normalize_address(addr) == state.wallet_address
+    end
+  end
+
+  defp decode_requirement(content) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, req} when is_map(req) ->
+        if Offering.valid_requirement?(req), do: {:ok, req}, else: {:error, :invalid_requirement}
+
+      _ ->
+        {:error, :requirement_not_json}
+    end
+  end
+
+  defp decode_requirement(_), do: {:error, :requirement_missing}
+
+  defp parse_job_id(id) when is_integer(id), do: id
+
+  defp parse_job_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {n, _} -> n
+      :error -> :erlang.phash2(id)
+    end
+  end
+
+  defp job_key(entry) do
+    {entry["chainId"], entry["jobId"]}
+  end
+
+  defp compute_deliverable_hash(deliverable) do
+    deliverable
+    |> Jason.encode!()
+    |> ExKeccak.hash_256()
+  end
+
+  defp put_session(state, key, session) do
+    %{state | sessions: Map.put(state.sessions, key, session)}
+  end
+
+  defp normalize_address(addr) when is_binary(addr), do: String.downcase(addr)
+
+  defp emit(_state, key, event, payload) do
+    :telemetry.execute(
+      [:raxol, :acp, :xochi, :solver, :event],
+      %{},
+      %{key: key, event: event, payload: payload}
+    )
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/hooks/fund_transfer_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/hooks/fund_transfer_test.exs
@@ -1,0 +1,55 @@
+defmodule Raxol.ACP.Hooks.FundTransferTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Hooks.FundTransfer
+
+  describe "encode_set_budget_data/2" do
+    test "encodes transfer_amount + destination as two 32-byte words" do
+      destination = "0x" <> String.duplicate("ab", 20)
+
+      data = FundTransfer.encode_set_budget_data(1_000_000, destination)
+
+      assert byte_size(data) == 64
+
+      <<amount::unsigned-big-256, addr_word::binary-size(32)>> = data
+      assert amount == 1_000_000
+
+      <<_padding::binary-size(12), addr_bytes::binary-size(20)>> = addr_word
+      assert "0x" <> Base.encode16(addr_bytes, case: :lower) == destination
+    end
+
+    test "round-trips through decode_set_budget_data/1" do
+      destination = "0x" <> String.duplicate("cd", 20)
+
+      data = FundTransfer.encode_set_budget_data(5_000_000, destination)
+
+      assert {:ok, %{transfer_amount: 5_000_000, destination: ^destination}} =
+               FundTransfer.decode_set_budget_data(data)
+    end
+
+    test "zero transfer_amount is valid" do
+      data = FundTransfer.encode_set_budget_data(0, "0x" <> String.duplicate("ab", 20))
+      assert byte_size(data) == 64
+    end
+  end
+
+  describe "decode_set_budget_data/1" do
+    test "rejects data of the wrong length" do
+      assert {:error, {:invalid_set_budget_data, 1}} = FundTransfer.decode_set_budget_data(<<1>>)
+      # 63 bytes (off by one)
+      assert {:error, {:invalid_set_budget_data, 63}} =
+               FundTransfer.decode_set_budget_data(<<0::unsigned-big-504>>)
+
+      # 65 bytes (one byte too many)
+      assert {:error, {:invalid_set_budget_data, 65}} =
+               FundTransfer.decode_set_budget_data(<<0::unsigned-big-520>>)
+    end
+  end
+
+  describe "encode_fund_data/0 + encode_submit_data/0" do
+    test "both return empty bytes for the basic FundTransfer flow" do
+      assert FundTransfer.encode_fund_data() == <<>>
+      assert FundTransfer.encode_submit_data() == <<>>
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
@@ -1,0 +1,283 @@
+defmodule Raxol.ACP.Xochi.SolverAgentTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{Agent, ProviderAdapter, Transport, JobApi, JobSession}
+  alias Raxol.ACP.Xochi.SolverAgent
+  alias Raxol.ACP.Hooks.FundTransfer
+
+  @solver_wallet "0xfeedfacefeedfacefeedfacefeedfacefeedface"
+  @evaluator "0x" <> String.duplicate("ed", 20)
+  @acp_core "0x238E541BfefD82238730D00a2208E5497F1832E0"
+  @fund_transfer_hook "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B"
+
+  setup do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(JobSession.Supervisor),
+        is_pid(pid) do
+      DynamicSupervisor.terminate_child(JobSession.Supervisor, pid)
+    end
+
+    transport = Transport.Mock.new()
+    job_api = JobApi.Mock.new(me: %{wallet_address: @solver_wallet, name: "Xochi"})
+
+    provider =
+      ProviderAdapter.Mock.new(address: @solver_wallet, supported_chain_ids: [8453])
+
+    {:ok, agent} =
+      Agent.start_link(
+        transport: transport,
+        api: job_api,
+        wallet_address: @solver_wallet,
+        supported_chain_ids: [8453],
+        default_role: :provider
+      )
+
+    {:ok,
+     transport: transport,
+     api: job_api,
+     provider: provider,
+     agent: agent}
+  end
+
+  defp start_solver(opts, ctx) do
+    SolverAgent.start_link(
+      Keyword.merge(
+        [
+          agent: ctx.agent,
+          provider: ctx.provider,
+          wallet_address: @solver_wallet,
+          evaluator_address: @evaluator,
+          chain_id: 8453,
+          acp_core_address: @acp_core,
+          fund_transfer_hook_address: @fund_transfer_hook
+        ],
+        opts
+      )
+    )
+  end
+
+  defp job_created_entry(opts \\ []) do
+    %{
+      "kind" => "system",
+      "event" => "job.created",
+      "chainId" => 8453,
+      "jobId" => Keyword.get(opts, :job_id, "42"),
+      "provider" => Keyword.get(opts, :provider, @solver_wallet)
+    }
+  end
+
+  defp requirement_message(opts \\ []) do
+    req =
+      Keyword.get(opts, :requirement, %{
+        "src_chain_id" => 8453,
+        "dst_chain_id" => 10,
+        "src_token" => "0x" <> String.duplicate("11", 20),
+        "dst_token" => "0x" <> String.duplicate("22", 20),
+        "amount_atomic" => "1000000",
+        "destination" => "0x" <> String.duplicate("ab", 20),
+        "slippage_bps" => 50
+      })
+
+    %{
+      "kind" => "message",
+      "contentType" => "requirement",
+      "chainId" => 8453,
+      "jobId" => Keyword.get(opts, :job_id, "42"),
+      "content" => Jason.encode!(req)
+    }
+  end
+
+  describe "job acceptance filtering" do
+    test "ignores jobs whose provider is someone else", ctx do
+      {:ok, solver} = start_solver([], ctx)
+
+      Agent.start_stream(ctx.agent)
+      Transport.Mock.deliver(ctx.transport, job_created_entry(provider: "0xother"))
+      Process.sleep(40)
+
+      assert SolverAgent.sessions(solver) == %{}
+    end
+
+    test "accepts jobs targeting our wallet address", ctx do
+      {:ok, solver} = start_solver([], ctx)
+
+      Agent.start_stream(ctx.agent)
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Process.sleep(40)
+
+      assert %{{8453, "42"} => %{status: :awaiting_requirement}} = SolverAgent.sessions(solver)
+    end
+
+    test "case-insensitive on the provider address", ctx do
+      {:ok, solver} = start_solver([], ctx)
+      Agent.start_stream(ctx.agent)
+
+      upper = String.upcase(@solver_wallet)
+      Transport.Mock.deliver(ctx.transport, job_created_entry(provider: upper))
+      Process.sleep(40)
+
+      assert SolverAgent.sessions(solver) |> map_size() == 1
+    end
+  end
+
+  describe "budget proposal" do
+    test "after job_created + requirement, submits set_budget on-chain", ctx do
+      {:ok, solver} = start_solver([fee_bps: 50], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{status: :budget_proposed, budget_atomic: budget}} =
+               SolverAgent.sessions(solver)
+
+      # 0.5% of 1_000_000 = 5_000.
+      assert budget == 5_000
+
+      assert [{8453, [call]}] = ProviderAdapter.Mock.sent_calls(ctx.provider)
+      assert call.to == @acp_core
+    end
+
+    test "fee_bps clamps to a minimum of 1", ctx do
+      {:ok, solver} = start_solver([fee_bps: 0], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{budget_atomic: 1}} = SolverAgent.sessions(solver)
+    end
+
+    test "malformed requirement marks the session :failed", ctx do
+      {:ok, solver} = start_solver([], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+
+      bad =
+        %{
+          "kind" => "message",
+          "contentType" => "requirement",
+          "chainId" => 8453,
+          "jobId" => "42",
+          "content" => "not-json"
+        }
+
+      Transport.Mock.deliver(ctx.transport, bad)
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{status: :failed}} = SolverAgent.sessions(solver)
+      # No on-chain calls were made.
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+  end
+
+  describe "settle flow" do
+    test "on job.funded, runs settle_fn and submits on-chain", ctx do
+      settle_stub = fn _ ->
+        {:ok,
+         %{
+           intent_id: "xochi-1",
+           quote_id: "q-1",
+           src_tx_hash: "0x" <> String.duplicate("a", 64),
+           dst_tx_hash: "0x" <> String.duplicate("b", 64),
+           status: "settled"
+         }}
+      end
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Transport.Mock.deliver(
+        ctx.transport,
+        %{
+          "kind" => "system",
+          "event" => "job.funded",
+          "chainId" => 8453,
+          "jobId" => "42"
+        }
+      )
+      Process.sleep(80)
+
+      assert %{{8453, "42"} => session} = SolverAgent.sessions(solver)
+      assert session.status == :submitted
+      assert session.deliverable.intent_id == "xochi-1"
+
+      # Two ProviderAdapter calls: set_budget then submit.
+      assert length(ProviderAdapter.Mock.sent_calls(ctx.provider)) == 2
+    end
+
+    test "settle_fn failure marks the session :failed; no submit call", ctx do
+      settle_stub = fn _ -> {:error, :solver_offline} end
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Transport.Mock.deliver(
+        ctx.transport,
+        %{
+          "kind" => "system",
+          "event" => "job.funded",
+          "chainId" => 8453,
+          "jobId" => "42"
+        }
+      )
+      Process.sleep(80)
+
+      assert %{{8453, "42"} => %{status: :failed}} = SolverAgent.sessions(solver)
+      # Just set_budget; no submit.
+      assert length(ProviderAdapter.Mock.sent_calls(ctx.provider)) == 1
+    end
+  end
+
+  describe "completion" do
+    test "job.completed event updates session status", ctx do
+      {:ok, solver} = start_solver([], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Process.sleep(40)
+
+      Transport.Mock.deliver(
+        ctx.transport,
+        %{
+          "kind" => "system",
+          "event" => "job.completed",
+          "chainId" => 8453,
+          "jobId" => "42"
+        }
+      )
+      Process.sleep(40)
+
+      session = SolverAgent.session(solver, {8453, "42"})
+      assert session.status == :completed
+    end
+  end
+
+  describe "encode/decode consistency with FundTransfer" do
+    test "the on-chain set_budget call carries the right FundTransfer data", ctx do
+      {:ok, _solver} = start_solver([], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      [{8453, [call]}] = ProviderAdapter.Mock.sent_calls(ctx.provider)
+      # Extract the dynamic bytes payload from the calldata. setBudget has
+      # selector(4) + 3 head words(96) = 100 bytes; the bytes length lives at
+      # offset 96 (third head slot pointer was at offset 100 from start of
+      # encoded args, so 64 from start of all head + 4 selector).
+      # Easier: re-encode the expected hook data and find it in the calldata.
+      expected_data =
+        FundTransfer.encode_set_budget_data(1_000_000, "0x" <> String.duplicate("ab", 20))
+
+      assert String.contains?(call.data, expected_data)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Where Xochi the protocol meets Xochi the ACP agent. Adds the FundTransferHook data encoder and the SolverAgent runtime that drives the full lifecycle on top of \`Raxol.ACP.Agent\` + \`HookClient\`.

Stacks on #270 (acpv2-provider-adapter). Part E of the v2 launch plan.

## New modules

**\`Raxol.ACP.Hooks.FundTransfer\`** -- encoders/decoders for the v2 \`FundTransferHook\` data parameter. \`encode_set_budget_data/2\` produces the 64-byte \`abi.encode(uint256 transferAmount, address destination)\` payload the hook reads on \`setBudget\`. \`decode_set_budget_data/1\` round-trips for tests and replay. \`encode_fund_data/0\` and \`encode_submit_data/0\` return empty bytes for the basic flow.

**\`Raxol.ACP.Xochi.SolverAgent\`** -- the GenServer runtime. Subscribes to a Raxol.ACP.Agent, filters for jobs targeting its wallet, and drives the lifecycle:

| Event | Action |
|---|---|
| \`job.created\` | filter by \`provider == our wallet\`; record session \`:awaiting_requirement\` |
| \`requirement\` message | parse JSON; compute fee (\`fee_bps\`, default 50); call \`HookClient.set_budget\` with FundTransfer-encoded data |
| \`job.funded\` | run \`settle_fn\` (default stub; production: \`Raxol.Payments.Protocols.Xochi.transfer/4\`); on success, \`HookClient.submit\` the deliverable hash |
| \`job.completed\` | mark session \`:completed\` |
| \`job.rejected\` / \`job.expired\` | finalize accordingly |

Per-session state map keyed by \`{chain_id, job_id}\`. Telemetry: \`[:raxol, :acp, :xochi, :solver, :event]\` on every significant transition.

## Public ABI

\`Raxol.ACP.ABI.encode_args/1\` promoted to public (was internal). FundTransfer uses it directly to encode the hook \`bytes\` data without a function selector.

## What's deferred

- **Real Xochi wiring** -- the default \`settle_fn\` is a deterministic stub. Production callers pass \`&Raxol.Payments.Protocols.Xochi.transfer/4\` via \`:settle_fn\`. The conversion between requirement schema and \`Raxol.Payments.Xochi.Schemas.QuoteRequest\` lives in a follow-up alongside live \`xochi_config\` / \`xochi_wallet\` examples.
- **Real Transport.SSE** -- still uses Transport.Mock.
- **Real ProviderAdapter.SCA** -- still uses ProviderAdapter.Mock.

The substrate is in place; the next PR (F) is the marketplace registration script and integration examples that ties the live config together.

## Manual testing

- [x] \`mix test test/raxol/acp/hooks/ test/raxol/acp/xochi/\` -- 25 tests, 0 failures
- [x] \`mix test\` (full suite) -- 497 tests, 0 failures, 5 excluded