### PR TITLE
ACP first offering: pure-storefront relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,6 @@ HANDOVER.md
 *HANDOVER.md
 *Engineering Review*.md
 *_integration_plan.md
+*SECURITY_FINDINGS.md
+*_FINDINGS.md
 packages/*/doc/

--- a/packages/raxol_acp/lib/raxol/acp/contract_client/onchain.ex
+++ b/packages/raxol_acp/lib/raxol/acp/contract_client/onchain.ex
@@ -481,14 +481,32 @@ defmodule Raxol.ACP.ContractClient.Onchain do
       ABI.encode_call(@sig_get_nonce, [{"address", account}, {"uint192", key}])
 
     case RPC.eth_call(ctx.client, %{to: ctx.wallet.entry_point(), data: call_data}) do
-      {:ok, hex} -> {:ok, decode_uint256(hex)}
-      {:error, _} = err -> err
+      {:ok, hex} ->
+        case decode_uint256(hex) do
+          {:ok, nonce} -> {:ok, nonce}
+          :error -> {:error, {:invalid_nonce_response, hex}}
+        end
+
+      {:error, _} = err ->
+        err
     end
   end
 
-  defp decode_uint256("0x" <> ""), do: 0
-  defp decode_uint256("0x" <> hex), do: String.to_integer(hex, 16)
-  defp decode_uint256(_), do: 0
+  # Decode an eth_call uint256 result. Fails closed on a malformed / non-hex
+  # response rather than raising (a bad RPC reply must not crash the send
+  # pipeline, nor silently become nonce 0). Exposed for tests.
+  @doc false
+  @spec decode_uint256(binary()) :: {:ok, non_neg_integer()} | :error
+  def decode_uint256("0x"), do: {:ok, 0}
+
+  def decode_uint256("0x" <> hex) do
+    case Integer.parse(hex, 16) do
+      {n, ""} when n >= 0 -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  def decode_uint256(_), do: :error
 
   defp send_with(ctx, method, call_data) do
     case nonce(ctx) do
@@ -638,23 +656,21 @@ defmodule Raxol.ACP.ContractClient.Onchain do
 
   # -- Nonce / fee / gas --
 
+  # The seeding step and the counter increment must not straddle two separate
+  # NonceServer calls: a peek/reset/get_next sequence lets two concurrent
+  # first-txs both observe an unseeded counter and collide on the same nonce
+  # (and a late reset can clobber a higher counter). `get_next_if_seeded/0` +
+  # `seed_and_next/1` do the reconciliation atomically inside the GenServer,
+  # keeping the "pending" fetch outside it.
   defp nonce(ctx) do
-    address = ctx.wallet.address()
+    case NonceServer.get_next_if_seeded() do
+      {:ok, n} ->
+        {:ok, n}
 
-    case NonceServer.peek() do
-      n when is_integer(n) and n > 0 ->
-        # Local NonceServer has been seeded; trust it.
-        {:ok, NonceServer.get_next()}
-
-      _ ->
-        # Fall back to chain-side pending nonce on first use.
-        case RPC.get_transaction_count(ctx.client, address) do
-          {:ok, n} ->
-            :ok = NonceServer.reset(n)
-            {:ok, NonceServer.get_next()}
-
-          {:error, _} = err ->
-            err
+      :unseeded ->
+        case RPC.get_transaction_count(ctx.client, ctx.wallet.address()) do
+          {:ok, chain_n} -> {:ok, NonceServer.seed_and_next(chain_n)}
+          {:error, _} = err -> err
         end
     end
   end

--- a/packages/raxol_acp/lib/raxol/acp/hook_client.ex
+++ b/packages/raxol_acp/lib/raxol/acp/hook_client.ex
@@ -137,10 +137,16 @@ defmodule Raxol.ACP.HookClient do
   @doc """
   Submit `createJob(...)` on ACP Core.
 
-  v2's createJob signature (from acp-node-v2 source):
+  Matches the deployed `AgenticCommerceV3` core (Blockscout-verified on Base):
 
       createJob(address provider, address evaluator, uint256 expiredAt,
-                address hookAddress, bytes hookData)
+                string description, address hook)
+
+  `hook` is the whitelisted hook contract (e.g. the FundTransferHook).
+  Per-call hook parameters are NOT passed here -- `createJob` takes no
+  `hookData`; the hook `optParams` flow through `setBudget`/`fund`/`submit`/
+  `complete` instead. `description` is the job's human-readable string
+  (defaults to `""`).
 
   Returns the assigned jobId via a separate `getJobIdFromTxHash` call
   in the SDK; this function returns the tx hash and lets the caller
@@ -151,31 +157,37 @@ defmodule Raxol.ACP.HookClient do
           chain_id(),
           String.t(),
           %{
-            provider: String.t(),
-            evaluator: String.t(),
-            expired_at: non_neg_integer(),
-            hook_address: String.t(),
-            hook_data: binary()
+            required(:provider) => String.t(),
+            required(:evaluator) => String.t(),
+            required(:expired_at) => non_neg_integer(),
+            required(:hook_address) => String.t(),
+            optional(:description) => String.t()
           }
         ) :: {:ok, tx_hash()} | {:error, term()}
-  def create_job(adapter, chain_id, acp_core_address, %{
-        provider: provider,
-        evaluator: evaluator,
-        expired_at: expired_at,
-        hook_address: hook_address,
-        hook_data: hook_data
-      }) do
+  def create_job(
+        adapter,
+        chain_id,
+        acp_core_address,
+        %{
+          provider: provider,
+          evaluator: evaluator,
+          expired_at: expired_at,
+          hook_address: hook_address
+        } = params
+      ) do
+    description = Map.get(params, :description, "")
+
     submit_single(
       adapter,
       chain_id,
       acp_core_address,
-      "createJob(address,address,uint256,address,bytes)",
+      "createJob(address,address,uint256,string,address)",
       [
         {"address", provider},
         {"address", evaluator},
         {"uint256", expired_at},
-        {"address", hook_address},
-        {"bytes", hook_data}
+        {"string", description},
+        {"address", hook_address}
       ]
     )
   end

--- a/packages/raxol_acp/lib/raxol/acp/onchain/permit2_approver.ex
+++ b/packages/raxol_acp/lib/raxol/acp/onchain/permit2_approver.ex
@@ -30,8 +30,11 @@ defmodule Raxol.ACP.Onchain.Permit2Approver do
           Raxol.ACP.ProviderAdapter.get_address(provider)
         )
 
-  The provider's EOA must be the same origin address the Xochi transfer signs its
-  Permit2 authorization from, since that is the address Permit2 pulls from.
+  The EOA behind `provider` (the JSON-RPC `ProviderAdapter`) must be the origin
+  wallet that signs the Xochi Permit2 authorization, since that is the address
+  Permit2 pulls from. In the storefront model the BUYER signs and holds this
+  allowance (raxol relays the buyer's signed intent and never pulls), so pass the
+  buyer's wallet here -- not the storefront/ACP-provider wallet.
   """
 
   alias Raxol.ACP.{ABI, ProviderAdapter}

--- a/packages/raxol_acp/lib/raxol/acp/onchain/transaction.ex
+++ b/packages/raxol_acp/lib/raxol/acp/onchain/transaction.ex
@@ -99,13 +99,25 @@ defmodule Raxol.ACP.Onchain.Transaction do
   payload.
 
   `signature` must be a 65-byte binary in `<<r::32, s::32, v::8>>` form.
-  `v` is the y-parity (0 or 1) returned by ExSecp256k1.sign/2.
+  `v` may be the y-parity (0/1) or Ethereum's legacy 27/28 form; it is
+  normalized to the 0/1 y-parity an EIP-1559 payload requires.
   """
   @spec serialize(t(), signature()) :: binary()
   def serialize(%__MODULE__{} = tx, <<r::binary-size(32), s::binary-size(32), v::8>>) do
-    fields = unsigned_fields(tx) ++ [v, strip_leading_zero_bytes(r), strip_leading_zero_bytes(s)]
+    fields =
+      unsigned_fields(tx) ++
+        [y_parity(v), strip_leading_zero_bytes(r), strip_leading_zero_bytes(s)]
+
     <<@type_byte>> <> Rlp.encode(fields)
   end
+
+  # EIP-1559 typed transactions carry the signature y-parity (0 or 1). Wallets
+  # pack signatures in Ethereum's legacy 27/28 form (see
+  # `Raxol.Payments.EIP712.pack_signature/1`), so normalize before encoding --
+  # a 27/28 value left in the y-parity slot makes strict decoders (alloy, and
+  # thus anvil / real nodes) reject the transaction as undecodable.
+  defp y_parity(v) when v in [0, 1], do: v
+  defp y_parity(v) when v in [27, 28], do: v - 27
 
   @doc """
   Convert a 0x-prefixed (or unprefixed) hex address to a 20-byte

--- a/packages/raxol_acp/lib/raxol/acp/seller/backend/web_socket/protocol.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/backend/web_socket/protocol.ex
@@ -105,7 +105,13 @@ defmodule Raxol.ACP.Seller.Backend.WebSocket.Protocol do
   log/telemetry and keep the connection alive.
   """
   @spec decode(binary()) :: decoded()
-  def decode(@eio_open <> rest), do: {:open, decode_json!(rest)}
+  def decode(@eio_open <> rest) do
+    case parse_json(rest) do
+      {:ok, map} when is_map(map) -> {:open, map}
+      _ -> {:unknown, @eio_open <> rest}
+    end
+  end
+
   def decode(@eio_close), do: :close
   def decode(@eio_close <> _), do: :close
   def decode(@eio_ping), do: :ping
@@ -148,28 +154,46 @@ defmodule Raxol.ACP.Seller.Backend.WebSocket.Protocol do
 
   # -- Internal: Socket.IO packet decoder --
 
-  defp decode_message(@sio_connect <> rest), do: {:connect_ok, decode_optional_json(rest)}
+  defp decode_message(@sio_connect <> rest) do
+    case parse_json(rest) do
+      {:ok, map} when is_map(map) -> {:connect_ok, map}
+      _ -> {:unknown, @eio_message <> @sio_connect <> rest}
+    end
+  end
+
   defp decode_message(@sio_disconnect <> _), do: :disconnect
   defp decode_message(@sio_event <> rest), do: decode_event(rest)
   defp decode_message(@sio_ack <> rest), do: decode_ack_frame(rest)
 
-  defp decode_message(@sio_connect_error <> rest),
-    do: {:connect_error, decode_optional_json(rest)}
+  defp decode_message(@sio_connect_error <> rest) do
+    case parse_json(rest) do
+      {:ok, term} -> {:connect_error, term}
+      :error -> {:unknown, @eio_message <> @sio_connect_error <> rest}
+    end
+  end
 
   defp decode_message(other), do: {:unknown, @eio_message <> other}
 
-  # EVENT body is `<ack_id?><json_array>`. ack_id is an optional run
-  # of digits; if present the server wants an ACK back with that id.
+  # EVENT body is `<ack_id?><json_array>`. ack_id is an optional run of digits;
+  # if present the server wants an ACK back with that id. A non-array body or
+  # invalid JSON is surfaced as `{:unknown, raw}` rather than crashing the
+  # connection -- a malformed frame from the server must not take the link down.
   defp decode_event(body) do
     {ack_id, json} = split_leading_digits(body)
-    [name | args] = decode_json!(json)
-    {:event, name, args, ack_id}
+
+    case parse_json(json) do
+      {:ok, [name | args]} -> {:event, name, args, ack_id}
+      _ -> {:unknown, @eio_message <> @sio_event <> body}
+    end
   end
 
   defp decode_ack_frame(body) do
     {ack_id, json} = split_leading_digits(body)
-    ack_id || raise ArgumentError, "Raxol.ACP.Seller.Backend.WebSocket.Protocol: ACK without id"
-    {:ack, ack_id, decode_json!(json)}
+
+    case {ack_id, parse_json(json)} do
+      {id, {:ok, payload}} when is_integer(id) and is_list(payload) -> {:ack, id, payload}
+      _ -> {:unknown, @eio_message <> @sio_ack <> body}
+    end
   end
 
   defp split_leading_digits(body) do
@@ -179,9 +203,15 @@ defmodule Raxol.ACP.Seller.Backend.WebSocket.Protocol do
     end
   end
 
-  defp decode_json!(""), do: %{}
-  defp decode_json!(json), do: Jason.decode!(json)
+  # Tolerant JSON parse. An empty body is the empty object (Socket.IO sends
+  # bodyless CONNECT/ACK frames); anything unparseable is `:error` so the caller
+  # can surface `{:unknown, raw}` instead of raising.
+  defp parse_json(""), do: {:ok, %{}}
 
-  defp decode_optional_json(""), do: %{}
-  defp decode_optional_json(json), do: Jason.decode!(json)
+  defp parse_json(json) do
+    case Jason.decode(json) do
+      {:ok, term} -> {:ok, term}
+      {:error, _} -> :error
+    end
+  end
 end

--- a/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
@@ -11,10 +11,21 @@ defmodule Raxol.ACP.Seller.Queue do
   ## Configuration
 
       config :raxol_acp,
-        seller_address: "0x..."   # 0x string, surfaced in handler ctx
+        seller_address: "0x...",          # 0x string, surfaced in handler ctx
+        seller_max_active_jobs: 100        # backpressure cap (default 100)
 
   Read from `Application` on every dispatch (not cached) so the seller
-  address can be rotated without restarting the supervision tree.
+  address and cap can be rotated without restarting the supervision tree.
+
+  ## Backpressure
+
+  A `:job_offered` starts a supervised `Job.Server`, so an unbounded stream of
+  offers is an unbounded stream of processes. The Queue caps concurrent jobs at
+  `:seller_max_active_jobs`: once `Job.Supervisor.active_count/0` reaches the cap,
+  further offers are dropped with reason `:at_capacity` (the seller is simply
+  full) rather than started. Events for jobs already in flight are never capped.
+  Because an over-cap offer is O(1) to reject, a flood drains the mailbox fast
+  instead of exhausting memory.
 
   ## Events handled
 
@@ -41,7 +52,8 @@ defmodule Raxol.ACP.Seller.Queue do
   - `[:raxol, :acp, :seller, :queue, :dropped]` -- event dropped.
     Metadata: `%{type, job_id, reason}` where reason is one of
     `:offering_not_registered`, `:job_not_running`, `:start_failed`,
-    `:unknown_event`.
+    `:at_capacity`, `:malformed`, `:unknown_event`, or
+    `{:handler_error, reason}`.
   """
 
   use Raxol.Core.Behaviours.BaseManager
@@ -59,9 +71,13 @@ defmodule Raxol.ACP.Seller.Queue do
   @doc """
   Dispatch a backend event. Asynchronous: returns `:ok` immediately and
   the Queue processes the event in its mailbox.
+
+  Accepts any map: a malformed event (wrong shape, missing keys) is dropped
+  with telemetry inside the Queue rather than crashing the caller, so a
+  misbehaving backend cannot take the dispatch path down.
   """
   @spec dispatch(map()) :: :ok
-  def dispatch(%{type: type} = event) when is_atom(type) do
+  def dispatch(event) when is_map(event) do
     GenServer.cast(__MODULE__, {:dispatch, event})
   end
 
@@ -81,68 +97,105 @@ defmodule Raxol.ACP.Seller.Queue do
   end
 
   defp read_defaults do
-    %{seller_address: Application.get_env(:raxol_acp, :seller_address)}
+    %{
+      seller_address: Application.get_env(:raxol_acp, :seller_address),
+      max_active_jobs: Application.get_env(:raxol_acp, :seller_max_active_jobs, 100)
+    }
   end
 
   # -- Event handlers --
+  #
+  # Each clause requires the keys it needs in the head, so a malformed backend
+  # event (missing job_id / offering / payload) drops with telemetry instead of
+  # crashing the Queue. Downstream Job.Server results are checked -- a failed
+  # transition drops with `{:handler_error, reason}` rather than being reported
+  # as a successful dispatch.
 
-  defp handle_event(%{type: :job_offered} = event, state) do
-    %{job_id: job_id, offering: name} = event
+  @known_types [:job_offered, :payment_received, :approval_received, :job_expired]
 
+  defp handle_event(%{type: :job_offered, job_id: job_id, offering: name} = event, state) do
     with {:ok, spec} <- lookup_offering(name, job_id),
+         :ok <- within_capacity(job_id, name, state),
          {:ok, _pid} <- start_job(event, spec, state) do
-      _ = Job.Server.accept_request(job_id)
-      emit(:dispatched, %{type: :job_offered, job_id: job_id, offering: name})
+      dispatch_result(Job.Server.accept_request(job_id), %{
+        type: :job_offered,
+        job_id: job_id,
+        offering: name
+      })
     end
   end
 
-  defp handle_event(%{type: :payment_received} = event, _state) do
-    %{job_id: job_id, payload: payload} = event
+  defp handle_event(%{type: :payment_received, job_id: job_id, payload: payload} = event, _state) do
     signature = Map.get(event, :signature)
 
-    case Job.Registry.whereis(job_id) do
-      :undefined ->
-        emit(:dropped, %{type: :payment_received, job_id: job_id, reason: :job_not_running})
-
-      _pid ->
-        _ = Job.Server.accept_payment(job_id, payload, signature)
-        emit(:dispatched, %{type: :payment_received, job_id: job_id})
-    end
+    route(:payment_received, job_id, fn ->
+      Job.Server.accept_payment(job_id, payload, signature)
+    end)
   end
 
-  defp handle_event(%{type: :approval_received} = event, _state) do
-    %{job_id: job_id, payload: payload} = event
+  defp handle_event(%{type: :approval_received, job_id: job_id, payload: payload} = event, _state) do
     signature = Map.get(event, :signature)
-
-    case Job.Registry.whereis(job_id) do
-      :undefined ->
-        emit(:dropped, %{type: :approval_received, job_id: job_id, reason: :job_not_running})
-
-      _pid ->
-        _ = Job.Server.approve(job_id, payload, signature)
-        emit(:dispatched, %{type: :approval_received, job_id: job_id})
-    end
+    route(:approval_received, job_id, fn -> Job.Server.approve(job_id, payload, signature) end)
   end
 
-  defp handle_event(%{type: :job_expired} = event, _state) do
-    %{job_id: job_id} = event
+  defp handle_event(%{type: :job_expired, job_id: job_id} = event, _state) do
     reason = Map.get(event, :reason, "expired")
 
-    case Job.Registry.whereis(job_id) do
-      :undefined ->
-        emit(:dropped, %{type: :job_expired, job_id: job_id, reason: :job_not_running})
+    route(:job_expired, job_id, fn ->
+      Job.Server.transition(job_id, :expire, %{reason: inspect(reason)}, <<>>)
+    end)
+  end
 
-      _pid ->
-        _ = Job.Server.transition(job_id, :expire, %{reason: inspect(reason)}, <<>>)
-        emit(:dispatched, %{type: :job_expired, job_id: job_id})
-    end
+  # A known type that reaches here is missing a required field -- malformed, not
+  # an unrecognised type.
+  defp handle_event(%{type: type} = event, _state) when type in @known_types do
+    emit(:dropped, %{type: type, job_id: Map.get(event, :job_id), reason: :malformed})
   end
 
   defp handle_event(%{type: type} = event, _state) do
     emit(:dropped, %{type: type, job_id: Map.get(event, :job_id), reason: :unknown_event})
   end
 
+  defp handle_event(event, _state) do
+    emit(:dropped, %{
+      type: Map.get(event, :type),
+      job_id: Map.get(event, :job_id),
+      reason: :malformed
+    })
+  end
+
   # -- Helpers --
+
+  # Route an event to a running Job.Server, checking the result so a failed
+  # transition is reported as a drop, not a dispatch.
+  defp route(type, job_id, fun) do
+    case Job.Registry.whereis(job_id) do
+      :undefined ->
+        emit(:dropped, %{type: type, job_id: job_id, reason: :job_not_running})
+
+      _pid ->
+        dispatch_result(fun.(), %{type: type, job_id: job_id})
+    end
+  end
+
+  defp dispatch_result({:error, reason}, meta),
+    do: emit(:dropped, Map.put(meta, :reason, {:handler_error, reason}))
+
+  defp dispatch_result(_ok, meta), do: emit(:dispatched, meta)
+
+  # Backpressure: cap the number of concurrent job processes. When the seller is
+  # already at `:seller_max_active_jobs` (default 100), a fresh :job_offered is
+  # rejected rather than started, so a flood of offers from a misbehaving or
+  # compromised backend cannot exhaust processes/memory. Events for jobs already
+  # in flight (payment/approval/expiry) are never capped.
+  defp within_capacity(job_id, name, %{max_active_jobs: max}) do
+    if Job.Supervisor.active_count() < max do
+      :ok
+    else
+      emit(:dropped, %{type: :job_offered, job_id: job_id, offering: name, reason: :at_capacity})
+      :error
+    end
+  end
 
   defp lookup_offering(name, job_id) do
     case OfferingRegistry.lookup(name) do

--- a/packages/raxol_acp/lib/raxol/acp/supervisor.ex
+++ b/packages/raxol_acp/lib/raxol/acp/supervisor.ex
@@ -38,12 +38,10 @@ defmodule Raxol.ACP.Supervisor do
 
   @impl true
   def init(_opts) do
-    initial_nonce = Application.get_env(:raxol_acp, :initial_nonce, 0)
-
     base = [
       Raxol.ACP.Job.Registry,
       Raxol.ACP.JobSession.Registry,
-      {Raxol.ACP.Wallet.NonceServer, [initial_nonce: initial_nonce]},
+      nonce_server_child(),
       Raxol.ACP.Offering.Registry,
       Raxol.ACP.Job.Store,
       Raxol.ACP.Job.Supervisor,
@@ -71,6 +69,18 @@ defmodule Raxol.ACP.Supervisor do
       max_restarts: 100,
       max_seconds: 5
     )
+  end
+
+  # Start the umbrella NonceServer seeded only when an operator has explicitly
+  # configured `:initial_nonce`. Otherwise start it unseeded so the first
+  # transaction reconciles the nonce from the chain
+  # (`eth_getTransactionCount(addr, "pending")`) rather than assuming 0 and
+  # colliding with the wallet's on-chain history.
+  defp nonce_server_child do
+    case Application.fetch_env(:raxol_acp, :initial_nonce) do
+      {:ok, n} -> {Raxol.ACP.Wallet.NonceServer, [initial_nonce: n]}
+      :error -> Raxol.ACP.Wallet.NonceServer
+    end
   end
 
   # Settlement accounting + rebalance advisor (recommend-only). Off unless

--- a/packages/raxol_acp/lib/raxol/acp/wallet/nonce_server.ex
+++ b/packages/raxol_acp/lib/raxol/acp/wallet/nonce_server.ex
@@ -54,7 +54,11 @@ defmodule Raxol.ACP.Wallet.NonceServer do
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
     initial = Keyword.get(opts, :initial_nonce, 0)
-    GenServer.start_link(__MODULE__, %{nonce: initial}, name: name)
+    # A server that was handed an explicit initial_nonce is already seeded
+    # (the caller asserts they know the on-chain count); a default server
+    # starts unseeded so the first user reconciles it from chain.
+    seeded = Keyword.get(opts, :seeded, Keyword.has_key?(opts, :initial_nonce))
+    GenServer.start_link(__MODULE__, %{nonce: initial, seeded: seeded}, name: name)
   end
 
   @doc """
@@ -83,11 +87,55 @@ defmodule Raxol.ACP.Wallet.NonceServer do
 
   Call this after reconciling with on-chain state (e.g. when an external
   transaction bumped the nonce, or after a transaction failed and we want
-  to retry the same nonce). Returns `:ok`.
+  to retry the same nonce). Marks the server seeded. Returns `:ok`.
   """
   @spec reset(server(), non_neg_integer()) :: :ok
   def reset(server \\ __MODULE__, nonce) when is_integer(nonce) and nonce >= 0 do
     GenServer.call(server, {:reset, nonce})
+  end
+
+  @doc """
+  Mark the server unseeded so the next `get_next_if_seeded/1` returns
+  `:unseeded` and the caller re-fetches the on-chain count.
+
+  Use this to recover from suspected nonce drift -- e.g. an external system
+  signed a transaction from the same wallet, so the local counter can no
+  longer be trusted and must be reconciled from chain. Returns `:ok`.
+  """
+  @spec resync(server()) :: :ok
+  def resync(server \\ __MODULE__) do
+    GenServer.call(server, :resync)
+  end
+
+  @doc """
+  Return the next nonce only if the counter has been seeded from chain
+  (via `reset/2`, `seed_and_next/2`, or an explicit `:initial_nonce`).
+
+  Returns `{:ok, nonce}` when seeded, or `:unseeded` otherwise -- in which
+  case the caller should fetch `eth_getTransactionCount(addr, "pending")`
+  and seed atomically via `seed_and_next/2`. Splitting the check from the
+  seed keeps the on-chain fetch outside the GenServer while still closing
+  the seeding race.
+  """
+  @spec get_next_if_seeded(server()) :: {:ok, non_neg_integer()} | :unseeded
+  def get_next_if_seeded(server \\ __MODULE__) do
+    GenServer.call(server, :get_next_if_seeded)
+  end
+
+  @doc """
+  Adopt `chain_nonce` as the counter base and return the next nonce -- but
+  only if the counter is still unseeded.
+
+  This closes the first-use race: if two callers both observe `:unseeded`
+  and both fetch the same on-chain count, the first to call `seed_and_next/2`
+  adopts it; the second's `chain_nonce` is ignored and it is handed the
+  current local next nonce instead. Either way every caller receives a
+  unique, monotonic nonce -- never a duplicate.
+  """
+  @spec seed_and_next(server(), non_neg_integer()) :: non_neg_integer()
+  def seed_and_next(server \\ __MODULE__, chain_nonce)
+      when is_integer(chain_nonce) and chain_nonce >= 0 do
+    GenServer.call(server, {:seed_and_next, chain_nonce})
   end
 
   # -- GenServer callbacks --
@@ -105,6 +153,33 @@ defmodule Raxol.ACP.Wallet.NonceServer do
   end
 
   def handle_manager_call({:reset, n}, _from, state) do
-    {:reply, :ok, %{state | nonce: n}}
+    {:reply, :ok, %{state | nonce: n, seeded: true}}
+  end
+
+  def handle_manager_call(:resync, _from, state) do
+    {:reply, :ok, %{state | seeded: false}}
+  end
+
+  def handle_manager_call(:get_next_if_seeded, _from, %{seeded: true, nonce: n} = state) do
+    {:reply, {:ok, n}, %{state | nonce: n + 1}}
+  end
+
+  def handle_manager_call(:get_next_if_seeded, _from, %{seeded: false} = state) do
+    {:reply, :unseeded, state}
+  end
+
+  # Still unseeded: adopt the chain nonce as the base.
+  def handle_manager_call({:seed_and_next, chain_nonce}, _from, %{seeded: false} = state) do
+    {:reply, chain_nonce, %{state | nonce: chain_nonce + 1, seeded: true}}
+  end
+
+  # Already seeded by a racing caller: ignore the chain nonce, hand out the
+  # current local next so the two callers never collide.
+  def handle_manager_call(
+        {:seed_and_next, _chain_nonce},
+        _from,
+        %{seeded: true, nonce: n} = state
+      ) do
+    {:reply, n, %{state | nonce: n + 1}}
   end
 end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -1,44 +1,43 @@
 defmodule Raxol.ACP.Xochi.Offering do
   @moduledoc """
-  Draft Xochi cross-chain intent offering schema for the Virtuals ACP
-  marketplace.
+  Xochi cross-chain intent offering schema for the Virtuals ACP marketplace.
 
-  Xochi launches as a **fund-transfer agent**: the buyer creates a job
-  whose hookAddress is the v2 `FundTransferHook`, escrows funds, and
-  the Xochi solver agent uses `setBudgetWithFundRequest(budget,
-  transferAmount, destination)` to (a) take its service fee from the
-  escrow and (b) route the rest through Xochi's quote+execute flow to
-  the buyer-specified destination on a different chain.
+  Raxol sells this as a **pure storefront**: the buyer quotes and signs a Xochi
+  cross-chain intent against Xochi itself, then creates a **plain** ACP job
+  (hook = `address(0)`) whose budget is raxol's storefront fee. On funding, the
+  storefront relays the buyer's pre-signed intent to Xochi (via
+  `Raxol.ACP.Xochi.Settler` -> `Raxol.Payments.Protocols.Xochi.execute_signed/2`)
+  and polls it to settlement. raxol never signs the transfer and never touches
+  the transferred funds -- the transfer moves through Xochi off-escrow, so the
+  ACP core's platform/evaluator take never bites the transfer amount. raxol
+  earns the storefront fee: on `complete`, the provider nets `budget * 0.90`.
 
-  This module defines the offering's JSON schema (for marketplace
-  registration), the canonical request shape, and the deliverable
-  shape Xochi returns when the intent settles.
+  This module defines the offering's JSON schema (for marketplace registration),
+  the canonical request shape (which carries the buyer's signed intent bundle),
+  and the deliverable shape returned when the intent settles.
 
   ## Lifecycle
 
-      job.created      -> buyer initiated, awaiting provider acceptance
-      budget.set       -> Xochi quoted; budget = service fee in USDC
-      job.funded       -> buyer escrowed the full transfer + fee
-      job.submitted    -> Xochi.execute returned an intent_id; solver
+      job.created      -> buyer initiated a plain job, awaiting acceptance
+      budget.set       -> storefront proposes budget = its fee (bps of transfer)
+      job.funded       -> buyer escrowed the storefront fee
+      job.submitted    -> storefront relayed the buyer's signed intent; solver
                           fills cross-chain; deliverable = { intent_id,
-                          src_tx_hash, dst_tx_hash, status }
-      job.completed    -> buyer verifies dst_tx; FundTransferHook
-                          releases escrow
+                          settlement_tx_hash, receiving_tx_hash, status }
+      job.completed    -> buyer verifies dst_tx; provider nets budget*0.90
 
-  The deliverable surfaces both src and dst transaction hashes so the
-  buyer (or an evaluator agent) can verify the cross-chain settlement
-  on-chain before approving.
+  The deliverable surfaces both src and dst transaction hashes so the buyer (or
+  an evaluator agent) can verify the cross-chain settlement on-chain before
+  approving.
 
-  ## Known limitations
+  ## Safety: the buyer signs, Riddler verifies
 
-  A `settlement_preference` of `private` is honored only on corridors that
-  support Xochi's dark-pool path. This offering does not yet surface a
-  privacy-downgrade warning when a requested-private route can only settle
-  publicly (the way the relay rail warns `:stealth_unavailable_on_tron`). This
-  is currently moot because the Xochi corridors are EVM-only and all support the
-  private path; it becomes relevant if a public-only chain (for example Tron) is
-  added, at which point a private request on that route would settle publicly and
-  should refuse or warn rather than silently downgrade.
+  Because the buyer signs the EIP-712 intent (and any origin-pull authorization)
+  against Xochi, and Riddler verifies it against its own server-persisted quote,
+  neither raxol nor the buyer can forge the amount or route. raxol relays the
+  opaque bundle without inspecting or re-signing it, so the destination, privacy
+  tier, and route are whatever the buyer signed -- there is no same-owner or
+  public-only gate on raxol's side (there is nothing raxol could misroute).
 
   ## Marketplace registration
 
@@ -60,11 +59,11 @@ defmodule Raxol.ACP.Xochi.Offering do
       name: "xochi_cross_chain_transfer",
       display_name: "Xochi Cross-Chain Transfer",
       description:
-        "Atomic cross-chain stablecoin transfer via Xochi intents. " <>
-          "Buyer escrows USDC on src chain, Xochi delivers to a recipient " <>
-          "on the dst chain, FundTransferHook releases service fee on settle.",
+        "Cross-chain stablecoin settlement storefront. The buyer signs a Xochi " <>
+          "intent, the storefront relays it and returns the settlement tx hashes; " <>
+          "the buyer escrows only the storefront fee (a plain job, no fund hook).",
       required_funds: true,
-      hook_kind: "fund_transfer",
+      hook_kind: "none",
       sla_minutes: 10,
       requirement_schema: requirement_schema(),
       deliverable_schema: deliverable_schema(),
@@ -84,8 +83,7 @@ defmodule Raxol.ACP.Xochi.Offering do
         "src_token",
         "dst_token",
         "amount_atomic",
-        "destination",
-        "slippage_bps"
+        "signed_intent"
       ],
       "additionalProperties" => false,
       "properties" => %{
@@ -110,40 +108,74 @@ defmodule Raxol.ACP.Xochi.Offering do
         "amount_atomic" => %{
           "type" => "string",
           "pattern" => "^[0-9]+$",
-          "description" => "Source amount in token base units (USDC: 1 USDC = 1_000_000)."
+          "description" =>
+            "Transfer size in token base units (USDC: 1 USDC = 1_000_000). Used to " <>
+              "size the storefront fee (bps of this) and to commit the deliverable " <>
+              "amount; the on-chain amount is fixed by the buyer's signed intent."
+        },
+        "signed_intent" => %{
+          "type" => "object",
+          "required" => ["intent_id", "quote_id", "signature", "nonce"],
+          "additionalProperties" => false,
+          "description" =>
+            "The buyer's pre-signed Xochi intent bundle. The buyer quotes and signs " <>
+              "the EIP-712 intent against Xochi directly; the storefront relays it " <>
+              "verbatim (Riddler verifies it against its own persisted quote, so the " <>
+              "amount and route cannot be forged).",
+          "properties" => %{
+            "intent_id" => %{
+              "type" => "string",
+              "description" => "Xochi intent id the buyer signed."
+            },
+            "quote_id" => %{
+              "type" => "string",
+              "description" => "Xochi quote id the signature binds to."
+            },
+            "signature" => %{
+              "type" => "string",
+              "pattern" => "^0x[0-9a-fA-F]+$",
+              "description" => "EIP-712 signature over the XochiIntent."
+            },
+            "nonce" => %{
+              "type" => "integer",
+              "minimum" => 0,
+              "description" => "Worker replay-dedup nonce."
+            },
+            "pull_signature" => %{
+              "type" => "string",
+              "pattern" => "^0x[0-9a-fA-F]+$",
+              "description" =>
+                "Optional ERC-3009/Permit2 origin-pull signature (absent for " <>
+                  "non-pulling methods)."
+            },
+            "aztec_proof" => %{
+              "type" => "string",
+              "description" => "Optional shielded-claim proof."
+            }
+          }
         },
         "destination" => %{
           "type" => "string",
           "pattern" => "^0x[0-9a-fA-F]{40}$",
           "description" =>
-            "Recipient on dst_chain_id. Not yet honored: settlement currently " <>
-              "delivers to the requester's own address on dst_chain_id. Delivery " <>
-              "to a different recipient is a future release; this field is kept " <>
-              "so requirements are forward-compatible."
+            "Optional: the recipient the buyer signed into their Xochi intent, for " <>
+              "the buyer's / evaluator's audit trail. raxol does not use or enforce " <>
+              "it -- the destination is fixed by the buyer's signature."
         },
         "slippage_bps" => %{
           "type" => "integer",
           "minimum" => 0,
           "maximum" => 1000,
           "default" => 50,
-          "description" => "Acceptable slippage in basis points (50 = 0.5%)."
+          "description" => "Optional audit hint; the buyer's signed quote fixes slippage."
         },
         "settlement_preference" => %{
           "type" => "string",
           "enum" => ["public", "private"],
           "default" => "public",
           "description" =>
-            "Settlement privacy. 'private' uses Xochi's dark pool path; 'public' uses standard solver routing."
-        },
-        "stealth_spending_pub_key" => %{
-          "type" => "string",
-          "pattern" => "^0x[0-9a-fA-F]+$",
-          "description" => "Optional stealth-address spending pubkey for shielded settlement."
-        },
-        "stealth_viewing_pub_key" => %{
-          "type" => "string",
-          "pattern" => "^0x[0-9a-fA-F]+$",
-          "description" => "Optional stealth-address viewing pubkey."
+            "Optional audit hint of the privacy tier the buyer signed. raxol relays " <>
+              "whatever the buyer signed and does not gate on this."
         }
       }
     }
@@ -155,7 +187,7 @@ defmodule Raxol.ACP.Xochi.Offering do
     %{
       "$schema" => "https://json-schema.org/draft/2020-12/schema",
       "type" => "object",
-      "required" => ["intent_id", "src_tx_hash", "status"],
+      "required" => ["intent_id", "settlement_tx_hash", "status"],
       "additionalProperties" => false,
       "properties" => %{
         "intent_id" => %{
@@ -166,15 +198,20 @@ defmodule Raxol.ACP.Xochi.Offering do
           "type" => "string",
           "description" => "Xochi quote identifier (audit trail)."
         },
-        "src_tx_hash" => %{
+        "settlement_tx_hash" => %{
           "type" => "string",
           "pattern" => "^0x[0-9a-fA-F]{64}$",
-          "description" => "Transaction hash on src_chain_id (intent lock)."
+          "description" =>
+            "The authoritative settlement transaction hash. For an instant fill " <>
+              "this is the destination delivery; for a two-leg bridge it is the " <>
+              "origin leg (with the destination arrival in receiving_tx_hash)."
         },
-        "dst_tx_hash" => %{
+        "receiving_tx_hash" => %{
           "type" => "string",
           "pattern" => "^0x[0-9a-fA-F]{64}$",
-          "description" => "Transaction hash on dst_chain_id (intent fill). Absent until settled."
+          "description" =>
+            "The destination-arrival transaction hash for a two-leg settlement. " <>
+              "Absent (null) for an instant single-tx fill."
         },
         "status" => %{
           "type" => "string",
@@ -200,17 +237,23 @@ defmodule Raxol.ACP.Xochi.Offering do
   def sla_minutes, do: 10
 
   @doc """
-  Whether a given requirement payload is well-formed enough to start
-  signing a Xochi quote. Cheap shape check only -- does not call
-  Riddler.
+  Whether a given requirement payload is well-formed enough to relay. Cheap
+  shape check only -- confirms the corridor fields plus a `signed_intent` bundle
+  carrying at least `intent_id`, `quote_id`, `signature`, and `nonce`. Does not
+  verify the signature (Riddler does that against its persisted quote).
   """
   @spec valid_requirement?(map()) :: boolean()
   def valid_requirement?(req) when is_map(req) do
-    required =
-      ~w(src_chain_id dst_chain_id src_token dst_token amount_atomic destination slippage_bps)
+    required = ~w(src_chain_id dst_chain_id src_token dst_token amount_atomic signed_intent)
 
-    Enum.all?(required, &Map.has_key?(req, &1))
+    Enum.all?(required, &Map.has_key?(req, &1)) and valid_signed_intent?(req["signed_intent"])
   end
 
   def valid_requirement?(_), do: false
+
+  defp valid_signed_intent?(bundle) when is_map(bundle) do
+    Enum.all?(~w(intent_id quote_id signature nonce), &Map.has_key?(bundle, &1))
+  end
+
+  defp valid_signed_intent?(_), do: false
 end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
@@ -1,16 +1,19 @@
 defmodule Raxol.ACP.Xochi.Settler do
   @moduledoc """
-  Adapter that converts `Raxol.ACP.Xochi.SolverAgent`'s `:settle_fn`
-  callback into a real `Raxol.Payments.Protocols.Xochi.transfer/4`
-  call.
+  Storefront relay: turns `Raxol.ACP.Xochi.SolverAgent`'s `:settle_fn`
+  callback into a `Raxol.Payments.Protocols.Xochi.execute_signed/2` call.
+
+  raxol is a pure storefront. The buyer quoted and signed the Xochi intent
+  against Xochi itself; the settler relays that pre-signed bundle WITHOUT
+  re-signing and polls it to settlement. raxol never signs the transfer and
+  never touches the transferred funds -- Riddler verifies the buyer's signature
+  against its own persisted quote, so the amount and route cannot be forged.
 
   ## Usage
 
       settle_fn =
         Raxol.ACP.Xochi.Settler.build(
-          wallet_address: "0xfeed...",
-          xochi_config: %{base_url: "https://riddler.axol.io", auth_token: "..."},
-          xochi_wallet: MyWallet,
+          xochi_config: %{base_url: "https://api.xochi.fi", auth_token: "..."},
           poll_timeout_ms: 120_000
         )
 
@@ -28,17 +31,18 @@ defmodule Raxol.ACP.Xochi.Settler do
         requirement: %{
           "src_chain_id" => 8453,
           "dst_chain_id" => 10,
-          "src_token"    => "0x...",
-          "dst_token"    => "0x...",
           "amount_atomic" => "1000000",
-          "destination"  => "0x...",
-          "slippage_bps" => 50,
-          "settlement_preference" => "public"
+          "signed_intent" => %{
+            "intent_id"      => "xi_...",
+            "quote_id"       => "xq_...",
+            "signature"      => "0x...",
+            "nonce"          => 7,
+            "pull_signature" => "0x..."    # optional
+          }
         },
-        transfer_amount_atomic: 1_000_000,
-        destination: "0x...",
-        xochi_config: %{...},   # passed through; same as settler config
-        xochi_wallet: MyWallet  # passed through
+        # threaded by SolverAgent (either is accepted):
+        signed_intent: %{...},             # the bundle, extracted from the requirement
+        transfer_amount_atomic: 1_000_000  # for the deliverable amount
       }
 
   ## Output shape
@@ -46,34 +50,27 @@ defmodule Raxol.ACP.Xochi.Settler do
   On settle success:
 
       {:ok, %{
-        intent_id:        "abc",
-        quote_id:         "xyz",
-        src_tx_hash:      "0x...",
-        dst_tx_hash:      "0x...",
-        status:           "settled",
-        fee_atomic:       "1000",
-        dst_amount_atomic: "999000"
+        intent_id:          "abc",
+        settlement_tx_hash: "0x...",
+        receiving_tx_hash:  "0x...",   # nil for an instant single-tx fill
+        amount_atomic:      "1000000",
+        status:             "completed"
       }}
 
-  On error: `{:error, reason}`. SolverAgent marks the session
-  `:failed` and does NOT submit a deliverable on-chain.
+  On error: `{:error, reason}`. SolverAgent marks the session `:failed` and does
+  NOT submit a deliverable on-chain.
   """
 
   alias Raxol.Payments.Protocols.Xochi
-  alias Raxol.Payments.Xochi.Schemas.{IntentStatus, QuoteRequest}
+  alias Raxol.Payments.Xochi.Schemas.IntentStatus
 
   @doc """
   Build a settle_fn closure.
 
   ## Required
 
-  - `:wallet_address` -- the solver's EOA on src chain. Used as the
-    `wallet` field of the `QuoteRequest` (Xochi pulls funds from this
-    address after the FundTransferHook payout lands).
-  - `:xochi_config` -- the Riddler/Xochi server config (base_url +
-    auth_token).
-  - `:xochi_wallet` -- a `Raxol.Payments.Wallet` module that signs the
-    XochiIntent.
+  - `:xochi_config` -- the Xochi worker config (base_url + auth). The buyer's
+    intent is relayed and polled through this endpoint.
 
   ## Optional
 
@@ -83,14 +80,12 @@ defmodule Raxol.ACP.Xochi.Settler do
   """
   @spec build(keyword()) :: (map() -> {:ok, map()} | {:error, term()})
   def build(opts) do
-    wallet_address = Keyword.fetch!(opts, :wallet_address)
     xochi_config = Keyword.fetch!(opts, :xochi_config)
-    xochi_wallet = Keyword.fetch!(opts, :xochi_wallet)
     poll_timeout = Keyword.get(opts, :poll_timeout_ms, 120_000)
     poll_interval = Keyword.get(opts, :poll_interval_ms, 2_000)
 
     fn settle_args ->
-      do_settle(settle_args, wallet_address, xochi_config, xochi_wallet,
+      do_settle(settle_args, xochi_config,
         timeout_ms: poll_timeout,
         interval_ms: poll_interval
       )
@@ -99,11 +94,33 @@ defmodule Raxol.ACP.Xochi.Settler do
 
   # -- Internal --
 
-  defp do_settle(args, wallet_address, xochi_config, xochi_wallet, poll_opts) do
-    with {:ok, request} <- build_quote_request(args, wallet_address),
+  defp do_settle(args, xochi_config, poll_opts) do
+    with {:ok, bundle} <- extract_signed_intent(args),
+         {:ok, intent_id} <- bundle_intent_id(bundle),
+         {:ok, _exec} <- Xochi.execute_signed(xochi_config, bundle),
          {:ok, %IntentStatus{} = status} <-
-           Xochi.transfer(xochi_config, request, xochi_wallet, poll_opts) do
-      settle_result(status)
+           Xochi.poll_status(xochi_config, intent_id, poll_opts) do
+      settle_result(status, args)
+    end
+  end
+
+  # The buyer's pre-signed intent bundle, threaded directly (`:signed_intent`) or
+  # carried in the requirement JSON (`requirement["signed_intent"]`). Keys may be
+  # atoms or strings; `execute_signed/2` normalizes and deep-validates them.
+  defp extract_signed_intent(%{signed_intent: bundle}) when is_map(bundle), do: {:ok, bundle}
+
+  defp extract_signed_intent(%{requirement: %{"signed_intent" => bundle}}) when is_map(bundle),
+    do: {:ok, bundle}
+
+  defp extract_signed_intent(_), do: {:error, :missing_signed_intent}
+
+  # The status is polled by the intent id the buyer signed (present under either
+  # key). `execute_signed/2` re-validates it, so an absent/blank id also fails
+  # there; checking here lets a malformed bundle fail before the relay POST.
+  defp bundle_intent_id(bundle) do
+    case bundle[:intent_id] || bundle["intent_id"] do
+      id when is_binary(id) and id != "" -> {:ok, id}
+      _ -> {:error, {:invalid_signed_intent, :intent_id}}
     end
   end
 
@@ -111,53 +128,41 @@ defmodule Raxol.ACP.Xochi.Settler do
   # :expired intent (which poll_status returns as `{:ok, status}`) must surface
   # as an error so SolverAgent does not submit a deliverable for a settlement
   # that never landed.
-  defp settle_result(%IntentStatus{status: :completed} = status),
-    do: to_deliverable(status)
+  defp settle_result(%IntentStatus{status: :completed} = status, args),
+    do: to_deliverable(status, args)
 
-  defp settle_result(%IntentStatus{status: s, intent_id: id, error: err})
+  defp settle_result(%IntentStatus{status: s, intent_id: id, error: err}, _args)
        when s in [:failed, :expired],
        do: {:error, {:settlement_failed, s, id, err}}
 
-  defp settle_result(%IntentStatus{status: s, intent_id: id}),
+  defp settle_result(%IntentStatus{status: s, intent_id: id}, _args),
     do: {:error, {:settlement_incomplete, s, id}}
 
-  defp build_quote_request(args, wallet_address) do
-    req = args.requirement
-
-    # Delivery goes to `wallet_address` (the requester) on the destination chain.
-    # `req["destination"]` is intentionally not honored yet: sending to a
-    # different recipient is a future capability, so for now the destination is
-    # kept equal to the funder for hardening. The field stays in the requirement
-    # (the schema and FundTransfer hook carry it) but does not retarget the
-    # settlement.
-    request = %QuoteRequest{
-      wallet: wallet_address,
-      from_chain_id: req["src_chain_id"],
-      to_chain_id: req["dst_chain_id"],
-      from_token: req["src_token"],
-      to_token: req["dst_token"],
-      from_amount: req["amount_atomic"],
-      slippage_bps: req["slippage_bps"] || 50,
-      settlement_preference: req["settlement_preference"] || "public"
-    }
-
-    case QuoteRequest.validate(request) do
-      :ok -> {:ok, request}
-      err -> err
-    end
-  end
-
-  # IntentStatus carries the origin fill as `tx_hash` and the destination arrival
-  # as `receiving_tx_hash`; the deliverable schema names them src_tx_hash /
-  # dst_tx_hash. Map them so the buyer/evaluator can verify the settlement
-  # on-chain (src_tx_hash is a required deliverable field).
-  defp to_deliverable(%IntentStatus{} = status) do
+  # `IntentStatus.tx_hash` is the authoritative settlement tx: for an instant fill
+  # it is the destination delivery; for a two-leg bridge it is the origin leg,
+  # with the destination arrival in `receiving_tx_hash` (nil for instant). Surface
+  # both under names that match that meaning, rather than a src/dst pair that
+  # mislabels the single instant-fill tx as the source leg. `amount_atomic` is the
+  # buyer's declared transfer amount, committed so the deliverable hash pins what
+  # was moved rather than only the tx hashes.
+  defp to_deliverable(%IntentStatus{} = status, args) do
     {:ok,
      %{
        intent_id: status.intent_id,
-       src_tx_hash: status.tx_hash,
-       dst_tx_hash: status.receiving_tx_hash,
+       settlement_tx_hash: status.tx_hash,
+       receiving_tx_hash: status.receiving_tx_hash,
+       amount_atomic: transfer_amount(args),
        status: to_string(status.status)
      }}
   end
+
+  # The deliverable's amount: the SolverAgent-threaded transfer amount, else the
+  # requirement's declared amount. It is display/audit metadata only -- the
+  # on-chain amount is fixed by the buyer's signed intent, not by this field.
+  defp transfer_amount(%{transfer_amount_atomic: n}) when is_integer(n),
+    do: Integer.to_string(n)
+
+  defp transfer_amount(%{requirement: %{"amount_atomic" => a}}), do: a
+
+  defp transfer_amount(_), do: nil
 end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
@@ -1,27 +1,26 @@
 defmodule Raxol.ACP.Xochi.SolverAgent do
   @moduledoc """
-  Runtime that drives a Xochi cross-chain transfer ACP job from
-  acceptance through settlement.
+  Runtime that drives a Xochi cross-chain transfer ACP job from acceptance
+  through settlement, as the storefront PROVIDER.
 
-  Subscribes to a `Raxol.ACP.Agent`, filters for v2 FundTransfer jobs
-  whose `provider` is this solver's wallet address, and runs the
-  lifecycle:
+  Subscribes to a `Raxol.ACP.Agent`, filters for plain jobs whose `provider` is
+  this solver's wallet address, and runs the lifecycle:
 
-  1. **`job.created`** -- record the job, wait for the buyer's
-     requirement message.
-  2. **`message` (contentType "requirement")** -- parse the
-     requirement JSON against
-     `Raxol.ACP.Xochi.Offering.requirement_schema/0`, compute the
-     service fee (default 50 bps via `:fee_bps`), and propose the
-     budget on-chain by calling
-     `Raxol.ACP.HookClient.set_budget/6` with FundTransfer hook
-     data (transferAmount, destination).
-  3. **`budget.set`** (echoed back via SSE) -- no-op for the solver;
-     just observe.
-  4. **`job.funded`** -- run `settle_fn` (default:
-     `Raxol.Payments.Protocols.Xochi.transfer/4`) and on success
-     submit the deliverable on-chain.
-  5. **`job.completed`** -- escrow released. Cleanup local state.
+  1. **`job.created`** -- record the job, wait for the buyer's requirement
+     message.
+  2. **`message` (contentType "requirement")** -- parse the requirement JSON
+     against `Raxol.ACP.Xochi.Offering.requirement_schema/0` (which carries the
+     buyer's signed intent bundle), compute the storefront fee (default 50 bps
+     via `:fee_bps`), and propose the budget on-chain via
+     `Raxol.ACP.HookClient.set_budget/6`. This is a PLAIN job (hook =
+     `address(0)`), so `set_budget` carries no hook data -- the budget is the
+     storefront fee, not the transfer. The transfer moves through Xochi
+     off-escrow, so the ACP core's take never bites it.
+  3. **`budget.set`** (echoed back via SSE) -- no-op for the solver; observe.
+  4. **`job.funded`** -- run `settle_fn` (default: a `Raxol.ACP.Xochi.Settler`
+     relay) which relays the buyer's pre-signed intent through Xochi and, on
+     success, submits the deliverable (the settlement tx hashes) on-chain.
+  5. **`job.completed`** -- provider nets `budget*0.90`. Cleanup local state.
 
   ## Configuration
 
@@ -32,11 +31,8 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
         evaluator_address: "0xevaluator...",
         chain_id: 8453,
         acp_core_address: "0x238E541BfefD82238730D00a2208E5497F1832E0",
-        fund_transfer_hook_address: "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B",
         fee_bps: 50,
-        settle_fn: &Raxol.Payments.Protocols.Xochi.transfer/4,
-        xochi_config: %{base_url: "...", auth_token: "..."},
-        xochi_wallet: MySigner
+        settle_fn: Raxol.ACP.Xochi.Settler.build(xochi_config: %{base_url: "..."})
       )
 
   ## Sessions
@@ -56,7 +52,6 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
   use GenServer
 
   alias Raxol.ACP.{Agent, HookClient}
-  alias Raxol.ACP.Hooks.FundTransfer
   alias Raxol.ACP.Xochi.Offering
 
   @type session_status ::
@@ -77,7 +72,6 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
           optional(:requirement) => map(),
           optional(:budget_atomic) => non_neg_integer(),
           optional(:transfer_amount_atomic) => non_neg_integer(),
-          optional(:destination) => String.t(),
           optional(:deliverable) => map(),
           optional(:settle_tx_hashes) => map()
         }
@@ -89,11 +83,9 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
           evaluator_address: String.t(),
           chain_id: pos_integer(),
           acp_core_address: String.t(),
-          fund_transfer_hook_address: String.t(),
           fee_bps: non_neg_integer(),
           settle_fn: fun(),
           xochi_config: map(),
-          xochi_wallet: module() | nil,
           sessions: %{Raxol.ACP.Transport.job_key() => session_state()}
         }
 
@@ -104,9 +96,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
     :evaluator_address,
     :chain_id,
     :acp_core_address,
-    :fund_transfer_hook_address,
     :xochi_config,
-    :xochi_wallet,
     settle_fn: nil,
     fee_bps: 50,
     sessions: %{}
@@ -145,11 +135,9 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       evaluator_address: Keyword.fetch!(opts, :evaluator_address),
       chain_id: Keyword.fetch!(opts, :chain_id),
       acp_core_address: Keyword.fetch!(opts, :acp_core_address),
-      fund_transfer_hook_address: Keyword.fetch!(opts, :fund_transfer_hook_address),
       fee_bps: Keyword.get(opts, :fee_bps, 50),
       settle_fn: Keyword.get(opts, :settle_fn, &default_settle/1),
-      xochi_config: Keyword.get(opts, :xochi_config, %{}),
-      xochi_wallet: Keyword.get(opts, :xochi_wallet)
+      xochi_config: Keyword.get(opts, :xochi_config, %{})
     }
 
     :ok = Agent.subscribe(state.agent)
@@ -253,16 +241,32 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
     end
   end
 
-  defp handle_job_funded(_entry, state) do
-    # Find a session in :budget_proposed or :awaiting_fund and settle.
-    Enum.reduce(state.sessions, state, fn
-      {key, %{status: status} = s}, acc
-      when status in [:budget_proposed, :awaiting_fund] ->
-        settle(acc, key, s)
+  # Settle only the session the funded event names. A single job.funded must
+  # never fan-settle every pending session -- doing so spends real funds via
+  # settle/3 for jobs that were not funded.
+  defp handle_job_funded(entry, state) do
+    case settle_target(state.sessions, job_key(entry)) do
+      {:ok, key, session} -> settle(state, key, session)
+      :none -> state
+    end
+  end
 
-      _, acc ->
-        acc
-    end)
+  @doc false
+  # Pure routing decision behind `handle_job_funded/2`: a funded event settles
+  # the session at its own `{chain_id, job_id}` and only when that session is
+  # awaiting funding. Any other key -- absent, or in a non-fundable state --
+  # returns `:none`. Selecting anything but the named key would re-open the
+  # fan-settle hole. Exposed for property tests.
+  @spec settle_target(%{optional(Raxol.ACP.Transport.job_key()) => session_state()}, term()) ::
+          {:ok, Raxol.ACP.Transport.job_key(), session_state()} | :none
+  def settle_target(sessions, key) do
+    case Map.fetch(sessions, key) do
+      {:ok, %{status: status} = session} when status in [:budget_proposed, :awaiting_fund] ->
+        {:ok, key, session}
+
+      _ ->
+        :none
+    end
   end
 
   defp handle_job_completed(entry, state) do
@@ -293,35 +297,42 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
   # -- Budget proposal --
 
+  @doc false
+  # The ACP job budget is the storefront fee only -- `fee_bps` basis points of
+  # the transfer amount. The transfer itself flows through Xochi (a buyer-signed
+  # intent the storefront relays), NOT through the ACP escrow, so the escrow is
+  # never sized to the transfer -- putting the transfer through the escrow would
+  # incur the core's 5-10% take on the full amount. Exposed for property tests.
+  @spec budget_for(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  def budget_for(transfer_atomic, fee_bps)
+      when is_integer(transfer_atomic) and transfer_atomic >= 0 and
+             is_integer(fee_bps) and fee_bps >= 0 do
+    div(transfer_atomic * fee_bps, 10_000)
+  end
+
+  # A storefront job is a PLAIN job (hook = address(0)): `set_budget` carries no
+  # hook data. The budget is the storefront fee; the transfer settles through
+  # Xochi off-escrow, so no FundTransfer hook is involved.
   defp propose_budget(state, key, session, requirement) do
     transfer_atomic = String.to_integer(requirement["amount_atomic"])
-    budget_atomic = max(div(transfer_atomic * state.fee_bps, 10_000), 1)
-    destination = requirement["destination"]
-
-    hook_data = FundTransfer.encode_set_budget_data(transfer_atomic, destination)
+    budget_atomic = budget_for(transfer_atomic, state.fee_bps)
 
     case HookClient.set_budget(
            state.provider,
            state.chain_id,
            state.acp_core_address,
            session.job_id_uint,
-           budget_atomic,
-           hook_data
+           budget_atomic
          ) do
       {:ok, tx_hash} ->
         emit(state, key, :budget_proposed, %{tx_hash: tx_hash, budget_atomic: budget_atomic})
 
-        updated = %{
-          session
-          | status: :budget_proposed
-        }
-
         updated =
-          updated
+          session
+          |> Map.put(:status, :budget_proposed)
           |> Map.put(:requirement, requirement)
           |> Map.put(:budget_atomic, budget_atomic)
           |> Map.put(:transfer_amount_atomic, transfer_atomic)
-          |> Map.put(:destination, destination)
 
         put_session(state, key, updated)
 
@@ -340,10 +351,8 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
     case state.settle_fn.(%{
            requirement: session.requirement,
-           transfer_amount_atomic: session.transfer_amount_atomic,
-           destination: session.destination,
-           xochi_config: state.xochi_config,
-           xochi_wallet: state.xochi_wallet
+           signed_intent: session.requirement["signed_intent"],
+           transfer_amount_atomic: session.transfer_amount_atomic
          }) do
       {:ok, %{intent_id: intent_id} = deliverable} ->
         submit_deliverable(state, key, session, deliverable, intent_id)
@@ -386,16 +395,16 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
   # -- Default settle (test-only) --
 
-  # In production, callers pass &Raxol.Payments.Protocols.Xochi.transfer/4
-  # via :settle_fn. The default below produces a deterministic stub so
-  # the SolverAgent can be exercised in tests without a live Xochi server.
+  # In production, callers pass a `Raxol.ACP.Xochi.Settler` relay closure via
+  # :settle_fn. The default below produces a deterministic stub so the
+  # SolverAgent can be exercised in tests without a live Xochi server.
   defp default_settle(%{requirement: req, transfer_amount_atomic: _}) do
     {:ok,
      %{
        intent_id: ("stub-intent-" <> :erlang.unique_integer([:positive])) |> to_string(),
        quote_id: "stub-quote",
-       src_tx_hash: "0x" <> String.duplicate("a", 64),
-       dst_tx_hash: "0x" <> String.duplicate("b", 64),
+       settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+       receiving_tx_hash: "0x" <> String.duplicate("b", 64),
        status: "settled",
        fee_atomic: "0",
        dst_amount_atomic: req["amount_atomic"]

--- a/packages/raxol_acp/lib/raxol/acp/xochi/transfer_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/transfer_offering.ex
@@ -3,11 +3,13 @@ defmodule Raxol.ACP.Xochi.TransferOffering do
   ACP offering that sells Xochi cross-chain stablecoin transfers.
 
   A buyer's job requirement names a source chain, destination chain, token,
-  amount, and destination address. `handle_request/2` accepts the job only when
-  the corridor is settleable (a solver-fillable token on a supported chain);
-  `handle_deliver/2` runs the transfer through `Raxol.ACP.Xochi.Settler`
-  (`Raxol.Payments.Protocols.Xochi`: quote, sign, execute, poll) and returns the
-  intent id and settlement tx hashes for on-chain verification.
+  amount, and its pre-signed Xochi intent bundle. `handle_request/2` accepts the
+  job only when the corridor is settleable (a solver-fillable token on a
+  supported chain); `handle_deliver/2` relays the buyer's signed intent through
+  `Raxol.ACP.Xochi.Settler`
+  (`Raxol.Payments.Protocols.Xochi.execute_signed/2`, then poll) -- raxol never
+  signs the transfer -- and returns the intent id and settlement tx hashes for
+  on-chain verification.
 
   The offering name is `"xochi_cross_chain_transfer"`, matching the marketplace
   metadata from `mix acp.register_offering`. When `:seller_enabled` is set,
@@ -19,9 +21,7 @@ defmodule Raxol.ACP.Xochi.TransferOffering do
   `handle_deliver/2` builds a `Raxol.ACP.Xochi.Settler` from:
 
       config :raxol_acp, :xochi_transfer_settler,
-        wallet_address: "0xsolver...",
         xochi_config: %{base_url: "https://api.xochi.fi", auth_token: "..."},
-        xochi_wallet: MyWalletModule,
         poll_timeout_ms: 120_000
 
   A `:settle_fn` (a one-arg function returning `{:ok, deliverable} | {:error,
@@ -45,7 +45,7 @@ defmodule Raxol.ACP.Xochi.TransferOffering do
   alias Raxol.ACP.Xochi.Settler
   alias Raxol.Payments.Assets
 
-  @settler_required [:wallet_address, :xochi_config, :xochi_wallet]
+  @settler_required [:xochi_config]
 
   @impl true
   def requirements_schema, do: Schema.requirement_schema()

--- a/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
+++ b/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
@@ -36,13 +36,13 @@ defmodule Mix.Tasks.Acp.RegisterOfferingTest do
       payload = RegisterOffering.build_payload(:mainnet)
 
       assert payload["name"] == "xochi_cross_chain_transfer"
-      assert payload["hookKind"] == "fund_transfer"
+      assert payload["hookKind"] == "none"
       assert payload["requiredFunds"] == true
       assert payload["slaMinutes"] == 10
       assert "payments" in payload["tags"]
     end
 
-    test "requirement schema is JSON-Schema 2020-12 with the 7 required fields" do
+    test "requirement schema is JSON-Schema 2020-12 with the corridor + signed-intent fields" do
       payload = RegisterOffering.build_payload(:mainnet)
       schema = payload["requirementSchema"]
 
@@ -59,8 +59,7 @@ defmodule Mix.Tasks.Acp.RegisterOfferingTest do
                  "src_token",
                  "dst_token",
                  "amount_atomic",
-                 "destination",
-                 "slippage_bps"
+                 "signed_intent"
                ])
              )
     end

--- a/packages/raxol_acp/test/raxol/acp/contract_client/onchain_live_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/contract_client/onchain_live_test.exs
@@ -65,13 +65,23 @@ defmodule Raxol.ACP.ContractClient.OnchainLiveTest do
     Application.put_env(:raxol_acp, :onchain_wallet, Wallet)
     Application.delete_env(:raxol_acp, :rpc)
     Application.delete_env(:raxol_acp, :sca_rpc)
-    NonceServer.reset(0)
+    # The minimal stub contract returns a word for every call but emits no
+    # JobCreated event, so create_job cannot resolve a real job id. This harness
+    # validates the EOA signing/broadcast/receipt pipeline, not event decoding
+    # (that is covered against real JobCreated logs elsewhere), so opt into the
+    # documented tx-hash placeholder rather than failing closed.
+    Application.put_env(:raxol_acp, :allow_placeholder_job_id, true)
+    # Unseed so the pipeline reconciles the wallet's real nonce from the fork
+    # (the stub deploy bumped anvil account #0), exercising the seed-from-chain
+    # path rather than assuming 0.
+    NonceServer.resync()
 
     on_exit(fn ->
       System.delete_env(@env_var)
       Application.delete_env(:raxol_acp, :chain)
       Application.delete_env(:raxol_acp, :chain_overrides)
       Application.delete_env(:raxol_acp, :onchain_wallet)
+      Application.delete_env(:raxol_acp, :allow_placeholder_job_id)
     end)
 
     :ok

--- a/packages/raxol_acp/test/raxol/acp/contract_client/onchain_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/contract_client/onchain_test.exs
@@ -35,7 +35,9 @@ defmodule Raxol.ACP.ContractClient.OnchainTest do
     Application.put_env(:raxol_acp, :chain, :mainnet)
     Application.put_env(:raxol_acp, :onchain_wallet, Wallet)
 
-    NonceServer.reset(0)
+    # Start each test with an unseeded NonceServer so the first broadcast
+    # reconciles the nonce from chain (eth_getTransactionCount "pending").
+    NonceServer.resync()
 
     on_exit(fn ->
       System.delete_env(@env_var)
@@ -174,6 +176,19 @@ defmodule Raxol.ACP.ContractClient.OnchainTest do
         _ ->
           default_rpc(req)
       end
+    end
+  end
+
+  describe "decode_uint256/1 (EntryPoint nonce decoding)" do
+    test "decodes valid hex, including the empty 0x word" do
+      assert Onchain.decode_uint256("0x1a") == {:ok, 26}
+      assert Onchain.decode_uint256("0x") == {:ok, 0}
+    end
+
+    test "fails closed on malformed or non-hex input instead of raising" do
+      assert Onchain.decode_uint256("0xzz") == :error
+      assert Onchain.decode_uint256("garbage") == :error
+      assert Onchain.decode_uint256("1a") == :error
     end
   end
 

--- a/packages/raxol_acp/test/raxol/acp/hook_client_live_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/hook_client_live_test.exs
@@ -60,7 +60,7 @@ defmodule Raxol.ACP.HookClientLiveTest do
       assert match?({:ok, _}, result) or match?({:error, _}, result)
     end
 
-    test "create_job encodes createJob(address,address,uint256,address,bytes)", %{adapter: a} do
+    test "create_job encodes createJob(address,address,uint256,string,address)", %{adapter: a} do
       provider = "0x" <> String.duplicate("ab", 20)
       evaluator = "0x" <> String.duplicate("cd", 20)
 
@@ -70,7 +70,7 @@ defmodule Raxol.ACP.HookClientLiveTest do
           evaluator: evaluator,
           expired_at: 1_900_000_000,
           hook_address: @fund_transfer_hook,
-          hook_data: <<>>
+          description: "xochi transfer"
         })
 
       # Tx broadcast OK (even if execution reverts) -> proves our calldata

--- a/packages/raxol_acp/test/raxol/acp/hook_client_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/hook_client_test.exs
@@ -89,13 +89,13 @@ defmodule Raxol.ACP.HookClientTest do
   end
 
   describe "create_job/4" do
-    test "encodes createJob(address,address,uint256,address,bytes)", %{adapter: a} do
+    test "encodes the deployed createJob(address,address,uint256,string,address)", %{adapter: a} do
       params = %{
         provider: "0x" <> String.duplicate("ab", 20),
         evaluator: "0x" <> String.duplicate("cd", 20),
         expired_at: 1_900_000_000,
         hook_address: "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B",
-        hook_data: <<>>
+        description: "xochi transfer"
       }
 
       assert {:ok, _tx} = HookClient.create_job(a, 8453, @core, params)
@@ -103,8 +103,10 @@ defmodule Raxol.ACP.HookClientTest do
       [{8453, [call]}] = Mock.sent_calls(a)
       assert call.to == @core
 
+      # Must match the on-chain AgenticCommerceV3 selector 0x41528812, not the
+      # old (address,bytes) shape which reverts on the real core.
       expected_selector =
-        ABI.function_selector("createJob(address,address,uint256,address,bytes)")
+        ABI.function_selector("createJob(address,address,uint256,string,address)")
 
       assert <<^expected_selector::binary-size(4), _rest::binary>> = call.data
     end

--- a/packages/raxol_acp/test/raxol/acp/onchain/transaction_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/onchain/transaction_test.exs
@@ -127,6 +127,21 @@ defmodule Raxol.ACP.Onchain.TransactionTest do
       refute Transaction.serialize(tx, sig0) == Transaction.serialize(tx, sig1)
     end
 
+    test "legacy 27/28 v normalizes to the 0/1 y-parity an EIP-1559 tx requires" do
+      tx = base_tx()
+      r = String.duplicate(<<0xAA>>, 32)
+      s = String.duplicate(<<0xBB>>, 32)
+
+      # Wallets pack signatures with v in {27, 28}; the encoded tx must carry the
+      # 0/1 y-parity, so a 27 signature serializes identically to a 0 one (and 28
+      # to 1). Without normalization the tx is undecodable by strict nodes.
+      assert Transaction.serialize(tx, r <> s <> <<27>>) ==
+               Transaction.serialize(tx, r <> s <> <<0>>)
+
+      assert Transaction.serialize(tx, r <> s <> <<28>>) ==
+               Transaction.serialize(tx, r <> s <> <<1>>)
+    end
+
     test "leading-zero r and s are stripped (canonical RLP)" do
       tx = base_tx()
       # An r/s value padded to 32 bytes with 31 leading zero bytes and

--- a/packages/raxol_acp/test/raxol/acp/seller/backend/web_socket/protocol_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/backend/web_socket/protocol_test.exs
@@ -75,6 +75,19 @@ defmodule Raxol.ACP.Seller.Backend.WebSocket.ProtocolTest do
     test "unknown socket.io subtype inside MESSAGE surfaces raw" do
       assert {:unknown, "49extra"} = Protocol.decode("49extra")
     end
+
+    test "malformed frames surface as :unknown instead of crashing" do
+      # Invalid JSON in an EVENT body.
+      assert {:unknown, "42[not json"} = Protocol.decode("42[not json")
+      # A non-array EVENT payload (Socket.IO events are always arrays).
+      assert {:unknown, ~s(42{"id":1})} = Protocol.decode(~s(42{"id":1}))
+      # An ACK frame with no id.
+      assert {:unknown, "43[true]"} = Protocol.decode("43[true]")
+      # Invalid JSON in an OPEN handshake.
+      assert {:unknown, "0{bad"} = Protocol.decode("0{bad")
+      # Invalid JSON in a CONNECT body.
+      assert {:unknown, "40{bad"} = Protocol.decode("40{bad")
+    end
   end
 
   describe "encode_pong/0" do

--- a/packages/raxol_acp/test/raxol/acp/seller/queue_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/queue_test.exs
@@ -174,4 +174,126 @@ defmodule Raxol.ACP.Seller.QueueTest do
                      200
     end
   end
+
+  describe "malformed events" do
+    setup do
+      :ok = SellerHelper.reset_seller(seller_address: @seller)
+      :ok = attach_telemetry([:dropped])
+      :ok
+    end
+
+    test ":job_offered missing :offering drops as :malformed without crashing the Queue" do
+      Queue.dispatch(%{type: :job_offered, job_id: "x"})
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dropped],
+                      %{type: :job_offered, reason: :malformed}},
+                     200
+
+      # The Queue survived a malformed event: a follow-up is still processed.
+      Queue.dispatch(%{type: :nonsense, job_id: "y"})
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dropped],
+                      %{type: :nonsense, reason: :unknown_event}},
+                     200
+    end
+
+    test "an event with no :type drops as :malformed instead of raising in the caller" do
+      Queue.dispatch(%{job_id: "z"})
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dropped],
+                      %{reason: :malformed}},
+                     200
+    end
+  end
+
+  describe "downstream errors are not swallowed" do
+    setup do
+      :ok = SellerHelper.reset_seller(seller_address: @seller)
+      :ok = attach_telemetry([:dispatched, :dropped])
+      {:ok, _spec} = EchoOffering.register()
+      :ok
+    end
+
+    test ":approval_received on a job not in :evaluation drops as {:handler_error, _}" do
+      {:ok, job_id} = ContractClient.create_job(@seller, @seller, 9_999_999_999)
+
+      Queue.dispatch(%{
+        type: :job_offered,
+        job_id: job_id,
+        offering: "test.echo",
+        request: %{"text" => "ping"},
+        buyer: @buyer
+      })
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dispatched],
+                      %{type: :job_offered}},
+                     500
+
+      :ok = wait_for_state(job_id, :negotiation)
+
+      # approve requires :evaluation; from :negotiation it is an invalid
+      # transition, so the Job.Server returns {:error, _}. That must surface as a
+      # drop, not a silently-swallowed "dispatched".
+      Queue.dispatch(%{type: :approval_received, job_id: job_id, payload: %{}})
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dropped],
+                      %{type: :approval_received, reason: {:handler_error, _}}},
+                     500
+    end
+  end
+
+  describe "backpressure" do
+    setup do
+      :ok = SellerHelper.reset_seller(seller_address: @seller)
+      :ok = attach_telemetry([:dispatched, :dropped])
+      {:ok, _spec} = EchoOffering.register()
+
+      prev = Application.get_env(:raxol_acp, :seller_max_active_jobs)
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:raxol_acp, :seller_max_active_jobs, prev),
+          else: Application.delete_env(:raxol_acp, :seller_max_active_jobs)
+      end)
+
+      :ok
+    end
+
+    test "rejects a second :job_offered once the active-job cap is reached" do
+      Application.put_env(:raxol_acp, :seller_max_active_jobs, 1)
+
+      {:ok, job_a} = ContractClient.create_job(@seller, @seller, 9_999_999_999)
+      {:ok, job_b} = ContractClient.create_job(@seller, @seller, 9_999_999_999)
+      assert job_a != job_b
+
+      Queue.dispatch(%{
+        type: :job_offered,
+        job_id: job_a,
+        offering: "test.echo",
+        request: %{},
+        buyer: @buyer
+      })
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dispatched],
+                      %{type: :job_offered, job_id: ^job_a}},
+                     500
+
+      :ok = wait_for_state(job_a, :negotiation)
+
+      # At the cap now; the second offer is rejected, not started.
+      Queue.dispatch(%{
+        type: :job_offered,
+        job_id: job_b,
+        offering: "test.echo",
+        request: %{},
+        buyer: @buyer
+      })
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dropped],
+                      %{type: :job_offered, job_id: ^job_b, reason: :at_capacity}},
+                     500
+
+      assert Job.Registry.whereis(job_b) == :undefined
+    end
+  end
 end

--- a/packages/raxol_acp/test/raxol/acp/wallet/nonce_server_property_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/wallet/nonce_server_property_test.exs
@@ -1,0 +1,48 @@
+defmodule Raxol.ACP.Wallet.NonceServerPropertyTest do
+  @moduledoc """
+  Concurrency invariant behind the nonce seeding fix: however many callers race
+  on first-use seeding, the NonceServer never hands out a duplicate nonce. Two
+  transactions signed with the same nonce means one is silently dropped by the
+  RPC, so uniqueness under concurrency is the property that matters. The nonces
+  handed out are also exactly the contiguous run starting at the seeded base --
+  no gaps that would strand later transactions.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.ACP.Wallet.NonceServer
+
+  property "concurrent seeders get unique, gap-free nonces for any base and count" do
+    check all(
+            base <- integer(0..1_000_000_000),
+            n <- integer(1..64),
+            max_runs: 40
+          ) do
+      server = start_unseeded()
+
+      nonces =
+        1..n
+        |> Task.async_stream(
+          fn _ ->
+            case NonceServer.get_next_if_seeded(server) do
+              {:ok, x} -> x
+              :unseeded -> NonceServer.seed_and_next(server, base)
+            end
+          end,
+          max_concurrency: 16,
+          ordered: false
+        )
+        |> Enum.map(fn {:ok, x} -> x end)
+
+      assert length(Enum.uniq(nonces)) == n, "duplicate nonce handed out under concurrency"
+      assert Enum.sort(nonces) == Enum.to_list(base..(base + n - 1)), "nonces are not gap-free"
+    end
+  end
+
+  defp start_unseeded do
+    name = Module.concat(__MODULE__, "Inst#{System.unique_integer([:positive])}")
+    {:ok, _pid} = NonceServer.start_link(name: name)
+    name
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/wallet/nonce_server_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/wallet/nonce_server_test.exs
@@ -77,6 +77,65 @@ defmodule Raxol.ACP.Wallet.NonceServerTest do
     end
   end
 
+  describe "atomic seeding" do
+    test "get_next_if_seeded reports unseeded until seeded, then hands out nonces" do
+      server = start()
+      assert NonceServer.get_next_if_seeded(server) == :unseeded
+      assert NonceServer.seed_and_next(server, 7) == 7
+      assert NonceServer.get_next_if_seeded(server) == {:ok, 8}
+      assert NonceServer.get_next_if_seeded(server) == {:ok, 9}
+    end
+
+    test "an explicit initial_nonce marks the server seeded" do
+      server = start(initial_nonce: 3)
+      assert NonceServer.get_next_if_seeded(server) == {:ok, 3}
+    end
+
+    test "reset marks an unseeded server seeded" do
+      server = start()
+      assert NonceServer.get_next_if_seeded(server) == :unseeded
+      :ok = NonceServer.reset(server, 20)
+      assert NonceServer.get_next_if_seeded(server) == {:ok, 20}
+    end
+
+    test "resync marks a seeded server unseeded so the next use re-fetches" do
+      server = start(initial_nonce: 9)
+      assert NonceServer.get_next_if_seeded(server) == {:ok, 9}
+      :ok = NonceServer.resync(server)
+      assert NonceServer.get_next_if_seeded(server) == :unseeded
+      # Re-seed from a (new) chain value and carry on.
+      assert NonceServer.seed_and_next(server, 30) == 30
+      assert NonceServer.get_next_if_seeded(server) == {:ok, 31}
+    end
+
+    test "seed_and_next hands out unique nonces even when callers race on seeding" do
+      server = start()
+      chain_nonce = 5
+
+      results =
+        1..100
+        |> Task.async_stream(
+          fn _ ->
+            case NonceServer.get_next_if_seeded(server) do
+              {:ok, n} -> n
+              :unseeded -> NonceServer.seed_and_next(server, chain_nonce)
+            end
+          end,
+          max_concurrency: 50,
+          ordered: false
+        )
+        |> Enum.map(fn {:ok, n} -> n end)
+        |> Enum.sort()
+
+      # No two callers get the same nonce; the base is the chain nonce, so the
+      # 100 assignments are exactly 5..104. A racy seed would repeat a value and
+      # break this equality.
+      assert length(Enum.uniq(results)) == 100
+      assert results == Enum.to_list(5..104)
+      assert NonceServer.peek(server) == 105
+    end
+  end
+
   describe "isolation between instances" do
     test "two instances increment independently" do
       a = start(initial_nonce: 0)

--- a/packages/raxol_acp/test/raxol/acp/xochi/fee_path_fork_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/fee_path_fork_test.exs
@@ -1,0 +1,195 @@
+defmodule Raxol.ACP.Xochi.FeePathForkTest do
+  @moduledoc """
+  `:live_chain` fork trace of the storefront FEE PATH against the REAL deployed
+  `AgenticCommerceV3` core on a Base fork. This is the on-chain half the
+  in-memory `live_order_test.exs` cannot exercise: it proves that a PLAIN job
+  (`hook = address(0)`) whose budget is the storefront fee pays raxol (the
+  provider) `net = budget - platformFee - evaluatorFee = budget * 0.90` on
+  completion, via the contract's real `PaymentReleased` event and real token
+  transfers.
+
+  Read from the verified source at `0x8e86FbEf4a4c927561cb6447cEd77ffFbf3B77BC`
+  (`AgenticCommerceV3.sol`):
+
+  - `whitelistedHooks[address(0)] = true` is set in `initialize`, so a plain job
+    (`hook = 0`) passes `createJob`'s whitelist check -- no hook, no escrow
+    routing, no `IACPHook` interface requirement.
+  - Roles are enforced distinct: `client != provider`, `evaluator != provider`.
+  - `setBudget` is PROVIDER-only; `fund` is CLIENT-only; `submit` is
+    PROVIDER-only; `complete` is EVALUATOR-only (Submitted -> Completed).
+  - On `complete`: `platformFee = budget*platformFeeBP/10000`,
+    `evalFee = budget*evaluatorFeeBP/10000`, `net = budget - platformFee - evalFee`
+    -> provider; emits `PaymentReleased(jobId, provider, net)`.
+
+  Roles map to three anvil accounts: account 0 = client (buyer), account 1 =
+  provider (raxol), account 2 = evaluator. Fees are READ from the fork's real
+  storage (`platformFeeBP`/`evaluatorFeeBP`, both 500 on the live deployment ->
+  a 10% take), so the assertion tracks the deployed config rather than a
+  hardcoded split.
+
+  USDC is dealt to the buyer by overwriting `balanceOf[buyer]` on the fork
+  (Circle FiatToken balances at slot 9); the test asserts the write took before
+  proceeding, so a wrong slot fails loudly instead of a confusing `fund` revert.
+
+  Tagged `:live_chain`; needs foundry (anvil + cast). Excluded by default. Run:
+
+      RAXOL_ACP_FORK_URL=https://mainnet.base.org \\
+        MIX_ENV=test mix test --include live_chain \\
+        test/raxol/acp/xochi/fee_path_fork_test.exs
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.HookClient
+  alias Raxol.ACP.ProviderAdapter.JSONRPC
+  alias Raxol.ACP.Test.AnvilHarness
+
+  @moduletag :live_chain
+  @moduletag timeout: 300_000
+
+  @chain_id 8453
+  @acp_core "0x238E541BfefD82238730D00a2208E5497F1832E0"
+  @usdc "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  # Circle FiatToken stores the balances mapping at storage slot 9.
+  @usdc_balance_slot 9
+  @zero_hook "0x0000000000000000000000000000000000000000"
+  # 0.005 USDC storefront fee.
+  @fee 5_000
+
+  setup_all do
+    rpc = AnvilHarness.start!(port: 8613, chain_id: @chain_id)
+
+    buyer = AnvilHarness.anvil_account(0)
+    provider = AnvilHarness.anvil_account(1)
+    evaluator = AnvilHarness.anvil_account(2)
+
+    for %{address: a} <- [buyer, provider, evaluator] do
+      AnvilHarness.anvil_set_balance(rpc, a, 10 * 10 ** 18)
+    end
+
+    %{
+      rpc: rpc,
+      buyer: buyer,
+      provider: provider,
+      evaluator: evaluator,
+      adapters: %{
+        buyer: adapter_for(rpc, buyer),
+        provider: adapter_for(rpc, provider),
+        evaluator: adapter_for(rpc, evaluator)
+      }
+    }
+  end
+
+  test "a plain-job storefront fee releases budget*0.90 to the provider", ctx do
+    %{rpc: rpc, buyer: buyer, provider: provider, evaluator: evaluator, adapters: a} = ctx
+
+    # Deal the buyer USDC and confirm the storage write landed (guards the slot).
+    AnvilHarness.deal_erc20(rpc, @usdc, buyer.address, @fee, @usdc_balance_slot)
+    assert AnvilHarness.erc20_balance(rpc, @usdc, buyer.address) == @fee
+
+    # Provider and evaluator start with no USDC, so post-flow balances are the
+    # exact amounts the contract paid them.
+    assert AnvilHarness.erc20_balance(rpc, @usdc, provider.address) == 0
+    assert AnvilHarness.erc20_balance(rpc, @usdc, evaluator.address) == 0
+
+    # 1. createJob(provider, evaluator, expiry, "", hook=0) -- the BUYER (client).
+    {:ok, create_tx} =
+      HookClient.create_job(a.buyer, @chain_id, @acp_core, %{
+        provider: provider.address,
+        evaluator: evaluator.address,
+        expired_at: now() + 3600,
+        hook_address: @zero_hook,
+        description: "xochi storefront fee"
+      })
+
+    AnvilHarness.assert_tx_success!(rpc, create_tx)
+
+    # This is the only job creator on the fork, so the post-createJob counter is
+    # our jobId (the contract does `++jobCounter`).
+    job_id = AnvilHarness.read_uint(rpc, @acp_core, "jobCounter()(uint256)")
+
+    # 2. setBudget(jobId, fee, "") -- the PROVIDER (raxol). budget = storefront fee.
+    {:ok, budget_tx} = HookClient.set_budget(a.provider, @chain_id, @acp_core, job_id, @fee)
+    AnvilHarness.assert_tx_success!(rpc, budget_tx)
+
+    # 3. approve(core, fee) + fund(jobId, fee, "") -- the BUYER. A successful fund
+    #    proves budget == fee (the contract reverts BudgetMismatch otherwise).
+    approve_usdc(rpc, buyer, @acp_core, @fee)
+    {:ok, fund_tx} = HookClient.fund(a.buyer, @chain_id, @acp_core, job_id, @fee)
+    AnvilHarness.assert_tx_success!(rpc, fund_tx)
+
+    # 4. submit(jobId, deliverable, "") -- the PROVIDER. With an evaluator set,
+    #    this is Funded -> Submitted (no auto-complete).
+    deliverable = "0x" <> String.duplicate("cd", 32)
+    {:ok, submit_tx} = HookClient.submit(a.provider, @chain_id, @acp_core, job_id, deliverable)
+    AnvilHarness.assert_tx_success!(rpc, submit_tx)
+
+    # 5. complete(jobId, reason, "") -- the EVALUATOR. Distributes the escrow.
+    reason = "0x" <> String.duplicate("11", 32)
+    {:ok, complete_tx} = HookClient.complete(a.evaluator, @chain_id, @acp_core, job_id, reason)
+    AnvilHarness.assert_tx_success!(rpc, complete_tx)
+
+    # Net paid to the provider, computed from the fork's real fee config.
+    platform_bp = AnvilHarness.read_uint(rpc, @acp_core, "platformFeeBP()(uint256)")
+    eval_bp = AnvilHarness.read_uint(rpc, @acp_core, "evaluatorFeeBP()(uint256)")
+    platform_fee = div(@fee * platform_bp, 10_000)
+    eval_fee = div(@fee * eval_bp, 10_000)
+    net = @fee - platform_fee - eval_fee
+
+    # The deployed config is a 10% take, so the provider nets 90% of the budget.
+    assert platform_bp == 500
+    assert eval_bp == 500
+    assert net == div(@fee * 90, 100)
+
+    # The money moved exactly as the fee model claims: the provider (raxol) got
+    # net, the evaluator got its fee, and the buyer's escrow is spent.
+    assert AnvilHarness.erc20_balance(rpc, @usdc, provider.address) == net
+    assert AnvilHarness.erc20_balance(rpc, @usdc, evaluator.address) == eval_fee
+    assert AnvilHarness.erc20_balance(rpc, @usdc, buyer.address) == 0
+
+    # And the completion receipt carries the real PaymentReleased event.
+    assert receipt_has_event?(rpc, complete_tx, "PaymentReleased(uint256,address,uint256)"),
+           "complete receipt did not emit PaymentReleased"
+  end
+
+  # -- Helpers --
+
+  defp adapter_for(rpc, %{private_key: pk}) do
+    JSONRPC.new(
+      chains: %{@chain_id => rpc},
+      private_key: pk,
+      fee_overrides: %{
+        @chain_id => %{
+          max_priority_fee_per_gas: 1_000_000_000,
+          max_fee_per_gas: 5_000_000_000
+        }
+      }
+    )
+  end
+
+  defp approve_usdc(rpc, %{private_key: pk}, spender, amount) do
+    {_out, 0} =
+      AnvilHarness.cast([
+        "send",
+        @usdc,
+        "approve(address,uint256)",
+        spender,
+        "#{amount}",
+        "--private-key",
+        "0x" <> Base.encode16(pk, case: :lower),
+        "--rpc-url",
+        rpc
+      ])
+
+    :ok
+  end
+
+  # topic0 of the event = keccak256 of its canonical signature; a completed job's
+  # receipt must contain it.
+  defp receipt_has_event?(rpc, tx_hash, signature) do
+    topic0 = "0x" <> Base.encode16(ExKeccak.hash_256(signature), case: :lower)
+    {receipt, 0} = AnvilHarness.cast(["receipt", tx_hash, "--rpc-url", rpc])
+    String.contains?(String.downcase(receipt), String.downcase(topic0))
+  end
+
+  defp now, do: System.system_time(:second)
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
@@ -4,19 +4,25 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
   seller settles it for real through Xochi + the Riddler solver.
 
   This is the end-to-end proof that the settlement services are orderable through
-  the ACP: a buyer creates a job, the seller's `Raxol.ACP.Xochi.TransferOffering`
-  accepts it and, on delivery, runs the real `Raxol.ACP.Xochi.Settler` ->
-  `Raxol.Payments.Protocols.Xochi.transfer/4`. The deliverable carries the intent
-  id and the on-chain settlement tx hashes.
+  the ACP under the PURE-STOREFRONT model: the buyer quotes and signs a Xochi
+  intent itself (`Raxol.Payments.Protocols.Xochi.quote_and_sign/3`), embeds the
+  signed bundle in the job requirement's `signed_intent`, and the seller's
+  `Raxol.ACP.Xochi.TransferOffering` accepts the job and, on delivery, relays the
+  bundle via `Raxol.ACP.Xochi.Settler` ->
+  `Raxol.Payments.Protocols.Xochi.execute_signed/2` (no re-signing) and polls it.
+  The deliverable carries the intent id and the on-chain settlement tx hashes.
+
+  Here the test plays BOTH roles: the funded `LiveWallet` is the buyer (it signs
+  the intent), and for a self-contained gate is also the job's provider address.
 
   The job orchestration uses the in-memory `ContractClient` (no live ACP escrow
   contracts); the SETTLEMENT is real and moves funds. The fuller on-chain escrow
   path (`ContractClient.Onchain` + `HookClient` + `SolverAgent`) is the existing
   `:live_chain` stack and is a separate gate.
 
-  Auth is the Member service token (`XOCHI_ORDER_LIVE_TOKEN`): the seller is a
-  Xochi Member, and the `Settler` uses one config for quote/execute/poll. (The
-  mandate path is exercised by the raxol_payments Xochi gate.)
+  Auth is the Member service token (`XOCHI_ORDER_LIVE_TOKEN`): one `xochi_config`
+  serves the buyer's quote+sign and the Settler's relay+poll. (The mandate path is
+  exercised by the raxol_payments Xochi gate.)
 
   USDC pulls via ERC-3009 and settles directly. USDT/WETH -- and USDG, the origin
   asset for any Robinhood-origin corridor -- pull via Permit2 and need a standing
@@ -32,13 +38,13 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
   `:live_xochi_order_preflight` (read-only); excluded by default and compiled
   only when the required env is present.
 
-  Funds settle to the seller wallet on the destination chain (the current
-  `Settler` delivers to the `QuoteRequest` wallet), so default the recipient to
-  the funded key's own address.
+  Funds settle to the buyer's own wallet on the destination chain -- the Xochi
+  `QuoteRequest` has no separate recipient (wallet = funder = recipient), so the
+  buyer's signed intent delivers to the funded key's own address.
 
       XOCHI_ORDER_LIVE_URL=https://api.xochi.fi \\
       XOCHI_ORDER_LIVE_TOKEN="$(op read 'op://Employee/Xochi production AGENT_SERVICE_TOKENS/credential')" \\
-      XOCHI_ORDER_LIVE_KEY=0x<funded seller key> \\
+      XOCHI_ORDER_LIVE_KEY=0x<funded buyer key> \\
       XOCHI_ORDER_RPC_8453=https://mainnet.base.org \\
       XOCHI_ORDER_TOKENS=USDC,USDT,WETH \\
         mix test --only live_xochi_order test/raxol/acp/xochi/live_order_test.exs
@@ -47,8 +53,8 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
 
   Overrides: XOCHI_ORDER_CORRIDORS ("from>to,from>to" or "mesh"),
   XOCHI_ORDER_TOKENS, XOCHI_ORDER_AMOUNT, XOCHI_ORDER_WETH_AMOUNT,
-  XOCHI_ORDER_DESTINATION, XOCHI_ORDER_ALLOW_ETH_ORIGIN, XOCHI_ORDER_SOLVER,
-  XOCHI_ORDER_SOLVER_PIN, XOCHI_ORDER_RPC_<chain>.
+  XOCHI_ORDER_ALLOW_ETH_ORIGIN, XOCHI_ORDER_SOLVER, XOCHI_ORDER_SOLVER_PIN,
+  XOCHI_ORDER_RPC_<chain>.
   """
 
   use ExUnit.Case, async: false
@@ -87,10 +93,9 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
       wallet_address = LiveWallet.address()
       xochi_config = %{base_url: url, auth_token: token}
 
+      # The relay Settler needs only :xochi_config (it never signs).
       Application.put_env(:raxol_acp, :xochi_transfer_settler,
-        wallet_address: wallet_address,
         xochi_config: xochi_config,
-        xochi_wallet: LiveWallet,
         poll_timeout_ms: 180_000
       )
 
@@ -100,7 +105,6 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
       cfg = %{
         xochi_config: xochi_config,
         wallet_address: wallet_address,
-        destination: System.get_env("XOCHI_ORDER_DESTINATION", wallet_address),
         stable_amount: System.get_env("XOCHI_ORDER_AMOUNT", "1.10")
       }
 
@@ -175,7 +179,13 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
     # -- Order one cell through the ACP job lifecycle --
 
     defp order_cell(cfg, from, to, token, label) do
-      requirement = requirement(cfg, from, to, token)
+      # The BUYER quotes + signs the Xochi intent itself; the signed bundle rides
+      # in the requirement. raxol (the offering) relays it -- it never re-signs.
+      {:ok, request} = quote_request(cfg, from, to, token)
+
+      {:ok, bundle} = XochiProtocol.quote_and_sign(cfg.xochi_config, request, LiveWallet)
+
+      requirement = requirement(cfg, from, to, token, bundle)
 
       {:ok, job_id} =
         ContractClient.create_job(cfg.wallet_address, cfg.wallet_address, future_ts())
@@ -204,13 +214,13 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
       assert is_binary(deliverable["intent_id"])
       assert deliverable["status"] in ["completed", "settled"]
 
-      assert deliverable["src_tx_hash"] =~ ~r/^0x[0-9a-fA-F]{64}$/,
+      assert deliverable["settlement_tx_hash"] =~ ~r/^0x[0-9a-fA-F]{64}$/,
              "#{label}: deliverable missing a settlement tx hash: #{inspect(deliverable)}"
 
       report_settlement(label, to, deliverable, started)
     end
 
-    defp requirement(cfg, from, to, token) do
+    defp requirement(cfg, from, to, token, bundle) do
       {:ok, src_token} = Assets.address(from, leg_symbol(from, token))
       {:ok, dst_token} = Assets.address(to, leg_symbol(to, token))
 
@@ -220,10 +230,14 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
         "src_token" => src_token,
         "dst_token" => dst_token,
         "amount_atomic" => amount_atomic(from, token, cfg.stable_amount),
-        "destination" => cfg.destination,
-        "slippage_bps" => 50,
-        "settlement_preference" => "public"
+        "signed_intent" => bundle_to_json(bundle)
       }
+    end
+
+    # The bundle from quote_and_sign/3 is atom-keyed; the ACP requirement is JSON
+    # (string keys). Stringify so valid_requirement?/execute_signed read it.
+    defp bundle_to_json(bundle) do
+      Map.new(bundle, fn {k, v} -> {to_string(k), v} end)
     end
 
     defp deliverable_from_memos(job_id, label) do
@@ -237,12 +251,24 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
 
     defp preflight_quote(cfg, from, to, token) do
       with {:ok, request} <- quote_request(cfg, from, to, token),
-           {:ok, quote} <- XochiProtocol.get_quote(cfg.xochi_config, request),
-           {:solve, true} <- {:solve, quote.can_solve},
+           {:ok, quote} <- solver_quote(cfg, request),
            :ok <- XochiProtocol.validate_pull(quote, request, LiveWallet) do
         {:ok, quote}
-      else
-        {:solve, _} -> {:error, :cannot_solve}
+      end
+    end
+
+    # A fillable quote, or a soft `:cannot_solve` when the solver reports it
+    # cannot fill this cell right now -- whether it answers 200 with
+    # can_solve:false OR a transient error whose body still says can_solve:false
+    # (e.g. 503 "Solver temporarily unavailable"). Only a fillable quote proceeds
+    # to the pull check (the hard, anti-drain solver-pin assertion). A genuine
+    # error (auth, connection, an unexpected shape) stays hard, so a real
+    # misconfiguration is not masked as a per-cell skip.
+    defp solver_quote(cfg, request) do
+      case XochiProtocol.get_quote(cfg.xochi_config, request) do
+        {:ok, %{can_solve: true} = quote} -> {:ok, quote}
+        {:ok, %{can_solve: false}} -> {:error, :cannot_solve}
+        {:error, {:http, _status, %{"can_solve" => false}}} -> {:error, :cannot_solve}
         other -> other
       end
     end
@@ -417,8 +443,8 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
       [live_xochi_order:#{label}] settled in #{elapsed}ms
         intent_id     #{deliverable["intent_id"]}
         status        #{deliverable["status"]}
-        src tx        #{tx_line(deliverable["src_tx_hash"], to_chain)}
-        dst tx        #{tx_line(deliverable["dst_tx_hash"], to_chain)}\
+        settle tx     #{tx_line(deliverable["settlement_tx_hash"], to_chain)}
+        recv tx       #{tx_line(deliverable["receiving_tx_hash"], to_chain)}\
       """)
     end
 

--- a/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
@@ -4,12 +4,12 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
   alias Raxol.ACP.Xochi.Offering
 
   describe "offering_metadata/0" do
-    test "is a fund-transfer offering with USDC settlement" do
+    test "is a storefront offering (plain job, no fund hook)" do
       meta = Offering.offering_metadata()
 
       assert meta.name == "xochi_cross_chain_transfer"
       assert meta.required_funds == true
-      assert meta.hook_kind == "fund_transfer"
+      assert meta.hook_kind == "none"
       assert meta.sla_minutes == 10
       assert "payments" in meta.tags
     end
@@ -31,7 +31,7 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
       assert schema["additionalProperties"] == false
     end
 
-    test "marks the 7 essential fields as required" do
+    test "marks the corridor fields plus the signed intent as required" do
       schema = Offering.requirement_schema()
       required = MapSet.new(schema["required"])
 
@@ -43,9 +43,20 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
                  "src_token",
                  "dst_token",
                  "amount_atomic",
-                 "destination",
-                 "slippage_bps"
+                 "signed_intent"
                ])
+             )
+    end
+
+    test "the signed_intent object requires the bundle fields" do
+      schema = Offering.requirement_schema()
+      bundle = schema["properties"]["signed_intent"]
+
+      assert bundle["type"] == "object"
+
+      assert MapSet.equal?(
+               MapSet.new(bundle["required"]),
+               MapSet.new(["intent_id", "quote_id", "signature", "nonce"])
              )
     end
 
@@ -58,23 +69,40 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
   end
 
   describe "valid_requirement?/1" do
-    test "accepts a minimal valid request" do
-      req = %{
+    defp minimal_req do
+      %{
         "src_chain_id" => 8453,
         "dst_chain_id" => 10,
         "src_token" => "0x" <> String.duplicate("ab", 20),
         "dst_token" => "0x" <> String.duplicate("cd", 20),
         "amount_atomic" => "1000000",
-        "destination" => "0x" <> String.duplicate("ef", 20),
-        "slippage_bps" => 50
+        "signed_intent" => %{
+          "intent_id" => "xi_1",
+          "quote_id" => "xq_1",
+          "signature" => "0x" <> String.duplicate("11", 65),
+          "nonce" => 7
+        }
       }
+    end
 
-      assert Offering.valid_requirement?(req)
+    test "accepts a minimal valid request" do
+      assert Offering.valid_requirement?(minimal_req())
     end
 
     test "rejects requests missing a required field" do
       refute Offering.valid_requirement?(%{"src_chain_id" => 8453})
       refute Offering.valid_requirement?(%{})
+      # missing the signed intent
+      refute Offering.valid_requirement?(Map.delete(minimal_req(), "signed_intent"))
+    end
+
+    test "rejects a signed_intent that is missing bundle fields or is not a map" do
+      refute Offering.valid_requirement?(%{
+               minimal_req()
+               | "signed_intent" => %{"intent_id" => "x"}
+             })
+
+      refute Offering.valid_requirement?(%{minimal_req() | "signed_intent" => "not-a-map"})
     end
 
     test "rejects non-map input" do
@@ -84,10 +112,10 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
   end
 
   describe "deliverable_schema/0" do
-    test "intent_id, src_tx_hash, status are required" do
+    test "intent_id, settlement_tx_hash, status are required" do
       schema = Offering.deliverable_schema()
       required = MapSet.new(schema["required"])
-      assert MapSet.equal?(required, MapSet.new(["intent_id", "src_tx_hash", "status"]))
+      assert MapSet.equal?(required, MapSet.new(["intent_id", "settlement_tx_hash", "status"]))
     end
 
     test "status is bounded" do

--- a/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
@@ -3,129 +3,79 @@ defmodule Raxol.ACP.Xochi.SettlerTest do
 
   alias Raxol.ACP.Xochi.Settler
 
-  @wallet "0xfeedfacefeedfacefeedfacefeedfacefeedface"
   @src_token "0x" <> String.duplicate("11", 20)
   @dst_token "0x" <> String.duplicate("22", 20)
-  @destination "0x" <> String.duplicate("33", 20)
 
-  defmodule StubWallet do
-    @moduledoc false
-    def address, do: "0xfeedfacefeedfacefeedfacefeedfacefeedface"
-    def chain_id, do: 8453
-    def sign_typed_data(_d, _t, _m), do: {:ok, <<7::size(520)>>}
-    def sign_message(_), do: {:ok, <<7::size(520)>>}
-    def sign_hash(_), do: {:ok, <<7::size(520)>>}
+  # A buyer-signed Xochi intent bundle, as it arrives in the requirement JSON
+  # (string keys). Signature values are opaque -- raxol relays them; Riddler
+  # verifies against its persisted quote.
+  defp signed_intent(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "intent_id" => "i1",
+        "quote_id" => "q1",
+        "signature" => "0x" <> String.duplicate("11", 65),
+        "nonce" => 7,
+        "pull_signature" => "0x" <> String.duplicate("22", 65)
+      },
+      overrides
+    )
   end
 
-  defp valid_requirement do
-    %{
-      "src_chain_id" => 8453,
-      "dst_chain_id" => 10,
-      "src_token" => @src_token,
-      "dst_token" => @dst_token,
-      "amount_atomic" => "1000000",
-      "destination" => @destination,
-      "slippage_bps" => 50,
-      "settlement_preference" => "public"
-    }
+  defp requirement(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "src_chain_id" => 8453,
+        "dst_chain_id" => 10,
+        "src_token" => @src_token,
+        "dst_token" => @dst_token,
+        "amount_atomic" => "1000000",
+        "signed_intent" => signed_intent()
+      },
+      overrides
+    )
   end
 
-  defp settle_args(req) do
-    %{
-      requirement: req,
-      transfer_amount_atomic: 1_000_000,
-      destination: @destination,
-      xochi_config: %{base_url: "http://stub", auth_token: "stub"},
-      xochi_wallet: nil
-    }
+  # The SolverAgent threads the bundle both ways: `:signed_intent` directly and
+  # inside `:requirement`. Default args carry both.
+  defp args(overrides \\ %{}) do
+    req = requirement()
+
+    Map.merge(
+      %{
+        requirement: req,
+        signed_intent: req["signed_intent"],
+        transfer_amount_atomic: 1_000_000
+      },
+      overrides
+    )
   end
 
   describe "build/1" do
-    test "raises when required option missing" do
-      assert_raise KeyError, fn -> Settler.build(xochi_config: %{}, xochi_wallet: nil) end
+    test "raises when :xochi_config is missing" do
+      assert_raise KeyError, fn -> Settler.build([]) end
     end
 
-    test "returns a function arity-1" do
-      f =
-        Settler.build(
-          wallet_address: @wallet,
-          xochi_config: %{base_url: "http://stub"},
-          xochi_wallet: nil
-        )
-
+    test "returns a function of arity 1" do
+      f = Settler.build(xochi_config: %{base_url: "https://xochi.test"})
       assert is_function(f, 1)
     end
   end
 
-  describe "settle_fn invocation (validation only)" do
-    # The settler's first job is to build a valid QuoteRequest from the
-    # settle args. If the requirement is malformed, we expect an early
-    # error before ever talking to Xochi. The "real" Xochi.transfer call
-    # is exercised by the SolverAgent live test path; here we verify the
-    # validation layer.
-
-    test "rejects an invalid src_token in the requirement" do
-      settler =
-        Settler.build(
-          wallet_address: @wallet,
-          xochi_config: %{base_url: "http://stub"},
-          xochi_wallet: nil
-        )
-
-      bad_req = %{valid_requirement() | "src_token" => "not-an-address"}
-
-      assert {:error, {:invalid_from_token, _}} = settler.(settle_args(bad_req))
-    end
-
-    test "rejects a non-positive chain id" do
-      settler =
-        Settler.build(
-          wallet_address: @wallet,
-          xochi_config: %{base_url: "http://stub"},
-          xochi_wallet: nil
-        )
-
-      bad_req = %{valid_requirement() | "src_chain_id" => 0}
-
-      assert {:error, {:invalid_chain_id, _}} = settler.(settle_args(bad_req))
-    end
-
-    test "rejects a malformed destination" do
-      settler =
-        Settler.build(
-          wallet_address: @wallet,
-          xochi_config: %{base_url: "http://stub"},
-          xochi_wallet: nil
-        )
-
-      bad_req = %{valid_requirement() | "dst_token" => "bad"}
-
-      assert {:error, {:invalid_to_token, _}} = settler.(settle_args(bad_req))
-    end
-  end
-
-  describe "settlement outcome handling" do
-    defp sim(status) do
+  describe "relay (pure storefront: no wallet, no re-signing)" do
+    # A worker sim over the real client paths (`/api/intent/*`). No quote call --
+    # the buyer already quoted; the settler only executes (relays) and polls.
+    # camelCase bodies: ExecuteResponse/IntentStatus read camelCase.
+    defp sim(status, test_pid) do
       fn conn ->
-        # Paths match `Raxol.Payments.Xochi.Client`: the worker endpoints
-        # (`/api/intent/*`), not the Riddler-direct `/xochi/*` paths. The
-        # bodies stay camelCase: `QuoteResponse.from_json` accepts both cases,
-        # and `ExecuteResponse`/`IntentStatus` read camelCase.
+        {:ok, raw, conn} = Plug.Conn.read_body(conn)
+
+        if conn.request_path == "/api/intent/execute" do
+          send(test_pid, {:relayed, Jason.decode!(raw)})
+        end
+
         body =
           case conn.request_path do
-            "/api/intent/quote" ->
-              %{
-                "intentId" => "i1",
-                "quoteId" => "q1",
-                "canSolve" => true,
-                "toAmount" => "999000",
-                "eip712Data" => %{
-                  "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
-                  "types" => %{"Intent" => [%{"name" => "amount", "type" => "uint256"}]},
-                  "message" => %{"amount" => 1_000_000}
-                }
-              }
-
             "/api/intent/execute" ->
               %{"success" => true, "intentId" => "i1", "status" => "executing"}
 
@@ -143,46 +93,69 @@ defmodule Raxol.ACP.Xochi.SettlerTest do
       end
     end
 
-    # The settler uses its build-time xochi_config, so the sim plug is wired there.
     defp settler_for(status) do
       Settler.build(
-        wallet_address: @wallet,
         xochi_config: %{
           base_url: "https://xochi.test",
           auth_token: "stub",
-          req_options: [plug: sim(status)]
+          req_options: [plug: sim(status, self())]
         },
-        xochi_wallet: StubWallet
+        poll_timeout_ms: 5_000,
+        poll_interval_ms: 10
       )
     end
 
-    defp args do
-      %{
-        requirement: valid_requirement(),
-        transfer_amount_atomic: 1_000_000,
-        destination: @destination,
-        xochi_config: %{},
-        xochi_wallet: StubWallet
-      }
+    test "relays the buyer's signed bundle verbatim, without re-signing" do
+      assert {:ok, _deliverable} = settler_for("completed").(args())
+
+      # The execute POST carries the BUYER's signature, pull_signature, and
+      # nonce unchanged -- raxol signs nothing.
+      assert_receive {:relayed, relayed}
+      assert relayed["signature"] == "0x" <> String.duplicate("11", 65)
+      assert relayed["pull_signature"] == "0x" <> String.duplicate("22", 65)
+      assert relayed["nonce"] == 7
+      assert relayed["intent_id"] == "i1"
+      assert relayed["quote_id"] == "q1"
     end
 
     test "a completed intent yields a deliverable with the settlement tx hashes" do
       assert {:ok, deliverable} = settler_for("completed").(args())
       assert deliverable.intent_id == "i1"
       assert deliverable.status == "completed"
-      # IntentStatus tx_hash / receiving_tx_hash surface as src / dst for the buyer.
-      assert deliverable.src_tx_hash == "0x" <> String.duplicate("a", 64)
-      assert deliverable.dst_tx_hash == "0x" <> String.duplicate("b", 64)
+      # IntentStatus tx_hash / receiving_tx_hash surface under matching names.
+      assert deliverable.settlement_tx_hash == "0x" <> String.duplicate("a", 64)
+      assert deliverable.receiving_tx_hash == "0x" <> String.duplicate("b", 64)
+      # The deliverable commits the declared transfer amount.
+      assert deliverable.amount_atomic == "1000000"
+    end
+
+    test "extracts the signed intent from the requirement when not threaded directly" do
+      only_requirement = %{requirement: requirement(), transfer_amount_atomic: 1_000_000}
+      assert {:ok, deliverable} = settler_for("completed").(only_requirement)
+      assert deliverable.intent_id == "i1"
     end
 
     test "a failed intent is an error, not a deliverable" do
-      assert {:error, {:settlement_failed, :failed, "i1", _}} =
-               settler_for("failed").(args())
+      assert {:error, {:settlement_failed, :failed, "i1", _}} = settler_for("failed").(args())
     end
 
     test "an expired intent is an error, not a deliverable" do
-      assert {:error, {:settlement_failed, :expired, "i1", _}} =
-               settler_for("expired").(args())
+      assert {:error, {:settlement_failed, :expired, "i1", _}} = settler_for("expired").(args())
+    end
+
+    test "errors before any relay when the requirement carries no signed_intent" do
+      no_bundle = %{requirement: Map.delete(requirement(), "signed_intent")}
+      assert {:error, :missing_signed_intent} = settler_for("completed").(no_bundle)
+      refute_received {:relayed, _}
+    end
+
+    test "errors before any relay when the signed intent has no intent_id" do
+      bundle = Map.delete(signed_intent(), "intent_id")
+
+      assert {:error, {:invalid_signed_intent, :intent_id}} =
+               settler_for("completed").(args(%{signed_intent: bundle}))
+
+      refute_received {:relayed, _}
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_property_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_property_test.exs
@@ -1,0 +1,124 @@
+defmodule Raxol.ACP.Xochi.SolverAgentPropertyTest do
+  @moduledoc """
+  Invariants behind two money-safety properties of the Xochi solver storefront:
+
+  1. The storefront budget (the fee) never exceeds the transfer, for any transfer
+     size and fee bps. The transfer settles through Xochi off-escrow, so the ACP
+     budget only ever holds the fee -- a fraction of the transfer, never the
+     transfer itself.
+
+  2. A funded job settles only the session at its own `{chain_id, job_id}`, never
+     another session, regardless of what else is in flight. This is the guard
+     against a single funding event fanning out and spending funds for jobs that
+     were never funded.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.ACP.Xochi.SolverAgent
+
+  @fundable [:budget_proposed, :awaiting_fund]
+
+  # -- budget_for/2 --
+
+  property "the storefront fee never exceeds the transfer for a fractional fee" do
+    check all(
+            transfer <- integer(0..1_000_000_000_000_000_000_000_000),
+            fee_bps <- integer(0..10_000)
+          ) do
+      # budget is the fee (<= 100% of the transfer). The transfer itself flows
+      # via Xochi, never through the escrow, so the budget is always <= transfer.
+      assert SolverAgent.budget_for(transfer, fee_bps) <= transfer
+    end
+  end
+
+  property "a zero fee yields a zero budget" do
+    check all(transfer <- integer(0..1_000_000_000_000_000_000)) do
+      assert SolverAgent.budget_for(transfer, 0) == 0
+    end
+  end
+
+  property "the budget never shrinks as the fee grows (monotonic in fee_bps)" do
+    check all(
+            transfer <- integer(0..1_000_000_000_000_000_000),
+            {lo, hi} <- ordered_fee_pair()
+          ) do
+      assert SolverAgent.budget_for(transfer, lo) <= SolverAgent.budget_for(transfer, hi)
+    end
+  end
+
+  # -- settle_target/2 --
+
+  property "settle_target selects only the funded key, never another session" do
+    check all(
+            sessions <- sessions_gen(),
+            key <- job_key_gen()
+          ) do
+      case SolverAgent.settle_target(sessions, key) do
+        {:ok, selected_key, session} ->
+          assert selected_key == key
+          assert session == Map.fetch!(sessions, key)
+          assert session.status in @fundable
+
+        :none ->
+          case Map.fetch(sessions, key) do
+            {:ok, %{status: status}} -> assert status not in @fundable
+            :error -> assert true
+          end
+      end
+    end
+  end
+
+  property "the target for a key ignores every other session in flight" do
+    check all(
+            sessions <- sessions_gen(),
+            key <- job_key_gen(),
+            other <- sessions_gen()
+          ) do
+      # Merge unrelated sessions at other keys; the funded key's own entry wins,
+      # so the decision for `key` must be unchanged. A fan-out regression (any
+      # dependence on other sessions) breaks this.
+      merged = Map.merge(Map.delete(other, key), sessions)
+
+      assert SolverAgent.settle_target(merged, key) == SolverAgent.settle_target(sessions, key)
+    end
+  end
+
+  # -- generators --
+
+  defp ordered_fee_pair do
+    gen all(a <- integer(0..100_000), b <- integer(0..100_000)) do
+      {min(a, b), max(a, b)}
+    end
+  end
+
+  # A small key space so lookups hit present and absent keys roughly evenly.
+  defp job_key_gen do
+    gen all(chain <- integer(1..3), job <- integer(1..5)) do
+      {chain, Integer.to_string(job)}
+    end
+  end
+
+  defp session_gen do
+    gen all(
+          status <-
+            member_of([
+              :awaiting_requirement,
+              :budget_proposed,
+              :awaiting_fund,
+              :settling,
+              :submitted,
+              :completed,
+              :rejected,
+              :failed
+            ])
+        ) do
+      %{status: status}
+    end
+  end
+
+  defp sessions_gen do
+    map_of(job_key_gen(), session_gen(), max_length: 8)
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
@@ -3,12 +3,10 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
 
   alias Raxol.ACP.{Agent, ProviderAdapter, Transport, JobApi, JobSession}
   alias Raxol.ACP.Xochi.SolverAgent
-  alias Raxol.ACP.Hooks.FundTransfer
 
   @solver_wallet "0xfeedfacefeedfacefeedfacefeedfacefeedface"
   @evaluator "0x" <> String.duplicate("ed", 20)
   @acp_core "0x238E541BfefD82238730D00a2208E5497F1832E0"
-  @fund_transfer_hook "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B"
 
   setup do
     for {_, pid, _, _} <- DynamicSupervisor.which_children(JobSession.Supervisor),
@@ -43,8 +41,7 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
           wallet_address: @solver_wallet,
           evaluator_address: @evaluator,
           chain_id: 8453,
-          acp_core_address: @acp_core,
-          fund_transfer_hook_address: @fund_transfer_hook
+          acp_core_address: @acp_core
         ],
         opts
       )
@@ -69,8 +66,12 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
         "src_token" => "0x" <> String.duplicate("11", 20),
         "dst_token" => "0x" <> String.duplicate("22", 20),
         "amount_atomic" => "1000000",
-        "destination" => "0x" <> String.duplicate("ab", 20),
-        "slippage_bps" => 50
+        "signed_intent" => %{
+          "intent_id" => "xi_1",
+          "quote_id" => "xq_1",
+          "signature" => "0x" <> String.duplicate("11", 65),
+          "nonce" => 7
+        }
       })
 
     %{
@@ -127,14 +128,31 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
       assert %{{8453, "42"} => %{status: :budget_proposed, budget_atomic: budget}} =
                SolverAgent.sessions(solver)
 
-      # 0.5% of 1_000_000 = 5_000.
+      # Budget is the storefront fee only: 0.5% of 1_000_000 = 5_000. The
+      # transfer flows via Xochi off-escrow, not through the ACP budget.
       assert budget == 5_000
 
       assert [{8453, [call]}] = ProviderAdapter.Mock.sent_calls(ctx.provider)
       assert call.to == @acp_core
     end
 
-    test "fee_bps clamps to a minimum of 1", ctx do
+    test "the budget is the storefront fee, a fraction of the transfer, not the transfer", ctx do
+      {:ok, solver} = start_solver([fee_bps: 50], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      %{{8453, "42"} => session} = SolverAgent.sessions(solver)
+
+      # The ACP escrow holds only the storefront fee; the transfer moves through
+      # Xochi. So the budget is a small fraction of the transfer, never >= it.
+      assert session.budget_atomic == 5_000
+      assert session.budget_atomic < session.transfer_amount_atomic
+    end
+
+    test "zero fee_bps yields a zero budget", ctx do
       {:ok, solver} = start_solver([fee_bps: 0], ctx)
       Agent.start_stream(ctx.agent)
 
@@ -142,7 +160,7 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
       Transport.Mock.deliver(ctx.transport, requirement_message())
       Process.sleep(60)
 
-      assert %{{8453, "42"} => %{budget_atomic: 1}} = SolverAgent.sessions(solver)
+      assert %{{8453, "42"} => %{budget_atomic: 0}} = SolverAgent.sessions(solver)
     end
 
     test "malformed requirement marks the session :failed", ctx do
@@ -176,8 +194,8 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
          %{
            intent_id: "xochi-1",
            quote_id: "q-1",
-           src_tx_hash: "0x" <> String.duplicate("a", 64),
-           dst_tx_hash: "0x" <> String.duplicate("b", 64),
+           settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+           receiving_tx_hash: "0x" <> String.duplicate("b", 64),
            status: "settled"
          }}
       end
@@ -206,6 +224,44 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
 
       # Two ProviderAdapter calls: set_budget then submit.
       assert length(ProviderAdapter.Mock.sent_calls(ctx.provider)) == 2
+    end
+
+    test "job.funded settles only the funded job, not other pending sessions", ctx do
+      settle_stub = fn _ ->
+        {:ok,
+         %{
+           intent_id: "xochi-42",
+           settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+           receiving_tx_hash: "0x" <> String.duplicate("b", 64),
+           status: "settled"
+         }}
+      end
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      # Two independent jobs both reach :budget_proposed.
+      Transport.Mock.deliver(ctx.transport, job_created_entry(job_id: "42"))
+      Transport.Mock.deliver(ctx.transport, requirement_message(job_id: "42"))
+      Transport.Mock.deliver(ctx.transport, job_created_entry(job_id: "77"))
+      Transport.Mock.deliver(ctx.transport, requirement_message(job_id: "77"))
+      Process.sleep(80)
+
+      assert %{status: :budget_proposed} = SolverAgent.session(solver, {8453, "42"})
+      assert %{status: :budget_proposed} = SolverAgent.session(solver, {8453, "77"})
+
+      # Fund ONLY job 42.
+      Transport.Mock.deliver(
+        ctx.transport,
+        %{"kind" => "system", "event" => "job.funded", "chainId" => 8453, "jobId" => "42"}
+      )
+
+      Process.sleep(80)
+
+      # Job 42 settled; job 77 must be untouched -- a job.funded for 42 must not
+      # settle (spend funds for) an unfunded job.
+      assert SolverAgent.session(solver, {8453, "42"}).status == :submitted
+      assert SolverAgent.session(solver, {8453, "77"}).status == :budget_proposed
     end
 
     test "settle_fn failure marks the session :failed; no submit call", ctx do
@@ -260,9 +316,9 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
     end
   end
 
-  describe "encode/decode consistency with FundTransfer" do
-    test "the on-chain set_budget call carries the right FundTransfer data", ctx do
-      {:ok, _solver} = start_solver([], ctx)
+  describe "plain job (hook = address(0))" do
+    test "set_budget is a plain setBudget with empty hook data and a fee budget", ctx do
+      {:ok, _solver} = start_solver([fee_bps: 50], ctx)
       Agent.start_stream(ctx.agent)
 
       Transport.Mock.deliver(ctx.transport, job_created_entry())
@@ -270,15 +326,19 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
       Process.sleep(60)
 
       [{8453, [call]}] = ProviderAdapter.Mock.sent_calls(ctx.provider)
-      # Extract the dynamic bytes payload from the calldata. setBudget has
-      # selector(4) + 3 head words(96) = 100 bytes; the bytes length lives at
-      # offset 96 (third head slot pointer was at offset 100 from start of
-      # encoded args, so 64 from start of all head + 4 selector).
-      # Easier: re-encode the expected hook data and find it in the calldata.
-      expected_data =
-        FundTransfer.encode_set_budget_data(1_000_000, "0x" <> String.duplicate("ab", 20))
+      assert call.to == @acp_core
 
-      assert String.contains?(call.data, expected_data)
+      # The calldata is exactly setBudget(jobId=42, amount=fee, data=<<>>) -- no
+      # FundTransfer payload. Re-encoding with the same ABI encoder pins it
+      # without hardcoding byte offsets. fee = 0.5% of 1_000_000 = 5_000.
+      expected =
+        Raxol.ACP.ABI.encode_call("setBudget(uint256,uint256,bytes)", [
+          {"uint256", 42},
+          {"uint256", 5_000},
+          {"bytes", <<>>}
+        ])
+
+      assert call.data == expected
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
@@ -27,8 +27,12 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
         "src_token" => @usdc_base,
         "dst_token" => @usdc_arb,
         "amount_atomic" => "1100000",
-        "destination" => "0x000000000000000000000000000000000000dEaD",
-        "slippage_bps" => 50
+        "signed_intent" => %{
+          "intent_id" => "xi_1",
+          "quote_id" => "xq_1",
+          "signature" => "0x" <> String.duplicate("11", 65),
+          "nonce" => 7
+        }
       },
       overrides
     )
@@ -113,9 +117,8 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
       assert {:error, {:settler_not_configured, missing}} =
                TransferOffering.handle_deliver(req(%{}), @ctx)
 
-      assert :wallet_address in missing
-      assert :xochi_config in missing
-      assert :xochi_wallet in missing
+      # The relay Settler needs only :xochi_config (no signing wallet).
+      assert missing == [:xochi_config]
     end
 
     test "delivers the settler's result, stringified with nils dropped" do
@@ -125,8 +128,8 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
            %{
              intent_id: "int_1",
              quote_id: "q_1",
-             src_tx_hash: "0xabc",
-             dst_tx_hash: nil,
+             settlement_tx_hash: "0xabc",
+             receiving_tx_hash: nil,
              status: "settled"
            }}
         end
@@ -137,11 +140,11 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
       assert deliverable == %{
                "intent_id" => "int_1",
                "quote_id" => "q_1",
-               "src_tx_hash" => "0xabc",
+               "settlement_tx_hash" => "0xabc",
                "status" => "settled"
              }
 
-      refute Map.has_key?(deliverable, "dst_tx_hash")
+      refute Map.has_key?(deliverable, "receiving_tx_hash")
     end
 
     test "propagates a settler error so the job expires instead of completing" do

--- a/packages/raxol_acp/test/support/anvil_harness.ex
+++ b/packages/raxol_acp/test/support/anvil_harness.ex
@@ -120,6 +120,61 @@ defmodule Raxol.ACP.Test.AnvilHarness do
     {String.trim(out), code}
   end
 
+  @doc """
+  Deal ERC-20 `amount` (base units) to `holder` on the fork by overwriting the
+  token's `balanceOf[holder]` storage slot.
+
+  `balance_slot` is the storage slot index of the `balances` mapping (Circle
+  FiatToken USDC uses slot 9). The slot for `holder` is `cast index address
+  holder balance_slot`. Verify with `erc20_balance/3` after -- a wrong slot
+  leaves the balance unchanged.
+  """
+  @spec deal_erc20(String.t(), String.t(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          :ok
+  def deal_erc20(rpc, token, holder, amount, balance_slot) do
+    {slot, 0} = cast(["index", "address", holder, "#{balance_slot}"])
+    value = "0x" <> (amount |> Integer.to_string(16) |> String.pad_leading(64, "0"))
+    {_out, 0} = cast(["rpc", "anvil_setStorageAt", token, slot, value, "--rpc-url", rpc])
+    :ok
+  end
+
+  @doc "Read an ERC-20 `balanceOf(holder)` on the fork, as an integer (base units)."
+  @spec erc20_balance(String.t(), String.t(), String.t()) :: non_neg_integer()
+  def erc20_balance(rpc, token, holder) do
+    {out, 0} = cast(["call", token, "balanceOf(address)(uint256)", holder, "--rpc-url", rpc])
+    parse_uint(out)
+  end
+
+  @doc "Read a no-arg `uint256` view function (e.g. `jobCounter()(uint256)`) on the fork."
+  @spec read_uint(String.t(), String.t(), String.t()) :: non_neg_integer()
+  def read_uint(rpc, to, signature) do
+    {out, 0} = cast(["call", to, signature, "--rpc-url", rpc])
+    parse_uint(out)
+  end
+
+  @doc "Assert a transaction succeeded (receipt status 1); flunk with the status otherwise."
+  @spec assert_tx_success!(String.t(), String.t()) :: :ok
+  def assert_tx_success!(rpc, tx_hash) do
+    {status, 0} = cast(["receipt", tx_hash, "status", "--rpc-url", rpc])
+
+    if String.trim(status) in ["1", "0x1"] do
+      :ok
+    else
+      ExUnit.Assertions.flunk("tx #{tx_hash} reverted (status #{status})")
+    end
+  end
+
+  # `cast call ...(uint256)` prints the decoded decimal (occasionally with a
+  # trailing scientific-notation annotation); take the leading token.
+  defp parse_uint(out) do
+    token = out |> String.trim() |> String.split() |> List.first() || "0"
+
+    case token do
+      "0x" <> hex -> String.to_integer(hex, 16)
+      dec -> String.to_integer(dec)
+    end
+  end
+
   defp ensure_foundry! do
     unless System.find_executable("anvil") && System.find_executable("cast") do
       ExUnit.Assertions.flunk(":live_chain tests require foundry (anvil + cast) on PATH")

--- a/packages/raxol_acp/test/support/anvil_harness.ex
+++ b/packages/raxol_acp/test/support/anvil_harness.ex
@@ -181,7 +181,11 @@ defmodule Raxol.ACP.Test.AnvilHarness do
   def assert_tx_success!(rpc, tx_hash) do
     {status, 0} = cast(["receipt", tx_hash, "status", "--rpc-url", rpc])
 
-    if String.trim(status) in ["1", "0x1"] do
+    # `cast receipt <tx> status` prints e.g. "1 (success)" / "0 (failure)"; the
+    # leading token is the raw status.
+    leading = status |> String.trim() |> String.split() |> List.first()
+
+    if leading in ["1", "0x1"] do
       :ok
     else
       ExUnit.Assertions.flunk("tx #{tx_hash} reverted (status #{status})")

--- a/packages/raxol_acp/test/support/anvil_harness.ex
+++ b/packages/raxol_acp/test/support/anvil_harness.ex
@@ -59,20 +59,40 @@ defmodule Raxol.ACP.Test.AnvilHarness do
   ]
 
   @doc """
-  Spawn an anvil fork. Returns the RPC URL.
+  Start (or attach to) an anvil fork. Returns the RPC URL.
+
+  By default spawns its own `anvil --fork-url ...` and cleans it up on exit. To
+  reuse an already-running fork instead (e.g. a persistent anvil in an OrbStack
+  container), set `RAXOL_ACP_ANVIL_RPC` to its RPC URL -- the harness attaches to
+  it (verifying the chain id), spawns nothing, and leaves it running.
 
   ## Options
 
-  - `:fork_url` -- chain to fork. Default
+  - `:fork_url` -- chain to fork when spawning. Default
     `System.get_env("RAXOL_ACP_FORK_URL", "https://mainnet.base.org")`.
-  - `:port` -- TCP port for the anvil RPC. Default `8600`. Pass a
+  - `:port` -- TCP port for the spawned anvil RPC. Default `8600`. Pass a
     unique port per test module.
   - `:chain_id` -- the chain id to expect from `eth_chainId`. Default
     `8453` (Base).
   """
   @spec start!(keyword()) :: String.t()
   def start!(opts \\ []) do
-    ensure_foundry!()
+    expected_chain_id = Keyword.get(opts, :chain_id, 8453)
+
+    rpc =
+      case System.get_env("RAXOL_ACP_ANVIL_RPC") do
+        nil -> spawn_fork(opts)
+        external -> reuse_fork(external)
+      end
+
+    wait_until_chain_id(rpc, expected_chain_id)
+    rpc
+  end
+
+  # Spawn our own anvil fork (the default). Needs anvil + cast on PATH.
+  defp spawn_fork(opts) do
+    ensure_binary!("anvil")
+    ensure_binary!("cast")
 
     port = Keyword.get(opts, :port, 8600)
 
@@ -83,16 +103,20 @@ defmodule Raxol.ACP.Test.AnvilHarness do
         System.get_env("RAXOL_ACP_FORK_URL", "https://mainnet.base.org")
       )
 
-    expected_chain_id = Keyword.get(opts, :chain_id, 8453)
-
-    rpc = "http://127.0.0.1:#{port}"
     os_pid = spawn_anvil(fork_url, port)
 
     ExUnit.Callbacks.on_exit(fn ->
       System.cmd("kill", ["-9", "#{os_pid}"], stderr_to_stdout: true)
     end)
 
-    wait_until_chain_id(rpc, expected_chain_id)
+    "http://127.0.0.1:#{port}"
+  end
+
+  # Reuse an already-running anvil fork named by RAXOL_ACP_ANVIL_RPC (e.g. a
+  # persistent fork in an OrbStack container). We neither spawn nor kill it; only
+  # `cast` is needed on PATH to talk to it.
+  defp reuse_fork(rpc) do
+    ensure_binary!("cast")
     rpc
   end
 
@@ -175,9 +199,9 @@ defmodule Raxol.ACP.Test.AnvilHarness do
     end
   end
 
-  defp ensure_foundry! do
-    unless System.find_executable("anvil") && System.find_executable("cast") do
-      ExUnit.Assertions.flunk(":live_chain tests require foundry (anvil + cast) on PATH")
+  defp ensure_binary!(bin) do
+    unless System.find_executable(bin) do
+      ExUnit.Assertions.flunk(":live_chain tests require #{bin} on PATH (install foundry)")
     end
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -121,18 +121,84 @@ defmodule Raxol.Payments.Protocols.Xochi do
   @spec execute(Client.config(), QuoteResponse.t(), module(), QuoteRequest.t() | nil) ::
           {:ok, Raxol.Payments.Xochi.Schemas.ExecuteResponse.t()} | {:error, term()}
   def execute(config, %QuoteResponse{} = quote_resp, wallet, request) do
+    with {:ok, bundle} <- sign_intent(quote_resp, wallet, request) do
+      execute_signed(config, bundle)
+    end
+  end
+
+  @doc """
+  Sign a quoted intent into a relayable bundle WITHOUT executing it.
+
+  The buyer-side counterpart to `execute_signed/2`: validates the quote, signs
+  the EIP-712 intent with `wallet`, and returns the opaque bundle
+  `%{intent_id, quote_id, signature, nonce}` (plus `pull_signature` when the
+  quote carried an origin-pull authorization) to hand to a storefront/relay or
+  to `execute_signed/2` directly. Does not talk to the worker.
+  """
+  @spec sign_intent(QuoteResponse.t(), module()) :: {:ok, signed_intent()} | {:error, term()}
+  def sign_intent(quote_resp, wallet), do: sign_intent(quote_resp, wallet, nil)
+
+  @doc """
+  Like `sign_intent/2`, but binds the served `pull_authorization` to the caller's
+  intended transfer (`request`) before signing it -- see `execute/4` for why this
+  matters. Pass `nil` only when there is no pull authorization to validate; a
+  pull presented with a `nil` request fails closed.
+  """
+  @spec sign_intent(QuoteResponse.t(), module(), QuoteRequest.t() | nil) ::
+          {:ok, signed_intent()} | {:error, term()}
+  def sign_intent(%QuoteResponse{} = quote_resp, wallet, request) do
     with :ok <- validate_quote(quote_resp),
          :ok <- validate_pull_authorization(quote_resp, request, wallet),
          {:ok, signature} <- sign_quote(quote_resp, wallet),
          {:ok, pull_signature} <- sign_pull_authorization(quote_resp, wallet) do
-      exec_request = %ExecuteRequest{
-        intent_id: quote_resp.intent_id,
-        quote_id: quote_resp.quote_id,
-        signature: signature,
-        nonce: signed_nonce(quote_resp),
-        pull_signature: pull_signature
-      }
+      {:ok, build_signed_intent(quote_resp, signature, pull_signature)}
+    end
+  end
 
+  @doc """
+  Buyer-side one-shot: `get_quote/2` then `sign_intent/3`.
+
+  Fetches a quote for `request` and signs it into a relayable bundle. The buyer
+  hands the bundle to a storefront (e.g. as an ACP requirement's `signed_intent`)
+  which relays it via `execute_signed/2`; the storefront never re-signs.
+  """
+  @spec quote_and_sign(Client.config(), QuoteRequest.t(), module()) ::
+          {:ok, signed_intent()} | {:error, term()}
+  def quote_and_sign(config, %QuoteRequest{} = request, wallet) do
+    with {:ok, quote_resp} <- get_quote(config, request) do
+      sign_intent(quote_resp, wallet, request)
+    end
+  end
+
+  @typedoc """
+  A buyer's pre-signed Xochi intent bundle, as handed to the storefront relay.
+
+  Keys may be atoms (internal callers) or strings (decoded from an ACP
+  requirement). Required: `intent_id`, `quote_id`, `signature`, `nonce`.
+  Optional: `pull_signature` (nil for non-pulling methods), `aztec_proof`
+  (shielded claims).
+  """
+  @type signed_intent :: %{optional(atom() | String.t()) => term()}
+
+  @doc """
+  Relay a buyer's pre-signed intent to Xochi WITHOUT re-signing.
+
+  The storefront (pure-relay) primitive. The buyer quoted and signed the EIP-712
+  intent (and any origin-pull authorization) against Xochi itself, then handed
+  raxol the opaque bundle `{intent_id, quote_id, signature, nonce,
+  pull_signature}`. raxol posts it verbatim; Riddler verifies the signature
+  against its own server-persisted quote, so neither raxol nor the buyer can
+  forge the amount or route.
+
+  Unlike `execute/3,4`, this takes no wallet and releases no signature -- raxol
+  is never on the fund-signing path. Fails closed with
+  `{:error, {:invalid_signed_intent, field}}` on a missing or malformed field,
+  before any network call.
+  """
+  @spec execute_signed(Client.config(), signed_intent()) ::
+          {:ok, Raxol.Payments.Xochi.Schemas.ExecuteResponse.t()} | {:error, term()}
+  def execute_signed(config, signed_intent) when is_map(signed_intent) do
+    with {:ok, exec_request} <- build_signed_execute_request(signed_intent) do
       Client.execute(config, exec_request)
     end
   end
@@ -262,6 +328,78 @@ defmodule Raxol.Payments.Protocols.Xochi do
   end
 
   # -- Private --
+
+  # Assemble the relayable bundle from a signed quote. `nonce` is the worker's
+  # replay-dedup key derived from the quote (see `signed_nonce/1`); the pull
+  # signature key is present only when the quote carried an origin pull, so a
+  # non-pulling bundle serializes without a null `pull_signature`.
+  defp build_signed_intent(quote_resp, signature, pull_signature) do
+    %{
+      intent_id: quote_resp.intent_id,
+      quote_id: quote_resp.quote_id,
+      signature: signature,
+      nonce: signed_nonce(quote_resp)
+    }
+    |> put_pull_signature(pull_signature)
+  end
+
+  defp put_pull_signature(bundle, nil), do: bundle
+  defp put_pull_signature(bundle, sig), do: Map.put(bundle, :pull_signature, sig)
+
+  # Build an ExecuteRequest from a buyer-supplied bundle without signing. Fails
+  # closed on a missing/malformed field so a bad relay never reaches the worker
+  # (and never crashes on ExecuteRequest's enforced keys). Keys may be atoms or
+  # strings; `nonce` must be a non-negative integer (the worker's replay-dedup
+  # key), not a coerced string.
+  defp build_signed_execute_request(signed) do
+    with {:ok, intent_id} <- require_binary(signed, :intent_id),
+         {:ok, quote_id} <- require_binary(signed, :quote_id),
+         {:ok, signature} <- require_binary(signed, :signature),
+         {:ok, nonce} <- require_nonce(signed),
+         {:ok, pull_signature} <- optional_binary(signed, :pull_signature),
+         {:ok, aztec_proof} <- optional_binary(signed, :aztec_proof) do
+      {:ok,
+       %ExecuteRequest{
+         intent_id: intent_id,
+         quote_id: quote_id,
+         signature: signature,
+         nonce: nonce,
+         pull_signature: pull_signature,
+         aztec_proof: aztec_proof
+       }}
+    end
+  end
+
+  # A field present under either its atom or its string key.
+  defp fetch_field(map, field) do
+    case Map.fetch(map, field) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(map, Atom.to_string(field))
+    end
+  end
+
+  defp require_binary(map, field) do
+    case fetch_field(map, field) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, {:invalid_signed_intent, field}}
+    end
+  end
+
+  defp require_nonce(map) do
+    case fetch_field(map, :nonce) do
+      {:ok, nonce} when is_integer(nonce) and nonce >= 0 -> {:ok, nonce}
+      _ -> {:error, {:invalid_signed_intent, :nonce}}
+    end
+  end
+
+  defp optional_binary(map, field) do
+    case fetch_field(map, field) do
+      :error -> {:ok, nil}
+      {:ok, nil} -> {:ok, nil}
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, {:invalid_signed_intent, field}}
+    end
+  end
 
   defp validate_quote(%QuoteResponse{can_solve: false, error: err}) do
     {:error, {:cannot_solve, err || "no solver available"}}

--- a/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
@@ -129,6 +129,266 @@ defmodule Raxol.Payments.Protocols.XochiTest do
     end
   end
 
+  describe "execute_signed/2 (storefront relay)" do
+    # raxol as pure storefront: it relays the BUYER's pre-signed intent without
+    # re-signing. There is no wallet argument -- raxol never touches the transfer
+    # funds; Riddler verifies the signature against its own persisted quote.
+    test "relays the buyer's signed bundle verbatim, without a wallet" do
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      assert {:ok, _} = Xochi.execute_signed(config, signed_bundle())
+      assert_receive {:req, "POST", "/api/intent/execute", _h, raw_body}
+      body = Jason.decode!(raw_body)
+
+      assert body["intent_id"] == "xi_" <> String.duplicate("a", 32)
+      assert body["quote_id"] == "xq_" <> String.duplicate("b", 32)
+      assert body["signature"] == "0x" <> String.duplicate("11", 65)
+      assert body["pull_signature"] == "0x" <> String.duplicate("22", 65)
+      assert body["nonce"] == 7
+    end
+
+    test "omits pull_signature for a non-pull bundle" do
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      bundle = Map.delete(signed_bundle(), :pull_signature)
+
+      assert {:ok, _} = Xochi.execute_signed(config, bundle)
+      assert_receive {:req, "POST", "/api/intent/execute", _h, raw_body}
+      refute Map.has_key?(Jason.decode!(raw_body), "pull_signature")
+    end
+
+    test "accepts a string-keyed bundle (as decoded from an ACP requirement)" do
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      bundle = %{
+        "intent_id" => "xi_str",
+        "quote_id" => "xq_str",
+        "signature" => "0x" <> String.duplicate("33", 65),
+        "nonce" => 9
+      }
+
+      assert {:ok, _} = Xochi.execute_signed(config, bundle)
+      assert_receive {:req, "POST", "/api/intent/execute", _h, raw_body}
+      body = Jason.decode!(raw_body)
+      assert body["intent_id"] == "xi_str"
+      assert body["nonce"] == 9
+    end
+
+    test "passes through an aztec_proof for a shielded claim" do
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      bundle = signed_bundle(%{aztec_proof: "0x" <> String.duplicate("ab", 64)})
+
+      assert {:ok, _} = Xochi.execute_signed(config, bundle)
+      assert_receive {:req, "POST", "/api/intent/execute", _h, raw_body}
+      assert Jason.decode!(raw_body)["aztec_proof"] == "0x" <> String.duplicate("ab", 64)
+    end
+
+    test "fails closed on a missing or malformed field, before any network call" do
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      for field <- [:intent_id, :quote_id, :signature] do
+        bundle = Map.delete(signed_bundle(), field)
+        assert {:error, {:invalid_signed_intent, ^field}} = Xochi.execute_signed(config, bundle)
+      end
+
+      # nonce must be a non-negative integer (the worker's replay-dedup key); a
+      # numeric string or a negative value is rejected, not coerced.
+      assert {:error, {:invalid_signed_intent, :nonce}} =
+               Xochi.execute_signed(config, signed_bundle(%{nonce: -1}))
+
+      assert {:error, {:invalid_signed_intent, :nonce}} =
+               Xochi.execute_signed(config, signed_bundle(%{nonce: "7"}))
+
+      # an empty signature is not a signature
+      assert {:error, {:invalid_signed_intent, :signature}} =
+               Xochi.execute_signed(config, signed_bundle(%{signature: ""}))
+
+      refute_received {:req, "POST", "/api/intent/execute", _h, _b}
+    end
+  end
+
+  describe "sign_intent/3 (buyer-side: quote -> sign -> bundle, no execute)" do
+    @signer_addr "0x1111111111111111111111111111111111111111"
+
+    test "returns a relayable bundle and does not POST execute" do
+      quote_resp = quote_with_nonce(42)
+
+      # No config, no network -- sign_intent never talks to the worker.
+      assert {:ok, bundle} = Xochi.sign_intent(quote_resp, SignerWallet)
+      assert bundle.intent_id == quote_resp.intent_id
+      assert bundle.quote_id == quote_resp.quote_id
+      assert bundle.nonce == 42
+      assert is_binary(bundle.signature)
+      assert String.starts_with?(bundle.signature, "0x")
+      # No pull authorization in this quote -> no pull_signature key.
+      refute Map.has_key?(bundle, :pull_signature)
+    end
+
+    test "the signed bundle relays verbatim through execute_signed" do
+      quote_resp = quote_with_nonce(42)
+      {:ok, bundle} = Xochi.sign_intent(quote_resp, SignerWallet)
+
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      assert {:ok, _} = Xochi.execute_signed(config, bundle)
+      assert_receive {:req, "POST", "/api/intent/execute", _h, raw}
+      body = Jason.decode!(raw)
+      assert body["signature"] == bundle.signature
+      assert body["nonce"] == 42
+      assert body["intent_id"] == quote_resp.intent_id
+      assert body["quote_id"] == quote_resp.quote_id
+    end
+
+    test "sign_intent + execute_signed produces the same POST as execute" do
+      # The extracted sign half composes back into the full execute: relaying the
+      # signed bundle yields byte-for-byte the request execute/3 would send.
+      quote_resp = quote_with_nonce(42)
+
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      assert {:ok, _} = Xochi.execute(config, quote_resp, SignerWallet)
+      assert_receive {:req, "POST", "/api/intent/execute", _h, direct_body}
+
+      {:ok, bundle} = Xochi.sign_intent(quote_resp, SignerWallet)
+      assert {:ok, _} = Xochi.execute_signed(config, bundle)
+      assert_receive {:req, "POST", "/api/intent/execute", _h, relayed_body}
+
+      assert Jason.decode!(direct_body) == Jason.decode!(relayed_body)
+    end
+
+    test "includes pull_signature when the quote carries an origin pull" do
+      pull = canonical_erc3009_pull(%{message: %{"from" => @signer_addr}})
+
+      quote_resp = %QuoteResponse{
+        intent_id: "xi_pull",
+        quote_id: "xq_pull",
+        can_solve: true,
+        payment_method: "erc3009",
+        eip712_data: %{
+          "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+          "primaryType" => "XochiIntent",
+          "types" => %{"XochiIntent" => [%{"name" => "intentId", "type" => "string"}]},
+          "message" => %{"intentId" => "xi_pull"}
+        },
+        pull_authorization: pull
+      }
+
+      request = %QuoteRequest{
+        wallet: @signer_addr,
+        from_chain_id: 8453,
+        to_chain_id: 42_161,
+        from_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        to_token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        from_amount: "1000000",
+        settlement_preference: "public"
+      }
+
+      assert {:ok, bundle} = Xochi.sign_intent(quote_resp, SignerWallet, request)
+      assert is_binary(bundle.pull_signature)
+      assert String.starts_with?(bundle.pull_signature, "0x")
+    end
+
+    test "rejects a quote that cannot be solved, without signing" do
+      quote_resp = %QuoteResponse{
+        intent_id: "i",
+        quote_id: "q",
+        can_solve: false,
+        error: "no liquidity"
+      }
+
+      assert {:error, {:cannot_solve, "no liquidity"}} =
+               Xochi.sign_intent(quote_resp, SignerWallet)
+    end
+
+    test "refuses to sign a served pull authorization with no request context" do
+      pull = canonical_erc3009_pull(%{message: %{"from" => @signer_addr}})
+
+      quote_resp = %QuoteResponse{
+        intent_id: "xi_noctx",
+        quote_id: "xq_noctx",
+        can_solve: true,
+        payment_method: "erc3009",
+        eip712_data: %{
+          "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+          "primaryType" => "XochiIntent",
+          "types" => %{"XochiIntent" => [%{"name" => "intentId", "type" => "string"}]},
+          "message" => %{"intentId" => "xi_noctx"}
+        },
+        pull_authorization: pull
+      }
+
+      assert {:error, {:authorization_mismatch, :no_request_context}} =
+               Xochi.sign_intent(quote_resp, SignerWallet)
+    end
+  end
+
+  describe "quote_and_sign/3 (buyer-side one-shot)" do
+    test "fetches a quote then signs it into a relayable bundle" do
+      quote_json = %{
+        "intentId" => "xi_qs",
+        "quoteId" => "xq_qs",
+        "canSolve" => true,
+        "eip712Data" => %{
+          "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+          "primaryType" => "XochiIntent",
+          "types" => %{"XochiIntent" => [%{"name" => "nonce", "type" => "uint256"}]},
+          "message" => %{"nonce" => 5}
+        }
+      }
+
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: json_plug(quote_json)]
+      }
+
+      request = %QuoteRequest{
+        wallet: "0x1111111111111111111111111111111111111111",
+        from_chain_id: 8453,
+        to_chain_id: 42_161,
+        from_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        to_token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        from_amount: "1000000",
+        settlement_preference: "public"
+      }
+
+      assert {:ok, bundle} = Xochi.quote_and_sign(config, request, SignerWallet)
+      assert bundle.intent_id == "xi_qs"
+      assert bundle.quote_id == "xq_qs"
+      assert bundle.nonce == 5
+      assert is_binary(bundle.signature)
+    end
+  end
+
   describe "execute/3 domain parity" do
     @anvil_key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     @anvil_addr "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
@@ -919,6 +1179,22 @@ defmodule Raxol.Payments.Protocols.XochiTest do
     }
   end
 
+  # A buyer-signed intent bundle, as handed to the storefront relay. raxol
+  # relays it verbatim; there is no wallet in execute_signed/2. Signature values
+  # are opaque (Riddler verifies them against its persisted quote).
+  defp signed_bundle(overrides \\ %{}) do
+    Map.merge(
+      %{
+        intent_id: "xi_" <> String.duplicate("a", 32),
+        quote_id: "xq_" <> String.duplicate("b", 32),
+        signature: "0x" <> String.duplicate("11", 65),
+        nonce: 7,
+        pull_signature: "0x" <> String.duplicate("22", 65)
+      },
+      overrides
+    )
+  end
+
   defp echo_plug(test_pid) do
     fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
@@ -927,6 +1203,15 @@ defmodule Raxol.Payments.Protocols.XochiTest do
       conn
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.send_resp(200, Jason.encode!(%{"status" => "submitted"}))
+    end
+  end
+
+  # Serves a fixed JSON body on any path (used to stub a quote response).
+  defp json_plug(json) do
+    fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(json))
     end
   end
 


### PR DESCRIPTION
## Summary

Reworks the ACP `xochi_cross_chain_transfer` offering into a **pure storefront**: the buyer quotes and signs the Xochi intent itself, and raxol relays the signed bundle without ever signing or holding the transfer funds. The transfer settles through Xochi off-escrow (no ACP-core haircut on the transfer amount); raxol earns only the storefront fee, netting 90% of the ACP budget on completion.

Also lands the on-chain/seller hardening the storefront rides on, plus a fork trace of the fee path against the real deployed core.

## What changed

**Harden ACP on-chain and seller paths**
- EIP-1559 y-parity: normalize the wallet's 27/28 `v` to 0/1 (a 27/28 y-parity was reverting every real on-chain EOA write)
- Real deployed `createJob(address,address,uint256,string,address)` selector + resolve the jobId from the `JobCreated` data word, fail-closed on an unresolved id
- Atomic seed-or-increment nonce assignment (concurrent first-txs cannot collide)
- Seller queue: crash-safe dispatch, never-swallow handler errors, concurrent-job backpressure cap

**Rework ACP offering as pure-storefront relay**
- `raxol_payments`: `Xochi.execute_signed/2` (relay a pre-signed intent, no re-sign) + `sign_intent/2,3` + `quote_and_sign/3` (buyer-side quote -> sign -> bundle); `execute/4` now composes the two
- Settler relays + polls (drops the self-sign / same-owner path); SolverAgent is the provider on a plain job (hook=0, budget=fee, no FundTransferHook)
- Requirement carries the buyer's `signed_intent`; the deliverable names its tx hashes `settlement_tx_hash` / `receiving_tx_hash` (honest for instant single-tx fills)
- Live order gate reworked to the relay model; preflight soft-skips a `can_solve:false` 503

**Add ACP fee-path fork trace**
- `:live_chain` test driving the real `AgenticCommerceV3` core on a Base fork: `createJob(hook=0)` -> `setBudget(fee)` -> `fund` -> `submit` -> `complete`, asserting the provider nets `budget*0.90` via real USDC balance deltas + the `PaymentReleased` event (fees read from the fork). `AnvilHarness` can spawn its own fork or reuse an external one via `RAXOL_ACP_ANVIL_RPC`.

## Live validation

- **Off-chain relay E2E settled real funds on prod Xochi** (Base -> Arbitrum USDC): `completed` in 1.66s, tx `0xbe9d6b1a56de29dbabf94b3dd22d9f598c6ff752f6deb6e37e34f75ed50cf279` -- Blockscout-verified on Arbitrum, the pinned solver `0x97D447…` delivered 1.092107 USDC to the buyer on the destination chain. Mesh preflight: 85/90 corridors quote fillable with the correct pinned solver.
- **On-chain fee path proven on a Base fork**: the fee-path fork trace runs green against the real deployed core -- `PaymentReleased` pays the provider `budget*0.90`, platform + evaluator each take 5% (read from the fork).

## Test status

- `raxol_payments`: 53 properties / 878 tests / 0 failures
- `raxol_acp`: 10 properties / 657 tests / 0 failures
- Fee-path fork trace: 1 test / 0 failures (Base fork, foundry)
- `mix compile --warnings-as-errors` + `mix format --check-formatted` clean

## Manual testing

- [x] Relay E2E settled real funds on prod Xochi (Base->Arbitrum USDC, tx `0xbe9d6b1a…cf279`, on-chain verified)
- [x] Mesh preflight (90 corridors) discovers the offering and quotes read-only with the correct solver pin
- [x] Fee-path fork trace runs green against a Base fork (`mix test --include live_chain test/raxol/acp/xochi/fee_path_fork_test.exs`): provider nets `budget*0.90`, `PaymentReleased` fires
- [ ] Broader live order settlement across more corridors/tokens
