### PR TITLE
Phase 25: workflow_mode :graph in Orchestrator

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/config.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config.ex
@@ -25,6 +25,7 @@ defmodule Raxol.Symphony.Config do
     :codex,
     :runner,
     :recording,
+    :workflow_mode,
     :workflow_path,
     :prompt_template
   ]
@@ -38,12 +39,19 @@ defmodule Raxol.Symphony.Config do
           codex: map(),
           runner: map(),
           recording: map(),
+          workflow_mode: :default | :graph,
           workflow_path: Path.t() | nil,
           prompt_template: binary()
         }
 
   @default_active_states ["Todo", "In Progress"]
-  @default_terminal_states ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
+  @default_terminal_states [
+    "Closed",
+    "Cancelled",
+    "Canceled",
+    "Duplicate",
+    "Done"
+  ]
   @default_linear_endpoint "https://api.linear.app/graphql"
   @default_polling_interval_ms 30_000
   @default_hooks_timeout_ms 60_000
@@ -64,8 +72,14 @@ defmodule Raxol.Symphony.Config do
   `Raxol.Symphony.Workflow.load/1`. `workflow_path` is used to resolve
   relative paths (e.g., a relative `workspace.root`).
   """
-  @spec from_workflow(%{config: map(), prompt_template: binary()}, Path.t() | nil) :: t()
-  def from_workflow(%{config: raw, prompt_template: prompt}, workflow_path \\ nil) do
+  @spec from_workflow(
+          %{config: map(), prompt_template: binary()},
+          Path.t() | nil
+        ) :: t()
+  def from_workflow(
+        %{config: raw, prompt_template: prompt},
+        workflow_path \\ nil
+      ) do
     %__MODULE__{
       tracker: tracker(raw),
       polling: polling(raw),
@@ -75,6 +89,7 @@ defmodule Raxol.Symphony.Config do
       codex: codex(raw),
       runner: runner(raw),
       recording: recording(raw),
+      workflow_mode: workflow_mode(raw),
       workflow_path: workflow_path,
       prompt_template: prompt
     }
@@ -102,11 +117,14 @@ defmodule Raxol.Symphony.Config do
 
     %{
       kind: kind,
-      endpoint: resolve_value(Map.get(section, :endpoint, default_endpoint(kind))),
-      api_key: resolve_value(Map.get(section, :api_key, default_api_key_env(kind))),
+      endpoint:
+        resolve_value(Map.get(section, :endpoint, default_endpoint(kind))),
+      api_key:
+        resolve_value(Map.get(section, :api_key, default_api_key_env(kind))),
       project_slug: resolve_value(Map.get(section, :project_slug)),
       active_states: Map.get(section, :active_states, @default_active_states),
-      terminal_states: Map.get(section, :terminal_states, @default_terminal_states)
+      terminal_states:
+        Map.get(section, :terminal_states, @default_terminal_states)
     }
   end
 
@@ -163,7 +181,9 @@ defmodule Raxol.Symphony.Config do
       max_retry_backoff_ms:
         Map.get(section, :max_retry_backoff_ms, @default_max_retry_backoff_ms),
       max_concurrent_agents_by_state:
-        normalize_state_map(Map.get(section, :max_concurrent_agents_by_state, %{}))
+        normalize_state_map(
+          Map.get(section, :max_concurrent_agents_by_state, %{})
+        )
     }
   end
 
@@ -175,9 +195,12 @@ defmodule Raxol.Symphony.Config do
       approval_policy: Map.get(section, :approval_policy),
       thread_sandbox: Map.get(section, :thread_sandbox),
       turn_sandbox_policy: Map.get(section, :turn_sandbox_policy),
-      turn_timeout_ms: Map.get(section, :turn_timeout_ms, @default_turn_timeout_ms),
-      read_timeout_ms: Map.get(section, :read_timeout_ms, @default_read_timeout_ms),
-      stall_timeout_ms: Map.get(section, :stall_timeout_ms, @default_stall_timeout_ms)
+      turn_timeout_ms:
+        Map.get(section, :turn_timeout_ms, @default_turn_timeout_ms),
+      read_timeout_ms:
+        Map.get(section, :read_timeout_ms, @default_read_timeout_ms),
+      stall_timeout_ms:
+        Map.get(section, :stall_timeout_ms, @default_stall_timeout_ms)
     }
   end
 
@@ -191,6 +214,21 @@ defmodule Raxol.Symphony.Config do
       kind: kind,
       agent: Map.get(section, :agent, %{})
     }
+  end
+
+  # Raxol extension: opt-in workflow mode. `:default` runs the prompt-only
+  # path the orchestrator has shipped since SPEC s7. `:graph` routes each
+  # dispatched worker through `Raxol.Symphony.Workflow.GraphAdapter` so the
+  # 5-stage pipeline (tracker_poll, candidate_selection, runner_dispatch,
+  # evidence_collection, completion) executes through main raxol's Phase 25
+  # workflow runtime: per-node telemetry, optional checkpoints, and a
+  # resumable execution boundary around each node.
+  defp workflow_mode(raw) do
+    case Map.get(raw, :workflow_mode, "default") do
+      "graph" -> :graph
+      :graph -> :graph
+      _ -> :default
+    end
   end
 
   # Raxol extension: per-run asciicast capture. When `enabled: true`, the
@@ -264,7 +302,9 @@ defmodule Raxol.Symphony.Config do
 
   defp normalize_state_map(_), do: %{}
 
-  defp normalize_state_key(k) when is_atom(k), do: k |> Atom.to_string() |> String.downcase()
+  defp normalize_state_key(k) when is_atom(k),
+    do: k |> Atom.to_string() |> String.downcase()
+
   defp normalize_state_key(k) when is_binary(k), do: String.downcase(k)
   defp normalize_state_key(k), do: k
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -40,8 +40,10 @@ defmodule Raxol.Symphony.Orchestrator do
   alias Raxol.Symphony.Orchestrator.State
   alias Raxol.Symphony.Runner
   alias Raxol.Symphony.Tracker
+  alias Raxol.Symphony.Workflow.GraphAdapter
   alias Raxol.Symphony.WorkflowStore
   alias Raxol.Symphony.Workspace
+  alias Raxol.Workflow.Compiled, as: WorkflowCompiled
 
   # -- Client API -------------------------------------------------------------
 
@@ -99,9 +101,14 @@ defmodule Raxol.Symphony.Orchestrator do
 
     config =
       case {Keyword.get(opts, :config), workflow_store} do
-        {%_{} = cfg, _} -> cfg
-        {nil, store} when not is_nil(store) -> WorkflowStore.get(store)
-        {nil, nil} -> raise ArgumentError, ":config or :workflow_store is required"
+        {%_{} = cfg, _} ->
+          cfg
+
+        {nil, store} when not is_nil(store) ->
+          WorkflowStore.get(store)
+
+        {nil, nil} ->
+          raise ArgumentError, ":config or :workflow_store is required"
       end
 
     runner_module = Keyword.get(opts, :runner_module)
@@ -181,7 +188,10 @@ defmodule Raxol.Symphony.Orchestrator do
     {:noreply, new_state}
   end
 
-  def handle_manager_info({:DOWN, ref, :process, _pid, reason}, %State{} = state) do
+  def handle_manager_info(
+        {:DOWN, ref, :process, _pid, reason},
+        %State{} = state
+      ) do
     case find_running_by_ref(state, ref) do
       nil ->
         # Maybe a listener; drop it from listeners.
@@ -209,7 +219,10 @@ defmodule Raxol.Symphony.Orchestrator do
         |> notify_listeners(:tick_completed)
 
       {:error, reason, state} ->
-        Logger.warning("symphony.orchestrator.preflight_failed reason=#{inspect(reason)}")
+        Logger.warning(
+          "symphony.orchestrator.preflight_failed reason=#{inspect(reason)}"
+        )
+
         notify_listeners(state, {:preflight_failed, reason})
     end
   end
@@ -220,20 +233,25 @@ defmodule Raxol.Symphony.Orchestrator do
   # in-memory config is preserved and dispatch is skipped this tick.
   defp preflight(%State{workflow_store: nil} = state) do
     case Schema.validate(state.config, validate_opts(state)) do
-      :ok -> {:ok, %State{state | last_preflight_error: nil}}
-      {:error, reason} -> {:error, reason, %State{state | last_preflight_error: reason}}
+      :ok ->
+        {:ok, %State{state | last_preflight_error: nil}}
+
+      {:error, reason} ->
+        {:error, reason, %State{state | last_preflight_error: reason}}
     end
   end
 
   defp preflight(%State{workflow_store: store} = state) do
     case WorkflowStore.get(store) do
       nil ->
-        {:error, :no_workflow_config, %State{state | last_preflight_error: :no_workflow_config}}
+        {:error, :no_workflow_config,
+         %State{state | last_preflight_error: :no_workflow_config}}
 
       latest_config ->
         case Schema.validate(latest_config, validate_opts(state)) do
           :ok ->
-            {:ok, %State{state | config: latest_config, last_preflight_error: nil}}
+            {:ok,
+             %State{state | config: latest_config, last_preflight_error: nil}}
 
           {:error, reason} ->
             {:error, reason, %State{state | last_preflight_error: reason}}
@@ -250,7 +268,9 @@ defmodule Raxol.Symphony.Orchestrator do
   defp dispatch_candidates(%State{} = state) do
     case Tracker.fetch_candidate_issues(state.config) do
       {:ok, issues} ->
-        eligible = Candidate.eligible(issues, state.config, state.running, state.claimed)
+        eligible =
+          Candidate.eligible(issues, state.config, state.running, state.claimed)
+
         Enum.reduce(eligible, state, &dispatch_issue(&2, &1, _attempt = nil))
 
       {:error, _reason} ->
@@ -260,7 +280,8 @@ defmodule Raxol.Symphony.Orchestrator do
 
   defp dispatch_issue(%State{} = state, %Issue{} = issue, attempt) do
     with {:ok, runner_mod} <- runner_module(state),
-         {:ok, %{path: workspace_path}} <- Workspace.ensure(state.config, issue.identifier) do
+         {:ok, %{path: workspace_path}} <-
+           Workspace.ensure(state.config, issue.identifier) do
       do_dispatch_issue(state, issue, attempt, runner_mod, workspace_path)
     else
       {:error, reason} ->
@@ -275,7 +296,10 @@ defmodule Raxol.Symphony.Orchestrator do
   defp do_dispatch_issue(state, issue, attempt, runner_mod, workspace_path) do
     capture_pid = maybe_start_capture(state, issue, attempt, workspace_path)
     task = spawn_worker_task(state, runner_mod, issue, attempt, workspace_path)
-    entry = build_running_entry(issue, attempt, workspace_path, task, capture_pid)
+
+    entry =
+      build_running_entry(issue, attempt, workspace_path, task, capture_pid)
+
     register_running(state, issue, entry)
   end
 
@@ -301,28 +325,102 @@ defmodule Raxol.Symphony.Orchestrator do
 
   defp maybe_start_capture(_state, _issue, _attempt, _workspace_path), do: nil
 
-  defp spawn_worker_task(%State{} = state, runner_mod, %Issue{} = issue, attempt, workspace_path) do
+  defp spawn_worker_task(
+         %State{} = state,
+         runner_mod,
+         %Issue{} = issue,
+         attempt,
+         workspace_path
+       ) do
     parent = self()
     config = state.config
 
     Task.Supervisor.async_nolink(
       task_supervisor(state),
       fn ->
-        runner_opts = [
-          parent: parent,
-          attempt: attempt,
-          workspace_path: workspace_path
-        ]
-
-        case runner_mod.run(issue, config, runner_opts) do
-          :ok -> :ok
-          {:error, reason} -> exit({:runner_error, reason})
-        end
+        run_worker_payload(
+          config.workflow_mode,
+          config,
+          runner_mod,
+          issue,
+          attempt,
+          workspace_path,
+          parent
+        )
       end
     )
   end
 
-  defp build_running_entry(%Issue{} = issue, attempt, workspace_path, task, capture_pid) do
+  defp run_worker_payload(
+         :graph,
+         config,
+         runner_mod,
+         issue,
+         attempt,
+         workspace_path,
+         parent
+       ) do
+    case GraphAdapter.from_workflow([]) do
+      {:ok, compiled} ->
+        state =
+          GraphAdapter.initial_state(
+            config: config,
+            runner_module: runner_mod,
+            candidates: [issue],
+            candidate: issue,
+            parent_pid: parent,
+            attempt: attempt,
+            workspace_path: workspace_path
+          )
+
+        graph_outcome(WorkflowCompiled.invoke(compiled, state))
+
+      {:error, reason} ->
+        exit({:graph_compile_failed, reason})
+    end
+  end
+
+  defp run_worker_payload(
+         _mode,
+         config,
+         runner_mod,
+         issue,
+         attempt,
+         workspace_path,
+         parent
+       ) do
+    runner_opts = [
+      parent: parent,
+      attempt: attempt,
+      workspace_path: workspace_path
+    ]
+
+    case runner_mod.run(issue, config, runner_opts) do
+      :ok -> :ok
+      {:error, reason} -> exit({:runner_error, reason})
+    end
+  end
+
+  defp graph_outcome({:ok, %{run_result: :ok}, _meta}), do: :ok
+
+  defp graph_outcome({:ok, %{run_result: {:error, reason}}, _meta}),
+    do: exit({:runner_error, reason})
+
+  defp graph_outcome({:ok, _final, _meta}), do: :ok
+
+  defp graph_outcome({:error, reason, _state}),
+    do: exit({:graph_runtime_error, reason})
+
+  defp graph_outcome({:interrupted, _run_id, _state, value}),
+    do: exit({:graph_interrupted, value})
+
+  defp build_running_entry(
+         %Issue{} = issue,
+         attempt,
+         workspace_path,
+         task,
+         capture_pid
+       ) do
     %{
       issue: issue,
       attempt: attempt,
@@ -405,7 +503,9 @@ defmodule Raxol.Symphony.Orchestrator do
   end
 
   defp record_runtime(%State{} = state, entry) do
-    elapsed_seconds = (System.monotonic_time(:millisecond) - entry.started_at) / 1_000
+    elapsed_seconds =
+      (System.monotonic_time(:millisecond) - entry.started_at) / 1_000
+
     totals = state.codex_totals
     new_totals = Map.update!(totals, :seconds_running, &(&1 + elapsed_seconds))
     %State{state | codex_totals: new_totals}
@@ -417,12 +517,28 @@ defmodule Raxol.Symphony.Orchestrator do
     schedule_retry(state, issue, attempt, Retry.continuation_delay_ms(), nil)
   end
 
-  defp schedule_failure_retry(%State{} = state, %Issue{} = issue, attempt, error) do
-    delay = Retry.failure_delay_ms(max(attempt, 1), state.config.agent.max_retry_backoff_ms)
+  defp schedule_failure_retry(
+         %State{} = state,
+         %Issue{} = issue,
+         attempt,
+         error
+       ) do
+    delay =
+      Retry.failure_delay_ms(
+        max(attempt, 1),
+        state.config.agent.max_retry_backoff_ms
+      )
+
     schedule_retry(state, issue, attempt, delay, error)
   end
 
-  defp schedule_retry(%State{} = state, %Issue{} = issue, attempt, delay_ms, error) do
+  defp schedule_retry(
+         %State{} = state,
+         %Issue{} = issue,
+         attempt,
+         delay_ms,
+         error
+       ) do
     state = cancel_retry(state, issue.id)
     timer_ref = Process.send_after(self(), {:retry_fire, issue.id}, delay_ms)
     due_at_ms = System.monotonic_time(:millisecond) + delay_ms
@@ -450,10 +566,17 @@ defmodule Raxol.Symphony.Orchestrator do
 
       %{timer_ref: ref} when is_reference(ref) ->
         Process.cancel_timer(ref)
-        %State{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}
+
+        %State{
+          state
+          | retry_attempts: Map.delete(state.retry_attempts, issue_id)
+        }
 
       _ ->
-        %State{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}
+        %State{
+          state
+          | retry_attempts: Map.delete(state.retry_attempts, issue_id)
+        }
     end
   end
 
@@ -465,7 +588,10 @@ defmodule Raxol.Symphony.Orchestrator do
   end
 
   defp retry_with_fresh_state(%State{} = state, issue_id, retry_entry) do
-    state = %{state | retry_attempts: Map.delete(state.retry_attempts, issue_id)}
+    state = %{
+      state
+      | retry_attempts: Map.delete(state.retry_attempts, issue_id)
+    }
 
     case Tracker.fetch_issue_states_by_ids(state.config, [issue_id]) do
       {:ok, [%Issue{} = issue]} ->
@@ -479,7 +605,11 @@ defmodule Raxol.Symphony.Orchestrator do
     end
   end
 
-  defp retry_with_refreshed_issue(%State{} = state, %Issue{} = issue, retry_entry) do
+  defp retry_with_refreshed_issue(
+         %State{} = state,
+         %Issue{} = issue,
+         retry_entry
+       ) do
     cond do
       Issue.terminal?(issue, state.config.tracker.terminal_states) ->
         %{state | claimed: MapSet.delete(state.claimed, issue.id)}
@@ -524,11 +654,21 @@ defmodule Raxol.Symphony.Orchestrator do
       state
     else
       now = System.monotonic_time(:millisecond)
-      Enum.reduce(state.running, state, &maybe_terminate_stalled(&1, &2, now, stall_timeout))
+
+      Enum.reduce(
+        state.running,
+        state,
+        &maybe_terminate_stalled(&1, &2, now, stall_timeout)
+      )
     end
   end
 
-  defp maybe_terminate_stalled({issue_id, entry}, %State{} = acc, now, stall_timeout) do
+  defp maybe_terminate_stalled(
+         {issue_id, entry},
+         %State{} = acc,
+         now,
+         stall_timeout
+       ) do
     last = entry.last_event_at_ms || entry.started_at
 
     if now - last > stall_timeout do
@@ -546,7 +686,13 @@ defmodule Raxol.Symphony.Orchestrator do
     Process.demonitor(entry.worker_ref, [:flush])
     Process.exit(entry.worker_pid, :kill)
     new_acc = remove_running(acc, issue_id, :stalled)
-    schedule_failure_retry(new_acc, entry.issue, (entry.attempt || 0) + 1, :stalled)
+
+    schedule_failure_retry(
+      new_acc,
+      entry.issue,
+      (entry.attempt || 0) + 1,
+      :stalled
+    )
   end
 
   defp reconcile_tracker_states(%State{} = state) do
@@ -615,10 +761,17 @@ defmodule Raxol.Symphony.Orchestrator do
   defp update_entry_from_event(entry, event) do
     %{
       entry
-      | last_event: Map.get(event, :event) || Map.get(event, "event") || entry.last_event,
-        last_message: Map.get(event, :message) || Map.get(event, "message") || entry.last_message,
+      | last_event:
+          Map.get(event, :event) || Map.get(event, "event") || entry.last_event,
+        last_message:
+          Map.get(event, :message) || Map.get(event, "message") ||
+            entry.last_message,
         last_event_at_ms: System.monotonic_time(:millisecond),
-        tokens: merge_tokens(entry.tokens, Map.get(event, :usage) || Map.get(event, "usage")),
+        tokens:
+          merge_tokens(
+            entry.tokens,
+            Map.get(event, :usage) || Map.get(event, "usage")
+          ),
         turn_count: entry.turn_count + maybe_turn_increment(event)
     }
   end
@@ -640,7 +793,8 @@ defmodule Raxol.Symphony.Orchestrator do
           (Map.get(usage, :input_tokens) || Map.get(usage, "input_tokens") || 0),
       output_tokens:
         current.output_tokens +
-          (Map.get(usage, :output_tokens) || Map.get(usage, "output_tokens") || 0),
+          (Map.get(usage, :output_tokens) || Map.get(usage, "output_tokens") ||
+             0),
       total_tokens:
         current.total_tokens +
           (Map.get(usage, :total_tokens) || Map.get(usage, "total_tokens") || 0)
@@ -725,10 +879,14 @@ defmodule Raxol.Symphony.Orchestrator do
     %State{state | tick_timer_ref: ref}
   end
 
-  defp runner_module(%State{runner_module: nil, config: config}), do: Runner.resolve(config)
+  defp runner_module(%State{runner_module: nil, config: config}),
+    do: Runner.resolve(config)
+
   defp runner_module(%State{runner_module: mod}), do: {:ok, mod}
 
-  defp task_supervisor(%State{task_supervisor: nil}), do: Raxol.Symphony.TaskSupervisor
+  defp task_supervisor(%State{task_supervisor: nil}),
+    do: Raxol.Symphony.TaskSupervisor
+
   defp task_supervisor(%State{task_supervisor: sup}), do: sup
 
   defp find_running_by_ref(%State{running: running}, ref) do

--- a/packages/raxol_symphony/lib/raxol/symphony/workflow/graph_adapter.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workflow/graph_adapter.ex
@@ -42,12 +42,18 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
       `Raxol.Symphony.Tracker.fetch_candidate_issues/1` semantics; the
       default uses the config's tracker kind.
 
-  ## Out of scope (deferred to a follow-up PR)
+  ## Orchestrator integration
 
-  - Wiring `workflow_mode: :graph` into the `Orchestrator` GenServer.
-    This adapter ships the translation function; the orchestrator
-    integration is opt-in via a separate PR so the default prompt-only
-    behavior stays unchanged.
+  Setting `workflow_mode: :graph` in the workflow config flips the
+  `Raxol.Symphony.Orchestrator` worker payload to invoke through this
+  adapter. The orchestrator pre-seeds `:candidates`, `:candidate`,
+  `:parent_pid`, `:attempt`, and `:workspace_path` in the initial
+  state; `tracker_poll` short-circuits when `:candidates` is already
+  set so the orchestrator's eligibility decision is not overwritten
+  by a second tracker round-trip.
+
+  ## Out of scope (deferred to follow-up PRs)
+
   - Interrupt-based pauses on runner dispatch. The runner is invoked
     synchronously (`Runner.run/3` returns `:ok | {:error, _}`), so this
     PR does not exercise `Workflow.interrupt/1`. A follow-up can wrap
@@ -79,7 +85,10 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
           optional(:run_result) => :ok | {:error, term()},
           optional(:evidence) => Evidence.t(),
           optional(:completed_at) => DateTime.t(),
-          optional(:runner_module) => module() | nil
+          optional(:runner_module) => module() | nil,
+          optional(:parent_pid) => pid(),
+          optional(:attempt) => non_neg_integer() | nil,
+          optional(:workspace_path) => Path.t()
         }
 
   @doc """
@@ -108,7 +117,12 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
 
   defp compile_opts(opts) do
     opts
-    |> Keyword.take([:saver, :failure_policy, :step_timeout_ms, :run_timeout_ms])
+    |> Keyword.take([
+      :saver,
+      :failure_policy,
+      :step_timeout_ms,
+      :run_timeout_ms
+    ])
   end
 
   @doc """
@@ -120,13 +134,32 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
   """
   @spec initial_state(keyword()) :: state()
   def initial_state(opts) do
-    %{
+    base = %{
       config: Keyword.fetch!(opts, :config),
       runner_module: Keyword.get(opts, :runner_module)
     }
+
+    base
+    |> maybe_put(:candidates, Keyword.get(opts, :candidates))
+    |> maybe_put(:candidate, Keyword.get(opts, :candidate))
+    |> maybe_put(:parent_pid, Keyword.get(opts, :parent_pid))
+    |> maybe_put(:attempt, Keyword.get(opts, :attempt))
+    |> maybe_put(:workspace_path, Keyword.get(opts, :workspace_path))
   end
 
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
   # --- Node bodies ---
+
+  # When the orchestrator pre-seeds `:candidates` (workflow_mode :graph
+  # routes one orchestrator-chosen issue per worker), skip the tracker
+  # round-trip entirely. The orchestrator already ran its eligibility
+  # gate; re-polling would race and could overwrite the pre-seeded list.
+  defp tracker_poll_node(%{candidates: pre_seeded} = state)
+       when is_list(pre_seeded) and pre_seeded != [] do
+    {:ok, state}
+  end
 
   defp tracker_poll_node(state) do
     case Tracker.fetch_candidate_issues(state.config) do
@@ -152,14 +185,20 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
     {:ok, Map.put(state, :run_result, {:error, :no_candidate})}
   end
 
-  defp runner_dispatch_node(%{candidate: %Issue{} = issue, config: config} = state) do
-    runner_opts = if state.runner_module, do: [runner_module: state.runner_module], else: []
+  defp runner_dispatch_node(
+         %{candidate: %Issue{} = issue, config: config} = state
+       ) do
+    runner_opts =
+      if state.runner_module, do: [runner_module: state.runner_module], else: []
+
+    parent = Map.get(state, :parent_pid, self())
+    attempt = Map.get(state, :attempt) || 1
 
     with {:ok, runner_module} <- Runner.resolve(config, runner_opts) do
       result =
         runner_module.run(issue, config,
-          parent: self(),
-          attempt: 1,
+          parent: parent,
+          attempt: attempt,
           workspace_path: Map.get(state, :workspace_path, "")
         )
 

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_workflow_mode_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_workflow_mode_test.exs
@@ -1,0 +1,144 @@
+defmodule Raxol.Symphony.OrchestratorWorkflowModeTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Config, Issue, Orchestrator}
+  alias Raxol.Symphony.Runners.Noop
+  alias Raxol.Symphony.Trackers.Memory
+
+  setup do
+    start_supervised!({Task.Supervisor, name: Raxol.Symphony.TaskSupervisor})
+    start_supervised!({Memory, []})
+    start_supervised!(Noop.Director)
+    Noop.Director.clear()
+
+    :ok
+  end
+
+  defp issue(id, identifier, state) do
+    %Issue{
+      id: id,
+      identifier: identifier,
+      title: "T-#{identifier}",
+      state: state
+    }
+  end
+
+  defp build_config(workflow_mode) do
+    raw = %{
+      tracker: %{
+        kind: "memory",
+        active_states: ["Todo", "In Progress"],
+        terminal_states: ["Done", "Cancelled"]
+      },
+      polling: %{interval_ms: 60_000},
+      agent: %{max_concurrent_agents: 3, max_retry_backoff_ms: 60_000},
+      codex: %{stall_timeout_ms: 0},
+      runner: %{kind: "noop"}
+    }
+
+    raw =
+      case workflow_mode do
+        nil -> raw
+        mode -> Map.put(raw, :workflow_mode, mode)
+      end
+
+    Config.from_workflow(%{config: raw, prompt_template: ""})
+  end
+
+  defp start_orchestrator(config) do
+    {:ok, pid} =
+      start_supervised(
+        {Orchestrator,
+         config: config, runner_module: Noop, auto_start_tick: false, name: nil},
+        id: {Orchestrator, make_ref()}
+      )
+
+    pid
+  end
+
+  defp wait_until(timeout_ms \\ 1_000, fun) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(deadline, fun)
+  end
+
+  defp do_wait_until(deadline, fun) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("wait_until timed out")
+
+      true ->
+        Process.sleep(20)
+        do_wait_until(deadline, fun)
+    end
+  end
+
+  describe "config.workflow_mode" do
+    test "defaults to :default when absent" do
+      config = build_config(nil)
+      assert config.workflow_mode == :default
+    end
+
+    test "string \"graph\" coerces to :graph" do
+      config = build_config("graph")
+      assert config.workflow_mode == :graph
+    end
+
+    test "atom :graph stays :graph" do
+      config = build_config(:graph)
+      assert config.workflow_mode == :graph
+    end
+
+    test "unknown values fall back to :default" do
+      config = build_config("nonsense")
+      assert config.workflow_mode == :default
+    end
+  end
+
+  describe "orchestrator dispatch with workflow_mode :graph" do
+    test "dispatches an eligible issue through the graph runtime" do
+      config = build_config(:graph)
+      Memory.put_issue(issue("g1", "GT-1", "Todo"))
+      Noop.Director.set("GT-1", {:succeed_after, 30})
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+
+      wait_until(fn ->
+        Orchestrator.snapshot(pid).counts.running == 0 and
+          MapSet.member?(:sys.get_state(pid).completed, "g1")
+      end)
+    end
+
+    test "runner failure under :graph mode schedules a retry like :default mode" do
+      config = build_config(:graph)
+      Memory.put_issue(issue("g2", "GT-2", "Todo"))
+      Noop.Director.set("GT-2", {:fail_after, 10, :simulated})
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+
+      wait_until(2_000, fn ->
+        Orchestrator.snapshot(pid).counts.retrying >= 1
+      end)
+    end
+
+    test ":default mode still dispatches without invoking the graph runtime" do
+      # Sanity: the default path is unaffected. Distinguishing path is
+      # implicit (same outcome shape); this just guards the regression.
+      config = build_config(:default)
+      Memory.put_issue(issue("d1", "DT-1", "Todo"))
+      Noop.Director.set("DT-1", {:succeed_after, 30})
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+
+      wait_until(fn ->
+        Orchestrator.snapshot(pid).counts.running == 0 and
+          MapSet.member?(:sys.get_state(pid).completed, "d1")
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes the explicit follow-up note in ADR-0015 and PR #288: the
`Raxol.Symphony.Workflow.GraphAdapter` shipped as a translator only.
This wires the GenServer flip so consumers can opt into the graph
runtime per Symphony config.

- New \`Config\` field \`workflow_mode :: :default | :graph\` (default
  \`:default\`). Coerces string \`"graph"\` from WORKFLOW.md.
- \`Orchestrator.spawn_worker_task\` routes through
  \`run_worker_payload/7\`. In \`:graph\` mode, it builds the canonical
  graph once per dispatch and runs \`WorkflowCompiled.invoke\` against
  it; failures translate to the same \`exit({:runner_error, _})\` shape
  the \`:default\` path uses so the existing worker-exit handler is
  unchanged.
- \`GraphAdapter\` accepts orchestrator-supplied state: \`:candidates\`,
  \`:candidate\`, \`:parent_pid\`, \`:attempt\`, \`:workspace_path\`.
  \`tracker_poll\` short-circuits when \`:candidates\` is pre-seeded so
  the orchestrator's eligibility decision is not raced.
  \`runner_dispatch\` reads the supplied \`parent_pid\` and \`attempt\`
  instead of defaulting to \`self()\` / 1.
- \`GraphAdapter.initial_state/1\` accepts the new keys and skips
  injecting any \`nil\` values into the state map.

The default (\`:default\`) prompt-only path is byte-identical to before.

## Test plan

- [x] +7 tests in \`orchestrator_workflow_mode_test.exs\` covering
      config coercion (4 cases) + end-to-end dispatch in :graph mode
      (success, failure, :default regression guard)
- [x] Existing \`graph_adapter_test.exs\` still green (6 tests)
- [x] Full \`raxol_symphony\` suite: 414 tests, 0 failures
- [x] \`mix credo --strict\` clean on touched files
- [x] \`mix format --check-formatted\` clean