### PR TITLE
Phase 25: failure_policy :compensate runtime

### DIFF
--- a/lib/raxol/workflow/graph.ex
+++ b/lib/raxol/workflow/graph.ex
@@ -65,6 +65,26 @@ defmodule Raxol.Workflow.Graph do
     put_node(graph, node)
   end
 
+  @doc """
+  Add a `FunctionNode` with an optional compensation function.
+
+  Convenience for `add_node/3 |> Node.function/3`. The
+  `compensate_fun` runs in reverse order under
+  `failure_policy: :compensate` when the run errors after this node
+  succeeded. It receives the current state and returns
+  `{:ok, new_state} | {:error, reason}`.
+  """
+  @spec add_node(
+          t(),
+          Node.id(),
+          (any() -> any()),
+          (any() -> {:ok, any()} | {:error, any()})
+        ) :: t()
+  def add_node(%__MODULE__{} = graph, id, fun, compensate_fun)
+      when is_function(fun, 1) and is_function(compensate_fun, 1) do
+    put_node(graph, Node.function(id, fun, compensate_fun))
+  end
+
   @doc "Add a static edge from `from` to `to`."
   @spec add_edge(t(), Node.id(), Node.id()) :: t()
   def add_edge(%__MODULE__{} = graph, from, to)

--- a/lib/raxol/workflow/node.ex
+++ b/lib/raxol/workflow/node.ex
@@ -47,20 +47,36 @@ defmodule Raxol.Workflow.Node do
 
   @doc """
   Called by the runtime's failure policy when `failure_policy: :compensate`
-  is set and an earlier node has already succeeded. Default is a no-op.
+  is set and the run errors after this node already succeeded. Receives
+  the current state (potentially modified by later compensations) and
+  returns either an updated state via `{:ok, new_state}` or an error
+  via `{:error, reason}`. Compensation errors are surfaced through
+  `node.compensated` telemetry but do not displace the run's original
+  failure reason. Default is a no-op that leaves the state untouched.
   """
   @callback compensate(state :: state(), opts :: keyword()) ::
-              :ok | {:error, any()}
+              {:ok, state()} | {:error, any()}
 
   @optional_callbacks init: 1, compensate: 2
 
   defmodule FunctionNode do
-    @moduledoc "A node backed by a 1-arity function."
+    @moduledoc """
+    A node backed by a 1-arity function.
 
-    @type t :: %__MODULE__{id: Raxol.Workflow.Node.id(), fun: (any() -> any())}
+    The optional `:compensate_fun` is invoked when the run fails under
+    `failure_policy: :compensate` and this node had already succeeded.
+    It receives the current state and returns
+    `{:ok, new_state} | {:error, reason}`.
+    """
+
+    @type t :: %__MODULE__{
+            id: Raxol.Workflow.Node.id(),
+            fun: (any() -> any()),
+            compensate_fun: (any() -> {:ok, any()} | {:error, any()}) | nil
+          }
 
     @enforce_keys [:id, :fun]
-    defstruct [:id, :fun]
+    defstruct [:id, :fun, compensate_fun: nil]
   end
 
   defmodule BehaviourNode do
@@ -97,6 +113,23 @@ defmodule Raxol.Workflow.Node do
   @spec function(id(), (state() -> result())) :: FunctionNode.t()
   def function(id, fun) when is_function(fun, 1),
     do: %FunctionNode{id: id, fun: fun}
+
+  @doc """
+  Construct a `FunctionNode` with an optional compensation function.
+
+  The compensation runs in reverse order under
+  `failure_policy: :compensate` when the run fails after this node
+  succeeded. It must be a 1-arity function returning
+  `{:ok, new_state} | {:error, reason}`.
+  """
+  @spec function(
+          id(),
+          (state() -> result()),
+          (state() -> {:ok, state()} | {:error, any()})
+        ) :: FunctionNode.t()
+  def function(id, fun, compensate_fun)
+      when is_function(fun, 1) and is_function(compensate_fun, 1),
+      do: %FunctionNode{id: id, fun: fun, compensate_fun: compensate_fun}
 
   @doc "Construct a `BehaviourNode`."
   @spec behaviour(id(), module(), keyword()) :: BehaviourNode.t()

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -28,6 +28,8 @@ defmodule Raxol.Workflow.Runtime do
   alias Raxol.Workflow.Node, as: WorkflowNode
   alias Raxol.Workflow.Node.{BehaviourNode, FunctionNode, TypedNode}
 
+  @executed_key :__raxol_workflow_executed__
+
   @start :__start__
   @end_ :__end__
 
@@ -60,6 +62,8 @@ defmodule Raxol.Workflow.Runtime do
       count_offset: count_offset
     } = prepare_invocation(compiled, initial_state, opts)
 
+    Process.put(@executed_key, [])
+
     try do
       emit_run_event(:started, %{run_id: run_id, graph_id: compiled.id})
 
@@ -71,10 +75,12 @@ defmodule Raxol.Workflow.Runtime do
         start_count,
         resume_from
       )
+      |> maybe_compensate_on_error(compiled, run_id)
       |> wrap_outcome(run_id, compiled.id, count_offset)
     after
       _ = TraceContext.clear()
       Scratchpad.clear()
+      Process.delete(@executed_key)
     end
   end
 
@@ -245,6 +251,80 @@ defmodule Raxol.Workflow.Runtime do
     )
   end
 
+  defp track_executed(node) do
+    Process.put(@executed_key, [node | Process.get(@executed_key, [])])
+  end
+
+  defp executed_nodes, do: Process.get(@executed_key, [])
+
+  # Under failure_policy: :compensate, the runtime walks the executed
+  # nodes in reverse and runs each one's compensate function. The
+  # state threads through compensations so an earlier compensation
+  # sees the result of a later one. Compensation errors are surfaced
+  # through node.compensated telemetry but do not displace the run's
+  # original failure reason.
+  defp maybe_compensate_on_error(
+         {:error, reason, state, count},
+         compiled,
+         run_id
+       ) do
+    if Map.get(compiled.opts, :failure_policy) == :compensate do
+      new_state = run_compensations(executed_nodes(), state, compiled, run_id)
+      {:error, reason, new_state, count}
+    else
+      {:error, reason, state, count}
+    end
+  end
+
+  defp maybe_compensate_on_error(other, _compiled, _run_id), do: other
+
+  defp run_compensations(nodes, state, compiled, run_id) do
+    Enum.reduce(nodes, state, fn node, acc_state ->
+      case do_compensate(node, acc_state) do
+        {:ok, next_state} ->
+          emit_node_event(:compensated, %{
+            run_id: run_id,
+            graph_id: compiled.id,
+            node_id: WorkflowNode.id(node),
+            result: :ok
+          })
+
+          next_state
+
+        {:error, comp_reason} ->
+          emit_node_event(:compensated, %{
+            run_id: run_id,
+            graph_id: compiled.id,
+            node_id: WorkflowNode.id(node),
+            result: {:error, comp_reason}
+          })
+
+          acc_state
+      end
+    end)
+  end
+
+  defp do_compensate(%FunctionNode{compensate_fun: nil}, state),
+    do: {:ok, state}
+
+  defp do_compensate(%FunctionNode{compensate_fun: fun}, state) do
+    fun.(state)
+  rescue
+    e -> {:error, {:exception, Exception.message(e)}}
+  end
+
+  defp do_compensate(%BehaviourNode{module: mod, opts: opts}, state) do
+    if function_exported?(mod, :compensate, 2) do
+      mod.compensate(state, opts)
+    else
+      {:ok, state}
+    end
+  rescue
+    e -> {:error, {:exception, Exception.message(e)}}
+  end
+
+  defp do_compensate(%TypedNode{}, state), do: {:ok, state}
+
   defp wrap_outcome({:ok, final_state, count}, run_id, graph_id, offset) do
     nodes_executed = count - offset
 
@@ -325,6 +405,7 @@ defmodule Raxol.Workflow.Runtime do
        ) do
     case attempt_node_with_retry(compiled, current_id, state, run_id, 1) do
       {:node_ok, new_state, _tag} ->
+        track_executed(Map.fetch!(compiled.nodes, current_id))
         persist_checkpoint(compiled, current_id, new_state, run_id, count)
 
         traverse(

--- a/test/raxol/workflow/compensate_test.exs
+++ b/test/raxol/workflow/compensate_test.exs
@@ -1,0 +1,249 @@
+defmodule Raxol.Workflow.CompensateTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  describe "failure_policy :compensate" do
+    test "runs compensations in reverse order for nodes that succeeded" do
+      {:ok, compiled} =
+        Graph.new(:saga)
+        |> Graph.add_node(
+          :reserve,
+          fn s -> {:ok, Map.put(s, :reserved, true)} end,
+          fn s -> {:ok, Map.put(s, :reserve_compensated, true)} end
+        )
+        |> Graph.add_node(
+          :charge,
+          fn s -> {:ok, Map.put(s, :charged, true)} end,
+          fn s -> {:ok, Map.put(s, :charge_compensated, true)} end
+        )
+        |> Graph.add_node(:ship, fn _ -> {:error, :ship_failed} end)
+        |> Graph.add_edge(:__start__, :reserve)
+        |> Graph.add_edge(:reserve, :charge)
+        |> Graph.add_edge(:charge, :ship)
+        |> Graph.add_edge(:ship, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      assert {:error, :ship_failed, final_state} =
+               Compiled.invoke(compiled, %{})
+
+      # Both compensations ran (charge first, then reserve).
+      assert final_state.reserved == true
+      assert final_state.charged == true
+      assert final_state.charge_compensated == true
+      assert final_state.reserve_compensated == true
+    end
+
+    test "compensations thread state through reverse execution" do
+      {:ok, compiled} =
+        Graph.new(:thread)
+        |> Graph.add_node(
+          :a,
+          fn s -> {:ok, Map.put(s, :a, true)} end,
+          fn s -> {:ok, Map.update(s, :order, [:a], &[:a | &1])} end
+        )
+        |> Graph.add_node(
+          :b,
+          fn s -> {:ok, Map.put(s, :b, true)} end,
+          fn s -> {:ok, Map.update(s, :order, [:b], &[:b | &1])} end
+        )
+        |> Graph.add_node(:c, fn _ -> {:error, :c_failed} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :c)
+        |> Graph.add_edge(:c, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      assert {:error, :c_failed, %{order: order}} =
+               Compiled.invoke(compiled, %{})
+
+      # b is compensated first (reverse order), prepending to :order.
+      # Then a, also prepending. Final order: [:a, :b].
+      assert order == [:a, :b]
+    end
+
+    test "nodes without compensate_fun are skipped silently" do
+      {:ok, compiled} =
+        Graph.new(:partial)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :a, true)} end)
+        |> Graph.add_node(
+          :b,
+          fn s -> {:ok, Map.put(s, :b, true)} end,
+          fn s -> {:ok, Map.put(s, :b_compensated, true)} end
+        )
+        |> Graph.add_node(:c, fn _ -> {:error, :boom} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :c)
+        |> Graph.add_edge(:c, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      assert {:error, :boom, final_state} = Compiled.invoke(compiled, %{})
+      # b had compensate; a did not.
+      assert final_state.b_compensated == true
+      refute Map.has_key?(final_state, :a_compensated)
+    end
+
+    test "no compensations run when the workflow succeeds" do
+      {:ok, compiled} =
+        Graph.new(:success)
+        |> Graph.add_node(
+          :a,
+          fn s -> {:ok, Map.put(s, :a, true)} end,
+          fn s -> {:ok, Map.put(s, :a_compensated, true)} end
+        )
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      assert {:ok, final, _meta} = Compiled.invoke(compiled, %{})
+      assert final.a == true
+      refute Map.has_key?(final, :a_compensated)
+    end
+
+    test "compensate is a no-op under :halt policy (default)" do
+      {:ok, compiled} =
+        Graph.new(:halt_default)
+        |> Graph.add_node(
+          :a,
+          fn s -> {:ok, Map.put(s, :a, true)} end,
+          fn s -> {:ok, Map.put(s, :a_compensated, true)} end
+        )
+        |> Graph.add_node(:b, fn _ -> {:error, :boom} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :__end__)
+        |> Graph.compile()
+
+      assert {:error, :boom, final_state} = Compiled.invoke(compiled, %{})
+      assert final_state.a == true
+      refute Map.has_key?(final_state, :a_compensated)
+    end
+
+    test "compensate errors are surfaced via telemetry, original failure still wins" do
+      test_pid = self()
+      handler_id = "compensate_tel_#{:erlang.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :workflow, :node, :compensated],
+        fn _event, _m, metadata, _ ->
+          send(test_pid, {:compensated, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {:ok, compiled} =
+        Graph.new(:comp_error)
+        |> Graph.add_node(
+          :a,
+          fn s -> {:ok, Map.put(s, :a, true)} end,
+          fn _ -> {:error, :compensation_failed} end
+        )
+        |> Graph.add_node(:b, fn _ -> {:error, :original_failure} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      assert {:error, :original_failure, _} = Compiled.invoke(compiled, %{})
+
+      assert_receive {:compensated,
+                      %{
+                        node_id: :a,
+                        result: {:error, :compensation_failed}
+                      }},
+                     500
+    end
+
+    test "raised exceptions inside compensate are caught and reported as :exception" do
+      test_pid = self()
+      handler_id = "compensate_raise_#{:erlang.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :workflow, :node, :compensated],
+        fn _event, _m, metadata, _ ->
+          send(test_pid, {:compensated, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {:ok, compiled} =
+        Graph.new(:comp_raise)
+        |> Graph.add_node(
+          :a,
+          fn s -> {:ok, Map.put(s, :a, true)} end,
+          fn _ -> raise "compensate kaboom" end
+        )
+        |> Graph.add_node(:b, fn _ -> {:error, :original} end)
+        |> Graph.add_edge(:__start__, :a)
+        |> Graph.add_edge(:a, :b)
+        |> Graph.add_edge(:b, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      Compiled.invoke(compiled, %{})
+
+      assert_receive {:compensated,
+                      %{
+                        node_id: :a,
+                        result: {:error, {:exception, "compensate kaboom"}}
+                      }},
+                     500
+    end
+  end
+
+  describe "BehaviourNode compensation" do
+    defmodule CompensableNode do
+      @behaviour Raxol.Workflow.Node
+
+      @impl true
+      def run(state, _opts), do: {:ok, Map.put(state, :ran, true)}
+
+      @impl true
+      def compensate(state, _opts),
+        do: {:ok, Map.put(state, :compensated, true)}
+    end
+
+    defmodule NonCompensableNode do
+      @behaviour Raxol.Workflow.Node
+
+      @impl true
+      def run(state, _opts), do: {:ok, Map.put(state, :nc_ran, true)}
+    end
+
+    test "BehaviourNode with compensate/2 runs under :compensate policy" do
+      {:ok, compiled} =
+        Graph.new(:beh_comp)
+        |> Graph.add_node(:beh, {CompensableNode, []})
+        |> Graph.add_node(:bomb, fn _ -> {:error, :boom} end)
+        |> Graph.add_edge(:__start__, :beh)
+        |> Graph.add_edge(:beh, :bomb)
+        |> Graph.add_edge(:bomb, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      assert {:error, :boom, final} = Compiled.invoke(compiled, %{})
+      assert final.ran == true
+      assert final.compensated == true
+    end
+
+    test "BehaviourNode without compensate/2 is silently skipped" do
+      {:ok, compiled} =
+        Graph.new(:beh_nocomp)
+        |> Graph.add_node(:nc, {NonCompensableNode, []})
+        |> Graph.add_node(:bomb, fn _ -> {:error, :boom} end)
+        |> Graph.add_edge(:__start__, :nc)
+        |> Graph.add_edge(:nc, :bomb)
+        |> Graph.add_edge(:bomb, :__end__)
+        |> Graph.compile(failure_policy: :compensate)
+
+      assert {:error, :boom, final} = Compiled.invoke(compiled, %{})
+      assert final.nc_ran == true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes the \`:compensate\` half of the ADR-0015 failure-policy note.
Saga-style undo: on terminal error, the runtime walks executed nodes
in reverse and runs each one's compensation function. State threads
through compensations so earlier ones see the results of later ones.

### API additions

- \`FunctionNode\` gains an optional \`:compensate_fun\` field.
- \`Node.function/3\` and \`Graph.add_node/4\` accept
  \`(id, do_fun, compensate_fun)\`.
- The \`Node\` behaviour's \`compensate/2\` callback now returns
  \`{:ok, state} | {:error, reason}\` (was \`:ok | {:error, _}\`) so
  state restoration works across the saga chain. The callback was
  declared but unused, so this is not a breaking change for any
  consumer.

### Runtime mechanics

- Process-dictionary list of executed node descriptors, cleared in
  the \`invoke\` try/after block (same pattern as \`Scratchpad\`).
- \`maybe_compensate_on_error\` between \`start_or_resume\` and
  \`wrap_outcome\`; reverses the executed list and threads state
  through \`do_compensate\` per node.
- New telemetry event \`[:raxol, :workflow, :node, :compensated]\`
  with \`{result: :ok | {:error, reason}}\` per compensation.
- Rescued exceptions inside \`compensate\` are surfaced as
  \`{:error, {:exception, message}}\` via telemetry; the original run
  failure reason still wins.

### Not yet covered

- \`TypedNode\` compensation defaults to a \`{:ok, state}\` no-op. Will
  need a protocol extension when a consumer needs it.

## Test plan

- [x] +9 compensate tests covering reverse-order execution, state
      threading, no-compensate skipping, success path no-op,
      \`:halt\` default no-op, compensate-error telemetry, raised
      exception in compensate, BehaviourNode with + without
      \`compensate/2\`.
- [x] Workflow suite: 8 properties + 124 tests, 0 failures
- [x] \`mix credo --strict\` clean
- [x] \`mix format --check-formatted\` clean