### PR TITLE
Harden ACP offering for marketplace listing

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -60,9 +60,10 @@ defmodule Raxol.ACP.Xochi.Offering do
       display_name: "Xochi Cross-Chain Transfer",
       description:
         "Cross-chain stablecoin settlement storefront. The buyer signs a Xochi " <>
-          "intent, the storefront relays it and returns the settlement tx hashes; " <>
-          "the buyer escrows only the storefront fee (a plain job, no fund hook).",
-      required_funds: true,
+          "intent, the storefront relays it and returns the settlement tx hashes. " <>
+          "The transfer moves off-escrow via the buyer's own signed intent, so " <>
+          "raxol never takes the buyer's funds; only the storefront fee is paid.",
+      required_funds: false,
       hook_kind: "none",
       sla_minutes: 10,
       requirement_schema: requirement_schema(),
@@ -245,9 +246,27 @@ defmodule Raxol.ACP.Xochi.Offering do
 
   def valid_requirement?(_), do: false
 
-  defp valid_signed_intent?(bundle) when is_map(bundle) do
-    Enum.all?(~w(intent_id quote_id signature nonce), &Map.has_key?(bundle, &1))
+  @doc """
+  Normalize a `signed_intent` value to a map. The marketplace schema builder may
+  deliver the bundle as a nested object (a map) or, if it only supports flat
+  fields, as a JSON string; accept both. Returns `:error` for anything else.
+  """
+  @spec decode_signed_intent(term()) :: {:ok, map()} | :error
+  def decode_signed_intent(bundle) when is_map(bundle), do: {:ok, bundle}
+
+  def decode_signed_intent(bundle) when is_binary(bundle) do
+    case Jason.decode(bundle) do
+      {:ok, map} when is_map(map) -> {:ok, map}
+      _ -> :error
+    end
   end
 
-  defp valid_signed_intent?(_), do: false
+  def decode_signed_intent(_), do: :error
+
+  defp valid_signed_intent?(bundle) do
+    case decode_signed_intent(bundle) do
+      {:ok, map} -> Enum.all?(~w(intent_id quote_id signature nonce), &Map.has_key?(map, &1))
+      :error -> false
+    end
+  end
 end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
@@ -105,14 +105,23 @@ defmodule Raxol.ACP.Xochi.Settler do
   end
 
   # The buyer's pre-signed intent bundle, threaded directly (`:signed_intent`) or
-  # carried in the requirement JSON (`requirement["signed_intent"]`). Keys may be
-  # atoms or strings; `execute_signed/2` normalizes and deep-validates them.
-  defp extract_signed_intent(%{signed_intent: bundle}) when is_map(bundle), do: {:ok, bundle}
+  # carried in the requirement (`requirement["signed_intent"]`). It may be a map
+  # (a nested object) or a JSON string (a flat marketplace schema); both normalize
+  # to a map. Keys may be atoms or strings; `execute_signed/2` deep-validates them.
+  defp extract_signed_intent(%{signed_intent: bundle}) when not is_nil(bundle),
+    do: normalize_bundle(bundle)
 
-  defp extract_signed_intent(%{requirement: %{"signed_intent" => bundle}}) when is_map(bundle),
-    do: {:ok, bundle}
+  defp extract_signed_intent(%{requirement: %{"signed_intent" => bundle}}),
+    do: normalize_bundle(bundle)
 
   defp extract_signed_intent(_), do: {:error, :missing_signed_intent}
+
+  defp normalize_bundle(bundle) do
+    case Raxol.ACP.Xochi.Offering.decode_signed_intent(bundle) do
+      {:ok, map} -> {:ok, map}
+      :error -> {:error, :missing_signed_intent}
+    end
+  end
 
   # The status is polled by the intent id the buyer signed (present under either
   # key). `execute_signed/2` re-validates it, so an absent/blank id also fails

--- a/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
+++ b/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Acp.RegisterOfferingTest do
 
       assert payload["name"] == "xochi_cross_chain_transfer"
       assert payload["hookKind"] == "none"
-      assert payload["requiredFunds"] == true
+      assert payload["requiredFunds"] == false
       assert payload["slaMinutes"] == 10
       assert "payments" in payload["tags"]
     end

--- a/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
@@ -8,7 +8,9 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
       meta = Offering.offering_metadata()
 
       assert meta.name == "xochi_cross_chain_transfer"
-      assert meta.required_funds == true
+      # raxol never takes the buyer's transfer funds (off-escrow relay), so the
+      # offering does not require a fund deposit.
+      assert meta.required_funds == false
       assert meta.hook_kind == "none"
       assert meta.sla_minutes == 10
       assert "payments" in meta.tags
@@ -103,6 +105,17 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
              })
 
       refute Offering.valid_requirement?(%{minimal_req() | "signed_intent" => "not-a-map"})
+    end
+
+    test "accepts a signed_intent delivered as a JSON string (flat marketplace schema)" do
+      json = Jason.encode!(minimal_req()["signed_intent"])
+      assert Offering.valid_requirement?(%{minimal_req() | "signed_intent" => json})
+    end
+
+    test "rejects a JSON-string signed_intent that is malformed or missing keys" do
+      refute Offering.valid_requirement?(%{minimal_req() | "signed_intent" => "{not json"})
+      partial = Jason.encode!(%{"intent_id" => "x"})
+      refute Offering.valid_requirement?(%{minimal_req() | "signed_intent" => partial})
     end
 
     test "rejects non-map input" do

--- a/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
@@ -135,6 +135,18 @@ defmodule Raxol.ACP.Xochi.SettlerTest do
       assert deliverable.intent_id == "i1"
     end
 
+    test "relays a signed intent delivered as a JSON string (flat marketplace schema)" do
+      json = Jason.encode!(signed_intent())
+      req = Map.put(requirement(), "signed_intent", json)
+      args = %{requirement: req, transfer_amount_atomic: 1_000_000}
+
+      assert {:ok, deliverable} = settler_for("completed").(args)
+      assert deliverable.intent_id == "i1"
+      assert_receive {:relayed, relayed}
+      assert relayed["signature"] == "0x" <> String.duplicate("11", 65)
+      assert relayed["nonce"] == 7
+    end
+
     test "a failed intent is an error, not a deliverable" do
       assert {:error, {:settlement_failed, :failed, "i1", _}} = settler_for("failed").(args())
     end


### PR DESCRIPTION
Two fixes so the Xochi Cross-Chain Transfer offering lists cleanly on Virtuals ACP:

- **`required_funds: true -> false`** in `offering_metadata`. Leftover from the escrow/FundTransfer model. In the relay model the transfer moves off-escrow via the buyer's own signed intent, so raxol never takes the buyer's funds -- the offering requires no fund deposit (only the storefront fee is paid). Maps to the marketplace "Require Funds" toggle = off.
- **Accept `signed_intent` as a JSON string OR a map.** The marketplace field builder may deliver the nested bundle as a JSON string (flat-field schemas) rather than an object. `Offering.decode_signed_intent/1` normalizes both; `valid_requirement?` and the `Settler` use it, so the offering works regardless of how the marketplace serializes the field.

## Test status
- raxol_acp: 10 properties / 661 tests / 0 failures; `--warnings-as-errors` + format clean
- New: JSON-string `signed_intent` accepted (`valid_requirement?` + Settler relay), malformed/partial rejected; `required_funds` assertions updated

## Manual testing
- [x] Offline suite green; example still emits a conforming requirement
- [ ] List the job on Virtuals with `signed_intent` as a flat/string field and confirm a real buyer submission relays