### PR TITLE
Surface stealth delivery fields in ACP Xochi relay

### DIFF
--- a/packages/raxol_acp/examples/buyer_signed_intent.exs
+++ b/packages/raxol_acp/examples/buyer_signed_intent.exs
@@ -24,8 +24,8 @@ defmodule BuyerWallet do
   use Raxol.Payments.Wallets.Env, env_var: "BUYER_PRIVATE_KEY"
 end
 
-# USDC, Base -> Arbitrum, 1.0 USDC. `wallet` is BOTH funder and recipient (Xochi
-# has no separate recipient field), so funds arrive at your own address on dst.
+# USDC, Base -> Arbitrum, 1.0 USDC. `recipient_address` is omitted, so Xochi
+# defaults the recipient to `wallet` -- funds arrive at your own address on dst.
 build_request = fn wallet_address ->
   %QuoteRequest{
     wallet: wallet_address,
@@ -39,25 +39,73 @@ build_request = fn wallet_address ->
   }
 end
 
+# Different recipient (public): funds settle to an address other than the funder.
+# The buyer signs `recipient_address` into the intent and raxol relays it
+# verbatim -- the storefront has no same-owner gate.
+build_diff_recipient_request = fn wallet_address ->
+  %QuoteRequest{
+    wallet: wallet_address,
+    from_chain_id: 8453,
+    to_chain_id: 42_161,
+    from_token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    to_token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    from_amount: "1000000",
+    settlement_preference: "public",
+    recipient_address: "0xRECIPIENT_ADDRESS",
+    slippage_bps: 50
+  }
+end
+
+# Stealth (ERC-5564): the buyer signs their compressed stealth spending/viewing
+# pubkeys and an ephemeral recipient into the intent, so funds land at a one-time
+# stealth address they alone control. `recipient_address` stays nil -- the
+# recipient is encoded in the stealth keys. Derive and encode the meta-address
+# with `Raxol.Payments.Xochi.Stealth`.
+build_stealth_request = fn wallet_address ->
+  %QuoteRequest{
+    wallet: wallet_address,
+    from_chain_id: 8453,
+    to_chain_id: 42_161,
+    from_token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    to_token: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    from_amount: "1000000",
+    settlement_preference: "stealth",
+    stealth_spending_pub_key: "0x02<compressed spending pubkey>",
+    stealth_viewing_pub_key: "0x03<compressed viewing pubkey>",
+    slippage_bps: 50
+  }
+end
+
 # Assemble the ACP job requirement from a bundle (atom-keyed) -- stringify the
 # bundle keys for JSON transport. This is what a buyer submits as the job
 # requirement to the "xochi_cross_chain_transfer" offering.
+#
+# `settlement_preference` and `destination` are optional audit hints the buyer /
+# evaluator reads; raxol relays the signed intent verbatim and does not gate on
+# them (the recipient and privacy tier are fixed by the signature inside
+# `signed_intent`).
 build_requirement = fn request, bundle ->
-  %{
+  base = %{
     "src_chain_id" => request.from_chain_id,
     "dst_chain_id" => request.to_chain_id,
     "src_token" => request.from_token,
     "dst_token" => request.to_token,
     "amount_atomic" => request.from_amount,
-    "signed_intent" => Map.new(bundle, fn {k, v} -> {to_string(k), v} end)
+    "signed_intent" => Map.new(bundle, fn {k, v} -> {to_string(k), v} end),
+    "settlement_preference" => request.settlement_preference
   }
+
+  case request.recipient_address do
+    nil -> base
+    addr -> Map.put(base, "destination", addr)
+  end
 end
 
 case System.get_env("BUYER_PRIVATE_KEY") do
   nil ->
     # No key -- show the shapes with a placeholder bundle (no network call).
-    request = build_request.("0xYOUR_WALLET")
-
+    # A shielded stealth claim additionally carries an `aztec_proof` in the
+    # bundle; raxol relays it verbatim through `execute_signed/2`.
     bundle = %{
       intent_id: "xi_<from Xochi>",
       quote_id: "xq_<from Xochi>",
@@ -69,8 +117,17 @@ case System.get_env("BUYER_PRIVATE_KEY") do
     IO.puts("(set BUYER_PRIVATE_KEY + XOCHI_MEMBER_TOKEN to sign for real)\n")
     IO.puts("signed_intent bundle (shape):")
     IO.inspect(bundle, pretty: true)
-    IO.puts("\nACP job requirement (hand this to the offering):")
-    IO.puts(Jason.encode!(build_requirement.(request, bundle), pretty: true))
+
+    # The same job requirement, three ways -- the recipient and privacy tier are
+    # whatever the buyer signs into the intent; the storefront relays it.
+    for {label, request} <- [
+          {"public (funder = recipient)", build_request.("0xYOUR_WALLET")},
+          {"different recipient", build_diff_recipient_request.("0xYOUR_WALLET")},
+          {"stealth (ERC-5564)", build_stealth_request.("0xYOUR_WALLET")}
+        ] do
+      IO.puts("\nACP job requirement -- #{label}:")
+      IO.puts(Jason.encode!(build_requirement.(request, bundle), pretty: true))
+    end
 
   _key ->
     request = build_request.(BuyerWallet.address())

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -24,6 +24,9 @@ defmodule Raxol.ACP.Xochi.Offering do
       job.submitted    -> storefront relayed the buyer's signed intent; solver
                           fills cross-chain; deliverable = { intent_id,
                           settlement_tx_hash, receiving_tx_hash, status }
+                          plus the ERC-5564 announcement ({ settlement_type,
+                          stealth_address, ephemeral_pub_key, view_tag }) for a
+                          stealth settlement
       job.completed    -> buyer verifies dst_tx; provider nets budget*0.90
 
   The deliverable surfaces both src and dst transaction hashes so the buyer (or
@@ -235,6 +238,36 @@ defmodule Raxol.ACP.Xochi.Offering do
           "type" => "string",
           "enum" => ["completed"],
           "description" => "Settlement lifecycle state; a delivered job is always completed."
+        },
+        "settlement_type" => %{
+          "type" => "string",
+          "enum" => ["public", "stealth", "shielded"],
+          "description" =>
+            "The privacy tier that settled, echoed from the poll status. Present " <>
+              "only when the buyer signed a non-public intent."
+        },
+        "stealth_address" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]{40}$",
+          "description" =>
+            "ERC-5564 stealth address the funds landed at (present only for a " <>
+              "stealth settlement). A public on-chain announcement field, not the " <>
+              "recipient's identity."
+        },
+        "ephemeral_pub_key" => %{
+          "type" => "string",
+          "pattern" => "^0x[0-9a-fA-F]+$",
+          "description" =>
+            "ERC-5564 ephemeral public key from the stealth announcement " <>
+              "(present only for a stealth settlement)."
+        },
+        "view_tag" => %{
+          "type" => "integer",
+          "minimum" => 0,
+          "maximum" => 255,
+          "description" =>
+            "ERC-5564 view tag byte from the stealth announcement " <>
+              "(present only for a stealth settlement)."
         }
       }
     }

--- a/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/settler.ex
@@ -54,7 +54,12 @@ defmodule Raxol.ACP.Xochi.Settler do
         settlement_tx_hash: "0x...",
         receiving_tx_hash:  "0x...",   # nil for an instant single-tx fill
         amount_atomic:      "1000000",
-        status:             "completed"
+        status:             "completed",
+        # Present only for a stealth settlement (nil otherwise):
+        settlement_type:    "stealth", # the privacy tier that settled
+        stealth_address:    "0x...",   # ERC-5564 announcement fields the buyer
+        ephemeral_pub_key:  "0x...",   # or evaluator verifies the delivery with
+        view_tag:           42
       }}
 
   On error: `{:error, reason}`. SolverAgent marks the session `:failed` and does
@@ -62,7 +67,7 @@ defmodule Raxol.ACP.Xochi.Settler do
   """
 
   alias Raxol.Payments.Protocols.Xochi
-  alias Raxol.Payments.Xochi.Schemas.IntentStatus
+  alias Raxol.Payments.Xochi.Schemas.{ExecuteResponse, IntentStatus}
 
   @doc """
   Build a settle_fn closure.
@@ -97,10 +102,10 @@ defmodule Raxol.ACP.Xochi.Settler do
   defp do_settle(args, xochi_config, poll_opts) do
     with {:ok, bundle} <- extract_signed_intent(args),
          {:ok, intent_id} <- bundle_intent_id(bundle),
-         {:ok, _exec} <- Xochi.execute_signed(xochi_config, bundle),
+         {:ok, %ExecuteResponse{} = exec} <- Xochi.execute_signed(xochi_config, bundle),
          {:ok, %IntentStatus{} = status} <-
            Xochi.poll_status(xochi_config, intent_id, poll_opts) do
-      settle_result(status, args)
+      settle_result(status, exec, args)
     end
   end
 
@@ -128,14 +133,14 @@ defmodule Raxol.ACP.Xochi.Settler do
   # :expired intent (which poll_status returns as `{:ok, status}`) must surface
   # as an error so SolverAgent does not submit a deliverable for a settlement
   # that never landed.
-  defp settle_result(%IntentStatus{status: :completed} = status, args),
-    do: to_deliverable(status, args)
+  defp settle_result(%IntentStatus{status: :completed} = status, exec, args),
+    do: to_deliverable(status, exec, args)
 
-  defp settle_result(%IntentStatus{status: s, intent_id: id, error: err}, _args)
+  defp settle_result(%IntentStatus{status: s, intent_id: id, error: err}, _exec, _args)
        when s in [:failed, :expired],
        do: {:error, {:settlement_failed, s, id, err}}
 
-  defp settle_result(%IntentStatus{status: s, intent_id: id}, _args),
+  defp settle_result(%IntentStatus{status: s, intent_id: id}, _exec, _args),
     do: {:error, {:settlement_incomplete, s, id}}
 
   # `IntentStatus.tx_hash` is the authoritative settlement tx: for an instant fill
@@ -145,16 +150,31 @@ defmodule Raxol.ACP.Xochi.Settler do
   # mislabels the single instant-fill tx as the source leg. `amount_atomic` is the
   # buyer's declared transfer amount, committed so the deliverable hash pins what
   # was moved rather than only the tx hashes.
-  defp to_deliverable(%IntentStatus{} = status, args) do
+  #
+  # For a stealth settlement the worker returns the ERC-5564 announcement
+  # (`stealth_address`/`ephemeral_pub_key`/`view_tag`) on the execute response and
+  # marks the settled intent `settlement_type: :stealth` on poll. These are the
+  # public on-chain announcement fields the buyer or evaluator needs to verify the
+  # delivery, not the recipient's identity; they are nil for a public settlement,
+  # so `TransferOffering.present/1` drops them and a public deliverable is
+  # byte-identical.
+  defp to_deliverable(%IntentStatus{} = status, %ExecuteResponse{} = exec, args) do
     {:ok,
      %{
        intent_id: status.intent_id,
        settlement_tx_hash: status.tx_hash,
        receiving_tx_hash: status.receiving_tx_hash,
        amount_atomic: transfer_amount(args),
-       status: to_string(status.status)
+       status: to_string(status.status),
+       settlement_type: settlement_type(status),
+       stealth_address: exec.stealth_address,
+       ephemeral_pub_key: exec.ephemeral_pub_key,
+       view_tag: exec.view_tag
      }}
   end
+
+  defp settlement_type(%IntentStatus{settlement_type: nil}), do: nil
+  defp settlement_type(%IntentStatus{settlement_type: t}), do: to_string(t)
 
   # The deliverable's amount: the SolverAgent-threaded transfer amount, else the
   # requirement's declared amount. It is display/audit metadata only -- the

--- a/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
@@ -133,9 +133,33 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
                  "settlement_tx_hash",
                  "receiving_tx_hash",
                  "amount_atomic",
-                 "status"
+                 "status",
+                 "settlement_type",
+                 "stealth_address",
+                 "ephemeral_pub_key",
+                 "view_tag"
                ])
              )
+    end
+
+    test "the ERC-5564 stealth fields are optional and typed (#368)" do
+      schema = Offering.deliverable_schema()
+      props = schema["properties"]
+      required = MapSet.new(schema["required"])
+
+      # A stealth settlement adds the announcement fields; a public one omits
+      # them, so none may be required (else a public deliverable fails to submit).
+      for key <- ["settlement_type", "stealth_address", "ephemeral_pub_key", "view_tag"] do
+        assert Map.has_key?(props, key)
+        refute MapSet.member?(required, key)
+      end
+
+      assert props["settlement_type"]["enum"] == ["public", "stealth", "shielded"]
+      assert props["stealth_address"]["pattern"] == "^0x[0-9a-fA-F]{40}$"
+      assert props["ephemeral_pub_key"]["type"] == "string"
+      assert props["view_tag"]["type"] == "integer"
+      assert props["view_tag"]["minimum"] == 0
+      assert props["view_tag"]["maximum"] == 255
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/settler_test.exs
@@ -157,5 +157,115 @@ defmodule Raxol.ACP.Xochi.SettlerTest do
 
       refute_received {:relayed, _}
     end
+
+    # A stealth settlement: the worker returns the ERC-5564 announcement
+    # (stealth_address / ephemeral_pub_key / view_tag) on execute and marks the
+    # settled intent settlement_type "stealth" on poll. The recipient and privacy
+    # tier live inside the buyer's opaque signature; the settler only relays.
+    defp stealth_sim(test_pid) do
+      fn conn ->
+        {:ok, raw, conn} = Plug.Conn.read_body(conn)
+
+        if conn.request_path == "/api/intent/execute" do
+          send(test_pid, {:relayed, Jason.decode!(raw)})
+        end
+
+        body =
+          case conn.request_path do
+            "/api/intent/execute" ->
+              %{
+                "success" => true,
+                "intentId" => "i1",
+                "status" => "executing",
+                "stealth_address" => "0x" <> String.duplicate("5c", 20),
+                "ephemeral_pub_key" => "0x02" <> String.duplicate("ab", 32),
+                "view_tag" => 42
+              }
+
+            "/api/intent/i1/status" ->
+              %{
+                "intentId" => "i1",
+                "status" => "completed",
+                "terminal" => true,
+                "settlement_type" => "stealth",
+                "txHash" => "0x" <> String.duplicate("a", 64),
+                "receivingTxHash" => "0x" <> String.duplicate("b", 64)
+              }
+          end
+
+        Req.Test.json(conn, body)
+      end
+    end
+
+    defp stealth_settler_for(test_pid) do
+      Settler.build(
+        xochi_config: %{
+          base_url: "https://xochi.test",
+          auth_token: "stub",
+          req_options: [plug: stealth_sim(test_pid)]
+        },
+        poll_timeout_ms: 5_000,
+        poll_interval_ms: 10
+      )
+    end
+
+    test "a stealth settlement surfaces the ERC-5564 announcement fields (#368)" do
+      # The buyer signed a stealth intent (keys + ephemeral recipient inside the
+      # signature) and its bundle carries a shielded-claim aztec_proof. The
+      # settler relays the opaque bundle verbatim, and the deliverable surfaces
+      # the public ERC-5564 announcement the evaluator verifies on-chain.
+      bundle = signed_intent(%{"aztec_proof" => "0x" <> String.duplicate("de", 40)})
+
+      stealth_args =
+        args(%{
+          requirement:
+            requirement(%{
+              "settlement_preference" => "stealth",
+              "destination" => "0x" <> String.duplicate("5c", 20),
+              "signed_intent" => bundle
+            }),
+          signed_intent: bundle
+        })
+
+      assert {:ok, deliverable} = stealth_settler_for(self()).(stealth_args)
+
+      assert deliverable.settlement_type == "stealth"
+      assert deliverable.stealth_address == "0x" <> String.duplicate("5c", 20)
+      assert deliverable.ephemeral_pub_key == "0x02" <> String.duplicate("ab", 32)
+      assert deliverable.view_tag == 42
+      assert deliverable.settlement_tx_hash == "0x" <> String.duplicate("a", 64)
+      assert deliverable.receiving_tx_hash == "0x" <> String.duplicate("b", 64)
+
+      # The buyer's opaque bundle -- signature and shielded-claim proof -- is
+      # relayed unchanged; raxol signs nothing and strips nothing.
+      assert_receive {:relayed, relayed}
+      assert relayed["signature"] == "0x" <> String.duplicate("11", 65)
+      assert relayed["aztec_proof"] == "0x" <> String.duplicate("de", 40)
+    end
+
+    test "a different-recipient intent is relayed and settled, not gated (#368)" do
+      # The recipient the buyer signed lives inside the opaque bundle; the
+      # requirement's `destination` is only an audit hint. The settle path must
+      # relay and settle it unchanged -- there is no same-owner or public-only
+      # gate on raxol's side.
+      diff_recipient_args =
+        args(%{
+          requirement:
+            requirement(%{
+              "settlement_preference" => "stealth",
+              "destination" => "0x" <> String.duplicate("fe", 20)
+            })
+        })
+
+      assert {:ok, deliverable} = settler_for("completed").(diff_recipient_args)
+      assert deliverable.intent_id == "i1"
+      assert deliverable.status == "completed"
+
+      # The buyer's bundle relays verbatim; the audit-hint destination never
+      # touches the relay POST.
+      assert_receive {:relayed, relayed}
+      assert relayed["signature"] == "0x" <> String.duplicate("11", 65)
+      refute Map.has_key?(relayed, "destination")
+    end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
@@ -167,6 +167,37 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
       refute Map.has_key?(deliverable, "receiving_tx_hash")
     end
 
+    test "a stealth deliverable surfaces the ERC-5564 announcement fields (#368)" do
+      Application.put_env(:raxol_acp, :xochi_transfer_settler,
+        settle_fn: fn %{requirement: _req} ->
+          {:ok,
+           %{
+             intent_id: "int_1",
+             settlement_tx_hash: "0xabc",
+             receiving_tx_hash: nil,
+             amount_atomic: "1100000",
+             status: "completed",
+             settlement_type: "stealth",
+             stealth_address: "0x" <> String.duplicate("5c", 20),
+             ephemeral_pub_key: "0x02" <> String.duplicate("ab", 32),
+             view_tag: 42
+           }}
+        end
+      )
+
+      r = req(%{"settlement_preference" => "stealth", "destination" => "0xrecipient"})
+      assert {:deliver, deliverable} = TransferOffering.handle_deliver(r, @ctx)
+
+      # present/1 stringifies keys and keeps the non-nil announcement fields
+      # (dropping only the nil receiving_tx_hash), so the evaluator can verify
+      # the stealth delivery on-chain.
+      assert deliverable["settlement_type"] == "stealth"
+      assert deliverable["stealth_address"] == "0x" <> String.duplicate("5c", 20)
+      assert deliverable["ephemeral_pub_key"] == "0x02" <> String.duplicate("ab", 32)
+      assert deliverable["view_tag"] == 42
+      refute Map.has_key?(deliverable, "receiving_tx_hash")
+    end
+
     test "propagates a settler error so the job expires instead of completing" do
       Application.put_env(:raxol_acp, :xochi_transfer_settler,
         settle_fn: fn _ -> {:error, {:settlement_failed, :expired, "int_x", nil}} end


### PR DESCRIPTION
## What

Closes #368. Surfaces the ERC-5564 stealth announcement in the
`xochi_cross_chain_transfer` ACP deliverable, and adds settle-path test coverage for
stealth and different-recipient relays.

## Why #368's premise was stale

#368 tracked a same-owner `Settler` that BUILDS a Xochi `QuoteRequest` and FAILS CLOSED
on a different recipient / non-public preference (`different_recipient_not_enabled`,
`ensure_same_owner`, `ensure_public`, `stealth_not_enabled`). **That model no longer
exists.** The `Settler` is now a pure relay: the buyer quotes + signs their own Xochi
intent (recipient + privacy baked into the signature), raxol relays the opaque
`signed_intent` bundle via `Payments.Protocols.Xochi.execute_signed/2` and polls to
settlement -- it never builds a `QuoteRequest`, never signs, never holds funds. Grepping
`packages/raxol_acp/lib/` for all four gate names returns nothing. The offering already
advertises `destination` + `settlement_preference: ["public","private","stealth"]` as
buyer-signed audit hints, and `handle_request` already accepts (does not gate) a stealth
/ different-recipient requirement.

So the relay already delivers the #368 capability -- with two real gaps, both fixed here.

## Changes

1. **`settler.ex`** -- the settler discarded the execute response (`{:ok, _exec}`), which
   is where the Xochi worker returns the ERC-5564 announcement (`stealth_address` /
   `ephemeral_pub_key` / `view_tag`) for a stealth settlement. Capture it and thread it
   (plus the poll's `settlement_type`) into the deliverable. All four fields are `nil`
   for a public settlement, so `TransferOffering.present/1` drops them and a public
   deliverable is byte-identical. These are the public on-chain announcement fields the
   buyer / evaluator needs to verify the delivery, not the recipient's identity.
2. **`offering.ex`** -- add the four fields as **optional** properties to
   `deliverable_schema/0` (`additionalProperties: false` stays; none are `required`), so
   a stealth deliverable validates. Lifecycle doc note updated.
3. **`examples/buyer_signed_intent.exs`** -- add stealth (ERC-5564 keys) and
   different-recipient (`recipient_address`) buyer variants alongside the public
   same-owner one, and carry the `destination` / `settlement_preference` audit hints in
   the requirement. Runs network-free.

## Tests (RED-proven)

- `settler_test.exs` (+2): a stealth settlement surfaces the announcement fields
  (RED = `KeyError` on the unmodified settler); a different-recipient intent is relayed
  and settled, not gated (RED-proven by temporarily re-introducing a `destination` gate,
  both #368 tests failing, then restored).
- `offering_test.exs` (update 1, +1): the delivered-fields set now includes the four
  fields (the exact-set assertion was the built-in RED); a new test asserts the fields
  are optional and typed.
- `transfer_offering_test.exs` (+1): a stealth `settle_fn` result surfaces the
  announcement through `handle_deliver` / `present/1`.

## Manual testing

- [x] `cd packages/raxol_acp && MIX_ENV=test mix test` -> 531 passed, 0 failures.
- [x] Scoped `mix format` + `--check-formatted` on all changed files -> clean.
- [x] `MIX_ENV=test mix compile --force` -> 0 warnings from the changed files (8
      pre-existing warnings unchanged with/without this diff).
- [x] `mix run examples/buyer_signed_intent.exs` -> prints the public, different-recipient,
      and stealth requirement shapes with no network call.

## Not in this PR

- No same-owner / storefront-signs-from-own-wallet `Settler` (would break the fund-safety
  arc -- raxol never holds funds; the relay is deliberate).
- No change to `Raxol.Payments` `ExecuteXochiIntent` / #416's `recipient_address`, which
  is raxol_payments' own agent-pays surface, not this storefront relay.
- No JSON-Schema runtime validator; offering tests assert schema structure directly (the
  package wires no validator).

## CI note

Root CI does not build `raxol_acp` -- the package suite
(`cd packages/raxol_acp && MIX_ENV=test mix test`) is the gate, and it is green.
