### PR TITLE
Parse snake_case quote response; guard method vs token

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
@@ -87,11 +87,26 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
   defp settle(config, wallet, request, amount, params, context) do
     with :ok <- assert_xochi_route(params),
          {:ok, quote} <- solvable_quote(config, request),
+         :ok <- assert_method(quote, request),
          :ok <- authorize(context, config, amount),
          {:ok, exec, filled_quote} <- execute(config, request, quote, wallet, context, amount) do
       {:ok, summary(request, filled_quote, exec)}
     end
   end
+
+  # Guard the server's method choice before signing: ERC-3009 is USDC-only (it
+  # signs against the USDC contract as the EIP-712 verifying contract), so an
+  # ERC-3009 quote for a non-USDC token would be a silently invalid signature.
+  defp assert_method(%QuoteResponse{payment_method: "erc3009"}, %QuoteRequest{
+         from_chain_id: chain,
+         from_token: token
+       }) do
+    if Assets.usdc?(chain, token),
+      do: :ok,
+      else: {:error, {:method_mismatch, :erc3009_requires_usdc}}
+  end
+
+  defp assert_method(_quote, _request), do: :ok
 
   defp fetch(context, key) do
     case Map.fetch(context, key) do

--- a/packages/raxol_payments/lib/raxol/payments/assets.ex
+++ b/packages/raxol_payments/lib/raxol/payments/assets.ex
@@ -79,6 +79,20 @@ defmodule Raxol.Payments.Assets do
     }
   }
 
+  # EVM USDC contracts per chain (lowercase). Used to enforce the ERC-3009
+  # USDC-only rule: ERC-3009 signs against the USDC contract as the EIP-712
+  # verifying contract, so using it for any other token is silently invalid.
+  @usdc %{
+    1 => ["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],
+    8453 => [
+      "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca"
+    ],
+    10 => ["0x0b2c639c533813f4aa9d7837caf62653d097ff85"],
+    42_161 => ["0xaf88d065e77c8cc2239327c5edb3a432268e5831"],
+    137 => ["0x3c499c542cef5e3811e1192ce70d8cc03d5c3359"]
+  }
+
   # Currency ticker fallback for protocols that don't carry an address.
   @tickers %{
     "USDC" => 6,
@@ -110,6 +124,18 @@ defmodule Raxol.Payments.Assets do
   end
 
   def decimals(_chain, _contract), do: @default_decimals
+
+  @doc """
+  True when `address` is a known USDC contract on `chain_id`. Case-insensitive;
+  accepts an integer chain id or a CAIP-2 string. EVM only.
+  """
+  @spec usdc?(integer() | String.t() | nil, String.t() | nil) :: boolean()
+  def usdc?(chain_id, address) when is_binary(address) do
+    chain = normalize_chain_id(chain_id)
+    String.downcase(address) in Map.get(@usdc, chain, [])
+  end
+
+  def usdc?(_chain, _address), do: false
 
   @doc """
   Look up decimals by ticker symbol. Returns `@default_decimals`

--- a/packages/raxol_payments/lib/raxol/payments/failure.ex
+++ b/packages/raxol_payments/lib/raxol/payments/failure.ex
@@ -37,6 +37,7 @@ defmodule Raxol.Payments.Failure do
           | :rejected
           | :stealth_keys_required
           | :sign_failed
+          | :method_mismatch
           | :invalid_request
           | :config_error
           | :network
@@ -138,6 +139,26 @@ defmodule Raxol.Payments.Failure do
 
   def from({:invalid_settlement, _} = detail),
     do: build(:invalid_request, "The settlement type is not valid.", false, detail)
+
+  # The quote's chosen payment method is wrong for the token (e.g. ERC-3009 for a
+  # non-USDC token would be a silently invalid signature).
+  def from({:method_mismatch, :erc3009_requires_usdc} = detail),
+    do:
+      build(
+        :method_mismatch,
+        "The quote selected ERC-3009, which is USDC-only, but this transfer is not USDC.",
+        false,
+        detail
+      )
+
+  def from({:method_mismatch, _} = detail),
+    do:
+      build(
+        :method_mismatch,
+        "The quote's payment method is incompatible with the transfer.",
+        false,
+        detail
+      )
 
   # Request validation.
   def from({:invalid_wallet, _} = detail), do: invalid_request(detail)

--- a/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
@@ -190,6 +190,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
       :estimated_gas_cost,
       :expiry,
       :eip712_data,
+      :payment_method,
       :error,
       can_solve: false,
       gasless: false,
@@ -206,33 +207,41 @@ defmodule Raxol.Payments.Xochi.Schemas do
             xochi_fee: String.t() | nil,
             xochi_fee_rate: String.t() | nil,
             estimated_gas_cost: String.t() | nil,
-            expiry: String.t() | nil,
+            expiry: term() | nil,
             gasless: boolean(),
             gasless_fee: String.t() | nil,
             eip712_data: map() | nil,
+            payment_method: String.t() | nil,
             settlement_options: [map()],
             error: String.t() | nil
           }
 
+    # The live Riddler response is snake_case with `eip712`; older/sim responses
+    # are camelCase with `eip712Data`. Accept both so the client does not break
+    # on the canonical (snake_case) shape. See ../xochi/RAXOL_QUOTE_CONTRACT.md.
     @spec from_json(map()) :: t()
     def from_json(json) do
       %__MODULE__{
-        intent_id: json["intentId"],
-        quote_id: json["quoteId"],
-        can_solve: json["canSolve"] || false,
-        to_amount: json["toAmount"],
-        min_to_amount: json["minToAmount"],
-        xochi_fee: json["xochiFee"],
-        xochi_fee_rate: json["xochiFeeRate"],
-        estimated_gas_cost: json["estimatedGasCost"],
-        expiry: json["expiry"],
-        gasless: json["gasless"] || false,
-        gasless_fee: json["gaslessFee"],
-        eip712_data: json["eip712Data"],
-        settlement_options: json["settlementOptions"] || [],
-        error: json["error"]
+        intent_id: pick(json, ["intent_id", "intentId"]),
+        quote_id: pick(json, ["quote_id", "quoteId"]),
+        can_solve: pick(json, ["can_solve", "canSolve"]) || false,
+        to_amount: pick(json, ["to_amount", "toAmount"]),
+        min_to_amount: pick(json, ["min_to_amount", "minToAmount"]),
+        xochi_fee: pick(json, ["xochi_fee", "xochiFee"]) || get_in(json, ["fee", "fee_amount"]),
+        xochi_fee_rate: pick(json, ["xochi_fee_rate", "xochiFeeRate"]),
+        estimated_gas_cost:
+          pick(json, ["estimated_gas_cost", "estimatedGasCost", "estimated_gas_cost_usd"]),
+        expiry: pick(json, ["expiry", "expires_at"]),
+        gasless: pick(json, ["gasless"]) || false,
+        gasless_fee: pick(json, ["gasless_fee", "gaslessFee"]),
+        eip712_data: pick(json, ["eip712", "eip712Data"]),
+        payment_method: pick(json, ["payment_method", "paymentMethod"]),
+        settlement_options: pick(json, ["settlement_options", "settlementOptions"]) || [],
+        error: pick(json, ["error", "reason"])
       }
     end
+
+    defp pick(json, keys), do: Enum.find_value(keys, fn key -> json[key] end)
   end
 
   defmodule ExecuteRequest do

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
@@ -331,6 +331,65 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntentTest do
     end
   end
 
+  describe "ExecuteXochiIntent method guard" do
+    defp stub_quote_method(payment_method) do
+      Req.Test.stub(__MODULE__, fn conn ->
+        case conn.request_path do
+          "/xochi/quote" ->
+            Req.Test.json(conn, %{
+              "intent_id" => "int_1",
+              "quote_id" => "q_1",
+              "can_solve" => true,
+              "to_amount" => "499000",
+              "payment_method" => payment_method,
+              "eip712" => %{
+                "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+                "types" => %{"Intent" => [%{"name" => "amount", "type" => "uint256"}]},
+                "message" => %{"amount" => 500_000}
+              }
+            })
+
+          "/xochi/execute" ->
+            Req.Test.json(conn, %{
+              "success" => true,
+              "intentId" => "int_1",
+              "status" => "executing",
+              "stealthAddress" => "0xstealth"
+            })
+        end
+      end)
+    end
+
+    defp method_ctx do
+      %{
+        wallet: SpyWallet,
+        xochi_config: config(),
+        ledger: start_supervised!({Ledger, [name: nil]}),
+        policy: policy(),
+        agent_id: "a1"
+      }
+    end
+
+    test "rejects an ERC-3009 quote for a non-USDC token before signing" do
+      stub_quote_method("erc3009")
+      # WETH on Base, not USDC.
+      params = base_params(%{from_token: "0x4200000000000000000000000000000000000006"})
+
+      assert {:error, %Failure{reason: :method_mismatch}} =
+               ExecuteXochiIntent.run(params, method_ctx())
+
+      refute_received :wallet_signed
+    end
+
+    test "allows an ERC-3009 quote for USDC" do
+      stub_quote_method("erc3009")
+
+      assert {:ok, result} = ExecuteXochiIntent.run(base_params(%{}), method_ctx())
+      assert result.status == "executing"
+      assert_received :wallet_signed
+    end
+  end
+
   describe "PollXochiStatus" do
     test "returns the terminal status" do
       stub_quote_and_execute()

--- a/packages/raxol_payments/test/raxol/payments/assets_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/assets_test.exs
@@ -105,4 +105,22 @@ defmodule Raxol.Payments.AssetsTest do
              )
     end
   end
+
+  describe "usdc?/2" do
+    test "recognizes USDC across chains, case-insensitively" do
+      assert Assets.usdc?(8453, "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+      assert Assets.usdc?(8453, "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913")
+      assert Assets.usdc?(42_161, "0xaf88d065e77c8cc2239327c5edb3a432268e5831")
+      assert Assets.usdc?("eip155:1", "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    end
+
+    test "rejects non-USDC tokens and unknown chains" do
+      # WETH on Base
+      refute Assets.usdc?(8453, "0x4200000000000000000000000000000000000006")
+      # USDC address but wrong chain
+      refute Assets.usdc?(42_161, "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913")
+      refute Assets.usdc?(8453, nil)
+      refute Assets.usdc?(nil, "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913")
+    end
+  end
 end

--- a/packages/raxol_payments/test/raxol/payments/failure_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/failure_test.exs
@@ -105,7 +105,8 @@ defmodule Raxol.Payments.FailureTest do
     end
 
     test "invalid meta-address maps to :stealth_keys_required" do
-      assert Failure.from({:invalid_meta_address, :invalid_format}).reason == :stealth_keys_required
+      assert Failure.from({:invalid_meta_address, :invalid_format}).reason ==
+               :stealth_keys_required
     end
 
     test "not_xochi_route maps to :route_unsupported" do
@@ -115,6 +116,13 @@ defmodule Raxol.Payments.FailureTest do
     test "execute_failed unwraps the inner reason" do
       f = Failure.from({:execute_failed, {:http, 503, %{}}})
       assert f.reason == :network
+    end
+
+    test "erc3009-for-non-USDC maps to :method_mismatch with a clear message" do
+      f = Failure.from({:method_mismatch, :erc3009_requires_usdc})
+      assert f.reason == :method_mismatch
+      refute f.retryable?
+      assert f.message =~ "USDC"
     end
   end
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
@@ -287,6 +287,50 @@ defmodule Raxol.Payments.Xochi.SchemasTest do
       resp = QuoteResponse.from_json(json)
       assert resp.can_solve == false
     end
+
+    test "parses the live snake_case shape with eip712 and payment_method" do
+      json = %{
+        "intent_id" => "xi_1",
+        "quote_id" => "xq_1",
+        "can_solve" => true,
+        "to_amount" => "24925000",
+        "min_to_amount" => "24800375",
+        "payment_method" => "erc3009",
+        "fee" => %{"fee_amount" => "75000", "total_bps" => 30},
+        "eip712" => %{"domain" => %{"name" => "Xochi"}, "types" => %{}, "message" => %{}},
+        "settlement_options" => ["public"]
+      }
+
+      resp = QuoteResponse.from_json(json)
+
+      assert resp.intent_id == "xi_1"
+      assert resp.quote_id == "xq_1"
+      assert resp.can_solve == true
+      assert resp.to_amount == "24925000"
+      assert resp.payment_method == "erc3009"
+
+      assert resp.eip712_data == %{
+               "domain" => %{"name" => "Xochi"},
+               "types" => %{},
+               "message" => %{}
+             }
+
+      assert resp.xochi_fee == "75000"
+      assert resp.settlement_options == ["public"]
+    end
+
+    test "an unfillable snake_case quote carries reason as error" do
+      json = %{
+        "intent_id" => "i",
+        "quote_id" => "q",
+        "can_solve" => false,
+        "reason" => "no liquidity"
+      }
+
+      resp = QuoteResponse.from_json(json)
+      assert resp.can_solve == false
+      assert resp.error == "no liquidity"
+    end
   end
 
   describe "ExecuteRequest.to_json/1" do


### PR DESCRIPTION
Two fixes from live validation against staging.

## Critical: parse the real quote response
`QuoteResponse.from_json` read camelCase + `eip712Data`, but the live riddler.axol.io `/xochi/quote` returns **snake_case + `eip712`** (`intent_id`, `can_solve`, `to_amount`, `payment_method`, ...). So raxol parsed `can_solve: false` / `eip712_data: nil` and the EVM settlement failed even on a successful quote. Conformance fixtures and the local sim used camelCase, which hid it. Now accepts both casings (and `eip712`/`eip712Data`), and parses `payment_method`. Contract noted for the xochi agent in `xochi/RAXOL_QUOTE_CONTRACT.md`.

## W2: method-vs-token guard
With `payment_method` now readable, `ExecuteXochiIntent` validates the server's method before signing: an ERC-3009 quote for a non-USDC token is rejected as `{:error, %Failure{reason: :method_mismatch}}` (ERC-3009 signs against the USDC contract as the EIP-712 verifying contract, so using it for any other token is a silently-invalid signature -- the Coinbase reference signer hard-errors on the same rule). Adds `Assets.usdc?/2` and the `:method_mismatch` reason.

Tests: snake_case + eip712 + payment_method parsing, `usdc?/2`, the method guard (rejects erc3009+non-USDC, allows erc3009+USDC), and the failure mapping. Full suite: 44 properties, 640 tests, 0 failures.