### PR TITLE
Skip heavy CI on docs-only changes

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -7,7 +7,7 @@ on:
       - 'web/**'
       - 'docs/**'
       - 'assets/**'
-      - '*.md'
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/**'
   pull_request:
@@ -16,7 +16,7 @@ on:
       - 'web/**'
       - 'docs/**'
       - 'assets/**'
-      - '*.md'
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/**'
   workflow_call:

--- a/.github/workflows/regression-testing.yml
+++ b/.github/workflows/regression-testing.yml
@@ -7,7 +7,7 @@ on:
       - 'web/**'
       - 'docs/**'
       - 'assets/**'
-      - '*.md'
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/**'
   pull_request:
@@ -16,7 +16,7 @@ on:
       - 'web/**'
       - 'docs/**'
       - 'assets/**'
-      - '*.md'
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/**'
   schedule:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,7 @@ on:
       - 'web/**'
       - 'docs/**'
       - 'assets/**'
-      - '*.md'
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/**'
   pull_request:
@@ -16,7 +16,7 @@ on:
       - 'web/**'
       - 'docs/**'
       - 'assets/**'
-      - '*.md'
+      - '**.md'
       - '.github/**'
       - '!.github/workflows/**'
   schedule:


### PR DESCRIPTION
## Problem

The `paths-ignore` filters in the heavy workflows used `'*.md'`, which GitHub matches **only at the repo root**. A markdown change in a subdirectory (e.g. a package README) is not matched, so the whole PR runs the full CI, regression, and security pipelines even when nothing but docs changed.

Concretely: #394 was docs-only, but ran everything because it touched `packages/raxol_acp/README.md`.

## Fix

Switch `'*.md'` -> `'**.md'` (GitHub's documented recursive glob -- matches markdown at any depth, root included) in the three PR-triggered heavy workflows:

- `ci-unified.yml`
- `regression-testing.yml`
- `security.yml`

Mixed code+docs PRs still run CI (the non-markdown files aren't ignored); **pure-docs PRs now skip**. The other two PR-triggered workflows already skip docs by construction: `performance-tracking.yml` uses a `paths:` allowlist of code paths, and `pr-comment.yml` runs on `workflow_run` after the heavy pipelines (which now won't fire on docs PRs).

The `!.github/workflows/**` negation is preserved, so changes to workflow files (like this one) still trigger CI.

## Manual testing

- [x] Verified all 6 `'*.md'` occurrences (2 per file x 3 files) became `'**.md'`
- [x] Confirmed `performance-tracking` (paths allowlist) + `pr-comment` (workflow_run) need no change
- [ ] Next docs-only PR should show the heavy jobs skipped