### PR TITLE
Pin MPP amount unit to atomic integers

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/protocols/mpp.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/mpp.ex
@@ -124,11 +124,13 @@ defmodule Raxol.Payments.Protocols.MPP do
 
   @impl true
   @spec amount(map()) :: Decimal.t()
-  # MPP's server-side unit convention is ambiguous (Stripe uses cents,
-  # other implementations vary). For now we passthrough what the server
-  # sends and trust callers to write `SpendingPolicy` caps in the same
-  # convention as the targeted MPP server. Revisit with `Assets.to_human`
-  # once we integrate a concrete MPP service.
+  # MPP amounts are atomic units: `parse_challenge` accepts only an integer or
+  # an all-digit string (see `validate_positive_amount`), so this is always a
+  # valid Decimal integer -- the same value the signed credential carries, so a
+  # `SpendingPolicy` cap must be written in the targeted server's atomic unit
+  # (Stripe cents, or EVM token base units). Mapping atomic units to a human
+  # amount per method (via `Assets.to_human`) needs that server's token/decimals
+  # and lands with the first concrete MPP integration.
   def amount(challenge) do
     challenge.amount
     |> to_string()
@@ -150,24 +152,20 @@ defmodule Raxol.Payments.Protocols.MPP do
     end
   end
 
+  # MPP amounts are atomic units: a positive integer, or an all-digit string
+  # (Stripe cents, or EVM token base units), matching the x402 convention. A
+  # float or a decimal string is malformed as atomic units, so the challenge is
+  # rejected at parse time -- fail closed rather than guess the unit. Once a
+  # concrete MPP server pins the per-method token/decimals, `amount/1` routes
+  # through `Assets.to_human` and this validation matches that convention.
   defp validate_positive_amount(amount) when is_integer(amount) and amount > 0,
     do: :ok
 
-  defp validate_positive_amount(amount) when is_float(amount) and amount > 0,
-    do: :ok
-
   defp validate_positive_amount(amount) when is_binary(amount) do
-    case Decimal.parse(amount) do
-      {dec, ""} ->
-        if Decimal.positive?(dec),
-          do: :ok,
-          else: {:error, {:invalid_amount, amount}}
-
-      _ ->
-        {:error, {:invalid_amount, amount}}
+    case Integer.parse(amount) do
+      {int, ""} when int > 0 -> :ok
+      _ -> {:error, {:invalid_amount, amount}}
     end
-  rescue
-    Decimal.Error -> {:error, {:invalid_amount, amount}}
   end
 
   defp validate_positive_amount(amount), do: {:error, {:invalid_amount, amount}}

--- a/packages/raxol_payments/test/raxol/payments/protocols/mpp_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/mpp_test.exs
@@ -56,12 +56,64 @@ defmodule Raxol.Payments.Protocols.MPPTest do
     test "returns error for missing header" do
       assert {:error, {:missing_header, "www-authenticate"}} = MPP.parse_challenge([])
     end
+
+    test "accepts an integer atomic amount" do
+      assert {:ok, %{amount: 100}} = MPP.parse_challenge(challenge_headers(%{"amount" => 100}))
+    end
+
+    test "rejects a float amount as malformed atomic units" do
+      assert {:error, {:invalid_amount, 1.5}} =
+               MPP.parse_challenge(challenge_headers(%{"amount" => 1.5}))
+    end
+
+    test "rejects a decimal-string amount as malformed atomic units" do
+      assert {:error, {:invalid_amount, "1.50"}} =
+               MPP.parse_challenge(challenge_headers(%{"amount" => "1.50"}))
+    end
+
+    test "rejects a zero amount" do
+      assert {:error, {:invalid_amount, 0}} =
+               MPP.parse_challenge(challenge_headers(%{"amount" => 0}))
+    end
   end
 
   describe "amount/1" do
-    test "returns Decimal from string amount" do
-      challenge = %{amount: "0.05"}
-      assert Decimal.equal?(MPP.amount(challenge), Decimal.new("0.05"))
+    test "returns a Decimal for an all-digit atomic amount" do
+      assert Decimal.equal?(MPP.amount(%{amount: "100"}), Decimal.new("100"))
+    end
+
+    test "returns a Decimal for an integer atomic amount" do
+      assert Decimal.equal?(MPP.amount(%{amount: 100}), Decimal.new(100))
+    end
+  end
+
+  describe "gate cap and signed amount stay the same unit" do
+    defmodule StubWallet do
+      def address, do: "0x1111111111111111111111111111111111111111"
+      def sign_message(_message), do: {:ok, <<0::256>>}
+    end
+
+    test "amount/1 and the signed credential both carry the challenge's atomic amount" do
+      # The SpendingPolicy cap reads amount/1; the on-the-wire credential carries
+      # build_payment's amount. Both derive from challenge.amount verbatim, so
+      # they can never diverge into different units.
+      challenge = %{
+        amount: 100,
+        currency: "USDC",
+        recipient: "0xabcdef1234567890abcdef1234567890abcdef12",
+        methods: ["tempo"],
+        network: "tempo:mainnet",
+        nonce: "abc123"
+      }
+
+      assert Decimal.equal?(MPP.amount(challenge), Decimal.new(100))
+
+      assert {:ok, [{"authorization", "Payment " <> encoded}]} =
+               MPP.build_payment(challenge, StubWallet)
+
+      {:ok, json} = Base.decode64(encoded)
+      {:ok, credential} = Jason.decode(json)
+      assert credential["amount"] == 100
     end
   end
 
@@ -88,5 +140,22 @@ defmodule Raxol.Payments.Protocols.MPPTest do
     test "returns error for missing header" do
       assert {:error, :no_receipt} = MPP.parse_receipt([])
     end
+  end
+
+  # Build a `www-authenticate: Payment <base64>` header from a base challenge
+  # merged with `overrides`, so a test can vary a single field (e.g. amount).
+  defp challenge_headers(overrides) do
+    payload =
+      %{
+        "amount" => 100,
+        "currency" => "USDC",
+        "recipient" => "0xabcdef1234567890abcdef1234567890abcdef12",
+        "network" => "tempo:mainnet",
+        "nonce" => "abc123"
+      }
+      |> Map.merge(overrides)
+      |> Jason.encode!()
+
+    [{"www-authenticate", "Payment " <> Base.encode64(payload)}]
   end
 end

--- a/packages/raxol_payments/test/raxol/payments/security_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/security_test.exs
@@ -44,9 +44,12 @@ defmodule Raxol.Payments.SecurityTest do
   end
 
   defp valid_mpp_payload(overrides \\ %{}) do
+    # MPP amounts are atomic units (integer or all-digit string); "150" is 150
+    # atomic units (e.g. Stripe cents). A decimal string like "1.50" is now
+    # rejected, so the valid baseline uses an all-digit string.
     Map.merge(
       %{
-        "amount" => "1.50",
+        "amount" => "150",
         "recipient" => @valid_address,
         "currency" => "USDC",
         "network" => "eip155:8453"
@@ -206,6 +209,20 @@ defmodule Raxol.Payments.SecurityTest do
     end
   end
 
+  describe "MPP parse_challenge rejects non-atomic amount" do
+    test "float amount" do
+      # Atomic units are integers; a float is malformed and its unit is
+      # ambiguous, so it is rejected rather than trusted (mirrors X402).
+      headers = mpp_headers(valid_mpp_payload(%{"amount" => 1.5}))
+      assert {:error, {:invalid_amount, _}} = MPP.parse_challenge(headers)
+    end
+
+    test "decimal string amount" do
+      headers = mpp_headers(valid_mpp_payload(%{"amount" => "1.50"}))
+      assert {:error, {:invalid_amount, _}} = MPP.parse_challenge(headers)
+    end
+  end
+
   describe "MPP parse_challenge rejects missing fields" do
     test "missing amount" do
       payload = valid_mpp_payload() |> Map.delete("amount")
@@ -221,10 +238,10 @@ defmodule Raxol.Payments.SecurityTest do
   end
 
   describe "MPP parse_challenge accepts valid challenge" do
-    test "string amount with recipient" do
+    test "all-digit string amount with recipient" do
       headers = mpp_headers(valid_mpp_payload())
       assert {:ok, challenge} = MPP.parse_challenge(headers)
-      assert challenge.amount == "1.50"
+      assert challenge.amount == "150"
       assert challenge.recipient == @valid_address
     end
 


### PR DESCRIPTION
Addresses #405 (validation half; unit-mapping half stays deferred -- see below).

## Context

#405 followed the x402 auto-pay fund-safety work (#403). Scoping it against the
code first confirmed what the issue suspected: **MPP has no live fund-safety
bug.** `amount/1` is a passthrough and `build_payment` signs `challenge.amount`
verbatim, so the gate cap and the signed amount derive from the same value with
no atomic<->human conversion between them -- no divergence, no gate-bypass.

The real blocker was a product decision: MPP's amount unit was ambiguous
(the moduledoc flagged "Stripe cents vs token units"). We pinned it to **atomic
integer units**, matching x402 and both underlying rails (Stripe = cents, Tempo
/ EVM = token base units). That unblocks the validation tightening.

## Change

`validate_positive_amount` now accepts only a **positive integer or an all-digit
string**, rejecting floats and decimal strings as malformed atomic units --
identical to x402's `validate_positive_amount` (`x402.ex:194`). Fail-closed at
parse time rather than guessing the unit.

`amount/1` is unchanged behaviorally (still a passthrough `Decimal`), but its doc
now pins the atomic-integer convention and records that the per-method
`Assets.to_human` mapping lands with the first concrete MPP integration.

## Tests

- `mpp_test.exs`: `parse_challenge` accepts an integer amount; rejects a float
  and a decimal string (both RED against the pre-change code, which accepted
  them; GREEN after) and zero. `amount/1` covers integer + all-digit string. A
  parity test asserts `amount/1` (the gate cap) and the signed credential's
  `amount` both carry the challenge's atomic value, so they can't diverge into
  different units.
- `security_test.exs`: the shared `valid_mpp_payload/1` baseline moves from the
  decimal string `"1.50"` to the all-digit `"150"` (this also repairs a latent
  drift -- the "missing recipient" test previously would have errored on the
  amount first). Added a symmetric "rejects non-atomic amount" block (float +
  decimal string), mirroring the existing X402 float-rejection tests.

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` -> 1002 passed,
      0 failures.
- [x] Float + decimal-string rejection confirmed RED without the change,
      GREEN with it.
- [x] `mix format --check-formatted` on the three changed files.
- [x] `mix compile` surfaces no new warnings from the changed file.

Note: root CI (`ci-unified.yml`) does not build `raxol_payments`, so the
package's own suite above is the validation gate.

## Not in this PR

- **Per-method human-amount mapping (`Assets.to_human`).** Mapping atomic units
  to a human amount needs the targeted MPP server's token/decimals, which needs
  a concrete MPP service integration. Deferred per #405's own guidance ("Do this
  alongside the first concrete MPP integration"); `amount/1` and the new
  validation doc both point at where it lands. #405 can stay open for that half.
