### PR TITLE
Extend signature conformance to ERC-3009 + Permit2

### DIFF
--- a/packages/raxol_payments/test/raxol/payments/conformance/permit2_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/permit2_conformance_test.exs
@@ -3,6 +3,7 @@ defmodule Raxol.Payments.Conformance.Permit2ConformanceTest do
 
   alias Raxol.Payments.Protocols.Permit2
   alias Raxol.Payments.Test.ConformanceFixture
+  alias Raxol.Payments.Test.ConformanceSigner
 
   @moduletag :conformance
 
@@ -13,37 +14,66 @@ defmodule Raxol.Payments.Conformance.Permit2ConformanceTest do
     end
   end
 
-  defmodule StaticWallet do
+  # Signs with secp256k1 key 1 (the conformance fixture's key) through the same
+  # primitives as Raxol.Payments.Wallets.Env, so Permit2.sign_quote/3 returns the
+  # exact signature bytes ethers produced. address/0 is the derived signer.
+  defmodule CanonicalWallet do
     @moduledoc false
     @behaviour Raxol.Payments.Wallet
+
+    @key Base.decode16!("0000000000000000000000000000000000000000000000000000000000000001")
+
     @impl true
     def address, do: "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+
     @impl true
     def chain_id, do: 0
+
     @impl true
     def sign_message(_msg), do: {:ok, <<0::512>>}
+
     @impl true
-    def sign_typed_data(_domain, _types, _message), do: {:ok, <<0::520>>}
+    def sign_typed_data(domain, types, message) do
+      with {:ok, digest} <- Raxol.Payments.EIP712.hash(domain, types, message),
+           {:ok, signature} <- ExSecp256k1.sign(digest, @key) do
+        {:ok, Raxol.Payments.EIP712.pack_signature(signature)}
+      end
+    end
+
     @impl true
-    def sign_hash(_digest), do: {:ok, <<0::520>>}
+    def sign_hash(<<digest::binary-size(32)>>) do
+      {:ok, signature} = ExSecp256k1.sign(digest, @key)
+      {:ok, Raxol.Payments.EIP712.pack_signature(signature)}
+    end
   end
 
   describe "Permit2 EIP-712 conformance vs CLI" do
     for vec <- ConformanceFixture.by_protocol("permit2") do
       @vec vec
 
-      test "digest + signed_object match CLI for #{vec["name"]}" do
+      test "digest + signed_object + signature match CLI for #{vec["name"]}" do
         vec = @vec
         chain_id = vec["domain"]["chainId"] || vec["domain"]["chain_id"]
         quote_map = vec["quote"]
 
-        assert {:ok, result} = Permit2.sign_quote(quote_map, chain_id, StaticWallet)
+        assert {:ok, result} = Permit2.sign_quote(quote_map, chain_id, CanonicalWallet)
 
         assert result.digest == vec["expected_digest"],
                "digest mismatch for #{vec["name"]}: got #{result.digest}, expected #{vec["expected_digest"]}"
 
         assert result.signed_object == vec["expected_signed_object"],
                "signed_object mismatch for #{vec["name"]}: got #{result.signed_object}, expected #{vec["expected_signed_object"]}"
+
+        # The CLI signs the PermitWitnessTransferFrom digest with ethers; the full
+        # sign_quote path must land on the same bytes and recover to the signer.
+        assert result.signature == vec["expected_signature"],
+               "signature mismatch for #{vec["name"]}: got #{result.signature}, expected #{vec["expected_signature"]}"
+
+        digest = ConformanceSigner.decode_hex!(result.digest)
+
+        assert ConformanceSigner.recover_address(digest, result.signature) ==
+                 String.downcase(vec["expected_signer"]),
+               "recovered signer mismatch for #{vec["name"]}"
       end
     end
   end

--- a/packages/raxol_payments/test/raxol/payments/conformance/x402_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/x402_conformance_test.exs
@@ -4,6 +4,7 @@ defmodule Raxol.Payments.Conformance.X402ConformanceTest do
   alias Raxol.Payments.Assets.UsdcDomains
   alias Raxol.Payments.EIP712
   alias Raxol.Payments.Test.ConformanceFixture
+  alias Raxol.Payments.Test.ConformanceSigner
 
   @moduletag :conformance
 
@@ -55,6 +56,27 @@ defmodule Raxol.Payments.Conformance.X402ConformanceTest do
 
         assert version == vec["domain"]["version"],
                "USDC version mismatch for chain #{chain_id}: got #{version}, expected #{vec["domain"]["version"]}"
+      end
+
+      # The digest test proves hashing parity; this proves the full
+      # hash -> sign -> pack_signature path lands on the exact bytes ethers
+      # produced and that they recover to the signer. Offline, no node.
+      test "signs + recovers identically to CLI for #{vec["name"]}" do
+        vec = @vec
+        domain = atomize_domain(vec["domain"])
+        message = parse_message(vec["message"])
+
+        assert {:ok, digest} = EIP712.hash(domain, @erc3009_types, message)
+
+        signature =
+          ConformanceSigner.sign_hex(digest, ConformanceSigner.decode_hex!(vec["private_key"]))
+
+        assert signature == vec["expected_signature"],
+               "signature mismatch for #{vec["name"]}: got #{signature}, expected #{vec["expected_signature"]}"
+
+        assert ConformanceSigner.recover_address(digest, signature) ==
+                 String.downcase(vec["expected_signer"]),
+               "recovered signer mismatch for #{vec["name"]}"
       end
     end
   end

--- a/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
@@ -3,6 +3,7 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
 
   alias Raxol.Payments.EIP712
   alias Raxol.Payments.Test.ConformanceFixture
+  alias Raxol.Payments.Test.ConformanceSigner
 
   @moduletag :conformance
 
@@ -92,13 +93,15 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
         message = eip712["message"]
 
         assert {:ok, digest} = EIP712.hash(domain, types, message)
-        signature = sign_digest(digest, decode_hex!(vec["private_key"]))
-        signature_hex = "0x" <> Base.encode16(signature, case: :lower)
 
-        assert signature_hex == vec["expected_signature"],
-               "signature mismatch for #{vec["name"]}: got #{signature_hex}, expected #{vec["expected_signature"]}"
+        signature =
+          ConformanceSigner.sign_hex(digest, ConformanceSigner.decode_hex!(vec["private_key"]))
 
-        assert recover_address(digest, signature) == String.downcase(vec["expected_signer"]),
+        assert signature == vec["expected_signature"],
+               "signature mismatch for #{vec["name"]}: got #{signature}, expected #{vec["expected_signature"]}"
+
+        assert ConformanceSigner.recover_address(digest, signature) ==
+                 String.downcase(vec["expected_signer"]),
                "recovered signer mismatch for #{vec["name"]}"
       end
 
@@ -119,11 +122,12 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
       message = shielded_message("shielded")
 
       assert {:ok, digest} = EIP712.hash(@shielded_domain, @xochi_types, message)
-      signature = sign_digest(digest, decode_hex!(@canonical_key))
-      signature_hex = "0x" <> Base.encode16(signature, case: :lower)
 
-      assert signature_hex == @shielded_signature
-      assert recover_address(digest, signature) == @canonical_signer
+      signature =
+        ConformanceSigner.sign_hex(digest, ConformanceSigner.decode_hex!(@canonical_key))
+
+      assert signature == @shielded_signature
+      assert ConformanceSigner.recover_address(digest, signature) == @canonical_signer
     end
 
     test "settlementPreference is bound into the digest (public != stealth != shielded)" do
@@ -216,25 +220,4 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
       "deadline" => 1_900_000_000
     }
   end
-
-  # -- Signing / recovery (mirror production primitives) --
-
-  # Mirrors Raxol.Payments.Wallets.Env.sign_hash/2: sign the EIP-712 digest and
-  # normalize v to the on-chain-canonical 27/28. Uses the primitives directly so
-  # the test stays hermetic (no env var, async-safe).
-  defp sign_digest(digest, privkey) do
-    {:ok, signature} = ExSecp256k1.sign(digest, privkey)
-    EIP712.pack_signature(signature)
-  end
-
-  # Mirrors Raxol.Payments.Mandate signer recovery: recover the public key from
-  # the 65-byte r||s||v signature and derive the 20-byte Ethereum address.
-  defp recover_address(digest, <<r::binary-size(32), s::binary-size(32), v::8>>) do
-    {:ok, pubkey} = ExSecp256k1.recover(digest, r, s, v - 27)
-    <<_prefix::8, key_bytes::binary>> = pubkey
-    <<_first_12::binary-size(12), address_bytes::binary-size(20)>> = ExKeccak.hash_256(key_bytes)
-    "0x" <> Base.encode16(address_bytes, case: :lower)
-  end
-
-  defp decode_hex!("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
 end

--- a/packages/raxol_payments/test/support/conformance_signer.ex
+++ b/packages/raxol_payments/test/support/conformance_signer.ex
@@ -1,0 +1,47 @@
+defmodule Raxol.Payments.Test.ConformanceSigner do
+  @moduledoc """
+  Shared signing / recovery helpers for the EIP-712 conformance suites.
+
+  The riddler-client conformance fixture pins, per vector, the ethers
+  `expected_signature` and `expected_signer` alongside the digest. These helpers
+  let the Xochi, ERC-3009 (x402), and Permit2 conformance tests assert those
+  byte-for-byte without a node or a live wallet.
+
+  Mirrors the production primitives so the assertions exercise the real path:
+
+  - `sign_hex/2` is `Raxol.Payments.Wallets.Env.sign_hash/2` (`ExSecp256k1.sign`
+    then `Raxol.Payments.EIP712.pack_signature/1`, RFC 6979, low-s, canonical v
+    of 27/28).
+  - `recover_address/2` is the `Raxol.Payments.Mandate` signer recovery
+    (`ExSecp256k1.recover` then keccak-of-pubkey address derivation).
+  """
+
+  alias Raxol.Payments.EIP712
+
+  @doc """
+  Sign a 32-byte EIP-712 `digest` with `privkey` (raw 32 bytes), returning the
+  canonical `0x` + r||s||v signature hex (v normalized to 27/28).
+  """
+  @spec sign_hex(<<_::256>>, <<_::256>>) :: String.t()
+  def sign_hex(<<digest::binary-size(32)>>, <<privkey::binary-size(32)>>) do
+    {:ok, signature} = ExSecp256k1.sign(digest, privkey)
+    "0x" <> Base.encode16(EIP712.pack_signature(signature), case: :lower)
+  end
+
+  @doc """
+  Recover the lowercase `0x` Ethereum address that produced `signature` (a `0x`
+  r||s||v hex) over `digest` (raw 32 bytes).
+  """
+  @spec recover_address(<<_::256>>, String.t()) :: String.t()
+  def recover_address(<<digest::binary-size(32)>>, signature) when is_binary(signature) do
+    <<r::binary-size(32), s::binary-size(32), v::8>> = decode_hex!(signature)
+    {:ok, pubkey} = ExSecp256k1.recover(digest, r, s, v - 27)
+    <<_prefix::8, key_bytes::binary>> = pubkey
+    <<_first_12::binary-size(12), address_bytes::binary-size(20)>> = ExKeccak.hash_256(key_bytes)
+    "0x" <> Base.encode16(address_bytes, case: :lower)
+  end
+
+  @doc "Decode a `0x`-prefixed hex string to raw bytes."
+  @spec decode_hex!(String.t()) :: binary()
+  def decode_hex!("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+end


### PR DESCRIPTION
## Summary

Extends the #339 work (signature byte-equality + signer recovery vs the
`riddler-client` conformance fixture) to the **ERC-3009 (x402)** and **Permit2**
rails. Those two suites previously asserted only the digest (Permit2 also the
`signed_object` calldata), so the fixture's `expected_signature` /
`expected_signer` went unchecked for all 24 of those vectors -- the same gap
#339 closed for Xochi.

Test-only, offline, no node or live solver.

## What changed

- **New `Raxol.Payments.Test.ConformanceSigner`** (test support) -- shared
  `sign_hex/2` and `recover_address/2`, mirroring the production primitives
  (`Wallets.Env.sign_hash/2` and `Mandate` signer recovery). Single source of
  truth for all three conformance suites.
- **ERC-3009 (x402)** -- new per-vector test asserts the full
  `hash -> sign -> pack_signature` lands on the fixture's `expected_signature`
  and recovers `expected_signer` (8 vectors).
- **Permit2** -- the suite signed with a zero-signature stub wallet; replaced
  with a canonical-key signing wallet so `Permit2.sign_quote/3` returns the real
  signature, then assert `expected_signature` + signer recovery alongside the
  existing digest / `signed_object` checks (16 vectors).
- **Xochi** -- refactored off its inline sign/recover helpers onto the shared
  module (no behavior change).

## Manual testing

- [x] `mix test --only conformance` -- 60 tests, 0 failures
- [x] `mix format --check-formatted` on touched files -- clean
- [x] Full `raxol_payments` suite -- 731 tests + 45 properties, 0 failures

## Notes

Follow-up to #339 (already closed); no issue to auto-close. With this, every
protocol in the conformance fixture (ERC-3009, Permit2, Xochi public + shielded)
is validated byte-for-byte for digest, signature, and signer against the
`riddler-client` reference.
