### PR TITLE
Reject reverted UserOp as a failed SCA write

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/provider_adapter/sca.ex
+++ b/packages/raxol_acp/lib/raxol/acp/provider_adapter/sca.ex
@@ -196,13 +196,29 @@ defmodule Raxol.ACP.ProviderAdapter.SCA do
              wallet.nonce_key()
            ),
          {:ok, op_hash} <- send_write_op(cfg, call, nonce),
-         {:ok, uo_receipt} <- wallet.await_user_operation(op_hash, cfg.wallet_opts) do
+         {:ok, uo_receipt} <- wallet.await_user_operation(op_hash, cfg.wallet_opts),
+         :ok <- check_user_op_succeeded(uo_receipt) do
       # A single call maps to one atomic UserOp; the on-chain tx hash is
       # in the bundler receipt (or the op hash if the receipt omits it).
       tx_hash = get_in(uo_receipt, ["receipt", "transactionHash"]) || op_hash
       {:ok, [tx_hash]}
     end
   end
+
+  # An ERC-4337 UserOp can be MINED while its inner execution -- our
+  # `execute(...)` wrapping the ACP hook call -- REVERTS: validation passed, so
+  # the op is included and the nonce is burned, but `eth_getUserOperationReceipt`
+  # reports `success: false`. Returning `{:ok, tx_hash}` for it would let the
+  # Provider mirror a status the chain never reached, breaking its "the on-chain
+  # write is the commit point; mirror only once it succeeds" invariant. Reject an
+  # explicit failure so a reverted write leaves the session untouched (SSE
+  # reconciliation of the real on-chain event is the recovery path). A receipt
+  # that omits `success` keeps the prior lenient behavior.
+  defp check_user_op_succeeded(%{"success" => false} = uo_receipt) do
+    {:error, {:user_op_reverted, Map.get(uo_receipt, "reason")}}
+  end
+
+  defp check_user_op_succeeded(_uo_receipt), do: :ok
 
   # The write op wraps the ACP call in execute(), carries the
   # session-entity nonce, and NEVER attaches initCode -- provisioning

--- a/packages/raxol_acp/test/raxol/acp/provider_adapter/sca_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/provider_adapter/sca_test.exs
@@ -196,6 +196,17 @@ defmodule Raxol.ACP.ProviderAdapter.SCATest do
 
       assert [] == drain_rpc_calls()
     end
+
+    test "a mined-but-reverted UserOp is not reported as a successful write" do
+      # The op passed validation (so it's included and the nonce is burned) but
+      # its inner execute() reverted: the receipt says success: false. Reporting
+      # {:ok, tx_hash} would let the Provider mirror a status the chain never
+      # reached; the adapter must surface the revert instead.
+      adapter = build_adapter(deployed: true, installed: true, op_success: false)
+
+      assert {:error, {:user_op_reverted, "AA23 reverted"}} =
+               ProviderAdapter.send_calls(adapter, @chain_id, [acp_call()])
+    end
   end
 
   describe "signing" do
@@ -278,8 +289,9 @@ defmodule Raxol.ACP.ProviderAdapter.SCATest do
     deployed = Keyword.get(opts, :deployed, true)
     installed = Keyword.get(opts, :installed, true)
     auto_provision = Keyword.get(opts, :auto_provision, true)
+    op_success = Keyword.get(opts, :op_success, true)
 
-    plug = install_stub(self(), deployed: deployed, installed: installed)
+    plug = install_stub(self(), deployed: deployed, installed: installed, op_success: op_success)
 
     SCA.new(
       wallet: SCAWallet,
@@ -299,6 +311,7 @@ defmodule Raxol.ACP.ProviderAdapter.SCATest do
   defp install_stub(events, opts) do
     deployed = Keyword.fetch!(opts, :deployed)
     installed = Keyword.fetch!(opts, :installed)
+    op_success = Keyword.fetch!(opts, :op_success)
     entry_point = SCAWallet.entry_point()
     single_signer = ModularAccount.single_signer_validation_address()
     owner = SessionKey.address()
@@ -323,7 +336,7 @@ defmodule Raxol.ACP.ProviderAdapter.SCATest do
             @op_hash
 
           "eth_getUserOperationReceipt" ->
-            user_op_receipt(req["params"])
+            user_op_receipt(req["params"], op_success)
 
           "eth_getTransactionReceipt" ->
             @receipt
@@ -369,8 +382,20 @@ defmodule Raxol.ACP.ProviderAdapter.SCATest do
     word_hex(key <<< 64)
   end
 
-  defp user_op_receipt([op_hash | _]) do
+  defp user_op_receipt([op_hash | _], true) do
     %{"userOpHash" => op_hash, "success" => true, "logs" => [], "receipt" => @receipt}
+  end
+
+  defp user_op_receipt([op_hash | _], false) do
+    # A UserOp included on-chain whose inner execute() reverted: success: false
+    # with the EntryPoint revert reason.
+    %{
+      "userOpHash" => op_hash,
+      "success" => false,
+      "reason" => "AA23 reverted",
+      "logs" => [],
+      "receipt" => @receipt
+    }
   end
 
   # -- Assertion helpers --


### PR DESCRIPTION
## What

Audit of the SCA / ERC-4337 bundler wallet write path
(`Raxol.ACP.ProviderAdapter.SCA` + `Raxol.ACP.Wallet.SCA.*`) for fund-safety,
following the same "a fund-moving step not reconciled on the non-happy path"
bug class as #402-#407. One confirmed, in-scope gap is fixed here; the rest of
the audit is summarized below with verdicts.

## The fix (confirmed gap)

**`ProviderAdapter.SCA.send_one` treated a mined-but-reverted UserOp as a
successful write.**

An ERC-4337 v0.7 UserOp can pass validation (so it is included on-chain and its
nonce is burned) while its inner execution -- the account's `execute(...)`
wrapping the ACP hook call (`setBudget`/`submit`/`complete`/`reject`) -- reverts.
`eth_getUserOperationReceipt` reports this as a top-level `"success": false`
(sibling of `"receipt"`; confirmed in the existing fixture
`sca_test.exs`).

`send_one` read only `uo_receipt["receipt"]["transactionHash"]` and never looked
at `"success"`, so it returned `{:ok, [tx_hash]}` for a reverted op. Via
`HookClient` -> `Provider`, that mirrored the session forward
(`:budget_set`/`:submitted`/`:completed`) even though the on-chain hook reverted
-- breaking the Provider's documented invariant: "the on-chain write is the
commit point; the mirror only runs once the chain write succeeds."

Failure scenario: a redelivery/retry issues a duplicate `submit`/`setBudget`
that reverts on-chain (job already past that state), or the inner call runs out
of gas; the SCA path reports success and the seller session claims a
delivery/budget that never settled -- stalling the job or masking a
non-delivery (work done, no on-chain proof, no payment).

`send_one` now checks the receipt: an explicit `"success": false` returns
`{:error, {:user_op_reverted, reason}}`, so the Provider leaves the session
untouched and SSE reconciliation of the real on-chain event remains the recovery
path. A receipt that omits `success` keeps the prior lenient behavior (targeted,
non-breaking).

## Tests

- Added an SCA-adapter test (RED against the un-fixed code -- it returned
  `{:ok, [tx_hash]}` for a `success: false` op; GREEN after) driving a reverted
  UserOp receipt through the full stubbed pipeline.
- Existing happy-path tests (`success: true`) unchanged.

## Manual testing

- [x] `cd packages/raxol_acp && MIX_ENV=test mix test` -> 521 passed, 0 failures
      (was 520; +1 new).
- [x] New test confirmed RED without the guard, GREEN with it.
- [x] `mix format --check-formatted` on the two changed files.
- [x] `mix compile` surfaces no new warnings from the changed file.

Note: root CI (`ci-unified.yml`) does not build `raxol_acp`, so the package's
own suite above is the validation gate.

## Audit results for the other questions (verdicts)

- **UserOp submission idempotency on await-timeout (Q1) -- real hazard, accepted
  class, NOT fixed here.** On `await_user_operation` timeout, `send_one` returns
  `{:error, :timeout}` and discards the known `op_hash`; the op may still land. A
  Provider re-drive fetches a fresh EntryPoint nonce via `getNonce` and builds a
  new op with the same callData -- a second on-chain execution. EntryPoint nonces
  do NOT prevent this (different nonce). It is bounded by on-chain contract
  idempotency plus the Provider status guard once the mirror lands (via the
  driver or SSE reconciliation) -- the same crash-before-mirror window scoped out
  of this arc (no on-chain preflight). A durable op-hash + resume-await would
  close it but needs a persistent store (larger, external). See "Not in this PR".
- **EntryPoint nonce handling (Q2) -- not a gap.** The SCA path never touches
  `NonceServer` (grep-confirmed) and never locally increments: it fetches the
  full nonce fresh from `EntryPoint.getNonce` on every op. A reverted op still
  advances the on-chain sequence, so the next `getNonce` returns the right value
  -- no stuck nonce, no gap. The Provisioner explicitly re-queries the owner
  nonce between deploy (op1) and install (op2) rather than incrementing.
- **First-tx self-deploy atomicity (Q3) -- not a fund-safety gap.** Provisioning
  is two non-atomic UserOps (deploy, then install), but idempotent via
  chain-state reads (`deployed?` / `installed?`): a crash mid-provision self-heals
  on the next `ensure_provisioned` (skip the done deploy, retry install). During
  the half-provisioned window no write op can validate (session key not yet
  installed), so no funds move; both provisioning ops are sponsored (gasless).
- **Paymaster / key-material leak (Q4) -- not a gap.** The SCA stack holds no
  private key. All raw signing delegates to `signer.sign_hash/1`, a
  `Raxol.Payments.Wallet` (`Env`/`Op`), both already hardened in #404 via
  `Secret.with_revealed`. `pack_uo_signature` / `pack_1271_eoa_signature` operate
  on the signature (r||s||v), never the key, so no key reaches a raising NIF arg.
- **Commit-point ordering, SCA vs JSONRPC (Q5) -- parity, with a caveat.** Both
  write on-chain first and mirror only on `{:ok, tx_hash}`. The SCA path waits
  for the bundler receipt (confirms mined) and, after this fix, rejects a
  reverted op -- so it is strictly better-confirmed than the JSONRPC EOA path,
  which returns on broadcast (`send_raw_transaction`) and never confirms the tx.
  Bringing the EOA path up to receipt-confirmation is a separate design change
  (see "Not in this PR").

## Not in this PR

- **Await-timeout double-execution (Q1).** Needs a durable op-hash store +
  resume-await to avoid re-minting an op when the first is still in flight;
  currently bounded by contract idempotency + SSE reconciliation, the accepted
  net for this window. Should be a tracked issue.
- **JSONRPC EOA path returns success on broadcast (Q1/Q5/F3).** The EOA adapter
  never waits for the receipt, so a reverted tx is also reported as success
  (weaker than the SCA path even before this fix). Adding receipt-polling is a
  design change; the EOA path's nonce behavior was already audited as
  inherent-EVM / NonceServer-handled. Should be a tracked issue.
