### PR TITLE
CI: drop EOL openssl@1.1 from nightly macOS setup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,9 +62,12 @@ jobs:
       - name: Setup OS dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install openssl@1.1 postgresql@16
-          echo "LDFLAGS=-L$(brew --prefix openssl@1.1)/lib" >> $GITHUB_ENV
-          echo "CFLAGS=-I$(brew --prefix openssl@1.1)/include" >> $GITHUB_ENV
+          # openssl@1.1 is EOL and no longer in Homebrew. Do NOT export
+          # LDFLAGS/CFLAGS for it either: a global LDFLAGS clobbers the termbox2
+          # NIF Makefile's `LDFLAGS ?= -shared`, dropping -shared so the .so links
+          # as an executable (`_main` undefined). Nothing needs openssl flags; OTP
+          # ships precompiled.
+          brew install postgresql@16
 
           brew services start postgresql@16 || true
           sleep 5


### PR DESCRIPTION
## Problem

The master **Nightly Build** has failed since 2026-06-24 (clean through 06-23). It is not a test regression: the macOS test-matrix jobs die at the dependency-setup step, before any test runs.

```
No available formula with the name "openssl@1.1".
Did you mean openssl@3.5, openssl@3.0, openssl@4 or openssl@3?
Process completed with exit code 1.
```

`nightly.yml` runs `brew install openssl@1.1 postgresql@16`. `openssl@1.1` is EOL and was removed from Homebrew, so the install exits 1 on the rolling `macos-latest` image. The "flaky across combos" pattern (only `1.19.0/28.2` and `1.18.3/27.2` failing) is just `macos-latest` mid image-rollout: some runners still cached the old bottle.

## Fix

Mirror the fix already applied to `ci-unified.yml` in #326: drop the `openssl@1.1` install and the `LDFLAGS`/`CFLAGS` exports. openssl was never needed (OTP ships precompiled), and the `LDFLAGS` export was itself harmful: a global `LDFLAGS` clobbers the termbox2 NIF Makefile's `LDFLAGS ?= -shared`, dropping `-shared` so the `.so` links as an executable. `nightly.yml` was simply missed when #326 fixed the unified pipeline.

Only the broken `openssl@1.1` lines change; `postgresql@16` install/start are untouched.

## Manual testing

- [x] grep for `openssl@1.1` in `.github/workflows/` returns no install references (only an explanatory comment)
- [x] `nightly.yml` validates as YAML
- [x] Change matches the known-green macOS block in `ci-unified.yml` (passing since 06-23)
- [ ] Confirm on the next scheduled nightly (or via manual `workflow_dispatch`) that the macOS matrix jobs go green
