### PR TITLE
Add raxol_acp accounting sidecar release image

### DIFF
--- a/.github/workflows/release-raxol-acp.yml
+++ b/.github/workflows/release-raxol-acp.yml
@@ -1,0 +1,100 @@
+name: Release raxol_acp sidecar image
+
+# Builds and publishes the read-only settlement-accounting sidecar image to GHCR.
+# Standalone by design: the root release.yml builds a (non-existent) root mix release
+# and must not gate this. A successful image build IS the compile gate here.
+#
+# Publishes to ghcr.io/droodotfoo/raxol-acp. The repo lives under DROOdotFOO, so the
+# job's GITHUB_TOKEN can push natively -- no PAT needed. The ops side pulls by digest;
+# make the GHCR package public (keyless, read-only image) so the pull needs no secret.
+
+on:
+  push:
+    tags:
+      - 'raxol-acp-v*'
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push the image to GHCR (off = build-only dry run)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-raxol-acp-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/droodotfoo/raxol-acp
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Push on a tag, or on manual dispatch only when the push input is true.
+      - name: Resolve push flag
+        id: flags
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.push }}" = "true" ]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to GHCR
+        if: steps.flags.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=match,pattern=raxol-acp-v(.*),group=1
+            type=sha,format=long
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/raxol-acp-v') }}
+            type=ref,event=branch
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.raxol-acp
+          platforms: linux/amd64
+          push: ${{ steps.flags.outputs.push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Record digest
+        if: steps.flags.outputs.push == 'true'
+        run: |
+          {
+            echo "## raxol_acp sidecar image published"
+            echo ""
+            echo "Digest-pin this in ansible-riddler (\`raxol_acp_image_digest\`):"
+            echo ""
+            echo '```'
+            echo "${{ env.IMAGE }}@${{ steps.build.outputs.digest }}"
+            echo '```'
+            echo ""
+            echo "Tags:"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -46,32 +46,16 @@ if config_env() == :prod do
   # RebalanceAdvisor runs periodically. Read-only: it reads the solver's balances
   # and receipts over public RPC and never moves funds (the Riddler auto-rebalancer
   # executes). Enable with RAXOL_ACCOUNTING_ENABLED=true and set the RPC_* + solver
-  # address vars.
-  accounting_rpc_urls =
-    %{
-      1 => System.get_env("RPC_ETH"),
-      10 => System.get_env("RPC_OPTIMISM"),
-      137 => System.get_env("RPC_POLYGON"),
-      8453 => System.get_env("RPC_BASE"),
-      42_161 => System.get_env("RPC_ARBITRUM"),
-      4663 => System.get_env("RPC_ROBINHOOD")
-    }
-    |> Enum.reject(fn {_chain, url} -> is_nil(url) or url == "" end)
-    |> Map.new()
+  # address vars. The env contract lives in Raxol.Payments.Accounting so this file and
+  # the raxol_acp sidecar release config read it identically. Guarded so a release
+  # without the payments app (the module is absent) skips it.
+  if Code.ensure_loaded?(Raxol.Payments.Accounting) do
+    {accounting_opts, accounting_enabled} =
+      Raxol.Payments.Accounting.env_config()
 
-  config :raxol_payments, :accounting,
-    rpc_urls: accounting_rpc_urls,
-    solver_address: System.get_env("XOCHI_SOLVER_ADDRESS"),
-    rebalance_interval_ms:
-      String.to_integer(
-        System.get_env("RAXOL_REBALANCE_INTERVAL_MS") || "300000"
-      ),
-    price_source:
-      String.to_atom(System.get_env("RAXOL_PRICE_SOURCE") || "coingecko")
-
-  config :raxol_acp,
-    accounting_enabled:
-      System.get_env("RAXOL_ACCOUNTING_ENABLED", "false") == "true"
+    config :raxol_payments, :accounting, accounting_opts
+    config :raxol_acp, accounting_enabled: accounting_enabled
+  end
 
   # Configure terminal settings from environment
   config :raxol, :terminal,

--- a/docker/Dockerfile.raxol-acp
+++ b/docker/Dockerfile.raxol-acp
@@ -1,0 +1,69 @@
+# Production image for the raxol_acp settlement-accounting sidecar.
+#
+# A slim, read-only, headless release: :raxol_acp + its runtime deps
+# (:raxol_payments, :raxol_core, req, cowboy, the rustler_precompiled crypto NIFs).
+# :raxol_agent / :raxol_mcp are runtime:false, so :raxol_terminal (the termbox C NIF)
+# is NOT in the final release -- though the BUILD still compiles it transitively,
+# since raxol_acp compile-depends on raxol_agent -> raxol -> raxol_terminal. Hence the
+# builder carries a C toolchain; the runner does not.
+#
+# Build from the repository root:
+#   docker build -f docker/Dockerfile.raxol-acp -t raxol-acp .
+#
+# Wallet-safe by construction: no private key is baked in or read at runtime; the
+# sidecar only reads balances/receipts over public RPC and never moves funds.
+
+ARG ELIXIR_IMAGE=elixir:1.19.4-otp-28
+ARG RUNNER_IMAGE=debian:bookworm-slim
+
+FROM ${ELIXIR_IMAGE} AS builder
+
+# build-essential + git: termbox2 C NIF (transitive) compiles here; ca-certificates:
+# rustler_precompiled downloads prebuilt crypto NIFs over TLS. No Node/Rust needed.
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends build-essential git ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+RUN mix local.hex --force && mix local.rebar --force
+
+ENV MIX_ENV="prod"
+# The transitive raxol_terminal build reads this; harmless for the acp release.
+ENV SKIP_TERMBOX2_TESTS="true"
+ENV TMPDIR="/tmp"
+
+# Build the release from the package that owns the accounting tree.
+WORKDIR /app/packages/raxol_acp
+
+RUN mix deps.get --only $MIX_ENV
+RUN mix deps.compile
+RUN mix compile
+RUN mix release raxol_acp
+
+# --- Runtime stage: no compilers, no Erlang install (ERTS ships in the release) ---
+FROM ${RUNNER_IMAGE} AS runner
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      libstdc++6 openssl libncurses6 locales ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+ENV MIX_ENV="prod"
+
+WORKDIR /app
+RUN chown nobody /app
+
+COPY --from=builder --chown=nobody:root \
+     /app/packages/raxol_acp/_build/prod/rel/raxol_acp ./
+
+USER nobody
+
+ENTRYPOINT ["/app/bin/raxol_acp"]
+CMD ["start"]

--- a/packages/raxol_acp/config/config.exs
+++ b/packages/raxol_acp/config/config.exs
@@ -1,0 +1,9 @@
+import Config
+
+# Compile-time base config for the raxol_acp sidecar release. The accounting
+# deployment contract is read at boot from the environment in runtime.exs; this
+# file only sets defaults that must exist before boot.
+#
+# Accounting is off unless RAXOL_ACCOUNTING_ENABLED=true (see runtime.exs), so the
+# release is inert until the operator opts in.
+config :raxol_acp, accounting_enabled: false

--- a/packages/raxol_acp/config/runtime.exs
+++ b/packages/raxol_acp/config/runtime.exs
@@ -1,0 +1,24 @@
+import Config
+
+# Runtime (boot-time) config for the read-only settlement-accounting sidecar.
+#
+# Prod-gated so `mix`/tests in this package are unaffected. Reads the accounting
+# deployment contract via `Raxol.Payments.Accounting.env_config/0` -- the same
+# helper the root raxol release uses -- so the two configs cannot drift.
+#
+# Deliberately NOT included: the origin-pull solver-pin guard from the root
+# config/runtime.exs. That guard fails a boot closed unless XOCHI_SOLVER_* is set,
+# to protect a node that SIGNS origin pulls. This sidecar is read-only and never
+# signs, so the guard is irrelevant here and would force an unrelated env var.
+#
+# The sidecar runs without Erlang distribution (see rel/env.sh.eex), so it holds no
+# cookie-reachable node and no signing key; the distribution/REPL boot gates in
+# Raxol.Payments.Deployment are therefore not wired here.
+if config_env() == :prod do
+  config :logger, level: :info
+
+  {accounting_opts, accounting_enabled} = Raxol.Payments.Accounting.env_config()
+
+  config :raxol_payments, :accounting, accounting_opts
+  config :raxol_acp, accounting_enabled: accounting_enabled
+end

--- a/packages/raxol_acp/mix.exs
+++ b/packages/raxol_acp/mix.exs
@@ -12,6 +12,7 @@ defmodule RaxolAcp.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      releases: releases(),
       dialyzer: [
         ignore_warnings: ".dialyzer_ignore.exs"
       ],
@@ -24,13 +25,30 @@ defmodule RaxolAcp.MixProject do
   end
 
   def application do
-    app = [extra_applications: [:logger]]
+    app = [extra_applications: [:logger, :crypto]]
 
     if Mix.env() != :test do
       Keyword.put(app, :mod, {RaxolAcp.Application, []})
     else
       app
     end
+  end
+
+  # Slim headless release for the read-only settlement-accounting sidecar. Includes
+  # :raxol_acp + its runtime deps (:raxol_payments, :raxol_core, req, cowboy, the
+  # crypto NIFs) but NOT :raxol_terminal -- :raxol_agent/:raxol_mcp are runtime:false,
+  # so the termbox NIF never enters the release. Build with
+  # `MIX_ENV=prod mix release raxol_acp` from this package.
+  defp releases do
+    [
+      raxol_acp: [
+        include_executables_for: [:unix],
+        steps: [:assemble],
+        # runtime_tools makes :observer/:recon remote diagnostics available without
+        # starting anything at boot; everything else is pulled from the dep tree.
+        applications: [runtime_tools: :load]
+      ]
+    ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/packages/raxol_acp/rel/env.sh.eex
+++ b/packages/raxol_acp/rel/env.sh.eex
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Release boot environment for the raxol_acp accounting sidecar.
+#
+# The sidecar is a single, read-only, keyless node. Boot WITHOUT Erlang distribution
+# by default: there is nothing to cluster, so a distributed node would only add a
+# cookie-reachable surface on the shared docker network (and, holding no signing key,
+# gains nothing from it). This also keeps boot clean of the plain-cookie transport
+# that Raxol.Payments.Deployment.assert_distribution_secure!/0 would otherwise flag.
+#
+# An operator who genuinely needs a clustered deploy can override RELEASE_DISTRIBUTION
+# (sname|name) and RELEASE_NODE in the container environment.
+export RELEASE_DISTRIBUTION="${RELEASE_DISTRIBUTION:-none}"

--- a/packages/raxol_payments/lib/raxol/payments/accounting.ex
+++ b/packages/raxol_payments/lib/raxol/payments/accounting.ex
@@ -1,0 +1,92 @@
+defmodule Raxol.Payments.Accounting do
+  @moduledoc """
+  Reads the settlement-accounting deployment contract from the environment.
+
+  The accounting sidecar (a read-only container that books each Xochi settlement
+  into `Raxol.Payments.SettlementLedger`) is configured entirely through env vars.
+  Two deployments read the same contract: the main `raxol` release (root
+  `config/runtime.exs`) and the slim `raxol_acp` sidecar release
+  (`packages/raxol_acp/config/runtime.exs`). Both call `env_config/0` so the
+  contract lives in one place and the two config files cannot drift.
+
+  ## Contract
+
+  | Env var                     | Meaning                                   | Default     |
+  | --------------------------- | ----------------------------------------- | ----------- |
+  | `RAXOL_ACCOUNTING_ENABLED`  | Start the ledger/accountant/monitor tree  | `false`     |
+  | `RPC_ETH` .. `RPC_ROBINHOOD`| Per-chain public RPC URL (read-only)      | (unset)     |
+  | `XOCHI_SOLVER_ADDRESS`      | Solver wallet to read balances for        | (unset)     |
+  | `RAXOL_REBALANCE_INTERVAL_MS`| RebalanceMonitor sweep interval          | `300000`    |
+  | `RAXOL_PRICE_SOURCE`        | USD price source for margin              | `coingecko` |
+
+  Read-only by construction: no wallet key is read here and none of the started
+  processes move funds (the Riddler auto-rebalancer executes; the monitor only
+  recommends). Omitting `XOCHI_SOLVER_ADDRESS` yields ledger-only mode -- the
+  `RebalanceMonitor` is not started (see `Raxol.ACP.Supervisor`).
+  """
+
+  # Chain id => env var holding that chain's RPC URL.
+  @rpc_env %{
+    1 => "RPC_ETH",
+    10 => "RPC_OPTIMISM",
+    137 => "RPC_POLYGON",
+    8453 => "RPC_BASE",
+    42_161 => "RPC_ARBITRUM",
+    4663 => "RPC_ROBINHOOD"
+  }
+
+  @default_rebalance_interval_ms "300000"
+  @default_price_source "coingecko"
+
+  @doc """
+  Reads the accounting contract into the two config values a deployment sets.
+
+  Returns `{accounting_opts, accounting_enabled?}` where `accounting_opts` is the
+  keyword list for `config :raxol_payments, :accounting` and `accounting_enabled?`
+  is the boolean for `config :raxol_acp, accounting_enabled:`.
+  """
+  @spec env_config() :: {keyword(), boolean()}
+  def env_config do
+    accounting = [
+      rpc_urls: rpc_urls(),
+      solver_address: System.get_env("XOCHI_SOLVER_ADDRESS"),
+      rebalance_interval_ms: rebalance_interval_ms(),
+      price_source: price_source()
+    ]
+
+    {accounting, enabled?()}
+  end
+
+  @doc "True when `RAXOL_ACCOUNTING_ENABLED` is exactly `\"true\"`."
+  @spec enabled?() :: boolean()
+  def enabled?,
+    do: System.get_env("RAXOL_ACCOUNTING_ENABLED", "false") == "true"
+
+  # Only chains with a non-empty RPC URL are included, so a partial deployment
+  # (say, Base + Optimism only) reads just those corridors.
+  @spec rpc_urls() :: %{optional(pos_integer()) => String.t()}
+  defp rpc_urls do
+    @rpc_env
+    |> Enum.reduce(%{}, fn {chain_id, env_var}, acc ->
+      case System.get_env(env_var) do
+        url when is_binary(url) and url != "" -> Map.put(acc, chain_id, url)
+        _ -> acc
+      end
+    end)
+  end
+
+  @spec rebalance_interval_ms() :: pos_integer()
+  defp rebalance_interval_ms do
+    String.to_integer(
+      System.get_env("RAXOL_REBALANCE_INTERVAL_MS") ||
+        @default_rebalance_interval_ms
+    )
+  end
+
+  @spec price_source() :: atom()
+  defp price_source do
+    String.to_atom(
+      System.get_env("RAXOL_PRICE_SOURCE") || @default_price_source
+    )
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/accounting_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/accounting_test.exs
@@ -1,0 +1,82 @@
+defmodule Raxol.Payments.AccountingTest do
+  # async: false -- reads/writes process-global OS env vars.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Payments.Accounting
+
+  @env_vars ~w(
+    RAXOL_ACCOUNTING_ENABLED
+    RPC_ETH RPC_OPTIMISM RPC_POLYGON RPC_BASE RPC_ARBITRUM RPC_ROBINHOOD
+    XOCHI_SOLVER_ADDRESS RAXOL_REBALANCE_INTERVAL_MS RAXOL_PRICE_SOURCE
+  )
+
+  setup do
+    saved = Map.new(@env_vars, fn v -> {v, System.get_env(v)} end)
+    Enum.each(@env_vars, &System.delete_env/1)
+
+    on_exit(fn ->
+      Enum.each(saved, fn
+        {v, nil} -> System.delete_env(v)
+        {v, val} -> System.put_env(v, val)
+      end)
+    end)
+
+    :ok
+  end
+
+  describe "enabled?/0" do
+    test "true only when RAXOL_ACCOUNTING_ENABLED is exactly \"true\"" do
+      refute Accounting.enabled?()
+
+      System.put_env("RAXOL_ACCOUNTING_ENABLED", "true")
+      assert Accounting.enabled?()
+
+      for other <- ["false", "1", "TRUE", "yes", ""] do
+        System.put_env("RAXOL_ACCOUNTING_ENABLED", other)
+        refute Accounting.enabled?(), "#{inspect(other)} must not enable accounting"
+      end
+    end
+  end
+
+  describe "env_config/0" do
+    test "defaults: empty rpc map, nil solver, 5-min interval, coingecko" do
+      {opts, enabled?} = Accounting.env_config()
+
+      refute enabled?
+      assert opts[:rpc_urls] == %{}
+      assert opts[:solver_address] == nil
+      assert opts[:rebalance_interval_ms] == 300_000
+      assert opts[:price_source] == :coingecko
+    end
+
+    test "maps each RPC env var to its chain id, dropping unset/blank ones" do
+      System.put_env("RPC_ETH", "https://eth.example")
+      System.put_env("RPC_BASE", "https://base.example")
+      System.put_env("RPC_ROBINHOOD", "https://rh.example")
+      # blank must be treated as unset
+      System.put_env("RPC_POLYGON", "")
+
+      {opts, _} = Accounting.env_config()
+
+      assert opts[:rpc_urls] == %{
+               1 => "https://eth.example",
+               8453 => "https://base.example",
+               4663 => "https://rh.example"
+             }
+    end
+
+    test "reads solver address, interval, price source, and the enabled flag" do
+      System.put_env("RAXOL_ACCOUNTING_ENABLED", "true")
+      System.put_env("XOCHI_SOLVER_ADDRESS", "0x97D4")
+      System.put_env("RAXOL_REBALANCE_INTERVAL_MS", "60000")
+      System.put_env("RAXOL_PRICE_SOURCE", "none")
+
+      {opts, enabled?} = Accounting.env_config()
+
+      assert enabled?
+      assert opts[:solver_address] == "0x97D4"
+      assert opts[:rebalance_interval_ms] == 60_000
+      assert opts[:price_source] == :none
+    end
+  end
+end


### PR DESCRIPTION
## Context

The ansible-riddler ops side has a **read-only settlement-accounting container** staged and
dormant to run beside `riddler-solver`, but it cannot deploy because this repo publishes no
image to pull. This ships that image.

Reframing that drove the approach: the accounting **application layer was already built and
wired** — `Raxol.ACP.Supervisor.accounting_children/0` starts `SettlementLedger` +
`SettlementAccountant` (+ `RebalanceMonitor` when a solver address is set), and
`config/runtime.exs` already read the ops env contract. Only **packaging** was missing.

Decision: ship the sidecar (not fold P&L into Riddler), **defer OTLP** (SigNoz is down, nothing
to land on), publish under `ghcr.io/droodotfoo/raxol-acp`.

## What changed

- **Slim release** — `releases/0` in `packages/raxol_acp/mix.exs`. Excludes `raxol_terminal`:
  `raxol_agent`/`raxol_mcp` are `runtime: false`, so the termbox NIF never enters the release.
- **Shared env helper** — `Raxol.Payments.Accounting.env_config/0` is the single source for the
  accounting env contract, read by **both** the root and the sidecar `config/runtime.exs` so
  they cannot drift. Root call is `Code.ensure_loaded?`-guarded (main raxol doesn't depend on
  raxol_payments).
- **Release config** — `packages/raxol_acp/config/{config,runtime}.exs`. Deliberately excludes
  the origin-pull solver-pin guard (the sidecar is read-only and never signs).
- **Non-distributed boot** — `packages/raxol_acp/rel/env.sh.eex` sets `RELEASE_DISTRIBUTION=none`
  (override-able): a keyless single node with no cookie-reachable surface.
- **Production Dockerfile** — `docker/Dockerfile.raxol-acp`, multi-stage. The builder carries a C
  toolchain (the build transitively compiles termbox via the `raxol_agent` compile-time dep),
  but the runtime image is slim and termbox-free. No Rust/Node (crypto NIFs are
  rustler_precompiled).
- **GHCR publish workflow** — `.github/workflows/release-raxol-acp.yml`, standalone (does not
  touch the broken root `release.yml`). Trigger: tag `raxol-acp-v*` or `workflow_dispatch` with
  a `push:false` build-only dry-run. Pushes natively via `GITHUB_TOKEN`; prints the digest.

## Manual testing

- [x] `MIX_ENV=prod mix release raxol_acp` — `_build/prod/rel/raxol_acp/lib` has **no
  raxol_terminal / no termbox `.so`**; only the two rustler_precompiled crypto NIFs ship.
- [x] Boot with `RAXOL_ACCOUNTING_ENABLED=true` + solver → `SettlementLedger` +
  `SettlementAccountant` + `RebalanceMonitor` all start.
- [x] Boot with accounting on, **no** `XOCHI_SOLVER_ADDRESS` → ledger + accountant start,
  monitor does **not** (v1 ledger-only, no code flag).
- [x] Boot with accounting off (default) → nothing starts, clean.
- [x] `Node.alive?() == false` on boot (non-distributed).
- [x] `raxol_payments` 866 tests / 0 failures (+ new `accounting_test.exs`); `raxol_acp` 639 / 0.
- [x] `mix format` + `mix credo --strict` clean.
- [ ] **Docker image build** — not run locally (daemon was down). Validate via the workflow
  `workflow_dispatch` with `push:false` (build-only dry run).

## After merge (deploy side)

1. Tag `raxol-acp-v0.2.0-pre.0` (or dispatch with `push:true`); grab the digest from the job
   summary. Recommend a `push:false` dry-run first to validate the Docker build in CI.
2. Make the GHCR package public (keyless, read-only image → no PAT/org coupling), or confirm the
   axol-io PAT can read a DROOdotFOO package.
3. Hand ops the digest for `raxol_acp_image_digest`, then flip `raxol_accounting_enabled: true`.

OTLP export stays deferred (tracked) until SigNoz is back on mini-axol; the `LoggerHandler`
gives log-based P&L observability today.
