### PR TITLE
docs: fix drift, tighten prose voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,95 +2,95 @@
 
 ### Fixed
 
-- **Layout engine: dynamic-children dropped from `column(opts, do: var)`** -- when callers wrote the inline keyword-list form `column(style: ..., do: items)` Elixir matched it against `def column/1` instead of `defmacro column/2`, and the `:do` key rode through into the layout function unread. `Flex.column/1` then saw `children: []` and rendered an empty container. Fix: `Raxol.Core.Renderer.View.promote_do_to_children/1` pops `:do` and re-keys it as `:children` (via `List.wrap` so single-child blocks work too); `View.column/1`, `View.row/1`, `View.box/1` all forward through it. Restored rendering for CheckboxDemo, TextAreaDemo, RadioGroupDemo.
-- **Layout engine: chart widget types dropped at layout step** -- `Components.chart/1` returns a `:box` element whose `:type` is overridden to one of `:line_chart`, `:bar_chart`, `:scatter_chart`, `:heatmap` so MCP's `ToolProvider` can discover them. The layout engine had no clauses for those types; they hit the catch-all warning and the element disappeared. Fix: added one `process_element/3` clause that rewrites the chart types to `:box` and forwards. Restored LineChart, ScatterChart, BarChart, CursorTrail, Heatmap demos.
-- **Layout engine: `style: %{position: {x, y}}` offset ignored on `:text` elements** -- chart cells emitted by `Raxol.UI.Charts.ViewBridge` carry their own relative position so each row lands at the right column. The `:text` layout clause used `space.x`, `space.y` unconditionally and stacked all cells at the same coordinate. Fix: extract `{dx, dy}` from `style.position` and add to the space origin.
-- **Layout engine: `:text_input` constructor shape mismatch** -- `Components.text_input/1` builds the element with top-level `:value` / `:placeholder` keys, but the layout clause required them inside `:attrs`. Element fell to the catch-all and dropped. Fix: added a clause that rewrites the new-DSL shape into the `:attrs`-shaped form and forwards.
+- **Layout engine: dynamic-children dropped from `column(opts, do: var)`**: when callers wrote the inline keyword-list form `column(style: ..., do: items)` Elixir matched it against `def column/1` instead of `defmacro column/2`, and the `:do` key rode through into the layout function unread. `Flex.column/1` then saw `children: []` and rendered an empty container. Fix: `Raxol.Core.Renderer.View.promote_do_to_children/1` pops `:do` and re-keys it as `:children` (via `List.wrap` so single-child blocks work too); `View.column/1`, `View.row/1`, `View.box/1` all forward through it. Restored rendering for CheckboxDemo, TextAreaDemo, RadioGroupDemo.
+- **Layout engine: chart widget types dropped at layout step**: `Components.chart/1` returns a `:box` element whose `:type` is overridden to one of `:line_chart`, `:bar_chart`, `:scatter_chart`, `:heatmap` so MCP's `ToolProvider` can discover them. The layout engine had no clauses for those types; they hit the catch-all warning and the element disappeared. Fix: added one `process_element/3` clause that rewrites the chart types to `:box` and forwards. Restored LineChart, ScatterChart, BarChart, CursorTrail, Heatmap demos.
+- **Layout engine: `style: %{position: {x, y}}` offset ignored on `:text` elements**: chart cells emitted by `Raxol.UI.Charts.ViewBridge` carry their own relative position so each row lands at the right column. The `:text` layout clause used `space.x`, `space.y` unconditionally and stacked all cells at the same coordinate. Fix: extract `{dx, dy}` from `style.position` and add to the space origin.
+- **Layout engine: `:text_input` constructor shape mismatch**: `Components.text_input/1` builds the element with top-level `:value` / `:placeholder` keys, but the layout clause required them inside `:attrs`. Element fell to the catch-all and dropped. Fix: added a clause that rewrites the new-DSL shape into the `:attrs`-shaped form and forwards.
 
 ### Added
 
-- **`test/property/layout_completeness_property_test.exs`** -- 3 properties locking down the layout-element-drop bug shape. Generates view trees (text / flex / box / chart) and asserts every `:text` content string in the input appears in the positioned-elements output. Sabotage-verified: comment out the chart-type clause and both relevant properties fail.
-- **`test/property/promote_do_to_children_property_test.exs`** -- 8 invariants for the helper above. Includes one property documenting that `[do: nil]` is intentionally indistinguishable from `[]` (because `Keyword.pop/2` can't disambiguate).
-- **`test/property/demo_update_totality_property_test.exs`** -- one property per Catalog demo (30 total). For each demo, folds random sequences of up to 30 mixed key events (chars, special keys, `:tick`, modifier combos) through `update/2` and asserts no exception plus correct `{model, commands_list}` shape. Catches state-machine edge cases that example tests don't reach (negative cursors, list overflows, unhandled tick states).
-- **`test/raxol/playground/demo_render_test.exs`** -- end-to-end render regression test that mounts every Catalog demo through `Raxol.Headless`, asserts both text-screenshot content lines and buffer cell paint coverage, and drives demos through documented key sequences (`@key_drives`) to reach state where the canonical widget content is visible. Caught the four framework bugs above on its first run.
-- **`raxol_symphony` Phases 0-14** -- Elixir/OTP port of OpenAI Symphony. Tracker-driven coding-agent orchestrator with two runner backends (`Runners.RaxolAgent` default; `Runners.Codex` Port-based JSON-RPC for parity with upstream Symphony Elixir) and six surfaces (terminal dashboard, LiveView, MCP tools + `symphony://runs` resource, Telegram per-issue session router, Watch push, JSON `/api/v1/*`). Workflow hot-reload via `WorkflowStore`, Linear (GraphQL) + GitHub Issues (state labels) trackers, evidence framework (`Evidence.GitHub` CI/PR comments, `Evidence.Complexity` cloc/SLOC fallback, `Evidence.Recording` cast scan), in-run asciinema capture (`Evidence.Capture` writes `<workspace>/.raxol_symphony/run-<attempt>.cast` per dispatch when `recording.enabled: true`). 399 tests, 0 failures. Pre-alpha, path-dep.
-- **`raxol_acp` v0.1 (engineering complete)** -- First Elixir/OTP-native Virtuals Agent Commerce Protocol implementation. Job lifecycle (`Job.{Server, StateMachine, Memo, Store, Supervisor, Registry}`), EIP-712 typed-data memos via `Raxol.Payments.EIP712`, on-chain client (`ContractClient.Onchain` over Req JSON-RPC, EIP-1559 typed-tx signing, Yellow-Paper RLP, log decoder for `create_job` job_id extraction), Seller stack (`Backend.InMemory` + `Queue` + `Runtime` + `Supervisor`, opt-in via `:seller_enabled`), `Wallet.NonceServer` for serialized nonce assignment, `mix raxol_acp.bench` sandbox-graduation harness. Optional DETS-backed `Job.Store` durability. 256 tests, 0 failures. Pre-alpha, path-dep. External-blocked: real ACP contract ABIs, `Wallet.SCA`, `Seller.Backend.WebSocket`.
-- **`Raxol.Payments.Wallet.sign_hash/1`** -- new behaviour callback for EIP-1559 transaction signing (sign-precomputed-digest semantics). `Wallets.Env` and `Wallets.Op` both implement.
-- **Workflow Graph (`Raxol.Workflow.*`, ADR-0015)** -- LangGraph-style stateful workflow primitive in main raxol: a declarative `Graph` builder with six-step structural validation, synchronous `Compiled.invoke/3` plus `async_invoke/3` and `stream_events/3`, a durable `Checkpoint.Saver` (Ets/Dets/Postgrex adapters), `Workflow.interrupt/1` human-in-the-loop with `Compiled.resume/4`, and `failure_policy: :retry | :compensate` (reverse-order saga rollback).
-- **Workflow concurrency (ADR-0019)** -- `Graph.add_channel/3` (typed reducers) and `Graph.add_join/4` (barrier); multi-node parallel branches via `Task.async_stream` (`parallelism :: pos_integer | :branches`), per-branch pause/resume, cancellation cascade, per-branch trace spans, and `branch_id` checkpoint/telemetry metadata. Real consumers: an ACP cross-chain settlement example and a Symphony parallel-candidates `GraphAdapter`.
-- **Effect system (`Raxol.Agent.Directive`)** -- struct-based directives (Async/Shell/SendAgent/Schedule/Spawn/Stop) with an `Executor` protocol replacing the closed Command tuple set; a CloudEvents v1.0 envelope (`Event.to_cloud_event/2`); `TraceContext` `causation_id` correlation.
-- **Agent-stack substrate (ADR-0020)** -- `Raxol.Agent.Cache`, `ThreadLog` (append-only audit), declarative `Policy.{Retry, Timeout, Cache}` via `PolicyApplier`, and the `Sandbox` protocol with `Sandbox.Chain` gating. Symphony's RaxolAgent runner adopts every primitive (tracker cache, thread-log audit, per-turn policies and sandboxes); a Session-backed sibling runner ships.
-- **Operator-flow contract (ADR-0018)** -- a first-class paused-run substrate end-to-end (Workflow Saver -> ACP Job -> Symphony Orchestrator -> MCP tools -> TUI/LiveView/Telegram/Watch); `Raxol.Symphony.PauseReason` consolidates reason formatting and is mechanically enforced via a `pause_reasons/0` callback.
-- **raxol_acp Workflow migration (ADR-0016)** -- `Job.Server`'s GenServer state machine replaced by a Workflow-backed implementation (`Job.Workflow`, a 10-node graph); `:via_workflow` flipped to the default.
-- **Self-improving agent loop (`raxol_agent`)** -- skills as filesystem procedural memory, an after-turn curation reviewer, and a Curator. `Raxol.Agent.Skill` parses/renders agentskills.io `SKILL.md`; `Raxol.Agent.Skills.Store` is a `BaseManager` disk index with usage telemetry persisted via `Core.Stores.Dets`, a managed root plus read-only `external_dirs` (default `~/.agents/skills`), and archive/state/pin; `skills_list`/`skill_view`/`skill_manage` Actions. `Raxol.Agent.SelfImprove.after_turn/3` spawns an isolated, unlinked reviewer on an auxiliary model that writes durable memory and `created_by: :agent` skills; `Raxol.Agent.Curator` ages `active -> stale -> archived` with interval-plus-idle gating, dry-run, and `tar.gz` backup/rollback. New `use Raxol.Agent` callbacks `skills_provider/0` and `self_improve/0`.
-- **Memory provider stack, full-text recall, dialectic user model (`raxol_agent`)** -- `Raxol.Agent.Memory.Stack` composes N memory providers (fan-out writes, merge + rerank + dedup reads); `Raxol.Agent.Memory.SessionSearch` is a BM25-lite inverted index over raw conversation items (`session_search` returns messages, not summaries); `Raxol.Agent.UserModel` derives a per-user dialectic block on an auxiliary model, injected into the last user message via the new optional `build_user_context/1` callback. New `memory_providers/0` callback.
-- **`Raxol.Agent.Turn`** -- the turn driver that assembles memory/skills/user-context/session-search context from an agent module's callbacks, records each turn to a `Conversation.Log`, and fires the after-turn self-improvement effects. Wires the loop end-to-end.
-- **`raxol_gateway` package (pre-alpha)** -- one daemon connecting many chat platforms through a shared `Gateway.Adapter` contract. `Route` keys sessions `agent:main:{platform}:{chat_type}:{chat_id}`; `SessionRouter` + `Session` run one process per chat under a `DynamicSupervisor` with idle/cooldown/max-session limits; `Pairing` issues DM codes and decides `authorize/2`; `Delivery` resolves four outbound destinations (direct, home, cross-platform, explicit `"platform:chat_id"` target); per-chat history plus `SessionRouter.handoff/3` move a conversation across platforms with its history intact. `Adapter.InMemory` is a reference adapter.
-- **Symphony opt-in self-improvement** -- `Raxol.Symphony.Runners.RaxolAgent` fires the `Agent.Turn` after-turn hook (skills curation, memory, user-model refresh, session index) on each turn when `agent.module` declares it, in both the workflow and simple run paths, without touching event forwarding, pause detection, policies, or sandboxes.
-- **ADRs 0021-0028** -- Hermes-extraction Tier 1 (self-improving agents, memory provider stack, unified messaging gateway) and Tier 2 (execution backends + hibernation, cronjob, execute_code, delegate_task, auxiliary-model routing) decision records.
-- **Idempotent crash recovery for cross-chain payment Actions (`raxol_payments`)** -- `Raxol.Payments.Checkpoint`, a nil-safe behaviour for a durable in-flight-intent store injected via `context[:checkpoint]`, with `derive_key/1` for a stable idempotency key. Three stores: `Checkpoint.ETS` (process-crash-durable), `Checkpoint.ContextStore` (backed by `Raxol.Agent.ContextStore`, so a deployed agent's in-flight intent rides the same store that backs its crash recovery), and nil (disabled, the default). `ExecuteXochiIntent` and `ExecuteRelayTransfer` checkpoint the dispatched intent before submit and resume it on a re-run after a crash (poll-before-re-sign, no second spend authorize) instead of re-quoting and signing twice; the relay rail keys on the logical payment (not the client-minted `transfer_id`) so a resume reuses the same id and an idempotent broadcaster dedupes a retried deposit. Drops the checkpoint on definite failure; protocol-tagged keys (`:xochi`/`:relay`) so a shared store can't collide. The ZERO cockpit crash beat (`examples/agents/zero_system.exs`) models the contract end-to-end. `:live_xochi` and `:live_relay` kill-and-resume gates. 24 new tests + the live variants; 0 failures.
-- **Auxiliary-model routing (`raxol_agent`, ADR-0028)** -- `Raxol.Agent.Auxiliary` routes background tasks (curation, user-model derivation, future titling/triage) to a cheap model per task kind instead of the frontier model. `resolve/2` maps a task kind to its slot's `ExecutorConfig`; `resolve_chain/2` adds the slot's fallback chain terminating at the primary executor; `select/2` walks the chain through `Backend.Selector` with an injectable availability predicate. Config is an `auxiliary:` slot map keyed by task kind with a `default_aux` catch-all. `SelfImprove` and `UserModel` consult the resolver when no explicit backend/model is set, keeping explicit config as an override; with `auxiliary:` unset every kind resolves to the primary executor.
+- **`test/property/layout_completeness_property_test.exs`**: 3 properties locking down the layout-element-drop bug shape. Generates view trees (text / flex / box / chart) and asserts every `:text` content string in the input appears in the positioned-elements output. Sabotage-verified: comment out the chart-type clause and both relevant properties fail.
+- **`test/property/promote_do_to_children_property_test.exs`**: 8 invariants for the helper above. Includes one property documenting that `[do: nil]` is intentionally indistinguishable from `[]` (because `Keyword.pop/2` can't disambiguate).
+- **`test/property/demo_update_totality_property_test.exs`**: one property per Catalog demo (30 total). For each demo, folds random sequences of up to 30 mixed key events (chars, special keys, `:tick`, modifier combos) through `update/2` and asserts no exception plus correct `{model, commands_list}` shape. Catches state-machine edge cases that example tests don't reach (negative cursors, list overflows, unhandled tick states).
+- **`test/raxol/playground/demo_render_test.exs`**: end-to-end render regression test that mounts every Catalog demo through `Raxol.Headless`, asserts both text-screenshot content lines and buffer cell paint coverage, and drives demos through documented key sequences (`@key_drives`) to reach state where the canonical widget content is visible. Caught the four framework bugs above on its first run.
+- **`raxol_symphony` Phases 0-14**: Elixir/OTP port of OpenAI Symphony. Tracker-driven coding-agent orchestrator with two runner backends (`Runners.RaxolAgent` default; `Runners.Codex` Port-based JSON-RPC for parity with upstream Symphony Elixir) and six surfaces (terminal dashboard, LiveView, MCP tools + `symphony://runs` resource, Telegram per-issue session router, Watch push, JSON `/api/v1/*`). Workflow hot-reload via `WorkflowStore`, Linear (GraphQL) + GitHub Issues (state labels) trackers, evidence framework (`Evidence.GitHub` CI/PR comments, `Evidence.Complexity` cloc/SLOC fallback, `Evidence.Recording` cast scan), in-run asciinema capture (`Evidence.Capture` writes `<workspace>/.raxol_symphony/run-<attempt>.cast` per dispatch when `recording.enabled: true`). 399 tests, 0 failures. Pre-alpha, path-dep.
+- **`raxol_acp` v0.1 (engineering complete)**: First Elixir/OTP-native Virtuals Agent Commerce Protocol implementation. Job lifecycle (`Job.{Server, StateMachine, Memo, Store, Supervisor, Registry}`), EIP-712 typed-data memos via `Raxol.Payments.EIP712`, on-chain client (`ContractClient.Onchain` over Req JSON-RPC, EIP-1559 typed-tx signing, Yellow-Paper RLP, log decoder for `create_job` job_id extraction), Seller stack (`Backend.InMemory` + `Queue` + `Runtime` + `Supervisor`, opt-in via `:seller_enabled`), `Wallet.NonceServer` for serialized nonce assignment, `mix raxol_acp.bench` sandbox-graduation harness. Optional DETS-backed `Job.Store` durability. 256 tests, 0 failures. Pre-alpha, path-dep. External-blocked: real ACP contract ABIs, `Wallet.SCA`, `Seller.Backend.WebSocket`.
+- **`Raxol.Payments.Wallet.sign_hash/1`**: new behaviour callback for EIP-1559 transaction signing (sign-precomputed-digest semantics). `Wallets.Env` and `Wallets.Op` both implement.
+- **Workflow Graph (`Raxol.Workflow.*`, ADR-0015)**: LangGraph-style stateful workflow primitive in main raxol: a declarative `Graph` builder with six-step structural validation, synchronous `Compiled.invoke/3` plus `async_invoke/3` and `stream_events/3`, a durable `Checkpoint.Saver` (Ets/Dets/Postgrex adapters), `Workflow.interrupt/1` human-in-the-loop with `Compiled.resume/4`, and `failure_policy: :retry | :compensate` (reverse-order saga rollback).
+- **Workflow concurrency (ADR-0019)**: `Graph.add_channel/3` (typed reducers) and `Graph.add_join/4` (barrier); multi-node parallel branches via `Task.async_stream` (`parallelism :: pos_integer | :branches`), per-branch pause/resume, cancellation cascade, per-branch trace spans, and `branch_id` checkpoint/telemetry metadata. Real consumers: an ACP cross-chain settlement example and a Symphony parallel-candidates `GraphAdapter`.
+- **Effect system (`Raxol.Agent.Directive`)**: struct-based directives (Async/Shell/SendAgent/Schedule/Spawn/Stop) with an `Executor` protocol replacing the closed Command tuple set; a CloudEvents v1.0 envelope (`Event.to_cloud_event/2`); `TraceContext` `causation_id` correlation.
+- **Agent-stack substrate (ADR-0020)**: `Raxol.Agent.Cache`, `ThreadLog` (append-only audit), declarative `Policy.{Retry, Timeout, Cache}` via `PolicyApplier`, and the `Sandbox` protocol with `Sandbox.Chain` gating. Symphony's RaxolAgent runner adopts every primitive (tracker cache, thread-log audit, per-turn policies and sandboxes); a Session-backed sibling runner ships.
+- **Operator-flow contract (ADR-0018)**: a first-class paused-run substrate end-to-end (Workflow Saver -> ACP Job -> Symphony Orchestrator -> MCP tools -> TUI/LiveView/Telegram/Watch); `Raxol.Symphony.PauseReason` consolidates reason formatting and is mechanically enforced via a `pause_reasons/0` callback.
+- **raxol_acp Workflow migration (ADR-0016)**: `Job.Server`'s GenServer state machine replaced by a Workflow-backed implementation (`Job.Workflow`, a 10-node graph); `:via_workflow` flipped to the default.
+- **Self-improving agent loop (`raxol_agent`)**: skills as filesystem procedural memory, an after-turn curation reviewer, and a Curator. `Raxol.Agent.Skill` parses/renders agentskills.io `SKILL.md`; `Raxol.Agent.Skills.Store` is a `BaseManager` disk index with usage telemetry persisted via `Core.Stores.Dets`, a managed root plus read-only `external_dirs` (default `~/.agents/skills`), and archive/state/pin; `skills_list`/`skill_view`/`skill_manage` Actions. `Raxol.Agent.SelfImprove.after_turn/3` spawns an isolated, unlinked reviewer on an auxiliary model that writes durable memory and `created_by: :agent` skills; `Raxol.Agent.Curator` ages `active -> stale -> archived` with interval-plus-idle gating, dry-run, and `tar.gz` backup/rollback. New `use Raxol.Agent` callbacks `skills_provider/0` and `self_improve/0`.
+- **Memory provider stack, full-text recall, dialectic user model (`raxol_agent`)**: `Raxol.Agent.Memory.Stack` composes N memory providers (fan-out writes, merge + rerank + dedup reads); `Raxol.Agent.Memory.SessionSearch` is a BM25-lite inverted index over raw conversation items (`session_search` returns messages, not summaries); `Raxol.Agent.UserModel` derives a per-user dialectic block on an auxiliary model, injected into the last user message via the new optional `build_user_context/1` callback. New `memory_providers/0` callback.
+- **`Raxol.Agent.Turn`**: the turn driver that assembles memory/skills/user-context/session-search context from an agent module's callbacks, records each turn to a `Conversation.Log`, and fires the after-turn self-improvement effects. Wires the loop end-to-end.
+- **`raxol_gateway` package (pre-alpha)**: one daemon connecting many chat platforms through a shared `Gateway.Adapter` contract. `Route` keys sessions `agent:main:{platform}:{chat_type}:{chat_id}`; `SessionRouter` + `Session` run one process per chat under a `DynamicSupervisor` with idle/cooldown/max-session limits; `Pairing` issues DM codes and decides `authorize/2`; `Delivery` resolves four outbound destinations (direct, home, cross-platform, explicit `"platform:chat_id"` target); per-chat history plus `SessionRouter.handoff/3` move a conversation across platforms with its history intact. `Adapter.InMemory` is a reference adapter.
+- **Symphony opt-in self-improvement**: `Raxol.Symphony.Runners.RaxolAgent` fires the `Agent.Turn` after-turn hook (skills curation, memory, user-model refresh, session index) on each turn when `agent.module` declares it, in both the workflow and simple run paths, without touching event forwarding, pause detection, policies, or sandboxes.
+- **ADRs 0021-0028**: Hermes-extraction Tier 1 (self-improving agents, memory provider stack, unified messaging gateway) and Tier 2 (execution backends + hibernation, cronjob, execute_code, delegate_task, auxiliary-model routing) decision records.
+- **Idempotent crash recovery for cross-chain payment Actions (`raxol_payments`)**: `Raxol.Payments.Checkpoint`, a nil-safe behaviour for a durable in-flight-intent store injected via `context[:checkpoint]`, with `derive_key/1` for a stable idempotency key. Three stores: `Checkpoint.ETS` (process-crash-durable), `Checkpoint.ContextStore` (backed by `Raxol.Agent.ContextStore`, so a deployed agent's in-flight intent rides the same store that backs its crash recovery), and nil (disabled, the default). `ExecuteXochiIntent` and `ExecuteRelayTransfer` checkpoint the dispatched intent before submit and resume it on a re-run after a crash (poll-before-re-sign, no second spend authorize) instead of re-quoting and signing twice; the relay rail keys on the logical payment (not the client-minted `transfer_id`) so a resume reuses the same id and an idempotent broadcaster dedupes a retried deposit. Drops the checkpoint on definite failure; protocol-tagged keys (`:xochi`/`:relay`) so a shared store can't collide. The ZERO cockpit crash beat (`examples/agents/zero_system.exs`) models the contract end-to-end. `:live_xochi` and `:live_relay` kill-and-resume gates. 24 new tests + the live variants; 0 failures.
+- **Auxiliary-model routing (`raxol_agent`, ADR-0028)**: `Raxol.Agent.Auxiliary` routes background tasks (curation, user-model derivation, future titling/triage) to a cheap model per task kind instead of the frontier model. `resolve/2` maps a task kind to its slot's `ExecutorConfig`; `resolve_chain/2` adds the slot's fallback chain terminating at the primary executor; `select/2` walks the chain through `Backend.Selector` with an injectable availability predicate. Config is an `auxiliary:` slot map keyed by task kind with a `default_aux` catch-all. `SelfImprove` and `UserModel` consult the resolver when no explicit backend/model is set, keeping explicit config as an override; with `auxiliary:` unset every kind resolves to the primary executor.
 
 ### Changed
 
-- **`Raxol.Agent.Memory.Store.Ets` DETS** -- migrated the hand-rolled `:dets` open/persist/delete/clear/sync/close to the shared `Raxol.Core.Stores.Dets` helper. Behaviour-preserving; the existing store tests pass unchanged.
+- **`Raxol.Agent.Memory.Store.Ets` DETS**: migrated the hand-rolled `:dets` open/persist/delete/clear/sync/close to the shared `Raxol.Core.Stores.Dets` helper. Behaviour-preserving; the existing store tests pass unchanged.
 
 ## [2.4.0] - 2026-04-14
 
 ### Added
 
-- **Phase 14B: Xochi Integration** -- Xochi as default agent-facing protocol for cross-chain payments. Cash-positive with tier-based fees (0.10-0.30%). Riddler solves intents behind the scenes.
-  - `Raxol.Payments.Xochi.Client` -- HTTP client for Xochi intent API (quote, execute, status, history)
-  - `Raxol.Payments.Xochi.Schemas` -- 5 typed structs (QuoteRequest, QuoteResponse, ExecuteRequest, ExecuteResponse, IntentStatus)
-  - `Raxol.Payments.Protocols.Xochi` -- full intent flow: `get_quote/2` -> `execute/3` (EIP-712 wallet signing) -> `poll_status/3`
-  - `Raxol.Payments.Riddler.Client` -- Commerce API client (B2B/direct solver access, not default)
-  - `Raxol.Payments.Router` -- cross-chain routes to `:xochi`, privacy to `:xochi`, same-chain stays `:x402`
-- **Phase 14C: PXE-Bridge Integration** -- Aztec Private eXecution Environment as settlement target for high-trust privacy tiers.
-  - `Raxol.Payments.Pxe.Client` -- JSON-RPC 2.0 client (aztec_createNote, aztec_getVersion, /status)
-  - `Raxol.Payments.Pxe.Schemas` -- CreateNoteParams, CreateNoteResult, HealthStatus
-  - `Raxol.Payments.PrivacyTier` -- Glass Cube model (6 tiers: open, public, standard, stealth, private, sovereign), attestation gating, downgrade logic
+- **Phase 14B: Xochi Integration**: Xochi as default agent-facing protocol for cross-chain payments. Cash-positive with tier-based fees (0.10-0.30%). Riddler solves intents behind the scenes.
+  - `Raxol.Payments.Xochi.Client`: HTTP client for Xochi intent API (quote, execute, status, history)
+  - `Raxol.Payments.Xochi.Schemas`: 5 typed structs (QuoteRequest, QuoteResponse, ExecuteRequest, ExecuteResponse, IntentStatus)
+  - `Raxol.Payments.Protocols.Xochi`: full intent flow: `get_quote/2` -> `execute/3` (EIP-712 wallet signing) -> `poll_status/3`
+  - `Raxol.Payments.Riddler.Client`: Commerce API client (B2B/direct solver access, not default)
+  - `Raxol.Payments.Router`: cross-chain routes to `:xochi`, privacy to `:xochi`, same-chain stays `:x402`
+- **Phase 14C: PXE-Bridge Integration**: Aztec Private eXecution Environment as settlement target for high-trust privacy tiers.
+  - `Raxol.Payments.Pxe.Client`: JSON-RPC 2.0 client (aztec_createNote, aztec_getVersion, /status)
+  - `Raxol.Payments.Pxe.Schemas`: CreateNoteParams, CreateNoteResult, HealthStatus
+  - `Raxol.Payments.PrivacyTier`: Glass Cube model (6 tiers: open, public, standard, stealth, private, sovereign), attestation gating, downgrade logic
   - Router settlement routing with trust-score-aware privacy depth
-- **Phase 14D: Stealth Settlement** -- Full ERC-5564/ERC-6538 in `Xochi.Stealth` (~300 LOC).
+- **Phase 14D: Stealth Settlement**: Full ERC-5564/ERC-6538 in `Xochi.Stealth` (~300 LOC).
   - ECDH stealth address derivation (secp256k1)
   - View tag scanning (256x speedup, 1:256 false positive rate)
   - Domain-separated key derivation from EVM signature
   - Meta-address encode/decode (st:eth:0x format)
   - 44 tests (32 unit + 12 e2e), stress-tested 500 round-trips at 0% failure
-- **Phase 14E: ZKSAR + Trust Tiers** -- Zero-knowledge attestation verification and trust scoring.
-  - `Raxol.Payments.Zksar` -- 6 ZK proof type verification (type, expiry, issuer, structure), batch verify, JSON parsing
-  - `Raxol.Payments.Zksar.TrustScore` -- diminishing-returns aggregation: `score = sum(weight_i / ln(rank + 1))`, capped at 100
+- **Phase 14E: ZKSAR + Trust Tiers**: Zero-knowledge attestation verification and trust scoring.
+  - `Raxol.Payments.Zksar`: 6 ZK proof type verification (type, expiry, issuer, structure), batch verify, JSON parsing
+  - `Raxol.Payments.Zksar.TrustScore`: diminishing-returns aggregation: `score = sum(weight_i / ln(rank + 1))`, capped at 100
   - PrivacyTier attestation requirements per tier, downgrade logic
   - Router attestation-aware routing with `trust_score_for/1`
-- **AutoPay wiring** -- `Backend.HTTP` accepts `:req_plugins` for transparent HTTP 402 handling. `Raxol.Payments.Req.AgentPlugin.auto_pay/1` builds the closure.
-- **Riddler solver wiring (ADR-0005)** -- Complete on both sides. 9 Xochi endpoints, fee policy (5 tiers + privacy premiums), stealth/ERC-4337 settlement, ZKSAR attestation, EIP-712 typed data. 119 Riddler tests + 347 raxol_payments tests.
-- **raxol_liveview package** -- TerminalBridge, TEALive, TerminalComponent, 5 themes, CSS asset. 37 tests.
-- **raxol_plugin package** -- `use Raxol.Plugin` macro, API facade, Manifest, Testing helpers, generator. 50 tests.
-- **Hex publishing readiness** -- All packages at v2.4.0 with LICENSE.md, README.md, package metadata, version-constrained path deps. Publishing order: raxol_sensor + raxol_core -> raxol_terminal/mcp/plugin/liveview -> raxol -> raxol_agent -> raxol_payments.
+- **AutoPay wiring**: `Backend.HTTP` accepts `:req_plugins` for transparent HTTP 402 handling. `Raxol.Payments.Req.AgentPlugin.auto_pay/1` builds the closure.
+- **Riddler solver wiring (ADR-0005)**: Complete on both sides. 9 Xochi endpoints, fee policy (5 tiers + privacy premiums), stealth/ERC-4337 settlement, ZKSAR attestation, EIP-712 typed data. 119 Riddler tests + 347 raxol_payments tests.
+- **raxol_liveview package**: TerminalBridge, TEALive, TerminalComponent, 5 themes, CSS asset. 37 tests.
+- **raxol_plugin package**: `use Raxol.Plugin` macro, API facade, Manifest, Testing helpers, generator. 50 tests.
+- **Hex publishing readiness**: All packages at v2.4.0 with LICENSE.md, README.md, package metadata, version-constrained path deps. Publishing order: raxol_sensor + raxol_core -> raxol_terminal/mcp/plugin/liveview -> raxol -> raxol_agent -> raxol_payments.
 
 ### Changed
 
-- Deprecated `Protocols.Riddler` -- now delegates to Xochi internally
+- Deprecated `Protocols.Riddler`: now delegates to Xochi internally
 - All sub-packages bumped to v2.4.0 (raxol_payments stays at 0.1.0)
 - Path deps now include version constraints (`~> 2.4`) for Hex compatibility
 
 ### Fixed
 
-- **Dashboard demo** -- `status_dot/1` used identical character for all scheduler load levels; now uses distinct ASCII indicators per threshold
-- **String.to_atom on external input** -- Replaced 6 unsafe catch-all `String.to_atom(s)` in schema parsers with explicit clauses + `:unknown`/`nil` fallback
-- **Duplicated `maybe_put/3`** -- Extracted to `Schemas.put_non_nil/3` shared helper
-- **Dialyzer specs** -- Tightened `{:error, term()}` to actual error tuple shapes in `metrics.ex`
-- **QuoteRequest validation** -- Added `validate/1` with eth address format checks
-- **Attestation filtering** -- PrivacyTier now filters attestations by `valid: true`
+- **Dashboard demo**: `status_dot/1` used identical character for all scheduler load levels; now uses distinct ASCII indicators per threshold
+- **String.to_atom on external input**: Replaced 6 unsafe catch-all `String.to_atom(s)` in schema parsers with explicit clauses + `:unknown`/`nil` fallback
+- **Duplicated `maybe_put/3`**: Extracted to `Schemas.put_non_nil/3` shared helper
+- **Dialyzer specs**: Tightened `{:error, term()}` to actual error tuple shapes in `metrics.ex`
+- **QuoteRequest validation**: Added `validate/1` with eth address format checks
+- **Attestation filtering**: PrivacyTier now filters attestations by `valid: true`
 
 ## [2.3.2] - 2026-03-30
 
 ### Added
 
-- **Headless session manager** (`Raxol.Headless`) -- GenServer managing non-interactive TEA app instances in `:agent` environment. Start from module or .exs file, take text screenshots, send keystrokes, read model state. Used by MCP tools and future test harness.
-- **MCP tools for Claude Code** -- 6 tools (`raxol_start`, `raxol_screenshot`, `raxol_send_key`, `raxol_get_model`, `raxol_stop`, `raxol_list`) injected into Tidewave at dev startup. Tidewave MCP proxy script for stdio transport.
-- **ADR-0012: MCP as Rendering Target** -- Architecture decision formalizing MCP as a first-class rendering target. Automatic tool derivation from widget tree via ToolProvider behaviour, focus lens with mouse tracking, context tree as MCP resources, agent-MCP symmetry, multi-surface cockpit vision (terminal, MCP, Telegram, speech, watch). Category theory foundations for design and property-based test invariants.
-- **SPECS.md Phases 8-11** -- raxol_mcp package, ToolProvider + tool derivation, context tree + resources, MCP test harness.
-- **Playground resize handling** -- Fixed resize event propagation in playground demos.
+- **Headless session manager** (`Raxol.Headless`): GenServer managing non-interactive TEA app instances in `:agent` environment. Start from module or .exs file, take text screenshots, send keystrokes, read model state. Used by MCP tools and future test harness.
+- **MCP tools for Claude Code**: 6 tools (`raxol_start`, `raxol_screenshot`, `raxol_send_key`, `raxol_get_model`, `raxol_stop`, `raxol_list`) injected into Tidewave at dev startup. Tidewave MCP proxy script for stdio transport.
+- **ADR-0012: MCP as Rendering Target**: Architecture decision formalizing MCP as a first-class rendering target. Automatic tool derivation from widget tree via ToolProvider behaviour, focus lens with mouse tracking, context tree as MCP resources, agent-MCP symmetry, multi-surface cockpit vision (terminal, MCP, Telegram, speech, watch). Category theory foundations for design and property-based test invariants.
+- **SPECS.md Phases 8-11**: raxol_mcp package, ToolProvider + tool derivation, context tree + resources, MCP test harness.
+- **Playground resize handling**: Fixed resize event propagation in playground demos.
 
 ### Changed
 
@@ -107,19 +107,19 @@
 
 ### Added
 
-- **Distributed swarm subsystem** -- libcluster integration with gossip, EPMD, DNS, and custom Tailscale strategy. CRDTs (LWW-Register, OR-Set) for shared state. Node health monitoring, seniority-based leader election, bandwidth-aware message routing. 11 modules, 2,100+ lines.
-- **AI agent framework** -- `use Raxol.Agent` for TEA-based agents with OTP supervision. Agent discovery via Registry, typed inter-agent messaging, headless or rendered. Three command types: async (SSE streaming), shell (Port), inter-agent. Team supervision via `Agent.Team`. Backend.HTTP streams across Anthropic, OpenAI, Ollama, Kimi, and Lumo (U2L encryption). Tiered fallback detection.
-- **Interactive playground** -- 28 demos across 8 categories (input, display, feedback, navigation, overlay, layout, visualization, effects). Search, filter by category/complexity, help overlay. Charts as View DSL widgets. SSH serving with `mix raxol.playground --ssh`.
-- **Time-travel debugging** -- `Raxol.start_link(MyApp, time_travel: true)` snapshots every `update/2` cycle into a circular buffer. Step back/forward, jump to any point, restore state. Recursive map diffing. Zero cost when disabled.
-- **Session recording and replay** -- Asciinema v2 format. Capture with timestamps, replay with pause/seek/speed controls. Stream replay.
-- **Sandboxed REPL** -- `Code.eval_string` with spawn_monitor timeout, IO capture via group_leader swap, persistent bindings. Three sandbox levels: unrestricted, standard, strict (whitelist-only, safe for SSH). Available as `mix raxol.repl`.
-- **Nx/Axon adaptive ML** -- Optional Nx vectorized fusion, Axon MLP recommender for layout, FeedbackLoop training. Gated behind `Code.ensure_loaded?`.
-- **Plugin system** -- Phase 1 mission plugin system (4 modules) with lifecycle management
-- **AGI Cockpit Console** -- Phase 2 cockpit with uptime panel, dependency checker, crash recovery, state machine
-- **`mix raxol.new`** -- Project generator with 4 templates (basic, phoenix, ssh, agent)
-- **`mix raxol.demo`** -- 4 built-in runnable demos
-- **`mix raxol.check`** -- Unified quality gate (format, compile, credo, dialyzer, security, test)
-- **Benchmark suite** -- Comparative benchmarks against Ratatui, BubbleTea, and Textual
+- **Distributed swarm subsystem**: libcluster integration with gossip, EPMD, DNS, and custom Tailscale strategy. CRDTs (LWW-Register, OR-Set) for shared state. Node health monitoring, seniority-based leader election, bandwidth-aware message routing. 11 modules, 2,100+ lines.
+- **AI agent framework**: `use Raxol.Agent` for TEA-based agents with OTP supervision. Agent discovery via Registry, typed inter-agent messaging, headless or rendered. Three command types: async (SSE streaming), shell (Port), inter-agent. Team supervision via `Agent.Team`. Backend.HTTP streams across Anthropic, OpenAI, Ollama, Kimi, and Lumo (U2L encryption). Tiered fallback detection.
+- **Interactive playground**: 28 demos across 8 categories (input, display, feedback, navigation, overlay, layout, visualization, effects). Search, filter by category/complexity, help overlay. Charts as View DSL widgets. SSH serving with `mix raxol.playground --ssh`.
+- **Time-travel debugging**: `Raxol.start_link(MyApp, time_travel: true)` snapshots every `update/2` cycle into a circular buffer. Step back/forward, jump to any point, restore state. Recursive map diffing. Zero cost when disabled.
+- **Session recording and replay**: Asciinema v2 format. Capture with timestamps, replay with pause/seek/speed controls. Stream replay.
+- **Sandboxed REPL**: `Code.eval_string` with spawn_monitor timeout, IO capture via group_leader swap, persistent bindings. Three sandbox levels: unrestricted, standard, strict (whitelist-only, safe for SSH). Available as `mix raxol.repl`.
+- **Nx/Axon adaptive ML**: Optional Nx vectorized fusion, Axon MLP recommender for layout, FeedbackLoop training. Gated behind `Code.ensure_loaded?`.
+- **Plugin system**: Phase 1 mission plugin system (4 modules) with lifecycle management
+- **AGI Cockpit Console**: Phase 2 cockpit with uptime panel, dependency checker, crash recovery, state machine
+- **`mix raxol.new`**: Project generator with 4 templates (basic, phoenix, ssh, agent)
+- **`mix raxol.demo`**: 4 built-in runnable demos
+- **`mix raxol.check`**: Unified quality gate (format, compile, credo, dialyzer, security, test)
+- **Benchmark suite**: Comparative benchmarks against Ratatui, BubbleTea, and Textual
 - **746+ new tests** across 21 modules (357 for core, 233 for runtime, 156 for plugins, 84 for converter/keyboard/engine/shutdown/initializer/scheduler)
 - Mouse click hit testing for buttons
 - Agent semantic view tree
@@ -243,7 +243,7 @@ Fixed failing GitHub Actions workflows and updated to latest Elixir/OTP versions
   - 100% test coverage: 3 parser tests, 11 graphics tests, 2 integration tests, 25+ DCS handler tests
   - Confirmed edge case handling: empty sequences, invalid colors, bounds checking, malformed DCS
   - Performance validated: ~3-5μs per pattern character, O(1) palette lookups, sparse pixel buffer
-  - Integration verified: Emulator → DCS Handler → SixelGraphics → Parser → Pixel Buffer → Screen Buffer → Cell
+  - Integration verified: Emulator -> DCS Handler -> SixelGraphics -> Parser -> Pixel Buffer -> Screen Buffer -> Cell
   - Documentation updated to reflect production-ready status with known limitations clearly defined
   - Known limitations documented: Plugin visualization integration (future), Kitty protocol (future), animations (spec limitation)
 
@@ -420,7 +420,7 @@ Four independent packages now available:
 - Core Concepts: CORE_CONCEPTS.md, MIGRATION_FROM_DIY.md
 - Cookbook: 5 practical guides (LiveView, VIM, Performance, Commands, Theming)
 - Feature docs: VIM, Parser, Search, Filesystem, Cursor Effects
-- 75% documentation reduction via DRY consolidation (5000+ lines → 1250 lines)
+- 75% documentation reduction via DRY consolidation (5000+ lines -> 1250 lines)
 - Beginner-friendly with clear migration paths
 
 ### Phase 5: Modular Package Split
@@ -596,9 +596,9 @@ Four independent packages now available:
 
 ### Examples
 
-- `unified_registry.ex` → `global_registry.ex`
-- `unified_config_manager.ex` → `config_server.ex`
-- `unified_collector.ex` → `metrics_collector.ex`
+- `unified_registry.ex` -> `global_registry.ex`
+- `unified_config_manager.ex` -> `config_server.ex`
+- `unified_collector.ex` -> `metrics_collector.ex`
 
 ## [1.15.0] - 2025-09-10
 
@@ -683,8 +683,8 @@ Four independent packages now available:
 ### Changed
 
 - **Compilation Quality**: Achieved ZERO compilation warnings (reduced from 88)
-  - Fixed all undefined function warnings (49 → 0)
-  - Resolved unused variable warnings (15 → 0)
+  - Fixed all undefined function warnings (49 -> 0)
+  - Resolved unused variable warnings (15 -> 0)
   - Fixed Logger.warn deprecation warnings
   - Created missing modules and corrected all API references
   - Full `--warnings-as-errors` compliance
@@ -742,7 +742,7 @@ Four independent packages now available:
 
 - **Performance Metrics**: Parser 3.3μs/op | Memory <2.8MB | Render <1ms
 - **Code Reduction**: 722 lines removed, 150+ duplicate patterns eliminated
-- **Module Consolidation**: 43+ modules consolidated, state management unified (16→4 managers)
+- **Module Consolidation**: 43+ modules consolidated, state management unified (16->4 managers)
 - **Documentation**: Updated README.md and CLAUDE.md with accurate commands
 
 ## [1.3.0] - 2025-09-12
@@ -1131,7 +1131,7 @@ mix credo
   - Animation: 971K FPS max, 99.5% smoothness
 
 - **Performance Breakthrough**
-  - Parser performance: 30x improvement (648μs → 3.3μs per operation)
+  - Parser performance: 30x improvement (648μs -> 3.3μs per operation)
   - EmulatorLite architecture: GenServer-free parsing path
   - SGR processor: 442x speedup using pattern matching optimization
   - All tests migrated to optimized architecture
@@ -1268,7 +1268,7 @@ mix credo
 ### Added
 
 - **Phase 8: Release Process Streamlining (COMPLETED)**
-  - Simplified `burrito.exs` configuration (127→98 lines, 23% reduction)
+  - Simplified `burrito.exs` configuration (127->98 lines, 23% reduction)
   - Added standardized mix aliases for release tasks:
     - `mix release.dev` - Development builds
     - `mix release.prod` - Production builds

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -1,6 +1,6 @@
 # Packages
 
-Raxol ships as a main package plus 13 focused subsystems. Use the main `raxol` package for the full framework, or grab individual packages for narrower needs.
+Raxol ships as a main package plus 14 focused subsystems. Use the main `raxol` package for the full framework, or grab individual packages for narrower needs.
 
 ## Main
 
@@ -27,6 +27,7 @@ Raxol ships as a main package plus 13 focused subsystems. Use the main `raxol` p
 | [`raxol_payments`](https://hex.pm/packages/raxol_payments) | `{:raxol_payments, "~> 0.1"}` | Agent payments, Xochi cross-chain, stealth  |
 | `raxol_acp` (pre-alpha)                                    | `path: "packages/raxol_acp"`  | Virtuals Agent Commerce Protocol (seller)   |
 | `raxol_symphony` (pre-alpha)                               | `path: "packages/raxol_symphony"` | Tracker-driven coding-agent orchestrator |
+| `raxol_gateway` (pre-alpha)                                | `path: "packages/raxol_gateway"`  | Unified messaging gateway (multi-platform) |
 
 ## Surfaces
 
@@ -49,18 +50,19 @@ raxol_plugin   --> raxol_core
 
 raxol_agent    --> raxol + raxol_mcp
 raxol_payments --> raxol_agent (compile-time only)
-raxol_acp      --> raxol_payments, raxol_mcp (compile-time only)
+raxol_acp      --> raxol_payments (runtime), raxol_mcp + raxol_agent (compile-time only)
 raxol_symphony --> raxol_core, raxol_agent, raxol_mcp (all optional)
 
 raxol_speech   --> raxol_core (+ bumblebee/nx/exla optional for STT)
 raxol_telegram --> raxol_core (+ raxol/telegex optional)
 raxol_watch    --> raxol_core (+ pigeon optional for APNS/FCM)
+raxol_gateway  --> raxol_core (+ raxol_agent optional)
 
 raxol_core     --> telemetry (only external dep)
 raxol_sensor   --> (none)
 ```
 
-The main `raxol` package does not depend on `raxol_agent`, `raxol_acp`, or any of the surface packages. You opt into those.
+The main `raxol` package does not depend on `raxol_agent`, `raxol_acp`, `raxol_gateway`, or any of the surface packages. You opt into those.
 
 ## Publishing
 

--- a/docs/adr/0005-runtime-plugin-system-architecture.md
+++ b/docs/adr/0005-runtime-plugin-system-architecture.md
@@ -141,14 +141,14 @@ The runtime approach lets plugins hot-load without process restarts and uses BEA
 ## References
 
 - [Plugin Development Guide](../plugins/GUIDE.md)
-- [Plugin Manager](../../lib/raxol/core/runtime/plugins/plugin_manager.ex)
-- [Plugin Behaviour](../../lib/raxol/core/runtime/plugins/plugin.ex)
-- [Lifecycle Management](../../lib/raxol/core/runtime/plugins/lifecycle.ex)
-- [State Management](../../lib/raxol/core/runtime/plugins/state_manager.ex)
+- [Plugin Manager](../../packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_manager.ex)
+- [Plugin Behaviour](../../packages/raxol_core/lib/raxol/core/runtime/plugins/plugin.ex)
+- [Lifecycle Management](../../packages/raxol_core/lib/raxol/core/runtime/plugins/lifecycle.ex)
+- [State Management](../../packages/raxol_core/lib/raxol/core/runtime/plugins/state_manager.ex)
 - [Dependency Manager](../../lib/raxol/core/runtime/plugins/dependency_manager.ex)
-- [Plugin Supervisor](../../lib/raxol/core/runtime/plugins/plugin_supervisor.ex)
-- [BEAM Analyzer](../../lib/raxol/core/runtime/plugins/security/beam_analyzer.ex)
-- [Capability Detector](../../lib/raxol/core/runtime/plugins/security/capability_detector.ex)
+- [Plugin Supervisor](../../packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_supervisor.ex)
+- [BEAM Analyzer](../../packages/raxol_core/lib/raxol/core/runtime/plugins/security/beam_analyzer.ex)
+- [Capability Detector](../../packages/raxol_core/lib/raxol/core/runtime/plugins/security/capability_detector.ex)
 
 ---
 

--- a/docs/adr/0008-phoenix-liveview-integration-architecture.md
+++ b/docs/adr/0008-phoenix-liveview-integration-architecture.md
@@ -172,7 +172,7 @@ LiveView gives us the best balance of performance, developer experience, and fea
 
 ## References
 
-- [TEALive Bridge](../../lib/raxol/live_view/tea_live.ex)
+- [TEALive Bridge](../../packages/raxol_liveview/lib/raxol/live_view/tea_live.ex)
 - [Phoenix LiveView Docs](https://hexdocs.pm/phoenix_live_view/)
 
 ---

--- a/docs/adr/0009-high-performance-buffer-management.md
+++ b/docs/adr/0009-high-performance-buffer-management.md
@@ -154,9 +154,9 @@ Telemetry-based metrics for operation latency and memory consumption via `:telem
 
 ## References
 
-- [BufferServer](../../lib/raxol/terminal/buffer/buffer_server.ex)
-- [Damage Tracker](../../lib/raxol/terminal/buffer/damage_tracker.ex)
-- [Buffer Manager](../../lib/raxol/terminal/buffer/buffer_manager.ex)
+- [BufferServer](../../packages/raxol_terminal/lib/raxol/terminal/buffer/buffer_server.ex)
+- [Damage Tracker](../../packages/raxol_terminal/lib/raxol/terminal/buffer/damage_tracker.ex)
+- [Buffer Manager](../../packages/raxol_terminal/lib/raxol/terminal/buffer/buffer_manager.ex)
 
 ---
 

--- a/docs/adr/0011-terminal-module-consolidation.md
+++ b/docs/adr/0011-terminal-module-consolidation.md
@@ -98,7 +98,7 @@ The audit confirmed existing GenServers (ConfigServer, MetricsCollector) already
 
 ## References
 
-- [Terminal Format Module](../../lib/raxol/terminal/format.ex)
+- [Terminal Format Module](../../packages/raxol_terminal/lib/raxol/terminal/format.ex)
 - [Performance Cache Module](../../lib/raxol/performance/cache.ex)
 - [ADR-0003: Terminal Emulation Strategy](0003-terminal-emulation-strategy.md)
 

--- a/docs/adr/0015-workflow-graph.md
+++ b/docs/adr/0015-workflow-graph.md
@@ -60,15 +60,15 @@ We will add `Raxol.Workflow.*` to main raxol as the canonical multi-step orchest
 
 Top-level `Raxol.Workflow.*` inside main raxol. Submodules:
 
-- `Raxol.Workflow.Graph` -- immutable graph builder (the construction-time API)
-- `Raxol.Workflow.Compiled` -- the runtime API after `Graph.compile/2`
-- `Raxol.Workflow.Node` -- node descriptor structs (`FunctionNode`, `BehaviourNode`, `TypedNode`)
-- `Raxol.Workflow.Edge` -- edge descriptor structs (`Edge`, `GuardedEdge`, `ConditionalEdge`)
-- `Raxol.Workflow.Checkpoint` -- checkpoint records and `Checkpoint.Saver` behaviour
-- `Raxol.Workflow.Checkpoint.Saver.Ets`, `Raxol.Workflow.Checkpoint.Saver.Dets` -- adapters
-- `Raxol.Workflow.Execution.Scratchpad` -- per-task execution state (process dict, justified)
-- `Raxol.Workflow.Execution.Channel` -- typed channel reducers between nodes
-- `Raxol.Workflow.Interrupt` -- the throw-caught exception used to pause a run
+- `Raxol.Workflow.Graph`: immutable graph builder (the construction-time API)
+- `Raxol.Workflow.Compiled`: the runtime API after `Graph.compile/2`
+- `Raxol.Workflow.Node`: node descriptor structs (`FunctionNode`, `BehaviourNode`, `TypedNode`)
+- `Raxol.Workflow.Edge`: edge descriptor structs (`Edge`, `GuardedEdge`, `ConditionalEdge`)
+- `Raxol.Workflow.Checkpoint`: checkpoint records and `Checkpoint.Saver` behaviour
+- `Raxol.Workflow.Checkpoint.Saver.Ets`, `Raxol.Workflow.Checkpoint.Saver.Dets`: adapters
+- `Raxol.Workflow.Execution.Scratchpad`: per-task execution state (process dict, justified)
+- `Raxol.Workflow.Execution.Channel`: typed channel reducers between nodes
+- `Raxol.Workflow.Interrupt`: the throw-caught exception used to pause a run
 
 No new package. No optional Mix dep. Workflow is part of `raxol` and ships with it.
 
@@ -103,10 +103,10 @@ Channels (`add_channel/4`) declare typed reducers between nodes. A workflow that
 
 `Raxol.Workflow.Compiled` exposes four entry points:
 
-- `invoke(compiled, initial_state, opts)` -- run synchronously to completion or interrupt. Returns `{:ok, final_state}` | `{:interrupted, run_id, state}` | `{:error, reason}`.
-- `async_invoke(compiled, initial_state, opts)` -- spawn the run under `DynamicSupervisor`, return the run pid + ref. Caller subscribes to `Phoenix.PubSub` events to follow progress.
-- `stream_events(compiled, initial_state, opts)` -- returns a lazy `Stream` of `Raxol.Core.Events.CloudEvent` structs as the run progresses. Each node emits start/stop events; the stream completes when the run terminates.
-- `resume(compiled, run_id, resume_value, opts)` -- consume an interrupt: hydrate from the checkpoint, feed `resume_value` to the scratchpad's resume queue, continue execution. Returns the same shape as `invoke/3`.
+- `invoke(compiled, initial_state, opts)`: run synchronously to completion or interrupt. Returns `{:ok, final_state}` | `{:interrupted, run_id, state}` | `{:error, reason}`.
+- `async_invoke(compiled, initial_state, opts)`: spawn the run under `DynamicSupervisor`, return the run pid + ref. Caller subscribes to `Phoenix.PubSub` events to follow progress.
+- `stream_events(compiled, initial_state, opts)`: returns a lazy `Stream` of `Raxol.Core.Events.CloudEvent` structs as the run progresses. Each node emits start/stop events; the stream completes when the run terminates.
+- `resume(compiled, run_id, resume_value, opts)`: consume an interrupt: hydrate from the checkpoint, feed `resume_value` to the scratchpad's resume queue, continue execution. Returns the same shape as `invoke/3`.
 
 Failure policy (`:retry`, `:halt`, `:compensate`), per-step timeout (`step_timeout_ms`), and total run timeout (`run_timeout_ms`) are options on `compile/2`. The runtime emits CloudEvents at the boundaries: `raxol.workflow.run.started`, `raxol.workflow.node.started`, `raxol.workflow.node.completed`, `raxol.workflow.node.failed`, `raxol.workflow.run.interrupted`, `raxol.workflow.run.completed`. Each event carries `trace_id`, `span_id`, `parent_span_id`, and `causation_id` via the Phase 24 propagation; subscribers can reconstruct the full execution graph from telemetry alone.
 
@@ -129,8 +129,8 @@ Failure policy (`:retry`, `:halt`, `:compensate`), per-step timeout (`step_timeo
 
 Two adapters ship in this phase:
 
-- **Ets** -- in-process ETS table, cleared at app stop. Default for tests and short-lived runs.
-- **Dets** -- file-backed DETS, survives BEAM restarts. Default for `raxol_acp` durable jobs.
+- **Ets**: in-process ETS table, cleared at app stop. Default for tests and short-lived runs.
+- **Dets**: file-backed DETS, survives BEAM restarts. Default for `raxol_acp` durable jobs.
 
 A `Saver.Postgrex` adapter is a natural follow-up for shared deployments but is *not* in scope for Phase 25. The behaviour shape is meant to support it without modification.
 

--- a/docs/adr/0017-acp-workflow-paused-jobs.md
+++ b/docs/adr/0017-acp-workflow-paused-jobs.md
@@ -11,7 +11,7 @@ ADR-0016 Phase A shipped a Workflow-backed implementation of the ACP Job lifecyc
 - **Paused jobs are not enumerable.** `[:raxol, :workflow, :run, :interrupted]` telemetry carries the reason, but consumers building dashboards must capture every event and maintain their own index. The Saver behaviour has no cross-thread query primitive; `list/3` is per-thread.
 - **The runtime writes no checkpoint for the interrupting node.** When a node throws `{:__workflow_interrupt__, value}`, the runtime emits `[:raxol, :workflow, :run, :interrupted]` and returns `{:interrupted, run_id, state, value}` to the caller (`lib/raxol/workflow/runtime.ex:502-516`). The latest checkpoint remains the *previous* successful node (`test/raxol/workflow/resume_test.exs:55` was the oracle for this invariant). Paused-ness is not derivable from Saver state.
 
-A seller building a "list active offers, here is what each one is waiting on" view today has to subscribe to telemetry, build an in-memory thread index, and reconcile that index against process death. The ACP semantic — "this job is paused, waiting for the buyer's signature" — is real, durable, and cross-node, but the substrate to express it queryably does not exist.
+A seller building a "list active offers, here is what each one is waiting on" view today has to subscribe to telemetry, build an in-memory thread index, and reconcile that index against process death. The ACP semantic ("this job is paused, waiting for the buyer's signature") is real, durable, and cross-node, but the substrate to express it queryably does not exist.
 
 ADR-0016 Phase B sketched a one-paragraph solution: "the seller's 'list paused jobs' view becomes a query against `Saver.list/3` filtered by jobs whose latest checkpoint metadata contains an `interrupt_reason`. Postgrex makes this a `WHERE` clause; Dets is a full scan but bounded." That sketch papered over three load-bearing details:
 
@@ -64,7 +64,7 @@ Two new telemetry events, both at the run level:
 
 The pre-existing `[:raxol, :workflow, :run, :interrupted]` continues to fire and gains an additional `interrupt_reason` key alongside the legacy `value` key. Consumers can migrate to `interrupt_reason` at their own pace; `value` is removed in the next breaking release.
 
-The three events together describe the lifecycle of a paused run as a sequence: `:interrupted` (the node threw, no durability yet) → `:paused` (the checkpoint committed) → `:resumed` (the resume is starting, before the node re-executes). Existing consumers that only care about "a run paused" can continue listening to `:interrupted`; consumers that care about durability subscribe to `:paused`.
+The three events together describe the lifecycle of a paused run as a sequence: `:interrupted` (the node threw, no durability yet) -> `:paused` (the checkpoint committed) -> `:resumed` (the resume is starting, before the node re-executes). Existing consumers that only care about "a run paused" can continue listening to `:interrupted`; consumers that care about durability subscribe to `:paused`.
 
 ### 4. New Saver callback: `list_paused/2`
 
@@ -121,7 +121,7 @@ The function lives on `Job.Server` because that module is already the public fac
 
 ### 6. Phase-typed reasons in raxol_acp
 
-`Raxol.ACP.Job.Workflow` renames the two reasons whose waiter is ambiguous in the bare-event name: `:awaiting_payment` → `:awaiting_buyer_payment` and `:awaiting_approval` → `:awaiting_evaluator_approval`. `:awaiting_request_response` (seller decides) and `:awaiting_delivery` (both sides wait) stay unchanged.
+`Raxol.ACP.Job.Workflow` renames the two reasons whose waiter is ambiguous in the bare-event name: `:awaiting_payment` -> `:awaiting_buyer_payment` and `:awaiting_approval` -> `:awaiting_evaluator_approval`. `:awaiting_request_response` (seller decides) and `:awaiting_delivery` (both sides wait) stay unchanged.
 
 A module-level `Raxol.ACP.Job.Workflow.pause_reasons/0` returns the canonical four atoms in phase-ladder order so dashboards can enumerate the expected reasons without scraping module source.
 
@@ -145,7 +145,7 @@ A module-level `Raxol.ACP.Job.Workflow.pause_reasons/0` returns the canonical fo
 
 ### What this ADR supersedes
 
-- **ADR-0016 §B's 3-reason list.** The prose said `:awaiting_buyer_payment | :awaiting_evaluator_approval | :awaiting_delivery`. The implemented contract is the four reasons in `Raxol.ACP.Job.Workflow.pause_reasons/0`: `:awaiting_request_response, :awaiting_buyer_payment, :awaiting_delivery, :awaiting_evaluator_approval`. The four-reason form is canonical; the three-reason prose was a sketch.
+- **ADR-0016 section B's 3-reason list.** The prose said `:awaiting_buyer_payment | :awaiting_evaluator_approval | :awaiting_delivery`. The implemented contract is the four reasons in `Raxol.ACP.Job.Workflow.pause_reasons/0`: `:awaiting_request_response, :awaiting_buyer_payment, :awaiting_delivery, :awaiting_evaluator_approval`. The four-reason form is canonical; the three-reason prose was a sketch.
 - **The implicit "latest checkpoint is the predecessor of the interrupting node" invariant.** After this ADR, the latest checkpoint of a paused run is the interrupting node itself, distinguished by `metadata.interrupt_reason`. Resume routes accordingly. The change is surgically scoped to checkpoints whose metadata carries the marker.
 - **`:value` as the canonical metadata key on `:interrupted`.** Both `value` and `interrupt_reason` are emitted from this PR; `value` is removed in the next breaking release. Consumers should migrate to `interrupt_reason`.
 
@@ -161,7 +161,7 @@ Rejected. The mirror is downstream of the workflow runtime's view of paused-ness
 
 When an interrupt fires, update the most recent successful checkpoint's metadata with the new `interrupt_reason` and `paused_at` keys. No new checkpoint, no resume semantics change.
 
-Rejected. The append-only contract on `Saver.put/3` is documented (`saver.ex:16-22`) and consumers — including time-travel debugging and audit-log readers — depend on it. Breaking it for this one feature is a much bigger cost than the test updates required by the chosen approach. The `:erlang.term_to_binary/1`-backed metadata blob is also not easily mutated in place across all three adapters.
+Rejected. The append-only contract on `Saver.put/3` is documented (`saver.ex:16-22`) and consumers (including time-travel debugging and audit-log readers) depend on it. Breaking it for this one feature is a much bigger cost than the test updates required by the chosen approach. The `:erlang.term_to_binary/1`-backed metadata blob is also not easily mutated in place across all three adapters.
 
 ### Scan-by-telemetry only
 

--- a/docs/adr/0018-operator-flow-contract.md
+++ b/docs/adr/0018-operator-flow-contract.md
@@ -15,7 +15,7 @@ The cost of leaving it undocumented is concrete:
 - A future surface author (Slack? Discord? web hooks for incident management? voice-driven SMS?) has to grep across `surfaces/` to derive the contract. If they get it wrong, every other channel diverges from theirs and the vocabulary fractures.
 - The vocabulary itself (`:awaiting_X` where X names the *external party* the run is waiting on) is a convention that fell out of the four ACP `pause_reasons/0` atoms plus `Codex.pause_for_approval`'s `:awaiting_approval`. It is consistent but it is implicit. The next pause reason added will either match this convention or won't, and there's no document to push on.
 - The callback shape (`sym:resume:<issue_id>:<decision>`) appears in three places (`Telegram.Formatter`, `Watch.Formatter`, `MCP.symphony_resume_run`'s description). They agree by coincidence right now. They could drift.
-- The lifecycle event ordering (`:worker_paused` → operator decision → `:worker_resumed`; or at the run level `:interrupted` → `:paused` → `:resumed`) is real semantics that consumers can rely on. None of it is written down.
+- The lifecycle event ordering (`:worker_paused` -> operator decision -> `:worker_resumed`; or at the run level `:interrupted` -> `:paused` -> `:resumed`) is real semantics that consumers can rely on. None of it is written down.
 
 This ADR makes the cross-layer pattern explicit so the next consumer doesn't have to re-derive it from the code.
 
@@ -97,7 +97,7 @@ Other operator-action callbacks in the same `sym:` namespace:
 
 A channel that renders Symphony state is obligated to render paused runs distinctly. The contract is *what*, not *how*:
 
-- The header / summary line must include the paused count separately from the running and retrying counts. (`"running 2, paused 1, retrying 0"` — not bundled into "active".)
+- The header / summary line must include the paused count separately from the running and retrying counts. (`"running 2, paused 1, retrying 0"`, not bundled into "active".)
 - The detail view must show, per paused entry: `issue_identifier`, `interrupt_reason` (via `format_reason/1` or equivalent), `paused_ms_ago`, and at least one of `last_event` or `last_message`.
 - The action surface must offer an operator-driven resume path that emits a `sym:resume:<issue_id>:<decision>` callback. The channel may add other actions (Stop, Dismiss, Refresh) but Approve+Reject (or equivalent) for paused entries is required.
 - The `empty_snapshot()` fallback (when the orchestrator is unreachable) must include `paused: []` and `counts.paused: 0` so the contract holds even under failure.
@@ -130,7 +130,7 @@ A channel that wants to expose pause state programmatically (an HTTP API, a quer
 ### What becomes possible
 
 - **New channels onboard without re-deriving the pattern.** A Slack or Discord author reads this ADR, builds a `Formatter`, and inherits the cross-channel callback shape for free.
-- **Cross-channel resolution.** An operator can pause on Watch, switch to their desk, see the same paused run on the LiveView dashboard, and resume from Telegram on their phone — all without losing context, because the `interrupt_reason` vocabulary and the issue_id are uniform.
+- **Cross-channel resolution.** An operator can pause on Watch, switch to their desk, see the same paused run on the LiveView dashboard, and resume from Telegram on their phone, all without losing context, because the `interrupt_reason` vocabulary and the issue_id are uniform.
 - **Cross-runner pause adoption.** A new runner (Anthropic-direct, OpenAI, a custom one) maps blocking operations to `{:pause, :awaiting_<subject>, token}` and gets channel surfacing for free. No surface-side changes needed.
 - **Analytics and audit.** Subscribing to `[:raxol, :workflow, :run, :paused | :resumed]` gives durable lifecycle data with `causation_id` chaining (per Phase 24). "How long was this paused before resolution?" becomes a metric.
 - **MCP-driven incident response.** Operators (or other agents) can write tools that walk paused runs and apply policies (auto-approve known-safe commands, escalate unknown ones to humans). The `interrupt_reason` vocabulary is the policy surface.
@@ -140,7 +140,7 @@ A channel that wants to expose pause state programmatically (an HTTP API, a quer
 - **The vocabulary is open.** New pause reasons land as new atoms with no registry, which means a typo (`:awating_review` vs `:awaiting_review`) ships and the offending runner emits an atom no surface filters on. Mitigation: each runner module documents its emitted atoms in the moduledoc; channel formatters' `format_reason/1` fallback prints the atom verbatim so the bug is visible.
 - **The callback shape is convention, not enforcement.** A surface author who ignores the `sym:resume:<issue_id>:<decision>` shape and rolls their own breaks cross-channel resolution. Mitigation: the ADR's "recipe" section makes the shape explicit and the three existing surfaces' code is the reference.
 - **The lifecycle event ordering is a soft contract.** The Workflow runtime *can* emit `:paused` without a preceding `:interrupted` if a future runtime change writes the pause checkpoint outside the node-catch path. Today the ordering holds because there's one code path; future changes must preserve it explicitly.
-- **Channel obligations are minimum bars.** A channel that shows only a paused count without per-entry details satisfies the letter but defeats the operator-flow purpose. Mitigation: the contract is what to show, not how — implementing reviewers can apply judgment.
+- **Channel obligations are minimum bars.** A channel that shows only a paused count without per-entry details satisfies the letter but defeats the operator-flow purpose. Mitigation: the contract is what to show, not how, so implementing reviewers can apply judgment.
 - **The `sym:approve:<issue_id>` legacy callback survives.** Used by `run_notification/1` in the Watch formatter for non-paused runs (the "Human Review" pattern), not for paused runs. Documented as legacy; phasing out tracked separately.
 
 ### What this ADR does not decide
@@ -164,7 +164,7 @@ Rejected. The vocabulary's value is the convention, not the enforcement. A regis
 
 Replace the atom with `%PauseReason{name: atom(), party: atom(), severity: atom()}` so surfaces can render structured fields rather than calling `Atom.to_string/1`.
 
-Rejected. The struct buys nothing the channel formatters' existing `format_reason/1` helpers don't already do. Severity is a surface decision (Watch wants `:high` priority on `:worker_paused`, LiveView doesn't care). Party is implicit in the atom name and varies — `:awaiting_ci` waits on a system, `:awaiting_human_approval` waits on a person; a single `:party` field flattens that distinction. The atom carries the information; the struct just hides it.
+Rejected. The struct buys nothing the channel formatters' existing `format_reason/1` helpers don't already do. Severity is a surface decision (Watch wants `:high` priority on `:worker_paused`, LiveView doesn't care). Party is implicit in the atom name and varies: `:awaiting_ci` waits on a system, `:awaiting_human_approval` waits on a person; a single `:party` field flattens that distinction. The atom carries the information; the struct just hides it.
 
 ### A different callback namespace per channel
 
@@ -176,7 +176,7 @@ Rejected. The whole point of the `sym:resume:` shape is that one router can hand
 
 Put the contract in `Telegram.Formatter`'s moduledoc, `Watch.Formatter`'s moduledoc, `MCP.symphony_list_paused`'s description, etc. Skip the ADR.
 
-Rejected. Moduledocs are great for module-local contracts but cross-layer patterns disappear into them. The pattern *between* channels — the convergence on a shared vocabulary and a shared callback shape — is exactly the thing an ADR is for. Future surface authors will read the existing moduledocs *plus* the ADR; the ADR is the single source.
+Rejected. Moduledocs are great for module-local contracts but cross-layer patterns disappear into them. The pattern *between* channels (the convergence on a shared vocabulary and a shared callback shape) is exactly the thing an ADR is for. Future surface authors will read the existing moduledocs *plus* the ADR; the ADR is the single source.
 
 ### Defer until a third runner is needed
 

--- a/docs/adr/0019-workflow-concurrency.md
+++ b/docs/adr/0019-workflow-concurrency.md
@@ -13,26 +13,26 @@ Proposed, 2026-06-16. Direct follow-up to ADR-0015 (Workflow Graph), which shipp
 The deferral is intentional. ADR-0015 prioritized a working runtime with checkpoints, interrupts, retry, compensate, and Postgrex durability over a richer execution model. Phase 25 shipped four months of capability inside that constraint; the deferred concurrency primitive is now the natural next chunk because every consumer that's piled on top of the runtime has the same shape:
 
 - **raxol_acp** Job.Workflow is a 10-node graph that walks one phase ladder. Cross-chain settlement (Xochi mandates, multi-party escrow) wants two on-chain calls in parallel followed by a reduction.
-- **Symphony** GraphAdapter is a 5-node strictly-sequential pipeline (`tracker_poll → candidate_selection → runner_dispatch → evidence_collection → completion` at `packages/raxol_symphony/lib/raxol/symphony/workflow/graph_adapter.ex:18-30`). The orchestrator gets concurrency at the *process* level by spawning multiple workers (`DynamicSupervisor` + `max_concurrent_agents`), each running the graph independently. The graph itself can't fan out.
+- **Symphony** GraphAdapter is a 5-node strictly-sequential pipeline (`tracker_poll -> candidate_selection -> runner_dispatch -> evidence_collection -> completion` at `packages/raxol_symphony/lib/raxol/symphony/workflow/graph_adapter.ex:18-30`). The orchestrator gets concurrency at the *process* level by spawning multiple workers (`DynamicSupervisor` + `max_concurrent_agents`), each running the graph independently. The graph itself can't fan out.
 - **Future Phase 26 sandboxed agents** will want to dispatch sub-tasks in parallel inside one workflow run rather than orchestrating that at the agent's `update/2` callback.
 
-The single existing parallel-adjacent feature is `ConditionalEdge.chooser` (in `lib/raxol/workflow/edge.ex:51-73`): its return type is documented as `(state → id | [id])` but the runtime only honors single-id returns. `runtime.ex:813-836` `pick_next/2` returns `{:ok, single_id} | :no_match | {:error, _}` — a list of ids is not destructured. That mismatch is the cleanest seam to extend.
+The single existing parallel-adjacent feature is `ConditionalEdge.chooser` (in `lib/raxol/workflow/edge.ex:51-73`): its return type is documented as `(state -> id | [id])` but the runtime only honors single-id returns. `runtime.ex:813-836` `pick_next/2` returns `{:ok, single_id} | :no_match | {:error, _}`; a list of ids is not destructured. That mismatch is the cleanest seam to extend.
 
 ### What ADR-0015 said about deferring
 
-ADR-0015 §96 quoted joins explicitly:
+ADR-0015 (joins) quoted them explicitly:
 
 > Join nodes (`add_join/4`) act as barriers: multiple incoming edges feed an N-arity reducer that produces the next state.
 
-And §98 quoted channels:
+And on channels:
 
 > Channels (`add_channel/4`) declare typed reducers between nodes. A workflow that fans out to three parallel branches each emitting a partial state can reduce them through a `Channel{:partial, into: :final, with: &Map.merge/2}` declaration.
 
-ADR-0015 §187-191 listed the deferred work plainly: distributed execution, joins, channels. Phase 25 was "make the single-branch substrate solid", and Phase 25 succeeded — `MIX_ENV=test mix test test/raxol/workflow/` passes 143/0 today.
+ADR-0015 listed the deferred work plainly: distributed execution, joins, channels. Phase 25 was "make the single-branch substrate solid", and Phase 25 succeeded: `MIX_ENV=test mix test test/raxol/workflow/` passes 143/0 today.
 
 ### Why this is a runtime change, not a library
 
-`Raxol.Workflow.Async` already provides `async_invoke/3` and `stream_events/3` for *external* concurrency — spawn a workflow run on another process, stream its events back. That doesn't help: the *graph itself* is still sequential. A consumer that wants two memo writes to happen at the same time can't express that as a graph; they have to spawn a Task inside one node's body and lose the runtime's checkpoint + retry + compensate + telemetry semantics for the parallel work. Graph-level concurrency means those semantics extend uniformly to the parallel branches.
+`Raxol.Workflow.Async` already provides `async_invoke/3` and `stream_events/3` for *external* concurrency: spawn a workflow run on another process, stream its events back. That doesn't help: the *graph itself* is still sequential. A consumer that wants two memo writes to happen at the same time can't express that as a graph; they have to spawn a Task inside one node's body and lose the runtime's checkpoint + retry + compensate + telemetry semantics for the parallel work. Graph-level concurrency means those semantics extend uniformly to the parallel branches.
 
 ### Greenfield design constraints
 
@@ -62,7 +62,7 @@ Graph.new(:partial_collect)
 |> Graph.add_edge(:report, :__end__)
 ```
 
-`add_channel/4` is metadata only — it doesn't add nodes or edges. It registers `{channel_name, %{into: key, with: reducer}}` on the Graph struct's new `channels` field. The Compiled struct picks it up.
+`add_channel/4` is metadata only: it doesn't add nodes or edges. It registers `{channel_name, %{into: key, with: reducer}}` on the Graph struct's new `channels` field. The Compiled struct picks it up.
 
 ### `add_join/4`
 
@@ -75,8 +75,8 @@ add_join(graph, target_node_id, upstream_ids, opts \\ [])
 - `target_node_id`: the join's own node id (must have been added via `add_node/3,4`).
 - `upstream_ids`: the list of branch nodes that must complete before the join runs. Must match the candidates of an earlier `add_conditional_edge` exactly (compiler validates).
 - `opts`:
-  - `:reduce` — explicit reducer `(state_list -> merged_state)`. Default: apply per-channel reducers; for keys not covered by a channel, use last-write-wins by branch order.
-  - `:timeout_ms` — max wall-clock to wait for all branches. On timeout, the join fails with `{:error, {:branch_timeout, missing_branches}}`. Default: inherit the run's `:run_timeout_ms`.
+  - `:reduce`: explicit reducer `(state_list -> merged_state)`. Default: apply per-channel reducers; for keys not covered by a channel, use last-write-wins by branch order.
+  - `:timeout_ms`: max wall-clock to wait for all branches. On timeout, the join fails with `{:error, {:branch_timeout, missing_branches}}`. Default: inherit the run's `:run_timeout_ms`.
 
 A `JoinEdge` edge type is created: `%JoinEdge{from: target_node_id, upstream: [ids], reducer: opts}`. The Compiled struct indexes it under `joins_by_node` for O(1) barrier lookup. The runtime keeps a `branch_completions` map per run keyed on `target_node_id` and counts down as branches arrive.
 
@@ -99,7 +99,7 @@ metadata: %{
 }
 ```
 
-`branch_id` is `nil` for any checkpoint that's not inside a parallel branch (which is *every* checkpoint in any existing graph — full back-compat). Inside a parallel branch, it's `{join_id, branch_index}` where `branch_index` is the position in the upstream list passed to `add_join/4`. The Saver's `list_paused/2` (per ADR-0017) returns all paused branches as separate entries; consumers can group by `run_id` to see "this run has three branches, two are awaiting CI, one is awaiting human approval."
+`branch_id` is `nil` for any checkpoint that's not inside a parallel branch (which is *every* checkpoint in any existing graph, full back-compat). Inside a parallel branch, it's `{join_id, branch_index}` where `branch_index` is the position in the upstream list passed to `add_join/4`. The Saver's `list_paused/2` (per ADR-0017) returns all paused branches as separate entries; consumers can group by `run_id` to see "this run has three branches, two are awaiting CI, one is awaiting human approval."
 
 `Saver` callback signature stays unchanged. The shape change is in metadata, which is opaque to the Saver.
 
@@ -145,12 +145,12 @@ Compile failures match the existing error tuple shape from ADR-0015's `compile/2
 
 ### What costs we accept
 
-- **Runtime complexity grows.** The sequential `step → traverse → step` loop becomes a state machine that tracks open branches per run, blocks on joins, handles per-branch failures + retries + compensations + pauses. The new code is bounded (~400 LOC of runtime + ~150 of compile-time validation + ~200 of test coverage) but it is real concurrency-aware code with race-condition surface.
+- **Runtime complexity grows.** The sequential `step -> traverse -> step` loop becomes a state machine that tracks open branches per run, blocks on joins, handles per-branch failures + retries + compensations + pauses. The new code is bounded (~400 LOC of runtime + ~150 of compile-time validation + ~200 of test coverage) but it is real concurrency-aware code with race-condition surface.
 - **`branch_id` is added to checkpoint metadata everywhere.** Existing checkpoints have `branch_id: nil` (which sequential code already handles via map access). Stored checkpoints from before this ADR don't have the field at all; reading them with the new runtime gets `nil` from `Map.get/3`. Forward compatible; not backward compatible from the new runtime's perspective.
-- **The chooser-returns-list path goes from "documented but ignored" to "load-bearing".** Any third-party Graph builder that returned lists from its chooser was previously seeing `{:error, {:chooser_returned_non_id, list}}` — and presumably has been writing single-id choosers. After this ADR, list returns become valid. No behavior change for single-id choosers.
+- **The chooser-returns-list path goes from "documented but ignored" to "load-bearing".** Any third-party Graph builder that returned lists from its chooser was previously seeing `{:error, {:chooser_returned_non_id, list}}`, and presumably has been writing single-id choosers. After this ADR, list returns become valid. No behavior change for single-id choosers.
 - **Compensation order in parallel regions is topological, not temporal.** If branch A finishes in 100ms and branch B in 50ms, and the join later fails, compensation runs A's nodes before B's (because A is the first branch in the upstream list). For most consumers this is fine; for state-dependent compensation it could matter. Documented in `failure_policy: :compensate`'s moduledoc.
 - **Saver shape change is metadata-only.** Adapters don't need to change. Pre-ADR Saver implementations that strip metadata to specific keys would silently drop `branch_id`; the documented contract is "Saver returns metadata verbatim from `put/3`" so any adapter that does that is correct.
-- **No cancellation cascade.** If branch A fails with `:halt`, branches B and C don't get killed — they finish their current node and then the run fails when their next checkpoint commits. Acceptable trade-off: cancellation cascade requires linking the parent process to each branch task, which complicates the `Task.async_stream` shape and breaks the per-attempt span isolation that retry semantics rely on. Cascaded cancellation can land as a follow-up.
+- **No cancellation cascade.** If branch A fails with `:halt`, branches B and C don't get killed; they finish their current node and then the run fails when their next checkpoint commits. Acceptable trade-off: cancellation cascade requires linking the parent process to each branch task, which complicates the `Task.async_stream` shape and breaks the per-attempt span isolation that retry semantics rely on. Cascaded cancellation can land as a follow-up.
 
 ### What this ADR does not decide
 
@@ -208,14 +208,14 @@ How we know the design is right:
 - **A reference parallel workflow lands as `test/raxol/workflow/parallel_test.exs`.** Two-branch fan-out, three-branch fan-out, mixed channel reducers, branch-failure-during-fan-out, pause-inside-branch, retry-per-branch, compensate-across-branches. ~12 tests covering the new surface.
 - **`raxol_acp` adopts joins for a cross-chain settlement demo.** ACP today doesn't need joins (each ACP job walks one chain). A demo workflow under `packages/raxol_acp/examples/` that simulates a two-chain settlement validates the API ergonomics from a real consumer's perspective.
 - **Symphony GraphAdapter stays sequential.** No changes required. The ADR-0019 work doesn't touch Symphony's graph; that adoption is a separate follow-up gated on Symphony's PausedSaver work landing.
-- **Telemetry round-trip:** a fan-out → join run emits `[:raxol, :workflow, :node, :*]` events with `branch_id` set on the parallel branches and `nil` on the rest. Property test verifies branch_id is set if and only if the node is downstream of a `ConditionalEdge` whose chooser returned a list.
+- **Telemetry round-trip:** a fan-out -> join run emits `[:raxol, :workflow, :node, :*]` events with `branch_id` set on the parallel branches and `nil` on the rest. Property test verifies branch_id is set if and only if the node is downstream of a `ConditionalEdge` whose chooser returned a list.
 - **Compile errors match the ADR-0015 shape:** structured tuples, no exceptions thrown, every invalid join configuration produces an actionable error.
 
 ## References
 
-- ADR-0015: Workflow Graph (`Raxol.Workflow.*`) — Phase 25 runtime, this ADR's predecessor
-- ADR-0017: Workflow paused-run query and pause-checkpoint contract — the metadata-extension precedent
-- ADR-0018: Operator-flow contract for paused runs — the per-channel surfacing the new branch-level events will flow through
+- ADR-0015: Workflow Graph (`Raxol.Workflow.*`): Phase 25 runtime, this ADR's predecessor
+- ADR-0017: Workflow paused-run query and pause-checkpoint contract: the metadata-extension precedent
+- ADR-0018: Operator-flow contract for paused runs: the per-channel surfacing the new branch-level events will flow through
 - `lib/raxol/workflow/runtime.ex:29-30` (the deferral comment quoted in Context)
 - `lib/raxol/workflow/runtime.ex:813-836` (`pick_next/2`, the seam)
 - `lib/raxol/workflow/edge.ex:51-73` (`ConditionalEdge`, which already accepts list-returning choosers)
@@ -223,4 +223,4 @@ How we know the design is right:
 - `lib/raxol/workflow/checkpoint.ex:31-48` (Checkpoint struct, where `branch_id` lands in metadata)
 - `packages/raxol_symphony/lib/raxol/symphony/workflow/graph_adapter.ex:18-30` (Symphony's sequential pipeline, the largest existing consumer)
 - LangGraph's channel design (referenced for naming, not constraint)
-- `caudena/beam_weaver` (cited in ADR-0015 §18; concurrency layer not adopted in Phase 25)
+- `caudena/beam_weaver` (cited in ADR-0015; concurrency layer not adopted in Phase 25)

--- a/docs/adr/0020-agent-sandbox-thread-policies.md
+++ b/docs/adr/0020-agent-sandbox-thread-policies.md
@@ -1,4 +1,4 @@
-# ADR-0020: Phase 26 — Agent Sandbox, Thread log, declarative Policies
+# ADR-0020: Phase 26: Agent Sandbox, Thread log, declarative Policies
 
 ## Status
 
@@ -12,15 +12,15 @@ Three structural gaps emerge as the agent stack picks up real consumers:
 
 ### Gap 1: Isolation is one-dimensional
 
-`PermissionHook`'s five modes are linear: each mode is a strict superset of the one below. A consumer that wants "filesystem reads anywhere but network calls only to api.openai.com and api.anthropic.com" cannot express that. The closest fit is `:full_access` (which permits network calls everywhere) plus a per-call check inside the agent's `update/2` body — which puts policy in imperative code rather than declarative configuration. Authors of multi-agent systems (a coordinator + several worker agents) cannot give each worker a different sandbox shape without writing custom CommandHooks per worker.
+`PermissionHook`'s five modes are linear: each mode is a strict superset of the one below. A consumer that wants "filesystem reads anywhere but network calls only to api.openai.com and api.anthropic.com" cannot express that. The closest fit is `:full_access` (which permits network calls everywhere) plus a per-call check inside the agent's `update/2` body, which puts policy in imperative code rather than declarative configuration. Authors of multi-agent systems (a coordinator + several worker agents) cannot give each worker a different sandbox shape without writing custom CommandHooks per worker.
 
-The structural issue is that `PermissionHook` is a single behaviour with a single mode field. Sandbox is conceptually orthogonal — filesystem, network, shell, inter-agent messaging are independent dimensions — and the current model collapses them into one ladder. Mode `:workspace_write` permits workspace-relative file writes *and* inter-agent messaging *and* async tasks; an author who wants the first but not the second cannot get there.
+The structural issue is that `PermissionHook` is a single behaviour with a single mode field. Sandbox is conceptually orthogonal (filesystem, network, shell, inter-agent messaging are independent dimensions) and the current model collapses them into one ladder. Mode `:workspace_write` permits workspace-relative file writes *and* inter-agent messaging *and* async tasks; an author who wants the first but not the second cannot get there.
 
 ### Gap 2: No durable, cross-session audit trail
 
 The `ContextCompactor` (`packages/raxol_agent/lib/raxol/agent/context_compactor.ex`) handles in-memory session history compaction. `Agent.Process.maybe_compact_history/2` (lines 340, 372, 411-430) summarizes older messages into a continuation system message when the session goes over `compaction_config.max_tokens`. The agent's working memory holds the *summary*; the original messages are gone from process state.
 
-There is no separate, durable, append-only record of what the agent actually did. After compaction, the question "what tool calls did this agent make in the last 24 hours?" can only be answered by walking telemetry events. After process termination, even that is gone (telemetry handlers are per-session). After server restart, the message history is reconstructed from the ContextStore's ETS snapshot — which is itself ephemeral (`packages/raxol_agent/lib/raxol/agent/context_store.ex`).
+There is no separate, durable, append-only record of what the agent actually did. After compaction, the question "what tool calls did this agent make in the last 24 hours?" can only be answered by walking telemetry events. After process termination, even that is gone (telemetry handlers are per-session). After server restart, the message history is reconstructed from the ContextStore's ETS snapshot, which is itself ephemeral (`packages/raxol_agent/lib/raxol/agent/context_store.ex`).
 
 The same gap shows up in agent-to-MCP introspection: ADR-0012 made MCP a rendering target derived from the component tree, but agent activity (tool calls, directive emissions, state transitions) is not exposed as an MCP resource. An operator using Claude as an MCP client cannot ask "show me MyAgent's last 100 tool calls"; that data structurally doesn't exist as a durable record.
 
@@ -35,7 +35,7 @@ Every Action that needs retry, every tool that needs caching, every external API
 
 ### What ADR-0019 said about Phase 26
 
-ADR-0019 §17, §142 cited Phase 26 sandboxed agents explicitly as the consumer that wants parallel sub-tasks inside one workflow:
+ADR-0019 cited Phase 26 sandboxed agents explicitly as the consumer that wants parallel sub-tasks inside one workflow:
 
 > Phase 26 sandboxed agents can dispatch parallel sub-tasks (one shell command per branch, one file edit per branch) inside one workflow with uniform sandbox + thread-log + policy semantics.
 
@@ -96,7 +96,7 @@ The `authorize/4` callback is the canonical check: filesystem sandbox inspects p
 
 ### 2. `Raxol.Agent.ThreadLog` behaviour
 
-A ThreadLog is an append-only, durable, cross-session record of agent activity. Mirrors the `Raxol.Workflow.Checkpoint.Saver` shape — a behaviour with multiple adapters — but the unit of storage is a `ThreadEvent`, not a checkpoint.
+A ThreadLog is an append-only, durable, cross-session record of agent activity. Mirrors the `Raxol.Workflow.Checkpoint.Saver` shape (a behaviour with multiple adapters) but the unit of storage is a `ThreadEvent`, not a checkpoint.
 
 ```elixir
 @type thread_id :: binary()
@@ -158,7 +158,7 @@ defmodule MyAgent.FetchData do
 end
 ```
 
-The policies apply outermost-first at invocation: cache check → rate-limit check → timeout wrap → retry wrap → `Action.run/2`. The reverse order of declaration is intentional: the author lists "what I want true at the top" and the runtime peels them off in order.
+The policies apply outermost-first at invocation: cache check -> rate-limit check -> timeout wrap -> retry wrap -> `Action.run/2`. The reverse order of declaration is intentional: the author lists "what I want true at the top" and the runtime peels them off in order.
 
 **Four policy structs**:
 
@@ -219,9 +219,9 @@ The pipeline is opt-in: agents that don't declare a `sandbox/0`, `thread_log/0`,
 
 Three new event families:
 
-- `[:raxol, :agent, :sandbox, :denied]` — fires when a Sandbox returns `{:deny, reason}`. Metadata: `agent_id`, `dimension` (`:filesystem | :network | :shell | :send_agent | :resource`), `reason`, `causation_id`.
-- `[:raxol, :agent, :thread_log, :appended]` — fires after every ThreadLog write. Metadata: `agent_id`, `kind`, `sequence`. High-volume; consumers should sample.
-- `[:raxol, :agent, :policy, :*]` — `:retry_attempt`, `:retry_exhausted`, `:rate_limited`, `:cache_hit`, `:cache_miss`, `:timeout`. Metadata: `agent_id`, `action_name`, `policy_kind`, plus policy-specific fields.
+- `[:raxol, :agent, :sandbox, :denied]`: fires when a Sandbox returns `{:deny, reason}`. Metadata: `agent_id`, `dimension` (`:filesystem | :network | :shell | :send_agent | :resource`), `reason`, `causation_id`.
+- `[:raxol, :agent, :thread_log, :appended]`: fires after every ThreadLog write. Metadata: `agent_id`, `kind`, `sequence`. High-volume; consumers should sample.
+- `[:raxol, :agent, :policy, :*]`: `:retry_attempt`, `:retry_exhausted`, `:rate_limited`, `:cache_hit`, `:cache_miss`, `:timeout`. Metadata: `agent_id`, `action_name`, `policy_kind`, plus policy-specific fields.
 
 All three event families flow through Phase 24's CloudEvents envelope with `causation_id` chaining. The existing `[:raxol, :agent, :*]` event family is unchanged.
 
@@ -251,7 +251,7 @@ All three event families flow through Phase 24's CloudEvents envelope with `caus
 - **Policy composition DSL.** Policies are a list of structs in declaration order. A future "policies form a tree with conditional application" syntax is not in scope.
 - **MCP tool derivation from Actions.** ADR-0012 made MCP a rendering target from the component tree. Extending it to agent Actions (so every Action becomes a callable MCP tool automatically) is its own ADR; this ADR ships the durable backing (`agent://<agent_id>/thread`) but not the per-Action tool derivation.
 - **Audit log retention enforcement.** ThreadLog adapters don't auto-truncate. A future retention policy struct (`Policy.AuditRetention`) could land but isn't in scope.
-- **Sandbox enforcement on directives emitted from non-Action paths.** `update/2` callbacks that emit directives outside an Action invocation route through the existing CommandHook chain (which Sandboxes feed). They don't get policy application — Cache, Retry, RateLimit, Timeout are tied to the Action surface, not arbitrary directive emissions. Documented as a deliberate scope boundary.
+- **Sandbox enforcement on directives emitted from non-Action paths.** `update/2` callbacks that emit directives outside an Action invocation route through the existing CommandHook chain (which Sandboxes feed). They don't get policy application: Cache, Retry, RateLimit, Timeout are tied to the Action surface, not arbitrary directive emissions. Documented as a deliberate scope boundary.
 - **Cross-agent Cache sharing.** `Cache.Ets` is per-agent; `Cache.Postgrex` is per-config (which may be shared). Cross-agent invalidation primitives ("when AgentA writes, AgentB's cache for the same key invalidates") are out of scope.
 - **Compile-time sandbox verification.** A future dialyzer-flavored check that "this Action's body cannot escape its declared Sandbox" is interesting but speculative; not in scope.
 
@@ -273,7 +273,7 @@ Rejected. Per-dimension modules let each dimension carry its own validation sema
 
 The durable-audit-log primitive is generic. `raxol_payments` could use it for transaction logs; `raxol_acp` for memo dispatch logs.
 
-Rejected for now. The `ThreadLog` is tied to agent semantics (`kind: :tool_call | :tool_result | :message | :summary`) — the schema reflects agent activity. A generic durable log (`Raxol.AppendOnlyLog`) could be extracted later if a non-agent consumer needs it, but starting with the agent-specific shape avoids a premature abstraction.
+Rejected for now. The `ThreadLog` is tied to agent semantics (`kind: :tool_call | :tool_result | :message | :summary`): the schema reflects agent activity. A generic durable log (`Raxol.AppendOnlyLog`) could be extracted later if a non-agent consumer needs it, but starting with the agent-specific shape avoids a premature abstraction.
 
 ### Make policies first-class graph nodes (like Workflow channels)
 
@@ -302,7 +302,7 @@ How we know the design is right:
 - **Symphony's RaxolAgent runner stays green.** `packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex` consumes agents through the existing surface; Phase 26 changes don't break the runner or its 444+ Symphony tests.
 - **ThreadLog round-trip:** an agent writes 100 tool calls, restarts, reads them back from `ThreadLog.Ets` (in-process persistence via the Ets table) and `ThreadLog.Dets` (cross-restart). Property test: `list/3` returns exactly what `append/2` wrote, in order, no gaps in `sequence`.
 - **Postgrex adapter is opt-in and tested via `:integration` tags (same pattern as `Saver.Postgrex`)**: gated on `RAXOL_AGENT_PG_URL` or `POSTGRES_*` env vars.
-- **Policy applier order is property-tested.** Property: applying Policy.Cache + Policy.Retry + Policy.Timeout produces identical outputs across reorderings of the policy list (modulo where caching takes effect). Specific composition order (Cache → RateLimit → Timeout → Retry → run) is documented and pinned.
+- **Policy applier order is property-tested.** Property: applying Policy.Cache + Policy.Retry + Policy.Timeout produces identical outputs across reorderings of the policy list (modulo where caching takes effect). Specific composition order (Cache -> RateLimit -> Timeout -> Retry -> run) is documented and pinned.
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -116,7 +116,7 @@ They preserve context for why decisions were made, help new contributors underst
 - [0019: Workflow concurrency (joins + channels)](0019-workflow-concurrency.md)
 
 ### Agent stack
-- [0020: Phase 26 — Agent Sandbox, Thread log, declarative Policies](0020-agent-sandbox-thread-policies.md)
+- [0020: Phase 26 - Agent Sandbox, Thread log, declarative Policies](0020-agent-sandbox-thread-policies.md)
 - [0021: Self-improving agents: runtime skills + background curation](0021-self-improving-agents-skills-curation.md)
 - [0022: Memory provider stack, full-text recall, dialectic user modeling](0022-memory-providers-fulltext-dialectic.md)
 - [0023: Unified messaging gateway (raxol_gateway)](0023-unified-messaging-gateway.md)

--- a/docs/cookbook/LIVEVIEW_INTEGRATION.md
+++ b/docs/cookbook/LIVEVIEW_INTEGRATION.md
@@ -348,7 +348,7 @@ The terminal backend ignores hints entirely and relies on server-computed frames
 - `examples/reference/liveview/tea_counter_live.ex`: TEA app rendered in the browser
 - `examples/reference/liveview/01_simple_terminal/`: Step-by-step simple terminal
 
-(These need a Phoenix host -- they are reference modules, not `mix run` scripts.)
+(These need a Phoenix host: they are reference modules, not `mix run` scripts.)
 
 ## Next Steps
 

--- a/docs/cookbook/THEMING.md
+++ b/docs/cookbook/THEMING.md
@@ -147,7 +147,7 @@ When using the LiveView bridge, theming is applied via CSS classes on the termin
 </div>
 ```
 
-Built-in LiveView themes: `:synthwave84`, `:nord`, `:dracula`, `:monokai`, `:gruvbox`, `:solarized_dark`, `:tokyo_night`.
+Built-in LiveView themes: `:synthwave84`, `:nord`, `:dracula`, `:monokai`, `:gruvbox_dark`, `:solarized_dark`, `:tokyo_night`.
 
 ### Custom CSS theme
 

--- a/docs/core/ARCHITECTURE.md
+++ b/docs/core/ARCHITECTURE.md
@@ -86,7 +86,7 @@ Each cell is one character at one position with its styling. Cell x-positions ac
 
 Platform-detected backend writes ANSI escape sequences:
 
-- **Unix/macOS**: Native C NIF via termbox2 (`lib/termbox2_nif/c_src/`)
+- **Unix/macOS**: Native C NIF via termbox2 (`packages/raxol_terminal/lib/termbox2_nif/c_src/`)
 - **Windows**: Pure Elixir `IOTerminal` using `IO.write/1`
 - **Browser**: LiveView bridge via PubSub (`Raxol.LiveView.TEALive` in `raxol_liveview` package). When positioned elements carry animation hints, `TerminalBridge.animation_css/1` emits CSS `transition` rules targeting `data-raxol-id` selectors, plus a `prefers-reduced-motion` media query. The browser handles interpolation client-side instead of re-rendering every frame from the server.
 - **SSH**: Erlang `:ssh` module (`Raxol.SSH.Server`)

--- a/docs/development/DEBUG_MODE.md
+++ b/docs/development/DEBUG_MODE.md
@@ -49,15 +49,16 @@ Raxol.Debug.debug_log(:parser, "ANSI sequence detected",
 ### Structured
 
 ```elixir
-Raxol.Debug.log_terminal_state(emulator, "State after input")
-Raxol.Debug.log_ansi_sequence(sequence, "Processing ESC sequence",
+Raxol.Debug.log_terminal_state(emulator, metadata: [label: "after input"])
+Raxol.Debug.log_ansi_sequence(sequence,
+  %{type: :csi, params: [31], final: ?m},
   metadata: [line: 42])
 Raxol.Debug.log_event_flow(:key_press, event_data, handler_result,
   metadata: [component: :input_handler])
 
 Raxol.Debug.log_render_metrics(%{
   frame_time_us: 16_000,
-  dirty_regions: 3,
+  dirty_regions: [{0, 0, 10, 5}, {20, 8, 12, 3}, {0, 22, 80, 2}],
   buffer_size: 1024,
   operations_count: 42
 })
@@ -72,15 +73,6 @@ result = Raxol.Debug.time_debug(:terminal, "render", fn ->
   render_terminal(buffer)
 end)
 # Output: [DEBUG] terminal - render completed in 15.3ms
-```
-
-### Inspect
-
-```elixir
-result = Raxol.Debug.inspect_debug(:parser, "parse", input, fn ->
-  parse_ansi(input)
-end)
-# Logs both input and output of the function
 ```
 
 ## Advanced
@@ -107,14 +99,22 @@ At `:detailed` or `:verbose` levels, metrics are collected every 100ms automatic
 [DEBUG] Performance: run_queue=0
 ```
 
-### Stats and Export
+### Inspecting Configuration
 
 ```elixir
-stats = Raxol.Debug.stats()
-# => %{log_count: 1523, trace_count: 342, profile_count: 89, ...}
+Raxol.Debug.debug_config()
+# => %{terminal: true, web: true, benchmark: false, parser: false,
+#      rendering: false, general: false, log_level: :debug}
 
-Raxol.Debug.clear_stats()
-Raxol.Debug.export("debug_session.json")
+Raxol.Debug.get_debug_level()
+# => :detailed
+```
+
+Toggle a single component at runtime with `enable_debug/1` and `disable_debug/1`:
+
+```elixir
+Raxol.Debug.enable_debug(:terminal)
+Raxol.Debug.disable_debug(:terminal)
 ```
 
 ## Configuration
@@ -127,7 +127,6 @@ level = "detailed"          # off, basic, detailed, verbose
 max_logs = 10000
 max_traces = 5000
 performance_sampling = 100  # ms
-export_on_error = true
 ```
 
 ### Runtime
@@ -179,11 +178,9 @@ Raxol.Debug.enable(:verbose)
 emulator
 |> process_input("\e[31mRed\e[0m")
 |> tap(fn state ->
-  Raxol.Debug.log_terminal_state(state, "After color change")
-  Raxol.Debug.log_ansi_sequence("\e[31m", "Color sequence")
+  Raxol.Debug.log_terminal_state(state, metadata: [label: "after color change"])
+  Raxol.Debug.log_ansi_sequence("\e[31m", %{type: :sgr, params: [31], final: ?m})
 end)
-
-Raxol.Debug.export("terminal_debug.json")
 ```
 
 ### Performance Analysis
@@ -196,11 +193,9 @@ for _ <- 1..100 do
     render_frame(buffer)
   end)
 end
-
-stats = Raxol.Debug.stats()
-IO.puts("Total profile count: #{stats.profile_count}")
-Raxol.Debug.export("performance_analysis.json")
 ```
+
+Each `time_debug/3` call logs its own timing line at `:verbose` level, so the durations show up inline in the log stream.
 
 ## Removing Debug Code in Production
 
@@ -258,10 +253,8 @@ Raxol.Debug.debug_log(:handler,
   "Event processed: key_press a with ctrl at #{DateTime.utc_now()}")
 ```
 
-Clean up after debugging:
+Turn debug mode back off when you are done:
 ```elixir
-Raxol.Debug.export("debug_#{Date.utc_today()}.json")
-Raxol.Debug.clear_stats()
 Raxol.Debug.disable()
 ```
 
@@ -276,31 +269,6 @@ end
 
 **Debug server not started:** Add `{Raxol.Debug, []}` to your supervision tree.
 
-**Too many logs:** Limit storage with `{Raxol.Debug, [max_logs: 1000, max_traces: 500]}` or clear periodically.
+**Too many logs:** Limit in-process storage with `{Raxol.Debug, [max_logs: 1000, max_traces: 500]}`.
 
 **Performance impact too high:** Use sampling (see above) or drop to a lower debug level.
-
-## Export Format
-
-```json
-{
-  "level": "detailed",
-  "stats": {
-    "log_count": 1523,
-    "trace_count": 342,
-    "profile_count": 89,
-    "start_time": "2024-01-15T10:00:00Z"
-  },
-  "logs": [
-    {
-      "level": "detailed",
-      "message": "Processing input",
-      "context": {},
-      "timestamp": "2024-01-15T10:00:01Z"
-    }
-  ],
-  "traces": [],
-  "profiles": {},
-  "exported_at": "2024-01-15T11:00:00Z"
-}
-```

--- a/docs/development/DUPLICATE_FILENAME_PREVENTION.md
+++ b/docs/development/DUPLICATE_FILENAME_PREVENTION.md
@@ -24,11 +24,11 @@ lib/raxol/core/events/event_manager.ex
 
 ### Standalone Script
 
-`scripts/quality/check_duplicate_filenames.exs` scans `lib/` and `test/`, categorizes duplicates by severity (`[CRITICAL]`, `[WARNING]`, `[INFO]`), suggests rename targets, and exits non-zero on findings for CI integration.
+`scripts/archived/replaced_by_mix_tasks/check_duplicate_filenames.exs` scans `lib/` and `test/`, categorizes duplicates by severity (`[CRITICAL]`, `[WARNING]`, `[INFO]`), suggests rename targets, and exits non-zero on findings for CI integration.
 
 ```bash
-mix run scripts/quality/check_duplicate_filenames.exs
-mix run scripts/quality/check_duplicate_filenames.exs --fix-suggestions
+mix run scripts/archived/replaced_by_mix_tasks/check_duplicate_filenames.exs
+mix run scripts/archived/replaced_by_mix_tasks/check_duplicate_filenames.exs --fix-suggestions
 ```
 
 ### Credo Integration

--- a/docs/features/ACP.md
+++ b/docs/features/ACP.md
@@ -17,13 +17,19 @@ Every job is a state machine. One supervised `Job.Server` runs per active job:
 `Raxol.ACP.Job.StateMachine` is a pure module with no GenServer and no side effects. `Job.Server` calls into it for transitions and persists the result via `Job.Store`.
 
 ```elixir
-{:ok, job_id} = Raxol.ACP.Job.Server.start(
-  offering: MyOffering,
-  buyer_address: "0x...",
-  amount_usdc: 50
+{:ok, _pid} = Raxol.ACP.Job.Server.start_link(
+  job_id: "0xabc...",
+  handler: MyOffering,
+  request: %{text: "..."},
+  buyer: "0x...",
+  seller: "0x..."
 )
 
-Raxol.ACP.Job.Server.deliver(job_id, %{result: "..."})
+# Accept the buyer's request, then (once payment is escrowed) deliver.
+# Both calls invoke the handler module configured above and address the
+# server by its job id.
+{:ok, :negotiation} = Raxol.ACP.Job.Server.accept_request("0xabc...")
+{:ok, :evaluation} = Raxol.ACP.Job.Server.deliver("0xabc...")
 ```
 
 ## Offerings
@@ -38,18 +44,26 @@ defmodule Raxol.ACP.Offerings.SentimentAnalysis do
     sla_minutes: 5,
     cluster: "analytics"
 
+  # Decide whether to take the job. Return {:accept, response} to enter
+  # negotiation, or {:reject, reason} to bow out.
   @impl true
-  def handle_request(job, params) do
-    {:ok, %{sentiment: analyze(params.text)}}
+  def handle_request(request, _ctx) do
+    {:accept, %{quoted_usdc: 10, text: request.text}}
+  end
+
+  # Payment is escrowed; produce the deliverable.
+  @impl true
+  def handle_deliver(request, _ctx) do
+    {:deliver, %{sentiment: analyze(request.text)}}
   end
 end
 ```
 
-The DSL injects the `Handler` behaviour and registers metadata in the ETS-backed `Registry`. `Job.Server.accept_request/1` and `deliver/1` auto-invoke the handler and auto-sign memos with the configured wallet.
+The DSL injects the `Handler` behaviour and registers metadata in the ETS-backed `Registry`. `Job.Server.accept_request/1` and `deliver/1` auto-invoke the handler and submit on-chain memos with the configured wallet.
 
 ## Memos
 
-Each phase emits an EIP-712 typed-data memo signed by the agent's wallet. Built via `Raxol.ACP.Job.Memo` on top of `Raxol.Payments.EIP712` and any `Raxol.Payments.Wallet` impl.
+Each phase emits an on-chain memo via `Raxol.ACP.ContractClient.create_memo/5`, mirroring `InteractionLedger.createMemo` from the deployed contract. There is no off-chain memo signing: the canonical ACP contract does not accept a separate memo signature, the transaction itself is the proof. Memo kinds are the `Raxol.ACP.Job.MemoType` enum (uint8, ids 0..9).
 
 | Phase         | Memo contents                                |
 | ------------- | -------------------------------------------- |

--- a/docs/features/AGENTIC_COMMERCE.md
+++ b/docs/features/AGENTIC_COMMERCE.md
@@ -74,15 +74,15 @@ Cross-chain settlement is asynchronous: there is a window between dispatching an
 
 The store is injected via `context[:checkpoint]` as a `{module, handle}` pair, so the recovery layer does not bind raxol_payments to a particular durability mechanism:
 
-- `Checkpoint.ETS` -- an ETS table; survives a process crash when owned by a process that outlives it (a supervisor, the cockpit). Used for standalone runs and the demo.
-- `Checkpoint.ContextStore` -- backed by `Raxol.Agent.ContextStore`, so a deployed agent's in-flight intent persists in the same durable store that backs its own crash recovery.
-- nil (the default) -- recovery disabled; every call quotes and signs.
+- `Checkpoint.ETS`: an ETS table; survives a process crash when owned by a process that outlives it (a supervisor, the cockpit). Used for standalone runs and the demo.
+- `Checkpoint.ContextStore`: backed by `Raxol.Agent.ContextStore`, so a deployed agent's in-flight intent persists in the same durable store that backs its own crash recovery.
+- nil (the default): recovery disabled; every call quotes and signs.
 
 The relay rail keys on the logical payment rather than its client-minted `transfer_id`, so a resume reuses the same `transfer_id` and an idempotent broadcaster dedupes a retried deposit. A definite execution failure (nothing dispatched) drops the checkpoint so a later retry starts clean. Set `context[:idempotency_key]` to force two otherwise-identical payments apart.
 
 ## Agent Actions
 
-Eight actions registered via the `Raxol.Agent.Action` behaviour, callable by LLMs:
+Ten actions registered via the `Raxol.Agent.Action` behaviour, callable by LLMs:
 
 | Action | What it does |
 |--------|-------------|
@@ -94,6 +94,8 @@ Eight actions registered via the `Raxol.Agent.Action` behaviour, callable by LLM
 | `payment_create_mandate` | Issue a Xochi delegation envelope from this wallet |
 | `payment_list_mandates` | List locally-stored Mandates (as member or as agent) |
 | `payment_revoke_mandate` | Locally delete a stored Mandate (Xochi KV unaffected) |
+| `payment_execute_xochi_intent` | Dispatch a cross-chain Xochi intent (checkpointed) |
+| `payment_poll_xochi_status` | Poll the status of a dispatched Xochi intent |
 
 ## Mandate (Xochi Delegation Envelope)
 

--- a/docs/features/MCP.md
+++ b/docs/features/MCP.md
@@ -53,7 +53,13 @@ A Component tree with 50 Components generates 100+ tools. That's too many for an
 - Recently interacted-with Components
 
 ```elixir
-{:ok, tools} = Raxol.MCP.FocusLens.relevant_tools(session)
+tools =
+  Raxol.MCP.FocusLens.filter(all_tools,
+    mode: :focused,
+    focused_id: "search_input",
+    max_tools: 15
+  )
+
 length(tools) # ~15, not ~100
 ```
 

--- a/docs/features/PLUGIN_SDK.md
+++ b/docs/features/PLUGIN_SDK.md
@@ -6,10 +6,7 @@
 
 ```elixir
 defmodule MyPlugin do
-  use Raxol.Plugin,
-    name: "my_plugin",
-    version: "0.1.0",
-    description: "Does a thing"
+  use Raxol.Plugin
 
   @impl true
   def init(_config) do
@@ -17,13 +14,18 @@ defmodule MyPlugin do
   end
 
   @impl true
-  def handle_event({:key, %{key: :tab}}, state) do
-    {:ok, %{state | counter: state.counter + 1}}
+  def filter_event({:key, %{key: :tab}} = event, _state) do
+    {:ok, event}
+  end
+
+  @impl true
+  def handle_command(:bump, _args, state) do
+    {:ok, %{state | counter: state.counter + 1}, :ok}
   end
 end
 ```
 
-`use Raxol.Plugin` sets the behaviour and provides six overridable defaults so you only implement what you need.
+`use Raxol.Plugin` sets the behaviour and provides six overridable defaults (`terminate/2`, `enable/1`, `disable/1`, `filter_event/2`, `handle_command/3`, `get_commands/0`) so you only implement what you need; only `init/1` is required. The `use` line takes no options. To declare plugin metadata (name, version, dependencies), build a `Raxol.Plugin.Manifest` (see [Manifests](#manifests)).
 
 ## Generator
 
@@ -31,31 +33,40 @@ end
 mix raxol.gen.plugin my_plugin
 ```
 
-Generates a plugin skeleton in `lib/raxol/plugins/my_plugin/` with manifest, behaviour, and a basic test file. Pass `--with-config` for a `Config` module, `--with-hooks` for lifecycle hooks.
+Generates a plugin module at `lib/my_plugin.ex` (the module name is underscored into the path) and a matching `test/my_plugin_test.exs` with a lifecycle smoke test. Pass a dotted name like `MyApp.Plugins.Logger` to nest the generated files.
 
 ## API Facade
 
 `Raxol.Plugin.API` wraps `Raxol.Core.Runtime.Plugins.PluginManager` with try/catch guards. Use it instead of calling the manager directly:
 
 ```elixir
-{:ok, _pid} = Raxol.Plugin.API.load("my_plugin", config: %{...})
-:ok = Raxol.Plugin.API.send_event("my_plugin", {:custom_event, data})
-{:ok, state} = Raxol.Plugin.API.get_state("my_plugin")
-Raxol.Plugin.API.unload("my_plugin")
+:ok = Raxol.Plugin.API.load(MyPlugin, %{some: "config"})
+:ok = Raxol.Plugin.API.enable(:my_plugin)
+state = Raxol.Plugin.API.get_state(:my_plugin)
+:ok = Raxol.Plugin.API.disable(:my_plugin)
+Raxol.Plugin.API.unload(:my_plugin)
 ```
 
-If the plugin crashes or doesn't exist, the API returns `{:error, reason}` rather than letting the exit propagate.
+`load/2` takes a module atom and a config map; the other functions take the plugin id (an atom). If the plugin crashes or doesn't exist, the API returns `{:error, reason}` rather than letting the exit propagate.
 
 ## Manifests
 
-`Raxol.Plugin.Manifest` builds a map of all plugins across packages at compile time. Useful for tooling that needs to know what plugins exist:
+`Raxol.Plugin.Manifest` builds a plain manifest map (not a struct, for cross-package safety) from keyword options and validates it. Use it to declare a plugin's identity, version, and dependencies:
 
 ```elixir
-Raxol.Plugin.Manifest.all()
-# => %{
-#   "my_plugin" => %{module: MyPlugin, version: "0.1.0", ...},
-#   ...
-# }
+manifest =
+  Raxol.Plugin.Manifest.new(
+    id: :my_plugin,
+    name: "My Plugin",
+    version: "0.1.0",
+    module: MyPlugin,
+    depends_on: [{:other_plugin, "~> 1.0"}]
+  )
+
+case Raxol.Plugin.Manifest.validate(manifest) do
+  :ok -> :ok
+  {:error, errors} -> IO.inspect(errors)
+end
 ```
 
 ## Testing
@@ -68,18 +79,22 @@ defmodule MyPluginTest do
   import Raxol.Plugin.Testing
 
   setup do
-    plugin = start_test_plugin(MyPlugin, config: %{})
-    {:ok, plugin: plugin}
+    {:ok, state} = setup_plugin(MyPlugin, %{})
+    {:ok, state: state}
   end
 
-  test "handles tab key", %{plugin: plugin} do
-    send_event(plugin, {:key, %{key: :tab}})
-    assert get_state(plugin).counter == 1
+  test "passes the tab key through", %{state: state} do
+    assert_handles_event(MyPlugin, {:key, %{key: :tab}}, state)
+  end
+
+  test "bump increments the counter", %{state: state} do
+    {new_state, :ok} = assert_handles_command(MyPlugin, :bump, [], state)
+    assert new_state.counter == 1
   end
 end
 ```
 
-`start_test_plugin/2` uses `start_supervised!` under the hood, so cleanup is automatic.
+The helpers exercise plugin callbacks in isolation without starting the full plugin manager, so there is no process to tear down: `setup_plugin/2` calls `init/1`, and `assert_handles_event/3` / `assert_handles_command/4` / `simulate_lifecycle/2` / `assert_halts_event/3` drive the other callbacks directly.
 
 ## What's in `raxol_core`
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -58,7 +58,7 @@ Pure functional in-memory VFS with REPL helpers and 7 LLM-callable agent actions
 
 ### [Speech](SPEECH.md)
 
-TTS for accessibility announcements, Whisper STT, 21 default voice commands.
+TTS for accessibility announcements, Whisper STT, 20 default voice commands.
 
 ### [Telegram](TELEGRAM.md)
 

--- a/docs/features/SYMPHONY.md
+++ b/docs/features/SYMPHONY.md
@@ -46,7 +46,7 @@ Every surface subscribes to the same orchestrator snapshot via Phoenix.PubSub, s
 
 - **Terminal**: TEA dashboard listing active runs and their state.
 - **LiveView**: `/symphony` mounts the same dashboard in the browser.
-- **MCP**: 5 tools (`list_runs`, `get_run`, `pause_run`, etc) plus `symphony://runs` as an MCP resource.
+- **MCP**: 7 tools (`list_runs`, `get_run`, `resume_run`, etc) plus `symphony://runs` as an MCP resource.
 - **Telegram**: per-issue session, inline keyboards, approval prompts.
 - **Watch**: debounced push to APNS/FCM, tap-to-approve actions.
 - **JSON API**: `/api/v1/runs`, `/api/v1/runs/:id`. Read-only by default.

--- a/docs/getting-started/COMPONENT_GALLERY.md
+++ b/docs/getting-started/COMPONENT_GALLERY.md
@@ -172,7 +172,7 @@ table(
 )
 ```
 
-The component module (`Raxol.UI.Components.Display.Table`) supports much more when used directly: `column_widths` (`:auto` or explicit list), `border_style`, `sortable`, `filterable`, `selectable`, `striped`, `alignments`. Handles keyboard navigation for row selection.
+The component module (`Raxol.UI.Components.Table`) supports much more when used directly: `column_widths` (`:auto` or explicit list), `border_style`, `sortable`, `filterable`, `selectable`, `striped`, `alignments`. Handles keyboard navigation for row selection.
 
 ### tree
 
@@ -516,7 +516,7 @@ alias Raxol.UI.Components.Progress.Spinner
 
 # Available styles: :dots, :line, :circle, :arrow, :bounce,
 #                   :pulse, :wave, :dots3, :square, :flip
-frame = Spinner.spinner(:tick, 0, style: :dots, text: "Loading...")
+frame = Spinner.spinner("Loading...", 0, type: :dots)
 ```
 
 | Module              | Use case                                                  |
@@ -678,7 +678,7 @@ All component modules follow the same pattern: `init/1` -> `handle_event/3` -> `
 | label         | `label/1`         | --                     | No           |
 | list          | `list/1`          | --                     | No           |
 | progress      | `progress/1`      | `Display.Progress`     | No           |
-| table         | `table/1`         | `Display.Table`        | Yes          |
+| table         | `table/1`         | `Table`                | Yes          |
 | tree          | --                | `Display.Tree`         | Yes          |
 | viewport      | --                | `Display.Viewport`     | Yes          |
 | status_bar    | --                | `Display.StatusBar`    | No           |

--- a/docs/getting-started/CORE_CONCEPTS.md
+++ b/docs/getting-started/CORE_CONCEPTS.md
@@ -164,7 +164,7 @@ end
 Raxol.start_link(MyApp)
 ```
 
-The same module renders to terminal, browser (LiveView via `Raxol.LiveView.TEALive`), SSH, and the MCP agent surface without changes. That's the whole point — one source of truth, four projections.
+The same module renders to terminal, browser (LiveView via `Raxol.LiveView.TEALive`), SSH, and the MCP agent surface without changes. That's the whole point: one source of truth, four projections.
 
 ### When you don't need TEA
 
@@ -180,7 +180,7 @@ Buffer.create_blank_buffer(80, 24)
 |> IO.puts()
 ```
 
-**You're embedding rendering inside an existing OTP process.** If you already have a GenServer or LiveView mount where Raxol is just one Component surface among many, you can call buffer ops directly from `handle_call` / `handle_event`. But if the *application* is the UI, wrap it in TEA and use a [`Raxol.LiveView.TEALive`](../cookbook/LIVEVIEW_INTEGRATION.md) mount or [`Raxol.SSH.serve/2`](../cookbook/SSH_DEPLOYMENT.md) instead — you'll get crash isolation, hot reload, and the agent surface for free.
+**You're embedding rendering inside an existing OTP process.** If you already have a GenServer or LiveView mount where Raxol is just one Component surface among many, you can call buffer ops directly from `handle_call` / `handle_event`. But if the *application* is the UI, wrap it in TEA and use a [`Raxol.LiveView.TEALive`](../cookbook/LIVEVIEW_INTEGRATION.md) mount or [`Raxol.SSH.serve/2`](../cookbook/SSH_DEPLOYMENT.md) instead: you'll get crash isolation, hot reload, and the agent surface for free.
 
 Avoid hand-rolling your own `loop(state)` recursive function. That was a pre-Raxol pattern; OTP supervision and TEA's update loop subsume it.
 

--- a/docs/platform/TERMINAL_DRIVER.md
+++ b/docs/platform/TERMINAL_DRIVER.md
@@ -27,7 +27,7 @@ Raxol uses a hybrid terminal backend: a native NIF when available, with automati
 `Driver.ex` checks at compile time whether the termbox2_nif module is available:
 
 ```elixir
-# lib/raxol/terminal/driver.ex:25
+# packages/raxol_terminal/lib/raxol/terminal/driver.ex
 @termbox2_available Code.ensure_loaded?(:termbox2_nif)
 ```
 

--- a/docs/platform/WINDOWS.md
+++ b/docs/platform/WINDOWS.md
@@ -168,7 +168,7 @@ Logger.info("IOTerminal available: #{Code.ensure_loaded?(Raxol.Terminal.IOTermin
 
 ### IOTerminal
 
-Located in `lib/raxol/terminal/io_terminal.ex`. Uses `stty` and ANSI escape sequences via `IO.ANSI` for raw terminal mode, and cross-platform terminal size detection via `:io.columns/0` and `:io.rows/0`. Supports 256 colors and unicode.
+Located in `packages/raxol_terminal/lib/raxol/terminal/io_terminal.ex`. Uses `stty` and ANSI escape sequences via `IO.ANSI` for raw terminal mode, and cross-platform terminal size detection via `:io.columns/0` and `:io.rows/0`. Supports 256 colors and unicode.
 
 API:
 
@@ -187,7 +187,7 @@ IOTerminal.set_title(title)
 
 ### Backend Selection
 
-The Driver (`lib/raxol/terminal/driver.ex`) handles this automatically:
+The Driver (`packages/raxol_terminal/lib/raxol/terminal/driver.ex`) handles this automatically:
 
 ```elixir
 @termbox2_available Code.ensure_loaded?(:termbox2_nif)
@@ -229,7 +229,7 @@ Potential optimizations, none currently needed:
 - [Windows Terminal Documentation](https://docs.microsoft.com/en-us/windows/terminal/)
 - [Console Virtual Terminal Sequences](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences)
 - [Erlang/OTP 28 Raw Mode](https://www.erlang.org/doc/apps/stdlib/shell.html)
-- [Raxol IOTerminal Tests](../../test/raxol/terminal/io_terminal_test.exs)
+- [Raxol IOTerminal Tests](../../packages/raxol_terminal/test/raxol/terminal/io_terminal_test.exs)
 
 ## Issues
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -30,10 +30,10 @@ Testing strategies: unit and integration tests, event filtering tests, property-
 
 ### Core Components
 
-- **[Plugin Manager](../../lib/raxol/core/runtime/plugins/plugin_manager.ex)** - Lifecycle and dependency management
-- **[Plugin Behaviour](../../lib/raxol/core/runtime/plugins/plugin.ex)** - Interface all plugins must implement
-- **[Plugin Reloader](../../lib/raxol/core/runtime/plugins/plugin_reloader.ex)** - Live plugin updates
-- **[Plugin Registry](../../lib/raxol/core/runtime/plugins/plugin_registry.ex)** - Plugin registration and lookup
+- **[Plugin Manager](../../packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_manager.ex)** - Lifecycle and dependency management
+- **[Plugin Behaviour](../../packages/raxol_core/lib/raxol/core/runtime/plugins/plugin.ex)** - Interface all plugins must implement
+- **[Plugin Reloader](../../packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_reloader.ex)** - Live plugin updates
+- **[Plugin Registry](../../packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_registry.ex)** - Plugin registration and lookup
 
 ## Create a Plugin
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -30,7 +30,8 @@ cd packages/raxol_terminal && MIX_ENV=test mix test
 cd packages/raxol_sensor   && MIX_ENV=test mix test
 cd packages/raxol_agent    && MIX_ENV=test mix test
 # ... plus raxol_mcp, raxol_payments, raxol_liveview, raxol_plugin,
-# raxol_speech, raxol_telegram, raxol_watch, raxol_acp, raxol_symphony
+# raxol_speech, raxol_telegram, raxol_watch, raxol_acp, raxol_symphony,
+# raxol_gateway
 ```
 
 ### All quality checks


### PR DESCRIPTION
## Summary

Documentation audit across the `docs/` tree and committed root docs for (1) factual
drift against the current codebase and (2) light prose-voice cleanup. 28 tracked
files changed; verified each factual claim against source before editing.

### Drift fixes (verified against code)

- **Stale package-extraction paths**: termbox2 NIF (`packages/raxol_terminal/...`),
  plugin system, terminal driver, io_terminal, and ADR reference links
  (ADRs 0005 / 0008 / 0009 / 0011).
- **Corrected counts**: 8 -> 10 payment actions, 5 -> 7 Symphony MCP tools,
  21 -> 20 voice commands, 13 -> 14 packages (`raxol_gateway` added to
  `PACKAGES.md` + the `raxol_acp` dependency line corrected).
- **Module renames**: `Display.Table` -> `Table`, `:gruvbox` -> `:gruvbox_dark`,
  spinner signature.
- **Code examples rewritten to the real API** (these referenced functions/callbacks
  that do not exist and would mislead users):
  - Plugin SDK: `use Raxol.Plugin` takes no opts; real callbacks
    `filter_event/2` / `handle_command/3`; `API.load/2` (module + config map);
    real `Testing` helpers; `Manifest.new/1` + `validate/1`.
  - Debug: removed phantom `inspect_debug` / `stats` / `clear_stats` / `export`;
    fixed `log_terminal_state` / `log_ansi_sequence` / `log_render_metrics` arg
    shapes.
  - ACP: `Job.Server.start_link/1` + `deliver/1`; real `Handler` callbacks.
  - MCP: `FocusLens.filter/2` (was a nonexistent `relevant_tools/1`).

### Voice (light, mechanical)

Prose em-dash ` -- ` -> colon/comma/parens; emoji and Unicode punctuation
(arrows, section signs) -> ASCII; dropped gratuitous jargon. Functional `--`
(CLI flags), markdown table rules, and fenced ASCII diagrams were left intact.
README and CLAUDE.md were already on-voice and unchanged.

## Deferred (not in this PR; need a decision)

- Package-count in dated planning snapshots (`AGENTS.md` / `ROADMAP.md`, gitignored
  `SPECS.md`) still say "11 packages": point-in-time, left as historical.
- `DUPLICATE_FILENAME_PREVENTION.md` "Credo Integration" section documents an
  unbuilt `Raxol.Credo.DuplicateFilenameCheck`: build vs delete.
- `docs/features/README.md` backend list says "Groq" where the code says Kimi.
- `THEMING.md` lists 7 LiveView themes (type union) vs 5 with palette maps.
- Benchmark numbers left as-is (not verifiable without re-running).

## Manual testing

- [x] All edited reference paths resolve against the current tree (verified with ls/grep)
- [x] Rewritten code examples checked against the real module source (Plugin API, Debug, ACP, MCP)
- [x] No double-punctuation artifacts or broken markdown tables introduced; additions are ASCII
- [ ] Render check on hexdocs / GitHub markdown (cosmetic)
