### PR TITLE
Phase 25 polish: docs + saga/retry demos

### DIFF
--- a/examples/workflow/retry_demo.exs
+++ b/examples/workflow/retry_demo.exs
@@ -1,0 +1,62 @@
+# Retry Demo: failure_policy :retry
+#
+# Models a flaky external call that fails the first two attempts and
+# succeeds on the third. Under failure_policy: :retry the runtime
+# retries with exponential backoff before giving up.
+#
+# What you'll learn:
+#   - failure_policy: :retry + max_attempts + retry_backoff_ms
+#   - Per-attempt telemetry: each attempt emits its own node.started +
+#     node.failed (or node.completed on the final success)
+#   - The exponential backoff schedule (base * 2^(attempt - 1))
+#
+# Run: mix run examples/workflow/retry_demo.exs
+
+alias Raxol.Workflow.Compiled
+alias Raxol.Workflow.Graph
+
+IO.puts("Retry demo: flaky API call, fails 2x then succeeds\n")
+
+:ets.new(:retry_demo_counter, [:public, :named_table, :set])
+:ets.insert(:retry_demo_counter, {:n, 0})
+
+:telemetry.attach(
+  "retry-demo-tap",
+  [:raxol, :workflow, :node, :failed],
+  fn _event, _m, metadata, _ ->
+    IO.puts("  attempt failed: #{inspect(metadata.reason)}")
+  end,
+  nil
+)
+
+{:ok, compiled} =
+  Graph.new(:retry_demo)
+  |> Graph.add_node(:flaky_api, fn state ->
+    n = :ets.update_counter(:retry_demo_counter, :n, 1)
+    IO.puts("  calling api (attempt #{n})")
+
+    if n <= 2 do
+      {:error, {:transient, n}}
+    else
+      {:ok, Map.put(state, :api_response, "ok after #{n} attempts")}
+    end
+  end)
+  |> Graph.add_edge(:__start__, :flaky_api)
+  |> Graph.add_edge(:flaky_api, :__end__)
+  |> Graph.compile(
+    failure_policy: :retry,
+    max_attempts: 5,
+    retry_backoff_ms: 50
+  )
+
+case Compiled.invoke(compiled, %{}) do
+  {:ok, final_state, meta} ->
+    IO.puts("\nrun succeeded after #{meta.nodes_executed} node(s)")
+    IO.puts("final state: #{inspect(final_state)}")
+
+  {:error, reason, _} ->
+    IO.puts("\nrun failed: #{inspect(reason)}")
+end
+
+:telemetry.detach("retry-demo-tap")
+:ets.delete(:retry_demo_counter)

--- a/examples/workflow/saga_demo.exs
+++ b/examples/workflow/saga_demo.exs
@@ -1,0 +1,72 @@
+# Saga Demo: failure_policy :compensate
+#
+# Models a 3-step order fulfillment that fails at the shipping step.
+# When :ship fails, the runtime walks back through the executed nodes
+# in reverse and runs each one's compensation function, threading
+# state through so the final result reflects a clean rollback.
+#
+# What you'll learn:
+#   - Graph.add_node/4 with (id, do_fun, compensate_fun)
+#   - failure_policy: :compensate via Graph.compile/2
+#   - State threading through reverse-order compensations
+#   - Telemetry: [:raxol, :workflow, :node, :compensated] events
+#
+# Run: mix run examples/workflow/saga_demo.exs
+
+alias Raxol.Workflow.Compiled
+alias Raxol.Workflow.Graph
+
+IO.puts("Saga demo: order with reserve -> charge -> ship, failing at :ship\n")
+
+# Attach a telemetry handler to print each compensation as it runs.
+:telemetry.attach(
+  "saga-demo-tap",
+  [:raxol, :workflow, :node, :compensated],
+  fn _event, _measurements, metadata, _ ->
+    IO.puts(
+      "  compensated #{inspect(metadata.node_id)} -> #{inspect(metadata.result)}"
+    )
+  end,
+  nil
+)
+
+{:ok, compiled} =
+  Graph.new(:order_saga)
+  |> Graph.add_node(
+    :reserve_inventory,
+    fn state ->
+      IO.puts("  reserving inventory")
+      {:ok, Map.put(state, :reserved, true)}
+    end,
+    fn state ->
+      IO.puts("  releasing reserved inventory")
+      {:ok, Map.put(state, :reserved, false)}
+    end
+  )
+  |> Graph.add_node(
+    :charge_payment,
+    fn state ->
+      IO.puts("  charging payment $#{state.amount}")
+      {:ok, Map.put(state, :charged, true)}
+    end,
+    fn state ->
+      IO.puts("  refunding payment $#{state.amount}")
+      {:ok, Map.put(state, :charged, false)}
+    end
+  )
+  |> Graph.add_node(:ship_order, fn _ ->
+    IO.puts("  attempting to ship - carrier unavailable")
+    {:error, :carrier_unavailable}
+  end)
+  |> Graph.add_edge(:__start__, :reserve_inventory)
+  |> Graph.add_edge(:reserve_inventory, :charge_payment)
+  |> Graph.add_edge(:charge_payment, :ship_order)
+  |> Graph.add_edge(:ship_order, :__end__)
+  |> Graph.compile(failure_policy: :compensate)
+
+{:error, reason, final_state} = Compiled.invoke(compiled, %{amount: 42})
+
+IO.puts("\nrun failed with reason: #{inspect(reason)}")
+IO.puts("final state: #{inspect(final_state)}")
+
+:telemetry.detach("saga-demo-tap")

--- a/lib/raxol/workflow/compiled.ex
+++ b/lib/raxol/workflow/compiled.ex
@@ -9,10 +9,14 @@ defmodule Raxol.Workflow.Compiled do
 
   ## Runtime entry points
 
-    * `invoke/3` -- synchronous execution. Ships in this PR.
-    * `async_invoke/3` -- spawn a run under a DynamicSupervisor. Follow-up PR.
-    * `stream_events/3` -- lazy CloudEvent stream of run progress. Follow-up PR.
-    * `resume/3` -- consume an interrupt, continue from the checkpointed step. Follow-up PR.
+    * `invoke/3` -- synchronous execution.
+    * `async_invoke/3` -- spawn a run in a separate process and return
+      a `{:ok, %{run_id, pid, ref}}` handle.
+    * `stream_events/3` -- lazy `CloudEvent` stream of run progress.
+    * `resume/4` -- consume an interrupt, continue from the
+      checkpointed step.
+    * `async_resume/4` -- async variant of `resume/4`.
+    * `resume_events/4` -- streaming variant of `resume/4`.
   """
 
   @type opts :: %{

--- a/lib/raxol/workflow/graph.ex
+++ b/lib/raxol/workflow/graph.ex
@@ -139,7 +139,8 @@ defmodule Raxol.Workflow.Graph do
     * `:run_timeout_ms` -- total run timeout (default `3_600_000`)
     * `:saver` -- `Raxol.Workflow.Checkpoint.Saver` module (defaults to `Ets`)
 
-  These options are stored on `Compiled` and consumed by the runtime.
+  These options are stored on `Compiled` and consumed by
+  `Raxol.Workflow.Runtime`.
   """
   @spec compile(t(), keyword()) ::
           {:ok, Compiled.t()}

--- a/lib/raxol/workflow/node.ex
+++ b/lib/raxol/workflow/node.ex
@@ -19,8 +19,8 @@ defmodule Raxol.Workflow.Node do
     * `{:interrupt, value}` -- pause the run for human-in-the-loop resume
     * `{:error, reason}` -- fail (handled by the workflow's failure policy)
 
-  The runtime is added in a follow-up PR; this module only defines the
-  descriptor shapes and behaviour so the `Graph` builder can carry them.
+  FunctionNodes also accept an optional 1-arity compensation function
+  that runs in reverse order under `failure_policy: :compensate`.
   """
 
   @type id :: atom() | binary()
@@ -157,9 +157,6 @@ defprotocol Raxol.Workflow.Node.Executor do
   implementing this protocol. Mirrors the
   `Raxol.Core.Runtime.Directive.Executor` shape: same callback name,
   same result tuple, same telemetry surface.
-
-  The runtime is added in a follow-up PR; this protocol is declared
-  now so the `Graph` builder can carry typed-node references.
   """
 
   @spec execute(t(), state :: any(), opts :: keyword()) ::

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -1,19 +1,33 @@
 defmodule Raxol.Workflow.Runtime do
   @moduledoc """
-  Synchronous execution runtime for `Raxol.Workflow.Compiled` graphs.
+  Execution runtime for `Raxol.Workflow.Compiled` graphs.
 
-  Implements the synchronous `invoke/3` path described in ADR-0015.
-  Walks the graph from `:__start__` to `:__end__`, executes each node
-  according to its descriptor type, dispatches any returned directives
-  through `Raxol.Core.Runtime.Directive.Executor`, and emits per-node
-  telemetry with full Phase 24 trace context (trace_id, span_id,
-  parent_span_id, causation_id) propagated through `TraceContext`.
+  Implements the synchronous `invoke/3` and `resume/4` paths described
+  in ADR-0015. Walks the graph from `:__start__` to `:__end__`,
+  executes each node according to its descriptor type, dispatches any
+  returned directives through `Raxol.Core.Runtime.Directive.Executor`,
+  and emits per-node telemetry with full Phase 24 trace context
+  (trace_id, span_id, parent_span_id, causation_id) propagated through
+  `TraceContext`.
 
-  Async invocation (`async_invoke`, `stream_events`), checkpoint
-  persistence, interrupt/resume, joins, and channel reducers land in
-  follow-up PRs. This module only implements the synchronous,
-  no-checkpoint path; the runtime catches `:interrupt` results and
-  returns them to the caller without persisting state.
+  ## Capabilities
+
+    * Per-attempt span + telemetry, with retry under
+      `failure_policy: :retry` (configurable `max_attempts` and
+      `retry_backoff_ms`).
+    * Saga-style compensation under `failure_policy: :compensate`,
+      walking executed nodes in reverse and emitting `node.compensated`
+      events.
+    * Optional `Checkpoint.Saver`-backed durability. Fresh runs
+      pre-checkpoint the initial state at step 0 so resumes work even
+      when the very first node interrupts.
+    * Human-in-the-loop pauses via `Workflow.interrupt/1` and
+      `Compiled.resume/4`.
+
+  Async wrappers (`async_invoke`, `stream_events`, `async_resume`,
+  `resume_events`) live in `Raxol.Workflow.Async`. Joins
+  (`add_join/4`) and channel reducers (`add_channel/4`) are still
+  follow-ups: the runtime is single-branch sequential today.
   """
 
   alias Raxol.Core.Runtime.Directive


### PR DESCRIPTION
## Summary

Cleanup PR after the Phase 25 follow-up wave (#290 -> #294).

### Docs

\`Raxol.Workflow.Runtime\`, \`.Compiled\`, \`.Node\`, and \`.Graph\`
moduledocs all still said "follow-up PR" for capabilities that have
since landed (async, resume, retry, compensate, checkpoints). Updated
to describe what the runtime actually does today, with one accurate
note about the still-deferred joins/channels.

### Examples

New \`examples/workflow/\` directory with two self-contained, runnable
demos:

- \`saga_demo.exs\` -- 3-step order fulfillment (reserve -> charge ->
  ship) that fails at shipping, then walks back through compensations
  in reverse with state threading. Telemetry tap prints each
  compensation as it runs.
- \`retry_demo.exs\` -- flaky API call that fails twice and succeeds
  on attempt 3 under \`failure_policy: :retry\` with
  \`max_attempts: 5, retry_backoff_ms: 50\`. Telemetry tap prints
  each failed attempt.

Both run via \`mix run examples/workflow/<demo>.exs\`.

## Test plan

- [x] Workflow suite: 8 properties + 124 tests, 0 failures (no test
      changes; this PR is docs + examples only)
- [x] Manually ran both demos, output matches the documented behavior
- [x] \`mix format --check-formatted\` clean