### PR TITLE
Fix x402 auto-pay budget leak and value binding

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/protocols/x402.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/x402.ex
@@ -64,6 +64,19 @@ defmodule Raxol.Payments.Protocols.X402 do
   @spec build_payment(map(), module()) ::
           {:ok, Headers.headers()} | {:error, term()}
   def build_payment(challenge, wallet) do
+    case atomic_value(challenge.price) do
+      {:ok, value} -> build_signed_payment(challenge, wallet, value)
+      {:error, _} = err -> err
+    end
+  end
+
+  # The signed ERC-3009 `value` is the atomic token amount the gate approved.
+  # x402 `maxAmountRequired` is atomic units (an integer); the spend gate reads
+  # the same field via `amount/1` as atomic. A float or decimal-string price is
+  # malformed as atomic units and would let the signed value diverge from the
+  # gated amount (a gate-bypass), so it is rejected before signing rather than
+  # coerced.
+  defp build_signed_payment(challenge, wallet, value) do
     chain_id = chain_id_from_network(challenge.network)
     %{name: name, version: version} = Raxol.Payments.Assets.UsdcDomains.lookup(chain_id)
 
@@ -88,7 +101,7 @@ defmodule Raxol.Payments.Protocols.X402 do
     message = %{
       from: wallet.address(),
       to: challenge.pay_to,
-      value: normalize_amount(challenge.price),
+      value: value,
       validAfter: challenge.valid_after,
       validBefore: challenge.valid_before || :os.system_time(:second) + 3600,
       nonce: challenge.nonce || generate_nonce()
@@ -153,22 +166,20 @@ defmodule Raxol.Payments.Protocols.X402 do
 
   defp chain_id_from_network(chain_id) when is_integer(chain_id), do: chain_id
 
-  defp normalize_amount(amount) when is_integer(amount) and amount >= 0,
-    do: amount
+  # Parse the challenge price strictly as non-negative atomic units. Only an
+  # integer or an all-digit string is a valid atomic amount; a float or a
+  # decimal string is rejected (fail closed) so the signed `value` is always the
+  # exact atomic amount the gate read via `amount/1`.
+  defp atomic_value(price) when is_integer(price) and price >= 0, do: {:ok, price}
 
-  defp normalize_amount(amount) when is_binary(amount) do
-    case Integer.parse(amount) do
-      {int, ""} when int >= 0 -> int
-      _ -> 0
+  defp atomic_value(price) when is_binary(price) do
+    case Integer.parse(price) do
+      {int, ""} when int >= 0 -> {:ok, int}
+      _ -> {:error, {:invalid_price, price}}
     end
   end
 
-  defp normalize_amount(amount) when is_float(amount) and amount >= 0 do
-    # USDC has 6 decimals; other tokens may differ
-    round(amount * 1_000_000)
-  end
-
-  defp normalize_amount(_amount), do: 0
+  defp atomic_value(price), do: {:error, {:invalid_price, price}}
 
   defp generate_nonce do
     :crypto.strong_rand_bytes(32)
@@ -176,24 +187,18 @@ defmodule Raxol.Payments.Protocols.X402 do
     |> then(&("0x" <> &1))
   end
 
+  # x402 `maxAmountRequired` is atomic token units: a positive integer, or an
+  # all-digit string. A float or a decimal string is malformed as atomic units
+  # (and would crash the atomic->human conversion in `amount/1`), so the
+  # challenge is rejected at parse time -- fail closed rather than guess or crash.
   defp validate_positive_amount(amount) when is_integer(amount) and amount > 0,
     do: :ok
 
-  defp validate_positive_amount(amount) when is_float(amount) and amount > 0,
-    do: :ok
-
   defp validate_positive_amount(amount) when is_binary(amount) do
-    case Decimal.parse(amount) do
-      {dec, ""} ->
-        if Decimal.positive?(dec),
-          do: :ok,
-          else: {:error, {:invalid_amount, amount}}
-
-      _ ->
-        {:error, {:invalid_amount, amount}}
+    case Integer.parse(amount) do
+      {int, ""} when int > 0 -> :ok
+      _ -> {:error, {:invalid_amount, amount}}
     end
-  rescue
-    Decimal.Error -> {:error, {:invalid_amount, amount}}
   end
 
   defp validate_positive_amount(amount), do: {:error, {:invalid_amount, amount}}

--- a/packages/raxol_payments/lib/raxol/payments/req/auto_pay.ex
+++ b/packages/raxol_payments/lib/raxol/payments/req/auto_pay.ex
@@ -55,33 +55,19 @@ defmodule Raxol.Payments.Req.AutoPay do
     protocols = Keyword.get(opts, :protocols, @default_protocols)
     headers = Raxol.Payments.Headers.flatten(response.headers)
 
-    with {:ok, protocol_mod, challenge} <- detect_and_parse(protocols, headers),
-         :ok <- try_spend_budget(protocol_mod, challenge, request, opts),
-         {:ok, payment_headers} <- protocol_mod.build_payment(challenge, wallet) do
-      # Build retry request: add payment headers and strip the auto_pay step
-      # to prevent infinite loops if the server returns 402 again.
-      retry_request =
-        request
-        |> add_payment_headers(payment_headers)
-        |> remove_auto_pay_step()
+    with {:ok, protocol_mod, challenge} <- detect_and_parse(protocols, headers) do
+      amount = protocol_mod.amount(challenge)
+      host = request_host(request)
 
-      case Req.Request.run(retry_request) do
-        {_req, %Req.Response{status: status} = paid_response}
-        when status in 200..299 ->
-          {request, paid_response}
+      case reserve_budget(protocol_mod, amount, host, opts) do
+        :ok ->
+          # Budget is now reserved. Any failure past this point -- a signing
+          # failure, or a failed/errored paid retry -- must release it, or a
+          # payment that never completed would permanently consume budget.
+          settle(request, response, protocol_mod, challenge, wallet, amount, host, opts)
 
-        {_req, %Req.Response{} = failed_response} ->
-          {request, failed_response}
-
-        {:error, reason} ->
-          {request,
-           %{
-             response
-             | body: %{
-                 error: :payment_retry_failed,
-                 reason: sanitize_error(reason)
-               }
-           }}
+        {:error, _} = denied ->
+          handle_failure(denied, request, response)
       end
     else
       error -> handle_failure(error, request, response)
@@ -89,6 +75,44 @@ defmodule Raxol.Payments.Req.AutoPay do
   end
 
   defp handle_response(req_response, _opts), do: req_response
+
+  # Sign and retry under a reservation already made by `reserve_budget/4`. Every
+  # non-success exit releases the reservation first, so only a 2xx paid retry
+  # (the payment landed) keeps the budget consumed.
+  defp settle(request, response, protocol_mod, challenge, wallet, amount, host, opts) do
+    case protocol_mod.build_payment(challenge, wallet) do
+      {:ok, payment_headers} ->
+        # Build retry request: add payment headers and strip the auto_pay step
+        # to prevent infinite loops if the server returns 402 again.
+        retry_request =
+          request
+          |> add_payment_headers(payment_headers)
+          |> remove_auto_pay_step()
+
+        case Req.Request.run(retry_request) do
+          {_req, %Req.Response{status: status} = paid_response}
+          when status in 200..299 ->
+            {request, paid_response}
+
+          {_req, %Req.Response{} = failed_response} ->
+            release_budget(protocol_mod, amount, host, opts)
+            {request, failed_response}
+
+          {:error, reason} ->
+            release_budget(protocol_mod, amount, host, opts)
+            {request, payment_retry_error(response, reason)}
+        end
+
+      {:error, _} = error ->
+        # Signed nothing, so nothing was paid: refund the reservation.
+        release_budget(protocol_mod, amount, host, opts)
+        handle_failure(error, request, response)
+    end
+  end
+
+  defp payment_retry_error(response, reason) do
+    %{response | body: %{error: :payment_retry_failed, reason: sanitize_error(reason)}}
+  end
 
   defp handle_failure({:error, :no_matching_protocol}, request, response),
     do: {request, response}
@@ -98,18 +122,14 @@ defmodule Raxol.Payments.Req.AutoPay do
          request,
          response
        ),
-       do:
-         {request,
-          %{response | body: %{error: :budget_exceeded, limit: limit_type}}}
+       do: {request, %{response | body: %{error: :budget_exceeded, limit: limit_type}}}
 
   defp handle_failure(
          {:error, {:gate_denied, {:domain_not_approved, domain}}},
          request,
          response
        ),
-       do:
-         {request,
-          %{response | body: %{error: :domain_not_approved, domain: domain}}}
+       do: {request, %{response | body: %{error: :domain_not_approved, domain: domain}}}
 
   defp handle_failure(
          {:error, {:gate_denied, {:requires_confirmation, amount, domain}}},
@@ -147,15 +167,29 @@ defmodule Raxol.Payments.Req.AutoPay do
     end)
   end
 
-  @spec try_spend_budget(module(), map(), Req.Request.t(), keyword()) ::
+  # Run the policy gate then atomically reserve the budget. `:ok` means the spend
+  # is authorized and recorded; release it with `release_budget/4` if the payment
+  # then fails to complete.
+  @spec reserve_budget(module(), Decimal.t(), String.t() | nil, keyword()) ::
           :ok | {:error, term()}
-  defp try_spend_budget(protocol_mod, challenge, request, opts) do
-    amount = protocol_mod.amount(challenge)
-    host = request_host(request)
-    policy = Keyword.get(opts, :policy)
-
-    with :ok <- enforce_policy_gate(policy, amount, host, opts) do
+  defp reserve_budget(protocol_mod, amount, host, opts) do
+    with :ok <- enforce_policy_gate(Keyword.get(opts, :policy), amount, host, opts) do
       enforce_budget(protocol_mod, amount, host, opts)
+    end
+  end
+
+  # Refund a reservation made by `reserve_budget/4`. Mirrors `do_enforce_budget`'s
+  # guard: budget is only reserved when both a policy and a ledger are present, so
+  # a release fires only in that same case (no spurious refund otherwise).
+  @spec release_budget(module(), Decimal.t(), String.t() | nil, keyword()) :: :ok
+  defp release_budget(protocol_mod, amount, host, opts) do
+    with %SpendingPolicy{} <- Keyword.get(opts, :policy),
+         ledger when not is_nil(ledger) <- Keyword.get(opts, :ledger) do
+      agent_id = Keyword.get(opts, :agent_id, :unknown)
+      metadata = %{protocol: protocol_mod.name(), domain: host, reason: :payment_failed}
+      Ledger.release(ledger, agent_id, amount, metadata)
+    else
+      _ -> :ok
     end
   end
 
@@ -166,9 +200,7 @@ defmodule Raxol.Payments.Req.AutoPay do
        do: {:error, {:gate_denied, :missing_host}}
 
   defp enforce_policy_gate(%SpendingPolicy{} = policy, amount, host, opts) do
-    case PolicyGate.evaluate(policy, amount, host,
-           on_confirm: Keyword.get(opts, :on_confirm)
-         ) do
+    case PolicyGate.evaluate(policy, amount, host, on_confirm: Keyword.get(opts, :on_confirm)) do
       :ok -> :ok
       {:deny, reason} -> {:error, {:gate_denied, reason}}
     end

--- a/packages/raxol_payments/test/raxol/payments/protocols/x402_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/x402_test.exs
@@ -144,8 +144,9 @@ defmodule Raxol.Payments.Protocols.X402Test do
       @impl true
       def sign_message(_msg), do: {:ok, <<0::512>>}
       @impl true
-      def sign_typed_data(domain, _types, _message) do
+      def sign_typed_data(domain, _types, message) do
         Process.put(:captured_domain, domain)
+        Process.put(:captured_message, message)
         {:ok, <<0::512>>}
       end
 
@@ -222,6 +223,96 @@ defmodule Raxol.Payments.Protocols.X402Test do
 
       assert %{name: "USD Coin", version: "2", chainId: 421_614} =
                Process.get(:captured_domain)
+    end
+  end
+
+  describe "build_payment/2 signed value binding" do
+    defmodule ValueWallet do
+      @moduledoc false
+      @behaviour Raxol.Payments.Wallet
+      @impl true
+      def address, do: "0x" <> String.duplicate("ab", 20)
+      @impl true
+      def chain_id, do: 8453
+      @impl true
+      def sign_message(_msg), do: {:ok, <<0::512>>}
+      @impl true
+      def sign_typed_data(_domain, _types, message) do
+        Process.put(:captured_message, message)
+        {:ok, <<0::512>>}
+      end
+
+      @impl true
+      def sign_hash(_digest), do: {:ok, <<0::520>>}
+    end
+
+    defp priced_challenge(price) do
+      %{
+        price: price,
+        currency: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        network: "eip155:8453",
+        pay_to: "0x" <> String.duplicate("cd", 20),
+        nonce: "0x" <> String.duplicate("12", 32),
+        valid_after: 0,
+        valid_before: 9_999_999_999,
+        extra: %{}
+      }
+    end
+
+    test "signs exactly the atomic integer price the gate reads" do
+      # amount/1 (the gate) reads price as atomic units; the signed value must be
+      # that same atomic integer, so the gate and the signature can never diverge.
+      challenge = priced_challenge(1_000_000)
+      assert {:ok, _} = X402.build_payment(challenge, ValueWallet)
+      assert Process.get(:captured_message).value == 1_000_000
+    end
+
+    test "signs the integer parsed from an all-digit string price" do
+      challenge = priced_challenge("250000")
+      assert {:ok, _} = X402.build_payment(challenge, ValueWallet)
+      assert Process.get(:captured_message).value == 250_000
+    end
+
+    test "refuses to sign a float price (would diverge from the gated amount)" do
+      assert {:error, {:invalid_price, _}} =
+               X402.build_payment(priced_challenge(0.05), ValueWallet)
+    end
+
+    test "refuses to sign a decimal-string price" do
+      assert {:error, {:invalid_price, _}} =
+               X402.build_payment(priced_challenge("0.05"), ValueWallet)
+    end
+  end
+
+  describe "parse_challenge/1 rejects malformed atomic amounts" do
+    defp challenge_header(price) do
+      body =
+        %{
+          "maxAmountRequired" => price,
+          "payTo" => "0x" <> String.duplicate("cd", 20),
+          "asset" => "0x" <> String.duplicate("ef", 20),
+          "network" => "eip155:8453"
+        }
+        |> Jason.encode!()
+        |> Base.encode64()
+
+      [{"payment-required", body}]
+    end
+
+    test "accepts a positive integer-string price" do
+      assert {:ok, %{price: "1000000"}} = X402.parse_challenge(challenge_header("1000000"))
+    end
+
+    test "rejects a float price" do
+      assert {:error, {:invalid_amount, _}} = X402.parse_challenge(challenge_header(0.05))
+    end
+
+    test "rejects a decimal-string price" do
+      assert {:error, {:invalid_amount, _}} = X402.parse_challenge(challenge_header("0.05"))
+    end
+
+    test "rejects a zero price" do
+      assert {:error, {:invalid_amount, _}} = X402.parse_challenge(challenge_header(0))
     end
   end
 end

--- a/packages/raxol_payments/test/raxol/payments/req/auto_pay_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/req/auto_pay_test.exs
@@ -51,6 +51,38 @@ defmodule Raxol.Payments.Req.AutoPayTest do
     end
   end
 
+  # 402 on the first request, then 2xx on the retry (which carries the signed
+  # x-payment header) -- i.e. a payment that actually completes.
+  defp stub_402_then_ok(amount) do
+    fn req ->
+      resp =
+        if Req.Request.get_header(req, "x-payment") == [] do
+          Req.Response.new(status: 402, body: "")
+          |> Req.Response.put_header("payment-required", x402_challenge(amount))
+        else
+          Req.Response.new(status: 200, body: "ok")
+        end
+
+      {req, resp}
+    end
+  end
+
+  # 402 on the first request, then a non-2xx on the retry -- the server did not
+  # honor the payment, so it did not complete.
+  defp stub_402_then_error(amount) do
+    fn req ->
+      resp =
+        if Req.Request.get_header(req, "x-payment") == [] do
+          Req.Response.new(status: 402, body: "")
+          |> Req.Response.put_header("payment-required", x402_challenge(amount))
+        else
+          Req.Response.new(status: 500, body: "server error")
+        end
+
+      {req, resp}
+    end
+  end
+
   describe "attach/2" do
     test "adds auto_pay response step to the request" do
       req =
@@ -152,9 +184,7 @@ defmodule Raxol.Payments.Req.AutoPayTest do
       Process.put(:wallet_signal_target, self())
 
       {:ok, ledger} =
-        Ledger.start_link(
-          table_name: :"gate_ledger_#{:erlang.unique_integer([:positive])}"
-        )
+        Ledger.start_link(table_name: :"gate_ledger_#{:erlang.unique_integer([:positive])}")
 
       on_exit(fn ->
         try do
@@ -296,15 +326,89 @@ defmodule Raxol.Payments.Req.AutoPayTest do
           policy: policy,
           agent_id: :test
         )
-        |> Req.Request.prepend_request_steps(stub: stub_402(1))
+        |> Req.Request.prepend_request_steps(stub: stub_402_then_ok(1))
 
-      _resp = Req.Request.run!(req)
+      resp = Req.Request.run!(req)
+      assert resp.status == 200
       assert_received :wallet_signed
 
       # Brief settle for the ledger cast/call to flush.
       :timer.sleep(20)
+      # A completed payment records exactly the spend -- no release.
       [entry] = Ledger.get_history(ledger, :test)
       assert entry.metadata.domain == "api.example.com"
+      refute entry.metadata[:type] == :release
+    end
+  end
+
+  describe "budget release on a payment that does not complete" do
+    setup do
+      Process.put(:wallet_signal_target, self())
+
+      {:ok, ledger} =
+        Ledger.start_link(table_name: :"autopay_release_#{:erlang.unique_integer()}")
+
+      policy = %SpendingPolicy{
+        per_request_max: Decimal.new("1000"),
+        session_max: Decimal.new("1000"),
+        lifetime_max: Decimal.new("1000"),
+        approved_domains: ["api.example.com"]
+      }
+
+      %{ledger: ledger, policy: policy}
+    end
+
+    defp autopay_req(ledger, policy, stub) do
+      Req.new(url: "https://api.example.com/data", retry: false)
+      |> AutoPay.attach(wallet: StubWallet, ledger: ledger, policy: policy, agent_id: :test)
+      |> Req.Request.prepend_request_steps(stub: stub)
+    end
+
+    test "a non-2xx paid retry releases the reservation", %{ledger: ledger, policy: policy} do
+      resp = autopay_req(ledger, policy, stub_402_then_error(1)) |> Req.Request.run!()
+      assert resp.status == 500
+      assert_received :wallet_signed
+
+      :timer.sleep(20)
+      # Spend was reserved then released; totals net back to zero.
+      assert Decimal.equal?(Ledger.get_totals(ledger, :test, policy).lifetime, "0")
+    end
+
+    test "a transport error on the paid retry releases the reservation", %{
+      ledger: ledger,
+      policy: policy
+    } do
+      # First request 402s; the retry (carrying x-payment) raises a transport error.
+      stub = fn req ->
+        if Req.Request.get_header(req, "x-payment") == [] do
+          resp =
+            Req.Response.new(status: 402, body: "")
+            |> Req.Response.put_header("payment-required", x402_challenge(1))
+
+          {req, resp}
+        else
+          {req, %Req.TransportError{reason: :econnrefused}}
+        end
+      end
+
+      _resp = autopay_req(ledger, policy, stub) |> Req.Request.run!()
+
+      :timer.sleep(20)
+      assert Decimal.equal?(Ledger.get_totals(ledger, :test, policy).lifetime, "0")
+    end
+
+    test "a malformed (float) price is rejected before any reservation or signing", %{
+      ledger: ledger,
+      policy: policy
+    } do
+      # A float price is not valid atomic units, so the x402 challenge is rejected
+      # at parse: no protocol matches, nothing is reserved, nothing is signed.
+      resp = autopay_req(ledger, policy, stub_402_then_ok(0.05)) |> Req.Request.run!()
+
+      assert resp.status == 402
+      refute_received :wallet_signed
+      :timer.sleep(20)
+      assert Decimal.equal?(Ledger.get_totals(ledger, :test, policy).lifetime, "0")
     end
   end
 end

--- a/packages/raxol_payments/test/raxol/payments/security_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/security_test.exs
@@ -25,7 +25,9 @@ defmodule Raxol.Payments.SecurityTest do
   defp valid_x402_payload(overrides \\ %{}) do
     Map.merge(
       %{
-        "maxAmountRequired" => "1.50",
+        # x402 `maxAmountRequired` is atomic token units (an integer), e.g.
+        # 1_500_000 = 1.50 USDC at 6 decimals -- not a human-decimal "1.50".
+        "maxAmountRequired" => "1500000",
         "payTo" => @valid_address,
         "asset" => "0x" <> String.duplicate("cd", 20),
         "network" => "eip155:8453"
@@ -119,11 +121,25 @@ defmodule Raxol.Payments.SecurityTest do
     end
   end
 
-  describe "X402 parse_challenge accepts valid challenges" do
-    test "string price" do
+  describe "X402 parse_challenge rejects non-integer (non-atomic) price" do
+    test "float price" do
+      # Atomic units are integers; a float amount is malformed and would also
+      # crash the atomic->human conversion, so the challenge is rejected.
+      headers = x402_headers(valid_x402_payload(%{"maxAmountRequired" => 1.5}))
+      assert {:error, {:invalid_amount, _}} = X402.parse_challenge(headers)
+    end
+
+    test "decimal string price" do
       headers = x402_headers(valid_x402_payload(%{"maxAmountRequired" => "1.50"}))
+      assert {:error, {:invalid_amount, _}} = X402.parse_challenge(headers)
+    end
+  end
+
+  describe "X402 parse_challenge accepts valid challenges" do
+    test "integer-string price" do
+      headers = x402_headers(valid_x402_payload(%{"maxAmountRequired" => "1500000"}))
       assert {:ok, challenge} = X402.parse_challenge(headers)
-      assert challenge.price == "1.50"
+      assert challenge.price == "1500000"
       assert challenge.pay_to == @valid_address
     end
 
@@ -133,21 +149,15 @@ defmodule Raxol.Payments.SecurityTest do
       assert challenge.price == 100
     end
 
-    test "float price" do
-      headers = x402_headers(valid_x402_payload(%{"maxAmountRequired" => 1.5}))
-      assert {:ok, challenge} = X402.parse_challenge(headers)
-      assert challenge.price == 1.5
-    end
-
     test "uses price key as fallback" do
       payload =
         valid_x402_payload()
         |> Map.delete("maxAmountRequired")
-        |> Map.put("price", "2.00")
+        |> Map.put("price", "2000000")
 
       headers = x402_headers(payload)
       assert {:ok, challenge} = X402.parse_challenge(headers)
-      assert challenge.price == "2.00"
+      assert challenge.price == "2000000"
     end
 
     test "uses pay_to key as fallback" do


### PR DESCRIPTION
## What

Two confirmed fund-safety gaps in the HTTP-402 auto-pay path, found while
auditing the payment surfaces after the Xochi/relay refund work.

## 1. Budget leak on a payment that does not complete

`Req.AutoPay` reserved budget (`try_spend`) and signed the payment, then on a
paid retry that returned non-2xx or errored, **never released the reservation**
-- the same leak class as the Xochi refund case. A signing failure after the
reservation leaked too.

`handle_response/2` now reserves, then delegates to `settle/8`; every non-success
exit past the reservation releases it first, so only a 2xx paid retry (the
payment actually landed) keeps the budget consumed. Mirrors the existing
`release_and_clear` guard: a release fires only when a policy + ledger are
present (i.e. only when a reservation was actually made).

## 2. Gate-vs-signature amount divergence on a malformed price

The budget gate reads `amount(challenge)` = `to_human(price, decimals)` (price as
**atomic** units), while the signed ERC-3009 `value` used `normalize_amount`,
which treated a **float** price as human (x1e6). A float price therefore diverged
in the gate-bypass direction; and in practice a float price also crashed
`amount/1` (its `to_decimal` has no float clause).

x402 `maxAmountRequired` is atomic units (an integer per the spec). This binds
the two together:

- `parse_challenge` (`validate_positive_amount`) now accepts only a positive
  integer or an all-digit string; a float or decimal string is rejected at parse
  (fail closed, no crash).
- `build_payment` signs `value` derived from the same strict `atomic_value/1`, so
  the signed amount is always exactly the atomic integer the gate read. It can no
  longer diverge, and a non-integer price is refused before any signature.

`security_test.exs` fixtures previously used a human-decimal price (`"1.50"`),
which the gate already misread as atomic -- those are updated to atomic integers,
with float/decimal prices now asserted as rejected.

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` -- 986 passed, 0 failures
- [x] New tests: non-2xx paid retry / transport-error retry / malformed-price all
      leave the ledger netted to zero; `build_payment` signs exactly the atomic
      integer price and refuses float/decimal prices; parse rejects float/decimal.
- [x] `mix compile` -- no new warnings from changed files
- [x] Changed files `mix format --check-formatted` clean

Scope: x402 only. MPP's amount binding was not in the confirmed finding and is
left for a separate look. The root CI does not exercise the `raxol_payments`
package (main app only), so the local suite is the validation.
