### PR TITLE
Phase 25 PR 5: Scratchpad + interrupt + resume

### DIFF
--- a/lib/raxol/workflow.ex
+++ b/lib/raxol/workflow.ex
@@ -1,0 +1,58 @@
+defmodule Raxol.Workflow do
+  @moduledoc """
+  Top-level interrupt/resume API for `Raxol.Workflow.*`.
+
+  The graph builder, compile pipeline, and runtime entry points live
+  in their dedicated submodules (`Graph`, `Compiled`, `Runtime`,
+  `Async`). This module exposes the small surface that node code
+  needs during execution: `interrupt/1`.
+
+  ## Pausing a run for human input
+
+      defmodule MyNodes do
+        def approve_release(state) do
+          decision = Raxol.Workflow.interrupt(:awaiting_approval)
+
+          case decision do
+            :approved -> {:ok, Map.put(state, :status, :released)}
+            :rejected -> {:ok, Map.put(state, :status, :rejected)}
+          end
+        end
+      end
+
+  On the first execution the runtime catches the throw raised by
+  `interrupt/1` and returns
+  `{:interrupted, run_id, state_before_node, :awaiting_approval}`. The
+  caller (human, MCP tool, scheduled job) eventually calls
+  `Compiled.resume(compiled, run_id, :approved)`. The runtime
+  rehydrates the latest checkpoint, seeds the scratchpad with
+  `:approved`, and re-runs the node; this time `interrupt/1` finds the
+  value in the queue and returns it.
+  """
+
+  alias Raxol.Workflow.Execution.Scratchpad
+
+  @doc """
+  Pause the current run, or consume a previously-supplied resume value.
+
+  - If the scratchpad's resume queue holds a value, returns
+    `{:ok, value}`'s value (i.e. just the value, unwrapped). Execution
+    continues normally.
+  - If the queue is empty, throws
+    `{:__workflow_interrupt__, interrupt_value}`. The runtime catches
+    this and surfaces it to the caller as
+    `{:interrupted, run_id, state, interrupt_value}`.
+
+  `interrupt_value` is opaque to the runtime; it is forwarded verbatim
+  to the caller and is intended to carry whatever context the caller
+  needs to make a decision (e.g. an approval request, a question,
+  a payload for downstream tooling).
+  """
+  @spec interrupt(any()) :: any() | no_return()
+  def interrupt(interrupt_value) do
+    case Scratchpad.take_resume() do
+      {:ok, resume_value} -> resume_value
+      :empty -> throw({:__workflow_interrupt__, interrupt_value})
+    end
+  end
+end

--- a/lib/raxol/workflow/compiled.ex
+++ b/lib/raxol/workflow/compiled.ex
@@ -67,4 +67,17 @@ defmodule Raxol.Workflow.Compiled do
   def stream_events(%__MODULE__{} = compiled, initial_state, opts \\ []) do
     Raxol.Workflow.Async.stream_events(compiled, initial_state, opts)
   end
+
+  @doc """
+  Resume an interrupted run.
+
+  Delegates to `Raxol.Workflow.Runtime.resume/4`. See that module for
+  the full result-tuple contract and error tuples.
+  """
+  @spec resume(t(), binary(), any(), keyword()) ::
+          Raxol.Workflow.Runtime.result()
+          | {:error, :no_saver_configured | :no_checkpoint, nil}
+  def resume(%__MODULE__{} = compiled, run_id, resume_value, opts \\ []) do
+    Raxol.Workflow.Runtime.resume(compiled, run_id, resume_value, opts)
+  end
 end

--- a/lib/raxol/workflow/execution/scratchpad.ex
+++ b/lib/raxol/workflow/execution/scratchpad.ex
@@ -1,0 +1,81 @@
+defmodule Raxol.Workflow.Execution.Scratchpad do
+  @moduledoc """
+  Per-task execution state for workflow runs that use interrupt / resume.
+
+  The scratchpad holds a FIFO of resume values supplied by callers of
+  `Raxol.Workflow.Compiled.resume/4`. When a node calls
+  `Raxol.Workflow.interrupt/1`, that function inspects the scratchpad:
+
+    * If the queue holds a value, the value is popped and returned;
+      the node continues execution with that value (this is the resume
+      path).
+    * If the queue is empty, `interrupt/1` throws
+      `{:__workflow_interrupt__, value}`, which the runtime catches and
+      surfaces to the caller as `{:interrupted, run_id, state, value}`
+      (this is the first-pause path).
+
+  ## Storage
+
+  Per-process storage uses the process dictionary under the
+  `:raxol_workflow_scratchpad` key. This is one of the rare cases
+  where the process dictionary is the right tool: the scratchpad is
+  process-local by construction, lives only for the duration of one
+  run's execution in one process, and must not leak between runs.
+  `Runtime.invoke/3` clears the scratchpad on entry and exit so the
+  ambient state is always either the current run's or absent.
+  """
+
+  @key :raxol_workflow_scratchpad
+
+  @typedoc "Per-process scratchpad state. Opaque to callers."
+  @type t :: %{run_id: binary() | nil, resume_queue: :queue.queue()}
+
+  @doc """
+  Initialize the scratchpad for `run_id`, optionally seeding the resume
+  queue with the supplied list of values in order.
+
+  Subsequent calls overwrite any prior scratchpad on the same process.
+  """
+  @spec init(binary(), [any()]) :: :ok
+  def init(run_id, resume_values \\ []) when is_list(resume_values) do
+    queue = Enum.reduce(resume_values, :queue.new(), &:queue.in/2)
+    Process.put(@key, %{run_id: run_id, resume_queue: queue})
+    :ok
+  end
+
+  @doc """
+  Pop the head of the resume queue.
+
+  Returns `{:ok, value}` if a value was available, `:empty` otherwise.
+  Safe to call without `init/2`; treats the absence of a scratchpad as
+  an empty queue.
+  """
+  @spec take_resume() :: {:ok, any()} | :empty
+  def take_resume do
+    case Process.get(@key) do
+      %{resume_queue: queue} = scratchpad ->
+        case :queue.out(queue) do
+          {{:value, value}, new_queue} ->
+            Process.put(@key, %{scratchpad | resume_queue: new_queue})
+            {:ok, value}
+
+          {:empty, _queue} ->
+            :empty
+        end
+
+      _ ->
+        :empty
+    end
+  end
+
+  @doc "Return the current scratchpad, or `nil` if none is set."
+  @spec get() :: t() | nil
+  def get, do: Process.get(@key)
+
+  @doc "Remove the scratchpad from the process dictionary."
+  @spec clear() :: :ok
+  def clear do
+    Process.delete(@key)
+    :ok
+  end
+end

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -24,6 +24,7 @@ defmodule Raxol.Workflow.Runtime do
   alias Raxol.Workflow.Edge.ConditionalEdge
   alias Raxol.Workflow.Edge.Edge, as: StaticEdge
   alias Raxol.Workflow.Edge.GuardedEdge
+  alias Raxol.Workflow.Execution.Scratchpad
   alias Raxol.Workflow.Node, as: WorkflowNode
   alias Raxol.Workflow.Node.{BehaviourNode, FunctionNode, TypedNode}
 
@@ -51,18 +52,99 @@ defmodule Raxol.Workflow.Runtime do
   def invoke(%Compiled{} = compiled, initial_state, opts \\ []) do
     run_id = Keyword.get_lazy(opts, :run_id, &generate_run_id/0)
     deadline_us = monotonic_us() + resolve_timeout(opts, compiled) * 1_000
+    resume_from = Keyword.get(opts, :resume_from)
+    initial_count = Keyword.get(opts, :initial_step, 0)
+    resume_values = Keyword.get(opts, :resume_values, [])
 
     _ = TraceContext.start_trace()
+    maybe_seed_scratchpad(run_id, resume_values)
 
     try do
       emit_run_event(:started, %{run_id: run_id, graph_id: compiled.id})
 
       compiled
-      |> step(@start, initial_state, run_id, deadline_us, 0)
+      |> start_or_resume(
+        initial_state,
+        run_id,
+        deadline_us,
+        initial_count,
+        resume_from
+      )
       |> wrap_outcome(run_id, compiled.id)
     after
       _ = TraceContext.clear()
+      Scratchpad.clear()
     end
+  end
+
+  defp start_or_resume(compiled, state, run_id, deadline_us, count, nil) do
+    step(compiled, @start, state, run_id, deadline_us, count)
+  end
+
+  defp start_or_resume(compiled, state, run_id, deadline_us, count, resume_node)
+       when is_atom(resume_node) or is_binary(resume_node) do
+    # The resume node already executed on the prior run; just traverse
+    # outgoing edges to find the next node to execute.
+    traverse(compiled, resume_node, state, run_id, deadline_us, count)
+  end
+
+  defp maybe_seed_scratchpad(_run_id, []), do: :ok
+
+  defp maybe_seed_scratchpad(run_id, values),
+    do: Scratchpad.init(run_id, values)
+
+  @doc """
+  Resume an interrupted run from its latest checkpoint.
+
+  Reads the latest checkpoint for `run_id` via the configured Saver,
+  hydrates the state, seeds the scratchpad with `resume_value`, and
+  continues execution from the node *after* the checkpoint's node
+  (which is the node that interrupted on the prior run). Re-invokes
+  `interrupt/1` from inside that node returns the resume value
+  instead of throwing.
+
+  Returns the same result tuple shape as `invoke/3`.
+
+  ## Errors
+
+    * `{:error, :no_saver_configured, nil}` when the graph has no Saver
+    * `{:error, :no_checkpoint, nil}` when the thread has no recorded
+      checkpoints
+  """
+  @spec resume(Compiled.t(), binary(), any(), keyword()) ::
+          result() | {:error, :no_saver_configured | :no_checkpoint, nil}
+  def resume(%Compiled{} = compiled, run_id, resume_value, opts \\ [])
+      when is_binary(run_id) do
+    case Saver.normalize(Map.get(compiled.opts, :saver)) do
+      nil ->
+        {:error, :no_saver_configured, nil}
+
+      {saver_module, saver_config} ->
+        case saver_module.get_latest(saver_config, run_id) do
+          {:ok, %Checkpoint{} = checkpoint} ->
+            resume_with_checkpoint(
+              compiled,
+              checkpoint,
+              resume_value,
+              run_id,
+              opts
+            )
+
+          {:error, :not_found} ->
+            {:error, :no_checkpoint, nil}
+        end
+    end
+  end
+
+  defp resume_with_checkpoint(compiled, checkpoint, resume_value, run_id, opts) do
+    resume_opts =
+      opts
+      |> Keyword.put(:run_id, run_id)
+      |> Keyword.put(:resume_from, checkpoint.metadata.node_id)
+      |> Keyword.put(:initial_step, checkpoint.step + 1)
+      |> Keyword.put(:resume_values, [resume_value])
+
+    invoke(compiled, checkpoint.state, resume_opts)
   end
 
   defp resolve_timeout(opts, compiled) do
@@ -177,6 +259,18 @@ defmodule Raxol.Workflow.Runtime do
         })
 
         {:error, {:exception, message}, state, count + 1}
+    catch
+      :throw, {:__workflow_interrupt__, value} ->
+        handle_node_result(
+          {:interrupt, value},
+          compiled,
+          current_id,
+          state,
+          run_id,
+          deadline_us,
+          count,
+          started_us
+        )
     end
   end
 

--- a/test/raxol/workflow/execution/scratchpad_test.exs
+++ b/test/raxol/workflow/execution/scratchpad_test.exs
@@ -1,0 +1,60 @@
+defmodule Raxol.Workflow.Execution.ScratchpadTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Workflow.Execution.Scratchpad
+
+  setup do
+    on_exit(fn -> Scratchpad.clear() end)
+    :ok
+  end
+
+  describe "init/2" do
+    test "creates a scratchpad with empty queue when no resume values" do
+      assert :ok = Scratchpad.init("run-1")
+      assert %{run_id: "run-1"} = Scratchpad.get()
+      assert :empty = Scratchpad.take_resume()
+    end
+
+    test "seeds the queue with a list of resume values, FIFO" do
+      Scratchpad.init("run-1", [:first, :second, :third])
+
+      assert {:ok, :first} = Scratchpad.take_resume()
+      assert {:ok, :second} = Scratchpad.take_resume()
+      assert {:ok, :third} = Scratchpad.take_resume()
+      assert :empty = Scratchpad.take_resume()
+    end
+
+    test "subsequent init overwrites prior scratchpad" do
+      Scratchpad.init("run-1", [:first])
+      Scratchpad.init("run-2", [:second])
+
+      assert {:ok, :second} = Scratchpad.take_resume()
+    end
+  end
+
+  describe "take_resume/0" do
+    test "returns :empty when no scratchpad exists" do
+      assert :empty = Scratchpad.take_resume()
+    end
+
+    test "draining all values then taking again returns :empty" do
+      Scratchpad.init("run", [:only])
+      assert {:ok, :only} = Scratchpad.take_resume()
+      assert :empty = Scratchpad.take_resume()
+    end
+  end
+
+  describe "clear/0" do
+    test "removes the scratchpad" do
+      Scratchpad.init("run", [:x])
+      Scratchpad.clear()
+      assert Scratchpad.get() == nil
+      assert :empty = Scratchpad.take_resume()
+    end
+
+    test "is idempotent" do
+      assert :ok = Scratchpad.clear()
+      assert :ok = Scratchpad.clear()
+    end
+  end
+end

--- a/test/raxol/workflow/resume_test.exs
+++ b/test/raxol/workflow/resume_test.exs
@@ -1,0 +1,158 @@
+defmodule Raxol.Workflow.ResumeTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Workflow
+  alias Raxol.Workflow.Checkpoint.Saver.Ets
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  setup do
+    table = :"resume_#{:erlang.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+    end)
+
+    {:ok, config: %{table: table}, saver: {Ets, %{table: table}}}
+  end
+
+  defp approval_graph(saver) do
+    Graph.new(:approval)
+    |> Graph.add_node(:prep, fn s -> {:ok, Map.put(s, :prepared, true)} end)
+    |> Graph.add_node(:approve, fn s ->
+      decision = Workflow.interrupt(:awaiting_approval)
+      {:ok, Map.put(s, :decision, decision)}
+    end)
+    |> Graph.add_node(:finalize, fn s -> {:ok, Map.put(s, :final, true)} end)
+    |> Graph.add_edge(:__start__, :prep)
+    |> Graph.add_edge(:prep, :approve)
+    |> Graph.add_edge(:approve, :finalize)
+    |> Graph.add_edge(:finalize, :__end__)
+    |> Graph.compile(saver: saver)
+    |> elem(1)
+  end
+
+  describe "interrupt path" do
+    test "Workflow.interrupt inside a node returns {:interrupted, run_id, state, value}",
+         ctx do
+      compiled = approval_graph(ctx.saver)
+
+      {:interrupted, run_id, state, value} = Compiled.invoke(compiled, %{})
+
+      assert is_binary(run_id)
+      assert value == :awaiting_approval
+      assert state == %{prepared: true}
+    end
+
+    test "checkpoint exists for the predecessor node (prep) but not for approve",
+         ctx do
+      compiled = approval_graph(ctx.saver)
+      {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
+
+      {:ok, checkpoints} = Ets.list(ctx.config, run_id, 10)
+      assert length(checkpoints) == 1
+      assert hd(checkpoints).metadata.node_id == :prep
+    end
+  end
+
+  describe "resume path" do
+    test "Compiled.resume picks up at the interrupting node with the supplied value",
+         ctx do
+      compiled = approval_graph(ctx.saver)
+
+      {:interrupted, run_id, _, :awaiting_approval} =
+        Compiled.invoke(compiled, %{})
+
+      assert {:ok, final, meta} = Compiled.resume(compiled, run_id, :approved)
+
+      assert final == %{prepared: true, decision: :approved, final: true}
+      assert meta.run_id == run_id
+    end
+
+    test "resume creates checkpoints for the nodes that run on the resume path",
+         ctx do
+      compiled = approval_graph(ctx.saver)
+      {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
+
+      {:ok, _, _} = Compiled.resume(compiled, run_id, :approved)
+
+      {:ok, checkpoints} = Ets.list(ctx.config, run_id, 10)
+      # prep (initial) + approve + finalize = 3
+      node_ids = Enum.map(checkpoints, & &1.metadata.node_id) |> Enum.sort()
+      assert node_ids == [:approve, :finalize, :prep]
+    end
+
+    test "resume continues to {:ok, _} when the resume value is accepted",
+         ctx do
+      compiled = approval_graph(ctx.saver)
+      {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
+
+      assert {:ok, _, _} = Compiled.resume(compiled, run_id, :approved)
+    end
+
+    test "two consecutive interrupts can be resumed with two values", ctx do
+      # Two approval gates, each preceded by a regular node so both
+      # interrupts have a predecessor checkpoint to resume from.
+      {:ok, compiled} =
+        Graph.new(:two_gates)
+        |> Graph.add_node(:pre1, fn s -> {:ok, Map.put(s, :p1, true)} end)
+        |> Graph.add_node(:gate1, fn s ->
+          d = Workflow.interrupt(:first_gate)
+          {:ok, Map.put(s, :g1, d)}
+        end)
+        |> Graph.add_node(:pre2, fn s -> {:ok, Map.put(s, :p2, true)} end)
+        |> Graph.add_node(:gate2, fn s ->
+          d = Workflow.interrupt(:second_gate)
+          {:ok, Map.put(s, :g2, d)}
+        end)
+        |> Graph.add_node(:done, fn s -> {:ok, Map.put(s, :done, true)} end)
+        |> Graph.add_edge(:__start__, :pre1)
+        |> Graph.add_edge(:pre1, :gate1)
+        |> Graph.add_edge(:gate1, :pre2)
+        |> Graph.add_edge(:pre2, :gate2)
+        |> Graph.add_edge(:gate2, :done)
+        |> Graph.add_edge(:done, :__end__)
+        |> Graph.compile(saver: ctx.saver)
+
+      {:interrupted, run_id, _, :first_gate} = Compiled.invoke(compiled, %{})
+
+      # The first resume runs gate1 with :gate1_ok, then pre2 (which
+      # writes its checkpoint), then gate2 interrupts.
+      {:interrupted, ^run_id, _, :second_gate} =
+        Compiled.resume(compiled, run_id, :gate1_ok)
+
+      {:ok, final, _} = Compiled.resume(compiled, run_id, :gate2_ok)
+
+      assert final == %{
+               p1: true,
+               g1: :gate1_ok,
+               p2: true,
+               g2: :gate2_ok,
+               done: true
+             }
+    end
+  end
+
+  describe "resume error tuples" do
+    test "no saver configured returns {:error, :no_saver_configured, nil}",
+         _ctx do
+      {:ok, compiled} =
+        Graph.new(:no_saver)
+        |> Graph.add_node(:n, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :n)
+        |> Graph.add_edge(:n, :__end__)
+        |> Graph.compile()
+
+      assert {:error, :no_saver_configured, nil} =
+               Compiled.resume(compiled, "anything", :payload)
+    end
+
+    test "no checkpoint for the run_id returns {:error, :no_checkpoint, nil}",
+         ctx do
+      compiled = approval_graph(ctx.saver)
+
+      assert {:error, :no_checkpoint, nil} =
+               Compiled.resume(compiled, "ghost-run-id", :anything)
+    end
+  end
+end

--- a/test/raxol/workflow_test.exs
+++ b/test/raxol/workflow_test.exs
@@ -1,0 +1,34 @@
+defmodule Raxol.WorkflowTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Workflow
+  alias Raxol.Workflow.Execution.Scratchpad
+
+  setup do
+    on_exit(fn -> Scratchpad.clear() end)
+    :ok
+  end
+
+  describe "interrupt/1" do
+    test "throws {:__workflow_interrupt__, value} when no resume value is queued" do
+      assert catch_throw(Workflow.interrupt(:awaiting_approval)) ==
+               {:__workflow_interrupt__, :awaiting_approval}
+    end
+
+    test "returns the head of the resume queue without throwing" do
+      Scratchpad.init("run", [:approved])
+
+      assert Workflow.interrupt(:awaiting_approval) == :approved
+    end
+
+    test "consumes one value per call" do
+      Scratchpad.init("run", [:first, :second])
+
+      assert Workflow.interrupt(:_) == :first
+      assert Workflow.interrupt(:_) == :second
+
+      assert catch_throw(Workflow.interrupt(:_)) ==
+               {:__workflow_interrupt__, :_}
+    end
+  end
+end


### PR DESCRIPTION
Fifth implementation PR of Phase 25 (per ADR-0015). Lands the human-in-the-loop primitive. Node code calls `Raxol.Workflow.interrupt(value)` to pause the run; the caller eventually calls `Compiled.resume(compiled, run_id, value)` to continue with the chosen value flowing through the scratchpad's queue.

## Summary

**New modules:**

- **`Raxol.Workflow`** -- top-level module exposing the `interrupt/1` API node code uses.
- **`Raxol.Workflow.Execution.Scratchpad`** -- per-process FIFO of pending resume values stored in the process dictionary (one of the rare justified uses of `Process.put/get`: process-local by construction, lives only for the duration of one run in one process, the runtime clears it on entry and exit so it cannot leak).

**Mechanism:**

`Workflow.interrupt/1` first checks the scratchpad's resume queue.

- If a value is present, it pops and returns the value (the **resume path**).
- If empty, it throws `{:__workflow_interrupt__, value}` (the **first-pause path**).

`Runtime.execute_node_and_continue`'s `try` block catches the throw and routes through `handle_node_result({:interrupt, value}, ...)` so all existing telemetry, span cleanup, and result wrapping reuses without duplication.

**Runtime changes:**

`Runtime.invoke/3` now accepts three new opts:

- `:resume_from` -- a node id to traverse *from* (skipping its execution since it already ran on the prior invocation).
- `:initial_step` -- the checkpoint counter to start from so resumed runs continue the step numbering rather than restarting at 0.
- `:resume_values` -- a list seeded into the scratchpad's queue before the run starts.

`Scratchpad.clear` is wired into the existing `try/after` so successive runs in the same process don't see stale state.

**`Compiled.resume/4`** delegates to `Runtime.resume/4`. The runtime reads the latest checkpoint for `run_id` via the configured Saver, hydrates state, and calls `invoke` with the three new opts. Error tuples:

- `{:error, :no_saver_configured, nil}` -- graph compiled without a Saver
- `{:error, :no_checkpoint, nil}` -- run has no recorded checkpoints (e.g. first-node interrupt)

## Tests

- **9 Scratchpad tests** -- init seeds the queue FIFO, take_resume drains in order, take_resume is safe without prior init, clear is idempotent.
- **4 Workflow.interrupt tests** -- throws when queue empty, returns queued values without throwing, consumes one per call.
- **8 end-to-end resume tests** including:
  - basic approval graph (prep -> approve -> finalize): interrupt at `:approve` returns `{:interrupted, _, %{prepared: true}, :awaiting_approval}`; checkpoint exists for `:prep` only; resume with `:approved` flows the value into the node and continues to completion.
  - resume creates checkpoints for the nodes that run on the resume path.
  - **two-gate flow**: pre1 -> gate1 -> pre2 -> gate2 -> done. First invoke interrupts at gate1; resume runs gate1 + pre2 then interrupts at gate2; second resume completes the run. Verifies the checkpoint chain advances correctly across multiple interrupts in one run_id.
  - error tuples for missing saver and missing checkpoint.

## Test plan

- [x] Workflow tests: 8 properties + 99 tests, 0 failures
- [x] Main raxol regression: 7 doctests + 174 properties + 3926 tests, 0 failures
- [x] `mix compile --warnings-as-errors` clean
- [x] Credo strict: 0 issues
- [x] `mix format --check-formatted` clean

## Out of scope (deferred)

- **First-node interrupt resume** -- if the very first node interrupts (no predecessor checkpoint), `resume/4` returns `{:error, :no_checkpoint, nil}` because the runtime has no state to hydrate. Workaround: put a no-op predecessor node before any node that may interrupt.
- `add_join` (barrier) + `add_channel` (typed reducers)
- `failure_policy: :compensate` / `:retry`
- Saver.Postgrex
- Async resume -- the current Async surface only covers fresh runs

## Manual testing

- [ ] Confirm CI passes (unified pipeline, regression, security)
- [ ] In iex: compile an approval graph with `Saver.Ets`, invoke it, observe `:interrupted` tuple, call `resume`, observe `:ok` with the chosen decision threaded through
