### PR TITLE
ci: bump cache@v5 and setup-node@v6 (Node 24)

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -98,7 +98,7 @@ jobs:
       
       - name: Cache dependencies
         id: deps-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -139,7 +139,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -173,7 +173,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -207,7 +207,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -266,7 +266,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -306,7 +306,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -345,7 +345,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -373,7 +373,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -382,7 +382,7 @@ jobs:
           key: ${{ needs.setup.outputs.cache-key }}
       
       - name: Restore PLT cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: priv/plts
           key: plt-${{ runner.os }}-${{ needs.setup.outputs.otp-version }}-${{ needs.setup.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
@@ -411,7 +411,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -488,7 +488,7 @@ jobs:
           otp-version: ${{ needs.setup.outputs.otp-version }}
       
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,7 +81,7 @@ jobs:
           install-rebar: true
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -134,7 +134,7 @@ jobs:
           install-rebar: true
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -196,7 +196,7 @@ jobs:
           install-rebar: true
 
       - name: Cache dependencies and PLTs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -264,7 +264,7 @@ jobs:
           install-rebar: true
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/performance-tracking.yml
+++ b/.github/workflows/performance-tracking.yml
@@ -82,7 +82,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
       
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -153,7 +153,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
       
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/regression-testing.yml
+++ b/.github/workflows/regression-testing.yml
@@ -88,7 +88,7 @@ jobs:
         otp-version: ${{ matrix.otp }}
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           _build
@@ -100,7 +100,7 @@ jobs:
           deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
 
     - name: Cache PLT files
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: priv/plts
         key: plt-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
@@ -200,7 +200,7 @@ jobs:
     - name: Download cached baselines
       if: github.event_name == 'push'
       continue-on-error: true
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: regression/performance/baselines
         key: performance-baseline-${{ github.ref_name }}-${{ github.sha }}
@@ -221,7 +221,7 @@ jobs:
 
     - name: Cache performance baselines
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: regression/performance/baselines
         key: performance-baseline-${{ github.ref_name }}-${{ github.sha }}
@@ -259,7 +259,7 @@ jobs:
         otp-version: ${{ matrix.otp }}
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           _build
@@ -394,7 +394,7 @@ jobs:
     - name: Download cached memory baselines
       if: github.event_name == 'push'
       continue-on-error: true
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: regression/memory/baselines
         key: memory-baseline-${{ github.ref_name }}-${{ matrix.scenario }}-${{ github.sha }}
@@ -415,7 +415,7 @@ jobs:
 
     - name: Cache memory baselines
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: regression/memory/baselines
         key: memory-baseline-${{ github.ref_name }}-${{ matrix.scenario }}-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Cache Mix dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v5
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v5
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Summary

- `actions/cache@v4` → `@v5` (25 occurrences across 6 workflows)
- `actions/setup-node@v4` → `@v6` (2 occurrences in security.yml)

Both v4 versions run on Node.js 20, which GitHub forces to Node 24 starting 2026-06-16 (tomorrow). Bumping to the latest majors aligns us with the upstream Node 24 baseline before the cutover and clears the deprecation warning currently surfacing on every CI run.

## Test plan

- [ ] Unified CI Pipeline passes on this PR
- [ ] Regression Testing passes
- [ ] Security Scanning passes
- [ ] No new deprecation annotations in the run logs