### PR TITLE
Phase 25 PR 3: async_invoke + stream_events

### DIFF
--- a/lib/raxol/workflow/async.ex
+++ b/lib/raxol/workflow/async.ex
@@ -1,0 +1,202 @@
+defmodule Raxol.Workflow.Async do
+  @moduledoc """
+  Asynchronous execution surface for `Raxol.Workflow.Compiled` graphs.
+
+  Wraps `Raxol.Workflow.Runtime.invoke/3` in a separately-spawned
+  process and a per-run telemetry handler so callers can either:
+
+    * fire-and-forget a run and monitor for completion
+      (`async_invoke/3`), or
+    * consume the run's progress as a lazy `Stream` of
+      `Raxol.Core.Events.CloudEvent` structs (`stream_events/3`)
+
+  This module ships the synchronous-spawn shape from ADR-0015. A
+  `Raxol.Workflow.RunSupervisor` (DynamicSupervisor) for production
+  hardening is a follow-up; the API here is supervisor-agnostic, so
+  swapping to a supervised spawn does not break existing callers.
+
+  The runtime emits telemetry events on `[:raxol, :workflow, :run, _]`
+  and `[:raxol, :workflow, :node, _]`; `stream_events/3` attaches a
+  handler scoped to its run_id and converts each event into a CloudEvent
+  before pushing it onto the stream.
+  """
+
+  alias Raxol.Core.Events.CloudEvent
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Runtime
+
+  @run_events [
+    [:raxol, :workflow, :run, :started],
+    [:raxol, :workflow, :run, :completed],
+    [:raxol, :workflow, :run, :interrupted],
+    [:raxol, :workflow, :run, :failed]
+  ]
+
+  @node_events [
+    [:raxol, :workflow, :node, :started],
+    [:raxol, :workflow, :node, :completed],
+    [:raxol, :workflow, :node, :failed]
+  ]
+
+  @all_events @run_events ++ @node_events
+
+  @terminal_run_kinds [:completed, :interrupted, :failed]
+
+  @doc """
+  Spawn the run in a separate process and return a handle immediately.
+
+  Returns `{:ok, %{run_id: binary, pid: pid, ref: reference}}`. The
+  caller can:
+
+    * `Process.demonitor(ref, [:flush])` if the result is no longer
+      needed.
+    * `receive` `{:DOWN, ref, :process, pid, reason}` to detect
+      completion.
+    * subscribe to `[:raxol, :workflow, *]` telemetry events filtered
+      by `run_id` for progress updates.
+
+  The spawned process is not linked to the caller; a worker crash
+  arrives as a `:DOWN` message rather than a synchronous exit signal.
+  """
+  @spec async_invoke(Compiled.t(), any(), keyword()) ::
+          {:ok, %{run_id: binary(), pid: pid(), ref: reference()}}
+  def async_invoke(%Compiled{} = compiled, initial_state, opts \\ []) do
+    run_id = Runtime.generate_run_id()
+    opts_with_id = Keyword.put(opts, :run_id, run_id)
+
+    pid =
+      spawn(fn ->
+        Runtime.invoke(compiled, initial_state, opts_with_id)
+      end)
+
+    ref = Process.monitor(pid)
+    {:ok, %{run_id: run_id, pid: pid, ref: ref}}
+  end
+
+  @doc """
+  Run the graph and return a lazy `Stream` of `CloudEvent` structs.
+
+  Each emitted telemetry event (run.started, node.started,
+  node.completed, etc.) is converted to a `Raxol.Core.Events.CloudEvent`
+  using the Phase 24 envelope and pushed onto the stream in the order
+  the runtime emits it. The stream terminates after the first run-level
+  terminal event (`completed`, `interrupted`, or `failed`).
+
+  ## Options
+
+    * `:timeout_ms` - per-event receive timeout (default 60_000). The
+      stream halts if no event arrives within the window.
+    * `:source` - CloudEvent source URI override; defaults to
+      `Application.get_env(:raxol, :workflow_event_source, "raxol://workflow")`.
+
+  Any `opts` not consumed here are forwarded to `Runtime.invoke/3`.
+  """
+  @spec stream_events(Compiled.t(), any(), keyword()) :: Enumerable.t()
+  def stream_events(%Compiled{} = compiled, initial_state, opts \\ []) do
+    Stream.resource(
+      fn -> start_stream(compiled, initial_state, opts) end,
+      &pull_next/1,
+      &cleanup/1
+    )
+  end
+
+  # --- Stream resource lifecycle ---
+
+  defp start_stream(compiled, initial_state, opts) do
+    run_id = Runtime.generate_run_id()
+    consumer_pid = self()
+    handler_id = "workflow_stream_" <> run_id
+    timeout_ms = Keyword.get(opts, :timeout_ms, 60_000)
+
+    source =
+      Keyword.get_lazy(opts, :source, fn ->
+        Application.get_env(:raxol, :workflow_event_source, "raxol://workflow")
+      end)
+
+    :telemetry.attach_many(
+      handler_id,
+      @all_events,
+      &handle_stream_event/4,
+      %{run_id: run_id, consumer_pid: consumer_pid, source: source}
+    )
+
+    runtime_opts =
+      opts
+      |> Keyword.put(:run_id, run_id)
+      |> Keyword.drop([:timeout_ms, :source])
+
+    pid =
+      spawn(fn ->
+        Runtime.invoke(compiled, initial_state, runtime_opts)
+      end)
+
+    ref = Process.monitor(pid)
+
+    %{
+      run_id: run_id,
+      handler_id: handler_id,
+      pid: pid,
+      ref: ref,
+      timeout_ms: timeout_ms,
+      terminal_received: false
+    }
+  end
+
+  defp pull_next(%{terminal_received: true} = state), do: {:halt, state}
+
+  defp pull_next(state) do
+    receive do
+      {:workflow_stream, %CloudEvent{} = ce} ->
+        {[ce], %{state | terminal_received: terminal?(ce)}}
+
+      {:DOWN, ref, :process, pid, _reason}
+      when ref == state.ref and pid == state.pid ->
+        {:halt, state}
+    after
+      state.timeout_ms -> {:halt, state}
+    end
+  end
+
+  defp cleanup(state) do
+    :telemetry.detach(state.handler_id)
+
+    Process.demonitor(state.ref, [:flush])
+
+    if Process.alive?(state.pid) do
+      Process.exit(state.pid, :kill)
+    end
+
+    :ok
+  end
+
+  defp terminal?(%CloudEvent{type: "raxol.workflow.run." <> kind}) do
+    String.to_existing_atom(kind) in @terminal_run_kinds
+  rescue
+    ArgumentError -> false
+  end
+
+  defp terminal?(_), do: false
+
+  # --- Telemetry -> CloudEvent ---
+
+  defp handle_stream_event(event, measurements, metadata, config) do
+    if Map.get(metadata, :run_id) == config.run_id do
+      cloud_event = to_cloud_event(event, measurements, metadata, config.source)
+      send(config.consumer_pid, {:workflow_stream, cloud_event})
+    end
+  end
+
+  defp to_cloud_event(
+         [:raxol, :workflow, scope, kind],
+         measurements,
+         metadata,
+         source
+       ) do
+    type = "raxol.workflow.#{scope}.#{kind}"
+
+    CloudEvent.new(type, source,
+      data: %{measurements: measurements, metadata: metadata},
+      subject: Map.get(metadata, :run_id)
+    )
+  end
+end

--- a/lib/raxol/workflow/compiled.ex
+++ b/lib/raxol/workflow/compiled.ex
@@ -44,4 +44,27 @@ defmodule Raxol.Workflow.Compiled do
   def invoke(%__MODULE__{} = compiled, initial_state, opts \\ []) do
     Raxol.Workflow.Runtime.invoke(compiled, initial_state, opts)
   end
+
+  @doc """
+  Spawn the run in a background process; return an immediate handle.
+
+  Delegates to `Raxol.Workflow.Async.async_invoke/3`. See that module
+  for the returned handle shape and the supported `opts`.
+  """
+  @spec async_invoke(t(), any(), keyword()) ::
+          {:ok, %{run_id: binary(), pid: pid(), ref: reference()}}
+  def async_invoke(%__MODULE__{} = compiled, initial_state, opts \\ []) do
+    Raxol.Workflow.Async.async_invoke(compiled, initial_state, opts)
+  end
+
+  @doc """
+  Return a lazy `Stream` of `Raxol.Core.Events.CloudEvent` structs
+  emitted by the run.
+
+  Delegates to `Raxol.Workflow.Async.stream_events/3`.
+  """
+  @spec stream_events(t(), any(), keyword()) :: Enumerable.t()
+  def stream_events(%__MODULE__{} = compiled, initial_state, opts \\ []) do
+    Raxol.Workflow.Async.stream_events(compiled, initial_state, opts)
+  end
 end

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -47,7 +47,7 @@ defmodule Raxol.Workflow.Runtime do
   """
   @spec invoke(Compiled.t(), any(), keyword()) :: result()
   def invoke(%Compiled{} = compiled, initial_state, opts \\ []) do
-    run_id = generate_run_id()
+    run_id = Keyword.get_lazy(opts, :run_id, &generate_run_id/0)
     deadline_us = monotonic_us() + resolve_timeout(opts, compiled) * 1_000
 
     _ = TraceContext.start_trace()
@@ -426,7 +426,9 @@ defmodule Raxol.Workflow.Runtime do
 
   # --- Misc ---
 
-  defp generate_run_id do
+  @doc "Generate a fresh 16-character hex run id."
+  @spec generate_run_id() :: binary()
+  def generate_run_id do
     :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
   end
 

--- a/test/raxol/workflow/async_property_test.exs
+++ b/test/raxol/workflow/async_property_test.exs
@@ -1,0 +1,91 @@
+# credo:disable-for-this-file Credo.Check.Refactor.AppendSingleItem
+defmodule Raxol.Workflow.AsyncPropertyTest do
+  @moduledoc """
+  Property tests for `Raxol.Workflow.Async.{async_invoke, stream_events}`.
+
+  The example tests in `async_test.exs` pin the shape and ordering of
+  a linear two-node run. The properties below check the same contracts
+  over generated chain sizes.
+
+  The `credo:disable` directive acknowledges the chain builder uses
+  `++ [:__end__]` to append the sentinel.
+  """
+
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  describe "property: stream_events count matches structure" do
+    property "an N-node linear chain yields exactly 2 + 2N CloudEvents" do
+      check all(chain_length <- integer(1..6), max_runs: 15) do
+        ids = for n <- 1..chain_length, do: String.to_atom("n_#{n}")
+
+        graph =
+          ids
+          |> Enum.reduce(Graph.new(:async_prop), fn id, g ->
+            Graph.add_node(g, id, fn s -> {:ok, s} end)
+          end)
+
+        graph =
+          [:__start__ | ids]
+          |> Enum.zip(ids ++ [:__end__])
+          |> Enum.reduce(graph, fn {from, to}, g ->
+            Graph.add_edge(g, from, to)
+          end)
+
+        {:ok, compiled} = Graph.compile(graph)
+        events = compiled |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+        # Expected layout:
+        #   run.started
+        #   node.started, node.completed (x N)
+        #   run.completed
+        # = 2 + 2N events
+        assert length(events) == 2 + 2 * chain_length
+
+        types = Enum.map(events, & &1.type)
+        assert hd(types) == "raxol.workflow.run.started"
+        assert List.last(types) == "raxol.workflow.run.completed"
+
+        node_starts = Enum.count(types, &(&1 == "raxol.workflow.node.started"))
+
+        node_completes =
+          Enum.count(types, &(&1 == "raxol.workflow.node.completed"))
+
+        assert node_starts == chain_length
+        assert node_completes == chain_length
+      end
+    end
+  end
+
+  describe "property: async_invoke handle correlates with telemetry" do
+    property "the run_id in the handle matches the run_id in stream_events output" do
+      check all(chain_length <- integer(1..4), max_runs: 10) do
+        ids = for n <- 1..chain_length, do: String.to_atom("c_#{n}")
+
+        graph =
+          ids
+          |> Enum.reduce(Graph.new(:corr), fn id, g ->
+            Graph.add_node(g, id, fn s -> {:ok, s} end)
+          end)
+
+        graph =
+          [:__start__ | ids]
+          |> Enum.zip(ids ++ [:__end__])
+          |> Enum.reduce(graph, fn {from, to}, g ->
+            Graph.add_edge(g, from, to)
+          end)
+
+        {:ok, compiled} = Graph.compile(graph)
+
+        events = compiled |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+        # All events should share one subject (the run_id).
+        subjects = events |> Enum.map(& &1.subject) |> Enum.uniq()
+        assert length(subjects) == 1
+      end
+    end
+  end
+end

--- a/test/raxol/workflow/async_test.exs
+++ b/test/raxol/workflow/async_test.exs
@@ -1,0 +1,196 @@
+defmodule Raxol.Workflow.AsyncTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Core.Events.CloudEvent
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  defp linear_two_nodes do
+    Graph.new(:async_lin)
+    |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :a, true)} end)
+    |> Graph.add_node(:b, fn s -> {:ok, Map.put(s, :b, true)} end)
+    |> Graph.add_edge(:__start__, :a)
+    |> Graph.add_edge(:a, :b)
+    |> Graph.add_edge(:b, :__end__)
+    |> Graph.compile()
+    |> elem(1)
+  end
+
+  describe "async_invoke/3" do
+    test "returns an immediate handle with run_id, pid, ref" do
+      assert {:ok, %{run_id: run_id, pid: pid, ref: ref}} =
+               Compiled.async_invoke(linear_two_nodes(), %{})
+
+      assert is_binary(run_id) and byte_size(run_id) == 16
+      assert is_pid(pid)
+      assert is_reference(ref)
+    end
+
+    test "monitor ref fires on run completion" do
+      assert {:ok, %{pid: pid, ref: ref}} =
+               Compiled.async_invoke(linear_two_nodes(), %{})
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 1_000
+    end
+
+    test "run_id propagates into telemetry metadata" do
+      handler_id = "async_test_#{:erlang.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :workflow, :run, :started],
+        fn _event, _m, metadata, _ ->
+          send(test_pid, {:got_start, metadata.run_id})
+        end,
+        nil
+      )
+
+      {:ok, %{run_id: run_id, ref: ref, pid: pid}} =
+        Compiled.async_invoke(linear_two_nodes(), %{})
+
+      assert_receive {:got_start, ^run_id}, 1_000
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+
+      :telemetry.detach(handler_id)
+    end
+
+    test "caller-supplied run_id (via opts forwarding) wins" do
+      # async_invoke generates its own run_id; ensure user opts don't
+      # silently override it. The handle's run_id is authoritative.
+      {:ok, %{run_id: ours, ref: ref, pid: pid}} =
+        Compiled.async_invoke(linear_two_nodes(), %{},
+          run_id: "ignored-by-async"
+        )
+
+      # The runtime will receive `ignored-by-async` (last-write wins in
+      # Keyword.put), but the handle reports what the caller can correlate
+      # against. This documents the contract.
+      assert is_binary(ours)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+    end
+
+    test "monitor ref fires on uncaught crash inside a node" do
+      {:ok, compiled} =
+        Graph.new(:async_crash)
+        |> Graph.add_node(:bomb, fn _ -> Process.exit(self(), :node_crash) end)
+        |> Graph.add_edge(:__start__, :bomb)
+        |> Graph.add_edge(:bomb, :__end__)
+        |> Graph.compile()
+
+      {:ok, %{pid: pid, ref: ref}} = Compiled.async_invoke(compiled, %{})
+      assert_receive {:DOWN, ^ref, :process, ^pid, :node_crash}, 1_000
+    end
+  end
+
+  describe "stream_events/3" do
+    test "yields CloudEvent structs for a linear two-node run" do
+      events =
+        linear_two_nodes() |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+      types = Enum.map(events, & &1.type)
+
+      assert "raxol.workflow.run.started" in types
+      assert "raxol.workflow.run.completed" in types
+      assert Enum.count(types, &(&1 == "raxol.workflow.node.started")) == 2
+      assert Enum.count(types, &(&1 == "raxol.workflow.node.completed")) == 2
+    end
+
+    test "events are emitted in order: run.started, node pairs, run.completed" do
+      events =
+        linear_two_nodes() |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+      types = Enum.map(events, & &1.type)
+
+      assert hd(types) == "raxol.workflow.run.started"
+      assert List.last(types) == "raxol.workflow.run.completed"
+    end
+
+    test "each CloudEvent carries the run_id as subject" do
+      events =
+        linear_two_nodes() |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+      subjects = events |> Enum.map(& &1.subject) |> Enum.uniq()
+      assert length(subjects) == 1
+      [subject] = subjects
+      assert is_binary(subject) and byte_size(subject) == 16
+    end
+
+    test "each CloudEvent has source, type, id, time, data" do
+      events =
+        linear_two_nodes() |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+      Enum.each(events, fn %CloudEvent{} = ce ->
+        assert ce.specversion == "1.0"
+        assert is_binary(ce.id) and byte_size(ce.id) == 16
+        assert is_binary(ce.source)
+        assert is_binary(ce.type)
+        assert %DateTime{} = ce.time
+        assert is_map(ce.data)
+        assert Map.has_key?(ce.data, :measurements)
+        assert Map.has_key?(ce.data, :metadata)
+      end)
+    end
+
+    test "stream halts after run.failed terminal event" do
+      {:ok, compiled} =
+        Graph.new(:stream_fail)
+        |> Graph.add_node(:nope, fn _ -> {:error, :node_failed} end)
+        |> Graph.add_edge(:__start__, :nope)
+        |> Graph.add_edge(:nope, :__end__)
+        |> Graph.compile()
+
+      events = compiled |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+      assert List.last(events).type == "raxol.workflow.run.failed"
+      types = Enum.map(events, & &1.type)
+      refute "raxol.workflow.run.completed" in types
+    end
+
+    test "stream halts after run.interrupted terminal event" do
+      {:ok, compiled} =
+        Graph.new(:stream_pause)
+        |> Graph.add_node(:pause, fn _ -> {:interrupt, :wait} end)
+        |> Graph.add_edge(:__start__, :pause)
+        |> Graph.add_edge(:pause, :__end__)
+        |> Graph.compile()
+
+      events = compiled |> Compiled.stream_events(%{}) |> Enum.to_list()
+
+      assert List.last(events).type == "raxol.workflow.run.interrupted"
+    end
+
+    test "source override is honored" do
+      events =
+        linear_two_nodes()
+        |> Compiled.stream_events(%{}, source: "raxol://custom")
+        |> Enum.to_list()
+
+      Enum.each(events, fn ce -> assert ce.source == "raxol://custom" end)
+    end
+
+    test "concurrent streams don't see each other's events" do
+      compiled = linear_two_nodes()
+
+      task_a =
+        Task.async(fn ->
+          compiled |> Compiled.stream_events(%{}) |> Enum.to_list()
+        end)
+
+      task_b =
+        Task.async(fn ->
+          compiled |> Compiled.stream_events(%{}) |> Enum.to_list()
+        end)
+
+      events_a = Task.await(task_a, 2_000)
+      events_b = Task.await(task_b, 2_000)
+
+      subjects_a = events_a |> Enum.map(& &1.subject) |> Enum.uniq()
+      subjects_b = events_b |> Enum.map(& &1.subject) |> Enum.uniq()
+
+      assert length(subjects_a) == 1
+      assert length(subjects_b) == 1
+      assert subjects_a != subjects_b
+    end
+  end
+end


### PR DESCRIPTION
Third implementation PR of Phase 25 (per ADR-0015). Lands the two asynchronous runtime entry points. Both spawn the run in a separate process (not linked to the caller) and surface progress through the same Phase 24 telemetry path that the sync `invoke/3` already emits.

## Summary

**New module: `Raxol.Workflow.Async`**

- **`async_invoke/3`** returns `{:ok, %{run_id, pid, ref}}` immediately. The caller monitors `ref` for `{:DOWN, _, _, pid, reason}` to detect completion or attaches telemetry handlers filtered on `run_id` for progress updates. The spawned process is unlinked, so a node crash arrives as `:DOWN` rather than a synchronous exit signal.
- **`stream_events/3`** returns a lazy `Stream` of `Raxol.Core.Events.CloudEvent` structs. A per-run `:telemetry` handler attaches before spawn, converts each emitted event to a CloudEvent envelope (type `raxol.workflow.<scope>.<kind>`, subject = run_id, data carries measurements + metadata), and pushes it onto the stream. The stream halts after the first run-level terminal event (`completed`, `interrupted`, `failed`). Cleanup detaches the handler, demonitors, and kills the run process if it's still alive when the consumer aborts the stream.

**`Runtime.invoke/3`** now accepts `:run_id` in opts (`Keyword.get_lazy` defaults to a fresh id). This lets the async wrappers pre-generate the id so the handle can correlate with telemetry events before the run starts. `generate_run_id/0` is now `@doc`-public for the same reason.

**`Compiled.invoke / async_invoke / stream_events`** all delegate to the matching backend. The moduledoc lists the four runtime entry points with PR status (sync `invoke` shipped; async + stream shipped now; `resume` in PR 5).

## Tests

- **13 example tests** covering: handle shape, monitor ref fires on completion, run_id propagation into telemetry metadata, crash propagation via `:DOWN`, CloudEvent envelope shape (specversion, id, source, type, time, data), terminal-event halt for each terminal kind (failed, interrupted), source override, ordering, concurrent stream isolation (subjects don't bleed across streams).
- **2 property tests**:
  - N-node chain (1..6) yields exactly `2 + 2N` CloudEvents in stream
  - All events for one run share one subject (the run_id)
- Both properties stable across seeds 0, 1, 42, 1234, 99999.

## Test plan

- [x] Workflow tests: 8 properties + 52 tests, 0 failures
- [x] Main raxol regression: 7 doctests + 174 properties + 3879 tests, 0 failures (was 172 + 3866; +2 properties + 13 tests + crash test)
- [x] `mix compile --warnings-as-errors` clean
- [x] Credo strict: 0 issues (one `# credo:disable-for-this-file` on the property test for the `++ [:__end__]` chain builder, same rationale as PRs 1+2)
- [x] `mix format --check-formatted` clean

## Out of scope (deferred to follow-up PRs)

- `Checkpoint.Saver` behaviour + `Ets`/`Dets` adapters (PR 4)
- `Execution.Scratchpad` + `Workflow.interrupt/1` throw mechanism + `resume/3` (PR 5)
- `Raxol.Workflow.RunSupervisor` DynamicSupervisor for production hardening (the API is supervisor-agnostic, so swapping to a supervised spawn is non-breaking)
- `add_join` (barrier) + `add_channel` (typed reducers)
- `failure_policy: :compensate` / `:retry`

## Manual testing

- [ ] Confirm CI passes (unified pipeline, regression, security)
- [ ] Run a stream over a longer graph in iex and verify `Enum.to_list/1` returns the CloudEvent sequence in submission order