### PR TITLE
Phase 24D: macro + hooks + causation + Pay directive

### DIFF
--- a/lib/raxol/core/runtime/application.ex
+++ b/lib/raxol/core/runtime/application.ex
@@ -77,6 +77,8 @@ defmodule Raxol.Core.Runtime.Application do
   initialization and after each state update.
   """
 
+  @compile {:no_warn_undefined, Raxol.Agent.Directive.Executor}
+
   @type context :: map()
   @type state :: term()
   @type message :: term()
@@ -312,8 +314,14 @@ defmodule Raxol.Core.Runtime.Application do
       {new_model, commands} when is_map(new_model) and is_list(commands) ->
         {:ok, {new_model, commands}}
 
-      {new_model, %Raxol.Core.Runtime.Command{} = cmd} when is_map(new_model) ->
-        {:ok, {new_model, [cmd]}}
+      {new_model, effect} when is_map(new_model) and is_struct(effect) ->
+        normalize_single_effect(
+          app_module,
+          new_model,
+          effect,
+          message,
+          current_model
+        )
 
       invalid_return ->
         log_invalid_update_result(
@@ -325,6 +333,34 @@ defmodule Raxol.Core.Runtime.Application do
 
         {:error, :invalid_update_result}
     end
+  end
+
+  defp normalize_single_effect(
+         app_module,
+         new_model,
+         effect,
+         message,
+         current_model
+       ) do
+    if known_effect?(effect) do
+      {:ok, {new_model, [effect]}}
+    else
+      log_invalid_update_result(
+        app_module,
+        {new_model, effect},
+        message,
+        current_model
+      )
+
+      {:error, :invalid_update_result}
+    end
+  end
+
+  defp known_effect?(%Raxol.Core.Runtime.Command{}), do: true
+
+  defp known_effect?(effect) do
+    Code.ensure_loaded?(Raxol.Agent.Directive.Executor) and
+      Raxol.Agent.Directive.Executor.impl_for(effect) != nil
   end
 
   defp log_missing_update_callback(app_module, message, current_model) do

--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -361,6 +361,21 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
 
   @impl true
   def handle_manager_cast(
+        {:dispatch, {:agent_message, _from, _payload} = msg, metadata},
+        state
+      )
+      when is_map(metadata) do
+    apply_causation(metadata)
+
+    Raxol.Core.Runtime.Log.debug(
+      "[Dispatcher] handle_cast :dispatch agent_message: #{inspect(msg)}"
+    )
+
+    dispatch_raw_message(msg, state)
+  end
+
+  @impl true
+  def handle_manager_cast(
         {:dispatch, {:agent_message, _from, _payload} = msg},
         state
       ) do
@@ -849,4 +864,10 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
   end
 
   defp test_env?, do: Code.ensure_loaded?(Mix) and Mix.env() == :test
+
+  defp apply_causation(%{causation_id: id}) when is_binary(id) do
+    Raxol.Core.Telemetry.TraceContext.set_causation(id)
+  end
+
+  defp apply_causation(_), do: :ok
 end

--- a/packages/raxol_agent/lib/raxol/agent.ex
+++ b/packages/raxol_agent/lib/raxol/agent.ex
@@ -18,14 +18,14 @@ defmodule Raxol.Agent do
         end
 
         def update({:agent_message, _from, {:analyze, file}}, model) do
-          {%{model | status: :working}, Command.async(fn sender ->
+          {%{model | status: :working}, Directive.async(fn sender ->
             result = do_analysis(file)
             sender.({:analysis_done, result})
           end)}
         end
 
         def update({:command_result, {:analysis_done, result}}, model) do
-          {%{model | findings: [result | model.findings], status: :idle}, Command.none()}
+          {%{model | findings: [result | model.findings], status: :idle}, []}
         end
       end
   """
@@ -35,11 +35,12 @@ defmodule Raxol.Agent do
       @behaviour Raxol.Core.Runtime.Application
 
       import Raxol.Core.Renderer.View, except: [view: 1]
+      alias Raxol.Agent.Directive
       alias Raxol.Core.Events.Event
       alias Raxol.Core.Runtime.Command
 
       def init(_), do: %{}
-      def update(_, state), do: {state, Command.none()}
+      def update(_, state), do: {state, []}
       def view(_model), do: nil
       def subscribe(_), do: []
       def subscriptions(_), do: []
@@ -110,13 +111,13 @@ defmodule Raxol.Agent do
                      available_actions: 0
 
       @doc false
-      def async(fun), do: Command.async(fun)
+      def async(fun), do: Directive.async(fun)
 
       @doc false
-      def shell(command, opts \\ []), do: Command.shell(command, opts)
+      def shell(command, opts \\ []), do: Directive.shell(command, opts)
 
       @doc false
-      def send_agent(target, message), do: Command.send_agent(target, message)
+      def send_agent(target, message), do: Directive.send_agent(target, message)
 
       @doc "Run an action synchronously. Returns `{:ok, result}` or `{:error, reason}`."
       @spec run_action(module(), map(), map()) ::
@@ -126,9 +127,9 @@ defmodule Raxol.Agent do
       end
 
       @doc "Run an action asynchronously. Result arrives as `{:command_result, {:action_result, module, result}}`."
-      @spec run_action_async(module(), map(), map()) :: Command.t()
+      @spec run_action_async(module(), map(), map()) :: Directive.Async.t()
       def run_action_async(action_module, params, context \\ %{}) do
-        Command.async(fn sender ->
+        Directive.async(fn sender ->
           case action_module.call(params, context) do
             {:ok, result} ->
               sender.({:action_result, action_module, result})
@@ -143,9 +144,9 @@ defmodule Raxol.Agent do
       end
 
       @doc "Run a pipeline asynchronously. Result arrives as `{:command_result, {:pipeline_result, result}}`."
-      @spec run_pipeline_async([module()], map(), map()) :: Command.t()
+      @spec run_pipeline_async([module()], map(), map()) :: Directive.Async.t()
       def run_pipeline_async(steps, params, context \\ %{}) do
-        Command.async(fn sender ->
+        Directive.async(fn sender ->
           case Raxol.Agent.Action.Pipeline.run(steps, params, context) do
             {:ok, result, _commands} ->
               sender.({:pipeline_result, result})

--- a/packages/raxol_agent/lib/raxol/agent/command_hook.ex
+++ b/packages/raxol_agent/lib/raxol/agent/command_hook.ex
@@ -41,14 +41,18 @@ defmodule Raxol.Agent.CommandHook do
   - `{:ok, result}` -- post-hook, optionally modify result
   """
 
+  alias Raxol.Agent.Directive
+  alias Raxol.Agent.Directive.{Async, SendAgent, Shell}
   alias Raxol.Core.Runtime.Command
+
+  @type effect :: Command.t() | Directive.t()
 
   @type hook_context :: %{
           agent_id: term(),
           agent_module: module()
         }
 
-  @type pre_result :: {:ok, Command.t()} | {:deny, term()}
+  @type pre_result :: {:ok, effect()} | {:deny, term()}
   @type post_result :: {:ok, term()} | {:error, term()}
 
   @doc """
@@ -57,7 +61,7 @@ defmodule Raxol.Agent.CommandHook do
   Return `{:ok, command}` to allow (optionally modify the command),
   or `{:deny, reason}` to block execution.
   """
-  @callback pre_execute(command :: Command.t(), context :: hook_context()) ::
+  @callback pre_execute(command :: effect(), context :: hook_context()) ::
               pre_result()
 
   @doc """
@@ -66,7 +70,7 @@ defmodule Raxol.Agent.CommandHook do
   Return `{:ok, result}` to pass through (optionally modify the result).
   """
   @callback post_execute(
-              command :: Command.t(),
+              command :: effect(),
               result :: term(),
               context :: hook_context()
             ) :: post_result()
@@ -79,7 +83,7 @@ defmodule Raxol.Agent.CommandHook do
   Hooks are evaluated in order. The first `:deny` short-circuits the chain.
   Each hook may modify the command before passing it to the next.
   """
-  @spec run_pre_hooks([module()], Command.t(), hook_context()) :: pre_result()
+  @spec run_pre_hooks([module()], effect(), hook_context()) :: pre_result()
   def run_pre_hooks([], command, _context), do: {:ok, command}
 
   def run_pre_hooks([hook | rest], command, context) do
@@ -94,7 +98,7 @@ defmodule Raxol.Agent.CommandHook do
 
   Hooks are evaluated in order. Each hook may modify the result.
   """
-  @spec run_post_hooks([module()], Command.t(), term(), hook_context()) ::
+  @spec run_post_hooks([module()], effect(), term(), hook_context()) ::
           post_result()
   def run_post_hooks([], _command, result, _context), do: {:ok, result}
 
@@ -119,73 +123,103 @@ defmodule Raxol.Agent.CommandHook do
   Denied commands are replaced with a `:none` command that sends a
   `{:command_denied, type, reason}` result back to the agent.
   """
-  @spec wrap_commands([Command.t()], [module()], hook_context()) :: [
-          Command.t()
-        ]
+  @spec wrap_commands([effect()], [module()], hook_context()) :: [effect()]
   def wrap_commands(commands, [], _context), do: commands
 
   def wrap_commands(commands, hooks, context) do
     Enum.map(commands, &maybe_wrap(&1, hooks, context))
   end
 
-  @hookable_types [:shell, :async, :system, :send_agent, :task]
+  @hookable_command_types [:shell, :async, :system, :send_agent, :task]
 
   defp maybe_wrap(%Command{type: type} = command, hooks, context)
-       when type in @hookable_types do
-    case run_pre_hooks(hooks, command, context) do
-      {:ok, command} ->
-        wrap_with_post_hooks(command, hooks, context)
+       when type in @hookable_command_types do
+    apply_hooks(command, hooks, context)
+  end
 
-      {:deny, reason} ->
-        Command.new(:async, fn sender ->
-          sender.({:command_denied, type, reason})
-        end)
+  defp maybe_wrap(%Async{} = directive, hooks, context),
+    do: apply_hooks(directive, hooks, context)
+
+  defp maybe_wrap(%Shell{} = directive, hooks, context),
+    do: apply_hooks(directive, hooks, context)
+
+  defp maybe_wrap(%SendAgent{} = directive, hooks, context),
+    do: apply_hooks(directive, hooks, context)
+
+  defp maybe_wrap(effect, _hooks, _context), do: effect
+
+  defp apply_hooks(effect, hooks, context) do
+    case run_pre_hooks(hooks, effect, context) do
+      {:ok, effect} -> wrap_with_post_hooks(effect, hooks, context)
+      {:deny, reason} -> build_denial(effect, reason)
     end
   end
 
-  defp maybe_wrap(command, _hooks, _context), do: command
+  defp build_denial(%Command{type: type}, reason) do
+    Command.new(:async, fn sender ->
+      sender.({:command_denied, type, reason})
+    end)
+  end
 
-  defp wrap_with_post_hooks(command, hooks, context) do
+  defp build_denial(directive, reason) do
+    type = effect_type(directive)
+
+    Directive.async(fn sender ->
+      sender.({:command_denied, type, reason})
+    end)
+  end
+
+  defp effect_type(%Async{}), do: :async
+  defp effect_type(%Shell{}), do: :shell
+  defp effect_type(%SendAgent{}), do: :send_agent
+
+  defp wrap_with_post_hooks(effect, hooks, context) do
     if Enum.any?(hooks, &function_exported?(&1, :post_execute, 3)) do
-      case command.type do
-        :async ->
-          original_fun = command.data
-
-          wrapped_fun = fn sender ->
-            wrapped_sender = fn result ->
-              case run_post_hooks(hooks, command, result, context) do
-                {:ok, modified_result} -> sender.(modified_result)
-                {:error, reason} -> sender.({:hook_error, reason})
-              end
-            end
-
-            original_fun.(wrapped_sender)
-          end
-
-          %{command | data: wrapped_fun}
-
-        :task ->
-          original_fun = command.data
-
-          wrapped_fun = fn ->
-            result = original_fun.()
-
-            case run_post_hooks(hooks, command, result, context) do
-              {:ok, modified_result} -> modified_result
-              {:error, reason} -> {:hook_error, reason}
-            end
-          end
-
-          %{command | data: wrapped_fun}
-
-        _ ->
-          # :shell, :system, :send_agent -- post-hooks can't easily wrap
-          # these since they use Port/GenServer internally. Pre-hooks
-          # are sufficient for these types.
-          command
-      end
+      do_wrap_post(effect, hooks, context)
     else
-      command
+      effect
+    end
+  end
+
+  defp do_wrap_post(%Command{type: :async} = command, hooks, context) do
+    original_fun = command.data
+    %{command | data: wrap_sender_fun(original_fun, command, hooks, context)}
+  end
+
+  defp do_wrap_post(%Command{type: :task} = command, hooks, context) do
+    original_fun = command.data
+    %{command | data: wrap_task_fun(original_fun, command, hooks, context)}
+  end
+
+  defp do_wrap_post(%Async{fun: fun} = directive, hooks, context) do
+    %{directive | fun: wrap_sender_fun(fun, directive, hooks, context)}
+  end
+
+  defp do_wrap_post(effect, _hooks, _context), do: effect
+
+  defp wrap_sender_fun(original_fun, effect, hooks, context) do
+    fn sender ->
+      original_fun.(build_wrapped_sender(sender, effect, hooks, context))
+    end
+  end
+
+  defp build_wrapped_sender(sender, effect, hooks, context) do
+    fn result ->
+      case run_post_hooks(hooks, effect, result, context) do
+        {:ok, modified} -> sender.(modified)
+        {:error, reason} -> sender.({:hook_error, reason})
+      end
+    end
+  end
+
+  defp wrap_task_fun(original_fun, effect, hooks, context) do
+    fn ->
+      result = original_fun.()
+
+      case run_post_hooks(hooks, effect, result, context) do
+        {:ok, modified} -> modified
+        {:error, reason} -> {:hook_error, reason}
+      end
     end
   end
 end

--- a/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
@@ -101,13 +101,20 @@ defimpl Raxol.Agent.Directive.Executor, for: Raxol.Agent.Directive.SendAgent do
   def execute(%SendAgent{target_id: target_id, message: message}, context) do
     with pid when is_pid(pid) <- Process.whereis(Raxol.Agent.Registry),
          [{agent_pid, _}] <- Registry.lookup(Raxol.Agent.Registry, target_id) do
-      GenServer.cast(agent_pid, {:send_message, message})
+      GenServer.cast(agent_pid, {:send_message, message, causation_metadata()})
     else
       _ ->
         send(
           context.pid,
           {:command_result, {:send_agent_error, :not_found, target_id}}
         )
+    end
+  end
+
+  defp causation_metadata do
+    case Raxol.Core.Telemetry.TraceContext.current() do
+      %{span_id: span_id} when is_binary(span_id) -> %{causation_id: span_id}
+      _ -> %{}
     end
   end
 end

--- a/packages/raxol_agent/lib/raxol/agent/permission_hook.ex
+++ b/packages/raxol_agent/lib/raxol/agent/permission_hook.ex
@@ -42,6 +42,7 @@ defmodule Raxol.Agent.PermissionHook do
 
   @behaviour Raxol.Agent.CommandHook
 
+  alias Raxol.Agent.Directive
   alias Raxol.Core.Runtime.Command
 
   @type mode ::
@@ -51,7 +52,8 @@ defmodule Raxol.Agent.PermissionHook do
           | :full_access
           | :allow
 
-  @type prompter :: (Command.t(), map() -> boolean())
+  @type effect :: Command.t() | Directive.t()
+  @type prompter :: (effect(), map() -> boolean())
 
   @type t :: %__MODULE__{
           mode: mode(),
@@ -116,14 +118,29 @@ defmodule Raxol.Agent.PermissionHook do
   @doc """
   Check whether a command is authorized under the given policy.
   """
-  @spec authorize(Command.t(), t(), map()) :: :allow | {:deny, String.t()}
+  @spec authorize(effect(), t(), map()) :: :allow | {:deny, String.t()}
   def authorize(%Command{type: type}, %__MODULE__{} = policy, context) do
+    check_type(type, policy, context)
+  end
+
+  def authorize(directive, %__MODULE__{} = policy, context) when is_struct(directive) do
+    check_type(effect_type(directive), policy, context)
+  end
+
+  defp check_type(type, %__MODULE__{} = policy, context) do
     if MapSet.member?(policy.denied_types, type) do
       maybe_prompt(type, policy, context)
     else
       :allow
     end
   end
+
+  defp effect_type(%Directive.Async{}), do: :async
+  defp effect_type(%Directive.Shell{}), do: :shell
+  defp effect_type(%Directive.SendAgent{}), do: :send_agent
+  defp effect_type(%Directive.Schedule{}), do: :delay
+  defp effect_type(%Directive.Spawn{}), do: :task
+  defp effect_type(%Directive.Stop{}), do: :quit
 
   @doc """
   Returns the minimum permission mode required for a command type.

--- a/packages/raxol_agent/lib/raxol/agent/session.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session.ex
@@ -35,7 +35,9 @@ defmodule Raxol.Agent.Session do
   def start_link(opts) do
     id = Keyword.fetch!(opts, :id)
 
-    GenServer.start_link(__MODULE__, opts, name: {:via, Registry, {Raxol.Agent.Registry, id}})
+    GenServer.start_link(__MODULE__, opts,
+      name: {:via, Registry, {Raxol.Agent.Registry, id}}
+    )
   end
 
   @doc "Send a message into the agent's TEA loop."
@@ -92,7 +94,9 @@ defmodule Raxol.Agent.Session do
     Process.unlink(lifecycle_pid)
     Process.monitor(lifecycle_pid)
 
-    Logger.info("[Agent.Session] Started agent #{inspect(id)} (#{inspect(app_module)})")
+    Logger.info(
+      "[Agent.Session] Started agent #{inspect(id)} (#{inspect(app_module)})"
+    )
 
     {:ok,
      %__MODULE__{
@@ -104,23 +108,37 @@ defmodule Raxol.Agent.Session do
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_cast({:send_message, message, metadata}, state)
+      when is_map(metadata) do
+    forward_to_dispatcher(state, message, metadata)
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_cast({:send_message, message}, state) do
+    forward_to_dispatcher(state, message, %{})
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_cast(_msg, state), do: {:noreply, state}
+
+  defp forward_to_dispatcher(state, message, metadata) do
     case get_dispatcher(state.lifecycle_pid) do
       nil ->
         :ok
 
       dispatcher_pid ->
-        GenServer.cast(
-          dispatcher_pid,
-          {:dispatch, {:agent_message, state.id, message}}
-        )
+        payload = {:agent_message, state.id, message}
+
+        cast =
+          if map_size(metadata) == 0,
+            do: {:dispatch, payload},
+            else: {:dispatch, payload, metadata}
+
+        GenServer.cast(dispatcher_pid, cast)
     end
 
     {:noreply, state}
   end
-
-  @impl Raxol.Core.Behaviours.BaseManager
-  def handle_manager_cast(_msg, state), do: {:noreply, state}
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_call(:get_model, _from, state) do

--- a/packages/raxol_agent/test/raxol/agent/command_hook_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/command_hook_test.exs
@@ -193,4 +193,90 @@ defmodule Raxol.Agent.CommandHookTest do
       assert {"echo modified: ls", _opts} = wrapped.data
     end
   end
+
+  alias Raxol.Agent.Directive
+  alias Raxol.Agent.Directive.{Async, SendAgent, Shell}
+
+  defmodule DenyDirectiveShellHook do
+    @behaviour CommandHook
+
+    @impl true
+    def pre_execute(%Shell{}, _context), do: {:deny, :shell_not_allowed}
+    def pre_execute(effect, _context), do: {:ok, effect}
+  end
+
+  defmodule DirectiveAuditHook do
+    @behaviour CommandHook
+
+    @impl true
+    def pre_execute(effect, context) do
+      send(context.test_pid, {:pre, struct_tag(effect)})
+      {:ok, effect}
+    end
+
+    @impl true
+    def post_execute(effect, result, context) do
+      send(context.test_pid, {:post, struct_tag(effect), result})
+      {:ok, result}
+    end
+
+    defp struct_tag(%Async{}), do: :async
+    defp struct_tag(%Shell{}), do: :shell
+    defp struct_tag(%SendAgent{}), do: :send_agent
+  end
+
+  describe "wrap_commands/3 with directives" do
+    test "non-hookable directives (Schedule, Spawn) pass through" do
+      effects = [Directive.schedule(50, :tick), Directive.spawn(fn -> :ok end)]
+      assert effects == CommandHook.wrap_commands(effects, [DenyDirectiveShellHook], @context)
+    end
+
+    test "denied shell directive becomes async denial" do
+      effects = [Directive.shell("rm -rf /")]
+      [wrapped] = CommandHook.wrap_commands(effects, [DenyDirectiveShellHook], @context)
+
+      assert %Async{} = wrapped
+
+      sender = fn msg -> send(self(), {:sent, msg}) end
+      wrapped.fun.(sender)
+
+      assert_received {:sent, {:command_denied, :shell, :shell_not_allowed}}
+    end
+
+    test "allowed async directive executes with post-hooks" do
+      original = Directive.async(fn sender -> sender.(:original_result) end)
+      context = Map.put(@context, :test_pid, self())
+
+      [wrapped] = CommandHook.wrap_commands([original], [DirectiveAuditHook], context)
+
+      assert %Async{} = wrapped
+
+      sender = fn msg -> send(self(), {:sent, msg}) end
+      wrapped.fun.(sender)
+
+      assert_received {:pre, :async}
+      assert_received {:post, :async, :original_result}
+      assert_received {:sent, :original_result}
+    end
+
+    test "shell directive passes through pre-hooks but no post-hook wrap" do
+      effects = [Directive.shell("ls")]
+      context = Map.put(@context, :test_pid, self())
+
+      [wrapped] = CommandHook.wrap_commands(effects, [DirectiveAuditHook], context)
+
+      assert %Shell{command: "ls"} = wrapped
+      assert_received {:pre, :shell}
+    end
+
+    test "send_agent directive passes through pre-hooks" do
+      effects = [Directive.send_agent(:target, :hello)]
+      context = Map.put(@context, :test_pid, self())
+
+      [wrapped] = CommandHook.wrap_commands(effects, [DirectiveAuditHook], context)
+
+      assert %SendAgent{target_id: :target, message: :hello} = wrapped
+      assert_received {:pre, :send_agent}
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/directive_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/directive_test.exs
@@ -82,8 +82,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("echo hello-from-shell")
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:shell_result, %{exit_status: 0, output: output}}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 0, output: output}}},
                      5_000
 
       assert String.contains?(output, "hello-from-shell")
@@ -101,8 +100,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("sleep 5", timeout: 100)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:shell_result, %{exit_status: :timeout}}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: :timeout}}},
                      2_000
     end
   end
@@ -112,8 +110,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.send_agent("nobody", :payload)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:send_agent_error, :not_found, "nobody"}},
+      assert_receive {:command_result, {:send_agent_error, :not_found, "nobody"}},
                      1_000
     end
 
@@ -127,7 +124,25 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.send_agent("self-as-agent", {:work, 42})
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:"$gen_cast", {:send_message, {:work, 42}}}, 1_000
+      assert_receive {:"$gen_cast", {:send_message, {:work, 42}, %{}}}, 1_000
+    end
+
+    test "cast carries causation_id when sender has an active span" do
+      {:ok, _} =
+        start_supervised({Registry, keys: :unique, name: Raxol.Agent.Registry})
+
+      {:ok, _} = Registry.register(Raxol.Agent.Registry, "causation-target", nil)
+
+      _ = Raxol.Core.Telemetry.TraceContext.start_trace()
+      %{span_id: span_id} = Raxol.Core.Telemetry.TraceContext.current()
+
+      directive = Directive.send_agent("causation-target", :payload)
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:"$gen_cast", {:send_message, :payload, %{causation_id: ^span_id}}},
+                     1_000
+    after
+      Raxol.Core.Telemetry.TraceContext.clear()
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/permission_hook_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/permission_hook_test.exs
@@ -220,4 +220,64 @@ defmodule Raxol.Agent.PermissionHookTest do
       assert is_binary(reason)
     end
   end
+
+  alias Raxol.Agent.Directive
+
+  describe "authorize/3 with directives" do
+    test "allows permitted directive types" do
+      policy = PermissionHook.policy(:full_access)
+
+      assert :allow ==
+               PermissionHook.authorize(Directive.shell("ls"), policy, @context)
+    end
+
+    test "denies restricted directive types" do
+      policy = PermissionHook.policy(:read_only)
+
+      assert {:deny, reason} =
+               PermissionHook.authorize(Directive.shell("ls"), policy, @context)
+
+      assert String.contains?(reason, ":shell")
+    end
+
+    test "Directive.send_agent allowed in :send_only mode" do
+      policy = PermissionHook.policy(:send_only)
+
+      assert :allow ==
+               PermissionHook.authorize(
+                 Directive.send_agent(:t, :hello),
+                 policy,
+                 @context
+               )
+    end
+
+    test "Directive.async allowed in :send_only mode" do
+      policy = PermissionHook.policy(:send_only)
+
+      assert :allow ==
+               PermissionHook.authorize(
+                 Directive.async(fn _s -> :ok end),
+                 policy,
+                 @context
+               )
+    end
+
+    test "Directive.schedule (mapped to :delay) allowed in :read_only mode" do
+      policy = PermissionHook.policy(:read_only)
+
+      assert :allow ==
+               PermissionHook.authorize(
+                 Directive.schedule(50, :tick),
+                 policy,
+                 @context
+               )
+    end
+
+    test "Directive.stop (mapped to :quit) allowed in :read_only mode" do
+      policy = PermissionHook.policy(:read_only)
+
+      assert :allow ==
+               PermissionHook.authorize(Directive.stop(), policy, @context)
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/session_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_test.exs
@@ -90,12 +90,26 @@ defmodule Raxol.Agent.SessionTest do
   defmodule DirectiveShellAgent do
     use Raxol.Agent
 
-    alias Raxol.Agent.Directive
-
     def init(_context), do: %{results: [], status: :idle}
 
     def update({:agent_message, _from, {:run, cmd}}, model) do
       {%{model | status: :running}, [Directive.shell(cmd)]}
+    end
+
+    def update({:command_result, {:shell_result, result}}, model) do
+      {%{model | results: [result | model.results], status: :done}, []}
+    end
+
+    def update(_msg, model), do: {model, []}
+  end
+
+  defmodule BareDirectiveAgent do
+    use Raxol.Agent
+
+    def init(_context), do: %{results: [], status: :idle}
+
+    def update({:agent_message, _from, {:run, cmd}}, model) do
+      {%{model | status: :running}, Directive.shell(cmd)}
     end
 
     def update({:command_result, {:shell_result, result}}, model) do
@@ -213,6 +227,21 @@ defmodule Raxol.Agent.SessionTest do
       [result] = model.results
       assert result.exit_status == 0
       assert String.contains?(result.output, "hello_directive")
+    end
+
+    @tag :unix_only
+    test "bare directive struct (not wrapped in list) is normalized" do
+      {:ok, _pid} =
+        Session.start_link(app_module: BareDirectiveAgent, id: :bare_directive)
+
+      Session.send_message(:bare_directive, {:run, "echo bare_directive"})
+      Process.sleep(500)
+
+      {:ok, model} = Session.get_model(:bare_directive)
+      assert model.status == :done
+      [result] = model.results
+      assert result.exit_status == 0
+      assert String.contains?(result.output, "bare_directive")
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/session_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_test.exs
@@ -119,6 +119,19 @@ defmodule Raxol.Agent.SessionTest do
     def update(_msg, model), do: {model, []}
   end
 
+  defmodule CausationCaptureAgent do
+    use Raxol.Agent
+
+    def init(_context), do: %{captured: nil}
+
+    def update({:agent_message, _from, :capture}, model) do
+      ctx = Raxol.Core.Telemetry.TraceContext.current()
+      {%{model | captured: ctx.causation_id}, []}
+    end
+
+    def update(_msg, model), do: {model, []}
+  end
+
   setup do
     start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
 
@@ -242,6 +255,30 @@ defmodule Raxol.Agent.SessionTest do
       [result] = model.results
       assert result.exit_status == 0
       assert String.contains?(result.output, "bare_directive")
+    end
+  end
+
+  describe "causation propagation" do
+    test "causation_id in send_message metadata reaches update/2" do
+      {:ok, pid} =
+        Session.start_link(app_module: CausationCaptureAgent, id: :causation_capture)
+
+      GenServer.cast(pid, {:send_message, :capture, %{causation_id: "upstream-xyz"}})
+      Process.sleep(200)
+
+      {:ok, model} = Session.get_model(:causation_capture)
+      assert model.captured == "upstream-xyz"
+    end
+
+    test "absent metadata leaves causation_id nil" do
+      {:ok, _pid} =
+        Session.start_link(app_module: CausationCaptureAgent, id: :causation_absent)
+
+      Session.send_message(:causation_absent, :capture)
+      Process.sleep(200)
+
+      {:ok, model} = Session.get_model(:causation_absent)
+      assert model.captured == nil
     end
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/directive/pay.ex
+++ b/packages/raxol_payments/lib/raxol/payments/directive/pay.ex
@@ -1,0 +1,82 @@
+defmodule Raxol.Payments.Directive.Pay do
+  @moduledoc """
+  Semantic payment directive.
+
+  Carries the spend metadata an agent runtime hook (`SpendingHook`) needs
+  to authorize before the side effect runs: `amount` and `domain`. The
+  side effect itself is a zero-arity `perform` closure that returns
+  `{:ok, result}` or `{:error, reason}`.
+
+  ## Result messages
+
+  Results land at the agent's `update/2` as:
+
+    * `{:command_result, {:pay_result, result}}` on `{:ok, result}`
+    * `{:command_result, {:pay_error, reason}}` on `{:error, reason}`
+    * `{:command_result, {:pay_error, {:exception, message}}}` on raise
+
+  ## Example
+
+      Raxol.Payments.Directive.Pay.new(
+        amount: Decimal.new("0.05"),
+        domain: "api.openai.com",
+        agent_id: :research_bot,
+        perform: fn ->
+          Req.post("https://api.openai.com/...")
+        end
+      )
+  """
+
+  @type perform :: (-> {:ok, term()} | {:error, term()})
+
+  @type t :: %__MODULE__{
+          amount: Decimal.t(),
+          domain: String.t(),
+          agent_id: term() | nil,
+          meta: map(),
+          perform: perform()
+        }
+
+  @enforce_keys [:amount, :domain, :perform]
+  defstruct [:amount, :domain, :agent_id, perform: nil, meta: %{}]
+
+  @doc """
+  Construct a Pay directive.
+
+  Required: `:amount`, `:domain`, `:perform`. Optional: `:agent_id`, `:meta`.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts) do
+    %__MODULE__{
+      amount: Keyword.fetch!(opts, :amount),
+      domain: Keyword.fetch!(opts, :domain),
+      perform: Keyword.fetch!(opts, :perform),
+      agent_id: Keyword.get(opts, :agent_id),
+      meta: Keyword.get(opts, :meta, %{})
+    }
+  end
+end
+
+defimpl Raxol.Agent.Directive.Executor, for: Raxol.Payments.Directive.Pay do
+  alias Raxol.Payments.Directive.Pay
+
+  def execute(%Pay{perform: perform}, context) do
+    pid = context.pid
+
+    Task.start(fn ->
+      try do
+        case perform.() do
+          {:ok, result} -> send(pid, {:command_result, {:pay_result, result}})
+          {:error, reason} -> send(pid, {:command_result, {:pay_error, reason}})
+          other -> send(pid, {:command_result, {:pay_result, other}})
+        end
+      rescue
+        e ->
+          send(
+            pid,
+            {:command_result, {:pay_error, {:exception, Exception.message(e)}}}
+          )
+      end
+    end)
+  end
+end

--- a/packages/raxol_payments/lib/raxol/payments/spending_hook.ex
+++ b/packages/raxol_payments/lib/raxol/payments/spending_hook.ex
@@ -25,6 +25,7 @@ defmodule Raxol.Payments.SpendingHook do
   @compile {:no_warn_undefined, Raxol.Agent.CommandHook}
   @behaviour Raxol.Agent.CommandHook
 
+  alias Raxol.Payments.Directive.Pay
   alias Raxol.Payments.{Ledger, PolicyGate, SpendingPolicy}
 
   @type config :: %{
@@ -77,6 +78,10 @@ defmodule Raxol.Payments.SpendingHook do
 
   # -- Private --
 
+  defp check_payment_command(%Pay{} = pay, context, config) do
+    apply_gate({pay.amount, pay.domain}, pay, context, config)
+  end
+
   defp check_payment_command(%{type: type} = command, context, config)
        when type in [:async, :shell] do
     command
@@ -111,6 +116,11 @@ defmodule Raxol.Payments.SpendingHook do
   end
 
   defp extract_payment_info(_command), do: nil
+
+  defp maybe_record_payment(%Pay{} = pay, _result, config) do
+    agent_id = pay.agent_id || Map.get(pay.meta, :agent_id, :unknown)
+    Ledger.record_spend(config.ledger, agent_id, pay.amount, pay.meta)
+  end
 
   defp maybe_record_payment(
          %{data: %{__payment__: %{amount: amount} = meta}},

--- a/packages/raxol_payments/test/raxol/payments/directive/pay_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/directive/pay_test.exs
@@ -1,0 +1,102 @@
+defmodule Raxol.Payments.Directive.PayTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Directive.Executor
+  alias Raxol.Payments.Directive.Pay
+
+  describe "new/1" do
+    test "builds a Pay with required fields" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.01"),
+          domain: "api.test.com",
+          perform: fn -> {:ok, :done} end
+        )
+
+      assert %Pay{
+               amount: %Decimal{},
+               domain: "api.test.com",
+               agent_id: nil,
+               meta: %{},
+               perform: perform
+             } = pay
+
+      assert is_function(perform, 0)
+    end
+
+    test "carries optional fields" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("1.00"),
+          domain: "api.test.com",
+          agent_id: :research,
+          meta: %{tag: "experiment"},
+          perform: fn -> {:ok, :done} end
+        )
+
+      assert pay.agent_id == :research
+      assert pay.meta == %{tag: "experiment"}
+    end
+
+    test "raises without required fields" do
+      assert_raise KeyError, fn ->
+        Pay.new(domain: "x", perform: fn -> {:ok, :done} end)
+      end
+    end
+  end
+
+  describe "Executor for Pay" do
+    test "successful perform sends pay_result" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.01"),
+          domain: "x.com",
+          perform: fn -> {:ok, %{ok: true}} end
+        )
+
+      Executor.execute(pay, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, {:pay_result, %{ok: true}}}, 1_000
+    end
+
+    test "error perform sends pay_error" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.01"),
+          domain: "x.com",
+          perform: fn -> {:error, :insufficient_funds} end
+        )
+
+      Executor.execute(pay, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, {:pay_error, :insufficient_funds}}, 1_000
+    end
+
+    test "raised exception sends pay_error with exception tag" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.01"),
+          domain: "x.com",
+          perform: fn -> raise "wallet locked" end
+        )
+
+      Executor.execute(pay, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, {:pay_error, {:exception, "wallet locked"}}},
+                     1_000
+    end
+
+    test "non-tuple return is treated as pay_result" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.01"),
+          domain: "x.com",
+          perform: fn -> :raw_value end
+        )
+
+      Executor.execute(pay, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result, {:pay_result, :raw_value}}, 1_000
+    end
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/spending_hook_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/spending_hook_test.exs
@@ -167,4 +167,65 @@ defmodule Raxol.Payments.SpendingHookTest do
       assert {:ok, :result} = SpendingHook.post_execute(command, :result, %{})
     end
   end
+
+  alias Raxol.Payments.Directive.Pay
+
+  describe "pre_execute/2 with Pay directive" do
+    test "denies Pay with unapproved domain" do
+      config = SpendingHook.get_config()
+      policy = %{config.policy | approved_domains: ["allowed.com"]}
+      SpendingHook.set_config(%{config | policy: policy})
+
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.01"),
+          domain: "evil.com",
+          perform: fn -> {:ok, :ignored} end
+        )
+
+      assert {:deny, {:domain_not_approved, "evil.com"}} =
+               SpendingHook.pre_execute(pay, %{agent_id: :test})
+    end
+
+    test "denies Pay over per-request budget" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("999.00"),
+          domain: "api.test.com",
+          perform: fn -> {:ok, :ignored} end
+        )
+
+      assert {:deny, {:over_budget, :per_request, _}} =
+               SpendingHook.pre_execute(pay, %{agent_id: :test})
+    end
+
+    test "allows Pay within budget" do
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.01"),
+          domain: "api.test.com",
+          perform: fn -> {:ok, :ignored} end
+        )
+
+      assert {:ok, ^pay} = SpendingHook.pre_execute(pay, %{agent_id: :test})
+    end
+  end
+
+  describe "post_execute/3 with Pay directive" do
+    test "records payment using agent_id field", %{ledger: ledger} do
+      pay =
+        Pay.new(
+          amount: Decimal.new("0.02"),
+          domain: "api.test.com",
+          agent_id: :pay_test,
+          perform: fn -> {:ok, :ignored} end
+        )
+
+      assert {:ok, :result} = SpendingHook.post_execute(pay, :result, %{})
+
+      :timer.sleep(10)
+      entries = Ledger.get_history(ledger, :pay_test)
+      assert length(entries) == 1
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Stacked on top of #276 (Phase 24 foundation). Four logical commits, each independently bisectable. Touches raxol_agent, raxol_core's runtime via main raxol's `lib/`, and raxol_payments.

- **D-3 macro injection** (`fb71fbff`). `Raxol.Agent.__using__` now aliases both `Command` and `Directive`; injected helpers (`async/1`, `shell/2`, `send_agent/2`, `run_action_async`, `run_pipeline_async`) construct Directives; the default `update/2` returns `[]`. `Raxol.Core.Runtime.Application.normalize_update_result/4` wraps a bare Directive struct in a list, matching the existing single-Command path (via a new `normalize_single_effect` + `known_effect?/1` pair guarded with `Code.ensure_loaded?` so main raxol still compiles without raxol_agent loaded). End-to-end verified by a new `BareDirectiveAgent` in `session_test`.

- **D-4 hook system** (`44be9e81`). `CommandHook.wrap_commands` matches `Directive.{Async, Shell, SendAgent}` and routes them through the same pre/post hook pipeline as Commands; denial path constructs a `Directive.async` notification when the input was a Directive, a `Command.new(:async, ...)` when it was a Command; `Async` post-hook wrapping reuses a shared `wrap_sender_fun` + `build_wrapped_sender` pair (depth-2 safe). `PermissionHook.authorize` gains a struct clause that maps each Directive to its equivalent type atom (`Async->:async`, `Shell->:shell`, `SendAgent->:send_agent`, `Schedule->:delay`, `Spawn->:task`, `Stop->:quit`) and reuses the existing mode/type machinery. CommandHook + PermissionHook typespecs widened to `effect()` union. +11 directive-shaped hook tests.

- **D-7 causation propagation** (`52270f04`). `SendAgent.execute/2` reads `TraceContext.current().span_id` and attaches it as `%{causation_id: id}` on the cast (empty map when no span active). `Session.handle_manager_cast` accepts both `{:send_message, msg}` and `{:send_message, msg, metadata}` shapes; forwards 3-tuple to the dispatcher when metadata is non-empty. Dispatcher gains a `{:dispatch, agent_message, metadata}` clause that calls `TraceContext.set_causation/1` before `dispatch_raw_message`. `CausationCaptureAgent` captures `TraceContext.current().causation_id` from inside `update/2`; both sender and receiver sides covered.

- **D-5 semantic payment directive** (`11a693bf`). New `Raxol.Payments.Directive.Pay` carries `:amount`, `:domain`, `:perform`, optional `:agent_id` and `:meta`. `defimpl Directive.Executor` runs `perform` in a Task and routes results to `{:command_result, {:pay_result, _}}` / `{:command_result, {:pay_error, _}}` / `{:command_result, {:pay_error, {:exception, msg}}}`. `SpendingHook.check_payment_command` and `maybe_record_payment` gain `%Pay{}` clauses ahead of the existing Command-shape clauses; the spending hook now extracts amount + domain from struct fields, no `__payment__` wrapping required.

## Test plan

- [ ] CI: raxol_agent suite green (483 tests, +15 from this PR's directive paths + causation)
- [ ] CI: raxol_core suite green (754, unchanged from #276)
- [ ] CI: main raxol runtime suite green (308, dispatcher + lifecycle + application changes)
- [ ] CI: raxol_payments non-conformance suite green (536 tests + 31 properties, +15 Pay/SpendingHook tests)
- [ ] CI: credo strict 0 new findings on all changed files
- [ ] CI: format --check-formatted passes
- [ ] Manual: pull the branch, define a tiny agent that returns `[Raxol.Payments.Directive.Pay.new(amount: Decimal.new("0.01"), domain: "api.test.com", perform: fn -> {:ok, :paid} end)]` from `update/2`, register the SpendingHook config, send it a message and confirm the agent's `update/2` receives `{:command_result, {:pay_result, :paid}}` (or `{:command_result, {:deny, _}}` when an out-of-policy domain/amount is used)
- [ ] Manual: confirm an agent emitting `Directive.send_agent` inside a `TraceContext.with_trace(...)` block causes the receiver to see the sender's `span_id` as `TraceContext.current().causation_id`