### PR TITLE
Harden ACP/SSH + payment bench (Fable review P1)

### DIFF
--- a/docs/features/AGENTIC_COMMERCE.md
+++ b/docs/features/AGENTIC_COMMERCE.md
@@ -168,6 +168,15 @@ Req.new(url: "https://api.xochi.fi/api/intent/quote")
 
 v1 follows the locked design at `xochi/docs/planning/agent-auth.md`. On the agent side, a `410 Gone` from Xochi (a revoked or exhausted envelope) prunes the local mandate through the outbound plugin and flags the response as terminal, so a server-side revocation converges locally without a manual `payment_revoke_mandate` call. The authenticated server-side revoke endpoint itself, along with the on-chain registry, Verified-Agent metadata, issuer browser UI, and auto-rotation on exhaustion, remain deferred.
 
+### Two delegation models (Mandate vs SCA session key)
+
+A deployed agent may carry two capability-delegation credentials, and they govern two different surfaces. Keep them distinct in an ops runbook so a de-authorization is complete:
+
+- **Xochi Mandate** (`Raxol.Payments.Mandate`, this package) governs Xochi API calls. A Member signs an EIP-712 envelope binding an agent wallet to a scoped budget; the agent presents it per call via `Req.Mandate`. Revoke it by letting it expire, or (once Xochi ships the revoke endpoint) by `H(envelope)`; a `410 Gone` prunes the local copy.
+- **ERC-4337 SCA session key** (`Raxol.ACP.Wallet.SCA`, in `raxol_acp`) governs Base/ACP UserOps. A session key installed on the modular account via `installValidation` signs sponsored UserOps for on-chain ACP job actions.
+
+The two are independent: revoking one does not revoke the other. An agent that must be fully de-authorized needs both its Mandate revoked or expired **and** its SCA session key uninstalled. The Mandate is a Xochi-side credential scoped to Xochi endpoints; the session key is a Base-side signer scoped to the modular account. A leaked key revoked on Xochi but still holding a valid session key can still act through the ACP path, and vice versa.
+
 ## AutoPay (Req Plugin)
 
 `Raxol.Payments.Req.AutoPay` is a Req response step. Add it to any Req client and HTTP 402 responses get handled transparently:

--- a/lib/raxol/ssh/cli_handler.ex
+++ b/lib/raxol/ssh/cli_handler.ex
@@ -6,6 +6,8 @@ defmodule Raxol.SSH.CLIHandler do
 
   defstruct [
     :app_module,
+    :server,
+    :peer_ip,
     :session_pid,
     :channel_id,
     :connection_ref,
@@ -15,22 +17,26 @@ defmodule Raxol.SSH.CLIHandler do
   @impl true
   def init(opts) do
     app_module = Keyword.fetch!(opts, :app_module)
-    {:ok, %__MODULE__{app_module: app_module}}
+    server = Keyword.get(opts, :server, Raxol.SSH.Server)
+    {:ok, %__MODULE__{app_module: app_module, server: server}}
   end
 
   @impl true
   def handle_msg({:ssh_channel_up, channel_id, connection_ref}, state) do
-    case Raxol.SSH.Server.register_connection() do
+    peer_ip = peer_ip(connection_ref)
+
+    case Raxol.SSH.Server.register_connection(state.server, peer_ip) do
       :ok ->
         {:ok,
          %{
            state
            | channel_id: channel_id,
              connection_ref: connection_ref,
+             peer_ip: peer_ip,
              registered: true
          }}
 
-      {:error, :max_connections} ->
+      {:error, _reason} ->
         _ =
           :ssh_connection.send(
             connection_ref,
@@ -106,8 +112,8 @@ defmodule Raxol.SSH.CLIHandler do
   def handle_ssh_msg(_msg, state), do: {:ok, state}
 
   @impl true
-  def terminate(_reason, %__MODULE__{registered: true}) do
-    Raxol.SSH.Server.unregister_connection()
+  def terminate(_reason, %__MODULE__{registered: true} = state) do
+    Raxol.SSH.Server.unregister_connection(state.server, state.peer_ip)
     :ok
   end
 
@@ -115,4 +121,18 @@ defmodule Raxol.SSH.CLIHandler do
 
   defp maybe_send(nil, _msg), do: :ok
   defp maybe_send(pid, msg), do: send(pid, msg)
+
+  # The peer IP scopes the per-source connection cap. Any surprise in the
+  # connection info degrades to a shared `:unknown` bucket rather than crashing
+  # the channel.
+  defp peer_ip(connection_ref) do
+    case :ssh.connection_info(connection_ref, [:peer]) do
+      [{:peer, {_name, {ip, _port}}}] -> ip
+      _ -> :unknown
+    end
+  rescue
+    _ -> :unknown
+  catch
+    _, _ -> :unknown
+  end
 end

--- a/lib/raxol/ssh/server.ex
+++ b/lib/raxol/ssh/server.ex
@@ -17,6 +17,10 @@ defmodule Raxol.SSH.Server do
     * `:host_keys_dir` - Directory for SSH host keys (default: `~/.raxol/ssh_keys`,
       a persistent path so keys survive restarts)
     * `:max_connections` - Maximum concurrent connections (default: 50)
+    * `:max_per_ip` - Maximum concurrent connections from one peer IP (default: 10),
+      so a single host cannot flood the pool
+    * `:negotiation_timeout` - Milliseconds a connection may spend in key exchange
+      and auth before it is dropped (default: 30_000), bounding slow-handshake holds
 
   ## Authentication (fail-closed)
 
@@ -40,11 +44,17 @@ defmodule Raxol.SSH.Server do
     :port,
     :host_keys_dir,
     :max_connections,
-    connections: 0
+    :max_per_ip,
+    connections: 0,
+    per_ip: %{}
   ]
 
   @default_port Raxol.Constants.default_ssh_port()
   @default_max_connections 50
+  @default_max_per_ip 10
+  # Cap how long an unauthenticated connection may hold resources during key
+  # exchange + auth, so a slow or stalled handshake cannot pin a slot.
+  @default_negotiation_timeout_ms 30_000
 
   @spec serve(module(), keyword()) :: GenServer.on_start()
   def serve(app_module, opts \\ []) do
@@ -99,39 +109,64 @@ defmodule Raxol.SSH.Server do
     GenServer.call(server, :connection_count)
   end
 
-  @doc "Registers a new connection. Returns :ok or {:error, :max_connections}."
-  @spec register_connection(GenServer.server()) ::
-          :ok | {:error, :max_connections}
-  def register_connection(server \\ __MODULE__) do
-    GenServer.call(server, :register_connection)
+  @doc """
+  Registers a new connection from `peer_ip`.
+
+  Returns `:ok`, `{:error, :max_connections}` (global cap), or
+  `{:error, :ip_limit}` (this peer already holds `max_per_ip` connections, so a
+  single host cannot exhaust the pool).
+  """
+  @spec register_connection(GenServer.server(), term()) ::
+          :ok | {:error, :max_connections | :ip_limit}
+  def register_connection(server \\ __MODULE__, peer_ip \\ :unknown) do
+    GenServer.call(server, {:register_connection, peer_ip})
   end
 
-  @doc "Unregisters a connection when it closes."
-  @spec unregister_connection(GenServer.server()) :: :ok
-  def unregister_connection(server \\ __MODULE__) do
-    GenServer.cast(server, :unregister_connection)
+  @doc "Unregisters a connection from `peer_ip` when it closes."
+  @spec unregister_connection(GenServer.server(), term()) :: :ok
+  def unregister_connection(server \\ __MODULE__, peer_ip \\ :unknown) do
+    GenServer.cast(server, {:unregister_connection, peer_ip})
+  end
+
+  @doc false
+  # Pure admission decision: global cap first, then the per-peer cap.
+  @spec admit(non_neg_integer(), map(), term(), pos_integer(), pos_integer()) ::
+          {:ok, non_neg_integer(), map()}
+          | {:error, :max_connections | :ip_limit}
+  def admit(connections, per_ip, peer_ip, max_connections, max_per_ip) do
+    cond do
+      connections >= max_connections ->
+        {:error, :max_connections}
+
+      Map.get(per_ip, peer_ip, 0) >= max_per_ip ->
+        {:error, :ip_limit}
+
+      true ->
+        {:ok, connections + 1, Map.update(per_ip, peer_ip, 1, &(&1 + 1))}
+    end
+  end
+
+  @doc false
+  # Pure release: frees a global and per-peer slot, never below zero, dropping
+  # an emptied per-peer bucket so the map does not grow unbounded.
+  @spec release(non_neg_integer(), map(), term()) :: {non_neg_integer(), map()}
+  def release(connections, per_ip, peer_ip) do
+    new_per_ip =
+      case Map.get(per_ip, peer_ip, 0) do
+        n when n <= 1 -> Map.delete(per_ip, peer_ip)
+        n -> Map.put(per_ip, peer_ip, n - 1)
+      end
+
+    {max(0, connections - 1), new_per_ip}
   end
 
   @impl true
   def init(opts) do
-    app_module = Keyword.fetch!(opts, :app_module)
-    port = Keyword.get(opts, :port, @default_port)
-    host_keys_dir = Keyword.get(opts, :host_keys_dir, default_host_keys_dir())
-
-    max_connections =
-      Keyword.get(opts, :max_connections, @default_max_connections)
-
     # Resolve authentication first: refuse to open the daemon at all when the
     # surface would be silently anonymous.
     case auth_daemon_opts(opts) do
       {:ok, auth_opts} ->
-        start_daemon(
-          app_module,
-          port,
-          host_keys_dir,
-          max_connections,
-          auth_opts
-        )
+        start_daemon(opts, auth_opts)
 
       {:error, :ssh_auth_required} ->
         {:stop,
@@ -142,19 +177,34 @@ defmodule Raxol.SSH.Server do
     end
   end
 
-  defp start_daemon(app_module, port, host_keys_dir, max_connections, auth_opts) do
+  defp start_daemon(opts, auth_opts) do
+    app_module = Keyword.fetch!(opts, :app_module)
+    port = Keyword.get(opts, :port, @default_port)
+    host_keys_dir = Keyword.get(opts, :host_keys_dir, default_host_keys_dir())
+
+    max_connections =
+      Keyword.get(opts, :max_connections, @default_max_connections)
+
+    max_per_ip = Keyword.get(opts, :max_per_ip, @default_max_per_ip)
+    server_name = Keyword.get(opts, :name, __MODULE__)
+
+    negotiation_timeout =
+      Keyword.get(opts, :negotiation_timeout, @default_negotiation_timeout_ms)
+
     ensure_host_keys(host_keys_dir)
 
     daemon_opts =
       [
         system_dir: String.to_charlist(host_keys_dir),
-        ssh_cli: {Raxol.SSH.CLIHandler, [app_module: app_module]}
+        ssh_cli:
+          {Raxol.SSH.CLIHandler, [app_module: app_module, server: server_name]},
+        negotiation_timeout: negotiation_timeout
       ] ++ auth_opts
 
     case :ssh.daemon(port, daemon_opts) do
       {:ok, daemon_ref} ->
         Raxol.Core.Runtime.Log.info(
-          "[SSH.Server] Listening on port #{port} for #{inspect(app_module)} (max #{max_connections} connections)"
+          "[SSH.Server] Listening on port #{port} for #{inspect(app_module)} (max #{max_connections} connections, #{max_per_ip}/peer)"
         )
 
         {:ok,
@@ -163,7 +213,8 @@ defmodule Raxol.SSH.Server do
            app_module: app_module,
            port: port,
            host_keys_dir: host_keys_dir,
-           max_connections: max_connections
+           max_connections: max_connections,
+           max_per_ip: max_per_ip
          }}
 
       {:error, reason} ->
@@ -177,34 +228,34 @@ defmodule Raxol.SSH.Server do
   end
 
   @impl true
-  def handle_call(
-        :register_connection,
-        _from,
-        %__MODULE__{connections: c, max_connections: m} = state
-      )
-      when c >= m do
-    Raxol.Core.Runtime.Log.warning(
-      "[SSH.Server] Connection rejected: #{c}/#{m}"
-    )
+  def handle_call({:register_connection, peer_ip}, _from, %__MODULE__{} = state) do
+    case admit(
+           state.connections,
+           state.per_ip,
+           peer_ip,
+           state.max_connections,
+           state.max_per_ip
+         ) do
+      {:ok, connections, per_ip} ->
+        Raxol.Core.Runtime.Log.info(
+          "[SSH.Server] Connection accepted (#{connections}/#{state.max_connections})"
+        )
 
-    {:reply, {:error, :max_connections}, state}
+        {:reply, :ok, %{state | connections: connections, per_ip: per_ip}}
+
+      {:error, reason} = err ->
+        Raxol.Core.Runtime.Log.warning(
+          "[SSH.Server] Connection rejected (#{reason}): #{state.connections}/#{state.max_connections}, peer #{inspect(peer_ip)}"
+        )
+
+        {:reply, err, state}
+    end
   end
 
   @impl true
-  def handle_call(:register_connection, _from, %__MODULE__{} = state) do
-    new_count = state.connections + 1
-
-    Raxol.Core.Runtime.Log.info(
-      "[SSH.Server] Connection accepted (#{new_count}/#{state.max_connections})"
-    )
-
-    {:reply, :ok, %{state | connections: new_count}}
-  end
-
-  @impl true
-  def handle_cast(:unregister_connection, %__MODULE__{} = state) do
-    new_count = max(0, state.connections - 1)
-    {:noreply, %{state | connections: new_count}}
+  def handle_cast({:unregister_connection, peer_ip}, %__MODULE__{} = state) do
+    {connections, per_ip} = release(state.connections, state.per_ip, peer_ip)
+    {:noreply, %{state | connections: connections, per_ip: per_ip}}
   end
 
   @impl true

--- a/packages/raxol_acp/lib/raxol/acp/job/server.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/server.ex
@@ -216,6 +216,23 @@ defmodule Raxol.ACP.Job.Server do
   end
 
   @doc """
+  Evaluator/buyer-side: reject the delivered work during `:evaluation`,
+  settling the job to `:rejected`.
+
+  Use this when an assigned evaluator (or the buyer) declines the deliverable.
+  The job settles immediately instead of waiting for the SLA timer, so the buyer
+  can reclaim the escrow via `reclaim/1`; the deliverable was rejected, so the
+  seller does not claim the budget. Same payload/signature semantics as
+  `approve/3` (the payload's `:reason` is recorded on the memo and the
+  `[:raxol, :acp, :job, :rejected]` telemetry).
+  """
+  @spec reject(GenServer.server() | binary(), map(), binary() | nil) ::
+          {:ok, StateMachine.state()} | {:error, term()}
+  def reject(server, payload, signature \\ nil) do
+    GenServer.call(resolve(server), {:reject, payload, signature})
+  end
+
+  @doc """
   Buyer-side reclaim of the escrowed budget for an expired / undelivered
   job. Calls `Raxol.ACP.ContractClient.withdraw_escrowed_funds/1` through
   the configured client. Intended after the job has passed its
@@ -313,7 +330,7 @@ defmodule Raxol.ACP.Job.Server do
   def init_manager(opts) do
     config =
       opts
-      |> Keyword.take([:handler, :request, :buyer, :seller])
+      |> Keyword.take([:handler, :request, :buyer, :seller, :evaluator])
       |> Map.new()
 
     job_id = Keyword.fetch!(opts, :job_id)
@@ -459,6 +476,10 @@ defmodule Raxol.ACP.Job.Server do
 
   def handle_manager_call({:approve, payload, signature}, _from, state) do
     do_transition(state, :approve, payload, signature)
+  end
+
+  def handle_manager_call({:reject, payload, signature}, _from, state) do
+    do_transition(state, :reject, payload, signature)
   end
 
   def handle_manager_call(:get_state, _from, state), do: {:reply, state, state}
@@ -617,14 +638,37 @@ defmodule Raxol.ACP.Job.Server do
       }
     )
 
+    maybe_emit_outcome(state, new_wf_state.current_state, new_memo)
+
     new_full_state
   end
+
+  # A graded terminal outcome (the buyer/evaluator completed or rejected the
+  # job) emits a dedicated event so reputation and ops can tell a rejection from
+  # a process crash, which emits no such event. Expiry keeps its own
+  # `[:raxol, :acp, :job, :expired]` signal on the timer path.
+  defp maybe_emit_outcome(state, to, memo) when to in [:completed, :rejected] do
+    :telemetry.execute(
+      [:raxol, :acp, :job, to],
+      %{},
+      %{
+        job_id: state.job_id,
+        from: state.state,
+        evaluator: Map.get(state.config, :evaluator),
+        reason: memo && Map.get(memo, :content),
+        tx_hash: memo && memo.tx_hash
+      }
+    )
+  end
+
+  defp maybe_emit_outcome(_state, _to, _memo), do: :ok
 
   defp ctx(state) do
     %{
       job_id: state.job_id,
       buyer: Map.get(state.config, :buyer),
       seller: Map.get(state.config, :seller),
+      evaluator: Map.get(state.config, :evaluator),
       state: state.state
     }
   end

--- a/packages/raxol_acp/lib/raxol/acp/job/state_machine.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/state_machine.ex
@@ -8,9 +8,13 @@ defmodule Raxol.ACP.Job.StateMachine do
       :request -> :negotiation -> :transaction -> :evaluation -> :completed
 
   A buyer's `:request` can be `:reject`ed by the seller (state 5 in the
-  canonical enum), and any non-terminal state can `:expire` (SLA breach
-  or buyer cancellation). `:completed`, `:rejected`, and `:expired` are
-  terminal -- no further transitions are valid.
+  canonical enum), and a delivered job can be `:reject`ed by the
+  evaluator or buyer during `:evaluation` (the deliverable is rejected).
+  Both settle to `:rejected`, so the buyer can reclaim the escrow
+  without waiting for the SLA timer. Any non-terminal state can
+  `:expire` (SLA breach or buyer cancellation). `:completed`,
+  `:rejected`, and `:expired` are terminal -- no further transitions are
+  valid.
 
   ## State -> canonical phase id mapping
 
@@ -32,7 +36,9 @@ defmodule Raxol.ACP.Job.StateMachine do
   ## Events
 
   - `:accept_request` -- seller accepts the buyer's request
-  - `:reject` -- seller rejects the buyer's request; valid only from `:request`
+  - `:reject` -- reject the job: the seller from `:request`, or the
+    evaluator/buyer from `:evaluation` (the delivered work is rejected).
+    Both settle to `:rejected`.
   - `:accept_payment` -- buyer's payment authorization is recorded;
     escrow holds funds
   - `:deliver` -- seller submits the deliverable
@@ -79,6 +85,7 @@ defmodule Raxol.ACP.Job.StateMachine do
   def next(:negotiation, :accept_payment), do: {:ok, :transaction}
   def next(:transaction, :deliver), do: {:ok, :evaluation}
   def next(:evaluation, :approve), do: {:ok, :completed}
+  def next(:evaluation, :reject), do: {:ok, :rejected}
 
   def next(state, :expire) when state in @non_terminal, do: {:ok, :expired}
 

--- a/packages/raxol_acp/lib/raxol/acp/job/workflow.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job/workflow.ex
@@ -18,7 +18,7 @@ defmodule Raxol.ACP.Job.Workflow do
               :memo_transaction -> :wait_transaction
                 :wait_transaction -[event]-> :memo_evaluation | :memo_expired
                   :memo_evaluation -> :wait_evaluation
-                    :wait_evaluation -[event]-> :memo_completed | :memo_expired
+                    :wait_evaluation -[event]-> :memo_completed | :memo_rejected | :memo_expired
                       :memo_completed -> :__end__
         :memo_rejected -> :__end__
         :memo_expired -> :__end__
@@ -170,7 +170,7 @@ defmodule Raxol.ACP.Job.Workflow do
     |> Graph.add_edge(:memo_evaluation, :wait_evaluation)
     |> Graph.add_conditional_edge(
       :wait_evaluation,
-      [:memo_completed, :memo_expired],
+      [:memo_completed, :memo_rejected, :memo_expired],
       &route_from_evaluation/1
     )
     |> Graph.add_edge(:memo_completed, :__end__)
@@ -279,6 +279,7 @@ defmodule Raxol.ACP.Job.Workflow do
   defp route_from_transaction(_), do: :memo_expired
 
   defp route_from_evaluation(%{pending_event: :approve}), do: :memo_completed
+  defp route_from_evaluation(%{pending_event: :reject}), do: :memo_rejected
   defp route_from_evaluation(_), do: :memo_expired
 
   # --- Memo node bodies ---

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -29,6 +29,17 @@ defmodule Raxol.ACP.Xochi.Offering do
   buyer (or an evaluator agent) can verify the cross-chain settlement
   on-chain before approving.
 
+  ## Known limitations
+
+  A `settlement_preference` of `private` is honored only on corridors that
+  support Xochi's dark-pool path. This offering does not yet surface a
+  privacy-downgrade warning when a requested-private route can only settle
+  publicly (the way the relay rail warns `:stealth_unavailable_on_tron`). This
+  is currently moot because the Xochi corridors are EVM-only and all support the
+  private path; it becomes relevant if a public-only chain (for example Tron) is
+  added, at which point a private request on that route would settle publicly and
+  should refuse or warn rather than silently downgrade.
+
   ## Marketplace registration
 
   When registering the offering at https://app.virtuals.io/acp/new, the

--- a/packages/raxol_acp/test/raxol/acp/job/evaluator_reject_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job/evaluator_reject_test.exs
@@ -1,0 +1,109 @@
+defmodule Raxol.ACP.Job.EvaluatorRejectTest do
+  @moduledoc """
+  The evaluator (or buyer) can reject a delivered job during `:evaluation`, so a
+  rejected deliverable settles to `:rejected` immediately instead of stranding
+  the escrow until the SLA timer fires. A graded terminal outcome (completed or
+  rejected) emits a dedicated telemetry event, so a rejection is distinguishable
+  from a process crash.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Raxol.ACP.TestSupport.WorkflowSetup
+
+  alias Raxol.ACP.ContractClient
+  alias Raxol.ACP.ContractClient.InMemory
+  alias Raxol.ACP.Job
+  alias Raxol.ACP.Job.Store
+
+  @seller "0x" <> String.duplicate("ab", 20)
+  @evaluator "0x" <> String.duplicate("ee", 20)
+  @sig <<0xDE, 0xAD>>
+
+  setup :with_isolated_workflow_saver
+
+  setup do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(Job.Supervisor),
+        is_pid(pid) do
+      DynamicSupervisor.terminate_child(Job.Supervisor, pid)
+    end
+
+    InMemory.reset()
+    Store.clear()
+    :ok
+  end
+
+  defp start_job(opts) do
+    {:ok, job_id} = ContractClient.create_job(@seller, @evaluator, 9_999_999_999)
+    opts = Keyword.put(opts, :job_id, job_id)
+    {:ok, _pid} = Job.Supervisor.start_job(opts)
+    job_id
+  end
+
+  defp drive_to_evaluation(job_id) do
+    assert {:ok, :negotiation} = Job.Server.transition(job_id, :accept_request, %{}, @sig)
+    assert {:ok, :transaction} = Job.Server.transition(job_id, :accept_payment, %{}, @sig)
+    assert {:ok, :evaluation} = Job.Server.transition(job_id, :deliver, %{}, @sig)
+    :ok
+  end
+
+  defp attach_outcome(event) do
+    ref = make_ref()
+    test = self()
+    handler = "outcome-#{inspect(ref)}"
+
+    :telemetry.attach(
+      handler,
+      [:raxol, :acp, :job, event],
+      fn _e, _m, meta, _ -> send(test, {:outcome, event, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+  end
+
+  describe "reject from :evaluation" do
+    test "settles the job to :rejected" do
+      job_id = start_job(evaluator: @evaluator)
+      drive_to_evaluation(job_id)
+
+      assert {:ok, :rejected} =
+               Job.Server.reject(job_id, %{reason: "output did not meet spec"}, @sig)
+    end
+
+    test "emits a :rejected outcome event carrying the reason and evaluator" do
+      attach_outcome(:rejected)
+      job_id = start_job(evaluator: @evaluator)
+      drive_to_evaluation(job_id)
+
+      assert {:ok, :rejected} = Job.Server.reject(job_id, %{reason: "bad output"}, @sig)
+
+      assert_receive {:outcome, :rejected, meta}
+      assert meta.from == :evaluation
+      assert meta.evaluator == @evaluator
+      assert meta.reason =~ "bad output"
+    end
+
+    test "is rejected before delivery (invalid from :negotiation)" do
+      job_id = start_job(evaluator: @evaluator)
+      assert {:ok, :negotiation} = Job.Server.transition(job_id, :accept_request, %{}, @sig)
+
+      assert {:error, {:invalid_transition, :negotiation, :reject}} =
+               Job.Server.reject(job_id, %{reason: "too early"}, @sig)
+    end
+  end
+
+  describe "approve from :evaluation" do
+    test "settles the job to :completed and emits a :completed outcome event" do
+      attach_outcome(:completed)
+      job_id = start_job(evaluator: @evaluator)
+      drive_to_evaluation(job_id)
+
+      assert {:ok, :completed} = Job.Server.approve(job_id, %{}, @sig)
+
+      assert_receive {:outcome, :completed, meta}
+      assert meta.from == :evaluation
+      assert meta.evaluator == @evaluator
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job/state_machine_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job/state_machine_test.exs
@@ -47,12 +47,18 @@ defmodule Raxol.ACP.Job.StateMachineTest do
     end
   end
 
-  describe ":reject from :request" do
-    test "transitions to :rejected" do
+  describe ":reject (seller from :request, evaluator from :evaluation)" do
+    test "seller reject from :request transitions to :rejected" do
       assert StateMachine.next(:request, :reject) == {:ok, :rejected}
     end
 
-    test "is not allowed once past :request" do
+    test "evaluator/buyer reject from :evaluation transitions to :rejected" do
+      # A rejected deliverable settles the job immediately, so the buyer can
+      # reclaim escrow without waiting for the SLA timer.
+      assert StateMachine.next(:evaluation, :reject) == {:ok, :rejected}
+    end
+
+    test "is not allowed from :negotiation or :transaction" do
       assert {:error, {:invalid_transition, :negotiation, :reject}} =
                StateMachine.next(:negotiation, :reject)
 

--- a/packages/raxol_payments/lib/mix/tasks/raxol_payments.bench.ex
+++ b/packages/raxol_payments/lib/mix/tasks/raxol_payments.bench.ex
@@ -1,0 +1,158 @@
+defmodule Mix.Tasks.RaxolPayments.Bench do
+  @shortdoc "Microbenchmark the payment hot paths: signing, ledger, checkpoint"
+
+  @moduledoc """
+  Measures the throughput of the fund-moving hot paths that actually gate DEX
+  volume: secp256k1 signing, atomic ledger reservations, and idempotency
+  checkpoint reads/writes. (The render frame budget does not gate volume; these
+  do.)
+
+      mix raxol_payments.bench
+      mix raxol_payments.bench --iterations 20000 --concurrency 16
+
+  Reports operations/sec and average latency per path. The concurrent ledger
+  figure exercises the single-GenServer reservation point (`Ledger.try_spend`),
+  the serialization ceiling for spend decisions.
+
+  The signing bench sets a throwaway key in `RAXOL_WALLET_KEY` for the run and
+  clears it after; it is for local measurement only.
+  """
+
+  use Mix.Task
+
+  alias Raxol.Payments.{Checkpoint, Ledger, SpendingPolicy}
+  alias Raxol.Payments.Wallets.Env, as: EnvWallet
+
+  # Hardhat account 0; a throwaway key for benchmarking only.
+  @privkey "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+  @default_iterations 5_000
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, _, _} =
+      OptionParser.parse(argv, strict: [iterations: :integer, concurrency: :integer])
+
+    iterations = Keyword.get(opts, :iterations, @default_iterations)
+    concurrency = Keyword.get(opts, :concurrency, System.schedulers_online())
+
+    Mix.Task.run("app.start")
+
+    IO.puts("""
+    raxol_payments.bench
+      iterations:  #{iterations}
+      concurrency: #{concurrency}
+    """)
+
+    bench_signing(iterations)
+    bench_ledger(iterations, concurrency)
+    bench_checkpoint(iterations)
+    :ok
+  end
+
+  defp bench_signing(n) do
+    System.put_env("RAXOL_WALLET_KEY", @privkey)
+    digest = :crypto.strong_rand_bytes(32)
+
+    domain = %{
+      name: "Bench",
+      version: "1",
+      chainId: 8453,
+      verifyingContract: "0x" <> String.duplicate("ab", 20)
+    }
+
+    types = %{"T" => [{"to", "address"}, {"value", "uint256"}]}
+    message = %{"to" => "0x" <> String.duplicate("cd", 20), "value" => 1_000_000}
+
+    {us_hash, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn _ -> {:ok, _} = EnvWallet.sign_hash(digest) end)
+      end)
+
+    report("wallet sign_hash (secp256k1)", n, us_hash)
+
+    {us_typed, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn _ ->
+          {:ok, _} = EnvWallet.sign_typed_data(domain, types, message)
+        end)
+      end)
+
+    report("wallet sign_typed_data (EIP-712 + secp256k1)", n, us_typed)
+  after
+    System.delete_env("RAXOL_WALLET_KEY")
+  end
+
+  defp bench_ledger(n, concurrency) do
+    policy = bench_policy()
+    amount = Decimal.new("0.0001")
+
+    ledger_seq = start_ledger(:seq)
+
+    {us_seq, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn _ -> :ok = Ledger.try_spend(ledger_seq, "a", amount, policy) end)
+      end)
+
+    report("Ledger.try_spend sequential", n, us_seq)
+
+    ledger_conc = start_ledger(:conc)
+
+    {us_conc, _} =
+      :timer.tc(fn ->
+        1..n
+        |> Task.async_stream(
+          fn _ -> Ledger.try_spend(ledger_conc, "a", amount, policy) end,
+          max_concurrency: concurrency,
+          ordered: false
+        )
+        |> Stream.run()
+      end)
+
+    report("Ledger.try_spend concurrent (#{concurrency})", n, us_conc)
+  end
+
+  defp bench_checkpoint(n) do
+    store = Checkpoint.ETS.new()
+
+    {us, _} =
+      :timer.tc(fn ->
+        Enum.each(1..n, fn i ->
+          key = "k#{i}"
+          :ok = Checkpoint.put(store, key, %{intent_id: key, status: :dispatched})
+          {:ok, _} = Checkpoint.fetch(store, key)
+        end)
+      end)
+
+    report("Checkpoint put+fetch (ETS)", n, us)
+  end
+
+  # Caps set far above the bench volume so every reservation succeeds and the
+  # measurement is the reservation cost, not cap rejection.
+  defp bench_policy do
+    %SpendingPolicy{
+      per_request_max: Decimal.new("1000000"),
+      session_max: Decimal.new("1000000000"),
+      lifetime_max: Decimal.new("1000000000000"),
+      session_window_ms: 3_600_000,
+      approved_domains: nil
+    }
+  end
+
+  defp start_ledger(tag) do
+    name = :"bench_ledger_#{tag}_#{System.unique_integer([:positive])}"
+    {:ok, ledger} = Ledger.start_link(table_name: name)
+    ledger
+  end
+
+  defp report(label, n, microseconds) do
+    ops = if microseconds > 0, do: round(n * 1_000_000 / microseconds), else: 0
+    avg_us = Float.round(microseconds / n, 2)
+
+    IO.puts(
+      "  " <>
+        String.pad_trailing(label, 48) <>
+        String.pad_leading(Integer.to_string(ops), 10) <>
+        " ops/s  " <> String.pad_leading(Float.to_string(avg_us), 8) <> " us/op"
+    )
+  end
+end

--- a/test/raxol/ssh/server_test.exs
+++ b/test/raxol/ssh/server_test.exs
@@ -43,6 +43,40 @@ defmodule Raxol.SSH.ServerTest do
     end
   end
 
+  # Connection accounting is a pure function so a per-IP flood can be exercised
+  # without binding a real SSH daemon.
+  describe "connection accounting (admit/release)" do
+    @ip_a {203, 0, 113, 1}
+    @ip_b {203, 0, 113, 2}
+
+    test "admits under both the global and per-IP caps" do
+      assert {:ok, 1, per_ip} = Server.admit(0, %{}, @ip_a, 100, 2)
+      assert {:ok, 2, _} = Server.admit(1, per_ip, @ip_a, 100, 2)
+    end
+
+    test "refuses a third connection from the same peer, independent of others" do
+      per_ip = %{@ip_a => 2}
+      # Global cap is far off, but this peer is at its per-IP limit.
+      assert {:error, :ip_limit} = Server.admit(2, per_ip, @ip_a, 100, 2)
+      # A different peer is unaffected.
+      assert {:ok, 3, _} = Server.admit(2, per_ip, @ip_b, 100, 2)
+    end
+
+    test "the global cap still takes precedence" do
+      assert {:error, :max_connections} = Server.admit(100, %{}, @ip_a, 100, 2)
+    end
+
+    test "release frees a global and per-IP slot, dropping empty buckets" do
+      assert {1, %{@ip_a => 1}} = Server.release(2, %{@ip_a => 2}, @ip_a)
+      assert {0, per_ip} = Server.release(1, %{@ip_a => 1}, @ip_a)
+      refute Map.has_key?(per_ip, @ip_a)
+    end
+
+    test "release never drops below zero" do
+      assert {0, _} = Server.release(0, %{}, @ip_a)
+    end
+  end
+
   describe "host key generation" do
     test "generates RSA host key" do
       dir =


### PR DESCRIPTION
## Summary

The P1 findings from the Fable engineering review, addressing the ACP evaluator
gap, connection-flood exposure, delegation ambiguity, and the missing
payment-throughput benchmark.

**Stacked on #356 (`harden/fable-p0`).** This PR targets `harden/fable-p0` so the
diff is P1-only; retarget to `master` once #356 merges. The ACP work is
independent of P0; the SSH and doc changes build on the P0 edits to the same
files.

## Changes (by commit)

- **Add ACP evaluator reject and terminal telemetry.** A delivered job can now be
  rejected by an evaluator/buyer during `:evaluation` (`Job.Server.reject/3`,
  `next(:evaluation, :reject) -> :rejected`, routed to the existing
  `:memo_rejected` workflow node). A rejected deliverable settles immediately so
  the buyer reclaims escrow via `reclaim/1`, instead of stranding until the SLA
  timer. The assigned evaluator is surfaced in `ctx`. `commit_transition` emits a
  dedicated `[:raxol, :acp, :job, :completed | :rejected]` event, so a rejection
  is distinguishable from a process crash (which emits nothing). The full terminal
  matrix (buyer-accept / evaluator-accept / evaluator-reject / expiry) is covered
  by `evaluator_reject_test.exs`.
- **Add SSH per-IP cap and auth timeout.** A per-peer connection cap
  (`:max_per_ip`, default 10) via pure `Server.admit/5` / `release/3` (peer IP
  threaded from the CLIHandler through `:ssh.connection_info`) stops a single host
  from exhausting the pool, and a `:negotiation_timeout` (default 30s) bounds how
  long an unauthenticated handshake can hold a slot.
- **Add `mix raxol_payments.bench`.** Microbenchmarks the fund-moving hot paths:
  secp256k1 signing, sequential + concurrent `Ledger.try_spend`, and checkpoint
  put/fetch. The first run confirms the ledger is the throughput ceiling
  (~1.5k ops/s with no gain under concurrency, i.e. the single-GenServer
  serialization point), versus ~7.6k signs/s and ~1.4M checkpoint ops/s.
- **Document delegation models and privacy limit.** A "Two delegation models"
  section in `AGENTIC_COMMERCE.md` delineates the Xochi Mandate (governs Xochi API
  calls) from the ERC-4337 SCA session key (governs Base/ACP UserOps): they are
  independent, and a full de-authorization needs both. `Xochi.Offering`'s moduledoc
  notes the privacy-downgrade limitation (moot today since Xochi corridors are
  EVM-only, latent if a public-only chain is added).

## Verification

- raxol_acp: 4 properties / 639 tests / 0 failures
- raxol_payments: 50 properties / 816 tests / 0 failures
- main raxol: 13 SSH tests / 0 failures (including the real-daemon integration tests)
- `mix compile --warnings-as-errors` and `mix format --check-formatted` clean

## Manual testing

- [ ] `cd packages/raxol_acp && MIX_ENV=test mix test test/raxol/acp/job` (evaluator matrix)
- [ ] `cd packages/raxol_payments && mix raxol_payments.bench --iterations 2000` prints the throughput table
- [ ] Confirm a job rejected during `:evaluation` settles to `:rejected` and emits
      `[:raxol, :acp, :job, :rejected]`
- [ ] `MIX_ENV=test mix test test/raxol/ssh/server_test.exs` (per-IP admit/release)

## Out of scope (follow-ups)

ACP privacy-downgrade *code* propagation (documented as a known limitation; moot
until a public-only chain is added to Xochi corridors) and a DETS 2GB volume alert
(minor; DETS is opt-in and off the critical path). Cross-repo Xochi items remain
tracked in the Xochi handover.
