### PR TITLE
Resolve Robinhood USDG cross-asset in live gates

### DIFF
--- a/packages/raxol_acp/examples/run_live_acp_order_gate.sh
+++ b/packages/raxol_acp/examples/run_live_acp_order_gate.sh
@@ -29,11 +29,18 @@
 #   XOCHI_ORDER_LIVE_KEY=0x<funded> XOCHI_ORDER_TOKENS=USDC \
 #     ./examples/run_live_acp_order_gate.sh
 #
-#   # 3. All three tokens across the 5-chain mesh (USDT/WETH need per-chain RPC):
+#   # 3. All three tokens across the 6-chain mesh (USDT/WETH/USDG need per-chain RPC):
 #   XOCHI_ORDER_LIVE_KEY=0x<funded> XOCHI_ORDER_CORRIDORS=mesh \
 #   XOCHI_ORDER_TOKENS=USDC,USDT,WETH \
 #   XOCHI_ORDER_RPC_8453=https://mainnet.base.org \
 #   XOCHI_ORDER_RPC_42161=https://arb1.arbitrum.io/rpc \
+#     ./examples/run_live_acp_order_gate.sh
+#
+#   # 4. A Robinhood-origin order (USDG->USDC cross-asset; USDG pulls via Permit2,
+#   #    so the 4663 origin needs an RPC for the allowance broadcast):
+#   XOCHI_ORDER_LIVE_KEY=0x<funded seller w/ USDG on 4663> \
+#   XOCHI_ORDER_CORRIDORS=4663>8453 XOCHI_ORDER_TOKENS=USDC \
+#   XOCHI_ORDER_RPC_4663=https://rpc.mainnet.chain.robinhood.com \
 #     ./examples/run_live_acp_order_gate.sh
 #
 # The Member service token is a long-lived 1Password credential, per-env:

--- a/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
@@ -18,11 +18,15 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
   Xochi Member, and the `Settler` uses one config for quote/execute/poll. (The
   mandate path is exercised by the raxol_payments Xochi gate.)
 
-  USDC pulls via ERC-3009 and settles directly. USDT/WETH pull via Permit2 and
-  need a standing on-chain allowance, which this gate broadcasts via
+  USDC pulls via ERC-3009 and settles directly. USDT/WETH -- and USDG, the origin
+  asset for any Robinhood-origin corridor -- pull via Permit2 and need a standing
+  on-chain allowance, which this gate broadcasts via
   `Raxol.ACP.Onchain.Permit2Approver` using a JSON-RPC provider built from the
-  funded key and `XOCHI_ORDER_RPC_<chain>`. A USDT/WETH cell with no RPC for its
-  origin chain is skipped (logged), not failed.
+  funded key and `XOCHI_ORDER_RPC_<chain>`. A Permit2-origin cell with no RPC for
+  its origin chain is skipped (logged), not failed. Robinhood Chain (4663) has no
+  USDC, so a stablecoin corridor touching it is cross-asset (USDG on the Robinhood
+  leg); order a `4663->8453` USDG->USDC corridor with
+  `XOCHI_ORDER_CORRIDORS=4663>8453 XOCHI_ORDER_RPC_4663=https://rpc.mainnet.chain.robinhood.com`.
 
   Moves real funds. Tagged `:live_xochi_order` (settle) and
   `:live_xochi_order_preflight` (read-only); excluded by default and compiled
@@ -65,7 +69,10 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
 
     # Riddler's universal solver (HD index-0); the pinned origin-pull recipient.
     @canonical_solver "0x97D447561fDe10E959E782a29411D8F89586d80b"
-    @evm_chains [1, 10, 137, 8453, 42_161]
+    # The six settleable EVM chains. Robinhood Chain (4663) has no USDC, only
+    # USDG, so a stablecoin corridor touching it is cross-asset (USDG on the
+    # Robinhood leg); see leg_symbol/2. USDG pulls via Permit2, never ERC-3009.
+    @evm_chains [1, 10, 137, 8453, 42_161, 4663]
 
     defmodule LiveWallet do
       @moduledoc false
@@ -204,8 +211,8 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
     end
 
     defp requirement(cfg, from, to, token) do
-      {:ok, src_token} = Assets.address(from, token)
-      {:ok, dst_token} = Assets.address(to, token)
+      {:ok, src_token} = Assets.address(from, leg_symbol(from, token))
+      {:ok, dst_token} = Assets.address(to, leg_symbol(to, token))
 
       %{
         "src_chain_id" => from,
@@ -251,8 +258,8 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
     end
 
     defp quote_request(cfg, from, to, token) do
-      with {:ok, src_token} <- Assets.address(from, token),
-           {:ok, dst_token} <- Assets.address(to, token) do
+      with {:ok, src_token} <- Assets.address(from, leg_symbol(from, token)),
+           {:ok, dst_token} <- Assets.address(to, leg_symbol(to, token)) do
         {:ok,
          %QuoteRequest{
            wallet: cfg.wallet_address,
@@ -272,9 +279,9 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
     # -- Permit2 allowance (USDT/WETH only) --
 
     defp ensure_permit2(from, token, owner) do
-      if permit2_token?(token) do
+      if permit2_origin?(from, token) do
         with {:ok, provider} <- provider_for(from),
-             {:ok, src_token} <- Assets.address(from, token) do
+             {:ok, src_token} <- Assets.address(from, leg_symbol(from, token)) do
           Permit2Approver.ensure_allowance(provider, from, src_token, owner)
         else
           :error -> {:error, {:unknown_token, token}}
@@ -327,7 +334,7 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
     end
 
     defp amount_atomic(from, token, stable_amount) do
-      {:ok, src_token} = Assets.address(from, token)
+      {:ok, src_token} = Assets.address(from, leg_symbol(from, token))
       decimals = Assets.decimals(from, src_token)
       Integer.to_string(Assets.to_atomic(Decimal.new(amount_for(token, stable_amount)), decimals))
     end
@@ -335,7 +342,24 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
     defp amount_for("WETH", _stable), do: System.get_env("XOCHI_ORDER_WETH_AMOUNT", "0.001")
     defp amount_for(_token, stable), do: stable
 
-    defp permit2_token?(token), do: String.upcase(token) in ["USDT", "WETH"]
+    # The origin pull rail: USDC pulls via ERC-3009, everything else (USDT, WETH,
+    # and Robinhood's USDG) via Permit2. Keyed on the ORIGIN leg's resolved token,
+    # so a Robinhood-origin corridor (USDG) needs a Permit2 allowance even when the
+    # logical corridor token is USDC.
+    defp permit2_origin?(from, token), do: String.upcase(leg_symbol(from, token)) != "USDC"
+
+    # Robinhood Chain (4663) carries no USDC/USDT: its only stablecoin is USDG. A
+    # stablecoin corridor touching 4663 is therefore cross-asset (USDG on the
+    # Robinhood leg, the requested stablecoin on the other) -- the fungible
+    # stablecoin group the solver fills. Every non-Robinhood leg, and WETH
+    # (canonical on 4663 too), passes through unchanged.
+    defp leg_symbol(4663, token) do
+      if stablecoin_symbol?(token), do: "USDG", else: token
+    end
+
+    defp leg_symbol(_chain, token), do: token
+
+    defp stablecoin_symbol?(token), do: String.upcase(token) in ["USDC", "USDT", "DAI", "USDG"]
 
     defp parse_corridors(spec) when spec in ["mesh", "all"] do
       for from <- @evm_chains, to <- @evm_chains, from != to, do: {from, to}
@@ -361,18 +385,28 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
 
     defp report_preflight(from, to, token, {:ok, info}) do
       IO.puts(
-        "  PASS #{from}->#{to} #{token} via #{info.method || "?"} (to_amount #{info.to_amount})"
+        "  PASS #{from}->#{to} #{asset_pair(from, to, token)} via #{info.method || "?"}" <>
+          " (to_amount #{info.to_amount})"
       )
     end
 
     defp report_preflight(from, to, token, {:soft, :cannot_solve}) do
       IO.puts(
-        "  SKIP #{from}->#{to} #{token}: solver cannot fill this cell yet (no funds needed)"
+        "  SKIP #{from}->#{to} #{asset_pair(from, to, token)}: " <>
+          "solver cannot fill this cell yet (no funds needed)"
       )
     end
 
     defp report_preflight(from, to, token, {:error, reason}) do
-      IO.puts("  FAIL #{from}->#{to} #{token}: #{inspect(reason)}")
+      IO.puts("  FAIL #{from}->#{to} #{asset_pair(from, to, token)}: #{inspect(reason)}")
+    end
+
+    # Render the corridor's asset pairing: "USDC" same-asset, "USDC->USDG" when a
+    # Robinhood leg swaps a stablecoin for USDG, so the log shows the cross-asset fill.
+    defp asset_pair(from, to, token) do
+      f = leg_symbol(from, token)
+      t = leg_symbol(to, token)
+      if f == t, do: f, else: "#{f}->#{t}"
     end
 
     defp report_settlement(label, to_chain, deliverable, started_ms) do

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -61,7 +61,10 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
   - `XOCHI_LIVE_CORRIDORS` -- `"from>to,from>to"` chain-id pairs (default
     `"8453>42161,42161>8453"`), or `"mesh"` for every ordered pair of the six
     supported EVM chains (1, 10, 137, 8453, 42161, 4663). Tokens resolve per chain
-    via `Raxol.Payments.Assets`.
+    via `Raxol.Payments.Assets`. Robinhood Chain (4663) has no USDC/USDT, so a
+    stablecoin corridor touching it is cross-asset (USDG on the Robinhood leg,
+    the requested stablecoin on the other) -- the fungible stablecoin group the
+    solver fills. The Robinhood leg pulls USDG via Permit2, never ERC-3009.
   - `XOCHI_LIVE_TOKENS` -- `"USDC,USDT,WETH"` (default `"USDC"`). USDC pulls via
     ERC-3009; USDT/WETH via Permit2 (needs a standing Permit2 allowance on each
     origin chain). The preflight asserts the served pull method per token
@@ -338,7 +341,8 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
               # USDT/WETH pull via Permit2, which needs a standing on-chain allowance
               # this gate does not broadcast (raxol_payments holds no tx code). Set the
               # allowance via the ACP order gate, then opt in with XOCHI_LIVE_SETTLE_PERMIT2.
-              permit2_token?(token) and System.get_env("XOCHI_LIVE_SETTLE_PERMIT2") != "true" ->
+              permit2_origin?(from, token) and
+                  System.get_env("XOCHI_LIVE_SETTLE_PERMIT2") != "true" ->
                 IO.puts(
                   "[live_xochi:matrix] SKIP #{label}: #{token} pulls via Permit2 and needs a " <>
                     "standing allowance. Order it through raxol_acp (run_live_acp_order_gate.sh), " <>
@@ -650,7 +654,13 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         end
       end
 
-      defp permit2_token?(token), do: String.upcase(token) in ["USDT", "WETH"]
+      # The origin pull rail for a corridor: USDC pulls via ERC-3009, every other
+      # token (USDT, WETH, and Robinhood's USDG) via Permit2. Keyed on the ORIGIN
+      # leg's resolved token, so a Robinhood-origin corridor (USDG) is classified
+      # as Permit2 -- and skipped without a standing allowance -- even when the
+      # logical corridor token is USDC.
+      defp permit2_origin?(from, token),
+        do: String.upcase(leg_symbol(from, token)) != "USDC"
 
       # Read-only preflight retries: a transient worker/oracle blip clears in
       # seconds and quoting moves no funds, so retry a transient cell before judging
@@ -727,7 +737,7 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
           with {:ok, request} <- preflight_request(wallet, from, to, token, amount),
                {:ok, quote} <- XochiProtocol.get_quote(config, request),
                :ok <- preflight_can_solve(quote),
-               :ok <- preflight_method(token, quote.payment_method),
+               :ok <- preflight_method(from, token, quote.payment_method),
                :ok <- XochiProtocol.validate_pull(quote, request, wallet) do
             {:ok,
              %{method: quote.payment_method, to_amount: quote.to_amount, fee: quote.xochi_fee}}
@@ -762,11 +772,13 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
 
       defp transient_preflight?(reason), do: Failure.from(reason).reason == :network
 
-      # USDC pulls via ERC-3009; USDT/WETH pull via Permit2. Asserting the served
-      # method per token catches a token routed to the wrong rail (which would
-      # otherwise fail on-chain at pull time) before any funds move.
-      defp preflight_method(token, method) do
-        want = expected_method(String.upcase(token))
+      # USDC pulls via ERC-3009; USDT/WETH/USDG pull via Permit2. Asserting the
+      # served method per token catches a token routed to the wrong rail (which
+      # would otherwise fail on-chain at pull time) before any funds move. Keyed on
+      # the ORIGIN leg's resolved token: a Robinhood-origin corridor pulls USDG via
+      # Permit2 even when the logical corridor token is USDC.
+      defp preflight_method(from, token, method) do
+        want = expected_method(String.upcase(leg_symbol(from, token)))
         got = method && String.downcase(method)
         if got == want, do: :ok, else: {:error, {:method_mismatch, token, got, want}}
       end
@@ -774,9 +786,24 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
       defp expected_method("USDC"), do: "erc3009"
       defp expected_method(_token), do: "permit2"
 
+      # Robinhood Chain (4663) carries no USDC/USDT: its only stablecoin is USDG.
+      # A stablecoin corridor touching 4663 is therefore cross-asset -- USDC/USDT
+      # on the EVM leg, USDG on the Robinhood leg -- which is exactly the fungible
+      # stablecoin group the solver fills ([USDC, USDT, DAI, USDG]). Resolve each
+      # leg to the token that actually exists on that chain; every non-Robinhood
+      # leg, and WETH (canonical on 4663 too), passes through unchanged.
+      defp leg_symbol(4663, token) do
+        if stablecoin_symbol?(token), do: "USDG", else: token
+      end
+
+      defp leg_symbol(_chain, token), do: token
+
+      defp stablecoin_symbol?(token),
+        do: String.upcase(token) in ["USDC", "USDT", "DAI", "USDG"]
+
       defp preflight_request(wallet, from, to, token, amount) do
-        with {:ok, from_token} <- Assets.address(from, token),
-             {:ok, to_token} <- Assets.address(to, token) do
+        with {:ok, from_token} <- Assets.address(from, leg_symbol(from, token)),
+             {:ok, to_token} <- Assets.address(to, leg_symbol(to, token)) do
           decimals = Assets.decimals(from, from_token)
           from_amount = Integer.to_string(Assets.to_atomic(Decimal.new(amount), decimals))
 
@@ -801,14 +828,23 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
 
       defp report_preflight(from, to, token, {:ok, info}) do
         IO.puts(
-          "  PASS #{from}->#{to} #{token} via #{info.method || "?"}" <>
+          "  PASS #{from}->#{to} #{asset_pair(from, to, token)} via #{info.method || "?"}" <>
             " (to_amount #{info.to_amount}, fee #{info.fee})" <>
             preflight_notes(from, info.method)
         )
       end
 
       defp report_preflight(from, to, token, {:error, reason}) do
-        IO.puts("  FAIL #{from}->#{to} #{token}: #{inspect(reason)}")
+        IO.puts("  FAIL #{from}->#{to} #{asset_pair(from, to, token)}: #{inspect(reason)}")
+      end
+
+      # Render the corridor's asset pairing: "USDC" for a same-asset corridor, or
+      # "USDC->USDG" when a Robinhood leg swaps a stablecoin for USDG, so the log
+      # makes the cross-asset fill explicit.
+      defp asset_pair(from, to, token) do
+        f = leg_symbol(from, token)
+        t = leg_symbol(to, token)
+        if f == t, do: f, else: "#{f}->#{t}"
       end
 
       # Per-cell operator notes that are not failures: an L1 origin costs real gas,
@@ -864,8 +900,8 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
           amount: amount,
           from_chain_id: from,
           to_chain_id: to,
-          from_token: token_for(from, token),
-          to_token: token_for(to, token),
+          from_token: token_for(from, leg_symbol(from, token)),
+          to_token: token_for(to, leg_symbol(to, token)),
           settlement: settlement
         }
 


### PR DESCRIPTION
## What

Cross-asset (USDC↔USDG) resolution for **Robinhood Chain (4663)** in the two live settlement gates, so `*↔4663` corridors are formed correctly instead of failing with `{:unknown_token, "USDC"}`.

Robinhood has no USDC — its only stablecoin is **USDG** — so a stablecoin corridor touching 4663 is inherently cross-asset. Both gates resolved the same symbol on both legs; this resolves each leg to the token that actually exists on that chain.

## Changes (live-only test/example files)

- `live_xochi_test.exs` (raxol_payments): `leg_symbol/2` maps 4663 stablecoins → USDG; origin-aware `permit2_origin?` (USDG pulls via Permit2, not ERC-3009); 4663 added to the mesh; cross-asset display.
- `live_order_test.exs` (raxol_acp): same cross-asset + origin-Permit2 handling for the ACP order gate, so a seller can serve a Robinhood order.
- `run_live_acp_order_gate.sh`: documents `XOCHI_ORDER_RPC_4663` for the USDG Permit2 allowance.

These tests are compile-gated behind live env vars (`XOCHI_LIVE_*` / `XOCHI_ORDER_*`) and excluded from normal CI. Validated by running the live mesh gate (10 real cross-chain settlements; `4663→*` preflight PASS via permit2).

## Manual testing
- [x] Live mesh gate green (`4663→*` USDG→USDC via permit2)
- [ ] `*→4663` into-Robinhood once Riddler gas-oracle fix (axol-io/Riddler#277/#278) deploys