### PR TITLE
Fix EOA nonce race in JSONRPC provider adapter

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/provider_adapter/jsonrpc.ex
+++ b/packages/raxol_acp/lib/raxol/acp/provider_adapter/jsonrpc.ex
@@ -28,12 +28,23 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
   use. Tests tagged `:live_chain` (requires `anvil` on PATH) run
   against this fork.
 
+  ## Nonce management
+
+  Nonce assignment is serialized through a `Raxol.ACP.Wallet.NonceServer`
+  (the `:nonce_server` config, default the umbrella instance). Every
+  transaction takes its nonce from the server's mailbox, so two concurrent
+  `send_calls/3` for the same EOA -- e.g. two in-flight seller jobs each
+  writing a hook call -- can never sign the same nonce. A send that fails
+  before broadcast resyncs the server so the next send re-fetches the
+  pending nonce from chain and re-fills the gap. One `NonceServer` instance
+  serializes one wallet address; run one instance per wallet.
+
   ## What's NOT covered
 
   - **Smart-contract account flows**: this adapter signs EIP-1559
     transactions as a plain EOA. For Modular Account v2 / paymaster
-    flows, use `Raxol.ACP.ProviderAdapter.SCA` (not yet implemented),
-    which wraps `Raxol.ACP.Wallet.SCA`.
+    flows, use `Raxol.ACP.ProviderAdapter.SCA`, which wraps
+    `Raxol.ACP.Wallet.SCA` and uses ERC-4337 EntryPoint nonces instead.
   - **Batch submission**: `send_calls/3` submits one EIP-1559 tx per
     call. The SDK's batch semantics (return one hash per call)
     are preserved, but the bundling efficiencies aren't.
@@ -42,12 +53,14 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
   @behaviour Raxol.ACP.ProviderAdapter
 
   alias Raxol.ACP.{ABI, Onchain.RPC, Onchain.Transaction, Secret}
+  alias Raxol.ACP.Wallet.NonceServer
 
   @type config :: %{
           chains: %{required(pos_integer()) => String.t()},
           private_key: Secret.t(),
           address: String.t(),
-          fee_overrides: %{optional(pos_integer()) => fee_override()}
+          fee_overrides: %{optional(pos_integer()) => fee_override()},
+          nonce_server: GenServer.server()
         }
 
   @type fee_override :: %{
@@ -68,6 +81,14 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
   - `:fee_overrides` -- per-chain `%{max_priority_fee_per_gas,
     max_fee_per_gas}` map. Use to short-circuit fee discovery on
     test forks (anvil's default fees are zero).
+  - `:nonce_server` -- the `Raxol.ACP.Wallet.NonceServer` instance that
+    serializes nonce assignment for THIS adapter's wallet address
+    (default `Raxol.ACP.Wallet.NonceServer`, the umbrella instance the
+    supervisor starts). One instance must map to exactly one address:
+    two concurrent `send_calls/3` for the same EOA route through the
+    server's mailbox so they can never sign the same nonce. If you run
+    more than one wallet, construct each adapter with a distinct
+    `:nonce_server`.
   """
   @spec new(keyword()) :: Raxol.ACP.ProviderAdapter.adapter()
   def new(opts) do
@@ -84,7 +105,8 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
       chains: chains,
       private_key: Secret.new(private_key),
       address: address,
-      fee_overrides: Keyword.get(opts, :fee_overrides, %{})
+      fee_overrides: Keyword.get(opts, :fee_overrides, %{}),
+      nonce_server: Keyword.get(opts, :nonce_server, NonceServer)
     }
 
     %{adapter: __MODULE__, config: config}
@@ -173,20 +195,47 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
 
   defp send_each(client, adapter, chain_id, calls, private_key) do
     address = adapter.config.address
+    nonce_server = adapter.config.nonce_server
 
-    with {:ok, starting_nonce} <- RPC.get_transaction_count(client, address) do
-      {results, _next_nonce} =
-        Enum.map_reduce(calls, starting_nonce, fn call, nonce ->
-          case submit_one(client, adapter, chain_id, call, private_key, nonce) do
-            {:ok, hash} -> {{:ok, hash}, nonce + 1}
-            {:error, _} = err -> {err, nonce}
-          end
-        end)
+    results =
+      Enum.map(calls, fn call ->
+        with {:ok, nonce} <- acquire_nonce(nonce_server, client, address),
+             {:ok, hash} <- submit_one(client, adapter, chain_id, call, private_key, nonce) do
+          {:ok, hash}
+        else
+          {:error, _} = err ->
+            # The tx never reached the chain, so its nonce was not consumed.
+            # Mark the counter unseeded so the next acquisition re-fetches the
+            # pending nonce from chain and re-fills the gap -- the same self-heal
+            # the old per-send `eth_getTransactionCount` gave, now without the
+            # cross-send nonce race.
+            NonceServer.resync(nonce_server)
+            err
+        end
+      end)
 
-      case Enum.find(results, &match?({:error, _}, &1)) do
-        nil -> {:ok, Enum.map(results, fn {:ok, hash} -> hash end)}
-        err -> err
-      end
+    case Enum.find(results, &match?({:error, _}, &1)) do
+      nil -> {:ok, Enum.map(results, fn {:ok, hash} -> hash end)}
+      err -> err
+    end
+  end
+
+  # Assign the next nonce, serialized through the wallet's NonceServer so two
+  # concurrent `send_calls` for the same EOA can never sign the same nonce (the
+  # GenServer mailbox is the serialization point). When the counter is unseeded
+  # -- first use, or after a failed send reset it -- fetch the pending nonce from
+  # chain once and adopt it atomically: `seed_and_next/2` closes the first-use
+  # race so two callers that both observe `:unseeded` still receive distinct,
+  # monotonic nonces.
+  defp acquire_nonce(nonce_server, client, address) do
+    case NonceServer.get_next_if_seeded(nonce_server) do
+      {:ok, nonce} ->
+        {:ok, nonce}
+
+      :unseeded ->
+        with {:ok, chain_nonce} <- RPC.get_transaction_count(client, address) do
+          {:ok, NonceServer.seed_and_next(nonce_server, chain_nonce)}
+        end
     end
   end
 

--- a/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
@@ -139,6 +139,16 @@ defmodule Raxol.ACP.JobSession.ProviderTest do
       assert JobSession.status(session) == :funded
       assert ProviderAdapter.Mock.sent_calls(adapter) == []
     end
+
+    test "does not advance the session when the chain write fails" do
+      adapter = ProviderAdapter.Mock.new()
+      ProviderAdapter.Mock.set_send_calls_error(adapter, :rpc_down)
+      session = start_session(:funded)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:error, :rpc_down} = Provider.deliver(p, %{req: 1})
+      assert JobSession.status(session) == :funded
+    end
   end
 
   describe "evaluate/2" do
@@ -172,6 +182,16 @@ defmodule Raxol.ACP.JobSession.ProviderTest do
 
       assert {:error, :evaluate_not_supported} = Provider.evaluate(p, %{result: "done"})
       assert ProviderAdapter.Mock.sent_calls(adapter) == []
+      assert JobSession.status(session) == :submitted
+    end
+
+    test "does not advance the session when the chain write fails" do
+      adapter = ProviderAdapter.Mock.new()
+      ProviderAdapter.Mock.set_send_calls_error(adapter, :rpc_down)
+      session = start_session(:submitted)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:error, :rpc_down} = Provider.evaluate(p, %{result: "done"})
       assert JobSession.status(session) == :submitted
     end
   end

--- a/packages/raxol_acp/test/raxol/acp/job_session/status_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/status_test.exs
@@ -74,6 +74,29 @@ defmodule Raxol.ACP.JobSession.StatusTest do
       assert {:error, _} = Status.validate(:budget_set, :submitted)
       assert {:error, _} = Status.validate(:funded, :completed)
     end
+
+    test "exhaustively agrees with the documented transition graph" do
+      # The canonical adjacency, mirrored here so any drift in Status's private
+      # @valid_transitions map is caught for every one of the 7x7 pairs.
+      legal = %{
+        open: [:budget_set, :expired],
+        budget_set: [:budget_set, :funded, :expired],
+        funded: [:submitted, :expired],
+        submitted: [:completed, :rejected, :expired],
+        completed: [],
+        rejected: [],
+        expired: []
+      }
+
+      for from <- Status.all(), to <- Status.all() do
+        expected =
+          if to in Map.fetch!(legal, from),
+            do: :ok,
+            else: {:error, {:invalid_transition, from, to}}
+
+        assert Status.validate(from, to) == expected, "validate(#{from}, #{to})"
+      end
+    end
   end
 
   describe "target_status/1" do

--- a/packages/raxol_acp/test/raxol/acp/job_session/telemetry_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/telemetry_test.exs
@@ -1,0 +1,105 @@
+defmodule Raxol.ACP.JobSession.TelemetryTest do
+  @moduledoc """
+  The `[:raxol, :acp, :job_session, :transition]` telemetry event is a
+  cross-package contract: `raxol_symphony`'s `Raxol.Symphony.ResumeOn` /
+  `Raxol.Symphony.Resumer` match on its metadata to auto-resume paused runs.
+  These tests pin the event name and the full metadata shape so a change can't
+  silently break that consumer.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{AssetToken, JobSession}
+
+  @event [:raxol, :acp, :job_session, :transition]
+  @chain 8453
+  @contract_keys [:action, :chain_id, :from, :job_id, :role, :to]
+
+  setup do
+    handler = {__MODULE__, System.unique_integer([:positive])}
+    test = self()
+
+    :telemetry.attach(
+      handler,
+      @event,
+      fn event, measurements, metadata, _config ->
+        send(test, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    :ok
+  end
+
+  defp start_session(role, status) do
+    job_id = "tel-#{System.unique_integer([:positive])}"
+
+    {:ok, pid} =
+      JobSession.Supervisor.start_session(
+        chain_id: @chain,
+        job_id: job_id,
+        role: role,
+        initial_status: status
+      )
+
+    {pid, job_id}
+  end
+
+  test "a role-gated transition emits exactly the 6-key metadata contract" do
+    {session, job_id} = start_session(:provider, :open)
+
+    assert {:ok, :budget_set} = JobSession.set_budget(session, AssetToken.usdc(0.25, @chain))
+
+    assert_receive {:telemetry, @event, measurements, metadata}, 500
+    assert measurements == %{}
+
+    assert %{
+             chain_id: @chain,
+             job_id: ^job_id,
+             role: :provider,
+             action: :set_budget,
+             from: :open,
+             to: :budget_set
+           } = metadata
+
+    # The Resumer subset-matches on this metadata; pin the exact key set so no
+    # field is added or dropped without updating the cross-package contract.
+    assert metadata |> Map.keys() |> Enum.sort() == @contract_keys
+  end
+
+  test "an observed apply_event emits the same contract with action :apply_event" do
+    {session, job_id} = start_session(:provider, :budget_set)
+
+    assert {:ok, :funded} = JobSession.apply_event(session, :funded, %{observed: true})
+
+    assert_receive {:telemetry, @event, _measurements, metadata}, 500
+
+    assert %{
+             chain_id: @chain,
+             job_id: ^job_id,
+             role: :provider,
+             action: :apply_event,
+             from: :budget_set,
+             to: :funded
+           } = metadata
+
+    assert metadata |> Map.keys() |> Enum.sort() == @contract_keys
+  end
+
+  test "a terminal transition still emits the contract before the session stops" do
+    {session, job_id} = start_session(:evaluator, :submitted)
+
+    assert {:ok, :completed} = JobSession.complete(session, "looks good")
+
+    assert_receive {:telemetry, @event, _measurements, metadata}, 500
+
+    assert %{
+             chain_id: @chain,
+             job_id: ^job_id,
+             role: :evaluator,
+             action: :complete,
+             from: :submitted,
+             to: :completed
+           } = metadata
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/provider_adapter/jsonrpc_nonce_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/provider_adapter/jsonrpc_nonce_test.exs
@@ -1,0 +1,162 @@
+defmodule Raxol.ACP.ProviderAdapter.JsonrpcNonceTest do
+  @moduledoc """
+  Hermetic proof that `Raxol.ACP.ProviderAdapter.JSONRPC` serializes nonce
+  assignment through `Raxol.ACP.Wallet.NonceServer`, so concurrent
+  `send_calls/3` for the same EOA never sign the same nonce.
+
+  The RPC is stubbed with a `:plug` (picked up from the `:raxol_acp, :rpc`
+  app config that the adapter's `RPC.client/1` reads); no real chain. A
+  `fee_overrides` entry skips fee discovery, so the only chain read that
+  matters here is `eth_getTransactionCount`, which the adapter must consult
+  ONLY to seed the counter -- never per send once seeded.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.ProviderAdapter
+  alias Raxol.ACP.ProviderAdapter.JSONRPC
+  alias Raxol.ACP.Wallet.NonceServer
+
+  @chain 8453
+  # Anvil/Foundry test account #0. A public test value, never a real key.
+  @privkey Base.decode16!(
+             "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+             case: :lower
+           )
+
+  setup do
+    table = :ets.new(:jsonrpc_nonce_stub, [:set, :public])
+    :ets.insert(table, {:get_tx_count_calls, 0})
+    :ets.insert(table, {:tx_counter, 0})
+    :ets.insert(table, {:chain_nonce, 5})
+    :ets.insert(table, {:fail_send, false})
+
+    Application.put_env(:raxol_acp, :rpc, plug: plug(table))
+    on_exit(fn -> Application.delete_env(:raxol_acp, :rpc) end)
+
+    %{table: table}
+  end
+
+  # -- Helpers --
+
+  # A fresh, uniquely-named NonceServer per test so counter state never leaks.
+  defp start_nonce_server(opts) do
+    name = Module.concat(__MODULE__, "NS#{System.unique_integer([:positive])}")
+    start_supervised!({NonceServer, Keyword.put(opts, :name, name)})
+    name
+  end
+
+  defp adapter(nonce_server) do
+    JSONRPC.new(
+      chains: %{@chain => "http://stub.invalid/rpc"},
+      private_key: @privkey,
+      fee_overrides: %{@chain => %{max_priority_fee_per_gas: 1, max_fee_per_gas: 2}},
+      nonce_server: nonce_server
+    )
+  end
+
+  defp call, do: %{to: "0x" <> String.duplicate("11", 20), data: <<>>, value: 0, gas: 200_000}
+
+  defp plug(table) do
+    fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      %{"method" => method, "id" => id} = Jason.decode!(body)
+
+      payload =
+        case method do
+          "eth_getTransactionCount" ->
+            :ets.update_counter(table, :get_tx_count_calls, 1)
+            [{:chain_nonce, n}] = :ets.lookup(table, :chain_nonce)
+            result(id, hex(n))
+
+          "eth_estimateGas" ->
+            result(id, hex(21_000))
+
+          "eth_sendRawTransaction" ->
+            case :ets.lookup(table, :fail_send) do
+              [{:fail_send, true}] ->
+                %{
+                  "jsonrpc" => "2.0",
+                  "id" => id,
+                  "error" => %{"code" => -32_000, "message" => "execution reverted"}
+                }
+
+              _ ->
+                n = :ets.update_counter(table, :tx_counter, 1)
+                result(id, "0x" <> String.pad_leading(Integer.to_string(n, 16), 64, "0"))
+            end
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(payload))
+    end
+  end
+
+  defp result(id, value), do: %{"jsonrpc" => "2.0", "id" => id, "result" => value}
+  defp hex(n), do: "0x" <> Integer.to_string(n, 16)
+
+  defp tx_count_calls(table) do
+    [{:get_tx_count_calls, n}] = :ets.lookup(table, :get_tx_count_calls)
+    n
+  end
+
+  # -- Tests --
+
+  test "a seeded server serves a whole batch without touching the chain", %{table: table} do
+    ns = start_nonce_server(initial_nonce: 5)
+    a = adapter(ns)
+
+    assert {:ok, [_, _, _]} = ProviderAdapter.send_calls(a, @chain, [call(), call(), call()])
+
+    # Consumed three consecutive nonces from the local counter; never fetched
+    # the chain nonce (the server was already seeded).
+    assert NonceServer.peek(ns) == 8
+    assert tx_count_calls(table) == 0
+  end
+
+  test "an unseeded server seeds from chain once, then serves locally", %{table: table} do
+    ns = start_nonce_server([])
+    a = adapter(ns)
+
+    assert {:ok, [_]} = ProviderAdapter.send_calls(a, @chain, [call()])
+    assert {:ok, [_]} = ProviderAdapter.send_calls(a, @chain, [call()])
+
+    # Two separate sends took distinct nonces (5 then 6) from the shared server;
+    # the chain was consulted only for the first (seeding) send.
+    assert NonceServer.peek(ns) == 7
+    assert tx_count_calls(table) == 1
+  end
+
+  test "concurrent send_calls for one wallet consume distinct serialized nonces" do
+    ns = start_nonce_server(initial_nonce: 100)
+    a = adapter(ns)
+
+    results =
+      1..20
+      |> Task.async_stream(fn _ -> ProviderAdapter.send_calls(a, @chain, [call()]) end,
+        max_concurrency: 16,
+        ordered: false
+      )
+      |> Enum.map(fn {:ok, r} -> r end)
+
+    assert Enum.all?(results, &match?({:ok, [_]}, &1))
+    # 20 concurrent sends consumed exactly 20 nonces -- no collision, no
+    # double-consume. Pre-fix, they would have raced on the same chain nonce.
+    assert NonceServer.peek(ns) == 120
+  end
+
+  test "a failed send resyncs so the next send re-fetches the pending nonce", %{table: table} do
+    ns = start_nonce_server(initial_nonce: 5)
+    a = adapter(ns)
+
+    :ets.insert(table, {:fail_send, true})
+    assert {:error, _} = ProviderAdapter.send_calls(a, @chain, [call()])
+
+    # After a failed broadcast the counter is unseeded again, so a good send
+    # re-fetches the (unchanged) pending nonce and re-fills the gap.
+    :ets.insert(table, {:fail_send, false})
+    assert {:ok, [_]} = ProviderAdapter.send_calls(a, @chain, [call()])
+
+    assert tx_count_calls(table) == 1
+  end
+end


### PR DESCRIPTION
## The bug

`Raxol.ACP.ProviderAdapter.JSONRPC.send_calls/3` fetched the pending nonce inline with `eth_getTransactionCount` at the top of each call (`send_each/5`). Nonces were correct *within* a single batch, but **two concurrent `send_calls` for the same EOA both read the same pending nonce**, signed transactions with it, and the RPC silently dropped one. This happens in the live seller path: `Seller.Queue` can drive multiple in-flight jobs, and each `JobSession.Provider` transition writes a `HookClient` call through the adapter. The dropped tx surfaces as fund loss on the retry.

`Raxol.ACP.Wallet.NonceServer` was built for exactly this (its mailbox serializes nonce assignment) but lost its only caller when `ContractClient.Onchain` was retired — it's still supervised but unused. The SCA/UserOp adapter is unaffected (it uses ERC-4337 EntryPoint nonces).

## The fix

Route `send_each`'s nonce assignment through the wallet's `NonceServer`:
- `get_next_if_seeded/1` serializes per-nonce handout via the GenServer mailbox — concurrent sends can't collide.
- On first use (unseeded), fetch the pending nonce once and adopt it with `seed_and_next/2`, which closes the first-use race (two callers that both observe `:unseeded` still get distinct nonces).
- A send that fails before broadcast calls `resync/1`, so the next send re-fetches the (unchanged) pending nonce and re-fills the gap — the same self-heal the old per-send fetch gave, now race-free.

`send_calls` gains a `:nonce_server` option (default the umbrella `Raxol.ACP.Wallet.NonceServer` the supervisor starts). One instance serializes one wallet address; multi-wallet deployments pass a distinct instance per wallet — documented at the construction site. `NonceServer` itself is untouched (avoids conflict with #391).

## Tests (all hermetic — no chain, no funds)

- **`jsonrpc_nonce_test.exs`** (new): RPC stubbed via a `:plug` (the same idiom as `onchain/rpc_test.exs`). Proves a seeded server serves a whole batch with zero chain fetches; an unseeded server seeds once then serves locally; **20 concurrent `send_calls` consume exactly 20 distinct nonces** (the race fix); and a failed send resyncs so the next send re-fetches. The concurrent-uniqueness of the underlying `get_next_if_seeded`/`seed_and_next` pattern is already property-proven in `nonce_server_property_test.exs`.
- **`telemetry_test.exs`** (new): pins the `[:raxol, :acp, :job_session, :transition]` 6-key metadata contract (`chain_id, job_id, role, action, from, to`) that `raxol_symphony`'s `Resumer` subset-matches — for a role-gated action, an `apply_event`, and a terminal transition. Guards against silently breaking the cross-package auto-resume seam.
- **`provider_test.exs`**: the commit-point-first invariant (a failed chain write leaves the `JobSession` untouched) was only covered for `accept_request`; added it for `deliver` and `evaluate`.
- **`status_test.exs`**: exhaustive 7x7 `validate/2` matrix vs the transition graph, catching any drift in the private adjacency map.

## Gate

Per `packages/raxol_acp`: `mix compile --warnings-as-errors` clean, `mix format --check-formatted` clean, `mix test` **654 tests + 10 properties, 0 failures** across seeds (default, 4242, 88).

Branched off `master`, independent of #391 (Phase 4). Neither touches the same lines.

## Manual testing

- [x] `cd packages/raxol_acp && MIX_ENV=test mix test test/raxol/acp/provider_adapter/jsonrpc_nonce_test.exs` (4 tests, 0 failures)
- [x] `cd packages/raxol_acp && MIX_ENV=test mix test` (654 tests + 10 properties, 0 failures; 3 seeds)
- [x] `cd packages/raxol_acp && MIX_ENV=test mix compile --warnings-as-errors && mix format --check-formatted`
- [ ] `:live_chain` / `:live_bundler` re-run against anvil (funds/foundry-gated; unchanged wire path, only nonce sourcing)
