### PR TITLE
Fix macOS NIF link broken by openssl env exports

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -463,10 +463,12 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.os == 'macos-latest'
         run: |
-          brew install openssl@3 postgresql@14
-          echo "LDFLAGS=-L$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
-          echo "CFLAGS=-I$(brew --prefix openssl@3)/include" >> $GITHUB_ENV
-          
+          # Do NOT export LDFLAGS/CFLAGS here: a global LDFLAGS clobbers the
+          # termbox2 NIF Makefile's `LDFLAGS ?= -shared`, dropping -shared so the
+          # .so links as an executable (`_main` undefined). Nothing in the build
+          # needs openssl flags; OTP ships precompiled.
+          brew install postgresql@14
+
           # Start PostgreSQL
           brew services start postgresql@14 || true
           sleep 5


### PR DESCRIPTION
## What broke

After #325 fixed the macOS `setup-beam` brew step (`openssl@1.1` was removed from Homebrew → `openssl@3`), the `Test macos-latest` job started failing one step later, at **Install dependencies**, while linking the vendored termbox2 NIF:

```
cc -L/opt/homebrew/opt/openssl@3/lib -undefined dynamic_lookup ... -o termbox2_nif.so
Undefined symbols for architecture arm64: "_main"
ld: symbol(s) not found for architecture arm64
```

This is **not** a flake and not the test-teardown race from #325 — it's a deterministic build break that was previously hidden behind the `openssl@1.1` brew failure (the job never reached the compile step).

## Root cause

The macOS step exported `LDFLAGS`/`CFLAGS` pointing at openssl. The termbox2 NIF Makefile declares its link flags with `?=`:

```make
LDFLAGS ?= -shared                         # yields to the env var
LDFLAGS += -undefined dynamic_lookup
$(CC) $(LDFLAGS) $(ERL_LDFLAGS) $^ -o $@
```

A global `LDFLAGS` env var pre-sets `LDFLAGS`, so `?= -shared` is skipped. The link then runs without `-shared`, so `clang` builds an executable (needs `_main`) instead of a shared library. Nothing in this build needs openssl flags — OTP ships precompiled via setup-beam.

This also explains why #325's PR run passed but master failed with identical code: the PR restored a **cached** `termbox2_nif.so` so `make` was a no-op; master rebuilt it fresh and hit the link. That cache-dependence made it look intermittent.

## Fix

Remove the `LDFLAGS`/`CFLAGS` openssl exports (and the now-unused `openssl@3` brew install) from the macOS step. The Makefile's `LDFLAGS ?= -shared` then applies.

## Proof (local, macОS arm64)

- `make -n` without env LDFLAGS → `cc -shared -undefined dynamic_lookup ... -o termbox2_nif.so`
- `make -n` with `LDFLAGS=-L.../openssl@3/lib` → same line **minus `-shared`** (reproduces the CI break)
- Forced rebuild with the fix → produces a valid `Mach-O 64-bit dynamically linked shared library arm64`
- `python3 -c "import yaml; yaml.safe_load(...)"` → workflow YAML valid

## Manual testing

- [x] `make -n` diff confirms `-shared` is dropped only when LDFLAGS is exported
- [x] `mix deps.compile raxol_terminal --force` links a valid shared `.so` with the fix
- [x] Workflow YAML parses
