### PR TITLE
Add OSC 8 hyperlinks to View DSL text(link:)

### DIFF
--- a/examples/agents/zero_system.exs
+++ b/examples/agents/zero_system.exs
@@ -190,6 +190,9 @@ defmodule ZeroSystem do
   @boot_hold 6
   @amount 25.0
   @policy %{per_request_max: 50.0, session_max: 100.0, lifetime_max: 250.0}
+  # Each settled DEBIT line is cmd-clickable to the settlement on Basescan
+  # (OSC 8 hyperlink) in terminals that support it.
+  @settle_tx_url "https://basescan.org/tx/0x7f3a9c2e5b1d4a6f8c0e2b4d6a8f1c3e5b7d9f0a2c4e6b8d0f2a4c6e8b0dfe21"
   @center {0.5, 0.5, 0.0}
   @gw 40
   @gh 10
@@ -742,7 +745,7 @@ defmodule ZeroSystem do
     do: text("  RESERVE #{pad(id)} #{usd(a)}", fg: :cyan)
 
   defp ledger_line({:debit, id, a}),
-    do: text("  DEBIT   #{pad(id)} #{usd(a)}", fg: :green)
+    do: text("  DEBIT   #{pad(id)} #{usd(a)}", fg: :green, link: @settle_tx_url)
 
   defp ledger_line({:crash, id}),
     do: text("  CRASH   #{pad(id)} died mid-flight", fg: :red, style: [:bold])

--- a/lib/raxol/core/renderer/view/components/text.ex
+++ b/lib/raxol/core/renderer/view/components/text.ex
@@ -13,11 +13,14 @@ defmodule Raxol.Core.Renderer.View.Components.Text do
     * `:style` - List of style atoms (e.g., [:bold, :underline])
     * `:align` - Text alignment (:left, :center, :right)
     * `:wrap` - Text wrapping mode (:none, :char, :word)
+    * `:link` - OSC 8 hyperlink URL; makes the text cmd-clickable in
+      terminals that support OSC 8 (iTerm2, kitty, WezTerm, ...)
 
   ## Examples
 
       Text.new("Hello, World!", fg: :red, style: [:bold])
       Text.new("Centered text", align: :center)
+      Text.new("0x7f3a..e21", link: "https://basescan.org/tx/0x7f3a..e21")
   """
   def new(content, opts \\ []) when is_binary(content) do
     %{
@@ -28,7 +31,8 @@ defmodule Raxol.Core.Renderer.View.Components.Text do
       bg: Keyword.get(opts, :bg),
       style: Keyword.get(opts, :style, []),
       align: Keyword.get(opts, :align, :left),
-      wrap: Keyword.get(opts, :wrap, :none)
+      wrap: Keyword.get(opts, :wrap, :none),
+      link: Keyword.get(opts, :link)
     }
   end
 

--- a/lib/raxol/core/renderer_compat.ex
+++ b/lib/raxol/core/renderer_compat.ex
@@ -103,10 +103,13 @@ defmodule Raxol.Core.Renderer do
       ansi_prefix = Style.to_ansi(style)
       text = chars |> Enum.reverse() |> Enum.join()
 
-      case ansi_prefix do
-        "" -> text
-        prefix -> prefix <> text <> Style.reset()
-      end
+      styled =
+        case ansi_prefix do
+          "" -> text
+          prefix -> prefix <> text <> Style.reset()
+        end
+
+      maybe_wrap_hyperlink(styled, style)
     end)
   end
 
@@ -175,10 +178,13 @@ defmodule Raxol.Core.Renderer do
   defp operation_to_ansi({:write, text, style}) do
     ansi_prefix = Style.to_ansi(style)
 
-    case ansi_prefix do
-      "" -> text
-      prefix -> prefix <> text <> Style.reset()
-    end
+    styled =
+      case ansi_prefix do
+        "" -> text
+        prefix -> prefix <> text <> Style.reset()
+      end
+
+    maybe_wrap_hyperlink(styled, style)
   end
 
   defp operation_to_ansi({:clear_line, y}) do
@@ -186,4 +192,19 @@ defmodule Raxol.Core.Renderer do
   end
 
   defp operation_to_ansi(_), do: ""
+
+  # Wrap already-styled content in an OSC 8 hyperlink when the cell style
+  # carries one (bare form, ST-terminated). Cells with no hyperlink emit
+  # exactly as before.
+  defp maybe_wrap_hyperlink(content, style) when is_map(style) do
+    case Map.get(style, :hyperlink) do
+      url when is_binary(url) and url != "" ->
+        "\e]8;;" <> url <> "\e\\" <> content <> "\e]8;;\e\\"
+
+      _ ->
+        content
+    end
+  end
+
+  defp maybe_wrap_hyperlink(content, _style), do: content
 end

--- a/lib/raxol/core/runtime/rendering/backends.ex
+++ b/lib/raxol/core/runtime/rendering/backends.ex
@@ -259,7 +259,8 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
 
   defp transform_cells_for_update(cells) when is_list(cells) do
     Enum.map(cells, fn {x, y, char, fg, bg, attrs_list} ->
-      attrs_map = Enum.into(attrs_list || [], %{}, fn atom -> {atom, true} end)
+      {hyperlink, style_atoms} = split_hyperlink(attrs_list || [])
+      attrs_map = Enum.into(style_atoms, %{}, fn atom -> {atom, true} end)
 
       cell_attrs =
         %{
@@ -267,9 +268,22 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
           background: bg
         }
         |> Map.merge(Map.take(attrs_map, [:bold, :underline, :italic]))
+        |> put_hyperlink(hyperlink)
 
       cell = %Raxol.Terminal.Cell{char: char, style: cell_attrs}
       {x, y, cell}
     end)
   end
+
+  # Pull a tagged `{:hyperlink, url}` entry out of the cell attrs list; the
+  # remaining entries are plain style atoms. Returns {url_or_nil, atoms}.
+  defp split_hyperlink(attrs_list) do
+    Enum.reduce(attrs_list, {nil, []}, fn
+      {:hyperlink, url}, {_url, atoms} -> {url, atoms}
+      other, {url, atoms} -> {url, [other | atoms]}
+    end)
+  end
+
+  defp put_hyperlink(style, nil), do: style
+  defp put_hyperlink(style, url), do: Map.put(style, :hyperlink, url)
 end

--- a/lib/raxol/demo/landing_scene.ex
+++ b/lib/raxol/demo/landing_scene.ex
@@ -25,6 +25,7 @@ defmodule Raxol.Demo.LandingScene do
   @spinner ~w(| / - \\)
   @width 76
   @tx "0x7f3a..e21"
+  @tx_url "https://basescan.org/tx/0x7f3a9c2e5b1d4a6f8c0e2b4d6a8f1c3e5b7d9f0a2c4e6b8d0f2a4c6e8b0dfe21"
 
   @coral {255, 205, 156}
   @warn {230, 132, 118}
@@ -210,7 +211,11 @@ defmodule Raxol.Demo.LandingScene do
   # scripted hover it gets a pointer and a highlight, the way it lights up under
   # a real mouse in the live terminal.
   defp explorer(false) do
-    text("  ↗ basescan.org/tx/#{@tx}", fg: @coral, style: [:underline, :italic])
+    text("  ↗ basescan.org/tx/#{@tx}",
+      fg: @coral,
+      style: [:underline, :italic],
+      link: @tx_url
+    )
   end
 
   defp explorer(true) do
@@ -220,7 +225,8 @@ defmodule Raxol.Demo.LandingScene do
         text(" ↗ basescan.org/tx/#{@tx} ",
           fg: @frost,
           bg: @indigo,
-          style: [:bold, :underline, :italic]
+          style: [:bold, :underline, :italic],
+          link: @tx_url
         )
       ]
     end

--- a/lib/raxol/demo/showcase.ex
+++ b/lib/raxol/demo/showcase.ex
@@ -22,6 +22,12 @@ defmodule Raxol.Demo.Showcase do
     "About"
   ]
 
+  # Clickable in OSC 8-aware terminals (iTerm2, kitty, WezTerm); plain text
+  # elsewhere.
+  @site_url "https://raxol.io"
+  @docs_url "https://hexdocs.pm/raxol"
+  @repo_url "https://github.com/DROOdotFOO/raxol"
+
   @sample_table_rows [
     ["1", "Elixir", "Functional", "1.17"],
     ["2", "Rust", "Systems", "1.82"],
@@ -310,6 +316,11 @@ defmodule Raxol.Demo.Showcase do
           "Widgets: text, box, button, checkbox, table, progress, list, modal"
         ),
         text(""),
+        text("-- Links (cmd-click in supported terminals) --", style: [:bold]),
+        link_line("Website", "raxol.io", @site_url),
+        link_line("Docs", "hexdocs.pm/raxol", @docs_url),
+        link_line("Source", "github.com/DROOdotFOO/raxol", @repo_url),
+        text(""),
         text("-- Keyboard Reference --", style: [:bold]),
         text("  1-5       Switch sections"),
         text("  Tab       Next section"),
@@ -319,6 +330,15 @@ defmodule Raxol.Demo.Showcase do
         text("  =/-/r     Counter controls (section 4)")
       ]
     end
+  end
+
+  # A labelled OSC 8 hyperlink: the displayed text is cmd-clickable to `url`.
+  defp link_line(label, display, url) do
+    text("  #{String.pad_trailing(label <> ":", 9)}#{display}",
+      fg: :cyan,
+      style: [:underline],
+      link: url
+    )
   end
 
   # -- Footer --

--- a/lib/raxol/ui/element_renderer.ex
+++ b/lib/raxol/ui/element_renderer.ex
@@ -255,7 +255,7 @@ defmodule Raxol.UI.ElementRenderer do
   defp render_text_if_valid_coordinates(x, y, text, style) do
     fg = resolve_fg(style)
     bg = resolve_bg(style)
-    attrs = extract_text_attrs(style)
+    attrs = extract_text_attrs(style) ++ hyperlink_attrs(style)
 
     # Width-aware text rendering - CJK/fullwidth chars advance x by 2
     text
@@ -310,5 +310,15 @@ defmodule Raxol.UI.ElementRenderer do
 
   defp extract_text_attrs(style) do
     Enum.filter(@text_attrs, fn attr -> Map.get(style, attr, false) == true end)
+  end
+
+  # An OSC 8 hyperlink rides along in the cell's attrs list as a tagged
+  # `{:hyperlink, url}` entry (keeping the 6-tuple cell shape intact). The
+  # ScreenBuffer bridge lifts it onto `cell.style.hyperlink`.
+  defp hyperlink_attrs(style) do
+    case Map.get(style, :link) || Map.get(style, :hyperlink) do
+      url when is_binary(url) and url != "" -> [{:hyperlink, url}]
+      _ -> []
+    end
   end
 end

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -235,6 +235,7 @@ defmodule Raxol.UI.Layout.Engine do
       fg: Map.get(attrs_map, :fg),
       bg: Map.get(attrs_map, :bg),
       style: style_map,
+      link: Map.get(attrs_map, :link),
       # Pass original attributes through, let Renderer handle styling
       attrs: Map.put(attrs_map, :original_type, type)
     }
@@ -265,6 +266,7 @@ defmodule Raxol.UI.Layout.Engine do
       fg: Map.get(element, :fg),
       bg: Map.get(element, :bg),
       style: style_map,
+      link: Map.get(element, :link),
       attrs: %{
         style: style_map,
         id: Map.get(element, :id),

--- a/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
@@ -178,52 +178,45 @@ defmodule Raxol.Terminal.Renderer do
   end
 
   defp render_row_optimized(row, theme, style_batching) do
-    case style_batching do
-      true -> render_batched_optimized(row, theme)
-      false -> render_individual_optimized(row, theme)
-    end
+    # Group by hyperlink first so a contiguous run of cells sharing a URL is
+    # wrapped in a single OSC 8 open/close pair, while SGR styling is free to
+    # vary within the link. Runs with no hyperlink render exactly as before.
+    row
+    |> Enum.chunk_by(&cell_hyperlink/1)
+    |> Enum.map_join("", fn chunk ->
+      chunk
+      |> render_style_runs(theme, style_batching)
+      |> maybe_wrap_hyperlink(hd(chunk).style)
+    end)
   end
 
-  # Batched rendering: group consecutive cells with the same style
-  defp render_batched_optimized(row, theme) do
-    row
+  # Render a run of cells (all sharing one hyperlink) into SGR-styled text:
+  # batched groups consecutive same-style cells, individual emits one at a time.
+  defp render_style_runs(cells, theme, true) do
+    cells
     |> Enum.chunk_by(& &1.style)
-    |> Enum.map_join("", fn cells_with_same_style ->
-      style = hd(cells_with_same_style).style
-      chars = Enum.map_join(cells_with_same_style, "", & &1.char)
-      ansi_prefix = build_ansi_prefix(style, theme)
-
-      styled =
-        case ansi_prefix do
-          "" -> chars
-          prefix -> prefix <> chars <> @ansi_reset
-        end
-
-      maybe_wrap_hyperlink(styled, style)
+    |> Enum.map_join("", fn same_style ->
+      style = hd(same_style).style
+      chars = Enum.map_join(same_style, "", & &1.char)
+      apply_sgr(build_ansi_prefix(style, theme), chars)
     end)
   end
 
-  # Individual cell rendering
-  defp render_individual_optimized(row, theme) do
-    row
-    |> Enum.map_join("", fn cell ->
-      ansi_prefix = build_ansi_prefix(cell.style, theme)
-
-      styled =
-        case ansi_prefix do
-          "" -> cell.char
-          prefix -> prefix <> cell.char <> @ansi_reset
-        end
-
-      maybe_wrap_hyperlink(styled, cell.style)
+  defp render_style_runs(cells, theme, _individual) do
+    Enum.map_join(cells, "", fn cell ->
+      apply_sgr(build_ansi_prefix(cell.style, theme), cell.char)
     end)
   end
 
-  # Wrap already-styled content in an OSC 8 hyperlink when the cell style
-  # carries one. Bare form `ESC ] 8 ; ; URL ST  <content>  ESC ] 8 ; ; ST`;
-  # clickable in OSC 8-aware terminals (iTerm2, kitty, WezTerm), ignored
-  # elsewhere. The SGR reset stays inside the link so colors close but the
-  # link spans the whole run.
+  defp apply_sgr("", content), do: content
+  defp apply_sgr(prefix, content), do: prefix <> content <> @ansi_reset
+
+  defp cell_hyperlink(cell), do: hyperlink_url(cell.style)
+
+  # Wrap already-styled content in a single OSC 8 hyperlink when the run carries
+  # one. Bare form `ESC ] 8 ; ; URL ST  <content>  ESC ] 8 ; ; ST`; clickable in
+  # OSC 8-aware terminals (iTerm2, kitty, WezTerm), ignored elsewhere. SGR may
+  # vary inside; the link spans the whole run.
   defp maybe_wrap_hyperlink(content, style) do
     case hyperlink_url(style) do
       url when is_binary(url) and url != "" ->

--- a/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
@@ -193,10 +193,13 @@ defmodule Raxol.Terminal.Renderer do
       chars = Enum.map_join(cells_with_same_style, "", & &1.char)
       ansi_prefix = build_ansi_prefix(style, theme)
 
-      case ansi_prefix do
-        "" -> chars
-        prefix -> prefix <> chars <> @ansi_reset
-      end
+      styled =
+        case ansi_prefix do
+          "" -> chars
+          prefix -> prefix <> chars <> @ansi_reset
+        end
+
+      maybe_wrap_hyperlink(styled, style)
     end)
   end
 
@@ -206,12 +209,34 @@ defmodule Raxol.Terminal.Renderer do
     |> Enum.map_join("", fn cell ->
       ansi_prefix = build_ansi_prefix(cell.style, theme)
 
-      case ansi_prefix do
-        "" -> cell.char
-        prefix -> prefix <> cell.char <> @ansi_reset
-      end
+      styled =
+        case ansi_prefix do
+          "" -> cell.char
+          prefix -> prefix <> cell.char <> @ansi_reset
+        end
+
+      maybe_wrap_hyperlink(styled, cell.style)
     end)
   end
+
+  # Wrap already-styled content in an OSC 8 hyperlink when the cell style
+  # carries one. Bare form `ESC ] 8 ; ; URL ST  <content>  ESC ] 8 ; ; ST`;
+  # clickable in OSC 8-aware terminals (iTerm2, kitty, WezTerm), ignored
+  # elsewhere. The SGR reset stays inside the link so colors close but the
+  # link spans the whole run.
+  defp maybe_wrap_hyperlink(content, style) do
+    case hyperlink_url(style) do
+      url when is_binary(url) and url != "" ->
+        "\e]8;;" <> url <> "\e\\" <> content <> "\e]8;;\e\\"
+
+      _ ->
+        content
+    end
+  end
+
+  defp hyperlink_url(%{__struct__: _} = style), do: Map.get(style, :hyperlink)
+  defp hyperlink_url(style) when is_map(style), do: Map.get(style, :hyperlink)
+  defp hyperlink_url(_style), do: nil
 
   # Build ANSI escape prefix from style and theme
   defp build_ansi_prefix(style, theme) do

--- a/packages/raxol_terminal/test/raxol/terminal/renderer_osc8_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/renderer_osc8_test.exs
@@ -19,6 +19,9 @@ defmodule Raxol.Terminal.RendererOSC8Test do
     |> ScreenBuffer.write_char(1, 0, "o", %{hyperlink: url})
   end
 
+  defp count(haystack, needle),
+    do: haystack |> String.split(needle) |> length() |> Kernel.-(1)
+
   describe "individual rendering (default)" do
     test "wraps linked cells in OSC 8 open/close" do
       url = "https://basescan.org/tx/0xabc"
@@ -47,6 +50,51 @@ defmodule Raxol.Terminal.RendererOSC8Test do
 
       assert String.contains?(output, osc8_open(url))
       assert String.contains?(output, @osc8_close)
+    end
+  end
+
+  describe "coalescing a contiguous run into one OSC 8 pair" do
+    test "individual mode wraps a multi-cell run once, not per glyph" do
+      url = "https://raxol.io"
+      output = Renderer.render(Renderer.new(linked_buffer(url)))
+
+      assert count(output, osc8_open(url)) == 1
+      assert count(output, @osc8_close) == 1
+    end
+
+    test "one OSC 8 pair spans a run even when SGR styling varies within it" do
+      url = "https://raxol.io"
+
+      buffer =
+        ScreenBuffer.new(4, 1)
+        |> ScreenBuffer.write_char(0, 0, "g", %{hyperlink: url, foreground: :red})
+        |> ScreenBuffer.write_char(1, 0, "o", %{hyperlink: url, foreground: :blue})
+
+      output =
+        Renderer.render(Renderer.new(buffer, %{foreground: %{red: "#F00", blue: "#00F"}}))
+
+      # single hyperlink wrap...
+      assert count(output, osc8_open(url)) == 1
+      assert count(output, @osc8_close) == 1
+      # ...but two distinct SGR colors inside it
+      assert String.contains?(output, "g")
+      assert String.contains?(output, "o")
+    end
+
+    test "adjacent runs with different URLs get separate pairs" do
+      a = "https://a.example"
+      b = "https://b.example"
+
+      buffer =
+        ScreenBuffer.new(4, 1)
+        |> ScreenBuffer.write_char(0, 0, "a", %{hyperlink: a})
+        |> ScreenBuffer.write_char(1, 0, "b", %{hyperlink: b})
+
+      output = Renderer.render(Renderer.new(buffer))
+
+      assert count(output, osc8_open(a)) == 1
+      assert count(output, osc8_open(b)) == 1
+      assert count(output, @osc8_close) == 2
     end
   end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/renderer_osc8_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/renderer_osc8_test.exs
@@ -1,0 +1,52 @@
+defmodule Raxol.Terminal.RendererOSC8Test do
+  @moduledoc """
+  OSC 8 hyperlink emission in the live terminal render path.
+
+  A cell whose style carries `:hyperlink` is wrapped in an OSC 8 open/close
+  pair so the text is cmd-clickable in OSC 8-aware terminals. Cells without a
+  hyperlink render exactly as before.
+  """
+  use ExUnit.Case, async: true
+  alias Raxol.Terminal.{Renderer, ScreenBuffer}
+
+  # OSC 8 bare form: ESC ] 8 ; ; URL ST  ...  ESC ] 8 ; ; ST  (ST = ESC \)
+  defp osc8_open(url), do: "\e]8;;" <> url <> "\e\\"
+  @osc8_close "\e]8;;\e\\"
+
+  defp linked_buffer(url) do
+    ScreenBuffer.new(4, 1)
+    |> ScreenBuffer.write_char(0, 0, "g", %{hyperlink: url})
+    |> ScreenBuffer.write_char(1, 0, "o", %{hyperlink: url})
+  end
+
+  describe "individual rendering (default)" do
+    test "wraps linked cells in OSC 8 open/close" do
+      url = "https://basescan.org/tx/0xabc"
+      renderer = Renderer.new(linked_buffer(url))
+
+      output = Renderer.render(renderer)
+
+      assert String.contains?(output, osc8_open(url))
+      assert String.contains?(output, @osc8_close)
+    end
+
+    test "no OSC 8 for cells without a hyperlink" do
+      buffer = ScreenBuffer.new(4, 1) |> ScreenBuffer.write_char(0, 0, "x")
+      output = Renderer.render(Renderer.new(buffer))
+
+      refute String.contains?(output, "\e]8")
+    end
+  end
+
+  describe "batched rendering" do
+    test "wraps a run of same-style linked cells once" do
+      url = "https://example.com/tx"
+      renderer = Renderer.new(linked_buffer(url), %{}, %{}, true)
+
+      output = Renderer.render(renderer)
+
+      assert String.contains?(output, osc8_open(url))
+      assert String.contains?(output, @osc8_close)
+    end
+  end
+end

--- a/test/raxol/core/renderer/view_test.exs
+++ b/test/raxol/core/renderer/view_test.exs
@@ -93,7 +93,8 @@ defmodule Raxol.Core.Renderer.ViewTest do
           fg: nil,
           bg: nil,
           wrap: :none,
-          align: :left
+          align: :left,
+          link: nil
         }
       ]
 

--- a/test/raxol/core/renderer_osc8_test.exs
+++ b/test/raxol/core/renderer_osc8_test.exs
@@ -1,0 +1,107 @@
+defmodule Raxol.Core.RendererOSC8Test do
+  @moduledoc """
+  OSC 8 hyperlink emission in the core/compat renderer path.
+
+  Covers the View DSL `link:` attribute and the `apply_diff/1` /
+  `render_to_ansi/1` emission that wraps runs of linked cells in the
+  OSC 8 open/close pair while leaving unlinked cells byte-identical.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Core.{Buffer, Renderer}
+  alias Raxol.Core.Renderer.View
+  alias Raxol.Core.Renderer.View.Components.Text
+
+  # OSC 8 bare form: ESC ] 8 ; ; URL ST  ...  ESC ] 8 ; ; ST  (ST = ESC \)
+  defp osc8_open(url), do: "\e]8;;" <> url <> "\e\\"
+  @osc8_close "\e]8;;\e\\"
+
+  describe "View DSL link: attribute" do
+    test "Text.new/2 carries the link onto the element" do
+      el = Text.new("0x7f3a", link: "https://basescan.org/tx/0x7f3a")
+      assert el.link == "https://basescan.org/tx/0x7f3a"
+    end
+
+    test "Text.new/2 link defaults to nil when omitted" do
+      assert Text.new("plain").link == nil
+    end
+
+    test "View.text/2 forwards the link option" do
+      assert View.text("x", link: "https://example.com").link ==
+               "https://example.com"
+    end
+  end
+
+  describe "apply_diff/1 OSC 8 emission" do
+    test "wraps a run of linked cells in the OSC 8 open/close pair" do
+      url = "https://basescan.org/tx/0xabc"
+      blank = Buffer.create_blank_buffer(10, 1)
+      linked = Buffer.write_at(blank, 0, 0, "tx", %{hyperlink: url})
+
+      out = Renderer.apply_diff(Renderer.render_diff(blank, linked))
+
+      assert String.contains?(out, osc8_open(url))
+      assert String.contains?(out, @osc8_close)
+      # the link text sits between the open and the close
+      assert out =~
+               ~r/#{Regex.escape(osc8_open(url))}.*tx.*#{Regex.escape(@osc8_close)}/s
+    end
+
+    test "leaves unlinked cells untouched (no OSC 8)" do
+      blank = Buffer.create_blank_buffer(10, 1)
+      plain = Buffer.write_at(blank, 0, 0, "tx", %{})
+
+      out = Renderer.apply_diff(Renderer.render_diff(blank, plain))
+
+      refute String.contains?(out, "\e]8")
+    end
+
+    test "an empty-string link is treated as no link" do
+      blank = Buffer.create_blank_buffer(10, 1)
+      empty = Buffer.write_at(blank, 0, 0, "tx", %{hyperlink: ""})
+
+      out = Renderer.apply_diff(Renderer.render_diff(blank, empty))
+
+      refute String.contains?(out, "\e]8")
+    end
+  end
+
+  describe "render_to_ansi/1 OSC 8 emission" do
+    test "wraps linked cells and closes the link" do
+      url = "https://example.com/x"
+      blank = Buffer.create_blank_buffer(6, 1)
+      linked = Buffer.write_at(blank, 0, 0, "go", %{hyperlink: url})
+
+      out = Renderer.render_to_ansi(linked)
+
+      assert String.contains?(out, osc8_open(url))
+      assert String.contains?(out, @osc8_close)
+    end
+  end
+
+  property "apply_diff wraps iff a hyperlink is present" do
+    check all(
+            text <- string(:alphanumeric, min_length: 1, max_length: 8),
+            host <- string(:alphanumeric, min_length: 1, max_length: 12)
+          ) do
+      url = "https://" <> host <> ".com"
+      width = String.length(text)
+      blank = Buffer.create_blank_buffer(width, 1)
+
+      linked_out =
+        blank
+        |> Buffer.write_at(0, 0, text, %{hyperlink: url})
+        |> then(&Renderer.apply_diff(Renderer.render_diff(blank, &1)))
+
+      plain_out =
+        blank
+        |> Buffer.write_at(0, 0, text, %{})
+        |> then(&Renderer.apply_diff(Renderer.render_diff(blank, &1)))
+
+      assert String.contains?(linked_out, osc8_open(url))
+      assert String.contains?(linked_out, @osc8_close)
+      refute String.contains?(plain_out, "\e]8")
+    end
+  end
+end

--- a/test/raxol/ui/hyperlink_live_path_test.exs
+++ b/test/raxol/ui/hyperlink_live_path_test.exs
@@ -1,0 +1,87 @@
+defmodule Raxol.UI.HyperlinkLivePathTest do
+  @moduledoc """
+  End-to-end threading of a `link:` through the live render pipeline:
+
+      ElementRenderer.render_text  ->  {:hyperlink, url} in the cell attrs
+      Backends.apply_cells_to_buffer  ->  cell.style.hyperlink on the ScreenBuffer
+      Terminal.Renderer.render  ->  OSC 8 escape around the run
+
+  This is the path a live TUI (cockpit / SSH / LiveView bridge) takes, distinct
+  from the `Raxol.Core.Renderer.apply_diff/1` compat path.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Renderer.View.Components.Text
+  alias Raxol.Core.Runtime.Rendering.Backends
+  alias Raxol.Terminal.Renderer
+  alias Raxol.UI.ElementRenderer
+  alias Raxol.UI.Layout.Engine, as: LayoutEngine
+  alias Raxol.UI.Renderer, as: UIRenderer
+
+  @url "https://basescan.org/tx/0xabc"
+
+  defp osc8_open(url), do: "\e]8;;" <> url <> "\e\\"
+  @osc8_close "\e]8;;\e\\"
+
+  test "render_text tags cells with the hyperlink when style carries :link" do
+    cells = ElementRenderer.render_text(0, 0, "go", %{link: @url}, %{})
+
+    assert Enum.all?(cells, fn {_x, _y, _char, _fg, _bg, attrs} ->
+             {:hyperlink, @url} in attrs
+           end)
+  end
+
+  test "render_text adds no hyperlink tag when no link is present" do
+    cells = ElementRenderer.render_text(0, 0, "go", %{fg: :red}, %{})
+
+    refute Enum.any?(cells, fn {_x, _y, _char, _fg, _bg, attrs} ->
+             Enum.any?(attrs, &match?({:hyperlink, _}, &1))
+           end)
+  end
+
+  test "tagged cells thread through the buffer bridge into an OSC 8 render" do
+    cells = ElementRenderer.render_text(0, 0, "go", %{link: @url}, %{})
+    buffer = Backends.apply_cells_to_buffer(cells, %{width: 8, height: 1})
+
+    output = Renderer.render(Renderer.new(buffer))
+
+    assert String.contains?(output, osc8_open(@url))
+    assert String.contains?(output, @osc8_close)
+  end
+
+  test "untagged cells produce no OSC 8 through the same path" do
+    cells = ElementRenderer.render_text(0, 0, "go", %{fg: :red}, %{})
+    buffer = Backends.apply_cells_to_buffer(cells, %{width: 8, height: 1})
+
+    output = Renderer.render(Renderer.new(buffer))
+
+    refute String.contains?(output, "\e]8")
+  end
+
+  describe "View DSL text(link:) through the real layout engine" do
+    test "LayoutEngine preserves :link on the positioned text element" do
+      el = Text.new("raxol.io", link: @url, fg: :cyan)
+      positioned = LayoutEngine.apply_layout(el, %{width: 20, height: 1})
+
+      assert Enum.any?(positioned, &(Map.get(&1, :link) == @url))
+    end
+
+    test "text(link:) renders its glyphs wrapped in OSC 8 end-to-end" do
+      el = Text.new("raxol.io", link: @url, fg: :cyan, style: [:underline])
+
+      output =
+        el
+        |> LayoutEngine.apply_layout(%{width: 20, height: 1})
+        |> UIRenderer.render_to_cells(nil)
+        |> Backends.apply_cells_to_buffer(%{width: 20, height: 1})
+        |> Renderer.new()
+        |> Renderer.render()
+
+      # real glyphs present (not just blank hyperlinked cells)
+      assert output =~ "r"
+      assert output =~ "x"
+      assert String.contains?(output, osc8_open(@url))
+      assert String.contains?(output, @osc8_close)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a `link:` attribute to the View DSL `text/2` that makes rendered text a cmd-clickable OSC 8 hyperlink in supporting terminals (iTerm2, kitty, WezTerm). Closes #317.

```elixir
text("0x7f3a..e21", link: "https://basescan.org/tx/0x7f3a...")
```

## How

The infrastructure already existed (`TextFormatting.hyperlink`, `cell.style.hyperlink`, OSC 8 input parsing) -- this is the missing wiring. The link threads through both render paths:

**Live terminal path** (what a running TUI / SSH / cockpit uses):

```
Text.new(link:)                  -> element :link key
LayoutEngine.process_element     -> preserved on the positioned text element
UIRenderer / ElementRenderer     -> tagged {:hyperlink, url} in the cell attrs list
Backends.apply_cells_to_buffer   -> lifted onto cell.style.hyperlink (ScreenBuffer)
Terminal.Renderer.render         -> OSC 8 wrap around the run
```

The link rides in the existing 6-tuple `attrs` list as a tagged `{:hyperlink, url}` entry, so the cell-tuple arity is unchanged and no tuple producer/consumer needed touching.

**Compat path** (`Raxol.Core.Renderer`, used by recording / LiveView bridge): `apply_diff/1` and `render_to_ansi/1` wrap linked runs in OSC 8 from `cell.style.hyperlink`.

Bare OSC 8 form emitted: `ESC ] 8 ; ; URL ST  <styled text>  ESC ] 8 ; ; ST`. Cells with no link render byte-identically. (Note: the pre-existing `AdvancedFeatures.create_hyperlink/3` emits a malformed single-semicolon bare form, so this emits the correct sequence directly rather than reuse it.)

## Consumers wired

- `Raxol.Demo.LandingScene` -- the Basescan tx ref is now clickable.
- `examples/agents/zero_system.exs` -- each settled DEBIT ledger line links to the settlement on Basescan.
- `Raxol.Demo.Showcase` -- the About tab gained a clickable Links section (site / docs / source), replacing plain-text values.

## Tests

- `test/raxol/core/renderer_osc8_test.exs` -- DSL `link:` attr + `apply_diff/1` / `render_to_ansi/1` OSC 8 wrapping, including the acceptance property "wraps iff a hyperlink is present" and "leaves unlinked cells untouched".
- `test/raxol/ui/hyperlink_live_path_test.exs` -- end-to-end live path: `ElementRenderer.render_text` tagging -> `Backends` bridge -> `Terminal.Renderer` OSC 8, plus `text(link:)` through the real `LayoutEngine`.
- `packages/raxol_terminal/test/raxol/terminal/renderer_osc8_test.exs` -- live emit in both individual and batched render modes.

## Manual testing

- [x] `mix test test/raxol/ui/ test/raxol/core/renderer/` -> 1081 tests, 0 failures
- [x] `cd packages/raxol_terminal && mix test test/raxol/terminal/renderer_test.exs test/raxol/terminal/renderer_osc8_test.exs` -> 22 tests, 0 failures
- [x] End-to-end render of a `text(link:)` element through the real `LayoutEngine` emits `ESC]8;;<url>ST <glyphs> ESC]8;;ST`
- [x] `mix format --check-formatted` on all changed files (root + raxol_terminal)
- [x] `examples/agents/zero_system.exs` syntax-checks
- [ ] Visual: run `mix raxol.demo showcase`, open the About tab in iTerm2/kitty, cmd-click a link
