### PR TITLE
Fix web release: ssh/public_key to :permanent

### DIFF
--- a/web/mix.exs
+++ b/web/mix.exs
@@ -50,8 +50,8 @@ defmodule RaxolPlayground.MixProject do
         steps: [:assemble],
         applications: [
           raxol_playground: :permanent,
-          ssh: :load,
-          public_key: :load,
+          ssh: :permanent,
+          public_key: :permanent,
           crypto: :permanent
         ]
       ]


### PR DESCRIPTION
## Problem

`flyctl deploy` fails at `mix release` (Elixir 1.17.1 in `docker/Dockerfile.web`):

> (Mix) Application :raxol_playground has mode :permanent but it depends on :ssh which is set to :load ... otherwise your release will fail to boot

A `:permanent` app cannot depend on a `:load` app under Elixir 1.17+.

## Root cause (pre-existing, not a recent change)

The `ssh: :load` / `public_key: :load` overrides were added in a3baec8e (2026-04-22). The running prod image (v44, 2026-04-01) predates that commit and used the default `:permanent` modes, so this config **never deployed successfully**. Any master deploy since April 22 fails here.

`raxol_playground` lists `:ssh`/`:public_key` in `extra_applications`, so it depends on them; forcing `:load` is invalid. `:ssh` started at boot is just the OTP ssh library, the daemon is gated separately by `RAXOL_SSH_PLAYGROUND`.

## Fix

Set `ssh` and `public_key` to `:permanent` in the release block, restoring the boot behavior of the last successfully-deployed image (v44).

## Manual testing

- [x] `MIX_ENV=prod mix release --overwrite` assembles cleanly (`Release created at _build/prod/rel/raxol_playground`) — the exact step that failed in the Docker build
- [ ] `flyctl deploy` after merge