### PR TITLE
Fail-closed solver pin for Xochi origin pulls

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -10,6 +10,25 @@ if config_env() == :prod do
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     ssl: true
 
+  # Xochi origin-pull solver pin (#333). Pin the solver collection address the
+  # agent will sign pulls to, so a forged/MITM'd quote cannot redirect funds.
+  # These must equal Riddler's canonical per-chain solver addresses (the
+  # HD-derived submitter; see Riddler Xochi.Config.solver_address/1). Permit2 is
+  # fail-closed regardless; set XOCHI_PULL_REQUIRE_SOLVER_PIN=true to hard-pin
+  # ERC-3009 too once the allowlist below is populated.
+  config :raxol_payments,
+    pull_solver_allowlist:
+      [
+        "XOCHI_SOLVER_ETH",
+        "XOCHI_SOLVER_BASE",
+        "XOCHI_SOLVER_ARBITRUM",
+        "XOCHI_SOLVER_OPTIMISM"
+      ]
+      |> Enum.map(&System.get_env/1)
+      |> Enum.reject(&(is_nil(&1) or &1 == "")),
+    pull_require_solver_pin:
+      System.get_env("XOCHI_PULL_REQUIRE_SOLVER_PIN", "false") == "true"
+
   # Configure terminal settings from environment
   config :raxol, :terminal,
     default_width: String.to_integer(System.get_env("TERMINAL_WIDTH") || "80"),

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -268,10 +268,10 @@ defmodule Raxol.Payments.Protocols.Xochi do
 
   # ERC-3009 ReceiveWithAuthorization: token is the EIP-712 verifyingContract,
   # `from` is the signer, `value` the pulled amount, `validBefore` the expiry.
-  # The recipient (`to`) is the solver collection address; it is only bound when
-  # the operator has pinned a solver allowlist (`solver_allowed?/1` is fail-open
-  # by default). ERC-3009's `msg.sender == to` plus the value cap keep the
-  # unbound `to` bounded. See GitHub #333.
+  # The recipient (`to`) is the solver collection address; it is enforced against
+  # the pinned allowlist when one is configured, and against a hard pin when
+  # `:pull_require_solver_pin` is set. With neither, an unpinned `to` is left
+  # bounded by ERC-3009's `msg.sender == to` plus the value cap. See GitHub #333.
   defp validate_erc3009_pull(pull, request, signer) do
     domain = pull["domain"] || %{}
     message = pull["message"] || %{}
@@ -282,16 +282,18 @@ defmodule Raxol.Payments.Protocols.Xochi do
       {:pull_token, addr_match?(domain["verifyingContract"], request.from_token)},
       {:pull_chain, int_match?(domain["chainId"], request.from_chain_id)},
       {:pull_value, int_within?(message["value"], request.from_amount)},
-      {:pull_to, solver_allowed?(message["to"])},
+      {:pull_to, solver_allowed?(message["to"], :erc3009)},
       {:pull_expiry, valid_window?(message["validBefore"])}
     ])
   end
 
   # Permit2 PermitWitnessTransferFrom: token + amount live under `permitted`,
   # the owner is recovered from the signature (the agent's own wallet), and
-  # `deadline` bounds validity. The `spender` is the solver; bound only when the
-  # operator pins a solver allowlist (fail-open by default). The `OriginPullWitness`
-  # ties the permit to one intent on-chain. See GitHub #333.
+  # `deadline` bounds validity. The `spender` is the solver. Unlike ERC-3009 there
+  # is no on-chain recipient guard -- the spender chooses where funds go -- so the
+  # spender pin is ALWAYS required (fail-closed): with no allowlist configured a
+  # permit2 pull is rejected before signing. The `OriginPullWitness` ties the
+  # permit to one intent on-chain. See GitHub #333.
   defp validate_permit2_pull(pull, request) do
     domain = pull["domain"] || %{}
     message = pull["message"] || %{}
@@ -302,7 +304,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
       {:pull_token, addr_match?(permitted["token"], request.from_token)},
       {:pull_chain, int_match?(domain["chainId"], request.from_chain_id)},
       {:pull_value, int_within?(permitted["amount"], request.from_amount)},
-      {:pull_spender, solver_allowed?(message["spender"])},
+      {:pull_spender, solver_allowed?(message["spender"], :permit2)},
       {:pull_expiry, valid_window?(message["deadline"])}
     ])
   end
@@ -336,19 +338,30 @@ defmodule Raxol.Payments.Protocols.Xochi do
     end
   end
 
-  # The origin-pull recipient/spender is the solver's collection address. There
-  # is no client-facing solver manifest, and solver addresses rotate, so a pinned
-  # allowlist is opt-in: when the operator configures
-  # `config :raxol_payments, :pull_solver_allowlist, ["0x..."]`, the pull `to`/
-  # `spender` must be in it; when unset (the default), the address is not bound
-  # and any solver is accepted. When Xochi serves a verifiable/attested solver
-  # set in the quote, this resolver is the seam to prefer it over static config.
-  defp solver_allowed?(addr) do
+  # The origin-pull recipient/spender is the solver's collection address.
+  # Configure the pin with
+  # `config :raxol_payments, :pull_solver_allowlist, ["0x..."]`; when set, the
+  # pull `to`/`spender` must be in it for both methods.
+  #
+  # Defaults when no allowlist is configured differ by method, because their
+  # on-chain guarantees differ: ERC-3009 binds `to` in the signed digest and the
+  # token enforces `msg.sender == to`, so an unpinned `to` stays bounded (funds can
+  # only reach the signed address) -- accepted unless `:pull_require_solver_pin` is
+  # set. Permit2 has NO on-chain recipient guard (the spender picks the recipient
+  # at call time), so the pin is the only destination control and is always
+  # required -- an unpinned permit2 pull is rejected (fail-closed).
+  #
+  # When Xochi serves a verifiable/attested solver set in the quote, this resolver
+  # is the seam to prefer it over static config. See GitHub #333.
+  defp solver_allowed?(addr, method) do
     case solver_allowlist() do
-      [] -> true
+      [] -> method == :erc3009 and not require_solver_pin?()
       list -> is_binary(addr) and normalize_address(addr) in list
     end
   end
+
+  defp require_solver_pin?,
+    do: Application.get_env(:raxol_payments, :pull_require_solver_pin, false)
 
   defp solver_allowlist do
     :raxol_payments

--- a/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
@@ -571,6 +571,93 @@ defmodule Raxol.Payments.Protocols.XochiTest do
       refute_received {:req, "POST", "/api/intent/execute", _h, _b}
     end
 
+    test "rejects a permit2 pull when no solver allowlist is configured (fail-closed)" do
+      # Permit2 has NO on-chain recipient guard -- the spender picks where funds go
+      # at call time -- so the pin is the only destination control and is always
+      # required. With no allowlist set, a permit2 pull is unsafe to sign.
+      pull = canonical_permit2_pull()
+
+      quote_resp = %QuoteResponse{
+        intent_id: "xi_p2o",
+        quote_id: "xq_p2o",
+        can_solve: true,
+        payment_method: "permit2",
+        eip712_data: %{
+          "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+          "primaryType" => "XochiIntent",
+          "types" => %{"XochiIntent" => [%{"name" => "intentId", "type" => "string"}]},
+          "message" => %{"intentId" => "xi_p2o"}
+        },
+        pull_authorization: pull
+      }
+
+      request = %QuoteRequest{
+        wallet: @anvil_addr,
+        from_chain_id: 8453,
+        to_chain_id: 42_161,
+        from_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        to_token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        from_amount: "1000000",
+        settlement_preference: "public"
+      }
+
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      assert {:error, {:authorization_mismatch, :pull_spender}} =
+               Xochi.execute(config, quote_resp, RealWallet, request)
+
+      refute_received {:req, "POST", "/api/intent/execute", _h, _b}
+    end
+
+    test "rejects an erc3009 pull when pull_require_solver_pin is set and no allowlist" do
+      # ERC-3009 is bounded even unpinned (the signed `to` + on-chain msg.sender ==
+      # to), but an operator can demand a hard pin. With the flag on and no
+      # allowlist, even a well-formed pull must be rejected before any signature.
+      Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
+      on_exit(fn -> Application.delete_env(:raxol_payments, :pull_require_solver_pin) end)
+
+      pull = canonical_erc3009_pull()
+
+      quote_resp = %QuoteResponse{
+        intent_id: "xi_pin",
+        quote_id: "xq_pin",
+        can_solve: true,
+        payment_method: "erc3009",
+        eip712_data: %{
+          "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+          "primaryType" => "XochiIntent",
+          "types" => %{"XochiIntent" => [%{"name" => "intentId", "type" => "string"}]},
+          "message" => %{"intentId" => "xi_pin"}
+        },
+        pull_authorization: pull
+      }
+
+      request = %QuoteRequest{
+        wallet: @anvil_addr,
+        from_chain_id: 8453,
+        to_chain_id: 42_161,
+        from_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        to_token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        from_amount: "1000000",
+        settlement_preference: "public"
+      }
+
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      assert {:error, {:authorization_mismatch, :pull_to}} =
+               Xochi.execute(config, quote_resp, RealWallet, request)
+
+      refute_received {:req, "POST", "/api/intent/execute", _h, _b}
+    end
+
     test "rejects a pull whose envelope or expiry diverges from the claimed method" do
       config = %{
         base_url: "https://api.xochi.fi",


### PR DESCRIPTION
## Summary

Makes the Xochi origin-pull solver pin **fail-closed** so an autonomous agent
cannot be tricked into signing a pull that sends its funds to an attacker. The
only forge vector is getting the agent to sign a bad `to`/`spender`; the defense
is pinning that address in the agent's own config, which a MITM or a compromised
quote server cannot influence.

## Changes

- `solver_allowed?/2` is now method-aware:
  - **Permit2: always fail-closed.** No on-chain recipient guard exists (the
    spender chooses the recipient at call time, and Riddler calls canonical
    Permit2), so the pin is the only destination control. With no allowlist set,
    a permit2 pull is rejected (`{:authorization_mismatch, :pull_spender}`)
    before any signature.
  - **ERC-3009: bounded-open by default, hard-pin on demand.** `to` is bound in
    the signed digest and the token enforces `msg.sender == to`, so an unpinned
    `to` stays bounded. `:pull_require_solver_pin` forces a hard pin.
  - Once `:pull_solver_allowlist` is set, both methods enforce it.
- `config/runtime.exs` (prod) wires the pin from `XOCHI_SOLVER_*` and
  `XOCHI_PULL_REQUIRE_SOLVER_PIN`.

Companion to Riddler PR #228 (`Xochi.Config.solver_address` single source of
truth + boot-time consistency check vs the HD-derived submitter). See #333.

## Manual testing

- [ ] `cd packages/raxol_payments && mix test test/raxol/payments/protocols/xochi_test.exs`
      -- 24 tests green, incl. new "permit2 no-allowlist rejects" and
      "erc3009 hard-pin rejects".
- [ ] With `XOCHI_SOLVER_*` set and `XOCHI_PULL_REQUIRE_SOLVER_PIN=true`, a quote
      whose served `to`/`spender` is not pinned returns
      `{:error, {:authorization_mismatch, :pull_to | :pull_spender}}` and signs nothing.

## Deploy notes

- New raxol build/deploy required.
- **Sequencing:** deploy Riddler #228 first, read the canonical per-chain solver
  address, set `XOCHI_SOLVER_*` to it, then set `XOCHI_PULL_REQUIRE_SOLVER_PIN=true`.
  If this ships before the allowlist is set, Permit2 pulls reject immediately
  (ERC-3009 keeps working) -- launch ERC-3009/USDC corridors first.
- No Xochi API/frontend change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
