### PR TITLE
Fix live gate report_settlement KeyError on completed status

### DIFF
--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -379,8 +379,8 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
       [live_xochi:#{label}] settled in #{elapsed}ms
         intent_id     #{intent.intent_id}
         status        #{status.status}
-        source tx     #{tx_line(status.tx_hash, params.from_chain_id)}
-        receiving tx  #{tx_line(status.receiving_tx_hash, params.to_chain_id)}\
+        fill tx       #{tx_line(Map.get(status, :tx_hash), params.to_chain_id)}
+        receiving tx  #{tx_line(Map.get(status, :receiving_tx_hash), params.to_chain_id)}\
       """)
     end
 


### PR DESCRIPTION
Once Riddler's terminal-status fix deployed, the live gate's poll started resolving to completed and reached report_settlement/5 for the first time, raising KeyError: key :receiving_tx_hash not found. The Xochi status map carries tx_hash (the fill) but no receiving_tx_hash, and map.field raises on a missing key. Use Map.get/2 and report the fill tx against the destination chain explorer. Test-only; the settlement itself already succeeds live (both legs settled, status completed, terminal true).