### PR TITLE
Make ACP seller delivery idempotent

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
@@ -96,10 +96,32 @@ defmodule Raxol.ACP.JobSession.Provider do
   Invokes `handle_deliver/2`. On `{:deliver, deliverable}` it writes
   `submit(job, keccak256(deliverable))` on-chain and mirrors the session to
   `:submitted`. On `{:error, reason}` it makes no change and returns the error.
-  Requires the session to already be `:funded`.
+
+  Idempotent by the session status: `handle_deliver/2` runs only from `:funded`.
+  On an already-`:submitted` session it is a no-op returning
+  `{:ok, %{status: :submitted, idempotent: true}}` (no second handler call or
+  on-chain write); from any other status it returns
+  `{:error, {:cannot_deliver, status}}` without invoking the handler.
   """
-  @spec deliver(t(), map()) :: ok(:submitted) | {:error, term()}
+  @spec deliver(t(), map()) ::
+          ok(:submitted)
+          | {:ok, %{status: :submitted, idempotent: true}}
+          | {:error, term()}
   def deliver(%__MODULE__{} = p, request) do
+    # Guard the side-effecting handler on the current status. `handle_deliver`
+    # produces the deliverable (its work runs BEFORE the on-chain commit), so a
+    # re-drive -- a redelivered payment event, or a retry after the commit landed
+    # but the mirror did not -- must not run it twice. Once the session reflects
+    # `:submitted` (via this driver's mirror or the SSE reconciliation of the
+    # on-chain event), a re-`deliver` is an idempotent no-op.
+    case safe_status(p.session) do
+      :funded -> do_deliver(p, request)
+      :submitted -> {:ok, %{status: :submitted, idempotent: true}}
+      other -> {:error, {:cannot_deliver, other}}
+    end
+  end
+
+  defp do_deliver(p, request) do
     case HandlerSeam.invoke(p.handler, :deliver, request, ctx(p)) do
       {:deliver, deliverable} ->
         with {:ok, tx} <-
@@ -173,6 +195,16 @@ defmodule Raxol.ACP.JobSession.Provider do
   # v1 `Job.Server` ctx shape so offering handlers are unchanged.
   defp ctx(p) do
     %{job_id: p.job_id, buyer: p.buyer, seller: p.seller, state: JobSession.status(p.session)}
+  end
+
+  # Read the session status without crashing on a terminal session, which stops
+  # its process once it reaches `:completed`/`:rejected`/`:expired`. A gone
+  # session is treated as an unknown status, so `deliver` refuses rather than
+  # racing a finished job.
+  defp safe_status(session) do
+    JobSession.status(session)
+  catch
+    :exit, _ -> :gone
   end
 
   # 32-byte commitment to the deliverable payload: keccak256 of its canonical

--- a/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
@@ -50,7 +50,7 @@ defmodule Raxol.ACP.Seller.Queue do
   - `[:raxol, :acp, :seller, :queue, :dropped]` -- event dropped. Metadata:
     `%{type, job_id, reason}` where reason is one of `:offering_not_registered`,
     `:job_not_running`, `:no_provider_adapter`, `:start_failed`, `:at_capacity`,
-    `:malformed`, `:unknown_event`, `{:rejected, reason}`, or
+    `:already_offered`, `:malformed`, `:unknown_event`, `{:rejected, reason}`, or
     `{:handler_error, reason}`.
   """
 
@@ -119,6 +119,12 @@ defmodule Raxol.ACP.Seller.Queue do
          defaults
        ) do
     cond do
+      Map.has_key?(state.jobs, job_id) ->
+        # A job we already accepted was re-offered (backend at-least-once
+        # redelivery). Re-running `handle_request` + `setBudget` would duplicate
+        # both, so drop the redelivery idempotently.
+        drop(:job_offered, job_id, %{offering: name}, :already_offered, state)
+
       defaults.provider_adapter == nil ->
         drop(:job_offered, job_id, %{offering: name}, :no_provider_adapter, state)
 
@@ -135,7 +141,14 @@ defmodule Raxol.ACP.Seller.Queue do
 
   defp handle_event(%{type: :payment_received, job_id: job_id} = event, state, _defaults) do
     with_job(:payment_received, job_id, state, fn %{provider: provider, request: request} ->
-      JobSession.apply_event(provider.session, :funded, %{payment: Map.get(event, :payload)})
+      # Only mirror `:funded` on the actual funding transition. Mirroring it
+      # unconditionally would regress an already-`:submitted` session back to
+      # `:funded` on a redelivered payment event (apply_event bypasses adjacency),
+      # re-arming a duplicate delivery. `Provider.deliver` then self-guards on
+      # status, so a redelivery is an idempotent no-op.
+      if JobSession.status(provider.session) == :budget_set do
+        JobSession.apply_event(provider.session, :funded, %{payment: Map.get(event, :payload)})
+      end
 
       case Provider.deliver(provider, request) do
         {:ok, _} -> dispatched(:payment_received, job_id, state)

--- a/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
@@ -149,6 +149,28 @@ defmodule Raxol.ACP.JobSession.ProviderTest do
       assert {:error, :rpc_down} = Provider.deliver(p, %{req: 1})
       assert JobSession.status(session) == :funded
     end
+
+    test "on an already-submitted session it is an idempotent no-op" do
+      # A redelivered payment event, or a retry after the on-chain submit landed
+      # but the mirror did not, must not re-run handle_deliver or re-submit.
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:submitted)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:ok, %{status: :submitted, idempotent: true}} = Provider.deliver(p, %{req: 1})
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+      assert JobSession.status(session) == :submitted
+    end
+
+    test "refuses to deliver before the job is funded, without invoking the handler" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:budget_set)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:error, {:cannot_deliver, :budget_set}} = Provider.deliver(p, %{req: 1})
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+      assert JobSession.status(session) == :budget_set
+    end
   end
 
   describe "evaluate/2" do

--- a/packages/raxol_acp/test/raxol/acp/seller/queue_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/queue_test.exs
@@ -227,6 +227,61 @@ defmodule Raxol.ACP.Seller.QueueTest do
     end
   end
 
+  describe "idempotent redelivery" do
+    setup do
+      attach_telemetry([:dispatched, :dropped])
+      {:ok, _spec} = EchoOffering.register()
+      :ok
+    end
+
+    test "a redelivered :job_offered drops as :already_offered, no duplicate setBudget", %{
+      adapter: adapter
+    } do
+      jid = job_id()
+      offer(jid)
+      :ok = wait_status(jid, :budget_set)
+
+      # Backend at-least-once redelivery of the same offer.
+      offer(jid)
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dropped],
+                      %{type: :job_offered, job_id: ^jid, reason: :already_offered}},
+                     500
+
+      # Only the first offer wrote setBudget.
+      assert length(ProviderAdapter.Mock.sent_calls(adapter)) == 1
+    end
+
+    test "a redelivered :payment_received does not re-deliver or regress the status", %{
+      adapter: adapter
+    } do
+      jid = job_id()
+      offer(jid)
+      :ok = wait_status(jid, :budget_set)
+
+      Queue.dispatch(%{type: :payment_received, job_id: jid, payload: %{}})
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dispatched],
+                      %{type: :payment_received, job_id: ^jid}},
+                     500
+
+      :ok = wait_status(jid, :submitted)
+      # setBudget + submit = 2 on-chain writes.
+      assert length(ProviderAdapter.Mock.sent_calls(adapter)) == 2
+
+      # Redeliver the payment event: it must not re-run the handler, re-submit, or
+      # regress :submitted back to :funded.
+      Queue.dispatch(%{type: :payment_received, job_id: jid, payload: %{}})
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dispatched],
+                      %{type: :payment_received, job_id: ^jid}},
+                     500
+
+      assert status(jid) == :submitted
+      assert length(ProviderAdapter.Mock.sent_calls(adapter)) == 2
+    end
+  end
+
   describe "backpressure" do
     setup do
       attach_telemetry([:dispatched, :dropped])


### PR DESCRIPTION
## What

Make the seller-side delivery path idempotent so a redelivered backend event (or
a retry after the on-chain commit landed but the local mirror did not) does not
re-run `handle_deliver` side effects or duplicate the on-chain submit.

## The gap

`Provider.deliver/2` invokes `handle_deliver` -- which produces the deliverable,
so its work runs BEFORE the on-chain commit -- unconditionally. The seller
`Queue`'s `:payment_received` handler made it worse: it mirrored `:funded`
unconditionally, and `apply_event` bypasses adjacency, so a **redelivered**
payment event (Socket.IO/WebSocket at-least-once) regressed an already-`:submitted`
session back to `:funded` and re-armed a second delivery -- duplicate handler side
effects and a duplicate `submit(...)` on-chain.

## Changes

- **`Provider.deliver/2`** is now idempotent by session status: `handle_deliver`
  runs only from `:funded`. On an already-`:submitted` session it is a no-op
  returning `{:ok, %{status: :submitted, idempotent: true}}` (no second handler
  call or on-chain write); from any other status it returns
  `{:error, {:cannot_deliver, status}}` without invoking the handler. Status is
  read via a guard that tolerates a stopped terminal session.
- **`Queue` `:payment_received`** mirrors `:funded` only on the actual funding
  transition (`status == :budget_set`), so a redelivered payment no longer
  regresses the status; `Provider.deliver` then self-guards the rest.
- **`Queue` `:job_offered`** drops a re-offer of a job already being handled as
  `:already_offered`, so `handle_request` + `setBudget` are not duplicated.

The commit-point ordering (on-chain write first, local mirror second) is
unchanged; this only prevents re-driving a step that already committed.

## Manual testing

- [x] `cd packages/raxol_acp && MIX_ENV=test mix test` -- 520 passed, 0 failures
- [x] New tests: `deliver` on an already-`:submitted` session is a no-op (no
      second on-chain call); `deliver` before funding is refused without invoking
      the handler; a redelivered `:job_offered` drops as `:already_offered` (one
      setBudget); a redelivered `:payment_received` neither re-submits nor
      regresses `:submitted`.
- [x] `mix compile` -- no new warnings from changed files
- [x] Changed files `mix format --check-formatted` clean

## Not in this PR

- `accept_request` / `evaluate` idempotency: `accept_request`'s `:budget_set`
  target overlaps a legitimate re-budget, and `evaluate` reaches a terminal state
  that stops the session -- both need a different guard than `deliver`. The
  `:already_offered` Queue guard already covers the common offer-redelivery case.
- On-chain status preflight: `HookClient` is write-only (no job-status read), so
  the narrow crash-before-mirror-before-SSE window is closed by the existing SSE
  reconciliation rather than an on-chain read. Adding a read seam is a larger change.

Root CI does not exercise `raxol_acp` (main app only), so the local suite is the
validation.
