### PR TITLE
Phase 25 PR 2: synchronous Compiled.invoke + telemetry

### DIFF
--- a/lib/raxol/workflow/compiled.ex
+++ b/lib/raxol/workflow/compiled.ex
@@ -4,13 +4,15 @@ defmodule Raxol.Workflow.Compiled do
 
   Returned by `Raxol.Workflow.Graph.compile/2`. The struct is opaque
   in the sense that consumers should not construct or pattern-match on
-  its fields directly; the runtime API
-  (`invoke/3`, `async_invoke/3`, `stream_events/3`, `resume/3`) is
-  added in a follow-up PR and will be the only supported interface.
+  its fields directly; the runtime API exposed here is the supported
+  interface.
 
-  The current PR ships the container only so the `Graph.compile/2`
-  return type is stable and the surface area can be reviewed
-  separately from the runtime implementation.
+  ## Runtime entry points
+
+    * `invoke/3` -- synchronous execution. Ships in this PR.
+    * `async_invoke/3` -- spawn a run under a DynamicSupervisor. Follow-up PR.
+    * `stream_events/3` -- lazy CloudEvent stream of run progress. Follow-up PR.
+    * `resume/3` -- consume an interrupt, continue from the checkpointed step. Follow-up PR.
   """
 
   @type opts :: %{
@@ -31,4 +33,15 @@ defmodule Raxol.Workflow.Compiled do
 
   @enforce_keys [:id, :nodes, :edges_by_source, :opts]
   defstruct [:id, :nodes, :edges_by_source, :opts]
+
+  @doc """
+  Run the compiled graph synchronously.
+
+  Delegates to `Raxol.Workflow.Runtime.invoke/3`. See that module for
+  the full result-tuple contract and the supported `opts`.
+  """
+  @spec invoke(t(), any(), keyword()) :: Raxol.Workflow.Runtime.result()
+  def invoke(%__MODULE__{} = compiled, initial_state, opts \\ []) do
+    Raxol.Workflow.Runtime.invoke(compiled, initial_state, opts)
+  end
 end

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -1,0 +1,434 @@
+defmodule Raxol.Workflow.Runtime do
+  @moduledoc """
+  Synchronous execution runtime for `Raxol.Workflow.Compiled` graphs.
+
+  Implements the synchronous `invoke/3` path described in ADR-0015.
+  Walks the graph from `:__start__` to `:__end__`, executes each node
+  according to its descriptor type, dispatches any returned directives
+  through `Raxol.Core.Runtime.Directive.Executor`, and emits per-node
+  telemetry with full Phase 24 trace context (trace_id, span_id,
+  parent_span_id, causation_id) propagated through `TraceContext`.
+
+  Async invocation (`async_invoke`, `stream_events`), checkpoint
+  persistence, interrupt/resume, joins, and channel reducers land in
+  follow-up PRs. This module only implements the synchronous,
+  no-checkpoint path; the runtime catches `:interrupt` results and
+  returns them to the caller without persisting state.
+  """
+
+  alias Raxol.Core.Runtime.Directive
+  alias Raxol.Core.Telemetry.TraceContext
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Edge.ConditionalEdge
+  alias Raxol.Workflow.Edge.Edge, as: StaticEdge
+  alias Raxol.Workflow.Edge.GuardedEdge
+  alias Raxol.Workflow.Node, as: WorkflowNode
+  alias Raxol.Workflow.Node.{BehaviourNode, FunctionNode, TypedNode}
+
+  @start :__start__
+  @end_ :__end__
+
+  @default_run_timeout_ms 60_000
+
+  @type result ::
+          {:ok, state :: any(), meta :: map()}
+          | {:interrupted, run_id :: binary(), state :: any(), value :: any()}
+          | {:error, reason :: any(), state :: any()}
+
+  @doc """
+  Run the compiled graph synchronously.
+
+  `opts` may include `:run_timeout_ms` (default 60_000) to bound the
+  total wall-clock time. Returns one of:
+
+    * `{:ok, final_state, %{run_id, nodes_executed}}`
+    * `{:interrupted, run_id, state, value}` when a node returns `{:interrupt, value}`
+    * `{:error, reason, state}` on node failure, raised exception, or walltime exceeded
+  """
+  @spec invoke(Compiled.t(), any(), keyword()) :: result()
+  def invoke(%Compiled{} = compiled, initial_state, opts \\ []) do
+    run_id = generate_run_id()
+    deadline_us = monotonic_us() + resolve_timeout(opts, compiled) * 1_000
+
+    _ = TraceContext.start_trace()
+
+    try do
+      emit_run_event(:started, %{run_id: run_id, graph_id: compiled.id})
+
+      compiled
+      |> step(@start, initial_state, run_id, deadline_us, 0)
+      |> wrap_outcome(run_id, compiled.id)
+    after
+      _ = TraceContext.clear()
+    end
+  end
+
+  defp resolve_timeout(opts, compiled) do
+    Keyword.get(
+      opts,
+      :run_timeout_ms,
+      Map.get(compiled.opts, :run_timeout_ms, @default_run_timeout_ms)
+    )
+  end
+
+  defp wrap_outcome({:ok, final_state, count}, run_id, graph_id) do
+    emit_run_event(:completed, %{
+      run_id: run_id,
+      graph_id: graph_id,
+      nodes_executed: count
+    })
+
+    {:ok, final_state, %{run_id: run_id, nodes_executed: count}}
+  end
+
+  defp wrap_outcome({:interrupted, state, value, count}, run_id, graph_id) do
+    emit_run_event(:interrupted, %{
+      run_id: run_id,
+      graph_id: graph_id,
+      nodes_executed: count,
+      value: value
+    })
+
+    {:interrupted, run_id, state, value}
+  end
+
+  defp wrap_outcome({:error, reason, state, count}, run_id, graph_id) do
+    emit_run_event(:failed, %{
+      run_id: run_id,
+      graph_id: graph_id,
+      nodes_executed: count,
+      reason: reason
+    })
+
+    {:error, reason, state}
+  end
+
+  # --- Execution loop ---
+
+  defp step(_compiled, @end_, state, _run_id, _deadline_us, count) do
+    {:ok, state, count}
+  end
+
+  defp step(compiled, current_id, state, run_id, deadline_us, count) do
+    cond do
+      monotonic_us() >= deadline_us ->
+        {:error, :run_timeout, state, count}
+
+      current_id == @start ->
+        # No work at start; just follow the outgoing edge.
+        traverse(compiled, current_id, state, run_id, deadline_us, count)
+
+      true ->
+        execute_node_and_continue(
+          compiled,
+          current_id,
+          state,
+          run_id,
+          deadline_us,
+          count
+        )
+    end
+  end
+
+  defp execute_node_and_continue(
+         compiled,
+         current_id,
+         state,
+         run_id,
+         deadline_us,
+         count
+       ) do
+    node = Map.fetch!(compiled.nodes, current_id)
+    span_name = "workflow.node.#{inspect(current_id)}"
+    _ = TraceContext.start_span(span_name)
+
+    started_us = monotonic_us()
+
+    emit_node_event(:started, %{
+      run_id: run_id,
+      graph_id: compiled.id,
+      node_id: current_id
+    })
+
+    try do
+      handle_node_result(
+        run_node(node, state),
+        compiled,
+        current_id,
+        state,
+        run_id,
+        deadline_us,
+        count,
+        started_us
+      )
+    rescue
+      e ->
+        _ = TraceContext.end_span()
+        message = Exception.message(e)
+
+        emit_node_event(:failed, %{
+          run_id: run_id,
+          graph_id: compiled.id,
+          node_id: current_id,
+          duration_us: monotonic_us() - started_us,
+          reason: {:exception, message}
+        })
+
+        {:error, {:exception, message}, state, count + 1}
+    end
+  end
+
+  defp handle_node_result(
+         {:ok, new_state},
+         compiled,
+         current_id,
+         _state,
+         run_id,
+         deadline_us,
+         count,
+         started_us
+       ) do
+    finish_node_ok(
+      compiled,
+      current_id,
+      new_state,
+      run_id,
+      deadline_us,
+      count,
+      started_us,
+      :ok
+    )
+  end
+
+  defp handle_node_result(
+         {:effects, directives, new_state},
+         compiled,
+         current_id,
+         _state,
+         run_id,
+         deadline_us,
+         count,
+         started_us
+       )
+       when is_list(directives) do
+    dispatch_effects(directives)
+
+    finish_node_ok(
+      compiled,
+      current_id,
+      new_state,
+      run_id,
+      deadline_us,
+      count,
+      started_us,
+      :effects
+    )
+  end
+
+  defp handle_node_result(
+         {:interrupt, value},
+         compiled,
+         current_id,
+         state,
+         run_id,
+         _deadline_us,
+         count,
+         started_us
+       ) do
+    end_span_and_emit(:completed, compiled, current_id, run_id, started_us, %{
+      result_type: :interrupt
+    })
+
+    {:interrupted, state, value, count + 1}
+  end
+
+  defp handle_node_result(
+         {:error, reason},
+         compiled,
+         current_id,
+         state,
+         run_id,
+         _deadline_us,
+         count,
+         started_us
+       ) do
+    end_span_and_emit(:failed, compiled, current_id, run_id, started_us, %{
+      reason: reason
+    })
+
+    {:error, reason, state, count + 1}
+  end
+
+  defp handle_node_result(
+         other,
+         compiled,
+         current_id,
+         state,
+         run_id,
+         _deadline_us,
+         count,
+         started_us
+       ) do
+    end_span_and_emit(:failed, compiled, current_id, run_id, started_us, %{
+      reason: {:invalid_result, other}
+    })
+
+    {:error, {:invalid_result, other}, state, count + 1}
+  end
+
+  defp end_span_and_emit(kind, compiled, current_id, run_id, started_us, extra) do
+    _ = TraceContext.end_span()
+
+    emit_node_event(
+      kind,
+      Map.merge(
+        %{
+          run_id: run_id,
+          graph_id: compiled.id,
+          node_id: current_id,
+          duration_us: monotonic_us() - started_us
+        },
+        extra
+      )
+    )
+  end
+
+  defp finish_node_ok(
+         compiled,
+         current_id,
+         new_state,
+         run_id,
+         deadline_us,
+         count,
+         started_us,
+         tag
+       ) do
+    emit_node_event(:completed, %{
+      run_id: run_id,
+      graph_id: compiled.id,
+      node_id: current_id,
+      duration_us: monotonic_us() - started_us,
+      result_type: tag
+    })
+
+    _ = TraceContext.end_span()
+    traverse(compiled, current_id, new_state, run_id, deadline_us, count + 1)
+  end
+
+  # --- Node execution ---
+
+  defp run_node(%FunctionNode{fun: fun}, state), do: fun.(state)
+
+  defp run_node(%BehaviourNode{module: module, opts: opts}, state) do
+    module.run(state, opts)
+  end
+
+  defp run_node(%TypedNode{struct: struct}, state) do
+    WorkflowNode.Executor.execute(struct, state, [])
+  end
+
+  # --- Edge traversal ---
+
+  defp traverse(compiled, current_id, state, run_id, deadline_us, count) do
+    outgoing = Map.get(compiled.edges_by_source, current_id, [])
+
+    case pick_next(outgoing, state) do
+      {:ok, next_id} ->
+        step(compiled, next_id, state, run_id, deadline_us, count)
+
+      :no_match ->
+        {:error, {:no_outgoing_edge_matched, current_id}, state, count}
+
+      {:error, reason} ->
+        {:error, reason, state, count}
+    end
+  end
+
+  defp pick_next([], _state), do: :no_match
+
+  defp pick_next([%StaticEdge{to: to} | _rest], _state), do: {:ok, to}
+
+  defp pick_next([%GuardedEdge{to: to, guard: guard} | rest], state) do
+    if guard.(state), do: {:ok, to}, else: pick_next(rest, state)
+  end
+
+  defp pick_next(
+         [%ConditionalEdge{chooser: chooser, candidates: candidates} | _rest],
+         state
+       ) do
+    case chooser.(state) do
+      id when is_atom(id) or is_binary(id) ->
+        if id in candidates do
+          {:ok, id}
+        else
+          {:error, {:chooser_returned_unknown_candidate, id, candidates}}
+        end
+
+      other ->
+        {:error, {:chooser_returned_non_id, other}}
+    end
+  end
+
+  # --- Effect dispatch ---
+
+  defp dispatch_effects(directives) do
+    context = %{pid: self(), runtime_pid: self()}
+
+    Enum.each(directives, fn directive ->
+      if is_struct(directive) and Directive.Executor.impl_for(directive) != nil do
+        Directive.Executor.execute(directive, context)
+      else
+        :ok
+      end
+    end)
+  end
+
+  # --- Telemetry helpers ---
+
+  defp emit_run_event(kind, metadata) do
+    :telemetry.execute(
+      [:raxol, :workflow, :run, kind],
+      %{},
+      add_trace_context(metadata)
+    )
+  end
+
+  defp emit_node_event(kind, metadata) do
+    measurements =
+      case Map.fetch(metadata, :duration_us) do
+        {:ok, dur} -> %{duration_us: dur}
+        :error -> %{}
+      end
+
+    :telemetry.execute(
+      [:raxol, :workflow, :node, kind],
+      measurements,
+      add_trace_context(Map.delete(metadata, :duration_us))
+    )
+  end
+
+  defp add_trace_context(metadata) do
+    case TraceContext.current() do
+      %{trace_id: nil} ->
+        metadata
+
+      ctx ->
+        metadata
+        |> Map.put(:trace_id, ctx.trace_id)
+        |> Map.put(:span_id, ctx.span_id)
+        |> maybe_put(:parent_span_id, ctx.parent_span_id)
+        |> maybe_put(:causation_id, ctx.causation_id)
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  # --- Misc ---
+
+  defp generate_run_id do
+    :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
+  end
+
+  defp monotonic_us, do: System.monotonic_time(:microsecond)
+end

--- a/test/raxol/workflow/runtime_property_test.exs
+++ b/test/raxol/workflow/runtime_property_test.exs
@@ -1,0 +1,105 @@
+# credo:disable-for-this-file Credo.Check.Refactor.AppendSingleItem
+defmodule Raxol.Workflow.RuntimePropertyTest do
+  @moduledoc """
+  Property tests for `Raxol.Workflow.Runtime.invoke/3`.
+
+  The example tests in `runtime_test.exs` pin specific shapes and
+  result tuples. The properties below stress the linear-chain happy
+  path and the telemetry contract over generated graph sizes.
+
+  The `credo:disable` directive above acknowledges that the chain
+  builder uses `++ [:__end__]` to append a sentinel; the generator is
+  a write-once helper, not a hot path.
+  """
+
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  describe "property: linear chains always terminate cleanly" do
+    property "an N-node chain of FunctionNodes returning {:ok, state+1} always returns {:ok, %{count: N}, _}" do
+      check all(chain_length <- integer(1..15), max_runs: 25) do
+        ids =
+          for n <- 1..chain_length, do: String.to_atom("step_#{n}")
+
+        graph =
+          ids
+          |> Enum.reduce(Graph.new(:linear_prop), fn id, g ->
+            Graph.add_node(g, id, fn s ->
+              {:ok, Map.update(s, :count, 1, &(&1 + 1))}
+            end)
+          end)
+
+        # Wire __start__ -> step_1 -> step_2 -> ... -> step_N -> __end__
+        graph =
+          [:__start__ | ids]
+          |> Enum.zip(ids ++ [:__end__])
+          |> Enum.reduce(graph, fn {from, to}, g ->
+            Graph.add_edge(g, from, to)
+          end)
+
+        assert {:ok, compiled} = Graph.compile(graph)
+        assert {:ok, %{count: n}, meta} = Compiled.invoke(compiled, %{})
+        assert n == chain_length
+        assert meta.nodes_executed == chain_length
+      end
+    end
+  end
+
+  describe "property: telemetry count matches structural execution count" do
+    property "node.started count == node.completed count == graph length" do
+      check all(chain_length <- integer(1..6), max_runs: 15) do
+        handler_id = "rtprop_#{:erlang.unique_integer([:positive])}"
+        test_pid = self()
+
+        :telemetry.attach_many(
+          handler_id,
+          [
+            [:raxol, :workflow, :node, :started],
+            [:raxol, :workflow, :node, :completed]
+          ],
+          fn event, _m, _md, _ ->
+            send(test_pid, {:tel, event})
+          end,
+          nil
+        )
+
+        ids = for n <- 1..chain_length, do: String.to_atom("n_#{n}")
+
+        graph =
+          ids
+          |> Enum.reduce(Graph.new(:tel_prop), fn id, g ->
+            Graph.add_node(g, id, fn s -> {:ok, s} end)
+          end)
+
+        graph =
+          [:__start__ | ids]
+          |> Enum.zip(ids ++ [:__end__])
+          |> Enum.reduce(graph, fn {from, to}, g ->
+            Graph.add_edge(g, from, to)
+          end)
+
+        {:ok, compiled} = Graph.compile(graph)
+        assert {:ok, _, _} = Compiled.invoke(compiled, %{})
+
+        started = drain_tel([:raxol, :workflow, :node, :started])
+        completed = drain_tel([:raxol, :workflow, :node, :completed])
+
+        :telemetry.detach(handler_id)
+
+        assert started == chain_length
+        assert completed == chain_length
+      end
+    end
+  end
+
+  defp drain_tel(event, count \\ 0) do
+    receive do
+      {:tel, ^event} -> drain_tel(event, count + 1)
+    after
+      0 -> count
+    end
+  end
+end

--- a/test/raxol/workflow/runtime_test.exs
+++ b/test/raxol/workflow/runtime_test.exs
@@ -1,0 +1,357 @@
+defmodule Raxol.Workflow.RuntimeTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  defmodule IncBehaviour do
+    @behaviour Raxol.Workflow.Node
+
+    @impl true
+    def run(state, opts) do
+      step = Keyword.get(opts, :step, 1)
+      {:ok, Map.update(state, :count, step, &(&1 + step))}
+    end
+  end
+
+  defmodule TaggedNode do
+    defstruct [:tag]
+  end
+
+  defimpl Raxol.Workflow.Node.Executor,
+    for: Raxol.Workflow.RuntimeTest.TaggedNode do
+    def execute(%{tag: tag}, state, _opts) do
+      {:ok, Map.update(state, :tags, [tag], &[tag | &1])}
+    end
+  end
+
+  defp linear_two_nodes do
+    Graph.new(:lin2)
+    |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :a, true)} end)
+    |> Graph.add_node(:b, fn s -> {:ok, Map.put(s, :b, true)} end)
+    |> Graph.add_edge(:__start__, :a)
+    |> Graph.add_edge(:a, :b)
+    |> Graph.add_edge(:b, :__end__)
+    |> Graph.compile()
+    |> elem(1)
+  end
+
+  describe "linear runs" do
+    test "two FunctionNodes execute in order and return final state" do
+      assert {:ok, final, meta} = Compiled.invoke(linear_two_nodes(), %{})
+      assert final == %{a: true, b: true}
+      assert meta.nodes_executed == 2
+      assert is_binary(meta.run_id)
+    end
+
+    test "BehaviourNode runs with opts" do
+      {:ok, compiled} =
+        Graph.new(:beh)
+        |> Graph.add_node(:inc, {IncBehaviour, [step: 5]})
+        |> Graph.add_edge(:__start__, :inc)
+        |> Graph.add_edge(:inc, :__end__)
+        |> Graph.compile()
+
+      assert {:ok, %{count: 5}, _meta} = Compiled.invoke(compiled, %{})
+    end
+
+    test "TypedNode dispatches via Node.Executor protocol" do
+      {:ok, compiled} =
+        Graph.new(:typed)
+        |> Graph.add_node(:tag, %TaggedNode{tag: :hello})
+        |> Graph.add_edge(:__start__, :tag)
+        |> Graph.add_edge(:tag, :__end__)
+        |> Graph.compile()
+
+      assert {:ok, %{tags: [:hello]}, _meta} = Compiled.invoke(compiled, %{})
+    end
+  end
+
+  describe "guarded edges" do
+    test "first matching guard wins" do
+      {:ok, compiled} =
+        Graph.new(:guards)
+        |> Graph.add_node(:start_n, fn s -> {:ok, s} end)
+        |> Graph.add_node(:left, fn s -> {:ok, Map.put(s, :branch, :left)} end)
+        |> Graph.add_node(:right, fn s -> {:ok, Map.put(s, :branch, :right)} end)
+        |> Graph.add_edge(:__start__, :start_n)
+        |> Graph.add_guarded_edge(:start_n, :left, fn s -> s.go == :left end)
+        |> Graph.add_guarded_edge(:start_n, :right, fn s -> s.go == :right end)
+        |> Graph.add_edge(:left, :__end__)
+        |> Graph.add_edge(:right, :__end__)
+        |> Graph.compile()
+
+      assert {:ok, %{branch: :left}, _} =
+               Compiled.invoke(compiled, %{go: :left})
+
+      assert {:ok, %{branch: :right}, _} =
+               Compiled.invoke(compiled, %{go: :right})
+    end
+
+    test "no guard matches -> {:error, :no_outgoing_edge_matched}" do
+      {:ok, compiled} =
+        Graph.new(:no_match)
+        |> Graph.add_node(:start_n, fn s -> {:ok, s} end)
+        |> Graph.add_node(:never, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :start_n)
+        |> Graph.add_guarded_edge(:start_n, :never, fn _ -> false end)
+        |> Graph.add_edge(:never, :__end__)
+        |> Graph.compile()
+
+      assert {:error, {:no_outgoing_edge_matched, :start_n}, %{}} =
+               Compiled.invoke(compiled, %{})
+    end
+  end
+
+  describe "conditional edges" do
+    test "chooser routes to a single candidate" do
+      {:ok, compiled} =
+        Graph.new(:cond)
+        |> Graph.add_node(:pick, fn s -> {:ok, s} end)
+        |> Graph.add_node(:x, fn s -> {:ok, Map.put(s, :took, :x)} end)
+        |> Graph.add_node(:y, fn s -> {:ok, Map.put(s, :took, :y)} end)
+        |> Graph.add_edge(:__start__, :pick)
+        |> Graph.add_conditional_edge(:pick, [:x, :y], fn s -> s.route end)
+        |> Graph.add_edge(:x, :__end__)
+        |> Graph.add_edge(:y, :__end__)
+        |> Graph.compile()
+
+      assert {:ok, %{took: :x}, _} = Compiled.invoke(compiled, %{route: :x})
+      assert {:ok, %{took: :y}, _} = Compiled.invoke(compiled, %{route: :y})
+    end
+
+    test "chooser returning unknown candidate is an error" do
+      {:ok, compiled} =
+        Graph.new(:bad_route)
+        |> Graph.add_node(:pick, fn s -> {:ok, s} end)
+        |> Graph.add_node(:x, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :pick)
+        |> Graph.add_conditional_edge(:pick, [:x], fn _ -> :ghost end)
+        |> Graph.add_edge(:x, :__end__)
+        |> Graph.compile()
+
+      assert {:error, {:chooser_returned_unknown_candidate, :ghost, [:x]}, _} =
+               Compiled.invoke(compiled, %{})
+    end
+  end
+
+  describe "result tuples" do
+    test "node returning {:interrupt, value} returns {:interrupted, run_id, state, value}" do
+      {:ok, compiled} =
+        Graph.new(:pause)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :seen, :a)} end)
+        |> Graph.add_node(:b, fn _s -> {:interrupt, :approval_required} end)
+        |> Graph.add_node(:c, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :c)
+        |> Graph.add_edge(:c, :__end__)
+        |> Graph.compile()
+
+      assert {:interrupted, run_id, state, :approval_required} =
+               Compiled.invoke(compiled, %{})
+
+      assert is_binary(run_id)
+      assert state == %{seen: :a}
+    end
+
+    test "node returning {:error, reason} returns {:error, reason, state}" do
+      {:ok, compiled} =
+        Graph.new(:err)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :seen, :a)} end)
+        |> Graph.add_node(:b, fn _s -> {:error, :kaboom} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :__end__)
+        |> Graph.compile()
+
+      assert {:error, :kaboom, %{seen: :a}} = Compiled.invoke(compiled, %{})
+    end
+
+    test "node returning {:effects, [], state} continues to next node" do
+      {:ok, compiled} =
+        Graph.new(:effects)
+        |> Graph.add_node(:a, fn s ->
+          {:effects, [], Map.put(s, :effects, :done)}
+        end)
+        |> Graph.add_node(:b, fn s -> {:ok, Map.put(s, :b, true)} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :__end__)
+        |> Graph.compile()
+
+      assert {:ok, %{effects: :done, b: true}, _} =
+               Compiled.invoke(compiled, %{})
+    end
+
+    test "node returning unexpected shape -> {:error, {:invalid_result, _}}" do
+      {:ok, compiled} =
+        Graph.new(:weird)
+        |> Graph.add_node(:a, fn _ -> :something_else end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :__end__)
+        |> Graph.compile()
+
+      assert {:error, {:invalid_result, :something_else}, %{}} =
+               Compiled.invoke(compiled, %{})
+    end
+
+    test "raised exception in node -> {:error, {:exception, msg}, state}" do
+      {:ok, compiled} =
+        Graph.new(:raise)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :seen, :a)} end)
+        |> Graph.add_node(:b, fn _ -> raise "boom" end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :__end__)
+        |> Graph.compile()
+
+      assert {:error, {:exception, "boom"}, %{seen: :a}} =
+               Compiled.invoke(compiled, %{})
+    end
+  end
+
+  describe "effects dispatch" do
+    test "Directive.spawn from {:effects, [...], state} fires async, state continues" do
+      {:ok, compiled} =
+        Graph.new(:dispatch)
+        |> Graph.add_node(:emit, fn s ->
+          test_pid = s.test_pid
+
+          dir =
+            Raxol.Core.Runtime.Directive.spawn_task(fn ->
+              send(test_pid, :fired)
+              {:ok, :fired}
+            end)
+
+          {:effects, [dir], Map.put(s, :emitted, true)}
+        end)
+        |> Graph.add_node(:next, fn s -> {:ok, Map.put(s, :next, true)} end)
+        |> Graph.add_edge(:__start__, :emit)
+        |> Graph.add_edge(:emit, :next)
+        |> Graph.add_edge(:next, :__end__)
+        |> Graph.compile()
+
+      assert {:ok, %{emitted: true, next: true}, _} =
+               Compiled.invoke(compiled, %{test_pid: self()})
+
+      assert_receive :fired, 500
+    end
+  end
+
+  describe "telemetry" do
+    setup do
+      handler_id = "workflow_test_#{:erlang.unique_integer([:positive])}"
+      test_pid = self()
+
+      events = [
+        [:raxol, :workflow, :run, :started],
+        [:raxol, :workflow, :run, :completed],
+        [:raxol, :workflow, :run, :interrupted],
+        [:raxol, :workflow, :run, :failed],
+        [:raxol, :workflow, :node, :started],
+        [:raxol, :workflow, :node, :completed],
+        [:raxol, :workflow, :node, :failed]
+      ]
+
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event, measurements, metadata, _ ->
+          send(test_pid, {:tel, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
+
+    test "run.started and run.completed bracket a successful run" do
+      Compiled.invoke(linear_two_nodes(), %{})
+
+      assert_receive {:tel, [:raxol, :workflow, :run, :started], %{},
+                      %{run_id: rid}}
+
+      assert is_binary(rid)
+
+      assert_receive {:tel, [:raxol, :workflow, :run, :completed], %{},
+                      %{nodes_executed: 2}}
+    end
+
+    test "each node emits started + completed with duration_us" do
+      Compiled.invoke(linear_two_nodes(), %{})
+
+      assert_receive {:tel, [:raxol, :workflow, :node, :started], _,
+                      %{node_id: :a}}
+
+      assert_receive {:tel, [:raxol, :workflow, :node, :completed],
+                      %{duration_us: d1}, %{node_id: :a, result_type: :ok}}
+
+      assert is_integer(d1) and d1 >= 0
+
+      assert_receive {:tel, [:raxol, :workflow, :node, :started], _,
+                      %{node_id: :b}}
+
+      assert_receive {:tel, [:raxol, :workflow, :node, :completed], _,
+                      %{node_id: :b}}
+    end
+
+    test "metadata carries trace_id and span_id" do
+      Compiled.invoke(linear_two_nodes(), %{})
+
+      assert_receive {:tel, [:raxol, :workflow, :run, :started], _,
+                      %{trace_id: trace_id, span_id: span_id}}
+
+      assert is_binary(trace_id) and is_binary(span_id)
+    end
+
+    test "interrupt emits run.interrupted" do
+      {:ok, compiled} =
+        Graph.new(:pause)
+        |> Graph.add_node(:pause, fn _ -> {:interrupt, :wait} end)
+        |> Graph.add_edge(:__start__, :pause)
+        |> Graph.add_edge(:pause, :__end__)
+        |> Graph.compile()
+
+      Compiled.invoke(compiled, %{})
+
+      assert_receive {:tel, [:raxol, :workflow, :run, :interrupted], _,
+                      %{value: :wait, nodes_executed: 1}}
+    end
+
+    test "node error emits run.failed" do
+      {:ok, compiled} =
+        Graph.new(:fail)
+        |> Graph.add_node(:nope, fn _ -> {:error, :nope_reason} end)
+        |> Graph.add_edge(:__start__, :nope)
+        |> Graph.add_edge(:nope, :__end__)
+        |> Graph.compile()
+
+      Compiled.invoke(compiled, %{})
+
+      assert_receive {:tel, [:raxol, :workflow, :run, :failed], _,
+                      %{reason: :nope_reason}}
+    end
+  end
+
+  describe "walltime guard" do
+    test "long-running graph aborts after run_timeout_ms" do
+      {:ok, compiled} =
+        Graph.new(:slow)
+        |> Graph.add_node(:slow, fn s ->
+          Process.sleep(100)
+          {:ok, s}
+        end)
+        |> Graph.add_edge(:__start__, :slow)
+        |> Graph.add_edge(:slow, :slow)
+        |> Graph.add_edge(:slow, :__end__)
+        |> Graph.compile()
+
+      # Static-edge precedence picks the first outgoing (self-loop). With
+      # a tiny timeout we should trip the deadline within a few iterations.
+      assert {:error, :run_timeout, _state} =
+               Compiled.invoke(compiled, %{}, run_timeout_ms: 50)
+    end
+  end
+end


### PR DESCRIPTION
Second implementation PR of Phase 25 (per ADR-0015). Lands the synchronous execution path for compiled workflow graphs. Walks the graph from `:__start__` to `:__end__`, executes each node, dispatches returned directives through the Phase 24 `Directive.Executor` protocol, and emits per-node telemetry with full `TraceContext` propagation.

## Summary

**New module: `Raxol.Workflow.Runtime`** -- `invoke/3` with:

- Edge traversal handling `StaticEdge`, `GuardedEdge` (first-true wins), and `ConditionalEdge` (chooser-returned id validated against declared candidates).
- Node dispatch for `FunctionNode` (`fun.(state)`), `BehaviourNode` (`module.run(state, opts)`), and `TypedNode` (`Node.Executor.execute(struct, state, [])`).
- Walltime guard: `run_timeout_ms` from `opts` or `Compiled.opts`, default `60_000`. Returns `{:error, :run_timeout, state}` when exceeded.
- Effects dispatch: `{:effects, [directive], new_state}` routes each struct through `Raxol.Core.Runtime.Directive.Executor.execute/2` with `context = %{pid: self(), runtime_pid: self()}`.
- Six telemetry event classes:
  - `[:raxol, :workflow, :run, :started | :completed | :interrupted | :failed]`
  - `[:raxol, :workflow, :node, :started | :completed | :failed]`
- TraceContext: `start_trace` at run entry, `start_span("workflow.node.<id>")` per node, `end_span` after each, `clear` on exit. Metadata carries `trace_id`, `span_id`, `parent_span_id`, `causation_id` when set, plus per-event measurements (`duration_us` on node completions).
- `try/after` ensures TraceContext cleanup even on uncaught exceptions.

**`Compiled.invoke/3`** now delegates to `Runtime`. The moduledoc updates to list the four runtime entry points; `invoke` shipped, `async_invoke`/`stream_events`/`resume` in later PRs.

**Result tuples:**

- `{:ok, final_state, %{run_id, nodes_executed}}`
- `{:interrupted, run_id, state, value}` on node `{:interrupt, value}`
- `{:error, reason, state}` on node failure / raised exception / walltime / no-matching-outgoing-edge

## Tests

- **19 example tests** covering: linear chains over each node type, `BehaviourNode` opts pass-through, guarded edges (first-match-wins + no-match error), conditional edges (single candidate routing + unknown candidate rejection), all four result tuples, raised exceptions, walltime guard, effects dispatch (`Directive.spawn_task` fires async, state continues), and five telemetry-shape assertions (run.started/completed bracketing, per-node started/completed with `duration_us`, `trace_id`/`span_id` in metadata, interrupted event on `{:interrupt, _}`, failed event on `{:error, _}`).
- **2 property tests:**
  - N-node chain of FunctionNodes returning `{:ok, state+1}` always produces `{:ok, %{count: N}, _}` for N in 1..15 (25 runs).
  - `node.started` count == `node.completed` count == chain length over telemetry capture for N in 1..6 (15 runs).
- Both properties stable across seeds 0, 1, 42, 1234.

## Test plan

- [x] Workflow tests: 6 properties + 39 tests, 0 failures
- [x] Main raxol regression: 7 doctests + 172 properties + 3866 tests, 0 failures (was 170 + 3847; +2 properties + 19 tests + new property file)
- [x] `mix compile --warnings-as-errors` clean
- [x] Credo strict: 0 issues (one `# credo:disable-for-this-file` on the property test for the same `++ [:__end__]` pattern explained in PR 1)
- [x] `mix format --check-formatted` clean

## Out of scope (deferred to follow-up PRs)

- `async_invoke` / `stream_events` (PR 3)
- `Checkpoint.Saver` behaviour + Ets/Dets adapters (PR 4)
- `Execution.Scratchpad` + `Workflow.interrupt/1` throw mechanism (PR 5)
- `add_join` (barrier) + `add_channel` (typed reducers)
- `failure_policy` enforcement (`:compensate`, `:retry`)
- per-step timeout (`step_timeout_ms`)

## Manual testing

- [ ] Confirm CI passes (unified pipeline, regression, security)
- [ ] Cross-check telemetry event names + metadata shape against ADR-0015's "Compiled runtime API" section