### PR TITLE
Phase 25: failure_policy :retry runtime

### DIFF
--- a/lib/raxol/workflow/compiled.ex
+++ b/lib/raxol/workflow/compiled.ex
@@ -17,6 +17,8 @@ defmodule Raxol.Workflow.Compiled do
 
   @type opts :: %{
           optional(:failure_policy) => :retry | :halt | :compensate,
+          optional(:max_attempts) => pos_integer(),
+          optional(:retry_backoff_ms) => non_neg_integer(),
           optional(:step_timeout_ms) => non_neg_integer(),
           optional(:run_timeout_ms) => non_neg_integer(),
           optional(:saver) => module()

--- a/lib/raxol/workflow/graph.ex
+++ b/lib/raxol/workflow/graph.ex
@@ -110,12 +110,16 @@ defmodule Raxol.Workflow.Graph do
   ## Options
 
     * `:failure_policy` -- one of `:retry`, `:halt`, `:compensate` (default `:halt`)
+    * `:max_attempts` -- when `:failure_policy` is `:retry`, the
+      maximum number of attempts per node (default `3`). Includes the
+      initial attempt; `1` disables retries.
+    * `:retry_backoff_ms` -- base backoff delay between retries; each
+      subsequent retry doubles (default `100`).
     * `:step_timeout_ms` -- per-node timeout (default `60_000`)
     * `:run_timeout_ms` -- total run timeout (default `3_600_000`)
     * `:saver` -- `Raxol.Workflow.Checkpoint.Saver` module (defaults to `Ets`)
 
-  These options are stored on `Compiled` and consumed by the runtime
-  in a follow-up PR.
+  These options are stored on `Compiled` and consumed by the runtime.
   """
   @spec compile(t(), keyword()) ::
           {:ok, Compiled.t()}
@@ -135,7 +139,7 @@ defmodule Raxol.Workflow.Graph do
          opts:
            opts
            |> Keyword.take(
-             ~w(failure_policy step_timeout_ms run_timeout_ms saver)a
+             ~w(failure_policy max_attempts retry_backoff_ms step_timeout_ms run_timeout_ms saver)a
            )
            |> Map.new()
        }}

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -32,6 +32,8 @@ defmodule Raxol.Workflow.Runtime do
   @end_ :__end__
 
   @default_run_timeout_ms 60_000
+  @default_max_attempts 3
+  @default_retry_backoff_ms 100
 
   @type result ::
           {:ok, state :: any(), meta :: map()}
@@ -321,6 +323,57 @@ defmodule Raxol.Workflow.Runtime do
          deadline_us,
          count
        ) do
+    case attempt_node_with_retry(compiled, current_id, state, run_id, 1) do
+      {:node_ok, new_state, _tag} ->
+        persist_checkpoint(compiled, current_id, new_state, run_id, count)
+
+        traverse(
+          compiled,
+          current_id,
+          new_state,
+          run_id,
+          deadline_us,
+          count + 1
+        )
+
+      {:interrupt, value, state_at_interrupt} ->
+        {:interrupted, state_at_interrupt, value, count + 1}
+
+      {:error, reason, state_at_error} ->
+        {:error, reason, state_at_error, count + 1}
+    end
+  end
+
+  # Retry loop. Each attempt gets its own span + telemetry events; on
+  # transient {:error, _} (including rescued exceptions and
+  # {:invalid_result, _}) we sleep with exponential backoff and try
+  # again, up to the configured max_attempts. Per-attempt telemetry
+  # makes attempt counts and retry latencies observable.
+  defp attempt_node_with_retry(compiled, current_id, state, run_id, attempt) do
+    case execute_node_once(compiled, current_id, state, run_id) do
+      {:error, _reason, _state} = err ->
+        max = retry_max_attempts(compiled)
+
+        if retry?(compiled) and attempt < max do
+          Process.sleep(compute_backoff(retry_backoff_ms(compiled), attempt))
+
+          attempt_node_with_retry(
+            compiled,
+            current_id,
+            state,
+            run_id,
+            attempt + 1
+          )
+        else
+          err
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp execute_node_once(compiled, current_id, state, run_id) do
     node = Map.fetch!(compiled.nodes, current_id)
     span_name = "workflow.node.#{inspect(current_id)}"
     _ = TraceContext.start_span(span_name)
@@ -334,141 +387,116 @@ defmodule Raxol.Workflow.Runtime do
     })
 
     try do
-      handle_node_result(
+      finalize_attempt(
         run_node(node, state),
         compiled,
         current_id,
         state,
         run_id,
-        deadline_us,
-        count,
         started_us
       )
     rescue
       e ->
-        _ = TraceContext.end_span()
         message = Exception.message(e)
 
-        emit_node_event(:failed, %{
-          run_id: run_id,
-          graph_id: compiled.id,
-          node_id: current_id,
-          duration_us: monotonic_us() - started_us,
+        end_span_and_emit(:failed, compiled, current_id, run_id, started_us, %{
           reason: {:exception, message}
         })
 
-        {:error, {:exception, message}, state, count + 1}
+        {:error, {:exception, message}, state}
     catch
       :throw, {:__workflow_interrupt__, value} ->
-        handle_node_result(
-          {:interrupt, value},
+        end_span_and_emit(
+          :completed,
           compiled,
           current_id,
-          state,
           run_id,
-          deadline_us,
-          count,
-          started_us
+          started_us,
+          %{
+            result_type: :interrupt
+          }
         )
+
+        {:interrupt, value, state}
     end
   end
 
-  defp handle_node_result(
+  defp finalize_attempt(
          {:ok, new_state},
          compiled,
          current_id,
          _state,
          run_id,
-         deadline_us,
-         count,
          started_us
        ) do
-    finish_node_ok(
-      compiled,
-      current_id,
-      new_state,
-      run_id,
-      deadline_us,
-      count,
-      started_us,
-      :ok
-    )
+    end_span_and_emit(:completed, compiled, current_id, run_id, started_us, %{
+      result_type: :ok
+    })
+
+    {:node_ok, new_state, :ok}
   end
 
-  defp handle_node_result(
+  defp finalize_attempt(
          {:effects, directives, new_state},
          compiled,
          current_id,
          _state,
          run_id,
-         deadline_us,
-         count,
          started_us
        )
        when is_list(directives) do
     dispatch_effects(directives)
 
-    finish_node_ok(
-      compiled,
-      current_id,
-      new_state,
-      run_id,
-      deadline_us,
-      count,
-      started_us,
-      :effects
-    )
+    end_span_and_emit(:completed, compiled, current_id, run_id, started_us, %{
+      result_type: :effects
+    })
+
+    {:node_ok, new_state, :effects}
   end
 
-  defp handle_node_result(
+  defp finalize_attempt(
          {:interrupt, value},
          compiled,
          current_id,
          state,
          run_id,
-         _deadline_us,
-         count,
          started_us
        ) do
     end_span_and_emit(:completed, compiled, current_id, run_id, started_us, %{
       result_type: :interrupt
     })
 
-    {:interrupted, state, value, count + 1}
+    {:interrupt, value, state}
   end
 
-  defp handle_node_result(
+  defp finalize_attempt(
          {:error, reason},
          compiled,
          current_id,
          state,
          run_id,
-         _deadline_us,
-         count,
          started_us
        ) do
     end_span_and_emit(:failed, compiled, current_id, run_id, started_us, %{
       reason: reason
     })
 
-    {:error, reason, state, count + 1}
+    {:error, reason, state}
   end
 
-  defp handle_node_result(
+  defp finalize_attempt(
          other,
          compiled,
          current_id,
          state,
          run_id,
-         _deadline_us,
-         count,
          started_us
        ) do
     end_span_and_emit(:failed, compiled, current_id, run_id, started_us, %{
       reason: {:invalid_result, other}
     })
 
-    {:error, {:invalid_result, other}, state, count + 1}
+    {:error, {:invalid_result, other}, state}
   end
 
   defp end_span_and_emit(kind, compiled, current_id, run_id, started_us, extra) do
@@ -488,28 +516,20 @@ defmodule Raxol.Workflow.Runtime do
     )
   end
 
-  defp finish_node_ok(
-         compiled,
-         current_id,
-         new_state,
-         run_id,
-         deadline_us,
-         count,
-         started_us,
-         tag
-       ) do
-    emit_node_event(:completed, %{
-      run_id: run_id,
-      graph_id: compiled.id,
-      node_id: current_id,
-      duration_us: monotonic_us() - started_us,
-      result_type: tag
-    })
+  defp retry?(compiled),
+    do: Map.get(compiled.opts, :failure_policy, :halt) == :retry
 
-    _ = TraceContext.end_span()
-    persist_checkpoint(compiled, current_id, new_state, run_id, count)
-    traverse(compiled, current_id, new_state, run_id, deadline_us, count + 1)
-  end
+  defp retry_max_attempts(compiled),
+    do: Map.get(compiled.opts, :max_attempts, @default_max_attempts)
+
+  defp retry_backoff_ms(compiled),
+    do: Map.get(compiled.opts, :retry_backoff_ms, @default_retry_backoff_ms)
+
+  # Exponential backoff: base * 2^(attempt - 1). attempt is the
+  # just-failed attempt number, so the first retry (attempt 1 -> 2)
+  # waits `base`, the second waits `2 * base`, and so on.
+  defp compute_backoff(base_ms, attempt) when attempt >= 1,
+    do: base_ms * Bitwise.bsl(1, attempt - 1)
 
   defp persist_checkpoint(compiled, current_id, state, run_id, count) do
     case Saver.normalize(Map.get(compiled.opts, :saver)) do

--- a/test/raxol/workflow/retry_test.exs
+++ b/test/raxol/workflow/retry_test.exs
@@ -1,0 +1,249 @@
+defmodule Raxol.Workflow.RetryTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  defp counter_table do
+    name = :"retry_counter_#{:erlang.unique_integer([:positive])}"
+    :ets.new(name, [:public, :named_table, :set])
+    name
+  end
+
+  defp bump(table, key) do
+    :ets.update_counter(table, key, 1, {key, 0})
+  end
+
+  defp get(table, key) do
+    case :ets.lookup(table, key) do
+      [{^key, n}] -> n
+      [] -> 0
+    end
+  end
+
+  defp flaky_graph(table, fail_until: fail_until, policy_opts: policy_opts) do
+    {:ok, compiled} =
+      Graph.new(:flaky)
+      |> Graph.add_node(:flaky, fn s ->
+        n = bump(table, :flaky)
+
+        if n <= fail_until do
+          {:error, {:transient, n}}
+        else
+          {:ok, Map.put(s, :flaky_runs, n)}
+        end
+      end)
+      |> Graph.add_edge(:__start__, :flaky)
+      |> Graph.add_edge(:flaky, :__end__)
+      |> Graph.compile(policy_opts)
+
+    compiled
+  end
+
+  describe "failure_policy :retry" do
+    test "halt is the default: a single failure surfaces immediately" do
+      table = counter_table()
+      compiled = flaky_graph(table, fail_until: 5, policy_opts: [])
+
+      assert {:error, {:transient, 1}, _state} =
+               Compiled.invoke(compiled, %{})
+
+      assert get(table, :flaky) == 1
+    end
+
+    test "retry succeeds once the underlying error clears" do
+      table = counter_table()
+
+      compiled =
+        flaky_graph(table,
+          fail_until: 2,
+          policy_opts: [
+            failure_policy: :retry,
+            max_attempts: 5,
+            retry_backoff_ms: 1
+          ]
+        )
+
+      assert {:ok, %{flaky_runs: 3}, %{nodes_executed: 1}} =
+               Compiled.invoke(compiled, %{})
+
+      assert get(table, :flaky) == 3
+    end
+
+    test "retry exhausts after max_attempts and returns the last error" do
+      table = counter_table()
+
+      compiled =
+        flaky_graph(table,
+          fail_until: 100,
+          policy_opts: [
+            failure_policy: :retry,
+            max_attempts: 3,
+            retry_backoff_ms: 1
+          ]
+        )
+
+      assert {:error, {:transient, 3}, _state} =
+               Compiled.invoke(compiled, %{})
+
+      assert get(table, :flaky) == 3
+    end
+
+    test "max_attempts: 1 disables retries even when policy is :retry" do
+      table = counter_table()
+
+      compiled =
+        flaky_graph(table,
+          fail_until: 100,
+          policy_opts: [
+            failure_policy: :retry,
+            max_attempts: 1,
+            retry_backoff_ms: 1
+          ]
+        )
+
+      assert {:error, {:transient, 1}, _state} =
+               Compiled.invoke(compiled, %{})
+
+      assert get(table, :flaky) == 1
+    end
+
+    test "raised exceptions are retried under :retry policy" do
+      table = counter_table()
+
+      {:ok, compiled} =
+        Graph.new(:flaky_raise)
+        |> Graph.add_node(:flaky, fn s ->
+          n = bump(table, :flaky)
+
+          if n <= 2 do
+            raise "transient #{n}"
+          else
+            {:ok, Map.put(s, :ran, n)}
+          end
+        end)
+        |> Graph.add_edge(:__start__, :flaky)
+        |> Graph.add_edge(:flaky, :__end__)
+        |> Graph.compile(
+          failure_policy: :retry,
+          max_attempts: 5,
+          retry_backoff_ms: 1
+        )
+
+      assert {:ok, %{ran: 3}, _meta} = Compiled.invoke(compiled, %{})
+      assert get(table, :flaky) == 3
+    end
+
+    test "halt policy does not retry exceptions either" do
+      table = counter_table()
+
+      {:ok, compiled} =
+        Graph.new(:halt_raise)
+        |> Graph.add_node(:bomb, fn _ -> raise "boom" end)
+        |> Graph.add_edge(:__start__, :bomb)
+        |> Graph.add_edge(:bomb, :__end__)
+        |> Graph.compile(failure_policy: :halt)
+
+      assert {:error, {:exception, "boom"}, _} = Compiled.invoke(compiled, %{})
+      _ = table
+    end
+  end
+
+  describe "retry telemetry" do
+    test "each attempt emits node.started + node.failed; final success emits node.completed" do
+      table = counter_table()
+      test_pid = self()
+      handler_id = "retry_tel_#{:erlang.unique_integer([:positive])}"
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:raxol, :workflow, :node, :started],
+          [:raxol, :workflow, :node, :completed],
+          [:raxol, :workflow, :node, :failed]
+        ],
+        fn event, _m, metadata, _ ->
+          send(test_pid, {:tel, event, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      compiled =
+        flaky_graph(table,
+          fail_until: 2,
+          policy_opts: [
+            failure_policy: :retry,
+            max_attempts: 5,
+            retry_backoff_ms: 1
+          ]
+        )
+
+      Compiled.invoke(compiled, %{})
+
+      # 3 attempts -> 3 :started, 2 :failed, 1 :completed
+      starts = collect(test_pid, [:raxol, :workflow, :node, :started], 3)
+      fails = collect(test_pid, [:raxol, :workflow, :node, :failed], 2)
+      completes = collect(test_pid, [:raxol, :workflow, :node, :completed], 1)
+
+      assert length(starts) == 3
+      assert length(fails) == 2
+      assert length(completes) == 1
+    end
+  end
+
+  describe "retry interaction with the saver" do
+    test "checkpoints are not written for failed attempts; only the final success",
+         _ctx do
+      table = counter_table()
+      ets_table = :"retry_ckpt_#{:erlang.unique_integer([:positive])}"
+
+      on_exit(fn ->
+        if :ets.whereis(ets_table) != :undefined, do: :ets.delete(ets_table)
+      end)
+
+      saver = {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: ets_table}}
+
+      compiled =
+        flaky_graph(table,
+          fail_until: 2,
+          policy_opts: [
+            failure_policy: :retry,
+            max_attempts: 5,
+            retry_backoff_ms: 1,
+            saver: saver
+          ]
+        )
+
+      {:ok, _final, meta} = Compiled.invoke(compiled, %{})
+
+      {:ok, checkpoints} =
+        Raxol.Workflow.Checkpoint.Saver.Ets.list(
+          %{table: ets_table},
+          meta.run_id,
+          10
+        )
+
+      # :__start__ initial + :flaky (one final successful checkpoint) = 2
+      assert length(checkpoints) == 2
+
+      node_ids =
+        checkpoints |> Enum.map(& &1.metadata.node_id) |> Enum.sort()
+
+      assert node_ids == [:__start__, :flaky]
+    end
+  end
+
+  # Helpers
+
+  defp collect(_pid, _event, 0), do: []
+
+  defp collect(pid, event, n) do
+    receive do
+      {:tel, ^event, metadata} -> [metadata | collect(pid, event, n - 1)]
+    after
+      500 -> []
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes the \`:retry\` half of the ADR-0015 follow-up note on failure
policy. \`:compensate\` is still deferred (needs a \`Node.compensate/2\`
behaviour + reverse-order execution path).

- New \`Graph.compile/2\` opts: \`:max_attempts\` (default 3; 1 disables
  retries) and \`:retry_backoff_ms\` (default 100). The base delay
  doubles each attempt: 100ms, 200ms, 400ms...
- Runtime refactor: \`execute_node_and_continue\` is split into
  \`execute_node_once\` (one attempt with span + telemetry +
  effect-or-error-or-interrupt verdict), \`attempt_node_with_retry\`
  (the retry loop), and a thin outer that traverses on success or
  returns on interrupt/error.
- Side effect contract preserved: effects (\`Directive\` dispatch) and
  checkpoint writes happen only on the successful attempt. Failed
  attempts emit \`node.started\` + \`node.failed\` for observability.
- Span lifecycle: each attempt opens + closes its own span so trace
  consumers see one span_id per attempt (same trace_id throughout).
- Raised exceptions are treated as transient under \`:retry\` and
  surface as \`{:error, {:exception, message}, _}\` after max_attempts.
- \`:halt\` remains the default.

## Test plan

- [x] +8 retry tests covering: default \`:halt\` semantics, successful
      retry, exhaustion, \`max_attempts: 1\` disabling retries, exception
      retry, \`:halt\` not retrying exceptions, per-attempt telemetry
      cardinality (started x N, failed x N-1, completed x 1), and
      checkpoint-only-on-success
- [x] Workflow suite: 8 properties + 115 tests, 0 failures
- [x] \`mix credo --strict\` clean
- [x] \`mix format --check-formatted\` clean