### PR TITLE
Add Xochi agent auth modes; fix stealth claim route

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments.ex
+++ b/packages/raxol_payments/lib/raxol/payments.ex
@@ -37,7 +37,7 @@ defmodule Raxol.Payments do
       alias Raxol.Payments.Protocols.Xochi
       alias Raxol.Payments.Xochi.Schemas.QuoteRequest
 
-      config = %{base_url: "https://xochi.fi", auth_token: "..."}
+      config = %{base_url: "https://api.xochi.fi", auth: {:mandate, wallet.address()}}
 
       request = %QuoteRequest{
         wallet: wallet.address(),

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
@@ -24,7 +24,8 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
   ## Context keys
 
   * `:wallet` -- wallet module signing the EIP-712 intent.
-  * `:xochi_config` -- `%{base_url:, auth_token:}` for `Xochi.Client`.
+  * `:xochi_config` -- `%{base_url:, auth:}` for `Xochi.Client` (e.g.
+    `auth: {:mandate, agent_wallet}`; see `Xochi.Client` for all auth modes).
   * `:policy`, `:ledger`, `:agent_id`, `:on_confirm` -- see `SpendGate`.
   * `:checkpoint` -- optional `{module, handle}` `Raxol.Payments.Checkpoint`
     store for idempotent recovery (nil disables it).

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -6,7 +6,8 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
 
   ## Context keys
 
-  * `:xochi_config` -- `%{base_url:, auth_token:}` for `Xochi.Client`.
+  * `:xochi_config` -- `%{base_url:, auth:}` for `Xochi.Client` (e.g.
+    `auth: {:mandate, agent_wallet}`; see `Xochi.Client` for all auth modes).
   """
 
   @compile {:no_warn_undefined, Raxol.Agent.Action}

--- a/packages/raxol_payments/lib/raxol/payments/req/mandate.ex
+++ b/packages/raxol_payments/lib/raxol/payments/req/mandate.ex
@@ -5,7 +5,7 @@ defmodule Raxol.Payments.Req.Mandate do
 
   The plugin maps the request path to a Mandate scope (`/api/intent/quote`
   -> `"quote"`, `/api/intent/execute` -> `"execute"`,
-  `/api/settlement/claim` -> `"stealth_claim"`), looks up the
+  `/api/stealth/claim` -> `"stealth_claim"`), looks up the
   soonest-expiring active Mandate for the agent in
   `Raxol.Payments.Mandate.Store` via `Raxol.Payments.Mandate.Check`,
   and sets `X-Xochi-Delegation` to the base64url envelope.
@@ -33,7 +33,7 @@ defmodule Raxol.Payments.Req.Mandate do
     `["xochi.fi", "api.xochi.fi"]`. Suffix match, so
     `staging.xochi.fi` works.
   - `:path_scopes` -- map of path prefix to scope. Default:
-    `%{"/api/intent/quote" => "quote", "/api/intent/execute" => "execute", "/api/settlement/claim" => "stealth_claim"}`.
+    `%{"/api/intent/quote" => "quote", "/api/intent/execute" => "execute", "/api/stealth/claim" => "stealth_claim"}`.
 
   The Mandate Store is a singleton (`Raxol.Payments.Mandate.Store`);
   start exactly one per node.
@@ -46,7 +46,7 @@ defmodule Raxol.Payments.Req.Mandate do
   @default_path_scopes %{
     "/api/intent/quote" => "quote",
     "/api/intent/execute" => "execute",
-    "/api/settlement/claim" => "stealth_claim"
+    "/api/stealth/claim" => "stealth_claim"
   }
 
   @doc "Attach the Mandate plugin to a Req request."
@@ -68,11 +68,21 @@ defmodule Raxol.Payments.Req.Mandate do
          {:ok, host} <- request_host(req),
          true <- xochi_host?(host, Keyword.get(opts, :hosts, @default_hosts)),
          {:ok, scope} <- match_scope(req, Keyword.get(opts, :path_scopes, @default_path_scopes)),
-         {:ok, mandate} <- Check.select_for_scope(scope, agent_wallet) do
+         {:ok, mandate} <- safe_select(scope, agent_wallet) do
       Mandate.to_envelope(mandate)
     else
       _ -> :skip
     end
+  end
+
+  # The Store is host-started and may be absent (raxol_payments is a library).
+  # A missing Store raises ArgumentError from the underlying :ets.lookup; treat
+  # that as "no mandate" so the request degrades to an unauthenticated call the
+  # worker answers with 402/401, rather than crashing the payment request.
+  defp safe_select(scope, agent_wallet) do
+    Check.select_for_scope(scope, agent_wallet)
+  rescue
+    ArgumentError -> {:error, :store_unavailable}
   end
 
   defp fetch_agent_wallet(opts) do

--- a/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
@@ -14,18 +14,37 @@ defmodule Raxol.Payments.Xochi.Client do
   - `execute/2` -- POST /api/intent/execute
   - `get_status/2` -- GET /api/intent/:id/status
   - `get_history/2` -- GET /api/intent/history?wallet=
-  - `prepare_claim/2` -- POST /api/intent/claim/prepare
-  - `submit_claim/2` -- POST /api/intent/claim/submit
+  - `claim/2` -- POST /api/stealth/claim
 
   Pinned contract: `xochi/docs/contracts/xochi-intent-api.md`. It covers quote,
-  execute, and status; the history and claim paths are not in it.
+  execute, and status; the history and stealth claim paths live in the worker's
+  OpenAPI spec.
+
+  ## Authentication
+
+  An autonomous agent cannot mint a passkey-issued Member JWT the way a browser
+  can, so the client supports the worker's three auth modes via `:auth`:
+
+  - `{:mandate, agent_wallet}` -- a Member signs an EIP-712 delegation envelope
+    once; the agent presents `X-Xochi-Delegation` per call. Best fit for an
+    agent acting for a Member. Wires `Raxol.Payments.Req.Mandate`, which looks
+    up the soonest-expiring active mandate for the wallet. Pass plugin overrides
+    with `{:mandate, agent_wallet, opts}`.
+  - `{:x402, wallet: MyWallet}` -- Guest mode. The agent signs an EIP-3009 USDC
+    micropayment per call and sends `X-PAYMENT`. Wires `Raxol.Payments.Req.AutoPay`
+    (restricted to `:x402`), which regenerates the payment from each 402 challenge.
+  - `{:member, jwt}` -- only if a passkey-issued JWT is provisioned out of band.
 
   ## Configuration
 
-      config = %{
-        base_url: "https://api.xochi.fi",
-        auth_token: "bearer-token"
-      }
+      # Mandate (recommended for agents)
+      config = %{base_url: "https://api.xochi.fi", auth: {:mandate, "0xAgent..."}}
+
+      # Guest / x402
+      config = %{base_url: "https://api.xochi.fi", auth: {:x402, wallet: MyWallet}}
+
+      # Member JWT (legacy `:auth_token` is equivalent to `{:member, token}`)
+      config = %{base_url: "https://api.xochi.fi", auth_token: "bearer-token"}
 
       {:ok, quote} = Xochi.Client.get_quote(config, %QuoteRequest{...})
   """
@@ -38,9 +57,17 @@ defmodule Raxol.Payments.Xochi.Client do
     IntentStatus
   }
 
+  @type auth ::
+          {:member, String.t()}
+          | {:mandate, String.t()}
+          | {:mandate, String.t(), keyword()}
+          | {:x402, keyword()}
+          | :none
+
   @type config :: %{
           :base_url => String.t(),
-          :auth_token => String.t(),
+          optional(:auth) => auth(),
+          optional(:auth_token) => String.t(),
           optional(:req_options) => keyword()
         }
 
@@ -89,56 +116,80 @@ defmodule Raxol.Payments.Xochi.Client do
   end
 
   @doc """
-  Prepare an unsigned claim for client-side signing.
+  Submit a gasless stealth settlement claim.
 
-  Returns the UserOp hash for the client to sign with their stealth key.
-  No private keys are sent to the server.
+  Posts the signed claim to the worker's single stealth claim endpoint
+  (`POST /api/stealth/claim`), which sponsors it via Pimlico/ERC-4337 and
+  proxies to the Riddler solver. The agent derives stealth keys from an
+  ERC-5564 announcement and signs the claim message before calling this.
+
+  Required params (snake_case, per the pinned contract): `:stealth_address`,
+  `:recipient`, `:ephemeral_pub_key`, `:signature`. Optional: `:view_tag`.
+  Returns `{:ok, %{"tx_hash" => ..., "status" => ...}}`.
   """
-  @spec prepare_claim(config(), map()) :: {:ok, map()} | error()
-  def prepare_claim(config, %{intent_id: _, recipient_address: _} = params) do
-    json = %{
-      "intentId" => params.intent_id,
-      "recipientAddress" => params.recipient_address
-    }
+  @spec claim(config(), map()) :: {:ok, map()} | error()
+  def claim(
+        config,
+        %{
+          stealth_address: _,
+          recipient: _,
+          ephemeral_pub_key: _,
+          signature: _
+        } = params
+      ) do
+    json =
+      %{
+        "stealth_address" => params.stealth_address,
+        "recipient" => params.recipient,
+        "ephemeral_pub_key" => params.ephemeral_pub_key,
+        "signature" => params.signature
+      }
+      |> maybe_put("view_tag", Map.get(params, :view_tag))
 
     config
     |> build_req()
-    |> Req.post(url: "/api/intent/claim/prepare", json: json)
-    |> handle_response(& &1)
-  end
-
-  @doc """
-  Submit a client-signed claim to the bundler.
-
-  The client signs the hash from `prepare_claim/2` and submits
-  the signature here.
-  """
-  @spec submit_claim(config(), map()) :: {:ok, map()} | error()
-  def submit_claim(config, %{intent_id: _, signature: _} = params) do
-    json = %{
-      "intentId" => params.intent_id,
-      "signature" => params.signature
-    }
-
-    config
-    |> build_req()
-    |> Req.post(url: "/api/intent/claim/submit", json: json)
+    |> Req.post(url: "/api/stealth/claim", json: json)
     |> handle_response(& &1)
   end
 
   # -- Private --
 
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
   defp build_req(config) do
     validate_base_url!(config.base_url)
 
-    [
-      base_url: config.base_url,
-      headers: [{"authorization", "Bearer #{config.auth_token}"}],
-      receive_timeout: 30_000
-    ]
+    [base_url: config.base_url, receive_timeout: 30_000]
     |> Keyword.merge(Map.get(config, :req_options, []))
     |> Req.new()
+    |> apply_auth(auth_mode(config))
   end
+
+  # Explicit `:auth` wins; a bare legacy `:auth_token` maps to Member Bearer;
+  # otherwise the request is anonymous (the worker answers 402 with a Guest
+  # invite).
+  defp auth_mode(%{auth: auth}), do: auth
+  defp auth_mode(%{auth_token: token}) when is_binary(token), do: {:member, token}
+  defp auth_mode(_), do: :none
+
+  defp apply_auth(req, {:member, token}) do
+    Req.Request.put_header(req, "authorization", "Bearer #{token}")
+  end
+
+  defp apply_auth(req, {:mandate, agent_wallet}) do
+    apply_auth(req, {:mandate, agent_wallet, []})
+  end
+
+  defp apply_auth(req, {:mandate, agent_wallet, opts}) do
+    Raxol.Payments.Req.Mandate.attach(req, [agent_wallet: agent_wallet] ++ opts)
+  end
+
+  defp apply_auth(req, {:x402, opts}) do
+    Raxol.Payments.Req.AutoPay.attach(req, Keyword.put(opts, :protocols, [:x402]))
+  end
+
+  defp apply_auth(req, :none), do: req
 
   defp validate_base_url!("https://" <> _), do: :ok
   defp validate_base_url!("http://localhost" <> _), do: :ok

--- a/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
@@ -76,10 +76,10 @@ defmodule Raxol.Payments.Req.MandateTest do
       assert [_] = header
     end
 
-    test "maps /api/settlement/claim to scope stealth_claim" do
+    test "maps /api/stealth/claim to scope stealth_claim" do
       put_mandate(scopes: ["stealth_claim"])
 
-      header = header_after_step(request_with_step("https://api.xochi.fi/api/settlement/claim"))
+      header = header_after_step(request_with_step("https://api.xochi.fi/api/stealth/claim"))
       assert [_] = header
     end
 
@@ -100,7 +100,7 @@ defmodule Raxol.Payments.Req.MandateTest do
     test "does not attach when no mandate covers the requested scope" do
       put_mandate(scopes: ["execute"])
 
-      header = header_after_step(request_with_step("https://api.xochi.fi/api/settlement/claim"))
+      header = header_after_step(request_with_step("https://api.xochi.fi/api/stealth/claim"))
       assert header == []
     end
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/client_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/client_test.exs
@@ -2,51 +2,111 @@ defmodule Raxol.Payments.Xochi.ClientTest do
   use ExUnit.Case, async: true
 
   alias Raxol.Payments.Xochi.Client
-  alias Raxol.Payments.Xochi.Schemas.QuoteRequest
 
-  @config %{base_url: "https://xochi.test", auth_token: "test-token"}
+  @claim_params %{
+    stealth_address: "0xstealth",
+    recipient: "0xrecipient",
+    ephemeral_pub_key: "0xephemeral",
+    signature: "0xsig"
+  }
 
-  describe "get_quote/2" do
-    test "returns parsed QuoteResponse on success" do
-      req = %QuoteRequest{
-        wallet: "0xabc",
-        from_chain_id: 1,
-        to_chain_id: 8453,
-        from_token: "0xA0b8",
-        to_token: "0x8335",
-        from_amount: "1000000",
-        settlement_preference: "public"
+  describe "auth modes" do
+    test "member mode sends an Authorization: Bearer header" do
+      assert {:ok, _} = Client.claim(config(auth: {:member, "jwt-123"}), @claim_params)
+      assert_receive {:req, _method, _path, headers, _body}
+      assert {"authorization", "Bearer jwt-123"} in downcase(headers)
+    end
+
+    test "legacy auth_token maps to a member Bearer header" do
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth_token: "legacy-jwt",
+        req_options: [plug: echo_plug(self())]
       }
 
-      # Client makes a real HTTP call; we test schema integration
-      # via schemas_test.exs. This verifies the function exists and
-      # returns a typed error for unreachable hosts.
-      assert {:error, _reason} = Client.get_quote(@config, req)
+      assert {:ok, _} = Client.claim(config, @claim_params)
+      assert_receive {:req, _method, _path, headers, _body}
+      assert {"authorization", "Bearer legacy-jwt"} in downcase(headers)
+    end
+
+    test "none mode sends no Authorization header" do
+      assert {:ok, _} = Client.claim(config(auth: :none), @claim_params)
+      assert_receive {:req, _method, _path, headers, _body}
+      refute has_header?(headers, "authorization")
+    end
+
+    test "x402 mode wires AutoPay without forcing an Authorization header" do
+      # On a 200 the AutoPay response step is a no-op; this asserts the wiring
+      # does not break the happy path or inject a Bearer/delegation header.
+      assert {:ok, _} = Client.claim(config(auth: {:x402, wallet: NoWallet}), @claim_params)
+      assert_receive {:req, _method, _path, headers, _body}
+      refute has_header?(headers, "authorization")
+      refute has_header?(headers, "x-payment")
+    end
+
+    test "mandate mode skips the delegation header when no Store is running" do
+      # raxol_payments is a library; the Store is host-started and absent here.
+      # The plugin must degrade to no header rather than crash the request.
+      assert {:ok, _} = Client.claim(config(auth: {:mandate, "0xagent"}), @claim_params)
+      assert_receive {:req, _method, _path, headers, _body}
+      refute has_header?(headers, "x-xochi-delegation")
     end
   end
 
-  describe "get_status/2" do
-    test "returns typed error for unreachable host" do
-      assert {:error, _reason} = Client.get_status(@config, "intent_1")
+  describe "claim/2" do
+    test "posts a snake_case body to /api/stealth/claim" do
+      params = Map.put(@claim_params, :view_tag, "0x1f")
+
+      assert {:ok, body} = Client.claim(config(auth: :none), params)
+      assert_receive {:req, "POST", "/api/stealth/claim", _headers, raw_body}
+
+      assert Jason.decode!(raw_body) == %{
+               "stealth_address" => "0xstealth",
+               "recipient" => "0xrecipient",
+               "ephemeral_pub_key" => "0xephemeral",
+               "signature" => "0xsig",
+               "view_tag" => "0x1f"
+             }
+
+      assert body["status"] == "submitted"
+      assert body["tx_hash"] == "0xabc"
+    end
+
+    test "omits view_tag when it is not provided" do
+      assert {:ok, _} = Client.claim(config(auth: :none), @claim_params)
+      assert_receive {:req, "POST", "/api/stealth/claim", _headers, raw_body}
+      refute Map.has_key?(Jason.decode!(raw_body), "view_tag")
     end
   end
 
-  describe "execute/2" do
-    test "returns typed error for unreachable host" do
-      req = %Raxol.Payments.Xochi.Schemas.ExecuteRequest{
-        intent_id: "i",
-        quote_id: "q",
-        signature: "0x",
-        nonce: 1
-      }
-
-      assert {:error, _reason} = Client.execute(@config, req)
+  describe "base_url validation" do
+    test "rejects a non-HTTPS base_url" do
+      config = %{base_url: "ftp://api.xochi.fi", auth: :none}
+      assert_raise ArgumentError, fn -> Client.claim(config, @claim_params) end
     end
   end
 
-  describe "get_history/2" do
-    test "returns typed error for unreachable host" do
-      assert {:error, _reason} = Client.get_history(@config, "0xwallet")
+  # -- Helpers --
+
+  defp config(opts) do
+    %{base_url: "https://api.xochi.fi", req_options: [plug: echo_plug(self())]}
+    |> Map.merge(Map.new(opts))
+  end
+
+  defp echo_plug(test_pid) do
+    fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:req, conn.method, conn.request_path, conn.req_headers, body})
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(%{"tx_hash" => "0xabc", "status" => "submitted"}))
     end
+  end
+
+  defp downcase(headers), do: Enum.map(headers, fn {k, v} -> {String.downcase(k), v} end)
+
+  defp has_header?(headers, name) do
+    Enum.any?(downcase(headers), fn {k, _v} -> k == name end)
   end
 end

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_smoke_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_smoke_test.exs
@@ -1,0 +1,124 @@
+defmodule Raxol.Payments.Xochi.LiveSmokeTest do
+  @moduledoc """
+  Fast, fund-free liveness checks against a real Xochi worker. Confirms the
+  repointed `/api/intent/*` routes reach the worker and that the live auth modes
+  behave, without moving funds (quote-only). Complements `LiveXochiTest`, which
+  drives the full fund-moving lifecycle.
+
+  Two auth modes work against prod today, and both are smoked here:
+
+    * x402 Guest (live on prod) -- an anonymous quote is gated, returning the
+      worker's "authenticate or pay" boundary (401 Member / 402 Guest x402
+      invite). Needs only `XOCHI_LIVE_URL`: no token, no key, no funds.
+    * Member (Bearer JWT) -- a $1 quote on a known-fillable corridor returns
+      `can_solve: true` with signable snake_case fields. Needs `XOCHI_LIVE_TOKEN`.
+
+  Mandate auth is not smoked: worker-side delegation verification is still on
+  Xochi's roadmap (see XOCHI_HANDOVER.md / xochi/docs/planning/agent-auth.md).
+
+  Tagged `:live_xochi` (excluded unless `XOCHI_LIVE_URL` is set, per
+  test_helper.exs) and compiled only when `XOCHI_LIVE_URL` is present, so opting
+  in without it yields no tests.
+
+      # x402 Guest gate only (no secrets, no funds):
+      XOCHI_LIVE_URL=https://api.xochi.fi \\
+        mix test test/raxol/payments/xochi/live_smoke_test.exs
+
+      # Add the Member quote round-trip:
+      XOCHI_LIVE_URL=https://api.xochi.fi \\
+      XOCHI_LIVE_TOKEN="$(op read 'op://Employee/Xochi worker token/credential')" \\
+        mix test test/raxol/payments/xochi/live_smoke_test.exs
+
+  The corridor defaults to a $1 Base -> Optimism USDC swap (the handover's first
+  verified $1 fill). Override with `XOCHI_LIVE_SMOKE_{FROM_CHAIN,TO_CHAIN,
+  FROM_TOKEN,TO_TOKEN,AMOUNT,WALLET}`.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :live_xochi
+  @moduletag timeout: 60_000
+
+  if System.get_env("XOCHI_LIVE_URL") do
+    alias Raxol.Payments.Xochi.Client
+    alias Raxol.Payments.Xochi.Schemas.QuoteRequest
+
+    # Base -> Optimism USDC, 1 USDC in atomic units (6 decimals). Verified to fill
+    # at $1 on prod 2026-06-21 (XOCHI_HANDOVER.md). All values are overridable.
+    @defaults %{
+      from_chain: 8453,
+      to_chain: 10,
+      from_token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      to_token: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+      amount: "1000000",
+      wallet: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    }
+
+    setup do
+      {:ok, url: System.fetch_env!("XOCHI_LIVE_URL"), request: sample_request()}
+    end
+
+    test "the worker is reachable and gates an anonymous quote", %{url: url, request: request} do
+      config = %{base_url: url, auth: :none}
+
+      case Client.get_quote(config, request) do
+        {:error, {:http, status, _body}} ->
+          assert status in [401, 402],
+                 "anonymous quote returned HTTP #{status}; expected an auth gate " <>
+                   "(401 Member / 402 Guest x402 invite)"
+
+        {:ok, quote} ->
+          flunk(
+            "anonymous quote was served without auth (can_solve=#{inspect(quote.can_solve)}); " <>
+              "the worker's quote auth boundary may be open"
+          )
+
+        {:error, reason} ->
+          flunk("could not reach the Xochi worker at #{url}: #{inspect(reason)}")
+      end
+    end
+
+    if System.get_env("XOCHI_LIVE_TOKEN") do
+      test "a Member quote fills the corridor with signable snake_case fields", %{
+        url: url,
+        request: request
+      } do
+        config = %{base_url: url, auth: {:member, System.fetch_env!("XOCHI_LIVE_TOKEN")}}
+
+        assert {:ok, quote} = Client.get_quote(config, request)
+
+        assert quote.can_solve == true,
+               "Member quote could not solve corridor #{request.from_chain_id}->" <>
+                 "#{request.to_chain_id} at #{request.from_amount}: #{inspect(quote.error)}"
+
+        # snake_case round-trip: the worker emits snake_case + `eip712`, parsed
+        # into these fields. All must be present for the agent to sign + execute.
+        assert is_binary(quote.intent_id)
+        assert is_binary(quote.quote_id)
+        assert is_binary(quote.to_amount)
+        refute is_nil(quote.eip712_data), "quote is missing eip712 typed data to sign"
+      end
+    end
+
+    defp sample_request do
+      %QuoteRequest{
+        wallet: env("XOCHI_LIVE_SMOKE_WALLET", @defaults.wallet),
+        from_chain_id: env_int("XOCHI_LIVE_SMOKE_FROM_CHAIN", @defaults.from_chain),
+        to_chain_id: env_int("XOCHI_LIVE_SMOKE_TO_CHAIN", @defaults.to_chain),
+        from_token: env("XOCHI_LIVE_SMOKE_FROM_TOKEN", @defaults.from_token),
+        to_token: env("XOCHI_LIVE_SMOKE_TO_TOKEN", @defaults.to_token),
+        from_amount: env("XOCHI_LIVE_SMOKE_AMOUNT", @defaults.amount),
+        settlement_preference: "public"
+      }
+    end
+
+    defp env(name, default), do: System.get_env(name) || default
+
+    defp env_int(name, default) do
+      case System.get_env(name) do
+        nil -> default
+        val -> String.to_integer(val)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes the two launch-critical blockers on the agent-facing Xochi path that
the Xochi team flagged in their repoint review. The repoint itself (base_url +
`/api/intent/*` routes) already landed via #314; this PR fixes auth and the
stealth-claim route on top of it.

### 1. Auth modes (the worker-token blocker)

The client hardcoded `Authorization: Bearer`. An autonomous agent cannot mint
a passkey-issued Member JWT the way a browser can, so quotes went out
unauthorized. `Xochi.Client` now resolves an `:auth` config into three modes:

| `:auth` | Header | Use |
| --- | --- | --- |
| `{:mandate, agent_wallet}` | `X-Xochi-Delegation` (via `Req.Mandate`) | **Recommended agent path** |
| `{:x402, wallet: Mod}` | `X-PAYMENT` (via `Req.AutoPay`, x402 only) | Guest; regenerates per 402 challenge |
| `{:member, jwt}` | `Authorization: Bearer` | Provisioned JWT only |

Legacy `:auth_token` maps to `{:member, _}`, so existing callers/tests are
unchanged. `:none` sends no auth — the worker answers `402` with the Guest
invite (verified live, see below).

### 2. Stealth claim route (404 fix)

`/api/intent/claim/{prepare,submit}` were never served by the worker. Replaced
with a single `claim/2` -> `POST /api/stealth/claim` using the pinned
contract's snake_case `StealthClaimRequest` fields (`stealth_address`,
`recipient`, `ephemeral_pub_key`, `signature`, optional `view_tag`).
`Req.Mandate`'s stealth scope path corrected `/api/settlement/claim` ->
`/api/stealth/claim`.

### Resilience

`raxol_payments` is a host-started library, so `Mandate.Store` may be absent.
The mandate path went through a raw `:ets.lookup` that would **raise** and
crash the payment request. It now degrades to an unauthenticated call (targeted
`ArgumentError` rescue), matching the plugin's documented "missing mandate ->
no header" contract.

### Not included

Mandate auth is wired and sends the header, but **worker-side delegation
verification is still on Xochi's roadmap** (`xochi/docs/planning/agent-auth.md`).
x402 Guest is live on prod today as the working fallback. Coordinate timing
before relying on mandate auth live.

## Manual testing

- `cd packages/raxol_payments && MIX_ENV=test mix test` -> 668 tests + 44
  properties, 0 failures.
- `mix compile --warnings-as-errors`, `mix format --check-formatted`,
  `mix credo --strict` on touched files -> clean.
- Live x402 Guest gate against prod (no secrets, no funds):
  `XOCHI_LIVE_URL=https://api.xochi.fi mix test test/raxol/payments/xochi/live_smoke_test.exs`
  -> passes. Raw probe confirms `POST /api/intent/quote` with no auth returns
  `HTTP 402 {"error":"Payment Required","price":"$0.0001",...,"network":"base"}`
  — x402 Guest mode is live.
- Member quote round-trip available with `XOCHI_LIVE_TOKEN` set (quote-only, no
  funds).
