### PR TITLE
Make ACP accept_request idempotent

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
@@ -66,10 +66,36 @@ defmodule Raxol.ACP.JobSession.Provider do
   `setBudget(job, budget)` on-chain and mirrors the session to `:budget_set`.
   On `{:reject, reason}` it makes no on-chain or local change and returns
   `{:rejected, reason}` -- the caller decides whether to expire the job.
+
+  Idempotent by the session status: `handle_request/2` + `setBudget` run only
+  from `:open`. On an already-`:budget_set` session it is a no-op returning
+  `{:ok, %{status: :budget_set, idempotent: true}}` (no second handler call or
+  on-chain write); from any other status it returns
+  `{:error, {:cannot_accept, status}}` without invoking the handler.
   """
   @spec accept_request(t(), map(), AssetToken.t()) ::
-          ok(:budget_set) | {:rejected, term()} | {:error, term()}
+          ok(:budget_set)
+          | {:ok, %{status: :budget_set, idempotent: true}}
+          | {:rejected, term()}
+          | {:error, term()}
   def accept_request(%__MODULE__{} = p, request, %AssetToken{} = budget) do
+    # Guard the side-effecting handler + on-chain `setBudget` on the current
+    # status. accept_request is the INITIAL accept: the seller's budget is fixed
+    # by the offering spec, so a re-offer never carries a new price and never
+    # means an intentional re-budget. If the session already reflects
+    # `:budget_set` -- because the write and mirror landed but the seller Queue
+    # lost its in-memory job tracking (a crash before it recorded the job) and
+    # the backend redelivered the offer, or via SSE reconciliation of the
+    # on-chain event -- a re-accept must not re-invoke the handler or re-write
+    # `setBudget`. Only `:open` runs the write.
+    case safe_status(p.session) do
+      :open -> do_accept_request(p, request, budget)
+      :budget_set -> {:ok, %{status: :budget_set, idempotent: true}}
+      other -> {:error, {:cannot_accept, other}}
+    end
+  end
+
+  defp do_accept_request(p, request, budget) do
     case HandlerSeam.invoke(p.handler, :request, request, ctx(p)) do
       {:accept, response} ->
         with {:ok, tx} <-

--- a/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/provider_test.exs
@@ -114,6 +114,33 @@ defmodule Raxol.ACP.JobSession.ProviderTest do
 
       assert JobSession.status(session) == :open
     end
+
+    test "on an already-budget_set session it is an idempotent no-op" do
+      # A redelivered offer, or a retry after the setBudget write and mirror
+      # landed but the seller Queue lost its job tracking, must not re-run
+      # handle_request or re-write setBudget.
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:budget_set)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:ok, %{status: :budget_set, idempotent: true}} =
+               Provider.accept_request(p, %{req: 1}, AssetToken.usdc(0.25, @chain))
+
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+      assert JobSession.status(session) == :budget_set
+    end
+
+    test "refuses to accept once the job has progressed, without invoking the handler" do
+      adapter = ProviderAdapter.Mock.new()
+      session = start_session(:funded)
+      p = provider(session, AcceptHandler, adapter)
+
+      assert {:error, {:cannot_accept, :funded}} =
+               Provider.accept_request(p, %{req: 1}, AssetToken.usdc(0.25, @chain))
+
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+      assert JobSession.status(session) == :funded
+    end
   end
 
   describe "deliver/2" do

--- a/packages/raxol_acp/test/raxol/acp/seller/queue_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/queue_test.exs
@@ -280,6 +280,36 @@ defmodule Raxol.ACP.Seller.QueueTest do
       assert status(jid) == :submitted
       assert length(ProviderAdapter.Mock.sent_calls(adapter)) == 2
     end
+
+    test "re-offering a job whose session survived a Queue restart does not re-write setBudget",
+         %{adapter: adapter} do
+      # Simulate the crash-before-tracking window: the setBudget write + mirror
+      # landed (session is :budget_set), but the Queue lost its in-memory job map
+      # (a restart resets it), so this job_id is NOT in state.jobs -- the
+      # :already_offered guard cannot fire. On backend redelivery the Queue
+      # re-adopts the surviving session; accept_request must self-guard on the
+      # :budget_set status so no second setBudget hits the chain.
+      jid = job_id()
+
+      {:ok, _pid} =
+        JobSession.Supervisor.start_session(
+          chain_id: @chain,
+          job_id: jid,
+          role: :provider,
+          initial_status: :budget_set
+        )
+
+      offer(jid)
+
+      assert_receive {:telemetry, [:raxol, :acp, :seller, :queue, :dispatched],
+                      %{type: :job_offered, job_id: ^jid}},
+                     500
+
+      # The session was pre-advanced out of band, so no setBudget was written by
+      # the Queue; the idempotent re-accept must not add one.
+      assert ProviderAdapter.Mock.sent_calls(adapter) == []
+      assert status(jid) == :budget_set
+    end
   end
 
   describe "backpressure" do


### PR DESCRIPTION
## What

Makes `Raxol.ACP.JobSession.Provider.accept_request/3` idempotent by the
session status, closing the same fund-safety gap #406 closed for `deliver/2`.

`accept_request` writes `setBudget` on-chain (the commit point) and then mirrors
the session to `:budget_set`. Its only production driver is the seller
`Queue.offer`, which guards redelivery with the `:already_offered` check
(job in `state.jobs`). But that check is defeated by a reachable window:

- The Queue writes `setBudget` on-chain and mirrors `:budget_set`, then crashes
  **before** it records the job in its in-memory map (BaseManager resets
  `state.jobs` on restart).
- The `JobSession` survives at `:budget_set` under its own supervisor.
- On backend at-least-once redelivery of `:job_offered`, `:already_offered`
  cannot fire (the map was reset), `start_session` re-adopts the surviving
  session via `already_started`, and **un-guarded `accept_request` re-invokes
  the handler and re-writes `setBudget`** -- a duplicate fund-moving on-chain
  write.

### The re-budget trap does not apply

The state machine allows a `:budget_set -> :budget_set` self-loop, so a blanket
"skip when `:budget_set`" would be wrong **if** a re-budget flowed through
`accept_request`. It does not: `accept_request` is the initial accept, and the
seller's budget is fixed by the offering spec (`AssetToken.usdc(spec.price_usdc)`),
so a re-offer always carries the identical budget and never means an intentional
re-budget. Guarding on `:open` is therefore safe.

## Change

`accept_request` now dispatches on `safe_status/1` (the same helper `deliver`
uses, tolerant of a stopped terminal session):

- `:open` -> run the handler + `setBudget` write (unchanged behavior).
- `:budget_set` -> idempotent no-op, `{:ok, %{status: :budget_set, idempotent: true}}`,
  no handler call, no on-chain write. The Queue re-adopts the surviving session.
- any other status -> `{:error, {:cannot_accept, status}}`, no handler call.

The handler body moved verbatim into a private `do_accept_request/3`.

## Tests

Each new test was confirmed RED against the un-guarded version (the Queue test
shows the actual duplicate `setBudget` write) and GREEN after:

- Provider: idempotent no-op from `:budget_set` (no second `setBudget`);
  refuses from `:funded` without invoking the handler.
- Queue: re-offering a job whose session survived a Queue restart (pre-started
  at `:budget_set`, not in `state.jobs`) dispatches with **zero** on-chain writes
  instead of a duplicate `setBudget`.

## Manual testing

- [x] `cd packages/raxol_acp && MIX_ENV=test mix test` -> 523 passed, 0 failures
      (was 520; +3 new).
- [x] New tests confirmed RED without the guard, GREEN with it.
- [x] `mix format --check-formatted` on the three changed files.
- [x] `mix compile` surfaces no new warnings from the changed file.

Note: root CI (`ci-unified.yml`) does not build `raxol_acp`, so the package's
own suite above is the validation gate.

## Not in this PR

- **`Provider.evaluate/2` idempotency.** Not a reachable gap today.
  `evaluate` has zero production drivers -- the Queue's `:approval_received`
  mirrors `:completed` directly via `apply_event` (and is already idempotent:
  `drop_job` means a redelivery drops as `:job_not_running`, with no on-chain
  write). `evaluate` is the self-evaluation path, exercised only by unit tests.
  Its `complete`/`reject` writes are terminal and stop the session, so a
  post-hoc status guard is ambiguous (`completed`/`rejected`/`expired`/
  never-existed all collapse to `:gone`). Deferred until a real redelivery
  driver exists, per "don't fix speculatively."
- The crash-before-tracking window itself (Queue state loss) is still recovered
  by SSE reconciliation of the on-chain event; this PR only removes the
  duplicate-write hazard on that recovery path.
