### PR TITLE
Extract Runtime.BranchMerge, pin fan-out edge cases

### DIFF
--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -32,7 +32,6 @@ defmodule Raxol.Workflow.Runtime do
 
   alias Raxol.Core.Runtime.Directive
   alias Raxol.Core.Telemetry.TraceContext
-  alias Raxol.Workflow.Channel
   alias Raxol.Workflow.Checkpoint
   alias Raxol.Workflow.Checkpoint.Saver
   alias Raxol.Workflow.Compiled
@@ -43,6 +42,7 @@ defmodule Raxol.Workflow.Runtime do
   alias Raxol.Workflow.Execution.Scratchpad
   alias Raxol.Workflow.Node, as: WorkflowNode
   alias Raxol.Workflow.Node.{BehaviourNode, FunctionNode, TypedNode}
+  alias Raxol.Workflow.Runtime.BranchMerge
 
   @executed_key :__raxol_workflow_executed__
   @branch_id_key :__raxol_workflow_branch_id__
@@ -424,7 +424,7 @@ defmodule Raxol.Workflow.Runtime do
   defp finalize_join(compiled, continuation, run_id, deadline_us, count) do
     branch_states = Enum.map(continuation.slots, fn {:done, st} -> st end)
     join = Map.fetch!(compiled.joins_by_node, continuation.join_target)
-    merged = merge_branch_states(branch_states, join, compiled.channels)
+    merged = BranchMerge.merge(branch_states, join, compiled.channels)
 
     # Continuation served its purpose; strip it before continuing from
     # the join so downstream sequential nodes don't see runtime
@@ -1078,7 +1078,7 @@ defmodule Raxol.Workflow.Runtime do
 
         case result do
           {:all_done, branch_states, new_count} ->
-            merged = merge_branch_states(branch_states, join, compiled.channels)
+            merged = BranchMerge.merge(branch_states, join, compiled.channels)
             step(compiled, join.target, merged, run_id, deadline_us, new_count)
 
           {:has_paused, slots, new_count} ->
@@ -1552,49 +1552,6 @@ defmodule Raxol.Workflow.Runtime do
       {:error, reason} ->
         {:error, reason, state, count}
     end
-  end
-
-  defp merge_branch_states(
-         branch_states,
-         %JoinEdge{reducer: reducer},
-         _channels
-       )
-       when is_function(reducer, 1) do
-    reducer.(branch_states)
-  end
-
-  defp merge_branch_states([first | rest], %JoinEdge{reducer: nil}, channels) do
-    channel_index = channel_index_by_key(channels)
-
-    Enum.reduce(rest, first, fn next_state, acc ->
-      reduce_branch_into(acc, next_state, channel_index)
-    end)
-  end
-
-  defp channel_index_by_key(channels) do
-    channels
-    |> Map.values()
-    |> Map.new(fn %Channel{into: key} = c -> {key, c} end)
-  end
-
-  defp reduce_branch_into(left, right, channel_index) do
-    Enum.reduce(Map.keys(right), left, fn key, acc ->
-      case Map.fetch(right, key) do
-        :error ->
-          acc
-
-        {:ok, right_val} ->
-          case Map.get(channel_index, key) do
-            %Channel{with: reducer} ->
-              Map.update(acc, key, right_val, fn left_val ->
-                reducer.(left_val, right_val)
-              end)
-
-            nil ->
-              Map.put(acc, key, right_val)
-          end
-      end
-    end)
   end
 
   # --- Effect dispatch ---

--- a/lib/raxol/workflow/runtime/branch_merge.ex
+++ b/lib/raxol/workflow/runtime/branch_merge.ex
@@ -1,0 +1,63 @@
+defmodule Raxol.Workflow.Runtime.BranchMerge do
+  @moduledoc """
+  Merges the terminal states of fan-out branches at a join.
+
+  A join carrying an explicit `:reduce` reducer delegates the whole
+  list of branch states to that function. Otherwise the branch states
+  fold left-to-right in branch-index order: a key declared on a
+  `Raxol.Workflow.Channel` is combined via the channel's `:with`
+  reducer, and any other key is last-write-wins by branch order.
+
+  Pure: given the same branch states, join, and channels it always
+  returns the same merged state and touches nothing outside its
+  arguments.
+  """
+
+  alias Raxol.Workflow.Channel
+  alias Raxol.Workflow.Edge.JoinEdge
+
+  @doc """
+  Merge `branch_states` (in branch-index order) into a single state
+  according to the join's reducer or the graph's declared channels.
+  """
+  @spec merge([map()], JoinEdge.t(), %{optional(term()) => Channel.t()}) ::
+          map()
+  def merge(branch_states, %JoinEdge{reducer: reducer}, _channels)
+      when is_function(reducer, 1) do
+    reducer.(branch_states)
+  end
+
+  def merge([first | rest], %JoinEdge{reducer: nil}, channels) do
+    channel_index = channel_index_by_key(channels)
+
+    Enum.reduce(rest, first, fn next_state, acc ->
+      reduce_branch_into(acc, next_state, channel_index)
+    end)
+  end
+
+  defp channel_index_by_key(channels) do
+    channels
+    |> Map.values()
+    |> Map.new(fn %Channel{into: key} = c -> {key, c} end)
+  end
+
+  defp reduce_branch_into(left, right, channel_index) do
+    Enum.reduce(Map.keys(right), left, fn key, acc ->
+      case Map.fetch(right, key) do
+        :error ->
+          acc
+
+        {:ok, right_val} ->
+          case Map.get(channel_index, key) do
+            %Channel{with: reducer} ->
+              Map.update(acc, key, right_val, fn left_val ->
+                reducer.(left_val, right_val)
+              end)
+
+            nil ->
+              Map.put(acc, key, right_val)
+          end
+      end
+    end)
+  end
+end

--- a/test/raxol/workflow/parallel_test.exs
+++ b/test/raxol/workflow/parallel_test.exs
@@ -9,9 +9,9 @@ defmodule Raxol.Workflow.ParallelTest do
   - 3-branch fan-out with an explicit `:reduce` reducer.
   - 3-branch fan-out with a `Channel`-keyed merge.
 
-  Per-branch failure semantics, pause-inside-branch, retry-per-branch,
-  and compensate-across-branches are deferred to follow-up work and are
-  intentionally not covered here.
+  Per-branch failure and pause-inside-branch semantics are covered
+  below. Retry-per-branch and compensate-across-branches are deferred
+  to follow-up work and are intentionally not covered here.
   """
 
   use ExUnit.Case, async: false
@@ -878,6 +878,96 @@ defmodule Raxol.Workflow.ParallelTest do
       assert :fast_fail_started in tags
       refute :slow_a_finished in tags
       refute :slow_b_finished in tags
+    end
+  end
+
+  describe "serial fan-out and fan-out error edges" do
+    test "serial fan-out (parallelism: 1): a branch error surfaces to the run" do
+      graph =
+        Graph.new(:serial_err)
+        |> Graph.add_node(:gate, fn s -> {:ok, s} end)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :a, true)} end)
+        |> Graph.add_node(:b_bomb, fn _s -> {:error, :b_boom} end)
+        |> Graph.add_node(:join, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :gate)
+        |> Graph.add_conditional_edge(:gate, [:a, :b_bomb], fn _ -> [:a, :b_bomb] end)
+        |> Graph.add_edge(:a, :join)
+        |> Graph.add_edge(:b_bomb, :join)
+        |> Graph.add_join(:join, [:a, :b_bomb], parallelism: 1)
+        |> Graph.add_edge(:join, :__end__)
+
+      {:ok, compiled} = Graph.compile(graph)
+      assert {:error, :b_boom, _state} = Compiled.invoke(compiled, %{})
+    end
+
+    test "serial fan-out (parallelism: 1): a branch interrupt surfaces with index-ordered slots" do
+      graph =
+        Graph.new(:serial_pause)
+        |> Graph.add_node(:gate, fn s -> {:ok, s} end)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :a, true)} end)
+        |> Graph.add_node(:b_pause, fn _s -> Raxol.Workflow.interrupt(:need_b) end)
+        |> Graph.add_node(:join, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :gate)
+        |> Graph.add_conditional_edge(:gate, [:a, :b_pause], fn _ ->
+          [:a, :b_pause]
+        end)
+        |> Graph.add_edge(:a, :join)
+        |> Graph.add_edge(:b_pause, :join)
+        |> Graph.add_join(:join, [:a, :b_pause], parallelism: 1)
+        |> Graph.add_edge(:join, :__end__)
+
+      {:ok, compiled} = Graph.compile(graph)
+
+      assert {:interrupted, _run_id, state, :need_b} =
+               Compiled.invoke(compiled, %{})
+
+      continuation = state.__raxol_workflow_fan_out__
+      assert continuation.join_target == :join
+      assert continuation.branch_ids == [:a, :b_pause]
+
+      # The serial path reverses its accumulator to restore branch-index
+      # order: branch 0 done, branch 1 paused.
+      assert [
+               {:done, %{a: true}},
+               {:paused, :b_pause, %{}, :need_b}
+             ] = continuation.slots
+    end
+
+    test "a list-returning chooser with no matching join fails with :fan_out_without_join" do
+      graph =
+        Graph.new(:no_join)
+        |> Graph.add_node(:gate, fn s -> {:ok, s} end)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :a, true)} end)
+        |> Graph.add_node(:b, fn s -> {:ok, Map.put(s, :b, true)} end)
+        |> Graph.add_edge(:__start__, :gate)
+        |> Graph.add_conditional_edge(:gate, [:a, :b], fn _ -> [:a, :b] end)
+        |> Graph.add_edge(:a, :__end__)
+        |> Graph.add_edge(:b, :__end__)
+
+      {:ok, compiled} = Graph.compile(graph)
+
+      assert {:error, {:fan_out_without_join, [:a, :b]}, _state} =
+               Compiled.invoke(compiled, %{})
+    end
+
+    test "a branch routing to :__end__ before the join fails with :branch_reached_end_before_join" do
+      graph =
+        Graph.new(:end_before_join)
+        |> Graph.add_node(:gate, fn s -> {:ok, s} end)
+        |> Graph.add_node(:a, fn s -> {:ok, Map.put(s, :a, true)} end)
+        |> Graph.add_node(:b, fn s -> {:ok, Map.put(s, :b, true)} end)
+        |> Graph.add_node(:join, fn s -> {:ok, s} end)
+        |> Graph.add_edge(:__start__, :gate)
+        |> Graph.add_conditional_edge(:gate, [:a, :b], fn _ -> [:a, :b] end)
+        |> Graph.add_edge(:a, :__end__)
+        |> Graph.add_edge(:b, :join)
+        |> Graph.add_join(:join, [:a, :b])
+        |> Graph.add_edge(:join, :__end__)
+
+      {:ok, compiled} = Graph.compile(graph)
+
+      assert {:error, {:branch_reached_end_before_join, :join}, _state} =
+               Compiled.invoke(compiled, %{})
     end
   end
 


### PR DESCRIPTION
## What

A structure-only refactor of the workflow runtime, plus the characterization tests that make it safe. This came out of a refactoring-strategy pass over the largest modules; the headline finding was that `Raxol.Workflow.Runtime` is a cohesive recursive interpreter that should not be split wholesale, so this lands only the one genuinely clean extraction.

## Changes

Two independently revertable commits:

1. **Add serial fan-out characterization tests** (test-only). Pins four previously-uncovered fan-out paths: serial (`parallelism: 1`) branch error and interrupt, plus the `fan_out_without_join` and `branch_reached_end_before_join` error edges. Every existing fan-out failure/interrupt test used the concurrent dispatch path only; these lock the serial path and the error tags.
2. **Extract `Runtime.BranchMerge`** (structure-only). Moves the pure branch-state merge (explicit reducer / channel reducer / last-write-wins) out of the interpreter into `Raxol.Workflow.Runtime.BranchMerge`. Two call sites delegate; behavior is identical.

## Why not extract the whole fan-out arm

That was the tempting large win from a line-count view, but the full call graph shows the fan-out code mutually recurses with the sequential loop through `step/6` and shares the node-execution, retry, checkpoint, and telemetry machinery. Extracting it would require making ~10 private functions public and introducing a bidirectional `Runtime <-> FanOut` dependency, which is more coupling to shave line count. Left in place as the wrong boundary.

## Manual testing

- [x] `MIX_ENV=test mix test test/raxol/workflow/parallel_test.exs test/raxol/workflow/runtime_test.exs` -> 51 tests, 0 failures
- [x] `MIX_ENV=test mix compile --warnings-as-errors` -> clean
- [x] `mix format --check-formatted` on the changed `lib/` files -> ok
- [x] credo/dialyzer neutral: the one `--strict` nesting note on `reduce_branch_into` moved with the code (it existed in `runtime.ex` on master)
