### PR TITLE
Live settlement gates: 5-chain Xochi, ACP order, relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ client = Req.new(base_url: "https://api.example.com")
 
 Three protocols behind one interface: x402 (Coinbase HTTP 402, same-chain), MPP (Stripe/Tempo machine payments), and Xochi (cross-chain intent settlement, 0.10-0.40% fees, stealth-capable). Per-request, per-session, and lifetime spending limits enforced by a ledger GenServer. See [Agentic Commerce docs](docs/features/AGENTIC_COMMERCE.md).
 
+## Agents that earn
+
+`raxol_acp` is the sell side: an Elixir/OTP-native implementation of the [Virtuals](https://virtuals.io) Agent Commerce Protocol that lets your agent offer services on Base and get paid for them. Declare an offering, implement two callbacks, and a buyer agent can discover it, escrow funds, and settle on-chain through the job lifecycle (request -> negotiation -> transaction -> evaluation -> completed), one supervised process per job.
+
+```elixir
+defmodule CrossChainTransfer do
+  use Raxol.ACP.Offering,
+    name: "xochi_cross_chain_transfer",
+    price_usdc: "0.25",
+    sla_minutes: 10,
+    cluster: "on_chain"
+
+  @impl true
+  def handle_request(req, _ctx), do: {:accept, req}
+
+  @impl true
+  def handle_deliver(req, _ctx), do: {:deliver, settle_cross_chain(req)}
+end
+```
+
+The two halves compose: an agent sells a service through `raxol_acp` and settles it through `raxol_payments`. The shipped `xochi_cross_chain_transfer` offering does exactly that, delivering a buyer's USDC/USDT/WETH transfer across any of the 5 EVM chains via Xochi and returning the on-chain settlement tx hashes for verification. Pre-alpha (not yet on Hex).
+
 ## Agents that improve
 
 `raxol_agent` agents get more capable the longer they run. A solved task becomes a reusable `SKILL.md` on disk. When a turn finishes, an isolated reviewer runs on a cheap model and writes durable memory plus new skills without spending the live turn's latency or context budget; a Curator ages and consolidates them on an idle gate. Memory layers a fast local store under external semantic providers, full-text `session_search` recalls the raw past messages rather than summaries, and a dialectic user model builds an understanding of who you are across sessions, injected per-turn without invalidating the prompt cache.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ client = Req.new(base_url: "https://api.example.com")
 # If 402 -> wallet signs EIP-712 -> Xochi settles cross-chain -> response arrives
 ```
 
-Three protocols behind one interface: x402 (Coinbase HTTP 402, same-chain), MPP (Stripe/Tempo machine payments), and Xochi (cross-chain intent settlement, 0.10-0.40% fees, stealth-capable). Per-request, per-session, and lifetime spending limits enforced by a ledger GenServer. See [Agentic Commerce docs](docs/features/AGENTIC_COMMERCE.md).
+Five protocols behind one interface: x402 (Coinbase HTTP 402, same-chain), MPP (Stripe/Tempo machine payments), Xochi (cross-chain intent settlement, 0.10-0.40% fees, stealth-capable, the agent default), Permit2 (`PermitWitnessTransferFrom` signing for most ERC-20s), and Riddler (direct solver access, deprecated in favor of Xochi). Per-request, per-session, and lifetime spending limits enforced by a ledger GenServer. See [Agentic Commerce docs](docs/features/AGENTIC_COMMERCE.md).
 
 ## Agents that earn
 

--- a/packages/raxol_acp/examples/run_live_acp_order_gate.sh
+++ b/packages/raxol_acp/examples/run_live_acp_order_gate.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Order the xochi_cross_chain_transfer ACP offering and settle it for real.
+#
+# This is the end-to-end proof that another agent can ORDER our cross-chain
+# settlement services through the ACP: a buyer creates a job, the seller's
+# Raxol.ACP.Xochi.TransferOffering accepts it, and on delivery the real
+# Raxol.ACP.Xochi.Settler runs Raxol.Payments.Protocols.Xochi.transfer (quote ->
+# sign -> execute -> poll) against the Xochi worker + Riddler solver. The
+# deliverable carries the intent id and the on-chain settlement tx hashes.
+#
+# The job orchestration uses the in-memory ContractClient (no live ACP escrow);
+# the SETTLEMENT is real and MOVES FUNDS. Auth is the Member service token (the
+# seller is a Xochi Member): the Settler uses one config for quote/execute/poll.
+#
+# USDC pulls via ERC-3009 and settles directly. USDT/WETH pull via Permit2 and
+# need a standing on-chain allowance, which this gate broadcasts once per token
+# per chain via Raxol.ACP.Onchain.Permit2Approver -- so each origin chain that
+# carries a USDT/WETH cell needs an RPC URL in XOCHI_ORDER_RPC_<chain>. A
+# USDT/WETH cell with no RPC for its origin chain is skipped (logged), not failed.
+#
+# The funded run settles only the FILLABLE SUBSET: it quotes each cell first and
+# skips (logs) any the solver cannot fill right now.
+#
+# Usage (from packages/raxol_acp/):
+#   # 1. Dry run: offering registration + read-only per-cell quote. NO funds move.
+#   XOCHI_ORDER_LIVE_KEY=0x<funded> DRY_RUN=1 ./examples/run_live_acp_order_gate.sh
+#
+#   # 2. Real run: orders and settles (needs a funded seller key). USDC only:
+#   XOCHI_ORDER_LIVE_KEY=0x<funded> XOCHI_ORDER_TOKENS=USDC \
+#     ./examples/run_live_acp_order_gate.sh
+#
+#   # 3. All three tokens across the 5-chain mesh (USDT/WETH need per-chain RPC):
+#   XOCHI_ORDER_LIVE_KEY=0x<funded> XOCHI_ORDER_CORRIDORS=mesh \
+#   XOCHI_ORDER_TOKENS=USDC,USDT,WETH \
+#   XOCHI_ORDER_RPC_8453=https://mainnet.base.org \
+#   XOCHI_ORDER_RPC_42161=https://arb1.arbitrum.io/rpc \
+#     ./examples/run_live_acp_order_gate.sh
+#
+# The Member service token is a long-lived 1Password credential, per-env:
+#   prod:    op://Employee/Xochi production AGENT_SERVICE_TOKENS/credential (default)
+#   staging: op://Employee/Xochi staging AGENT_SERVICE_TOKENS/credential
+#
+# Overrides: XOCHI_ORDER_LIVE_URL, XOCHI_ORDER_LIVE_TOKEN, OP_TOKEN_REF,
+# XOCHI_ORDER_CORRIDORS ("from>to,from>to" or "mesh"), XOCHI_ORDER_TOKENS,
+# XOCHI_ORDER_AMOUNT, XOCHI_ORDER_WETH_AMOUNT, XOCHI_ORDER_DESTINATION,
+# XOCHI_ORDER_ALLOW_ETH_ORIGIN, XOCHI_ORDER_SOLVER, XOCHI_ORDER_SOLVER_PIN,
+# XOCHI_ORDER_RPC_<chain>.
+set -euo pipefail
+
+XOCHI_ORDER_LIVE_URL="${XOCHI_ORDER_LIVE_URL:-https://api.xochi.fi}"
+OP_TOKEN_REF="${OP_TOKEN_REF:-op://Employee/Xochi production AGENT_SERVICE_TOKENS/credential}"
+XOCHI_ORDER_TOKENS="${XOCHI_ORDER_TOKENS:-USDC,USDT,WETH}"
+XOCHI_ORDER_CORRIDORS="${XOCHI_ORDER_CORRIDORS:-8453>42161}"
+
+if [[ -z "${XOCHI_ORDER_LIVE_KEY:-}" ]]; then
+  printf 'error: set XOCHI_ORDER_LIVE_KEY to a funded seller private key\n' >&2
+  exit 1
+fi
+
+if [[ -z "${XOCHI_ORDER_LIVE_TOKEN:-}" ]]; then
+  if ! command -v op >/dev/null 2>&1; then
+    printf 'error: op CLI not found; set XOCHI_ORDER_LIVE_TOKEN directly\n' >&2
+    exit 1
+  fi
+  printf 'reading Xochi worker token from 1Password (%s)...\n' "$OP_TOKEN_REF" >&2
+  XOCHI_ORDER_LIVE_TOKEN="$(op read "$OP_TOKEN_REF")"
+fi
+
+export XOCHI_ORDER_LIVE_URL XOCHI_ORDER_LIVE_TOKEN XOCHI_ORDER_LIVE_KEY \
+  XOCHI_ORDER_TOKENS XOCHI_ORDER_CORRIDORS
+
+# Preflight: confirm the offering is registered and quote every cell read-only
+# (can_solve + the pinned origin-pull solver). No funds move; this is all DRY_RUN
+# runs. Aborts before any funded run if a cell serves the wrong solver.
+printf 'preflight: offering discovery + read-only quotes for [%s] x [%s] (NO funds move)...\n' \
+  "$XOCHI_ORDER_CORRIDORS" "$XOCHI_ORDER_TOKENS" >&2
+if ! env MIX_ENV=test mix test --only live_xochi_order_preflight \
+    test/raxol/acp/xochi/live_order_test.exs; then
+  printf 'preflight FAILED: a cell served the wrong solver, or the offering is not registered.\n' >&2
+  printf 'No funds moved. Fix the cell or narrow XOCHI_ORDER_CORRIDORS / XOCHI_ORDER_TOKENS.\n' >&2
+  exit 1
+fi
+
+if [[ -n "${DRY_RUN:-}" ]]; then
+  printf 'DRY_RUN set: preflight passed, NO funds moved.\n' >&2
+  printf 're-run without DRY_RUN to place the real ACP order and settle.\n' >&2
+  exit 0
+fi
+
+printf 'ordering through the ACP: this settles the fillable subset for REAL...\n' >&2
+exec env MIX_ENV=test mix test --only live_xochi_order_settle \
+  test/raxol/acp/xochi/live_order_test.exs

--- a/packages/raxol_acp/lib/raxol/acp/onchain/permit2_approver.ex
+++ b/packages/raxol_acp/lib/raxol/acp/onchain/permit2_approver.ex
@@ -1,0 +1,147 @@
+defmodule Raxol.ACP.Onchain.Permit2Approver do
+  @moduledoc """
+  On-chain ERC-20 Permit2 allowance management, backed by raxol_acp's EVM
+  transaction stack.
+
+  A Xochi cross-chain transfer of USDT or WETH pulls the origin funds through
+  the universal Permit2 contract, which requires a standing ERC-20 allowance the
+  origin wallet must grant once per token per chain. (USDC pulls via ERC-3009 and
+  needs no allowance.) This module reads the current allowance and, when it is
+  short, broadcasts a max `approve(Permit2, uint256.max)` so the pull lands.
+
+  It lives in raxol_acp (not raxol_payments) for the same reason as
+  `Raxol.ACP.Relay.OnchainBroadcaster`: this is where the proven EIP-1559 signing
+  / RLP / nonce / JSON-RPC stack lives, and raxol_payments stays free of
+  fund-moving transaction code.
+
+  ## Usage
+
+      provider =
+        Raxol.ACP.ProviderAdapter.JSONRPC.new(
+          chains: %{8453 => System.fetch_env!("BASE_RPC_URL")},
+          private_key: origin_eoa_private_key
+        )
+
+      {:ok, _} =
+        Raxol.ACP.Onchain.Permit2Approver.ensure_allowance(
+          provider,
+          8453,
+          usdt_on_base,
+          Raxol.ACP.ProviderAdapter.get_address(provider)
+        )
+
+  The provider's EOA must be the same origin address the Xochi transfer signs its
+  Permit2 authorization from, since that is the address Permit2 pulls from.
+  """
+
+  alias Raxol.ACP.{ABI, ProviderAdapter}
+
+  # Universal Permit2, identical on every EVM chain. Matches
+  # `Raxol.Payments.Protocols.Permit2.verifying_contract/0`.
+  @permit2_address "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  @approve_signature "approve(address,uint256)"
+  @allowance_signature "allowance(address,address)"
+  @max_uint256 Integer.pow(2, 256) - 1
+  # Treat any allowance below half of max as "not a standing max approval", so a
+  # spent-down, finite, or zero allowance triggers a fresh max approve.
+  @allowance_floor Integer.pow(2, 255)
+
+  @doc "The universal Permit2 contract address (the approval spender)."
+  @spec permit2_address() :: String.t()
+  def permit2_address, do: @permit2_address
+
+  @doc "The maximum uint256 value granted by a default approve."
+  @spec max_uint256() :: non_neg_integer()
+  def max_uint256, do: @max_uint256
+
+  @doc """
+  Build the ERC-20 `approve(Permit2, amount)` call (selector `0x095ea7b3`).
+  Exposed so the encoding can be verified without broadcasting.
+  """
+  @spec approve_call(String.t(), non_neg_integer()) :: ProviderAdapter.call()
+  def approve_call(token, amount \\ @max_uint256)
+      when is_binary(token) and is_integer(amount) and amount >= 0 do
+    %{
+      to: token,
+      data:
+        ABI.encode_call(@approve_signature, [{"address", @permit2_address}, {"uint256", amount}]),
+      value: 0
+    }
+  end
+
+  @doc """
+  Read the current Permit2 allowance `owner` has granted for `token` on
+  `chain_id`. Returns the allowance as a non-negative integer.
+  """
+  @spec allowance(ProviderAdapter.adapter(), pos_integer(), String.t(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, term()}
+  def allowance(provider, chain_id, token, owner)
+      when is_binary(token) and is_binary(owner) do
+    params = %{
+      address: token,
+      signature: @allowance_signature,
+      args: [{"address", owner}, {"address", @permit2_address}]
+    }
+
+    with {:ok, raw} <- ProviderAdapter.read_contract(provider, chain_id, params) do
+      decode_uint256(raw)
+    end
+  end
+
+  @doc """
+  Ensure `owner` has granted Permit2 a sufficient allowance for `token` on
+  `chain_id`, broadcasting a max `approve` only when it is short. Idempotent: a
+  standing max approval returns `{:ok, :sufficient}` with no transaction.
+
+  ## Options
+
+  - `:min_allowance` -- the allowance considered sufficient. Defaults to `2^255`
+    (a standing max approval); pass the transfer amount to approve lazily.
+  - `:amount` -- the amount to approve when short. Defaults to `uint256.max`.
+  """
+  @spec ensure_allowance(
+          ProviderAdapter.adapter(),
+          pos_integer(),
+          String.t(),
+          String.t(),
+          keyword()
+        ) ::
+          {:ok, :sufficient} | {:ok, {:approved, String.t()}} | {:error, term()}
+  def ensure_allowance(provider, chain_id, token, owner, opts \\ [])
+      when is_binary(token) and is_binary(owner) do
+    min_required = Keyword.get(opts, :min_allowance, @allowance_floor)
+    amount = Keyword.get(opts, :amount, @max_uint256)
+
+    with {:ok, current} <- allowance(provider, chain_id, token, owner) do
+      if current >= min_required do
+        {:ok, :sufficient}
+      else
+        approve(provider, chain_id, token, amount)
+      end
+    end
+  end
+
+  # -- Internal --
+
+  defp approve(provider, chain_id, token, amount) do
+    case ProviderAdapter.send_calls(provider, chain_id, [approve_call(token, amount)]) do
+      {:ok, [hash | _]} -> {:ok, {:approved, hash}}
+      {:ok, []} -> {:error, :no_tx_hash}
+      {:error, _} = err -> err
+    end
+  end
+
+  # read_contract returns the raw eth_call word: "0x" + 64 hex from JSON-RPC, or
+  # an integer from a canned mock. Both decode to a non-negative integer.
+  defp decode_uint256(value) when is_integer(value) and value >= 0, do: {:ok, value}
+  defp decode_uint256("0x"), do: {:ok, 0}
+
+  defp decode_uint256("0x" <> hex) when is_binary(hex) do
+    case Integer.parse(hex, 16) do
+      {n, ""} -> {:ok, n}
+      _ -> {:error, {:invalid_allowance, "0x" <> hex}}
+    end
+  end
+
+  defp decode_uint256(other), do: {:error, {:invalid_allowance, other}}
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -104,7 +104,11 @@ defmodule Raxol.ACP.Xochi.Offering do
         "destination" => %{
           "type" => "string",
           "pattern" => "^0x[0-9a-fA-F]{40}$",
-          "description" => "Recipient address on dst_chain_id."
+          "description" =>
+            "Recipient on dst_chain_id. Not yet honored: settlement currently " <>
+              "delivers to the requester's own address on dst_chain_id. Delivery " <>
+              "to a different recipient is a future release; this field is kept " <>
+              "so requirements are forward-compatible."
         },
         "slippage_bps" => %{
           "type" => "integer",

--- a/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
@@ -60,7 +60,7 @@ defmodule Raxol.ACP.Xochi.Settler do
   """
 
   alias Raxol.Payments.Protocols.Xochi
-  alias Raxol.Payments.Xochi.Schemas.{QuoteRequest, IntentStatus}
+  alias Raxol.Payments.Xochi.Schemas.{IntentStatus, QuoteRequest}
 
   @doc """
   Build a settle_fn closure.
@@ -124,6 +124,12 @@ defmodule Raxol.ACP.Xochi.Settler do
   defp build_quote_request(args, wallet_address) do
     req = args.requirement
 
+    # Delivery goes to `wallet_address` (the requester) on the destination chain.
+    # `req["destination"]` is intentionally not honored yet: sending to a
+    # different recipient is a future capability, so for now the destination is
+    # kept equal to the funder for hardening. The field stays in the requirement
+    # (the schema and FundTransfer hook carry it) but does not retarget the
+    # settlement.
     request = %QuoteRequest{
       wallet: wallet_address,
       from_chain_id: req["src_chain_id"],
@@ -141,16 +147,17 @@ defmodule Raxol.ACP.Xochi.Settler do
     end
   end
 
+  # IntentStatus carries the origin fill as `tx_hash` and the destination arrival
+  # as `receiving_tx_hash`; the deliverable schema names them src_tx_hash /
+  # dst_tx_hash. Map them so the buyer/evaluator can verify the settlement
+  # on-chain (src_tx_hash is a required deliverable field).
   defp to_deliverable(%IntentStatus{} = status) do
     {:ok,
      %{
        intent_id: status.intent_id,
-       quote_id: Map.get(status, :quote_id),
-       src_tx_hash: Map.get(status, :src_tx_hash),
-       dst_tx_hash: Map.get(status, :dst_tx_hash),
-       status: to_string(status.status),
-       fee_atomic: Map.get(status, :fee_atomic),
-       dst_amount_atomic: Map.get(status, :to_amount) || Map.get(status, :dst_amount_atomic)
+       src_tx_hash: status.tx_hash,
+       dst_tx_hash: status.receiving_tx_hash,
+       status: to_string(status.status)
      }}
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/onchain/permit2_approver_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/onchain/permit2_approver_test.exs
@@ -1,0 +1,159 @@
+defmodule Raxol.ACP.Onchain.Permit2ApproverTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Onchain.Permit2Approver
+  alias Raxol.ACP.ProviderAdapter.Mock
+
+  @token "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2"
+  @owner "0x" <> String.duplicate("ab", 20)
+  @allowance_sig "allowance(address,address)"
+  # ERC-20 approve(address,uint256) selector.
+  @approve_selector <<0x09, 0x5E, 0xA7, 0xB3>>
+
+  defp max_word, do: "0x" <> String.duplicate("f", 64)
+  defp zero_word, do: "0x" <> String.duplicate("0", 64)
+
+  describe "permit2_address/0" do
+    test "matches the universal Permit2 address the payments protocol signs against" do
+      assert Permit2Approver.permit2_address() ==
+               Raxol.Payments.Protocols.Permit2.verifying_contract()
+    end
+  end
+
+  describe "approve_call/2" do
+    test "encodes approve(Permit2, max) targeting the token" do
+      call = Permit2Approver.approve_call(@token)
+
+      assert call.to == @token
+      assert call.value == 0
+      assert <<@approve_selector::binary, args::binary>> = call.data
+      # spender word (Permit2, left-padded) then the amount word (uint256.max).
+      assert byte_size(args) == 64
+      <<_pad::binary-size(12), spender::binary-size(20), amount::unsigned-big-256>> = args
+
+      permit2 =
+        Permit2Approver.permit2_address()
+        |> String.replace_prefix("0x", "")
+        |> Base.decode16!(case: :mixed)
+
+      assert spender == permit2
+      assert amount == Permit2Approver.max_uint256()
+    end
+
+    test "encodes a custom approve amount" do
+      call = Permit2Approver.approve_call(@token, 1_000_000)
+
+      <<@approve_selector::binary, _spender::binary-size(32), amount::unsigned-big-256>> =
+        call.data
+
+      assert amount == 1_000_000
+    end
+  end
+
+  describe "allowance/4" do
+    test "reads and decodes a hex allowance word" do
+      adapter = Mock.new()
+
+      :ok =
+        Mock.set_contract_read(
+          adapter,
+          @token,
+          @allowance_sig,
+          "0x" <> String.pad_leading("64", 64, "0")
+        )
+
+      assert {:ok, 100} = Permit2Approver.allowance(adapter, 8453, @token, @owner)
+    end
+
+    test "decodes an empty '0x' word as zero" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, "0x")
+
+      assert {:ok, 0} = Permit2Approver.allowance(adapter, 8453, @token, @owner)
+    end
+
+    test "accepts an integer canned value" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, 42)
+
+      assert {:ok, 42} = Permit2Approver.allowance(adapter, 8453, @token, @owner)
+    end
+
+    test "surfaces the provider read error" do
+      adapter = Mock.new()
+
+      assert {:error, {:no_canned_read, _, _}} =
+               Permit2Approver.allowance(adapter, 8453, @token, @owner)
+    end
+  end
+
+  describe "ensure_allowance/5" do
+    test "is a no-op when a standing max approval exists" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, max_word())
+
+      assert {:ok, :sufficient} = Permit2Approver.ensure_allowance(adapter, 8453, @token, @owner)
+      assert Mock.sent_calls(adapter) == []
+    end
+
+    test "broadcasts a max approve when the allowance is short" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, zero_word())
+
+      assert {:ok, {:approved, "0x" <> _}} =
+               Permit2Approver.ensure_allowance(adapter, 8453, @token, @owner)
+
+      assert [{8453, [call]}] = Mock.sent_calls(adapter)
+      assert call.to == @token
+      assert <<@approve_selector::binary, _rest::binary>> = call.data
+    end
+
+    test "min_allowance lets a finite allowance count as sufficient" do
+      adapter = Mock.new()
+      # 1_000_000 atomic allowance is enough for a 1 USDC transfer.
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, 1_000_000)
+
+      assert {:ok, :sufficient} =
+               Permit2Approver.ensure_allowance(adapter, 8453, @token, @owner,
+                 min_allowance: 1_000_000
+               )
+
+      assert Mock.sent_calls(adapter) == []
+    end
+  end
+
+  # Real approve + allowance read-back against a Base fork. Opt-in; needs
+  # foundry (anvil + cast) on PATH.
+  describe "live approve on a Base fork" do
+    @describetag :live_chain
+
+    setup do
+      rpc = Raxol.ACP.Test.AnvilHarness.start!(port: 8_613)
+      account = Raxol.ACP.Test.AnvilHarness.anvil_account(0)
+
+      provider =
+        Raxol.ACP.ProviderAdapter.JSONRPC.new(
+          chains: %{8453 => rpc},
+          private_key: account.private_key,
+          fee_overrides: %{
+            8453 => %{max_priority_fee_per_gas: 1_000_000_000, max_fee_per_gas: 2_000_000_000}
+          }
+        )
+
+      %{provider: provider, owner: account.address}
+    end
+
+    test "approves Permit2 and reads the new allowance back", %{provider: provider, owner: owner} do
+      assert {:ok, 0} = Permit2Approver.allowance(provider, 8453, @token, owner)
+
+      assert {:ok, {:approved, "0x" <> _}} =
+               Permit2Approver.ensure_allowance(provider, 8453, @token, owner)
+
+      assert {:ok, after_allowance} = Permit2Approver.allowance(provider, 8453, @token, owner)
+      assert after_allowance == Permit2Approver.max_uint256()
+
+      # Idempotent: a standing max approval broadcasts nothing further.
+      assert {:ok, :sufficient} = Permit2Approver.ensure_allowance(provider, 8453, @token, owner)
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/relay/live_relay_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/relay/live_relay_test.exs
@@ -3,9 +3,11 @@ defmodule Raxol.ACP.Relay.LiveRelayTest do
   Full EVM -> Tron transfer through the Relay rail against a real Riddler
   endpoint, funded by the on-chain deposit broadcaster.
 
-  `ExecuteRelayTransfer` quotes, authorizes the spend, and initiates execution;
-  the `OnchainBroadcaster` broadcasts the ERC-20 deposit on the source chain;
-  `PollRelayStatus` waits for `:completed`.
+  Each source token runs a read-only `/relay/quote` preflight (assert `can_fill`
+  + a deposit address) before any broadcast, then `ExecuteRelayTransfer` quotes,
+  authorizes the spend, and initiates execution; the `OnchainBroadcaster`
+  broadcasts the ERC-20 deposit on the source chain; `PollRelayStatus` waits for
+  `:completed`. Each settlement reports the deposit tx with an explorer link.
 
   Moves real funds: opt-in, excluded by default, compiled only when the required
   env is present.
@@ -16,9 +18,14 @@ defmodule Raxol.ACP.Relay.LiveRelayTest do
       RELAY_LIVE_RPC=https://mainnet.base.org \\
         mix test --include live_relay test/raxol/acp/relay/live_relay_test.exs
 
-  Defaults (Base USDC -> Tron USDT, 0.10 USDC) are overridable via
-  RELAY_LIVE_FROM_CHAIN, RELAY_LIVE_FROM_TOKEN, RELAY_LIVE_TO_TOKEN,
-  RELAY_LIVE_TO_ADDRESS, RELAY_LIVE_AMOUNT.
+  Multiple source tokens (each resolved per chain via `Raxol.Payments.Assets`)
+  settle in one run via `RELAY_LIVE_TOKENS` (default `USDC`); the destination is
+  always Tron. Defaults (Base -> Tron USDT, 0.10) are overridable via
+  RELAY_LIVE_FROM_CHAIN, RELAY_LIVE_TOKENS, RELAY_LIVE_FROM_TOKEN (a raw origin
+  address that overrides the token list), RELAY_LIVE_TO_TOKEN, RELAY_LIVE_TO_ADDRESS,
+  RELAY_LIVE_AMOUNT.
+
+  Or use the runner: ../raxol_payments/examples/run_live_relay_gate.sh
   """
 
   use ExUnit.Case, async: false
@@ -39,7 +46,10 @@ defmodule Raxol.ACP.Relay.LiveRelayTest do
       PollRelayStatus
     }
 
-    alias Raxol.Payments.{Ledger, SpendingPolicy}
+    alias Raxol.Payments.{Assets, Ledger, Relay, SpendingPolicy}
+    alias Raxol.Payments.Relay.Schemas.QuoteRequest
+
+    @tron 728_126_428
 
     defmodule LiveWallet do
       @moduledoc false
@@ -88,31 +98,46 @@ defmodule Raxol.ACP.Relay.LiveRelayTest do
       {:ok, context: context, from_chain: from_chain}
     end
 
-    test "agent completes an EVM->Tron transfer end-to-end", %{
+    test "agent completes an EVM->Tron transfer for each source token", %{
       context: context,
       from_chain: from_chain
     } do
-      params = %{
-        amount: System.get_env("RELAY_LIVE_AMOUNT", "0.10"),
-        from_chain_id: from_chain,
-        to_chain_id: 728_126_428,
-        from_token: System.get_env("RELAY_LIVE_FROM_TOKEN", @usdc_base),
-        to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
-        to_address: System.get_env("RELAY_LIVE_TO_ADDRESS", @usdt_tron)
-      }
+      amount = System.get_env("RELAY_LIVE_AMOUNT", "0.10")
+      to_address = System.get_env("RELAY_LIVE_TO_ADDRESS", @usdt_tron)
+      cells = source_cells(from_chain)
 
-      assert {:ok, transfer} = ExecuteRelayTransfer.call(params, context)
-      assert transfer.funding == "broadcast"
-      assert is_binary(transfer.deposit_tx_hash), "no deposit tx broadcast"
+      # Preflight every cell read-only first: a dead corridor aborts the run
+      # before any deposit is broadcast.
+      for {src_token, label} <- cells do
+        assert {:ok, quote} = relay_quote(context, from_chain, src_token, amount, to_address)
+        assert quote.can_fill, "#{label}: relay quote not fillable: #{inspect(quote)}"
 
-      assert {:ok, status} =
-               PollRelayStatus.call(
-                 %{transfer_id: transfer.transfer_id},
-                 context
-               )
+        assert is_binary(quote.deposit_address),
+               "#{label}: relay quote returned no deposit address"
+      end
 
-      assert status.status == "completed",
-             "live transfer #{transfer.transfer_id} ended in #{status.status}, expected completed"
+      for {src_token, label} <- cells do
+        params = %{
+          amount: amount,
+          from_chain_id: from_chain,
+          to_chain_id: @tron,
+          from_token: src_token,
+          to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
+          to_address: to_address
+        }
+
+        assert {:ok, transfer} = ExecuteRelayTransfer.call(params, context)
+        assert transfer.funding == "broadcast"
+        assert is_binary(transfer.deposit_tx_hash), "#{label}: no deposit tx broadcast"
+
+        assert {:ok, status} =
+                 PollRelayStatus.call(%{transfer_id: transfer.transfer_id}, context)
+
+        assert status.status == "completed",
+               "#{label}: transfer #{transfer.transfer_id} ended in #{status.status}, expected completed"
+
+        report_relay(label, transfer, status, from_chain)
+      end
     end
 
     test "a resumed run reuses the in-flight transfer without a second deposit", %{
@@ -154,6 +179,75 @@ defmodule Raxol.ACP.Relay.LiveRelayTest do
       assert status.status == "completed",
              "live transfer #{transfer.transfer_id} ended in #{status.status}, expected completed"
     end
+
+    # A raw RELAY_LIVE_FROM_TOKEN overrides the token list with one custom cell;
+    # otherwise resolve each RELAY_LIVE_TOKENS symbol to its origin address.
+    defp source_cells(from_chain) do
+      case System.get_env("RELAY_LIVE_FROM_TOKEN") do
+        nil ->
+          "RELAY_LIVE_TOKENS"
+          |> System.get_env("USDC")
+          |> parse_list()
+          |> Enum.map(&resolve_src(from_chain, &1))
+
+        addr ->
+          [{addr, "#{from_chain}:custom->Tron"}]
+      end
+    end
+
+    defp resolve_src(from_chain, token) do
+      case Assets.address(from_chain, token) do
+        {:ok, addr} -> {addr, "#{from_chain}:#{token}->Tron"}
+        :error -> flunk("no #{token} address on chain #{from_chain}; set RELAY_LIVE_FROM_TOKEN")
+      end
+    end
+
+    defp relay_quote(context, from_chain, src_token, amount, to_address) do
+      decimals = Assets.decimals(from_chain, src_token)
+      atomic = Integer.to_string(Assets.to_atomic(Decimal.new(amount), decimals))
+
+      request = %QuoteRequest{
+        transfer_id: "preflight_" <> Base.encode16(:crypto.strong_rand_bytes(6), case: :lower),
+        from_chain_id: from_chain,
+        to_chain_id: @tron,
+        from_token: src_token,
+        to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
+        from_amount: atomic,
+        from_address: LiveWallet.address(),
+        to_address: to_address,
+        slippage_bps: 50
+      }
+
+      Relay.get_quote(context.relay_config, request)
+    end
+
+    defp report_relay(label, transfer, status, from_chain) do
+      IO.puts("""
+
+      [live_relay:#{label}] settled
+        transfer_id   #{transfer.transfer_id}
+        status        #{status.status}
+        deposit tx    #{deposit_line(transfer.deposit_tx_hash, from_chain)}\
+      """)
+    end
+
+    defp deposit_line(nil, _chain), do: "(none reported)"
+
+    defp deposit_line(hash, chain) do
+      case explorer_base(chain) do
+        nil -> hash
+        base -> base <> hash
+      end
+    end
+
+    defp explorer_base(1), do: "https://etherscan.io/tx/"
+    defp explorer_base(8453), do: "https://basescan.org/tx/"
+    defp explorer_base(42_161), do: "https://arbiscan.io/tx/"
+    defp explorer_base(10), do: "https://optimistic.etherscan.io/tx/"
+    defp explorer_base(137), do: "https://polygonscan.com/tx/"
+    defp explorer_base(_), do: nil
+
+    defp parse_list(spec), do: spec |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
 
     defp lifetime(context) do
       Ledger.get_totals(context.ledger, context.agent_id, context.policy).lifetime

--- a/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
@@ -1,0 +1,407 @@
+defmodule Raxol.ACP.Xochi.LiveOrderTest do
+  @moduledoc """
+  Another agent orders the `xochi_cross_chain_transfer` ACP offering and the
+  seller settles it for real through Xochi + the Riddler solver.
+
+  This is the end-to-end proof that the settlement services are orderable through
+  the ACP: a buyer creates a job, the seller's `Raxol.ACP.Xochi.TransferOffering`
+  accepts it and, on delivery, runs the real `Raxol.ACP.Xochi.Settler` ->
+  `Raxol.Payments.Protocols.Xochi.transfer/4`. The deliverable carries the intent
+  id and the on-chain settlement tx hashes.
+
+  The job orchestration uses the in-memory `ContractClient` (no live ACP escrow
+  contracts); the SETTLEMENT is real and moves funds. The fuller on-chain escrow
+  path (`ContractClient.Onchain` + `HookClient` + `SolverAgent`) is the existing
+  `:live_chain` stack and is a separate gate.
+
+  Auth is the Member service token (`XOCHI_ORDER_LIVE_TOKEN`): the seller is a
+  Xochi Member, and the `Settler` uses one config for quote/execute/poll. (The
+  mandate path is exercised by the raxol_payments Xochi gate.)
+
+  USDC pulls via ERC-3009 and settles directly. USDT/WETH pull via Permit2 and
+  need a standing on-chain allowance, which this gate broadcasts via
+  `Raxol.ACP.Onchain.Permit2Approver` using a JSON-RPC provider built from the
+  funded key and `XOCHI_ORDER_RPC_<chain>`. A USDT/WETH cell with no RPC for its
+  origin chain is skipped (logged), not failed.
+
+  Moves real funds. Tagged `:live_xochi_order` (settle) and
+  `:live_xochi_order_preflight` (read-only); excluded by default and compiled
+  only when the required env is present.
+
+  Funds settle to the seller wallet on the destination chain (the current
+  `Settler` delivers to the `QuoteRequest` wallet), so default the recipient to
+  the funded key's own address.
+
+      XOCHI_ORDER_LIVE_URL=https://api.xochi.fi \\
+      XOCHI_ORDER_LIVE_TOKEN="$(op read 'op://Employee/Xochi production AGENT_SERVICE_TOKENS/credential')" \\
+      XOCHI_ORDER_LIVE_KEY=0x<funded seller key> \\
+      XOCHI_ORDER_RPC_8453=https://mainnet.base.org \\
+      XOCHI_ORDER_TOKENS=USDC,USDT,WETH \\
+        mix test --only live_xochi_order test/raxol/acp/xochi/live_order_test.exs
+
+  Or use the runner: examples/run_live_acp_order_gate.sh
+
+  Overrides: XOCHI_ORDER_CORRIDORS ("from>to,from>to" or "mesh"),
+  XOCHI_ORDER_TOKENS, XOCHI_ORDER_AMOUNT, XOCHI_ORDER_WETH_AMOUNT,
+  XOCHI_ORDER_DESTINATION, XOCHI_ORDER_ALLOW_ETH_ORIGIN, XOCHI_ORDER_SOLVER,
+  XOCHI_ORDER_SOLVER_PIN, XOCHI_ORDER_RPC_<chain>.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :live_xochi_order
+  @moduletag timeout: 600_000
+
+  if System.get_env("XOCHI_ORDER_LIVE_URL") && System.get_env("XOCHI_ORDER_LIVE_KEY") do
+    alias Raxol.ACP.{ContractClient, Job}
+    alias Raxol.ACP.ContractClient.InMemory
+    alias Raxol.ACP.Offering.Registry, as: OfferingRegistry
+    alias Raxol.ACP.Onchain.Permit2Approver
+    alias Raxol.ACP.ProviderAdapter.JSONRPC
+    alias Raxol.ACP.Xochi.TransferOffering
+    alias Raxol.Payments.Assets
+    alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
+    alias Raxol.Payments.Xochi.Schemas.QuoteRequest
+
+    # Riddler's universal solver (HD index-0); the pinned origin-pull recipient.
+    @canonical_solver "0x97D447561fDe10E959E782a29411D8F89586d80b"
+    @evm_chains [1, 10, 137, 8453, 42_161]
+
+    defmodule LiveWallet do
+      @moduledoc false
+      use Raxol.Payments.Wallets.Env, env_var: "XOCHI_ORDER_LIVE_KEY"
+    end
+
+    setup do
+      pin_live_solver()
+
+      url = System.fetch_env!("XOCHI_ORDER_LIVE_URL")
+      token = System.get_env("XOCHI_ORDER_LIVE_TOKEN", "")
+      wallet_address = LiveWallet.address()
+      xochi_config = %{base_url: url, auth_token: token}
+
+      Application.put_env(:raxol_acp, :xochi_transfer_settler,
+        wallet_address: wallet_address,
+        xochi_config: xochi_config,
+        xochi_wallet: LiveWallet,
+        poll_timeout_ms: 180_000
+      )
+
+      ensure_registered()
+      on_exit(fn -> Application.delete_env(:raxol_acp, :xochi_transfer_settler) end)
+
+      cfg = %{
+        xochi_config: xochi_config,
+        wallet_address: wallet_address,
+        destination: System.get_env("XOCHI_ORDER_DESTINATION", wallet_address),
+        stable_amount: System.get_env("XOCHI_ORDER_AMOUNT", "1.10")
+      }
+
+      {:ok, cfg: cfg}
+    end
+
+    @tag :live_xochi_order_preflight
+    test "the offering is discoverable and every cell quotes read-only", %{cfg: cfg} do
+      assert {:ok, spec} = OfferingRegistry.lookup(TransferOffering.offering_name())
+      assert spec.handler == TransferOffering
+
+      cells = cells()
+      IO.puts("[live_xochi_order:preflight] checking #{length(cells)} cells (NO funds move)")
+
+      results =
+        Enum.map(cells, fn {from, to, token} ->
+          outcome = preflight_cell(cfg, from, to, token)
+          report_preflight(from, to, token, outcome)
+          {{from, to, token}, outcome}
+        end)
+
+      # A pin mismatch (wrong solver served) is a hard failure; a cell the solver
+      # simply cannot fill yet is a soft note (the funded run skips it).
+      failures = for {cell, {:error, reason}} <- results, do: {cell, reason}
+
+      assert failures == [],
+             "preflight failed for #{length(failures)} cell(s), no funds moved: #{inspect(failures)}"
+    end
+
+    @tag :live_xochi_order_settle
+    test "a buyer orders the offering and the seller settles the fillable subset", %{cfg: cfg} do
+      cells = cells()
+      IO.puts("[live_xochi_order] ordering #{length(cells)} cells through the ACP (REAL funds)")
+
+      for cell <- cells, do: run_cell(cfg, cell)
+    end
+
+    # -- Cell iteration --
+
+    defp cells do
+      corridors = parse_corridors(System.get_env("XOCHI_ORDER_CORRIDORS", "8453>42161"))
+      tokens = parse_list(System.get_env("XOCHI_ORDER_TOKENS", "USDC,USDT,WETH"))
+      for {from, to} <- corridors, token <- tokens, do: {from, to, token}
+    end
+
+    defp run_cell(cfg, {from, to, token}) do
+      label = "#{from}->#{to}:#{token}"
+
+      if from == 1 and System.get_env("XOCHI_ORDER_ALLOW_ETH_ORIGIN") != "true" do
+        IO.puts(
+          "[live_xochi_order] SKIP #{label}: Ethereum origin is quote-only " <>
+            "(set XOCHI_ORDER_ALLOW_ETH_ORIGIN=true to settle from L1)"
+        )
+      else
+        run_fillable_cell(cfg, from, to, token, label)
+      end
+    end
+
+    # Only order a cell the solver can fill now, and (for USDT/WETH) only once the
+    # Permit2 allowance is in place. A non-fillable cell or a missing RPC is a
+    # logged skip, not a failure -- this is the fillable subset.
+    defp run_fillable_cell(cfg, from, to, token, label) do
+      with {:ok, _quote} <- preflight_quote(cfg, from, to, token),
+           {:ok, _allowance} <- ensure_permit2(from, token, cfg.wallet_address) do
+        order_cell(cfg, from, to, token, label)
+      else
+        {:error, reason} ->
+          IO.puts("[live_xochi_order] SKIP #{label}: #{inspect(reason)}; no funds moved")
+      end
+    end
+
+    # -- Order one cell through the ACP job lifecycle --
+
+    defp order_cell(cfg, from, to, token, label) do
+      requirement = requirement(cfg, from, to, token)
+
+      {:ok, job_id} =
+        ContractClient.create_job(cfg.wallet_address, cfg.wallet_address, future_ts())
+
+      {:ok, _pid} =
+        Job.Supervisor.start_job(
+          job_id: job_id,
+          handler: TransferOffering,
+          request: requirement,
+          buyer: cfg.wallet_address,
+          seller: cfg.wallet_address
+        )
+
+      assert {:ok, :negotiation} = Job.Server.accept_request(job_id),
+             "#{label}: seller rejected the request (job #{job_id})"
+
+      assert {:ok, :transaction} = Job.Server.accept_payment(job_id, %{})
+
+      started = System.monotonic_time(:millisecond)
+
+      assert {:ok, :evaluation} = Job.Server.deliver(job_id),
+             "#{label}: settlement did not deliver (job #{job_id}); the intent failed or expired"
+
+      deliverable = deliverable_from_memos(job_id, label)
+
+      assert is_binary(deliverable["intent_id"])
+      assert deliverable["status"] in ["completed", "settled"]
+
+      assert deliverable["src_tx_hash"] =~ ~r/^0x[0-9a-fA-F]{64}$/,
+             "#{label}: deliverable missing a settlement tx hash: #{inspect(deliverable)}"
+
+      report_settlement(label, to, deliverable, started)
+    end
+
+    defp requirement(cfg, from, to, token) do
+      {:ok, src_token} = Assets.address(from, token)
+      {:ok, dst_token} = Assets.address(to, token)
+
+      %{
+        "src_chain_id" => from,
+        "dst_chain_id" => to,
+        "src_token" => src_token,
+        "dst_token" => dst_token,
+        "amount_atomic" => amount_atomic(from, token, cfg.stable_amount),
+        "destination" => cfg.destination,
+        "slippage_bps" => 50,
+        "settlement_preference" => "public"
+      }
+    end
+
+    defp deliverable_from_memos(job_id, label) do
+      case Enum.find(InMemory.list_memos(job_id), &(&1.next_phase == :evaluation)) do
+        nil -> flunk("#{label}: no evaluation memo for job #{job_id}")
+        memo -> Jason.decode!(memo.content)
+      end
+    end
+
+    # -- Read-only quote (fillability + solver pin) --
+
+    defp preflight_quote(cfg, from, to, token) do
+      with {:ok, request} <- quote_request(cfg, from, to, token),
+           {:ok, quote} <- XochiProtocol.get_quote(cfg.xochi_config, request),
+           {:solve, true} <- {:solve, quote.can_solve},
+           :ok <- XochiProtocol.validate_pull(quote, request, LiveWallet) do
+        {:ok, quote}
+      else
+        {:solve, _} -> {:error, :cannot_solve}
+        other -> other
+      end
+    end
+
+    # For the preflight report, split "cannot solve yet" (soft) from a real
+    # failure like a solver-pin mismatch (hard).
+    defp preflight_cell(cfg, from, to, token) do
+      case preflight_quote(cfg, from, to, token) do
+        {:ok, quote} -> {:ok, %{method: quote.payment_method, to_amount: quote.to_amount}}
+        {:error, :cannot_solve} -> {:soft, :cannot_solve}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+
+    defp quote_request(cfg, from, to, token) do
+      with {:ok, src_token} <- Assets.address(from, token),
+           {:ok, dst_token} <- Assets.address(to, token) do
+        {:ok,
+         %QuoteRequest{
+           wallet: cfg.wallet_address,
+           from_chain_id: from,
+           to_chain_id: to,
+           from_token: src_token,
+           to_token: dst_token,
+           from_amount: amount_atomic(from, token, cfg.stable_amount),
+           settlement_preference: "public",
+           slippage_bps: 50
+         }}
+      else
+        :error -> {:error, {:unknown_token, token}}
+      end
+    end
+
+    # -- Permit2 allowance (USDT/WETH only) --
+
+    defp ensure_permit2(from, token, owner) do
+      if permit2_token?(token) do
+        with {:ok, provider} <- provider_for(from),
+             {:ok, src_token} <- Assets.address(from, token) do
+          Permit2Approver.ensure_allowance(provider, from, src_token, owner)
+        else
+          :error -> {:error, {:unknown_token, token}}
+          {:error, _} = err -> err
+        end
+      else
+        {:ok, :not_needed}
+      end
+    end
+
+    defp provider_for(chain) do
+      case System.get_env("XOCHI_ORDER_RPC_#{chain}") do
+        nil ->
+          {:error, {:no_rpc_for_chain, chain, "set XOCHI_ORDER_RPC_#{chain}"}}
+
+        url ->
+          key = decode_key(System.fetch_env!("XOCHI_ORDER_LIVE_KEY"))
+          {:ok, JSONRPC.new(chains: %{chain => url}, private_key: key)}
+      end
+    end
+
+    # -- Solver pin (scoped to this module, restored on exit) --
+
+    defp pin_live_solver do
+      if System.get_env("XOCHI_ORDER_SOLVER_PIN", "true") != "false" do
+        solver = System.get_env("XOCHI_ORDER_SOLVER", @canonical_solver)
+        prior_allowlist = Application.get_env(:raxol_payments, :pull_solver_allowlist)
+        prior_require = Application.get_env(:raxol_payments, :pull_require_solver_pin)
+
+        Application.put_env(:raxol_payments, :pull_solver_allowlist, [solver])
+        Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
+
+        on_exit(fn ->
+          restore_env(:pull_solver_allowlist, prior_allowlist)
+          restore_env(:pull_require_solver_pin, prior_require)
+        end)
+      end
+    end
+
+    defp restore_env(key, nil), do: Application.delete_env(:raxol_payments, key)
+    defp restore_env(key, value), do: Application.put_env(:raxol_payments, key, value)
+
+    # -- Helpers --
+
+    defp ensure_registered do
+      case OfferingRegistry.lookup(TransferOffering.offering_name()) do
+        {:ok, _spec} -> :ok
+        :error -> TransferOffering.register()
+      end
+    end
+
+    defp amount_atomic(from, token, stable_amount) do
+      {:ok, src_token} = Assets.address(from, token)
+      decimals = Assets.decimals(from, src_token)
+      Integer.to_string(Assets.to_atomic(Decimal.new(amount_for(token, stable_amount)), decimals))
+    end
+
+    defp amount_for("WETH", _stable), do: System.get_env("XOCHI_ORDER_WETH_AMOUNT", "0.001")
+    defp amount_for(_token, stable), do: stable
+
+    defp permit2_token?(token), do: String.upcase(token) in ["USDT", "WETH"]
+
+    defp parse_corridors(spec) when spec in ["mesh", "all"] do
+      for from <- @evm_chains, to <- @evm_chains, from != to, do: {from, to}
+    end
+
+    defp parse_corridors(spec) do
+      spec
+      |> String.split(",", trim: true)
+      |> Enum.map(fn pair ->
+        [from, to] = String.split(pair, ">", parts: 2)
+        {String.to_integer(String.trim(from)), String.to_integer(String.trim(to))}
+      end)
+    end
+
+    defp parse_list(spec), do: spec |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+
+    defp future_ts, do: System.system_time(:second) + 3600
+
+    defp decode_key("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+    defp decode_key(hex), do: Base.decode16!(hex, case: :mixed)
+
+    # -- Reporting --
+
+    defp report_preflight(from, to, token, {:ok, info}) do
+      IO.puts(
+        "  PASS #{from}->#{to} #{token} via #{info.method || "?"} (to_amount #{info.to_amount})"
+      )
+    end
+
+    defp report_preflight(from, to, token, {:soft, :cannot_solve}) do
+      IO.puts(
+        "  SKIP #{from}->#{to} #{token}: solver cannot fill this cell yet (no funds needed)"
+      )
+    end
+
+    defp report_preflight(from, to, token, {:error, reason}) do
+      IO.puts("  FAIL #{from}->#{to} #{token}: #{inspect(reason)}")
+    end
+
+    defp report_settlement(label, to_chain, deliverable, started_ms) do
+      elapsed = System.monotonic_time(:millisecond) - started_ms
+
+      IO.puts("""
+
+      [live_xochi_order:#{label}] settled in #{elapsed}ms
+        intent_id     #{deliverable["intent_id"]}
+        status        #{deliverable["status"]}
+        src tx        #{tx_line(deliverable["src_tx_hash"], to_chain)}
+        dst tx        #{tx_line(deliverable["dst_tx_hash"], to_chain)}\
+      """)
+    end
+
+    defp tx_line(nil, _chain_id), do: "(none reported)"
+
+    defp tx_line(hash, chain_id) do
+      case explorer_base(chain_id) do
+        nil -> hash
+        base -> base <> hash
+      end
+    end
+
+    defp explorer_base(1), do: "https://etherscan.io/tx/"
+    defp explorer_base(8453), do: "https://basescan.org/tx/"
+    defp explorer_base(42_161), do: "https://arbiscan.io/tx/"
+    defp explorer_base(10), do: "https://optimistic.etherscan.io/tx/"
+    defp explorer_base(137), do: "https://polygonscan.com/tx/"
+    defp explorer_base(_), do: nil
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
@@ -130,7 +130,13 @@ defmodule Raxol.ACP.Xochi.SettlerTest do
               %{"success" => true, "intentId" => "i1", "status" => "executing"}
 
             "/api/intent/i1/status" ->
-              %{"intentId" => "i1", "status" => status, "terminal" => true}
+              %{
+                "intentId" => "i1",
+                "status" => status,
+                "terminal" => true,
+                "txHash" => "0x" <> String.duplicate("a", 64),
+                "receivingTxHash" => "0x" <> String.duplicate("b", 64)
+              }
           end
 
         Req.Test.json(conn, body)
@@ -160,10 +166,13 @@ defmodule Raxol.ACP.Xochi.SettlerTest do
       }
     end
 
-    test "a completed intent yields a deliverable" do
+    test "a completed intent yields a deliverable with the settlement tx hashes" do
       assert {:ok, deliverable} = settler_for("completed").(args())
       assert deliverable.intent_id == "i1"
       assert deliverable.status == "completed"
+      # IntentStatus tx_hash / receiving_tx_hash surface as src / dst for the buyer.
+      assert deliverable.src_tx_hash == "0x" <> String.duplicate("a", 64)
+      assert deliverable.dst_tx_hash == "0x" <> String.duplicate("b", 64)
     end
 
     test "a failed intent is an error, not a deliverable" do

--- a/packages/raxol_acp/test/test_helper.exs
+++ b/packages/raxol_acp/test/test_helper.exs
@@ -2,12 +2,23 @@
 #   :live_chain / :live_bundler / :live_acp_dev -- spin up a real Anvil node and
 #     exercise the on-chain pipeline (need foundry: anvil + cast).
 #   :live_relay -- moves real funds (broadcasts an on-chain deposit).
+#   :live_xochi_order / :live_xochi_order_preflight -- a buyer orders the
+#     xochi_cross_chain_transfer offering; the settle variant moves real funds
+#     (see run_live_acp_order_gate.sh). The preflight variant is read-only.
 #   :cli_signer -- spawns the riddler-client CLI; auto-enabled when
 #     RIDDLER_CLI_DIR is set.
 #
 # A single ExUnit.start sets the full list; a second ExUnit.configure(exclude:)
 # would replace it rather than merge, so it is computed once here.
-live_exclude = [:live_chain, :live_bundler, :live_acp_dev, :live_relay]
+live_exclude = [
+  :live_chain,
+  :live_bundler,
+  :live_acp_dev,
+  :live_relay,
+  :live_xochi_order,
+  :live_xochi_order_preflight
+]
+
 cli_exclude = if System.get_env("RIDDLER_CLI_DIR"), do: [], else: [:cli_signer]
 
 ExUnit.start(exclude: live_exclude ++ cli_exclude)

--- a/packages/raxol_payments/examples/README.md
+++ b/packages/raxol_payments/examples/README.md
@@ -31,38 +31,66 @@ MIX_ENV=test mix run examples/crosschain_stealth_payment.exs
 
 ## 3. Graduate to live (MOVES REAL FUNDS)
 
-These submit real mainnet intents. Each runs a read-only quote preflight first
-and aborts before moving funds if auth fails or the solver cannot fill.
+Each gate runs a read-only preflight first and aborts before moving funds if auth
+fails, the solver cannot fill, or a route is dead. Under `DRY_RUN` only the
+preflight runs. Rehearse each with `DRY_RUN=1` before a funded run.
 
-**`run_live_xochi_gate.sh`** settles cross-chain through the Xochi worker.
-Defaults to a $1 Base -> Optimism USDC transfer (the corridor Xochi verified
-fills at $1). Auth is a Member Bearer (the worker token in 1Password); one token
-covers the whole quote -> execute -> poll lifecycle. Dry-run first:
+**`run_live_xochi_gate.sh`** settles cross-chain through the Xochi worker. In
+matrix mode (`XOCHI_LIVE_MATRIX=true`) it validates the full 5-chain x 3-token
+grid (Ethereum, Optimism, Polygon, Base, Arbitrum x USDC, USDT, WETH):
+the read-only preflight quotes every cell and asserts `can_solve`, the correct
+pull method per token (USDC -> ERC-3009, USDT/WETH -> Permit2), and the pinned
+Riddler solver; the funded run settles only the fillable subset. USDC settles
+here directly; USDT/WETH need a standing Permit2 allowance, so their real
+settlement is the ACP order gate below (or opt in with `XOCHI_LIVE_SETTLE_PERMIT2=true`
+once the allowance is set). Auth defaults to a self-signed mandate; `member` uses
+the worker token in 1Password.
 
 ```bash
-XOCHI_LIVE_KEY=0x<funded base key> DRY_RUN=1 ./examples/run_live_xochi_gate.sh
-XOCHI_LIVE_KEY=0x<funded base key>           ./examples/run_live_xochi_gate.sh
+# full 5x3 grid, read-only (no funds)
+XOCHI_LIVE_KEY=0x<funded> DRY_RUN=1 XOCHI_LIVE_MATRIX=true \
+  XOCHI_LIVE_CORRIDORS=mesh XOCHI_LIVE_TOKENS=USDC,USDT,WETH \
+  ./examples/run_live_xochi_gate.sh
+# settle the fillable USDC subset for real
+XOCHI_LIVE_KEY=0x<funded> XOCHI_LIVE_MATRIX=true \
+  XOCHI_LIVE_CORRIDORS=mesh XOCHI_LIVE_TOKENS=USDC ./examples/run_live_xochi_gate.sh
 ```
 
-**`run_live_relay_gate.sh`** quotes the EVM->Tron Relay path through the Riddler
-solver. A quote moves no funds, so it needs no key, just the staging token and a
-source address. The full EVM->Tron settlement (which broadcasts an on-chain
-deposit) lives in a separate raxol_acp `:live_relay` test.
+**`../../raxol_acp/examples/run_live_acp_order_gate.sh`** is the proof another
+agent can ORDER these settlements through the ACP: a buyer creates a job for the
+`xochi_cross_chain_transfer` offering and the seller settles it via Xochi for
+real. It sets the Permit2 allowance for USDT/WETH first (needs
+`XOCHI_ORDER_RPC_<chain>`), then settles the fillable subset across USDC/USDT/WETH.
 
 ```bash
-RELAY_LIVE_FROM_ADDRESS=0x<base address> ./examples/run_live_relay_gate.sh
+XOCHI_ORDER_LIVE_KEY=0x<funded> DRY_RUN=1 ./run_live_acp_order_gate.sh
+XOCHI_ORDER_LIVE_KEY=0x<funded> XOCHI_ORDER_RPC_8453=https://mainnet.base.org \
+  XOCHI_ORDER_TOKENS=USDC,USDT,WETH ./run_live_acp_order_gate.sh
+```
+
+**`run_live_relay_gate.sh`** settles a full EVM->Tron transfer through the
+Riddler Relay rail. A read-only `/relay/quote` probe runs first (all `DRY_RUN`
+runs); the real settlement broadcasts the on-chain deposit via the raxol_acp
+`:live_relay` test, so it needs a funded key and a source-chain RPC. Multiple
+source tokens settle via `RELAY_LIVE_TOKENS`.
+
+```bash
+RELAY_LIVE_FROM_ADDRESS=0x<base address> DRY_RUN=1 ./examples/run_live_relay_gate.sh
+RELAY_LIVE_FROM_ADDRESS=0x<base address> RELAY_LIVE_KEY=0x<funded> \
+  RELAY_LIVE_RPC=https://mainnet.base.org ./examples/run_live_relay_gate.sh
 ```
 
 ## The progression at a glance
 
-| Stage            | Script                            | Funds         | Target                   |
-| ---------------- | --------------------------------- | ------------- | ------------------------ |
-| Rehearse         | `preflight.exs`                   | none          | local echo server        |
-| Launch path      | `crosschain_stealth_payment.exs`  | none          | in-process Xochi sim     |
-| Live cross-chain | `run_live_xochi_gate.sh`          | real          | Xochi worker (prod)      |
-| Live Tron quote  | `run_live_relay_gate.sh`          | none (quote)  | Riddler solver (staging) |
+| Stage            | Script                            | Funds         | Target                    |
+| ---------------- | --------------------------------- | ------------- | ------------------------- |
+| Rehearse         | `preflight.exs`                   | none          | local echo server         |
+| Launch path      | `crosschain_stealth_payment.exs`  | none          | in-process Xochi sim      |
+| Live cross-chain | `run_live_xochi_gate.sh`          | real          | Xochi worker (5 chains)   |
+| Live ACP order   | `run_live_acp_order_gate.sh`      | real          | ACP job -> Xochi worker   |
+| Live Tron settle | `run_live_relay_gate.sh`          | real          | Riddler Relay (Tron)      |
 
-The live gates are tagged `:live_xochi` / `:live_relay` and excluded by default;
-they only run when their endpoint env var is set (see `test/test_helper.exs`).
-For the architecture these examples exercise, see
-[Agentic Commerce docs](../../../docs/features/AGENTIC_COMMERCE.md).
+The live gates are tagged `:live_xochi` / `:live_xochi_order` / `:live_relay` and
+excluded by default; they only run when their endpoint env var is set (see each
+package's `test/test_helper.exs`). For the architecture these examples exercise,
+see [Agentic Commerce docs](../../../docs/features/AGENTIC_COMMERCE.md).

--- a/packages/raxol_payments/examples/run_live_relay_gate.sh
+++ b/packages/raxol_payments/examples/run_live_relay_gate.sh
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
-# Run the live Tron Relay quote gate against the Riddler solver (read-only).
+# Settle a full EVM->Tron transfer through the Relay rail (Riddler solver).
 #
-# Riddler serves the /relay/* routes the raxol Relay client calls. A quote moves
-# no funds, so this needs no private key -- just the endpoint, the staging bearer
-# token, and the EVM source address the quote is priced for.
-#
-# The full EVM->Tron settlement (which broadcasts an on-chain deposit) is a
-# separate raxol_acp :live_relay test, since broadcasting needs the EVM tx stack.
+# A read-only /relay/quote probe validates the endpoint + token and moves no
+# funds; under DRY_RUN that is all that runs. The real settlement broadcasts an
+# on-chain ERC-20 deposit to the Riddler deposit address, so it needs the EVM tx
+# stack that lives in raxol_acp: this gate runs the raxol_acp `:live_relay` test
+# (ExecuteRelayTransfer -> OnchainBroadcaster -> PollRelayStatus), which moves
+# REAL funds. Multiple source tokens settle in one run via RELAY_LIVE_TOKENS
+# (each resolved per chain via Raxol.Payments.Assets); the destination is Tron.
 #
 # Usage (from packages/raxol_payments/):
-#   RELAY_LIVE_FROM_ADDRESS=0x<base address> ./examples/run_live_relay_gate.sh
+#   # 1. Dry run: quote probe only, NO funds move, no key needed.
+#   RELAY_LIVE_FROM_ADDRESS=0x<base address> DRY_RUN=1 ./examples/run_live_relay_gate.sh
+#
+#   # 2. Real settlement: broadcasts the deposit (needs a funded key + an RPC).
+#   RELAY_LIVE_FROM_ADDRESS=0x<base address> \
+#   RELAY_LIVE_KEY=0x<funded source-chain key> \
+#   RELAY_LIVE_RPC=https://mainnet.base.org \
+#   RELAY_LIVE_TOKENS=USDC,USDT \
+#     ./examples/run_live_relay_gate.sh
 #
 # Override the endpoint or token source with RELAY_LIVE_URL / RELAY_LIVE_TOKEN.
+# Corridor overrides: RELAY_LIVE_FROM_CHAIN, RELAY_LIVE_TOKENS,
+# RELAY_LIVE_FROM_TOKEN (a raw origin address overriding the token list),
+# RELAY_LIVE_TO_TOKEN, RELAY_LIVE_TO_ADDRESS, RELAY_LIVE_AMOUNT.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACP_DIR="$SCRIPT_DIR/../../raxol_acp"
 
 RELAY_LIVE_URL="${RELAY_LIVE_URL:-https://riddler.axol.io}"
 # The /relay/* routes authenticate against TRON_RELAY_API_TOKEN, which
@@ -37,7 +52,7 @@ if [[ -z "${RELAY_LIVE_TOKEN:-}" ]]; then
   RELAY_LIVE_TOKEN="$(op read "$OP_TOKEN_REF")"
 fi
 
-printf 'validating relay quote endpoint (read-only, no funds move)...\n' >&2
+printf 'preflight: validating relay quote endpoint (read-only, no funds move)...\n' >&2
 quote_body="$(printf '{"transfer_id":"probe","from_chain_id":8453,"to_chain_id":728126428,"from_token":"%s","to_token":"%s","from_amount":"%s","from_address":"%s","to_address":"%s","slippage_bps":50}' \
   "$RELAY_LIVE_FROM_TOKEN" "$RELAY_LIVE_TO_TOKEN" "$RELAY_LIVE_AMOUNT" "$RELAY_LIVE_FROM_ADDRESS" "$RELAY_LIVE_TO_ADDRESS")"
 
@@ -48,12 +63,31 @@ code="$(curl -sS -m 20 -o /dev/null -w '%{http_code}' \
   -d "$quote_body")"
 
 if [[ "$code" != "200" ]]; then
-  printf 'warning: relay quote probe returned http %s (continuing to the gate)\n' "$code" >&2
-else
-  printf 'relay quote ok (http 200). running the gate...\n' >&2
+  printf 'preflight FAILED: relay quote probe returned http %s. Fix the endpoint/token.\n' "$code" >&2
+  printf 'No funds moved. Aborting.\n' >&2
+  exit 1
 fi
 
-export RELAY_LIVE_URL RELAY_LIVE_TOKEN RELAY_LIVE_FROM_ADDRESS
+printf 'preflight ok: relay quote reachable (http 200).\n' >&2
+
+if [[ -n "${DRY_RUN:-}" ]]; then
+  printf 'DRY_RUN set: quote confirmed, NO funds moved.\n' >&2
+  printf 're-run without DRY_RUN (with RELAY_LIVE_KEY + RELAY_LIVE_RPC) to settle.\n' >&2
+  exit 0
+fi
+
+if [[ -z "${RELAY_LIVE_KEY:-}" || -z "${RELAY_LIVE_RPC:-}" ]]; then
+  printf 'error: the real settlement broadcasts an on-chain deposit and needs\n' >&2
+  printf 'RELAY_LIVE_KEY (funded source-chain key) and RELAY_LIVE_RPC (source-chain RPC).\n' >&2
+  exit 1
+fi
+
+export RELAY_LIVE_URL RELAY_LIVE_TOKEN RELAY_LIVE_FROM_ADDRESS RELAY_LIVE_KEY RELAY_LIVE_RPC
 export RELAY_LIVE_FROM_TOKEN RELAY_LIVE_TO_TOKEN RELAY_LIVE_TO_ADDRESS RELAY_LIVE_AMOUNT
+
+# The full EVM->Tron settlement broadcasts the deposit, so it runs in raxol_acp
+# (where the EIP-1559 signing / RLP / JSON-RPC stack lives).
+printf 'settling EVM->Tron for REAL (broadcasts an on-chain deposit)...\n' >&2
+cd "$ACP_DIR"
 exec env MIX_ENV=test mix test --include live_relay \
-  test/raxol/payments/relay/live_relay_test.exs
+  test/raxol/acp/relay/live_relay_test.exs

--- a/packages/raxol_payments/examples/run_live_xochi_gate.sh
+++ b/packages/raxol_payments/examples/run_live_xochi_gate.sh
@@ -61,21 +61,29 @@
 # pin, plus XOCHI_LIVE_SETTLEMENT=stealth with XOCHI_LIVE_RECIPIENT_META for the
 # private path.
 #
-# Matrix mode (XOCHI_LIVE_MATRIX=true): settle every corridor x token x settlement
-# type in one run, MOVING REAL FUNDS PER CELL. A read-only per-cell preflight runs
-# first (quote every cell, assert can_solve + the pinned solver); it aborts before
-# any funds move if a cell fails, and is all that runs under DRY_RUN. Bounded by:
-#   XOCHI_LIVE_CORRIDORS         "from>to,from>to" chain ids (default 8453>42161,42161>8453)
-#   XOCHI_LIVE_TOKENS            "USDC,USDT,WETH" (default USDC)
+# Matrix mode (XOCHI_LIVE_MATRIX=true): validate every corridor x token x settlement
+# type in one run. A read-only per-cell preflight runs first (quote every cell,
+# assert can_solve, the served pull method per token, and the pinned solver); it
+# aborts before any funds move if a cell fails, and is all that runs under DRY_RUN.
+# The funded run then settles only the FILLABLE SUBSET: it re-quotes each cell and
+# skips (logs) any the solver cannot fill right now. Bounded by:
+#   XOCHI_LIVE_CORRIDORS         "from>to,from>to" chain ids, OR "mesh" for all 20
+#                                ordered pairs of the 5 EVM chains (default 8453>42161,42161>8453)
+#   XOCHI_LIVE_TOKENS            "USDC,USDT,WETH" (default USDC,USDT,WETH)
 #   XOCHI_LIVE_SETTLEMENTS       "public,stealth" (default public; stealth needs META)
 #   XOCHI_LIVE_AMOUNT            per-cell stablecoin amount (default 1.10)
 #   XOCHI_LIVE_WETH_AMOUNT       per-cell WETH amount (default 0.001; 18-decimal token)
 #   XOCHI_LIVE_ALLOW_ETH_ORIGIN  set true to settle Ethereum-origin cells (default: quote-only)
+#   XOCHI_LIVE_SETTLE_PERMIT2    set true to settle USDT/WETH cells in the funded run
 # Tokens resolve per chain via Raxol.Payments.Assets across the five EVM chains
-# (1, 10, 137, 8453, 42161). USDC pulls via ERC-3009; USDT/WETH via Permit2, which
-# needs a standing Permit2 allowance on each origin chain. Example:
-#   XOCHI_LIVE_KEY=0x<funded> XOCHI_LIVE_MATRIX=true XOCHI_LIVE_TOKENS=USDC,USDT,WETH \
-#   XOCHI_LIVE_SETTLEMENTS=public,stealth XOCHI_LIVE_RECIPIENT_META=st:eth:0x... \
+# (1, 10, 137, 8453, 42161). USDC pulls via ERC-3009 and settles here directly.
+# USDT/WETH pull via Permit2, which needs a standing on-chain Permit2 allowance this
+# gate does not broadcast, so USDT/WETH funded cells are skipped by default: order
+# them through raxol_acp (examples/run_live_acp_order_gate.sh, which sets the
+# allowance and settles for real), or set XOCHI_LIVE_SETTLE_PERMIT2=true once the
+# allowance is in place. Example (full 5x3 preflight + fillable USDC settlement):
+#   XOCHI_LIVE_KEY=0x<funded> XOCHI_LIVE_MATRIX=true XOCHI_LIVE_CORRIDORS=mesh \
+#   XOCHI_LIVE_TOKENS=USDC,USDT,WETH \
 #     ./examples/run_live_xochi_gate.sh
 set -euo pipefail
 
@@ -92,7 +100,7 @@ XOCHI_LIVE_TO_TOKEN="${XOCHI_LIVE_TO_TOKEN:-0xaf88d065e77c8cc2239327c5edb3a43226
 # Each cell moves real funds; bounded by the corridor/settlement lists below.
 XOCHI_LIVE_MATRIX="${XOCHI_LIVE_MATRIX:-false}"
 XOCHI_LIVE_CORRIDORS="${XOCHI_LIVE_CORRIDORS:-8453>42161,42161>8453}"
-XOCHI_LIVE_TOKENS="${XOCHI_LIVE_TOKENS:-USDC}"
+XOCHI_LIVE_TOKENS="${XOCHI_LIVE_TOKENS:-USDC,USDT,WETH}"
 XOCHI_LIVE_SETTLEMENTS="${XOCHI_LIVE_SETTLEMENTS:-public}"
 
 if [[ -z "${XOCHI_LIVE_KEY:-}" ]]; then
@@ -163,6 +171,9 @@ if [[ "$XOCHI_LIVE_MATRIX" == "true" ]]; then
   fi
   if [[ -n "${XOCHI_LIVE_ALLOW_ETH_ORIGIN:-}" ]]; then
     export XOCHI_LIVE_ALLOW_ETH_ORIGIN
+  fi
+  if [[ -n "${XOCHI_LIVE_SETTLE_PERMIT2:-}" ]]; then
+    export XOCHI_LIVE_SETTLE_PERMIT2
   fi
 
   # Per-cell preflight: quote every corridor x token read-only and assert

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -59,11 +59,19 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
   settlement), so it is bounded by env:
 
   - `XOCHI_LIVE_CORRIDORS` -- `"from>to,from>to"` chain-id pairs (default
-    `"8453>42161,42161>8453"`). Tokens resolve per chain via `Raxol.Payments.Assets`
-    for the five supported EVM chains (1, 10, 137, 8453, 42161).
+    `"8453>42161,42161>8453"`), or `"mesh"` for every ordered pair of the five
+    supported EVM chains (1, 10, 137, 8453, 42161). Tokens resolve per chain via
+    `Raxol.Payments.Assets`.
   - `XOCHI_LIVE_TOKENS` -- `"USDC,USDT,WETH"` (default `"USDC"`). USDC pulls via
     ERC-3009; USDT/WETH via Permit2 (needs a standing Permit2 allowance on each
-    origin chain).
+    origin chain). The preflight asserts the served pull method per token
+    (USDC -> erc3009, USDT/WETH -> permit2) read-only.
+  - `XOCHI_LIVE_SETTLE_PERMIT2` -- set to `true` to settle USDT/WETH cells in the
+    funded matrix. Off by default: those pulls need a standing Permit2 allowance
+    this gate does not broadcast, so order them through raxol_acp
+    (`run_live_acp_order_gate.sh`), which sets the allowance and settles for real.
+    The funded matrix re-quotes each cell and skips (logs) any the solver cannot
+    fill right now, settling only the fillable subset.
   - `XOCHI_LIVE_SETTLEMENTS` -- `"public,stealth"` (default `"public"`). Stealth
     cells require `XOCHI_LIVE_RECIPIENT_META`.
   - `XOCHI_LIVE_AMOUNT` -- per-cell stablecoin amount (default `1.10`, above the
@@ -287,26 +295,69 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
                   "(set XOCHI_LIVE_ALLOW_ETH_ORIGIN=true to settle from L1)"
               )
 
+            # USDT/WETH pull via Permit2, which needs a standing on-chain allowance
+            # this gate does not broadcast (raxol_payments holds no tx code). Set the
+            # allowance via the ACP order gate, then opt in with XOCHI_LIVE_SETTLE_PERMIT2.
+            permit2_token?(token) and System.get_env("XOCHI_LIVE_SETTLE_PERMIT2") != "true" ->
+              IO.puts(
+                "[live_xochi:matrix] SKIP #{label}: #{token} pulls via Permit2 and needs a " <>
+                  "standing allowance. Order it through raxol_acp (run_live_acp_order_gate.sh), " <>
+                  "or set XOCHI_LIVE_SETTLE_PERMIT2=true once the allowance is in place."
+              )
+
             true ->
-              amount = amount_for(token, stable_amount)
-              params = matrix_params(from, to, token, settlement, amount, meta)
-              started = System.monotonic_time(:millisecond)
-
-              assert {:ok, intent} = ExecuteXochiIntent.call(params, context),
-                     "execute failed for #{label}"
-
-              assert {:ok, status} =
-                       PollXochiStatus.call(%{intent_id: intent.intent_id}, poll_context)
-
-              assert status.terminal == true
-
-              assert status.status == "completed",
-                     "#{label} (#{intent.intent_id}) ended #{status.status}"
-
-              report_settlement(label, intent, status, params, started)
+              settle_fillable_cell(
+                {context, poll_context},
+                {from, to, token, settlement},
+                stable_amount,
+                meta,
+                label
+              )
           end
         end
       end
+
+      # Settle one matrix cell, but only if the solver can actually fill it now:
+      # re-quote read-only first and skip (log) a non-fillable cell instead of
+      # failing the whole run. Implements "settle the fillable subset".
+      defp settle_fillable_cell(
+             {context, poll_context},
+             {from, to, token, settlement},
+             stable_amount,
+             meta,
+             label
+           ) do
+        amount = amount_for(token, stable_amount)
+
+        case preflight_cell(context, from, to, token, amount) do
+          {:error, reason} ->
+            IO.puts(
+              "[live_xochi:matrix] SKIP #{label}: not fillable now " <>
+                "(#{inspect(reason)}); no funds moved"
+            )
+
+          {:ok, _info} ->
+            params = matrix_params(from, to, token, settlement, amount, meta)
+            settle_and_assert({context, poll_context}, params, label)
+        end
+      end
+
+      defp settle_and_assert({context, poll_context}, params, label) do
+        started = System.monotonic_time(:millisecond)
+
+        assert {:ok, intent} = ExecuteXochiIntent.call(params, context),
+               "execute failed for #{label}"
+
+        assert {:ok, status} = PollXochiStatus.call(%{intent_id: intent.intent_id}, poll_context)
+        assert status.terminal == true
+
+        assert status.status == "completed",
+               "#{label} (#{intent.intent_id}) ended #{status.status}"
+
+        report_settlement(label, intent, status, params, started)
+      end
+
+      defp permit2_token?(token), do: String.upcase(token) in ["USDT", "WETH"]
 
       @tag :live_xochi_preflight
       test "every configured corridor x token quotes can_solve and serves the pinned solver", %{
@@ -347,10 +398,23 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         with {:ok, request} <- preflight_request(wallet, from, to, token, amount),
              {:ok, quote} <- XochiProtocol.get_quote(config, request),
              :ok <- preflight_can_solve(quote),
+             :ok <- preflight_method(token, quote.payment_method),
              :ok <- XochiProtocol.validate_pull(quote, request, wallet) do
           {:ok, %{method: quote.payment_method, to_amount: quote.to_amount, fee: quote.xochi_fee}}
         end
       end
+
+      # USDC pulls via ERC-3009; USDT/WETH pull via Permit2. Asserting the served
+      # method per token catches a token routed to the wrong rail (which would
+      # otherwise fail on-chain at pull time) before any funds move.
+      defp preflight_method(token, method) do
+        want = expected_method(String.upcase(token))
+        got = method && String.downcase(method)
+        if got == want, do: :ok, else: {:error, {:method_mismatch, token, got, want}}
+      end
+
+      defp expected_method("USDC"), do: "erc3009"
+      defp expected_method(_token), do: "permit2"
 
       defp preflight_request(wallet, from, to, token, amount) do
         with {:ok, from_token} <- Assets.address(from, token),
@@ -404,6 +468,16 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
             else: ""
 
         l1 <> permit2
+      end
+
+      # The five supported EVM chains: Ethereum, Optimism, Polygon, Base, Arbitrum.
+      @evm_chains [1, 10, 137, 8453, 42_161]
+
+      # "mesh" (or "all") expands to every ordered pair of the five EVM chains (20
+      # corridors), so the preflight validates the full grid in one run. The
+      # explicit "from>to,from>to" form still works for a narrower run.
+      defp parse_corridors(spec) when spec in ["mesh", "all"] do
+        for from <- @evm_chains, to <- @evm_chains, from != to, do: {from, to}
       end
 
       defp parse_corridors(spec) do


### PR DESCRIPTION
## Summary

Turns the live payment gates into real end-to-end validators and makes the
cross-chain settlement services orderable through the ACP. Validates that the
raxol agent can drive the Riddler solver + Xochi for public settlement across all
5 EVM chains (1/10/137/8453/42161) for USDC, USDT, and WETH, that the relay rail
settles EVM->Tron for real, and that another agent can order these through the ACP.

## What changed

- **Xochi gate** (`run_live_xochi_gate.sh` + `live_xochi_test.exs`): matrix mode
  takes `XOCHI_LIVE_CORRIDORS=mesh` (all 20 ordered pairs of the 5 chains), default
  tokens `USDC,USDT,WETH`. Preflight asserts `can_solve` + the per-token pull method
  (USDC->erc3009, USDT/WETH->permit2) + the pinned solver, read-only. The funded run
  settles the fillable subset (re-quotes, skips non-solvable). USDT/WETH funded cells
  gated behind `XOCHI_LIVE_SETTLE_PERMIT2`.
- **ACP order gate** (new `run_live_acp_order_gate.sh` + `live_order_test.exs`, tags
  `:live_xochi_order` / `:live_xochi_order_preflight`): a buyer creates a job for
  `xochi_cross_chain_transfer`; the seller settles via the real `Settler` ->
  `Xochi.transfer`. Sets the Permit2 allowance for USDT/WETH first.
- **Permit2 approver** (new `Raxol.ACP.Onchain.Permit2Approver`): reads allowance and
  broadcasts `approve(Permit2, max)`. Lives in raxol_acp (the EVM broadcast stack is
  there; raxol_payments holds no fund-moving tx code by design).
- **Relay gate** (`run_live_relay_gate.sh`): now drives a real EVM->Tron settlement
  (was quote-only). The ACP `:live_relay` test gained a two-pass preflight, multi
  source-token via `RELAY_LIVE_TOKENS`, and settlement reporting.
- **Bug fix**: `Settler.to_deliverable` read non-existent `IntentStatus` fields
  (`:src_tx_hash`/`:dst_tx_hash`), dropping the settlement tx hashes the deliverable
  schema marks required; now maps `tx_hash`/`receiving_tx_hash`.
- **Doc**: `TransferOffering` `destination` is not honored yet (delivers to the
  requester's own address); recipient routing is a future release. Called out in
  `Settler.build_quote_request` and the `Xochi.Offering` schema.

## Manual testing

- [x] `raxol_acp` full suite: 634 tests, 0 failures
- [x] `raxol_payments` full suite: 787 tests, 0 failures
- [x] `mix credo --strict` clean on all new/edited lib + test files
- [x] `mix format --check-formatted` clean
- [x] `shellcheck` clean on all three gate scripts; input guards fire on missing env
- [x] Both gated live-test blocks compile under their env flags (0 tests when excluded)
- [ ] Live DRY_RUN preflights (need 1Password + network): `DRY_RUN=1` on each gate
- [ ] Funded live runs (need the funded solver wallet): mesh USDC, then ACP USDT/WETH,
      then relay EVM->Tron

## Notes

Live settlement of USDT/WETH runs through the ACP order gate (it broadcasts the
Permit2 approve); the payments Xochi gate settles USDC directly and validates
USDT/WETH read-only. `Raxol.Payments.Assets` already resolves all 5 chains x 3 tokens,
so no asset changes were needed.
