### PR TITLE
Harden Xochi live gate; add examples guide

### DIFF
--- a/packages/raxol_payments/README.md
+++ b/packages/raxol_payments/README.md
@@ -42,6 +42,14 @@ plugin = AgentPlugin.auto_pay(
 )
 ```
 
+## Examples
+
+A guided path from an offline rehearsal to a real on-chain settlement lives in
+[`examples/`](examples/README.md): `preflight.exs` (local echo server, no funds)
+-> `crosschain_stealth_payment.exs` (in-process Xochi sim, no funds) ->
+`run_live_xochi_gate.sh` (live cross-chain settlement, real funds). Start with
+the README there.
+
 ## Architecture
 
 - `Raxol.Payments.Protocol`: behaviour for payment protocol detection + signing

--- a/packages/raxol_payments/examples/README.md
+++ b/packages/raxol_payments/examples/README.md
@@ -1,0 +1,68 @@
+# raxol_payments examples
+
+A guided path from a fully offline rehearsal to a real on-chain settlement. Each
+script documents its own usage and environment in its header; this file is the
+map and the recommended order.
+
+Run everything from `packages/raxol_payments/`.
+
+## 1. Rehearse the pay-stack (no funds, no network)
+
+**`preflight.exs`** drives a single request through the whole stack: wallet ->
+`SpendingPolicy` -> `Ledger` -> `AutoPay` -> `:on_confirm` -> `Req`, against the
+local echo server. If the wiring does not fly here, it will not fly on mainnet.
+
+```bash
+mix raxol_payments.echo --port 4002      # terminal A: start the echo server
+mix run examples/preflight.exs           # terminal B: run against it
+```
+
+## 2. Walk the launch path (no funds, in-process sim)
+
+**`crosschain_stealth_payment.exs`** is the private cross-chain flow an agent
+takes: issue a delegation mandate, execute a stealth Xochi intent (spend
+authorized before signing), poll to settlement. Every step goes through the same
+`Action.call/2` entry point the agent ReAct loop dispatches to, but against an
+in-process Xochi sim, so it spends nothing.
+
+```bash
+MIX_ENV=test mix run examples/crosschain_stealth_payment.exs
+```
+
+## 3. Graduate to live (MOVES REAL FUNDS)
+
+These submit real mainnet intents. Each runs a read-only quote preflight first
+and aborts before moving funds if auth fails or the solver cannot fill.
+
+**`run_live_xochi_gate.sh`** settles cross-chain through the Xochi worker.
+Defaults to a $1 Base -> Optimism USDC transfer (the corridor Xochi verified
+fills at $1). Auth is a Member Bearer (the worker token in 1Password); one token
+covers the whole quote -> execute -> poll lifecycle. Dry-run first:
+
+```bash
+XOCHI_LIVE_KEY=0x<funded base key> DRY_RUN=1 ./examples/run_live_xochi_gate.sh
+XOCHI_LIVE_KEY=0x<funded base key>           ./examples/run_live_xochi_gate.sh
+```
+
+**`run_live_relay_gate.sh`** quotes the EVM->Tron Relay path through the Riddler
+solver. A quote moves no funds, so it needs no key, just the staging token and a
+source address. The full EVM->Tron settlement (which broadcasts an on-chain
+deposit) lives in a separate raxol_acp `:live_relay` test.
+
+```bash
+RELAY_LIVE_FROM_ADDRESS=0x<base address> ./examples/run_live_relay_gate.sh
+```
+
+## The progression at a glance
+
+| Stage            | Script                            | Funds         | Target                   |
+| ---------------- | --------------------------------- | ------------- | ------------------------ |
+| Rehearse         | `preflight.exs`                   | none          | local echo server        |
+| Launch path      | `crosschain_stealth_payment.exs`  | none          | in-process Xochi sim     |
+| Live cross-chain | `run_live_xochi_gate.sh`          | real          | Xochi worker (prod)      |
+| Live Tron quote  | `run_live_relay_gate.sh`          | none (quote)  | Riddler solver (staging) |
+
+The live gates are tagged `:live_xochi` / `:live_relay` and excluded by default;
+they only run when their endpoint env var is set (see `test/test_helper.exs`).
+For the architecture these examples exercise, see
+[Agentic Commerce docs](../../../docs/features/AGENTIC_COMMERCE.md).

--- a/packages/raxol_payments/examples/run_live_xochi_gate.sh
+++ b/packages/raxol_payments/examples/run_live_xochi_gate.sh
@@ -1,23 +1,37 @@
 #!/usr/bin/env bash
 # Run the live Xochi crosschain payment gate against the Xochi worker.
 #
-# The worker (api.xochi.fi, or api-stg.xochi.fi for staging) serves the
-# /api/intent/* routes the raxol client calls, applies trust-tier fees, and
-# calls the Riddler solver internally. The bearer token is the Xochi worker
-# token in 1Password. This MOVES REAL FUNDS: you supply a funded Base mainnet
-# private key, and the default route is Base -> Arbitrum USDC at 10 USDC.
+# The worker (api.xochi.fi) serves the /api/intent/* routes the raxol client
+# calls, applies trust-tier fees, and calls the Riddler solver internally. Auth
+# is a Member Bearer (the "Xochi worker token" in 1Password): one token covers
+# the whole quote -> execute -> poll lifecycle, which is why the gate uses Member
+# rather than per-call x402 Guest micropayments (each /status poll would pay).
 #
-# Settlement defaults to public. For the private path, set
-# XOCHI_LIVE_SETTLEMENT=stealth and XOCHI_LIVE_RECIPIENT_META=st:eth:0x...
+# This MOVES REAL FUNDS. Default route is a $1 (1 USDC) Base -> Optimism transfer,
+# the corridor Xochi verified fills at $1 on prod. The test file runs two cases,
+# so a full run settles ~2 USDC total (the end-to-end transfer + the crash-resume
+# transfer). Settlement defaults to public.
 #
-# Usage (from packages/raxol_payments/):
-#   XOCHI_LIVE_KEY=0x<funded base mainnet key> ./examples/run_live_xochi_gate.sh
+# Two steps, safest first:
+#   # 1. Dry run: quote-only, NO funds move. Confirms auth + the $1 fill.
+#   XOCHI_LIVE_KEY=0x<funded base key> DRY_RUN=1 ./examples/run_live_xochi_gate.sh
 #
-# Override the endpoint or token source with XOCHI_LIVE_URL / XOCHI_LIVE_TOKEN.
+#   # 2. Real run: submits mainnet intents and settles.
+#   XOCHI_LIVE_KEY=0x<funded base key> ./examples/run_live_xochi_gate.sh
+#
+# Overrides: XOCHI_LIVE_URL, XOCHI_LIVE_TOKEN, XOCHI_LIVE_AMOUNT (human USDC,
+# default 1.00), XOCHI_LIVE_FROM_CHAIN / XOCHI_LIVE_TO_CHAIN,
+# XOCHI_LIVE_FROM_TOKEN / XOCHI_LIVE_TO_TOKEN, plus XOCHI_LIVE_SETTLEMENT=stealth
+# with XOCHI_LIVE_RECIPIENT_META for the private path.
 set -euo pipefail
 
 XOCHI_LIVE_URL="${XOCHI_LIVE_URL:-https://api.xochi.fi}"
 OP_TOKEN_REF="${OP_TOKEN_REF:-op://Employee/Xochi worker token/credential}"
+XOCHI_LIVE_AMOUNT="${XOCHI_LIVE_AMOUNT:-1.00}"
+XOCHI_LIVE_FROM_CHAIN="${XOCHI_LIVE_FROM_CHAIN:-8453}"
+XOCHI_LIVE_TO_CHAIN="${XOCHI_LIVE_TO_CHAIN:-10}"
+XOCHI_LIVE_FROM_TOKEN="${XOCHI_LIVE_FROM_TOKEN:-0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913}"
+XOCHI_LIVE_TO_TOKEN="${XOCHI_LIVE_TO_TOKEN:-0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85}"
 
 if [[ -z "${XOCHI_LIVE_KEY:-}" ]]; then
   printf 'error: set XOCHI_LIVE_KEY to a funded Base mainnet (8453) private key\n' >&2
@@ -33,8 +47,13 @@ if [[ -z "${XOCHI_LIVE_TOKEN:-}" ]]; then
   XOCHI_LIVE_TOKEN="$(op read "$OP_TOKEN_REF")"
 fi
 
-printf 'validating quote endpoint (read-only, no funds move)...\n' >&2
-quote_body='{"wallet":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","from_chain_id":8453,"to_chain_id":42161,"from_token":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","to_token":"0xaf88d065e77c8cc2239327c5edb3a432268e5831","from_amount":"10000000","settlement_preference":"public","slippage_bps":50}'
+# USDC has 6 decimals; convert the human amount to atomic units for the probe.
+atomic="$(awk -v a="$XOCHI_LIVE_AMOUNT" 'BEGIN { printf "%d", a * 1000000 }')"
+
+printf 'preflight: quoting %s USDC %s -> %s (read-only, no funds move)...\n' \
+  "$XOCHI_LIVE_AMOUNT" "$XOCHI_LIVE_FROM_CHAIN" "$XOCHI_LIVE_TO_CHAIN" >&2
+quote_body="$(printf '{"wallet":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","from_chain_id":%s,"to_chain_id":%s,"from_token":"%s","to_token":"%s","from_amount":"%s","settlement_preference":"public","slippage_bps":50}' \
+  "$XOCHI_LIVE_FROM_CHAIN" "$XOCHI_LIVE_TO_CHAIN" "$XOCHI_LIVE_FROM_TOKEN" "$XOCHI_LIVE_TO_TOKEN" "$atomic")"
 probe="$(curl -sS -m 20 -w '\n%{http_code}' \
   -X POST "$XOCHI_LIVE_URL/api/intent/quote" \
   -H "authorization: Bearer $XOCHI_LIVE_TOKEN" \
@@ -44,11 +63,30 @@ code="${probe##*$'\n'}"
 body="${probe%$'\n'*}"
 
 if [[ "$code" != "200" ]]; then
-  printf 'warning: quote probe returned http %s: %s (continuing to the gate)\n' "$code" "$body" >&2
-else
-  printf 'quote ok (http 200). running the gate (this submits a REAL mainnet intent)...\n' >&2
+  printf 'preflight FAILED: quote returned http %s: %s\n' "$code" "$body" >&2
+  printf 'a 401/402 means the Member Bearer token was not accepted. Fix auth before\n' >&2
+  printf 'the real run (or wait on Xochi mandate verification). Aborting; no funds moved.\n' >&2
+  exit 1
 fi
 
-export XOCHI_LIVE_URL XOCHI_LIVE_TOKEN XOCHI_LIVE_KEY
+if ! grep -qE '"can_solve"[[:space:]]*:[[:space:]]*true' <<<"$body"; then
+  printf 'preflight FAILED: quote ok (http 200) but can_solve != true:\n%s\n' "$body" >&2
+  printf 'the solver will not fill this corridor/amount. Aborting; no funds moved.\n' >&2
+  exit 1
+fi
+
+printf 'preflight ok: can_solve=true at %s USDC.\n' "$XOCHI_LIVE_AMOUNT" >&2
+
+if [[ -n "${DRY_RUN:-}" ]]; then
+  printf 'DRY_RUN set: auth + fill confirmed, NO funds moved.\n' >&2
+  printf 're-run without DRY_RUN to submit the real mainnet intents.\n' >&2
+  exit 0
+fi
+
+printf 'running the gate: this submits REAL mainnet intents and settles ~%s USDC per case...\n' \
+  "$XOCHI_LIVE_AMOUNT" >&2
+
+export XOCHI_LIVE_URL XOCHI_LIVE_TOKEN XOCHI_LIVE_KEY XOCHI_LIVE_AMOUNT \
+  XOCHI_LIVE_FROM_CHAIN XOCHI_LIVE_TO_CHAIN XOCHI_LIVE_FROM_TOKEN XOCHI_LIVE_TO_TOKEN
 exec env MIX_ENV=test mix test --include live_xochi \
   test/raxol/payments/xochi/live_xochi_test.exs

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -82,6 +82,7 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         }
         |> maybe_put_recipient()
 
+      started = System.monotonic_time(:millisecond)
       assert {:ok, intent} = ExecuteXochiIntent.call(params, context)
       assert is_binary(intent.intent_id)
 
@@ -90,6 +91,8 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
 
       assert status.status == "completed",
              "live intent #{intent.intent_id} ended in #{status.status}, expected completed"
+
+      report_settlement("end-to-end", intent, status, params, started)
     end
 
     test "a resumed run reuses the in-flight intent without a second signature", %{
@@ -114,6 +117,7 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         }
         |> maybe_put_recipient()
 
+      started = System.monotonic_time(:millisecond)
       assert {:ok, intent} = ExecuteXochiIntent.call(params, context)
       assert is_binary(intent.intent_id)
       charged = lifetime(context)
@@ -132,6 +136,8 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
 
       assert status.status == "completed",
              "live intent #{intent.intent_id} ended in #{status.status}, expected completed"
+
+      report_settlement("crash-resume", intent, status, params, started)
     end
 
     defp lifetime(context) do
@@ -151,5 +157,34 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         val -> String.to_integer(val)
       end
     end
+
+    # Print the verifiable settlement artifacts so an operator running the gate can
+    # confirm the real on-chain transfer independently and eyeball end-to-end latency.
+    defp report_settlement(label, intent, status, params, started_ms) do
+      elapsed = System.monotonic_time(:millisecond) - started_ms
+
+      IO.puts("""
+
+      [live_xochi:#{label}] settled in #{elapsed}ms
+        intent_id     #{intent.intent_id}
+        status        #{status.status}
+        source tx     #{tx_line(status.tx_hash, params.from_chain_id)}
+        receiving tx  #{tx_line(status.receiving_tx_hash, params.to_chain_id)}\
+      """)
+    end
+
+    defp tx_line(nil, _chain_id), do: "(none reported)"
+
+    defp tx_line(hash, chain_id) do
+      case explorer_base(chain_id) do
+        nil -> hash
+        base -> base <> hash
+      end
+    end
+
+    defp explorer_base(8453), do: "https://basescan.org/tx/"
+    defp explorer_base(42_161), do: "https://arbiscan.io/tx/"
+    defp explorer_base(10), do: "https://optimistic.etherscan.io/tx/"
+    defp explorer_base(_), do: nil
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #319. Makes the live fund-moving Xochi gate safer and
self-verifying, and gives `packages/raxol_payments/examples/` a front door so a
new reader knows what to run and in what order. No production code changes; this
is the live gate runner, the (default-excluded) live test, and docs.

## Gate runner: `run_live_xochi_gate.sh`

- **Tuned to the launch claim.** Defaults to a **$1 Base -> Optimism** USDC
  transfer, the corridor Xochi verified fills at $1 on prod. Overridable via
  `XOCHI_LIVE_AMOUNT` and the chain/token env vars.
- **Fails closed.** The read-only quote preflight now **aborts before moving
  funds** on a non-200 (bad/expired Bearer) or `can_solve != true`, instead of
  warning and continuing. Verified live: a throwaway token returns
  `401 {"error":"Invalid or expired token"}` and the script exits 1 with no funds
  at risk.
- **Dry run.** `DRY_RUN=1` stops after the preflight, so auth and the fill can be
  confirmed before any real settlement.

```bash
# confirm auth + $1 fill, no funds:
XOCHI_LIVE_KEY=0x<funded base key> DRY_RUN=1 ./examples/run_live_xochi_gate.sh
# real run:
XOCHI_LIVE_KEY=0x<funded base key>           ./examples/run_live_xochi_gate.sh
```

## Gate test: `live_xochi_test.exs`

On settlement, both cases now print the **verifiable artifacts** rather than a
bare pass: `intent_id`, source + receiving tx with **per-chain explorer links**
(Base/Optimism/Arbitrum), and **end-to-end latency**. A gate run hands you a
checkable on-chain tx, which is the whole point of the launch claim. No new
hard assertions, so it cannot false-fail; the completion assertion is unchanged.

## Examples front door

- New `examples/README.md` maps the **rehearse -> graduate** progression:
  `preflight.exs` (local echo, no funds) -> `crosschain_stealth_payment.exs`
  (in-process Xochi sim, no funds) -> `run_live_xochi_gate.sh` (live cross-chain,
  real funds) -> `run_live_relay_gate.sh` (live Tron quote, no funds), with a
  summary table and a pointer to the gating in `test_helper.exs`.
- Linked from the package README.

## Manual testing

- `cd packages/raxol_payments && MIX_ENV=test mix test` -> 668 tests + 44
  properties, 0 failures.
- Gate test compiles clean with the live body active (dummy env + tag excluded);
  `mix format --check-formatted` and `mix credo --strict` clean on touched files.
- `bash -n` + `shellcheck` clean on the runner; live preflight-abort path
  exercised against prod with a throwaway token (401 -> clean exit, no funds).
