### PR TITLE
Phase 25: async_resume + resume_events

### DIFF
--- a/lib/raxol/workflow/async.ex
+++ b/lib/raxol/workflow/async.ex
@@ -74,6 +74,39 @@ defmodule Raxol.Workflow.Async do
   end
 
   @doc """
+  Spawn a resume in a separate process and return a handle immediately.
+
+  Mirrors `async_invoke/3` but for the resume path. Looks up the
+  latest checkpoint for `run_id` synchronously before spawning so the
+  resume preconditions surface as a regular error tuple rather than
+  hiding inside a normal-exit `:DOWN` message.
+
+  Returns `{:ok, %{run_id, pid, ref}}` on success or one of:
+
+    * `{:error, :no_saver_configured, nil}` -- graph has no Saver
+    * `{:error, :no_checkpoint, nil}` -- no checkpoint for `run_id`
+  """
+  @spec async_resume(Compiled.t(), binary(), any(), keyword()) ::
+          {:ok, %{run_id: binary(), pid: pid(), ref: reference()}}
+          | {:error, :no_saver_configured | :no_checkpoint, nil}
+  def async_resume(%Compiled{} = compiled, run_id, resume_value, opts \\ [])
+      when is_binary(run_id) do
+    case Runtime.preflight_resume(compiled, run_id) do
+      {:ok, _checkpoint} ->
+        pid =
+          spawn(fn ->
+            Runtime.resume(compiled, run_id, resume_value, opts)
+          end)
+
+        ref = Process.monitor(pid)
+        {:ok, %{run_id: run_id, pid: pid, ref: ref}}
+
+      {:error, reason} ->
+        {:error, reason, nil}
+    end
+  end
+
+  @doc """
   Run the graph and return a lazy `Stream` of `CloudEvent` structs.
 
   Each emitted telemetry event (run.started, node.started,
@@ -100,10 +133,94 @@ defmodule Raxol.Workflow.Async do
     )
   end
 
+  @doc """
+  Resume a run and return a lazy `Stream` of `CloudEvent` structs.
+
+  Mirrors `stream_events/3` but for the resume path. The stream
+  carries telemetry events emitted during the resume invocation only;
+  events emitted during the original (interrupted) run are not
+  replayed.
+
+  Preconditions (no saver, no checkpoint) raise `ArgumentError` from
+  the stream start function rather than yielding an empty stream that
+  the consumer would block on. Callers that want a tuple-shaped
+  preflight should use `async_resume/4`.
+
+  Accepts the same options as `stream_events/3`.
+  """
+  @spec resume_events(Compiled.t(), binary(), any(), keyword()) ::
+          Enumerable.t()
+  def resume_events(%Compiled{} = compiled, run_id, resume_value, opts \\ [])
+      when is_binary(run_id) do
+    Stream.resource(
+      fn -> start_resume_stream(compiled, run_id, resume_value, opts) end,
+      &pull_next/1,
+      &cleanup/1
+    )
+  end
+
   # --- Stream resource lifecycle ---
 
   defp start_stream(compiled, initial_state, opts) do
-    run_id = Runtime.generate_run_id()
+    %{
+      handler_id: handler_id,
+      source: source,
+      timeout_ms: timeout_ms,
+      run_id: run_id
+    } =
+      attach_stream_handler(opts)
+
+    runtime_opts =
+      opts
+      |> Keyword.put(:run_id, run_id)
+      |> Keyword.drop([:timeout_ms, :source])
+
+    pid = spawn(fn -> Runtime.invoke(compiled, initial_state, runtime_opts) end)
+    ref = Process.monitor(pid)
+
+    %{
+      run_id: run_id,
+      handler_id: handler_id,
+      pid: pid,
+      ref: ref,
+      timeout_ms: timeout_ms,
+      terminal_received: false
+    }
+  end
+
+  defp start_resume_stream(compiled, run_id, resume_value, opts) do
+    case Runtime.preflight_resume(compiled, run_id) do
+      {:ok, _checkpoint} ->
+        %{handler_id: handler_id, timeout_ms: timeout_ms} =
+          attach_stream_handler(Keyword.put(opts, :run_id, run_id))
+
+        runtime_opts = Keyword.drop(opts, [:timeout_ms, :source, :run_id])
+
+        pid =
+          spawn(fn ->
+            Runtime.resume(compiled, run_id, resume_value, runtime_opts)
+          end)
+
+        ref = Process.monitor(pid)
+
+        %{
+          run_id: run_id,
+          handler_id: handler_id,
+          pid: pid,
+          ref: ref,
+          timeout_ms: timeout_ms,
+          terminal_received: false
+        }
+
+      {:error, reason} ->
+        raise ArgumentError,
+              "resume_events preflight failed: #{inspect(reason)}; " <>
+                "use async_resume/4 for a tuple-shaped result"
+    end
+  end
+
+  defp attach_stream_handler(opts) do
+    run_id = Keyword.get_lazy(opts, :run_id, &Runtime.generate_run_id/0)
     consumer_pid = self()
     handler_id = "workflow_stream_" <> run_id
     timeout_ms = Keyword.get(opts, :timeout_ms, 60_000)
@@ -120,25 +237,11 @@ defmodule Raxol.Workflow.Async do
       %{run_id: run_id, consumer_pid: consumer_pid, source: source}
     )
 
-    runtime_opts =
-      opts
-      |> Keyword.put(:run_id, run_id)
-      |> Keyword.drop([:timeout_ms, :source])
-
-    pid =
-      spawn(fn ->
-        Runtime.invoke(compiled, initial_state, runtime_opts)
-      end)
-
-    ref = Process.monitor(pid)
-
     %{
       run_id: run_id,
       handler_id: handler_id,
-      pid: pid,
-      ref: ref,
-      timeout_ms: timeout_ms,
-      terminal_received: false
+      source: source,
+      timeout_ms: timeout_ms
     }
   end
 

--- a/lib/raxol/workflow/async.ex
+++ b/lib/raxol/workflow/async.ex
@@ -162,12 +162,7 @@ defmodule Raxol.Workflow.Async do
   # --- Stream resource lifecycle ---
 
   defp start_stream(compiled, initial_state, opts) do
-    %{
-      handler_id: handler_id,
-      source: source,
-      timeout_ms: timeout_ms,
-      run_id: run_id
-    } =
+    %{handler_id: handler_id, timeout_ms: timeout_ms, run_id: run_id} =
       attach_stream_handler(opts)
 
     runtime_opts =

--- a/lib/raxol/workflow/compiled.ex
+++ b/lib/raxol/workflow/compiled.ex
@@ -80,4 +80,27 @@ defmodule Raxol.Workflow.Compiled do
   def resume(%__MODULE__{} = compiled, run_id, resume_value, opts \\ []) do
     Raxol.Workflow.Runtime.resume(compiled, run_id, resume_value, opts)
   end
+
+  @doc """
+  Spawn a resume in a background process; return an immediate handle.
+
+  Delegates to `Raxol.Workflow.Async.async_resume/4`.
+  """
+  @spec async_resume(t(), binary(), any(), keyword()) ::
+          {:ok, %{run_id: binary(), pid: pid(), ref: reference()}}
+          | {:error, :no_saver_configured | :no_checkpoint, nil}
+  def async_resume(%__MODULE__{} = compiled, run_id, resume_value, opts \\ []) do
+    Raxol.Workflow.Async.async_resume(compiled, run_id, resume_value, opts)
+  end
+
+  @doc """
+  Return a lazy `Stream` of `Raxol.Core.Events.CloudEvent` structs
+  emitted by the resume invocation.
+
+  Delegates to `Raxol.Workflow.Async.resume_events/4`.
+  """
+  @spec resume_events(t(), binary(), any(), keyword()) :: Enumerable.t()
+  def resume_events(%__MODULE__{} = compiled, run_id, resume_value, opts \\ []) do
+    Raxol.Workflow.Async.resume_events(compiled, run_id, resume_value, opts)
+  end
 end

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -184,23 +184,42 @@ defmodule Raxol.Workflow.Runtime do
           result() | {:error, :no_saver_configured | :no_checkpoint, nil}
   def resume(%Compiled{} = compiled, run_id, resume_value, opts \\ [])
       when is_binary(run_id) do
+    case preflight_resume(compiled, run_id) do
+      {:ok, checkpoint} ->
+        resume_with_checkpoint(
+          compiled,
+          checkpoint,
+          resume_value,
+          run_id,
+          opts
+        )
+
+      {:error, reason} ->
+        {:error, reason, nil}
+    end
+  end
+
+  @doc """
+  Look up the latest checkpoint for `run_id` via the configured Saver,
+  without applying it. Used by `Raxol.Workflow.Async` to surface
+  resume preconditions synchronously before spawning a worker.
+
+  Returns `{:ok, checkpoint}` when a checkpoint is found,
+  `{:error, :no_saver_configured}` when the graph has no Saver, or
+  `{:error, :no_checkpoint}` when no checkpoint exists for `run_id`.
+  """
+  @spec preflight_resume(Compiled.t(), binary()) ::
+          {:ok, Checkpoint.t()}
+          | {:error, :no_saver_configured | :no_checkpoint}
+  def preflight_resume(%Compiled{} = compiled, run_id) when is_binary(run_id) do
     case Saver.normalize(Map.get(compiled.opts, :saver)) do
       nil ->
-        {:error, :no_saver_configured, nil}
+        {:error, :no_saver_configured}
 
       {saver_module, saver_config} ->
         case saver_module.get_latest(saver_config, run_id) do
-          {:ok, %Checkpoint{} = checkpoint} ->
-            resume_with_checkpoint(
-              compiled,
-              checkpoint,
-              resume_value,
-              run_id,
-              opts
-            )
-
-          {:error, :not_found} ->
-            {:error, :no_checkpoint, nil}
+          {:ok, %Checkpoint{} = checkpoint} -> {:ok, checkpoint}
+          {:error, :not_found} -> {:error, :no_checkpoint}
         end
     end
   end

--- a/test/raxol/workflow/async_resume_test.exs
+++ b/test/raxol/workflow/async_resume_test.exs
@@ -1,0 +1,157 @@
+defmodule Raxol.Workflow.AsyncResumeTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Core.Events.CloudEvent
+  alias Raxol.Workflow
+  alias Raxol.Workflow.Checkpoint.Saver.Ets
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  setup do
+    table = :"async_resume_#{:erlang.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+    end)
+
+    {:ok, config: %{table: table}, saver: {Ets, %{table: table}}}
+  end
+
+  defp approval_graph(saver) do
+    {:ok, compiled} =
+      Graph.new(:async_resume)
+      |> Graph.add_node(:prep, fn s -> {:ok, Map.put(s, :prep, true)} end)
+      |> Graph.add_node(:gate, fn s ->
+        d = Workflow.interrupt(:wait)
+        {:ok, Map.put(s, :gate, d)}
+      end)
+      |> Graph.add_node(:done, fn s -> {:ok, Map.put(s, :done, true)} end)
+      |> Graph.add_edge(:__start__, :prep)
+      |> Graph.add_edge(:prep, :gate)
+      |> Graph.add_edge(:gate, :done)
+      |> Graph.add_edge(:done, :__end__)
+      |> Graph.compile(saver: saver)
+
+    compiled
+  end
+
+  describe "async_resume/4" do
+    test "returns a handle keyed on the supplied run_id", ctx do
+      compiled = approval_graph(ctx.saver)
+      {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
+
+      assert {:ok, %{run_id: ^run_id, pid: pid, ref: ref}} =
+               Compiled.async_resume(compiled, run_id, :approved)
+
+      assert is_pid(pid)
+      assert is_reference(ref)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 1_000
+    end
+
+    test "resume completes and writes the resume-path checkpoints", ctx do
+      compiled = approval_graph(ctx.saver)
+      {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
+
+      {:ok, %{ref: ref, pid: pid}} =
+        Compiled.async_resume(compiled, run_id, :approved)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 1_000
+
+      {:ok, checkpoints} = Ets.list(ctx.config, run_id, 10)
+
+      node_ids =
+        checkpoints |> Enum.map(& &1.metadata.node_id) |> Enum.sort()
+
+      assert node_ids == [:__start__, :done, :gate, :prep]
+    end
+
+    test "returns {:error, :no_saver_configured, nil} when no saver wired" do
+      {:ok, compiled} =
+        Graph.new(:no_saver)
+        |> Graph.add_node(:n, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :n)
+        |> Graph.add_edge(:n, :__end__)
+        |> Graph.compile()
+
+      assert {:error, :no_saver_configured, nil} =
+               Compiled.async_resume(compiled, "any", :payload)
+    end
+
+    test "returns {:error, :no_checkpoint, nil} when run_id is unknown", ctx do
+      compiled = approval_graph(ctx.saver)
+
+      assert {:error, :no_checkpoint, nil} =
+               Compiled.async_resume(compiled, "ghost-run-id", :payload)
+    end
+  end
+
+  describe "resume_events/4" do
+    test "emits CloudEvents for the resume invocation and terminates on completion",
+         ctx do
+      compiled = approval_graph(ctx.saver)
+      {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
+
+      events =
+        compiled
+        |> Compiled.resume_events(run_id, :approved, timeout_ms: 1_500)
+        |> Enum.to_list()
+
+      assert Enum.any?(events, fn
+               %CloudEvent{type: "raxol.workflow.run.started"} -> true
+               _ -> false
+             end)
+
+      assert Enum.any?(events, fn
+               %CloudEvent{type: "raxol.workflow.run.completed"} -> true
+               _ -> false
+             end)
+
+      assert Enum.any?(events, fn
+               %CloudEvent{type: "raxol.workflow.node.completed", data: data} ->
+                 data.metadata.node_id == :done
+
+               _ ->
+                 false
+             end)
+    end
+
+    test "every emitted event carries the resumed run_id as subject", ctx do
+      compiled = approval_graph(ctx.saver)
+      {:interrupted, run_id, _, _} = Compiled.invoke(compiled, %{})
+
+      events =
+        compiled
+        |> Compiled.resume_events(run_id, :approved, timeout_ms: 1_500)
+        |> Enum.to_list()
+
+      assert events != []
+      assert Enum.all?(events, fn %CloudEvent{subject: s} -> s == run_id end)
+    end
+
+    test "raises ArgumentError when preflight fails (no saver)" do
+      {:ok, compiled} =
+        Graph.new(:no_saver_stream)
+        |> Graph.add_node(:n, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :n)
+        |> Graph.add_edge(:n, :__end__)
+        |> Graph.compile()
+
+      assert_raise ArgumentError, ~r/no_saver_configured/, fn ->
+        compiled
+        |> Compiled.resume_events("any", :payload)
+        |> Enum.to_list()
+      end
+    end
+
+    test "raises ArgumentError when run_id has no checkpoint", ctx do
+      compiled = approval_graph(ctx.saver)
+
+      assert_raise ArgumentError, ~r/no_checkpoint/, fn ->
+        compiled
+        |> Compiled.resume_events("ghost", :payload)
+        |> Enum.to_list()
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes the third Phase 25 follow-up: the Async surface only covered
fresh runs. This adds the symmetric resume pair so consumers can
fire-and-forget a resume or consume its progress as a CloudEvent
stream.

- \`Raxol.Workflow.Async.async_resume/4\` -- spawn + monitor a resume
  call. Returns \`{:ok, %{run_id, pid, ref}}\` on success or
  \`{:error, :no_saver_configured | :no_checkpoint, nil}\` synchronously
  (preconditions are checked before spawning).
- \`Raxol.Workflow.Async.resume_events/4\` -- lazy Stream of
  \`Raxol.Core.Events.CloudEvent\` emitted during the resume invocation.
  Events from the original (interrupted) run are not replayed. Raises
  \`ArgumentError\` on preflight failure since blocking the consumer on
  an empty stream would be a worse failure mode.
- \`Raxol.Workflow.Runtime.preflight_resume/2\` -- lifts the saver
  lookup out of \`resume/4\` so both async wrappers can surface
  precondition failures as tuples without hiding them inside a
  normal-exit \`:DOWN\` message. \`resume/4\` delegates to the same
  helper, so its behavior is byte-identical.
- \`Raxol.Workflow.Compiled.async_resume/4\` + \`resume_events/4\`
  delegates added so the package's primary entry point exposes the new
  surface.

## Test plan

- [x] +8 tests in \`async_resume_test.exs\` covering happy path,
      checkpoint write-through under async resume, error tuples for
      both pre-flight failures, CloudEvent contents (type, subject),
      and \`ArgumentError\` from the stream variant on pre-flight
      failure.
- [x] Full workflow suite: 8 properties + 107 tests, 0 failures
- [x] \`mix credo --strict\` clean on touched files
- [x] \`mix format --check-formatted\` clean