### PR TITLE
Point live xochi gate at staging mainnet route

### DIFF
--- a/packages/raxol_payments/examples/run_live_xochi_gate.sh
+++ b/packages/raxol_payments/examples/run_live_xochi_gate.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
-# Run the live Xochi crosschain stealth payment gate against the Riddler solver.
+# Run the live Xochi crosschain payment gate against the Riddler solver.
 #
 # Riddler serves the /xochi/* routes the raxol client calls. The bearer token is
-# the staging-scoped Riddler token in 1Password. You supply a funded Base
-# Sepolia private key (the intent moves real testnet USDC).
+# the staging-scoped Riddler token in 1Password. The riddler.axol.io staging
+# endpoint serves mainnet routes only, so this MOVES REAL FUNDS: you supply a
+# funded Base mainnet private key, and the default route is Base -> Arbitrum USDC
+# at 10 USDC (the minimum order size that prices on staging).
+#
+# Settlement defaults to public. For the private path, set
+# XOCHI_LIVE_SETTLEMENT=stealth and XOCHI_LIVE_RECIPIENT_META=st:eth:0x...
 #
 # Usage (from packages/raxol_payments/):
-#   XOCHI_LIVE_KEY=0x<funded base-sepolia key> ./examples/run_live_xochi_gate.sh
+#   XOCHI_LIVE_KEY=0x<funded base mainnet key> ./examples/run_live_xochi_gate.sh
 #
 # Override the endpoint or token source with XOCHI_LIVE_URL / XOCHI_LIVE_TOKEN.
 set -euo pipefail
@@ -15,7 +20,7 @@ XOCHI_LIVE_URL="${XOCHI_LIVE_URL:-https://riddler.axol.io}"
 OP_TOKEN_REF="${OP_TOKEN_REF:-op://Employee/Xochi staging RIDDLER_API_TOKEN/credential}"
 
 if [[ -z "${XOCHI_LIVE_KEY:-}" ]]; then
-  printf 'error: set XOCHI_LIVE_KEY to a funded Base Sepolia (84532) private key\n' >&2
+  printf 'error: set XOCHI_LIVE_KEY to a funded Base mainnet (8453) private key\n' >&2
   exit 1
 fi
 
@@ -29,20 +34,19 @@ if [[ -z "${XOCHI_LIVE_TOKEN:-}" ]]; then
 fi
 
 printf 'validating quote endpoint (read-only, no funds move)...\n' >&2
-quote_body='{"wallet":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","from_chain_id":84532,"to_chain_id":421614,"from_token":"0x036CbD53842c5426634e7929541eC2318f3dCF7e","to_token":"0x036CbD53842c5426634e7929541eC2318f3dCF7e","from_amount":"100000","settlement_preference":"stealth","slippage_bps":50}'
-code="$(curl -sS -m 20 -o /dev/null -w '%{http_code}' \
+quote_body='{"wallet":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","from_chain_id":8453,"to_chain_id":42161,"from_token":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","to_token":"0xaf88d065e77c8cc2239327c5edb3a432268e5831","from_amount":"10000000","settlement_preference":"public","slippage_bps":50}'
+probe="$(curl -sS -m 20 -w '\n%{http_code}' \
   -X POST "$XOCHI_LIVE_URL/xochi/quote" \
   -H "authorization: Bearer $XOCHI_LIVE_TOKEN" \
   -H 'content-type: application/json' \
   -d "$quote_body")"
+code="${probe##*$'\n'}"
+body="${probe%$'\n'*}"
 
-if [[ "$code" == "422" ]]; then
-  printf 'error: quote returned 422 -- Riddler at %s lacks the snake_case fix (need image >= 0ae99e7)\n' "$XOCHI_LIVE_URL" >&2
-  exit 1
-elif [[ "$code" != "200" ]]; then
-  printf 'warning: quote probe returned http %s (continuing to the gate)\n' "$code" >&2
+if [[ "$code" != "200" ]]; then
+  printf 'warning: quote probe returned http %s: %s (continuing to the gate)\n' "$code" "$body" >&2
 else
-  printf 'quote ok (http 200). running the full gate (this submits a real testnet intent)...\n' >&2
+  printf 'quote ok (http 200). running the gate (this submits a REAL mainnet intent)...\n' >&2
 fi
 
 export XOCHI_LIVE_URL XOCHI_LIVE_TOKEN XOCHI_LIVE_KEY

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -1,30 +1,33 @@
 defmodule Raxol.Payments.Xochi.LiveXochiTest do
   @moduledoc """
-  Launch gate: the full agent crosschain stealth payment lifecycle against a
-  real (testnet) Xochi endpoint.
+  The full agent crosschain payment lifecycle against a real Xochi endpoint:
+  `ExecuteXochiIntent` quotes, authorizes the spend, signs, and submits the
+  intent; `PollXochiStatus` waits for `:completed`.
 
-  This is the live-validated evidence that the agent path works end to end:
-  `ExecuteXochiIntent` quotes, authorizes the spend, signs, and submits a real
-  intent; `PollXochiStatus` waits for it to reach `:completed`.
+  Moves real funds. The endpoint is the Riddler solver, which serves the
+  `/xochi/*` routes this client calls (the Xochi worker at api*.xochi.fi serves
+  `/api/intent/*` and is not the right target). The token is the staging-scoped
+  Riddler bearer token.
 
-  Tagged `:live_xochi` and excluded by default. The test is only compiled when
-  the required env is present, so opting in without it yields no tests rather
-  than a spurious failure.
+  The riddler.axol.io staging endpoint serves mainnet routes only, so the
+  defaults are mainnet Base -> Arbitrum USDC at 10 USDC (the minimum order size
+  that prices on staging; smaller amounts are rejected). Settlement defaults to
+  `public`; set `XOCHI_LIVE_SETTLEMENT=stealth` with `XOCHI_LIVE_RECIPIENT_META`
+  to exercise the private path.
 
-  The endpoint is the Riddler solver, which serves the `/xochi/*` routes this
-  client calls (the Xochi worker at api*.xochi.fi serves `/api/intent/*` and is
-  not the right target). The token is the staging-scoped Riddler bearer token.
+  Tagged `:live_xochi` and excluded by default. Compiled only when the required
+  env is present, so opting in without it yields no tests.
 
       XOCHI_LIVE_URL=https://riddler.axol.io \\
       XOCHI_LIVE_TOKEN="$(op read 'op://Employee/Xochi staging RIDDLER_API_TOKEN/credential')" \\
-      XOCHI_LIVE_KEY=0x<funded Base-Sepolia private key> \\
+      XOCHI_LIVE_KEY=0x<funded Base mainnet private key> \\
         mix test --include live_xochi test/raxol/payments/xochi/live_xochi_test.exs
 
   Or use the runner: examples/run_live_xochi_gate.sh
 
-  Optional overrides (Base Sepolia -> Arbitrum Sepolia USDC defaults otherwise):
-  XOCHI_LIVE_FROM_CHAIN, XOCHI_LIVE_TO_CHAIN, XOCHI_LIVE_FROM_TOKEN,
-  XOCHI_LIVE_TO_TOKEN, XOCHI_LIVE_AMOUNT, XOCHI_LIVE_RECIPIENT_META.
+  Overrides: XOCHI_LIVE_FROM_CHAIN, XOCHI_LIVE_TO_CHAIN, XOCHI_LIVE_FROM_TOKEN,
+  XOCHI_LIVE_TO_TOKEN, XOCHI_LIVE_AMOUNT, XOCHI_LIVE_SETTLEMENT,
+  XOCHI_LIVE_RECIPIENT_META.
   """
 
   use ExUnit.Case, async: false
@@ -48,9 +51,9 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
       ledger = start_supervised!({Ledger, [name: nil]})
 
       policy = %SpendingPolicy{
-        per_request_max: Decimal.new("5.00"),
-        session_max: Decimal.new("20.00"),
-        lifetime_max: Decimal.new("100.00"),
+        per_request_max: Decimal.new("50.00"),
+        session_max: Decimal.new("100.00"),
+        lifetime_max: Decimal.new("500.00"),
         session_window_ms: 3_600_000,
         approved_domains: [host]
       }
@@ -66,17 +69,17 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
       {:ok, context: context}
     end
 
-    test "agent completes a crosschain stealth payment end-to-end", %{context: context} do
+    test "agent completes a crosschain payment end-to-end", %{context: context} do
       params =
         %{
-          amount: System.get_env("XOCHI_LIVE_AMOUNT", "0.10"),
-          from_chain_id: env_int("XOCHI_LIVE_FROM_CHAIN", 84_532),
-          to_chain_id: env_int("XOCHI_LIVE_TO_CHAIN", 421_614),
+          amount: System.get_env("XOCHI_LIVE_AMOUNT", "10.00"),
+          from_chain_id: env_int("XOCHI_LIVE_FROM_CHAIN", 8453),
+          to_chain_id: env_int("XOCHI_LIVE_TO_CHAIN", 42_161),
           from_token:
-            System.get_env("XOCHI_LIVE_FROM_TOKEN", "0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
+            System.get_env("XOCHI_LIVE_FROM_TOKEN", "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
           to_token:
-            System.get_env("XOCHI_LIVE_TO_TOKEN", "0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
-          settlement: "stealth"
+            System.get_env("XOCHI_LIVE_TO_TOKEN", "0xaf88d065e77c8cc2239327c5edb3a432268e5831"),
+          settlement: System.get_env("XOCHI_LIVE_SETTLEMENT", "public")
         }
         |> maybe_put_recipient()
 


### PR DESCRIPTION
Staging (riddler.axol.io) serves mainnet routes only and rejects amounts below the ~10 USDC minimum, so the live_xochi gate's testnet defaults (Base Sepolia -> Arb Sepolia, 0.10 USDC) returned 'unsupported route' / 'below_min_order_size' and never ran.

- Default to Base -> Arbitrum USDC at 10 USDC (validated working on staging)
- Raise the gate policy caps above the 10 USDC minimum so the spend gate doesn't deny the test's own spend
- Make settlement configurable via XOCHI_LIVE_SETTLEMENT (default public; stealth needs XOCHI_LIVE_RECIPIENT_META)
- Fix the runner's stale pre-flight probe (was testnet + a snake_case 422 message that no longer applies)

Moves real funds; still opt-in (excluded by default, needs --include + a funded XOCHI_LIVE_KEY). Validated read-only: Base->Arb quote returns can_solve:true at >=10 USDC.

Context: see RELAY_QUOTE_500_HANDOVER.md in the riddler repo for the staging findings (EVM works >=10 USDC; Tron /relay/quote 500s, being fixed).