### PR TITLE
Omnigent extraction: executor, item-log, tunnel, authz, cross-vendor review

### DIFF
--- a/packages/raxol_agent/.gitignore
+++ b/packages/raxol_agent/.gitignore
@@ -1,0 +1,2 @@
+# ExUnit @tag :tmp_dir artifacts
+/tmp/

--- a/packages/raxol_agent/lib/raxol/agent/ai_backend.ex
+++ b/packages/raxol_agent/lib/raxol/agent/ai_backend.ex
@@ -33,5 +33,43 @@ defmodule Raxol.Agent.AIBackend do
   @doc "List of supported capabilities."
   @callback capabilities() :: [:completion | :streaming | :tool_use | :vision]
 
-  @optional_callbacks [stream: 2]
+  @doc """
+  Whether the backend runs its own internal tool-call loop.
+
+  When `true`, the vendor owns the agent loop (e.g. a wrapped Claude Code or
+  Codex CLI) and the framework must NOT drive tool dispatch itself -- it injects
+  its tools into the vendor instead. When `false` (the default), the framework's
+  ReAct loop drives tool calls. Defaults to `false` for backends that omit it.
+  """
+  @callback handles_tools_internally?() :: boolean()
+
+  @doc "Maximum context window in tokens, or `nil` when unknown."
+  @callback max_context_tokens() :: pos_integer() | nil
+
+  @optional_callbacks [stream: 2, handles_tools_internally?: 0, max_context_tokens: 0]
+
+  @doc """
+  Query whether a backend handles tools internally, defaulting to `false`.
+
+  Safe to call on any backend module: backends that do not implement the
+  optional callback are treated as framework-driven.
+  """
+  @spec handles_tools_internally?(module()) :: boolean()
+  def handles_tools_internally?(backend) when is_atom(backend) do
+    if function_exported?(backend, :handles_tools_internally?, 0) do
+      backend.handles_tools_internally?()
+    else
+      false
+    end
+  end
+
+  @doc "Query a backend's max context window, defaulting to `nil`."
+  @spec max_context_tokens(module()) :: pos_integer() | nil
+  def max_context_tokens(backend) when is_atom(backend) do
+    if function_exported?(backend, :max_context_tokens, 0) do
+      backend.max_context_tokens()
+    else
+      nil
+    end
+  end
 end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/engine.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/engine.ex
@@ -1,0 +1,167 @@
+defmodule Raxol.Agent.Authorization.Engine do
+  @moduledoc """
+  Pure ALLOW/ASK/DENY authorization reducer.
+
+  Evaluates an ordered list of `Raxol.Agent.Authorization.Policy` at a phase and
+  folds them into one `Decision` (the omnigent PolicyEngine model):
+
+    * **DENY** short-circuits: the label writes accumulated from prior ALLOWs are
+      kept, the decision is DENY with the reason. No further policies run.
+    * **ALLOW** applies its (whitelisted) writes to the running labels via a
+      monotonic merge, then continues.
+    * **ASK** accumulates an approval request and holds its writes in ESCROW
+      (applied only on approval), then continues.
+
+  Final action: DENY if any policy denied, else ASK if any policy asked, else
+  ALLOW. "Stricter session first" is just list order -- prepend session policies;
+  there is no separate tiering engine.
+
+  ## Approval memory and the spawn tree
+
+  Approving an ASK can be remembered (per `Policy.scope`): `:session` for the
+  engine's lifetime, `:root` per evaluation `route`. Passing the root of a spawn
+  tree as `route` and scoping `:root` makes one approval cover the whole tree.
+
+  ## State threading
+
+  `evaluate/5` is pure -- it returns a `Decision` but does NOT mutate state.
+  Callers `commit/2` an ALLOW (or DENY) decision to fold its labels in, or
+  `approve/2` an ASK decision to release escrow and remember the approval.
+  """
+
+  alias Raxol.Agent.Authorization.{Labels, Policy}
+
+  defmodule State do
+    @moduledoc "Engine state: current labels, remembered approvals, monotonic spec."
+    @type t :: %__MODULE__{labels: map(), approvals: MapSet.t(), monotonic: map()}
+    defstruct labels: %{}, approvals: %MapSet{}, monotonic: %{}
+  end
+
+  defmodule Decision do
+    @moduledoc "The folded outcome of one `evaluate/5` pass."
+    @type t :: %__MODULE__{
+            action: :allow | :ask | :deny,
+            labels: map(),
+            reason: term(),
+            asks: [map()],
+            escrow: map(),
+            route: term()
+          }
+    defstruct action: :allow, labels: %{}, reason: nil, asks: [], escrow: %{}, route: nil
+  end
+
+  @doc "Build engine state. Options: `:labels`, `:monotonic`."
+  @spec new(keyword()) :: State.t()
+  def new(opts \\ []) do
+    %State{
+      labels: Keyword.get(opts, :labels, %{}),
+      approvals: MapSet.new(),
+      monotonic: Keyword.get(opts, :monotonic, %{})
+    }
+  end
+
+  @doc """
+  Evaluate ordered `policies` at `phase` with `context` against `state`.
+
+  Options: `:route` -- evaluation route for `:root`-scoped approval memory.
+  Returns a `Decision`; does not mutate `state`.
+  """
+  @spec evaluate([Policy.t()], Policy.phase(), map(), State.t(), keyword()) :: Decision.t()
+  def evaluate(policies, phase, context, %State{} = state, opts \\ []) do
+    route = Keyword.get(opts, :route, :default)
+
+    policies
+    |> Enum.filter(&Policy.applies?(&1, phase, state.labels))
+    |> reduce(context, route, state)
+  end
+
+  @doc "Fold a decision's labels into state (used for ALLOW/DENY outcomes)."
+  @spec commit(Decision.t(), State.t()) :: State.t()
+  def commit(%Decision{labels: labels}, %State{} = state), do: %{state | labels: labels}
+
+  @doc """
+  Approve an ASK decision: release escrowed writes into the labels and remember
+  the approval per each ask's scope.
+  """
+  @spec approve(Decision.t(), State.t()) :: State.t()
+  def approve(%Decision{action: :ask} = decision, %State{} = state) do
+    labels = Labels.merge(state.labels, decision.escrow, state.monotonic)
+    approvals = Enum.reduce(decision.asks, state.approvals, &remember(&1, decision.route, &2))
+    %{state | labels: labels, approvals: approvals}
+  end
+
+  # -- Reduction --------------------------------------------------------------
+
+  defp reduce(policies, context, route, state) do
+    acc0 = %{labels: state.labels, asks: [], escrow: %{}}
+
+    outcome =
+      Enum.reduce_while(policies, {:ok, acc0}, fn policy, {:ok, acc} ->
+        case decide(policy, context, route, state) do
+          {:deny, reason} -> {:halt, {:deny, reason, acc}}
+          {:allow, writes} -> {:cont, {:ok, apply_allow(acc, writes, state)}}
+          {:ask, prompt, writes} -> {:cont, {:ok, hold_ask(acc, policy, prompt, writes)}}
+        end
+      end)
+
+    finalize(outcome, route)
+  end
+
+  # An ASK whose approval is remembered for this route is treated as ALLOW.
+  defp decide(policy, context, route, state) do
+    verdict = Policy.run(policy, context)
+
+    case verdict.action do
+      :ask ->
+        if approved?(state, policy, route),
+          do: {:allow, verdict.writes},
+          else: {:ask, verdict.prompt, verdict.writes}
+
+      :allow ->
+        {:allow, verdict.writes}
+
+      :deny ->
+        {:deny, verdict.reason}
+    end
+  end
+
+  defp apply_allow(acc, writes, state),
+    do: %{acc | labels: Labels.merge(acc.labels, writes, state.monotonic)}
+
+  defp hold_ask(acc, policy, prompt, writes) do
+    %{
+      acc
+      | asks: acc.asks ++ [%{policy: policy.name, prompt: prompt, scope: policy.scope}],
+        escrow: Map.merge(acc.escrow, writes)
+    }
+  end
+
+  defp finalize({:deny, reason, acc}, route),
+    do: %Decision{action: :deny, reason: reason, labels: acc.labels, route: route}
+
+  defp finalize({:ok, %{asks: []} = acc}, route),
+    do: %Decision{action: :allow, labels: acc.labels, route: route}
+
+  defp finalize({:ok, acc}, route),
+    do: %Decision{
+      action: :ask,
+      labels: acc.labels,
+      asks: acc.asks,
+      escrow: acc.escrow,
+      route: route
+    }
+
+  # -- Approval memory --------------------------------------------------------
+
+  defp approved?(state, policy, route),
+    do: MapSet.member?(state.approvals, approval_key(policy.name, policy.scope, route))
+
+  defp remember(%{scope: :once}, _route, approvals), do: approvals
+
+  defp remember(%{policy: name, scope: scope}, route, approvals),
+    do: MapSet.put(approvals, approval_key(name, scope, route))
+
+  defp approval_key(name, :session, _route), do: {name, :session}
+  defp approval_key(name, :root, route), do: {name, {:root, route}}
+  defp approval_key(name, :once, _route), do: {name, :once}
+end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/hook.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/hook.ex
@@ -1,0 +1,131 @@
+defmodule Raxol.Agent.Authorization.Hook do
+  @moduledoc """
+  Composes the ALLOW/ASK/DENY engine into the `Raxol.Agent.CommandHook` chain.
+
+  This is the integration seam: where `Raxol.Agent.PermissionHook` is deny-only,
+  this hook evaluates the authorization engine at the `:tool_call` phase for each
+  directive and maps the decision to a hook result:
+
+    * ALLOW -> `{:ok, command}` (commit labels)
+    * DENY  -> `{:deny, reason}` (commit prior-ALLOW labels)
+    * ASK   -> resolved synchronously via a `:prompter` (the same pattern
+      PermissionHook uses); on approve `{:ok, command}` + release escrow, on deny
+      `{:deny, {:ask_denied, prompts}}`. With no prompter, a pending ASK is denied
+      `{:deny, {:requires_approval, prompts}}`.
+
+  Configure per process (like PermissionHook) with `configure/1`; the engine
+  `State` (labels, approvals) is held in the process dictionary and threaded
+  across calls. When not configured, the hook is a neutral no-op so it composes
+  safely with other hooks.
+  """
+
+  @behaviour Raxol.Agent.CommandHook
+
+  alias Raxol.Agent.Authorization.Engine
+  alias Raxol.Agent.Directive.{Async, SendAgent, Shell}
+
+  @config_key {__MODULE__, :config}
+
+  @doc """
+  Configure the hook for the current process.
+
+  Options: `:policies`, `:labels`, `:monotonic`, `:route`, and `:prompter`
+  (`(decision, context) -> :approve | :deny`).
+  """
+  @spec configure(keyword()) :: :ok
+  def configure(opts) do
+    config = %{
+      policies: Keyword.get(opts, :policies, []),
+      state:
+        Engine.new(
+          labels: Keyword.get(opts, :labels, %{}),
+          monotonic: Keyword.get(opts, :monotonic, %{})
+        ),
+      prompter: Keyword.get(opts, :prompter),
+      route: Keyword.get(opts, :route, :default)
+    }
+
+    Process.put(@config_key, config)
+    :ok
+  end
+
+  @doc "Remove the hook configuration for the current process."
+  @spec clear() :: :ok
+  def clear do
+    Process.delete(@config_key)
+    :ok
+  end
+
+  @doc "The current label snapshot for the configured process (or `%{}`)."
+  @spec labels() :: map()
+  def labels do
+    case Process.get(@config_key) do
+      nil -> %{}
+      %{state: state} -> state.labels
+    end
+  end
+
+  @impl true
+  def pre_execute(command, context) do
+    case Process.get(@config_key) do
+      nil -> {:ok, command}
+      config -> authorize(command, context, config)
+    end
+  end
+
+  # -- Internals --------------------------------------------------------------
+
+  defp authorize(command, context, config) do
+    ctx = Map.merge(context, %{directive: command, type: directive_type(command)})
+
+    decision =
+      Engine.evaluate(config.policies, :tool_call, ctx, config.state, route: config.route)
+
+    handle(decision, command, ctx, config)
+  end
+
+  defp handle(%{action: :allow} = decision, command, _ctx, config) do
+    put_state(config, Engine.commit(decision, config.state))
+    {:ok, command}
+  end
+
+  defp handle(%{action: :deny} = decision, _command, _ctx, config) do
+    put_state(config, Engine.commit(decision, config.state))
+    {:deny, decision.reason}
+  end
+
+  defp handle(%{action: :ask} = decision, command, ctx, config) do
+    committed = Engine.commit(decision, config.state)
+    prompts = Enum.map(decision.asks, & &1.prompt)
+
+    case approve?(decision, ctx, config.prompter) do
+      true ->
+        put_state(config, Engine.approve(decision, committed))
+        {:ok, command}
+
+      false ->
+        put_state(config, committed)
+        {:deny, denial_reason(config.prompter, prompts)}
+    end
+  end
+
+  defp approve?(_decision, _ctx, nil), do: false
+
+  defp approve?(decision, ctx, prompter) when is_function(prompter, 2) do
+    case prompter.(decision, ctx) do
+      :approve -> true
+      true -> true
+      _ -> false
+    end
+  end
+
+  defp denial_reason(nil, prompts), do: {:requires_approval, prompts}
+  defp denial_reason(_prompter, prompts), do: {:ask_denied, prompts}
+
+  defp put_state(config, state), do: Process.put(@config_key, %{config | state: state})
+
+  defp directive_type(%Shell{}), do: :shell
+  defp directive_type(%SendAgent{}), do: :send_agent
+  defp directive_type(%Async{}), do: :async
+  defp directive_type(_other), do: :unknown
+end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/labels.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/labels.ex
@@ -1,0 +1,49 @@
+defmodule Raxol.Agent.Authorization.Labels do
+  @moduledoc """
+  Label state for the authorization engine, with monotonic merge.
+
+  Labels are a plain map that policies read (to gate on) and write (verdict
+  `writes`). When several policies write the SAME key, a monotonic label keeps the
+  MOST-RESTRICTIVE value rather than last-write-wins -- the CRDT-flavored
+  `_merge_monotonic_writes` from omnigent. This guarantees a stricter policy can
+  never be loosened by a later, more permissive one in the same pass.
+
+  A monotonic spec maps a label key to an ordering, least-restrictive first:
+
+      %{access: [:read, :write, :admin], risk: [:low, :medium, :high]}
+
+  Keys not in the spec merge last-write-wins.
+  """
+
+  @type labels :: map()
+  @type monotonic :: %{optional(term()) => [term()]}
+
+  @doc """
+  Merge `writes` into `labels`. Monotonic keys keep the most-restrictive value;
+  other keys take the written value.
+  """
+  @spec merge(labels(), map(), monotonic()) :: labels()
+  def merge(labels, writes, monotonic \\ %{}) do
+    Enum.reduce(writes, labels, fn {key, value}, acc ->
+      case Map.fetch(monotonic, key) do
+        {:ok, ordering} -> Map.put(acc, key, most_restrictive(Map.get(acc, key), value, ordering))
+        :error -> Map.put(acc, key, value)
+      end
+    end)
+  end
+
+  # The value with the higher rank in the ordering wins; the incoming value wins
+  # ties so an equally-ranked rewrite is idempotent.
+  defp most_restrictive(nil, value, _ordering), do: value
+
+  defp most_restrictive(current, value, ordering) do
+    if rank(value, ordering) >= rank(current, ordering), do: value, else: current
+  end
+
+  defp rank(value, ordering) do
+    case Enum.find_index(ordering, &(&1 == value)) do
+      nil -> -1
+      index -> index
+    end
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/policy.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/policy.ex
@@ -1,0 +1,89 @@
+defmodule Raxol.Agent.Authorization.Policy do
+  @moduledoc """
+  A single policy in the ALLOW/ASK/DENY authorization engine.
+
+  Distinct from `Raxol.Agent.Policy` (operational resilience: retry/cache/timeout)
+  and from the deny-only `Raxol.Agent.PermissionHook` -- this is the authorization
+  trichotomy with label state and human-in-the-loop ASK.
+
+  A policy is data: when it applies (phase + condition gate), what labels it may
+  write, how its ASK approvals are remembered, and an `evaluate` function that
+  returns a `Raxol.Agent.Authorization.Verdict`.
+
+  ## Applicability gates (cheap-first)
+
+    1. **Phase** -- `phases` is `:all` or a list
+       (`:input | :tool_call | :tool_result | :output`).
+    2. **Conditions** -- a label gate `%{key => value | [values]}`: AND across
+       keys, OR within a key's list, against the current label snapshot.
+
+  ## Writable labels
+
+  `writable_labels` is `:all` or a whitelist; a verdict's `writes` are filtered to
+  keys the policy may write before they touch label state.
+
+  ## ASK scope (approval memory)
+
+    * `:once`    -- not remembered; ask again next time.
+    * `:session` -- remembered for the engine's lifetime.
+    * `:root`    -- remembered per evaluation `route` (e.g. the root of a spawn
+      tree), so approving once covers the whole tree.
+  """
+
+  alias Raxol.Agent.Authorization.Verdict
+
+  @type phase :: :input | :tool_call | :tool_result | :output | atom()
+  @type scope :: :once | :session | :root
+
+  @type t :: %__MODULE__{
+          name: atom() | binary(),
+          phases: :all | [phase()],
+          conditions: map(),
+          writable_labels: :all | [term()],
+          scope: scope(),
+          evaluate: (map() -> Verdict.t())
+        }
+
+  @enforce_keys [:name, :evaluate]
+  defstruct name: nil,
+            phases: :all,
+            conditions: %{},
+            writable_labels: :all,
+            scope: :session,
+            evaluate: nil
+
+  @doc "Build a policy. Requires `:name` and `:evaluate`."
+  @spec new(keyword() | map()) :: t()
+  def new(attrs), do: struct!(__MODULE__, attrs)
+
+  @doc "Run the policy's `evaluate` against `context`, filtering its writes."
+  @spec run(t(), map()) :: Verdict.t()
+  def run(%__MODULE__{evaluate: evaluate} = policy, context) do
+    verdict = evaluate.(context)
+    %{verdict | writes: filter_writes(verdict.writes, policy.writable_labels)}
+  end
+
+  @doc "Does this policy apply at `phase` given the current `labels`?"
+  @spec applies?(t(), phase(), map()) :: boolean()
+  def applies?(%__MODULE__{} = policy, phase, labels) do
+    phase_match?(policy.phases, phase) and conditions_met?(policy.conditions, labels)
+  end
+
+  defp phase_match?(:all, _phase), do: true
+  defp phase_match?(phases, phase) when is_list(phases), do: phase in phases
+
+  # AND across keys, OR within a key's list of accepted values.
+  defp conditions_met?(conditions, labels) do
+    Enum.all?(conditions, fn {key, accepted} ->
+      value = Map.get(labels, key)
+
+      case accepted do
+        list when is_list(list) -> value in list
+        single -> value == single
+      end
+    end)
+  end
+
+  defp filter_writes(writes, :all), do: writes
+  defp filter_writes(writes, allowed) when is_list(allowed), do: Map.take(writes, allowed)
+end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/server.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/server.ex
@@ -1,0 +1,105 @@
+defmodule Raxol.Agent.Authorization.Server do
+  @moduledoc """
+  Per-workflow authorization engine as a GenServer.
+
+  Holds the ordered policy list and the engine `State` (labels, approvals), and
+  serializes `evaluate`/`approve` so concurrent phases never race the label state.
+  ALLOW and DENY decisions commit their labels immediately; ASK decisions commit
+  the prior-ALLOW labels but hold their own writes in escrow until `approve/2`.
+
+  Pending ASKs are keyed by evaluation `route`, so a spawn tree (one root route)
+  has at most one outstanding approval, and `approve/2` releases it for the whole
+  tree.
+  """
+
+  use GenServer
+
+  alias Raxol.Agent.Authorization.Engine
+
+  defstruct policies: [], state: nil, pending: %{}
+
+  @type server :: GenServer.server()
+
+  @doc """
+  Start the engine.
+
+  Options: `:policies` (ordered list), `:labels`, `:monotonic`, `:name`.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name)
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @doc "Evaluate the policies at `phase`. Returns a `Engine.Decision`."
+  @spec evaluate(server(), atom(), map(), keyword()) :: Engine.Decision.t()
+  def evaluate(server, phase, context, opts \\ []),
+    do: GenServer.call(server, {:evaluate, phase, context, opts})
+
+  @doc "Approve the pending ASK for `route`: release escrow and remember it."
+  @spec approve(server(), term()) :: :ok | {:error, :no_pending}
+  def approve(server, route \\ :default), do: GenServer.call(server, {:approve, route})
+
+  @doc "Reject the pending ASK for `route` (drops it; no label change)."
+  @spec reject(server(), term()) :: :ok | {:error, :no_pending}
+  def reject(server, route \\ :default), do: GenServer.call(server, {:reject, route})
+
+  @doc "The current label snapshot."
+  @spec labels(server()) :: map()
+  def labels(server), do: GenServer.call(server, :labels)
+
+  # -- GenServer --------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %__MODULE__{
+      policies: Keyword.get(opts, :policies, []),
+      state:
+        Engine.new(
+          labels: Keyword.get(opts, :labels, %{}),
+          monotonic: Keyword.get(opts, :monotonic, %{})
+        )
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:evaluate, phase, context, opts}, _from, server) do
+    route = Keyword.get(opts, :route, :default)
+    decision = Engine.evaluate(server.policies, phase, context, server.state, route: route)
+    server = apply_decision(server, decision, route)
+    {:reply, decision, server}
+  end
+
+  def handle_call({:approve, route}, _from, server) do
+    case Map.pop(server.pending, route) do
+      {nil, _pending} ->
+        {:reply, {:error, :no_pending}, server}
+
+      {decision, pending} ->
+        engine_state = Engine.approve(decision, server.state)
+        {:reply, :ok, %{server | state: engine_state, pending: pending}}
+    end
+  end
+
+  def handle_call({:reject, route}, _from, server) do
+    case Map.pop(server.pending, route) do
+      {nil, _pending} -> {:reply, {:error, :no_pending}, server}
+      {_decision, pending} -> {:reply, :ok, %{server | pending: pending}}
+    end
+  end
+
+  def handle_call(:labels, _from, server), do: {:reply, server.state.labels, server}
+
+  # ALLOW/DENY commit their labels now; ASK commits prior-ALLOW labels and parks
+  # the decision (its escrow waits for approval).
+  defp apply_decision(server, %{action: :ask} = decision, route) do
+    engine_state = Engine.commit(decision, server.state)
+    %{server | state: engine_state, pending: Map.put(server.pending, route, decision)}
+  end
+
+  defp apply_decision(server, decision, _route),
+    do: %{server | state: Engine.commit(decision, server.state)}
+end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/verdict.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/verdict.ex
@@ -1,0 +1,38 @@
+defmodule Raxol.Agent.Authorization.Verdict do
+  @moduledoc """
+  The outcome a single authorization policy returns when it evaluates.
+
+  One of three actions (the ALLOW/ASK/DENY trichotomy from omnigent's
+  PolicyEngine), each optionally carrying `writes` -- label updates the policy
+  wants applied:
+
+    * `:allow` -- permit; `writes` are applied immediately.
+    * `:ask`   -- require human approval; `writes` are held in escrow and applied
+      only once approved. `prompt` is shown to the approver.
+    * `:deny`  -- refuse; `reason` explains why. Short-circuits the engine.
+  """
+
+  @type action :: :allow | :ask | :deny
+
+  @type t :: %__MODULE__{
+          action: action(),
+          writes: map(),
+          reason: term(),
+          prompt: binary() | nil
+        }
+
+  @enforce_keys [:action]
+  defstruct action: :allow, writes: %{}, reason: nil, prompt: nil
+
+  @doc "An allow verdict, optionally writing labels."
+  @spec allow(map()) :: t()
+  def allow(writes \\ %{}), do: %__MODULE__{action: :allow, writes: writes}
+
+  @doc "An ask verdict with an approver `prompt`, optionally escrowing labels."
+  @spec ask(binary(), map()) :: t()
+  def ask(prompt, writes \\ %{}), do: %__MODULE__{action: :ask, prompt: prompt, writes: writes}
+
+  @doc "A deny verdict with a `reason`."
+  @spec deny(term()) :: t()
+  def deny(reason), do: %__MODULE__{action: :deny, reason: reason}
+end

--- a/packages/raxol_agent/lib/raxol/agent/backend/claude_code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/claude_code.ex
@@ -1,0 +1,12 @@
+defmodule Raxol.Agent.Backend.ClaudeCode do
+  @moduledoc """
+  AIBackend wrapping the Claude Code CLI as a native harness.
+
+  The CLI owns its agent loop; Raxol tools are injected over MCP. Selected via
+  `harness: :claude_native` in a `Raxol.Agent.ExecutorConfig`. See
+  `Raxol.Agent.Backend.Native` for options and `Raxol.Agent.Harness.ClaudeCode`
+  for the driver.
+  """
+
+  use Raxol.Agent.Backend.Native, driver: Raxol.Agent.Harness.ClaudeCode
+end

--- a/packages/raxol_agent/lib/raxol/agent/backend/cursor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/cursor.ex
@@ -1,0 +1,12 @@
+defmodule Raxol.Agent.Backend.Cursor do
+  @moduledoc """
+  AIBackend wrapping the Cursor agent CLI (`cursor-agent`) as a native harness.
+
+  The CLI owns its agent loop; Raxol tools are injected over MCP. Selected via
+  `harness: :cursor` in a `Raxol.Agent.ExecutorConfig`. See
+  `Raxol.Agent.Backend.Native` for options and `Raxol.Agent.Harness.Cursor` for
+  the driver.
+  """
+
+  use Raxol.Agent.Backend.Native, driver: Raxol.Agent.Harness.Cursor
+end

--- a/packages/raxol_agent/lib/raxol/agent/backend/native.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/native.ex
@@ -1,0 +1,299 @@
+defmodule Raxol.Agent.Backend.Native do
+  @moduledoc """
+  Generic `Raxol.Agent.AIBackend` runtime for native CLI harnesses.
+
+  Spawns a `Raxol.Agent.NativeHarness` driver's CLI via a Port, streams its
+  normalized events, and adapts them to the AIBackend stream shape
+  (`{:chunk, text}` / `{:done, response}`). Because the CLI owns its own agent
+  loop, backends built here report `handles_tools_internally? == true`, and the
+  agent's tools are injected into the CLI over MCP (see
+  `Raxol.Agent.Harness.McpToolConfig`).
+
+  Define a per-vendor backend with the `__using__/1` macro:
+
+      defmodule Raxol.Agent.Backend.ClaudeCode do
+        use Raxol.Agent.Backend.Native, driver: Raxol.Agent.Harness.ClaudeCode
+      end
+
+  ## Backend options
+
+  - `:model` -- model id (or omit for the CLI default).
+  - `:system_prompt` -- appended system prompt.
+  - `:cwd` -- working directory for the CLI.
+  - `:timeout` -- per-run timeout in ms (default 120s).
+  - `:actions` -- Action modules to expose to the CLI as MCP tools.
+  - `:mcp_server_command` / `:mcp_server_args` -- the MCP server launcher; tools
+    are injected only when this is set (and `:actions` is non-empty).
+  - `:extra_args` -- raw argv appended to the CLI invocation.
+  """
+
+  @default_timeout 120_000
+  @line_bytes 1_048_576
+
+  alias Raxol.Agent.Harness.McpToolConfig
+  alias Raxol.Agent.NativeHarness
+
+  @doc false
+  defmacro __using__(macro_opts) do
+    driver = Keyword.fetch!(macro_opts, :driver)
+
+    quote bind_quoted: [driver: driver] do
+      @behaviour Raxol.Agent.AIBackend
+      @native_driver driver
+
+      @impl true
+      def complete(messages, opts \\ []),
+        do: Raxol.Agent.Backend.Native.complete(@native_driver, messages, opts)
+
+      @impl true
+      def stream(messages, opts \\ []),
+        do: Raxol.Agent.Backend.Native.stream(@native_driver, messages, opts)
+
+      @impl true
+      def available?, do: Raxol.Agent.NativeHarness.available?(@native_driver)
+
+      @impl true
+      def name, do: @native_driver.name()
+
+      @impl true
+      def capabilities, do: [:completion, :streaming, :tool_use]
+
+      @impl true
+      def handles_tools_internally?, do: true
+
+      @doc "The native harness driver backing this backend."
+      def driver, do: @native_driver
+    end
+  end
+
+  # -- Runtime ----------------------------------------------------------------
+
+  @doc "Run one turn and return the final response (drains the stream)."
+  @spec complete(module(), [map()], keyword()) :: {:ok, map()} | {:error, term()}
+  def complete(driver, messages, opts) do
+    case stream(driver, messages, opts) do
+      {:ok, events} -> collect(events)
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc "Run one turn and return `{:ok, stream}` of AIBackend stream events."
+  @spec stream(module(), [map()], keyword()) :: {:ok, Enumerable.t()} | {:error, term()}
+  def stream(driver, messages, opts) do
+    case System.find_executable(driver.executable()) do
+      nil ->
+        {:error, {:executable_not_found, driver.executable()}}
+
+      exe ->
+        {mcp_path, cleanup} = maybe_build_mcp_config(driver, opts)
+        config = run_config(messages, opts, mcp_path)
+        args = driver.args(config)
+        {:ok, build_stream(driver, exe, args, opts, cleanup)}
+    end
+  end
+
+  # -- Stream plumbing --------------------------------------------------------
+
+  defp build_stream(driver, exe, args, opts, cleanup) do
+    cwd = Keyword.get(opts, :cwd)
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    caller = self()
+    ref = make_ref()
+
+    reader =
+      spawn_link(fn ->
+        run_port(exe, args, cwd, driver, timeout, caller, ref)
+      end)
+
+    Stream.resource(
+      fn -> %{ref: ref, reader: reader, done: false} end,
+      &next_event/1,
+      fn _ ->
+        if Process.alive?(reader), do: Process.exit(reader, :normal)
+        cleanup.()
+      end
+    )
+  end
+
+  defp next_event(%{done: true} = state), do: {:halt, state}
+
+  defp next_event(%{ref: ref} = state) do
+    receive do
+      {^ref, {:done, _} = event} -> {[event], %{state | done: true}}
+      {^ref, {:error, _} = event} -> {[event], %{state | done: true}}
+      {^ref, event} -> {[event], state}
+    end
+  end
+
+  defp run_port(exe, args, cwd, driver, timeout, caller, ref) do
+    port =
+      Port.open(
+        {:spawn_executable, exe},
+        [:binary, :exit_status, :stderr_to_stdout, :hide, {:line, @line_bytes}, {:args, args}] ++
+          cd_opt(cwd)
+      )
+
+    drain(port, driver, timeout, caller, ref, %{buffer: "", content: "", usage: %{}, done: false})
+  end
+
+  defp drain(port, driver, timeout, caller, ref, state) do
+    receive do
+      {^port, {:data, {:eol, chunk}}} ->
+        line = state.buffer <> chunk
+        state = handle_line(driver, line, caller, ref, %{state | buffer: ""})
+        if state.done, do: close(port), else: drain(port, driver, timeout, caller, ref, state)
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        drain(port, driver, timeout, caller, ref, %{state | buffer: state.buffer <> chunk})
+
+      {^port, {:exit_status, status}} ->
+        finalize_exit(status, state, caller, ref)
+    after
+      timeout ->
+        close(port)
+        send(caller, {ref, {:error, :timeout}})
+    end
+  end
+
+  defp handle_line(driver, line, caller, ref, state) do
+    driver.parse_line(line)
+    |> Enum.reduce(state, fn event, acc -> apply_event(event, caller, ref, acc) end)
+  end
+
+  defp apply_event(_event, _caller, _ref, %{done: true} = state), do: state
+
+  defp apply_event({:text, text}, caller, ref, state) do
+    send(caller, {ref, {:chunk, text}})
+    %{state | content: state.content <> text}
+  end
+
+  defp apply_event({:reasoning, _text}, _caller, _ref, state), do: state
+  defp apply_event({:tool_call, _info}, _caller, _ref, state), do: state
+
+  defp apply_event({:done, %{content: content, usage: usage}}, caller, ref, state) do
+    final = if content == "", do: state.content, else: content
+    send(caller, {ref, {:done, response(final, usage)}})
+    %{state | done: true}
+  end
+
+  defp apply_event({:error, reason}, caller, ref, state) do
+    send(caller, {ref, {:error, reason}})
+    %{state | done: true}
+  end
+
+  # Driver never emitted a terminal :done -- synthesize one from accumulated text
+  # on a clean exit, or surface a non-zero exit as an error.
+  defp finalize_exit(_status, %{done: true}, _caller, _ref), do: :ok
+
+  defp finalize_exit(0, state, caller, ref) do
+    send(caller, {ref, {:done, response(state.content, state.usage)}})
+  end
+
+  defp finalize_exit(status, _state, caller, ref) do
+    send(caller, {ref, {:error, {:exit, status}}})
+  end
+
+  defp close(port) do
+    if Port.info(port), do: Port.close(port)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp response(content, usage) do
+    %{content: content, usage: usage, metadata: %{backend: :native}}
+  end
+
+  # -- complete/2 drain -------------------------------------------------------
+
+  defp collect(events) do
+    Enum.reduce_while(events, {:ok, %{content: "", usage: %{}, metadata: %{backend: :native}}}, fn
+      {:chunk, _text}, acc ->
+        {:cont, acc}
+
+      {:done, response}, _acc ->
+        {:halt, {:ok, response}}
+
+      {:error, reason}, _acc ->
+        {:halt, {:error, reason}}
+
+      _other, acc ->
+        {:cont, acc}
+    end)
+  end
+
+  # -- run config + MCP injection ---------------------------------------------
+
+  defp run_config(messages, opts, mcp_path) do
+    %{
+      prompt: prompt_from(messages),
+      model: Keyword.get(opts, :model),
+      system_prompt: system_prompt_from(messages, opts),
+      mcp_config_path: mcp_path,
+      cwd: Keyword.get(opts, :cwd),
+      extra_args: Keyword.get(opts, :extra_args, [])
+    }
+  end
+
+  defp prompt_from(messages) do
+    messages
+    |> Enum.filter(&(role(&1) == :user))
+    |> Enum.map_join("\n\n", &content_of/1)
+  end
+
+  defp system_prompt_from(messages, opts) do
+    case Keyword.get(opts, :system_prompt) do
+      sp when is_binary(sp) and sp != "" ->
+        sp
+
+      _ ->
+        messages
+        |> Enum.filter(&(role(&1) == :system))
+        |> Enum.map_join("\n\n", &content_of/1)
+        |> blank_to_nil()
+    end
+  end
+
+  defp role(%{role: r}), do: normalize_role(r)
+  defp role(%{"role" => r}), do: normalize_role(r)
+  defp role(_), do: :user
+
+  defp normalize_role(r) when is_atom(r), do: r
+  defp normalize_role("system"), do: :system
+  defp normalize_role("assistant"), do: :assistant
+  defp normalize_role(_), do: :user
+
+  defp content_of(%{content: c}), do: to_string(c)
+  defp content_of(%{"content" => c}), do: to_string(c)
+  defp content_of(_), do: ""
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(other), do: other
+
+  # Build the --mcp-config artifact when actions + a server command are supplied.
+  defp maybe_build_mcp_config(driver, opts) do
+    actions = Keyword.get(opts, :actions, [])
+    command = Keyword.get(opts, :mcp_server_command)
+
+    if NativeHarness.injects_mcp_tools?(driver) and actions != [] and is_binary(command) do
+      case McpToolConfig.write(
+             actions: actions,
+             command: command,
+             args: Keyword.get(opts, :mcp_server_args, [])
+           ) do
+        {:ok, path} -> {path, mcp_cleanup(path)}
+        {:error, _} -> {nil, &noop/0}
+      end
+    else
+      {nil, &noop/0}
+    end
+  end
+
+  defp mcp_cleanup(config_path) do
+    fn -> File.rm_rf(Path.dirname(config_path)) end
+  end
+
+  defp noop, do: :ok
+
+  defp cd_opt(nil), do: []
+  defp cd_opt(cwd), do: [{:cd, cwd}]
+end

--- a/packages/raxol_agent/lib/raxol/agent/backend/selector.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/selector.ex
@@ -1,0 +1,64 @@
+defmodule Raxol.Agent.Backend.Selector do
+  @moduledoc """
+  Resolve a `Raxol.Agent.ExecutorConfig` to a concrete backend module + options.
+
+  This is the explicit replacement for `Raxol.Agent.Backend.HTTP`'s implicit
+  `base_url` substring detection: a named harness maps to a backend module and a
+  set of default options (provider hint, base URL), which are merged with the
+  config's own model/auth/opts.
+
+  Native CLI harnesses (`:claude_native`, `:codex`, `:cursor`) are reserved for
+  the future "vendor owns the loop" path and currently resolve to an error.
+  """
+
+  alias Raxol.Agent.ExecutorConfig
+
+  # harness => {backend_module, default_opts}
+  @harness_table %{
+    anthropic: {Raxol.Agent.Backend.HTTP, [provider: :anthropic]},
+    openai: {Raxol.Agent.Backend.HTTP, [provider: :openai]},
+    kimi: {Raxol.Agent.Backend.HTTP, [provider: :kimi]},
+    ollama: {Raxol.Agent.Backend.HTTP, [provider: :ollama]},
+    llm7: {Raxol.Agent.Backend.HTTP, [provider: :openai, base_url: "https://api.llm7.io"]},
+    lumo: {Raxol.Agent.Backend.Lumo, []},
+    mock: {Raxol.Agent.Backend.Mock, []},
+    # Native harnesses: the CLI owns its loop; Raxol tools are injected over MCP.
+    claude_native: {Raxol.Agent.Backend.ClaudeCode, []},
+    cursor: {Raxol.Agent.Backend.Cursor, []}
+  }
+
+  # Codex speaks a stateful `app-server` JSON-RPC protocol (not the stream-json
+  # NDJSON interface the native backends share); it is served by
+  # `Raxol.Symphony.Runners.Codex` rather than an agent backend here.
+  @reserved_harnesses [:codex]
+
+  @doc """
+  Resolve an executor config to `{:ok, backend_module, backend_opts}`.
+
+  The returned `backend_opts` are the harness defaults merged with the config's
+  flattened `model`/`auth`/`opts` (config values win on conflict). Returns
+  `{:error, {:harness_not_implemented, harness}}` for reserved native harnesses
+  and `{:error, {:unknown_harness, harness}}` otherwise.
+  """
+  @spec select(ExecutorConfig.t()) ::
+          {:ok, module(), keyword()} | {:error, term()}
+  def select(%ExecutorConfig{harness: harness} = config) do
+    case Map.fetch(@harness_table, harness) do
+      {:ok, {backend, defaults}} ->
+        opts = Keyword.merge(defaults, ExecutorConfig.to_backend_opts(config))
+        {:ok, backend, opts}
+
+      :error ->
+        {:error, reason_for(harness)}
+    end
+  end
+
+  @doc "List the harness atoms this selector can resolve to a backend."
+  @spec supported_harnesses() :: [ExecutorConfig.harness()]
+  def supported_harnesses, do: Map.keys(@harness_table)
+
+  defp reason_for(harness) when harness in @reserved_harnesses,
+    do: {:harness_not_implemented, harness}
+
+  defp reason_for(harness), do: {:unknown_harness, harness}
+end

--- a/packages/raxol_agent/lib/raxol/agent/conversation/item.ex
+++ b/packages/raxol_agent/lib/raxol/agent/conversation/item.ex
@@ -1,0 +1,99 @@
+defmodule Raxol.Agent.Conversation.Item do
+  @moduledoc """
+  One immutable entry in a `Raxol.Agent.Conversation.Log`.
+
+  Every event in a conversation -- assistant messages, tool calls and their
+  results, reasoning, errors, compaction markers, terminal I/O, slash commands --
+  is a typed `Item`. A single append-only log of these unifies what every surface
+  (terminal, browser, phone, MCP) renders, and lets a reconnecting client
+  reconcile by stable `id`.
+
+  Items are append-only and never mutated. The store assigns `seq` (monotonic per
+  conversation, 0-based) and derives a stable `id` of `"<conversation_id>:<seq>"`,
+  so snapshot + live tail can be deduped by `id` with no coordination.
+
+  ## Types
+
+  | type | typical `data` | meaning |
+  | --- | --- | --- |
+  | `:message` | `%{role, content, usage}` | an assistant/user message |
+  | `:tool_call` | `%{name, arguments, id}` | the model requested a tool |
+  | `:tool_result` | `%{name, result}` | the result of a tool call |
+  | `:reasoning` | `%{text}` | chain-of-thought / thinking |
+  | `:error` | `%{reason}` | an error in the turn |
+  | `:compaction` | `%{summary, last_seq}` | a summarization marker |
+  | `:resource_event` | `%{kind, ...}` | session/sub-agent lifecycle |
+  | `:slash_command` | `%{command, args}` | a user slash command |
+  | `:terminal` | `%{stream, text}` | terminal input/output observation |
+
+  The set is open; adapters round-trip arbitrary atoms.
+  """
+
+  @type type ::
+          :message
+          | :tool_call
+          | :tool_result
+          | :reasoning
+          | :error
+          | :compaction
+          | :resource_event
+          | :slash_command
+          | :terminal
+          | atom()
+
+  @type status :: :completed | :in_progress | :action_required | atom() | nil
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          conversation_id: binary(),
+          seq: non_neg_integer(),
+          type: type(),
+          status: status(),
+          response_id: binary() | nil,
+          created_at: DateTime.t(),
+          created_by: term() | nil,
+          data: map()
+        }
+
+  @enforce_keys [:id, :conversation_id, :seq, :type, :created_at]
+  defstruct [
+    :id,
+    :conversation_id,
+    :seq,
+    :type,
+    :status,
+    :response_id,
+    :created_at,
+    :created_by,
+    data: %{}
+  ]
+
+  @doc "The stable item id derived from a conversation id and sequence."
+  @spec id(binary(), non_neg_integer()) :: binary()
+  def id(conversation_id, seq), do: "#{conversation_id}:#{seq}"
+
+  @doc """
+  Construct an Item. Used by stores when materializing items on `append`;
+  callers go through `Raxol.Agent.Conversation.Log.append/3` instead.
+
+  Requires `:conversation_id`, `:seq`, and `:type`. `:id` defaults to
+  `id/2`, `:status` to `:completed`, and `:created_at` to now.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts) do
+    conversation_id = Keyword.fetch!(opts, :conversation_id)
+    seq = Keyword.fetch!(opts, :seq)
+
+    %__MODULE__{
+      id: Keyword.get_lazy(opts, :id, fn -> id(conversation_id, seq) end),
+      conversation_id: conversation_id,
+      seq: seq,
+      type: Keyword.fetch!(opts, :type),
+      status: Keyword.get(opts, :status, :completed),
+      response_id: Keyword.get(opts, :response_id),
+      created_at: Keyword.get_lazy(opts, :created_at, &DateTime.utc_now/0),
+      created_by: Keyword.get(opts, :created_by),
+      data: Keyword.get(opts, :data, %{})
+    }
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/conversation/log.ex
+++ b/packages/raxol_agent/lib/raxol/agent/conversation/log.ex
@@ -1,0 +1,206 @@
+defmodule Raxol.Agent.Conversation.Log do
+  @moduledoc """
+  Append-only conversation item log with live-tail-no-replay streaming.
+
+  Wraps a `Raxol.Agent.Conversation.Store` (durability) with an in-process
+  subscriber fan-out (liveness). The stream itself keeps NO replay buffer -- all
+  history lives in the store. This is the omnigent model: durability in the store,
+  the stream is ephemeral pub/sub.
+
+  ## Exact snapshot/live-tail partition
+
+  `subscribe/3` returns a snapshot AND registers the caller as a subscriber in a
+  single serialized `GenServer.call`. Because `append/3` is also a serialized
+  call, the two never interleave: a subscribe processed before an append excludes
+  those items from its snapshot but receives them on the live tail; a subscribe
+  processed after an append includes them in the snapshot and is NOT re-sent them.
+  So a reconnecting client sees every item exactly once with no gap and no dupe --
+  belt-and-suspenders deduping by `Item.id` is then trivial.
+
+  Live items arrive as `{:conversation_item, conversation_id, item}` messages.
+  Subscribers are monitored; their subscriptions are dropped automatically when
+  they exit.
+
+  ## Usage
+
+      {:ok, log} = Log.start_link(name: MyLog)
+      {:ok, %{snapshot: history, last_seq: cursor}} = Log.subscribe(log, "conv-1")
+      {:ok, [item]} = Log.append(log, "conv-1", %{type: :message, data: %{content: "hi"}})
+      # the subscriber's mailbox now holds {:conversation_item, "conv-1", item}
+
+  Reconnect by passing the last seq seen: `Log.subscribe(log, conv, after: cursor)`.
+  """
+
+  use GenServer
+
+  alias Raxol.Agent.Conversation.Store
+
+  defstruct store: nil, subscribers: %{}, monitors: %{}
+
+  @type server :: GenServer.server()
+  @type conversation_id :: binary()
+
+  # -- Public API -------------------------------------------------------------
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name)
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @doc "Append one item (a map) or a list of items; broadcasts to subscribers."
+  @spec append(server(), conversation_id(), Store.new_item() | [Store.new_item()]) ::
+          {:ok, [Raxol.Agent.Conversation.Item.t()]}
+  def append(server, conversation_id, item) when is_map(item),
+    do: append(server, conversation_id, [item])
+
+  def append(server, conversation_id, items) when is_list(items),
+    do: GenServer.call(server, {:append, conversation_id, items})
+
+  @doc """
+  Subscribe the caller to a conversation; returns its snapshot + last seq.
+
+  Options: `:after` -- only snapshot items after this seq (for reconnect).
+  """
+  @spec subscribe(server(), conversation_id(), keyword()) ::
+          {:ok, %{snapshot: [Raxol.Agent.Conversation.Item.t()], last_seq: integer() | nil}}
+  def subscribe(server, conversation_id, opts \\ []),
+    do: GenServer.call(server, {:subscribe, conversation_id, self(), opts})
+
+  @doc "Stop receiving live items for a conversation."
+  @spec unsubscribe(server(), conversation_id()) :: :ok
+  def unsubscribe(server, conversation_id),
+    do: GenServer.call(server, {:unsubscribe, conversation_id, self()})
+
+  @doc "Page through stored items (passthrough to the store, no subscription)."
+  @spec items(server(), conversation_id(), keyword()) ::
+          {:ok, [Raxol.Agent.Conversation.Item.t()]}
+  def items(server, conversation_id, opts \\ []),
+    do: GenServer.call(server, {:items, conversation_id, opts})
+
+  @doc "Conversation metadata (`%{id, last_seq, item_count}`) or `{:error, :not_found}`."
+  @spec get_conversation(server(), conversation_id()) :: {:ok, map()} | {:error, :not_found}
+  def get_conversation(server, conversation_id),
+    do: GenServer.call(server, {:get_conversation, conversation_id})
+
+  @doc "List known conversation ids."
+  @spec list_conversations(server()) :: {:ok, [conversation_id()]}
+  def list_conversations(server), do: GenServer.call(server, :list_conversations)
+
+  # -- GenServer --------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    store = Store.normalize(Keyword.get(opts, :store, default_store()))
+    {:ok, %__MODULE__{store: store}}
+  end
+
+  defp default_store, do: {Raxol.Agent.Conversation.Store.ETS, %{}}
+
+  @impl true
+  def handle_call({:append, conversation_id, new_items}, _from, state) do
+    {:ok, items} = Store.append(state.store, conversation_id, new_items)
+    broadcast(state, conversation_id, items)
+    {:reply, {:ok, items}, state}
+  end
+
+  def handle_call({:subscribe, conversation_id, pid, opts}, _from, state) do
+    list_opts = snapshot_opts(opts)
+    {:ok, snapshot} = Store.list_items(state.store, conversation_id, list_opts)
+
+    last_seq =
+      case List.last(snapshot) do
+        nil -> Keyword.get(opts, :after)
+        item -> item.seq
+      end
+
+    state = add_subscriber(state, conversation_id, pid)
+    {:reply, {:ok, %{snapshot: snapshot, last_seq: last_seq}}, state}
+  end
+
+  def handle_call({:unsubscribe, conversation_id, pid}, _from, state) do
+    {:reply, :ok, remove_subscriber(state, conversation_id, pid)}
+  end
+
+  def handle_call({:items, conversation_id, opts}, _from, state) do
+    {:reply, Store.list_items(state.store, conversation_id, opts), state}
+  end
+
+  def handle_call({:get_conversation, conversation_id}, _from, state) do
+    {:reply, Store.get_conversation(state.store, conversation_id), state}
+  end
+
+  def handle_call(:list_conversations, _from, state) do
+    {:reply, Store.list_conversations(state.store), state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, drop_pid(state, pid)}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- Subscriber bookkeeping -------------------------------------------------
+
+  defp snapshot_opts(opts) do
+    base = [limit: :all]
+
+    case Keyword.get(opts, :after) do
+      nil -> base
+      after_seq -> [{:after, after_seq} | base]
+    end
+  end
+
+  defp broadcast(state, conversation_id, items) do
+    for pid <- Map.get(state.subscribers, conversation_id, MapSet.new()),
+        item <- items do
+      send(pid, {:conversation_item, conversation_id, item})
+    end
+  end
+
+  defp add_subscriber(state, conversation_id, pid) do
+    set = Map.get(state.subscribers, conversation_id, MapSet.new())
+
+    if MapSet.member?(set, pid) do
+      state
+    else
+      ref = Process.monitor(pid)
+
+      %{
+        state
+        | subscribers: Map.put(state.subscribers, conversation_id, MapSet.put(set, pid)),
+          monitors: Map.put(state.monitors, {pid, conversation_id}, ref)
+      }
+    end
+  end
+
+  defp remove_subscriber(state, conversation_id, pid) do
+    set = state.subscribers |> Map.get(conversation_id, MapSet.new()) |> MapSet.delete(pid)
+
+    monitors =
+      case Map.pop(state.monitors, {pid, conversation_id}) do
+        {nil, monitors} ->
+          monitors
+
+        {ref, monitors} ->
+          Process.demonitor(ref, [:flush])
+          monitors
+      end
+
+    %{state | subscribers: Map.put(state.subscribers, conversation_id, set), monitors: monitors}
+  end
+
+  defp drop_pid(state, pid) do
+    subscribers =
+      Map.new(state.subscribers, fn {conv, set} -> {conv, MapSet.delete(set, pid)} end)
+
+    monitors =
+      state.monitors
+      |> Enum.reject(fn {{p, _conv}, _ref} -> p == pid end)
+      |> Map.new()
+
+    %{state | subscribers: subscribers, monitors: monitors}
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/conversation/recorder.ex
+++ b/packages/raxol_agent/lib/raxol/agent/conversation/recorder.ex
@@ -1,0 +1,97 @@
+defmodule Raxol.Agent.Conversation.Recorder do
+  @moduledoc """
+  Records `Raxol.Agent.Stream` events into a `Raxol.Agent.Conversation.Log`.
+
+  Bridges the ephemeral agent event stream to the durable item log, mapping each
+  event tuple to one (or zero) conversation items:
+
+  | event | item |
+  | --- | --- |
+  | `{:tool_use, %{name, arguments, id}}` | `:tool_call` |
+  | `{:tool_result, %{name, result}}` | `:tool_result` |
+  | `{:done, %{content, usage}}` | `:message` (assistant) |
+  | `{:error, reason}` | `:error` |
+  | `{:text_delta, _}` / `{:turn_complete, _}` | (none -- content lands at `:done`) |
+
+  Pass `:response_id` in `opts` to tag every recorded item with the turn it
+  belongs to.
+
+  ## Usage
+
+      stream = Raxol.Agent.Stream.react(prompt, backend: ..., actions: [...])
+      {:ok, items} = Recorder.record_stream(log, "conv-1", stream, response_id: "r1")
+  """
+
+  alias Raxol.Agent.Conversation.{Item, Log}
+
+  @doc "Record a single agent event; returns the items appended (possibly none)."
+  @spec record_event(Log.server(), binary(), keyword(), tuple()) :: {:ok, [Item.t()]}
+  def record_event(log, conversation_id, opts, event) do
+    case items_for(event, opts) do
+      [] -> {:ok, []}
+      new_items -> Log.append(log, conversation_id, new_items)
+    end
+  end
+
+  @doc """
+  Record an entire agent stream into the log.
+
+  Drains the stream (recording each event) and returns every appended item in
+  order. Side effect: the stream is consumed.
+  """
+  @spec record_stream(Log.server(), binary(), Enumerable.t(), keyword()) :: {:ok, [Item.t()]}
+  def record_stream(log, conversation_id, stream, opts \\ []) do
+    items =
+      Enum.flat_map(stream, fn event ->
+        {:ok, items} = record_event(log, conversation_id, opts, event)
+        items
+      end)
+
+    {:ok, items}
+  end
+
+  # -- Event -> item mapping --------------------------------------------------
+
+  defp items_for({:tool_use, %{name: name} = tu}, opts) do
+    [
+      %{
+        type: :tool_call,
+        status: :completed,
+        created_by: :assistant,
+        response_id: response_id(opts),
+        data: %{name: name, arguments: Map.get(tu, :arguments, %{}), id: Map.get(tu, :id)}
+      }
+    ]
+  end
+
+  defp items_for({:tool_result, %{name: name} = tr}, opts) do
+    [
+      %{
+        type: :tool_result,
+        created_by: :tool,
+        response_id: response_id(opts),
+        data: %{name: name, result: Map.get(tr, :result)}
+      }
+    ]
+  end
+
+  defp items_for({:done, %{content: content} = done}, opts) do
+    [
+      %{
+        type: :message,
+        status: :completed,
+        created_by: :assistant,
+        response_id: response_id(opts),
+        data: %{role: :assistant, content: content, usage: Map.get(done, :usage, %{})}
+      }
+    ]
+  end
+
+  defp items_for({:error, reason}, opts) do
+    [%{type: :error, response_id: response_id(opts), data: %{reason: inspect(reason)}}]
+  end
+
+  defp items_for(_event, _opts), do: []
+
+  defp response_id(opts), do: Keyword.get(opts, :response_id)
+end

--- a/packages/raxol_agent/lib/raxol/agent/conversation/store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/conversation/store.ex
@@ -1,0 +1,89 @@
+defmodule Raxol.Agent.Conversation.Store do
+  @moduledoc """
+  Behaviour for `Raxol.Agent.Conversation.Item` persistence.
+
+  Mirrors `Raxol.Agent.ThreadLog`'s pluggable-adapter shape, but for the
+  conversation item log: the store owns durability and assigns each item a stable
+  `seq`/`id`; live fan-out and the snapshot/tail partition live in
+  `Raxol.Agent.Conversation.Log`.
+
+  One adapter ships today: `Raxol.Agent.Conversation.Store.ETS` (in-process,
+  ordered_set on `{conversation_id, seq}`). A durable adapter (DETS/Postgrex) is a
+  deliberate follow-up, matching ThreadLog's `Ets`/`Postgrex` split.
+
+  ## Append is the only writer
+
+  `append/3` assigns consecutive `seq` values atomically per conversation and
+  returns the materialized items. Items are never updated or deleted; the log is
+  append-only.
+
+  ## Cursor pagination
+
+  `list_items/3` accepts `:after`/`:before` sequence cursors (both exclusive),
+  `:limit`, `:order`, and a `:type` filter. A reconnecting client pages forward by
+  passing the last `seq` it has as `:after`.
+  """
+
+  alias Raxol.Agent.Conversation.Item
+
+  @type config :: map()
+  @type conversation_id :: binary()
+
+  @typedoc "A new item to append; the store assigns id/seq/created_at."
+  @type new_item :: %{
+          required(:type) => Item.type(),
+          optional(:data) => map(),
+          optional(:status) => Item.status(),
+          optional(:response_id) => binary() | nil,
+          optional(:created_by) => term()
+        }
+
+  @typedoc """
+  Options for `list_items/3`:
+
+    * `:after` -- return items with `seq >` this value (exclusive cursor).
+    * `:before` -- return items with `seq <` this value (exclusive).
+    * `:limit` -- max items, or `:all`. Default 1000.
+    * `:order` -- `:asc` (default) or `:desc`.
+    * `:type` -- a type atom or list of types to filter by.
+  """
+  @type list_opts :: keyword()
+
+  @callback append(config(), conversation_id(), [new_item()]) :: {:ok, [Item.t()]}
+  @callback list_items(config(), conversation_id(), list_opts()) :: {:ok, [Item.t()]}
+  @callback get_conversation(config(), conversation_id()) ::
+              {:ok, map()} | {:error, :not_found}
+  @callback list_conversations(config()) :: {:ok, [conversation_id()]}
+
+  # --- Module-level dispatcher ---------------------------------------------
+
+  @doc "Normalize a store opt into `{module, config}` form."
+  @spec normalize(module() | {module(), config()}) :: {module(), config()}
+  def normalize({module, config}) when is_atom(module) and is_map(config),
+    do: {module, config}
+
+  def normalize(module) when is_atom(module), do: {module, %{}}
+
+  @doc "Dispatch `append` to the adapter."
+  @spec append({module(), config()}, conversation_id(), [new_item()]) :: {:ok, [Item.t()]}
+  def append({module, config}, conversation_id, items)
+      when is_atom(module) and is_binary(conversation_id) and is_list(items),
+      do: module.append(config, conversation_id, items)
+
+  @doc "Dispatch `list_items` to the adapter."
+  @spec list_items({module(), config()}, conversation_id(), list_opts()) :: {:ok, [Item.t()]}
+  def list_items({module, config}, conversation_id, opts \\ [])
+      when is_atom(module),
+      do: module.list_items(config, conversation_id, opts)
+
+  @doc "Dispatch `get_conversation` to the adapter."
+  @spec get_conversation({module(), config()}, conversation_id()) ::
+          {:ok, map()} | {:error, :not_found}
+  def get_conversation({module, config}, conversation_id) when is_atom(module),
+    do: module.get_conversation(config, conversation_id)
+
+  @doc "Dispatch `list_conversations` to the adapter."
+  @spec list_conversations({module(), config()}) :: {:ok, [conversation_id()]}
+  def list_conversations({module, config}) when is_atom(module),
+    do: module.list_conversations(config)
+end

--- a/packages/raxol_agent/lib/raxol/agent/conversation/store/ets.ex
+++ b/packages/raxol_agent/lib/raxol/agent/conversation/store/ets.ex
@@ -1,0 +1,160 @@
+defmodule Raxol.Agent.Conversation.Store.ETS do
+  @moduledoc """
+  ETS-backed `Raxol.Agent.Conversation.Store` adapter.
+
+  Items live in a named `ordered_set` keyed on `{conversation_id, seq}`, so
+  iteration is naturally sequence-ordered within a conversation. Sequence
+  allocation uses a sibling `set` and `:ets.update_counter/3` for atomic, 0-based
+  per-conversation increments (the same pattern as `Raxol.Agent.ThreadLog.Ets`). A
+  third `set` tracks known conversation ids for `list_conversations/1`.
+
+  ## Config
+
+      %{table: :my_conversation_items}
+
+  Defaults to `:raxol_conversation_items`. Conversations sharing a table name
+  share its items; isolate by passing distinct names.
+
+  ## Lifetime
+
+  Tables live for the duration of the BEAM; not supervised, not persisted. A
+  durable adapter is a follow-up.
+  """
+
+  @behaviour Raxol.Agent.Conversation.Store
+
+  alias Raxol.Agent.Conversation.Item
+
+  @default_table :raxol_conversation_items
+
+  @doc "Ensure the items, sequence-counter, and conversation-registry tables exist."
+  @spec ensure_tables(map()) :: {atom(), atom(), atom()}
+  def ensure_tables(config) do
+    items = Map.get(config, :table, @default_table)
+    counters = :"#{items}_seq"
+    convs = :"#{items}_convs"
+
+    ensure_table(items, [:ordered_set, :public, :named_table, read_concurrency: true])
+    ensure_table(counters, [:set, :public, :named_table, write_concurrency: true])
+    ensure_table(convs, [:set, :public, :named_table, read_concurrency: true])
+
+    {items, counters, convs}
+  end
+
+  defp ensure_table(name, opts) do
+    case :ets.whereis(name) do
+      :undefined -> :ets.new(name, opts)
+      _ -> name
+    end
+  end
+
+  @impl true
+  def append(config, conversation_id, new_items) do
+    {items, counters, convs} = ensure_tables(config)
+    :ets.insert(convs, {conversation_id})
+
+    materialized =
+      Enum.map(new_items, fn attrs ->
+        seq = next_sequence(counters, conversation_id)
+
+        item =
+          Item.new(
+            conversation_id: conversation_id,
+            seq: seq,
+            type: Map.fetch!(attrs, :type),
+            status: Map.get(attrs, :status, :completed),
+            response_id: Map.get(attrs, :response_id),
+            created_by: Map.get(attrs, :created_by),
+            data: Map.get(attrs, :data, %{})
+          )
+
+        :ets.insert(items, {{conversation_id, seq}, item})
+        item
+      end)
+
+    {:ok, materialized}
+  end
+
+  # 0-based atomic sequence allocation per conversation.
+  defp next_sequence(counters, conversation_id) do
+    :ets.update_counter(counters, conversation_id, {2, 1}, {conversation_id, -1})
+  end
+
+  @impl true
+  def list_items(config, conversation_id, opts \\ []) do
+    {items, _counters, _convs} = ensure_tables(config)
+    after_seq = Keyword.get(opts, :after, -1)
+    before = Keyword.get(opts, :before, :infinity)
+    limit = Keyword.get(opts, :limit, 1_000)
+    order = Keyword.get(opts, :order, :asc)
+    type = Keyword.get(opts, :type)
+
+    stream =
+      items
+      |> walk(conversation_id, after_seq, before)
+      |> maybe_filter_type(type)
+
+    result =
+      case limit do
+        :all -> Enum.to_list(stream)
+        n when is_integer(n) and n >= 0 -> Enum.take(stream, n)
+      end
+
+    {:ok, maybe_reverse(result, order)}
+  end
+
+  @impl true
+  def get_conversation(config, conversation_id) do
+    {_items, counters, _convs} = ensure_tables(config)
+
+    case :ets.lookup(counters, conversation_id) do
+      [{^conversation_id, last_seq}] when last_seq >= 0 ->
+        {:ok, %{id: conversation_id, last_seq: last_seq, item_count: last_seq + 1}}
+
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  @impl true
+  def list_conversations(config) do
+    {_items, _counters, convs} = ensure_tables(config)
+    {:ok, for({id} <- :ets.tab2list(convs), do: id)}
+  end
+
+  # --- Walk helpers ---------------------------------------------------------
+
+  defp walk(items, conversation_id, after_seq, before) do
+    Stream.unfold({conversation_id, after_seq}, fn key ->
+      next_in_conversation(items, conversation_id, before, key)
+    end)
+  end
+
+  defp next_in_conversation(items, conversation_id, before, key) do
+    case :ets.next(items, key) do
+      :"$end_of_table" ->
+        nil
+
+      {^conversation_id, seq} = found when before == :infinity or seq < before ->
+        [{^found, item}] = :ets.lookup(items, found)
+        {item, found}
+
+      {^conversation_id, _seq_at_or_past_before} ->
+        nil
+
+      _other_conversation ->
+        nil
+    end
+  end
+
+  defp maybe_filter_type(stream, nil), do: stream
+
+  defp maybe_filter_type(stream, types) when is_list(types),
+    do: Stream.filter(stream, &(&1.type in types))
+
+  defp maybe_filter_type(stream, type),
+    do: Stream.filter(stream, &(&1.type == type))
+
+  defp maybe_reverse(list, :asc), do: list
+  defp maybe_reverse(list, :desc), do: Enum.reverse(list)
+end

--- a/packages/raxol_agent/lib/raxol/agent/executor_config.ex
+++ b/packages/raxol_agent/lib/raxol/agent/executor_config.ex
@@ -1,0 +1,96 @@
+defmodule Raxol.Agent.ExecutorConfig do
+  @moduledoc """
+  Explicit `{harness, model, auth}` configuration for an agent executor.
+
+  This is the front door for selecting where an agent's turns run. A `harness`
+  names the runtime/vendor (`:anthropic`, `:openai`, `:lumo`, ...); `model` and
+  `auth` say which model behind it and with what credentials. This replaces the
+  implicit `base_url` substring detection in `Raxol.Agent.Backend.HTTP` with a
+  named, declarative struct.
+
+  Resolve a config to a concrete backend module + options with
+  `Raxol.Agent.Backend.Selector.select/1`. The struct itself only knows how to
+  flatten itself into the keyword list backends already consume
+  (`to_backend_opts/1`).
+
+  ## Examples
+
+      iex> Raxol.Agent.ExecutorConfig.new(harness: :anthropic, model: "claude-opus-4-8")
+      %Raxol.Agent.ExecutorConfig{harness: :anthropic, model: "claude-opus-4-8", auth: %{}, opts: []}
+
+      iex> cfg = Raxol.Agent.ExecutorConfig.new(harness: :openai, model: "gpt-5", auth: %{api_key: "sk-x"})
+      iex> Raxol.Agent.ExecutorConfig.to_backend_opts(cfg)
+      [model: "gpt-5", api_key: "sk-x"]
+  """
+
+  @enforce_keys [:harness]
+  defstruct harness: nil, model: nil, auth: %{}, opts: []
+
+  @type harness ::
+          :anthropic
+          | :openai
+          | :kimi
+          | :ollama
+          | :llm7
+          | :lumo
+          | :mock
+          | :claude_native
+          | :codex
+          | :cursor
+
+  @type t :: %__MODULE__{
+          harness: harness(),
+          model: String.t() | nil,
+          auth: map(),
+          opts: keyword()
+        }
+
+  @doc """
+  Build an `ExecutorConfig` from a keyword list or map.
+
+  Recognized keys: `:harness` (required), `:model`, `:auth`, `:opts`. The
+  `:harness` value is required and must be an atom.
+  """
+  @spec new(keyword() | map()) :: t()
+  def new(attrs) when is_list(attrs), do: new(Map.new(attrs))
+
+  def new(%{harness: harness} = attrs) when is_atom(harness) and not is_nil(harness) do
+    %__MODULE__{
+      harness: harness,
+      model: Map.get(attrs, :model),
+      auth: Map.get(attrs, :auth, %{}),
+      opts: Map.get(attrs, :opts, [])
+    }
+  end
+
+  @doc """
+  Alias for `new/1` to read naturally when parsing external keyword config.
+  """
+  @spec from_keyword(keyword()) :: t()
+  def from_keyword(kw) when is_list(kw), do: new(kw)
+
+  @doc """
+  Flatten this config into the keyword options a backend consumes.
+
+  Order of precedence (later wins): auth fields, then explicit `:opts`, with the
+  `:model` placed first so an `:opts`-supplied model can still override it.
+  """
+  @spec to_backend_opts(t()) :: keyword()
+  def to_backend_opts(%__MODULE__{model: model, auth: auth, opts: opts}) do
+    []
+    |> put_model(model)
+    |> Keyword.merge(auth_to_opts(auth))
+    |> Keyword.merge(opts)
+  end
+
+  defp put_model(kw, nil), do: kw
+  defp put_model(kw, model), do: Keyword.put(kw, :model, model)
+
+  defp auth_to_opts(auth) when is_map(auth) do
+    auth
+    |> Enum.filter(fn {k, _v} -> is_atom(k) end)
+    |> Enum.map(fn {k, v} -> {k, v} end)
+  end
+
+  defp auth_to_opts(_), do: []
+end

--- a/packages/raxol_agent/lib/raxol/agent/harness/claude_code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/harness/claude_code.ex
@@ -1,0 +1,46 @@
+defmodule Raxol.Agent.Harness.ClaudeCode do
+  @moduledoc """
+  Native harness driver for the Claude Code CLI (`claude`).
+
+  Drives a single non-interactive run via `claude -p <prompt> --output-format
+  stream-json --verbose`, injecting Raxol's tools with `--mcp-config <path>`.
+  Parses the `stream-json` NDJSON protocol via `Raxol.Agent.Harness.StreamJson`.
+
+  The CLI owns its agent loop and tool dispatch, so a backend built on this driver
+  reports `handles_tools_internally? == true`.
+  """
+
+  @behaviour Raxol.Agent.NativeHarness
+
+  alias Raxol.Agent.Harness.StreamJson
+
+  @impl true
+  def executable, do: "claude"
+
+  @impl true
+  def name, do: "Claude Code"
+
+  @impl true
+  def args(config) do
+    prompt = Map.get(config, :prompt, "")
+
+    ["-p", prompt, "--output-format", "stream-json", "--verbose"]
+    |> append_model(Map.get(config, :model))
+    |> append_system_prompt(Map.get(config, :system_prompt))
+    |> append_mcp_config(Map.get(config, :mcp_config_path))
+    |> Kernel.++(Map.get(config, :extra_args, []))
+  end
+
+  @impl true
+  defdelegate parse_line(line), to: StreamJson
+
+  defp append_model(args, nil), do: args
+  defp append_model(args, model), do: args ++ ["--model", model]
+
+  defp append_system_prompt(args, nil), do: args
+  defp append_system_prompt(args, ""), do: args
+  defp append_system_prompt(args, prompt), do: args ++ ["--append-system-prompt", prompt]
+
+  defp append_mcp_config(args, nil), do: args
+  defp append_mcp_config(args, path), do: args ++ ["--mcp-config", path]
+end

--- a/packages/raxol_agent/lib/raxol/agent/harness/cursor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/harness/cursor.ex
@@ -1,0 +1,42 @@
+defmodule Raxol.Agent.Harness.Cursor do
+  @moduledoc """
+  Native harness driver for the Cursor agent CLI (`cursor-agent`).
+
+  `cursor-agent` mirrors Claude Code's non-interactive interface: `cursor-agent
+  -p <prompt> --output-format stream-json`, emitting the same `stream-json` NDJSON
+  protocol (parsed via `Raxol.Agent.Harness.StreamJson`). Tools are injected with
+  `--mcp-config <path>`.
+
+  The CLI owns its agent loop and tool dispatch, so a backend built on this driver
+  reports `handles_tools_internally? == true`.
+  """
+
+  @behaviour Raxol.Agent.NativeHarness
+
+  alias Raxol.Agent.Harness.StreamJson
+
+  @impl true
+  def executable, do: "cursor-agent"
+
+  @impl true
+  def name, do: "Cursor"
+
+  @impl true
+  def args(config) do
+    prompt = Map.get(config, :prompt, "")
+
+    ["-p", prompt, "--output-format", "stream-json"]
+    |> append_model(Map.get(config, :model))
+    |> append_mcp_config(Map.get(config, :mcp_config_path))
+    |> Kernel.++(Map.get(config, :extra_args, []))
+  end
+
+  @impl true
+  defdelegate parse_line(line), to: StreamJson
+
+  defp append_model(args, nil), do: args
+  defp append_model(args, model), do: args ++ ["--model", model]
+
+  defp append_mcp_config(args, nil), do: args
+  defp append_mcp_config(args, path), do: args ++ ["--mcp-config", path]
+end

--- a/packages/raxol_agent/lib/raxol/agent/harness/mcp_tool_config.ex
+++ b/packages/raxol_agent/lib/raxol/agent/harness/mcp_tool_config.ex
@@ -1,0 +1,141 @@
+defmodule Raxol.Agent.Harness.McpToolConfig do
+  @moduledoc """
+  Builds the MCP configuration that injects Raxol's tools into a native CLI.
+
+  This is the "vendor owns the loop, we inject our tools" trick from omnigent:
+  when a native harness runs its own agent loop, the framework cannot drive tool
+  dispatch. Instead it exposes the agent's Actions to the CLI as an MCP server,
+  which the CLI discovers via its `--mcp-config <path>` flag and calls directly.
+
+  Two artifacts are produced:
+
+  - The **MCP config** the CLI consumes -- `{"mcpServers": {"<name>": {command,
+    args, env}}}`. The CLI launches that command as a child and speaks MCP to it.
+  - A **tool manifest** -- the Action tool definitions (derived via
+    `Raxol.Agent.Action.ToolConverter`) written to a side file whose path is
+    passed to the server command via the `RAXOL_MCP_TOOLS_FILE` env var, so the
+    spawned MCP server can load exactly this agent's tools.
+
+  The referenced `:command` must be an MCP server that exposes the manifest's
+  tools (e.g. a `mix mcp.server` variant); wiring a specific server binary is the
+  caller's responsibility. This module owns the config/manifest format only.
+  """
+
+  alias Raxol.Agent.Action.ToolConverter
+
+  @default_server_name "raxol"
+  @tools_env_var "RAXOL_MCP_TOOLS_FILE"
+
+  @type opts :: [
+          actions: [module()],
+          tools: [map()],
+          server_name: String.t(),
+          command: String.t(),
+          args: [String.t()],
+          env: %{optional(String.t()) => String.t()},
+          dir: Path.t()
+        ]
+
+  @doc """
+  Derive MCP tool definitions (`%{"name", "description", "inputSchema"}`) from
+  Action modules, via `ToolConverter.to_tool_definitions/1`.
+  """
+  @spec tool_definitions([module()]) :: [map()]
+  def tool_definitions(actions) when is_list(actions) do
+    actions
+    |> ToolConverter.to_tool_definitions()
+    |> Enum.map(&to_mcp_tool/1)
+  end
+
+  @doc """
+  Build the MCP config map the CLI consumes.
+
+  Requires `:command` (the MCP server launcher). Tools come from `:tools`
+  (pre-derived) or `:actions` (derived here). The tool manifest path is injected
+  into the server entry's env as `RAXOL_MCP_TOOLS_FILE` when `:tools_file` is
+  given.
+  """
+  @spec config(opts()) :: map()
+  def config(opts) do
+    name = Keyword.get(opts, :server_name, @default_server_name)
+    command = Keyword.fetch!(opts, :command)
+    args = Keyword.get(opts, :args, [])
+    env = build_env(opts)
+
+    entry =
+      %{"command" => command, "args" => args}
+      |> maybe_put_env(env)
+
+    %{"mcpServers" => %{name => entry}}
+  end
+
+  @doc """
+  Write the MCP config and tool manifest to disk.
+
+  Writes the manifest (`<dir>/raxol_mcp_tools.json`) and the config
+  (`<dir>/raxol_mcp_config.json`), wiring the manifest path into the server env.
+  Returns `{:ok, config_path}`. `:dir` defaults to a unique temp directory.
+  """
+  @spec write(opts()) :: {:ok, Path.t()} | {:error, term()}
+  def write(opts) do
+    dir = Keyword.get_lazy(opts, :dir, &unique_tmp_dir/0)
+    File.mkdir_p!(dir)
+
+    tools = resolve_tools(opts)
+    tools_file = Path.join(dir, "raxol_mcp_tools.json")
+    config_file = Path.join(dir, "raxol_mcp_config.json")
+
+    with :ok <- File.write(tools_file, Jason.encode!(%{"tools" => tools})),
+         cfg = config(Keyword.put(opts, :tools_file, tools_file)),
+         :ok <- File.write(config_file, Jason.encode!(cfg)) do
+      {:ok, config_file}
+    end
+  end
+
+  @doc "The env var name carrying the tool manifest path to the MCP server."
+  @spec tools_env_var() :: String.t()
+  def tools_env_var, do: @tools_env_var
+
+  # -- Internals --------------------------------------------------------------
+
+  defp resolve_tools(opts) do
+    case Keyword.get(opts, :tools) do
+      tools when is_list(tools) -> tools
+      _ -> tool_definitions(Keyword.get(opts, :actions, []))
+    end
+  end
+
+  defp build_env(opts) do
+    base = Keyword.get(opts, :env, %{})
+
+    case Keyword.get(opts, :tools_file) do
+      nil -> base
+      path -> Map.put(base, @tools_env_var, path)
+    end
+  end
+
+  defp maybe_put_env(entry, env) when map_size(env) == 0, do: entry
+  defp maybe_put_env(entry, env), do: Map.put(entry, "env", env)
+
+  defp to_mcp_tool(%{"function" => %{"name" => name} = fun}) do
+    %{
+      "name" => name,
+      "description" => Map.get(fun, "description", ""),
+      "inputSchema" => Map.get(fun, "parameters", %{"type" => "object", "properties" => %{}})
+    }
+  end
+
+  defp to_mcp_tool(%{"name" => name} = tool) do
+    %{
+      "name" => name,
+      "description" => Map.get(tool, "description", ""),
+      "inputSchema" =>
+        Map.get(tool, "inputSchema") || Map.get(tool, "parameters") ||
+          %{"type" => "object", "properties" => %{}}
+    }
+  end
+
+  defp unique_tmp_dir do
+    Path.join(System.tmp_dir!(), "raxol_mcp_#{System.unique_integer([:positive])}")
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/harness/stream_json.ex
+++ b/packages/raxol_agent/lib/raxol/agent/harness/stream_json.ex
@@ -1,0 +1,70 @@
+defmodule Raxol.Agent.Harness.StreamJson do
+  @moduledoc """
+  Parser for the `--output-format stream-json` NDJSON protocol shared by Claude
+  Code and Cursor's `cursor-agent`.
+
+  Each stdout line is a standalone JSON object tagged with a `type`:
+
+  - `system` (init/config) -- ignored.
+  - `assistant` -- a model message; its `content` blocks become `:text`,
+    `:reasoning` (thinking), or `:tool_call` events.
+  - `user` -- tool results echoed back; ignored (the MCP server owns execution).
+  - `result` -- the terminal event; `success` yields `{:done, ...}` with the
+    final text + usage, an error subtype yields `{:error, ...}`.
+
+  Non-JSON lines (banners, warnings) parse to `[]` so stray output never breaks a
+  run. Returns `Raxol.Agent.NativeHarness` event tuples.
+  """
+
+  alias Raxol.Agent.NativeHarness
+
+  @doc "Parse one NDJSON line into normalized harness events."
+  @spec parse_line(String.t()) :: [NativeHarness.event()]
+  def parse_line(line) do
+    case Jason.decode(String.trim(line)) do
+      {:ok, %{} = obj} -> parse_object(obj)
+      _ -> []
+    end
+  end
+
+  defp parse_object(%{"type" => "assistant", "message" => %{"content" => content}})
+       when is_list(content) do
+    Enum.flat_map(content, &parse_block/1)
+  end
+
+  defp parse_object(%{"type" => "result", "subtype" => "success"} = obj) do
+    [{:done, %{content: result_text(obj), usage: usage(obj)}}]
+  end
+
+  defp parse_object(%{"type" => "result", "subtype" => subtype} = obj) do
+    [{:error, {:result_error, subtype, result_text(obj)}}]
+  end
+
+  defp parse_object(_other), do: []
+
+  defp parse_block(%{"type" => "text", "text" => text}) when is_binary(text),
+    do: [{:text, text}]
+
+  defp parse_block(%{"type" => "thinking", "thinking" => text}) when is_binary(text),
+    do: [{:reasoning, text}]
+
+  defp parse_block(%{"type" => "tool_use", "name" => name} = block) do
+    [{:tool_call, %{name: name, input: Map.get(block, "input", %{}), id: Map.get(block, "id")}}]
+  end
+
+  defp parse_block(_other), do: []
+
+  defp result_text(obj) do
+    case Map.get(obj, "result") do
+      text when is_binary(text) -> text
+      _ -> ""
+    end
+  end
+
+  defp usage(obj) do
+    case Map.get(obj, "usage") do
+      %{} = usage -> usage
+      _ -> %{}
+    end
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/native_harness.ex
+++ b/packages/raxol_agent/lib/raxol/agent/native_harness.ex
@@ -1,0 +1,100 @@
+defmodule Raxol.Agent.NativeHarness do
+  @moduledoc """
+  Behaviour for a native CLI harness: an external coding-agent CLI (Claude Code,
+  Cursor, ...) that owns its own agent loop and tool dispatch.
+
+  This is the "vendor owns the loop" half of the meta-harness. A backend built on
+  a native harness reports `handles_tools_internally?() == true`, so the
+  framework's ReAct loop does NOT drive tool calls; instead the CLI runs its own
+  loop and Raxol's tools are injected into it over MCP (see
+  `Raxol.Agent.Harness.McpToolConfig`).
+
+  A harness driver is a small, mostly-pure module that knows three things about
+  its CLI:
+
+  - `executable/0` -- the binary name to look up on `PATH`.
+  - `args/1` -- the argv (after the executable) to spawn one non-interactive run.
+  - `parse_line/1` -- turn one line of the CLI's stdout into normalized events.
+
+  The generic Port runtime (`Raxol.Agent.Backend.Native`) handles spawning,
+  line framing, streaming, and exit/timeout. Drivers stay protocol-only and are
+  trivially unit-testable.
+
+  ## Normalized events
+
+  `parse_line/1` returns a (possibly empty) list of these tuples, in order:
+
+  - `{:text, binary}` -- assistant text to surface to the user.
+  - `{:reasoning, binary}` -- chain-of-thought / thinking text.
+  - `{:tool_call, map}` -- the CLI invoked a tool (observability only; the tool
+    itself is served by the injected MCP server, not by the framework).
+  - `{:done, %{content: binary, usage: map}}` -- the run finished; `content` is
+    the final answer, `usage` is token accounting (may be empty).
+  - `{:error, term}` -- the CLI reported an error.
+  """
+
+  @type event ::
+          {:text, binary()}
+          | {:reasoning, binary()}
+          | {:tool_call, map()}
+          | {:done, %{content: binary(), usage: map()}}
+          | {:error, term()}
+
+  @typedoc """
+  Run configuration passed to `args/1`. Keys:
+
+  - `:prompt` -- the user prompt for this run.
+  - `:model` -- model id, or `nil` for the CLI default.
+  - `:system_prompt` -- optional system/append prompt.
+  - `:mcp_config_path` -- path to the MCP config file injecting Raxol tools, or
+    `nil` when no tools are exposed.
+  - `:cwd` -- working directory.
+  - `:extra_args` -- raw argv appended verbatim.
+  """
+  @type run_config :: %{
+          optional(:prompt) => binary(),
+          optional(:model) => binary() | nil,
+          optional(:system_prompt) => binary() | nil,
+          optional(:mcp_config_path) => Path.t() | nil,
+          optional(:cwd) => Path.t() | nil,
+          optional(:extra_args) => [binary()]
+        }
+
+  @doc "The CLI binary name, looked up on `PATH`."
+  @callback executable() :: String.t()
+
+  @doc "The argv (after the executable) for one non-interactive run."
+  @callback args(run_config()) :: [String.t()]
+
+  @doc "Parse one stdout line into zero or more normalized events."
+  @callback parse_line(line :: String.t()) :: [event()]
+
+  @doc "Human-readable harness name."
+  @callback name() :: String.t()
+
+  @doc """
+  Whether this harness exposes Raxol tools to the CLI over MCP.
+
+  When `true` (the default for tool-using harnesses), the runtime builds an MCP
+  config from the agent's Actions and passes its path in `run_config.mcp_config_path`.
+  """
+  @callback injects_mcp_tools?() :: boolean()
+
+  @optional_callbacks injects_mcp_tools?: 0
+
+  @doc "Whether the CLI for `driver` is available on this machine."
+  @spec available?(module()) :: boolean()
+  def available?(driver) when is_atom(driver) do
+    not is_nil(System.find_executable(driver.executable()))
+  end
+
+  @doc "Query `injects_mcp_tools?/0`, defaulting to `true`."
+  @spec injects_mcp_tools?(module()) :: boolean()
+  def injects_mcp_tools?(driver) when is_atom(driver) do
+    if function_exported?(driver, :injects_mcp_tools?, 0) do
+      driver.injects_mcp_tools?()
+    else
+      true
+    end
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/stream.ex
+++ b/packages/raxol_agent/lib/raxol/agent/stream.ex
@@ -40,8 +40,13 @@ defmodule Raxol.Agent.Stream do
 
   Common options for `run/2` and `react/2`:
 
-  - `:backend` -- AIBackend module (default: `Raxol.Agent.Backend.Mock`)
-  - `:backend_opts` -- keyword list passed to backend (api_key, model, etc.)
+  - `:executor` -- `Raxol.Agent.ExecutorConfig` selecting backend + model + auth
+    (takes precedence over `:backend`)
+  - `:backend` -- AIBackend module (default: `Raxol.Agent.Backend.Mock`); ignored
+    when `:executor` is given
+  - `:backend_opts` -- keyword list passed to backend (api_key, model, etc.);
+    merged over the executor's resolved opts
+  - `:model` -- per-request model override (wins over `:executor`/`:backend_opts`)
   - `:system_prompt` -- system message prepended to conversation
   - `:messages` -- pre-built message list (overrides prompt)
   - `:stream` -- whether to use streaming backend (default: `true`)
@@ -100,8 +105,11 @@ defmodule Raxol.Agent.Stream do
   @spec run(String.t() | [map()], keyword()) :: Enumerable.t()
   def run(prompt_or_messages, opts \\ []) do
     messages = build_messages(prompt_or_messages, opts)
-    backend = Keyword.get(opts, :backend, Raxol.Agent.Backend.Mock)
-    backend_opts = Keyword.get(opts, :backend_opts, [])
+    {backend, backend_opts} = resolve_backend(opts)
+    do_completion(backend, messages, backend_opts, opts)
+  end
+
+  defp do_completion(backend, messages, backend_opts, opts) do
     use_streaming = Keyword.get(opts, :stream, true)
 
     if use_streaming and function_exported?(backend, :stream, 2) do
@@ -131,8 +139,26 @@ defmodule Raxol.Agent.Stream do
   @spec react(String.t() | [map()], keyword()) :: Enumerable.t()
   def react(prompt_or_messages, opts \\ []) do
     messages = build_messages(prompt_or_messages, opts)
-    backend = Keyword.get(opts, :backend, Raxol.Agent.Backend.Mock)
-    backend_opts = Keyword.get(opts, :backend_opts, [])
+    {backend, backend_opts} = resolve_backend(opts)
+
+    if Raxol.Agent.AIBackend.handles_tools_internally?(backend) do
+      native_react(messages, backend, backend_opts, opts)
+    else
+      framework_react(messages, backend, backend_opts, opts)
+    end
+  end
+
+  # Vendor-owns-loop backends (native CLI harnesses) run their own tool loop with
+  # Raxol's tools injected over MCP, so the framework just streams their output.
+  defp native_react(messages, backend, backend_opts, opts) do
+    context = Keyword.get(opts, :context, %{})
+
+    messages
+    |> maybe_enrich_memory(context)
+    |> then(&do_completion(backend, &1, backend_opts, opts))
+  end
+
+  defp framework_react(messages, backend, backend_opts, opts) do
     actions = Keyword.get(opts, :actions, [])
     max_iterations = Keyword.get(opts, :max_iterations, @default_max_iterations)
     context = Keyword.get(opts, :context, %{})
@@ -452,6 +478,57 @@ defmodule Raxol.Agent.Stream do
   end
 
   defp parse_tool_result_message(_), do: []
+
+  # -- Private: Backend Resolution --------------------------------------------
+
+  # Resolves the backend module + options from the caller's opts.
+  #
+  # Precedence: an `:executor` (ExecutorConfig) selects the backend + base opts;
+  # otherwise `:backend` (default Mock) is used. Explicit `:backend_opts`
+  # override the executor's resolved opts, and a top-level `:model` overrides
+  # everything (the substrate for a `/model` mid-session switch).
+  defp resolve_backend(opts) do
+    {backend, base_opts} = backend_from_opts(opts)
+
+    backend_opts =
+      base_opts
+      |> Keyword.merge(Keyword.get(opts, :backend_opts, []))
+      |> maybe_override_model(Keyword.get(opts, :model))
+      |> maybe_inject_actions(backend, opts)
+
+    {backend, backend_opts}
+  end
+
+  # Native (vendor-owns-loop) backends expose Raxol's tools to the CLI over MCP,
+  # so they need the Action modules in their opts to build the MCP config.
+  defp maybe_inject_actions(backend_opts, backend, opts) do
+    with true <- Raxol.Agent.AIBackend.handles_tools_internally?(backend),
+         actions when is_list(actions) and actions != [] <- Keyword.get(opts, :actions) do
+      Keyword.put_new(backend_opts, :actions, actions)
+    else
+      _ -> backend_opts
+    end
+  end
+
+  defp backend_from_opts(opts) do
+    case Keyword.get(opts, :executor) do
+      %Raxol.Agent.ExecutorConfig{} = executor ->
+        case Raxol.Agent.Backend.Selector.select(executor) do
+          {:ok, backend, executor_opts} -> {backend, executor_opts}
+          {:error, _reason} -> {fallback_backend(opts), []}
+        end
+
+      _ ->
+        {fallback_backend(opts), []}
+    end
+  end
+
+  defp fallback_backend(opts) do
+    Keyword.get(opts, :backend, Raxol.Agent.Backend.Mock)
+  end
+
+  defp maybe_override_model(backend_opts, nil), do: backend_opts
+  defp maybe_override_model(backend_opts, model), do: Keyword.put(backend_opts, :model, model)
 
   # -- Private: Message Building ----------------------------------------------
 

--- a/packages/raxol_agent/lib/raxol/agent/tunnel.ex
+++ b/packages/raxol_agent/lib/raxol/agent/tunnel.ex
@@ -1,0 +1,274 @@
+defmodule Raxol.Agent.Tunnel do
+  @moduledoc """
+  One endpoint of the reverse co-driving tunnel.
+
+  The co-driving model from omnigent: a host dials OUT to a server over a single
+  link (the server never dials in), and many logical channels are multiplexed
+  over that one link. A teammate's browser "attaches" by opening a channel on the
+  server endpoint; the frames tunnel down to the host endpoint, which spawns the
+  channel's handler **locally** -- so the work runs on the owner's machine, and
+  the owner's filesystem and credentials never leave it.
+
+  In the BEAM this is a GenServer holding the link plus a registry of channels.
+  An endpoint is `role: :server` or `role: :host`. Only the host sets `:on_open`,
+  the callback that materializes a local handler for each inbound channel.
+
+  ## The link
+
+  The endpoint is transport-agnostic. Outbound frames go through a `send_fun`
+  (`binary -> any`); inbound bytes arrive as `{:tunnel_recv, binary}` messages.
+  `Raxol.Agent.Tunnel.Link.connect/2` wires two endpoints together in-process
+  (deterministic, no network). A real WebSocket transport (e.g. Mint.WebSocket on
+  the host, Bandit on the server) is a drop-in adapter: read the socket and send
+  `{:tunnel_recv, bytes}` to the endpoint; set `send_fun` to write the socket.
+
+  ## Channels
+
+  - `open_channel/3` (typically called on the server) allocates a `channel_id`,
+    registers the caller (or `:owner`) as the local channel owner, and sends an
+    `:open` frame. The peer's `:on_open` spawns its handler.
+  - `send_data/3` sends channel I/O to the peer.
+  - `close_channel/3` closes a channel on both ends.
+
+  A channel owner receives `{:tunnel_data, channel_id, data}` for inbound I/O and
+  `{:tunnel_closed, channel_id, reason}` when the channel closes. Owners are
+  monitored: if an owner dies, its channel is closed and the peer notified.
+  """
+
+  use GenServer
+
+  alias Raxol.Agent.Tunnel.Frame
+
+  defstruct role: :server,
+            host_id: nil,
+            capabilities: [],
+            send_fun: nil,
+            on_open: nil,
+            channels: %{},
+            monitors: %{},
+            peer_hello: nil
+
+  @type server :: GenServer.server()
+  @type channel_id :: binary()
+
+  # -- Public API -------------------------------------------------------------
+
+  @doc """
+  Start a tunnel endpoint.
+
+  Options:
+
+    * `:role` -- `:server` (default) or `:host`.
+    * `:host_id` / `:capabilities` -- host identity, sent in the hello frame.
+    * `:on_open` -- host callback `(%{channel_id, path, meta, tunnel} -> {:ok, pid} | {:error, term})`.
+    * `:send_fun` -- `(binary -> any)` link writer; may be set later via `set_link/2`.
+    * `:name` -- optional registered name.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name)
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @doc "Attach the outbound link writer. A host sends its hello frame on attach."
+  @spec set_link(server(), (binary() -> any())) :: :ok
+  def set_link(tunnel, send_fun) when is_function(send_fun, 1),
+    do: GenServer.call(tunnel, {:set_link, send_fun})
+
+  @doc """
+  Open a channel to the peer. Returns `{:ok, channel_id}`.
+
+  `:owner` (default the caller) receives this side's `{:tunnel_data, ...}` /
+  `{:tunnel_closed, ...}` messages. `:meta` is an arbitrary map sent in the open
+  frame.
+  """
+  @spec open_channel(server(), binary(), keyword()) ::
+          {:ok, channel_id()} | {:error, :no_link}
+  def open_channel(tunnel, path, opts \\ []) do
+    owner = Keyword.get(opts, :owner, self())
+    meta = Keyword.get(opts, :meta, %{})
+    GenServer.call(tunnel, {:open_channel, path, owner, meta})
+  end
+
+  @doc "Send channel data to the peer. Pass `binary: true` for raw bytes."
+  @spec send_data(server(), channel_id(), binary(), keyword()) :: :ok | {:error, term()}
+  def send_data(tunnel, channel_id, data, opts \\ []),
+    do: GenServer.call(tunnel, {:send_data, channel_id, data, opts})
+
+  @doc "Close a channel on both ends."
+  @spec close_channel(server(), channel_id(), binary()) :: :ok
+  def close_channel(tunnel, channel_id, reason \\ ""),
+    do: GenServer.call(tunnel, {:close_channel, channel_id, reason})
+
+  @doc "List this endpoint's open channel ids."
+  @spec channels(server()) :: [channel_id()]
+  def channels(tunnel), do: GenServer.call(tunnel, :channels)
+
+  @doc "The peer's hello payload (`%{host_id, capabilities}`) or `nil`."
+  @spec peer_hello(server()) :: map() | nil
+  def peer_hello(tunnel), do: GenServer.call(tunnel, :peer_hello)
+
+  # -- GenServer --------------------------------------------------------------
+
+  @impl true
+  def init(opts) do
+    state = %__MODULE__{
+      role: Keyword.get(opts, :role, :server),
+      host_id: Keyword.get(opts, :host_id),
+      capabilities: Keyword.get(opts, :capabilities, []),
+      on_open: Keyword.get(opts, :on_open),
+      send_fun: Keyword.get(opts, :send_fun)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:set_link, send_fun}, _from, state) do
+    state = %{state | send_fun: send_fun}
+    {:reply, :ok, maybe_say_hello(state)}
+  end
+
+  def handle_call({:open_channel, _path, _owner, _meta}, _from, %{send_fun: nil} = state),
+    do: {:reply, {:error, :no_link}, state}
+
+  def handle_call({:open_channel, path, owner, meta}, _from, state) do
+    channel_id = Frame.new_channel_id()
+    state = register_channel(state, channel_id, owner, path)
+    send_frame(state, Frame.open(channel_id, path, meta))
+    {:reply, {:ok, channel_id}, state}
+  end
+
+  def handle_call({:send_data, channel_id, data, opts}, _from, state) do
+    case Map.has_key?(state.channels, channel_id) do
+      true ->
+        send_frame(state, Frame.data(channel_id, data, opts))
+        {:reply, :ok, state}
+
+      false ->
+        {:reply, {:error, :unknown_channel}, state}
+    end
+  end
+
+  def handle_call({:close_channel, channel_id, reason}, _from, state) do
+    send_frame(state, Frame.close(channel_id, 1000, reason))
+    {:reply, :ok, drop_channel(state, channel_id)}
+  end
+
+  def handle_call(:channels, _from, state),
+    do: {:reply, Map.keys(state.channels), state}
+
+  def handle_call(:peer_hello, _from, state),
+    do: {:reply, state.peer_hello, state}
+
+  @impl true
+  def handle_info({:tunnel_recv, binary}, state) do
+    case Frame.decode(binary) do
+      {:ok, frame} -> {:noreply, route(frame, state)}
+      {:error, _} -> {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case Map.pop(state.monitors, ref) do
+      {nil, _monitors} ->
+        {:noreply, state}
+
+      {channel_id, monitors} ->
+        send_frame(state, Frame.close(channel_id, 1001, "owner_down"))
+        {:noreply, drop_channel(%{state | monitors: monitors}, channel_id)}
+    end
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- Frame routing ----------------------------------------------------------
+
+  defp route(%Frame{kind: :hello, payload: payload}, state),
+    do: %{state | peer_hello: payload}
+
+  defp route(%Frame{kind: :open, channel_id: cid, payload: payload}, state),
+    do: accept_open(state, cid, Map.get(payload, "path", ""), Map.get(payload, "meta", %{}))
+
+  defp route(%Frame{kind: :data, channel_id: cid} = frame, state) do
+    case Map.get(state.channels, cid) do
+      %{owner: owner} -> send(owner, {:tunnel_data, cid, Frame.read_data(frame)})
+      nil -> :ok
+    end
+
+    state
+  end
+
+  defp route(%Frame{kind: :close, channel_id: cid, payload: payload}, state) do
+    deliver_closed(state, cid, Map.get(payload, "reason", ""))
+    drop_channel(state, cid)
+  end
+
+  # Peer asked to open a channel; the host materializes a local handler.
+  defp accept_open(%{on_open: nil} = state, cid, _path, _meta) do
+    send_frame(state, Frame.close(cid, 1003, "no_handler"))
+    state
+  end
+
+  defp accept_open(%{on_open: on_open} = state, cid, path, meta) do
+    case on_open.(%{channel_id: cid, path: path, meta: meta, tunnel: self()}) do
+      {:ok, owner} when is_pid(owner) ->
+        register_channel(state, cid, owner, path)
+
+      {:error, reason} ->
+        send_frame(state, Frame.close(cid, 1003, to_string_reason(reason)))
+        state
+    end
+  end
+
+  # -- Channel bookkeeping ----------------------------------------------------
+
+  defp register_channel(state, channel_id, owner, path) do
+    ref = Process.monitor(owner)
+
+    %{
+      state
+      | channels: Map.put(state.channels, channel_id, %{owner: owner, path: path}),
+        monitors: Map.put(state.monitors, ref, channel_id)
+    }
+  end
+
+  defp drop_channel(state, channel_id) do
+    monitors =
+      case Enum.find(state.monitors, fn {_ref, cid} -> cid == channel_id end) do
+        {ref, _cid} ->
+          Process.demonitor(ref, [:flush])
+          Map.delete(state.monitors, ref)
+
+        nil ->
+          state.monitors
+      end
+
+    %{state | channels: Map.delete(state.channels, channel_id), monitors: monitors}
+  end
+
+  defp deliver_closed(state, channel_id, reason) do
+    case Map.get(state.channels, channel_id) do
+      %{owner: owner} -> send(owner, {:tunnel_closed, channel_id, reason})
+      nil -> :ok
+    end
+  end
+
+  defp maybe_say_hello(%{role: :host, send_fun: send_fun} = state) when is_function(send_fun) do
+    send_frame(state, Frame.hello(state.host_id, state.capabilities))
+    state
+  end
+
+  defp maybe_say_hello(state), do: state
+
+  defp send_frame(%{send_fun: send_fun}, frame) when is_function(send_fun, 1) do
+    send_fun.(Frame.encode(frame))
+    :ok
+  end
+
+  defp send_frame(_state, _frame), do: :ok
+
+  defp to_string_reason(reason) when is_binary(reason), do: reason
+  defp to_string_reason(reason), do: inspect(reason)
+end

--- a/packages/raxol_agent/lib/raxol/agent/tunnel/frame.ex
+++ b/packages/raxol_agent/lib/raxol/agent/tunnel/frame.ex
@@ -1,0 +1,116 @@
+defmodule Raxol.Agent.Tunnel.Frame do
+  @moduledoc """
+  Wire frame for the reverse co-driving tunnel.
+
+  A single outbound link carries many logical channels, demultiplexed by
+  `channel_id`. Four frame kinds ride the link (ported from omnigent's
+  `ws.open` / `ws.frame` / `ws.close` plus a hello handshake):
+
+    * `:hello` -- sent once by the host after it dials out; carries its identity
+      and capabilities. `channel_id` is `nil`.
+    * `:open` -- open a new channel; payload `%{"path", "meta"}`. The opener
+      allocates the `channel_id`; the peer spawns the channel's local handler.
+    * `:data` -- channel I/O; payload `%{"data", "binary"}` (base64 when binary).
+    * `:close` -- close a channel; payload `%{"code", "reason"}`.
+
+  Frames serialize to JSON so any byte transport (a real WebSocket, an in-memory
+  link) can carry them. Decoding maps the kind through an explicit whitelist --
+  never `String.to_atom/1` on link input.
+  """
+
+  @type kind :: :hello | :open | :data | :close
+
+  @type t :: %__MODULE__{
+          channel_id: binary() | nil,
+          kind: kind(),
+          payload: map()
+        }
+
+  @enforce_keys [:kind]
+  defstruct [:channel_id, :kind, payload: %{}]
+
+  @doc "Generate a fresh channel id (4 random bytes, lowercase hex)."
+  @spec new_channel_id() :: binary()
+  def new_channel_id, do: :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
+
+  @doc "A host hello frame announcing identity + capabilities."
+  @spec hello(binary(), [binary()]) :: t()
+  def hello(host_id, capabilities) do
+    %__MODULE__{kind: :hello, payload: %{"host_id" => host_id, "capabilities" => capabilities}}
+  end
+
+  @doc "An open frame for `channel_id` targeting `path` with optional `meta`."
+  @spec open(binary(), binary(), map()) :: t()
+  def open(channel_id, path, meta \\ %{}) do
+    %__MODULE__{channel_id: channel_id, kind: :open, payload: %{"path" => path, "meta" => meta}}
+  end
+
+  @doc """
+  A data frame carrying `data` for `channel_id`.
+
+  Text data rides verbatim; pass `binary: true` to base64-encode arbitrary bytes.
+  """
+  @spec data(binary(), binary(), keyword()) :: t()
+  def data(channel_id, data, opts \\ []) do
+    if Keyword.get(opts, :binary, false) do
+      %__MODULE__{
+        channel_id: channel_id,
+        kind: :data,
+        payload: %{"data" => Base.encode64(data), "binary" => true}
+      }
+    else
+      %__MODULE__{
+        channel_id: channel_id,
+        kind: :data,
+        payload: %{"data" => data, "binary" => false}
+      }
+    end
+  end
+
+  @doc "A close frame for `channel_id`."
+  @spec close(binary(), non_neg_integer(), binary()) :: t()
+  def close(channel_id, code \\ 1000, reason \\ "") do
+    %__MODULE__{
+      channel_id: channel_id,
+      kind: :close,
+      payload: %{"code" => code, "reason" => reason}
+    }
+  end
+
+  @doc "Decode a data frame's payload back to its raw bytes/text."
+  @spec read_data(t()) :: binary()
+  def read_data(%__MODULE__{kind: :data, payload: %{"data" => data, "binary" => true}}),
+    do: Base.decode64!(data)
+
+  def read_data(%__MODULE__{kind: :data, payload: %{"data" => data}}), do: data
+
+  @doc "Serialize a frame to a JSON binary for the link."
+  @spec encode(t()) :: binary()
+  def encode(%__MODULE__{channel_id: channel_id, kind: kind, payload: payload}) do
+    Jason.encode!(%{"c" => channel_id, "k" => Atom.to_string(kind), "p" => payload})
+  end
+
+  @doc "Decode a JSON binary from the link into a frame."
+  @spec decode(binary()) :: {:ok, t()} | {:error, term()}
+  def decode(binary) when is_binary(binary) do
+    with {:ok, %{"k" => kind_str} = map} <- Jason.decode(binary),
+         {:ok, kind} <- decode_kind(kind_str) do
+      {:ok,
+       %__MODULE__{
+         channel_id: Map.get(map, "c"),
+         kind: kind,
+         payload: Map.get(map, "p", %{})
+       }}
+    else
+      {:error, _} = error -> error
+      _ -> {:error, :malformed_frame}
+    end
+  end
+
+  # Explicit whitelist -- never String.to_atom/1 on link input.
+  defp decode_kind("hello"), do: {:ok, :hello}
+  defp decode_kind("open"), do: {:ok, :open}
+  defp decode_kind("data"), do: {:ok, :data}
+  defp decode_kind("close"), do: {:ok, :close}
+  defp decode_kind(other), do: {:error, {:unknown_kind, other}}
+end

--- a/packages/raxol_agent/lib/raxol/agent/tunnel/link.ex
+++ b/packages/raxol_agent/lib/raxol/agent/tunnel/link.ex
@@ -1,0 +1,42 @@
+defmodule Raxol.Agent.Tunnel.Link do
+  @moduledoc """
+  In-process link between two `Raxol.Agent.Tunnel` endpoints.
+
+  Wires each endpoint's outbound `send_fun` to deliver frames into the other's
+  mailbox as `{:tunnel_recv, binary}`. This is a real, deterministic transport
+  (no network) for tests and same-node co-driving: the full open/data/close
+  multiplex runs through the actual `Frame` encode/decode path.
+
+  A cross-machine transport (Mint.WebSocket on the host dialling out to a
+  Bandit/Cowboy endpoint on the server) is the production adapter: it does the
+  same two things this helper does -- set each endpoint's `send_fun` to write the
+  socket, and forward inbound socket bytes as `{:tunnel_recv, bytes}`.
+  """
+
+  alias Raxol.Agent.Tunnel
+
+  @doc """
+  Connect two endpoints so frames flow both ways in-process.
+
+  Accepts pids or registered names. The host endpoint sends its hello frame when
+  its link is attached.
+  """
+  @spec connect(Tunnel.server(), Tunnel.server()) :: :ok
+  def connect(a, b) do
+    a_pid = resolve(a)
+    b_pid = resolve(b)
+
+    :ok = Tunnel.set_link(b_pid, fn binary -> send(a_pid, {:tunnel_recv, binary}) end)
+    :ok = Tunnel.set_link(a_pid, fn binary -> send(b_pid, {:tunnel_recv, binary}) end)
+    :ok
+  end
+
+  defp resolve(pid) when is_pid(pid), do: pid
+
+  defp resolve(name) do
+    case GenServer.whereis(name) do
+      pid when is_pid(pid) -> pid
+      _ -> raise ArgumentError, "no tunnel registered as #{inspect(name)}"
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/ai_backend_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/ai_backend_test.exs
@@ -1,7 +1,25 @@
 defmodule Raxol.Agent.AIBackendTest do
   use ExUnit.Case, async: true
 
+  alias Raxol.Agent.AIBackend
   alias Raxol.Agent.Backend.Mock
+
+  defmodule InternalLoopBackend do
+    @behaviour Raxol.Agent.AIBackend
+
+    @impl true
+    def complete(_messages, _opts), do: {:ok, %{content: "", usage: %{}, metadata: %{}}}
+    @impl true
+    def available?, do: true
+    @impl true
+    def name, do: "Internal Loop"
+    @impl true
+    def capabilities, do: [:completion, :tool_use]
+    @impl true
+    def handles_tools_internally?, do: true
+    @impl true
+    def max_context_tokens, do: 200_000
+  end
 
   describe "Mock backend" do
     test "returns default response" do
@@ -69,6 +87,24 @@ defmodule Raxol.Agent.AIBackendTest do
       assert Mock.name() == "Mock Backend"
       assert :completion in Mock.capabilities()
       assert :streaming in Mock.capabilities()
+    end
+  end
+
+  describe "capability negotiation" do
+    test "handles_tools_internally?/1 defaults to false for backends without the callback" do
+      refute AIBackend.handles_tools_internally?(Mock)
+    end
+
+    test "handles_tools_internally?/1 returns the backend's value when implemented" do
+      assert AIBackend.handles_tools_internally?(InternalLoopBackend)
+    end
+
+    test "max_context_tokens/1 defaults to nil for backends without the callback" do
+      assert AIBackend.max_context_tokens(Mock) == nil
+    end
+
+    test "max_context_tokens/1 returns the backend's value when implemented" do
+      assert AIBackend.max_context_tokens(InternalLoopBackend) == 200_000
     end
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/authorization/engine_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/authorization/engine_test.exs
@@ -1,0 +1,124 @@
+defmodule Raxol.Agent.Authorization.EngineTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Authorization.{Engine, Policy, Verdict}
+
+  defp pol(name, evaluate, attrs \\ []) do
+    Policy.new(Keyword.merge([name: name, evaluate: evaluate], attrs))
+  end
+
+  defp allow(writes), do: fn _ -> Verdict.allow(writes) end
+  defp ask(prompt, writes \\ %{}), do: fn _ -> Verdict.ask(prompt, writes) end
+  defp deny(reason), do: fn _ -> Verdict.deny(reason) end
+
+  describe "ALLOW" do
+    test "all-allow yields :allow with merged labels" do
+      policies = [pol(:a, allow(%{x: 1})), pol(:b, allow(%{y: 2}))]
+      decision = Engine.evaluate(policies, :tool_call, %{}, Engine.new())
+
+      assert decision.action == :allow
+      assert decision.labels == %{x: 1, y: 2}
+    end
+  end
+
+  describe "DENY" do
+    test "short-circuits and keeps prior-ALLOW writes" do
+      policies = [
+        pol(:a, allow(%{x: 1})),
+        pol(:b, deny(:forbidden)),
+        pol(:c, allow(%{y: 2}))
+      ]
+
+      decision = Engine.evaluate(policies, :tool_call, %{}, Engine.new())
+
+      assert decision.action == :deny
+      assert decision.reason == :forbidden
+      # `a`'s write survives; `c` never ran.
+      assert decision.labels == %{x: 1}
+    end
+  end
+
+  describe "ASK" do
+    test "yields :ask, holding the ask's writes in escrow (not in labels yet)" do
+      policies = [pol(:a, allow(%{x: 1})), pol(:b, ask("approve?", %{y: 2}))]
+      decision = Engine.evaluate(policies, :tool_call, %{}, Engine.new())
+
+      assert decision.action == :ask
+      assert decision.labels == %{x: 1}
+      assert decision.escrow == %{y: 2}
+      assert [%{policy: :b, prompt: "approve?"}] = decision.asks
+    end
+
+    test "approve releases escrow into the labels" do
+      policies = [pol(:b, ask("approve?", %{y: 2}))]
+      state = Engine.new()
+      decision = Engine.evaluate(policies, :tool_call, %{}, state)
+
+      state = Engine.approve(decision, state)
+      assert state.labels == %{y: 2}
+    end
+  end
+
+  describe "monotonic merge across policies" do
+    test "the most-restrictive write wins regardless of order" do
+      monotonic = %{access: [:read, :write, :admin]}
+      policies = [pol(:a, allow(%{access: :admin})), pol(:b, allow(%{access: :read}))]
+
+      decision = Engine.evaluate(policies, :tool_call, %{}, Engine.new(monotonic: monotonic))
+      assert decision.labels == %{access: :admin}
+    end
+  end
+
+  describe "applicability" do
+    test "phase gating excludes non-matching policies" do
+      policies = [pol(:out, deny(:nope), phases: [:output])]
+      decision = Engine.evaluate(policies, :tool_call, %{}, Engine.new())
+      assert decision.action == :allow
+    end
+
+    test "condition gating reads the label snapshot" do
+      policies = [pol(:prod_only, deny(:blocked), conditions: %{env: :prod})]
+
+      assert Engine.evaluate(policies, :tool_call, %{}, Engine.new(labels: %{env: :dev})).action ==
+               :allow
+
+      assert Engine.evaluate(policies, :tool_call, %{}, Engine.new(labels: %{env: :prod})).action ==
+               :deny
+    end
+  end
+
+  describe "approval memory" do
+    test ":session scope auto-approves subsequent evaluations" do
+      policies = [pol(:b, ask("approve?", %{y: 2}), scope: :session)]
+      state = Engine.new()
+
+      d1 = Engine.evaluate(policies, :tool_call, %{}, state)
+      assert d1.action == :ask
+      state = Engine.approve(d1, state)
+
+      d2 = Engine.evaluate(policies, :tool_call, %{}, state)
+      assert d2.action == :allow
+    end
+
+    test ":root scope covers the same route but not a different one" do
+      policies = [pol(:b, ask("approve?"), scope: :root)]
+      state = Engine.new()
+
+      d1 = Engine.evaluate(policies, :tool_call, %{}, state, route: "tree-1")
+      state = Engine.approve(d1, state)
+
+      assert Engine.evaluate(policies, :tool_call, %{}, state, route: "tree-1").action == :allow
+      assert Engine.evaluate(policies, :tool_call, %{}, state, route: "tree-2").action == :ask
+    end
+
+    test ":once scope is never remembered" do
+      policies = [pol(:b, ask("approve?"), scope: :once)]
+      state = Engine.new()
+
+      d1 = Engine.evaluate(policies, :tool_call, %{}, state)
+      state = Engine.approve(d1, state)
+
+      assert Engine.evaluate(policies, :tool_call, %{}, state).action == :ask
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/authorization/hook_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/authorization/hook_test.exs
@@ -1,0 +1,73 @@
+defmodule Raxol.Agent.Authorization.HookTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Authorization.{Hook, Policy, Verdict}
+  alias Raxol.Agent.Directive.{Async, Shell}
+
+  setup do
+    on_exit(&Hook.clear/0)
+    :ok
+  end
+
+  defp shell(cmd \\ "ls"), do: %Shell{command: cmd, opts: []}
+  defp async, do: %Async{fun: fn _sender -> :ok end}
+  defp ctx, do: %{agent_id: :a, agent_module: __MODULE__}
+
+  defp deny_shell do
+    Policy.new(
+      name: :deny_shell,
+      phases: [:tool_call],
+      evaluate: fn %{type: type} ->
+        if type == :shell, do: Verdict.deny(:no_shell), else: Verdict.allow()
+      end
+    )
+  end
+
+  defp ask_policy(scope \\ :session, writes \\ %{}) do
+    Policy.new(
+      name: :ask_net,
+      phases: [:tool_call],
+      scope: scope,
+      evaluate: fn _ -> Verdict.ask("allow shell?", writes) end
+    )
+  end
+
+  test "is a neutral no-op when not configured" do
+    assert {:ok, _} = Hook.pre_execute(shell(), ctx())
+  end
+
+  test "allows a directive no policy denies" do
+    Hook.configure(policies: [deny_shell()])
+    assert {:ok, %Async{}} = Hook.pre_execute(async(), ctx())
+  end
+
+  test "denies a shell directive" do
+    Hook.configure(policies: [deny_shell()])
+    assert {:deny, :no_shell} = Hook.pre_execute(shell("rm -rf /"), ctx())
+  end
+
+  test "an ASK approved by the prompter allows and releases escrow" do
+    Hook.configure(
+      policies: [ask_policy(:session, %{net: :granted})],
+      prompter: fn _d, _c -> :approve end
+    )
+
+    assert {:ok, %Shell{}} = Hook.pre_execute(shell(), ctx())
+    assert Hook.labels() == %{net: :granted}
+  end
+
+  test "an ASK denied by the prompter denies with the prompts" do
+    Hook.configure(policies: [ask_policy()], prompter: fn _d, _c -> :deny end)
+    assert {:deny, {:ask_denied, ["allow shell?"]}} = Hook.pre_execute(shell(), ctx())
+  end
+
+  test "an ASK with no prompter requires approval" do
+    Hook.configure(policies: [ask_policy()])
+    assert {:deny, {:requires_approval, ["allow shell?"]}} = Hook.pre_execute(shell(), ctx())
+  end
+
+  test "composes in the CommandHook chain" do
+    Hook.configure(policies: [deny_shell()])
+    assert {:deny, :no_shell} = Raxol.Agent.CommandHook.run_pre_hooks([Hook], shell(), ctx())
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/authorization/labels_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/authorization/labels_test.exs
@@ -1,0 +1,30 @@
+defmodule Raxol.Agent.Authorization.LabelsTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Authorization.Labels
+
+  @monotonic %{access: [:read, :write, :admin], risk: [:low, :medium, :high]}
+
+  describe "merge/3" do
+    test "non-monotonic keys take the written value (last-write-wins)" do
+      assert Labels.merge(%{a: 1}, %{a: 2, b: 3}) == %{a: 2, b: 3}
+    end
+
+    test "monotonic keys keep the most-restrictive value" do
+      labels = Labels.merge(%{}, %{access: :write}, @monotonic)
+      # A less-restrictive write does not loosen it.
+      assert Labels.merge(labels, %{access: :read}, @monotonic) == %{access: :write}
+      # A more-restrictive write tightens it.
+      assert Labels.merge(labels, %{access: :admin}, @monotonic) == %{access: :admin}
+    end
+
+    test "a first write to a monotonic key sets it" do
+      assert Labels.merge(%{}, %{risk: :medium}, @monotonic) == %{risk: :medium}
+    end
+
+    test "an unranked value is least-restrictive (rank -1)" do
+      labels = Labels.merge(%{}, %{access: :unknown}, @monotonic)
+      assert Labels.merge(labels, %{access: :read}, @monotonic) == %{access: :read}
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/authorization/policy_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/authorization/policy_test.exs
@@ -1,0 +1,44 @@
+defmodule Raxol.Agent.Authorization.PolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Authorization.{Policy, Verdict}
+
+  defp pol(attrs),
+    do: Policy.new(Keyword.merge([name: :p, evaluate: fn _ -> Verdict.allow() end], attrs))
+
+  describe "applies?/3" do
+    test "phase :all applies to any phase" do
+      assert Policy.applies?(pol(phases: :all), :tool_call, %{})
+    end
+
+    test "a phase list gates by phase" do
+      p = pol(phases: [:tool_call])
+      assert Policy.applies?(p, :tool_call, %{})
+      refute Policy.applies?(p, :output, %{})
+    end
+
+    test "conditions AND across keys" do
+      p = pol(conditions: %{env: :prod, tier: :paid})
+      assert Policy.applies?(p, :tool_call, %{env: :prod, tier: :paid})
+      refute Policy.applies?(p, :tool_call, %{env: :prod, tier: :free})
+    end
+
+    test "conditions OR within a key's list" do
+      p = pol(conditions: %{env: [:prod, :staging]})
+      assert Policy.applies?(p, :tool_call, %{env: :staging})
+      refute Policy.applies?(p, :tool_call, %{env: :dev})
+    end
+  end
+
+  describe "run/2" do
+    test "filters writes to the writable_labels whitelist" do
+      p = pol(writable_labels: [:a], evaluate: fn _ -> Verdict.allow(%{a: 1, b: 2}) end)
+      assert Policy.run(p, %{}).writes == %{a: 1}
+    end
+
+    test ":all permits any write" do
+      p = pol(writable_labels: :all, evaluate: fn _ -> Verdict.allow(%{a: 1, b: 2}) end)
+      assert Policy.run(p, %{}).writes == %{a: 1, b: 2}
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/authorization/server_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/authorization/server_test.exs
@@ -1,0 +1,64 @@
+defmodule Raxol.Agent.Authorization.ServerTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Authorization.{Policy, Server, Verdict}
+
+  defp pol(name, evaluate, attrs \\ []),
+    do: Policy.new(Keyword.merge([name: name, evaluate: evaluate], attrs))
+
+  defp start(policies, opts \\ []) do
+    start_supervised!({Server, [policies: policies] ++ opts})
+  end
+
+  test "an allow decision commits its labels" do
+    server = start([pol(:a, fn _ -> Verdict.allow(%{x: 1}) end)])
+    assert %{action: :allow} = Server.evaluate(server, :tool_call, %{})
+    assert Server.labels(server) == %{x: 1}
+  end
+
+  test "a deny decision commits prior-allow labels" do
+    server =
+      start([
+        pol(:a, fn _ -> Verdict.allow(%{x: 1}) end),
+        pol(:b, fn _ -> Verdict.deny(:no) end)
+      ])
+
+    assert %{action: :deny, reason: :no} = Server.evaluate(server, :tool_call, %{})
+    assert Server.labels(server) == %{x: 1}
+  end
+
+  describe "ask lifecycle" do
+    test "ask parks pending; approve releases escrow" do
+      server = start([pol(:b, fn _ -> Verdict.ask("ok?", %{y: 2}) end)])
+
+      assert %{action: :ask} = Server.evaluate(server, :tool_call, %{}, route: "r1")
+      # escrow not yet applied
+      assert Server.labels(server) == %{}
+
+      assert :ok = Server.approve(server, "r1")
+      assert Server.labels(server) == %{y: 2}
+    end
+
+    test "reject drops the pending ask without applying escrow" do
+      server = start([pol(:b, fn _ -> Verdict.ask("ok?", %{y: 2}) end)])
+      assert %{action: :ask} = Server.evaluate(server, :tool_call, %{}, route: "r1")
+
+      assert :ok = Server.reject(server, "r1")
+      assert Server.labels(server) == %{}
+      assert {:error, :no_pending} = Server.approve(server, "r1")
+    end
+
+    test "approving an unknown route errors" do
+      server = start([pol(:a, fn _ -> Verdict.allow() end)])
+      assert {:error, :no_pending} = Server.approve(server, "nope")
+    end
+
+    test "a :session-scoped approval auto-allows the next evaluation" do
+      server = start([pol(:b, fn _ -> Verdict.ask("ok?") end, scope: :session)])
+
+      assert %{action: :ask} = Server.evaluate(server, :tool_call, %{}, route: "r1")
+      :ok = Server.approve(server, "r1")
+      assert %{action: :allow} = Server.evaluate(server, :tool_call, %{})
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/authorization/verdict_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/authorization/verdict_test.exs
@@ -1,0 +1,18 @@
+defmodule Raxol.Agent.Authorization.VerdictTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Authorization.Verdict
+
+  test "allow/1 builds an allow verdict" do
+    assert %Verdict{action: :allow, writes: %{}} = Verdict.allow()
+    assert %Verdict{action: :allow, writes: %{a: 1}} = Verdict.allow(%{a: 1})
+  end
+
+  test "ask/2 builds an ask verdict with a prompt and escrowed writes" do
+    assert %Verdict{action: :ask, prompt: "ok?", writes: %{a: 1}} = Verdict.ask("ok?", %{a: 1})
+  end
+
+  test "deny/1 builds a deny verdict with a reason" do
+    assert %Verdict{action: :deny, reason: :nope} = Verdict.deny(:nope)
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/backend/native_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/native_test.exs
@@ -1,0 +1,125 @@
+defmodule Raxol.Agent.Backend.NativeTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Backend.Native
+
+  @fake_cli Path.expand("../../../support/fake_stream_cli.sh", __DIR__)
+
+  # A driver whose "CLI" is the fake stream-json script. The scenario is passed
+  # through `extra_args` so each test can drive a different code path.
+  defmodule FakeDriver do
+    @behaviour Raxol.Agent.NativeHarness
+
+    @script Path.expand("../../../support/fake_stream_cli.sh", __DIR__)
+
+    @impl true
+    def executable, do: @script
+    @impl true
+    def name, do: "Fake"
+    @impl true
+    def parse_line(line), do: Raxol.Agent.Harness.StreamJson.parse_line(line)
+
+    @impl true
+    def args(config) do
+      case Map.get(config, :extra_args, []) do
+        [] -> ["happy"]
+        scenario -> scenario
+      end
+    end
+  end
+
+  defp messages, do: [%{role: :user, content: "hello"}]
+
+  defp run_scenario(scenario) do
+    {:ok, stream} = Native.stream(FakeDriver, messages(), extra_args: [scenario])
+    Enum.to_list(stream)
+  end
+
+  describe "stream/3" do
+    test "streams text chunks then a done event with the final content and usage" do
+      events = run_scenario("happy")
+
+      assert [{:chunk, "Hello "}, {:chunk, "world"}, {:done, done}] = events
+      assert done.content == "Hello world"
+      assert done.usage == %{"input_tokens" => 3, "output_tokens" => 2}
+    end
+
+    test "tool_use blocks are not surfaced as text (the MCP server owns execution)" do
+      events = run_scenario("tool")
+      texts = for {:chunk, t} <- events, do: t
+      assert texts == ["done"]
+      assert {:done, %{content: "done"}} = List.last(events)
+    end
+
+    test "an error result becomes an error event" do
+      assert [{:error, {:result_error, "error_max_turns", "too long"}}] = run_scenario("error")
+    end
+
+    test "a non-zero exit with no result line becomes an exit error" do
+      assert [{:error, {:exit, 3}}] = run_scenario("exit_nonzero")
+    end
+
+    test "a clean exit without a result line synthesizes a done from accumulated text" do
+      events = run_scenario("no_done")
+      assert [{:chunk, "partial"}, {:done, %{content: "partial"}}] = events
+    end
+
+    test "returns an error when the executable is not found" do
+      defmodule MissingDriver do
+        @behaviour Raxol.Agent.NativeHarness
+        @impl true
+        def executable, do: "definitely_not_a_real_binary_xyz"
+        @impl true
+        def name, do: "Missing"
+        @impl true
+        def args(_), do: []
+        @impl true
+        def parse_line(_), do: []
+      end
+
+      assert {:error, {:executable_not_found, "definitely_not_a_real_binary_xyz"}} =
+               Native.stream(MissingDriver, messages(), [])
+    end
+  end
+
+  describe "complete/3" do
+    test "drains the stream and returns the final response" do
+      assert {:ok, %{content: "Hello world", usage: %{"input_tokens" => 3}}} =
+               Native.complete(FakeDriver, messages(), extra_args: ["happy"])
+    end
+
+    test "propagates an error result" do
+      assert {:error, {:result_error, "error_max_turns", _}} =
+               Native.complete(FakeDriver, messages(), extra_args: ["error"])
+    end
+  end
+
+  test "the fake CLI script exists and is executable" do
+    assert File.exists?(@fake_cli)
+  end
+
+  # -- Macro-built vendor backends --------------------------------------------
+
+  describe "Backend.ClaudeCode / Backend.Cursor" do
+    test "report they handle tools internally" do
+      assert Raxol.Agent.Backend.ClaudeCode.handles_tools_internally?()
+      assert Raxol.Agent.Backend.Cursor.handles_tools_internally?()
+    end
+
+    test "expose their driver and a streaming capability" do
+      assert Raxol.Agent.Backend.ClaudeCode.driver() == Raxol.Agent.Harness.ClaudeCode
+      assert Raxol.Agent.Backend.Cursor.driver() == Raxol.Agent.Harness.Cursor
+      assert :streaming in Raxol.Agent.Backend.ClaudeCode.capabilities()
+    end
+
+    test "available?/0 returns a boolean (depends on the CLI being installed)" do
+      assert is_boolean(Raxol.Agent.Backend.ClaudeCode.available?())
+      assert is_boolean(Raxol.Agent.Backend.Cursor.available?())
+    end
+
+    test "names come from the driver" do
+      assert Raxol.Agent.Backend.ClaudeCode.name() == "Claude Code"
+      assert Raxol.Agent.Backend.Cursor.name() == "Cursor"
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/backend/selector_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/selector_test.exs
@@ -1,0 +1,84 @@
+defmodule Raxol.Agent.Backend.SelectorTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Backend.Selector
+  alias Raxol.Agent.ExecutorConfig
+
+  describe "select/1" do
+    test "resolves HTTP-backed harnesses with a provider hint" do
+      for {harness, provider} <- [
+            anthropic: :anthropic,
+            openai: :openai,
+            kimi: :kimi,
+            ollama: :ollama
+          ] do
+        cfg = ExecutorConfig.new(harness: harness)
+        assert {:ok, Raxol.Agent.Backend.HTTP, opts} = Selector.select(cfg)
+        assert opts[:provider] == provider
+      end
+    end
+
+    test "resolves llm7 to the HTTP backend with a base_url default" do
+      cfg = ExecutorConfig.new(harness: :llm7)
+      assert {:ok, Raxol.Agent.Backend.HTTP, opts} = Selector.select(cfg)
+      assert opts[:provider] == :openai
+      assert opts[:base_url] == "https://api.llm7.io"
+    end
+
+    test "resolves lumo and mock to their dedicated backends" do
+      assert {:ok, Raxol.Agent.Backend.Lumo, _} =
+               Selector.select(ExecutorConfig.new(harness: :lumo))
+
+      assert {:ok, Raxol.Agent.Backend.Mock, _} =
+               Selector.select(ExecutorConfig.new(harness: :mock))
+    end
+
+    test "merges config model and auth over harness defaults" do
+      cfg =
+        ExecutorConfig.new(
+          harness: :anthropic,
+          model: "claude-opus-4-8",
+          auth: %{api_key: "sk-x"}
+        )
+
+      assert {:ok, Raxol.Agent.Backend.HTTP, opts} = Selector.select(cfg)
+
+      assert opts[:provider] == :anthropic
+      assert opts[:model] == "claude-opus-4-8"
+      assert opts[:api_key] == "sk-x"
+    end
+
+    test "config opts override harness defaults" do
+      cfg = ExecutorConfig.new(harness: :llm7, opts: [base_url: "https://override"])
+      assert {:ok, _, opts} = Selector.select(cfg)
+      assert opts[:base_url] == "https://override"
+    end
+
+    test "resolves native CLI harnesses to their backends" do
+      assert {:ok, Raxol.Agent.Backend.ClaudeCode, _} =
+               Selector.select(ExecutorConfig.new(harness: :claude_native))
+
+      assert {:ok, Raxol.Agent.Backend.Cursor, _} =
+               Selector.select(ExecutorConfig.new(harness: :cursor))
+    end
+
+    test "codex is reserved (served by the symphony app-server runner)" do
+      cfg = ExecutorConfig.new(harness: :codex)
+      assert {:error, {:harness_not_implemented, :codex}} = Selector.select(cfg)
+    end
+
+    test "unknown harness returns an error" do
+      cfg = ExecutorConfig.new(harness: :nonsense)
+      assert {:error, {:unknown_harness, :nonsense}} = Selector.select(cfg)
+    end
+  end
+
+  describe "supported_harnesses/0" do
+    test "lists the resolvable harnesses" do
+      supported = Selector.supported_harnesses()
+      assert :anthropic in supported
+      assert :mock in supported
+      refute :codex in supported
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/conversation/item_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/conversation/item_test.exs
@@ -1,0 +1,51 @@
+defmodule Raxol.Agent.Conversation.ItemTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Conversation.Item
+
+  describe "id/2" do
+    test "derives a stable id from conversation id and sequence" do
+      assert Item.id("conv-1", 0) == "conv-1:0"
+      assert Item.id("conv-1", 42) == "conv-1:42"
+    end
+  end
+
+  describe "new/1" do
+    test "builds an item with a derived id and defaults" do
+      item = Item.new(conversation_id: "c", seq: 3, type: :message)
+
+      assert item.id == "c:3"
+      assert item.conversation_id == "c"
+      assert item.seq == 3
+      assert item.type == :message
+      assert item.status == :completed
+      assert item.data == %{}
+      assert item.response_id == nil
+      assert %DateTime{} = item.created_at
+    end
+
+    test "accepts explicit status, data, response_id, and created_by" do
+      item =
+        Item.new(
+          conversation_id: "c",
+          seq: 0,
+          type: :tool_call,
+          status: :action_required,
+          data: %{name: "x"},
+          response_id: "r1",
+          created_by: :assistant
+        )
+
+      assert item.status == :action_required
+      assert item.data == %{name: "x"}
+      assert item.response_id == "r1"
+      assert item.created_by == :assistant
+    end
+
+    test "requires conversation_id, seq, and type" do
+      assert_raise KeyError, fn -> Item.new(seq: 0, type: :message) end
+      assert_raise KeyError, fn -> Item.new(conversation_id: "c", type: :message) end
+      assert_raise KeyError, fn -> Item.new(conversation_id: "c", seq: 0) end
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/conversation/log_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/conversation/log_test.exs
@@ -1,0 +1,123 @@
+defmodule Raxol.Agent.Conversation.LogTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Conversation.Log
+  alias Raxol.Agent.Conversation.Store.ETS
+
+  setup do
+    table = :"log_items_#{System.unique_integer([:positive])}"
+    log = start_supervised!({Log, store: {ETS, %{table: table}}})
+    %{log: log, conv: "conv-#{System.unique_integer([:positive])}"}
+  end
+
+  describe "append + subscribe" do
+    test "a subscriber receives items appended after it subscribes", %{log: log, conv: conv} do
+      {:ok, %{snapshot: [], last_seq: nil}} = Log.subscribe(log, conv)
+      {:ok, [item]} = Log.append(log, conv, %{type: :message, data: %{n: 1}})
+
+      assert_receive {:conversation_item, ^conv, ^item}
+    end
+
+    test "append accepts a single item map or a list", %{log: log, conv: conv} do
+      assert {:ok, [_]} = Log.append(log, conv, %{type: :message})
+      assert {:ok, [_, _]} = Log.append(log, conv, [%{type: :message}, %{type: :reasoning}])
+    end
+  end
+
+  describe "exact snapshot/live-tail partition" do
+    test "subscribing between appends never gaps or duplicates", %{log: log, conv: conv} do
+      {:ok, [_item0]} = Log.append(log, conv, %{type: :message, data: %{n: 0}})
+
+      {:ok, %{snapshot: snapshot, last_seq: last_seq}} = Log.subscribe(log, conv)
+      assert Enum.map(snapshot, & &1.seq) == [0]
+      assert last_seq == 0
+
+      {:ok, [item1]} = Log.append(log, conv, %{type: :message, data: %{n: 1}})
+
+      # The post-subscribe item arrives live...
+      assert_receive {:conversation_item, ^conv, ^item1}
+      # ...and the pre-subscribe item (already in the snapshot) is NOT re-sent.
+      refute_received {:conversation_item, ^conv, %{seq: 0}}
+    end
+
+    test "reconnect with :after only snapshots items past the cursor", %{log: log, conv: conv} do
+      {:ok, _} = Log.append(log, conv, [%{type: :message}, %{type: :message}, %{type: :message}])
+
+      {:ok, %{snapshot: snapshot, last_seq: last_seq}} = Log.subscribe(log, conv, after: 0)
+      assert Enum.map(snapshot, & &1.seq) == [1, 2]
+      assert last_seq == 2
+    end
+  end
+
+  describe "multiple subscribers" do
+    test "every subscriber receives each appended item", %{log: log, conv: conv} do
+      parent = self()
+
+      other =
+        spawn_link(fn ->
+          {:ok, _} = Log.subscribe(log, conv)
+          send(parent, :ready)
+
+          receive do
+            {:conversation_item, ^conv, item} -> send(parent, {:other_got, item.seq})
+          end
+        end)
+
+      assert_receive :ready
+      {:ok, %{}} = Log.subscribe(log, conv)
+
+      {:ok, [item]} = Log.append(log, conv, %{type: :message})
+      assert_receive {:conversation_item, ^conv, ^item}
+      assert_receive {:other_got, 0}
+
+      Process.exit(other, :normal)
+    end
+  end
+
+  describe "subscriber lifecycle" do
+    test "unsubscribe stops live delivery", %{log: log, conv: conv} do
+      {:ok, _} = Log.subscribe(log, conv)
+      :ok = Log.unsubscribe(log, conv)
+
+      {:ok, _} = Log.append(log, conv, %{type: :message})
+      refute_receive {:conversation_item, ^conv, _}
+    end
+
+    test "a dead subscriber is dropped without breaking the log", %{log: log, conv: conv} do
+      parent = self()
+
+      doomed =
+        spawn(fn ->
+          {:ok, _} = Log.subscribe(log, conv)
+          send(parent, :subscribed)
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive :subscribed
+      ref = Process.monitor(doomed)
+      Process.exit(doomed, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^doomed, _}
+
+      # A live subscriber still works after the dead one is cleaned up.
+      {:ok, _} = Log.subscribe(log, conv)
+      {:ok, [item]} = Log.append(log, conv, %{type: :message})
+      assert_receive {:conversation_item, ^conv, ^item}
+      assert Process.alive?(log)
+    end
+  end
+
+  describe "queries" do
+    test "items/3 pages through stored history", %{log: log, conv: conv} do
+      {:ok, _} = Log.append(log, conv, [%{type: :message}, %{type: :tool_call}])
+      {:ok, items} = Log.items(log, conv, type: :message)
+      assert Enum.map(items, & &1.type) == [:message]
+    end
+
+    test "get_conversation and list_conversations", %{log: log, conv: conv} do
+      {:ok, _} = Log.append(log, conv, %{type: :message})
+      assert {:ok, %{id: ^conv, item_count: 1}} = Log.get_conversation(log, conv)
+      assert {:ok, ids} = Log.list_conversations(log)
+      assert conv in ids
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/conversation/recorder_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/conversation/recorder_test.exs
@@ -1,0 +1,89 @@
+defmodule Raxol.Agent.Conversation.RecorderTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Conversation.{Log, Recorder}
+  alias Raxol.Agent.Conversation.Store.ETS
+
+  setup do
+    table = :"rec_items_#{System.unique_integer([:positive])}"
+    log = start_supervised!({Log, store: {ETS, %{table: table}}})
+    %{log: log, conv: "conv-#{System.unique_integer([:positive])}"}
+  end
+
+  describe "record_event/4" do
+    test "maps a tool_use to a tool_call item", %{log: log, conv: conv} do
+      {:ok, [item]} =
+        Recorder.record_event(log, conv, [response_id: "r1"], {
+          :tool_use,
+          %{name: "search", arguments: %{q: "x"}, id: "t1"}
+        })
+
+      assert item.type == :tool_call
+      assert item.data.name == "search"
+      assert item.data.arguments == %{q: "x"}
+      assert item.response_id == "r1"
+      assert item.created_by == :assistant
+    end
+
+    test "maps a tool_result to a tool_result item", %{log: log, conv: conv} do
+      {:ok, [item]} =
+        Recorder.record_event(
+          log,
+          conv,
+          [],
+          {:tool_result, %{name: "search", result: %{hits: 3}}}
+        )
+
+      assert item.type == :tool_result
+      assert item.data.result == %{hits: 3}
+      assert item.created_by == :tool
+    end
+
+    test "maps a done to an assistant message item", %{log: log, conv: conv} do
+      {:ok, [item]} =
+        Recorder.record_event(log, conv, [], {:done, %{content: "the answer", usage: %{t: 1}}})
+
+      assert item.type == :message
+      assert item.data.role == :assistant
+      assert item.data.content == "the answer"
+      assert item.data.usage == %{t: 1}
+    end
+
+    test "maps an error to an error item", %{log: log, conv: conv} do
+      {:ok, [item]} = Recorder.record_event(log, conv, [], {:error, :boom})
+      assert item.type == :error
+      assert item.data.reason == ":boom"
+    end
+
+    test "ignores text_delta and turn_complete (content lands at :done)", %{log: log, conv: conv} do
+      assert {:ok, []} = Recorder.record_event(log, conv, [], {:text_delta, "hi"})
+      assert {:ok, []} = Recorder.record_event(log, conv, [], {:turn_complete, %{iteration: 0}})
+    end
+  end
+
+  describe "record_stream/4" do
+    test "appends one item per meaningful event, in order", %{log: log, conv: conv} do
+      events = [
+        {:text_delta, "hi"},
+        {:tool_use, %{name: "x", arguments: %{}, id: "t"}},
+        {:tool_result, %{name: "x", result: %{ok: true}}},
+        {:done, %{content: "answer", usage: %{}}}
+      ]
+
+      {:ok, items} = Recorder.record_stream(log, conv, events, response_id: "r1")
+
+      assert Enum.map(items, & &1.type) == [:tool_call, :tool_result, :message]
+      assert Enum.map(items, & &1.seq) == [0, 1, 2]
+      assert List.last(items).data.content == "answer"
+      assert Enum.all?(items, &(&1.response_id == "r1"))
+    end
+
+    test "the recorded items are durable in the log", %{log: log, conv: conv} do
+      events = [{:done, %{content: "done", usage: %{}}}]
+      {:ok, _} = Recorder.record_stream(log, conv, events)
+
+      {:ok, stored} = Log.items(log, conv)
+      assert Enum.map(stored, & &1.type) == [:message]
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/conversation/store/ets_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/conversation/store/ets_test.exs
@@ -1,0 +1,102 @@
+defmodule Raxol.Agent.Conversation.Store.ETSTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Conversation.Store.ETS
+
+  setup do
+    %{config: %{table: :"items_#{System.unique_integer([:positive])}"}}
+  end
+
+  describe "append/3" do
+    test "assigns monotonic 0-based sequences and stable ids", %{config: config} do
+      {:ok, items} =
+        ETS.append(config, "c", [
+          %{type: :message, data: %{n: 1}},
+          %{type: :tool_call, data: %{n: 2}}
+        ])
+
+      assert Enum.map(items, & &1.seq) == [0, 1]
+      assert Enum.map(items, & &1.id) == ["c:0", "c:1"]
+      assert Enum.map(items, & &1.type) == [:message, :tool_call]
+    end
+
+    test "continues the sequence across append calls", %{config: config} do
+      {:ok, [a]} = ETS.append(config, "c", [%{type: :message}])
+      {:ok, [b]} = ETS.append(config, "c", [%{type: :message}])
+      assert a.seq == 0
+      assert b.seq == 1
+    end
+
+    test "sequences are independent per conversation", %{config: config} do
+      {:ok, [a]} = ETS.append(config, "c1", [%{type: :message}])
+      {:ok, [b]} = ETS.append(config, "c2", [%{type: :message}])
+      assert a.seq == 0
+      assert b.seq == 0
+    end
+  end
+
+  describe "list_items/3" do
+    setup %{config: config} do
+      {:ok, _} =
+        ETS.append(config, "c", [
+          %{type: :message, data: %{n: 0}},
+          %{type: :tool_call, data: %{n: 1}},
+          %{type: :message, data: %{n: 2}}
+        ])
+
+      :ok
+    end
+
+    test "returns items in sequence order", %{config: config} do
+      {:ok, items} = ETS.list_items(config, "c")
+      assert Enum.map(items, & &1.seq) == [0, 1, 2]
+    end
+
+    test ":after is an exclusive cursor", %{config: config} do
+      {:ok, items} = ETS.list_items(config, "c", after: 0)
+      assert Enum.map(items, & &1.seq) == [1, 2]
+    end
+
+    test ":before is exclusive", %{config: config} do
+      {:ok, items} = ETS.list_items(config, "c", before: 2)
+      assert Enum.map(items, & &1.seq) == [0, 1]
+    end
+
+    test ":type filters by item type", %{config: config} do
+      {:ok, items} = ETS.list_items(config, "c", type: :message)
+      assert Enum.map(items, & &1.seq) == [0, 2]
+    end
+
+    test ":limit caps the result", %{config: config} do
+      {:ok, items} = ETS.list_items(config, "c", limit: 2)
+      assert Enum.map(items, & &1.seq) == [0, 1]
+    end
+
+    test ":order :desc reverses", %{config: config} do
+      {:ok, items} = ETS.list_items(config, "c", order: :desc)
+      assert Enum.map(items, & &1.seq) == [2, 1, 0]
+    end
+
+    test "an unknown conversation yields an empty list", %{config: config} do
+      assert {:ok, []} = ETS.list_items(config, "nope")
+    end
+  end
+
+  describe "get_conversation/2 and list_conversations/1" do
+    test "reports last_seq and item_count", %{config: config} do
+      {:ok, _} = ETS.append(config, "c", [%{type: :message}, %{type: :message}])
+      assert {:ok, %{id: "c", last_seq: 1, item_count: 2}} = ETS.get_conversation(config, "c")
+    end
+
+    test "returns :not_found for an unknown conversation", %{config: config} do
+      assert {:error, :not_found} = ETS.get_conversation(config, "nope")
+    end
+
+    test "lists known conversation ids", %{config: config} do
+      {:ok, _} = ETS.append(config, "c1", [%{type: :message}])
+      {:ok, _} = ETS.append(config, "c2", [%{type: :message}])
+      {:ok, ids} = ETS.list_conversations(config)
+      assert Enum.sort(ids) == ["c1", "c2"]
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/executor_config_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/executor_config_test.exs
@@ -1,0 +1,83 @@
+defmodule Raxol.Agent.ExecutorConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.ExecutorConfig
+
+  describe "new/1" do
+    test "builds from a keyword list" do
+      cfg = ExecutorConfig.new(harness: :anthropic, model: "claude-opus-4-8")
+
+      assert %ExecutorConfig{
+               harness: :anthropic,
+               model: "claude-opus-4-8",
+               auth: %{},
+               opts: []
+             } = cfg
+    end
+
+    test "builds from a map" do
+      cfg = ExecutorConfig.new(%{harness: :openai, auth: %{api_key: "sk-x"}})
+
+      assert cfg.harness == :openai
+      assert cfg.auth == %{api_key: "sk-x"}
+    end
+
+    test "defaults model, auth, and opts" do
+      cfg = ExecutorConfig.new(harness: :mock)
+
+      assert cfg.model == nil
+      assert cfg.auth == %{}
+      assert cfg.opts == []
+    end
+
+    test "requires a non-nil atom harness" do
+      assert_raise FunctionClauseError, fn -> ExecutorConfig.new(model: "x") end
+      assert_raise FunctionClauseError, fn -> ExecutorConfig.new(harness: nil) end
+    end
+  end
+
+  describe "from_keyword/1" do
+    test "is an alias for new/1" do
+      assert ExecutorConfig.from_keyword(harness: :mock) == ExecutorConfig.new(harness: :mock)
+    end
+  end
+
+  describe "to_backend_opts/1" do
+    test "includes model when set" do
+      cfg = ExecutorConfig.new(harness: :openai, model: "gpt-5")
+      assert ExecutorConfig.to_backend_opts(cfg) == [model: "gpt-5"]
+    end
+
+    test "omits model when nil" do
+      cfg = ExecutorConfig.new(harness: :openai)
+      assert ExecutorConfig.to_backend_opts(cfg) == []
+    end
+
+    test "flattens auth map into keyword opts" do
+      cfg = ExecutorConfig.new(harness: :openai, model: "gpt-5", auth: %{api_key: "sk-x"})
+      opts = ExecutorConfig.to_backend_opts(cfg)
+
+      assert opts[:model] == "gpt-5"
+      assert opts[:api_key] == "sk-x"
+    end
+
+    test "explicit opts override auth-derived keys" do
+      cfg =
+        ExecutorConfig.new(
+          harness: :openai,
+          auth: %{base_url: "https://from-auth"},
+          opts: [base_url: "https://from-opts"]
+        )
+
+      assert ExecutorConfig.to_backend_opts(cfg)[:base_url] == "https://from-opts"
+    end
+
+    test "ignores non-atom auth keys" do
+      cfg = ExecutorConfig.new(harness: :openai, auth: %{"string_key" => "v", api_key: "sk-x"})
+      opts = ExecutorConfig.to_backend_opts(cfg)
+
+      assert opts[:api_key] == "sk-x"
+      refute Keyword.has_key?(opts, :string_key)
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/harness/claude_code_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/harness/claude_code_test.exs
@@ -1,0 +1,51 @@
+defmodule Raxol.Agent.Harness.ClaudeCodeTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Harness.ClaudeCode
+
+  describe "executable/0 and name/0" do
+    test "names the claude binary" do
+      assert ClaudeCode.executable() == "claude"
+      assert ClaudeCode.name() == "Claude Code"
+    end
+  end
+
+  describe "args/1" do
+    test "builds a non-interactive stream-json invocation" do
+      args = ClaudeCode.args(%{prompt: "do x"})
+      assert args == ["-p", "do x", "--output-format", "stream-json", "--verbose"]
+    end
+
+    test "appends model, system prompt, and mcp config when present" do
+      args =
+        ClaudeCode.args(%{
+          prompt: "p",
+          model: "claude-opus-4-8",
+          system_prompt: "be terse",
+          mcp_config_path: "/tmp/mcp.json"
+        })
+
+      assert "--model" in args and "claude-opus-4-8" in args
+      assert "--append-system-prompt" in args and "be terse" in args
+      assert "--mcp-config" in args and "/tmp/mcp.json" in args
+    end
+
+    test "omits optional flags when their values are nil/blank" do
+      args = ClaudeCode.args(%{prompt: "p", model: nil, system_prompt: "", mcp_config_path: nil})
+      refute "--model" in args
+      refute "--append-system-prompt" in args
+      refute "--mcp-config" in args
+    end
+
+    test "appends extra_args verbatim at the end" do
+      args = ClaudeCode.args(%{prompt: "p", extra_args: ["--foo", "bar"]})
+      assert List.last(args) == "bar"
+      assert "--foo" in args
+    end
+  end
+
+  test "parse_line/1 delegates to the stream-json parser" do
+    line = ~s({"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}})
+    assert ClaudeCode.parse_line(line) == [{:text, "hi"}]
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/harness/cursor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/harness/cursor_test.exs
@@ -1,0 +1,27 @@
+defmodule Raxol.Agent.Harness.CursorTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Harness.Cursor
+
+  test "names the cursor-agent binary" do
+    assert Cursor.executable() == "cursor-agent"
+    assert Cursor.name() == "Cursor"
+  end
+
+  describe "args/1" do
+    test "builds a stream-json invocation" do
+      assert Cursor.args(%{prompt: "p"}) == ["-p", "p", "--output-format", "stream-json"]
+    end
+
+    test "appends model and mcp config when present" do
+      args = Cursor.args(%{prompt: "p", model: "gpt-5", mcp_config_path: "/tmp/m.json"})
+      assert "--model" in args and "gpt-5" in args
+      assert "--mcp-config" in args and "/tmp/m.json" in args
+    end
+  end
+
+  test "parse_line/1 delegates to the stream-json parser" do
+    line = ~s({"type":"result","subtype":"success","result":"ok","usage":{}})
+    assert [{:done, %{content: "ok"}}] = Cursor.parse_line(line)
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/harness/mcp_tool_config_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/harness/mcp_tool_config_test.exs
@@ -1,0 +1,77 @@
+defmodule Raxol.Agent.Harness.McpToolConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Harness.McpToolConfig
+
+  defmodule Greet do
+    use Raxol.Agent.Action,
+      name: "greet",
+      description: "Greet a person",
+      schema: [
+        input: [name: [type: :string, required: true, description: "Who to greet"]]
+      ]
+
+    @impl true
+    def run(%{name: name}, _ctx), do: {:ok, %{greeting: "hi #{name}"}}
+  end
+
+  describe "tool_definitions/1" do
+    test "derives MCP tool defs from Action modules" do
+      assert [%{"name" => "greet", "description" => "Greet a person", "inputSchema" => schema}] =
+               McpToolConfig.tool_definitions([Greet])
+
+      assert schema["type"] == "object"
+      assert Map.has_key?(schema["properties"], "name")
+    end
+  end
+
+  describe "config/1" do
+    test "builds an mcpServers map with the launcher command" do
+      cfg =
+        McpToolConfig.config(
+          actions: [Greet],
+          command: "mix",
+          args: ["mcp.server"],
+          server_name: "raxol"
+        )
+
+      assert %{"mcpServers" => %{"raxol" => entry}} = cfg
+      assert entry["command"] == "mix"
+      assert entry["args"] == ["mcp.server"]
+    end
+
+    test "injects the tools manifest path into the server env" do
+      cfg = McpToolConfig.config(command: "mix", tools_file: "/tmp/tools.json")
+      entry = cfg["mcpServers"]["raxol"]
+      assert entry["env"][McpToolConfig.tools_env_var()] == "/tmp/tools.json"
+    end
+
+    test "omits env when there is none" do
+      cfg = McpToolConfig.config(command: "mix")
+      refute Map.has_key?(cfg["mcpServers"]["raxol"], "env")
+    end
+  end
+
+  describe "write/1" do
+    @tag :tmp_dir
+    test "writes config + tools manifest and wires the manifest path", %{tmp_dir: dir} do
+      assert {:ok, config_path} =
+               McpToolConfig.write(
+                 actions: [Greet],
+                 command: "mix",
+                 args: ["mcp.server"],
+                 dir: dir
+               )
+
+      assert File.exists?(config_path)
+      config = config_path |> File.read!() |> Jason.decode!()
+      entry = config["mcpServers"]["raxol"]
+
+      tools_file = entry["env"][McpToolConfig.tools_env_var()]
+      assert File.exists?(tools_file)
+
+      manifest = tools_file |> File.read!() |> Jason.decode!()
+      assert [%{"name" => "greet"}] = manifest["tools"]
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/harness/stream_json_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/harness/stream_json_test.exs
@@ -1,0 +1,57 @@
+defmodule Raxol.Agent.Harness.StreamJsonTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Harness.StreamJson
+
+  describe "parse_line/1" do
+    test "extracts text blocks from assistant messages" do
+      line = ~s({"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}})
+      assert StreamJson.parse_line(line) == [{:text, "hi"}]
+    end
+
+    test "extracts thinking blocks as reasoning" do
+      line = ~s({"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"}]}})
+      assert StreamJson.parse_line(line) == [{:reasoning, "hmm"}]
+    end
+
+    test "extracts tool_use blocks as tool calls" do
+      line =
+        ~s({"type":"assistant","message":{"content":[{"type":"tool_use","name":"do_it","id":"t1","input":{"x":1}}]}})
+
+      assert [{:tool_call, %{name: "do_it", id: "t1", input: %{"x" => 1}}}] =
+               StreamJson.parse_line(line)
+    end
+
+    test "handles multiple blocks in order" do
+      line =
+        ~s({"type":"assistant","message":{"content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}})
+
+      assert StreamJson.parse_line(line) == [{:text, "a"}, {:text, "b"}]
+    end
+
+    test "a success result becomes a done event with content and usage" do
+      line =
+        ~s({"type":"result","subtype":"success","result":"final","usage":{"input_tokens":5}})
+
+      assert [{:done, %{content: "final", usage: %{"input_tokens" => 5}}}] =
+               StreamJson.parse_line(line)
+    end
+
+    test "an error result becomes an error event" do
+      line = ~s({"type":"result","subtype":"error_max_turns","result":"too long"})
+
+      assert [{:error, {:result_error, "error_max_turns", "too long"}}] =
+               StreamJson.parse_line(line)
+    end
+
+    test "system and user lines are ignored" do
+      assert StreamJson.parse_line(~s({"type":"system","subtype":"init"})) == []
+      assert StreamJson.parse_line(~s({"type":"user","message":{"content":[]}})) == []
+    end
+
+    test "non-JSON lines parse to nothing" do
+      assert StreamJson.parse_line("warning: something") == []
+      assert StreamJson.parse_line("") == []
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/stream_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/stream_test.exs
@@ -339,4 +339,155 @@ defmodule Raxol.Agent.StreamTest do
       assert tool_count == 2
     end
   end
+
+  # -- Backend resolution (executor + model override) -------------------------
+
+  defmodule EchoModelBackend do
+    @behaviour Raxol.Agent.AIBackend
+
+    @impl true
+    def complete(_messages, opts) do
+      {:ok, %{content: "model=#{inspect(Keyword.get(opts, :model))}", usage: %{}, metadata: %{}}}
+    end
+
+    @impl true
+    def available?, do: true
+    @impl true
+    def name, do: "Echo Model"
+    @impl true
+    def capabilities, do: [:completion]
+  end
+
+  describe "backend resolution" do
+    test ":model overrides the backend_opts model" do
+      text =
+        "hi"
+        |> AgentStream.run(
+          backend: EchoModelBackend,
+          backend_opts: [model: "base"],
+          model: "override",
+          stream: false
+        )
+        |> AgentStream.collect_text()
+
+      assert text == "model=\"override\""
+    end
+
+    test "backend_opts model is used when no :model override is given" do
+      text =
+        "hi"
+        |> AgentStream.run(
+          backend: EchoModelBackend,
+          backend_opts: [model: "base"],
+          stream: false
+        )
+        |> AgentStream.collect_text()
+
+      assert text == "model=\"base\""
+    end
+
+    test ":executor selects the backend module" do
+      cfg = Raxol.Agent.ExecutorConfig.new(harness: :mock)
+
+      {:ok, info} =
+        "hi"
+        |> AgentStream.run(executor: cfg, backend_opts: [response: "from-mock"], stream: false)
+        |> AgentStream.collect()
+
+      assert info.content == "from-mock"
+    end
+
+    test ":executor takes precedence over :backend" do
+      cfg = Raxol.Agent.ExecutorConfig.new(harness: :mock)
+
+      {:ok, info} =
+        "hi"
+        |> AgentStream.run(
+          executor: cfg,
+          backend: EchoModelBackend,
+          backend_opts: [response: "from-mock"],
+          stream: false
+        )
+        |> AgentStream.collect()
+
+      # Mock (resolved from executor) wins over the explicit EchoModelBackend.
+      assert info.content == "from-mock"
+    end
+
+    test "falls back to :backend when the executor harness is unresolvable" do
+      cfg = Raxol.Agent.ExecutorConfig.new(harness: :codex)
+
+      text =
+        "hi"
+        |> AgentStream.run(
+          executor: cfg,
+          backend: EchoModelBackend,
+          backend_opts: [model: "fallback"],
+          stream: false
+        )
+        |> AgentStream.collect_text()
+
+      assert text == "model=\"fallback\""
+    end
+  end
+
+  # -- Native (vendor-owns-loop) backends -------------------------------------
+
+  defmodule FakeNativeBackend do
+    @behaviour Raxol.Agent.AIBackend
+
+    @impl true
+    def complete(_messages, opts) do
+      report(opts)
+      {:ok, %{content: "native answer", usage: %{}, metadata: %{}}}
+    end
+
+    @impl true
+    def stream(_messages, opts) do
+      report(opts)
+      {:ok, [{:chunk, "native answer"}, {:done, %{content: "native answer", usage: %{}}}]}
+    end
+
+    @impl true
+    def available?, do: true
+    @impl true
+    def name, do: "Fake Native"
+    @impl true
+    def capabilities, do: [:completion, :streaming, :tool_use]
+    @impl true
+    def handles_tools_internally?, do: true
+
+    defp report(opts) do
+      if pid = Keyword.get(opts, :test_pid), do: send(pid, {:native_opts, opts})
+    end
+  end
+
+  describe "react/2 with a native backend" do
+    test "streams the vendor output without running the framework tool loop" do
+      events =
+        AgentStream.react("hi",
+          backend: FakeNativeBackend,
+          backend_opts: [test_pid: self()],
+          actions: [AddNumbers]
+        )
+        |> Enum.to_list()
+
+      assert {:done, %{content: "native answer"}} = List.last(events)
+      assert Enum.any?(events, &match?({:text_delta, "native answer"}, &1))
+      # The vendor owns the loop, so the framework emits no tool_use events.
+      refute Enum.any?(events, &match?({:tool_use, _}, &1))
+    end
+
+    test "injects the agent's Actions into the native backend opts (for MCP)" do
+      AgentStream.react("hi",
+        backend: FakeNativeBackend,
+        backend_opts: [test_pid: self()],
+        actions: [AddNumbers]
+      )
+      |> Stream.run()
+
+      assert_receive {:native_opts, opts}
+      assert AddNumbers in Keyword.get(opts, :actions, [])
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/tunnel/frame_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/tunnel/frame_test.exs
@@ -1,0 +1,70 @@
+defmodule Raxol.Agent.Tunnel.FrameTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Tunnel.Frame
+
+  describe "new_channel_id/0" do
+    test "is 8 lowercase hex chars and random" do
+      id = Frame.new_channel_id()
+      assert id =~ ~r/^[0-9a-f]{8}$/
+      refute id == Frame.new_channel_id()
+    end
+  end
+
+  describe "constructors" do
+    test "hello carries identity and capabilities" do
+      f = Frame.hello("host-1", ["claude", "codex"])
+      assert f.kind == :hello
+      assert f.channel_id == nil
+      assert f.payload == %{"host_id" => "host-1", "capabilities" => ["claude", "codex"]}
+    end
+
+    test "open carries path and meta" do
+      f = Frame.open("c1", "/runner/x", %{"k" => "v"})
+      assert f.kind == :open
+      assert f.channel_id == "c1"
+      assert f.payload == %{"path" => "/runner/x", "meta" => %{"k" => "v"}}
+    end
+
+    test "data defaults to text" do
+      f = Frame.data("c1", "hi")
+      assert f.payload == %{"data" => "hi", "binary" => false}
+      assert Frame.read_data(f) == "hi"
+    end
+
+    test "data with binary: true base64-encodes and round-trips" do
+      bytes = <<0, 255, 16, 32>>
+      f = Frame.data("c1", bytes, binary: true)
+      assert f.payload["binary"] == true
+      assert Frame.read_data(f) == bytes
+    end
+
+    test "close carries code and reason" do
+      f = Frame.close("c1", 1001, "owner_down")
+      assert f.payload == %{"code" => 1001, "reason" => "owner_down"}
+    end
+  end
+
+  describe "encode/decode round-trip" do
+    test "every kind survives a round-trip" do
+      for frame <- [
+            Frame.hello("h", ["a"]),
+            Frame.open("c1", "/p", %{"m" => 1}),
+            Frame.data("c1", "payload"),
+            Frame.close("c1", 1000, "bye")
+          ] do
+        assert {:ok, decoded} = Frame.decode(Frame.encode(frame))
+        assert decoded == frame
+      end
+    end
+
+    test "rejects an unknown kind without creating an atom" do
+      json = Jason.encode!(%{"c" => "c1", "k" => "evil_kind", "p" => %{}})
+      assert {:error, {:unknown_kind, "evil_kind"}} = Frame.decode(json)
+    end
+
+    test "rejects malformed json" do
+      assert {:error, _} = Frame.decode("not json")
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/tunnel_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/tunnel_test.exs
@@ -1,0 +1,158 @@
+defmodule Raxol.Agent.TunnelTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Tunnel
+  alias Raxol.Agent.Tunnel.Link
+
+  # A host on_open that spawns a local echo handler. The handler runs on the
+  # host endpoint (the "owner's machine"): it echoes inbound data back through
+  # the host tunnel, and reports closes to the test process.
+  defp echo_on_open(test_pid) do
+    fn %{channel_id: _cid, tunnel: tunnel} ->
+      handler =
+        spawn(fn -> echo_loop(tunnel, test_pid) end)
+
+      {:ok, handler}
+    end
+  end
+
+  defp echo_loop(tunnel, test_pid) do
+    receive do
+      {:tunnel_data, cid, data} ->
+        Tunnel.send_data(tunnel, cid, "echo:" <> data)
+        echo_loop(tunnel, test_pid)
+
+      {:tunnel_closed, cid, reason} ->
+        send(test_pid, {:host_closed, cid, reason})
+    end
+  end
+
+  defp connected(opts \\ []) do
+    test_pid = self()
+
+    host =
+      start_supervised!(
+        {Tunnel,
+         [
+           role: :host,
+           host_id: "host-1",
+           capabilities: ["claude", "codex"],
+           on_open: Keyword.get(opts, :on_open, echo_on_open(test_pid))
+         ]},
+        id: :host
+      )
+
+    server = start_supervised!({Tunnel, [role: :server]}, id: :server)
+    :ok = Link.connect(host, server)
+    %{host: host, server: server}
+  end
+
+  describe "hello handshake" do
+    test "the server learns the host identity after the link is attached" do
+      %{server: server} = connected()
+
+      assert %{"host_id" => "host-1", "capabilities" => ["claude", "codex"]} =
+               Tunnel.peer_hello(server)
+    end
+  end
+
+  describe "channel open + data" do
+    test "data sent on the server is handled on the host and echoes back" do
+      %{server: server} = connected()
+
+      {:ok, cid} = Tunnel.open_channel(server, "/runner/session-1")
+      :ok = Tunnel.send_data(server, cid, "ping")
+
+      assert_receive {:tunnel_data, ^cid, "echo:ping"}
+    end
+
+    test "the host materializes a channel for each open" do
+      %{host: host, server: server} = connected()
+      {:ok, cid} = Tunnel.open_channel(server, "/runner/x")
+
+      # The host registered a local channel handler for the attach.
+      assert cid in Tunnel.channels(host)
+      assert cid in Tunnel.channels(server)
+    end
+  end
+
+  describe "multiplexing many channels over one link" do
+    test "channels are isolated by id" do
+      %{server: server} = connected()
+
+      {:ok, c1} = Tunnel.open_channel(server, "/runner/a")
+      {:ok, c2} = Tunnel.open_channel(server, "/runner/b")
+
+      :ok = Tunnel.send_data(server, c1, "one")
+      :ok = Tunnel.send_data(server, c2, "two")
+
+      assert_receive {:tunnel_data, ^c1, "echo:one"}
+      assert_receive {:tunnel_data, ^c2, "echo:two"}
+    end
+  end
+
+  describe "close" do
+    test "closing on the server tears the channel down on the host" do
+      %{host: host, server: server} = connected()
+      {:ok, cid} = Tunnel.open_channel(server, "/runner/x")
+
+      :ok = Tunnel.close_channel(server, cid, "done")
+
+      assert_receive {:host_closed, ^cid, "done"}
+      refute cid in Tunnel.channels(server)
+      wait_until(fn -> cid not in Tunnel.channels(host) end)
+    end
+  end
+
+  describe "owner liveness" do
+    test "a dead channel owner closes the channel and notifies the peer" do
+      %{host: host, server: server} = connected()
+
+      owner = spawn(fn -> Process.sleep(:infinity) end)
+      {:ok, cid} = Tunnel.open_channel(server, "/runner/x", owner: owner)
+      assert cid in Tunnel.channels(server)
+
+      Process.exit(owner, :kill)
+
+      # The server drops the channel and the host is told (owner_down).
+      wait_until(fn -> cid not in Tunnel.channels(server) end)
+      assert_receive {:host_closed, ^cid, "owner_down"}
+      wait_until(fn -> cid not in Tunnel.channels(host) end)
+    end
+  end
+
+  describe "error handling" do
+    test "sending on an unknown channel errors" do
+      %{server: server} = connected()
+      assert {:error, :unknown_channel} = Tunnel.send_data(server, "deadbeef", "x")
+    end
+
+    test "opening without a link errors" do
+      tunnel = start_supervised!({Tunnel, [role: :server]})
+      assert {:error, :no_link} = Tunnel.open_channel(tunnel, "/runner/x")
+    end
+
+    test "an open with no host handler is refused" do
+      no_handler = start_supervised!({Tunnel, [role: :host, host_id: "h"]}, id: :nh_host)
+      server = start_supervised!({Tunnel, [role: :server]}, id: :nh_server)
+      :ok = Link.connect(no_handler, server)
+
+      {:ok, cid} = Tunnel.open_channel(server, "/runner/x", owner: self())
+      # Host refuses (no on_open) and sends a close; the server owner is notified.
+      assert_receive {:tunnel_closed, ^cid, "no_handler"}
+    end
+  end
+
+  # Deterministic spin without sleeps-as-timing: polls a predicate up to a bound.
+  defp wait_until(fun, attempts \\ 50)
+  defp wait_until(_fun, 0), do: flunk("condition not met in time")
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(5)
+      wait_until(fun, attempts - 1)
+    end
+  end
+end

--- a/packages/raxol_agent/test/support/fake_stream_cli.sh
+++ b/packages/raxol_agent/test/support/fake_stream_cli.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Fake native CLI emitting the stream-json NDJSON protocol for harness tests.
+# The first argument selects a scenario.
+set -u
+mode="${1:-happy}"
+
+case "$mode" in
+  happy)
+    printf '%s\n' '{"type":"system","subtype":"init","model":"fake"}'
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"Hello "}]}}'
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"world"}]}}'
+    printf '%s\n' '{"type":"result","subtype":"success","result":"Hello world","usage":{"input_tokens":3,"output_tokens":2}}'
+    ;;
+  tool)
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"do_it","id":"t1","input":{"x":1}}]}}'
+    printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}'
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}'
+    printf '%s\n' '{"type":"result","subtype":"success","result":"done","usage":{}}'
+    ;;
+  error)
+    printf '%s\n' '{"type":"result","subtype":"error_max_turns","result":"too long"}'
+    ;;
+  exit_nonzero)
+    printf '%s\n' '{"type":"system","subtype":"init"}'
+    exit 3
+    ;;
+  no_done)
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"partial"}]}}'
+    ;;
+  *)
+    printf '%s\n' '{"type":"result","subtype":"success","result":"","usage":{}}'
+    ;;
+esac

--- a/packages/raxol_symphony/lib/raxol/symphony/config.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config.ex
@@ -24,6 +24,7 @@ defmodule Raxol.Symphony.Config do
     :agent,
     :codex,
     :runner,
+    :review,
     :recording,
     :workflow_mode,
     :workflow_path,
@@ -38,6 +39,7 @@ defmodule Raxol.Symphony.Config do
           agent: map(),
           codex: map(),
           runner: map(),
+          review: map(),
           recording: map(),
           workflow_mode: :default | :graph,
           workflow_path: Path.t() | nil,
@@ -88,6 +90,7 @@ defmodule Raxol.Symphony.Config do
       agent: agent(raw),
       codex: codex(raw),
       runner: runner(raw),
+      review: review(raw),
       recording: recording(raw),
       workflow_mode: workflow_mode(raw),
       workflow_path: workflow_path,
@@ -117,14 +120,11 @@ defmodule Raxol.Symphony.Config do
 
     %{
       kind: kind,
-      endpoint:
-        resolve_value(Map.get(section, :endpoint, default_endpoint(kind))),
-      api_key:
-        resolve_value(Map.get(section, :api_key, default_api_key_env(kind))),
+      endpoint: resolve_value(Map.get(section, :endpoint, default_endpoint(kind))),
+      api_key: resolve_value(Map.get(section, :api_key, default_api_key_env(kind))),
       project_slug: resolve_value(Map.get(section, :project_slug)),
       active_states: Map.get(section, :active_states, @default_active_states),
-      terminal_states:
-        Map.get(section, :terminal_states, @default_terminal_states)
+      terminal_states: Map.get(section, :terminal_states, @default_terminal_states)
     }
   end
 
@@ -181,9 +181,7 @@ defmodule Raxol.Symphony.Config do
       max_retry_backoff_ms:
         Map.get(section, :max_retry_backoff_ms, @default_max_retry_backoff_ms),
       max_concurrent_agents_by_state:
-        normalize_state_map(
-          Map.get(section, :max_concurrent_agents_by_state, %{})
-        )
+        normalize_state_map(Map.get(section, :max_concurrent_agents_by_state, %{}))
     }
   end
 
@@ -195,12 +193,9 @@ defmodule Raxol.Symphony.Config do
       approval_policy: Map.get(section, :approval_policy),
       thread_sandbox: Map.get(section, :thread_sandbox),
       turn_sandbox_policy: Map.get(section, :turn_sandbox_policy),
-      turn_timeout_ms:
-        Map.get(section, :turn_timeout_ms, @default_turn_timeout_ms),
-      read_timeout_ms:
-        Map.get(section, :read_timeout_ms, @default_read_timeout_ms),
-      stall_timeout_ms:
-        Map.get(section, :stall_timeout_ms, @default_stall_timeout_ms)
+      turn_timeout_ms: Map.get(section, :turn_timeout_ms, @default_turn_timeout_ms),
+      read_timeout_ms: Map.get(section, :read_timeout_ms, @default_read_timeout_ms),
+      stall_timeout_ms: Map.get(section, :stall_timeout_ms, @default_stall_timeout_ms)
     }
   end
 
@@ -213,6 +208,23 @@ defmodule Raxol.Symphony.Config do
     %{
       kind: kind,
       agent: Map.get(section, :agent, %{})
+    }
+  end
+
+  # Raxol extension: opt-in cross-vendor review. When `enabled: true` and
+  # `runner.kind == "review"`, the Review runner implements with
+  # `implementer_kind` then pauses for a different-vendor `reviewer_kind` to
+  # review the diff (ported from omnigent's Polly cross-vendor invariant).
+  defp review(raw) do
+    section = Map.get(raw, :review, %{})
+
+    %{
+      enabled: Map.get(section, :enabled, false),
+      implementer_kind: Map.get(section, :implementer_kind, "raxol_agent"),
+      reviewer_kind: Map.get(section, :reviewer_kind),
+      candidate_kinds: Map.get(section, :candidate_kinds),
+      base_ref: Map.get(section, :base_ref),
+      acceptance: resolve_value(Map.get(section, :acceptance))
     }
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
@@ -18,7 +18,9 @@ defmodule Raxol.Symphony.Config.Schema do
   alias Raxol.Symphony.Config
 
   @supported_tracker_kinds ~w(linear github memory)
-  @supported_runner_kinds ~w(raxol_agent codex)
+  @supported_runner_kinds ~w(raxol_agent codex review)
+  # Kinds usable as the implementer or reviewer behind a "review" runner.
+  @reviewable_kinds ~w(raxol_agent raxol_agent_session codex)
 
   @type error ::
           :missing_tracker_kind
@@ -27,6 +29,8 @@ defmodule Raxol.Symphony.Config.Schema do
           | :missing_tracker_project_slug
           | :missing_codex_command
           | {:unsupported_runner_kind, binary()}
+          | :missing_reviewer_kind
+          | :reviewer_kind_must_differ
           | {:invalid_value, atom(), term()}
 
   @doc """
@@ -45,7 +49,8 @@ defmodule Raxol.Symphony.Config.Schema do
          :ok <- validate_polling(config.polling),
          :ok <- validate_workspace(config.workspace),
          :ok <- validate_hooks(config.hooks),
-         :ok <- validate_agent(config.agent) do
+         :ok <- validate_agent(config.agent),
+         :ok <- validate_review(config.review) do
       if Keyword.get(opts, :skip_runner, false) do
         :ok
       else
@@ -116,6 +121,23 @@ defmodule Raxol.Symphony.Config.Schema do
   end
 
   defp validate_runner(_runner, _codex), do: :ok
+
+  # -- Review -----------------------------------------------------------------
+
+  defp validate_review(%{enabled: true} = review) do
+    implementer = review.implementer_kind
+    reviewer = review.reviewer_kind
+
+    cond do
+      blank?(reviewer) -> {:error, :missing_reviewer_kind}
+      reviewer == implementer -> {:error, :reviewer_kind_must_differ}
+      implementer not in @reviewable_kinds -> {:error, {:unsupported_runner_kind, implementer}}
+      reviewer not in @reviewable_kinds -> {:error, {:unsupported_runner_kind, reviewer}}
+      true -> :ok
+    end
+  end
+
+  defp validate_review(_review), do: :ok
 
   # -- Helpers ----------------------------------------------------------------
 

--- a/packages/raxol_symphony/lib/raxol/symphony/review.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/review.ex
@@ -1,0 +1,97 @@
+defmodule Raxol.Symphony.Review do
+  @moduledoc """
+  Cross-vendor review policy: pick a reviewer that is a DIFFERENT vendor than the
+  implementer, render the review prompt, and define the human-escalation reason.
+
+  Ported from omnigent's Polly orchestrator, where review is always performed by a
+  different vendor than the implementer and requires at least two available
+  vendors -- otherwise the work escalates to a human. Here a "vendor" is a runner
+  kind (`"raxol_agent"`, `"codex"`, ...); two distinct kinds are two distinct
+  vendors.
+
+  This module is pure: vendor availability is supplied by the caller as a
+  predicate, so detection (a `command -v`-style probe) stays at the edge and the
+  selection logic is trivially testable.
+  """
+
+  alias Raxol.Symphony.Review.Contract
+
+  @escalation_reason :awaiting_human
+
+  @doc """
+  Pick a reviewer vendor distinct from `implementer`.
+
+  Requires at least two distinct AVAILABLE candidate vendors and at least one
+  available candidate that is not the implementer. Returns the first such
+  reviewer, or `{:error, :insufficient_vendors}` when the cross-vendor invariant
+  cannot be satisfied (the caller should escalate to a human).
+  """
+  @spec select_reviewer(String.t(), [String.t()], (String.t() -> boolean())) ::
+          {:ok, String.t()} | {:error, :insufficient_vendors}
+  def select_reviewer(implementer, candidates, available?)
+      when is_binary(implementer) and is_list(candidates) and is_function(available?, 1) do
+    available =
+      candidates
+      |> Enum.uniq()
+      |> Enum.filter(available?)
+
+    reviewers = Enum.reject(available, &(&1 == implementer))
+
+    if length(available) >= 2 and reviewers != [] do
+      {:ok, hd(reviewers)}
+    else
+      {:error, :insufficient_vendors}
+    end
+  end
+
+  @doc "The pause reason used when the cross-vendor invariant cannot be met."
+  @spec escalation_reason() :: :awaiting_human
+  def escalation_reason, do: @escalation_reason
+
+  @doc """
+  Render a review prompt from a Contract.
+
+  The prompt contains only the issue, diff, summary, and acceptance criteria --
+  never a workspace path -- preserving the Contract-only isolation invariant.
+  """
+  @spec review_prompt(Contract.t()) :: String.t()
+  def review_prompt(%Contract{} = c) do
+    """
+    You are reviewing changes implemented by a different agent
+    (#{c.implementer_kind || "unknown"}). You have ONLY the diff and the
+    acceptance contract below -- you do not have access to the implementer's
+    workspace. Judge correctness, tests, security, and whether the acceptance
+    criteria are met. Approve only if the change is correct and complete.
+
+    ## Issue
+    #{c.issue_identifier}#{title_suffix(c.issue_title)}
+
+    ## Acceptance criteria
+    #{blank_to_placeholder(c.acceptance_criteria, "(none provided)")}
+
+    ## Implementer summary
+    #{blank_to_placeholder(c.summary, "(none provided)")}
+
+    ## Diff
+    #{diff_block(c.diff)}
+    """
+  end
+
+  defp title_suffix(nil), do: ""
+  defp title_suffix(""), do: ""
+  defp title_suffix(title), do: " -- #{title}"
+
+  defp blank_to_placeholder(value, placeholder) do
+    case String.trim(to_string(value)) do
+      "" -> placeholder
+      trimmed -> trimmed
+    end
+  end
+
+  defp diff_block(diff) do
+    case String.trim(to_string(diff)) do
+      "" -> "(no diff captured)"
+      _ -> "```diff\n#{diff}\n```"
+    end
+  end
+end

--- a/packages/raxol_symphony/lib/raxol/symphony/review/contract.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/review/contract.ex
@@ -1,0 +1,108 @@
+defmodule Raxol.Symphony.Review.Contract do
+  @moduledoc """
+  The artifact a reviewer is given for a cross-vendor review.
+
+  A Contract is the ONLY thing a reviewer sees: the issue under review, a unified
+  diff of the implementer's changes, a short summary, and the acceptance criteria.
+  It deliberately carries NO reference to the implementer's workspace, so a
+  reviewer running a different vendor cannot reach into the worktree and have its
+  stray edits leak into the deliverable (the cross-vendor isolation invariant from
+  omnigent's Polly orchestrator).
+
+  Build one with `build/2`; the diff is collected with an injectable git runner so
+  tests stay deterministic and the workspace never leaks past this module.
+  """
+
+  alias Raxol.Symphony.Issue
+
+  @enforce_keys [:issue_identifier]
+  defstruct [
+    :issue_identifier,
+    :issue_title,
+    :implementer_kind,
+    :base_ref,
+    diff: "",
+    summary: "",
+    acceptance_criteria: ""
+  ]
+
+  @type t :: %__MODULE__{
+          issue_identifier: String.t(),
+          issue_title: String.t() | nil,
+          implementer_kind: String.t() | nil,
+          base_ref: String.t() | nil,
+          diff: String.t(),
+          summary: String.t(),
+          acceptance_criteria: String.t()
+        }
+
+  @doc """
+  Build a Contract for `issue` from the implementer's workspace.
+
+  Options:
+
+  - `:workspace_path` -- implementer worktree to diff (used only here; never
+    placed on the Contract).
+  - `:diff` -- explicit diff string; when given, no git is run.
+  - `:git_runner` -- `(args :: [binary], cwd :: Path.t -> {:ok, binary} | {:error, term})`
+    for tests; defaults to a real `git` invocation. Diff is best-effort: a git
+    failure yields an empty diff rather than failing the build.
+  - `:base_ref` -- base to diff against (`git diff <base>...HEAD`); when `nil`,
+    diffs the working tree against `HEAD`.
+  - `:implementer_kind`, `:summary`, `:acceptance_criteria` -- metadata.
+  """
+  @spec build(Issue.t(), keyword()) :: t()
+  def build(%Issue{} = issue, opts) do
+    %__MODULE__{
+      issue_identifier: issue.identifier,
+      issue_title: Map.get(issue, :title),
+      implementer_kind: Keyword.get(opts, :implementer_kind),
+      base_ref: Keyword.get(opts, :base_ref),
+      diff: resolve_diff(opts),
+      summary: Keyword.get(opts, :summary, ""),
+      acceptance_criteria: Keyword.get(opts, :acceptance_criteria, "")
+    }
+  end
+
+  defp resolve_diff(opts) do
+    case Keyword.get(opts, :diff) do
+      diff when is_binary(diff) -> diff
+      _ -> diff_from_git(opts)
+    end
+  end
+
+  defp diff_from_git(opts) do
+    case Keyword.get(opts, :workspace_path) do
+      workspace when is_binary(workspace) ->
+        git = Keyword.get(opts, :git_runner, &default_git/2)
+
+        case git.(diff_args(Keyword.get(opts, :base_ref)), workspace) do
+          {:ok, output} -> output
+          {:error, _} -> ""
+        end
+
+      _ ->
+        ""
+    end
+  end
+
+  defp diff_args(nil), do: ["diff", "HEAD"]
+  defp diff_args(base) when is_binary(base), do: ["diff", "#{base}...HEAD"]
+
+  defp default_git(args, cwd) do
+    cond do
+      not File.dir?(cwd) -> {:error, :workspace_missing}
+      is_nil(System.find_executable("git")) -> {:error, :git_not_found}
+      true -> run_git(args, cwd)
+    end
+  end
+
+  defp run_git(args, cwd) do
+    case System.cmd("git", args, cd: cwd, stderr_to_stdout: true) do
+      {output, 0} -> {:ok, output}
+      {output, status} -> {:error, {:git_failed, status, String.trim(output)}}
+    end
+  rescue
+    e in ErlangError -> {:error, {:exception, e}}
+  end
+end

--- a/packages/raxol_symphony/lib/raxol/symphony/runner.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runner.ex
@@ -106,6 +106,9 @@ defmodule Raxol.Symphony.Runner do
   defp resolve_from_config(%Config{runner: %{kind: "noop"}}),
     do: {:ok, Raxol.Symphony.Runners.Noop}
 
+  defp resolve_from_config(%Config{runner: %{kind: "review"}}),
+    do: {:ok, Raxol.Symphony.Runners.Review}
+
   defp resolve_from_config(%Config{runner: %{kind: kind}}),
     do: {:error, {:unsupported_runner_kind, kind}}
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/review.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/review.ex
@@ -1,0 +1,204 @@
+defmodule Raxol.Symphony.Runners.Review do
+  @moduledoc """
+  A `Raxol.Symphony.Runner` decorator that adds cross-vendor review.
+
+  Activated with `runner.kind: "review"` plus a `review:` config block. It runs in
+  two phases, riding the orchestrator's generic pause/resume primitive (no
+  orchestrator changes needed):
+
+  1. **Implement.** Resolve and run `review.implementer_kind` against the real
+     workspace. If it succeeds and review is enabled, build a
+     `Raxol.Symphony.Review.Contract` (diff of the implementer's changes), pick a
+     different-vendor reviewer via `Raxol.Symphony.Review.select_reviewer/3`, and
+     pause `:awaiting_review` carrying the Contract. If no different vendor is
+     available, pause `:awaiting_human` instead. Any non-`:ok` implementer result
+     passes through unchanged.
+
+  2. **Review (on resume).** Resolve the reviewer vendor and run it against a
+     FRESH isolated workspace with ONLY the Contract -- never the implementer's
+     worktree. `:ok` from the reviewer means approved (the run completes);
+     `{:error, reason}` means changes requested, surfaced as
+     `{:error, {:changes_requested, reason}}` so the orchestrator's failure retry
+     re-dispatches the implementer with the feedback. A human escalation
+     (`:awaiting_human`) resumes with an operator decision in `:resume_value`.
+
+  ## Test seams
+
+  All edge effects are injectable via `opts` so the flow is unit-testable without
+  real vendors or git:
+
+  - `:review_runner_resolver` -- `(kind :: String.t -> {:ok, module} | {:error, term})`
+  - `:review_vendor_availability` -- `(kind :: String.t -> boolean)`
+  - `:review_git_runner` -- forwarded to `Contract.build/2`
+  """
+
+  @behaviour Raxol.Symphony.Runner
+
+  alias Raxol.Symphony.{Config, Issue, Review, Runner}
+  alias Raxol.Symphony.Review.Contract
+
+  @impl true
+  def run(%Issue{} = issue, %Config{} = config, opts) do
+    if Keyword.has_key?(opts, :resume_value) do
+      review_phase(issue, config, opts)
+    else
+      implement_phase(issue, config, opts)
+    end
+  end
+
+  # -- Phase 1: implement -----------------------------------------------------
+
+  defp implement_phase(issue, config, opts) do
+    review = config.review
+    implementer_kind = review.implementer_kind
+
+    with {:ok, impl_mod} <- resolve(config, implementer_kind, opts),
+         :ok <- impl_mod.run(issue, config, opts) do
+      maybe_request_review(issue, config, opts, implementer_kind)
+    else
+      # Implementer paused, errored, returned a non-:ok result, or could not be
+      # resolved -- pass it through. Review only triggers on a clean :ok.
+      {:error, {:unsupported_runner_kind, _}} = err -> err
+      other -> other
+    end
+  end
+
+  defp maybe_request_review(issue, config, opts, implementer_kind) do
+    review = config.review
+
+    if review.enabled do
+      contract = build_contract(issue, config, opts, implementer_kind)
+      candidates = candidate_kinds(review, implementer_kind)
+
+      case Review.select_reviewer(implementer_kind, candidates, availability_fun(opts)) do
+        {:ok, reviewer_kind} ->
+          {:pause, :awaiting_review,
+           %{
+             contract: contract,
+             reviewer_kind: reviewer_kind,
+             implementer_kind: implementer_kind
+           }}
+
+        {:error, :insufficient_vendors} ->
+          {:pause, Review.escalation_reason(),
+           %{
+             contract: contract,
+             implementer_kind: implementer_kind,
+             reason: :insufficient_vendors
+           }}
+      end
+    else
+      :ok
+    end
+  end
+
+  # -- Phase 2: review (on resume) --------------------------------------------
+
+  defp review_phase(issue, config, opts) do
+    token = Keyword.get(opts, :resume_token, %{})
+
+    case Map.get(token, :reviewer_kind) do
+      kind when is_binary(kind) -> dispatch_reviewer(issue, config, opts, token, kind)
+      _ -> human_decision(opts)
+    end
+  end
+
+  defp dispatch_reviewer(issue, config, opts, token, reviewer_kind) do
+    contract = Map.fetch!(token, :contract)
+
+    case resolve(config, reviewer_kind, opts) do
+      {:ok, reviewer_mod} ->
+        with_isolated_workspace(fn isolated ->
+          reviewer_opts = [
+            parent: Keyword.fetch!(opts, :parent),
+            workspace_path: isolated,
+            review_contract: contract,
+            review_prompt: Review.review_prompt(contract)
+          ]
+
+          map_review_result(reviewer_mod.run(issue, config, reviewer_opts))
+        end)
+
+      {:error, reason} ->
+        {:error, {:reviewer_unresolved, reason}}
+    end
+  end
+
+  defp map_review_result(:ok), do: :ok
+  defp map_review_result({:error, reason}), do: {:error, {:changes_requested, reason}}
+  defp map_review_result({:pause, _, _} = pause), do: pause
+  defp map_review_result(other), do: other
+
+  # A human escalation resumes with the operator's decision in :resume_value.
+  defp human_decision(opts) do
+    case Keyword.get(opts, :resume_value) do
+      :approved -> :ok
+      :rejected -> {:error, {:changes_requested, :rejected_by_human}}
+      other -> {:error, {:unexpected_human_decision, other}}
+    end
+  end
+
+  # -- Helpers ----------------------------------------------------------------
+
+  defp build_contract(issue, config, opts, implementer_kind) do
+    contract_opts =
+      [
+        workspace_path: Keyword.get(opts, :workspace_path),
+        implementer_kind: implementer_kind,
+        base_ref: config.review.base_ref,
+        acceptance_criteria: config.review.acceptance || "",
+        summary: ""
+      ]
+      |> maybe_put_git_runner(Keyword.get(opts, :review_git_runner))
+
+    Contract.build(issue, contract_opts)
+  end
+
+  # Only forward :git_runner when set -- Contract.build/2 falls back to its own
+  # default git invocation when the key is absent (but not when it is nil).
+  defp maybe_put_git_runner(opts, nil), do: opts
+  defp maybe_put_git_runner(opts, fun), do: Keyword.put(opts, :git_runner, fun)
+
+  defp candidate_kinds(review, implementer_kind) do
+    case review.candidate_kinds do
+      list when is_list(list) and list != [] -> list
+      _ -> Enum.uniq([implementer_kind, review.reviewer_kind])
+    end
+  end
+
+  defp resolve(config, kind, opts) do
+    resolver =
+      Keyword.get(opts, :review_runner_resolver, fn k ->
+        Runner.resolve(%{config | runner: Map.put(config.runner, :kind, k)})
+      end)
+
+    resolver.(kind)
+  end
+
+  defp availability_fun(opts) do
+    Keyword.get(opts, :review_vendor_availability, &default_available?/1)
+  end
+
+  defp default_available?(kind)
+       when kind in ["raxol_agent", "raxol_agent_session", "noop", "review"],
+       do: true
+
+  defp default_available?("codex"), do: not is_nil(System.find_executable("codex"))
+  defp default_available?(_), do: false
+
+  defp with_isolated_workspace(fun) do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony_review_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+
+    try do
+      fun.(dir)
+    after
+      File.rm_rf(dir)
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/review/contract_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/review/contract_test.exs
@@ -1,0 +1,60 @@
+defmodule Raxol.Symphony.Review.ContractTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.Issue
+  alias Raxol.Symphony.Review.Contract
+
+  defp issue do
+    %Issue{id: "i-1", identifier: "MT-7", title: "Add widget", state: "Todo"}
+  end
+
+  describe "build/2" do
+    test "carries issue metadata and explicit diff" do
+      c = Contract.build(issue(), diff: "DIFF", implementer_kind: "codex", summary: "did it")
+
+      assert c.issue_identifier == "MT-7"
+      assert c.issue_title == "Add widget"
+      assert c.implementer_kind == "codex"
+      assert c.diff == "DIFF"
+      assert c.summary == "did it"
+    end
+
+    test "collects the diff with an injected git runner (no base ref)" do
+      git = fn args, cwd ->
+        assert args == ["diff", "HEAD"]
+        assert cwd == "/tmp/ws"
+        {:ok, "GIT DIFF"}
+      end
+
+      c = Contract.build(issue(), workspace_path: "/tmp/ws", git_runner: git)
+      assert c.diff == "GIT DIFF"
+    end
+
+    test "uses base_ref in the diff range when provided" do
+      git = fn args, _cwd ->
+        assert args == ["diff", "main...HEAD"]
+        {:ok, "RANGE DIFF"}
+      end
+
+      c = Contract.build(issue(), workspace_path: "/tmp/ws", base_ref: "main", git_runner: git)
+      assert c.diff == "RANGE DIFF"
+    end
+
+    test "a git failure yields an empty diff rather than raising" do
+      git = fn _args, _cwd -> {:error, :git_failed} end
+      c = Contract.build(issue(), workspace_path: "/tmp/ws", git_runner: git)
+      assert c.diff == ""
+    end
+
+    test "no workspace and no diff yields an empty diff" do
+      c = Contract.build(issue(), implementer_kind: "codex")
+      assert c.diff == ""
+    end
+
+    test "the contract never carries a workspace reference" do
+      c = Contract.build(issue(), workspace_path: "/tmp/ws", diff: "X")
+      refute Map.has_key?(c, :workspace_path)
+      refute Map.has_key?(c, :workspace)
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/review_config_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/review_config_test.exs
@@ -1,0 +1,60 @@
+defmodule Raxol.Symphony.ReviewConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.Config
+  alias Raxol.Symphony.Config.Schema
+
+  defp build(review) do
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{kind: "memory"},
+        runner: %{kind: "review"},
+        review: review
+      },
+      prompt_template: ""
+    })
+  end
+
+  describe "review config defaults" do
+    test "review is disabled by default with a raxol_agent implementer" do
+      config = build(%{})
+      assert config.review.enabled == false
+      assert config.review.implementer_kind == "raxol_agent"
+      assert config.review.reviewer_kind == nil
+    end
+  end
+
+  describe "schema validation" do
+    test "accepts an enabled review with a distinct reviewer" do
+      config = build(%{enabled: true, implementer_kind: "raxol_agent", reviewer_kind: "codex"})
+      assert :ok = Schema.validate(config)
+    end
+
+    test "a disabled review never fails validation" do
+      config =
+        build(%{enabled: false, implementer_kind: "raxol_agent", reviewer_kind: "raxol_agent"})
+
+      assert :ok = Schema.validate(config)
+    end
+
+    test "rejects a missing reviewer when enabled" do
+      config = build(%{enabled: true, implementer_kind: "raxol_agent"})
+      assert {:error, :missing_reviewer_kind} = Schema.validate(config)
+    end
+
+    test "rejects a reviewer equal to the implementer" do
+      config = build(%{enabled: true, implementer_kind: "codex", reviewer_kind: "codex"})
+      assert {:error, :reviewer_kind_must_differ} = Schema.validate(config)
+    end
+
+    test "rejects an unsupported reviewer kind" do
+      config = build(%{enabled: true, implementer_kind: "raxol_agent", reviewer_kind: "bogus"})
+      assert {:error, {:unsupported_runner_kind, "bogus"}} = Schema.validate(config)
+    end
+
+    test "the review runner kind resolves" do
+      assert {:ok, Raxol.Symphony.Runners.Review} =
+               Raxol.Symphony.Runner.resolve(build(%{}))
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/review_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/review_test.exs
@@ -1,0 +1,78 @@
+defmodule Raxol.Symphony.ReviewTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.Review
+  alias Raxol.Symphony.Review.Contract
+
+  defp always_available, do: fn _ -> true end
+
+  describe "select_reviewer/3" do
+    test "picks a different vendor when two are available" do
+      assert {:ok, "b"} = Review.select_reviewer("a", ["a", "b"], always_available())
+    end
+
+    test "picks the first available different vendor" do
+      avail = fn k -> k in ["a", "c"] end
+      assert {:ok, "c"} = Review.select_reviewer("a", ["a", "b", "c"], avail)
+    end
+
+    test "deduplicates candidate kinds" do
+      assert {:ok, "b"} = Review.select_reviewer("a", ["a", "b", "b", "a"], always_available())
+    end
+
+    test "escalates when only the implementer is available" do
+      avail = fn k -> k == "a" end
+      assert {:error, :insufficient_vendors} = Review.select_reviewer("a", ["a", "b"], avail)
+    end
+
+    test "escalates when there is only one candidate" do
+      assert {:error, :insufficient_vendors} =
+               Review.select_reviewer("a", ["a"], always_available())
+    end
+
+    test "escalates when no available candidate differs from the implementer" do
+      assert {:error, :insufficient_vendors} =
+               Review.select_reviewer("a", ["a", "a"], always_available())
+    end
+  end
+
+  describe "escalation_reason/0" do
+    test "is :awaiting_human" do
+      assert Review.escalation_reason() == :awaiting_human
+    end
+  end
+
+  describe "review_prompt/1" do
+    test "includes the issue, diff, criteria, and implementer -- but never a workspace" do
+      contract =
+        Contract.build(
+          %Raxol.Symphony.Issue{id: "i", identifier: "MT-9", title: "T", state: "Todo"},
+          diff: "the-diff",
+          implementer_kind: "codex",
+          acceptance_criteria: "must pass tests"
+        )
+
+      prompt = Review.review_prompt(contract)
+
+      assert prompt =~ "MT-9"
+      assert prompt =~ "the-diff"
+      assert prompt =~ "must pass tests"
+      assert prompt =~ "codex"
+      # review_prompt only ever sees a Contract, which has no path field, so a
+      # filesystem path can never leak into the reviewer's input.
+      refute prompt =~ "/tmp"
+    end
+
+    test "renders placeholders when fields are blank" do
+      contract =
+        Contract.build(
+          %Raxol.Symphony.Issue{id: "i", identifier: "MT-1", title: "T", state: "Todo"},
+          []
+        )
+
+      prompt = Review.review_prompt(contract)
+      assert prompt =~ "(no diff captured)"
+      assert prompt =~ "(none provided)"
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/review_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/review_test.exs
@@ -1,0 +1,232 @@
+defmodule Raxol.Symphony.Runners.ReviewTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.{Config, Issue}
+  alias Raxol.Symphony.Review.Contract
+  alias Raxol.Symphony.Runners.Review, as: ReviewRunner
+
+  # -- Fake vendor runners ----------------------------------------------------
+
+  defmodule OkRunner do
+    @behaviour Raxol.Symphony.Runner
+    @impl true
+    def run(_issue, _config, _opts), do: :ok
+  end
+
+  defmodule ErrorRunner do
+    @behaviour Raxol.Symphony.Runner
+    @impl true
+    def run(_issue, _config, _opts), do: {:error, :boom}
+  end
+
+  # Reviewers report the exact opts they were handed to the test pid (via
+  # :parent) so we can assert the Contract-only isolation invariant.
+  defmodule ApproveReviewer do
+    @behaviour Raxol.Symphony.Runner
+    @impl true
+    def run(_issue, _config, opts) do
+      send(Keyword.fetch!(opts, :parent), {:reviewer_opts, opts})
+      :ok
+    end
+  end
+
+  defmodule RejectReviewer do
+    @behaviour Raxol.Symphony.Runner
+    @impl true
+    def run(_issue, _config, opts) do
+      send(Keyword.fetch!(opts, :parent), {:reviewer_opts, opts})
+      {:error, :needs_work}
+    end
+  end
+
+  # -- Fixtures ---------------------------------------------------------------
+
+  defp issue, do: %Issue{id: "i-1", identifier: "MT-1", title: "Do thing", state: "Todo"}
+
+  defp config(review_overrides) do
+    review =
+      Map.merge(
+        %{
+          enabled: true,
+          implementer_kind: "impl",
+          reviewer_kind: "rev",
+          candidate_kinds: ["impl", "rev"]
+        },
+        review_overrides
+      )
+
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{kind: "memory"},
+        runner: %{kind: "review"},
+        review: review
+      },
+      prompt_template: ""
+    })
+  end
+
+  defp resolver(map) do
+    fn kind ->
+      case Map.fetch(map, kind) do
+        {:ok, mod} -> {:ok, mod}
+        :error -> {:error, {:unknown_kind, kind}}
+      end
+    end
+  end
+
+  # -- Implement phase --------------------------------------------------------
+
+  describe "implement phase" do
+    test "passes :ok through when review is disabled" do
+      opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: resolver(%{"impl" => OkRunner})
+      ]
+
+      assert :ok = ReviewRunner.run(issue(), config(%{enabled: false}), opts)
+    end
+
+    test "pauses :awaiting_review with a contract and a different reviewer" do
+      opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: resolver(%{"impl" => OkRunner, "rev" => ApproveReviewer}),
+        review_vendor_availability: fn _ -> true end,
+        review_git_runner: fn _args, _cwd -> {:ok, "THE DIFF"} end
+      ]
+
+      assert {:pause, :awaiting_review, token} = ReviewRunner.run(issue(), config(%{}), opts)
+      assert token.reviewer_kind == "rev"
+      assert token.implementer_kind == "impl"
+      assert %Contract{diff: "THE DIFF", implementer_kind: "impl"} = token.contract
+    end
+
+    test "escalates to :awaiting_human when no different vendor is available" do
+      opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: resolver(%{"impl" => OkRunner}),
+        review_vendor_availability: fn k -> k == "impl" end,
+        review_git_runner: fn _args, _cwd -> {:ok, ""} end
+      ]
+
+      assert {:pause, :awaiting_human, token} = ReviewRunner.run(issue(), config(%{}), opts)
+      assert token.reason == :insufficient_vendors
+    end
+
+    test "passes an implementer error through unchanged" do
+      opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: resolver(%{"impl" => ErrorRunner})
+      ]
+
+      assert {:error, :boom} = ReviewRunner.run(issue(), config(%{}), opts)
+    end
+  end
+
+  # -- Review phase (resume) --------------------------------------------------
+
+  describe "review phase" do
+    defp resume_opts(token, extra) do
+      [
+        parent: self(),
+        resume_token: token,
+        resume_value: :proceed,
+        review_runner_resolver: resolver(%{"rev" => ApproveReviewer, "reject" => RejectReviewer})
+      ] ++ extra
+    end
+
+    test "approves when the reviewer returns :ok" do
+      token = %{
+        reviewer_kind: "rev",
+        implementer_kind: "impl",
+        contract: %Contract{issue_identifier: "MT-1", diff: "d"}
+      }
+
+      assert :ok = ReviewRunner.run(issue(), config(%{}), resume_opts(token, []))
+    end
+
+    test "surfaces a rejection as changes_requested" do
+      token = %{
+        reviewer_kind: "reject",
+        implementer_kind: "impl",
+        contract: %Contract{issue_identifier: "MT-1"}
+      }
+
+      assert {:error, {:changes_requested, :needs_work}} =
+               ReviewRunner.run(issue(), config(%{}), resume_opts(token, []))
+    end
+
+    test "the reviewer receives the Contract only -- never the implementer workspace" do
+      contract = %Contract{issue_identifier: "MT-1", diff: "d", implementer_kind: "impl"}
+      token = %{reviewer_kind: "rev", implementer_kind: "impl", contract: contract}
+
+      assert :ok = ReviewRunner.run(issue(), config(%{}), resume_opts(token, []))
+
+      assert_receive {:reviewer_opts, ropts}
+      assert ropts[:review_contract] == contract
+      assert is_binary(ropts[:review_prompt])
+      # An isolated workspace, NOT the implementer's worktree.
+      assert ropts[:workspace_path] != "/tmp/ws"
+      refute Keyword.has_key?(ropts, :resume_token)
+    end
+  end
+
+  # -- Full implement -> pause -> review -> complete cycle ---------------------
+
+  describe "full review cycle" do
+    test "implement pauses for review, then the resumed reviewer completes it" do
+      res = resolver(%{"impl" => OkRunner, "rev" => ApproveReviewer})
+
+      implement_opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: res,
+        review_vendor_availability: fn _ -> true end,
+        review_git_runner: fn _args, _cwd -> {:ok, "DIFF"} end
+      ]
+
+      # Phase 1: implement -> pause carrying the review token (as the
+      # orchestrator would park it).
+      assert {:pause, :awaiting_review, token} =
+               ReviewRunner.run(issue(), config(%{}), implement_opts)
+
+      # Phase 2: orchestrator resumes with the token; the different-vendor
+      # reviewer runs against the Contract and approves -> run completes.
+      resume = [
+        parent: self(),
+        resume_token: token,
+        resume_value: :proceed,
+        review_runner_resolver: res
+      ]
+
+      assert :ok = ReviewRunner.run(issue(), config(%{}), resume)
+      assert_receive {:reviewer_opts, ropts}
+      assert ropts[:review_contract] == token.contract
+      assert ropts[:workspace_path] != "/tmp/ws"
+    end
+  end
+
+  # -- Human escalation resume ------------------------------------------------
+
+  describe "human escalation resume" do
+    defp human_opts(decision) do
+      [
+        parent: self(),
+        resume_token: %{implementer_kind: "impl", reason: :insufficient_vendors},
+        resume_value: decision
+      ]
+    end
+
+    test "an :approved decision completes the run" do
+      assert :ok = ReviewRunner.run(issue(), config(%{}), human_opts(:approved))
+    end
+
+    test "a :rejected decision requests changes" do
+      assert {:error, {:changes_requested, :rejected_by_human}} =
+               ReviewRunner.run(issue(), config(%{}), human_opts(:rejected))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts patterns of value from [`omnigent-ai/omnigent`](https://github.com/omnigent-ai/omnigent) (a Python meta-harness) into Raxol, all built BEAM-native. Six features across `raxol_agent` and `raxol_symphony`, each in its own commit.

| Area | What |
| --- | --- |
| Executor + native harnesses | Explicit `ExecutorConfig {harness, model, auth}` + `Backend.Selector` replacing implicit base-url detection; `AIBackend` capability callbacks (`handles_tools_internally?`, `max_context_tokens`); `Stream` `:executor`/`:model` overrides and a native-backend branch; `NativeHarness` behaviour + Claude Code / Cursor drivers wrapping the `stream-json` CLI, exposing Raxol tools via `--mcp-config`. Codex stays on the symphony app-server runner (documented boundary). |
| Conversation item-log | Immutable typed `Item` log + ETS store (cursor pagination) + `Log` GenServer with **exact snapshot/live-tail partition** (no gap, no dupe on reconnect) + `Recorder` bridging `Agent.Stream`. |
| Reverse co-driving tunnel | Single outbound link multiplexing many channels; the host's `on_open` spawns each channel's handler **locally** ("attach runs on YOUR machine"); transport-agnostic via `send_fun` + `{:tunnel_recv, binary}`, with an in-process `Link` for tests and a documented WebSocket adapter slot. |
| Authorization engine | ALLOW/ASK/DENY pure reducer: DENY short-circuits, ASK escrows label writes until approval, monotonic most-restrictive label merge, per-route approval memory (one approval can cover a spawn tree); a per-workflow `Server` and a `CommandHook` integration. |
| Cross-vendor review | Symphony `Runners.Review` decorator: implement with one vendor, pause `:awaiting_review`, then review with a **different** vendor against a diff-only `Contract` (never the worktree); needs >=2 vendors or escalates to a human. Rides the orchestrator's existing pause/resume. |

Design notes and the full extraction report are in the commit messages.

## Commits

- `Add agent executor config and native harnesses`
- `Add conversation item-log with live-tail streaming`
- `Add reverse co-driving tunnel`
- `Add ALLOW/ASK/DENY authorization engine`
- `Add cross-vendor review workflow`

(Executor config and native harnesses are combined because they share `stream.ex`/`selector.ex`.)

## Test plan

All new code is covered by deterministic unit tests (no network, no fixed sleeps); native CLIs are driven by a fake `stream-json` script.

- `raxol_agent`: 782 tests, 0 failures
- `raxol_symphony`: 694 tests + 23 doctests, 0 failures
- Format clean; credo: no issues on all new files

## Manual testing

- [ ] `cd packages/raxol_agent && MIX_ENV=test mix test`
- [ ] `cd packages/raxol_symphony && MIX_ENV=test mix test`
- [ ] `cd packages/raxol_agent && mix format --check-formatted && mix credo`
- [ ] With a real `claude` CLI installed: drive `Raxol.Agent.Stream.react/2` with `executor: ExecutorConfig.new(harness: :claude_native)` and confirm tool injection via `--mcp-config`
- [ ] Wire a `Raxol.Agent.Tunnel.Link` between two endpoints and confirm open/data/close multiplexing

## Notes

- Nothing here depends on or touches the in-flight `lib/raxol/workflow/*` changes.
- Added `packages/raxol_agent/.gitignore` to ignore ExUnit `:tmp_dir` artifacts.
- Deferred (documented): durable conversation store adapter, a real WebSocket tunnel transport, and Tier-2 items (downgrade-gate budget, agent YAML spec).
