### PR TITLE
Fix flaky process isolation property test on macOS CI

### DIFF
--- a/test/property/process_isolation_property_test.exs
+++ b/test/property/process_isolation_property_test.exs
@@ -141,6 +141,7 @@ defmodule Raxol.Property.ProcessIsolationTest do
       end
     end
 
+    @tag capture_log: true
     property "multiple concurrent child crashes don't kill parent" do
       check all(
               reasons <-
@@ -158,9 +159,11 @@ defmodule Raxol.Property.ProcessIsolationTest do
           crash_child(pid, reason)
         end)
 
-        # Wait for every child's :DOWN message
+        # Wait for every child's :DOWN message. Use a generous timeout to
+        # absorb scheduler jitter when up to 10 crash reports land in Logger
+        # simultaneously on a loaded CI runner.
         for {_pid, ref} <- children do
-          assert {:ok, _} = await_down(ref)
+          assert {:ok, _} = await_down(ref, 2_000)
         end
 
         # Parent alive, all children dead


### PR DESCRIPTION
## Summary

Run `27501718061` on master failed only on the `Test macos-latest` matrix job. Single failing property: `Raxol.Property.ProcessIsolationTest` -- "multiple concurrent child crashes don't kill parent" (failed after 73 successful runs).

## Root cause

The property starts up to 10 `CrashableChild` GenServers concurrently and crashes them all in one batch. Reasons include `{:raise, _}`, which produces a full Logger crash report with stacktrace. With many crash reports landing simultaneously and the test running `async: true` alongside hundreds of others, Logger backpressures and the sequential `await_down(ref)` calls miss the default 500ms timeout on a loaded macOS-latest runner.

Locally the test ran 5x clean in ~0.3s each. The previous flake fix (commit `8d99fb7c`) replaced a hopeful `Process.sleep(50)` with deterministic `await_down/1` but kept the 500ms default.

## Fix

- `@tag capture_log: true` on the multi-crash property -- we're verifying process lifecycle, not log output, so suppressing the crash reports removes the largest source of scheduler stall.
- Pass an explicit `2_000` ms timeout to `await_down/2` to absorb residual CI jitter.

No behavior change to the system under test.

## Manual testing

- [x] `mix format --check-formatted` clean on the edited file
- [x] `mix test test/property/process_isolation_property_test.exs` -- 5/5 runs green locally
- [x] `mix test test/property/` -- 168 properties, 22 tests, 0 failures
- [ ] Unified CI green on this branch