### PR TITLE
Confirm EOA tx receipt before reporting write success

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/provider_adapter/jsonrpc.ex
+++ b/packages/raxol_acp/lib/raxol/acp/provider_adapter/jsonrpc.ex
@@ -60,7 +60,8 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
           private_key: Secret.t(),
           address: String.t(),
           fee_overrides: %{optional(pos_integer()) => fee_override()},
-          nonce_server: GenServer.server()
+          nonce_server: GenServer.server(),
+          receipt_wait_opts: keyword()
         }
 
   @type fee_override :: %{
@@ -89,6 +90,10 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
     server's mailbox so they can never sign the same nonce. If you run
     more than one wallet, construct each adapter with a distinct
     `:nonce_server`.
+  - `:receipt_wait_opts` -- keyword passed to `RPC.await_receipt/3` when
+    confirming a broadcast tx (`:timeout_ms` default 30_000, `:interval_ms`
+    default 250). `send_calls/3` waits for the receipt and rejects a
+    reverted tx before reporting success.
   """
   @spec new(keyword()) :: Raxol.ACP.ProviderAdapter.adapter()
   def new(opts) do
@@ -106,7 +111,8 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
       private_key: Secret.new(private_key),
       address: address,
       fee_overrides: Keyword.get(opts, :fee_overrides, %{}),
-      nonce_server: Keyword.get(opts, :nonce_server, NonceServer)
+      nonce_server: Keyword.get(opts, :nonce_server, NonceServer),
+      receipt_wait_opts: Keyword.get(opts, :receipt_wait_opts, [])
     }
 
     %{adapter: __MODULE__, config: config}
@@ -204,11 +210,14 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
           {:ok, hash}
         else
           {:error, _} = err ->
-            # The tx never reached the chain, so its nonce was not consumed.
-            # Mark the counter unseeded so the next acquisition re-fetches the
-            # pending nonce from chain and re-fills the gap -- the same self-heal
-            # the old per-send `eth_getTransactionCount` gave, now without the
-            # cross-send nonce race.
+            # Re-sync the nonce counter to chain truth on any failure. A
+            # pre-broadcast failure (sign/estimate/send) leaves the nonce
+            # unconsumed; a post-broadcast failure (the tx reverted, or its
+            # receipt didn't arrive before the await timeout) already consumed
+            # it. Either way, marking the counter unseeded makes the next
+            # acquisition re-fetch the pending nonce from chain -- which reflects
+            # whichever happened -- so we never reuse a consumed nonce nor strand
+            # an unconsumed one.
             NonceServer.resync(nonce_server)
             err
         end
@@ -248,10 +257,26 @@ defmodule Raxol.ACP.ProviderAdapter.JSONRPC do
          tx <- Transaction.new(Map.put(tx_attrs, :gas_limit, gas_limit)),
          {:ok, signature} <- sign_tx(tx, private_key),
          signed <- Transaction.serialize(tx, signature),
-         {:ok, hash} <- RPC.send_raw_transaction(client, signed) do
+         {:ok, hash} <- RPC.send_raw_transaction(client, signed),
+         {:ok, receipt} <- RPC.await_receipt(client, hash, adapter.config.receipt_wait_opts),
+         :ok <- confirm_success(receipt, hash) do
       {:ok, hash}
     end
   end
+
+  # A broadcast tx is only a successful write once it is MINED and its receipt
+  # reports success. `eth_getTransactionReceipt.status` is `0x0` for a reverted
+  # tx (mined, nonce consumed, but the call rolled back); returning `{:ok, hash}`
+  # for it would let the Provider mirror a write the chain undid. Reject an
+  # explicit revert so the session stays put -- parity with the SCA path, which
+  # checks the UserOp receipt's `success` flag. A receipt without a `status`
+  # keeps the prior lenient behavior.
+  defp confirm_success(receipt, hash) do
+    if reverted?(receipt), do: {:error, {:tx_reverted, hash}}, else: :ok
+  end
+
+  defp reverted?(%{"status" => "0x" <> hex}), do: match?({0, ""}, Integer.parse(hex, 16))
+  defp reverted?(_receipt), do: false
 
   defp fees(client, fee_overrides, chain_id) do
     case Map.get(fee_overrides, chain_id) do

--- a/packages/raxol_acp/test/raxol/acp/provider_adapter/jsonrpc_nonce_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/provider_adapter/jsonrpc_nonce_test.exs
@@ -84,6 +84,12 @@ defmodule Raxol.ACP.ProviderAdapter.JsonrpcNonceTest do
                 n = :ets.update_counter(table, :tx_counter, 1)
                 result(id, "0x" <> String.pad_leading(Integer.to_string(n, 16), 64, "0"))
             end
+
+          # send_calls now confirms the tx before reporting success; a mined
+          # receipt with status 0x1 keeps the nonce assertions focused on the
+          # send path.
+          "eth_getTransactionReceipt" ->
+            result(id, %{"status" => "0x1", "blockNumber" => "0x1"})
         end
 
       conn

--- a/packages/raxol_acp/test/raxol/acp/provider_adapter/jsonrpc_receipt_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/provider_adapter/jsonrpc_receipt_test.exs
@@ -1,0 +1,130 @@
+defmodule Raxol.ACP.ProviderAdapter.JsonrpcReceiptTest do
+  @moduledoc """
+  Hermetic proof that `Raxol.ACP.ProviderAdapter.JSONRPC.send_calls/3`
+  confirms a transaction on-chain before reporting success. A mined-but-
+  reverted tx (`status: 0x0`) surfaces as `{:error, {:tx_reverted, hash}}`
+  rather than a false `{:ok, hash}`, so the Provider never mirrors a
+  rolled-back write. This is the EOA-path parity for the SCA adapter's
+  UserOp `success` check.
+
+  RPC is stubbed via a `:plug` (picked up from the `:raxol_acp, :rpc` app
+  config that the adapter's `RPC.client/1` reads); no real chain.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.ProviderAdapter
+  alias Raxol.ACP.ProviderAdapter.JSONRPC
+  alias Raxol.ACP.Wallet.NonceServer
+
+  @chain 8453
+  # Anvil/Foundry test account #0. A public test value, never a real key.
+  @privkey Base.decode16!(
+             "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+             case: :lower
+           )
+
+  setup do
+    table = :ets.new(:jsonrpc_receipt_stub, [:set, :public])
+    :ets.insert(table, {:tx_counter, 0})
+    :ets.insert(table, {:receipt_status, "0x1"})
+    :ets.insert(table, {:receipt_ready, true})
+
+    Application.put_env(:raxol_acp, :rpc, plug: plug(table))
+    on_exit(fn -> Application.delete_env(:raxol_acp, :rpc) end)
+
+    %{table: table}
+  end
+
+  # -- Helpers --
+
+  defp start_nonce_server do
+    name = Module.concat(__MODULE__, "NS#{System.unique_integer([:positive])}")
+    start_supervised!({NonceServer, [name: name, initial_nonce: 5]})
+    name
+  end
+
+  defp adapter(nonce_server, extra \\ []) do
+    JSONRPC.new(
+      Keyword.merge(
+        [
+          chains: %{@chain => "http://stub.invalid/rpc"},
+          private_key: @privkey,
+          fee_overrides: %{@chain => %{max_priority_fee_per_gas: 1, max_fee_per_gas: 2}},
+          nonce_server: nonce_server
+        ],
+        extra
+      )
+    )
+  end
+
+  defp call, do: %{to: "0x" <> String.duplicate("11", 20), data: <<>>, value: 0, gas: 200_000}
+
+  defp plug(table) do
+    fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      %{"method" => method, "id" => id, "params" => params} = Jason.decode!(body)
+
+      payload =
+        case method do
+          "eth_getTransactionCount" ->
+            result(id, "0x5")
+
+          "eth_estimateGas" ->
+            result(id, "0x5208")
+
+          "eth_sendRawTransaction" ->
+            n = :ets.update_counter(table, :tx_counter, 1)
+            result(id, "0x" <> String.pad_leading(Integer.to_string(n, 16), 64, "0"))
+
+          "eth_getTransactionReceipt" ->
+            receipt(id, params, table)
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(payload))
+    end
+  end
+
+  defp receipt(id, [hash | _], table) do
+    case :ets.lookup(table, :receipt_ready) do
+      [{:receipt_ready, false}] ->
+        # Pending forever -- drives the await timeout.
+        result(id, nil)
+
+      _ ->
+        [{:receipt_status, status}] = :ets.lookup(table, :receipt_status)
+        result(id, %{"status" => status, "transactionHash" => hash, "blockNumber" => "0x1"})
+    end
+  end
+
+  defp result(id, value), do: %{"jsonrpc" => "2.0", "id" => id, "result" => value}
+
+  # -- Tests --
+
+  test "a successful tx (status 0x1) is reported as a successful write" do
+    adapter = adapter(start_nonce_server())
+
+    assert {:ok, [hash]} = ProviderAdapter.send_calls(adapter, @chain, [call()])
+    assert String.starts_with?(hash, "0x")
+  end
+
+  test "a mined-but-reverted tx (status 0x0) is not reported as a successful write", %{
+    table: table
+  } do
+    :ets.insert(table, {:receipt_status, "0x0"})
+    adapter = adapter(start_nonce_server())
+
+    assert {:error, {:tx_reverted, hash}} = ProviderAdapter.send_calls(adapter, @chain, [call()])
+    assert String.starts_with?(hash, "0x")
+  end
+
+  test "a tx whose receipt never arrives times out instead of reporting success", %{
+    table: table
+  } do
+    :ets.insert(table, {:receipt_ready, false})
+    adapter = adapter(start_nonce_server(), receipt_wait_opts: [timeout_ms: 30, interval_ms: 5])
+
+    assert {:error, :timeout} = ProviderAdapter.send_calls(adapter, @chain, [call()])
+  end
+end


### PR DESCRIPTION
Closes #411.

## What

Brings the JSONRPC EOA write path to parity with the SCA path (#409): a
transaction is only reported as a successful write once it is **mined and its
receipt reports success**. Same "a fund-moving step not reconciled on the
non-happy path" class as #402-#409 -- here the non-happy path is "tx mined but
reverted".

## The gap

`ProviderAdapter.JSONRPC.submit_one` returned `{:ok, hash}` as soon as
`eth_sendRawTransaction` accepted the tx into the mempool -- it never fetched the
receipt or checked `status`. A tx that is mined but **reverts** (`status: 0x0`;
nonce consumed, gas burned, call rolled back) was therefore reported as a
successful write, so `HookClient` -> `Provider` mirrored the session forward
(`:budget_set`/`:submitted`/`:completed`) even though the on-chain hook reverted
-- breaking the Provider's "mirror only once the chain write succeeds" invariant.

## Change

`submit_one` now, after broadcast, calls `RPC.await_receipt/3` and rejects an
explicit revert:

- `status: 0x1` (or absent) -> `{:ok, hash}` (unchanged success path).
- `status: 0x0` -> `{:error, {:tx_reverted, hash}}` -> Provider leaves the
  session untouched.
- receipt never arrives within the wait window -> `{:error, :timeout}`.

New `:receipt_wait_opts` config (default `[]` -> RPC's 30s / 250ms) threads the
await timeout/interval; tests use a short override.

### NonceServer interaction

`send_each` already resyncs the nonce counter on any error. The comment is
updated: a pre-broadcast failure leaves the nonce unconsumed, while a
post-broadcast failure (revert / await timeout) consumed it -- but in both cases
marking the counter unseeded makes the next acquisition re-fetch the pending
nonce from chain, which already reflects whichever happened, so no nonce is
reused or stranded. (Nonce-serialization behavior is unchanged; the existing
hermetic nonce tests still pass, now exercising the receipt-await path.)

## Tests

New hermetic `jsonrpc_receipt_test.exs` (Plug-stubbed RPC, no chain):

- success (`status: 0x1`) -> `{:ok, [hash]}`.
- reverted (`status: 0x0`) -> `{:error, {:tx_reverted, hash}}` -- RED against the
  un-fixed code (it returned `{:ok, [hash]}`), GREEN after.
- receipt never arrives -> `{:error, :timeout}` -- also RED before (returned
  `{:ok, [hash]}`).

The existing `jsonrpc_nonce_test.exs` stub gains an `eth_getTransactionReceipt`
clause (returns `status: 0x1`) so its four nonce tests keep passing through the
new confirm step.

## Manual testing

- [x] `cd packages/raxol_acp && MIX_ENV=test mix test` -> 527 passed, 0 failures
      (was 524; +3 new).
- [x] Revert + timeout tests confirmed RED without the guard, GREEN with it.
- [x] `mix format --check-formatted` on the three changed files.
- [x] `mix compile` surfaces no new warnings from the changed file.
- [ ] `:live_chain` (anvil) suite -- unchanged; `send_calls` now waits for the
      receipt it already fetched separately in those tests (anvil mines
      immediately). Not run here (needs foundry).

Note: root CI (`ci-unified.yml`) does not build `raxol_acp`, so the package's own
suite above is the validation gate.

## Not in this PR

- **Await-timeout double-execution (#410).** Confirming the receipt introduces
  the same bounded window the SCA path already has: a slow tx that times out
  returns an error, and a Provider re-drive could re-broadcast while the first is
  still pending. Bounded by on-chain contract idempotency + the Provider status
  guard once the mirror lands (SSE reconciliation). The durable op/tx-hash
  resume-await that would close it for both paths is tracked in #410.
