### PR TITLE
Finalize ACP first offering: schema, fee, docs

### DIFF
--- a/docs/features/ACP.md
+++ b/docs/features/ACP.md
@@ -61,6 +61,16 @@ end
 
 The DSL injects the `Handler` behaviour and registers metadata in the ETS-backed `Registry`. `Job.Server.accept_request/1` and `deliver/1` auto-invoke the handler and submit on-chain memos with the configured wallet.
 
+## Xochi Cross-Chain Transfer (the first offering)
+
+`Raxol.ACP.Xochi.TransferOffering` is the first offering: a **pure storefront** for cross-chain stablecoin transfers. raxol never signs or holds the buyer's funds.
+
+- The buyer quotes and signs a Xochi intent themselves (`Raxol.Payments.Protocols.Xochi.quote_and_sign/3`) and puts the signed bundle in the job requirement's `signed_intent`.
+- On delivery, `Raxol.ACP.Xochi.Settler` relays that bundle to Xochi via `execute_signed/2` (no re-signing) and polls it to settlement; the deliverable is the on-chain settlement tx hashes.
+- The transfer settles through Xochi off-escrow, so the ACP core's take never bites it. The job is a **plain job** (`hook = address(0)`); the ACP budget is only raxol's storefront fee -- **8 bps of the transfer**, set via `:fee_bps`. On completion the provider nets `budget * 0.90`.
+
+`packages/raxol_acp/examples/buyer_signed_intent.exs` shows the buyer flow and the requirement/deliverable schemas to register on the marketplace.
+
 ## Memos
 
 Each phase emits an on-chain memo via `Raxol.ACP.ContractClient.create_memo/5`, mirroring `InteractionLedger.createMemo` from the deployed contract. There is no off-chain memo signing: the canonical ACP contract does not accept a separate memo signature, the transaction itself is the proof. Memo kinds are the `Raxol.ACP.Job.MemoType` enum (uint8, ids 0..9).
@@ -88,7 +98,7 @@ Start a `Job.Server` with `:expired_at` (unix seconds) and it arms a timer that 
 
 ## Nonce Serialization
 
-The `Raxol.ACP.Wallet.NonceServer` GenServer serializes EVM nonce assignment through its mailbox. The original integration plan claimed process-per-job avoided concurrent-Alchemy collisions, but it doesn't. NonceServer does. A transaction that fails before it is broadcast rolls the consumed nonce back, so the next transaction reuses it instead of leaving a gap that would strand every later transaction (the SCA path reads its nonce fresh per call and is unaffected).
+The `Raxol.ACP.Wallet.NonceServer` GenServer serializes EVM nonce assignment through its mailbox, so concurrent jobs from one wallet cannot collide on a nonce. A transaction that fails before it is broadcast rolls the consumed nonce back, so the next transaction reuses it instead of leaving a gap that would strand every later transaction (the SCA path reads its nonce fresh per call and is unaffected).
 
 ## Seller Stack
 
@@ -101,15 +111,9 @@ Opt-in via `:seller_enabled` in config:
 
 `Backend.WebSocket` (talking to Virtuals' relayer) is on the roadmap. The protocol spec is available via the `virtuals-protocol-acp` skill.
 
-## What's Blocked
+## Status
 
-External dependencies still pending:
-
-- `Wallet.SCA`: needs Virtuals' SCA contract spec
-- Real Virtuals ABIs (current encoder uses placeholder method ids)
-- WebSocket protocol implementation
-
-`mix raxol_acp.bench` is a sandbox-graduation harness that runs end-to-end against the InMemory backend.
+Pre-alpha, not yet on Hex. The `Wallet.SCA` ERC-4337 stack, the real vendored ABIs (`priv/abi/`), and the `Backend.WebSocket` Socket.IO client are implemented; the on-chain paths are fork-validated against the real deployed core on Base. `mix raxol_acp.bench` runs end-to-end against the InMemory backend.
 
 ## See Also
 

--- a/docs/features/AGENTIC_COMMERCE.md
+++ b/docs/features/AGENTIC_COMMERCE.md
@@ -58,6 +58,14 @@ The quote will carry an optional `fee_breakdown`: the per-layer split (solver, v
 
 Flow: `get_quote/2` -> `execute/3` (wallet signs EIP-712 intent) -> `poll_status/3`.
 
+For a storefront that settles on a buyer's behalf, the signing and the submission split into a buyer-side half and a relay-side half:
+
+- `sign_intent/2,3` and `quote_and_sign/3` (buyer side) quote and sign the intent and return the opaque bundle `{intent_id, quote_id, signature, nonce, pull_signature}` **without submitting** -- the buyer hands this to the storefront.
+- `execute_signed/2` (relay side) posts a pre-signed bundle to Xochi **without re-signing**, so the relay never holds the buyer's key.
+- `execute/4` is the two composed: `sign_intent` then `execute_signed`.
+
+The Xochi Cross-Chain Transfer ACP offering (in `raxol_acp`, see [ACP](ACP.md)) is built on this split -- the buyer signs, raxol relays. `packages/raxol_acp/examples/buyer_signed_intent.exs` shows the buyer flow.
+
 Xochi is the default for cross-chain and privacy (stealth addresses, shielded transfers). It's cash-positive by design: the protocol takes a fee, the agent pays it, done.
 
 ### Riddler (direct solver, B2B only)

--- a/packages/raxol_acp/README.md
+++ b/packages/raxol_acp/README.md
@@ -43,6 +43,10 @@ See `Raxol.ACP.Supervisor` for the supervision tree. Subsystems:
 - **SCA wallet**: `Raxol.ACP.Wallet.SCA` is a full ERC-4337 v0.7 / Alchemy Modular Account v2 stack (UserOp, bundler, paymaster, counterfactual CREATE2 provisioning, session keys). `Onchain` detects an SCA wallet and routes writes through sponsored UserOps, self-deploying on the first tx. Live-validated against the real on-chain EntryPoint on a Base fork.
 - **Seller runtime**: `Raxol.ACP.Seller.{Runtime, Queue, Supervisor}` plus `Backend.{InMemory, WebSocket}`. The WebSocket backend speaks Socket.IO v4 / Engine.IO over `Mint.WebSocket`; the runtime dispatches incoming jobs to the queue.
 
+## First offering: Xochi Cross-Chain Transfer
+
+`Raxol.ACP.Xochi.TransferOffering` sells cross-chain stablecoin transfers as a **pure storefront**. The buyer quotes and signs a Xochi intent themselves (`Raxol.Payments.Protocols.Xochi.quote_and_sign/3`) and puts the signed bundle in the job requirement; on delivery `Raxol.ACP.Xochi.Settler` relays it to Xochi via `execute_signed/2` and returns the settlement tx hashes. raxol never signs or holds the transfer funds. The transfer settles off-escrow through Xochi; the ACP budget is only raxol's storefront fee (8 bps of the transfer, via `:fee_bps`). See `examples/buyer_signed_intent.exs`.
+
 ## Dependencies
 
 - `raxol_payments` for wallet signing (`Raxol.Payments.EIP712`, `Raxol.Payments.Wallet`) and Xochi cross-chain settlement

--- a/packages/raxol_acp/examples/buyer_signed_intent.exs
+++ b/packages/raxol_acp/examples/buyer_signed_intent.exs
@@ -1,0 +1,98 @@
+# Buyer-side: produce the `signed_intent` bundle for the "Xochi Cross-Chain
+# Transfer" ACP offering, then assemble the job requirement raxol relays.
+#
+# raxol sells the transfer as a PURE STOREFRONT: the buyer quotes and signs the
+# Xochi intent itself (raxol never sees the key and never signs), and hands raxol
+# the opaque `signed_intent` bundle. raxol relays it via
+# `Raxol.Payments.Protocols.Xochi.execute_signed/2` and returns the settlement tx
+# hashes. The transfer settles through Xochi off-escrow; the ACP job budget is
+# only raxol's storefront fee (8 bps of the transfer, the Standard-tier routing
+# rate).
+#
+# Run (needs a funded key + a Xochi Member token or mandate):
+#
+#     BUYER_PRIVATE_KEY=0x... XOCHI_MEMBER_TOKEN=... \
+#       mix run examples/buyer_signed_intent.exs
+#
+# Without BUYER_PRIVATE_KEY it prints the shapes without hitting the network.
+
+alias Raxol.Payments.Protocols.Xochi
+alias Raxol.Payments.Xochi.Schemas.QuoteRequest
+
+# The buyer's wallet holds the origin funds. raxol never sees this key.
+defmodule BuyerWallet do
+  use Raxol.Payments.Wallets.Env, env_var: "BUYER_PRIVATE_KEY"
+end
+
+# USDC, Base -> Arbitrum, 1.0 USDC. `wallet` is BOTH funder and recipient (Xochi
+# has no separate recipient field), so funds arrive at your own address on dst.
+build_request = fn wallet_address ->
+  %QuoteRequest{
+    wallet: wallet_address,
+    from_chain_id: 8453,
+    to_chain_id: 42_161,
+    from_token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    to_token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    from_amount: "1000000",
+    settlement_preference: "public",
+    slippage_bps: 50
+  }
+end
+
+# Assemble the ACP job requirement from a bundle (atom-keyed) -- stringify the
+# bundle keys for JSON transport. This is what a buyer submits as the job
+# requirement to the "xochi_cross_chain_transfer" offering.
+build_requirement = fn request, bundle ->
+  %{
+    "src_chain_id" => request.from_chain_id,
+    "dst_chain_id" => request.to_chain_id,
+    "src_token" => request.from_token,
+    "dst_token" => request.to_token,
+    "amount_atomic" => request.from_amount,
+    "signed_intent" => Map.new(bundle, fn {k, v} -> {to_string(k), v} end)
+  }
+end
+
+case System.get_env("BUYER_PRIVATE_KEY") do
+  nil ->
+    # No key -- show the shapes with a placeholder bundle (no network call).
+    request = build_request.("0xYOUR_WALLET")
+
+    bundle = %{
+      intent_id: "xi_<from Xochi>",
+      quote_id: "xq_<from Xochi>",
+      signature: "0x<EIP-712 signature over the XochiIntent>",
+      nonce: 0,
+      pull_signature: "0x<ERC-3009/Permit2 origin-pull signature>"
+    }
+
+    IO.puts("(set BUYER_PRIVATE_KEY + XOCHI_MEMBER_TOKEN to sign for real)\n")
+    IO.puts("signed_intent bundle (shape):")
+    IO.inspect(bundle, pretty: true)
+    IO.puts("\nACP job requirement (hand this to the offering):")
+    IO.puts(Jason.encode!(build_requirement.(request, bundle), pretty: true))
+
+  _key ->
+    request = build_request.(BuyerWallet.address())
+
+    # Xochi config. Auth here is a Member token; also {:mandate, agent_wallet}
+    # or {:x402, wallet: BuyerWallet}. See Raxol.Payments.Xochi.Client.
+    config = %{
+      base_url: System.get_env("XOCHI_URL", "https://api.xochi.fi"),
+      auth_token: System.get_env("XOCHI_MEMBER_TOKEN", "")
+    }
+
+    # Quote + sign in one call. raxol never sees the key; the bundle is what you
+    # hand the storefront.
+    case Xochi.quote_and_sign(config, request, BuyerWallet) do
+      {:ok, bundle} ->
+        IO.puts("signed_intent bundle:")
+        IO.inspect(bundle, pretty: true)
+        IO.puts("\nACP job requirement (hand this to the offering):")
+        IO.puts(Jason.encode!(build_requirement.(request, bundle), pretty: true))
+
+      {:error, reason} ->
+        IO.puts("quote_and_sign failed: #{inspect(reason)}")
+        IO.puts("(needs a funded key + a valid Xochi auth token / mandate)")
+    end
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -194,10 +194,6 @@ defmodule Raxol.ACP.Xochi.Offering do
           "type" => "string",
           "description" => "Xochi intent identifier returned by POST /xochi/quote."
         },
-        "quote_id" => %{
-          "type" => "string",
-          "description" => "Xochi quote identifier (audit trail)."
-        },
         "settlement_tx_hash" => %{
           "type" => "string",
           "pattern" => "^0x[0-9a-fA-F]{64}$",
@@ -213,20 +209,18 @@ defmodule Raxol.ACP.Xochi.Offering do
             "The destination-arrival transaction hash for a two-leg settlement. " <>
               "Absent (null) for an instant single-tx fill."
         },
+        "amount_atomic" => %{
+          "type" => "string",
+          "pattern" => "^[0-9]+$",
+          "description" =>
+            "The transfer amount settled, in token base units (matches the " <>
+              "requirement's amount_atomic; committed so the deliverable hash pins " <>
+              "what was moved)."
+        },
         "status" => %{
           "type" => "string",
-          "enum" => ["pending", "settled", "failed", "refunded"],
-          "description" => "Lifecycle state of the Xochi intent."
-        },
-        "fee_atomic" => %{
-          "type" => "string",
-          "pattern" => "^[0-9]+$",
-          "description" => "Xochi service fee charged in USDC base units."
-        },
-        "dst_amount_atomic" => %{
-          "type" => "string",
-          "pattern" => "^[0-9]+$",
-          "description" => "Amount actually received on dst_chain_id (post-slippage)."
+          "enum" => ["completed"],
+          "description" => "Settlement lifecycle state; a delivered job is always completed."
         }
       }
     }

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
@@ -10,7 +10,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
      message.
   2. **`message` (contentType "requirement")** -- parse the requirement JSON
      against `Raxol.ACP.Xochi.Offering.requirement_schema/0` (which carries the
-     buyer's signed intent bundle), compute the storefront fee (default 50 bps
+     buyer's signed intent bundle), compute the storefront fee (default 8 bps
      via `:fee_bps`), and propose the budget on-chain via
      `Raxol.ACP.HookClient.set_budget/6`. This is a PLAIN job (hook =
      `address(0)`), so `set_budget` carries no hook data -- the budget is the
@@ -31,7 +31,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
         evaluator_address: "0xevaluator...",
         chain_id: 8453,
         acp_core_address: "0x238E541BfefD82238730D00a2208E5497F1832E0",
-        fee_bps: 50,
+        fee_bps: 8,
         settle_fn: Raxol.ACP.Xochi.Settler.build(xochi_config: %{base_url: "..."})
       )
 
@@ -98,7 +98,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
     :acp_core_address,
     :xochi_config,
     settle_fn: nil,
-    fee_bps: 50,
+    fee_bps: 8,
     sessions: %{}
   ]
 
@@ -135,7 +135,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       evaluator_address: Keyword.fetch!(opts, :evaluator_address),
       chain_id: Keyword.fetch!(opts, :chain_id),
       acp_core_address: Keyword.fetch!(opts, :acp_core_address),
-      fee_bps: Keyword.get(opts, :fee_bps, 50),
+      fee_bps: Keyword.get(opts, :fee_bps, 8),
       settle_fn: Keyword.get(opts, :settle_fn, &default_settle/1),
       xochi_config: Keyword.get(opts, :xochi_config, %{})
     }

--- a/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
+++ b/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
@@ -64,14 +64,11 @@ defmodule Mix.Tasks.Acp.RegisterOfferingTest do
              )
     end
 
-    test "deliverable schema has settled/failed/refunded/pending status enum" do
+    test "deliverable schema bounds status to completed" do
       payload = RegisterOffering.build_payload(:mainnet)
       enum = payload["deliverableSchema"]["properties"]["status"]["enum"]
 
-      assert MapSet.equal?(
-               MapSet.new(enum),
-               MapSet.new(["pending", "settled", "failed", "refunded"])
-             )
+      assert enum == ["completed"]
     end
 
     test "payload round-trips through JSON" do

--- a/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
@@ -118,15 +118,24 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
       assert MapSet.equal?(required, MapSet.new(["intent_id", "settlement_tx_hash", "status"]))
     end
 
-    test "status is bounded" do
+    test "status is bounded to completed (a delivered job always settled)" do
       schema = Offering.deliverable_schema()
+      assert schema["properties"]["status"]["enum"] == ["completed"]
+    end
 
-      assert schema["properties"]["status"]["enum"] == [
-               "pending",
-               "settled",
-               "failed",
-               "refunded"
-             ]
+    test "the delivered fields match what the Settler produces" do
+      props = Offering.deliverable_schema()["properties"]
+
+      assert MapSet.equal?(
+               MapSet.new(Map.keys(props)),
+               MapSet.new([
+                 "intent_id",
+                 "settlement_tx_hash",
+                 "receiving_tx_hash",
+                 "amount_atomic",
+                 "status"
+               ])
+             )
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
@@ -127,10 +127,10 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
           {:ok,
            %{
              intent_id: "int_1",
-             quote_id: "q_1",
              settlement_tx_hash: "0xabc",
              receiving_tx_hash: nil,
-             status: "settled"
+             amount_atomic: "1100000",
+             status: "completed"
            }}
         end
       )
@@ -139,9 +139,9 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
 
       assert deliverable == %{
                "intent_id" => "int_1",
-               "quote_id" => "q_1",
                "settlement_tx_hash" => "0xabc",
-               "status" => "settled"
+               "amount_atomic" => "1100000",
+               "status" => "completed"
              }
 
       refute Map.has_key?(deliverable, "receiving_tx_hash")


### PR DESCRIPTION
The `xochi_cross_chain_transfer` deliverable schema drifted from what the relay `Settler` actually delivers, which would misrepresent the offering to buyers/evaluators on the marketplace.

- Add `amount_atomic` (the Settler produces it; `additionalProperties: false` was forbidding it)
- Drop `fee_atomic` / `dst_amount_atomic` (never produced by the relay -- the buyer has these from their own Xochi quote) and `quote_id`
- Fix the `status` enum to `["completed"]` (the only state a delivered job is in; was `pending/settled/failed/refunded`, none of which the relay emits)

The schema now exactly matches the Settler's `to_deliverable` output: `{intent_id, settlement_tx_hash, receiving_tx_hash?, amount_atomic, status}`.

## Test status
- raxol_acp: 10 properties / 658 tests / 0 failures; format + warnings clean
- Updated the two enum tests + the transfer_offering stub; added a test pinning the deliverable field set to the Settler's output

## Manual testing
- [x] `mix run` prints the reconciled schema; fields match `Settler.to_deliverable/2`