### PR TITLE
Phase 25: pre-checkpoint initial state for first-node resume

### DIFF
--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -50,14 +50,13 @@ defmodule Raxol.Workflow.Runtime do
   """
   @spec invoke(Compiled.t(), any(), keyword()) :: result()
   def invoke(%Compiled{} = compiled, initial_state, opts \\ []) do
-    run_id = Keyword.get_lazy(opts, :run_id, &generate_run_id/0)
-    deadline_us = monotonic_us() + resolve_timeout(opts, compiled) * 1_000
-    resume_from = Keyword.get(opts, :resume_from)
-    initial_count = Keyword.get(opts, :initial_step, 0)
-    resume_values = Keyword.get(opts, :resume_values, [])
-
-    _ = TraceContext.start_trace()
-    maybe_seed_scratchpad(run_id, resume_values)
+    %{
+      run_id: run_id,
+      deadline_us: deadline_us,
+      resume_from: resume_from,
+      start_count: start_count,
+      count_offset: count_offset
+    } = prepare_invocation(compiled, initial_state, opts)
 
     try do
       emit_run_event(:started, %{run_id: run_id, graph_id: compiled.id})
@@ -67,13 +66,83 @@ defmodule Raxol.Workflow.Runtime do
         initial_state,
         run_id,
         deadline_us,
-        initial_count,
+        start_count,
         resume_from
       )
-      |> wrap_outcome(run_id, compiled.id)
+      |> wrap_outcome(run_id, compiled.id, count_offset)
     after
       _ = TraceContext.clear()
       Scratchpad.clear()
+    end
+  end
+
+  defp prepare_invocation(compiled, initial_state, opts) do
+    run_id = Keyword.get_lazy(opts, :run_id, &generate_run_id/0)
+    deadline_us = monotonic_us() + resolve_timeout(opts, compiled) * 1_000
+    resume_from = Keyword.get(opts, :resume_from)
+    initial_count = Keyword.get(opts, :initial_step, 0)
+    resume_values = Keyword.get(opts, :resume_values, [])
+
+    _ = TraceContext.start_trace()
+    maybe_seed_scratchpad(run_id, resume_values)
+
+    start_count =
+      maybe_persist_initial_checkpoint(
+        compiled,
+        initial_state,
+        run_id,
+        resume_from,
+        initial_count
+      )
+
+    %{
+      run_id: run_id,
+      deadline_us: deadline_us,
+      resume_from: resume_from,
+      start_count: start_count,
+      count_offset: start_count - initial_count
+    }
+  end
+
+  # Fresh runs pre-checkpoint the initial state at step 0 with
+  # node_id: :__start__. This lets `resume/4` work when the very first
+  # node interrupts (otherwise there would be no predecessor checkpoint
+  # to hydrate). Resumes (resume_from != nil or initial_count > 0) skip
+  # this so the existing step 0 checkpoint is not overwritten.
+  defp maybe_persist_initial_checkpoint(
+         compiled,
+         initial_state,
+         run_id,
+         nil,
+         0
+       ) do
+    persist_initial_checkpoint(compiled, initial_state, run_id)
+    1
+  end
+
+  defp maybe_persist_initial_checkpoint(_, _, _, _, initial_count),
+    do: initial_count
+
+  defp persist_initial_checkpoint(compiled, state, run_id) do
+    case Saver.normalize(Map.get(compiled.opts, :saver)) do
+      nil ->
+        :ok
+
+      {saver_module, saver_config} ->
+        checkpoint =
+          Checkpoint.new(
+            thread_id: run_id,
+            step: 0,
+            state: state,
+            parent_step: nil,
+            metadata: %{
+              node_id: @start,
+              run_id: run_id,
+              graph_id: compiled.id
+            }
+          )
+
+        saver_module.put(saver_config, run_id, checkpoint)
     end
   end
 
@@ -155,32 +224,43 @@ defmodule Raxol.Workflow.Runtime do
     )
   end
 
-  defp wrap_outcome({:ok, final_state, count}, run_id, graph_id) do
+  defp wrap_outcome({:ok, final_state, count}, run_id, graph_id, offset) do
+    nodes_executed = count - offset
+
     emit_run_event(:completed, %{
       run_id: run_id,
       graph_id: graph_id,
-      nodes_executed: count
+      nodes_executed: nodes_executed
     })
 
-    {:ok, final_state, %{run_id: run_id, nodes_executed: count}}
+    {:ok, final_state, %{run_id: run_id, nodes_executed: nodes_executed}}
   end
 
-  defp wrap_outcome({:interrupted, state, value, count}, run_id, graph_id) do
+  defp wrap_outcome(
+         {:interrupted, state, value, count},
+         run_id,
+         graph_id,
+         offset
+       ) do
+    nodes_executed = count - offset
+
     emit_run_event(:interrupted, %{
       run_id: run_id,
       graph_id: graph_id,
-      nodes_executed: count,
+      nodes_executed: nodes_executed,
       value: value
     })
 
     {:interrupted, run_id, state, value}
   end
 
-  defp wrap_outcome({:error, reason, state, count}, run_id, graph_id) do
+  defp wrap_outcome({:error, reason, state, count}, run_id, graph_id, offset) do
+    nodes_executed = count - offset
+
     emit_run_event(:failed, %{
       run_id: run_id,
       graph_id: graph_id,
-      nodes_executed: count,
+      nodes_executed: nodes_executed,
       reason: reason
     })
 

--- a/packages/raxol_symphony/test/raxol/symphony/workflow/graph_adapter_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workflow/graph_adapter_test.exs
@@ -125,12 +125,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       {:ok, checkpoints} =
         Raxol.Workflow.Checkpoint.Saver.Ets.list(%{table: table}, meta.run_id, 10)
 
-      # One per successful node = 5
-      assert length(checkpoints) == 5
+      # :__start__ initial + one per successful node = 6
+      assert length(checkpoints) == 6
 
       node_ids = checkpoints |> Enum.map(& &1.metadata.node_id) |> Enum.sort()
 
       assert node_ids == [
+               :__start__,
                :candidate_selection,
                :completion,
                :evidence_collection,

--- a/test/raxol/workflow/checkpoint_integration_test.exs
+++ b/test/raxol/workflow/checkpoint_integration_test.exs
@@ -28,15 +28,15 @@ defmodule Raxol.Workflow.CheckpointIntegrationTest do
   end
 
   describe "runtime writes checkpoints when :saver is configured" do
-    test "one checkpoint per successful node", ctx do
+    test "one checkpoint per successful node plus initial __start__", ctx do
       compiled = two_node_graph(ctx.saver)
       {:ok, _final, meta} = Compiled.invoke(compiled, %{})
 
       {:ok, checkpoints} = Ets.list(ctx.config, meta.run_id, 10)
-      assert length(checkpoints) == 2
+      assert length(checkpoints) == 3
 
       steps = checkpoints |> Enum.map(& &1.step) |> Enum.sort()
-      assert steps == [0, 1]
+      assert steps == [0, 1, 2]
     end
 
     test "checkpoints carry node_id, run_id, graph_id metadata", ctx do
@@ -51,14 +51,29 @@ defmodule Raxol.Workflow.CheckpointIntegrationTest do
       assert md.node_id in [:a, :b]
     end
 
+    test "initial checkpoint at step 0 is :__start__ with the initial state",
+         ctx do
+      compiled = two_node_graph(ctx.saver)
+      {:ok, _final, meta} = Compiled.invoke(compiled, %{seed: 1})
+
+      {:ok, all} = Ets.list(ctx.config, meta.run_id, 10)
+      [initial] = Enum.filter(all, &(&1.step == 0))
+
+      assert initial.metadata.node_id == :__start__
+      assert initial.state == %{seed: 1}
+      assert initial.parent_step == nil
+    end
+
     test "checkpoint state reflects the state after each node", ctx do
       compiled = two_node_graph(ctx.saver)
       {:ok, _final, meta} = Compiled.invoke(compiled, %{})
 
-      {:ok, [latest, earlier]} = Ets.list(ctx.config, meta.run_id, 10)
+      {:ok, all} = Ets.list(ctx.config, meta.run_id, 10)
+      ordered = Enum.sort_by(all, & &1.step)
+      [_initial, after_a, after_b] = ordered
 
-      assert earlier.state == %{a: true}
-      assert latest.state == %{a: true, b: true}
+      assert after_a.state == %{a: true}
+      assert after_b.state == %{a: true, b: true}
     end
 
     test "parent_step chains through the run", ctx do
@@ -70,6 +85,7 @@ defmodule Raxol.Workflow.CheckpointIntegrationTest do
 
       assert Enum.at(ordered, 0).parent_step == nil
       assert Enum.at(ordered, 1).parent_step == 0
+      assert Enum.at(ordered, 2).parent_step == 1
     end
 
     test "no checkpoints when :saver is absent", ctx do
@@ -100,8 +116,10 @@ defmodule Raxol.Workflow.CheckpointIntegrationTest do
       {:interrupted, run_id, _state, :wait} = Compiled.invoke(compiled, %{})
 
       {:ok, checkpoints} = Ets.list(ctx.config, run_id, 10)
-      assert length(checkpoints) == 1
-      assert hd(checkpoints).state == %{a: true}
+      assert length(checkpoints) == 2
+      latest = hd(checkpoints)
+      assert latest.metadata.node_id == :a
+      assert latest.state == %{a: true}
     end
 
     test "error: no checkpoint for the failing node, prior ones preserved",
@@ -118,12 +136,10 @@ defmodule Raxol.Workflow.CheckpointIntegrationTest do
 
       {:error, :boom, _state} = Compiled.invoke(compiled, %{})
 
-      # Only :a's checkpoint should exist (we don't have the run_id
-      # in the error tuple, so list across the thread the runtime
-      # used; we sniff via the Ets table contents).
+      # :__start__ initial + :a; no checkpoint for the failing :b.
       table = ctx.config.table
       all = :ets.tab2list(table)
-      assert length(all) == 1
+      assert length(all) == 2
     end
   end
 end

--- a/test/raxol/workflow/resume_test.exs
+++ b/test/raxol/workflow/resume_test.exs
@@ -44,14 +44,20 @@ defmodule Raxol.Workflow.ResumeTest do
       assert state == %{prepared: true}
     end
 
-    test "checkpoint exists for the predecessor node (prep) but not for approve",
+    test "checkpoints exist for :__start__ and :prep but not :approve",
          ctx do
       compiled = approval_graph(ctx.saver)
       {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
 
       {:ok, checkpoints} = Ets.list(ctx.config, run_id, 10)
-      assert length(checkpoints) == 1
-      assert hd(checkpoints).metadata.node_id == :prep
+      assert length(checkpoints) == 2
+      latest = hd(checkpoints)
+      assert latest.metadata.node_id == :prep
+
+      node_ids =
+        checkpoints |> Enum.map(& &1.metadata.node_id) |> Enum.sort()
+
+      assert node_ids == [:__start__, :prep]
     end
   end
 
@@ -77,9 +83,9 @@ defmodule Raxol.Workflow.ResumeTest do
       {:ok, _, _} = Compiled.resume(compiled, run_id, :approved)
 
       {:ok, checkpoints} = Ets.list(ctx.config, run_id, 10)
-      # prep (initial) + approve + finalize = 3
+      # :__start__ (initial) + prep + approve + finalize = 4
       node_ids = Enum.map(checkpoints, & &1.metadata.node_id) |> Enum.sort()
-      assert node_ids == [:approve, :finalize, :prep]
+      assert node_ids == [:__start__, :approve, :finalize, :prep]
     end
 
     test "resume continues to {:ok, _} when the resume value is accepted",
@@ -130,6 +136,52 @@ defmodule Raxol.Workflow.ResumeTest do
                g2: :gate2_ok,
                done: true
              }
+    end
+  end
+
+  describe "first-node-interrupt resume" do
+    test "resume works when the very first real node interrupts", ctx do
+      {:ok, compiled} =
+        Graph.new(:first_gate)
+        |> Graph.add_node(:gate, fn s ->
+          d = Workflow.interrupt(:wait_for_approval)
+          {:ok, Map.put(s, :gate, d)}
+        end)
+        |> Graph.add_node(:done, fn s -> {:ok, Map.put(s, :done, true)} end)
+        |> Graph.add_edge(:__start__, :gate)
+        |> Graph.add_edge(:gate, :done)
+        |> Graph.add_edge(:done, :__end__)
+        |> Graph.compile(saver: ctx.saver)
+
+      {:interrupted, run_id, state, :wait_for_approval} =
+        Compiled.invoke(compiled, %{init: true})
+
+      assert state == %{init: true}
+
+      assert {:ok, final, meta} =
+               Compiled.resume(compiled, run_id, :approved)
+
+      assert final == %{init: true, gate: :approved, done: true}
+      assert meta.run_id == run_id
+    end
+
+    test "the initial __start__ checkpoint carries the initial state", ctx do
+      {:ok, compiled} =
+        Graph.new(:first_gate_state)
+        |> Graph.add_node(:gate, fn _ -> {:interrupt, :pause} end)
+        |> Graph.add_edge(:__start__, :gate)
+        |> Graph.add_edge(:gate, :__end__)
+        |> Graph.compile(saver: ctx.saver)
+
+      {:interrupted, run_id, _, :pause} =
+        Compiled.invoke(compiled, %{seeded: :value})
+
+      {:ok, checkpoints} = Ets.list(ctx.config, run_id, 10)
+      assert length(checkpoints) == 1
+      [initial] = checkpoints
+      assert initial.step == 0
+      assert initial.metadata.node_id == :__start__
+      assert initial.state == %{seeded: :value}
     end
   end
 


### PR DESCRIPTION
## Summary

Closes the documented Phase 25 limitation where \`Compiled.resume/4\`
returned \`{:error, :no_checkpoint, nil}\` when the very first node in a
graph interrupted (no predecessor checkpoint to hydrate).

Fresh \`invoke/3\` calls now persist a step-0 checkpoint with
\`node_id: :__start__\` carrying the initial state, before traversing
into the first node. Resume picks that up and continues from the first
real node with the supplied resume value.

- Resumes skip the pre-checkpoint so the existing step-0 entry is not
  overwritten.
- \`nodes_executed\` subtracts the initial-step offset, so the reported
  count still matches "nodes executed in this invoke call" (existing
  telemetry contract preserved).
- \`invoke/3\` refactored into \`prepare_invocation/3\` + outer try block
  to keep ABC complexity below Credo's strict ceiling.

## Test plan

- [x] +2 \`first-node-interrupt resume\` tests in \`resume_test.exs\`
- [x] +1 \`initial checkpoint at step 0\` test in \`checkpoint_integration_test.exs\`
- [x] Updated existing checkpoint count + node_id assertions for the new step-0 entry
- [x] Updated Symphony GraphAdapter test (5 -> 6 checkpoints + \`:__start__\` in sorted node_ids)
- [x] \`mix credo lib/raxol/workflow/runtime.ex --strict\` clean
- [x] \`mix format --check-formatted\` clean
- [x] Workflow suite: 8 properties + 99 tests, 0 failures
- [x] Symphony GraphAdapter: 6 tests, 0 failures