### PR TITLE
Live Relay validation gates (Tron)

### DIFF
--- a/packages/raxol_acp/test/raxol/acp/relay/live_relay_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/relay/live_relay_test.exs
@@ -1,0 +1,128 @@
+defmodule Raxol.ACP.Relay.LiveRelayTest do
+  @moduledoc """
+  Full EVM -> Tron transfer through the Relay rail against a real Riddler
+  endpoint, funded by the on-chain deposit broadcaster.
+
+  `ExecuteRelayTransfer` quotes, authorizes the spend, and initiates execution;
+  the `OnchainBroadcaster` broadcasts the ERC-20 deposit on the source chain;
+  `PollRelayStatus` waits for `:completed`.
+
+  Moves real funds: opt-in, excluded by default, compiled only when the required
+  env is present.
+
+      RELAY_LIVE_URL=https://riddler.axol.io \\
+      RELAY_LIVE_TOKEN="$(op read 'op://Employee/Xochi staging RIDDLER_API_TOKEN/credential')" \\
+      RELAY_LIVE_KEY=0x<funded source-chain private key> \\
+      RELAY_LIVE_RPC=https://mainnet.base.org \\
+        mix test --include live_relay test/raxol/acp/relay/live_relay_test.exs
+
+  Defaults (Base USDC -> Tron USDT, 0.10 USDC) are overridable via
+  RELAY_LIVE_FROM_CHAIN, RELAY_LIVE_FROM_TOKEN, RELAY_LIVE_TO_TOKEN,
+  RELAY_LIVE_TO_ADDRESS, RELAY_LIVE_AMOUNT.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :live_relay
+  @moduletag timeout: 300_000
+
+  @usdc_base "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  @usdt_tron "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+
+  if System.get_env("RELAY_LIVE_URL") && System.get_env("RELAY_LIVE_KEY") &&
+       System.get_env("RELAY_LIVE_RPC") do
+    alias Raxol.ACP.ProviderAdapter.JSONRPC
+    alias Raxol.ACP.Relay.OnchainBroadcaster
+
+    alias Raxol.Payments.Actions.Payments.{
+      ExecuteRelayTransfer,
+      PollRelayStatus
+    }
+
+    alias Raxol.Payments.{Ledger, SpendingPolicy}
+
+    defmodule LiveWallet do
+      @moduledoc false
+      use Raxol.Payments.Wallets.Env, env_var: "RELAY_LIVE_KEY"
+    end
+
+    setup do
+      url = System.fetch_env!("RELAY_LIVE_URL")
+      from_chain = env_int("RELAY_LIVE_FROM_CHAIN", 8453)
+
+      provider =
+        JSONRPC.new(
+          chains: %{from_chain => System.fetch_env!("RELAY_LIVE_RPC")},
+          private_key: decode_key(System.fetch_env!("RELAY_LIVE_KEY"))
+        )
+
+      OnchainBroadcaster.configure(provider)
+
+      on_exit(fn ->
+        Application.delete_env(:raxol_acp, :relay_broadcaster_provider)
+      end)
+
+      ledger = start_supervised!({Ledger, [name: nil]})
+      host = url |> URI.parse() |> Map.get(:host)
+
+      policy = %SpendingPolicy{
+        per_request_max: Decimal.new("5.00"),
+        session_max: Decimal.new("20.00"),
+        lifetime_max: Decimal.new("100.00"),
+        session_window_ms: 3_600_000,
+        approved_domains: [host]
+      }
+
+      context = %{
+        wallet: LiveWallet,
+        relay_config: %{
+          base_url: url,
+          auth_token: System.get_env("RELAY_LIVE_TOKEN", "")
+        },
+        broadcaster: OnchainBroadcaster,
+        ledger: ledger,
+        policy: policy,
+        agent_id: :live_relay
+      }
+
+      {:ok, context: context, from_chain: from_chain}
+    end
+
+    test "agent completes an EVM->Tron transfer end-to-end", %{
+      context: context,
+      from_chain: from_chain
+    } do
+      params = %{
+        amount: System.get_env("RELAY_LIVE_AMOUNT", "0.10"),
+        from_chain_id: from_chain,
+        to_chain_id: 728_126_428,
+        from_token: System.get_env("RELAY_LIVE_FROM_TOKEN", @usdc_base),
+        to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
+        to_address: System.get_env("RELAY_LIVE_TO_ADDRESS", @usdt_tron)
+      }
+
+      assert {:ok, transfer} = ExecuteRelayTransfer.call(params, context)
+      assert transfer.funding == "broadcast"
+      assert is_binary(transfer.deposit_tx_hash), "no deposit tx broadcast"
+
+      assert {:ok, status} =
+               PollRelayStatus.call(
+                 %{transfer_id: transfer.transfer_id},
+                 context
+               )
+
+      assert status.status == "completed",
+             "live transfer #{transfer.transfer_id} ended in #{status.status}, expected completed"
+    end
+
+    defp env_int(name, default) do
+      case System.get_env(name) do
+        nil -> default
+        val -> String.to_integer(val)
+      end
+    end
+
+    defp decode_key("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+    defp decode_key(hex), do: Base.decode16!(hex, case: :mixed)
+  end
+end

--- a/packages/raxol_acp/test/test_helper.exs
+++ b/packages/raxol_acp/test/test_helper.exs
@@ -1,27 +1,36 @@
-# `:live_chain` tests spin up a real Anvil node + deploy a stub contract
-# and exercise the on-chain pipeline end-to-end. They need foundry
-# (anvil + cast) installed and are slow, so they're opt-in:
+# Opt-in tags, excluded by default; enable with `mix test --include <tag>`:
+#   :live_chain / :live_bundler / :live_acp_dev -- spin up a real Anvil node and
+#     exercise the on-chain pipeline (need foundry: anvil + cast).
+#   :live_relay -- moves real funds (broadcasts an on-chain deposit).
+#   :cli_signer -- spawns the riddler-permit2-erc3009 CLI; auto-enabled when
+#     RIDDLER_CLI_DIR is set.
 #
-#     mix test --include live_chain
-ExUnit.start(exclude: [:live_chain, :live_bundler, :live_acp_dev])
+# A single ExUnit.start sets the full list; a second ExUnit.configure(exclude:)
+# would replace it rather than merge, so it is computed once here.
+live_exclude = [:live_chain, :live_bundler, :live_acp_dev, :live_relay]
+cli_exclude = if System.get_env("RIDDLER_CLI_DIR"), do: [], else: [:cli_signer]
 
-# Tests tagged :cli_signer spawn the riddler-permit2-erc3009 CLI as a
-# black-box buyer-side signer. Skipped by default unless RIDDLER_CLI_DIR
-# is set.
-unless System.get_env("RIDDLER_CLI_DIR") do
-  ExUnit.configure(exclude: [:cli_signer])
-end
+ExUnit.start(exclude: live_exclude ++ cli_exclude)
 
 # Configure the in-memory contract client for the test run. The test/support
 # impl is the second real implementation of the ContractClient behaviour --
 # not a mock; see Raxol.ACP.ContractClient for the rationale.
-Application.put_env(:raxol_acp, :contract_client, Raxol.ACP.ContractClient.InMemory)
+Application.put_env(
+  :raxol_acp,
+  :contract_client,
+  Raxol.ACP.ContractClient.InMemory
+)
 
 # Bring up the seller stack with the in-process backend. Tests that need
 # specific Queue defaults (wallet, memo_opts, seller_address) overwrite
 # the env and recycle the Queue in their own setup.
 Application.put_env(:raxol_acp, :seller_enabled, true)
-Application.put_env(:raxol_acp, :seller_backend, Raxol.ACP.Seller.Backend.InMemory)
+
+Application.put_env(
+  :raxol_acp,
+  :seller_backend,
+  Raxol.ACP.Seller.Backend.InMemory
+)
 
 # In :test the OTP application's :mod is not declared, so neither the
 # supervisor nor the InMemory contract client auto-start. Bring them up

--- a/packages/raxol_payments/examples/run_live_relay_gate.sh
+++ b/packages/raxol_payments/examples/run_live_relay_gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run the live Tron Relay quote gate against the Riddler solver (read-only).
+#
+# Riddler serves the /relay/* routes the raxol Relay client calls. A quote moves
+# no funds, so this needs no private key -- just the endpoint, the staging bearer
+# token, and the EVM source address the quote is priced for.
+#
+# The full EVM->Tron settlement (which broadcasts an on-chain deposit) is a
+# separate raxol_acp :live_relay test, since broadcasting needs the EVM tx stack.
+#
+# Usage (from packages/raxol_payments/):
+#   RELAY_LIVE_FROM_ADDRESS=0x<base address> ./examples/run_live_relay_gate.sh
+#
+# Override the endpoint or token source with RELAY_LIVE_URL / RELAY_LIVE_TOKEN.
+set -euo pipefail
+
+RELAY_LIVE_URL="${RELAY_LIVE_URL:-https://riddler.axol.io}"
+OP_TOKEN_REF="${OP_TOKEN_REF:-op://Employee/Xochi staging RIDDLER_API_TOKEN/credential}"
+RELAY_LIVE_FROM_TOKEN="${RELAY_LIVE_FROM_TOKEN:-0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913}"
+RELAY_LIVE_TO_TOKEN="${RELAY_LIVE_TO_TOKEN:-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t}"
+RELAY_LIVE_TO_ADDRESS="${RELAY_LIVE_TO_ADDRESS:-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t}"
+RELAY_LIVE_AMOUNT="${RELAY_LIVE_AMOUNT:-100000}"
+
+if [[ -z "${RELAY_LIVE_FROM_ADDRESS:-}" ]]; then
+  printf 'error: set RELAY_LIVE_FROM_ADDRESS to the EVM source (Base) address\n' >&2
+  exit 1
+fi
+
+if [[ -z "${RELAY_LIVE_TOKEN:-}" ]]; then
+  if ! command -v op >/dev/null 2>&1; then
+    printf 'error: op CLI not found; set RELAY_LIVE_TOKEN directly\n' >&2
+    exit 1
+  fi
+  printf 'reading Riddler token from 1Password (%s)...\n' "$OP_TOKEN_REF" >&2
+  RELAY_LIVE_TOKEN="$(op read "$OP_TOKEN_REF")"
+fi
+
+printf 'validating relay quote endpoint (read-only, no funds move)...\n' >&2
+quote_body="$(printf '{"transfer_id":"probe","from_chain_id":8453,"to_chain_id":728126428,"from_token":"%s","to_token":"%s","from_amount":"%s","from_address":"%s","to_address":"%s","slippage_bps":50}' \
+  "$RELAY_LIVE_FROM_TOKEN" "$RELAY_LIVE_TO_TOKEN" "$RELAY_LIVE_AMOUNT" "$RELAY_LIVE_FROM_ADDRESS" "$RELAY_LIVE_TO_ADDRESS")"
+
+code="$(curl -sS -m 20 -o /dev/null -w '%{http_code}' \
+  -X POST "$RELAY_LIVE_URL/relay/quote" \
+  -H "authorization: Bearer $RELAY_LIVE_TOKEN" \
+  -H 'content-type: application/json' \
+  -d "$quote_body")"
+
+if [[ "$code" != "200" ]]; then
+  printf 'warning: relay quote probe returned http %s (continuing to the gate)\n' "$code" >&2
+else
+  printf 'relay quote ok (http 200). running the gate...\n' >&2
+fi
+
+export RELAY_LIVE_URL RELAY_LIVE_TOKEN RELAY_LIVE_FROM_ADDRESS
+export RELAY_LIVE_FROM_TOKEN RELAY_LIVE_TO_TOKEN RELAY_LIVE_TO_ADDRESS RELAY_LIVE_AMOUNT
+exec env MIX_ENV=test mix test --include live_relay \
+  test/raxol/payments/relay/live_relay_test.exs

--- a/packages/raxol_payments/test/raxol/payments/relay/live_relay_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/relay/live_relay_test.exs
@@ -1,0 +1,75 @@
+defmodule Raxol.Payments.Relay.LiveRelayTest do
+  @moduledoc """
+  Read-only live check of the Tron Relay client against a real Riddler endpoint.
+
+  Requests a `/relay/quote` and asserts the route returns a fillable quote with a
+  deposit address. A quote moves no funds, so it is safe against mainnet. The
+  full EVM->Tron settlement, which broadcasts an on-chain deposit, is a raxol_acp
+  `:live_relay` test (broadcasting needs the EVM transaction stack in that
+  package).
+
+  Tagged `:live_relay`, excluded by default, and compiled only when the endpoint
+  env is present. The endpoint is the Riddler solver serving the `/relay/*`
+  routes (the Xochi worker at api*.xochi.fi serves `/api/intent/*`).
+
+      RELAY_LIVE_URL=https://riddler.axol.io \\
+      RELAY_LIVE_TOKEN="$(op read 'op://Employee/Xochi staging RIDDLER_API_TOKEN/credential')" \\
+      RELAY_LIVE_FROM_ADDRESS=0x<your Base address> \\
+        mix test --include live_relay test/raxol/payments/relay/live_relay_test.exs
+
+  Or use the runner: examples/run_live_relay_gate.sh
+
+  Defaults (Base USDC -> Tron USDT) are overridable via RELAY_LIVE_FROM_CHAIN,
+  RELAY_LIVE_TO_CHAIN, RELAY_LIVE_FROM_TOKEN, RELAY_LIVE_TO_TOKEN,
+  RELAY_LIVE_AMOUNT, RELAY_LIVE_TO_ADDRESS.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :live_relay
+  @moduletag timeout: 120_000
+
+  @usdc_base "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  @usdt_tron "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+  @tron_recipient "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+
+  if System.get_env("RELAY_LIVE_URL") do
+    alias Raxol.Payments.Relay
+    alias Raxol.Payments.Relay.Schemas.QuoteRequest
+
+    test "relay quote endpoint is reachable and returns a fillable quote" do
+      config = %{
+        base_url: System.fetch_env!("RELAY_LIVE_URL"),
+        auth_token: System.get_env("RELAY_LIVE_TOKEN", "")
+      }
+
+      request = %QuoteRequest{
+        transfer_id:
+          "live_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower),
+        from_chain_id: env_int("RELAY_LIVE_FROM_CHAIN", 8453),
+        to_chain_id: env_int("RELAY_LIVE_TO_CHAIN", 728_126_428),
+        from_token: System.get_env("RELAY_LIVE_FROM_TOKEN", @usdc_base),
+        to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
+        from_amount: System.get_env("RELAY_LIVE_AMOUNT", "100000"),
+        from_address: System.fetch_env!("RELAY_LIVE_FROM_ADDRESS"),
+        to_address: System.get_env("RELAY_LIVE_TO_ADDRESS", @tron_recipient)
+      }
+
+      assert {:ok, quote} = Relay.get_quote(config, request),
+             "relay quote request failed against #{config.base_url}"
+
+      assert quote.can_fill,
+             "relay quote not fillable: #{inspect(Map.take(quote, [:can_fill, :metadata]))}"
+
+      assert is_binary(quote.deposit_address),
+             "relay quote returned no deposit address: #{inspect(quote)}"
+    end
+
+    defp env_int(name, default) do
+      case System.get_env(name) do
+        nil -> default
+        val -> String.to_integer(val)
+      end
+    end
+  end
+end

--- a/packages/raxol_payments/test/test_helper.exs
+++ b/packages/raxol_payments/test/test_helper.exs
@@ -16,12 +16,16 @@ ExUnit.start()
 #     Xochi endpoint with a funded wallet (XOCHI_LIVE_URL).
 gated_tags = [
   {[:cli_signer, :conformance],
-   System.get_env("RIDDLER_CLI_DIR") || System.get_env("CONFORMANCE_FIXTURE_PATH")},
+   System.get_env("RIDDLER_CLI_DIR") ||
+     System.get_env("CONFORMANCE_FIXTURE_PATH")},
   {[:stealth_conformance], System.get_env("STEALTH_VECTORS_PATH")},
-  {[:live_xochi], System.get_env("XOCHI_LIVE_URL")}
+  {[:live_xochi], System.get_env("XOCHI_LIVE_URL")},
+  {[:live_relay], System.get_env("RELAY_LIVE_URL")}
 ]
 
 excluded =
-  Enum.flat_map(gated_tags, fn {tags, enabled} -> if enabled, do: [], else: tags end)
+  Enum.flat_map(gated_tags, fn {tags, enabled} ->
+    if enabled, do: [], else: tags
+  end)
 
 ExUnit.configure(exclude: excluded)


### PR DESCRIPTION
## Live Relay validation gates

Opt-in harnesses to validate the Tron rail against a real Riddler endpoint
(`riddler.axol.io`, which serves `/relay/*`).

- **Read-only quote check** (`raxol_payments`, `:live_relay`): requests a
  `/relay/quote` and asserts a fillable quote with a deposit address. Moves no
  funds; safe against mainnet. Auto-enabled when `RELAY_LIVE_URL` is set.
  Runner: `examples/run_live_relay_gate.sh`.
- **Full EVM→Tron settlement** (`raxol_acp`, `:live_relay`): drives
  `ExecuteRelayTransfer` → `OnchainBroadcaster` (broadcasts the ERC-20 deposit)
  → `PollRelayStatus` to `:completed`. Moves real funds; always excluded by
  default, needs `--include live_relay` plus `RELAY_LIVE_URL`, `RELAY_LIVE_KEY`,
  `RELAY_LIVE_RPC`.

Also fixes the raxol_acp test_helper: a second `ExUnit.configure(exclude:)` was
replacing the `ExUnit.start` exclude list rather than merging, so `:live_chain`
et al. ran as "invalid" instead of excluded. The fund-moving `:live_relay` tag
depends on reliable exclusion, so the excludes are now computed once. This also
clears the prior 9 "invalid" results (raxol_acp now 585 tests, 0 failures, 0
invalid).

### Running

```
# read-only connectivity:
RELAY_LIVE_FROM_ADDRESS=0x<base addr> ./examples/run_live_relay_gate.sh

# full settlement (real funds):
RELAY_LIVE_URL=https://riddler.axol.io RELAY_LIVE_KEY=0x<key> \
RELAY_LIVE_RPC=https://mainnet.base.org \
  mix test --include live_relay test/raxol/acp/relay/live_relay_test.exs
```

### Manual testing

- [ ] `MIX_ENV=test mix test` green in both packages (live gates excluded)
- [ ] read-only relay quote gate against staging returns a fillable quote
- [ ] full EVM→Tron settlement on a funded testnet/mainnet wallet
