### PR TITLE
Harden fund-moving surfaces (Fable review P0)

### DIFF
--- a/docs/cookbook/SSH_DEPLOYMENT.md
+++ b/docs/cookbook/SSH_DEPLOYMENT.md
@@ -5,11 +5,17 @@ This is one of the things that falls out naturally from running on the BEAM, whe
 
 ## Quick Start
 
-Any TEA app can be served over SSH with one line:
+Any TEA app can be served over SSH. Authentication is required unless anonymous access is explicitly requested, so a fund-bearing surface is never silently anonymous:
 
 ```elixir
-Raxol.SSH.serve(MyApp, port: 2222)
+# Public, read-only app (a dashboard, a component catalog): anonymous is fine.
+Raxol.SSH.serve(MyApp, port: 2222, allow_anonymous: true)
+
+# A surface that can reach payment Actions: require a public key.
+Raxol.SSH.serve(MyApp, port: 2222, authorized_keys_dir: "/etc/raxol/authorized")
 ```
+
+With neither option the server refuses to start. See [Authentication](#authentication) below.
 
 Connect from any machine:
 
@@ -59,8 +65,8 @@ defmodule MySshApp do
   def subscribe(_model), do: []
 end
 
-# Start SSH server
-{:ok, _} = Raxol.SSH.serve(MySshApp, port: 2222)
+# Start SSH server (a public counter demo, so anonymous access is intended)
+{:ok, _} = Raxol.SSH.serve(MySshApp, port: 2222, allow_anonymous: true)
 
 # Keep alive
 Process.sleep(:infinity)
@@ -97,16 +103,26 @@ Each connection is isolated. One user's crash doesn't affect others.
 
 ## Configuration
 
+### Authentication
+
+A surface that can reach payment Actions must not be silently anonymous, so authentication is fail-closed: pass one of two options, or the server refuses to start.
+
+- `allow_anonymous: true` accepts any connection. Use it for a public, read-only app (a dashboard, the component playground).
+- `authorized_keys_dir: "/path"` requires public-key auth. The directory holds an `authorized_keys` file listing the permitted public keys, and a connection must present a listed key.
+
+For any surface that can move funds, use `authorized_keys_dir` and bind the connection to that identity before it reaches a payment Action. Do not rely on an in-app login screen inside an otherwise-anonymous SSH session, which would put credential handling inside your `update/2` instead of the transport.
+
 ### Port and host keys
 
 ```elixir
 Raxol.SSH.serve(MyApp,
   port: 3000,
-  host_keys_dir: "/etc/raxol/ssh_keys"  # default: /tmp/raxol_ssh_keys
+  host_keys_dir: "/etc/raxol/ssh_keys",  # default: ~/.raxol/ssh_keys
+  allow_anonymous: true
 )
 ```
 
-Host keys are auto-generated on first run. For production, use a persistent directory so clients don't get host key warnings on restart.
+Host keys are auto-generated on first run under a persistent per-user directory (`~/.raxol/ssh_keys`), so clients do not get host-key-changed warnings on restart. Point `host_keys_dir` at a directory your service account owns to keep the key stable across deploys.
 
 ### Running alongside a Phoenix app
 
@@ -117,7 +133,10 @@ Add the SSH server to your supervision tree:
 def start(_type, _args) do
   children = [
     MyAppWeb.Endpoint,
-    {Raxol.SSH.Server, app_module: MyTerminalApp, port: 2222}
+    {Raxol.SSH.Server,
+     app_module: MyTerminalApp,
+     port: 2222,
+     authorized_keys_dir: "/etc/raxol/authorized"}
   ]
 
   Supervisor.start_link(children, strategy: :one_for_one)
@@ -137,6 +156,10 @@ mkdir -p /etc/raxol/ssh_keys
 ssh-keygen -t rsa -f /etc/raxol/ssh_keys/ssh_host_rsa_key -N ""
 ssh-keygen -t ecdsa -f /etc/raxol/ssh_keys/ssh_host_ecdsa_key -N ""
 ```
+
+### Isolation from signing
+
+Do not co-locate an SSH surface with a node that holds signing keys. The interactive REPL and any anonymous surface are capability-escape risks next to a wallet, so keep the payment node separate. On the signing node, call `Raxol.Payments.Deployment.assert_signing_isolated!/0` at boot: it refuses to start when `RAXOL_REPL_EXPOSED=true`. If the SSH box joins an Erlang cluster with the signing node, run distribution over TLS (`-proto_dist inet_tls` with per-node certs), never a shared magic cookie, and gate it with `Raxol.Payments.Deployment.assert_distribution_secure!/0`.
 
 ### Systemd service
 

--- a/docs/features/AGENTIC_COMMERCE.md
+++ b/docs/features/AGENTIC_COMMERCE.md
@@ -168,6 +168,15 @@ Req.new(url: "https://api.xochi.fi/api/intent/quote")
 
 v1 follows the locked design at `xochi/docs/planning/agent-auth.md`. On the agent side, a `410 Gone` from Xochi (a revoked or exhausted envelope) prunes the local mandate through the outbound plugin and flags the response as terminal, so a server-side revocation converges locally without a manual `payment_revoke_mandate` call. The authenticated server-side revoke endpoint itself, along with the on-chain registry, Verified-Agent metadata, issuer browser UI, and auto-rotation on exhaustion, remain deferred.
 
+### Two delegation models (Mandate vs SCA session key)
+
+A deployed agent may carry two capability-delegation credentials, and they govern two different surfaces. Keep them distinct in an ops runbook so a de-authorization is complete:
+
+- **Xochi Mandate** (`Raxol.Payments.Mandate`, this package) governs Xochi API calls. A Member signs an EIP-712 envelope binding an agent wallet to a scoped budget; the agent presents it per call via `Req.Mandate`. Revoke it by letting it expire, or (once Xochi ships the revoke endpoint) by `H(envelope)`; a `410 Gone` prunes the local copy.
+- **ERC-4337 SCA session key** (`Raxol.ACP.Wallet.SCA`, in `raxol_acp`) governs Base/ACP UserOps. A session key installed on the modular account via `installValidation` signs sponsored UserOps for on-chain ACP job actions.
+
+The two are independent: revoking one does not revoke the other. An agent that must be fully de-authorized needs both its Mandate revoked or expired **and** its SCA session key uninstalled. The Mandate is a Xochi-side credential scoped to Xochi endpoints; the session key is a Base-side signer scoped to the modular account. A leaked key revoked on Xochi but still holding a valid session key can still act through the ACP path, and vice versa.
+
 ## AutoPay (Req Plugin)
 
 `Raxol.Payments.Req.AutoPay` is a Req response step. Add it to any Req client and HTTP 402 responses get handled transparently:

--- a/docs/features/AGENTIC_COMMERCE.md
+++ b/docs/features/AGENTIC_COMMERCE.md
@@ -29,8 +29,8 @@ Ledger records the spend
 
 Two wallet implementations behind the `Raxol.Payments.Wallet` behaviour:
 
-- `Wallets.Env`: private key from an environment variable. Simple, good for dev and CI.
-- `Wallets.Op`: private key fetched from 1Password via a GenServer. No plaintext key on disk.
+- `Wallets.Env`: private key from an environment variable. Simple, good for dev and CI. In a deployed release it refuses to load (a plaintext key in an env var lands in process listings and crash dumps) unless the operator opts in with `RAXOL_ALLOW_ENV_WALLET=true` or `config :raxol_payments, :allow_env_wallet, true`. Use `Wallets.Op` in production.
+- `Wallets.Op`: private key fetched from 1Password via a GenServer. No plaintext key on disk. The key is fetched once at first use, wrapped in a `Secret`, and signed with locally, so signing does not round-trip 1Password per request.
 
 Both implement the `Raxol.Payments.Wallet` callbacks: `address/0`, `chain_id/0`, and three signing functions: `sign_message/1` (raw message), `sign_typed_data/3` (EIP-712 typed data), and `sign_hash/1` (precomputed 32-byte digest). The behaviour has no balance callback.
 
@@ -43,6 +43,10 @@ Handles HTTP 402 Payment Required responses. The server says "pay me X to addres
 ### MPP (Machine Payments Protocol)
 
 Stripe/Tempo's protocol for machine-to-machine payments. Same HTTP 402 flow, different wire format. The `AutoPay` Req plugin handles both x402 and MPP automatically; just add it as a response step.
+
+### Permit2
+
+`PermitWitnessTransferFrom` signing for Riddler's `/order` origin pull. Where x402 signs an ERC-3009 `transferWithAuthorization` (USDC only), Permit2 covers most ERC-20 tokens: the wallet signs a Permit2 witness that binds the transfer to the solver's order, so Riddler can pull the origin funds gaslessly (the agent must already hold a one-time Permit2 approval on-chain). `Protocols.Permit2.sign_quote/3` returns the digest, signed object, and signature; the digest is pinned byte-for-byte against viem in CI.
 
 ### Xochi
 
@@ -70,7 +74,7 @@ Three layers of limits in `SpendingPolicy`:
 
 The `Ledger` is an ETS-backed GenServer that tracks cumulative spend. `SpendingHook` implements the `CommandHook` behaviour from raxol_agent. It runs before every command and can deny execution if limits would be exceeded.
 
-Both spend paths reserve atomically before signing: the `SpendGate` choke point (payment Actions) and `SpendingHook` (Pay directives) call `Ledger.try_spend`, which checks the caps and records in one step, and refund via `Ledger.release` when execution then fails, so two commands cannot both pass a check before either records. A non-positive or non-finite amount is rejected up front (it can never lower the running total). A missing policy leaves the gate permissive by default; a fund-moving deployment sets `require_policy: true` (payment context or `config :raxol_payments, :require_policy`) so `SpendGate` fails closed instead of allowing unlimited spend.
+Both spend paths reserve atomically before signing: the `SpendGate` choke point (payment Actions) and `SpendingHook` (Pay directives) call `Ledger.try_spend`, which checks the caps and records in one step, and refund via `Ledger.release` when execution then fails, so two commands cannot both pass a check before either records. A non-positive or non-finite amount is rejected up front (it can never lower the running total). A missing policy leaves the gate permissive in development, but a deployed release fails closed: `require_policy` defaults to true in production (a deployed OTP release, detected by `Raxol.Payments.Deployment` via `RELEASE_NAME`) and false in development and tests, so a production `SpendGate` with no `SpendingPolicy` rejects the spend rather than allowing unlimited spend. Set the context flag or `config :raxol_payments, :require_policy` to override.
 
 ## Crash Recovery
 
@@ -84,9 +88,33 @@ The store is injected via `context[:checkpoint]` as a `{module, handle}` pair, s
 - `Checkpoint.ContextStore`: backed by `Raxol.Agent.ContextStore`, so a deployed agent's in-flight intent persists in the same durable store that backs its own crash recovery.
 - nil (the default): recovery disabled; every call quotes and signs.
 
-Without a checkpoint, `ExecuteXochiIntent` still proceeds but emits `[:raxol, :payments, :xochi, :unchecked_settlement]`, so the double-settle exposure is observable rather than silent. A fund-moving deployment closes the window by injecting a durable store and setting `require_checkpoint: true` (payment context or `config :raxol_payments, :require_checkpoint`), which fails the Action closed with `{:error, %Failure{reason: :checkpoint_required}}` before any signature when no store is present. A poll that never reaches a terminal status returns `%Failure{reason: :stranded}` and emits `[:raxol, :payments, :xochi, :intent_stranded]` with the intent id, so a stranded settlement is reconciled rather than blindly re-executed.
+Without a checkpoint, `ExecuteXochiIntent` in development still proceeds but emits `[:raxol, :payments, :xochi, :unchecked_settlement]`, so the double-settle exposure is observable rather than silent. A deployed release fails closed by default: `require_checkpoint` defaults to true in production (detected via `RELEASE_NAME`) and false in development and tests, so a production Action with no durable store returns `{:error, %Failure{reason: :checkpoint_required}}` before any signature. Inject a store to close the window; set the context flag or `config :raxol_payments, :require_checkpoint` to override. A poll that never reaches a terminal status returns `%Failure{reason: :stranded}` and emits `[:raxol, :payments, :xochi, :intent_stranded]` with the intent id, so a stranded settlement is reconciled rather than blindly re-executed.
 
 The relay rail keys on the logical payment rather than its client-minted `transfer_id`, so a resume reuses the same `transfer_id` and an idempotent broadcaster dedupes a retried deposit. A definite execution failure (nothing dispatched) drops the checkpoint so a later retry starts clean. Set `context[:idempotency_key]` to force two otherwise-identical payments apart.
+
+## Production Safety
+
+A process that holds a signing key is the crown jewel, so the fund-moving defaults are paranoid in a deployed release and permissive in development and tests. `Raxol.Payments.Deployment.production?/0` decides which: it is true for a deployed OTP release (detected by the `RELEASE_NAME` the release boot script sets, which survives into the running node where `Mix.env/0` does not), and can be forced either way with `config :raxol_payments, :deployment` or `RAXOL_PAYMENTS_DEPLOYMENT`.
+
+- **Signing boundary.** Every fund-moving Action reaches `wallet.sign_*` only after `SpendGate.authorize/3` returns `:ok`. `sign_hash/1` (the opaque-digest signer) is reachable only through `Mandate.sign/2`, which builds the digest from a validated struct, never an arbitrary hash. A property test asserts a gate rejection yields zero signatures across the amount space, and a guard test keeps any new Action from reaching a signer without the gate.
+- **Fail-closed defaults.** In production, `require_policy` and `require_checkpoint` default to true (see Spending Controls and Crash Recovery), and `Wallets.Env` refuses to load (see Wallet Backends).
+- **EIP-712 golden vectors.** The digest for every signed struct (x402 ERC-3009, the Xochi intent, the Permit2 witness, the Mandate) is pinned to a committed value that default CI checks on every run, so a change to a type definition or the encoder turns CI red rather than silently signing against the wrong struct.
+
+Two boot gates fail closed for a fund-moving deployment; call them at startup, alongside `Protocols.Xochi.assert_origin_pull_pinned!/2`:
+
+```elixir
+# In your application start/2, before serving traffic:
+Raxol.Payments.Deployment.assert_distribution_secure!()
+# Halts a production node that participates in plain (non-TLS) Erlang
+# distribution: a shared magic cookie lets any peer invoke exported functions
+# and read ETS. Require -proto_dist inet_tls with per-node certs, or set
+# RAXOL_ALLOW_INSECURE_DISTRIBUTION=true to override.
+
+Raxol.Payments.Deployment.assert_signing_isolated!()
+# Halts a production node that both signs and exposes the interactive REPL
+# (RAXOL_REPL_EXPOSED=true). Evaluating code on a node that holds keys is a
+# capability-escape surface: keep the REPL on a node that cannot sign.
+```
 
 ## Agent Actions
 
@@ -101,7 +129,7 @@ Twelve actions registered via the `Raxol.Agent.Action` behaviour, callable by LL
 | `payment_list_history` | Transaction history for this session |
 | `payment_create_mandate` | Issue a Xochi delegation envelope from this wallet |
 | `payment_list_mandates` | List locally-stored Mandates (as member or as agent) |
-| `payment_revoke_mandate` | Locally delete a stored Mandate (Xochi KV unaffected) |
+| `payment_revoke_mandate` | Locally delete a stored Mandate (server budget honored until expiry; a 410 auto-prunes) |
 | `payment_execute_xochi_intent` | Dispatch a cross-chain Xochi intent (checkpointed) |
 | `payment_poll_xochi_status` | Poll the status of a dispatched Xochi intent |
 | `payment_execute_relay_transfer` | Initiate a Tron transfer via Riddler Relay (checkpointed); Tron is public-only |
@@ -138,7 +166,7 @@ Req.new(url: "https://api.xochi.fi/api/intent/quote")
 
 `Mandate.Store` is a singleton (named ETS tables); start exactly one per node. Optional DETS persistence via `:mandate_store_path` in `config :raxol_payments`. Mandate is **orthogonal** to `SpendingPolicy`/`Ledger`: those govern operator-set session budgets locally; Mandate is a credential carried to Xochi for tier inheritance.
 
-v1 follows the locked design at `xochi/docs/planning/agent-auth.md`. Server-side revoke endpoint, on-chain registry, Verified-Agent metadata, issuer browser UI, and auto-rotation on exhaustion are deferred.
+v1 follows the locked design at `xochi/docs/planning/agent-auth.md`. On the agent side, a `410 Gone` from Xochi (a revoked or exhausted envelope) prunes the local mandate through the outbound plugin and flags the response as terminal, so a server-side revocation converges locally without a manual `payment_revoke_mandate` call. The authenticated server-side revoke endpoint itself, along with the on-chain registry, Verified-Agent metadata, issuer browser UI, and auto-rotation on exhaustion, remain deferred.
 
 ## AutoPay (Req Plugin)
 

--- a/lib/mix/tasks/raxol.playground.ex
+++ b/lib/mix/tasks/raxol.playground.ex
@@ -60,7 +60,10 @@ defmodule Mix.Tasks.Raxol.Playground do
     {:ok, pid} =
       Raxol.SSH.serve(Raxol.Playground.App,
         port: port,
-        max_connections: max
+        max_connections: max,
+        # The playground is a public, read-only component catalog: anonymous
+        # access is intended. Surfaces that reach payment Actions must not.
+        allow_anonymous: true
       )
 
     ref = Process.monitor(pid)

--- a/lib/raxol/application.ex
+++ b/lib/raxol/application.ex
@@ -343,11 +343,16 @@ defmodule Raxol.Application do
       host_keys_dir =
         System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys"
 
-      {Raxol.SSH.Server,
-       app_module: Raxol.Playground.App,
-       port: port,
-       host_keys_dir: host_keys_dir,
-       max_connections: max_connections}
+      {
+        Raxol.SSH.Server,
+        # The playground is a public, read-only component catalog: anonymous
+        # access is intended. A fund-bearing surface must set authorized_keys_dir.
+        app_module: Raxol.Playground.App,
+        port: port,
+        host_keys_dir: host_keys_dir,
+        max_connections: max_connections,
+        allow_anonymous: true
+      }
     end
   end
 

--- a/lib/raxol/playground/demos/repl_demo.ex
+++ b/lib/raxol/playground/demos/repl_demo.ex
@@ -126,7 +126,9 @@ defmodule Raxol.Playground.Demos.ReplDemo do
   defp eval_input(model) do
     code = String.trim(model.input)
 
-    case Sandbox.check(code) do
+    # The playground is served anonymously over SSH, so the REPL demo runs at
+    # the whitelist-only strict level -- never the default standard blocklist.
+    case Sandbox.check(code, :strict) do
       :ok ->
         do_eval(model, code)
 

--- a/lib/raxol/repl/sandbox.ex
+++ b/lib/raxol/repl/sandbox.ex
@@ -52,7 +52,32 @@ defmodule Raxol.REPL.Sandbox do
     {Node, :connect, "node connection"},
     {GenServer, :call, "arbitrary GenServer interaction"},
     {GenServer, :cast, "arbitrary GenServer interaction"},
-    {Kernel, :apply, "dynamic function application"}
+    {Kernel, :apply, "dynamic function application"},
+    # Message passing / process reach: a sandboxed eval sharing a node with a
+    # signing process must not be able to message or look it up. `send` (special
+    # form) is handled separately; these close the qualified-call variants and
+    # the erlang-atom bypasses that a module whitelist alone would still permit.
+    {Kernel, :send, "message sending"},
+    {Kernel, :spawn, "process spawning"},
+    {Kernel, :spawn_link, "process spawning"},
+    {Kernel, :spawn_monitor, "process spawning"},
+    {Kernel, :exit, "process termination"},
+    {Process, :send, "message sending"},
+    {Process, :send_after, "delayed message sending"},
+    {Process, :whereis, "process lookup"},
+    {Process, :register, "process registration"},
+    {:erlang, :send, "message sending"},
+    {:erlang, :whereis, "process lookup"},
+    {:erlang, :spawn, "process spawning"},
+    {:erlang, :spawn_link, "process spawning"},
+    {:erlang, :binary_to_term, "term deserialization"},
+    {:erlang, :binary_to_atom, "dynamic atom creation"},
+    {:erlang, :list_to_atom, "dynamic atom creation"},
+    {:gen_server, :call, "arbitrary GenServer interaction"},
+    {:gen_server, :cast, "arbitrary GenServer interaction"},
+    {:rpc, :call, "remote procedure call"},
+    {:rpc, :cast, "remote procedure call"},
+    {:global, :whereis_name, "process lookup"}
   ]
 
   @allowed_strict_modules [
@@ -160,6 +185,15 @@ defmodule Raxol.REPL.Sandbox do
 
   defp check_node({:send, _, args}, _level) when is_list(args) do
     ["send is not allowed (message sending to arbitrary processes)"]
+  end
+
+  defp check_node({kind, _, args}, _level)
+       when kind in [:spawn, :spawn_link, :spawn_monitor] and is_list(args) do
+    ["#{kind} is not allowed (process spawning)"]
+  end
+
+  defp check_node({:receive, _, _}, _level) do
+    ["receive is not allowed (message interception)"]
   end
 
   defp check_node({kind, _, _}, _level)

--- a/lib/raxol/ssh/cli_handler.ex
+++ b/lib/raxol/ssh/cli_handler.ex
@@ -6,6 +6,8 @@ defmodule Raxol.SSH.CLIHandler do
 
   defstruct [
     :app_module,
+    :server,
+    :peer_ip,
     :session_pid,
     :channel_id,
     :connection_ref,
@@ -15,22 +17,26 @@ defmodule Raxol.SSH.CLIHandler do
   @impl true
   def init(opts) do
     app_module = Keyword.fetch!(opts, :app_module)
-    {:ok, %__MODULE__{app_module: app_module}}
+    server = Keyword.get(opts, :server, Raxol.SSH.Server)
+    {:ok, %__MODULE__{app_module: app_module, server: server}}
   end
 
   @impl true
   def handle_msg({:ssh_channel_up, channel_id, connection_ref}, state) do
-    case Raxol.SSH.Server.register_connection() do
+    peer_ip = peer_ip(connection_ref)
+
+    case Raxol.SSH.Server.register_connection(state.server, peer_ip) do
       :ok ->
         {:ok,
          %{
            state
            | channel_id: channel_id,
              connection_ref: connection_ref,
+             peer_ip: peer_ip,
              registered: true
          }}
 
-      {:error, :max_connections} ->
+      {:error, _reason} ->
         _ =
           :ssh_connection.send(
             connection_ref,
@@ -106,8 +112,8 @@ defmodule Raxol.SSH.CLIHandler do
   def handle_ssh_msg(_msg, state), do: {:ok, state}
 
   @impl true
-  def terminate(_reason, %__MODULE__{registered: true}) do
-    Raxol.SSH.Server.unregister_connection()
+  def terminate(_reason, %__MODULE__{registered: true} = state) do
+    Raxol.SSH.Server.unregister_connection(state.server, state.peer_ip)
     :ok
   end
 
@@ -115,4 +121,18 @@ defmodule Raxol.SSH.CLIHandler do
 
   defp maybe_send(nil, _msg), do: :ok
   defp maybe_send(pid, msg), do: send(pid, msg)
+
+  # The peer IP scopes the per-source connection cap. Any surprise in the
+  # connection info degrades to a shared `:unknown` bucket rather than crashing
+  # the channel.
+  defp peer_ip(connection_ref) do
+    case :ssh.connection_info(connection_ref, [:peer]) do
+      [{:peer, {_name, {ip, _port}}}] -> ip
+      _ -> :unknown
+    end
+  rescue
+    _ -> :unknown
+  catch
+    _, _ -> :unknown
+  end
 end

--- a/lib/raxol/ssh/server.ex
+++ b/lib/raxol/ssh/server.ex
@@ -14,8 +14,20 @@ defmodule Raxol.SSH.Server do
   ## Options
 
     * `:port` - Port to listen on (default: 2222)
-    * `:host_keys_dir` - Directory for SSH host keys (default: "/tmp/raxol_ssh_keys")
+    * `:host_keys_dir` - Directory for SSH host keys (default: `~/.raxol/ssh_keys`,
+      a persistent path so keys survive restarts)
     * `:max_connections` - Maximum concurrent connections (default: 50)
+
+  ## Authentication (fail-closed)
+
+  A surface that can reach payment Actions must not be silently anonymous, so
+  authentication is required unless anonymous access is explicitly requested:
+
+    * `:allow_anonymous` - `true` accepts any connection (BBS/playground use).
+    * `:authorized_keys_dir` - a directory holding an `authorized_keys` file;
+      connections must present a listed public key.
+
+  With neither, the server refuses to start.
   """
 
   use GenServer
@@ -36,13 +48,43 @@ defmodule Raxol.SSH.Server do
 
   @spec serve(module(), keyword()) :: GenServer.on_start()
   def serve(app_module, opts \\ []) do
-    start_link(
-      app_module: app_module,
-      port: Keyword.get(opts, :port, @default_port),
-      host_keys_dir: Keyword.get(opts, :host_keys_dir, "/tmp/raxol_ssh_keys"),
-      max_connections:
-        Keyword.get(opts, :max_connections, @default_max_connections)
-    )
+    start_link([app_module: app_module] ++ opts)
+  end
+
+  @doc """
+  Default directory for SSH host keys: a persistent per-user path.
+
+  A host key under `/tmp` rotates on reboot, which trains clients to click
+  through the host-key-changed warning -- the one warning that matters. Keys
+  live under the user's home so they survive restarts.
+  """
+  @spec default_host_keys_dir() :: String.t()
+  def default_host_keys_dir, do: Path.expand("~/.raxol/ssh_keys")
+
+  @doc """
+  Build the `:ssh.daemon` authentication options, failing closed.
+
+  Returns `{:ok, opts}` for `allow_anonymous: true` (no auth) or
+  `authorized_keys_dir: dir` (public-key auth), and `{:error, :ssh_auth_required}`
+  when neither is given so the caller refuses to start an anonymous surface.
+  """
+  @spec auth_daemon_opts(keyword()) ::
+          {:ok, keyword()} | {:error, :ssh_auth_required}
+  def auth_daemon_opts(opts) do
+    anonymous? = Keyword.get(opts, :allow_anonymous, false) == true
+    keys_dir = Keyword.get(opts, :authorized_keys_dir)
+
+    cond do
+      anonymous? ->
+        {:ok, [no_auth_needed: true]}
+
+      is_binary(keys_dir) ->
+        {:ok,
+         [user_dir: String.to_charlist(keys_dir), auth_methods: ~c"publickey"]}
+
+      true ->
+        {:error, :ssh_auth_required}
+    end
   end
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -74,18 +116,40 @@ defmodule Raxol.SSH.Server do
   def init(opts) do
     app_module = Keyword.fetch!(opts, :app_module)
     port = Keyword.get(opts, :port, @default_port)
-    host_keys_dir = Keyword.get(opts, :host_keys_dir, "/tmp/raxol_ssh_keys")
+    host_keys_dir = Keyword.get(opts, :host_keys_dir, default_host_keys_dir())
 
     max_connections =
       Keyword.get(opts, :max_connections, @default_max_connections)
 
+    # Resolve authentication first: refuse to open the daemon at all when the
+    # surface would be silently anonymous.
+    case auth_daemon_opts(opts) do
+      {:ok, auth_opts} ->
+        start_daemon(
+          app_module,
+          port,
+          host_keys_dir,
+          max_connections,
+          auth_opts
+        )
+
+      {:error, :ssh_auth_required} ->
+        {:stop,
+         {:ssh_auth_required,
+          "SSH server refused to start: no authentication configured. Pass " <>
+            "allow_anonymous: true for anonymous access (e.g. a playground), or " <>
+            "authorized_keys_dir: <dir> to require public-key auth."}}
+    end
+  end
+
+  defp start_daemon(app_module, port, host_keys_dir, max_connections, auth_opts) do
     ensure_host_keys(host_keys_dir)
 
-    daemon_opts = [
-      system_dir: String.to_charlist(host_keys_dir),
-      ssh_cli: {Raxol.SSH.CLIHandler, [app_module: app_module]},
-      no_auth_needed: true
-    ]
+    daemon_opts =
+      [
+        system_dir: String.to_charlist(host_keys_dir),
+        ssh_cli: {Raxol.SSH.CLIHandler, [app_module: app_module]}
+      ] ++ auth_opts
 
     case :ssh.daemon(port, daemon_opts) do
       {:ok, daemon_ref} ->

--- a/lib/raxol/ssh/server.ex
+++ b/lib/raxol/ssh/server.ex
@@ -17,6 +17,10 @@ defmodule Raxol.SSH.Server do
     * `:host_keys_dir` - Directory for SSH host keys (default: `~/.raxol/ssh_keys`,
       a persistent path so keys survive restarts)
     * `:max_connections` - Maximum concurrent connections (default: 50)
+    * `:max_per_ip` - Maximum concurrent connections from one peer IP (default: 10),
+      so a single host cannot flood the pool
+    * `:negotiation_timeout` - Milliseconds a connection may spend in key exchange
+      and auth before it is dropped (default: 30_000), bounding slow-handshake holds
 
   ## Authentication (fail-closed)
 
@@ -40,11 +44,17 @@ defmodule Raxol.SSH.Server do
     :port,
     :host_keys_dir,
     :max_connections,
-    connections: 0
+    :max_per_ip,
+    connections: 0,
+    per_ip: %{}
   ]
 
   @default_port Raxol.Constants.default_ssh_port()
   @default_max_connections 50
+  @default_max_per_ip 10
+  # Cap how long an unauthenticated connection may hold resources during key
+  # exchange + auth, so a slow or stalled handshake cannot pin a slot.
+  @default_negotiation_timeout_ms 30_000
 
   @spec serve(module(), keyword()) :: GenServer.on_start()
   def serve(app_module, opts \\ []) do
@@ -99,39 +109,64 @@ defmodule Raxol.SSH.Server do
     GenServer.call(server, :connection_count)
   end
 
-  @doc "Registers a new connection. Returns :ok or {:error, :max_connections}."
-  @spec register_connection(GenServer.server()) ::
-          :ok | {:error, :max_connections}
-  def register_connection(server \\ __MODULE__) do
-    GenServer.call(server, :register_connection)
+  @doc """
+  Registers a new connection from `peer_ip`.
+
+  Returns `:ok`, `{:error, :max_connections}` (global cap), or
+  `{:error, :ip_limit}` (this peer already holds `max_per_ip` connections, so a
+  single host cannot exhaust the pool).
+  """
+  @spec register_connection(GenServer.server(), term()) ::
+          :ok | {:error, :max_connections | :ip_limit}
+  def register_connection(server \\ __MODULE__, peer_ip \\ :unknown) do
+    GenServer.call(server, {:register_connection, peer_ip})
   end
 
-  @doc "Unregisters a connection when it closes."
-  @spec unregister_connection(GenServer.server()) :: :ok
-  def unregister_connection(server \\ __MODULE__) do
-    GenServer.cast(server, :unregister_connection)
+  @doc "Unregisters a connection from `peer_ip` when it closes."
+  @spec unregister_connection(GenServer.server(), term()) :: :ok
+  def unregister_connection(server \\ __MODULE__, peer_ip \\ :unknown) do
+    GenServer.cast(server, {:unregister_connection, peer_ip})
+  end
+
+  @doc false
+  # Pure admission decision: global cap first, then the per-peer cap.
+  @spec admit(non_neg_integer(), map(), term(), pos_integer(), pos_integer()) ::
+          {:ok, non_neg_integer(), map()}
+          | {:error, :max_connections | :ip_limit}
+  def admit(connections, per_ip, peer_ip, max_connections, max_per_ip) do
+    cond do
+      connections >= max_connections ->
+        {:error, :max_connections}
+
+      Map.get(per_ip, peer_ip, 0) >= max_per_ip ->
+        {:error, :ip_limit}
+
+      true ->
+        {:ok, connections + 1, Map.update(per_ip, peer_ip, 1, &(&1 + 1))}
+    end
+  end
+
+  @doc false
+  # Pure release: frees a global and per-peer slot, never below zero, dropping
+  # an emptied per-peer bucket so the map does not grow unbounded.
+  @spec release(non_neg_integer(), map(), term()) :: {non_neg_integer(), map()}
+  def release(connections, per_ip, peer_ip) do
+    new_per_ip =
+      case Map.get(per_ip, peer_ip, 0) do
+        n when n <= 1 -> Map.delete(per_ip, peer_ip)
+        n -> Map.put(per_ip, peer_ip, n - 1)
+      end
+
+    {max(0, connections - 1), new_per_ip}
   end
 
   @impl true
   def init(opts) do
-    app_module = Keyword.fetch!(opts, :app_module)
-    port = Keyword.get(opts, :port, @default_port)
-    host_keys_dir = Keyword.get(opts, :host_keys_dir, default_host_keys_dir())
-
-    max_connections =
-      Keyword.get(opts, :max_connections, @default_max_connections)
-
     # Resolve authentication first: refuse to open the daemon at all when the
     # surface would be silently anonymous.
     case auth_daemon_opts(opts) do
       {:ok, auth_opts} ->
-        start_daemon(
-          app_module,
-          port,
-          host_keys_dir,
-          max_connections,
-          auth_opts
-        )
+        start_daemon(opts, auth_opts)
 
       {:error, :ssh_auth_required} ->
         {:stop,
@@ -142,19 +177,34 @@ defmodule Raxol.SSH.Server do
     end
   end
 
-  defp start_daemon(app_module, port, host_keys_dir, max_connections, auth_opts) do
+  defp start_daemon(opts, auth_opts) do
+    app_module = Keyword.fetch!(opts, :app_module)
+    port = Keyword.get(opts, :port, @default_port)
+    host_keys_dir = Keyword.get(opts, :host_keys_dir, default_host_keys_dir())
+
+    max_connections =
+      Keyword.get(opts, :max_connections, @default_max_connections)
+
+    max_per_ip = Keyword.get(opts, :max_per_ip, @default_max_per_ip)
+    server_name = Keyword.get(opts, :name, __MODULE__)
+
+    negotiation_timeout =
+      Keyword.get(opts, :negotiation_timeout, @default_negotiation_timeout_ms)
+
     ensure_host_keys(host_keys_dir)
 
     daemon_opts =
       [
         system_dir: String.to_charlist(host_keys_dir),
-        ssh_cli: {Raxol.SSH.CLIHandler, [app_module: app_module]}
+        ssh_cli:
+          {Raxol.SSH.CLIHandler, [app_module: app_module, server: server_name]},
+        negotiation_timeout: negotiation_timeout
       ] ++ auth_opts
 
     case :ssh.daemon(port, daemon_opts) do
       {:ok, daemon_ref} ->
         Raxol.Core.Runtime.Log.info(
-          "[SSH.Server] Listening on port #{port} for #{inspect(app_module)} (max #{max_connections} connections)"
+          "[SSH.Server] Listening on port #{port} for #{inspect(app_module)} (max #{max_connections} connections, #{max_per_ip}/peer)"
         )
 
         {:ok,
@@ -163,7 +213,8 @@ defmodule Raxol.SSH.Server do
            app_module: app_module,
            port: port,
            host_keys_dir: host_keys_dir,
-           max_connections: max_connections
+           max_connections: max_connections,
+           max_per_ip: max_per_ip
          }}
 
       {:error, reason} ->
@@ -177,34 +228,34 @@ defmodule Raxol.SSH.Server do
   end
 
   @impl true
-  def handle_call(
-        :register_connection,
-        _from,
-        %__MODULE__{connections: c, max_connections: m} = state
-      )
-      when c >= m do
-    Raxol.Core.Runtime.Log.warning(
-      "[SSH.Server] Connection rejected: #{c}/#{m}"
-    )
+  def handle_call({:register_connection, peer_ip}, _from, %__MODULE__{} = state) do
+    case admit(
+           state.connections,
+           state.per_ip,
+           peer_ip,
+           state.max_connections,
+           state.max_per_ip
+         ) do
+      {:ok, connections, per_ip} ->
+        Raxol.Core.Runtime.Log.info(
+          "[SSH.Server] Connection accepted (#{connections}/#{state.max_connections})"
+        )
 
-    {:reply, {:error, :max_connections}, state}
+        {:reply, :ok, %{state | connections: connections, per_ip: per_ip}}
+
+      {:error, reason} = err ->
+        Raxol.Core.Runtime.Log.warning(
+          "[SSH.Server] Connection rejected (#{reason}): #{state.connections}/#{state.max_connections}, peer #{inspect(peer_ip)}"
+        )
+
+        {:reply, err, state}
+    end
   end
 
   @impl true
-  def handle_call(:register_connection, _from, %__MODULE__{} = state) do
-    new_count = state.connections + 1
-
-    Raxol.Core.Runtime.Log.info(
-      "[SSH.Server] Connection accepted (#{new_count}/#{state.max_connections})"
-    )
-
-    {:reply, :ok, %{state | connections: new_count}}
-  end
-
-  @impl true
-  def handle_cast(:unregister_connection, %__MODULE__{} = state) do
-    new_count = max(0, state.connections - 1)
-    {:noreply, %{state | connections: new_count}}
+  def handle_cast({:unregister_connection, peer_ip}, %__MODULE__{} = state) do
+    {connections, per_ip} = release(state.connections, state.per_ip, peer_ip)
+    {:noreply, %{state | connections: connections, per_ip: per_ip}}
   end
 
   @impl true

--- a/packages/raxol_acp/lib/raxol/acp/job/server.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/server.ex
@@ -216,6 +216,23 @@ defmodule Raxol.ACP.Job.Server do
   end
 
   @doc """
+  Evaluator/buyer-side: reject the delivered work during `:evaluation`,
+  settling the job to `:rejected`.
+
+  Use this when an assigned evaluator (or the buyer) declines the deliverable.
+  The job settles immediately instead of waiting for the SLA timer, so the buyer
+  can reclaim the escrow via `reclaim/1`; the deliverable was rejected, so the
+  seller does not claim the budget. Same payload/signature semantics as
+  `approve/3` (the payload's `:reason` is recorded on the memo and the
+  `[:raxol, :acp, :job, :rejected]` telemetry).
+  """
+  @spec reject(GenServer.server() | binary(), map(), binary() | nil) ::
+          {:ok, StateMachine.state()} | {:error, term()}
+  def reject(server, payload, signature \\ nil) do
+    GenServer.call(resolve(server), {:reject, payload, signature})
+  end
+
+  @doc """
   Buyer-side reclaim of the escrowed budget for an expired / undelivered
   job. Calls `Raxol.ACP.ContractClient.withdraw_escrowed_funds/1` through
   the configured client. Intended after the job has passed its
@@ -313,7 +330,7 @@ defmodule Raxol.ACP.Job.Server do
   def init_manager(opts) do
     config =
       opts
-      |> Keyword.take([:handler, :request, :buyer, :seller])
+      |> Keyword.take([:handler, :request, :buyer, :seller, :evaluator])
       |> Map.new()
 
     job_id = Keyword.fetch!(opts, :job_id)
@@ -459,6 +476,10 @@ defmodule Raxol.ACP.Job.Server do
 
   def handle_manager_call({:approve, payload, signature}, _from, state) do
     do_transition(state, :approve, payload, signature)
+  end
+
+  def handle_manager_call({:reject, payload, signature}, _from, state) do
+    do_transition(state, :reject, payload, signature)
   end
 
   def handle_manager_call(:get_state, _from, state), do: {:reply, state, state}
@@ -617,14 +638,37 @@ defmodule Raxol.ACP.Job.Server do
       }
     )
 
+    maybe_emit_outcome(state, new_wf_state.current_state, new_memo)
+
     new_full_state
   end
+
+  # A graded terminal outcome (the buyer/evaluator completed or rejected the
+  # job) emits a dedicated event so reputation and ops can tell a rejection from
+  # a process crash, which emits no such event. Expiry keeps its own
+  # `[:raxol, :acp, :job, :expired]` signal on the timer path.
+  defp maybe_emit_outcome(state, to, memo) when to in [:completed, :rejected] do
+    :telemetry.execute(
+      [:raxol, :acp, :job, to],
+      %{},
+      %{
+        job_id: state.job_id,
+        from: state.state,
+        evaluator: Map.get(state.config, :evaluator),
+        reason: memo && Map.get(memo, :content),
+        tx_hash: memo && memo.tx_hash
+      }
+    )
+  end
+
+  defp maybe_emit_outcome(_state, _to, _memo), do: :ok
 
   defp ctx(state) do
     %{
       job_id: state.job_id,
       buyer: Map.get(state.config, :buyer),
       seller: Map.get(state.config, :seller),
+      evaluator: Map.get(state.config, :evaluator),
       state: state.state
     }
   end

--- a/packages/raxol_acp/lib/raxol/acp/job/state_machine.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/state_machine.ex
@@ -8,9 +8,13 @@ defmodule Raxol.ACP.Job.StateMachine do
       :request -> :negotiation -> :transaction -> :evaluation -> :completed
 
   A buyer's `:request` can be `:reject`ed by the seller (state 5 in the
-  canonical enum), and any non-terminal state can `:expire` (SLA breach
-  or buyer cancellation). `:completed`, `:rejected`, and `:expired` are
-  terminal -- no further transitions are valid.
+  canonical enum), and a delivered job can be `:reject`ed by the
+  evaluator or buyer during `:evaluation` (the deliverable is rejected).
+  Both settle to `:rejected`, so the buyer can reclaim the escrow
+  without waiting for the SLA timer. Any non-terminal state can
+  `:expire` (SLA breach or buyer cancellation). `:completed`,
+  `:rejected`, and `:expired` are terminal -- no further transitions are
+  valid.
 
   ## State -> canonical phase id mapping
 
@@ -32,7 +36,9 @@ defmodule Raxol.ACP.Job.StateMachine do
   ## Events
 
   - `:accept_request` -- seller accepts the buyer's request
-  - `:reject` -- seller rejects the buyer's request; valid only from `:request`
+  - `:reject` -- reject the job: the seller from `:request`, or the
+    evaluator/buyer from `:evaluation` (the delivered work is rejected).
+    Both settle to `:rejected`.
   - `:accept_payment` -- buyer's payment authorization is recorded;
     escrow holds funds
   - `:deliver` -- seller submits the deliverable
@@ -79,6 +85,7 @@ defmodule Raxol.ACP.Job.StateMachine do
   def next(:negotiation, :accept_payment), do: {:ok, :transaction}
   def next(:transaction, :deliver), do: {:ok, :evaluation}
   def next(:evaluation, :approve), do: {:ok, :completed}
+  def next(:evaluation, :reject), do: {:ok, :rejected}
 
   def next(state, :expire) when state in @non_terminal, do: {:ok, :expired}
 

--- a/packages/raxol_acp/lib/raxol/acp/job/workflow.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/workflow.ex
@@ -18,7 +18,7 @@ defmodule Raxol.ACP.Job.Workflow do
               :memo_transaction -> :wait_transaction
                 :wait_transaction -[event]-> :memo_evaluation | :memo_expired
                   :memo_evaluation -> :wait_evaluation
-                    :wait_evaluation -[event]-> :memo_completed | :memo_expired
+                    :wait_evaluation -[event]-> :memo_completed | :memo_rejected | :memo_expired
                       :memo_completed -> :__end__
         :memo_rejected -> :__end__
         :memo_expired -> :__end__
@@ -170,7 +170,7 @@ defmodule Raxol.ACP.Job.Workflow do
     |> Graph.add_edge(:memo_evaluation, :wait_evaluation)
     |> Graph.add_conditional_edge(
       :wait_evaluation,
-      [:memo_completed, :memo_expired],
+      [:memo_completed, :memo_rejected, :memo_expired],
       &route_from_evaluation/1
     )
     |> Graph.add_edge(:memo_completed, :__end__)
@@ -279,6 +279,7 @@ defmodule Raxol.ACP.Job.Workflow do
   defp route_from_transaction(_), do: :memo_expired
 
   defp route_from_evaluation(%{pending_event: :approve}), do: :memo_completed
+  defp route_from_evaluation(%{pending_event: :reject}), do: :memo_rejected
   defp route_from_evaluation(_), do: :memo_expired
 
   # --- Memo node bodies ---

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -29,6 +29,17 @@ defmodule Raxol.ACP.Xochi.Offering do
   buyer (or an evaluator agent) can verify the cross-chain settlement
   on-chain before approving.
 
+  ## Known limitations
+
+  A `settlement_preference` of `private` is honored only on corridors that
+  support Xochi's dark-pool path. This offering does not yet surface a
+  privacy-downgrade warning when a requested-private route can only settle
+  publicly (the way the relay rail warns `:stealth_unavailable_on_tron`). This
+  is currently moot because the Xochi corridors are EVM-only and all support the
+  private path; it becomes relevant if a public-only chain (for example Tron) is
+  added, at which point a private request on that route would settle publicly and
+  should refuse or warn rather than silently downgrade.
+
   ## Marketplace registration
 
   When registering the offering at https://app.virtuals.io/acp/new, the

--- a/packages/raxol_acp/test/raxol/acp/job/evaluator_reject_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job/evaluator_reject_test.exs
@@ -1,0 +1,109 @@
+defmodule Raxol.ACP.Job.EvaluatorRejectTest do
+  @moduledoc """
+  The evaluator (or buyer) can reject a delivered job during `:evaluation`, so a
+  rejected deliverable settles to `:rejected` immediately instead of stranding
+  the escrow until the SLA timer fires. A graded terminal outcome (completed or
+  rejected) emits a dedicated telemetry event, so a rejection is distinguishable
+  from a process crash.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Raxol.ACP.TestSupport.WorkflowSetup
+
+  alias Raxol.ACP.ContractClient
+  alias Raxol.ACP.ContractClient.InMemory
+  alias Raxol.ACP.Job
+  alias Raxol.ACP.Job.Store
+
+  @seller "0x" <> String.duplicate("ab", 20)
+  @evaluator "0x" <> String.duplicate("ee", 20)
+  @sig <<0xDE, 0xAD>>
+
+  setup :with_isolated_workflow_saver
+
+  setup do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(Job.Supervisor),
+        is_pid(pid) do
+      DynamicSupervisor.terminate_child(Job.Supervisor, pid)
+    end
+
+    InMemory.reset()
+    Store.clear()
+    :ok
+  end
+
+  defp start_job(opts) do
+    {:ok, job_id} = ContractClient.create_job(@seller, @evaluator, 9_999_999_999)
+    opts = Keyword.put(opts, :job_id, job_id)
+    {:ok, _pid} = Job.Supervisor.start_job(opts)
+    job_id
+  end
+
+  defp drive_to_evaluation(job_id) do
+    assert {:ok, :negotiation} = Job.Server.transition(job_id, :accept_request, %{}, @sig)
+    assert {:ok, :transaction} = Job.Server.transition(job_id, :accept_payment, %{}, @sig)
+    assert {:ok, :evaluation} = Job.Server.transition(job_id, :deliver, %{}, @sig)
+    :ok
+  end
+
+  defp attach_outcome(event) do
+    ref = make_ref()
+    test = self()
+    handler = "outcome-#{inspect(ref)}"
+
+    :telemetry.attach(
+      handler,
+      [:raxol, :acp, :job, event],
+      fn _e, _m, meta, _ -> send(test, {:outcome, event, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+  end
+
+  describe "reject from :evaluation" do
+    test "settles the job to :rejected" do
+      job_id = start_job(evaluator: @evaluator)
+      drive_to_evaluation(job_id)
+
+      assert {:ok, :rejected} =
+               Job.Server.reject(job_id, %{reason: "output did not meet spec"}, @sig)
+    end
+
+    test "emits a :rejected outcome event carrying the reason and evaluator" do
+      attach_outcome(:rejected)
+      job_id = start_job(evaluator: @evaluator)
+      drive_to_evaluation(job_id)
+
+      assert {:ok, :rejected} = Job.Server.reject(job_id, %{reason: "bad output"}, @sig)
+
+      assert_receive {:outcome, :rejected, meta}
+      assert meta.from == :evaluation
+      assert meta.evaluator == @evaluator
+      assert meta.reason =~ "bad output"
+    end
+
+    test "is rejected before delivery (invalid from :negotiation)" do
+      job_id = start_job(evaluator: @evaluator)
+      assert {:ok, :negotiation} = Job.Server.transition(job_id, :accept_request, %{}, @sig)
+
+      assert {:error, {:invalid_transition, :negotiation, :reject}} =
+               Job.Server.reject(job_id, %{reason: "too early"}, @sig)
+    end
+  end
+
+  describe "approve from :evaluation" do
+    test "settles the job to :completed and emits a :completed outcome event" do
+      attach_outcome(:completed)
+      job_id = start_job(evaluator: @evaluator)
+      drive_to_evaluation(job_id)
+
+      assert {:ok, :completed} = Job.Server.approve(job_id, %{}, @sig)
+
+      assert_receive {:outcome, :completed, meta}
+      assert meta.from == :evaluation
+      assert meta.evaluator == @evaluator
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job/state_machine_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job/state_machine_test.exs
@@ -47,12 +47,18 @@ defmodule Raxol.ACP.Job.StateMachineTest do
     end
   end
 
-  describe ":reject from :request" do
-    test "transitions to :rejected" do
+  describe ":reject (seller from :request, evaluator from :evaluation)" do
+    test "seller reject from :request transitions to :rejected" do
       assert StateMachine.next(:request, :reject) == {:ok, :rejected}
     end
 
-    test "is not allowed once past :request" do
+    test "evaluator/buyer reject from :evaluation transitions to :rejected" do
+      # A rejected deliverable settles the job immediately, so the buyer can
+      # reclaim escrow without waiting for the SLA timer.
+      assert StateMachine.next(:evaluation, :reject) == {:ok, :rejected}
+    end
+
+    test "is not allowed from :negotiation or :transaction" do
       assert {:error, {:invalid_transition, :negotiation, :reject}} =
                StateMachine.next(:negotiation, :reject)
 

--- a/packages/raxol_payments/README.md
+++ b/packages/raxol_payments/README.md
@@ -10,10 +10,11 @@ Agent payment protocols for Elixir. Autonomous agents that can pay for things: x
 
 ## Features
 
-- **Protocol behaviour**: pluggable payment protocols (Xochi, x402, MPP)
-- **Wallet behaviour**: `Wallets.Env` (env var) and `Wallets.Op` (1Password via GenServer)
+- **Protocol behaviour**: five pluggable payment protocols (x402, MPP, Xochi, Permit2, Riddler). Riddler is deprecated and delegates to Xochi.
+- **Wallet behaviour**: `Wallets.Env` (env var, refuses to load in production without opt-in) and `Wallets.Op` (1Password via GenServer, key cached and signed with locally)
 - **AutoPay**: Req response step handling HTTP 402 transparently
 - **Xochi**: cross-chain intent settlement (quote -> sign -> execute -> poll)
+- **Permit2**: `PermitWitnessTransferFrom` signing for Riddler `/order` origin pulls (most ERC-20 tokens; x402 covers USDC via ERC-3009)
 - **Stealth**: ERC-5564/ERC-6538 stealth addresses (~300 LOC, secp256k1)
 - **ZKSAR**: zero-knowledge attestation verification (6 proof types)
 - **TrustScore**: diminishing-returns trust aggregation (0-100)

--- a/packages/raxol_payments/lib/mix/tasks/raxol_payments.bench.ex
+++ b/packages/raxol_payments/lib/mix/tasks/raxol_payments.bench.ex
@@ -1,0 +1,158 @@
+defmodule Mix.Tasks.RaxolPayments.Bench do
+  @shortdoc "Microbenchmark the payment hot paths: signing, ledger, checkpoint"
+
+  @moduledoc """
+  Measures the throughput of the fund-moving hot paths that actually gate DEX
+  volume: secp256k1 signing, atomic ledger reservations, and idempotency
+  checkpoint reads/writes. (The render frame budget does not gate volume; these
+  do.)
+
+      mix raxol_payments.bench
+      mix raxol_payments.bench --iterations 20000 --concurrency 16
+
+  Reports operations/sec and average latency per path. The concurrent ledger
+  figure exercises the single-GenServer reservation point (`Ledger.try_spend`),
+  the serialization ceiling for spend decisions.
+
+  The signing bench sets a throwaway key in `RAXOL_WALLET_KEY` for the run and
+  clears it after; it is for local measurement only.
+  """
+
+  use Mix.Task
+
+  alias Raxol.Payments.{Checkpoint, Ledger, SpendingPolicy}
+  alias Raxol.Payments.Wallets.Env, as: EnvWallet
+
+  # Hardhat account 0; a throwaway key for benchmarking only.
+  @privkey "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+  @default_iterations 5_000
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, _, _} =
+      OptionParser.parse(argv, strict: [iterations: :integer, concurrency: :integer])
+
+    iterations = Keyword.get(opts, :iterations, @default_iterations)
+    concurrency = Keyword.get(opts, :concurrency, System.schedulers_online())
+
+    Mix.Task.run("app.start")
+
+    IO.puts("""
+    raxol_payments.bench
+      iterations:  #{iterations}
+      concurrency: #{concurrency}
+    """)
+
+    bench_signing(iterations)
+    bench_ledger(iterations, concurrency)
+    bench_checkpoint(iterations)
+    :ok
+  end
+
+  defp bench_signing(n) do
+    System.put_env("RAXOL_WALLET_KEY", @privkey)
+    digest = :crypto.strong_rand_bytes(32)
+
+    domain = %{
+      name: "Bench",
+      version: "1",
+      chainId: 8453,
+      verifyingContract: "0x" <> String.duplicate("ab", 20)
+    }
+
+    types = %{"T" => [{"to", "address"}, {"value", "uint256"}]}
+    message = %{"to" => "0x" <> String.duplicate("cd", 20), "value" => 1_000_000}
+
+    {us_hash, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn _ -> {:ok, _} = EnvWallet.sign_hash(digest) end)
+      end)
+
+    report("wallet sign_hash (secp256k1)", n, us_hash)
+
+    {us_typed, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn _ ->
+          {:ok, _} = EnvWallet.sign_typed_data(domain, types, message)
+        end)
+      end)
+
+    report("wallet sign_typed_data (EIP-712 + secp256k1)", n, us_typed)
+  after
+    System.delete_env("RAXOL_WALLET_KEY")
+  end
+
+  defp bench_ledger(n, concurrency) do
+    policy = bench_policy()
+    amount = Decimal.new("0.0001")
+
+    ledger_seq = start_ledger(:seq)
+
+    {us_seq, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn _ -> :ok = Ledger.try_spend(ledger_seq, "a", amount, policy) end)
+      end)
+
+    report("Ledger.try_spend sequential", n, us_seq)
+
+    ledger_conc = start_ledger(:conc)
+
+    {us_conc, _} =
+      :timer.tc(fn ->
+        1..n
+        |> Task.async_stream(
+          fn _ -> Ledger.try_spend(ledger_conc, "a", amount, policy) end,
+          max_concurrency: concurrency,
+          ordered: false
+        )
+        |> Stream.run()
+      end)
+
+    report("Ledger.try_spend concurrent (#{concurrency})", n, us_conc)
+  end
+
+  defp bench_checkpoint(n) do
+    store = Checkpoint.ETS.new()
+
+    {us, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn i ->
+          key = "k#{i}"
+          :ok = Checkpoint.put(store, key, %{intent_id: key, status: :dispatched})
+          {:ok, _} = Checkpoint.fetch(store, key)
+        end)
+      end)
+
+    report("Checkpoint put+fetch (ETS)", n, us)
+  end
+
+  # Caps set far above the bench volume so every reservation succeeds and the
+  # measurement is the reservation cost, not cap rejection.
+  defp bench_policy do
+    %SpendingPolicy{
+      per_request_max: Decimal.new("1000000"),
+      session_max: Decimal.new("1000000000"),
+      lifetime_max: Decimal.new("1000000000000"),
+      session_window_ms: 3_600_000,
+      approved_domains: nil
+    }
+  end
+
+  defp start_ledger(tag) do
+    name = :"bench_ledger_#{tag}_#{System.unique_integer([:positive])}"
+    {:ok, ledger} = Ledger.start_link(table_name: name)
+    ledger
+  end
+
+  defp report(label, n, microseconds) do
+    ops = if microseconds > 0, do: round(n * 1_000_000 / microseconds), else: 0
+    avg_us = Float.round(microseconds / n, 2)
+
+    IO.puts(
+      "  " <>
+        String.pad_trailing(label, 48) <>
+        String.pad_leading(Integer.to_string(ops), 10) <>
+        " ops/s  " <> String.pad_leading(Float.to_string(avg_us), 8) <> " us/op"
+    )
+  end
+end

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
@@ -196,10 +196,21 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
     end
   end
 
+  # Fail closed by default in a deployed release: a real settlement with no
+  # durable checkpoint risks a double-settle on a crash-retry. An explicit
+  # context flag or `config :raxol_payments, :require_checkpoint` overrides;
+  # development and tests stay permissive.
   defp require_checkpoint?(context) do
     case Map.get(context, :require_checkpoint) do
-      flag when is_boolean(flag) -> flag
-      _ -> Application.get_env(:raxol_payments, :require_checkpoint, false)
+      flag when is_boolean(flag) ->
+        flag
+
+      _ ->
+        Application.get_env(
+          :raxol_payments,
+          :require_checkpoint,
+          Raxol.Payments.Deployment.production?()
+        )
     end
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/revoke_mandate.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/revoke_mandate.ex
@@ -4,7 +4,11 @@ defmodule Raxol.Payments.Actions.Payments.RevokeMandate do
 
   v1 has no server revoke endpoint -- Xochi's KV budget counter for
   this envelope remains until `expires_at` per the agent-auth design
-  doc (2026-04-27).
+  doc (2026-04-27). When Xochi does revoke or exhaust a mandate, it
+  answers a protected call with `410 Gone`; the outbound plugin
+  (`Raxol.Payments.Req.Mandate`) prunes the local envelope on that
+  response, so a server-side revocation converges locally without this
+  Action.
   """
 
   @compile {:no_warn_undefined, Raxol.Agent.Action}

--- a/packages/raxol_payments/lib/raxol/payments/actions/spend_gate.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/spend_gate.ex
@@ -101,7 +101,8 @@ defmodule Raxol.Payments.Actions.SpendGate do
   # is convenient for tests and unconfigured callers but wrong for a fund-moving
   # deployment. `require_policy: true` (context) or
   # `config :raxol_payments, :require_policy, true` fails closed when no
-  # `SpendingPolicy` is in context. Off by default (behaviour unchanged).
+  # `SpendingPolicy` is in context. In a deployed release this is the default;
+  # development and tests stay permissive.
   defp require_policy(context) do
     if policy_required?(context) and not match?(%SpendingPolicy{}, Map.get(context, :policy)),
       do: {:error, {:policy_required, :no_spending_policy}},
@@ -110,8 +111,15 @@ defmodule Raxol.Payments.Actions.SpendGate do
 
   defp policy_required?(context) do
     case Map.get(context, :require_policy) do
-      flag when is_boolean(flag) -> flag
-      _ -> Application.get_env(:raxol_payments, :require_policy, false)
+      flag when is_boolean(flag) ->
+        flag
+
+      _ ->
+        Application.get_env(
+          :raxol_payments,
+          :require_policy,
+          Raxol.Payments.Deployment.production?()
+        )
     end
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/deployment.ex
+++ b/packages/raxol_payments/lib/raxol/payments/deployment.ex
@@ -1,0 +1,129 @@
+defmodule Raxol.Payments.Deployment do
+  @moduledoc """
+  Runtime deployment detection for fund-moving defaults.
+
+  Money-moving code fails closed in production. "Production" here means running
+  as a deployed OTP release: `mix release` sets `RELEASE_NAME` in the boot
+  environment and it survives into the running node, unlike `Mix.env/0`, which
+  is not available at runtime in a release. Development, tests, and `mix run` do
+  not set it, so their behaviour is unchanged.
+
+  Override with `config :raxol_payments, :deployment, :production | :development`
+  or the `RAXOL_PAYMENTS_DEPLOYMENT` env var (`"production"` / `"development"`) --
+  primarily so tests can exercise the production path.
+  """
+
+  @doc """
+  True when running as a deployed release (or forced via override).
+
+  Fund-moving defaults (`require_policy`, `require_checkpoint`, the env-var
+  wallet) key off this to fail closed in production while staying permissive in
+  development and tests.
+  """
+  @spec production?() :: boolean()
+  def production? do
+    case override() do
+      :production -> true
+      :development -> false
+      nil -> release?()
+    end
+  end
+
+  defp override do
+    case Application.get_env(:raxol_payments, :deployment) do
+      :production -> :production
+      :development -> :development
+      _ -> env_override()
+    end
+  end
+
+  defp env_override do
+    case System.get_env("RAXOL_PAYMENTS_DEPLOYMENT") do
+      "production" -> :production
+      "development" -> :development
+      _ -> nil
+    end
+  end
+
+  defp release?, do: is_binary(System.get_env("RELEASE_NAME"))
+
+  # -- Boot gates (call at startup in a fund-moving deployment) --
+
+  @doc """
+  True when Erlang distribution is disabled or running over TLS.
+
+  A distributed node on the default cookie transport is reachable by any node
+  that holds the cookie and can invoke any exported function or read any ETS
+  table, so a signing node must run distribution over `-proto_dist inet_tls`
+  (per-node certs), not a shared magic cookie.
+  """
+  @spec distribution_tls?() :: boolean()
+  def distribution_tls?, do: not Node.alive?() or proto_dist() == "inet_tls"
+
+  defp proto_dist do
+    case :init.get_argument(:proto_dist) do
+      {:ok, [[value] | _]} -> to_string(value)
+      _ -> "inet_tcp"
+    end
+  end
+
+  @doc false
+  # Pure decision seam so the raise logic is testable without a live cluster.
+  @spec insecure_distribution?(boolean(), boolean(), boolean()) :: boolean()
+  def insecure_distribution?(production?, distribution_tls?, allowed?),
+    do: production? and not distribution_tls? and not allowed?
+
+  @doc """
+  Raise in production when this node participates in plain (non-TLS) Erlang
+  distribution. Call at boot in a fund-moving deployment so a misconfigured
+  cluster halts instead of exposing the wallet over cookie-only distribution.
+  Override with `RAXOL_ALLOW_INSECURE_DISTRIBUTION=true` (or
+  `config :raxol_payments, :allow_insecure_distribution, true`).
+  """
+  @spec assert_distribution_secure!() :: :ok
+  def assert_distribution_secure! do
+    if insecure_distribution?(
+         production?(),
+         distribution_tls?(),
+         insecure_distribution_allowed?()
+       ) do
+      raise ArgumentError,
+            "Erlang distribution is running over a plain (non-TLS) transport on a " <>
+              "production node. A node holding signing keys must use per-node TLS " <>
+              "distribution (-proto_dist inet_tls -ssl_dist_optfile <file>). Set " <>
+              "RAXOL_ALLOW_INSECURE_DISTRIBUTION=true to override."
+    end
+
+    :ok
+  end
+
+  defp insecure_distribution_allowed? do
+    System.get_env("RAXOL_ALLOW_INSECURE_DISTRIBUTION") == "true" or
+      Application.get_env(:raxol_payments, :allow_insecure_distribution, false) == true
+  end
+
+  @doc """
+  Raise in production when a signing node also exposes the interactive REPL.
+
+  Evaluating code on a node that holds signing keys is a capability-escape
+  surface (see `Raxol.REPL.Sandbox`): keep the REPL and the wallet on separate
+  nodes. A deployment that exposes the REPL sets `RAXOL_REPL_EXPOSED=true` (or
+  `config :raxol_payments, :repl_exposed, true`); a signing deployment calls
+  this at boot to refuse that co-location.
+  """
+  @spec assert_signing_isolated!() :: :ok
+  def assert_signing_isolated! do
+    if production?() and repl_exposed?() do
+      raise ArgumentError,
+            "This node holds signing keys and also exposes the interactive REPL " <>
+              "(RAXOL_REPL_EXPOSED=true). Move the REPL to a node that cannot sign."
+    end
+
+    :ok
+  end
+
+  defp repl_exposed? do
+    System.get_env("RAXOL_REPL_EXPOSED") == "true" or
+      Application.get_env(:raxol_payments, :repl_exposed, false) == true
+  end
+end

--- a/packages/raxol_payments/lib/raxol/payments/req/mandate.ex
+++ b/packages/raxol_payments/lib/raxol/payments/req/mandate.ex
@@ -40,7 +40,7 @@ defmodule Raxol.Payments.Req.Mandate do
   """
 
   alias Raxol.Payments.Mandate
-  alias Raxol.Payments.Mandate.Check
+  alias Raxol.Payments.Mandate.{Check, Store}
 
   @default_hosts ["xochi.fi", "api.xochi.fi"]
   @default_path_scopes %{
@@ -49,10 +49,64 @@ defmodule Raxol.Payments.Req.Mandate do
     "/api/stealth/claim" => "stealth_claim"
   }
 
-  @doc "Attach the Mandate plugin to a Req request."
+  @doc """
+  Attach the Mandate plugin to a Req request.
+
+  Adds a request step that presents the delegation envelope, and a response
+  step that prunes a revoked/exhausted mandate on a `410 Gone` from Xochi.
+  """
   @spec attach(Req.Request.t(), keyword()) :: Req.Request.t()
   def attach(%Req.Request{} = req, opts) do
-    Req.Request.append_request_steps(req, mandate: &maybe_attach_header(&1, opts))
+    req
+    |> Req.Request.append_request_steps(mandate: &maybe_attach_header(&1, opts))
+    |> Req.Request.append_response_steps(mandate_revocation: &maybe_prune_revoked(&1, opts))
+  end
+
+  # A 410 Gone from a Xochi host means the presented mandate was revoked or its
+  # budget exhausted server-side. Drop it from the local Store so it is never
+  # presented again, and flag the response so the caller treats it as terminal
+  # rather than a retryable transport error. This is the agent-side half of
+  # mandate revocation; the authenticated server-side revoke endpoint is Xochi's.
+  @spec maybe_prune_revoked(
+          {Req.Request.t(), Req.Response.t() | Exception.t()},
+          keyword()
+        ) :: {Req.Request.t(), Req.Response.t() | Exception.t()}
+  defp maybe_prune_revoked({%Req.Request{} = req, %Req.Response{status: 410} = resp}, opts) do
+    if xochi_host_request?(req, opts) do
+      prune_attached_mandate(req)
+      {req, Req.Response.put_private(resp, :xochi_mandate_revoked, true)}
+    else
+      {req, resp}
+    end
+  end
+
+  defp maybe_prune_revoked(pair, _opts), do: pair
+
+  defp xochi_host_request?(req, opts) do
+    case request_host(req) do
+      {:ok, host} -> xochi_host?(host, Keyword.get(opts, :hosts, @default_hosts))
+      _ -> false
+    end
+  end
+
+  defp prune_attached_mandate(req) do
+    with [envelope | _] <- Req.Request.get_header(req, "x-xochi-delegation"),
+         {:ok, mandate} <- Mandate.from_envelope(envelope),
+         hash when is_binary(hash) <- mandate.envelope_hash do
+      safe_delete(hash)
+    else
+      _ -> :ok
+    end
+  end
+
+  # The Store is host-started and may be absent; a missing process must not turn
+  # a handled 410 into a crash.
+  defp safe_delete(hash) do
+    Store.delete(hash)
+  rescue
+    ArgumentError -> :ok
+  catch
+    :exit, _ -> :ok
   end
 
   @spec maybe_attach_header(Req.Request.t(), keyword()) :: Req.Request.t()

--- a/packages/raxol_payments/lib/raxol/payments/wallets/env.ex
+++ b/packages/raxol_payments/lib/raxol/payments/wallets/env.ex
@@ -143,6 +143,12 @@ defmodule Raxol.Payments.Wallets.Env do
   # and use. See `Raxol.Payments.Wallets.Op` for the same posture in a stateful
   # wallet.
   defp load_key(env_var) do
+    with :ok <- allowed_in_deployment() do
+      decode_key(env_var)
+    end
+  end
+
+  defp decode_key(env_var) do
     case System.get_env(env_var) do
       nil ->
         {:error, {:env_not_set, env_var}}
@@ -157,6 +163,24 @@ defmodule Raxol.Payments.Wallets.Env do
           :error -> {:error, :invalid_hex}
         end
     end
+  end
+
+  # A plaintext key in an env var is fine for dev and CI but a liability in a
+  # deployed release, where it lands in process listings, crash dumps, and
+  # orchestrator config. In production this wallet refuses to load unless the
+  # operator explicitly opts in with `RAXOL_ALLOW_ENV_WALLET=true` (or
+  # `config :raxol_payments, :allow_env_wallet, true`). Use `Wallets.Op` instead.
+  defp allowed_in_deployment do
+    if Raxol.Payments.Deployment.production?() and not env_wallet_allowed?() do
+      {:error, :env_wallet_forbidden_in_production}
+    else
+      :ok
+    end
+  end
+
+  defp env_wallet_allowed? do
+    System.get_env("RAXOL_ALLOW_ENV_WALLET") == "true" or
+      Application.get_env(:raxol_payments, :allow_env_wallet, false) == true
   end
 
   defp derive_address(pubkey) do

--- a/packages/raxol_payments/test/property/signing_boundary_property_test.exs
+++ b/packages/raxol_payments/test/property/signing_boundary_property_test.exs
@@ -1,0 +1,380 @@
+defmodule Raxol.Payments.SigningBoundaryPropertyTest do
+  @moduledoc """
+  The signing boundary is the crown jewel: a BEAM process holds a key that can
+  move USDC/USDT/WETH across chains. The invariant that must never regress is
+
+      a spend-gate rejection implies zero wallet signatures.
+
+  Put another way, no money-moving Action may reach `wallet.sign_*` unless
+  `SpendGate.authorize/3` returned `:ok` first. The per-Action tests each pin one
+  rejection reason (over per-request); this file generalizes that to the whole
+  rejection space and adds two structural guards so a future Action can't quietly
+  open a path to the signer.
+
+  ## How it detects a leak
+
+  `SentinelWallet` announces every signature to the test process. Since an Action
+  runs synchronously in that process, a signature reached after the gate said no
+  lands in the mailbox and `refute_received :wallet_signed` fails. The Action must
+  also return the gate's error (not a network/route error), so the "no signature"
+  assertion is never vacuously true.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Payments.Actions.Payments
+  alias Raxol.Payments.Actions.Payments.{ExecuteRelayTransfer, ExecuteXochiIntent}
+  alias Raxol.Payments.{Failure, Ledger, SpendingPolicy}
+  alias Raxol.Payments.Xochi.Stealth
+
+  @usdc_base "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  @usdt_trc20 "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8"
+  @tron 728_126_428
+  @tron_addr "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+
+  # A gate rejection surfaces through `Failure.from/1` as one of these reasons.
+  # Asserting the failure is one of them proves the gate stopped the payment,
+  # rather than an unrelated error making "no signature" vacuously true.
+  @gate_reasons [:over_budget, :rejected, :policy_required]
+
+  # Wallet whose every signer announces itself to the calling (test) process.
+  defmodule SentinelWallet do
+    @moduledoc false
+    def address, do: "0x1111111111111111111111111111111111111111"
+    def chain_id, do: 8453
+    def sign_typed_data(_domain, _types, _message), do: signed()
+    def sign_message(_message), do: signed()
+    def sign_hash(_digest), do: signed()
+
+    defp signed do
+      send(self(), :wallet_signed)
+      {:ok, <<7::size(520)>>}
+    end
+  end
+
+  # -- ExecuteXochiIntent: gate rejection never signs --
+
+  describe "ExecuteXochiIntent signing boundary" do
+    property "no amount over the per-request cap is ever signed" do
+      # Any amount above the 0.10 cap must be denied at the gate before signing,
+      # for the whole range of amounts a caller might submit.
+      check all(cents <- integer(11..500)) do
+        stub_xochi()
+        ledger = fresh_ledger()
+
+        ctx =
+          xochi_ctx(ledger, xochi_policy(%{per_request_max: dec("0.10")}))
+
+        params = xochi_params(cents_to_amount(cents))
+
+        assert {:error, %Failure{reason: :over_budget}} =
+                 ExecuteXochiIntent.run(params, ctx)
+
+        refute_received :wallet_signed
+      end
+    end
+
+    test "no categorical gate rejection is ever signed" do
+      # The non-budget gate branches (domain not approved, confirmation withheld,
+      # a required-but-missing policy) must each stop before the signature too.
+      for scenario <- categorical_xochi_scenarios() do
+        stub_xochi()
+        ledger = fresh_ledger()
+        ctx = categorical_ctx(ledger, scenario)
+
+        assert {:error, %Failure{reason: reason}} =
+                 ExecuteXochiIntent.run(xochi_params("0.50"), ctx),
+               "#{scenario.label}: expected a gate rejection"
+
+        assert reason in @gate_reasons,
+               "#{scenario.label}: #{inspect(reason)} is not a gate rejection"
+
+        refute_received :wallet_signed
+      end
+    end
+  end
+
+  # -- ExecuteRelayTransfer: gate rejection never signs, even with a gasless
+  # quote that WOULD sign if the gate were bypassed --
+
+  describe "ExecuteRelayTransfer signing boundary" do
+    property "no amount over the per-request cap is signed, even on a gasless quote" do
+      # A gasless quote is the relay path that actually signs typed data. If the
+      # gate is honored, no amount over the cap reaches that signature.
+      check all(cents <- integer(11..500)) do
+        stub_relay_gasless()
+        ledger = fresh_ledger()
+
+        ctx =
+          relay_ctx(ledger, relay_policy(%{per_request_max: dec("0.10")}))
+
+        params = relay_params(cents_to_amount(cents))
+
+        assert {:error, %Failure{reason: :over_budget}} =
+                 ExecuteRelayTransfer.run(params, ctx)
+
+        refute_received :wallet_signed
+      end
+    end
+  end
+
+  # -- Structural guards: keep the boundary from silently widening --
+
+  describe "signing-boundary structural guards" do
+    test "every sensitive money-moving Action has a known signing mechanism" do
+      # If a new `sensitive: true` Action appears, this fails until it is
+      # classified here. Each entry names how it is kept from reaching a signer
+      # without authorization:
+      #
+      #   ExecuteXochiIntent  -- SpendGate.authorize/3 before Xochi.execute signs
+      #   ExecuteRelayTransfer-- SpendGate.authorize/3 before wallet.sign_typed_data
+      #   Transfer            -- authorize-only; never signs (returns "authorized")
+      #   CreateMandate       -- signs a struct-derived Mandate digest (sign_hash),
+      #                          not an arbitrary hash; gated at LLM tool dispatch
+      #                          by `sensitive: true` (see ToolGateTest)
+      known_sensitive =
+        MapSet.new([
+          Payments.Transfer,
+          Payments.ExecuteXochiIntent,
+          Payments.ExecuteRelayTransfer,
+          Payments.CreateMandate
+        ])
+
+      actual_sensitive =
+        Payments.actions()
+        |> Enum.filter(& &1.__action_meta__().sensitive)
+        |> MapSet.new()
+
+      assert actual_sensitive == known_sensitive,
+             "sensitive Action set changed; classify the new/removed Action's " <>
+               "signing mechanism here. Added: #{inspect(MapSet.difference(actual_sensitive, known_sensitive) |> MapSet.to_list())}, " <>
+               "removed: #{inspect(MapSet.difference(known_sensitive, actual_sensitive) |> MapSet.to_list())}"
+    end
+
+    test "no Action module reaches the opaque-digest signer sign_hash" do
+      # `sign_hash/1` signs a precomputed 32-byte digest with no amount to check,
+      # so it must stay unreachable from LLM-callable Actions. Its only intended
+      # caller is `Mandate.sign/2`, which computes the digest from a validated
+      # Mandate struct. Guard: no file under the Actions tree references it.
+      offenders =
+        "lib/raxol/payments/actions/**/*.ex"
+        |> Path.wildcard()
+        |> Enum.filter(fn path -> File.read!(path) =~ "sign_hash" end)
+
+      assert offenders == [],
+             "these Action modules reference sign_hash and may bypass the gate: " <>
+               inspect(offenders)
+    end
+  end
+
+  # -- Helpers --
+
+  defp dec(s), do: Decimal.new(s)
+
+  defp cents_to_amount(cents),
+    do: cents |> Decimal.new() |> Decimal.div(100) |> Decimal.to_string()
+
+  defp fresh_ledger do
+    spec =
+      Supervisor.child_spec({Ledger, [name: nil]},
+        id: {:ledger, System.unique_integer([:positive])}
+      )
+
+    start_supervised!(spec)
+  end
+
+  # Xochi ------------------------------------------------------------------
+
+  defp xochi_config do
+    %{
+      base_url: "https://xochi.test",
+      auth_token: "token",
+      req_options: [plug: {Req.Test, __MODULE__}]
+    }
+  end
+
+  defp xochi_policy(overrides) do
+    Map.merge(
+      %SpendingPolicy{
+        per_request_max: dec("1.00"),
+        session_max: dec("1000.00"),
+        lifetime_max: dec("1000.00"),
+        session_window_ms: 3_600_000,
+        approved_domains: ["xochi.test"]
+      },
+      overrides
+    )
+  end
+
+  defp xochi_ctx(ledger, policy) do
+    %{
+      wallet: SentinelWallet,
+      xochi_config: xochi_config(),
+      ledger: ledger,
+      policy: policy,
+      agent_id: "a1"
+    }
+  end
+
+  defp xochi_params(amount) do
+    %{
+      amount: amount,
+      from_chain_id: 8453,
+      to_chain_id: 42_161,
+      from_token: @usdc_base,
+      to_token: @usdc_base,
+      settlement: "stealth",
+      recipient_meta_address: recipient_meta()
+    }
+  end
+
+  defp recipient_meta do
+    {:ok, %{spending: {_, spending_pub}, viewing: {_, viewing_pub}}} =
+      Stealth.derive_keys("0x" <> String.duplicate("11", 65))
+
+    Stealth.encode_meta_address(%{
+      spending_pub_key: spending_pub,
+      viewing_pub_key: viewing_pub
+    })
+  end
+
+  # A quote that would lead to a signature (canSolve, eip712Data). toAmount is
+  # large enough to clear any same-asset delivery floor for the tested amounts,
+  # so the gate -- not the floor -- is the thing that stops the payment.
+  defp stub_xochi do
+    Req.Test.stub(__MODULE__, fn conn ->
+      case conn.request_path do
+        "/api/intent/quote" ->
+          Req.Test.json(conn, %{
+            "intentId" => "int_1",
+            "quoteId" => "q_1",
+            "canSolve" => true,
+            "toAmount" => "5000000",
+            "xochiFee" => "1000",
+            "eip712Data" => %{
+              "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+              "types" => %{"Intent" => [%{"name" => "amount", "type" => "uint256"}]},
+              "message" => %{"amount" => 500_000}
+            }
+          })
+
+        "/api/intent/execute" ->
+          Req.Test.json(conn, %{
+            "success" => true,
+            "intentId" => "int_1",
+            "status" => "executing",
+            "stealthAddress" => "0xstealth"
+          })
+      end
+    end)
+  end
+
+  defp categorical_xochi_scenarios do
+    [
+      %{
+        label: :domain_not_approved,
+        policy: xochi_policy(%{approved_domains: ["not-xochi.test"]}),
+        extra_ctx: %{}
+      },
+      %{
+        label: :confirmation_withheld,
+        policy: xochi_policy(%{require_confirmation_above: dec("0.00")}),
+        extra_ctx: %{}
+      },
+      %{
+        # A required-but-missing policy: no SpendingPolicy in context, and
+        # require_policy on -- the guard must fail closed rather than treat a
+        # missing policy as unlimited spend.
+        label: :policy_required_but_missing,
+        policy: nil,
+        extra_ctx: %{require_policy: true}
+      }
+    ]
+  end
+
+  # Build the context for a categorical scenario. A nil policy means "no
+  # SpendingPolicy in context", so the :policy key is left out entirely.
+  defp categorical_ctx(ledger, %{policy: nil, extra_ctx: extra}) do
+    ledger
+    |> xochi_ctx(nil)
+    |> Map.delete(:policy)
+    |> Map.merge(extra)
+  end
+
+  defp categorical_ctx(ledger, %{policy: policy, extra_ctx: extra}) do
+    ledger
+    |> xochi_ctx(policy)
+    |> Map.merge(extra)
+  end
+
+  # Relay ------------------------------------------------------------------
+
+  defp relay_config do
+    %{
+      base_url: "https://relay.test",
+      auth_token: "token",
+      req_options: [plug: {Req.Test, __MODULE__}]
+    }
+  end
+
+  defp relay_policy(overrides) do
+    Map.merge(
+      %SpendingPolicy{
+        per_request_max: dec("1.00"),
+        session_max: dec("1000.00"),
+        lifetime_max: dec("1000.00"),
+        session_window_ms: 3_600_000,
+        approved_domains: ["relay.test"]
+      },
+      overrides
+    )
+  end
+
+  defp relay_ctx(ledger, policy) do
+    %{
+      wallet: SentinelWallet,
+      relay_config: relay_config(),
+      ledger: ledger,
+      policy: policy,
+      agent_id: "a1"
+    }
+  end
+
+  defp relay_params(amount) do
+    %{
+      amount: amount,
+      from_chain_id: 8453,
+      to_chain_id: @tron,
+      from_token: @usdc_base,
+      to_token: @usdt_trc20,
+      to_address: @tron_addr,
+      settlement: "public"
+    }
+  end
+
+  # A gasless quote: the relay path that actually signs typed data. If the gate
+  # were bypassed, `maybe_sign_gasless` would reach SentinelWallet.sign_typed_data.
+  defp stub_relay_gasless do
+    Req.Test.stub(__MODULE__, fn conn ->
+      case conn.request_path do
+        "/relay/quote" ->
+          Req.Test.json(conn, %{
+            "transfer_id" => "t_1",
+            "quote_id" => "q_1",
+            "can_fill" => true,
+            "to_amount" => "499000",
+            "deposit_address" => "0xdeposit",
+            "gasless" => %{
+              "domain" => %{"name" => "Permit2", "chainId" => 8453},
+              "types" => %{"Permit" => [%{"name" => "amount", "type" => "uint256"}]},
+              "message" => %{"amount" => 500_000}
+            }
+          })
+
+        "/relay/execute" ->
+          Req.Test.json(conn, %{"transfer_id" => "t_1", "status" => "pending"})
+      end
+    end)
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/deployment_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/deployment_test.exs
@@ -1,0 +1,87 @@
+defmodule Raxol.Payments.DeploymentTest do
+  # async: false -- mutates process-global env (Application env + OS env).
+  use ExUnit.Case, async: false
+
+  alias Raxol.Payments.Deployment
+
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:raxol_payments, :deployment)
+      Application.delete_env(:raxol_payments, :repl_exposed)
+      Application.delete_env(:raxol_payments, :allow_insecure_distribution)
+      System.delete_env("RAXOL_PAYMENTS_DEPLOYMENT")
+      System.delete_env("RELEASE_NAME")
+      System.delete_env("RAXOL_REPL_EXPOSED")
+      System.delete_env("RAXOL_ALLOW_INSECURE_DISTRIBUTION")
+    end)
+
+    :ok
+  end
+
+  test "defaults to non-production in dev/test (no RELEASE_NAME)" do
+    System.delete_env("RELEASE_NAME")
+    refute Deployment.production?()
+  end
+
+  test "detects a deployed release via RELEASE_NAME" do
+    System.put_env("RELEASE_NAME", "raxol")
+    assert Deployment.production?()
+  end
+
+  test "config override wins over release detection" do
+    System.put_env("RELEASE_NAME", "raxol")
+    Application.put_env(:raxol_payments, :deployment, :development)
+    refute Deployment.production?()
+
+    Application.delete_env(:raxol_payments, :deployment)
+    Application.put_env(:raxol_payments, :deployment, :production)
+    assert Deployment.production?()
+  end
+
+  test "env var override forces production without a release" do
+    System.put_env("RAXOL_PAYMENTS_DEPLOYMENT", "production")
+    assert Deployment.production?()
+  end
+
+  describe "assert_distribution_secure!/0" do
+    test "insecure_distribution?/3 truth table" do
+      # Only production + non-TLS + not-allowed is insecure.
+      assert Deployment.insecure_distribution?(true, false, false)
+      refute Deployment.insecure_distribution?(false, false, false)
+      refute Deployment.insecure_distribution?(true, true, false)
+      refute Deployment.insecure_distribution?(true, false, true)
+    end
+
+    test "passes when distribution is disabled (test node is not alive)" do
+      Application.put_env(:raxol_payments, :deployment, :production)
+      refute Node.alive?()
+      assert :ok = Deployment.assert_distribution_secure!()
+    end
+
+    test "distribution_tls? is true for a non-distributed node" do
+      assert Deployment.distribution_tls?()
+    end
+  end
+
+  describe "assert_signing_isolated!/0" do
+    test "raises in production when the REPL is exposed on a signing node" do
+      Application.put_env(:raxol_payments, :deployment, :production)
+      System.put_env("RAXOL_REPL_EXPOSED", "true")
+
+      assert_raise ArgumentError, ~r/exposes the interactive REPL/, fn ->
+        Deployment.assert_signing_isolated!()
+      end
+    end
+
+    test "passes in production when the REPL is not exposed" do
+      Application.put_env(:raxol_payments, :deployment, :production)
+      assert :ok = Deployment.assert_signing_isolated!()
+    end
+
+    test "passes in development even when the REPL is exposed" do
+      Application.put_env(:raxol_payments, :deployment, :development)
+      System.put_env("RAXOL_REPL_EXPOSED", "true")
+      assert :ok = Deployment.assert_signing_isolated!()
+    end
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/eip712_golden_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/eip712_golden_test.exs
@@ -1,0 +1,192 @@
+defmodule Raxol.Payments.EIP712GoldenTest do
+  @moduledoc """
+  Committed EIP-712 golden hashes for every signed struct, checked in default CI.
+
+  Fable review §1.1/§3.1: the conformance suite verifies raxol's hashing against
+  viem byte-for-byte, but it is `@moduletag :conformance` and skipped unless the
+  external fixture/CLI is present -- so a change to a signed struct's type or
+  domain would not turn CI red. These self-contained goldens close that gap: a
+  canonical vector per struct, hashed through the production code path, pinned to
+  a committed digest. Editing a type definition, domain, or the encoder changes
+  the digest and fails here.
+
+  The Xochi vector additionally pins the full signature against riddler-client's
+  own viem pin (`@shielded_signature`), so it is a live cross-repo contract, not
+  just a self-consistency lock. The x402/Permit2/Mandate digests are drift locks
+  whose viem parity is established by the conformance suite when it runs.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.{EIP712, Mandate}
+  alias Raxol.Payments.Assets.UsdcDomains
+  alias Raxol.Payments.Protocols.Permit2
+  alias Raxol.Payments.Test.ConformanceSigner
+
+  # secp256k1 key 1 and its derived address (shared with the conformance suite).
+  @canonical_key "0x0000000000000000000000000000000000000000000000000000000000000001"
+  @canonical_signer "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+
+  # -- Xochi intent (viem-verified, mirrors riddler-client) --
+
+  @xochi_types %{
+    "XochiIntent" => [
+      {"intentId", "string"},
+      {"quoteId", "string"},
+      {"wallet", "address"},
+      {"fromChainId", "uint256"},
+      {"toChainId", "uint256"},
+      {"fromToken", "address"},
+      {"toToken", "address"},
+      {"fromAmount", "uint256"},
+      {"toAmount", "uint256"},
+      {"settlementPreference", "string"},
+      {"nonce", "uint256"},
+      {"deadline", "uint256"}
+    ]
+  }
+  @xochi_domain %{name: "XochiIntent", version: "1", chainId: 8453}
+  @xochi_message %{
+    "intentId" => "shielded-test",
+    "quoteId" => "shielded-test",
+    "wallet" => "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+    "fromChainId" => 8453,
+    "toChainId" => 10,
+    "fromToken" => "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "toToken" => "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+    "fromAmount" => "1000000",
+    "toAmount" => "1000000",
+    "settlementPreference" => "shielded",
+    "nonce" => 0,
+    "deadline" => 1_900_000_000
+  }
+  # Pinned in riddler-client test-xochi.js; the cross-repo byte-equality contract.
+  @xochi_signature "0xbe2545d815e4ce15d859e9bdee5bcb3a2f81e94a4b0fd0586220bd0235682d2f4bd1ea6082ddb8e59bb5557e91cb2f80e4dd3aef800e0fa4eabd0367a04c86061b"
+  @xochi_golden_digest "0xdbed39b9cac50396d859f0b229f988208dcb9cc344ffe128e55cc9d72b50a704"
+
+  # -- x402 ERC-3009 ReceiveWithAuthorization --
+
+  @erc3009_types %{
+    "ReceiveWithAuthorization" => [
+      {"from", "address"},
+      {"to", "address"},
+      {"value", "uint256"},
+      {"validAfter", "uint256"},
+      {"validBefore", "uint256"},
+      {"nonce", "bytes32"}
+    ]
+  }
+  @usdc_base "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  @erc3009_message %{
+    "from" => "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+    "to" => "0x2222222222222222222222222222222222222222",
+    "value" => 1_000_000,
+    "validAfter" => 0,
+    "validBefore" => 1_900_000_000,
+    "nonce" => "0x" <> String.duplicate("ab", 32)
+  }
+  @erc3009_golden_digest "0x794300931b17739ae0d4456a276138ccb6fe8ca18265210dd5849260902d1379"
+
+  # -- Permit2 PermitWitnessTransferFrom --
+
+  @permit2_quote %{
+    "request" => %{
+      "inputAmount" => "1000000",
+      "inputToken" => "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    },
+    "quoteExpires" => 1_900_000_000,
+    "gasless" => %{
+      "to" => "0x2222222222222222222222222222222222222222",
+      "nonce" => "1",
+      "orderId" => "0x" <> String.duplicate("cd", 32)
+    }
+  }
+  @permit2_golden_digest "0xbe6ff8e898322b18fd9a80fac9ff02234b136ec81e07bff3e5f4c4b7542bde0e"
+
+  defmodule CanonicalWallet do
+    @moduledoc false
+    @behaviour Raxol.Payments.Wallet
+    @key Base.decode16!("0000000000000000000000000000000000000000000000000000000000000001")
+
+    @impl true
+    def address, do: "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+    @impl true
+    def chain_id, do: 8453
+
+    @impl true
+    def sign_message(_msg), do: {:ok, <<0::512>>}
+
+    @impl true
+    def sign_typed_data(domain, types, message) do
+      with {:ok, digest} <- EIP712.hash(domain, types, message),
+           {:ok, sig} <- ExSecp256k1.sign(digest, @key) do
+        {:ok, EIP712.pack_signature(sig)}
+      end
+    end
+
+    @impl true
+    def sign_hash(<<digest::binary-size(32)>>) do
+      {:ok, sig} = ExSecp256k1.sign(digest, @key)
+      {:ok, EIP712.pack_signature(sig)}
+    end
+  end
+
+  # -- Mandate --
+
+  @mandate_attrs %{
+    human_wallet: "0x1111111111111111111111111111111111111111",
+    agent_wallet: "0x2222222222222222222222222222222222222222",
+    scopes: ["quote", "execute"],
+    max_amount_usd: 250,
+    max_calls: 20,
+    expires_at: 1_900_000_000,
+    nonce: "0x" <> String.duplicate("00", 31) <> "01"
+  }
+  @mandate_golden_digest "0xea60fa2779dcda0f94a2c3b71b99ceb077447d4ab018fd4c99fa798903cbce48"
+
+  defp hex(bytes), do: "0x" <> Base.encode16(bytes, case: :lower)
+
+  describe "Xochi intent golden (viem-verified)" do
+    test "digest is pinned and the signature matches riddler-client's viem pin" do
+      assert {:ok, digest} = EIP712.hash(@xochi_domain, @xochi_types, @xochi_message)
+      assert hex(digest) == @xochi_golden_digest
+
+      signature =
+        ConformanceSigner.sign_hex(digest, ConformanceSigner.decode_hex!(@canonical_key))
+
+      assert signature == @xochi_signature
+      assert ConformanceSigner.recover_address(digest, signature) == @canonical_signer
+    end
+  end
+
+  describe "x402 ERC-3009 golden" do
+    test "digest is pinned for the canonical USDC ReceiveWithAuthorization" do
+      %{name: name, version: version} = UsdcDomains.lookup(8453)
+
+      domain = %{
+        name: name,
+        version: version,
+        chainId: 8453,
+        verifyingContract: @usdc_base
+      }
+
+      assert {:ok, digest} = EIP712.hash(domain, @erc3009_types, @erc3009_message)
+      assert hex(digest) == @erc3009_golden_digest
+    end
+  end
+
+  describe "Permit2 PermitWitnessTransferFrom golden" do
+    test "digest is pinned through the production sign_quote path" do
+      assert {:ok, result} = Permit2.sign_quote(@permit2_quote, 8453, CanonicalWallet)
+      assert result.digest == @permit2_golden_digest
+    end
+  end
+
+  describe "Mandate golden" do
+    test "digest is pinned for the canonical mandate" do
+      assert {:ok, mandate} = Mandate.build(@mandate_attrs)
+      assert {:ok, digest} = Mandate.digest(mandate)
+      assert hex(digest) == @mandate_golden_digest
+    end
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/fail_closed_defaults_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/fail_closed_defaults_test.exs
@@ -1,0 +1,120 @@
+defmodule Raxol.Payments.FailClosedDefaultsTest do
+  @moduledoc """
+  In a deployed release the spend gate and settlement path fail closed by
+  default: a missing SpendingPolicy or a missing idempotency checkpoint stops
+  the payment rather than defaulting to unlimited spend / double-settle risk.
+  Development and tests stay permissive (the rest of the suite depends on that).
+  """
+
+  # async: false -- toggles the process-global production flag.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Payments.Actions.Payments.ExecuteXochiIntent
+  alias Raxol.Payments.Actions.SpendGate
+  alias Raxol.Payments.{Failure, Ledger, SpendingPolicy}
+  alias Raxol.Payments.Xochi.Stealth
+
+  @usdc_base "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+  defmodule Wallet do
+    @moduledoc false
+    def address, do: "0x1111111111111111111111111111111111111111"
+    def chain_id, do: 8453
+    def sign_typed_data(_d, _t, _m), do: {:ok, <<7::size(520)>>}
+    def sign_message(_), do: {:ok, <<7::size(520)>>}
+    def sign_hash(_), do: {:ok, <<7::size(520)>>}
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:raxol_payments, :deployment) end)
+    :ok
+  end
+
+  defp production, do: Application.put_env(:raxol_payments, :deployment, :production)
+  defp development, do: Application.put_env(:raxol_payments, :deployment, :development)
+
+  describe "require_policy default" do
+    test "production fails closed when no SpendingPolicy is in context" do
+      production()
+      ctx = %{ledger: start_supervised!({Ledger, [name: nil]}), agent_id: "a1"}
+
+      assert {:error, {:policy_required, :no_spending_policy}} =
+               SpendGate.authorize(ctx, Decimal.new("0.50"), target: {:domain, "x.test"})
+    end
+
+    test "development treats a missing policy as an unrestricted no-op" do
+      development()
+      ctx = %{ledger: start_supervised!({Ledger, [name: nil]}), agent_id: "a1"}
+
+      assert :ok =
+               SpendGate.authorize(ctx, Decimal.new("0.50"), target: {:domain, "x.test"})
+    end
+  end
+
+  describe "require_checkpoint default" do
+    # No Req stub: the checkpoint guard must trip before any network or signature.
+    test "production fails closed when no checkpoint store is in context" do
+      production()
+
+      assert {:error, %Failure{reason: :checkpoint_required, retryable?: false}} =
+               ExecuteXochiIntent.run(xochi_params(), xochi_ctx())
+    end
+
+    test "development proceeds without a checkpoint (unchecked settlement)" do
+      development()
+
+      # Reaching the quote endpoint at all proves the checkpoint guard did not
+      # trip. The stub declines to solve, so the run ends on a quote-level
+      # failure, never :checkpoint_required.
+      Req.Test.stub(__MODULE__, fn conn ->
+        Req.Test.json(conn, %{"canSolve" => false, "error" => "no route"})
+      end)
+
+      result = ExecuteXochiIntent.run(xochi_params(), xochi_ctx())
+      assert {:error, %Failure{} = failure} = result
+      refute failure.reason == :checkpoint_required
+    end
+  end
+
+  defp xochi_ctx do
+    %{
+      wallet: Wallet,
+      xochi_config: %{
+        base_url: "https://xochi.test",
+        auth_token: "token",
+        req_options: [plug: {Req.Test, __MODULE__}]
+      },
+      ledger: start_supervised!({Ledger, [name: nil]}),
+      policy: %SpendingPolicy{
+        per_request_max: Decimal.new("1.00"),
+        session_max: Decimal.new("5.00"),
+        lifetime_max: Decimal.new("10.00"),
+        session_window_ms: 3_600_000,
+        approved_domains: ["xochi.test"]
+      },
+      agent_id: "a1"
+    }
+  end
+
+  defp xochi_params do
+    %{
+      amount: "0.50",
+      from_chain_id: 8453,
+      to_chain_id: 42_161,
+      from_token: @usdc_base,
+      to_token: @usdc_base,
+      settlement: "stealth",
+      recipient_meta_address: recipient_meta()
+    }
+  end
+
+  defp recipient_meta do
+    {:ok, %{spending: {_, spending_pub}, viewing: {_, viewing_pub}}} =
+      Stealth.derive_keys("0x" <> String.duplicate("11", 65))
+
+    Stealth.encode_meta_address(%{
+      spending_pub_key: spending_pub,
+      viewing_pub_key: viewing_pub
+    })
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
@@ -150,4 +150,58 @@ defmodule Raxol.Payments.Req.MandateTest do
       refute header == [far_envelope]
     end
   end
+
+  describe "410 Gone revocation (agent-side)" do
+    test "prunes the local mandate and flags the response on a 410 from Xochi" do
+      mandate = put_mandate()
+      hash = mandate.envelope_hash
+      assert {:ok, _} = Store.get(hash)
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        # the mandate was presented before the worker rejected it
+        assert Plug.Conn.get_req_header(conn, "x-xochi-delegation") != []
+        Plug.Conn.send_resp(conn, 410, "gone")
+      end)
+
+      {:ok, resp} =
+        Req.new(url: "https://api.xochi.fi/api/intent/quote", plug: {Req.Test, __MODULE__})
+        |> ReqMandate.attach(agent_wallet: @agent)
+        |> Req.request()
+
+      assert resp.status == 410
+      assert resp.private[:xochi_mandate_revoked] == true
+      # The revoked mandate is gone locally, so it can never be presented again.
+      assert :error = Store.get(hash)
+    end
+
+    test "does not prune on a non-410 Xochi response" do
+      mandate = put_mandate()
+      hash = mandate.envelope_hash
+
+      Req.Test.stub(__MODULE__, fn conn -> Plug.Conn.send_resp(conn, 402, "pay") end)
+
+      {:ok, resp} =
+        Req.new(url: "https://api.xochi.fi/api/intent/quote", plug: {Req.Test, __MODULE__})
+        |> ReqMandate.attach(agent_wallet: @agent)
+        |> Req.request()
+
+      assert resp.status == 402
+      refute resp.private[:xochi_mandate_revoked]
+      assert {:ok, _} = Store.get(hash)
+    end
+
+    test "does not prune on a 410 from a non-Xochi host" do
+      mandate = put_mandate()
+      hash = mandate.envelope_hash
+
+      Req.Test.stub(__MODULE__, fn conn -> Plug.Conn.send_resp(conn, 410, "gone") end)
+
+      {:ok, _resp} =
+        Req.new(url: "https://example.com/api/intent/quote", plug: {Req.Test, __MODULE__})
+        |> ReqMandate.attach(agent_wallet: @agent)
+        |> Req.request()
+
+      assert {:ok, _} = Store.get(hash)
+    end
+  end
 end

--- a/packages/raxol_payments/test/raxol/payments/wallets/env_production_guard_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/wallets/env_production_guard_test.exs
@@ -1,0 +1,51 @@
+defmodule Raxol.Payments.Wallets.EnvProductionGuardTest do
+  # async: false -- toggles the process-global production flag.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Payments.Wallets.Env
+
+  @test_env_var "TEST_WALLET_KEY_PROD_GUARD"
+  @test_privkey "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+  @digest String.duplicate(<<0xAB>>, 32)
+
+  setup do
+    System.put_env(@test_env_var, @test_privkey)
+    Application.put_env(:raxol_payments, :deployment, :production)
+
+    on_exit(fn ->
+      System.delete_env(@test_env_var)
+      System.delete_env("RAXOL_ALLOW_ENV_WALLET")
+      Application.delete_env(:raxol_payments, :deployment)
+      Application.delete_env(:raxol_payments, :allow_env_wallet)
+    end)
+
+    :ok
+  end
+
+  test "refuses to sign in production without an explicit opt-in" do
+    assert {:error, :env_wallet_forbidden_in_production} =
+             Env.sign_hash(@digest, @test_env_var)
+  end
+
+  test "refuses to derive an address in production" do
+    assert_raise RuntimeError, ~r/env_wallet_forbidden_in_production/, fn ->
+      Env.address(@test_env_var)
+    end
+  end
+
+  test "the RAXOL_ALLOW_ENV_WALLET env opt-in re-enables it in production" do
+    System.put_env("RAXOL_ALLOW_ENV_WALLET", "true")
+    assert {:ok, sig} = Env.sign_hash(@digest, @test_env_var)
+    assert byte_size(sig) == 65
+  end
+
+  test "the config opt-in re-enables it in production" do
+    Application.put_env(:raxol_payments, :allow_env_wallet, true)
+    assert {:ok, _sig} = Env.sign_hash(@digest, @test_env_var)
+  end
+
+  test "development is unaffected (signs freely)" do
+    Application.put_env(:raxol_payments, :deployment, :development)
+    assert {:ok, _sig} = Env.sign_hash(@digest, @test_env_var)
+  end
+end

--- a/test/raxol/repl/sandbox_test.exs
+++ b/test/raxol/repl/sandbox_test.exs
@@ -111,4 +111,61 @@ defmodule Raxol.REPL.SandboxTest do
       assert Enum.any?(violations, &String.contains?(&1, "not in whitelist"))
     end
   end
+
+  # The strict level guards an SSH/web-exposed REPL that may share a node with
+  # signing processes (the payments wallet GenServer, ledger). Sandboxed code
+  # must not be able to message, spawn near, or otherwise reach those processes
+  # in the milliseconds before the eval timeout fires.
+  describe "capability isolation (cannot reach signing processes)" do
+    test "denies Kernel.send to a named process (strict)" do
+      assert {:error, _} =
+               Sandbox.check(
+                 "Kernel.send(Raxol.Payments.Wallets.Op, :x)",
+                 :strict
+               )
+    end
+
+    test "denies Kernel.send to a named process (standard)" do
+      assert {:error, _} =
+               Sandbox.check(
+                 "Kernel.send(Raxol.Payments.Wallets.Op, :x)",
+                 :standard
+               )
+    end
+
+    test "denies the bare send special form" do
+      assert {:error, _} = Sandbox.check("send(SomeProc, :msg)", :strict)
+    end
+
+    test "denies spawn / spawn_link / spawn_monitor (strict)" do
+      assert {:error, _} = Sandbox.check("spawn(fn -> :ok end)", :strict)
+      assert {:error, _} = Sandbox.check("spawn_link(fn -> :ok end)", :strict)
+
+      assert {:error, _} =
+               Sandbox.check("spawn_monitor(fn -> :ok end)", :strict)
+    end
+
+    test "denies :gen_server.call (standard blocklist hole)" do
+      assert {:error, _} =
+               Sandbox.check(":gen_server.call(Wallet, :m)", :standard)
+    end
+
+    test "denies :erlang.send and :rpc.call (standard)" do
+      assert {:error, _} = Sandbox.check(":erlang.send(Wallet, :m)", :standard)
+
+      assert {:error, _} =
+               Sandbox.check(":rpc.call(node(), M, :f, [])", :standard)
+    end
+
+    test "denies Process.send / Process.whereis (standard)" do
+      assert {:error, _} = Sandbox.check("Process.whereis(Wallet)", :standard)
+
+      assert {:error, _} =
+               Sandbox.check("Process.send(Wallet, :m, [])", :standard)
+    end
+
+    test "still allows safe whitelisted computation (strict)" do
+      assert :ok = Sandbox.check("Enum.map([1, 2, 3], &(&1 * 2))", :strict)
+    end
+  end
 end

--- a/test/raxol/ssh/server_test.exs
+++ b/test/raxol/ssh/server_test.exs
@@ -43,6 +43,40 @@ defmodule Raxol.SSH.ServerTest do
     end
   end
 
+  # Connection accounting is a pure function so a per-IP flood can be exercised
+  # without binding a real SSH daemon.
+  describe "connection accounting (admit/release)" do
+    @ip_a {203, 0, 113, 1}
+    @ip_b {203, 0, 113, 2}
+
+    test "admits under both the global and per-IP caps" do
+      assert {:ok, 1, per_ip} = Server.admit(0, %{}, @ip_a, 100, 2)
+      assert {:ok, 2, _} = Server.admit(1, per_ip, @ip_a, 100, 2)
+    end
+
+    test "refuses a third connection from the same peer, independent of others" do
+      per_ip = %{@ip_a => 2}
+      # Global cap is far off, but this peer is at its per-IP limit.
+      assert {:error, :ip_limit} = Server.admit(2, per_ip, @ip_a, 100, 2)
+      # A different peer is unaffected.
+      assert {:ok, 3, _} = Server.admit(2, per_ip, @ip_b, 100, 2)
+    end
+
+    test "the global cap still takes precedence" do
+      assert {:error, :max_connections} = Server.admit(100, %{}, @ip_a, 100, 2)
+    end
+
+    test "release frees a global and per-IP slot, dropping empty buckets" do
+      assert {1, %{@ip_a => 1}} = Server.release(2, %{@ip_a => 2}, @ip_a)
+      assert {0, per_ip} = Server.release(1, %{@ip_a => 1}, @ip_a)
+      refute Map.has_key?(per_ip, @ip_a)
+    end
+
+    test "release never drops below zero" do
+      assert {0, _} = Server.release(0, %{}, @ip_a)
+    end
+  end
+
   describe "host key generation" do
     test "generates RSA host key" do
       dir =

--- a/test/raxol/ssh/server_test.exs
+++ b/test/raxol/ssh/server_test.exs
@@ -3,6 +3,46 @@ defmodule Raxol.SSH.ServerTest do
 
   alias Raxol.SSH.Server
 
+  describe "authentication (fail-closed)" do
+    test "refuses to start with no auth configured" do
+      # An SSH surface that can reach payment Actions must not be silently
+      # anonymous. With neither allow_anonymous nor authorized_keys_dir, the
+      # server refuses to start rather than accepting any connection.
+      # start_link links, and a {:stop, _} init propagates an exit signal, so
+      # trap it to inspect the {:error, reason} return.
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {:ssh_auth_required, _msg}} =
+               Server.start_link(app_module: Raxol.Playground.App, port: 0)
+    end
+
+    test "allow_anonymous yields no_auth_needed daemon opts" do
+      assert {:ok, opts} = Server.auth_daemon_opts(allow_anonymous: true)
+      assert opts[:no_auth_needed] == true
+    end
+
+    test "authorized_keys_dir yields public-key auth daemon opts" do
+      assert {:ok, opts} =
+               Server.auth_daemon_opts(authorized_keys_dir: "/etc/raxol/keys")
+
+      assert opts[:user_dir] == ~c"/etc/raxol/keys"
+      assert opts[:auth_methods] == ~c"publickey"
+      refute Keyword.has_key?(opts, :no_auth_needed)
+    end
+
+    test "no auth option fails closed" do
+      assert {:error, :ssh_auth_required} = Server.auth_daemon_opts([])
+    end
+  end
+
+  describe "host key default" do
+    test "default host keys dir is persistent, not /tmp" do
+      dir = Server.default_host_keys_dir()
+      refute String.starts_with?(dir, "/tmp")
+      assert String.contains?(dir, ".raxol")
+    end
+  end
+
   describe "host key generation" do
     test "generates RSA host key" do
       dir =
@@ -43,6 +83,7 @@ defmodule Raxol.SSH.ServerTest do
          port: port,
          host_keys_dir: dir,
          max_connections: 2,
+         allow_anonymous: true,
          name: :test_ssh_server}
       )
 
@@ -83,6 +124,7 @@ defmodule Raxol.SSH.ServerTest do
          port: port,
          host_keys_dir: dir,
          max_connections: 10,
+         allow_anonymous: true,
          name: :test_ssh_zero}
       )
 


### PR DESCRIPTION
## Summary

Addresses the P0 findings from an external engineering review of the fund-moving
surfaces (`raxol_payments` + the SSH/REPL surfaces), threat model "a process with
a wallet". Every change is **fail-closed in a deployed release and unchanged in
development and tests**, so the existing suite behaves identically.

Production is detected by a new `Raxol.Payments.Deployment.production?/0`, which
keys off the `RELEASE_NAME` a `mix release` sets at boot (it survives into the
running node, unlike `Mix.env/0`), overridable via config or
`RAXOL_PAYMENTS_DEPLOYMENT` for tests.

## Changes (by commit)

- **Fail closed SSH auth; host keys off `/tmp`.** Anonymous SSH is now opt-in
  (`allow_anonymous: true`) or public-key (`authorized_keys_dir:`); with neither
  the server refuses to start, so a fund-bearing surface is never silently
  anonymous. Host keys default to `~/.raxol/ssh_keys` (was `/tmp`). The playground
  opts into anonymous explicitly (mix task + the fly child spec).
- **Fail-closed payment defaults and boot gates.** `require_policy` and
  `require_checkpoint` default to `production?()`. `Wallets.Env` refuses to load a
  key in a release unless `RAXOL_ALLOW_ENV_WALLET=true`. Two boot gates a
  deployment calls at startup: `assert_distribution_secure!/0` (halts a prod node
  on plain-cookie Erlang distribution) and `assert_signing_isolated!/0` (halts a
  signing node that exposes the REPL via `RAXOL_REPL_EXPOSED=true`).
- **Lock signing boundary; pin EIP-712 goldens.** A property test proves a spend-gate
  rejection yields zero wallet signatures across the amount space, plus a completeness
  guard over the sensitive Action set and a guard that no Action reaches the
  opaque-digest `sign_hash`. A golden test pins the EIP-712 digest for every signed
  struct (x402 ERC-3009, XochiIntent with its viem-pinned signature, Permit2, Mandate)
  in default CI; the real conformance suite is `@moduletag :conformance` and
  fixture-gated, so it never ran in CI.
- **Harden REPL sandbox capability isolation.** The SSH-exposed playground REPL now
  runs at `:strict` (was `:standard`). Closed live bypasses where sandboxed code could
  reach a signing GenServer: `Kernel.send`, the spawn family, `:gen_server`,
  `:erlang.send`, `:rpc`, `Process.send`/`whereis`.
- **Prune revoked mandate on 410 Gone.** The outbound mandate plugin drops the local
  mandate on a `410 Gone` from Xochi and flags the response terminal (the agent-side
  half of mandate revocation).
- **Reconcile payment docs with code.** `AGENTIC_COMMERCE.md` (Permit2 section, a
  Production Safety section, corrected fail-closed prose), `SSH_DEPLOYMENT.md` (auth +
  host-key defaults), and the payments README protocol count (3 to 5).

## Verification

- `raxol_payments`: 50 properties / 816 tests / 0 failures
- main raxol: 175 properties / 4024 tests / 0 failures
- SSH suite 8/8 (including the real-daemon integration tests)
- `mix compile --warnings-as-errors` clean, `mix format --check-formatted` clean
- Signing-boundary and gate-bypass invariants mutation-checked (bypassing the gate
  turns the property red)

## Manual testing

- [ ] `MIX_ENV=test mix test` in `packages/raxol_payments` (816 tests green)
- [ ] `MIX_ENV=test mix test test/raxol/ssh test/raxol/repl` (SSH + sandbox)
- [ ] Confirm `Raxol.SSH.serve(App, port: 2222)` with no auth option returns
      `{:error, {:ssh_auth_required, _}}`
- [ ] Confirm the fly playground still starts (it passes `allow_anonymous: true`)
- [ ] With `RAXOL_PAYMENTS_DEPLOYMENT=production`, confirm a payment context with no
      policy fails `SpendGate` and `Wallets.Env` refuses to sign

## Out of scope (follow-ups)

Cross-repo (tracked in the Xochi handover): an authenticated mandate revoke endpoint
returning `410 Gone`, D1 mandate-budget decrement atomicity, and a reciprocal TS
golden-hash CI check. Raxol P1: ACP evaluator role + terminal-state matrix, ACP
reputation telemetry, SCA/Mandate delegation dedup, `mix raxol_payments.bench`.
