### PR TITLE
ADR-0016 Phase A: Workflow module + Job.Server :via_workflow path

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/job/server.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/server.ex
@@ -34,12 +34,35 @@ defmodule Raxol.ACP.Job.Server do
   Emits `[:raxol, :acp, :job, :transition]` on every successful
   transition with metadata
   `%{job_id, from, to, memo_type, tx_hash}`.
+
+  ## Workflow-backed mode (ADR-0016 Phase A)
+
+  Pass `via_workflow: true` (or set
+  `Application.put_env(:raxol_acp, :job_via_workflow, true)`) to route
+  transitions through `Raxol.ACP.Job.Workflow` instead of the inline
+  state machine. The public API is unchanged; internally the
+  Phase 25 `Raxol.Workflow` runtime drives each transition, writes a
+  checkpoint to the configured Saver after every memo, and emits
+  per-node telemetry on `[:raxol, :workflow, :*]` in addition to the
+  legacy `[:raxol, :acp, :job, :transition]` event. On a transient
+  restart the new process hydrates from the Saver's latest
+  checkpoint, matching the existing Store-hydration behavior.
+
+  Saver selection:
+
+      Application.put_env(:raxol_acp, :job_workflow_saver,
+        {Raxol.Workflow.Checkpoint.Saver.Dets, %{name: MyDets}})
+
+  Defaults to `Saver.Ets` with a shared named table when no override
+  is configured.
   """
 
   use Raxol.Core.Behaviours.BaseManager
 
   alias Raxol.ACP.ContractClient
   alias Raxol.ACP.Job.{MemoType, Registry, StateMachine, Store}
+  alias Raxol.ACP.Job.Workflow, as: JobWorkflow
+  alias Raxol.Workflow.Compiled, as: WorkflowCompiled
 
   @type memo :: %{
           next_phase: StateMachine.state(),
@@ -64,10 +87,20 @@ defmodule Raxol.ACP.Job.Server do
           state: StateMachine.state(),
           memos: [memo()],
           config: config(),
-          persist?: boolean()
+          persist?: boolean(),
+          via_workflow?: boolean(),
+          compiled: WorkflowCompiled.t() | nil
         }
 
-  defstruct [:job_id, :state, memos: [], config: %{}, persist?: true]
+  defstruct [
+    :job_id,
+    :state,
+    :compiled,
+    memos: [],
+    config: %{},
+    persist?: true,
+    via_workflow?: false
+  ]
 
   # -- Public API --
 
@@ -112,7 +145,12 @@ defmodule Raxol.ACP.Job.Server do
   payload and signature. Low-level entry point used by both
   orchestration helpers and tests that want to bypass the handler.
   """
-  @spec transition(GenServer.server() | binary(), StateMachine.event(), map(), binary()) ::
+  @spec transition(
+          GenServer.server() | binary(),
+          StateMachine.event(),
+          map(),
+          binary()
+        ) ::
           {:ok, StateMachine.state()} | {:error, term()}
   def transition(server, event, payload, signature) do
     GenServer.call(resolve(server), {:transition, event, payload, signature})
@@ -196,7 +234,21 @@ defmodule Raxol.ACP.Job.Server do
     job_id = Keyword.fetch!(opts, :job_id)
     persist? = Keyword.get(opts, :persist?, true)
     initial = Keyword.get(opts, :initial_state, StateMachine.initial())
-    {state, memos} = hydrate(job_id, persist?, initial)
+
+    via_workflow? =
+      Keyword.get(
+        opts,
+        :via_workflow,
+        Application.get_env(:raxol_acp, :job_via_workflow, false)
+      )
+
+    {state, memos, compiled} =
+      if via_workflow? do
+        hydrate_via_workflow(job_id, persist?, initial)
+      else
+        {s, ms} = hydrate(job_id, persist?, initial)
+        {s, ms, nil}
+      end
 
     {:ok,
      %__MODULE__{
@@ -204,9 +256,59 @@ defmodule Raxol.ACP.Job.Server do
        state: state,
        memos: memos,
        config: config,
-       persist?: persist?
+       persist?: persist?,
+       via_workflow?: via_workflow?,
+       compiled: compiled
      }}
   end
+
+  # Workflow-backed hydration. Compiles the canonical ACP graph and
+  # either resumes from a prior checkpoint or invokes the workflow
+  # fresh to create the initial __start__ checkpoint. State is read
+  # back from the workflow runtime so it stays the single source of
+  # truth while the legacy Store is kept in sync via mirror writes
+  # for backward compatibility.
+  defp hydrate_via_workflow(job_id, persist?, _initial) do
+    saver = if persist?, do: configured_workflow_saver(), else: nil
+    {:ok, compiled} = JobWorkflow.compile(maybe_saver_opts(saver))
+
+    workflow_state = ensure_workflow_run(compiled, saver, job_id)
+    {workflow_state.current_state, workflow_state.memos, compiled}
+  end
+
+  defp ensure_workflow_run(compiled, saver, job_id) do
+    case load_workflow_state(saver, job_id) do
+      {:ok, state} ->
+        state
+
+      :not_found ->
+        initial_state = JobWorkflow.initial_state(job_id)
+
+        case WorkflowCompiled.invoke(compiled, initial_state, run_id: job_id) do
+          {:interrupted, _run_id, state, _value} -> state
+        end
+    end
+  end
+
+  defp load_workflow_state(nil, _job_id), do: :not_found
+
+  defp load_workflow_state({mod, cfg}, job_id) do
+    case mod.get_latest(cfg, job_id) do
+      {:ok, ckpt} -> {:ok, ckpt.state}
+      {:error, :not_found} -> :not_found
+    end
+  end
+
+  defp configured_workflow_saver do
+    Application.get_env(
+      :raxol_acp,
+      :job_workflow_saver,
+      {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: :raxol_acp_job_workflow}}
+    )
+  end
+
+  defp maybe_saver_opts(nil), do: []
+  defp maybe_saver_opts(saver), do: [saver: saver]
 
   # Restore prior state + memos from the Store on a transient restart.
   # If persistence is disabled or no record exists, fall back to the
@@ -221,12 +323,17 @@ defmodule Raxol.ACP.Job.Server do
   defp hydrate(_job_id, false, initial), do: {initial, []}
 
   @impl Raxol.Core.Behaviours.BaseManager
-  def handle_manager_call({:transition, event, payload, signature}, _from, state) do
+  def handle_manager_call(
+        {:transition, event, payload, signature},
+        _from,
+        state
+      ) do
     do_transition(state, event, payload, signature)
   end
 
   def handle_manager_call(:accept_request, _from, state) do
-    with {:ok, %{handler: handler, request: request}} <- need(state.config, [:handler, :request]) do
+    with {:ok, %{handler: handler, request: request}} <-
+           need(state.config, [:handler, :request]) do
       case handler.handle_request(request, ctx(state)) do
         {:accept, response} ->
           do_transition(state, :accept_request, response, nil)
@@ -244,7 +351,8 @@ defmodule Raxol.ACP.Job.Server do
   end
 
   def handle_manager_call(:deliver, _from, state) do
-    with {:ok, %{handler: handler, request: request}} <- need(state.config, [:handler, :request]) do
+    with {:ok, %{handler: handler, request: request}} <-
+           need(state.config, [:handler, :request]) do
       case handler.handle_deliver(request, ctx(state)) do
         {:deliver, deliverable} ->
           do_transition(state, :deliver, deliverable, nil)
@@ -262,18 +370,101 @@ defmodule Raxol.ACP.Job.Server do
   end
 
   def handle_manager_call(:get_state, _from, state), do: {:reply, state, state}
-  def handle_manager_call(:current_state, _from, state), do: {:reply, state.state, state}
-  def handle_manager_call(:memos, _from, state), do: {:reply, state.memos, state}
+
+  def handle_manager_call(:current_state, _from, state),
+    do: {:reply, state.state, state}
+
+  def handle_manager_call(:memos, _from, state),
+    do: {:reply, state.memos, state}
 
   # -- Private --
 
   defp do_transition(state, event, payload, signature) do
+    if state.via_workflow? do
+      do_transition_via_workflow(state, event, payload, signature)
+    else
+      do_transition_legacy(state, event, payload, signature)
+    end
+  end
+
+  # Workflow-backed transition path. The state-machine guard mirrors
+  # the legacy one so callers see the same `{:error, {:invalid_transition, _, _}}`
+  # shape for events that the current phase does not accept. Successful
+  # transitions delegate to `Compiled.resume/4`; on terminal phase, the
+  # workflow returns `{:ok, _, _}` and the GenServer stops with `:normal`.
+  defp do_transition_via_workflow(state, event, payload, signature) do
+    case StateMachine.next(state.state, event) do
+      {:ok, _next_state} ->
+        dispatch_workflow_resume(state, event, payload, signature)
+
+      {:error, _} = err ->
+        {:reply, err, state}
+    end
+  end
+
+  defp dispatch_workflow_resume(state, event, payload, signature) do
+    case WorkflowCompiled.resume(
+           state.compiled,
+           state.job_id,
+           {event, payload, signature}
+         ) do
+      {:interrupted, _run_id, new_wf_state, _value} ->
+        finalize_workflow_transition(state, new_wf_state, terminal?: false)
+
+      {:ok, new_wf_state, _meta} ->
+        finalize_workflow_transition(state, new_wf_state, terminal?: true)
+
+      {:error, reason, _wf_state} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  defp finalize_workflow_transition(state, new_wf_state, terminal?: terminal?) do
+    new_memo = List.last(new_wf_state.memos)
+
+    new_full_state = %{
+      state
+      | state: new_wf_state.current_state,
+        memos: new_wf_state.memos
+    }
+
+    if state.persist? and new_memo do
+      Store.append_memo(state.job_id, new_wf_state.current_state, new_memo)
+    end
+
+    :telemetry.execute(
+      [:raxol, :acp, :job, :transition],
+      %{},
+      %{
+        job_id: state.job_id,
+        from: state.state,
+        to: new_wf_state.current_state,
+        memo_type: new_memo && new_memo.memo_type,
+        next_phase: new_wf_state.current_state,
+        tx_hash: new_memo && new_memo.tx_hash
+      }
+    )
+
+    if terminal? do
+      {:stop, :normal, {:ok, new_wf_state.current_state}, new_full_state}
+    else
+      {:reply, {:ok, new_wf_state.current_state}, new_full_state}
+    end
+  end
+
+  defp do_transition_legacy(state, event, payload, signature) do
     memo_type = memo_type_for_event(event)
     content = encode_content(payload)
 
     with {:ok, new_state} <- StateMachine.next(state.state, event),
          {:ok, tx_hash} <-
-           ContractClient.create_memo(state.job_id, content, memo_type, false, new_state) do
+           ContractClient.create_memo(
+             state.job_id,
+             content,
+             memo_type,
+             false,
+             new_state
+           ) do
       memo = %{
         next_phase: new_state,
         memo_type: memo_type,

--- a/packages/raxol_acp/lib/raxol/acp/job/workflow.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/workflow.ex
@@ -1,0 +1,324 @@
+defmodule Raxol.ACP.Job.Workflow do
+  @moduledoc """
+  Phase 25 `Raxol.Workflow` graph mirroring `Raxol.ACP.Job.StateMachine`.
+
+  Phase A of the ADR-0016 migration: this module compiles a graph
+  that has the same state-machine shape as the current `Job.Server`
+  implementation. Each transition fires exactly one
+  `ContractClient.create_memo` call, the workflow checkpoints after
+  every memo write, and waiting phases interrupt to wait for the
+  next inbound event.
+
+  ## Topology
+
+      :__start__ -> :wait_request
+        :wait_request -[event]-> :memo_negotiation | :memo_rejected | :memo_expired
+          :memo_negotiation -> :wait_negotiation
+            :wait_negotiation -[event]-> :memo_transaction | :memo_expired
+              :memo_transaction -> :wait_transaction
+                :wait_transaction -[event]-> :memo_evaluation | :memo_expired
+                  :memo_evaluation -> :wait_evaluation
+                    :wait_evaluation -[event]-> :memo_completed | :memo_expired
+                      :memo_completed -> :__end__
+        :memo_rejected -> :__end__
+        :memo_expired -> :__end__
+
+  ## Why two kinds of nodes
+
+  Each non-terminal phase splits into two nodes:
+
+    * `:wait_*` -- pure interrupt; no side effects. On first invocation
+      it throws to pause the run; on resume it pops the event tuple
+      from the scratchpad and writes it into state.
+    * `:memo_*` -- side-effecting call to
+      `Raxol.ACP.ContractClient.create_memo/5`. No interrupt. Eligible
+      for `failure_policy: :retry` because re-running it does not
+      re-pop the scratchpad.
+
+  Combining them in one node would break retry: the workflow's
+  retry loop re-runs the whole node body, and `Workflow.interrupt/1`
+  cannot be re-popped on retry (the scratchpad value was consumed by
+  the first attempt). The split keeps memo writes retryable and
+  interrupts side-effect-free.
+
+  ## State shape
+
+  The workflow threads a single state map through every node:
+
+      %{
+        job_id: ContractClient.job_id(),
+        memos: [Raxol.ACP.Job.Server.memo()],
+        pending_event: atom() | nil,
+        pending_payload: any() | nil,
+        pending_signature: binary() | nil,
+        current_state: Raxol.ACP.Job.StateMachine.state(),
+        next_state: Raxol.ACP.Job.StateMachine.state() | nil
+      }
+
+  `pending_*` is written by a `:wait_*` node when it pops the event
+  from the scratchpad; the following `:memo_*` node reads those
+  fields, fires the on-chain call, appends to `memos`, and clears
+  `pending_*`. `current_state` advances after each successful memo
+  write; `next_state` is the routing target the conditional edges
+  read.
+
+  ## Resume semantics
+
+  `Compiled.resume/4` looks up the latest checkpoint, hydrates the
+  state, and resumes from the node after the checkpoint's node. For
+  this workflow that means: the last successful `:memo_*` node wrote
+  a checkpoint, the runtime resumes by traversing into the next
+  `:wait_*` node, the wait node pops the scratchpad value (the new
+  event) and the run continues. Phase A's `Job.Server` facade calls
+  resume with the event tuple as the resume value.
+
+  ## Out of scope for this module
+
+  - Wiring this graph into `Raxol.ACP.Job.Server` (Phase A PR 2).
+  - Per-phase interrupt reasons in the seller protocol (Phase B).
+  - `TypedNode` per phase (a polish refactor after Phase A stabilises).
+  """
+
+  alias Raxol.ACP.ContractClient
+  alias Raxol.ACP.Job.StateMachine
+  alias Raxol.Workflow
+  alias Raxol.Workflow.Compiled
+  alias Raxol.Workflow.Graph
+
+  @type event :: :accept_request | :accept_payment | :deliver | :approve | :reject | :expire
+  @type resume_value :: {event(), payload :: any(), signature :: binary() | nil}
+
+  @type state :: %{
+          job_id: ContractClient.job_id(),
+          memos: [map()],
+          pending_event: event() | nil,
+          pending_payload: any() | nil,
+          pending_signature: binary() | nil,
+          current_state: StateMachine.state(),
+          next_state: StateMachine.state() | nil
+        }
+
+  @default_max_attempts 3
+  @default_retry_backoff_ms 200
+
+  @doc """
+  Compile the canonical ACP Job workflow.
+
+  ## Options
+
+    * `:saver` -- forwarded to `Raxol.Workflow.Graph.compile/2`.
+      Defaults to `nil` (volatile; no resume support). Production
+      usage should pass `{Raxol.Workflow.Checkpoint.Saver.Dets, %{...}}`
+      or `{Saver.Postgrex, %{conn: ..., table: ...}}`.
+    * `:max_attempts` / `:retry_backoff_ms` -- forwarded to the
+      retry policy. Defaults `3` and `200ms`.
+
+  Returns the compiled graph or a structured error from
+  `Raxol.Workflow.Graph.compile/2`.
+  """
+  @spec compile(keyword()) :: {:ok, Compiled.t()} | {:error, term()}
+  def compile(opts \\ []) do
+    Graph.new(:acp_job)
+    |> add_phase_nodes()
+    |> add_phase_edges()
+    |> Graph.compile(compile_opts(opts))
+  end
+
+  defp add_phase_nodes(graph) do
+    graph
+    |> Graph.add_node(:wait_request, &wait_request/1)
+    |> Graph.add_node(:wait_negotiation, &wait_negotiation/1)
+    |> Graph.add_node(:wait_transaction, &wait_transaction/1)
+    |> Graph.add_node(:wait_evaluation, &wait_evaluation/1)
+    |> Graph.add_node(:memo_negotiation, memo_node(:negotiation))
+    |> Graph.add_node(:memo_transaction, memo_node(:transaction))
+    |> Graph.add_node(:memo_evaluation, memo_node(:evaluation))
+    |> Graph.add_node(:memo_completed, memo_node(:completed))
+    |> Graph.add_node(:memo_rejected, memo_node(:rejected))
+    |> Graph.add_node(:memo_expired, memo_node(:expired))
+  end
+
+  defp add_phase_edges(graph) do
+    graph
+    |> Graph.add_edge(:__start__, :wait_request)
+    |> Graph.add_conditional_edge(
+      :wait_request,
+      [:memo_negotiation, :memo_rejected, :memo_expired],
+      &route_from_request/1
+    )
+    |> Graph.add_edge(:memo_negotiation, :wait_negotiation)
+    |> Graph.add_conditional_edge(
+      :wait_negotiation,
+      [:memo_transaction, :memo_expired],
+      &route_from_negotiation/1
+    )
+    |> Graph.add_edge(:memo_transaction, :wait_transaction)
+    |> Graph.add_conditional_edge(
+      :wait_transaction,
+      [:memo_evaluation, :memo_expired],
+      &route_from_transaction/1
+    )
+    |> Graph.add_edge(:memo_evaluation, :wait_evaluation)
+    |> Graph.add_conditional_edge(
+      :wait_evaluation,
+      [:memo_completed, :memo_expired],
+      &route_from_evaluation/1
+    )
+    |> Graph.add_edge(:memo_completed, :__end__)
+    |> Graph.add_edge(:memo_rejected, :__end__)
+    |> Graph.add_edge(:memo_expired, :__end__)
+  end
+
+  defp compile_opts(opts) do
+    [
+      failure_policy: :retry,
+      max_attempts: Keyword.get(opts, :max_attempts, @default_max_attempts),
+      retry_backoff_ms: Keyword.get(opts, :retry_backoff_ms, @default_retry_backoff_ms)
+    ]
+    |> maybe_put_saver(opts)
+  end
+
+  @doc """
+  Build the initial state for a fresh job invocation.
+  """
+  @spec initial_state(ContractClient.job_id()) :: state()
+  def initial_state(job_id) do
+    %{
+      job_id: job_id,
+      memos: [],
+      pending_event: nil,
+      pending_payload: nil,
+      pending_signature: nil,
+      current_state: StateMachine.initial(),
+      next_state: nil
+    }
+  end
+
+  # --- Wait node bodies ---
+  #
+  # Each wait node simply interrupts to pause for the next event,
+  # then on resume pops the event tuple from the scratchpad and
+  # writes it to `pending_*`. The following conditional edge reads
+  # those fields to pick the destination `:memo_*` node.
+
+  defp wait_request(state), do: pop_event(state, :awaiting_request_response)
+  defp wait_negotiation(state), do: pop_event(state, :awaiting_payment)
+  defp wait_transaction(state), do: pop_event(state, :awaiting_delivery)
+  defp wait_evaluation(state), do: pop_event(state, :awaiting_approval)
+
+  # The wait node always returns `{:ok, _}` so that the workflow's
+  # `failure_policy: :retry` does not re-enter `Workflow.interrupt/1`
+  # on a node whose scratchpad value has already been popped. Event
+  # validation lives at the edge: unknown events route to
+  # `:memo_expired` so the run terminates cleanly rather than
+  # cycling. Callers (`Job.Server` facade in Phase A PR 2) are
+  # responsible for sending valid events.
+  defp pop_event(state, reason) do
+    {event, payload, signature} =
+      case Workflow.interrupt(reason) do
+        {e, p, s} -> {e, p, s}
+        other -> {{:bad_resume_value, other}, nil, nil}
+      end
+
+    {:ok,
+     %{
+       state
+       | pending_event: event,
+         pending_payload: payload,
+         pending_signature: signature
+     }}
+  end
+
+  # --- Conditional-edge choosers ---
+
+  defp route_from_request(%{pending_event: :accept_request}), do: :memo_negotiation
+  defp route_from_request(%{pending_event: :reject}), do: :memo_rejected
+  defp route_from_request(_), do: :memo_expired
+
+  defp route_from_negotiation(%{pending_event: :accept_payment}),
+    do: :memo_transaction
+
+  defp route_from_negotiation(_), do: :memo_expired
+
+  defp route_from_transaction(%{pending_event: :deliver}), do: :memo_evaluation
+  defp route_from_transaction(_), do: :memo_expired
+
+  defp route_from_evaluation(%{pending_event: :approve}), do: :memo_completed
+  defp route_from_evaluation(_), do: :memo_expired
+
+  # --- Memo node bodies ---
+  #
+  # A memo node fires one `ContractClient.create_memo` for the
+  # phase it is named after, appends a memo record to state, advances
+  # `current_state`, and clears the pending fields. No interrupts;
+  # this node is retry-safe.
+
+  defp memo_node(next_phase) do
+    fn state -> write_memo(state, next_phase) end
+  end
+
+  defp write_memo(state, next_phase) do
+    event = state.pending_event
+    payload = state.pending_payload
+    signature = state.pending_signature
+    memo_type = memo_type_for_event(event)
+    content = encode_content(payload)
+
+    case ContractClient.create_memo(
+           state.job_id,
+           content,
+           memo_type,
+           false,
+           next_phase
+         ) do
+      {:ok, tx_hash} ->
+        memo = %{
+          next_phase: next_phase,
+          memo_type: memo_type,
+          content: content,
+          is_secured: false,
+          payload: ensure_payload(payload),
+          signature: signature,
+          tx_hash: tx_hash,
+          transitioned_at: DateTime.utc_now()
+        }
+
+        # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+        new_memos = state.memos ++ [memo]
+
+        {:ok,
+         %{
+           state
+           | memos: new_memos,
+             current_state: next_phase,
+             next_state: nil,
+             pending_event: nil,
+             pending_payload: nil,
+             pending_signature: nil
+         }}
+
+      {:error, _reason} = err ->
+        err
+    end
+  end
+
+  # --- Helpers (mirror Job.Server private fns) ---
+
+  defp memo_type_for_event(:accept_payment), do: :txhash
+  defp memo_type_for_event(:approve), do: :txhash
+  defp memo_type_for_event(_), do: :message
+
+  defp encode_content(nil), do: ""
+  defp encode_content(payload) when is_binary(payload), do: payload
+  defp encode_content(payload) when is_map(payload), do: Jason.encode!(payload)
+
+  defp ensure_payload(payload) when is_map(payload), do: payload
+  defp ensure_payload(_), do: nil
+
+  defp maybe_put_saver(opts, caller_opts) do
+    case Keyword.get(caller_opts, :saver) do
+      nil -> opts
+      saver -> Keyword.put(opts, :saver, saver)
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job/server_workflow_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job/server_workflow_test.exs
@@ -1,0 +1,239 @@
+defmodule Raxol.ACP.Job.ServerWorkflowTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.ContractClient
+  alias Raxol.ACP.ContractClient.InMemory
+  alias Raxol.ACP.Job
+
+  @seller "0x" <> String.duplicate("ab", 20)
+  @sig "0x" <> String.duplicate("ff", 65)
+
+  setup do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(Job.Supervisor),
+        is_pid(pid) do
+      DynamicSupervisor.terminate_child(Job.Supervisor, pid)
+    end
+
+    InMemory.reset()
+    Job.Store.clear()
+    :ok
+  end
+
+  defp ets_saver do
+    table = :"acp_server_wf_#{:erlang.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+    end)
+
+    {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: table}}
+  end
+
+  defp start_workflow_job(opts \\ []) do
+    {:ok, job_id} = ContractClient.create_job(@seller, @seller, 9_999_999_999)
+
+    {:ok, _pid} =
+      Job.Supervisor.start_job(
+        Keyword.merge(
+          [
+            job_id: job_id,
+            via_workflow: true,
+            persist?: true
+          ],
+          opts
+        )
+      )
+
+    job_id
+  end
+
+  describe "Job.Server with :via_workflow true: parity with the legacy path" do
+    setup do
+      saver = ets_saver()
+      Application.put_env(:raxol_acp, :job_workflow_saver, saver)
+
+      on_exit(fn ->
+        Application.delete_env(:raxol_acp, :job_workflow_saver)
+      end)
+
+      {:ok, saver: saver}
+    end
+
+    test "happy path: request -> negotiation -> transaction -> evaluation -> completed" do
+      job_id = start_workflow_job()
+
+      assert {:ok, :negotiation} =
+               Job.Server.transition(job_id, :accept_request, %{step: 1}, @sig)
+
+      assert {:ok, :transaction} =
+               Job.Server.transition(job_id, :accept_payment, %{step: 2}, @sig)
+
+      assert {:ok, :evaluation} =
+               Job.Server.transition(job_id, :deliver, %{step: 3}, @sig)
+
+      assert {:ok, :completed} =
+               Job.Server.transition(job_id, :approve, %{step: 4}, @sig)
+    end
+
+    test "memo history mirrors the legacy path's record shape" do
+      job_id = start_workflow_job()
+
+      Job.Server.transition(job_id, :accept_request, %{step: 1}, @sig)
+      Job.Server.transition(job_id, :accept_payment, %{step: 2}, @sig)
+
+      memos = Job.Server.memos(job_id)
+      assert length(memos) == 2
+
+      [m1, m2] = memos
+      assert m1.next_phase == :negotiation
+      assert m1.payload == %{step: 1}
+      assert m1.signature == @sig
+      assert m1.memo_type == :message
+
+      assert m2.next_phase == :transaction
+      assert m2.payload == %{step: 2}
+      assert m2.memo_type == :txhash
+    end
+
+    test "invalid event for current phase returns the legacy error tuple" do
+      job_id = start_workflow_job()
+
+      assert {:error, {:invalid_transition, :request, :deliver}} =
+               Job.Server.transition(job_id, :deliver, %{}, @sig)
+    end
+
+    test "Store gets mirrored writes for backward compat" do
+      job_id = start_workflow_job()
+
+      Job.Server.transition(job_id, :accept_request, %{step: 1}, @sig)
+
+      assert {:ok, %{state: :negotiation, memos: [memo]}} =
+               Job.Store.load(job_id)
+
+      assert memo.next_phase == :negotiation
+      assert memo.payload == %{step: 1}
+    end
+
+    test "telemetry: [:raxol, :acp, :job, :transition] still fires" do
+      test_pid = self()
+      handler_id = "acp_wf_tel_#{:erlang.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :acp, :job, :transition],
+        fn _e, _m, metadata, _ -> send(test_pid, {:transition, metadata}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      job_id = start_workflow_job()
+      Job.Server.transition(job_id, :accept_request, %{}, @sig)
+
+      assert_receive {:transition,
+                      %{
+                        job_id: ^job_id,
+                        from: :request,
+                        to: :negotiation,
+                        next_phase: :negotiation
+                      }},
+                     500
+    end
+
+    test "terminal phase stops the server with :normal" do
+      job_id = start_workflow_job()
+      Job.Server.transition(job_id, :accept_request, %{}, @sig)
+      Job.Server.transition(job_id, :accept_payment, %{}, @sig)
+      Job.Server.transition(job_id, :deliver, %{}, @sig)
+
+      pid = Job.Registry.whereis(job_id)
+      ref = Process.monitor(pid)
+
+      assert {:ok, :completed} =
+               Job.Server.transition(job_id, :approve, %{}, @sig)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+    end
+
+    test "reject from :request lands at :rejected and stops the server" do
+      job_id = start_workflow_job()
+
+      pid = Job.Registry.whereis(job_id)
+      ref = Process.monitor(pid)
+
+      assert {:ok, :rejected} =
+               Job.Server.transition(job_id, :reject, %{reason: "no"}, @sig)
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+    end
+  end
+
+  describe "workflow-mode hydration on restart" do
+    setup do
+      saver = ets_saver()
+      # Pre-create the ETS table from this test process so it
+      # outlives the Job.Server we will kill below. Job.Server
+      # checkpoints stored here survive the :transient restart.
+      {Raxol.Workflow.Checkpoint.Saver.Ets, cfg} = saver
+      Raxol.Workflow.Checkpoint.Saver.Ets.ensure_table(cfg)
+
+      Application.put_env(:raxol_acp, :job_workflow_saver, saver)
+
+      on_exit(fn ->
+        Application.delete_env(:raxol_acp, :job_workflow_saver)
+      end)
+
+      {:ok, saver: saver}
+    end
+
+    test "a restarted server hydrates state and memos from the Workflow's Saver" do
+      job_id = start_workflow_job()
+
+      Job.Server.transition(job_id, :accept_request, %{step: 1}, @sig)
+      Job.Server.transition(job_id, :accept_payment, %{step: 2}, @sig)
+
+      pid = Job.Registry.whereis(job_id)
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}, 500
+
+      new_pid = wait_for_new_pid(job_id, pid)
+      assert new_pid != pid
+
+      assert Job.Server.current_state(job_id) == :transaction
+      memos = Job.Server.memos(job_id)
+      assert Enum.map(memos, & &1.next_phase) == [:negotiation, :transaction]
+
+      assert {:ok, :evaluation} =
+               Job.Server.transition(job_id, :deliver, %{step: 3}, @sig)
+    end
+  end
+
+  defp wait_for_new_pid(job_id, old_pid, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait(job_id, old_pid, deadline)
+  end
+
+  defp do_wait(job_id, old_pid, deadline) do
+    case Job.Registry.whereis(job_id) do
+      :undefined ->
+        if System.monotonic_time(:millisecond) < deadline do
+          Process.sleep(20)
+          do_wait(job_id, old_pid, deadline)
+        else
+          flunk("Job.Server never restarted")
+        end
+
+      ^old_pid ->
+        if System.monotonic_time(:millisecond) < deadline do
+          Process.sleep(20)
+          do_wait(job_id, old_pid, deadline)
+        else
+          flunk("Job.Server still pointing at old pid")
+        end
+
+      new_pid ->
+        new_pid
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job/workflow_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job/workflow_test.exs
@@ -1,0 +1,382 @@
+defmodule Raxol.ACP.Job.WorkflowTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.ContractClient
+  alias Raxol.ACP.ContractClient.InMemory
+  alias Raxol.ACP.Job.Workflow, as: JobWorkflow
+  alias Raxol.Workflow.Checkpoint.Saver.Ets
+  alias Raxol.Workflow.Compiled
+
+  @provider "0x" <> String.duplicate("ab", 20)
+  @evaluator "0x" <> String.duplicate("cd", 20)
+  @expired_at 9_999_999_999
+
+  setup do
+    InMemory.reset()
+    :ok
+  end
+
+  defp ets_saver do
+    table = :"acp_job_wf_#{:erlang.unique_integer([:positive])}"
+    on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table) end)
+    {Ets, %{table: table}}
+  end
+
+  defp new_job do
+    {:ok, job_id} = ContractClient.create_job(@provider, @evaluator, @expired_at)
+    job_id
+  end
+
+  defp compiled(opts \\ []) do
+    {:ok, compiled} = JobWorkflow.compile(opts)
+    compiled
+  end
+
+  describe "compile/1" do
+    test "produces a Compiled graph with the canonical node set" do
+      compiled = compiled()
+      node_ids = Map.keys(compiled.nodes) |> Enum.sort()
+
+      assert node_ids == [
+               :memo_completed,
+               :memo_evaluation,
+               :memo_expired,
+               :memo_negotiation,
+               :memo_rejected,
+               :memo_transaction,
+               :wait_evaluation,
+               :wait_negotiation,
+               :wait_request,
+               :wait_transaction
+             ]
+    end
+
+    test "configures the retry policy from defaults" do
+      compiled = compiled()
+      assert compiled.opts.failure_policy == :retry
+      assert compiled.opts.max_attempts == 3
+      assert compiled.opts.retry_backoff_ms == 200
+    end
+
+    test "max_attempts and retry_backoff_ms can be overridden" do
+      compiled = compiled(max_attempts: 5, retry_backoff_ms: 50)
+      assert compiled.opts.max_attempts == 5
+      assert compiled.opts.retry_backoff_ms == 50
+    end
+
+    test "saver is omitted by default and threaded through when provided" do
+      assert compiled().opts |> Map.has_key?(:saver) == false
+
+      saver = ets_saver()
+      assert compiled(saver: saver).opts.saver == saver
+    end
+  end
+
+  describe "initial_state/1" do
+    test "returns the expected map shape for a fresh job" do
+      job_id = new_job()
+      state = JobWorkflow.initial_state(job_id)
+
+      assert state.job_id == job_id
+      assert state.memos == []
+      assert state.current_state == :request
+      assert state.next_state == nil
+      assert state.pending_event == nil
+      assert state.pending_payload == nil
+      assert state.pending_signature == nil
+    end
+  end
+
+  describe "happy path: request -> completed" do
+    test "each transition writes one memo and the run ends at :completed" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+      state = JobWorkflow.initial_state(job_id)
+
+      # 1) Initial invoke pauses at wait_request
+      {:interrupted, run_id, _, :awaiting_request_response} =
+        Compiled.invoke(compiled, state)
+
+      assert is_binary(run_id)
+
+      # 2) Buyer accepts the request -> memo_negotiation writes, pauses at wait_negotiation
+      {:interrupted, ^run_id, after_neg, :awaiting_payment} =
+        Compiled.resume(compiled, run_id, {:accept_request, %{step: 1}, nil})
+
+      assert after_neg.current_state == :negotiation
+      assert [m1] = after_neg.memos
+      assert m1.next_phase == :negotiation
+      assert m1.memo_type == :message
+
+      # 3) Payment accepted -> memo_transaction
+      {:interrupted, ^run_id, after_tx, :awaiting_delivery} =
+        Compiled.resume(compiled, run_id, {:accept_payment, %{tx: "0xabc"}, "sig"})
+
+      assert after_tx.current_state == :transaction
+      assert length(after_tx.memos) == 2
+      [_, m2] = after_tx.memos
+      assert m2.memo_type == :txhash
+      assert m2.signature == "sig"
+
+      # 4) Delivery -> memo_evaluation
+      {:interrupted, ^run_id, after_eval, :awaiting_approval} =
+        Compiled.resume(compiled, run_id, {:deliver, %{url: "ipfs://x"}, nil})
+
+      assert after_eval.current_state == :evaluation
+      assert length(after_eval.memos) == 3
+
+      # 5) Approval -> memo_completed -> __end__
+      {:ok, final, meta} =
+        Compiled.resume(compiled, run_id, {:approve, %{score: 5}, nil})
+
+      assert final.current_state == :completed
+      assert length(final.memos) == 4
+
+      assert Enum.map(final.memos, & &1.next_phase) ==
+               [:negotiation, :transaction, :evaluation, :completed]
+
+      assert meta.run_id == run_id
+    end
+  end
+
+  describe "rejection and expiration" do
+    test "reject from :request lands at memo_rejected and ends the run" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      {:ok, final, _meta} =
+        Compiled.resume(compiled, run_id, {:reject, %{reason: "no inventory"}, nil})
+
+      assert final.current_state == :rejected
+      assert [memo] = final.memos
+      assert memo.next_phase == :rejected
+    end
+
+    test "expire from :request ends the run with a :memo_expired" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      {:ok, final, _meta} =
+        Compiled.resume(compiled, run_id, {:expire, %{reason: "sla"}, nil})
+
+      assert final.current_state == :expired
+      assert [memo] = final.memos
+      assert memo.next_phase == :expired
+    end
+
+    test "expire from :negotiation also ends with :memo_expired" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      {:interrupted, ^run_id, _, _} =
+        Compiled.resume(compiled, run_id, {:accept_request, %{}, nil})
+
+      {:ok, final, _} =
+        Compiled.resume(compiled, run_id, {:expire, %{}, nil})
+
+      assert final.current_state == :expired
+      assert length(final.memos) == 2
+      assert Enum.map(final.memos, & &1.next_phase) == [:negotiation, :expired]
+    end
+
+    test "expire from :transaction" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      Compiled.resume(compiled, run_id, {:accept_request, %{}, nil})
+      Compiled.resume(compiled, run_id, {:accept_payment, %{}, nil})
+
+      {:ok, final, _} = Compiled.resume(compiled, run_id, {:expire, %{}, nil})
+      assert final.current_state == :expired
+      assert length(final.memos) == 3
+    end
+
+    test "expire from :evaluation" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      Compiled.resume(compiled, run_id, {:accept_request, %{}, nil})
+      Compiled.resume(compiled, run_id, {:accept_payment, %{}, nil})
+      Compiled.resume(compiled, run_id, {:deliver, %{}, nil})
+
+      {:ok, final, _} = Compiled.resume(compiled, run_id, {:expire, %{}, nil})
+      assert final.current_state == :expired
+      assert length(final.memos) == 4
+    end
+  end
+
+  describe "invalid events route to :memo_expired" do
+    # Wait nodes never return :error (would conflict with the retry
+    # policy on a node whose scratchpad value has been consumed).
+    # Unknown events route through the conditional edge's fallback
+    # to :memo_expired, ending the run cleanly. The Job.Server facade
+    # in Phase A PR 2 will validate events up front via
+    # Raxol.ACP.Job.StateMachine.next/2 so unknown events never reach
+    # the workflow.
+
+    test "an event not valid for the current phase routes to :memo_expired" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      # :deliver is not a valid event for :request; the run expires.
+      {:ok, final, _} =
+        Compiled.resume(compiled, run_id, {:deliver, %{}, nil})
+
+      assert final.current_state == :expired
+      assert [memo] = final.memos
+      assert memo.next_phase == :expired
+    end
+
+    test "a non-tuple resume value also routes to :memo_expired" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      {:ok, final, _} = Compiled.resume(compiled, run_id, :not_a_tuple)
+      assert final.current_state == :expired
+    end
+  end
+
+  describe "memo content encoding" do
+    test "string payloads pass through unchanged" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      {:interrupted, _, after_neg, _} =
+        Compiled.resume(compiled, run_id, {:accept_request, "raw text", nil})
+
+      [memo] = after_neg.memos
+      assert memo.content == "raw text"
+      # binary payloads do not appear in the memo's payload field
+      assert memo.payload == nil
+    end
+
+    test "map payloads are JSON-encoded for content and preserved verbatim in payload" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      payload = %{foo: "bar"}
+
+      {:interrupted, _, after_neg, _} =
+        Compiled.resume(compiled, run_id, {:accept_request, payload, nil})
+
+      [memo] = after_neg.memos
+      assert memo.content == ~s({"foo":"bar"})
+      assert memo.payload == payload
+    end
+
+    test "nil payload encodes as empty string" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      {:interrupted, _, after_neg, _} =
+        Compiled.resume(compiled, run_id, {:accept_request, nil, nil})
+
+      [memo] = after_neg.memos
+      assert memo.content == ""
+    end
+
+    test ":accept_payment uses memo_type :txhash" do
+      compiled = compiled(saver: ets_saver())
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      Compiled.resume(compiled, run_id, {:accept_request, %{}, nil})
+
+      {:interrupted, _, after_tx, _} =
+        Compiled.resume(compiled, run_id, {:accept_payment, %{}, "sig"})
+
+      [_, memo] = after_tx.memos
+      assert memo.memo_type == :txhash
+    end
+  end
+
+  describe "checkpoints" do
+    test "saver records a checkpoint after every successful memo write" do
+      table = :"acp_job_wf_ckpt_#{:erlang.unique_integer([:positive])}"
+      on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table) end)
+      saver_config = %{table: table}
+      saver = {Ets, saver_config}
+
+      compiled = compiled(saver: saver)
+      job_id = new_job()
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled, JobWorkflow.initial_state(job_id))
+
+      Compiled.resume(compiled, run_id, {:accept_request, %{}, nil})
+      Compiled.resume(compiled, run_id, {:accept_payment, %{}, nil})
+
+      {:ok, checkpoints} = Ets.list(saver_config, run_id, 50)
+
+      node_ids =
+        checkpoints
+        |> Enum.map(& &1.metadata.node_id)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert :__start__ in node_ids
+      assert :memo_negotiation in node_ids
+      assert :memo_transaction in node_ids
+    end
+
+    test "resume picks up after the last memo write across separate compile invocations" do
+      table = :"acp_job_wf_resume_#{:erlang.unique_integer([:positive])}"
+      on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table) end)
+      saver = {Ets, %{table: table}}
+
+      job_id = new_job()
+
+      # First "process": drive partway, then drop the compiled handle.
+      compiled1 = compiled(saver: saver)
+
+      {:interrupted, run_id, _, _} =
+        Compiled.invoke(compiled1, JobWorkflow.initial_state(job_id))
+
+      Compiled.resume(compiled1, run_id, {:accept_request, %{step: 1}, nil})
+      Compiled.resume(compiled1, run_id, {:accept_payment, %{step: 2}, nil})
+
+      # Second "process": fresh compile against the same saver table.
+      compiled2 = compiled(saver: saver)
+
+      Compiled.resume(compiled2, run_id, {:deliver, %{step: 3}, nil})
+
+      {:ok, final, _} =
+        Compiled.resume(compiled2, run_id, {:approve, %{step: 4}, nil})
+
+      assert final.current_state == :completed
+      assert length(final.memos) == 4
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Full ADR-0016 Phase A in a single PR. Builds the workflow module
then wires it into \`Job.Server\` behind an opt-in flag. The default
path is unchanged; the workflow path is reachable via
\`via_workflow: true\` (or
\`Application.put_env(:raxol_acp, :job_via_workflow, true)\`).

### Part 1: \`Raxol.ACP.Job.Workflow\` (standalone module)

A Phase 25 \`Raxol.Workflow\` graph whose shape mirrors
\`Raxol.ACP.Job.StateMachine\`. Each non-terminal phase splits into a
\`:wait_*\` node (pure interrupt) and a \`:memo_*\` node (fires
\`ContractClient.create_memo\`, retry-eligible). The split is
load-bearing: the workflow runtime's retry loop re-runs the node
body, and \`Workflow.interrupt/1\` cannot be re-popped on retry.
Keeping interrupts side-effect-free and memo writes interrupt-free
lets \`failure_policy: :retry\` work cleanly.

Defaults: \`failure_policy: :retry\`, \`max_attempts: 3\`,
\`retry_backoff_ms: 200\`, saver opt-in. **19 tests** covering compile
shape, happy path, reject/expire from every phase, invalid-event
routing to \`:memo_expired\`, memo content encoding, checkpoint
writes, and resume across separate \`compile\` invocations.

### Part 2: \`Job.Server\` \`via_workflow\` path

\`Job.Server\` gains a \`:via_workflow\` boolean (also via app env).
When true:

- \`init_manager\` compiles the workflow with the configured Saver and
  either invokes fresh (creating the \`__start__\` checkpoint) or
  hydrates from the Saver's latest checkpoint.
- Each transition validates via \`StateMachine.next/2\` (preserves the
  legacy \`{:error, {:invalid_transition, _, _}}\` shape), then
  delegates to \`Compiled.resume/4\` with the event tuple as the
  resume value. Result tuples translate back to the legacy reply
  shapes: \`{:interrupted, _}\` -> \`{:ok, new_state}\`, \`{:ok, _, _}\`
  -> stop with \`:normal\` (terminal phase), \`{:error, reason, _}\` ->
  \`{:reply, {:error, reason}, state}\`.
- \`finalize_workflow_transition\` mirrors writes to
  \`Raxol.ACP.Job.Store\` for backward compat (existing readers of
  \`Store.load\` see the same shape) and re-emits
  \`[:raxol, :acp, :job, :transition]\` with the same metadata
  structure consumers depend on.
- Saver selection via \`Application.get_env(:raxol_acp, :job_workflow_saver, ...)\`.
  Defaults to \`Saver.Ets\` with a shared named table.

**+8 integration tests** in \`server_workflow_test.exs\`: happy path,
memo shape parity, invalid-event error shape, Store mirror writes,
telemetry continuity, terminal \`:normal\` stop, reject shortcut, and
transient-restart hydration via the Saver.

### Default path unchanged

\`via_workflow\` defaults to \`false\`. The existing 593 raxol_acp tests
pass without modification. Total now **601 tests, 0 failures**.

### Out of scope (per ADR-0016)

- Phase B (interrupts for waiting phases, per-phase telemetry reasons)
- Flipping the default to \`via_workflow: true\` (next session, after
  the opt-in path has stabilized)
- Phase 24F (\`Command\` struct deletion, independent of this)

## Test plan

- [x] Workflow standalone suite: 19 tests, 0 failures
- [x] \`Job.Server\` workflow-mode integration: 8 tests, 0 failures
- [x] Full raxol_acp suite: 601 tests, 0 failures (9 invalid + 2
      excluded; all pre-existing)
- [x] \`mix credo --strict\` clean on new code (3 remaining
      readability issues are in pre-existing legacy code)
- [x] \`mix format --check-formatted\` clean