### PR TITLE
Fix Postgrex checkpoint DDL multi-statement error (Integration Tests)

### DIFF
--- a/lib/raxol/workflow/checkpoint/saver/postgrex.ex
+++ b/lib/raxol/workflow/checkpoint/saver/postgrex.ex
@@ -202,6 +202,37 @@ defmodule Raxol.Workflow.Checkpoint.Saver.Postgrex do
     """
   end
 
+  @doc """
+  Returns `create_table_sql/1` split into individual statements.
+
+  `create_table_sql/1` is a two-statement DDL script (table + index) suitable for
+  `psql` or a migration file. `Postgrex.query/4` uses the extended protocol, which
+  runs one command per query, so callers driving the DDL through Postgrex must run
+  each statement separately. This is the list to iterate over.
+  """
+  @spec create_table_statements(String.t()) :: [String.t()]
+  def create_table_statements(table \\ @default_table) do
+    table
+    |> create_table_sql()
+    |> String.split(";", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  @doc """
+  Create the checkpoint table and its index on `conn`.
+
+  Runs each statement from `create_table_statements/1` separately, since Postgrex
+  cannot prepare a multi-statement query. Use this instead of passing
+  `create_table_sql/1` to `Postgrex.query/4` directly.
+  """
+  @spec create_table!(term(), String.t()) :: :ok
+  def create_table!(conn, table \\ @default_table) do
+    ensure_postgrex_loaded!()
+    Enum.each(create_table_statements(table), &Postgrex.query!(conn, &1, []))
+    :ok
+  end
+
   # --- SQL builders (exposed @doc false so tests can pin the shape) ---
 
   @doc false

--- a/test/raxol/workflow/checkpoint/saver/postgrex_test.exs
+++ b/test/raxol/workflow/checkpoint/saver/postgrex_test.exs
@@ -49,6 +49,22 @@ defmodule Raxol.Workflow.Checkpoint.Saver.PostgrexTest do
     end
   end
 
+  describe "create_table_statements/1" do
+    test "splits the DDL into one runnable statement per command" do
+      assert [create_table, create_index] = Saver.create_table_statements()
+
+      assert create_table =~
+               "CREATE TABLE IF NOT EXISTS raxol_workflow_checkpoints"
+
+      assert create_index =~
+               "CREATE INDEX IF NOT EXISTS raxol_workflow_checkpoints_paused_idx"
+
+      # Each statement is a single command (Postgrex cannot prepare multi-command SQL).
+      refute create_table =~ ";"
+      refute create_index =~ ";"
+    end
+  end
+
   describe "insert_sql/1" do
     test "uses ON CONFLICT DO NOTHING for the append-only contract" do
       sql = Saver.insert_sql("raxol_workflow_checkpoints")
@@ -210,7 +226,7 @@ defmodule Raxol.Workflow.Checkpoint.Saver.PostgrexTest do
     test "put + get_latest returns the same checkpoint" do
       conn = start_conn!()
       table = unique_table()
-      Postgrex.query!(conn, Saver.create_table_sql(table), [])
+      Saver.create_table!(conn, table)
       config = %{conn: conn, table: table}
 
       ckpt =
@@ -232,7 +248,7 @@ defmodule Raxol.Workflow.Checkpoint.Saver.PostgrexTest do
     test "ON CONFLICT makes put/3 idempotent" do
       conn = start_conn!()
       table = unique_table()
-      Postgrex.query!(conn, Saver.create_table_sql(table), [])
+      Saver.create_table!(conn, table)
       config = %{conn: conn, table: table}
 
       ckpt =
@@ -255,7 +271,7 @@ defmodule Raxol.Workflow.Checkpoint.Saver.PostgrexTest do
     test "list/3 returns checkpoints newest-first up to limit" do
       conn = start_conn!()
       table = unique_table()
-      Postgrex.query!(conn, Saver.create_table_sql(table), [])
+      Saver.create_table!(conn, table)
       config = %{conn: conn, table: table}
 
       for step <- 0..5 do
@@ -283,7 +299,7 @@ defmodule Raxol.Workflow.Checkpoint.Saver.PostgrexTest do
     test "delete_thread/2 removes all checkpoints for the thread" do
       conn = start_conn!()
       table = unique_table()
-      Postgrex.query!(conn, Saver.create_table_sql(table), [])
+      Saver.create_table!(conn, table)
       config = %{conn: conn, table: table}
 
       for step <- 0..2 do
@@ -308,7 +324,7 @@ defmodule Raxol.Workflow.Checkpoint.Saver.PostgrexTest do
     test "two threads in the same table do not see each other's checkpoints" do
       conn = start_conn!()
       table = unique_table()
-      Postgrex.query!(conn, Saver.create_table_sql(table), [])
+      Saver.create_table!(conn, table)
       config = %{conn: conn, table: table}
 
       Saver.put(


### PR DESCRIPTION
## Summary

Fixes the `Integration Tests` job, which is currently red on `master`. The 5 failing tests are `Raxol.Workflow.Checkpoint.Saver.PostgrexTest` "live Postgres roundtrip" cases, all failing with:

```
** (Postgrex.Error) ERROR 42601 (syntax_error) cannot insert multiple commands into a prepared statement
```

## Root cause

`Saver.create_table_sql/1` returns a **two-statement** DDL script (`CREATE TABLE ...; CREATE INDEX ...;`). The tests ran it through `Postgrex.query!/3`, which uses the extended (prepared-statement) protocol — that allows only one command per query, so Postgres rejects it.

## Fix

- Add `Saver.create_table_statements/1` — the DDL split into one runnable command per statement (pure, testable without a DB).
- Add `Saver.create_table!/2` — runs those statements separately via Postgrex. This also fixes the same footgun for any real consumer that was setting up the table through `Postgrex.query`.
- Use `Saver.create_table!/2` in the 5 integration tests instead of passing the multi-statement string to `Postgrex.query!`.

No change to `create_table_sql/1` (still correct for `psql`/migration files, where multi-statement is fine).

## Test plan

Verified locally against a real Postgres:

- Unit (no DB): `mix test test/raxol/workflow/checkpoint/saver/postgrex_test.exs --exclude integration` → **11 tests, 0 failures**
- Live Postgres: `POSTGRES_HOST=localhost POSTGRES_DB=postgres POSTGRES_USER=... mix test test/raxol/workflow/checkpoint/saver/postgrex_test.exs --only integration` → **5 tests, 0 failures** (was 5/5 failing before the fix)

## Manual testing

- [ ] `mix test test/raxol/workflow/checkpoint/saver/postgrex_test.exs --exclude integration`
- [ ] With Postgres available: `mix test --only integration --exclude skip_on_ci` (the CI Integration Tests command)
- [ ] `mix format --check-formatted && mix credo lib/raxol/workflow/checkpoint/saver/postgrex.ex`
