### PR TITLE
Phase 24 foundation: extensible Directive system

### DIFF
--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -12,6 +12,8 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
   require Raxol.Core.Runtime.Command
   require Raxol.Core.UserPreferences
 
+  @compile {:no_warn_undefined, Raxol.Agent.Directive.Executor}
+
   alias Raxol.Core.Events.Event
   alias Raxol.Core.FocusManager
   alias Raxol.Core.Runtime.Application
@@ -824,17 +826,26 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     )
 
     Enum.each(commands, fn command ->
-      case command do
-        %Command{} = cmd ->
-          command_module.execute(cmd, context)
+      cond do
+        match?(%Command{}, command) ->
+          command_module.execute(command, context)
 
-        _ ->
+        directive?(command) ->
+          Raxol.Agent.Directive.Executor.execute(command, context)
+
+        true ->
           Raxol.Core.Runtime.Log.warning_with_context(
-            "[#{__MODULE__}] Invalid command format: #{inspect(command)}. Expected %Raxol.Core.Runtime.Command{}. Ignoring.",
+            "[#{__MODULE__}] Invalid effect format: #{inspect(command)}. Expected %Raxol.Core.Runtime.Command{} or a directive struct. Ignoring.",
             %{command: command}
           )
       end
     end)
+  end
+
+  defp directive?(effect) do
+    is_struct(effect) and
+      Code.ensure_loaded?(Raxol.Agent.Directive.Executor) and
+      Raxol.Agent.Directive.Executor.impl_for(effect) != nil
   end
 
   defp test_env?, do: Code.ensure_loaded?(Mix) and Mix.env() == :test

--- a/lib/raxol/core/runtime/lifecycle.ex
+++ b/lib/raxol/core/runtime/lifecycle.ex
@@ -18,6 +18,9 @@ defmodule Raxol.Core.Runtime.Lifecycle do
   """
 
   use GenServer
+
+  @compile {:no_warn_undefined, Raxol.Agent.Directive.Executor}
+
   alias Raxol.Core.Runtime.Backpressure
   alias Raxol.Core.Runtime.Lifecycle.{Initializer, Shutdown}
   alias Raxol.Core.Runtime.Log
@@ -423,13 +426,24 @@ defmodule Raxol.Core.Runtime.Lifecycle do
   end
 
   defp execute_initial_command(command, context) do
-    if match?(%Raxol.Core.Runtime.Command{}, command) do
-      Raxol.Core.Runtime.Command.execute(command, context)
-    else
-      Log.error(
-        "Invalid initial command found: #{inspect(command)}. Expected %Raxol.Core.Runtime.Command{}."
-      )
+    cond do
+      match?(%Raxol.Core.Runtime.Command{}, command) ->
+        Raxol.Core.Runtime.Command.execute(command, context)
+
+      directive?(command) ->
+        Raxol.Agent.Directive.Executor.execute(command, context)
+
+      true ->
+        Log.error(
+          "Invalid initial effect found: #{inspect(command)}. Expected %Raxol.Core.Runtime.Command{} or a directive struct."
+        )
     end
+  end
+
+  defp directive?(effect) do
+    is_struct(effect) and
+      Code.ensure_loaded?(Raxol.Agent.Directive.Executor) and
+      Raxol.Agent.Directive.Executor.impl_for(effect) != nil
   end
 
   defp log_waiting_status(state) do

--- a/packages/raxol_agent/lib/raxol/agent/action.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action.ex
@@ -41,9 +41,10 @@ defmodule Raxol.Agent.Action do
 
   @type params :: map()
   @type context :: map()
+  @type effect :: Raxol.Core.Runtime.Command.t() | Raxol.Agent.Directive.t()
   @type result ::
           {:ok, map()}
-          | {:ok, map(), [Raxol.Core.Runtime.Command.t()]}
+          | {:ok, map(), [effect()]}
           | {:error, term()}
 
   @doc "Execute the action with validated params and context."

--- a/packages/raxol_agent/lib/raxol/agent/action/pipeline.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action/pipeline.ex
@@ -27,8 +27,10 @@ defmodule Raxol.Agent.Action.Pipeline do
 
   Returns `{:ok, final_state, all_commands}` or `{:error, {step_module, reason}}`.
   """
+  @type effect :: Raxol.Core.Runtime.Command.t() | Raxol.Agent.Directive.t()
+
   @spec run(pipeline(), map(), map()) ::
-          {:ok, map(), [Raxol.Core.Runtime.Command.t()]} | {:error, {module(), term()}}
+          {:ok, map(), [effect()]} | {:error, {module(), term()}}
   def run(steps, initial_params, context \\ %{}) do
     Enum.reduce_while(steps, {:ok, initial_params, []}, fn step, {:ok, state, cmds} ->
       {module, step_params} = normalize_step(step)

--- a/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
@@ -38,8 +38,10 @@ defmodule Raxol.Agent.Action.ToolConverter do
 
   Returns `{:ok, result}` or `{:error, reason}`.
   """
+  @type effect :: Raxol.Core.Runtime.Command.t() | Raxol.Agent.Directive.t()
+
   @spec dispatch_tool_call(map(), [module()], map()) ::
-          {:ok, map()} | {:ok, map(), [Raxol.Core.Runtime.Command.t()]} | {:error, term()}
+          {:ok, map()} | {:ok, map(), [effect()]} | {:error, term()}
   def dispatch_tool_call(tool_call, action_modules, context \\ %{}) do
     name = Map.get(tool_call, "name") || Map.get(tool_call, :name)
     raw_args = Map.get(tool_call, "arguments") || Map.get(tool_call, :arguments, %{})

--- a/packages/raxol_agent/lib/raxol/agent/directive.ex
+++ b/packages/raxol_agent/lib/raxol/agent/directive.ex
@@ -1,0 +1,182 @@
+defmodule Raxol.Agent.Directive do
+  @moduledoc """
+  Extensible struct-based effect descriptors for raxol agents.
+
+  Each directive is a bare struct with a `Raxol.Agent.Directive.Executor`
+  protocol implementation that the runtime invokes to perform the effect.
+  External packages define their own directive structs and protocol impls
+  without modifying this module.
+
+  ## Built-in directives
+
+  | Directive | Effect |
+  | --- | --- |
+  | `Async` | Spawn a task with a sender callback for multi-message replies |
+  | `Shell` | Run a shell command via Port, return structured exit/output |
+  | `SendAgent` | Route a message to another agent by id (via Registry) |
+  | `Schedule` | Send a message after a delay (Process.send_after) |
+  | `Spawn` | Spawn a task whose return value is sent back once |
+  | `Stop` | Signal the runtime to stop |
+
+  ## Examples
+
+      Directive.async(fn sender ->
+        sender.({:progress, 50})
+        sender.({:done, do_work()})
+      end)
+
+      Directive.shell("ls -la", timeout: 5_000)
+      Directive.send_agent("worker-1", {:task, payload})
+      Directive.schedule(1_000, :tick)
+      Directive.spawn(fn -> {:result, expensive_op()} end)
+      Directive.stop()
+
+  ## Execution
+
+      Raxol.Agent.Directive.Executor.execute(directive, %{
+        pid: self(),
+        runtime_pid: runtime_pid
+      })
+
+  Result messages arrive at `context.pid` as `{:command_result, payload}`.
+  """
+
+  alias __MODULE__.{Async, Schedule, SendAgent, Shell, Spawn, Stop}
+
+  @type t ::
+          Async.t()
+          | Schedule.t()
+          | SendAgent.t()
+          | Shell.t()
+          | Spawn.t()
+          | Stop.t()
+          | struct()
+
+  defmodule Async do
+    @moduledoc """
+    Spawn a task with a sender callback. The function receives a `sender/1`
+    closure that can be invoked multiple times to send messages back to the
+    TEA loop as `{:command_result, msg}`.
+
+    Exceptions inside the function are caught and sent back as
+    `{:command_result, {:async_error, message}}`.
+    """
+
+    @type sender :: (term() -> :ok)
+    @type t :: %__MODULE__{fun: (sender() -> any())}
+
+    @enforce_keys [:fun]
+    defstruct [:fun]
+  end
+
+  defmodule Shell do
+    @moduledoc """
+    Run a shell command via Port. Returns a single
+    `{:command_result, {:shell_result, %{exit_status: status, output: binary}}}`
+    message when the command completes or the timeout elapses.
+
+    Options: `:timeout` (default from `Raxol.Core.Defaults`), `:cd`, `:env`.
+    """
+
+    @type t :: %__MODULE__{command: String.t(), opts: keyword()}
+
+    @enforce_keys [:command]
+    defstruct command: nil, opts: []
+  end
+
+  defmodule SendAgent do
+    @moduledoc """
+    Route a message to another agent by id. The target is looked up in
+    `Raxol.Agent.Registry`; on success the message arrives as
+    `{:send_message, message}` via `GenServer.cast/2`; on failure the
+    sender receives `{:command_result, {:send_agent_error, :not_found, target_id}}`.
+    """
+
+    @type t :: %__MODULE__{target_id: term(), message: term()}
+
+    @enforce_keys [:target_id, :message]
+    defstruct [:target_id, :message]
+  end
+
+  defmodule Schedule do
+    @moduledoc """
+    Send a message after the given delay (in milliseconds) as
+    `{:command_result, payload}`.
+    """
+
+    @type t :: %__MODULE__{interval_ms: non_neg_integer(), payload: term()}
+
+    @enforce_keys [:interval_ms, :payload]
+    defstruct [:interval_ms, :payload]
+  end
+
+  defmodule Spawn do
+    @moduledoc """
+    Spawn a Task that invokes `fun/0` and sends its return value back as
+    `{:command_result, result}`. Use `Async` instead when the task needs
+    to send multiple messages.
+    """
+
+    @type t :: %__MODULE__{fun: (-> any())}
+
+    @enforce_keys [:fun]
+    defstruct [:fun]
+  end
+
+  defmodule Stop do
+    @moduledoc """
+    Signal the runtime to stop. Sends `:quit_runtime` to `context.runtime_pid`.
+    """
+
+    @type t :: %__MODULE__{reason: term()}
+
+    defstruct reason: :normal
+  end
+
+  @doc """
+  Construct an Async directive with a sender-callback function.
+  """
+  @spec async((Async.sender() -> any())) :: Async.t()
+  def async(fun) when is_function(fun, 1), do: %Async{fun: fun}
+
+  @doc """
+  Construct a Shell directive.
+
+  Options:
+    * `:timeout` - max execution time in ms (default: runtime default)
+    * `:cd` - working directory
+    * `:env` - environment variables as `[{key, value}]`
+  """
+  @spec shell(String.t(), keyword()) :: Shell.t()
+  def shell(command, opts \\ []) when is_binary(command) and is_list(opts) do
+    %Shell{command: command, opts: opts}
+  end
+
+  @doc """
+  Construct a SendAgent directive.
+  """
+  @spec send_agent(term(), term()) :: SendAgent.t()
+  def send_agent(target_id, message),
+    do: %SendAgent{target_id: target_id, message: message}
+
+  @doc """
+  Construct a Schedule directive. `interval_ms` must be non-negative.
+  """
+  @spec schedule(non_neg_integer(), term()) :: Schedule.t()
+  def schedule(interval_ms, payload)
+      when is_integer(interval_ms) and interval_ms >= 0 do
+    %Schedule{interval_ms: interval_ms, payload: payload}
+  end
+
+  @doc """
+  Construct a Spawn directive with a no-arg function.
+  """
+  @spec spawn((-> any())) :: Spawn.t()
+  def spawn(fun) when is_function(fun, 0), do: %Spawn{fun: fun}
+
+  @doc """
+  Construct a Stop directive.
+  """
+  @spec stop(term()) :: Stop.t()
+  def stop(reason \\ :normal), do: %Stop{reason: reason}
+end

--- a/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
@@ -1,0 +1,140 @@
+defprotocol Raxol.Agent.Directive.Executor do
+  @moduledoc """
+  Protocol for executing `Raxol.Agent.Directive` structs.
+
+  External packages register their own directive types by defining a struct
+  and implementing this protocol for it.
+
+  ## Context
+
+  The `context` map carries at minimum:
+
+    * `:pid` - process to receive `{:command_result, payload}` messages
+    * `:runtime_pid` - process to receive runtime-level signals (e.g. quit)
+
+  Effect messages land at `context.pid` as `{:command_result, payload}`.
+  Consumers rely on the asynchronous result message rather than the return
+  value of `execute/2`.
+  """
+
+  @spec execute(t(), context :: map()) :: any()
+  def execute(directive, context)
+end
+
+defimpl Raxol.Agent.Directive.Executor, for: Raxol.Agent.Directive.Async do
+  alias Raxol.Agent.Directive.Async
+
+  def execute(%Async{fun: fun}, context) do
+    pid = context.pid
+    sender = fn msg -> send(pid, {:command_result, msg}) end
+
+    Task.start(fn ->
+      try do
+        fun.(sender)
+      rescue
+        e -> send(pid, {:command_result, {:async_error, Exception.message(e)}})
+      end
+    end)
+  end
+end
+
+defimpl Raxol.Agent.Directive.Executor, for: Raxol.Agent.Directive.Shell do
+  alias Raxol.Agent.Directive.Shell
+
+  def execute(%Shell{command: command, opts: opts}, context) do
+    timeout =
+      Keyword.get(
+        opts,
+        :timeout,
+        Raxol.Core.Defaults.health_check_interval_ms()
+      )
+
+    cd = Keyword.get(opts, :cd)
+    env = Keyword.get(opts, :env, [])
+
+    Task.start(fn ->
+      charlist_env =
+        Enum.map(env, fn {k, v} ->
+          {String.to_charlist(to_string(k)), String.to_charlist(to_string(v))}
+        end)
+
+      port_opts =
+        [
+          :binary,
+          :exit_status,
+          :use_stdio,
+          :stderr_to_stdout,
+          args: ["-c", command]
+        ]
+        |> maybe_add_port_opt(:cd, cd)
+        |> maybe_add_port_opt(:env, if(charlist_env != [], do: charlist_env))
+
+      port = Port.open({:spawn_executable, "/bin/sh"}, port_opts)
+      result = collect_port_output(port, [], timeout)
+      send(context.pid, {:command_result, {:shell_result, result}})
+    end)
+  end
+
+  defp maybe_add_port_opt(opts, _key, nil), do: opts
+  defp maybe_add_port_opt(opts, key, value), do: [{key, value} | opts]
+
+  defp collect_port_output(port, acc, timeout) do
+    receive do
+      {^port, {:data, data}} ->
+        collect_port_output(port, [data | acc], timeout)
+
+      {^port, {:exit_status, status}} ->
+        output = acc |> Enum.reverse() |> IO.iodata_to_binary()
+        %{exit_status: status, output: output}
+    after
+      timeout ->
+        Port.close(port)
+        output = acc |> Enum.reverse() |> IO.iodata_to_binary()
+        %{exit_status: :timeout, output: output}
+    end
+  end
+end
+
+defimpl Raxol.Agent.Directive.Executor, for: Raxol.Agent.Directive.SendAgent do
+  alias Raxol.Agent.Directive.SendAgent
+
+  def execute(%SendAgent{target_id: target_id, message: message}, context) do
+    with pid when is_pid(pid) <- Process.whereis(Raxol.Agent.Registry),
+         [{agent_pid, _}] <- Registry.lookup(Raxol.Agent.Registry, target_id) do
+      GenServer.cast(agent_pid, {:send_message, message})
+    else
+      _ ->
+        send(
+          context.pid,
+          {:command_result, {:send_agent_error, :not_found, target_id}}
+        )
+    end
+  end
+end
+
+defimpl Raxol.Agent.Directive.Executor, for: Raxol.Agent.Directive.Schedule do
+  alias Raxol.Agent.Directive.Schedule
+
+  def execute(%Schedule{interval_ms: interval_ms, payload: payload}, context) do
+    Process.send_after(context.pid, {:command_result, payload}, interval_ms)
+  end
+end
+
+defimpl Raxol.Agent.Directive.Executor, for: Raxol.Agent.Directive.Spawn do
+  alias Raxol.Agent.Directive.Spawn
+
+  def execute(%Spawn{fun: fun}, context) do
+    Task.start(fn ->
+      result = fun.()
+      send(context.pid, {:command_result, result})
+    end)
+  end
+end
+
+defimpl Raxol.Agent.Directive.Executor, for: Raxol.Agent.Directive.Stop do
+  alias Raxol.Agent.Directive.Stop
+
+  def execute(%Stop{}, context) do
+    send(context.runtime_pid, :quit_runtime)
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/strategy.ex
+++ b/packages/raxol_agent/lib/raxol/agent/strategy.ex
@@ -13,9 +13,10 @@ defmodule Raxol.Agent.Strategy do
   @type command :: {module(), map()} | [{module(), map()}]
   @type state :: map()
   @type context :: map()
+  @type effect :: Raxol.Core.Runtime.Command.t() | Raxol.Agent.Directive.t()
   @type result ::
           {:ok, state()}
-          | {:ok, state(), [Raxol.Core.Runtime.Command.t()]}
+          | {:ok, state(), [effect()]}
           | {:error, term()}
 
   @doc """

--- a/packages/raxol_agent/test/raxol/agent/directive_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/directive_test.exs
@@ -1,0 +1,161 @@
+defmodule Raxol.Agent.DirectiveTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Directive
+  alias Raxol.Agent.Directive.{Async, Schedule, SendAgent, Shell, Spawn, Stop}
+  alias Raxol.Agent.Directive.Executor
+
+  describe "constructors" do
+    test "async/1 builds an Async struct" do
+      fun = fn _sender -> :ok end
+      assert %Async{fun: ^fun} = Directive.async(fun)
+    end
+
+    test "shell/2 builds a Shell struct with default opts" do
+      assert %Shell{command: "echo hi", opts: []} = Directive.shell("echo hi")
+    end
+
+    test "shell/2 carries opts" do
+      assert %Shell{command: "ls", opts: [timeout: 5_000, cd: "/tmp"]} =
+               Directive.shell("ls", timeout: 5_000, cd: "/tmp")
+    end
+
+    test "send_agent/2 builds a SendAgent struct" do
+      assert %SendAgent{target_id: "worker", message: {:task, 1}} =
+               Directive.send_agent("worker", {:task, 1})
+    end
+
+    test "schedule/2 builds a Schedule struct" do
+      assert %Schedule{interval_ms: 1_000, payload: :tick} =
+               Directive.schedule(1_000, :tick)
+    end
+
+    test "schedule/2 accepts zero interval" do
+      assert %Schedule{interval_ms: 0, payload: :now} =
+               Directive.schedule(0, :now)
+    end
+
+    test "spawn/1 builds a Spawn struct" do
+      fun = fn -> :result end
+      assert %Spawn{fun: ^fun} = Directive.spawn(fun)
+    end
+
+    test "stop/0 defaults reason to :normal" do
+      assert %Stop{reason: :normal} = Directive.stop()
+    end
+
+    test "stop/1 carries a custom reason" do
+      assert %Stop{reason: :shutdown} = Directive.stop(:shutdown)
+    end
+  end
+
+  describe "Executor for Async" do
+    test "sender callback delivers messages to context.pid" do
+      directive =
+        Directive.async(fn sender ->
+          sender.(:first)
+          sender.(:second)
+          sender.({:progress, 50})
+        end)
+
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, :first}, 1_000
+      assert_receive {:command_result, :second}, 1_000
+      assert_receive {:command_result, {:progress, 50}}, 1_000
+    end
+
+    test "raised exceptions are reported as :async_error" do
+      directive =
+        Directive.async(fn _sender ->
+          raise "boom"
+        end)
+
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, {:async_error, "boom"}}, 1_000
+    end
+  end
+
+  describe "Executor for Shell" do
+    test "captures stdout and exit_status 0" do
+      directive = Directive.shell("echo hello-from-shell")
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result,
+                      {:shell_result, %{exit_status: 0, output: output}}},
+                     5_000
+
+      assert String.contains?(output, "hello-from-shell")
+    end
+
+    test "non-zero exit_status is returned" do
+      directive = Directive.shell("exit 7")
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, {:shell_result, %{exit_status: 7}}},
+                     5_000
+    end
+
+    test "timeout closes the port and reports :timeout" do
+      directive = Directive.shell("sleep 5", timeout: 100)
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result,
+                      {:shell_result, %{exit_status: :timeout}}},
+                     2_000
+    end
+  end
+
+  describe "Executor for SendAgent" do
+    test "registry-missing path reports :send_agent_error" do
+      directive = Directive.send_agent("nobody", :payload)
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result,
+                      {:send_agent_error, :not_found, "nobody"}},
+                     1_000
+    end
+
+    test "registered agent receives the cast" do
+      {:ok, _} =
+        start_supervised({Registry, keys: :unique, name: Raxol.Agent.Registry})
+
+      {:ok, _} =
+        Registry.register(Raxol.Agent.Registry, "self-as-agent", :metadata)
+
+      directive = Directive.send_agent("self-as-agent", {:work, 42})
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:"$gen_cast", {:send_message, {:work, 42}}}, 1_000
+    end
+  end
+
+  describe "Executor for Schedule" do
+    test "delivers payload after interval_ms" do
+      directive = Directive.schedule(50, {:tick, 1})
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      refute_receive {:command_result, _}, 10
+      assert_receive {:command_result, {:tick, 1}}, 500
+    end
+  end
+
+  describe "Executor for Spawn" do
+    test "single return value is delivered as command_result" do
+      directive = Directive.spawn(fn -> {:done, :answer} end)
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, {:done, :answer}}, 1_000
+    end
+  end
+
+  describe "Executor for Stop" do
+    test "sends :quit_runtime to context.runtime_pid" do
+      directive = Directive.stop()
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive :quit_runtime, 1_000
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/session_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_test.exs
@@ -87,6 +87,24 @@ defmodule Raxol.Agent.SessionTest do
     def update(_msg, model), do: {model, Command.none()}
   end
 
+  defmodule DirectiveShellAgent do
+    use Raxol.Agent
+
+    alias Raxol.Agent.Directive
+
+    def init(_context), do: %{results: [], status: :idle}
+
+    def update({:agent_message, _from, {:run, cmd}}, model) do
+      {%{model | status: :running}, [Directive.shell(cmd)]}
+    end
+
+    def update({:command_result, {:shell_result, result}}, model) do
+      {%{model | results: [result | model.results], status: :done}, []}
+    end
+
+    def update(_msg, model), do: {model, []}
+  end
+
   setup do
     start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
 
@@ -179,6 +197,22 @@ defmodule Raxol.Agent.SessionTest do
       [result] = model.results
       assert result.exit_status == 0
       assert String.contains?(result.output, "hello_agent")
+    end
+
+    @tag :unix_only
+    test "agent executes shell directives and receives results" do
+      {:ok, _pid} =
+        Session.start_link(app_module: DirectiveShellAgent, id: :directive_shell)
+
+      Session.send_message(:directive_shell, {:run, "echo hello_directive"})
+      Process.sleep(500)
+
+      {:ok, model} = Session.get_model(:directive_shell)
+      assert model.status == :done
+      assert length(model.results) == 1
+      [result] = model.results
+      assert result.exit_status == 0
+      assert String.contains?(result.output, "hello_directive")
     end
   end
 

--- a/packages/raxol_core/lib/raxol/core/events/cloud_event.ex
+++ b/packages/raxol_core/lib/raxol/core/events/cloud_event.ex
@@ -1,0 +1,148 @@
+defmodule Raxol.Core.Events.CloudEvent do
+  @moduledoc """
+  CloudEvents v1.0 envelope ([cloudevents.io](https://cloudevents.io/)).
+
+  Standardized event metadata so raxol events can interoperate with
+  webhook receivers, pub/sub fabrics, and message brokers without
+  bespoke serialization. Conversion to and from `Raxol.Core.Events.Event`
+  is provided by that module.
+
+  ## Required fields
+
+    * `:specversion` - "1.0"
+    * `:id` - unique within the source
+    * `:source` - URI-reference identifying the producer (e.g. `"raxol://node-1"`)
+    * `:type` - reverse-DNS style event type (e.g. `"raxol.key"`)
+
+  ## Optional fields
+
+    * `:time` - `DateTime.t()` when the event occurred
+    * `:data` - event payload (any term)
+    * `:datacontenttype` - MIME type of `:data` (e.g. `"application/json"`)
+    * `:subject` - subject of the event in the context of the source
+
+  ## Examples
+
+      ce = CloudEvent.new("raxol.key", "raxol://node-1",
+        data: %{key: :enter, state: :pressed}
+      )
+
+      map = CloudEvent.to_map(ce)
+      # => %{specversion: "1.0", id: "...", source: "raxol://node-1",
+      #      type: "raxol.key", time: ~U[...], data: %{...}}
+
+      {:ok, ce2} = CloudEvent.from_map(map)
+  """
+
+  @specversion "1.0"
+
+  @type t :: %__MODULE__{
+          specversion: String.t(),
+          id: String.t(),
+          source: String.t(),
+          type: String.t(),
+          time: DateTime.t() | nil,
+          data: term() | nil,
+          datacontenttype: String.t() | nil,
+          subject: String.t() | nil
+        }
+
+  @enforce_keys [:id, :source, :type]
+  defstruct specversion: @specversion,
+            id: nil,
+            source: nil,
+            type: nil,
+            time: nil,
+            data: nil,
+            datacontenttype: nil,
+            subject: nil
+
+  @doc """
+  Construct a CloudEvent. `type` and `source` are required.
+
+  ## Options
+
+    * `:id` - explicit id (default: random 16 hex chars)
+    * `:time` - `DateTime.t()` (default: `DateTime.utc_now/0`)
+    * `:data` - event payload
+    * `:datacontenttype` - MIME type of `:data`
+    * `:subject` - subject of the event
+  """
+  @spec new(String.t(), String.t(), keyword()) :: t()
+  def new(type, source, opts \\ [])
+      when is_binary(type) and is_binary(source) do
+    %__MODULE__{
+      specversion: @specversion,
+      id: Keyword.get(opts, :id) || generate_id(),
+      source: source,
+      type: type,
+      time: Keyword.get(opts, :time, DateTime.utc_now()),
+      data: Keyword.get(opts, :data),
+      datacontenttype: Keyword.get(opts, :datacontenttype),
+      subject: Keyword.get(opts, :subject)
+    }
+  end
+
+  @doc """
+  Returns the CloudEvent as a map suitable for JSON encoding.
+  Nil-valued optional fields are dropped. Atom keys; convert to
+  string keys at the serialization boundary if needed.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = ce) do
+    %{
+      specversion: ce.specversion,
+      id: ce.id,
+      source: ce.source,
+      type: ce.type
+    }
+    |> maybe_put(:time, ce.time)
+    |> maybe_put(:data, ce.data)
+    |> maybe_put(:datacontenttype, ce.datacontenttype)
+    |> maybe_put(:subject, ce.subject)
+  end
+
+  @doc """
+  Build a CloudEvent from a map (atom or string keys).
+
+  Returns `{:error, :missing_required_field}` if `:id`, `:source`, or
+  `:type` is absent. Unknown fields are dropped silently.
+  """
+  @spec from_map(map()) :: {:ok, t()} | {:error, :missing_required_field}
+  def from_map(map) when is_map(map) do
+    with {:ok, id} <- fetch(map, :id),
+         {:ok, source} <- fetch(map, :source),
+         {:ok, type} <- fetch(map, :type) do
+      {:ok,
+       %__MODULE__{
+         specversion: get(map, :specversion, @specversion),
+         id: id,
+         source: source,
+         type: type,
+         time: get(map, :time),
+         data: get(map, :data),
+         datacontenttype: get(map, :datacontenttype),
+         subject: get(map, :subject)
+       }}
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp fetch(map, key) do
+    case get(map, key) do
+      nil -> {:error, :missing_required_field}
+      "" -> {:error, :missing_required_field}
+      value -> {:ok, value}
+    end
+  end
+
+  defp get(map, key, default \\ nil) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key), default)
+  end
+
+  defp generate_id do
+    :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
+  end
+end

--- a/packages/raxol_core/lib/raxol/core/events/event.ex
+++ b/packages/raxol_core/lib/raxol/core/events/event.ex
@@ -397,4 +397,57 @@ defmodule Raxol.Core.Events.Event do
       %Raxol.Core.Events.Event{type: :key, data: unquote(data_pattern)}
     end
   end
+
+  # -- CloudEvents v1.0 interop --
+
+  @type_prefix "raxol."
+
+  @doc """
+  Convert an Event to a `Raxol.Core.Events.CloudEvent`.
+
+  The CloudEvents `type` is `"raxol.<atom>"`. The `source` defaults to
+  the `:event_source` application env (or `"raxol://localhost"`).
+
+  ## Options
+
+    * `:source` - override the source URI for this conversion
+  """
+  @spec to_cloud_event(t(), keyword()) :: Raxol.Core.Events.CloudEvent.t()
+  def to_cloud_event(%__MODULE__{} = event, opts \\ []) do
+    source =
+      Keyword.get(opts, :source) ||
+        Application.get_env(:raxol_core, :event_source, "raxol://localhost")
+
+    Raxol.Core.Events.CloudEvent.new(
+      @type_prefix <> Atom.to_string(event.type),
+      source,
+      data: event.data,
+      time: event.timestamp
+    )
+  end
+
+  @doc """
+  Build an Event from a `Raxol.Core.Events.CloudEvent`.
+
+  Returns `{:error, :unknown_event_type}` if the CloudEvents `type` does
+  not strip to a known atom in the current VM (existing-atoms only, to
+  avoid memory-leak risk on external input).
+  """
+  @spec from_cloud_event(Raxol.Core.Events.CloudEvent.t()) ::
+          {:ok, t()} | {:error, :unknown_event_type}
+  def from_cloud_event(%Raxol.Core.Events.CloudEvent{} = ce) do
+    raw =
+      case ce.type do
+        @type_prefix <> rest -> rest
+        other -> other
+      end
+
+    try do
+      atom = String.to_existing_atom(raw)
+      timestamp = ce.time || DateTime.utc_now()
+      {:ok, new(atom, ce.data, timestamp)}
+    rescue
+      ArgumentError -> {:error, :unknown_event_type}
+    end
+  end
 end

--- a/packages/raxol_core/lib/raxol/core/events/telemetry_adapter.ex
+++ b/packages/raxol_core/lib/raxol/core/events/telemetry_adapter.ex
@@ -131,13 +131,24 @@ defmodule Raxol.Core.Events.TelemetryAdapter do
       %{trace_id: nil} ->
         metadata
 
-      %{trace_id: trace_id, span_id: span_id, parent_span_id: parent_span_id} ->
+      %{
+        trace_id: trace_id,
+        span_id: span_id,
+        parent_span_id: parent_span_id,
+        causation_id: causation_id
+      } ->
         metadata
         |> Map.put(:trace_id, trace_id)
         |> Map.put(:span_id, span_id)
         |> maybe_put_parent_span(parent_span_id)
+        |> maybe_put_causation(causation_id)
     end
   end
+
+  defp maybe_put_causation(metadata, nil), do: metadata
+
+  defp maybe_put_causation(metadata, id),
+    do: Map.put(metadata, :causation_id, id)
 
   @spec maybe_put_parent_span(
           %{

--- a/packages/raxol_core/lib/raxol/core/telemetry/trace_context.ex
+++ b/packages/raxol_core/lib/raxol/core/telemetry/trace_context.ex
@@ -30,6 +30,15 @@ defmodule Raxol.Core.Telemetry.TraceContext do
   - `:raxol_span_id` - Current span identifier
   - `:raxol_parent_span_id` - Parent span for nested operations
   - `:raxol_span_stack` - Stack of span IDs for nesting
+  - `:raxol_causation_id` - Id of the event/span that caused the current work
+
+  ## Causation vs parent span
+
+  `parent_span_id` reflects synchronous nesting (a span starts inside
+  another). `causation_id` reflects asynchronous handoff (an event
+  caused this work to happen, possibly across processes or messages).
+  Both can hold values simultaneously and serve different debugging
+  needs.
 
   ## Integration
 
@@ -39,11 +48,13 @@ defmodule Raxol.Core.Telemetry.TraceContext do
 
   @type trace_id :: String.t()
   @type span_id :: String.t()
+  @type causation_id :: String.t()
 
   @type context :: %{
           trace_id: trace_id() | nil,
           span_id: span_id() | nil,
-          parent_span_id: span_id() | nil
+          parent_span_id: span_id() | nil,
+          causation_id: causation_id() | nil
         }
 
   @doc """
@@ -143,8 +154,29 @@ defmodule Raxol.Core.Telemetry.TraceContext do
     %{
       trace_id: Process.get(:raxol_trace_id),
       span_id: Process.get(:raxol_span_id),
-      parent_span_id: Process.get(:raxol_parent_span_id)
+      parent_span_id: Process.get(:raxol_parent_span_id),
+      causation_id: Process.get(:raxol_causation_id)
     }
+  end
+
+  @doc """
+  Sets the causation id for the current process.
+
+  Use this when handing work off across messages or processes: the
+  sender's `span_id` becomes the receiver's `causation_id`, forming a
+  chain independent of synchronous span nesting.
+
+  Passing `nil` clears the causation id.
+  """
+  @spec set_causation(causation_id() | nil) :: context()
+  def set_causation(nil) do
+    Process.delete(:raxol_causation_id)
+    current()
+  end
+
+  def set_causation(id) when is_binary(id) do
+    Process.put(:raxol_causation_id, id)
+    current()
   end
 
   @doc """
@@ -158,6 +190,7 @@ defmodule Raxol.Core.Telemetry.TraceContext do
     Process.delete(:raxol_span_id)
     Process.delete(:raxol_parent_span_id)
     Process.delete(:raxol_span_stack)
+    Process.delete(:raxol_causation_id)
     :ok
   end
 
@@ -253,6 +286,7 @@ defmodule Raxol.Core.Telemetry.TraceContext do
     |> maybe_put("x-trace-id", ctx.trace_id)
     |> maybe_put("x-span-id", ctx.span_id)
     |> maybe_put("x-parent-span-id", ctx.parent_span_id)
+    |> maybe_put("x-causation-id", ctx.causation_id)
   end
 
   @doc """
@@ -266,6 +300,7 @@ defmodule Raxol.Core.Telemetry.TraceContext do
   def from_headers(headers) when is_map(headers) do
     trace_id = Map.get(headers, "x-trace-id")
     parent_span_id = Map.get(headers, "x-span-id")
+    causation_id = Map.get(headers, "x-causation-id")
 
     _ =
       if trace_id do
@@ -273,6 +308,10 @@ defmodule Raxol.Core.Telemetry.TraceContext do
 
         if parent_span_id do
           Process.put(:raxol_parent_span_id, parent_span_id)
+        end
+
+        if causation_id do
+          Process.put(:raxol_causation_id, causation_id)
         end
       end
 

--- a/packages/raxol_core/test/raxol/core/events/cloud_event_test.exs
+++ b/packages/raxol_core/test/raxol/core/events/cloud_event_test.exs
@@ -1,0 +1,183 @@
+defmodule Raxol.Core.Events.CloudEventTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.CloudEvent
+  alias Raxol.Core.Events.Event
+
+  describe "new/3" do
+    test "sets required fields with defaults" do
+      ce = CloudEvent.new("raxol.key", "raxol://node-1")
+
+      assert ce.specversion == "1.0"
+      assert ce.type == "raxol.key"
+      assert ce.source == "raxol://node-1"
+      assert is_binary(ce.id) and byte_size(ce.id) == 16
+      assert %DateTime{} = ce.time
+      assert ce.data == nil
+    end
+
+    test "carries optional fields" do
+      time = ~U[2026-06-14 12:00:00Z]
+
+      ce =
+        CloudEvent.new("raxol.timer", "raxol://node-1",
+          id: "fixed",
+          time: time,
+          data: %{tick: 1},
+          datacontenttype: "application/json",
+          subject: "ticker"
+        )
+
+      assert ce.id == "fixed"
+      assert ce.time == time
+      assert ce.data == %{tick: 1}
+      assert ce.datacontenttype == "application/json"
+      assert ce.subject == "ticker"
+    end
+
+    test "ids are unique across calls" do
+      ids = for _ <- 1..20, do: CloudEvent.new("raxol.x", "raxol://x").id
+      assert Enum.uniq(ids) == ids
+    end
+  end
+
+  describe "to_map/1" do
+    test "includes required fields and drops nil optionals" do
+      ce = CloudEvent.new("raxol.key", "raxol://node-1", time: nil)
+      map = CloudEvent.to_map(ce)
+
+      assert Map.has_key?(map, :specversion)
+      assert Map.has_key?(map, :id)
+      assert Map.has_key?(map, :source)
+      assert Map.has_key?(map, :type)
+      refute Map.has_key?(map, :time)
+      refute Map.has_key?(map, :data)
+      refute Map.has_key?(map, :datacontenttype)
+      refute Map.has_key?(map, :subject)
+    end
+
+    test "includes present optional fields" do
+      ce =
+        CloudEvent.new("raxol.timer", "raxol://node-1",
+          data: %{tick: 1},
+          subject: "ticker"
+        )
+
+      map = CloudEvent.to_map(ce)
+
+      assert map.data == %{tick: 1}
+      assert map.subject == "ticker"
+    end
+  end
+
+  describe "from_map/1" do
+    test "rebuilds from atom-keyed map" do
+      original = CloudEvent.new("raxol.key", "raxol://node-1", data: :payload)
+      {:ok, ce} = original |> CloudEvent.to_map() |> CloudEvent.from_map()
+
+      assert ce.id == original.id
+      assert ce.source == original.source
+      assert ce.type == original.type
+      assert ce.data == :payload
+    end
+
+    test "rebuilds from string-keyed map" do
+      map = %{
+        "specversion" => "1.0",
+        "id" => "abc123",
+        "source" => "external://producer",
+        "type" => "com.example.thing",
+        "data" => %{"k" => "v"}
+      }
+
+      assert {:ok, ce} = CloudEvent.from_map(map)
+      assert ce.id == "abc123"
+      assert ce.source == "external://producer"
+      assert ce.type == "com.example.thing"
+      assert ce.data == %{"k" => "v"}
+    end
+
+    test "rejects missing id" do
+      map = %{source: "x", type: "y"}
+      assert CloudEvent.from_map(map) == {:error, :missing_required_field}
+    end
+
+    test "rejects missing source" do
+      map = %{id: "1", type: "y"}
+      assert CloudEvent.from_map(map) == {:error, :missing_required_field}
+    end
+
+    test "rejects missing type" do
+      map = %{id: "1", source: "x"}
+      assert CloudEvent.from_map(map) == {:error, :missing_required_field}
+    end
+
+    test "rejects empty required field" do
+      map = %{id: "", source: "x", type: "y"}
+      assert CloudEvent.from_map(map) == {:error, :missing_required_field}
+    end
+  end
+
+  describe "Event.to_cloud_event/2" do
+    test "prefixes type with 'raxol.' and carries data and timestamp" do
+      time = ~U[2026-06-14 12:00:00Z]
+      event = Event.new(:key, %{key: :enter}, time)
+
+      ce = Event.to_cloud_event(event, source: "raxol://node-7")
+
+      assert ce.type == "raxol.key"
+      assert ce.source == "raxol://node-7"
+      assert ce.data == %{key: :enter}
+      assert ce.time == time
+    end
+
+    test "falls back to app env source then default" do
+      Application.delete_env(:raxol_core, :event_source)
+      event = Event.new(:timer, :tick)
+      ce = Event.to_cloud_event(event)
+      assert ce.source == "raxol://localhost"
+
+      Application.put_env(:raxol_core, :event_source, "raxol://configured")
+      ce2 = Event.to_cloud_event(event)
+      assert ce2.source == "raxol://configured"
+    after
+      Application.delete_env(:raxol_core, :event_source)
+    end
+  end
+
+  describe "Event.from_cloud_event/1" do
+    test "round-trips a raxol event" do
+      original = Event.new(:key, %{key: :enter})
+      ce = Event.to_cloud_event(original, source: "raxol://x")
+      assert {:ok, event} = Event.from_cloud_event(ce)
+
+      assert event.type == :key
+      assert event.data == %{key: :enter}
+      assert event.timestamp == original.timestamp
+    end
+
+    test "handles foreign type without 'raxol.' prefix when atom exists" do
+      _ = :timer
+      ce = CloudEvent.new("timer", "external://x", data: :payload)
+      assert {:ok, event} = Event.from_cloud_event(ce)
+      assert event.type == :timer
+      assert event.data == :payload
+    end
+
+    test "returns error for unknown atom type" do
+      ce =
+        CloudEvent.new(
+          "raxol.never_loaded_as_atom_qwertyuiop_xyz_123",
+          "raxol://x"
+        )
+
+      assert Event.from_cloud_event(ce) == {:error, :unknown_event_type}
+    end
+
+    test "uses now() when CloudEvent.time is nil" do
+      ce = CloudEvent.new("raxol.timer", "raxol://x", time: nil)
+      {:ok, event} = Event.from_cloud_event(ce)
+      assert %DateTime{} = event.timestamp
+    end
+  end
+end

--- a/packages/raxol_core/test/raxol/core/telemetry/trace_context_test.exs
+++ b/packages/raxol_core/test/raxol/core/telemetry/trace_context_test.exs
@@ -49,7 +49,12 @@ defmodule Raxol.Core.Telemetry.TraceContextTest do
     test "returns nil fields when no trace started" do
       ctx = TraceContext.current()
 
-      assert ctx == %{trace_id: nil, span_id: nil, parent_span_id: nil}
+      assert ctx == %{
+               trace_id: nil,
+               span_id: nil,
+               parent_span_id: nil,
+               causation_id: nil
+             }
     end
 
     test "returns active context after start_trace" do
@@ -300,6 +305,61 @@ defmodule Raxol.Core.Telemetry.TraceContextTest do
       ctx = TraceContext.from_headers(%{})
 
       assert ctx.trace_id == nil
+    end
+
+    test "round-trips causation_id through headers" do
+      _ = TraceContext.start_trace()
+      _ = TraceContext.set_causation("caused-by-event-42")
+
+      headers = TraceContext.to_headers()
+      assert headers["x-causation-id"] == "caused-by-event-42"
+
+      TraceContext.clear()
+      _ = TraceContext.from_headers(headers)
+
+      assert TraceContext.current().causation_id == "caused-by-event-42"
+    end
+  end
+
+  describe "causation_id" do
+    test "current/0 includes causation_id field defaulting to nil" do
+      ctx = TraceContext.current()
+      assert Map.has_key?(ctx, :causation_id)
+      assert ctx.causation_id == nil
+    end
+
+    test "set_causation/1 stores the id in the current process" do
+      _ = TraceContext.start_trace()
+      _ = TraceContext.set_causation("event-99")
+
+      assert TraceContext.current().causation_id == "event-99"
+    end
+
+    test "set_causation(nil) clears the id" do
+      _ = TraceContext.start_trace()
+      _ = TraceContext.set_causation("event-99")
+      _ = TraceContext.set_causation(nil)
+
+      assert TraceContext.current().causation_id == nil
+    end
+
+    test "clear/0 removes causation_id" do
+      _ = TraceContext.start_trace()
+      _ = TraceContext.set_causation("event-99")
+      :ok = TraceContext.clear()
+
+      assert TraceContext.current().causation_id == nil
+    end
+
+    test "causation_id is independent of parent_span_id" do
+      _ = TraceContext.start_trace()
+      _ = TraceContext.set_causation("upstream-span")
+      _ = TraceContext.start_span("child")
+
+      ctx = TraceContext.current()
+      assert ctx.causation_id == "upstream-span"
+      assert is_binary(ctx.parent_span_id)
+      refute ctx.parent_span_id == ctx.causation_id
     end
   end
 end


### PR DESCRIPTION
## Summary

Phase 24 foundation, per the 2026-06-14 jido/beam_weaver extraction plan. Five focused commits, +1061/-19 across raxol_core, raxol_agent, and main raxol's runtime. Phase 24D-3+ (`Raxol.Agent` macro migration, hook updates, custom-effect ports, final `Command` deletion) intentionally deferred to follow-up PRs since they touch user-facing surfaces and warrant their own planning.

- **Directive struct family + Executor protocol** (`packages/raxol_agent/lib/raxol/agent/directive*`). Six built-in types (Async, Shell, SendAgent, Schedule, Spawn, Stop); per-struct `defimpl` mirrors `Raxol.Core.Runtime.Command.execute_command_type/3` byte-for-byte so result message shapes are unchanged. External packages register custom directive structs without touching core.
- **CloudEvents v1.0 envelope** (`packages/raxol_core/lib/raxol/core/events/cloud_event.ex`). Zero new external deps; uses `:crypto.strong_rand_bytes` for ids. `Event.to_cloud_event/2` + `from_cloud_event/1` with `"raxol."` type prefix; inbound uses `String.to_existing_atom` to avoid memory-leak risk on untrusted input.
- **`causation_id` in TraceContext** (`packages/raxol_core/lib/raxol/core/telemetry/`). Captures async handoff identity, orthogonal to `parent_span_id` nesting. `set_causation/1` helper, `x-causation-id` header round-trip, `TelemetryAdapter` propagates into emitted metadata.
- **Runtime dispatch extension** (`lib/raxol/core/runtime/{events/dispatcher.ex,lifecycle.ex}`). `process_commands` and `execute_initial_command` now route any struct implementing `Directive.Executor` through the protocol, alongside the existing `%Command{}` path. Cross-package reference guarded with `Code.ensure_loaded?` + `@compile {:no_warn_undefined, ...}`; main raxol still compiles standalone.
- **Broadened effect typespecs**. `Action`, `Pipeline`, `Strategy`, `ToolConverter` declare a shared `@type effect :: Command.t() | Directive.t()` so directives flow through without dialyzer mismatches.

End-to-end verified via `DirectiveShellAgent` in `session_test.exs`: an agent returns `[Directive.shell(cmd)]` from `update/2`, the runtime dispatches it, and the agent receives the standard `{:command_result, {:shell_result, %{exit_status, output}}}` callback. Result-shape parity means consumer code keeps working unchanged.

## Test plan

- [ ] CI: raxol_core suite green (754 tests locally, was 730 baseline + 24 new)
- [ ] CI: raxol_agent suite green (468 tests locally, was 467 baseline + 1 new end-to-end test)
- [ ] CI: main raxol runtime suite green (308 0 failures locally)
- [ ] CI: credo strict reports 0 new findings on changed files
- [ ] CI: format --check-formatted passes
- [ ] Manual: pull the branch, confirm an agent module returning `[Raxol.Agent.Directive.shell("echo x")]` from `update/2` receives the standard `{:command_result, {:shell_result, _}}` callback (covered by the new `DirectiveShellAgent` test, but worth eyeball-confirming)
- [ ] Manual: confirm raxol_payments / raxol_acp continue to pass (they still construct Commands; the dispatcher's existing `%Command{}` clause is untouched)