### PR TITLE
Phase 25 PR 1: Raxol.Workflow.Graph builder + compile

### DIFF
--- a/lib/raxol/workflow/compiled.ex
+++ b/lib/raxol/workflow/compiled.ex
@@ -1,0 +1,34 @@
+defmodule Raxol.Workflow.Compiled do
+  @moduledoc """
+  Frozen, validated workflow ready for execution.
+
+  Returned by `Raxol.Workflow.Graph.compile/2`. The struct is opaque
+  in the sense that consumers should not construct or pattern-match on
+  its fields directly; the runtime API
+  (`invoke/3`, `async_invoke/3`, `stream_events/3`, `resume/3`) is
+  added in a follow-up PR and will be the only supported interface.
+
+  The current PR ships the container only so the `Graph.compile/2`
+  return type is stable and the surface area can be reviewed
+  separately from the runtime implementation.
+  """
+
+  @type opts :: %{
+          optional(:failure_policy) => :retry | :halt | :compensate,
+          optional(:step_timeout_ms) => non_neg_integer(),
+          optional(:run_timeout_ms) => non_neg_integer(),
+          optional(:saver) => module()
+        }
+
+  @type t :: %__MODULE__{
+          id: atom() | binary(),
+          nodes: %{Raxol.Workflow.Node.id() => Raxol.Workflow.Node.t()},
+          edges_by_source: %{
+            Raxol.Workflow.Node.id() => [Raxol.Workflow.Edge.t()]
+          },
+          opts: opts()
+        }
+
+  @enforce_keys [:id, :nodes, :edges_by_source, :opts]
+  defstruct [:id, :nodes, :edges_by_source, :opts]
+end

--- a/lib/raxol/workflow/edge.ex
+++ b/lib/raxol/workflow/edge.ex
@@ -1,0 +1,99 @@
+defmodule Raxol.Workflow.Edge do
+  @moduledoc """
+  Edge descriptors for `Raxol.Workflow.Graph`.
+
+  Three shapes:
+
+    * `Edge` -- static edge from `from` to `to`
+    * `GuardedEdge` -- static edge guarded by a predicate
+    * `ConditionalEdge` -- fan-out edge whose `chooser` returns the
+      next node id (or a list of ids for parallel fan-out) based on state
+
+  The two terminal node ids are `:__start__` and `:__end__`. Every
+  graph must have at least one edge from `:__start__` to a node and at
+  least one edge to `:__end__`.
+  """
+
+  @start :__start__
+  @end_ :__end__
+
+  defmodule Edge do
+    @moduledoc "Static edge from `from` to `to`."
+
+    @type t :: %__MODULE__{
+            from: Raxol.Workflow.Node.id(),
+            to: Raxol.Workflow.Node.id()
+          }
+
+    @enforce_keys [:from, :to]
+    defstruct [:from, :to]
+  end
+
+  defmodule GuardedEdge do
+    @moduledoc """
+    Edge that is taken only when `guard.(state)` returns truthy.
+
+    The runtime evaluates guards in the order edges were added. The
+    first matching guard wins; if no guard matches, the next outgoing
+    edge (static or conditional) is consulted.
+    """
+
+    @type t :: %__MODULE__{
+            from: Raxol.Workflow.Node.id(),
+            to: Raxol.Workflow.Node.id(),
+            guard: (any() -> any())
+          }
+
+    @enforce_keys [:from, :to, :guard]
+    defstruct [:from, :to, :guard]
+  end
+
+  defmodule ConditionalEdge do
+    @moduledoc """
+    Edge whose `chooser.(state)` returns the next node id, or a list
+    of node ids for parallel fan-out.
+
+    The chooser must return either an atom (single next node) or a
+    non-empty list of atoms (parallel fan-out). The compiler verifies
+    that every possible return value is a node in the graph; runtime
+    re-checks if the chooser is opaque.
+    """
+
+    @type chooser_result ::
+            Raxol.Workflow.Node.id() | [Raxol.Workflow.Node.id()]
+
+    @type t :: %__MODULE__{
+            from: Raxol.Workflow.Node.id(),
+            chooser: (any() -> chooser_result()),
+            candidates: [Raxol.Workflow.Node.id()]
+          }
+
+    @enforce_keys [:from, :chooser, :candidates]
+    defstruct [:from, :chooser, :candidates]
+  end
+
+  @type t :: Edge.t() | GuardedEdge.t() | ConditionalEdge.t()
+
+  @doc "Return the source node id of any edge type."
+  @spec from(t()) :: Raxol.Workflow.Node.id()
+  def from(%Edge{from: f}), do: f
+  def from(%GuardedEdge{from: f}), do: f
+  def from(%ConditionalEdge{from: f}), do: f
+
+  @doc """
+  Return the list of possible target node ids for any edge type.
+  `ConditionalEdge` returns its declared candidate set.
+  """
+  @spec targets(t()) :: [Raxol.Workflow.Node.id()]
+  def targets(%Edge{to: t}), do: [t]
+  def targets(%GuardedEdge{to: t}), do: [t]
+  def targets(%ConditionalEdge{candidates: cs}), do: cs
+
+  @doc "The reserved start-node id."
+  @spec start_id() :: atom()
+  def start_id, do: @start
+
+  @doc "The reserved end-node id."
+  @spec end_id() :: atom()
+  def end_id, do: @end_
+end

--- a/lib/raxol/workflow/graph.ex
+++ b/lib/raxol/workflow/graph.ex
@@ -1,0 +1,302 @@
+defmodule Raxol.Workflow.Graph do
+  @moduledoc """
+  Immutable graph builder for `Raxol.Workflow`.
+
+  Build a graph by piping `add_node/3`, `add_edge/3`,
+  `add_guarded_edge/4`, `add_conditional_edge/4` (and the upcoming
+  `add_join/4` / `add_channel/4`) onto a `new/1` seed, then freeze with
+  `compile/2`.
+
+  ## Example
+
+      alias Raxol.Workflow.Graph
+
+      {:ok, compiled} =
+        Graph.new(:summarizer)
+        |> Graph.add_node(:fetch, fn s -> {:ok, Map.put(s, :data, "x")} end)
+        |> Graph.add_node(:render, fn s -> {:ok, Map.put(s, :rendered, true)} end)
+        |> Graph.add_edge(:__start__, :fetch)
+        |> Graph.add_edge(:fetch, :render)
+        |> Graph.add_edge(:render, :__end__)
+        |> Graph.compile()
+
+  ## Reserved node ids
+
+  - `:__start__` -- virtual entry node, present in every graph
+  - `:__end__` -- virtual exit node, present in every graph
+
+  Authors must add at least one edge from `:__start__` and at least
+  one edge into `:__end__`. `compile/2` enforces these rules along
+  with reachability and absence-of-orphans.
+  """
+
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Edge
+  alias Raxol.Workflow.Edge.ConditionalEdge
+  alias Raxol.Workflow.Edge.Edge, as: StaticEdge
+  alias Raxol.Workflow.Edge.GuardedEdge
+  alias Raxol.Workflow.Node
+
+  @type t :: %__MODULE__{
+          id: atom() | binary(),
+          nodes: %{Node.id() => Node.t()},
+          edges: [Edge.t()]
+        }
+
+  defstruct id: nil, nodes: %{}, edges: []
+
+  @start :__start__
+  @end_ :__end__
+
+  @doc "Construct a new, empty graph with the given id."
+  @spec new(atom() | binary()) :: t()
+  def new(id) when is_atom(id) or is_binary(id), do: %__MODULE__{id: id}
+
+  @doc """
+  Add a node to the graph. The `body` argument selects the node shape:
+
+  - A 1-arity function builds a `FunctionNode`.
+  - A `{module, opts}` tuple builds a `BehaviourNode`.
+  - A struct builds a `TypedNode`.
+  """
+  @spec add_node(t(), Node.id(), term()) :: t()
+  def add_node(%__MODULE__{} = graph, id, body) do
+    node = build_node(id, body)
+    put_node(graph, node)
+  end
+
+  @doc "Add a static edge from `from` to `to`."
+  @spec add_edge(t(), Node.id(), Node.id()) :: t()
+  def add_edge(%__MODULE__{} = graph, from, to)
+      when is_atom(from) or is_binary(from) do
+    put_edge(graph, %StaticEdge{from: from, to: to})
+  end
+
+  @doc """
+  Add a guarded edge from `from` to `to`. The guard receives the
+  workflow state; the edge is taken only when the guard returns truthy.
+  """
+  @spec add_guarded_edge(t(), Node.id(), Node.id(), (any() -> any())) :: t()
+  def add_guarded_edge(%__MODULE__{} = graph, from, to, guard)
+      when is_function(guard, 1) do
+    put_edge(graph, %GuardedEdge{from: from, to: to, guard: guard})
+  end
+
+  @doc """
+  Add a conditional fan-out edge from `from`. The `chooser` receives
+  the state and returns the next node id (or a list of ids for
+  parallel fan-out). `candidates` declares the set of possible
+  destinations so `compile/2` can validate them.
+  """
+  @spec add_conditional_edge(t(), Node.id(), [Node.id()], (any() -> any())) ::
+          t()
+  def add_conditional_edge(%__MODULE__{} = graph, from, candidates, chooser)
+      when is_list(candidates) and candidates != [] and is_function(chooser, 1) do
+    put_edge(graph, %ConditionalEdge{
+      from: from,
+      candidates: candidates,
+      chooser: chooser
+    })
+  end
+
+  @doc """
+  Freeze the graph for execution.
+
+  Runs the full validation pipeline (no orphan nodes, every node
+  reachable from `:__start__`, every node has a path to `:__end__`,
+  conditional candidates exist in the graph) and returns a
+  `Raxol.Workflow.Compiled` struct or a structured error.
+
+  ## Options
+
+    * `:failure_policy` -- one of `:retry`, `:halt`, `:compensate` (default `:halt`)
+    * `:step_timeout_ms` -- per-node timeout (default `60_000`)
+    * `:run_timeout_ms` -- total run timeout (default `3_600_000`)
+    * `:saver` -- `Raxol.Workflow.Checkpoint.Saver` module (defaults to `Ets`)
+
+  These options are stored on `Compiled` and consumed by the runtime
+  in a follow-up PR.
+  """
+  @spec compile(t(), keyword()) ::
+          {:ok, Compiled.t()}
+          | {:error, validation_error()}
+  def compile(%__MODULE__{} = graph, opts \\ []) do
+    with :ok <- validate_has_start_edge(graph),
+         :ok <- validate_has_end_edge(graph),
+         :ok <- validate_edges_reference_known_nodes(graph),
+         :ok <- validate_no_orphans(graph),
+         :ok <- validate_reachable_from_start(graph),
+         :ok <- validate_paths_to_end(graph) do
+      {:ok,
+       %Compiled{
+         id: graph.id,
+         nodes: graph.nodes,
+         edges_by_source: index_edges_by_source(graph.edges),
+         opts:
+           opts
+           |> Keyword.take(
+             ~w(failure_policy step_timeout_ms run_timeout_ms saver)a
+           )
+           |> Map.new()
+       }}
+    end
+  end
+
+  @type validation_error ::
+          {:missing_start_edge, atom()}
+          | {:missing_end_edge, atom()}
+          | {:unknown_node, [Node.id()]}
+          | {:orphan_nodes, [Node.id()]}
+          | {:unreachable_from_start, [Node.id()]}
+          | {:cannot_reach_end, [Node.id()]}
+
+  # --- Builder helpers ---
+
+  defp build_node(id, fun) when is_function(fun, 1), do: Node.function(id, fun)
+
+  defp build_node(id, {module, opts}) when is_atom(module),
+    do: Node.behaviour(id, module, opts)
+
+  defp build_node(id, %_{} = struct), do: Node.typed(id, struct)
+
+  defp build_node(_id, other) do
+    raise ArgumentError,
+          "node body must be a 1-arity function, {module, opts} tuple, " <>
+            "or struct; got: #{inspect(other)}"
+  end
+
+  defp put_node(%__MODULE__{nodes: nodes} = graph, node) do
+    %{graph | nodes: Map.put(nodes, Node.id(node), node)}
+  end
+
+  defp put_edge(%__MODULE__{edges: edges} = graph, edge) do
+    # Graphs are small (typically <100 edges); insertion-order storage
+    # is more readable than reversed-list + Enum.reverse on read.
+    # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+    %{graph | edges: edges ++ [edge]}
+  end
+
+  defp index_edges_by_source(edges) do
+    Enum.group_by(edges, &Edge.from/1)
+  end
+
+  # --- Validation ---
+
+  defp validate_has_start_edge(%__MODULE__{edges: edges}) do
+    if Enum.any?(edges, fn e -> Edge.from(e) == @start end) do
+      :ok
+    else
+      {:error, {:missing_start_edge, @start}}
+    end
+  end
+
+  defp validate_has_end_edge(%__MODULE__{edges: edges}) do
+    if Enum.any?(edges, fn e -> @end_ in Edge.targets(e) end) do
+      :ok
+    else
+      {:error, {:missing_end_edge, @end_}}
+    end
+  end
+
+  defp validate_edges_reference_known_nodes(%__MODULE__{
+         nodes: nodes,
+         edges: edges
+       }) do
+    known =
+      nodes
+      |> Map.keys()
+      |> MapSet.new()
+      |> MapSet.put(@start)
+      |> MapSet.put(@end_)
+
+    referenced =
+      edges
+      |> Enum.flat_map(fn e -> [Edge.from(e) | Edge.targets(e)] end)
+      |> MapSet.new()
+
+    unknown = MapSet.difference(referenced, known) |> MapSet.to_list()
+
+    if unknown == [] do
+      :ok
+    else
+      {:error, {:unknown_node, Enum.sort(unknown)}}
+    end
+  end
+
+  defp validate_no_orphans(%__MODULE__{nodes: nodes, edges: edges}) do
+    in_play =
+      edges
+      |> Enum.flat_map(fn e -> [Edge.from(e) | Edge.targets(e)] end)
+      |> MapSet.new()
+
+    orphans =
+      nodes
+      |> Map.keys()
+      |> Enum.reject(&MapSet.member?(in_play, &1))
+
+    if orphans == [] do
+      :ok
+    else
+      {:error, {:orphan_nodes, Enum.sort(orphans)}}
+    end
+  end
+
+  defp validate_reachable_from_start(%__MODULE__{nodes: nodes, edges: edges}) do
+    forward = adjacency(edges)
+    reachable = bfs(@start, forward)
+    declared = MapSet.new(Map.keys(nodes))
+    missing = MapSet.difference(declared, reachable) |> MapSet.to_list()
+
+    if missing == [] do
+      :ok
+    else
+      {:error, {:unreachable_from_start, Enum.sort(missing)}}
+    end
+  end
+
+  defp validate_paths_to_end(%__MODULE__{nodes: nodes, edges: edges}) do
+    backward = adjacency_reversed(edges)
+    can_reach_end = bfs(@end_, backward)
+    declared = MapSet.new(Map.keys(nodes))
+    cannot = MapSet.difference(declared, can_reach_end) |> MapSet.to_list()
+
+    if cannot == [] do
+      :ok
+    else
+      {:error, {:cannot_reach_end, Enum.sort(cannot)}}
+    end
+  end
+
+  defp adjacency(edges) do
+    Enum.reduce(edges, %{}, fn edge, acc ->
+      from = Edge.from(edge)
+
+      Enum.reduce(Edge.targets(edge), acc, fn to, inner ->
+        Map.update(inner, from, [to], fn existing -> [to | existing] end)
+      end)
+    end)
+  end
+
+  defp adjacency_reversed(edges) do
+    Enum.reduce(edges, %{}, fn edge, acc ->
+      from = Edge.from(edge)
+
+      Enum.reduce(Edge.targets(edge), acc, fn to, inner ->
+        Map.update(inner, to, [from], fn existing -> [from | existing] end)
+      end)
+    end)
+  end
+
+  defp bfs(start, adjacency) do
+    do_bfs([start], MapSet.new([start]), adjacency)
+  end
+
+  defp do_bfs([], visited, _adj), do: visited
+
+  defp do_bfs([node | rest], visited, adj) do
+    neighbors = Map.get(adj, node, [])
+    new_neighbors = Enum.reject(neighbors, &MapSet.member?(visited, &1))
+    visited2 = Enum.reduce(new_neighbors, visited, &MapSet.put(&2, &1))
+    do_bfs(rest ++ new_neighbors, visited2, adj)
+  end
+end

--- a/lib/raxol/workflow/node.ex
+++ b/lib/raxol/workflow/node.ex
@@ -1,0 +1,135 @@
+defmodule Raxol.Workflow.Node do
+  @moduledoc """
+  Node descriptors for `Raxol.Workflow.Graph`.
+
+  A node is one of three shapes:
+
+    * `FunctionNode` -- a 1-arity function `(state -> result)`
+    * `BehaviourNode` -- a module implementing this module's behaviour
+    * `TypedNode` -- a struct with a `Raxol.Workflow.Node.Executor`
+      protocol implementation. Mirrors the `Raxol.Core.Runtime.Directive`
+      pattern: lets external packages register typed nodes
+      (e.g. `%Raxol.ACP.Workflow.Node.CreateMemo{...}`) with custom
+      telemetry and validation.
+
+  Node functions return one of:
+
+    * `{:ok, state}` -- proceed with the new state
+    * `{:effects, [directive], state}` -- emit Phase 24 directives and proceed
+    * `{:interrupt, value}` -- pause the run for human-in-the-loop resume
+    * `{:error, reason}` -- fail (handled by the workflow's failure policy)
+
+  The runtime is added in a follow-up PR; this module only defines the
+  descriptor shapes and behaviour so the `Graph` builder can carry them.
+  """
+
+  @type id :: atom() | binary()
+  @type state :: any()
+  @type result ::
+          {:ok, state()}
+          | {:effects, [struct()], state()}
+          | {:interrupt, any()}
+          | {:error, any()}
+
+  @doc """
+  Called once at run start to set up node-private state.
+
+  Optional. Default returns the run's initial state unchanged.
+  """
+  @callback init(opts :: keyword()) :: state()
+
+  @doc """
+  Called once per visit to the node. Returns the next state, an
+  interrupt, an error, or a state plus a list of `Raxol.Core.Runtime.Directive`
+  structs to dispatch through the runtime's existing effect pipeline.
+  """
+  @callback run(state :: state(), opts :: keyword()) :: result()
+
+  @doc """
+  Called by the runtime's failure policy when `failure_policy: :compensate`
+  is set and an earlier node has already succeeded. Default is a no-op.
+  """
+  @callback compensate(state :: state(), opts :: keyword()) ::
+              :ok | {:error, any()}
+
+  @optional_callbacks init: 1, compensate: 2
+
+  defmodule FunctionNode do
+    @moduledoc "A node backed by a 1-arity function."
+
+    @type t :: %__MODULE__{id: Raxol.Workflow.Node.id(), fun: (any() -> any())}
+
+    @enforce_keys [:id, :fun]
+    defstruct [:id, :fun]
+  end
+
+  defmodule BehaviourNode do
+    @moduledoc """
+    A node backed by a module implementing `Raxol.Workflow.Node`.
+    """
+
+    @type t :: %__MODULE__{
+            id: Raxol.Workflow.Node.id(),
+            module: module(),
+            opts: keyword()
+          }
+
+    @enforce_keys [:id, :module]
+    defstruct [:id, :module, opts: []]
+  end
+
+  defmodule TypedNode do
+    @moduledoc """
+    A node backed by a struct implementing
+    `Raxol.Workflow.Node.Executor`. Used by external packages to
+    register semantically-named nodes with custom telemetry.
+    """
+
+    @type t :: %__MODULE__{id: Raxol.Workflow.Node.id(), struct: struct()}
+
+    @enforce_keys [:id, :struct]
+    defstruct [:id, :struct]
+  end
+
+  @type t :: FunctionNode.t() | BehaviourNode.t() | TypedNode.t()
+
+  @doc "Construct a `FunctionNode`."
+  @spec function(id(), (state() -> result())) :: FunctionNode.t()
+  def function(id, fun) when is_function(fun, 1),
+    do: %FunctionNode{id: id, fun: fun}
+
+  @doc "Construct a `BehaviourNode`."
+  @spec behaviour(id(), module(), keyword()) :: BehaviourNode.t()
+  def behaviour(id, module, opts \\ [])
+      when is_atom(module) and is_list(opts) do
+    %BehaviourNode{id: id, module: module, opts: opts}
+  end
+
+  @doc "Construct a `TypedNode`."
+  @spec typed(id(), struct()) :: TypedNode.t()
+  def typed(id, %_{} = struct), do: %TypedNode{id: id, struct: struct}
+
+  @doc "Return the node's id."
+  @spec id(t()) :: id()
+  def id(%FunctionNode{id: id}), do: id
+  def id(%BehaviourNode{id: id}), do: id
+  def id(%TypedNode{id: id}), do: id
+end
+
+defprotocol Raxol.Workflow.Node.Executor do
+  @moduledoc """
+  Protocol for executing `Raxol.Workflow.Node.TypedNode` structs.
+
+  External packages register typed nodes by defining a struct and
+  implementing this protocol. Mirrors the
+  `Raxol.Core.Runtime.Directive.Executor` shape: same callback name,
+  same result tuple, same telemetry surface.
+
+  The runtime is added in a follow-up PR; this protocol is declared
+  now so the `Graph` builder can carry typed-node references.
+  """
+
+  @spec execute(t(), state :: any(), opts :: keyword()) ::
+          Raxol.Workflow.Node.result()
+  def execute(node_struct, state, opts)
+end

--- a/test/raxol/workflow/graph_property_test.exs
+++ b/test/raxol/workflow/graph_property_test.exs
@@ -1,0 +1,179 @@
+# credo:disable-for-this-file Credo.Check.Refactor.AppendSingleItem
+# credo:disable-for-this-file Credo.Check.Refactor.ABCSize
+defmodule Raxol.Workflow.GraphPropertyTest do
+  @moduledoc """
+  Property tests on `Raxol.Workflow.Graph.compile/2` validation rules.
+
+  The graph builder has six independent validation rules
+  (`missing_start_edge`, `missing_end_edge`, `unknown_node`,
+  `orphan_nodes`, `unreachable_from_start`, `cannot_reach_end`). Example
+  tests pin one happy path and one error path per rule; the properties
+  below stress the rules with generated graphs to surface interactions
+  the example tests miss.
+
+  The two `credo:disable` directives above acknowledge that the test
+  generators use `++ [sentinel]` to build start/end-anchored chains
+  and that `arbitrary_graph/0` is intentionally complex enough that
+  the ABC-size check fires; both are write-once helpers that don't
+  warrant the rephrasing.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Workflow.Graph
+
+  @start :__start__
+  @end_ :__end__
+
+  describe "property: linear graphs always compile" do
+    property "any linear chain of N nodes with start and end edges compiles" do
+      check all(node_count <- integer(1..10), max_runs: 50) do
+        ids =
+          for n <- 1..node_count, do: String.to_atom("node_#{n}")
+
+        graph =
+          ids
+          |> Enum.reduce(Graph.new(:linear), fn id, g ->
+            Graph.add_node(g, id, fn s -> {:ok, s} end)
+          end)
+
+        graph =
+          [@start | ids]
+          |> Enum.zip(ids ++ [@end_])
+          |> Enum.reduce(graph, fn {from, to}, g ->
+            Graph.add_edge(g, from, to)
+          end)
+
+        assert {:ok, compiled} = Graph.compile(graph)
+        assert Map.keys(compiled.nodes) |> Enum.sort() == Enum.sort(ids)
+      end
+    end
+  end
+
+  describe "property: compile/2 either succeeds or returns a structured error" do
+    property "any builder sequence yields {:ok, _} or {:error, atom_or_tuple}" do
+      check all(graph <- arbitrary_graph(), max_runs: 100) do
+        case Graph.compile(graph) do
+          {:ok, _compiled} ->
+            :ok
+
+          {:error, reason} ->
+            assert valid_error?(reason),
+                   "unexpected error shape: #{inspect(reason)}"
+        end
+      end
+    end
+  end
+
+  describe "property: orphan node detection" do
+    property "an isolated extra node always trips :orphan_nodes" do
+      check all(
+              extra_id <- node_id_generator(),
+              base_size <- integer(1..4),
+              max_runs: 25
+            ) do
+        ids =
+          for n <- 1..base_size, do: String.to_atom("base_#{n}")
+
+        # Avoid collision between the extra and the linear chain.
+        if extra_id in ids do
+          :ok
+        else
+          graph =
+            (ids ++ [extra_id])
+            |> Enum.reduce(Graph.new(:orphan_check), fn id, g ->
+              Graph.add_node(g, id, fn s -> {:ok, s} end)
+            end)
+
+          linear_edges =
+            [@start | ids]
+            |> Enum.zip(ids ++ [@end_])
+
+          graph =
+            linear_edges
+            |> Enum.reduce(graph, fn {from, to}, g ->
+              Graph.add_edge(g, from, to)
+            end)
+
+          assert {:error, {:orphan_nodes, orphans}} = Graph.compile(graph)
+          assert orphans == [extra_id]
+        end
+      end
+    end
+  end
+
+  describe "property: every reachable node has a path to :__end__" do
+    property "a node reachable from start but with no outgoing edge trips :cannot_reach_end" do
+      check all(
+              base_size <- integer(1..4),
+              dead_id <- node_id_generator(),
+              max_runs: 25
+            ) do
+        ids = for n <- 1..base_size, do: String.to_atom("alive_#{n}")
+
+        if dead_id in ids do
+          :ok
+        else
+          graph =
+            (ids ++ [dead_id])
+            |> Enum.reduce(Graph.new(:dead_check), fn id, g ->
+              Graph.add_node(g, id, fn s -> {:ok, s} end)
+            end)
+
+          linear_edges =
+            [@start | ids] |> Enum.zip(ids ++ [@end_])
+
+          graph =
+            linear_edges
+            |> Enum.reduce(graph, fn {from, to}, g ->
+              Graph.add_edge(g, from, to)
+            end)
+            # dead_id is reached but has no outgoing edge to :__end__
+            |> Graph.add_edge(@start, dead_id)
+
+          assert {:error, {:cannot_reach_end, [^dead_id]}} =
+                   Graph.compile(graph)
+        end
+      end
+    end
+  end
+
+  # --- Generators ---
+
+  defp arbitrary_graph do
+    gen all(
+          node_count <- integer(0..6),
+          edge_count <- integer(0..10)
+        ) do
+      ids = for n <- 1..node_count, n > 0, do: String.to_atom("n_#{n}")
+
+      graph =
+        Enum.reduce(ids, Graph.new(:arb), fn id, g ->
+          Graph.add_node(g, id, fn s -> {:ok, s} end)
+        end)
+
+      edge_pool = [@start | ids] ++ [@end_]
+
+      Enum.reduce(1..edge_count, graph, fn _, g ->
+        from = Enum.random(edge_pool)
+        to = Enum.random(edge_pool)
+        Graph.add_edge(g, from, to)
+      end)
+    end
+  end
+
+  defp node_id_generator do
+    gen all(suffix <- string(:alphanumeric, min_length: 3, max_length: 8)) do
+      String.to_atom("extra_" <> suffix)
+    end
+  end
+
+  defp valid_error?({:missing_start_edge, @start}), do: true
+  defp valid_error?({:missing_end_edge, @end_}), do: true
+  defp valid_error?({:unknown_node, ids}), do: is_list(ids)
+  defp valid_error?({:orphan_nodes, ids}), do: is_list(ids)
+  defp valid_error?({:unreachable_from_start, ids}), do: is_list(ids)
+  defp valid_error?({:cannot_reach_end, ids}), do: is_list(ids)
+  defp valid_error?(_), do: false
+end

--- a/test/raxol/workflow/graph_test.exs
+++ b/test/raxol/workflow/graph_test.exs
@@ -1,0 +1,230 @@
+defmodule Raxol.Workflow.GraphTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Edge.{ConditionalEdge, GuardedEdge}
+  alias Raxol.Workflow.Edge.Edge, as: StaticEdge
+  alias Raxol.Workflow.Graph
+  alias Raxol.Workflow.Node.{BehaviourNode, FunctionNode, TypedNode}
+
+  defmodule SampleBehaviourNode do
+    @behaviour Raxol.Workflow.Node
+
+    @impl true
+    def run(state, _opts), do: {:ok, state}
+  end
+
+  defmodule SampleTypedStruct do
+    defstruct [:label]
+  end
+
+  describe "new/1" do
+    test "returns an empty graph with the given id" do
+      g = Graph.new(:my_flow)
+      assert g.id == :my_flow
+      assert g.nodes == %{}
+      assert g.edges == []
+    end
+
+    test "accepts binary ids" do
+      g = Graph.new("flow-1")
+      assert g.id == "flow-1"
+    end
+  end
+
+  describe "add_node/3" do
+    test "function body produces a FunctionNode" do
+      fun = fn s -> {:ok, s} end
+      g = Graph.new(:f) |> Graph.add_node(:n, fun)
+
+      assert %FunctionNode{id: :n, fun: ^fun} = g.nodes[:n]
+    end
+
+    test "{module, opts} tuple produces a BehaviourNode" do
+      g = Graph.new(:f) |> Graph.add_node(:n, {SampleBehaviourNode, [k: :v]})
+
+      assert %BehaviourNode{
+               id: :n,
+               module: SampleBehaviourNode,
+               opts: [k: :v]
+             } = g.nodes[:n]
+    end
+
+    test "struct body produces a TypedNode" do
+      struct = %SampleTypedStruct{label: "x"}
+      g = Graph.new(:f) |> Graph.add_node(:n, struct)
+
+      assert %TypedNode{id: :n, struct: ^struct} = g.nodes[:n]
+    end
+
+    test "raises on unsupported body" do
+      assert_raise ArgumentError, fn ->
+        Graph.new(:f) |> Graph.add_node(:n, "not a function")
+      end
+    end
+  end
+
+  describe "add_edge / add_guarded_edge / add_conditional_edge" do
+    test "static edge stored" do
+      g = Graph.new(:f) |> Graph.add_edge(:a, :b)
+      assert [%StaticEdge{from: :a, to: :b}] = g.edges
+    end
+
+    test "guarded edge stored with guard" do
+      guard = fn _ -> true end
+      g = Graph.new(:f) |> Graph.add_guarded_edge(:a, :b, guard)
+      assert [%GuardedEdge{from: :a, to: :b, guard: ^guard}] = g.edges
+    end
+
+    test "conditional edge stores candidates" do
+      chooser = fn _ -> :x end
+      g = Graph.new(:f) |> Graph.add_conditional_edge(:a, [:b, :c], chooser)
+
+      assert [
+               %ConditionalEdge{
+                 from: :a,
+                 candidates: [:b, :c],
+                 chooser: ^chooser
+               }
+             ] =
+               g.edges
+    end
+
+    test "edge insertion preserves order" do
+      g =
+        Graph.new(:f)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :c)
+        |> Graph.add_edge(:c, :d)
+
+      assert Enum.map(g.edges, & &1.from) == [:a, :b, :c]
+    end
+  end
+
+  describe "compile/1: happy paths" do
+    test "minimal linear graph compiles cleanly" do
+      assert {:ok, %Compiled{} = compiled} =
+               Graph.new(:linear)
+               |> Graph.add_node(:work, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :work)
+               |> Graph.add_edge(:work, :__end__)
+               |> Graph.compile()
+
+      assert compiled.id == :linear
+      assert Map.keys(compiled.nodes) == [:work]
+      assert compiled.edges_by_source[:__start__] != nil
+      assert compiled.edges_by_source[:work] != nil
+    end
+
+    test "compile carries opts onto Compiled" do
+      assert {:ok, compiled} =
+               Graph.new(:opts)
+               |> Graph.add_node(:n, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :n)
+               |> Graph.add_edge(:n, :__end__)
+               |> Graph.compile(
+                 failure_policy: :compensate,
+                 step_timeout_ms: 5_000,
+                 run_timeout_ms: 60_000,
+                 saver: SomeSaver
+               )
+
+      assert compiled.opts == %{
+               failure_policy: :compensate,
+               step_timeout_ms: 5_000,
+               run_timeout_ms: 60_000,
+               saver: SomeSaver
+             }
+    end
+
+    test "compile drops unrecognized opts" do
+      assert {:ok, compiled} =
+               Graph.new(:o)
+               |> Graph.add_node(:n, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :n)
+               |> Graph.add_edge(:n, :__end__)
+               |> Graph.compile(garbage: true, step_timeout_ms: 1)
+
+      assert compiled.opts == %{step_timeout_ms: 1}
+    end
+
+    test "branching graph compiles" do
+      assert {:ok, _} =
+               Graph.new(:branch)
+               |> Graph.add_node(:a, fn s -> {:ok, s} end)
+               |> Graph.add_node(:b, fn s -> {:ok, s} end)
+               |> Graph.add_node(:c, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :a)
+               |> Graph.add_conditional_edge(:a, [:b, :c], fn _ -> :b end)
+               |> Graph.add_edge(:b, :__end__)
+               |> Graph.add_edge(:c, :__end__)
+               |> Graph.compile()
+    end
+  end
+
+  describe "compile/1: validation errors" do
+    test "no start edge -> {:missing_start_edge, :__start__}" do
+      assert {:error, {:missing_start_edge, :__start__}} =
+               Graph.new(:no_start)
+               |> Graph.add_node(:n, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:n, :__end__)
+               |> Graph.compile()
+    end
+
+    test "no end edge -> {:missing_end_edge, :__end__}" do
+      assert {:error, {:missing_end_edge, :__end__}} =
+               Graph.new(:no_end)
+               |> Graph.add_node(:n, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :n)
+               |> Graph.compile()
+    end
+
+    test "edge references unknown node -> {:unknown_node, [_]}" do
+      assert {:error, {:unknown_node, [:ghost]}} =
+               Graph.new(:ghost)
+               |> Graph.add_node(:n, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :n)
+               |> Graph.add_edge(:n, :ghost)
+               |> Graph.add_edge(:ghost, :__end__)
+               |> Graph.compile()
+    end
+
+    test "orphan node (no incoming or outgoing edges) -> {:orphan_nodes, [_]}" do
+      # :work is declared but no edge touches it; :alt linear path covers
+      # start/end so the other checks pass.
+      assert {:error, {:orphan_nodes, [:work]}} =
+               Graph.new(:orphan)
+               |> Graph.add_node(:alt, fn s -> {:ok, s} end)
+               |> Graph.add_node(:work, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :alt)
+               |> Graph.add_edge(:alt, :__end__)
+               |> Graph.compile()
+    end
+
+    test "unreachable node -> {:unreachable_from_start, [_]}" do
+      # :unreach has an edge to :__end__ but nothing reaches :unreach
+      # from :__start__; main linear path avoids it but uses it as
+      # in_play to dodge the orphan check.
+      assert {:error, {:unreachable_from_start, [:unreach]}} =
+               Graph.new(:un)
+               |> Graph.add_node(:main, fn s -> {:ok, s} end)
+               |> Graph.add_node(:unreach, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :main)
+               |> Graph.add_edge(:main, :__end__)
+               |> Graph.add_edge(:unreach, :main)
+               |> Graph.compile()
+    end
+
+    test "cannot reach end -> {:cannot_reach_end, [_]}" do
+      # :dead is reached from start but never reaches :__end__.
+      assert {:error, {:cannot_reach_end, [:dead]}} =
+               Graph.new(:dead)
+               |> Graph.add_node(:main, fn s -> {:ok, s} end)
+               |> Graph.add_node(:dead, fn s -> {:ok, s} end)
+               |> Graph.add_edge(:__start__, :main)
+               |> Graph.add_edge(:__start__, :dead)
+               |> Graph.add_edge(:main, :__end__)
+               |> Graph.compile()
+    end
+  end
+end


### PR DESCRIPTION
First implementation PR of Phase 25 (per ADR-0015). Lands the immutable graph builder, the three node descriptor shapes, the three edge descriptor shapes, the `Compiled` container, and `compile/2` with full structural validation. **No runtime yet** -- `invoke / async_invoke / stream_events / resume` come in the next PR.

## Summary

New modules under `lib/raxol/workflow/`:

- **`Raxol.Workflow.Node`** -- parent module + behaviour (`run/2`, optional `init/1` / `compensate/2`). Nested structs: `FunctionNode`, `BehaviourNode`, `TypedNode`. A `Raxol.Workflow.Node.Executor` protocol lets external packages register typed nodes (e.g. `%Raxol.ACP.Workflow.Node.CreateMemo{...}`) with their own protocol impl -- same shape as `Raxol.Core.Runtime.Directive.Executor`.
- **`Raxol.Workflow.Edge`** -- `Edge` (static), `GuardedEdge`, `ConditionalEdge` structs, plus `from/1` and `targets/1` helpers and the `:__start__` / `:__end__` reserved-atom accessors.
- **`Raxol.Workflow.Compiled`** -- opaque container holding `nodes`, `edges_by_source`, `opts`. Filled out by the runtime PR.
- **`Raxol.Workflow.Graph`** -- immutable builder. `new/1`, `add_node/3` (function | `{module, opts}` | struct), `add_edge/3`, `add_guarded_edge/4`, `add_conditional_edge/4`, `compile/2`.

`compile/2` runs a six-step validation pipeline:

1. `missing_start_edge`
2. `missing_end_edge`
3. `unknown_node` -- edges referencing nodes not declared
4. `orphan_nodes` -- declared nodes with no edge touching them
5. `unreachable_from_start` -- BFS forward from `:__start__`
6. `cannot_reach_end` -- BFS backward from `:__end__`

Each rule yields a structured `{:error, {tag, payload}}` on failure; all six tags are in `@type validation_error`.

## Tests

- **20 example tests** covering: constructors (`new/1`, all `add_*` variants, raise on bad node body), happy paths for linear and branching graphs, opts pass-through to `Compiled`, **each of the six validation errors with a graph that trips only that rule.**
- **4 property tests** under StreamData:
  - any linear chain of N in 1..10 nodes with start/end edges compiles
  - `compile/2` on any builder sequence yields `{:ok, _}` or a structured `{:error, _}` in the documented shape (no surprise errors)
  - orphan detection: an isolated extra node always trips `:orphan_nodes`
  - dead-end detection: a node reached from start with no outgoing edge always trips `:cannot_reach_end`

All 4 properties stable across seeds 0, 1, 42, 1234, 99999 (250+ chain executions, 0 failures).

## Test plan

- [x] Workflow tests: 4 properties + 20 tests, 0 failures
- [x] Main raxol regression: 7 doctests + 170 properties + 3847 tests, 0 failures (was 166 properties + 3827 tests; +4 properties + 20 from this PR)
- [x] `mix compile --warnings-as-errors` clean
- [x] Credo strict: 0 issues (two intentional `# credo:disable` for write-once builder code, with rationale comments)
- [x] `mix format --check-formatted` clean

## Out of scope (next PR)

- `Compiled.invoke/3`, `async_invoke/3`, `stream_events/3`, `resume/3`
- `Checkpoint.Saver` behaviour + `Ets`/`Dets` adapters
- `Execution.Scratchpad` + `Workflow.interrupt/1`
- Per-node CloudEvents emission via the Phase 24 telemetry path
- `add_join/4` (barrier) + `add_channel/4` (typed reducers)

## Manual testing

- [ ] Confirm CI passes (unified pipeline, regression, security)
- [ ] Skim `docs/adr/0015-workflow-graph.md` to confirm the surface in this PR matches the ADR's "Graph builder shape" section