### PR TITLE
Drop flaky wall-clock asserts from CI timing tests

### DIFF
--- a/test/raxol/minimal_test.exs
+++ b/test/raxol/minimal_test.exs
@@ -35,6 +35,8 @@ defmodule Raxol.MinimalTest do
       GenServer.stop(pid)
     end
 
+    # Wall-clock perf bound; tight enough to flake on loaded CI runners.
+    @tag :skip_on_ci
     test "measures startup time" do
       start_time = System.monotonic_time(:microsecond)
       {:ok, pid} = Raxol.Minimal.start_terminal()

--- a/test/raxol/workflow/parallel_test.exs
+++ b/test/raxol/workflow/parallel_test.exs
@@ -867,20 +867,14 @@ defmodule Raxol.Workflow.ParallelTest do
 
       {:ok, compiled} = Graph.compile(graph)
 
-      started_us = System.monotonic_time(:microsecond)
       assert {:error, :boom, _state} = Compiled.invoke(compiled, %{})
-      elapsed_ms = div(System.monotonic_time(:microsecond) - started_us, 1_000)
-
-      # Sibling sleeps are 300 ms each; cascade should kill them
-      # before either finishes. Allow up to 200 ms for scheduler jitter.
-      assert elapsed_ms < 200,
-             "expected cascade to short-circuit < 200 ms; took #{elapsed_ms} ms"
 
       tags = :ets.tab2list(table) |> Enum.map(fn {_ts, tag} -> tag end)
 
-      # The fast-fail branch ran; the slow branches may have logged
-      # `:started` before being killed, but neither should have logged
-      # `:finished`.
+      # The fast-fail branch ran; the slow branches (300 ms sleeps) may have
+      # logged `:started` before being killed, but the cascade kills them
+      # before either logs `:finished`. The absence of `:finished` is the
+      # cancellation proof -- a wall-clock bound would only flake on CI.
       assert :fast_fail_started in tags
       refute :slow_a_finished in tags
       refute :slow_b_finished in tags


### PR DESCRIPTION
## What

Follow-up to #304. Removes two CI-hostile wall-clock assertions surfaced by
a sweep of timing-based tests.

## Changes

- **`parallel_test.exs` cancellation cascade**: removed the redundant
  `elapsed_ms < 200` assertion. The test already proves the cascade kills
  siblings via `refute :slow_a_finished` / `refute :slow_b_finished` (the
  300 ms branches never log `:finished`). The timing bound added flake risk
  (~45 ms margin against ~155 ms orchestration overhead, the same profile
  that broke #304's sibling test) with no extra correctness guarantee. The
  test still runs on CI.
- **`minimal_test.exs` "measures startup time"**: tagged `:skip_on_ci`. A
  pure `startup_time_ms < 50` perf bound with no functional coverage; tight
  enough to flake on a loaded runner. Matches the repo convention for the
  parser sub-quadratic perf test.

## Sweep result

Audited ~15 files with wall-clock assertions. The rest are safe: 1 s+
ceilings, lower-bound/ordering checks, or computed-field assertions (not
measured elapsed). `animation/framework_test.exs` keeps its 500 ms bound
(250 ms headroom + `wait_for_*` synchronization).

## Manual testing

- [x] `mix test test/raxol/workflow/parallel_test.exs test/raxol/minimal_test.exs` -> 37 tests, 0 failures, 2 excluded
- [x] Cancellation cascade test still runs on CI (only the speedup + startup perf tests are skipped)
