### PR TITLE
Surface solver substatus on Xochi status polls

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -31,7 +31,13 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
         settlement_speed: [type: :string],
         note_commitment: [type: :string],
         nullifier_hash: [type: :string],
-        l2_tx_hash: [type: :string]
+        l2_tx_hash: [type: :string],
+        substatus: [type: :string],
+        substatus_message: [
+          type: :string,
+          description:
+            "Solver-supplied detail on the current/terminal status (e.g. the reconcile reason behind an in-doubt settlement). Present when the worker forwards one."
+        ]
       ]
     ]
 
@@ -53,8 +59,11 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
 
           {:ok, %IntentStatus{} = status, _elapsed_ms} ->
             # Terminal but not completed (failed/expired/refunded): a failed
-            # order must surface as an error, never as {:ok, ...}.
-            {:error, Failure.from({:settlement, status.status, status.error})}
+            # order must surface as an error, never as {:ok, ...}. Fall back to
+            # the solver's substatus_message when no explicit error is set, so
+            # the reason a settlement failed (e.g. a reconcile detail) is not lost.
+            {:error,
+             Failure.from({:settlement, status.status, status.error || status.substatus_message})}
 
           {:error, reason} ->
             {:error, Failure.from(reason)}
@@ -89,7 +98,12 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
       # present-nil is treated as absent by the output schema.
       note_commitment: status.note_commitment,
       nullifier_hash: status.nullifier_hash,
-      l2_tx_hash: status.l2_tx_hash
+      l2_tx_hash: status.l2_tx_hash,
+      # Solver-supplied progress detail, when forwarded by the worker. Lets a
+      # caller see why a settlement is where it is (e.g. an in-doubt reconcile
+      # note) instead of only the coarse status. nil when none is present.
+      substatus: status.substatus,
+      substatus_message: status.substatus_message
     }
   end
 

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
@@ -736,6 +736,43 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntentTest do
       assert result.nullifier_hash == nullifier
       assert result.l2_tx_hash == l2_tx
     end
+
+    test "surfaces solver substatus / substatus_message on a completed status" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.json(conn, %{
+          "intentId" => "int_1",
+          "status" => "completed",
+          "substatus" => "settled",
+          "substatus_message" => "filled from solver inventory",
+          "terminal" => true
+        })
+      end)
+
+      assert {:ok, result} =
+               PollXochiStatus.call(%{intent_id: "int_1"}, %{xochi_config: config()})
+
+      assert result.substatus == "settled"
+      assert result.substatus_message == "filled from solver inventory"
+    end
+
+    test "carries substatus_message into the error when a failed status has no explicit error" do
+      # An in-doubt settlement the reconcile sweep ultimately couldn't confirm
+      # ends `failed` with the reason in substatus_message rather than `error`.
+      # That reason must reach the caller, not be dropped.
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.json(conn, %{
+          "intentId" => "int_4",
+          "status" => "failed",
+          "substatus_message" => "reconcile: solver did not confirm execution",
+          "terminal" => true
+        })
+      end)
+
+      assert {:error, %Failure{reason: :not_filled} = failure} =
+               PollXochiStatus.run(%{intent_id: "int_4"}, %{xochi_config: config()})
+
+      assert failure.message =~ "reconcile: solver did not confirm execution"
+    end
   end
 
   # The Action behaviour's `call/2` validates the output against the output


### PR DESCRIPTION
## Summary

Polish follow-up to the in-doubt / reconcile surfacing from #343. `PollXochiStatus`
now surfaces the solver's `substatus` / `substatus_message`, so a settlement's
*reason* (e.g. the reconcile detail behind an in-doubt intent) reaches the caller
instead of only the coarse status.

`IntentStatus.from_json/1` already parsed both fields; the Action was dropping
them.

## What changed

- **Output schema + completed summary** -- added `substatus` and
  `substatus_message` (optional `:string`; nil = absent).
- **Failed/expired error** -- the settlement error now falls back to
  `substatus_message` when no explicit `error` is set, so a status that fails
  with the reason only in `substatus_message` (the reconcile-sweep outcome of an
  in-doubt settlement) surfaces that reason rather than a generic "did not fill".

Together with the execute-side `reconciling` flag (#343), the in-doubt story is
complete: execute reports in-doubt during limbo, and polling to a terminal state
carries the reason.

## Scope note

This surfaces the reason at **terminal** status (completed summary / failed
error), which is where a definitive reason exists. The still-executing limbo
window keeps returning a retryable timeout (poll again); carrying the
last-observed status through the shared `Poll.run` timeout would be a broader
change to that engine (and the relay path), so it's intentionally out of scope
here.

## Manual testing

- [x] `mix test test/raxol/payments/actions/payments/execute_xochi_intent_test.exs` -- 32 tests, 0 failures
- [x] `mix format --check-formatted` on touched files -- clean
- [x] Full `raxol_payments` suite -- 733 tests + 45 properties, 0 failures
