### PR TITLE
Fix negative trust score crash; add payments PBTs

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/router.ex
+++ b/packages/raxol_payments/lib/raxol/payments/router.ex
@@ -125,15 +125,22 @@ defmodule Raxol.Payments.Router do
     case {Keyword.get(opts, :trust_score), Keyword.get(opts, :attestations)} do
       {nil, attestations} when is_list(attestations) and attestations != [] ->
         score = Zksar.TrustScore.aggregate(attestations)
-        Keyword.put(opts, :trust_score, min(score, @max_trust_score))
+        Keyword.put(opts, :trust_score, clamp_score(score))
 
       {score, _} when is_integer(score) ->
-        Keyword.put(opts, :trust_score, min(score, @max_trust_score))
+        Keyword.put(opts, :trust_score, clamp_score(score))
 
       _ ->
         opts
     end
   end
+
+  # A trust score is a non-negative 0..100 value, but callers can pass any
+  # integer (an explicit override, an aggregation quirk). Clamp to the valid
+  # band so an out-of-range score degrades to the nearest tier -- below 0 is
+  # the least trusted (public), above 100 the most -- rather than crashing
+  # `PrivacyTier.from_trust_score/2` or leaking a negative through `trust_score_for/1`.
+  defp clamp_score(score), do: score |> max(0) |> min(@max_trust_score)
 
   defp select_protocol(privacy, _cross_chain) when privacy in [:stealth, :shielded], do: :xochi
   defp select_protocol(_privacy, true), do: :xochi

--- a/packages/raxol_payments/test/property/ledger_release_property_test.exs
+++ b/packages/raxol_payments/test/property/ledger_release_property_test.exs
@@ -1,0 +1,106 @@
+defmodule Raxol.Payments.LedgerReleasePropertyTest do
+  @moduledoc """
+  Properties for `Raxol.Payments.Ledger.release/4` -- the refund path that
+  compensates a `try_spend/5` reservation whose downstream execution failed
+  after signing. `release` inserts a `-amount` entry, so the session/lifetime
+  totals net back out.
+
+  The existing cap properties (`ledger_property_test`) never call `release`,
+  and the model-based test fixes the policy to `unrestricted` -- so nothing
+  today pins release against a real cap. These do: a released amount frees
+  EXACTLY that much lifetime budget, no more and no less.
+
+  The policy is shaped so only the lifetime cap binds (per-request admits any
+  single generated amount; session is set far above lifetime with a wide
+  window), isolating the release netting from the other two caps.
+  """
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  alias Raxol.Payments.{Ledger, SpendingPolicy}
+
+  @agent :a
+
+  defp fresh_ledger do
+    {:ok, pid} =
+      Ledger.start_link(table_name: :"prop_release_#{:erlang.unique_integer([:positive])}")
+
+    pid
+  end
+
+  # Shaped so ONLY the lifetime cap binds: per-request and session are set far
+  # above any reachable running sum, so every single amount clears them and the
+  # release netting is tested against lifetime alone.
+  defp policy(lifetime) do
+    %SpendingPolicy{
+      per_request_max: Decimal.new(lifetime + 1_000_000),
+      session_max: Decimal.new(lifetime + 1_000_000),
+      lifetime_max: Decimal.new(lifetime),
+      session_window_ms: 3_600_000
+    }
+  end
+
+  defp command do
+    one_of([
+      tuple({constant(:spend), integer(1..120)}),
+      tuple({constant(:release), integer(1..120)})
+    ])
+  end
+
+  property "try_spend decisions match the running sum with releases netted in" do
+    check all(
+            lifetime <- integer(50..300),
+            cmds <- list_of(command(), min_length: 1, max_length: 60)
+          ) do
+      ledger = fresh_ledger()
+      policy = policy(lifetime)
+
+      try do
+        Enum.reduce(cmds, 0, fn
+          {:spend, a}, net ->
+            expected = if net + a <= lifetime, do: :ok, else: {:over_limit, :lifetime}
+            assert Ledger.try_spend(ledger, @agent, Decimal.new(a), policy) == expected
+            if expected == :ok, do: net + a, else: net
+
+          {:release, r}, net ->
+            # Well-formed usage: never release more than is currently reserved.
+            # (A cast; mailbox order guarantees the next try_spend call sees it.)
+            r = min(r, net)
+            :ok = Ledger.release(ledger, @agent, Decimal.new(r))
+            net - r
+        end)
+      after
+        GenServer.stop(ledger)
+      end
+    end
+  end
+
+  property "release frees exactly the released amount of lifetime budget" do
+    check all(
+            lifetime <- integer(50..300),
+            refund <- integer(1..300)
+          ) do
+      refund = min(refund, lifetime)
+      ledger = fresh_ledger()
+      policy = policy(lifetime)
+
+      try do
+        # Fill the lifetime cap to the brim.
+        assert Ledger.try_spend(ledger, @agent, Decimal.new(lifetime), policy) == :ok
+
+        assert Ledger.try_spend(ledger, @agent, Decimal.new(1), policy) ==
+                 {:over_limit, :lifetime}
+
+        # Refund `refund`; exactly that much becomes spendable again.
+        :ok = Ledger.release(ledger, @agent, Decimal.new(refund))
+        assert Ledger.try_spend(ledger, @agent, Decimal.new(refund), policy) == :ok
+
+        # ...and not a cent more -- we are back at the cap.
+        assert Ledger.try_spend(ledger, @agent, Decimal.new(1), policy) ==
+                 {:over_limit, :lifetime}
+      after
+        GenServer.stop(ledger)
+      end
+    end
+  end
+end

--- a/packages/raxol_payments/test/property/router_property_test.exs
+++ b/packages/raxol_payments/test/property/router_property_test.exs
@@ -1,0 +1,117 @@
+defmodule Raxol.Payments.RouterPropertyTest do
+  @moduledoc """
+  Properties for `Raxol.Payments.Router` trust-score -> settlement/protocol
+  routing. The example tests cover realistic 0..100 scores; these pin the
+  behaviour across the whole integer range -- including the out-of-contract
+  inputs (negative, over-100) a caller can supply -- and the ordering
+  invariants that keep a low-trust agent out of a high-privacy tier.
+
+  `settlement` privacy is ordered `:public < :stealth < :shielded`.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Payments.Router
+
+  @privacy_rank %{public: 0, stealth: 1, shielded: 2}
+  @settlements [:public, :stealth, :shielded]
+  @protocols [:x402, :mpp, :xochi, :riddler, :relay]
+  @tiers [:open, :public, :standard, :stealth, :private, :sovereign]
+
+  # Deliberately spans below 0 and above 100: a caller can pass any integer,
+  # and the router must clamp rather than crash or mis-tier.
+  defp score, do: integer(-100..200)
+
+  describe "settlement_for/1" do
+    property "returns a valid settlement for ANY integer trust score" do
+      check all(s <- score()) do
+        assert Router.settlement_for(trust_score: s) in @settlements
+      end
+    end
+
+    property "privacy is non-decreasing in trust score (monotonic)" do
+      check all(a <- score(), b <- score()) do
+        lo = min(a, b)
+        hi = max(a, b)
+
+        assert @privacy_rank[Router.settlement_for(trust_score: lo)] <=
+                 @privacy_rank[Router.settlement_for(trust_score: hi)]
+      end
+    end
+
+    property "a score outside [0,100] behaves exactly like the clamped score" do
+      check all(s <- score()) do
+        clamped = s |> max(0) |> min(100)
+
+        assert Router.settlement_for(trust_score: s) ==
+                 Router.settlement_for(trust_score: clamped)
+      end
+    end
+
+    property "an explicit :privacy overrides any trust score" do
+      check all(
+              s <- score(),
+              privacy <- member_of(@settlements)
+            ) do
+        assert Router.settlement_for(trust_score: s, privacy: privacy) == privacy
+      end
+    end
+
+    property "tier_override never grants more privacy than the score earned" do
+      check all(
+              s <- integer(0..100),
+              override <- member_of(@tiers)
+            ) do
+        earned = Router.settlement_for(trust_score: s)
+        with_override = Router.settlement_for(trust_score: s, tier_override: override)
+
+        # A user may opt DOWN into less privacy, never up past what they earned.
+        assert @privacy_rank[with_override] <= @privacy_rank[earned]
+      end
+    end
+  end
+
+  describe "select/1" do
+    property "always returns a known protocol atom for any option mix" do
+      check all(
+              cross_chain <- boolean(),
+              privacy <- member_of([:auto | @settlements]),
+              s <- score()
+            ) do
+        assert Router.select(cross_chain: cross_chain, privacy: privacy, trust_score: s) in @protocols
+      end
+    end
+
+    property "a forced :protocol overrides all routing" do
+      check all(
+              forced <- member_of(@protocols),
+              cross_chain <- boolean(),
+              s <- integer(0..100)
+            ) do
+        assert Router.select(protocol: forced, cross_chain: cross_chain, trust_score: s) ==
+                 forced
+      end
+    end
+
+    property "cross-chain (non-Tron) always routes to xochi" do
+      check all(s <- integer(0..100)) do
+        assert Router.select(
+                 cross_chain: true,
+                 from_chain_id: 8453,
+                 to_chain_id: 42_161,
+                 trust_score: s
+               ) ==
+                 :xochi
+      end
+    end
+  end
+
+  describe "trust_score_for/1" do
+    property "returns a value in [0,100] for any integer score" do
+      check all(s <- score()) do
+        result = Router.trust_score_for(trust_score: s)
+        assert result >= 0 and result <= 100
+      end
+    end
+  end
+end


### PR DESCRIPTION
Property-based hardening of two money-adjacent raxol_payments paths that had **zero property coverage**, plus the real bug the Router property surfaced. Followed the property-testing discipline: surveyed the 12 existing property tests first, and deliberately did NOT duplicate them or write properties that just test a dependency (RNG/hash).

## Router — a real bug, found by the property

`PrivacyTier.from_trust_score/2` has function clauses only for `nil` and `score >= 0`. `Router.maybe_compute_trust_score` clamped only the **upper** bound (`min(score, 100)`), so a negative `:trust_score`:
- passed straight through to `PrivacyTier.from_trust_score` → **`FunctionClauseError`** in `Router.select/1` / `settlement_for/1`, and
- leaked out of `trust_score_for/1` as a raw negative.

For money routing that's both an availability risk (a crash on the settlement path) and a privacy-tier risk. The property shrank the counterexample to the minimal input: **`-1`**.

**Fix:** clamp the trust score to `[0, 100]` at the Router boundary (`clamp_score/1`). Router is the *only* caller of `PrivacyTier.from_trust_score` (verified), so this fully closes the crash class without changing `PrivacyTier`'s `non_neg_integer` contract. A below-range score degrades to the least-trusted tier (public) — the safe default.

**`router_property_test.exs`** (new, 9 properties) — Router had only example tests (realistic 0–100 scores, so they never hit the bug):
- `settlement_for/1` is total and returns a valid settlement for **any** integer score
- privacy is **monotonic** non-decreasing in trust score
- a score outside `[0,100]` behaves exactly like the clamped score
- an explicit `:privacy` and a forced `:protocol` always override routing
- `select/1` is total (always a known protocol atom)
- `tier_override` never grants more privacy than the score earned
- `trust_score_for/1` stays in `[0,100]`

## Ledger.release — genuine uncovered refund path

`Ledger.release/4` (the refund that compensates a `try_spend` reservation whose downstream execution failed) had **no property coverage**: the cap properties never call it, and the model-based test fixes the policy to `unrestricted` so it never exercises release against a cap.

**`ledger_release_property_test.exs`** (new, 2 properties):
- **model-based oracle**: across random spend/release sequences, `try_spend` decisions match the running sum with releases netted in
- **exact restore**: `release(R)` frees exactly `R` of lifetime budget — no more, no less

(The netting is correct — no bug here; the path is simply now pinned. One observation: `release/4` is unguarded — a caller *can* release more than reserved and drive the total negative, granting phantom headroom. That's out-of-contract "garbage in" and not tested as a bug, but worth a guard if we ever expose release to less-trusted callers.)

## Deliberately skipped (per the property-testing litmus test)

- **Mandate auto-nonce uniqueness** — `build/1` auto-generates via `:crypto.strong_rand_bytes(32)`; a uniqueness property would just test the RNG across a 2^256 space, not Mandate's logic.
- **Checkpoint `derive_key` collision resistance** — it's `sha256` of separator-joined fields; a collision property tests SHA-256, not the code (the only reachable collision needs a field containing the `\x1f` separator, which the structured inputs can't produce).

## Gate

Per `packages/raxol_payments`: `mix compile --warnings-as-errors` clean, `mix format --check-formatted` clean, `mix test` **64 properties + 894 tests, 0 failures** across seeds (default, 313). Existing `router_test.exs` (28 example tests) still green.

Branched off `master`, independent of #391/#392 (disjoint packages/files).

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test test/property/router_property_test.exs test/property/ledger_release_property_test.exs` (11 properties, 0 failures)
- [x] Confirmed RED before the fix: the Router totality/monotonicity/clamp/select/trust_score_for properties all failed on `-1` (FunctionClauseError); GREEN after the clamp
- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` (64 properties + 894 tests, 0 failures; 2 seeds)
- [x] `mix compile --warnings-as-errors && mix format --check-formatted`
