### PR TITLE
raxol_acp v2: real Auth + JobApi.HTTP + Transport.SSE

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/auth.ex
+++ b/packages/raxol_acp/lib/raxol/acp/auth.ex
@@ -1,0 +1,245 @@
+defmodule Raxol.ACP.Auth do
+  @moduledoc """
+  EIP-712 → bearer JWT auth flow for the Virtuals ACP API
+  (`api.acp.virtuals.io`).
+
+  ## Protocol
+
+  1. Build EIP-712 typed data:
+
+         domain  = {name: "ACP", version: "1", chainId: <chain_id>}
+         types   = {AgentAuth: [{wallet,address}, {chainId,uint256}, {issuedAt,uint256}]}
+         message = {wallet: <our_address>, chainId, issuedAt: <ms_now>}
+
+  2. Sign via the configured `Raxol.ACP.ProviderAdapter`.
+  3. POST `/auth/agent` with JSON body:
+
+         {walletAddress, signature, issuedAt, chainId}
+
+  4. Response: `{"data": {"token": "<jwt>"}}`.
+  5. Use `Authorization: Bearer <jwt>` on subsequent HTTP and SSE
+     requests.
+  6. Refresh when the JWT's `exp` claim is within 60s of now, or on a
+     401 from any authed request.
+
+  ## Usage
+
+      {:ok, auth} =
+        Raxol.ACP.Auth.start_link(
+          provider: my_provider,
+          server_url: "https://api-dev.acp.virtuals.io",
+          chain_id: 8453
+        )
+
+      {:ok, token} = Raxol.ACP.Auth.token(auth)
+      # ... use token in Authorization: Bearer ...
+
+      :ok = Raxol.ACP.Auth.invalidate(auth)
+      # ... next token/1 will re-authenticate ...
+
+  ## State machine
+
+      :idle -> :refreshing -> :valid -> :refreshing -> :valid -> ...
+
+  Token refresh is serialized through the GenServer's call queue so
+  concurrent `token/1` callers share one network round-trip.
+  """
+
+  use GenServer
+
+  alias Raxol.ACP.ProviderAdapter
+
+  @type t :: %__MODULE__{
+          provider: ProviderAdapter.adapter(),
+          server_url: String.t(),
+          chain_id: pos_integer(),
+          token: String.t() | nil,
+          expires_at_ms: integer() | nil,
+          req_options: keyword()
+        }
+
+  defstruct [:provider, :server_url, :chain_id, :req_options, token: nil, expires_at_ms: nil]
+
+  # Refresh ~60s before the JWT expires.
+  @refresh_buffer_ms 60_000
+
+  # -- Public API --
+
+  @doc """
+  Start an Auth process.
+
+  ## Required options
+
+  - `:provider` -- a `Raxol.ACP.ProviderAdapter.adapter()` used for
+    `sign_typed_data/3`. Must be able to sign for the configured
+    chain_id and the address you want to authenticate as.
+  - `:server_url` -- e.g. `"https://api-dev.acp.virtuals.io"`.
+  - `:chain_id` -- e.g. `8453`.
+
+  ## Optional
+
+  - `:req_options` -- extra options threaded into `Req.post/1` (e.g.
+    `:plug` for stubbing).
+  - `:name` -- if set, registers the GenServer under that name.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    case Keyword.fetch(opts, :name) do
+      {:ok, name} -> GenServer.start_link(__MODULE__, opts, name: name)
+      :error -> GenServer.start_link(__MODULE__, opts)
+    end
+  end
+
+  @doc """
+  Return a valid bearer JWT, refreshing if needed.
+
+  Calls are serialized through the GenServer so concurrent callers
+  share one network round-trip per refresh.
+  """
+  @spec token(GenServer.server()) :: {:ok, String.t()} | {:error, term()}
+  def token(server), do: GenServer.call(server, :token, 30_000)
+
+  @doc "Forget the current token so the next `token/1` re-authenticates."
+  @spec invalidate(GenServer.server()) :: :ok
+  def invalidate(server), do: GenServer.call(server, :invalidate)
+
+  @doc "Inspect the current state (testing aid)."
+  @spec get_state(GenServer.server()) :: t()
+  def get_state(server), do: GenServer.call(server, :get_state)
+
+  # -- GenServer callbacks --
+
+  @impl GenServer
+  def init(opts) do
+    state = %__MODULE__{
+      provider: Keyword.fetch!(opts, :provider),
+      server_url: normalize_url(Keyword.fetch!(opts, :server_url)),
+      chain_id: Keyword.fetch!(opts, :chain_id),
+      req_options: Keyword.get(opts, :req_options, [])
+    }
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:token, _from, state) do
+    case ensure_valid(state) do
+      {:ok, %__MODULE__{token: t} = new_state} -> {:reply, {:ok, t}, new_state}
+      {:error, reason, new_state} -> {:reply, {:error, reason}, new_state}
+    end
+  end
+
+  def handle_call(:invalidate, _from, state) do
+    {:reply, :ok, %{state | token: nil, expires_at_ms: nil}}
+  end
+
+  def handle_call(:get_state, _from, state), do: {:reply, state, state}
+
+  # -- Internals --
+
+  defp ensure_valid(state) do
+    if token_still_valid?(state) do
+      {:ok, state}
+    else
+      authenticate(state)
+    end
+  end
+
+  defp token_still_valid?(%__MODULE__{token: nil}), do: false
+  defp token_still_valid?(%__MODULE__{expires_at_ms: nil}), do: false
+
+  defp token_still_valid?(%__MODULE__{expires_at_ms: exp}) do
+    System.system_time(:millisecond) + @refresh_buffer_ms < exp
+  end
+
+  defp authenticate(state) do
+    issued_at = System.system_time(:millisecond)
+
+    typed_data = build_auth_typed_data(state, issued_at)
+
+    with {:ok, sig_bytes} <-
+           ProviderAdapter.sign_typed_data(state.provider, state.chain_id, typed_data),
+         signature_hex <- "0x" <> Base.encode16(sig_bytes, case: :lower),
+         {:ok, %{"data" => %{"token" => token}}} <- post_auth(state, signature_hex, issued_at),
+         {:ok, exp_ms} <- decode_jwt_exp_ms(token) do
+      {:ok, %{state | token: token, expires_at_ms: exp_ms}}
+    else
+      {:error, reason} -> {:error, reason, %{state | token: nil, expires_at_ms: nil}}
+      err -> {:error, {:auth_failed, err}, %{state | token: nil, expires_at_ms: nil}}
+    end
+  end
+
+  defp build_auth_typed_data(state, issued_at_ms) do
+    %{
+      domain: %{
+        name: "ACP",
+        version: "1",
+        chainId: state.chain_id
+      },
+      types: %{
+        "AgentAuth" => [
+          {"wallet", "address"},
+          {"chainId", "uint256"},
+          {"issuedAt", "uint256"}
+        ]
+      },
+      message: %{
+        "wallet" => ProviderAdapter.get_address(state.provider),
+        "chainId" => state.chain_id,
+        "issuedAt" => issued_at_ms
+      }
+    }
+  end
+
+  defp post_auth(state, signature_hex, issued_at_ms) do
+    body = %{
+      "walletAddress" => ProviderAdapter.get_address(state.provider),
+      "signature" => signature_hex,
+      "issuedAt" => issued_at_ms,
+      "chainId" => state.chain_id
+    }
+
+    url = state.server_url <> "/auth/agent"
+    opts = [url: url, json: body] ++ state.req_options
+
+    case Req.post(opts) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        {:ok, body}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_status, status, body}}
+
+      {:error, reason} ->
+        {:error, {:transport, reason}}
+    end
+  end
+
+  defp decode_jwt_exp_ms(jwt) do
+    with [_, payload_b64, _] <- String.split(jwt, "."),
+         {:ok, payload_json} <- decode_base64url(payload_b64),
+         {:ok, %{"exp" => exp_seconds}} <- Jason.decode(payload_json) do
+      {:ok, exp_seconds * 1000}
+    else
+      _ -> {:error, :invalid_jwt}
+    end
+  end
+
+  defp decode_base64url(str) do
+    padded =
+      str
+      |> String.replace("-", "+")
+      |> String.replace("_", "/")
+      |> pad_base64()
+
+    Base.decode64(padded)
+  end
+
+  defp pad_base64(str) do
+    case rem(byte_size(str), 4) do
+      0 -> str
+      n -> str <> String.duplicate("=", 4 - n)
+    end
+  end
+
+  defp normalize_url(url), do: String.trim_trailing(url, "/")
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_api/http.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_api/http.ex
@@ -1,0 +1,207 @@
+defmodule Raxol.ACP.JobApi.HTTP do
+  @moduledoc """
+  Real `Raxol.ACP.JobApi` implementation against the Virtuals ACP REST
+  API.
+
+  ## Endpoints
+
+  | Method | Path | Used for |
+  |---|---|---|
+  | GET  | `/jobs`                                       | `get_active_jobs/1` |
+  | GET  | `/jobs/{chainId}/{jobId}`                     | (single job lookup) |
+  | POST | `/jobs/{chainId}/{jobId}/deliverable`         | `post_deliverable/4` |
+  | GET  | `/agents/search?query=&chainIds=`             | `browse_agents/3` |
+  | GET  | `/agents/wallet/{walletAddress}`              | `get_agent_by_wallet_address/2`, `get_me/1` |
+
+  All requests carry `Authorization: Bearer <jwt>` where the JWT comes
+  from `Raxol.ACP.Auth`. On a 401 the token is invalidated and the
+  request is retried once.
+
+  ## Construction
+
+      api =
+        Raxol.ACP.JobApi.HTTP.new(
+          auth: my_auth_pid,
+          server_url: "https://api-dev.acp.virtuals.io",
+          chain_ids: [8453]
+        )
+  """
+
+  @behaviour Raxol.ACP.JobApi
+
+  alias Raxol.ACP.Auth
+
+  @doc """
+  Build an adapter.
+
+  ## Required options
+
+  - `:auth` -- `pid()` or name of a `Raxol.ACP.Auth` GenServer.
+  - `:server_url` -- e.g. `https://api-dev.acp.virtuals.io`.
+
+  ## Optional
+
+  - `:chain_ids` -- list of chain IDs to send as the `chainIds` query
+    param on `browse_agents`. Default `[8453]`.
+  - `:req_options` -- extra options threaded into Req (useful for
+    stubbing).
+  """
+  @spec new(keyword()) :: Raxol.ACP.JobApi.t()
+  def new(opts) do
+    config = %{
+      auth: Keyword.fetch!(opts, :auth),
+      server_url: opts |> Keyword.fetch!(:server_url) |> String.trim_trailing("/"),
+      chain_ids: Keyword.get(opts, :chain_ids, [8453]),
+      req_options: Keyword.get(opts, :req_options, [])
+    }
+
+    %{adapter: __MODULE__, config: config}
+  end
+
+  # -- Behaviour callbacks --
+
+  @impl Raxol.ACP.JobApi
+  def browse_agents(%{config: cfg}, keyword, params) do
+    query = build_browse_query(keyword, params, cfg.chain_ids)
+    url = cfg.server_url <> "/agents/search?" <> URI.encode_query(query)
+
+    case authed_request(cfg, :get, url, nil) do
+      {:ok, %{"data" => agents}} when is_list(agents) ->
+        {:ok, Enum.map(agents, &normalize_agent/1)}
+
+      {:ok, body} ->
+        {:error, {:unexpected_body, body}}
+
+      err ->
+        err
+    end
+  end
+
+  @impl Raxol.ACP.JobApi
+  def get_agent_by_wallet_address(%{config: cfg}, wallet_address) do
+    url = cfg.server_url <> "/agents/wallet/" <> wallet_address
+
+    case authed_request(cfg, :get, url, nil) do
+      {:ok, %{"data" => nil}} -> {:ok, nil}
+      {:ok, %{"data" => agent}} -> {:ok, normalize_agent(agent)}
+      {:error, {:http_status, 404, _}} -> {:ok, nil}
+      err -> err
+    end
+  end
+
+  @impl Raxol.ACP.JobApi
+  def get_me(%{config: cfg} = api) do
+    # We need our own wallet address. Fetch from the Auth process's provider.
+    # Cheaper: ask the Auth state.
+    address = our_address(cfg)
+    get_agent_by_wallet_address(api, address)
+  end
+
+  @impl Raxol.ACP.JobApi
+  def get_active_jobs(%{config: cfg}) do
+    url = cfg.server_url <> "/jobs"
+
+    case authed_request(cfg, :get, url, nil) do
+      {:ok, %{"jobs" => jobs}} when is_list(jobs) -> {:ok, jobs}
+      {:ok, body} -> {:error, {:unexpected_body, body}}
+      err -> err
+    end
+  end
+
+  @impl Raxol.ACP.JobApi
+  def post_deliverable(%{config: cfg}, chain_id, job_id, deliverable) do
+    url = cfg.server_url <> "/jobs/#{chain_id}/#{job_id}/deliverable"
+
+    payload =
+      case deliverable do
+        s when is_binary(s) -> %{"deliverable" => s}
+        other -> %{"deliverable" => Jason.encode!(other)}
+      end
+
+    case authed_request(cfg, :post, url, payload) do
+      {:ok, _} -> :ok
+      err -> err
+    end
+  end
+
+  # -- Internal --
+
+  defp authed_request(cfg, method, url, body, retried? \\ false) do
+    case Auth.token(cfg.auth) do
+      {:ok, token} ->
+        headers = [{"authorization", "Bearer " <> token}, {"accept", "application/json"}]
+        opts = base_opts(cfg) ++ [url: url, method: method, headers: headers]
+
+        opts =
+          if body do
+            opts ++ [json: body]
+          else
+            opts
+          end
+
+        case Req.request(opts) do
+          {:ok, %Req.Response{status: 200, body: resp}} ->
+            {:ok, resp}
+
+          {:ok, %Req.Response{status: 401, body: _}} when not retried? ->
+            :ok = Auth.invalidate(cfg.auth)
+            authed_request(cfg, method, url, body, true)
+
+          {:ok, %Req.Response{status: status, body: body}} ->
+            {:error, {:http_status, status, body}}
+
+          {:error, reason} ->
+            {:error, {:transport, reason}}
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp base_opts(cfg), do: cfg.req_options
+
+  defp build_browse_query(keyword, params, default_chain_ids) do
+    chain_ids = Map.get(params, :chain_ids, default_chain_ids) |> Enum.join(",")
+
+    base = %{"query" => keyword, "chainIds" => chain_ids}
+
+    base
+    |> maybe_put_query("topK", Map.get(params, :top_k))
+    |> maybe_put_query("isOnline", encode_online(Map.get(params, :is_online)))
+    |> maybe_put_query("cluster", Map.get(params, :cluster))
+    |> maybe_put_query("sortBy", encode_sort(Map.get(params, :sort_by)))
+    |> maybe_put_query("showHidden", Map.get(params, :show_hidden))
+  end
+
+  defp maybe_put_query(map, _key, nil), do: map
+  defp maybe_put_query(map, key, value), do: Map.put(map, key, value)
+
+  defp encode_online(:online), do: "true"
+  defp encode_online(:offline), do: "false"
+  defp encode_online(_), do: nil
+
+  defp encode_sort(nil), do: nil
+  defp encode_sort(atom), do: Atom.to_string(atom)
+
+  # Pull the agent's wallet address from the underlying Auth's provider.
+  defp our_address(cfg) do
+    case Auth.get_state(cfg.auth) do
+      %Auth{provider: provider} ->
+        Raxol.ACP.ProviderAdapter.get_address(provider)
+    end
+  end
+
+  defp normalize_agent(agent) when is_map(agent) do
+    %{
+      wallet_address: agent["walletAddress"] || agent["wallet_address"],
+      name: agent["name"] || "",
+      description: agent["description"],
+      cluster: agent["cluster"],
+      offerings: agent["offerings"],
+      is_online: agent["isOnline"] || agent["is_online"],
+      successful_job_count: agent["successfulJobCount"] || agent["successful_job_count"],
+      success_rate: agent["successRate"] || agent["success_rate"]
+    }
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/transport/sse.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/sse.ex
@@ -1,0 +1,220 @@
+defmodule Raxol.ACP.Transport.SSE do
+  @moduledoc """
+  Real `Raxol.ACP.Transport` against the Virtuals ACP Server-Sent
+  Events stream at `{server_url}/chats/stream`.
+
+  ## Architecture
+
+  `connect/2` spawns a `Task` that opens an HTTP GET to the SSE
+  endpoint via `Req` with a streaming `:into` callback. The callback
+  parses SSE frames line-by-line and forwards each completed event
+  to the configured owner pid as `{:transport, entry_map}`.
+
+  The Task's pid is stashed in the transport's config so
+  `disconnect/1` can kill it.
+
+  ## SSE frame format
+
+  Standard EventSource. Lines separated by `\\n`; an empty line ends
+  the event. Recognised fields:
+
+  - `data:` -- accumulated as the event body
+  - `event:` -- the SSE event type (the v2 server uses `entry`)
+  - `id:` -- ignored
+
+  Anything else is ignored (no `retry:` handling -- we reconnect
+  externally if the stream drops).
+
+  ## Construction
+
+      transport =
+        Raxol.ACP.Transport.SSE.new(
+          auth: my_auth_pid,
+          server_url: "https://api-dev.acp.virtuals.io",
+          supported_chain_ids: [8453]
+        )
+
+  Then in your agent:
+
+      Raxol.ACP.Transport.connect(transport, %{
+        owner: self(),
+        chain_ids: [8453],
+        wallet_address: "0x..."
+      })
+  """
+
+  @behaviour Raxol.ACP.Transport
+
+  alias Raxol.ACP.Auth
+
+  @doc """
+  Build a transport.
+
+  ## Required
+
+  - `:auth` -- `pid()` or name of a `Raxol.ACP.Auth` process.
+  - `:server_url` -- e.g. `https://api-dev.acp.virtuals.io`.
+
+  ## Optional
+
+  - `:supported_chain_ids` -- defaults to `[8453]`. Sent as the
+    `x-supported-chains` header.
+  - `:req_options` -- extra options threaded into Req (for testing).
+  """
+  @spec new(keyword()) :: Raxol.ACP.Transport.t()
+  def new(opts) do
+    table = :ets.new(:raxol_acp_transport_sse, [:set, :public])
+    :ets.insert(table, {:stream_task, nil})
+
+    config = %{
+      auth: Keyword.fetch!(opts, :auth),
+      server_url: opts |> Keyword.fetch!(:server_url) |> String.trim_trailing("/"),
+      supported_chain_ids: Keyword.get(opts, :supported_chain_ids, [8453]),
+      req_options: Keyword.get(opts, :req_options, []),
+      table: table
+    }
+
+    %{adapter: __MODULE__, config: config}
+  end
+
+  # -- Transport behaviour --
+
+  @impl Raxol.ACP.Transport
+  def connect(%{config: cfg}, %{owner: owner}) do
+    case Auth.token(cfg.auth) do
+      {:ok, token} ->
+        url = cfg.server_url <> "/chats/stream"
+
+        headers = [
+          {"authorization", "Bearer " <> token},
+          {"accept", "text/event-stream"},
+          {"x-supported-chains", Jason.encode!(cfg.supported_chain_ids)}
+        ]
+
+        task =
+          Task.async(fn ->
+            stream_loop(owner, url, headers, cfg.req_options)
+          end)
+
+        :ets.insert(cfg.table, {:stream_task, task})
+        :ok
+
+      err ->
+        err
+    end
+  end
+
+  @impl Raxol.ACP.Transport
+  def disconnect(%{config: cfg}) do
+    case :ets.lookup(cfg.table, :stream_task) do
+      [{:stream_task, nil}] ->
+        :ok
+
+      [{:stream_task, %Task{} = task}] ->
+        Task.shutdown(task, :brutal_kill)
+        :ets.insert(cfg.table, {:stream_task, nil})
+        :ok
+    end
+  end
+
+  @impl Raxol.ACP.Transport
+  def get_history(%{config: cfg}, {chain_id, job_id}) do
+    case Auth.token(cfg.auth) do
+      {:ok, token} ->
+        url = cfg.server_url <> "/jobs/#{chain_id}/#{job_id}"
+
+        case Req.get(url: url, headers: [{"authorization", "Bearer " <> token}]) do
+          {:ok, %Req.Response{status: 200, body: %{"data" => %{"entries" => entries}}}}
+          when is_list(entries) ->
+            {:ok, entries}
+
+          {:ok, %Req.Response{status: 200, body: _}} ->
+            {:ok, []}
+
+          {:ok, %Req.Response{status: 404}} ->
+            {:ok, []}
+
+          {:ok, %Req.Response{status: status, body: body}} ->
+            {:error, {:http_status, status, body}}
+
+          err ->
+            err
+        end
+
+      err ->
+        err
+    end
+  end
+
+  @impl Raxol.ACP.Transport
+  def post_message(%{config: cfg}, {chain_id, job_id}, content, content_type) do
+    case Auth.token(cfg.auth) do
+      {:ok, token} ->
+        url = cfg.server_url <> "/jobs/#{chain_id}/#{job_id}/messages"
+
+        body = %{"content" => content, "contentType" => content_type}
+
+        case Req.post(url: url, headers: [{"authorization", "Bearer " <> token}], json: body) do
+          {:ok, %Req.Response{status: status}} when status in 200..299 ->
+            :ok
+
+          {:ok, %Req.Response{status: status, body: body}} ->
+            {:error, {:http_status, status, body}}
+
+          err ->
+            err
+        end
+
+      err ->
+        err
+    end
+  end
+
+  @impl Raxol.ACP.Transport
+  def send_message(transport, key, content, content_type) do
+    # The v2 SDK distinguishes "stream send" from "REST post"; for our
+    # purposes both go through POST /messages and the stream picks up the
+    # echoed entry via SSE. So we delegate.
+    post_message(transport, key, content, content_type)
+  end
+
+  # -- SSE streaming --
+
+  defp stream_loop(owner, url, headers, req_options) do
+    opts =
+      [
+        url: url,
+        method: :get,
+        headers: headers,
+        into: fn {:data, data}, {req, resp} ->
+          handle_chunk(owner, data)
+          {:cont, {req, resp}}
+        end
+      ] ++ req_options
+
+    # Req blocks until the stream closes; if the server closes, we exit
+    # normally. The caller (Agent) is responsible for reconnecting.
+    try do
+      Req.request(opts)
+    catch
+      _, _ -> :ok
+    end
+  end
+
+  defp handle_chunk(owner, data) do
+    # Buffer partials in the process dictionary; this task is short-lived
+    # per connection so there's no leakage.
+    buffer = Process.get(:sse_buffer, "")
+    accumulated = buffer <> data
+
+    {frames, rest} = Raxol.ACP.Transport.SSE.Parser.split_frames(accumulated)
+    Process.put(:sse_buffer, rest)
+
+    for frame <- frames do
+      case Raxol.ACP.Transport.SSE.Parser.parse_frame(frame) do
+        {:ok, entry} -> send(owner, {:transport, entry})
+        {:error, _} -> :ok
+      end
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
@@ -1,0 +1,65 @@
+defmodule Raxol.ACP.Transport.SSE.Parser do
+  @moduledoc """
+  Pure SSE wire-format parser used by `Raxol.ACP.Transport.SSE`.
+
+  Extracted into its own module so tests can hit it directly without
+  spinning up a stream. No state -- callers buffer their own partials
+  between `split_frames/1` calls.
+  """
+
+  @doc """
+  Split a chunk of SSE bytes into complete frames + a remainder.
+
+  Frames are separated by `\\n\\n`. The trailing fragment (if any) is
+  returned as the second element so the caller can prepend it to the
+  next chunk.
+
+      iex> Raxol.ACP.Transport.SSE.Parser.split_frames("data: 1\\n\\ndata: 2\\n\\n")
+      {["data: 1", "data: 2"], ""}
+
+      iex> Raxol.ACP.Transport.SSE.Parser.split_frames("data: a\\n\\ndata: b")
+      {["data: a"], "data: b"}
+  """
+  @spec split_frames(binary()) :: {[binary()], binary()}
+  def split_frames(text) when is_binary(text) do
+    parts = String.split(text, "\n\n")
+
+    case parts do
+      [] -> {[], ""}
+      [partial] -> {[], partial}
+      list -> {Enum.drop(list, -1), List.last(list)}
+    end
+  end
+
+  @doc """
+  Parse a single SSE frame's data field into a JSON map.
+
+  - `data:` lines (with or without leading space) are concatenated.
+  - `event:` / `id:` / other field lines are ignored.
+  - The accumulated `data` is parsed as JSON; the value must be an
+    object.
+  """
+  @spec parse_frame(binary()) :: {:ok, map()} | {:error, :no_data | :invalid_json}
+  def parse_frame(frame) when is_binary(frame) do
+    data =
+      frame
+      |> String.split("\n")
+      |> Enum.flat_map(&extract_data_line/1)
+      |> Enum.join("\n")
+
+    case data do
+      "" ->
+        {:error, :no_data}
+
+      json ->
+        case Jason.decode(json) do
+          {:ok, value} when is_map(value) -> {:ok, value}
+          _ -> {:error, :invalid_json}
+        end
+    end
+  end
+
+  defp extract_data_line("data: " <> rest), do: [rest]
+  defp extract_data_line("data:" <> rest), do: [String.trim_leading(rest, " ")]
+  defp extract_data_line(_), do: []
+end

--- a/packages/raxol_acp/test/raxol/acp/auth_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/auth_test.exs
@@ -1,0 +1,105 @@
+defmodule Raxol.ACP.AuthTest do
+  @moduledoc """
+  Live tests for `Raxol.ACP.Auth` against the real Virtuals dev API at
+  `https://api-dev.acp.virtuals.io`. No mocks -- the EIP-712 typed data
+  is signed and POSTed for real; the JWT comes back from the real
+  server.
+
+  Tagged `:live_acp_dev`. Skipped by default unless
+  `RAXOL_ACP_AGENT_PRIVATE_KEY` is set.
+
+      RAXOL_ACP_AGENT_PRIVATE_KEY=0x<32-byte hex> \\
+        mix test test/raxol/acp/auth_test.exs --include live_acp_dev
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.Auth
+  alias Raxol.ACP.ProviderAdapter.JSONRPC
+
+  @moduletag :live_acp_dev
+
+  setup_all do
+    case load_credentials() do
+      {:ok, creds} ->
+        {:ok, creds}
+
+      :error ->
+        {:skip,
+         "RAXOL_ACP_AGENT_PRIVATE_KEY not set -- skipping live Virtuals dev API tests. " <>
+           "Set the env var to a 32-byte hex private key for a registered dev-API agent."}
+    end
+  end
+
+  setup ctx do
+    {:ok, auth} =
+      Auth.start_link(
+        provider: ctx.provider,
+        server_url: ctx.server_url,
+        chain_id: 8453
+      )
+
+    %{auth: auth}
+  end
+
+  describe "token/1 against real Virtuals dev API" do
+    test "first call performs EIP-712 sign + POST /auth/agent + JWT decode", %{auth: auth} do
+      assert {:ok, token} = Auth.token(auth)
+      assert is_binary(token)
+
+      assert [_h, _payload, _sig] = String.split(token, ".")
+
+      state = Auth.get_state(auth)
+      assert state.token == token
+      assert is_integer(state.expires_at_ms)
+      assert state.expires_at_ms > System.system_time(:millisecond)
+    end
+
+    test "subsequent calls return the cached token", %{auth: auth} do
+      assert {:ok, t1} = Auth.token(auth)
+      assert {:ok, t2} = Auth.token(auth)
+      assert t1 == t2
+    end
+
+    test "invalidate/1 forces a fresh authentication", %{auth: auth} do
+      assert {:ok, t1} = Auth.token(auth)
+      :ok = Auth.invalidate(auth)
+      state = Auth.get_state(auth)
+      assert state.token == nil
+
+      assert {:ok, t2} = Auth.token(auth)
+      assert is_binary(t2)
+      # The dev API may or may not issue the same JWT depending on its
+      # implementation; we don't assert difference, just that we got one.
+    end
+  end
+
+  # -- Credential loading --
+
+  defp load_credentials do
+    with {:ok, pk_hex} <- System.fetch_env("RAXOL_ACP_AGENT_PRIVATE_KEY"),
+         {:ok, pk} <- decode_private_key(pk_hex) do
+      server_url =
+        System.get_env("RAXOL_ACP_SERVER_URL", "https://api-dev.acp.virtuals.io")
+
+      rpc_url = System.get_env("RAXOL_ACP_RPC_URL", "https://mainnet.base.org")
+
+      provider =
+        JSONRPC.new(
+          chains: %{8453 => rpc_url},
+          private_key: pk
+        )
+
+      {:ok, provider: provider, server_url: server_url}
+    else
+      _ -> :error
+    end
+  end
+
+  defp decode_private_key("0x" <> hex) when byte_size(hex) == 64,
+    do: {:ok, Base.decode16!(hex, case: :mixed)}
+
+  defp decode_private_key(hex) when byte_size(hex) == 64,
+    do: {:ok, Base.decode16!(hex, case: :mixed)}
+
+  defp decode_private_key(_), do: :error
+end

--- a/packages/raxol_acp/test/raxol/acp/job_api/http_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_api/http_test.exs
@@ -1,0 +1,84 @@
+defmodule Raxol.ACP.JobApi.HTTPTest do
+  @moduledoc """
+  Live tests for `Raxol.ACP.JobApi.HTTP` against the real Virtuals dev
+  API. Same gating as `Raxol.ACP.AuthTest`: skipped unless
+  `RAXOL_ACP_AGENT_PRIVATE_KEY` is set.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{Auth, JobApi}
+  alias Raxol.ACP.JobApi.HTTP
+  alias Raxol.ACP.ProviderAdapter.JSONRPC
+
+  @moduletag :live_acp_dev
+
+  setup_all do
+    case System.fetch_env("RAXOL_ACP_AGENT_PRIVATE_KEY") do
+      :error ->
+        {:skip,
+         "RAXOL_ACP_AGENT_PRIVATE_KEY not set -- skipping live Virtuals dev API tests"}
+
+      {:ok, pk_hex} ->
+        pk = decode_pk(pk_hex)
+
+        server_url =
+          System.get_env("RAXOL_ACP_SERVER_URL", "https://api-dev.acp.virtuals.io")
+
+        rpc_url = System.get_env("RAXOL_ACP_RPC_URL", "https://mainnet.base.org")
+
+        provider = JSONRPC.new(chains: %{8453 => rpc_url}, private_key: pk)
+
+        {:ok, auth} = Auth.start_link(provider: provider, server_url: server_url, chain_id: 8453)
+        api = HTTP.new(auth: auth, server_url: server_url, chain_ids: [8453])
+
+        {:ok, api: api, provider: provider}
+    end
+  end
+
+  describe "get_active_jobs/1" do
+    test "returns a list (possibly empty) of jobs assigned to this agent", %{api: api} do
+      assert {:ok, jobs} = JobApi.get_active_jobs(api)
+      assert is_list(jobs)
+    end
+  end
+
+  describe "browse_agents/3" do
+    test "empty keyword returns a list (may be paginated)", %{api: api} do
+      assert {:ok, agents} = JobApi.browse_agents(api, "", %{top_k: 5})
+      assert is_list(agents)
+    end
+
+    test "keyword filter returns matching agents", %{api: api} do
+      # Use a deliberately rare keyword that's unlikely to match anything.
+      # The shape of the response should still be a list (possibly empty).
+      assert {:ok, agents} =
+               JobApi.browse_agents(api, "xochi-unlikely-match-#{:rand.uniform(1_000_000)}", %{})
+
+      assert is_list(agents)
+    end
+  end
+
+  describe "get_agent_by_wallet_address/2 + get_me/1" do
+    test "get_me returns our own agent registration", %{api: api, provider: provider} do
+      case JobApi.get_me(api) do
+        {:ok, nil} ->
+          flunk(
+            "Our wallet #{Raxol.ACP.ProviderAdapter.get_address(provider)} is not registered " <>
+              "on api-dev.acp.virtuals.io. Register at https://app.virtuals.io/acp/new (dev env) first."
+          )
+
+        {:ok, agent} ->
+          assert agent.wallet_address
+          assert is_binary(agent.name)
+      end
+    end
+
+    test "unknown wallet returns nil", %{api: api} do
+      random_addr = "0x" <> Base.encode16(:crypto.strong_rand_bytes(20), case: :lower)
+      assert {:ok, nil} = JobApi.get_agent_by_wallet_address(api, random_addr)
+    end
+  end
+
+  defp decode_pk("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+  defp decode_pk(hex), do: Base.decode16!(hex, case: :mixed)
+end

--- a/packages/raxol_acp/test/raxol/acp/transport/sse_parser_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/transport/sse_parser_test.exs
@@ -1,0 +1,69 @@
+defmodule Raxol.ACP.Transport.SSEParserTest do
+  @moduledoc """
+  Pure unit tests for the SSE frame splitter and JSON parser. These
+  don't hit the network -- they verify our wire-level parsing against
+  hand-crafted SSE chunks.
+
+  The functions tested are internal to `Raxol.ACP.Transport.SSE` and
+  exposed here via a small public surface for testability rather than
+  by reaching into private functions.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Transport.SSE.Parser
+
+  describe "split_frames/1" do
+    test "single complete frame; no remainder" do
+      input = "data: {\"a\":1}\n\n"
+      assert {[frame], ""} = Parser.split_frames(input)
+      assert frame == "data: {\"a\":1}"
+    end
+
+    test "two complete frames" do
+      input = "data: 1\n\ndata: 2\n\n"
+      assert {[f1, f2], ""} = Parser.split_frames(input)
+      assert f1 == "data: 1"
+      assert f2 == "data: 2"
+    end
+
+    test "partial frame at end is buffered" do
+      input = "data: complete\n\ndata: partial"
+      assert {[complete], rest} = Parser.split_frames(input)
+      assert complete == "data: complete"
+      assert rest == "data: partial"
+    end
+
+    test "no frames yet" do
+      input = "data: still partial"
+      assert {[], "data: still partial"} = Parser.split_frames(input)
+    end
+  end
+
+  describe "parse_frame/1" do
+    test "single-line data with JSON object" do
+      assert {:ok, %{"a" => 1}} = Parser.parse_frame("data: {\"a\":1}")
+    end
+
+    test "multi-line data concatenates" do
+      frame = "data: {\"a\":\ndata: 1}"
+      assert {:ok, %{"a" => 1}} = Parser.parse_frame(frame)
+    end
+
+    test "handles 'data:' without a trailing space" do
+      assert {:ok, %{"x" => true}} = Parser.parse_frame("data:{\"x\":true}")
+    end
+
+    test "ignores `event:` and `id:` lines" do
+      frame = "event: entry\nid: 42\ndata: {\"ok\":1}"
+      assert {:ok, %{"ok" => 1}} = Parser.parse_frame(frame)
+    end
+
+    test "empty data returns error" do
+      assert {:error, :no_data} = Parser.parse_frame("event: heartbeat")
+    end
+
+    test "non-JSON data returns error" do
+      assert {:error, :invalid_json} = Parser.parse_frame("data: not-json")
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/transport/sse_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/transport/sse_test.exs
@@ -1,0 +1,74 @@
+defmodule Raxol.ACP.Transport.SSETest do
+  @moduledoc """
+  Live tests for `Raxol.ACP.Transport.SSE` against the real Virtuals
+  dev API. Verifies the SSE connection opens cleanly and entries
+  arrive in the documented shape.
+
+  Skipped unless `RAXOL_ACP_AGENT_PRIVATE_KEY` is set.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{Auth, Transport}
+  alias Raxol.ACP.Transport.SSE
+  alias Raxol.ACP.ProviderAdapter.JSONRPC
+
+  @moduletag :live_acp_dev
+
+  setup_all do
+    case System.fetch_env("RAXOL_ACP_AGENT_PRIVATE_KEY") do
+      :error ->
+        {:skip,
+         "RAXOL_ACP_AGENT_PRIVATE_KEY not set -- skipping live Virtuals dev API tests"}
+
+      {:ok, pk_hex} ->
+        pk = decode_pk(pk_hex)
+
+        server_url =
+          System.get_env("RAXOL_ACP_SERVER_URL", "https://api-dev.acp.virtuals.io")
+
+        rpc_url = System.get_env("RAXOL_ACP_RPC_URL", "https://mainnet.base.org")
+
+        provider = JSONRPC.new(chains: %{8453 => rpc_url}, private_key: pk)
+
+        {:ok, auth} = Auth.start_link(provider: provider, server_url: server_url, chain_id: 8453)
+
+        {:ok, auth: auth, server_url: server_url, provider: provider}
+    end
+  end
+
+  setup ctx do
+    transport =
+      SSE.new(
+        auth: ctx.auth,
+        server_url: ctx.server_url,
+        supported_chain_ids: [8453]
+      )
+
+    %{transport: transport}
+  end
+
+  describe "connect/2 + disconnect/1" do
+    test "opens the stream and disconnect cleanly stops it", %{transport: transport} do
+      assert :ok =
+               Transport.connect(transport, %{
+                 owner: self(),
+                 chain_ids: [8453],
+                 wallet_address: "0x" <> String.duplicate("0", 40)
+               })
+
+      # Give the stream up to 5s to either dump cached entries (if our
+      # agent has any active jobs) or just idle. Either is success.
+      receive do
+        {:transport, entry} ->
+          assert is_map(entry)
+      after
+        5_000 -> :ok
+      end
+
+      :ok = Transport.disconnect(transport)
+    end
+  end
+
+  defp decode_pk("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+  defp decode_pk(hex), do: Base.decode16!(hex, case: :mixed)
+end

--- a/packages/raxol_acp/test/test_helper.exs
+++ b/packages/raxol_acp/test/test_helper.exs
@@ -3,7 +3,7 @@
 # (anvil + cast) installed and are slow, so they're opt-in:
 #
 #     mix test --include live_chain
-ExUnit.start(exclude: [:live_chain, :live_bundler])
+ExUnit.start(exclude: [:live_chain, :live_bundler, :live_acp_dev])
 
 # Configure the in-memory contract client for the test run. The test/support
 # impl is the second real implementation of the ContractClient behaviour --


### PR DESCRIPTION
## Summary

Completes the no-mocks pivot for the Virtuals API side. Real EIP-712 auth, real REST client, real SSE stream against api-dev.acp.virtuals.io.

Stacks on #272 (acpv2-marketplace, the JSONRPC adapter PR). Part F2 of the v2 launch plan.

## New modules

- **Raxol.ACP.Auth** -- GenServer managing the EIP-712 -> JWT auth flow per acp-node-v2 agentAuth.ts. Builds typed data, signs via ProviderAdapter, POSTs /auth/agent, caches JWT until 60s before exp claim, serializes refreshes through GenServer call queue.

- **Raxol.ACP.JobApi.HTTP** -- real implementation of the 5 REST endpoints. On 401, invalidates Auth and retries once. Normalizes camelCase response fields to snake_case.

- **Raxol.ACP.Transport.SSE** -- real EventSource against /chats/stream. Opens via Req with streaming :into callback in a Task; parses SSE frames line-by-line; forwards {:transport, entry_map} to the owner pid.

- **Raxol.ACP.Transport.SSE.Parser** -- pure functions for split_frames/1 and parse_frame/1, extracted for testability.

## Real-endpoint tests

Tagged \`:live_acp_dev\`, skipped by default. Opt in with \`RAXOL_ACP_AGENT_PRIVATE_KEY=0x... mix test --include live_acp_dev\`.

- auth_test.exs (3 tests) -- full sign + POST + JWT decode roundtrip
- job_api/http_test.exs (5 tests) -- get_active_jobs, browse_agents, get_me (requires wallet registered at https://app.virtuals.io/acp/new dev env), unknown-wallet lookup
- transport/sse_test.exs (1 test) -- connect / 5s drain / disconnect lifecycle

Pure tests:
- transport/sse_parser_test.exs (10 tests) -- frame splitter, data field accumulation, JSON parsing

## Manual testing

- [x] \`mix test\` (no live tags) -- 507 tests, 0 failures, 32 excluded
- [x] \`mix test --include live_acp_dev\` (no creds) -- 9 setup_all skips, 0 failures
- [ ] With RAXOL_ACP_AGENT_PRIVATE_KEY set: all live tests pass (validate on operator machine)