### PR TITLE
Add mandate auth mode to live Xochi gate

### DIFF
--- a/packages/raxol_payments/examples/run_live_xochi_gate.sh
+++ b/packages/raxol_payments/examples/run_live_xochi_gate.sh
@@ -2,11 +2,22 @@
 # Run the live Xochi crosschain payment gate against the Xochi worker.
 #
 # The worker (api.xochi.fi) serves the /api/intent/* routes the raxol client
-# calls, applies trust-tier fees, and calls the Riddler solver internally. Auth
-# is a long-lived Member service token in 1Password (never expires; rotate to
-# revoke): one token covers the whole quote -> execute -> poll lifecycle, which is
-# why the gate uses Member rather than per-call x402 Guest micropayments (each
-# /status poll would pay). The token is per-env:
+# calls, applies trust-tier fees, and calls the Riddler solver internally.
+#
+# Auth (XOCHI_LIVE_AUTH, default "mandate"):
+#   mandate -- the agent-native path. The funded key signs an EIP-712 delegation
+#     envelope and self-delegates, which Raxol.Payments.Req.Mandate presents as
+#     X-Xochi-Delegation on quote/execute, inheriting the key's Member tier. The
+#     worker scopes mandates to quote/execute only, so /status polling falls back
+#     to the Member service token -- a mandate run needs BOTH the funded key and
+#     the service token.
+#   member -- drive the whole quote -> execute -> poll lifecycle off the Member
+#     service token. One token covers everything, with no per-call x402 Guest
+#     micropayment (each /status poll would otherwise pay). Required where x402 is
+#     disabled and no mandate is provisioned.
+#
+# The Member service token is a long-lived credential in 1Password (never
+# expires; rotate to revoke), per-env:
 #   prod:    op://Employee/Xochi production AGENT_SERVICE_TOKENS/credential (default)
 #   staging: op://Employee/Xochi staging AGENT_SERVICE_TOKENS/credential
 # Staging (api-stg.xochi.fi) has x402 disabled, so Member is the only auth path
@@ -32,13 +43,15 @@
 #   # 2. Real run: submits mainnet intents and settles (needs a funded key).
 #   XOCHI_LIVE_KEY=0x<funded base key> ./examples/run_live_xochi_gate.sh
 #
-# Overrides: XOCHI_LIVE_URL, XOCHI_LIVE_TOKEN, XOCHI_LIVE_AMOUNT (human USDC,
-# default 1.00), XOCHI_LIVE_FROM_CHAIN / XOCHI_LIVE_TO_CHAIN,
-# XOCHI_LIVE_FROM_TOKEN / XOCHI_LIVE_TO_TOKEN, plus XOCHI_LIVE_SETTLEMENT=stealth
-# with XOCHI_LIVE_RECIPIENT_META for the private path.
+# Overrides: XOCHI_LIVE_AUTH (mandate|member), XOCHI_LIVE_AGENT_WALLET,
+# XOCHI_LIVE_URL, XOCHI_LIVE_TOKEN, XOCHI_LIVE_AMOUNT (human USDC, default 1.00),
+# XOCHI_LIVE_FROM_CHAIN / XOCHI_LIVE_TO_CHAIN, XOCHI_LIVE_FROM_TOKEN /
+# XOCHI_LIVE_TO_TOKEN, plus XOCHI_LIVE_SETTLEMENT=stealth with
+# XOCHI_LIVE_RECIPIENT_META for the private path.
 set -euo pipefail
 
 XOCHI_LIVE_URL="${XOCHI_LIVE_URL:-https://api.xochi.fi}"
+XOCHI_LIVE_AUTH="${XOCHI_LIVE_AUTH:-mandate}"
 OP_TOKEN_REF="${OP_TOKEN_REF:-op://Employee/Xochi production AGENT_SERVICE_TOKENS/credential}"
 XOCHI_LIVE_AMOUNT="${XOCHI_LIVE_AMOUNT:-1.00}"
 XOCHI_LIVE_FROM_CHAIN="${XOCHI_LIVE_FROM_CHAIN:-8453}"
@@ -63,8 +76,13 @@ fi
 # USDC has 6 decimals; convert the human amount to atomic units for the probe.
 atomic="$(awk -v a="$XOCHI_LIVE_AMOUNT" 'BEGIN { printf "%d", a * 1000000 }')"
 
-printf 'preflight: quoting %s USDC %s -> %s (read-only, no funds move)...\n' \
-  "$XOCHI_LIVE_AMOUNT" "$XOCHI_LIVE_FROM_CHAIN" "$XOCHI_LIVE_TO_CHAIN" >&2
+# The preflight quote uses the Member token to confirm connectivity + can_solve
+# (and that the token polling will need is valid). In mandate mode the gate's own
+# quote/execute then authenticate via the signed X-Xochi-Delegation envelope,
+# which the Elixir test builds and exercises; signing EIP-712 in bash is not
+# practical here.
+printf 'preflight (auth=%s): quoting %s USDC %s -> %s (read-only, no funds move)...\n' \
+  "$XOCHI_LIVE_AUTH" "$XOCHI_LIVE_AMOUNT" "$XOCHI_LIVE_FROM_CHAIN" "$XOCHI_LIVE_TO_CHAIN" >&2
 # Mirror the fields Raxol.Payments.Xochi.Schemas.QuoteRequest.to_json sends;
 # `deadline` is required by the worker (a future unix ts, max 1h ahead).
 deadline="$(( $(date +%s) + 300 ))"
@@ -80,8 +98,8 @@ body="${probe%$'\n'*}"
 
 if [[ "$code" != "200" ]]; then
   printf 'preflight FAILED: quote returned http %s: %s\n' "$code" "$body" >&2
-  printf 'a 401/402 means the Member Bearer token was not accepted. Fix auth before\n' >&2
-  printf 'the real run (or wait on Xochi mandate verification). Aborting; no funds moved.\n' >&2
+  printf 'a 401/402 means the Member Bearer token was not accepted. Fix auth\n' >&2
+  printf '(check OP_TOKEN_REF matches XOCHI_LIVE_URL env). Aborting; no funds moved.\n' >&2
   exit 1
 fi
 
@@ -103,6 +121,7 @@ printf 'running the gate: this submits REAL mainnet intents and settles ~%s USDC
   "$XOCHI_LIVE_AMOUNT" >&2
 
 export XOCHI_LIVE_URL XOCHI_LIVE_TOKEN XOCHI_LIVE_KEY XOCHI_LIVE_AMOUNT \
-  XOCHI_LIVE_FROM_CHAIN XOCHI_LIVE_TO_CHAIN XOCHI_LIVE_FROM_TOKEN XOCHI_LIVE_TO_TOKEN
+  XOCHI_LIVE_FROM_CHAIN XOCHI_LIVE_TO_CHAIN XOCHI_LIVE_FROM_TOKEN XOCHI_LIVE_TO_TOKEN \
+  XOCHI_LIVE_AUTH
 exec env MIX_ENV=test mix test --include live_xochi \
   test/raxol/payments/xochi/live_xochi_test.exs

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -7,7 +7,19 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
   Moves real funds. The endpoint is the Xochi worker (`api.xochi.fi`, or
   `api-stg.xochi.fi` for staging), which serves the `/api/intent/*` routes this
   client calls, applies trust-tier fees, and calls the Riddler solver internally.
-  The token is the Xochi worker bearer token.
+
+  ## Auth (`XOCHI_LIVE_AUTH`)
+
+  Defaults to `mandate`, the agent-native path: the funded gate key signs an
+  EIP-712 delegation envelope and self-delegates (it is both the Member whose
+  Trust Tier the worker applies and the agent that presents the envelope), which
+  `Raxol.Payments.Req.Mandate` attaches as `X-Xochi-Delegation` on quote and
+  execute. The worker scopes mandates to quote/execute/stealth_claim only, so
+  status polling falls back to the Member service token (`XOCHI_LIVE_TOKEN`) --
+  a mandate run therefore needs both the funded key and the service token. Set
+  `XOCHI_LIVE_AUTH=member` to drive the whole lifecycle off the Member service
+  token instead (the legacy path; the only option where x402 is disabled and no
+  mandate is provisioned).
 
   Defaults are mainnet Base -> Arbitrum USDC at 10 USDC. Settlement defaults to
   `public`; set `XOCHI_LIVE_SETTLEMENT=stealth` with `XOCHI_LIVE_RECIPIENT_META`
@@ -18,15 +30,15 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
   env is present, so opting in without it yields no tests.
 
       XOCHI_LIVE_URL=https://api.xochi.fi \\
-      XOCHI_LIVE_TOKEN="$(op read 'op://Employee/Xochi worker token/credential')" \\
+      XOCHI_LIVE_TOKEN="$(op read 'op://Employee/Xochi production AGENT_SERVICE_TOKENS/credential')" \\
       XOCHI_LIVE_KEY=0x<funded Base mainnet private key> \\
         mix test --include live_xochi test/raxol/payments/xochi/live_xochi_test.exs
 
   Or use the runner: examples/run_live_xochi_gate.sh
 
-  Overrides: XOCHI_LIVE_FROM_CHAIN, XOCHI_LIVE_TO_CHAIN, XOCHI_LIVE_FROM_TOKEN,
-  XOCHI_LIVE_TO_TOKEN, XOCHI_LIVE_AMOUNT, XOCHI_LIVE_SETTLEMENT,
-  XOCHI_LIVE_RECIPIENT_META.
+  Overrides: XOCHI_LIVE_AUTH, XOCHI_LIVE_AGENT_WALLET, XOCHI_LIVE_FROM_CHAIN,
+  XOCHI_LIVE_TO_CHAIN, XOCHI_LIVE_FROM_TOKEN, XOCHI_LIVE_TO_TOKEN,
+  XOCHI_LIVE_AMOUNT, XOCHI_LIVE_SETTLEMENT, XOCHI_LIVE_RECIPIENT_META.
   """
 
   use ExUnit.Case, async: false
@@ -37,7 +49,8 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
 
   if System.get_env("XOCHI_LIVE_URL") && System.get_env("XOCHI_LIVE_KEY") do
     alias Raxol.Payments.Actions.Payments.{ExecuteXochiIntent, PollXochiStatus}
-    alias Raxol.Payments.{Ledger, SpendingPolicy}
+    alias Raxol.Payments.{Ledger, Mandate, SpendingPolicy}
+    alias Raxol.Payments.Mandate.Store, as: MandateStore
 
     defmodule LiveWallet do
       @moduledoc false
@@ -47,6 +60,7 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
     setup do
       url = System.fetch_env!("XOCHI_LIVE_URL")
       host = url |> URI.parse() |> Map.get(:host)
+      member_token = System.get_env("XOCHI_LIVE_TOKEN", "")
       ledger = start_supervised!({Ledger, [name: nil]})
 
       policy = %SpendingPolicy{
@@ -57,18 +71,26 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         approved_domains: [host]
       }
 
+      {exec_config, poll_config} =
+        auth_configs(System.get_env("XOCHI_LIVE_AUTH", "mandate"), url, member_token)
+
       context = %{
         wallet: LiveWallet,
-        xochi_config: %{base_url: url, auth_token: System.get_env("XOCHI_LIVE_TOKEN", "")},
+        xochi_config: exec_config,
         ledger: ledger,
         policy: policy,
         agent_id: :live_gate
       }
 
-      {:ok, context: context}
+      # Status/history are not mandate scopes, so polling authenticates with the
+      # Member service token even when quote/execute go through a mandate.
+      {:ok, context: context, poll_context: %{context | xochi_config: poll_config}}
     end
 
-    test "agent completes a crosschain payment end-to-end", %{context: context} do
+    test "agent completes a crosschain payment end-to-end", %{
+      context: context,
+      poll_context: poll_context
+    } do
       params =
         %{
           amount: System.get_env("XOCHI_LIVE_AMOUNT", "10.00"),
@@ -86,7 +108,7 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
       assert {:ok, intent} = ExecuteXochiIntent.call(params, context)
       assert is_binary(intent.intent_id)
 
-      assert {:ok, status} = PollXochiStatus.call(%{intent_id: intent.intent_id}, context)
+      assert {:ok, status} = PollXochiStatus.call(%{intent_id: intent.intent_id}, poll_context)
       assert status.terminal == true
 
       assert status.status == "completed",
@@ -96,7 +118,8 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
     end
 
     test "a resumed run reuses the in-flight intent without a second signature", %{
-      context: context
+      context: context,
+      poll_context: poll_context
     } do
       # The crash-recovery path: an idempotency checkpoint lets a re-run of the
       # same payment resume the dispatched intent instead of quoting and signing
@@ -131,7 +154,7 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
       assert Decimal.equal?(lifetime(context), charged),
              "resume charged the ledger a second time"
 
-      assert {:ok, status} = PollXochiStatus.call(%{intent_id: intent.intent_id}, context)
+      assert {:ok, status} = PollXochiStatus.call(%{intent_id: intent.intent_id}, poll_context)
       assert status.terminal == true
 
       assert status.status == "completed",
@@ -142,6 +165,50 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
 
     defp lifetime(context) do
       Ledger.get_totals(context.ledger, context.agent_id, context.policy).lifetime
+    end
+
+    # Build {execute, poll} client configs for the chosen auth mode. Mandate is the
+    # agent-native default: the funded key presents an EIP-712 delegation envelope
+    # it signed itself on quote/execute, inheriting its own Member tier. Status
+    # polling is out of mandate scope, so it keeps the Member service token.
+    defp auth_configs("mandate", url, member_token) do
+      agent_wallet =
+        "XOCHI_LIVE_AGENT_WALLET"
+        |> System.get_env(LiveWallet.address())
+        |> String.downcase()
+
+      install_mandate(agent_wallet)
+
+      {%{base_url: url, auth: {:mandate, agent_wallet}},
+       %{base_url: url, auth_token: member_token}}
+    end
+
+    defp auth_configs(_member, url, member_token) do
+      config = %{base_url: url, auth_token: member_token}
+      {config, config}
+    end
+
+    # Sign and store a mandate the Req.Mandate plugin resolves by agent_wallet. The
+    # funded key self-delegates: it is the human_wallet (the EIP-712 signer whose
+    # tier the worker applies, and which must equal the quote wallet) and the
+    # presenting agent. max_amount_usd: 0 caps by call count only -- the worker
+    # prices a notional cap fee-inclusive, so a fixed cap risks tripping the gate.
+    defp install_mandate(agent_wallet) do
+      start_supervised!(MandateStore)
+
+      {:ok, mandate} =
+        Mandate.build(%{
+          human_wallet: LiveWallet.address(),
+          agent_wallet: agent_wallet,
+          scopes: ["quote", "execute"],
+          max_amount_usd: 0,
+          max_calls: 50,
+          expires_at: System.system_time(:second) + 3600
+        })
+
+      {:ok, signed} = Mandate.sign(mandate, LiveWallet)
+      :ok = Mandate.verify(signed)
+      :ok = MandateStore.put(signed)
     end
 
     defp maybe_put_recipient(params) do


### PR DESCRIPTION
## What

Flips the live Xochi settlement gate to the agent-native **mandate** auth path,
selectable via a new `XOCHI_LIVE_AUTH` env (default `mandate`).

- **Mandate mode (default):** the funded gate key self-delegates -- it signs an
  EIP-712 `Raxol.Payments.Mandate` as `human_wallet` and presents it as the agent
  on quote/execute via `X-Xochi-Delegation` (`Raxol.Payments.Req.Mandate`), stored
  in the singleton `Mandate.Store`. Scopes `["quote","execute"]`; `max_calls: 50`;
  `max_amount_usd: 0` (call-count enforcement only -- a notional cap is priced
  fee-inclusive on the worker and could trip the gate).
- **Status polling stays on the Member service token** via a separate `poll_context`,
  because status/history are out of mandate scope on the worker.
- **`XOCHI_LIVE_AUTH=member`** reproduces the prior token-only lifecycle as a fallback.
- The runner (`run_live_xochi_gate.sh`) threads `XOCHI_LIVE_AUTH` /
  `XOCHI_LIVE_AGENT_WALLET` through and documents the hybrid.

## Why

The Member service token works but is not the agent-native model. The mandate path
lets an agent act for a Member and inherit the Member's Trust Tier without a passkey
JWT, which is the intended production auth for autonomous cross-chain settlement.

## Validation

- Compiles clean under the env guard (`--warnings-as-errors`, `:live_xochi` /
  `:live_property` excluded so no network), `shellcheck` clean, `mix format` clean.
- **Mandate auth validated LIVE against `api.xochi.fi`:** a read-only mandate-authed
  quote (throwaway signer, no funds, no Member token) returned HTTP 200 with
  `X-Xochi-Delegation` accepted -- the worker recovered `human_wallet`, matched the
  `quote` scope, and enforced `wallet == human_wallet`.

A full end-to-end *settlement* run was not completed because the EVM corridor
(Base->Arb) currently quotes `unprofitable` and would hang at settle on the deployed
solver. That is an upstream Riddler deploy gap (the #144 nonce-pool + #136 gas-oracle
fixes are on riddler master but predate the live image), not a problem with this
change. This PR is the gate harness + auth wiring; it is independent of that deploy.

## Manual testing

- [ ] Staging dry-run (Member-only, no funds): `XOCHI_LIVE_URL=https://api-stg.xochi.fi OP_TOKEN_REF=".../Xochi staging AGENT_SERVICE_TOKENS/credential" XOCHI_LIVE_KEY=0x<funded> DRY_RUN=1 ./examples/run_live_xochi_gate.sh`
- [ ] Prod dry-run (auth + can_solve, no funds): same with the prod URL/token + `DRY_RUN=1`.
- [ ] Mandate-authed quote returns HTTP 200 (auth accepted) against `api.xochi.fi`.
- [ ] After the upstream riddler redeploy: real run settles end to end and the resume case reuses the in-flight intent without a second signature.
