### PR TITLE
Note stealth in Xochi conformance comment

### DIFF
--- a/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
@@ -112,8 +112,9 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
     end
   end
 
-  # The conformance.json generator only emits `public` Xochi vectors, so the
-  # shielded (Aztec) signature is pinned directly against the CLI's own pin.
+  # The conformance.json generator emits `public` and `stealth` Xochi vectors
+  # but not `shielded` (Aztec), so the shielded signature is pinned directly
+  # against the CLI's own pin.
   # Shielded settlement is note-based and carries no stealth address; the only
   # client-side artifact is this signature, so a regression in EIP-712 hashing
   # or the settlementPreference binding is caught here without a live solver.


### PR DESCRIPTION
Corrects a stale comment in the Xochi conformance test. The comment
claimed the `conformance.json` generator emits only `public` Xochi
vectors, but riddler-client now emits both `public` and `stealth`
vectors (only `shielded`/Aztec is absent, which is why the shielded
signature is still pinned manually).

Comment-only change; test behavior is unchanged.

### Evidence the corrected wording is accurate
- `test/raxol/payments/xochi/stealth_conformance_test.exs` exists as a
  dedicated stealth conformance suite.
- `xochi_conformance_test.exs:133` asserts `settlementPreference` binding
  over `~w(public stealth shielded)`.
- Only the `shielded` vector is pinned inline (`@shielded_signature`)
  because the generator does not emit it.

### Provenance
Salvaged from the abandoned `chore/xochi-conformance-comment` branch
(commit `f0cbb4b4`), cherry-picked clean onto current master during a
stale-branch triage. The other two branches flagged for salvage
(`feat/osc8-hyperlinks` OSC 8 coalescing, `fix-xochi-gate-runner`
ErrorRecovery teardown guard) turned out to be already in master via
re-implementation, so nothing to carry forward there.

### Manual testing
- [ ] `MIX_ENV=test mix format --check-formatted`
- [ ] `cd packages/raxol_payments && MIX_ENV=test mix test --only conformance`
