### PR TITLE
Point ZERO demo comment at SPECS.md

### DIFF
--- a/examples/agents/zero_system.exs
+++ b/examples/agents/zero_system.exs
@@ -1,6 +1,7 @@
 # ZERO System -- the cockpit
 #
-# The singular launch demo (see DEMO_SPEC.md). One piloted run that chains the
+# The singular launch demo (see SPECS.md "Launch Demo: ZERO System Cockpit").
+# One piloted run that chains the
 # cockpit beats and streams the agent's reasoning live:
 #
 #   boot       G.U.N.D.A.M. self-check -- probes real modules


### PR DESCRIPTION
DEMO_SPEC.md and BEAT3_INTENT_RECOVERY_REQ.md were scratch planning docs (untracked, now removed; action items offloaded to TODO.md/HANDOVER.md, the ZERO spec lives in SPECS.md). zero_system.exs had a dangling 'see DEMO_SPEC.md' comment -- repoint it to SPECS.md. Comment-only.