### PR TITLE
Add recipient_address to Xochi QuoteRequest

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
@@ -79,6 +79,11 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
           type: :string,
           description: "Recipient ERC-6538 stealth meta-address (st:eth:0x...)"
         ],
+        recipient_address: [
+          type: :string,
+          description:
+            "Destination recipient for a plaintext (public) transfer. Required for a cross-VM route (e.g. an EVM wallet paying a Tron base58 address); omit for same-VM, where Xochi defaults it to the sending wallet."
+        ],
         slippage_bps: [type: :integer, default: 50, description: "Max slippage (default 50)"],
         trust_score: [type: :integer, description: "Trust score for tier/fee"],
         min_to_amount: [
@@ -243,6 +248,9 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
           request.from_token,
           request.to_token,
           request.from_amount,
+          # The recipient is part of the payment's identity: a transfer to
+          # recipient A must never be treated as a resume of one to recipient B.
+          request.recipient_address,
           request.settlement_preference,
           request.stealth_spending_pub_key,
           request.stealth_viewing_pub_key
@@ -368,6 +376,7 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
         from_token: from_token,
         to_token: Map.fetch!(params, :to_token),
         from_amount: from_amount,
+        recipient_address: Map.get(params, :recipient_address),
         settlement_preference: settlement,
         slippage_bps: Map.get(params, :slippage_bps) || 50,
         trust_score: Map.get(params, :trust_score),

--- a/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
@@ -40,6 +40,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
       :from_token,
       :to_token,
       :from_amount,
+      :recipient_address,
       :trust_score,
       :stealth_spending_pub_key,
       :stealth_viewing_pub_key,
@@ -59,6 +60,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
             from_token: String.t(),
             to_token: String.t(),
             from_amount: String.t(),
+            recipient_address: String.t() | nil,
             settlement_preference: settlement(),
             deadline: integer() | nil,
             slippage_bps: non_neg_integer(),
@@ -97,10 +99,22 @@ defmodule Raxol.Payments.Xochi.Schemas do
            {:stealth_keys_required,
             "stealth settlement requires compressed spending and viewing public keys"}}
 
+        not recipient_address_valid?(req.recipient_address) ->
+          {:error, {:invalid_recipient_address, "must be a non-empty string when set"}}
+
         true ->
           :ok
       end
     end
+
+    # `recipient_address` is optional: nil lets Riddler default it to `wallet`
+    # (same-VM). When set (required for a cross-VM route, e.g. an EVM wallet
+    # paying a Tron address), it must be a non-empty string. The chain-specific
+    # format (EVM `0x`-hex vs TVM/SVM base58) is validated by Riddler against
+    # `to_chain_id`, which owns the chain->VM mapping.
+    defp recipient_address_valid?(nil), do: true
+    defp recipient_address_valid?(addr) when is_binary(addr), do: addr != ""
+    defp recipient_address_valid?(_), do: false
 
     defp stealth_keys_present?(%__MODULE__{
            stealth_spending_pub_key: spend,
@@ -130,6 +144,7 @@ defmodule Raxol.Payments.Xochi.Schemas do
       }
 
       base
+      |> Raxol.Payments.Xochi.Schemas.put_non_nil("recipient_address", req.recipient_address)
       |> Raxol.Payments.Xochi.Schemas.put_non_nil("trust_score", req.trust_score)
       |> Raxol.Payments.Xochi.Schemas.put_non_nil(
         "stealth_spending_pub_key",

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/execute_xochi_intent_test.exs
@@ -217,6 +217,103 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntentTest do
     end
   end
 
+  describe "ExecuteXochiIntent recipient_address" do
+    test "sends recipient_address on the quote request for a public transfer" do
+      Req.Test.stub(__MODULE__, fn conn ->
+        case conn.request_path do
+          "/api/intent/quote" ->
+            {:ok, raw, conn} = Plug.Conn.read_body(conn)
+            send(self(), {:quote_body, Jason.decode!(raw)})
+
+            Req.Test.json(conn, %{
+              "intentId" => "int_1",
+              "quoteId" => "q_1",
+              "canSolve" => true,
+              "toAmount" => "499000",
+              "xochiFee" => "1000",
+              "eip712Data" => %{
+                "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+                "types" => %{"Intent" => [%{"name" => "amount", "type" => "uint256"}]},
+                "message" => %{"amount" => 500_000}
+              }
+            })
+
+          "/api/intent/execute" ->
+            Req.Test.json(conn, %{
+              "success" => true,
+              "intentId" => "int_1",
+              "status" => "executing"
+            })
+        end
+      end)
+
+      ledger = start_supervised!({Ledger, [name: nil]})
+
+      ctx = %{
+        wallet: SpyWallet,
+        xochi_config: config(),
+        ledger: ledger,
+        policy: policy(),
+        agent_id: "a1"
+      }
+
+      recipient = "0x2222222222222222222222222222222222222222"
+
+      params =
+        base_params(%{
+          settlement: "public",
+          recipient_meta_address: nil,
+          recipient_address: recipient
+        })
+
+      assert {:ok, _result} = ExecuteXochiIntent.run(params, ctx)
+
+      assert_received {:quote_body, body}
+      assert body["recipient_address"] == recipient
+      assert body["settlement_preference"] == "public"
+    end
+
+    test "two public transfers differing only by recipient are distinct payments" do
+      # A payment to recipient B must never resume recipient A's checkpoint --
+      # otherwise B's funds would follow A's already-signed intent. The recipient
+      # is part of the derived idempotency key, so each signs independently.
+      stub_quote_and_execute()
+      ledger = start_supervised!({Ledger, [name: nil]})
+      store = Checkpoint.ETS.new()
+
+      ctx = %{
+        wallet: SpyWallet,
+        xochi_config: config(),
+        ledger: ledger,
+        policy: policy(),
+        agent_id: "a1",
+        checkpoint: store
+      }
+
+      pub = fn recipient ->
+        base_params(%{
+          settlement: "public",
+          recipient_meta_address: nil,
+          recipient_address: recipient
+        })
+      end
+
+      assert {:ok, _} =
+               ExecuteXochiIntent.run(pub.("0x2222222222222222222222222222222222222222"), ctx)
+
+      assert_received :wallet_signed
+
+      assert {:ok, _} =
+               ExecuteXochiIntent.run(pub.("0x3333333333333333333333333333333333333333"), ctx)
+
+      # Signed a SECOND time -- recipient B was not resumed as recipient A's payment.
+      assert_received :wallet_signed
+
+      totals = Ledger.get_totals(ledger, "a1", policy())
+      assert Decimal.equal?(totals.lifetime, Decimal.new("1.00"))
+    end
+  end
+
   describe "ExecuteXochiIntent quote-expired retry" do
     test "re-quotes and re-executes once when the first execute reports expiry" do
       Req.Test.stub(__MODULE__, fn conn ->

--- a/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
@@ -66,6 +66,37 @@ defmodule Raxol.Payments.Xochi.SchemasTest do
       refute Map.has_key?(json, "trust_score")
     end
 
+    test "includes recipient_address when set" do
+      req = %QuoteRequest{
+        wallet: "0xabc",
+        from_chain_id: 8453,
+        to_chain_id: 728_126_428,
+        from_token: "0xA0b8",
+        to_token: "0x8335",
+        from_amount: "1000000",
+        settlement_preference: "public",
+        recipient_address: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+      }
+
+      json = QuoteRequest.to_json(req)
+      assert json["recipient_address"] == "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+    end
+
+    test "omits recipient_address when nil (Xochi defaults it to the wallet)" do
+      req = %QuoteRequest{
+        wallet: "0xabc",
+        from_chain_id: 1,
+        to_chain_id: 8453,
+        from_token: "0xA0b8",
+        to_token: "0x8335",
+        from_amount: "1000000",
+        settlement_preference: "public"
+      }
+
+      json = QuoteRequest.to_json(req)
+      refute Map.has_key?(json, "recipient_address")
+    end
+
     test "includes attestations when non-empty" do
       attestation = %{
         type_code: 0x01,
@@ -163,6 +194,39 @@ defmodule Raxol.Payments.Xochi.SchemasTest do
       }
 
       assert :ok = QuoteRequest.validate(req)
+    end
+
+    test "accepts a non-EVM (base58) recipient_address -- Riddler validates the format" do
+      # A cross-VM route (EVM origin, Tron destination) sends a base58 recipient.
+      # raxol must not apply its EVM 0x-hex check to it; Riddler validates the
+      # format against to_chain_id.
+      req = %QuoteRequest{
+        wallet: @valid_addr,
+        from_chain_id: 8453,
+        to_chain_id: 728_126_428,
+        from_token: @valid_addr,
+        to_token: @valid_addr,
+        from_amount: "1000000",
+        settlement_preference: "public",
+        recipient_address: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+      }
+
+      assert :ok = QuoteRequest.validate(req)
+    end
+
+    test "empty recipient_address returns error" do
+      req = %QuoteRequest{
+        wallet: @valid_addr,
+        from_chain_id: 1,
+        to_chain_id: 8453,
+        from_token: @valid_addr,
+        to_token: @valid_addr,
+        from_amount: "1000000",
+        settlement_preference: "public",
+        recipient_address: ""
+      }
+
+      assert {:error, {:invalid_recipient_address, _}} = QuoteRequest.validate(req)
     end
 
     test "invalid wallet address returns error" do


### PR DESCRIPTION
Closes #399.

## What

Adds an optional `recipient_address` to the Xochi `QuoteRequest`, the one change
raxol_payments needs to route an **EVM->Tron** (cross-VM) payment. Riddler
(master `85f94de0`) already supports it: the served EIP-712 intent binds the
recipient, and raxol signs Riddler's `eip712_data` verbatim, so no signing
change is needed here -- only the quote request has to carry the destination.

## Change

- **`Xochi.Schemas.QuoteRequest`**: new `recipient_address` field (`String.t() |
  nil`), sent via `put_non_nil` (omitted when nil, so EVM->EVM routes are
  unaffected -- Riddler defaults it to `wallet`). `validate/1` rejects only a
  present-but-empty value; it does **not** apply the EVM `0x`-hex check, since a
  cross-VM recipient is base58 (Tron/Solana) -- Riddler validates the format
  against `to_chain_id`, which owns the chain->VM mapping.
- **`ExecuteXochiIntent`**: new `recipient_address` input, threaded into the
  built `QuoteRequest`. Also added to the derived **idempotency key** -- a
  transfer to recipient A must never resume the checkpoint of a transfer to
  recipient B (otherwise B's funds would follow A's already-signed intent).

Stealth delivery is unchanged and separate (it uses the meta-address pubkeys, not
`recipient_address`); wiring stealth/different-recipient into the ACP offering is
the follow-up #368, which this unblocks.

## Tests (all new; the idempotency one is RED without the key change)

- Schema `to_json`: includes `recipient_address` when set, omits when nil.
- Schema `validate`: accepts a base58 (non-EVM) recipient (proves no EVM
  format-check on the client); rejects an empty string.
- Action: a public transfer sends `recipient_address` on the quote request.
- Action: two public transfers differing **only** by recipient are distinct
  payments (each signs; lifetime charged twice). Confirmed RED with
  `recipient_address` removed from the idempotency key -- the second payment
  resumed the first's checkpoint and never signed.

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` -> 1008 passed,
      0 failures (+6 new).
- [x] Idempotency test confirmed RED without the key change, GREEN with it.
- [x] `mix format --check-formatted` on the four changed files.
- [x] `mix compile` -> no new warnings.
- [ ] Live EVM->Tron quote+execute against Riddler -- needs a running Riddler +
      a Tron destination (a `:live_*` path); not run here.

Note: root CI does not build `raxol_payments`, so the package's own suite above
is the validation gate.

## Not in this PR

- **Tron->EVM deposit route (#400)** -- a different flow (no EIP-712 signing;
  deposit-attestation verify + poll); net-new, tracked separately.
- **ACP stealth / different-recipient offering wiring (#368)** -- consumes this
  primitive on the seller side; separate issue.
- Live E2E validation against Riddler (needs the running solver + a Tron rail).
