### PR TITLE
Xochi: validate EIP-712 signing + surface settlement state

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
@@ -76,7 +76,12 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
         from_amount: [type: :string],
         to_amount: [type: :string],
         xochi_fee: [type: :string],
-        stealth_address: [type: :string]
+        stealth_address: [type: :string],
+        reconciling: [
+          type: :boolean,
+          description:
+            "True when the settlement is in doubt: the worker could not confirm the solver executed, so the intent stays non-terminal. Poll the intent status to resolve; do not re-execute."
+        ]
       ]
     ]
 
@@ -122,6 +127,14 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
       {:ok, summary}
     end
   end
+
+  # An in-doubt (reconciling) settlement has not landed yet: the worker could not
+  # confirm the solver executed (typically an upstream Riddler 5xx/timeout wrapped
+  # as a 200) and kept the intent non-terminal. No stealth address exists yet --
+  # it appears only once the intent resolves to completed via polling -- so the
+  # stealth-address guard below must not fire. The in-doubt state is surfaced to
+  # the caller via the summary's `reconciling` flag instead.
+  defp assert_settlement_privacy(_request, %{reconciling: true}), do: :ok
 
   # A stealth settlement must come back with the stealth address the worker
   # derived and announced. A nil there means the funds did not land on a stealth
@@ -351,7 +364,11 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
       from_amount: request.from_amount,
       to_amount: quote.to_amount,
       xochi_fee: quote.xochi_fee,
-      stealth_address: exec.stealth_address
+      stealth_address: exec.stealth_address,
+      # Surface the in-doubt state rather than reporting a clean success: an
+      # execute the worker could not confirm (often a wrapped upstream 5xx) is
+      # not a completed payment. Poll the intent status to resolve.
+      reconciling: exec.reconciling
     }
   end
 end

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -28,7 +28,10 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
         terminal: [type: :boolean],
         tx_hash: [type: :string],
         settlement_type: [type: :string],
-        settlement_speed: [type: :string]
+        settlement_speed: [type: :string],
+        note_commitment: [type: :string],
+        nullifier_hash: [type: :string],
+        l2_tx_hash: [type: :string]
       ]
     ]
 
@@ -79,7 +82,14 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
       terminal: IntentStatus.terminal?(status),
       tx_hash: status.tx_hash,
       settlement_type: status.settlement_type && to_string(status.settlement_type),
-      settlement_speed: speed(elapsed_ms, budget_ms)
+      settlement_speed: speed(elapsed_ms, budget_ms),
+      # Shielded (Aztec) settlements are note-based: the note commitment,
+      # nullifier, and L2 tx surface here at terminal status in place of an
+      # on-chain stealth address. nil for public/stealth settlements, where a
+      # present-nil is treated as absent by the output schema.
+      note_commitment: status.note_commitment,
+      nullifier_hash: status.nullifier_hash,
+      l2_tx_hash: status.l2_tx_hash
     }
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
@@ -288,7 +288,8 @@ defmodule Raxol.Payments.Xochi.Schemas do
       :ephemeral_pub_key,
       :view_tag,
       :error,
-      success: false
+      success: false,
+      reconciling: false
     ]
 
     @type t :: %__MODULE__{
@@ -300,7 +301,8 @@ defmodule Raxol.Payments.Xochi.Schemas do
             stealth_address: String.t() | nil,
             ephemeral_pub_key: String.t() | nil,
             view_tag: integer() | nil,
-            error: String.t() | nil
+            error: String.t() | nil,
+            reconciling: boolean()
           }
 
     # The Xochi worker's execute response is snake_case (`intent_id`, `tx_hash`,
@@ -319,7 +321,11 @@ defmodule Raxol.Payments.Xochi.Schemas do
         stealth_address: pick(json, ["stealth_address", "stealthAddress"]),
         ephemeral_pub_key: pick(json, ["ephemeral_pub_key", "ephemeralPubKey"]),
         view_tag: pick(json, ["view_tag", "viewTag"]),
-        error: json["error"]
+        error: json["error"],
+        # In-doubt: the worker could not confirm the solver executed (a Riddler
+        # 5xx/timeout wrapped as a 200) and kept the intent non-terminal. Funds
+        # may be in flight; the caller must poll to resolve, never re-execute.
+        reconciling: pick(json, ["reconciling"]) || false
       }
     end
 

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
@@ -705,6 +705,37 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntentTest do
       assert {:error, %Failure{reason: :expired, retryable?: true}} =
                PollXochiStatus.run(%{intent_id: "int_3"}, ctx)
     end
+
+    # Mirrors riddler-client test-xochi.js "shielded status RESULT_JSON carries
+    # note_commitment + l2_tx_hash". A shielded (Aztec) settlement is note-based:
+    # at terminal status it announces a note commitment / nullifier / L2 tx in
+    # place of a stealth address, and an agent polling must be able to read them.
+    test "surfaces shielded note fields at terminal status" do
+      note = "0x" <> String.duplicate("ab", 32)
+      nullifier = "0x" <> String.duplicate("cd", 32)
+      l2_tx = "0x" <> String.duplicate("ef", 32)
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.json(conn, %{
+          "intentId" => "int_sh",
+          "status" => "completed",
+          "settlementType" => "shielded",
+          "noteCommitment" => note,
+          "nullifierHash" => nullifier,
+          "l2TxHash" => l2_tx,
+          "terminal" => true
+        })
+      end)
+
+      # call/2 (not run/2) so the new note fields pass the output schema.
+      assert {:ok, result} =
+               PollXochiStatus.call(%{intent_id: "int_sh"}, %{xochi_config: config()})
+
+      assert result.settlement_type == "shielded"
+      assert result.note_commitment == note
+      assert result.nullifier_hash == nullifier
+      assert result.l2_tx_hash == l2_tx
+    end
   end
 
   # The Action behaviour's `call/2` validates the output against the output
@@ -812,6 +843,54 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntentTest do
       assert is_nil(result.stealth_address)
     end
 
+    test "a clean execute reports reconciling: false" do
+      stub_quote(%{
+        "success" => true,
+        "intentId" => "int_1",
+        "status" => "executing",
+        "stealthAddress" => "0xstealth"
+      })
+
+      assert {:ok, result} = ExecuteXochiIntent.call(base_params(%{}), call_ctx())
+      assert result.reconciling == false
+    end
+
+    test "an in-doubt (reconciling) execute surfaces reconciling, not a clean success" do
+      # The worker could not confirm the solver executed (a Riddler 5xx/timeout
+      # wrapped as a 200) and kept the intent non-terminal: success=true,
+      # status=executing, reconciling=true, no tx hash. raxol must surface the
+      # in-doubt state, not report a settled payment.
+      stub_quote(%{
+        "success" => true,
+        "intent_id" => "int_1",
+        "status" => "executing",
+        "reconciling" => true
+      })
+
+      params = base_params(%{settlement: "public", recipient_meta_address: nil})
+
+      assert {:ok, result} = ExecuteXochiIntent.call(params, call_ctx())
+      assert result.status == "executing"
+      assert result.reconciling == true
+    end
+
+    test "an in-doubt stealth execute is not misreported as a missing stealth address" do
+      # A reconciling stealth execute has no stealth address yet (it appears once
+      # the intent resolves to completed via polling). That is the in-doubt state,
+      # not a privacy downgrade, so the stealth-address guard must not fail closed
+      # here -- the in-doubt is surfaced via `reconciling` instead.
+      stub_quote(%{
+        "success" => true,
+        "intent_id" => "int_1",
+        "status" => "executing",
+        "reconciling" => true
+      })
+
+      assert {:ok, result} = ExecuteXochiIntent.call(base_params(%{}), call_ctx())
+      assert result.reconciling == true
+      assert is_nil(result.stealth_address)
+    end
+
     test "an explicit nil slippage falls back to the 50 bps default, never null" do
       # A present nil must not defeat the documented default and reach the worker
       # as null (an unbounded-slippage downgrade).
@@ -871,6 +950,10 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntentTest do
       assert result.terminal == true
       assert is_nil(result.tx_hash)
       assert is_nil(result.settlement_type)
+      # A public/stealth settlement carries no note fields; present-nil must pass.
+      assert is_nil(result.note_commitment)
+      assert is_nil(result.nullifier_hash)
+      assert is_nil(result.l2_tx_hash)
     end
   end
 end

--- a/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
@@ -6,6 +6,51 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
 
   @moduletag :conformance
 
+  # secp256k1 private key 1 from the conformance fixtures; derives the signer
+  # below. Pinned here so the shielded vector signs without the JSON fixture.
+  @canonical_key "0x0000000000000000000000000000000000000000000000000000000000000001"
+  @canonical_signer "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+
+  # XochiIntent typed data, byte-for-byte aligned with the CLI's XOCHI_TYPES
+  # (riddler-client src/xochi-signing.js) and
+  # Riddler.Integrations.Xochi.EIP712.type_definitions/0.
+  @xochi_types %{
+    "XochiIntent" => [
+      {"intentId", "string"},
+      {"quoteId", "string"},
+      {"wallet", "address"},
+      {"fromChainId", "uint256"},
+      {"toChainId", "uint256"},
+      {"fromToken", "address"},
+      {"toToken", "address"},
+      {"fromAmount", "uint256"},
+      {"toAmount", "uint256"},
+      {"settlementPreference", "string"},
+      {"nonce", "uint256"},
+      {"deadline", "uint256"}
+    ]
+  }
+
+  # The shielded XochiIntent domain mirrors the fixture generator: name/version
+  # are locked for determinism (production reads them from the quote response).
+  @shielded_domain %{name: "XochiIntent", version: "1", chainId: 8453}
+
+  # Pinned in riddler-client test-xochi.js ("shielded intent signs
+  # deterministically"); the cross-repo byte-equality contract for the private
+  # settlement path.
+  @shielded_signature "0xbe2545d815e4ce15d859e9bdee5bcb3a2f81e94a4b0fd0586220bd0235682d2f4bd1ea6082ddb8e59bb5557e91cb2f80e4dd3aef800e0fa4eabd0367a04c86061b"
+
+  # The fixture domain (above) is a determinism-locked synthetic, NOT the live
+  # worker domain. The live worker domain-separates with name "Xochi", version
+  # "1-prod", and a bytes32 salt (no verifyingContract) -- pinned byte-for-byte
+  # against viem in eip712_test.exs "salt domain". Kept here to guard the drift.
+  @live_domain %{
+    name: "Xochi",
+    version: "1-prod",
+    chainId: 8453,
+    salt: "0x50c4e63fec78d6897bf2f854fbe944310903876e56027940293bb80e79f75fe2"
+  }
+
   setup_all do
     case ConformanceFixture.locate() do
       {:ok, _path} -> :ok
@@ -34,12 +79,106 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
                "digest mismatch for #{vec["name"]}: got #{digest_hex}, expected #{vec["expected_digest"]}"
       end
 
+      # The fixture pins the ethers signature and signer for every vector. The
+      # digest test above only proves hashing parity; this proves the full
+      # hash -> sign -> pack_signature path lands on the exact bytes ethers
+      # produced (deterministic RFC 6979, low-s, on-chain-canonical v of 27/28),
+      # and that those bytes recover to the intent wallet. Always-on, no node.
+      test "signs + recovers identically to CLI for #{vec["name"]}" do
+        vec = @vec
+        eip712 = vec["eip712"]
+        domain = atomize_domain(eip712["domain"])
+        types = atomize_types(eip712["types"])
+        message = eip712["message"]
+
+        assert {:ok, digest} = EIP712.hash(domain, types, message)
+        signature = sign_digest(digest, decode_hex!(vec["private_key"]))
+        signature_hex = "0x" <> Base.encode16(signature, case: :lower)
+
+        assert signature_hex == vec["expected_signature"],
+               "signature mismatch for #{vec["name"]}: got #{signature_hex}, expected #{vec["expected_signature"]}"
+
+        assert recover_address(digest, signature) == String.downcase(vec["expected_signer"]),
+               "recovered signer mismatch for #{vec["name"]}"
+      end
+
       test "domain has no verifyingContract for #{vec["name"]}" do
         vec = @vec
         refute Map.has_key?(vec["eip712"]["domain"], "verifyingContract")
       end
     end
   end
+
+  # The conformance.json generator only emits `public` Xochi vectors, so the
+  # shielded (Aztec) signature is pinned directly against the CLI's own pin.
+  # Shielded settlement is note-based and carries no stealth address; the only
+  # client-side artifact is this signature, so a regression in EIP-712 hashing
+  # or the settlementPreference binding is caught here without a live solver.
+  describe "shielded XochiIntent signature (pinned, mirrors riddler-client)" do
+    test "signs the pinned shielded vector byte-for-byte and recovers to the signer" do
+      message = shielded_message("shielded")
+
+      assert {:ok, digest} = EIP712.hash(@shielded_domain, @xochi_types, message)
+      signature = sign_digest(digest, decode_hex!(@canonical_key))
+      signature_hex = "0x" <> Base.encode16(signature, case: :lower)
+
+      assert signature_hex == @shielded_signature
+      assert recover_address(digest, signature) == @canonical_signer
+    end
+
+    test "settlementPreference is bound into the digest (public != stealth != shielded)" do
+      digests =
+        for pref <- ~w(public stealth shielded) do
+          assert {:ok, digest} =
+                   EIP712.hash(@shielded_domain, @xochi_types, shielded_message(pref))
+
+          digest
+        end
+
+      assert digests == Enum.uniq(digests), "settlement preferences must not collide"
+    end
+  end
+
+  # The conformance fixture validates raxol's EIP-712 hashing math against a
+  # domain the generator locks "for determinism" (XochiIntent / version "1" /
+  # no salt). That is deliberately NOT the live worker domain (Xochi / version
+  # "1-prod" / salt). raxol signs whatever domain the quote serves verbatim
+  # (Protocols.Xochi.eip712_domain/1 copies salt + verifyingContract), so the
+  # live path is correct regardless -- but a fixture digest must never be taken
+  # for a live one. This guard fails loudly if the two domains ever converge,
+  # forcing a conscious decision about whether the fixture should track live.
+  describe "live-vs-fixture domain drift guard" do
+    test "the fixture domain differs from the live worker domain (name, version, salt)" do
+      fixture = ConformanceFixture.by_name("xochi-base-optimism-usdc")["eip712"]["domain"]
+
+      assert fixture["name"] == "XochiIntent"
+      assert fixture["name"] != @live_domain.name
+
+      assert fixture["version"] == "1"
+      assert fixture["version"] != @live_domain.version
+
+      refute Map.has_key?(fixture, "salt")
+      assert Map.has_key?(@live_domain, :salt)
+    end
+
+    test "the same XochiIntent message hashes differently under each domain" do
+      message = shielded_message("public")
+
+      assert {:ok, fixture_digest} =
+               EIP712.hash(
+                 %{name: "XochiIntent", version: "1", chainId: 8453},
+                 @xochi_types,
+                 message
+               )
+
+      assert {:ok, live_digest} = EIP712.hash(@live_domain, @xochi_types, message)
+
+      refute fixture_digest == live_digest,
+             "fixture and live domains must not collide: a fixture-signed intent must never validate against the live worker"
+    end
+  end
+
+  # -- Fixture shape helpers --
 
   defp atomize_domain(domain) do
     %{name: domain["name"], chainId: domain["chainId"]}
@@ -60,4 +199,42 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
       {type_name, tuples}
     end)
   end
+
+  defp shielded_message(settlement) do
+    %{
+      "intentId" => "shielded-test",
+      "quoteId" => "shielded-test",
+      "wallet" => "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+      "fromChainId" => 8453,
+      "toChainId" => 10,
+      "fromToken" => "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "toToken" => "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+      "fromAmount" => "1000000",
+      "toAmount" => "1000000",
+      "settlementPreference" => settlement,
+      "nonce" => 0,
+      "deadline" => 1_900_000_000
+    }
+  end
+
+  # -- Signing / recovery (mirror production primitives) --
+
+  # Mirrors Raxol.Payments.Wallets.Env.sign_hash/2: sign the EIP-712 digest and
+  # normalize v to the on-chain-canonical 27/28. Uses the primitives directly so
+  # the test stays hermetic (no env var, async-safe).
+  defp sign_digest(digest, privkey) do
+    {:ok, signature} = ExSecp256k1.sign(digest, privkey)
+    EIP712.pack_signature(signature)
+  end
+
+  # Mirrors Raxol.Payments.Mandate signer recovery: recover the public key from
+  # the 65-byte r||s||v signature and derive the 20-byte Ethereum address.
+  defp recover_address(digest, <<r::binary-size(32), s::binary-size(32), v::8>>) do
+    {:ok, pubkey} = ExSecp256k1.recover(digest, r, s, v - 27)
+    <<_prefix::8, key_bytes::binary>> = pubkey
+    <<_first_12::binary-size(12), address_bytes::binary-size(20)>> = ExKeccak.hash_256(key_bytes)
+    "0x" <> Base.encode16(address_bytes, case: :lower)
+  end
+
+  defp decode_hex!("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
 end


### PR DESCRIPTION
## Summary

Cross-validates raxol's Xochi EIP-712 signing against the `riddler-client`
reference vectors, and properly surfaces two Xochi settlement states that were
previously dropped or misread. Closes four raxol-owned follow-ups (#339-#342)
filed against the live-gate work.

All changes are in `raxol_payments`. The validation is offline and always-on
(no node, no live solver); the surfacing changes pair lib + test in one commit
so each commit passes on its own.

## What changed

### Conformance validation vs `riddler-client` (#339, #340, #341)
`xochi_conformance_test.exs` previously asserted only the EIP-712 **digest** for
the Xochi vectors -- the fixture's `expected_signature` / `expected_signer` went
unchecked.

- **#339** -- assert the full `hash -> sign -> pack_signature` path lands on the
  exact bytes ethers produced (deterministic RFC 6979, low-s, canonical v 27/28)
  and that the signature recovers to the intent wallet, for all 5 fixture vectors.
- **#340** -- pin the shielded XochiIntent signature directly against the value
  `riddler-client/src/test-xochi.js` pins (the JSON fixture has no shielded
  vector). Independently reproduced (`node src/test-xochi.js` is green too).
- **#341** -- guard the live-vs-fixture domain drift: the fixture domain
  (`XochiIntent` / `1` / no salt, locked "for determinism" by the generator) is
  pinned distinct from the live worker domain (`Xochi` / `1-prod` / salt, which
  `eip712_test.exs` already validates byte-for-byte vs viem), and the same
  message is shown to hash differently under each, so a fixture-signed intent can
  never be mistaken for a live one.

### Surface shielded note fields at terminal status (#342)
`IntentStatus.from_json/1` parsed `note_commitment` / `nullifier_hash` /
`l2_tx_hash` but `PollXochiStatus` dropped them from its output schema and
summary, so an agent polling a shielded settlement never saw the note commitment.
Added them as optional outputs and surfaced them. Mirrors the
`shielded status RESULT_JSON carries note_commitment + l2_tx_hash` test in
`riddler-client`.

### Surface the Xochi in-doubt (reconcile) execute state
On a Riddler 5xx/timeout it cannot confirm, the worker returns **HTTP 200** with
`reconciling: true` / `status: "executing"` / `success: true` and no
`tx_hash` / `stealth_address` (the intent stays non-terminal; funds may be in
flight; the client must poll, never re-execute). raxol read that as a clean
success, and for stealth the `stealth_address_missing` guard would misreport it
as a privacy downgrade.

- `ExecuteResponse` parses `reconciling`; `ExecuteXochiIntent` surfaces it as a
  new optional `:boolean` output and exempts the in-doubt case from the
  stealth-address guard.
- Kept as `{:ok, summary}` with `reconciling: true` (not a hard error) on
  purpose: the worker contract is `success: true` / poll-to-resolve, and a hard
  error would risk abandoning in-flight funds or triggering a re-execute.

## Manual testing

- [x] `mix test test/raxol/payments/conformance/xochi_conformance_test.exs --include conformance` -- 19 tests, 0 failures
- [x] `mix test test/raxol/payments/actions/payments/execute_xochi_intent_test.exs` -- 67 tests (incl. schemas), 0 failures
- [x] `mix compile --warnings-as-errors` -- clean for touched files
- [x] Full `raxol_payments` suite -- 731 tests + 45 properties, 0 failures
- [x] `node src/test-xochi.js` in `riddler-client` -- 17 passed (reference side)

## Notes

- Left bare HTTP 5xx mapping as-is (`Failure.http_failure` -> retryable
  `:network`): the worker never returns a bare 500 when funds may move.
- `reconciling` is execute-only; GET-status conveys in-doubt as a non-terminal
  `executing` status plus `substatus_message`.


## Closes

Closes #339
Closes #340
Closes #341
Closes #342
