### PR TITLE
Handle refunded status + reconcile budget on refund

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_relay_transfer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_relay_transfer.ex
@@ -143,6 +143,9 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteRelayTransfer do
          {:ok, status} <- execute(config, quote, signature, context, amount),
          {:ok, deposit_tx} <- maybe_broadcast(quote, request, signature, context, amount) do
       summary = summary(quote, status, warnings, signature, deposit_tx)
+      # Dispatched: bind the reserved amount to the transfer id so a later refund
+      # (observed by PollRelayStatus) releases exactly this reservation.
+      SpendGate.tag_reservation(context, quote.transfer_id, amount)
       Checkpoint.put(store, key, settled_record(summary))
       {:ok, summary}
     else

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
@@ -445,6 +445,7 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
 
     case Xochi.execute(config, quote, wallet, request) do
       {:ok, exec} ->
+        tag_dispatch(context, exec, amount)
         {:ok, exec, quote}
 
       {:error, reason} ->
@@ -460,8 +461,12 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
         Checkpoint.put(store, key, dispatched_record(quote))
 
         case Xochi.execute(config, quote, wallet, request) do
-          {:ok, exec} -> {:ok, exec, quote}
-          {:error, reason} -> release_and_clear(context, amount, reason, store, key)
+          {:ok, exec} ->
+            tag_dispatch(context, exec, amount)
+            {:ok, exec, quote}
+
+          {:error, reason} ->
+            release_and_clear(context, amount, reason, store, key)
         end
 
       {:error, reason} ->
@@ -476,6 +481,13 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
     Checkpoint.delete(store, key)
     {:error, {:execute_failed, reason}}
   end
+
+  # The intent dispatched: bind the reserved amount to its id so a later refund
+  # (observed by PollXochiStatus) releases exactly this reservation, idempotently.
+  defp tag_dispatch(context, %{intent_id: intent_id}, amount) when is_binary(intent_id),
+    do: SpendGate.tag_reservation(context, intent_id, amount)
+
+  defp tag_dispatch(_context, _exec, _amount), do: :ok
 
   defp quote_expired?({:http, _status, body}) when is_map(body) do
     code = to_string(body["error"] || body["reason"] || "")

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_relay_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_relay_status.ex
@@ -17,7 +17,7 @@ defmodule Raxol.Payments.Actions.Payments.PollRelayStatus do
   use Raxol.Agent.Action,
     name: "payment_poll_relay_status",
     description:
-      "Poll a Relay (Tron) transfer by id until it reaches a terminal status (completed or failed). Returns the final status and tx hash.",
+      "Poll a Relay (Tron) transfer by id until it reaches a terminal status (completed, failed, or refunded). Returns the final status and tx hash.",
     schema: [
       input: [
         transfer_id: [type: :string, required: true],
@@ -50,7 +50,10 @@ defmodule Raxol.Payments.Actions.Payments.PollRelayStatus do
             {:ok, summary(status, elapsed_ms, budget)}
 
           {:ok, %StatusResponse{} = status, _elapsed_ms} ->
-            {:error, Failure.from({:settlement, status.status, status.error})}
+            # Terminal but not completed (failed/refunded): surface as an error
+            # carrying the most specific reason, so a refund's reason is not lost.
+            reason = status.error || status.refund_reason
+            {:error, Failure.from({:settlement, status.status, reason})}
 
           {:error, reason} ->
             {:error, Failure.from(reason)}

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_relay_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_relay_status.ex
@@ -3,13 +3,19 @@ defmodule Raxol.Payments.Actions.Payments.PollRelayStatus do
   Agent Action that polls a Relay (Tron) transfer until it reaches a terminal
   status.
 
-  Read-only: it does not move funds, so it does not pass through `SpendGate`. A
-  completed transfer returns `{:ok, summary}`; a failed transfer surfaces as
+  It never signs or moves funds, so it does not authorize a spend. It does
+  reconcile the execute-time budget reservation at a terminal status: a refund
+  releases it (`SpendGate.release_by_intent/2`, idempotent), any other terminal
+  status forgets the tag while the spend stands. Pass the same `:ledger` and
+  `:agent_id` used for the execute for this to take effect. A completed transfer
+  returns `{:ok, summary}`; a failed or refunded transfer surfaces as
   `{:error, %Failure{}}`, never as `{:ok, ...}`.
 
   ## Context keys
 
   * `:relay_config` -- `%{base_url:, auth_token:}` for `Relay.Client`.
+  * `:ledger`, `:agent_id` -- optional; the `Ledger` and key from the execute, so
+    a refund releases that reservation. See `SpendGate`.
   """
 
   @compile {:no_warn_undefined, Raxol.Agent.Action}
@@ -34,6 +40,7 @@ defmodule Raxol.Payments.Actions.Payments.PollRelayStatus do
       ]
     ]
 
+  alias Raxol.Payments.Actions.SpendGate
   alias Raxol.Payments.{Failure, Poll, Relay}
   alias Raxol.Payments.Relay.Schemas.StatusResponse
 
@@ -47,13 +54,21 @@ defmodule Raxol.Payments.Actions.Payments.PollRelayStatus do
 
         case Relay.poll_status_timed(config, transfer_id, opts) do
           {:ok, %StatusResponse{status: :completed} = status, elapsed_ms} ->
+            # Settled: the spend stands. Drop the reservation tag.
+            SpendGate.forget_reservation(context, transfer_id)
             {:ok, summary(status, elapsed_ms, budget)}
 
+          {:ok, %StatusResponse{status: :refunded} = status, _elapsed_ms} ->
+            # The origin funds came back: release the execute-time reservation
+            # idempotently so a refunded transfer stops consuming budget.
+            SpendGate.release_by_intent(context, transfer_id)
+            {:error, Failure.from({:settlement, :refunded, status.error || status.refund_reason})}
+
           {:ok, %StatusResponse{} = status, _elapsed_ms} ->
-            # Terminal but not completed (failed/refunded): surface as an error
-            # carrying the most specific reason, so a refund's reason is not lost.
-            reason = status.error || status.refund_reason
-            {:error, Failure.from({:settlement, status.status, reason})}
+            # Terminal but not completed or refunded (failed): the spend stands
+            # (funds may already have moved) -- forget the tag, keep the reason.
+            SpendGate.forget_reservation(context, transfer_id)
+            {:error, Failure.from({:settlement, status.status, status.error})}
 
           {:error, reason} ->
             {:error, Failure.from(reason)}

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -15,7 +15,7 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
   use Raxol.Agent.Action,
     name: "payment_poll_xochi_status",
     description:
-      "Poll a Xochi intent by id until it reaches a terminal status (completed, failed, expired). Returns the final status and settlement details.",
+      "Poll a Xochi intent by id until it reaches a terminal status (completed, failed, expired, refunded). Returns the final status and settlement details.",
     schema: [
       input: [
         intent_id: [type: :string, required: true],
@@ -59,11 +59,12 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
 
           {:ok, %IntentStatus{} = status, _elapsed_ms} ->
             # Terminal but not completed (failed/expired/refunded): a failed
-            # order must surface as an error, never as {:ok, ...}. Fall back to
-            # the solver's substatus_message when no explicit error is set, so
-            # the reason a settlement failed (e.g. a reconcile detail) is not lost.
-            {:error,
-             Failure.from({:settlement, status.status, status.error || status.substatus_message})}
+            # order must surface as an error, never as {:ok, ...}. Carry the most
+            # specific reason available -- an explicit error, then the refund
+            # reason on a refund, then the solver's substatus_message -- so why a
+            # settlement failed (e.g. a reconcile detail) is never lost.
+            reason = status.error || status.refund_reason || status.substatus_message
+            {:error, Failure.from({:settlement, status.status, reason})}
 
           {:error, :timeout} ->
             # A poll that never reached a terminal status is not a clean failure:

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -2,12 +2,19 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
   @moduledoc """
   Agent Action that polls a Xochi intent until it reaches a terminal status.
 
-  Read-only: it does not move funds, so it does not pass through `SpendGate`.
+  It never signs or moves funds, so it does not authorize a spend. It does
+  reconcile the execute-time budget reservation at a terminal status: a refund
+  releases it (`SpendGate.release_by_intent/2`, idempotent), any other terminal
+  status forgets the tag while the spend stands. Pass the same `:ledger` and
+  `:agent_id` used for the execute for this to take effect; without them it is a
+  no-op and the reservation is left untouched.
 
   ## Context keys
 
   * `:xochi_config` -- `%{base_url:, auth:}` for `Xochi.Client` (e.g.
     `auth: {:mandate, agent_wallet}`; see `Xochi.Client` for all auth modes).
+  * `:ledger`, `:agent_id` -- optional; the `Ledger` and key from the execute, so
+    a refund releases that reservation. See `SpendGate`.
   """
 
   @compile {:no_warn_undefined, Raxol.Agent.Action}
@@ -41,6 +48,7 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
       ]
     ]
 
+  alias Raxol.Payments.Actions.SpendGate
   alias Raxol.Payments.{Failure, Poll}
   alias Raxol.Payments.Protocols.Xochi
   alias Raxol.Payments.Xochi.Schemas.IntentStatus
@@ -55,15 +63,28 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
 
         case Xochi.poll_status_timed(config, intent_id, opts) do
           {:ok, %IntentStatus{status: :completed} = status, elapsed_ms} ->
+            # Settled: the spend stands. Drop the reservation tag so the ledger's
+            # in-flight set stays bounded; nothing to release.
+            SpendGate.forget_reservation(context, intent_id)
             {:ok, summary(status, elapsed_ms, budget)}
 
-          {:ok, %IntentStatus{} = status, _elapsed_ms} ->
-            # Terminal but not completed (failed/expired/refunded): a failed
-            # order must surface as an error, never as {:ok, ...}. Carry the most
-            # specific reason available -- an explicit error, then the refund
-            # reason on a refund, then the solver's substatus_message -- so why a
-            # settlement failed (e.g. a reconcile detail) is never lost.
+          {:ok, %IntentStatus{status: :refunded} = status, _elapsed_ms} ->
+            # The origin funds came back. Release the execute-time budget
+            # reservation, idempotently -- a re-poll of an already-refunded intent
+            # releases nothing further -- so a refunded payment stops consuming
+            # budget. Still surfaced as an error carrying the refund reason.
+            SpendGate.release_by_intent(context, intent_id)
             reason = status.error || status.refund_reason || status.substatus_message
+            {:error, Failure.from({:settlement, :refunded, reason})}
+
+          {:ok, %IntentStatus{} = status, _elapsed_ms} ->
+            # Terminal but not completed or refunded (failed/expired): a failed
+            # order must surface as an error, never as {:ok, ...}. The origin pull
+            # may already have moved funds, so the spend stands -- forget the tag
+            # (no release), but keep the reason (an explicit error, then the
+            # solver's substatus_message) so why it failed is never lost.
+            SpendGate.forget_reservation(context, intent_id)
+            reason = status.error || status.substatus_message
             {:error, Failure.from({:settlement, status.status, reason})}
 
           {:error, :timeout} ->

--- a/packages/raxol_payments/lib/raxol/payments/actions/spend_gate.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/spend_gate.ex
@@ -77,6 +77,48 @@ defmodule Raxol.Payments.Actions.SpendGate do
     end
   end
 
+  @doc """
+  Tag the reservation just made for `amount` with the intent (or transfer) id it
+  funded, so a later refund can release it by id. Call once execution dispatches.
+  No-op when no ledger is configured. See `Ledger.tag_reservation/4`.
+  """
+  @spec tag_reservation(map(), String.t(), Decimal.t()) :: :ok
+  def tag_reservation(context, intent_id, %Decimal{} = amount) when is_map(context) do
+    case Map.get(context, :ledger) do
+      nil -> :ok
+      ledger -> Ledger.tag_reservation(ledger, agent_id(context), intent_id, amount)
+    end
+  end
+
+  @doc """
+  Idempotently release the reservation tagged for `intent_id` (a refund reversed
+  the spend). Returns `:released`, `:noop`, or `:noop` when no ledger is
+  configured. Safe to call on every observation of a refund -- a second call for
+  an already-released intent is a no-op. See `Ledger.release_by_intent/3`.
+  """
+  @spec release_by_intent(map(), String.t()) :: :released | :noop
+  def release_by_intent(context, intent_id) when is_map(context) do
+    case Map.get(context, :ledger) do
+      nil -> :noop
+      ledger -> Ledger.release_by_intent(ledger, agent_id(context), intent_id)
+    end
+  end
+
+  @doc """
+  Drop the reservation tag for `intent_id` without releasing budget (the spend
+  stands; the intent settled or failed with funds kept). No-op when no ledger is
+  configured. See `Ledger.forget_reservation/3`.
+  """
+  @spec forget_reservation(map(), String.t()) :: :ok
+  def forget_reservation(context, intent_id) when is_map(context) do
+    case Map.get(context, :ledger) do
+      nil -> :ok
+      ledger -> Ledger.forget_reservation(ledger, agent_id(context), intent_id)
+    end
+  end
+
+  defp agent_id(context), do: Map.get(context, :agent_id, :unknown)
+
   # -- Amount validation --
 
   # A spend must be a positive, finite amount. Zero, negative, and non-finite

--- a/packages/raxol_payments/lib/raxol/payments/failure.ex
+++ b/packages/raxol_payments/lib/raxol/payments/failure.ex
@@ -298,12 +298,19 @@ defmodule Raxol.Payments.Failure do
       )
 
   defp settlement_failure(:refunded, error),
-    do: build(:refunded, "The transfer failed and the funds were refunded.", false, error)
+    do: build(:refunded, refunded_message(error), false, error)
 
   defp settlement_failure(:settlement_failed, error),
     do: build(:settlement_failed, "Settlement failed after execution.", false, error)
 
   defp settlement_failure(_status, error), do: failed_settlement(error)
+
+  # A refund returns the origin funds; carry the solver's reason into the sentence
+  # when one is present so the agent sees why, not just that it was refunded.
+  defp refunded_message(reason) when is_binary(reason) and reason != "",
+    do: "The transfer failed and the funds were refunded (#{reason})."
+
+  defp refunded_message(_), do: "The transfer failed and the funds were refunded."
 
   defp failed_settlement(error) when is_binary(error) and error != "" do
     cond do

--- a/packages/raxol_payments/lib/raxol/payments/ledger.ex
+++ b/packages/raxol_payments/lib/raxol/payments/ledger.ex
@@ -101,6 +101,51 @@ defmodule Raxol.Payments.Ledger do
   end
 
   @doc """
+  Tag a settled reservation with the on-chain intent (or transfer) it funded.
+
+  Recorded once execution dispatches, when both the reserved amount and the
+  intent id are known (the reservation itself is made earlier, before the id
+  exists). It lets a later terminal outcome release exactly that amount by intent
+  id via `release_by_intent/3`, without the caller re-threading the amount. A
+  no-op tag (nil id or non-positive amount) is ignored.
+  """
+  @spec tag_reservation(GenServer.server(), term(), String.t(), Decimal.t()) :: :ok
+  def tag_reservation(server, agent_id, intent_id, amount) do
+    GenServer.cast(server, {:tag_reservation, agent_id, intent_id, amount})
+  end
+
+  @doc """
+  Idempotently release the reservation tagged for `intent_id`.
+
+  Inserts a single compensating `-amount` entry the FIRST time it is called for a
+  tagged intent, then drops the tag; any later call for the same intent id is a
+  no-op. This is what makes a refund safe to observe more than once (e.g. a
+  re-poll of an already-refunded intent) without double-releasing budget, which
+  would under-count spend and hand back real headroom.
+
+  Returns `:released` when it reversed the reservation, `:noop` when there was no
+  live tag (already released, forgotten, or never tagged). A freeze does not block
+  a release -- refunding budget on returned funds is not a spend.
+  """
+  @spec release_by_intent(GenServer.server(), term(), String.t()) :: :released | :noop
+  def release_by_intent(server, agent_id, intent_id) do
+    GenServer.call(server, {:release_by_intent, agent_id, intent_id})
+  end
+
+  @doc """
+  Drop the reservation tag for `intent_id` WITHOUT releasing budget.
+
+  Used when an intent reaches a terminal status whose funds are kept on the books
+  (completed, or a failure whose origin pull may already have moved funds): the
+  spend stands, and only the tag is cleared so the reservation map stays bounded
+  to in-flight intents.
+  """
+  @spec forget_reservation(GenServer.server(), term(), String.t()) :: :ok
+  def forget_reservation(server, agent_id, intent_id) do
+    GenServer.cast(server, {:forget_reservation, agent_id, intent_id})
+  end
+
+  @doc """
   Get spend history for an agent.
   """
   @spec get_history(GenServer.server(), term(), keyword()) :: [entry()]
@@ -210,7 +255,7 @@ defmodule Raxol.Payments.Ledger do
         read_concurrency: true
       ])
 
-    {:ok, %{table: table, subscribers: %{}, frozen?: false}}
+    {:ok, %{table: table, subscribers: %{}, frozen?: false, reservations: %{}}}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -227,6 +272,30 @@ defmodule Raxol.Payments.Ledger do
     :ets.insert(state.table, {agent_id, entry})
     notify_subscribers(state.subscribers, entry)
     {:noreply, state}
+  end
+
+  # Tag only a positive, finite amount against a real intent id. A tag is a bare
+  # {agent_id, intent_id} => amount record in state, not a ledger entry, so it
+  # never affects spend totals; only `release_by_intent` turns it into a
+  # compensating entry.
+  def handle_manager_cast(
+        {:tag_reservation, agent_id, intent_id, %Decimal{coef: coef} = amount},
+        state
+      )
+      when is_binary(intent_id) and intent_id != "" and is_integer(coef) do
+    if Decimal.compare(amount, 0) == :gt do
+      reservations = Map.put(state.reservations, {agent_id, intent_id}, amount)
+      {:noreply, %{state | reservations: reservations}}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_manager_cast({:tag_reservation, _agent_id, _intent_id, _amount}, state),
+    do: {:noreply, state}
+
+  def handle_manager_cast({:forget_reservation, agent_id, intent_id}, state) do
+    {:noreply, %{state | reservations: Map.delete(state.reservations, {agent_id, intent_id})}}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -266,6 +335,37 @@ defmodule Raxol.Payments.Ledger do
         )
 
         {:reply, over, state}
+    end
+  end
+
+  # Idempotent by the presence of the tag: the first call reverses the reserved
+  # amount and drops the tag; a second call finds no tag and is a no-op. Not gated
+  # on the freeze flag -- releasing budget on returned funds is not a spend.
+  def handle_manager_call({:release_by_intent, agent_id, intent_id}, _from, state) do
+    key = {agent_id, intent_id}
+
+    case Map.fetch(state.reservations, key) do
+      {:ok, amount} ->
+        entry =
+          build_entry(agent_id, Decimal.negate(amount), %{
+            type: :release,
+            intent_id: intent_id,
+            reason: :refunded
+          })
+
+        :ets.insert(state.table, {agent_id, entry})
+        notify_subscribers(state.subscribers, entry)
+
+        :telemetry.execute(
+          [:raxol, :payments, :refund_reconciled],
+          %{amount: amount},
+          %{agent_id: agent_id, intent_id: intent_id}
+        )
+
+        {:reply, :released, %{state | reservations: Map.delete(state.reservations, key)}}
+
+      :error ->
+        {:reply, :noop, state}
     end
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/relay/schemas.ex
+++ b/packages/raxol_payments/lib/raxol/payments/relay/schemas.ex
@@ -207,12 +207,16 @@ defmodule Raxol.Payments.Relay.Schemas do
       :actual_to_amount,
       :actual_fees,
       :error,
+      # Solver-supplied reason for a refunded transfer; present only on the
+      # terminal `:refunded` status.
+      :refund_reason,
       :created_at,
       :updated_at,
       terminal: false
     ]
 
-    @type status :: :pending | :executing | :confirming | :completed | :failed | :unknown
+    @type status ::
+            :pending | :executing | :confirming | :completed | :failed | :refunded | :unknown
 
     @type t :: %__MODULE__{
             transfer_id: String.t(),
@@ -223,12 +227,13 @@ defmodule Raxol.Payments.Relay.Schemas do
             actual_to_amount: String.t() | nil,
             actual_fees: map() | nil,
             error: String.t() | nil,
+            refund_reason: String.t() | nil,
             created_at: String.t() | nil,
             updated_at: String.t() | nil,
             terminal: boolean()
           }
 
-    @terminal_statuses [:completed, :failed]
+    @terminal_statuses [:completed, :failed, :refunded]
 
     @spec from_json(map()) :: t()
     def from_json(json) do
@@ -243,6 +248,7 @@ defmodule Raxol.Payments.Relay.Schemas do
         actual_to_amount: json["actual_to_amount"],
         actual_fees: json["actual_fees"],
         error: json["error"],
+        refund_reason: json["refund_reason"] || json["refundReason"],
         created_at: json["created_at"],
         updated_at: json["updated_at"],
         terminal: status in @terminal_statuses
@@ -257,6 +263,7 @@ defmodule Raxol.Payments.Relay.Schemas do
     defp parse_status("confirming"), do: :confirming
     defp parse_status("completed"), do: :completed
     defp parse_status("failed"), do: :failed
+    defp parse_status("refunded"), do: :refunded
     defp parse_status(_), do: :unknown
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
@@ -349,6 +349,9 @@ defmodule Raxol.Payments.Xochi.Schemas do
       :tx_hash,
       :receiving_tx_hash,
       :error,
+      # Solver-supplied reason a refunded intent was refunded (worker
+      # `refundReason`); present only on the terminal `:refunded` status.
+      :refund_reason,
       :updated_at,
       :substatus,
       :substatus_message,
@@ -373,6 +376,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
             | :completed
             | :failed
             | :expired
+            | :refunded
 
     @type settlement_type :: :public | :stealth | :shielded | nil
     @type attestation_status :: :verified | :rejected | :not_required | nil
@@ -383,6 +387,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
             tx_hash: String.t() | nil,
             receiving_tx_hash: String.t() | nil,
             error: String.t() | nil,
+            refund_reason: String.t() | nil,
             updated_at: String.t() | nil,
             substatus: String.t() | nil,
             substatus_message: String.t() | nil,
@@ -394,7 +399,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
             terminal: boolean()
           }
 
-    @terminal_statuses [:completed, :failed, :expired]
+    @terminal_statuses [:completed, :failed, :expired, :refunded]
 
     # The Xochi worker's status response is snake_case (`intent_id`, `tx_hash`,
     # `terminal`, ...); older/sim responses are camelCase. Accept both so the poll
@@ -411,6 +416,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
         tx_hash: pick(json, ["tx_hash", "txHash"]),
         receiving_tx_hash: pick(json, ["receiving_tx_hash", "receivingTxHash"]),
         error: json["error"],
+        refund_reason: pick(json, ["refund_reason", "refundReason"]),
         updated_at: pick(json, ["updated_at", "updatedAt"]),
         substatus: json["substatus"],
         substatus_message: pick(json, ["substatus_message", "substatusMessage"]),
@@ -446,6 +452,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
     defp parse_status("completed"), do: :completed
     defp parse_status("failed"), do: :failed
     defp parse_status("expired"), do: :expired
+    defp parse_status("refunded"), do: :refunded
     defp parse_status(_s), do: :unknown
 
     defp parse_settlement_type(nil), do: nil

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/poll_relay_status_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/poll_relay_status_test.exs
@@ -1,0 +1,88 @@
+defmodule Raxol.Payments.Actions.Payments.PollRelayStatusTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.Actions.Payments.PollRelayStatus
+  alias Raxol.Payments.{Failure, Ledger, SpendingPolicy}
+
+  defp config do
+    %{
+      base_url: "https://relay.test",
+      auth_token: "token",
+      req_options: [plug: {Req.Test, __MODULE__}]
+    }
+  end
+
+  defp policy do
+    %SpendingPolicy{
+      per_request_max: Decimal.new("10.00"),
+      session_max: Decimal.new("100.00"),
+      lifetime_max: Decimal.new("1000.00"),
+      session_window_ms: 3_600_000
+    }
+  end
+
+  defp reserve_and_tag(ledger, transfer_id) do
+    :ok = Ledger.try_spend(ledger, "agent_1", Decimal.new("1.00"), policy(), %{})
+    :ok = Ledger.tag_reservation(ledger, "agent_1", transfer_id, Decimal.new("1.00"))
+  end
+
+  defp start_ledger do
+    {:ok, ledger} = Ledger.start_link(table_name: :"relay_poll_#{:erlang.unique_integer()}")
+    ledger
+  end
+
+  test "a refunded transfer surfaces as :refunded and releases the reservation" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, %{
+        "transfer_id" => "t_r",
+        "status" => "refunded",
+        "refundReason" => "reverted on Tron"
+      })
+    end)
+
+    ledger = start_ledger()
+    reserve_and_tag(ledger, "t_r")
+    ctx = %{relay_config: config(), ledger: ledger, agent_id: "agent_1"}
+    params = %{transfer_id: "t_r", timeout_ms: 40, interval_ms: 10}
+
+    assert {:error, %Failure{reason: :refunded, detail: "reverted on Tron"}} =
+             PollRelayStatus.run(params, ctx)
+
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "0")
+
+    # Idempotent: a re-poll of the already-refunded transfer releases nothing more.
+    assert {:error, %Failure{reason: :refunded}} = PollRelayStatus.run(params, ctx)
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "0")
+  end
+
+  test "a failed transfer keeps the spend and forgets the tag" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, %{"transfer_id" => "t_f", "status" => "failed", "error" => "reverted"})
+    end)
+
+    ledger = start_ledger()
+    reserve_and_tag(ledger, "t_f")
+    ctx = %{relay_config: config(), ledger: ledger, agent_id: "agent_1"}
+    params = %{transfer_id: "t_f", timeout_ms: 40, interval_ms: 10}
+
+    assert {:error, %Failure{}} = PollRelayStatus.run(params, ctx)
+    # A failure may have moved funds, so the spend stands; only the tag is dropped.
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "1.00")
+    assert :noop = Ledger.release_by_intent(ledger, "agent_1", "t_f")
+  end
+
+  test "a completed transfer keeps the spend and forgets the tag" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, %{"transfer_id" => "t_c", "status" => "completed", "tx_hash" => "0xabc"})
+    end)
+
+    ledger = start_ledger()
+    reserve_and_tag(ledger, "t_c")
+    ctx = %{relay_config: config(), ledger: ledger, agent_id: "agent_1"}
+    params = %{transfer_id: "t_c", timeout_ms: 40, interval_ms: 10}
+
+    assert {:ok, %{status: "completed"}} = PollRelayStatus.run(params, ctx)
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "1.00")
+    assert :noop = Ledger.release_by_intent(ledger, "agent_1", "t_c")
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/poll_xochi_status_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/poll_xochi_status_test.exs
@@ -2,13 +2,22 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatusTest do
   use ExUnit.Case, async: true
 
   alias Raxol.Payments.Actions.Payments.PollXochiStatus
-  alias Raxol.Payments.Failure
+  alias Raxol.Payments.{Failure, Ledger, SpendingPolicy}
 
   defp config do
     %{
       base_url: "https://xochi.test",
       auth_token: "t",
       req_options: [plug: {Req.Test, __MODULE__}]
+    }
+  end
+
+  defp policy do
+    %SpendingPolicy{
+      per_request_max: Decimal.new("10.00"),
+      session_max: Decimal.new("100.00"),
+      lifetime_max: Decimal.new("1000.00"),
+      session_window_ms: 3_600_000
     }
   end
 
@@ -78,5 +87,47 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatusTest do
              PollXochiStatus.run(params, %{xochi_config: config()})
 
     assert to_string(failure) == "The transfer failed and the funds were refunded."
+  end
+
+  test "a refunded poll releases the execute-time reservation, idempotently" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, %{"intent_id" => "int_r3", "status" => "refunded", "terminal" => true})
+    end)
+
+    {:ok, ledger} = Ledger.start_link(table_name: :"poll_refund_#{:erlang.unique_integer()}")
+    ctx = %{xochi_config: config(), ledger: ledger, agent_id: "agent_1"}
+
+    # Mirror the execute path: reserve budget and tag it with the intent id.
+    :ok = Ledger.try_spend(ledger, "agent_1", Decimal.new("1.00"), policy(), %{})
+    :ok = Ledger.tag_reservation(ledger, "agent_1", "int_r3", Decimal.new("1.00"))
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "1.00")
+
+    params = %{intent_id: "int_r3", timeout_ms: 40, interval_ms: 10}
+
+    assert {:error, %Failure{reason: :refunded}} = PollXochiStatus.run(params, ctx)
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "0")
+
+    # Re-polling the same refunded intent must not release a second time.
+    assert {:error, %Failure{reason: :refunded}} = PollXochiStatus.run(params, ctx)
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "0")
+  end
+
+  test "a completed poll keeps the spend and forgets the tag" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, %{"intent_id" => "int_c", "status" => "completed", "terminal" => true})
+    end)
+
+    {:ok, ledger} = Ledger.start_link(table_name: :"poll_done_#{:erlang.unique_integer()}")
+    ctx = %{xochi_config: config(), ledger: ledger, agent_id: "agent_1"}
+
+    :ok = Ledger.try_spend(ledger, "agent_1", Decimal.new("1.00"), policy(), %{})
+    :ok = Ledger.tag_reservation(ledger, "agent_1", "int_c", Decimal.new("1.00"))
+
+    params = %{intent_id: "int_c", timeout_ms: 40, interval_ms: 10}
+
+    assert {:ok, %{status: "completed"}} = PollXochiStatus.run(params, ctx)
+    # The spend stands; the tag is forgotten so a later stray release is a no-op.
+    assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy()).lifetime, "1.00")
+    assert :noop = Ledger.release_by_intent(ledger, "agent_1", "int_c")
   end
 end

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/poll_xochi_status_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/poll_xochi_status_test.exs
@@ -47,4 +47,36 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatusTest do
       :telemetry.detach(handler_id)
     end
   end
+
+  test "a refunded terminal status surfaces as a :refunded failure carrying the reason" do
+    # The worker reports the intent refunded and terminal, with a refundReason.
+    # The poll must stop (refunded is terminal), fail (not {:ok, ...}), and carry
+    # the reason so the agent sees why the funds came back.
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, %{
+        "intent_id" => "int_r",
+        "status" => "refunded",
+        "terminal" => true,
+        "refundReason" => "solver timeout"
+      })
+    end)
+
+    params = %{intent_id: "int_r", timeout_ms: 40, interval_ms: 10}
+
+    assert {:error, %Failure{reason: :refunded, retryable?: false, detail: "solver timeout"}} =
+             PollXochiStatus.run(params, %{xochi_config: config()})
+  end
+
+  test "a refunded status without a refundReason still surfaces as :refunded" do
+    Req.Test.stub(__MODULE__, fn conn ->
+      Req.Test.json(conn, %{"intent_id" => "int_r2", "status" => "refunded", "terminal" => true})
+    end)
+
+    params = %{intent_id: "int_r2", timeout_ms: 40, interval_ms: 10}
+
+    assert {:error, %Failure{reason: :refunded} = failure} =
+             PollXochiStatus.run(params, %{xochi_config: config()})
+
+    assert to_string(failure) == "The transfer failed and the funds were refunded."
+  end
 end

--- a/packages/raxol_payments/test/raxol/payments/failure_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/failure_test.exs
@@ -45,9 +45,18 @@ defmodule Raxol.Payments.FailureTest do
       assert f.retryable?
     end
 
-    test "refunded maps to :refunded" do
+    test "refunded maps to :refunded and is not retryable" do
       f = Failure.from({:settlement, :refunded, nil})
       assert f.reason == :refunded
+      refute f.retryable?
+      assert to_string(f) == "The transfer failed and the funds were refunded."
+    end
+
+    test "refunded carries the solver reason into the message and detail" do
+      f = Failure.from({:settlement, :refunded, "solver timeout"})
+      assert f.reason == :refunded
+      assert f.detail == "solver timeout"
+      assert to_string(f) == "The transfer failed and the funds were refunded (solver timeout)."
     end
   end
 

--- a/packages/raxol_payments/test/raxol/payments/ledger_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/ledger_test.exs
@@ -264,4 +264,64 @@ defmodule Raxol.Payments.LedgerTest do
       assert Decimal.equal?(totals.lifetime, Decimal.new("0"))
     end
   end
+
+  describe "intent-keyed reservation release" do
+    setup %{ledger: ledger} do
+      policy = %SpendingPolicy{
+        per_request_max: Decimal.new("10.00"),
+        session_max: Decimal.new("100.00"),
+        lifetime_max: Decimal.new("1000.00"),
+        session_window_ms: 3_600_000
+      }
+
+      # Reserve a spend the way the SpendGate does, then tag it with the intent id
+      # the execute dispatched (as ExecuteXochiIntent does on success).
+      :ok = Ledger.try_spend(ledger, "agent_1", Decimal.new("1.00"), policy, %{})
+      :ok = Ledger.tag_reservation(ledger, "agent_1", "intent_1", Decimal.new("1.00"))
+      %{policy: policy}
+    end
+
+    test "release_by_intent reverses the reservation exactly once", ctx do
+      %{ledger: ledger, policy: policy} = ctx
+
+      assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy).lifetime, "1.00")
+
+      assert :released = Ledger.release_by_intent(ledger, "agent_1", "intent_1")
+      assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy).lifetime, "0")
+
+      # A re-poll of an already-refunded intent must not release again -- that
+      # would under-count spend and hand back real headroom.
+      assert :noop = Ledger.release_by_intent(ledger, "agent_1", "intent_1")
+      assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy).lifetime, "0")
+    end
+
+    test "release_by_intent is a no-op for an untagged intent", %{ledger: ledger} do
+      assert :noop = Ledger.release_by_intent(ledger, "agent_1", "never_tagged")
+    end
+
+    test "forget_reservation drops the tag so no release can follow", ctx do
+      %{ledger: ledger, policy: policy} = ctx
+
+      :ok = Ledger.forget_reservation(ledger, "agent_1", "intent_1")
+      # Cast ordering: a following call is serialized behind it.
+      assert :noop = Ledger.release_by_intent(ledger, "agent_1", "intent_1")
+      # The spend stands -- forget does not refund.
+      assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy).lifetime, "1.00")
+    end
+
+    test "a freeze does not block releasing a refund", ctx do
+      %{ledger: ledger, policy: policy} = ctx
+
+      :ok = Ledger.freeze(ledger)
+      assert :released = Ledger.release_by_intent(ledger, "agent_1", "intent_1")
+      assert Decimal.equal?(Ledger.get_totals(ledger, "agent_1", policy).lifetime, "0")
+    end
+
+    test "a non-positive or empty tag is ignored", %{ledger: ledger} do
+      :ok = Ledger.tag_reservation(ledger, "agent_1", "zero", Decimal.new("0"))
+      :ok = Ledger.tag_reservation(ledger, "agent_1", "", Decimal.new("1.00"))
+      assert :noop = Ledger.release_by_intent(ledger, "agent_1", "zero")
+      assert :noop = Ledger.release_by_intent(ledger, "agent_1", "")
+    end
+  end
 end

--- a/packages/raxol_payments/test/raxol/payments/relay/schemas_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/relay/schemas_test.exs
@@ -111,10 +111,26 @@ defmodule Raxol.Payments.Relay.SchemasTest do
             {"executing", false},
             {"confirming", false},
             {"completed", true},
-            {"failed", true}
+            {"failed", true},
+            {"refunded", true}
           ] do
         status = StatusResponse.from_json(%{"transfer_id" => "t", "status" => s})
         assert StatusResponse.terminal?(status) == terminal
+      end
+    end
+
+    test "parses the refunded status and its reason (camelCase and snake_case)" do
+      for key <- ["refundReason", "refund_reason"] do
+        status =
+          StatusResponse.from_json(%{
+            "transfer_id" => "t",
+            "status" => "refunded",
+            key => "reverted on Tron"
+          })
+
+        assert status.status == :refunded
+        assert status.refund_reason == "reverted on Tron"
+        assert StatusResponse.terminal?(status)
       end
     end
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
@@ -455,11 +455,30 @@ defmodule Raxol.Payments.Xochi.SchemasTest do
     end
 
     test "detects terminal statuses" do
-      for s <- ["completed", "failed", "expired"] do
+      for s <- ["completed", "failed", "expired", "refunded"] do
         json = %{"intentId" => "i", "status" => s}
         status = IntentStatus.from_json(json)
         assert IntentStatus.terminal?(status), "expected #{s} to be terminal"
       end
+    end
+
+    test "parses the refunded status and its reason (camelCase and snake_case)" do
+      for key <- ["refundReason", "refund_reason"] do
+        json = %{"intent_id" => "int_r", "status" => "refunded", key => "solver timeout"}
+        status = IntentStatus.from_json(json)
+        assert status.status == :refunded
+        assert status.refund_reason == "solver timeout"
+        # Terminal independently of the worker's `terminal` flag: refunded is a
+        # terminal status, so a poll stops even if the worker omits the flag.
+        assert IntentStatus.terminal?(status)
+      end
+    end
+
+    test "refund_reason is nil when the worker omits it" do
+      json = %{"intent_id" => "int_r", "status" => "refunded", "terminal" => true}
+      status = IntentStatus.from_json(json)
+      assert status.status == :refunded
+      assert status.refund_reason == nil
     end
 
     test "non-terminal statuses" do


### PR DESCRIPTION
## What

Two related fund-critical changes on the Xochi and relay (Tron) poll paths:

1. **Handle the `refunded` terminal status end-to-end** (closes #401).
2. **Release the execute-time budget reservation on a refund**, idempotently and
   intent-keyed — the audit gap found while reviewing the paths for #401.

## 1. Refunded status handling

Before, a `refunded` status parsed to `:unknown`: the Xochi poller treated it as
terminal only because the worker set `terminal: true`, surfaced a generic "order
did not fill" instead of the `:refunded` `Failure` that already existed
(`failure.ex`), and dropped `refundReason`. The relay path was worse — its
terminality is `status in @terminal_statuses` with no `terminal` flag fallback,
so a `refunded` status would parse to `:unknown`, stay non-terminal, and the poll
would hang to timeout.

- `Xochi.Schemas.IntentStatus` / `Relay.Schemas.StatusResponse`: `:refunded` in
  the type, `parse_status/1`, and `@terminal_statuses`; new `refund_reason` field
  (`refund_reason` / `refundReason`).
- `Failure`: the `:refunded` message carries the reason when present
  (`"...refunded (solver timeout)."`); still non-retryable.
- Pollers list `refunded` and thread `error || refund_reason` into the failure.

## 2. Idempotent intent-keyed budget release

`ExecuteXochiIntent` / `ExecuteRelayTransfer` reserve budget via `SpendGate` and
refund it only on a *definite execute failure*. Once execute succeeds, the
terminal outcome is observed by the separate poll action, and a later `:refunded`
never released the reservation — so the spending `Ledger` kept counting a spend
whose funds were returned.

The dedup state lives in the `Ledger` (it already owns spend/release tracking) —
no new supervised process:

- `Ledger.tag_reservation/4` — at dispatch (both amount and intent id known), bind
  the reserved amount to the intent/transfer id in a `{agent_id, intent_id}` map.
- `Ledger.release_by_intent/3` — a `call` that reverses the reserved amount and
  drops the tag the FIRST time; a second call finds no tag and is a `:noop`. This
  is what makes a refund safe to observe more than once (e.g. a re-poll) without
  double-releasing, which would under-count spend and hand back real headroom.
  Not gated on the freeze flag — refunding returned funds is not a spend.
- `Ledger.forget_reservation/3` — drop the tag without releasing (completed, or a
  failure whose origin pull may already have moved funds); keeps the map bounded
  to in-flight intents.
- `SpendGate` gains thin `context`-aware wrappers for the three.
- The execute actions tag on dispatch; the pollers release on `:refunded` and
  forget on any other terminal status. A stranded/timeout poll keeps the tag so a
  later poll can still release.

Opt-in and backward compatible: the pollers reconcile only when the caller passes
the same `:ledger` / `:agent_id` used for the execute; without them it is a no-op
and the reservation is left untouched (the prior fail-safe behavior).

Emits `[:raxol, :payments, :refund_reconciled]` (amount + intent id + agent id)
for observability.

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` — 974 passed, 0 failures
- [x] New tests: intent-keyed release idempotency (release once, re-poll `:noop`,
      untagged `:noop`, forget-then-release `:noop`, freeze does not block, empty/
      non-positive tags ignored), refunded/completed/failed poll paths on both
      Xochi and relay assert the ledger nets back (or holds) correctly.
- [x] `mix compile` — no new warnings from changed files
- [x] Changed files `mix format --check-formatted` clean

EVM->EVM signing is unchanged and remains immune to Riddler's EIP-712 v1->v3 bump
(`sign_quote/2` signs the served `eip712_data` verbatim).
