### PR TITLE
Seller migration Phase 1: JobSession.Provider driver

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
@@ -1,0 +1,185 @@
+defmodule Raxol.ACP.JobSession.Provider do
+  @moduledoc """
+  Drives a `Raxol.ACP.JobSession` from the PROVIDER side, tying together the
+  three things a provider must do at each lifecycle point:
+
+  1. invoke the offering's `Raxol.ACP.Offering.Handler` callback (via
+     `Raxol.ACP.JobSession.HandlerSeam`) to make the accept / deliver /
+     evaluate decision,
+  2. write the corresponding hook call on-chain through
+     `Raxol.ACP.HookClient` + the injected `Raxol.ACP.ProviderAdapter`, and
+  3. mirror the resulting status into the local `JobSession` via
+     `JobSession.apply_event/3`.
+
+  The on-chain write is the commit point: it happens FIRST, and the local
+  `apply_event` mirror only runs once the chain write succeeds -- so a failed
+  write leaves the session untouched (local never claims more than the chain
+  has). Because the mirror is an observed transition it bypasses role and
+  adjacency gating, so it never fights the state machine.
+
+  This is the generic form of what `Raxol.ACP.Xochi.SolverAgent` does bespoke
+  for the storefront. Jobs are plain (no hook data on `setBudget`); carrying
+  `FundTransferHook` data is a later extension.
+
+  A `Provider` is a plain struct built with `new/1`; its functions are pure
+  orchestration over the session and the adapter (no process of its own -- a
+  runtime such as the seller `Queue` calls them).
+  """
+
+  alias Raxol.ACP.{AssetToken, HookClient, JobSession}
+  alias Raxol.ACP.JobSession.HandlerSeam
+
+  @enforce_keys [:session, :handler, :adapter, :chain_id, :acp_core_address, :job_id]
+  defstruct [
+    :session,
+    :handler,
+    :adapter,
+    :chain_id,
+    :acp_core_address,
+    :job_id,
+    buyer: nil,
+    seller: nil
+  ]
+
+  @type t :: %__MODULE__{
+          session: GenServer.server() | JobSession.job_key(),
+          handler: module(),
+          adapter: Raxol.ACP.ProviderAdapter.adapter(),
+          chain_id: pos_integer(),
+          acp_core_address: String.t(),
+          job_id: non_neg_integer(),
+          buyer: String.t() | nil,
+          seller: String.t() | nil
+        }
+
+  @type ok(status) ::
+          {:ok, %{:status => status, :tx_hash => String.t(), optional(atom()) => term()}}
+
+  @doc "Build a provider driver. See the struct fields for the required keys."
+  @spec new(keyword()) :: t()
+  def new(opts), do: struct!(__MODULE__, opts)
+
+  @doc """
+  Decide on a buyer's job request.
+
+  Invokes `handle_request/2`. On `{:accept, response}` it writes
+  `setBudget(job, budget)` on-chain and mirrors the session to `:budget_set`.
+  On `{:reject, reason}` it makes no on-chain or local change and returns
+  `{:rejected, reason}` -- the caller decides whether to expire the job.
+  """
+  @spec accept_request(t(), map(), AssetToken.t()) ::
+          ok(:budget_set) | {:rejected, term()} | {:error, term()}
+  def accept_request(%__MODULE__{} = p, request, %AssetToken{} = budget) do
+    case HandlerSeam.invoke(p.handler, :request, request, ctx(p)) do
+      {:accept, response} ->
+        with {:ok, tx} <-
+               HookClient.set_budget(
+                 p.adapter,
+                 p.chain_id,
+                 p.acp_core_address,
+                 p.job_id,
+                 budget.raw_amount
+               ),
+             {:ok, :budget_set} <-
+               JobSession.apply_event(p.session, :budget_set, %{tx_hash: tx}) do
+          {:ok, %{status: :budget_set, tx_hash: tx, response: response}}
+        end
+
+      {:reject, reason} ->
+        {:rejected, reason}
+    end
+  end
+
+  @doc """
+  Produce and submit the deliverable once the job is funded.
+
+  Invokes `handle_deliver/2`. On `{:deliver, deliverable}` it writes
+  `submit(job, keccak256(deliverable))` on-chain and mirrors the session to
+  `:submitted`. On `{:error, reason}` it makes no change and returns the error.
+  Requires the session to already be `:funded`.
+  """
+  @spec deliver(t(), map()) :: ok(:submitted) | {:error, term()}
+  def deliver(%__MODULE__{} = p, request) do
+    case HandlerSeam.invoke(p.handler, :deliver, request, ctx(p)) do
+      {:deliver, deliverable} ->
+        with {:ok, tx} <-
+               HookClient.submit(
+                 p.adapter,
+                 p.chain_id,
+                 p.acp_core_address,
+                 p.job_id,
+                 deliverable_hash(deliverable)
+               ),
+             {:ok, :submitted} <-
+               JobSession.apply_event(p.session, :submitted, %{tx_hash: tx}) do
+          {:ok, %{status: :submitted, tx_hash: tx, deliverable: deliverable}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Evaluate a submitted deliverable, when this provider is also the evaluator.
+
+  Invokes `handle_evaluate/2`. `{:approve, _}` writes `complete/3` and mirrors
+  `:completed`; `{:reject, reason}` writes `reject/3` and mirrors `:rejected`
+  (both terminal, so the session then stops). When the handler does not
+  implement `handle_evaluate/2`, returns `{:error, :evaluate_not_supported}`
+  so the caller can defer to an external evaluator.
+  """
+  @spec evaluate(t(), map()) ::
+          ok(:completed) | ok(:rejected) | {:error, :evaluate_not_supported} | {:error, term()}
+  def evaluate(%__MODULE__{} = p, deliverable) do
+    case HandlerSeam.invoke(p.handler, :evaluate, deliverable, ctx(p)) do
+      {:approve, response} -> finalize_evaluation(p, deliverable, :completed, response)
+      {:reject, reason} -> finalize_evaluation(p, deliverable, :rejected, reason)
+      {:error, :evaluate_not_supported} = err -> err
+    end
+  end
+
+  # -- Internals --
+
+  defp finalize_evaluation(p, deliverable, :completed, info) do
+    with {:ok, tx} <-
+           HookClient.complete(
+             p.adapter,
+             p.chain_id,
+             p.acp_core_address,
+             p.job_id,
+             deliverable_hash(deliverable)
+           ),
+         {:ok, :completed} <- JobSession.apply_event(p.session, :completed, %{tx_hash: tx}) do
+      {:ok, %{status: :completed, tx_hash: tx, info: info}}
+    end
+  end
+
+  defp finalize_evaluation(p, deliverable, :rejected, info) do
+    with {:ok, tx} <-
+           HookClient.reject(
+             p.adapter,
+             p.chain_id,
+             p.acp_core_address,
+             p.job_id,
+             deliverable_hash(deliverable)
+           ),
+         {:ok, :rejected} <- JobSession.apply_event(p.session, :rejected, %{tx_hash: tx}) do
+      {:ok, %{status: :rejected, tx_hash: tx, info: info}}
+    end
+  end
+
+  # Handler ctx: the job id plus the parties and current status, matching the
+  # v1 `Job.Server` ctx shape so offering handlers are unchanged.
+  defp ctx(p) do
+    %{job_id: p.job_id, buyer: p.buyer, seller: p.seller, state: JobSession.status(p.session)}
+  end
+
+  # 32-byte commitment to the deliverable payload: keccak256 of its canonical
+  # JSON (matching `Xochi.SolverAgent`). HookClient.submit takes 32 raw bytes.
+  defp deliverable_hash(deliverable) do
+    deliverable
+    |> Jason.encode!()
+    |> ExKeccak.hash_256()
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/provider_adapter/mock.ex
+++ b/packages/raxol_acp/lib/raxol/acp/provider_adapter/mock.ex
@@ -38,6 +38,7 @@ defmodule Raxol.ACP.ProviderAdapter.Mock do
     :ets.insert(table, {:receipts, %{}})
     :ets.insert(table, {:contract_reads, %{}})
     :ets.insert(table, {:logs, []})
+    :ets.insert(table, {:send_calls_error, nil})
 
     %{adapter: __MODULE__, config: %{table: table}}
   end
@@ -67,6 +68,17 @@ defmodule Raxol.ACP.ProviderAdapter.Mock do
     :ok
   end
 
+  @doc """
+  Make `send_calls/3` fail with `{:error, reason}`, simulating a bundler / RPC
+  failure so tests can exercise the on-chain-write-fails path. Pass `nil` to
+  clear. A failed call is not recorded in `sent_calls/1`.
+  """
+  @spec set_send_calls_error(Raxol.ACP.ProviderAdapter.adapter(), term()) :: :ok
+  def set_send_calls_error(%{config: %{table: table}}, reason) do
+    :ets.insert(table, {:send_calls_error, reason})
+    :ok
+  end
+
   @doc "All `send_calls/3` invocations in order: `[{chain_id, calls}, ...]`."
   @spec sent_calls(Raxol.ACP.ProviderAdapter.adapter()) :: [{pos_integer(), [map()]}]
   def sent_calls(%{config: %{table: table}}) do
@@ -85,9 +97,15 @@ defmodule Raxol.ACP.ProviderAdapter.Mock do
 
   @impl Raxol.ACP.ProviderAdapter
   def send_calls(%{config: %{table: table}}, chain_id, calls) do
-    record(table, :sent_calls, {chain_id, calls})
-    hashes = Enum.map(calls, fn _ -> mint_tx_hash(table) end)
-    {:ok, hashes}
+    case :ets.lookup(table, :send_calls_error) do
+      [{:send_calls_error, nil}] ->
+        record(table, :sent_calls, {chain_id, calls})
+        hashes = Enum.map(calls, fn _ -> mint_tx_hash(table) end)
+        {:ok, hashes}
+
+      [{:send_calls_error, reason}] ->
+        {:error, reason}
+    end
   end
 
   @impl Raxol.ACP.ProviderAdapter

--- a/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
@@ -1,0 +1,199 @@
+defmodule Raxol.ACP.JobSession.ProviderTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{ABI, AssetToken, JobSession, ProviderAdapter}
+  alias Raxol.ACP.JobSession.Provider
+
+  @core "0x238E541BfefD82238730D00a2208E5497F1832E0"
+  @chain 8453
+
+  setup do
+    for {_, pid, _, _} <- DynamicSupervisor.which_children(JobSession.Supervisor), is_pid(pid) do
+      DynamicSupervisor.terminate_child(JobSession.Supervisor, pid)
+    end
+
+    :ok
+  end
+
+  defmodule AcceptHandler do
+    @behaviour Raxol.ACP.Offering.Handler
+    @impl true
+    def handle_request(req, _ctx), do: {:accept, %{ack: req}}
+    @impl true
+    def handle_deliver(_req, _ctx), do: {:deliver, %{result: "done"}}
+    @impl true
+    def handle_evaluate(_deliverable, _ctx), do: {:approve, %{}}
+  end
+
+  defmodule RejectHandler do
+    @behaviour Raxol.ACP.Offering.Handler
+    @impl true
+    def handle_request(_req, _ctx), do: {:reject, :not_for_me}
+    @impl true
+    def handle_deliver(_req, _ctx), do: {:error, :cannot_build}
+    @impl true
+    def handle_evaluate(_deliverable, _ctx), do: {:reject, :bad_work}
+  end
+
+  defmodule NoEvaluateHandler do
+    @behaviour Raxol.ACP.Offering.Handler
+    @impl true
+    def handle_request(req, _ctx), do: {:accept, %{ack: req}}
+    @impl true
+    def handle_deliver(_req, _ctx), do: {:deliver, %{result: "done"}}
+  end
+
+  # Adapter whose on-chain writes always fail -- exercises the "chain write
+  # fails, local session must not advance" path.
+  defmodule FailingAdapter do
+    @behaviour Raxol.ACP.ProviderAdapter
+    def new, do: %{adapter: __MODULE__, config: %{}}
+    @impl true
+    def send_calls(_a, _chain, _calls), do: {:error, :rpc_down}
+    @impl true
+    def sign_message(_a, _c, _m), do: {:error, :unused}
+    @impl true
+    def sign_typed_data(_a, _c, _t), do: {:error, :unused}
+    @impl true
+    def get_transaction_receipt(_a, _c, _h), do: {:error, :unused}
+    @impl true
+    def read_contract(_a, _c, _p), do: {:error, :unused}
+    @impl true
+    def get_logs(_a, _c, _f), do: {:error, :unused}
+    @impl true
+    def get_address(_a), do: "0xprovider"
+    @impl true
+    def supported_chain_ids(_a), do: [8453]
+  end
+
+  defp start_session(status) do
+    job_id = "job-#{System.unique_integer([:positive])}"
+
+    {:ok, pid} =
+      JobSession.Supervisor.start_session(
+        chain_id: @chain,
+        job_id: job_id,
+        role: :provider,
+        initial_status: status
+      )
+
+    pid
+  end
+
+  defp provider(session, handler, adapter) do
+    Provider.new(
+      session: session,
+      handler: handler,
+      adapter: adapter,
+      chain_id: @chain,
+      acp_core_address: @core,
+      job_id: 42,
+      buyer: "0xbuyer",
+      seller: "0xseller"
+    )
+  end
+
+  defp assert_one_call(adapter, signature) do
+    assert [{@chain, [call]}] = ProviderAdapter.Mock.sent_calls(adapter)
+    assert call.to == @core
+    selector = ABI.function_selector(signature)
+    assert <<^selector::binary-size(4), _rest::binary>> = call.data
+  end
+
+  describe "accept_request/3" do
+    test "accept: writes setBudget on-chain and mirrors :budget_set" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:open)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:ok, %{status: :budget_set, tx_hash: tx, response: %{ack: %{req: 1}}}} =
+               Provider.accept_request(p, %{req: 1}, AssetToken.usdc(0.25, @chain))
+
+      assert is_binary(tx)
+      assert JobSession.status(session) == :budget_set
+      assert_one_call(adapter, "setBudget(uint256,uint256,bytes)")
+    end
+
+    test "reject: no on-chain write, session unchanged" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:open)
+      p = provider(session, RejectHandler, adapter)
+
+      assert {:rejected, :not_for_me} =
+               Provider.accept_request(p, %{req: 1}, AssetToken.usdc(0.25, @chain))
+
+      assert JobSession.status(session) == :open
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+    end
+
+    test "does not advance the session when the chain write fails" do
+      session = start_session(:open)
+      p = provider(session, AcceptHandler, FailingAdapter.new())
+
+      assert {:error, :rpc_down} =
+               Provider.accept_request(p, %{req: 1}, AssetToken.usdc(0.25, @chain))
+
+      assert JobSession.status(session) == :open
+    end
+  end
+
+  describe "deliver/2" do
+    test "deliver: writes submit on-chain and mirrors :submitted" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:funded)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:ok, %{status: :submitted, tx_hash: tx, deliverable: %{result: "done"}}} =
+               Provider.deliver(p, %{req: 1})
+
+      assert is_binary(tx)
+      assert JobSession.status(session) == :submitted
+      assert_one_call(adapter, "submit(uint256,bytes32,bytes)")
+    end
+
+    test "handler error: no write, session unchanged" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:funded)
+      p = provider(session, RejectHandler, adapter)
+
+      assert {:error, :cannot_build} = Provider.deliver(p, %{req: 1})
+      assert JobSession.status(session) == :funded
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+    end
+  end
+
+  describe "evaluate/2" do
+    test "approve: writes complete on-chain, mirrors :completed, and stops the session" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:submitted)
+      ref = Process.monitor(session)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:ok, %{status: :completed, tx_hash: tx}} = Provider.evaluate(p, %{result: "done"})
+      assert is_binary(tx)
+      assert_one_call(adapter, "complete(uint256,bytes32,bytes)")
+      assert_receive {:DOWN, ^ref, :process, ^session, :normal}, 500
+    end
+
+    test "reject: writes reject on-chain and mirrors :rejected" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:submitted)
+      p = provider(session, RejectHandler, adapter)
+
+      assert {:ok, %{status: :rejected, info: :bad_work}} =
+               Provider.evaluate(p, %{result: "bad"})
+
+      assert_one_call(adapter, "reject(uint256,bytes32,bytes)")
+    end
+
+    test "handler without handle_evaluate/2 defers to an external evaluator" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:submitted)
+      p = provider(session, NoEvaluateHandler, adapter)
+
+      assert {:error, :evaluate_not_supported} = Provider.evaluate(p, %{result: "done"})
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+      assert JobSession.status(session) == :submitted
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
@@ -43,29 +43,6 @@ defmodule Raxol.ACP.JobSession.ProviderTest do
     def handle_deliver(_req, _ctx), do: {:deliver, %{result: "done"}}
   end
 
-  # Adapter whose on-chain writes always fail -- exercises the "chain write
-  # fails, local session must not advance" path.
-  defmodule FailingAdapter do
-    @behaviour Raxol.ACP.ProviderAdapter
-    def new, do: %{adapter: __MODULE__, config: %{}}
-    @impl true
-    def send_calls(_a, _chain, _calls), do: {:error, :rpc_down}
-    @impl true
-    def sign_message(_a, _c, _m), do: {:error, :unused}
-    @impl true
-    def sign_typed_data(_a, _c, _t), do: {:error, :unused}
-    @impl true
-    def get_transaction_receipt(_a, _c, _h), do: {:error, :unused}
-    @impl true
-    def read_contract(_a, _c, _p), do: {:error, :unused}
-    @impl true
-    def get_logs(_a, _c, _f), do: {:error, :unused}
-    @impl true
-    def get_address(_a), do: "0xprovider"
-    @impl true
-    def supported_chain_ids(_a), do: [8453]
-  end
-
   defp start_session(status) do
     job_id = "job-#{System.unique_integer([:positive])}"
 
@@ -127,8 +104,10 @@ defmodule Raxol.ACP.JobSession.ProviderTest do
     end
 
     test "does not advance the session when the chain write fails" do
+      adapter = ProviderAdapter.Mock.new()
+      ProviderAdapter.Mock.set_send_calls_error(adapter, :rpc_down)
       session = start_session(:open)
-      p = provider(session, AcceptHandler, FailingAdapter.new())
+      p = provider(session, AcceptHandler, adapter)
 
       assert {:error, :rpc_down} =
                Provider.accept_request(p, %{req: 1}, AssetToken.usdc(0.25, @chain))


### PR DESCRIPTION
Phase 1 of the seller-stack v1->v2 migration (epic #384). Closes #380.

**Stacked on #385 (Phase 0)** -- base is `feat/seller-phase0-jobsession`; retarget to `master` once #385 merges. Uses Phase 0's `JobSession.apply_event/3` + `HandlerSeam`.

## What changed
New `Raxol.ACP.JobSession.Provider` -- the generic provider driver that ties the three provider responsibilities together at each lifecycle point:
1. invoke the offering's `Offering.Handler` callback (via `HandlerSeam`),
2. write the hook call on-chain through `HookClient` + the injected `ProviderAdapter`,
3. mirror the resulting status into the local `JobSession` via `apply_event`.

**Ordering:** the on-chain write is the commit point -- it runs FIRST, and the `apply_event` mirror only runs once the chain write succeeds, so a failed write leaves the session untouched (local never claims more than the chain has). The mirror is an observed transition, so it bypasses role/adjacency gating and never fights the state machine.

Operations:
- `accept_request/3` -- `handle_request` -> accept: `setBudget` + mirror `:budget_set`; reject: no-op, `{:rejected, reason}`.
- `deliver/2` -- `handle_deliver` -> deliver: `submit(keccak256(deliverable))` + mirror `:submitted`; error: no-op.
- `evaluate/2` -- `handle_evaluate` -> approve: `complete` + mirror `:completed` (terminal); reject: `reject` + mirror `:rejected`; absent: `{:error, :evaluate_not_supported}` (defer to an external evaluator).

This is the generic form of what `Xochi.SolverAgent` does bespoke for the storefront. Plain jobs (no hook data on `setBudget`); `FundTransferHook` data is a later extension. Pure orchestration module (no process of its own -- the Phase-2 `Queue` calls it).

## Tests (`provider_test.exs`, 8)
Against `ProviderAdapter.Mock` + a `FailingAdapter`: accept/reject/chain-fail for request; deliver happy/error; evaluate approve (asserts terminal session stop) / reject / no-evaluate-defer. Each asserts the JobSession status mirror AND the on-chain call (selector + `to` == core) -- or its absence.

## Manual testing
- [ ] `cd packages/raxol_acp && MIX_ENV=test mix test test/raxol/acp/job_session/provider_test.exs` -- 8 tests, 0 failures
- [ ] `MIX_ENV=test mix test` (full raxol_acp) -- 0 failures
- [ ] `MIX_ENV=test mix compile --warnings-as-errors` + `mix format --check-formatted` clean