### PR TITLE
Guard wallet private key from crash-report leak

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/secret.ex
+++ b/packages/raxol_payments/lib/raxol/payments/secret.ex
@@ -33,6 +33,28 @@ defmodule Raxol.Payments.Secret do
   @spec reveal(t()) :: binary()
   def reveal(%__MODULE__{bytes: bytes}), do: bytes
 
+  @doc """
+  Reveal the wrapped bytes only for `fun`, converting any exception raised inside
+  it into `{:error, :secret_operation_crashed}`.
+
+  The reveal-and-use sites pass the raw key as an argument to a signing NIF. If
+  that NIF raises (e.g. `badarg` on a malformed key), the raw bytes would appear
+  as a call argument in the crash stacktrace and OTP crash report. Running the
+  call under this guard turns such a raise into a fixed error atom before it can
+  reach a log, so the key never leaves this function. Normal `{:ok, _}` /
+  `{:error, _}` returns from `fun` pass through unchanged.
+  """
+  @spec with_revealed(t(), (binary() -> result)) ::
+          result | {:error, :secret_operation_crashed}
+        when result: term()
+  def with_revealed(%__MODULE__{bytes: bytes}, fun) when is_function(fun, 1) do
+    fun.(bytes)
+  rescue
+    _exception -> {:error, :secret_operation_crashed}
+  catch
+    _kind, _reason -> {:error, :secret_operation_crashed}
+  end
+
   defimpl Inspect do
     def inspect(_secret, _opts), do: "#Raxol.Payments.Secret<redacted>"
   end

--- a/packages/raxol_payments/lib/raxol/payments/wallets/env.ex
+++ b/packages/raxol_payments/lib/raxol/payments/wallets/env.ex
@@ -81,7 +81,7 @@ defmodule Raxol.Payments.Wallets.Env do
   @spec address(String.t()) :: String.t()
   def address(env_var) do
     with {:ok, secret} <- load_key(env_var),
-         {:ok, pubkey} <- ExSecp256k1.create_public_key(Secret.reveal(secret)) do
+         {:ok, pubkey} <- Secret.with_revealed(secret, &ExSecp256k1.create_public_key/1) do
       derive_address(pubkey)
     else
       {:error, reason} -> raise "Failed to derive address: #{inspect(reason)}"
@@ -93,14 +93,7 @@ defmodule Raxol.Payments.Wallets.Env do
   def sign_message(message, env_var) do
     with {:ok, secret} <- load_key(env_var) do
       hash = ExKeccak.hash_256(message)
-
-      case ExSecp256k1.sign(hash, Secret.reveal(secret)) do
-        {:ok, signature} ->
-          {:ok, Raxol.Payments.EIP712.pack_signature(signature)}
-
-        {:error, reason} ->
-          {:error, {:sign_failed, reason}}
-      end
+      Secret.with_revealed(secret, &sign_digest(&1, hash))
     end
   end
 
@@ -110,13 +103,7 @@ defmodule Raxol.Payments.Wallets.Env do
   def sign_typed_data(domain, types, message, env_var) do
     with {:ok, secret} <- load_key(env_var),
          {:ok, hash} <- Raxol.Payments.EIP712.hash(domain, types, message) do
-      case ExSecp256k1.sign(hash, Secret.reveal(secret)) do
-        {:ok, signature} ->
-          {:ok, Raxol.Payments.EIP712.pack_signature(signature)}
-
-        {:error, reason} ->
-          {:error, {:sign_failed, reason}}
-      end
+      Secret.with_revealed(secret, &sign_digest(&1, hash))
     end
   end
 
@@ -124,17 +111,21 @@ defmodule Raxol.Payments.Wallets.Env do
   @spec sign_hash(<<_::256>>, String.t()) :: {:ok, binary()} | {:error, term()}
   def sign_hash(<<digest::binary-size(32)>>, env_var) do
     with {:ok, secret} <- load_key(env_var) do
-      case ExSecp256k1.sign(digest, Secret.reveal(secret)) do
-        {:ok, signature} ->
-          {:ok, Raxol.Payments.EIP712.pack_signature(signature)}
-
-        {:error, reason} ->
-          {:error, {:sign_failed, reason}}
-      end
+      Secret.with_revealed(secret, &sign_digest(&1, digest))
     end
   end
 
   # -- Private --
+
+  # Sign a 32-byte digest with the revealed key. Always called inside
+  # `Secret.with_revealed/2`, so a raising signing NIF cannot carry the key into
+  # a crash report.
+  defp sign_digest(key, digest) do
+    case ExSecp256k1.sign(digest, key) do
+      {:ok, signature} -> {:ok, Raxol.Payments.EIP712.pack_signature(signature)}
+      {:error, reason} -> {:error, {:sign_failed, reason}}
+    end
+  end
 
   # The key is wrapped in `Secret` the moment it is decoded and revealed only at
   # the signing NIF call. Even though this wallet is stateless (it re-reads the

--- a/packages/raxol_payments/lib/raxol/payments/wallets/op.ex
+++ b/packages/raxol_payments/lib/raxol/payments/wallets/op.ex
@@ -90,7 +90,7 @@ defmodule Raxol.Payments.Wallets.Op do
   def handle_manager_call({:sign_message, message}, _from, state) do
     case ensure_loaded(state) do
       {:ok, state} ->
-        result = do_sign_message(Secret.reveal(state.privkey), message)
+        result = Secret.with_revealed(state.privkey, &do_sign_message(&1, message))
         {:reply, result, state}
 
       {:error, reason} ->
@@ -101,7 +101,9 @@ defmodule Raxol.Payments.Wallets.Op do
   def handle_manager_call({:sign_typed_data, domain, types, message}, _from, state) do
     case ensure_loaded(state) do
       {:ok, state} ->
-        result = do_sign_typed_data(Secret.reveal(state.privkey), domain, types, message)
+        result =
+          Secret.with_revealed(state.privkey, &do_sign_typed_data(&1, domain, types, message))
+
         {:reply, result, state}
 
       {:error, reason} ->
@@ -112,7 +114,7 @@ defmodule Raxol.Payments.Wallets.Op do
   def handle_manager_call({:sign_hash, digest}, _from, state) do
     case ensure_loaded(state) do
       {:ok, state} ->
-        result = do_sign_hash(Secret.reveal(state.privkey), digest)
+        result = Secret.with_revealed(state.privkey, &do_sign_hash(&1, digest))
         {:reply, result, state}
 
       {:error, reason} ->
@@ -125,14 +127,14 @@ defmodule Raxol.Payments.Wallets.Op do
   defp ensure_loaded(%{privkey: %Secret{}} = state), do: {:ok, state}
 
   defp ensure_loaded(%{op_ref: op_ref} = state) do
-    case fetch_from_op(op_ref) do
-      {:ok, privkey} ->
-        {:ok, pubkey} = ExSecp256k1.create_public_key(privkey)
-        address = derive_address(pubkey)
-        {:ok, %{state | privkey: Secret.new(privkey), address: address}}
-
-      {:error, reason} ->
-        {:error, reason}
+    # Wrap the fetched key in `Secret` immediately, so the raw bytes only leave
+    # the wrapper inside `with_revealed` (which contains any NIF raise). A
+    # non-`{:ok, _}` return from the NIF now fails the load gracefully instead of
+    # crashing the wallet on a bad key.
+    with {:ok, privkey} <- fetch_from_op(op_ref),
+         secret = Secret.new(privkey),
+         {:ok, pubkey} <- Secret.with_revealed(secret, &ExSecp256k1.create_public_key/1) do
+      {:ok, %{state | privkey: secret, address: derive_address(pubkey)}}
     end
   end
 

--- a/packages/raxol_payments/test/raxol/payments/secret_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/secret_test.exs
@@ -53,4 +53,37 @@ defmodule Raxol.Payments.SecretTest do
       refute String.Chars.impl_for(Secret.new(@key))
     end
   end
+
+  describe "with_revealed/2" do
+    test "reveals the raw bytes to the function and passes its result through" do
+      secret = Secret.new(@key)
+      assert Secret.with_revealed(secret, fn bytes -> {:ok, bytes} end) == {:ok, @key}
+    end
+
+    test "passes an {:error, _} return through unchanged" do
+      secret = Secret.new(@key)
+      assert Secret.with_revealed(secret, fn _ -> {:error, :nope} end) == {:error, :nope}
+    end
+
+    test "converts a raise into a fixed error atom without surfacing the exception" do
+      secret = Secret.new(@key)
+
+      # A signing NIF that raises badarg would put the raw key in its stacktrace;
+      # the guard must swallow the exception entirely, leaking nothing.
+      result = Secret.with_revealed(secret, fn _ -> raise "boom #{@key_hex_lower}" end)
+
+      assert result == {:error, :secret_operation_crashed}
+      refute inspect(result) =~ @key_hex_lower
+    end
+
+    test "converts a throw and an exit into the same fixed error atom" do
+      secret = Secret.new(@key)
+
+      assert Secret.with_revealed(secret, fn _ -> throw(:boom) end) ==
+               {:error, :secret_operation_crashed}
+
+      assert Secret.with_revealed(secret, fn _ -> exit(:boom) end) ==
+               {:error, :secret_operation_crashed}
+    end
+  end
 end

--- a/packages/raxol_payments/test/raxol/payments/wallets/env_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/wallets/env_test.exs
@@ -141,4 +141,20 @@ defmodule Raxol.Payments.Wallets.EnvTest do
       assert via_hash == via_message
     end
   end
+
+  describe "signing failure containment" do
+    # A 32-byte all-zero key is a valid length but an invalid secp256k1 scalar.
+    # The signing NIF rejects it -- whether it returns an error or raises, the
+    # `Secret.with_revealed` guard must surface a clean error tuple, never crash
+    # the caller or carry the key bytes into a report.
+    @zero_key "0x" <> String.duplicate("0", 64)
+    @some_digest String.duplicate(<<0xAB>>, 32)
+
+    test "an invalid-scalar key yields an error, not a crash or a leak" do
+      System.put_env(@test_env_var, @zero_key)
+
+      assert {:error, reason} = Env.sign_hash(@some_digest, @test_env_var)
+      refute inspect(reason) =~ String.duplicate("0", 64)
+    end
+  end
 end


### PR DESCRIPTION
## What

Close a private-key disclosure vector in the two wallet backends, found in the
fund-surface audit.

The `Secret` wrapper already keeps the key out of `inspect`/crash-dumped process
state. But both wallets reveal the raw bytes and pass them **as a bare argument**
to a signing NIF (`ExSecp256k1.sign` / `create_public_key`). If that NIF raises
`badarg` (e.g. a malformed key), Erlang puts the call arguments -- including the
raw key -- into the crash stacktrace and the OTP crash report. `Wallets.Op` also
had a bare `{:ok, pubkey} = create_public_key(privkey)` match that crashes the
wallet GenServer on any non-`{:ok}` return instead of failing gracefully.

## Changes

- **`Secret.with_revealed/2`** -- reveals the wrapped bytes only for the given
  function and converts any raise/throw/exit inside it into a fixed
  `{:error, :secret_operation_crashed}` before it can reach a log. Normal
  `{:ok, _}` / `{:error, _}` returns pass through unchanged, so a NIF that
  *returns* an error keeps its detail; only a *raise* is genericized.
- **`Wallets.Op`** -- signing now runs the reveal through `with_revealed`; the
  key-load path wraps the fetched key in `Secret` immediately and uses `with`
  (no bare match), so a bad key fails the load gracefully.
- **`Wallets.Env`** -- same guard around address derivation and signing; the
  three sign paths share a small `sign_digest/2` helper.

The Secret wrapper's redaction, the signature bytes, and the on-chain-canonical
recovery byte are all unchanged.

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` -- 991 passed, 0 failures
- [x] New tests: `with_revealed` reveals bytes + passes returns through, and
      converts raise/throw/exit into the fixed atom without surfacing the value;
      signing with an invalid-scalar key returns an error (no crash, no key in
      the error).
- [x] `mix compile` -- no new warnings from changed files
- [x] Changed files `mix format --check-formatted` clean

Root CI does not exercise `raxol_payments` (main app only), so the local suite is
the validation.
