### PR TITLE
Verify Xochi Tron deposit-route quotes before funding

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments.ex
@@ -32,6 +32,7 @@ defmodule Raxol.Payments.Actions.Payments do
     Raxol.Payments.Actions.Payments.RevokeMandate,
     Raxol.Payments.Actions.Payments.ExecuteXochiIntent,
     Raxol.Payments.Actions.Payments.PollXochiStatus,
+    Raxol.Payments.Actions.Payments.ExecuteDepositRoute,
     Raxol.Payments.Actions.Payments.ExecuteRelayTransfer,
     Raxol.Payments.Actions.Payments.PollRelayStatus
   ]

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_deposit_route.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_deposit_route.ex
@@ -1,0 +1,134 @@
+defmodule Raxol.Payments.Actions.Payments.ExecuteDepositRoute do
+  @moduledoc """
+  Fetch and verify a Tron-origin cross-chain deposit-route quote.
+
+  A non-EVM (Tron) origin has no gasless pull, so the quote returns a bare
+  `deposit_address` the payer funds directly. This action fetches the quote and
+  verifies its `deposit_attestation` recovers to the pinned signer BEFORE
+  returning the deposit instructions, failing closed otherwise -- so the agent
+  never sends TRC-20 funds to an address a compromised quote endpoint could have
+  swapped.
+
+  raxol does not send the funds (it has no Tron transaction stack): the agent's
+  own Tron wallet funds `deposit_address` before `deposit_deadline`, then polls
+  settlement with `payment_poll_xochi_status` (`pending -> completed | refunded`,
+  with the refund reason surfaced on rejection).
+
+  ## Context
+
+    * `:xochi_config` -- `%{base_url:, auth}` for the quote endpoint.
+    * `:deposit_attestation_signer` -- optional operator pin for the expected
+      signer; otherwise `config :raxol_payments, :xochi_deposit_attestation_signer`,
+      otherwise the live capability matrix's `deposit_attestation_signer`.
+
+  Errors are machine-readable: `:attestation_mismatch`, `:missing_attestation`,
+  `:deposit_signer_unavailable`, `:not_a_deposit_route`, `{:not_solvable, reason}`,
+  or a request-validation tuple (e.g. `{:invalid_wallet, _}`).
+  """
+
+  use Raxol.Agent.Action,
+    name: "payment_execute_deposit_route",
+    sensitive: true,
+    description:
+      "Fetch and verify a Tron-origin cross-chain deposit-route quote. Returns the verified deposit_address (+ deadline) for your own Tron wallet to fund; raxol does not send the funds. Poll settlement with payment_poll_xochi_status.",
+    schema: [
+      input: [
+        wallet: [type: :string, required: true, description: "Your Tron (base58) sending wallet"],
+        from_chain_id: [
+          type: :integer,
+          required: true,
+          description: "Origin chain id (Tron: 728126428)"
+        ],
+        to_chain_id: [type: :integer, required: true, description: "Destination (EVM) chain id"],
+        from_token: [
+          type: :string,
+          required: true,
+          description: "Origin TRC-20 token (Tron base58)"
+        ],
+        to_token: [
+          type: :string,
+          required: true,
+          description: "Destination token contract (0x...)"
+        ],
+        amount_atomic: [
+          type: :string,
+          required: true,
+          description: "Amount to send, in origin-token base units (an integer string)"
+        ],
+        recipient_address: [
+          type: :string,
+          required: true,
+          description: "EVM destination recipient (0x...); the Tron wallet cannot receive on EVM"
+        ],
+        slippage_bps: [type: :integer, default: 50, description: "Max slippage (default 50)"],
+        trust_score: [type: :integer, description: "Trust score for tier/fee"]
+      ],
+      output: [
+        intent_id: [type: :string],
+        deposit_address: [
+          type: :string,
+          description: "Send the TRC-20 deposit here -- verified against the pinned signer"
+        ],
+        deposit_deadline: [
+          type: :integer,
+          description: "Unix seconds until which a landed deposit is still filled"
+        ],
+        from_amount: [type: :string],
+        to_amount: [type: :string],
+        recipient_address: [type: :string]
+      ]
+    ]
+
+  alias Raxol.Payments.Protocols.Xochi
+  alias Raxol.Payments.Xochi.Schemas.DepositRouteRequest
+
+  @spec run(map(), map()) :: {:ok, map()} | {:error, term()}
+  @impl true
+  def run(params, context) do
+    with {:ok, config} <- fetch_config(context),
+         {:ok, instructions} <-
+           Xochi.deposit_route_quote(config, build_request(params), signer_opts(context)) do
+      {:ok, summary(instructions)}
+    end
+  end
+
+  defp fetch_config(context) do
+    case Map.fetch(context, :xochi_config) do
+      {:ok, config} -> {:ok, config}
+      :error -> {:error, {:missing_context, :xochi_config}}
+    end
+  end
+
+  # An operator's out-of-band signer pin (and, for tests, a pre-fetched
+  # capability matrix) pass straight through to the protocol's signer resolution.
+  defp signer_opts(context) do
+    context
+    |> Map.take([:deposit_attestation_signer, :capabilities])
+    |> Map.to_list()
+  end
+
+  defp build_request(params) do
+    %DepositRouteRequest{
+      wallet: Map.fetch!(params, :wallet),
+      from_chain_id: Map.fetch!(params, :from_chain_id),
+      to_chain_id: Map.fetch!(params, :to_chain_id),
+      from_token: Map.fetch!(params, :from_token),
+      to_token: Map.fetch!(params, :to_token),
+      from_amount: Map.fetch!(params, :amount_atomic),
+      recipient_address: Map.fetch!(params, :recipient_address),
+      slippage_bps: Map.get(params, :slippage_bps) || 50,
+      trust_score: Map.get(params, :trust_score)
+    }
+  end
+
+  defp summary(instructions) do
+    Map.take(instructions, [
+      :intent_id,
+      :deposit_address,
+      :deposit_deadline,
+      :from_amount,
+      :to_amount,
+      :recipient_address
+    ])
+  end
+end

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -53,8 +53,15 @@ defmodule Raxol.Payments.Protocols.Xochi do
   @behaviour Raxol.Payments.Protocol
 
   alias Raxol.Payments.Poll
-  alias Raxol.Payments.Xochi.Client
-  alias Raxol.Payments.Xochi.Schemas.{ExecuteRequest, IntentStatus, QuoteRequest, QuoteResponse}
+  alias Raxol.Payments.Xochi.{Capabilities, Client, DepositAttestation}
+
+  alias Raxol.Payments.Xochi.Schemas.{
+    DepositRouteRequest,
+    ExecuteRequest,
+    IntentStatus,
+    QuoteRequest,
+    QuoteResponse
+  }
 
   # -- Protocol behaviour (stubs -- Xochi is not a 402 protocol) --
 
@@ -93,6 +100,126 @@ defmodule Raxol.Payments.Protocols.Xochi do
           {:ok, QuoteResponse.t()} | {:error, term()}
   def get_quote(config, %QuoteRequest{} = request) do
     Client.get_quote(config, request)
+  end
+
+  @doc """
+  Fetch a deposit-route quote and verify its `deposit_attestation` before
+  returning the deposit instructions -- the authenticated form of a Tron-origin
+  quote.
+
+  A non-EVM origin has no gasless pull, so the quote returns a bare
+  `deposit_address` the payer must fund directly. A MITM or compromised endpoint
+  could swap that address, so raxol verifies the attestation recovers to the
+  pinned signer BEFORE surfacing the address, failing closed when no signer is
+  pinned or the attestation does not verify. raxol never sends the funds; the
+  returned instructions are for the caller's own Tron wallet to fund, then poll
+  with `poll_status/3`.
+
+  Signer resolution, in precedence order: `opts[:deposit_attestation_signer]`
+  (an operator's out-of-band pin), else `config :raxol_payments,
+  :xochi_deposit_attestation_signer`, else the live capability matrix's
+  `deposit_attestation_signer`.
+
+  ## Options
+
+    * `:deposit_attestation_signer` -- pin the expected signer explicitly.
+    * `:capabilities` -- a pre-fetched `Capabilities.t()` (skips the network).
+  """
+  @spec deposit_route_quote(Client.config(), DepositRouteRequest.t(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def deposit_route_quote(config, %DepositRouteRequest{} = request, opts \\ []) do
+    with {:ok, quote} <- Client.get_deposit_route_quote(config, request),
+         :ok <- ensure_solvable(quote),
+         {:ok, instructions} <- verify_deposit_route(config, request, quote, opts) do
+      {:ok, instructions}
+    end
+  end
+
+  @doc """
+  Verify a deposit-route quote's attestation against the pinned signer and return
+  the deposit instructions, or a fail-closed error. See `deposit_route_quote/3`
+  for signer resolution.
+  """
+  @spec verify_deposit_route(
+          Client.config(),
+          DepositRouteRequest.t(),
+          QuoteResponse.t(),
+          keyword()
+        ) :: {:ok, map()} | {:error, term()}
+  def verify_deposit_route(
+        config,
+        %DepositRouteRequest{} = request,
+        %QuoteResponse{} = quote,
+        opts \\ []
+      ) do
+    with :ok <- ensure_deposit_route(quote),
+         {:ok, signer} <- resolve_deposit_signer(config, opts),
+         :ok <-
+           DepositAttestation.verify(
+             deposit_binding_fields(request, quote),
+             quote.deposit_attestation,
+             signer
+           ) do
+      {:ok, deposit_instructions(request, quote)}
+    end
+  end
+
+  defp ensure_solvable(%QuoteResponse{can_solve: true}), do: :ok
+  defp ensure_solvable(%QuoteResponse{error: reason}), do: {:error, {:not_solvable, reason}}
+
+  defp ensure_deposit_route(%QuoteResponse{} = quote) do
+    if QuoteResponse.deposit_route?(quote), do: :ok, else: {:error, :not_a_deposit_route}
+  end
+
+  # Pin the expected signer, failing closed when none is available -- a bare
+  # deposit address with nothing to authenticate it against must not be trusted.
+  defp resolve_deposit_signer(config, opts) do
+    signer =
+      opts[:deposit_attestation_signer] ||
+        Application.get_env(:raxol_payments, :xochi_deposit_attestation_signer) ||
+        Capabilities.deposit_attestation_signer(deposit_capabilities(config, opts))
+
+    case signer do
+      s when is_binary(s) and s != "" -> {:ok, s}
+      _ -> {:error, :deposit_signer_unavailable}
+    end
+  end
+
+  defp deposit_capabilities(config, opts) do
+    case Keyword.get(opts, :capabilities) do
+      %{} = caps -> caps
+      _ -> Capabilities.get(config)
+    end
+  end
+
+  # The attestation binds fields split across the request (origin) and the quote
+  # response (ids + deposit address); reassemble them for recovery.
+  defp deposit_binding_fields(%DepositRouteRequest{} = request, %QuoteResponse{} = quote) do
+    %{
+      intent_id: quote.intent_id,
+      quote_id: quote.quote_id,
+      from_chain_id: request.from_chain_id,
+      from_token: request.from_token,
+      from_amount: request.from_amount,
+      deposit_address: quote.deposit_address
+    }
+  end
+
+  defp deposit_instructions(%DepositRouteRequest{} = request, %QuoteResponse{} = quote) do
+    %{
+      intent_id: quote.intent_id,
+      quote_id: quote.quote_id,
+      deposit_address: quote.deposit_address,
+      deposit_deadline: quote.deposit_deadline,
+      from_chain_id: request.from_chain_id,
+      from_token: request.from_token,
+      from_amount: request.from_amount,
+      to_chain_id: request.to_chain_id,
+      to_token: request.to_token,
+      recipient_address: request.recipient_address,
+      to_amount: quote.to_amount,
+      expires_at: quote.expiry
+    }
   end
 
   @doc """

--- a/packages/raxol_payments/lib/raxol/payments/xochi/capabilities.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/capabilities.ex
@@ -58,7 +58,8 @@ defmodule Raxol.Payments.Xochi.Capabilities do
   @type t :: %{
           source: :live | :fallback,
           chains: [chain()],
-          tokens: [token()]
+          tokens: [token()],
+          deposit_attestation_signer: String.t() | nil
         }
 
   @table __MODULE__
@@ -121,7 +122,7 @@ defmodule Raxol.Payments.Xochi.Capabilities do
     end
   end
 
-  def parse(%{"chains" => chains, "tokens" => tokens})
+  def parse(%{"chains" => chains, "tokens" => tokens} = matrix)
       when is_list(chains) and is_list(tokens) do
     case Enum.flat_map(chains, &parse_chain/1) do
       [] ->
@@ -132,7 +133,8 @@ defmodule Raxol.Payments.Xochi.Capabilities do
          %{
            source: :live,
            chains: parsed_chains,
-           tokens: Enum.flat_map(tokens, &parse_token/1)
+           tokens: Enum.flat_map(tokens, &parse_token/1),
+           deposit_attestation_signer: parse_signer(matrix["deposit_attestation_signer"])
          }}
     end
   end
@@ -155,7 +157,10 @@ defmodule Raxol.Payments.Xochi.Capabilities do
       tokens:
         Enum.map(Assets.evm_tokens(), fn {symbol, by_chain} ->
           %{symbol: symbol, roles: [:origin, :destination], addresses: by_chain}
-        end)
+        end),
+      # No live matrix means no published signer; a deposit-route verify then
+      # fails closed (nothing to pin the attestation against).
+      deposit_attestation_signer: nil
     }
   end
 
@@ -218,6 +223,14 @@ defmodule Raxol.Payments.Xochi.Capabilities do
   @spec chain_ids(t()) :: [pos_integer()]
   def chain_ids(%{chains: chains}), do: Enum.map(chains, & &1.chain_id)
 
+  @doc """
+  The pinned deposit-route attestation signer (lowercased `0x`), or `nil` when
+  the matrix does not publish one (a deposit-route verify then fails closed).
+  """
+  @spec deposit_attestation_signer(t()) :: String.t() | nil
+  def deposit_attestation_signer(%{deposit_attestation_signer: signer}), do: signer
+  def deposit_attestation_signer(_), do: nil
+
   @doc "VM family for a chain id; `:evm` when the chain is unknown."
   @spec vm_type(t(), pos_integer() | String.t() | nil) :: vm_type()
   def vm_type(%{chains: chains}, chain_id) do
@@ -268,6 +281,16 @@ defmodule Raxol.Payments.Xochi.Capabilities do
   # ============================================================
   # Private
   # ============================================================
+
+  # The published attestation signer must be a well-formed EVM address; a
+  # malformed value is treated as absent (nil), so verify fails closed rather
+  # than pinning against garbage.
+  defp parse_signer(signer) when is_binary(signer) do
+    normalized = signer |> String.trim() |> String.downcase()
+    if Regex.match?(~r/^0x[0-9a-f]{40}$/, normalized), do: normalized, else: nil
+  end
+
+  defp parse_signer(_), do: nil
 
   defp parse_chain(%{"chain_id" => id} = chain) when is_integer(id) and id > 0 do
     [

--- a/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
@@ -50,6 +50,7 @@ defmodule Raxol.Payments.Xochi.Client do
   """
 
   alias Raxol.Payments.Xochi.Schemas.{
+    DepositRouteRequest,
     QuoteRequest,
     QuoteResponse,
     ExecuteRequest,
@@ -80,6 +81,24 @@ defmodule Raxol.Payments.Xochi.Client do
       config
       |> build_req()
       |> Req.post(url: "/api/intent/quote", json: QuoteRequest.to_json(request))
+      |> handle_response(&QuoteResponse.from_json/1)
+    end
+  end
+
+  @doc """
+  Request a deposit-route quote for a non-EVM (Tron) origin.
+
+  Same `/api/intent/quote` endpoint as `get_quote/2`, but the request allows a
+  base58 origin and the response carries a `deposit_address` + `deposit_attestation`
+  (verify it before sending funds) instead of EIP-712 typed data to sign.
+  """
+  @spec get_deposit_route_quote(config(), DepositRouteRequest.t()) ::
+          {:ok, QuoteResponse.t()} | error()
+  def get_deposit_route_quote(config, %DepositRouteRequest{} = request) do
+    with :ok <- DepositRouteRequest.validate(request) do
+      config
+      |> build_req()
+      |> Req.post(url: "/api/intent/quote", json: DepositRouteRequest.to_json(request))
       |> handle_response(&QuoteResponse.from_json/1)
     end
   end

--- a/packages/raxol_payments/lib/raxol/payments/xochi/deposit_attestation.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/deposit_attestation.ex
@@ -1,0 +1,147 @@
+defmodule Raxol.Payments.Xochi.DepositAttestation do
+  @moduledoc """
+  Client-side verification of a Xochi deposit-route quote's `deposit_attestation`.
+
+  A non-EVM origin (Tron/Solana) has no gasless pull, so a deposit-route quote
+  returns a bare `deposit_address` for the payer to send funds to directly. A
+  MITM or a compromised quote endpoint could swap that address and steal the
+  deposit, so Riddler signs the quote's binding fields with a dedicated,
+  solver-distinct key whose address is published in `GET /xochi/capabilities` as
+  `deposit_attestation_signer`. raxol pins that address and verifies the
+  attestation recovers to it BEFORE any funds move, failing closed otherwise.
+
+  Byte-exact parity with the Riddler signer
+  (`Riddler.Integrations.Xochi.DepositAttestation`): the signed message is seven
+  lines joined by a single `\\n` (no trailing newline), UTF-8:
+
+      xochi-deposit-attestation:v1
+      <intent_id>
+      <quote_id>
+      <from_chain_id>
+      <from_token>
+      <from_amount>
+      <deposit_address>
+
+  EVM (`0x`-hex) addresses are lowercased; base58 values (a Tron TRC-20 contract,
+  the Tron deposit address) are verbatim. `from_chain_id` and `from_amount` are
+  decimal; `from_amount` is in base units, matching the quote's `from_amount`.
+  The signature is `0x` + 65 bytes (`r || s || v`), `v` in {27, 28}, an EIP-191
+  `personal_sign`.
+  """
+
+  @message_prefix "xochi-deposit-attestation:v1"
+  @eip191_prefix "\x19Ethereum Signed Message:\n"
+
+  @type fields :: %{
+          intent_id: String.t(),
+          quote_id: String.t(),
+          from_chain_id: integer(),
+          from_token: String.t(),
+          from_amount: String.t() | integer(),
+          deposit_address: String.t()
+        }
+
+  @doc "The byte-exact attestation message for the given quote binding fields."
+  @spec message(fields()) :: String.t()
+  def message(%{
+        intent_id: intent_id,
+        quote_id: quote_id,
+        from_chain_id: from_chain_id,
+        from_token: from_token,
+        from_amount: from_amount,
+        deposit_address: deposit_address
+      }) do
+    Enum.join(
+      [
+        @message_prefix,
+        to_string(intent_id),
+        to_string(quote_id),
+        Integer.to_string(from_chain_id),
+        normalize_address(from_token),
+        to_string(from_amount),
+        normalize_address(deposit_address)
+      ],
+      "\n"
+    )
+  end
+
+  @doc """
+  Recover the signer address (lowercased `0x`) from an attestation over `fields`.
+  """
+  @spec recover(fields(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def recover(%{} = fields, "0x" <> hex), do: recover(fields, hex)
+
+  def recover(%{} = fields, hex) when is_binary(hex) and byte_size(hex) == 130 do
+    with {:ok, {r, s, recovery_id}} <- decode_signature(hex),
+         digest = eip191_digest(message(fields)),
+         {:ok, pubkey} <- ExSecp256k1.recover(digest, r, s, recovery_id) do
+      {:ok, address_from_pubkey(pubkey)}
+    else
+      _ -> {:error, :invalid_signature}
+    end
+  end
+
+  def recover(_fields, _sig), do: {:error, :invalid_signature}
+
+  @doc """
+  Verify `signature` over `fields` recovers to `expected_signer`, fail closed.
+
+    * `{:error, :missing_attestation}` -- the quote carried no signature.
+    * `{:error, :signer_unavailable}` -- no signer is pinned (nothing to verify
+      against; refuse rather than trust the bare deposit address).
+    * `{:error, :attestation_mismatch}` -- it recovers to a different address.
+    * `{:error, :invalid_signature}` -- it cannot be recovered.
+  """
+  @spec verify(fields(), String.t() | nil, String.t() | nil) :: :ok | {:error, atom()}
+  def verify(_fields, nil, _signer), do: {:error, :missing_attestation}
+  def verify(_fields, "", _signer), do: {:error, :missing_attestation}
+  def verify(_fields, _signature, nil), do: {:error, :signer_unavailable}
+  def verify(_fields, _signature, ""), do: {:error, :signer_unavailable}
+
+  def verify(%{} = fields, signature, expected_signer)
+      when is_binary(signature) and is_binary(expected_signer) do
+    case recover(fields, signature) do
+      {:ok, recovered} ->
+        if addr_eq?(recovered, expected_signer),
+          do: :ok,
+          else: {:error, :attestation_mismatch}
+
+      {:error, _} ->
+        {:error, :invalid_signature}
+    end
+  end
+
+  # -- Private --
+
+  # EVM addresses lowercased; base58 (Tron/Solana) values verbatim. Non-address
+  # strings (intent/quote ids) never reach here.
+  defp normalize_address("0x" <> _ = address), do: String.downcase(address)
+  defp normalize_address(other), do: other
+
+  defp eip191_digest(message) do
+    prefixed = @eip191_prefix <> Integer.to_string(byte_size(message)) <> message
+    ExKeccak.hash_256(prefixed)
+  end
+
+  defp decode_signature(hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, <<r::binary-size(32), s::binary-size(32), v::8>>} ->
+        {:ok, {r, s, normalize_recovery_id(v)}}
+
+      _ ->
+        {:error, :invalid_signature}
+    end
+  end
+
+  # EIP-191/personal_sign uses v in {27, 28}; ExSecp256k1 wants a 0/1 recovery id.
+  defp normalize_recovery_id(v) when v >= 27, do: v - 27
+  defp normalize_recovery_id(v), do: v
+
+  # address = last 20 bytes of keccak256(uncompressed pubkey without the 0x04 tag).
+  defp address_from_pubkey(<<_prefix::8, xy::binary-size(64)>>) do
+    <<_first12::binary-size(12), addr::binary-size(20)>> = ExKeccak.hash_256(xy)
+    "0x" <> Base.encode16(addr, case: :lower)
+  end
+
+  defp addr_eq?(a, b), do: String.downcase(a) == String.downcase(b)
+end

--- a/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/schemas.ex
@@ -192,6 +192,106 @@ defmodule Raxol.Payments.Xochi.Schemas do
     end
   end
 
+  defmodule DepositRouteRequest do
+    @moduledoc """
+    A cross-VM deposit-route quote request: a non-EVM origin (Tron) settling to
+    an EVM destination. The origin has no gasless pull, so the quote returns a
+    `deposit_address` (+ `deposit_attestation` to verify) instead of EIP-712
+    typed data to sign.
+
+    Serializes to the same `/api/intent/quote` wire keys as `QuoteRequest`, but
+    validates the origin fields as Tron base58 and the destination fields as EVM
+    `0x`-hex. Only a Tron origin is supported today; other non-EVM origins reject
+    at `validate/1`.
+    """
+
+    @tron_chain_id 728_126_428
+
+    @enforce_keys [:wallet, :from_chain_id, :to_chain_id, :from_token, :to_token, :from_amount]
+    defstruct [
+      :wallet,
+      :from_chain_id,
+      :to_chain_id,
+      :from_token,
+      :to_token,
+      :from_amount,
+      :recipient_address,
+      :trust_score,
+      settlement_preference: "public",
+      slippage_bps: 50
+    ]
+
+    @type t :: %__MODULE__{
+            wallet: String.t(),
+            from_chain_id: pos_integer(),
+            to_chain_id: pos_integer(),
+            from_token: String.t(),
+            to_token: String.t(),
+            from_amount: String.t(),
+            recipient_address: String.t() | nil,
+            trust_score: non_neg_integer() | nil,
+            settlement_preference: String.t(),
+            slippage_bps: non_neg_integer()
+          }
+
+    @spec validate(t()) :: :ok | {:error, term()}
+    def validate(%__MODULE__{} = req) do
+      alias Raxol.Payments.Tron
+      alias Raxol.Payments.Xochi.Schemas
+
+      cond do
+        req.from_chain_id != @tron_chain_id ->
+          {:error, {:unsupported_origin_vm, "deposit routes support a Tron origin only"}}
+
+        not Tron.Address.valid?(req.wallet) ->
+          {:error, {:invalid_wallet, "origin wallet must be a Tron base58 address"}}
+
+        not Tron.Address.valid?(req.from_token) ->
+          {:error, {:invalid_from_token, "origin token must be a Tron base58 address"}}
+
+        req.to_chain_id < 1 ->
+          {:error, {:invalid_chain_id, "to_chain_id must be positive"}}
+
+        Schemas.validate_eth_address(req.to_token) != :ok ->
+          {:error, {:invalid_to_token, "destination token must be 0x + 40 hex chars"}}
+
+        # A cross-VM route pays an EVM destination distinct from the Tron wallet,
+        # so a valid EVM recipient is required -- the wallet cannot receive on EVM.
+        Schemas.validate_eth_address(req.recipient_address) != :ok ->
+          {:error,
+           {:invalid_recipient_address, "destination recipient must be 0x + 40 hex chars"}}
+
+        not positive_int_string?(req.from_amount) ->
+          {:error, {:invalid_from_amount, "must be a positive base-unit integer string"}}
+
+        true ->
+          :ok
+      end
+    end
+
+    @spec to_json(t()) :: map()
+    def to_json(%__MODULE__{} = req) do
+      %{
+        "wallet" => req.wallet,
+        "from_chain_id" => req.from_chain_id,
+        "to_chain_id" => req.to_chain_id,
+        "from_token" => req.from_token,
+        "to_token" => req.to_token,
+        "from_amount" => req.from_amount,
+        "recipient_address" => req.recipient_address,
+        "settlement_preference" => req.settlement_preference,
+        "slippage_bps" => req.slippage_bps
+      }
+      |> Raxol.Payments.Xochi.Schemas.put_non_nil("trust_score", req.trust_score)
+    end
+
+    defp positive_int_string?(amount) when is_binary(amount) do
+      match?({n, ""} when n > 0, Integer.parse(amount))
+    end
+
+    defp positive_int_string?(_), do: false
+  end
+
   defmodule QuoteResponse do
     @moduledoc false
     @enforce_keys [:intent_id, :quote_id]
@@ -206,6 +306,9 @@ defmodule Raxol.Payments.Xochi.Schemas do
       :expiry,
       :eip712_data,
       :pull_authorization,
+      :deposit_address,
+      :deposit_attestation,
+      :deposit_deadline,
       :payment_method,
       :error,
       can_solve: false,
@@ -228,10 +331,22 @@ defmodule Raxol.Payments.Xochi.Schemas do
             gasless_fee: String.t() | nil,
             eip712_data: map() | nil,
             pull_authorization: map() | nil,
+            deposit_address: String.t() | nil,
+            deposit_attestation: String.t() | nil,
+            deposit_deadline: integer() | nil,
             payment_method: String.t() | nil,
             settlement_options: [map()],
             error: String.t() | nil
           }
+
+    @doc """
+    A deposit-route quote: a non-EVM (Tron/Solana) origin with no gasless pull,
+    so the quote carries a `deposit_address` the payer sends funds to (verify the
+    `deposit_attestation` first) instead of EIP-712 typed data to sign.
+    """
+    @spec deposit_route?(t()) :: boolean()
+    def deposit_route?(%__MODULE__{deposit_address: a}) when is_binary(a) and a != "", do: true
+    def deposit_route?(_), do: false
 
     # The Xochi worker response is snake_case with `eip712`; older/sim responses
     # are camelCase with `eip712Data`. Accept both so the client does not break
@@ -253,6 +368,9 @@ defmodule Raxol.Payments.Xochi.Schemas do
         gasless_fee: pick(json, ["gasless_fee", "gaslessFee"]),
         eip712_data: pick(json, ["eip712", "eip712Data"]),
         pull_authorization: pick(json, ["pull_authorization", "pullAuthorization"]),
+        deposit_address: pick(json, ["deposit_address", "depositAddress"]),
+        deposit_attestation: pick(json, ["deposit_attestation", "depositAttestation"]),
+        deposit_deadline: pick(json, ["deposit_deadline", "depositDeadline"]),
         payment_method: pick(json, ["payment_method", "paymentMethod"]),
         settlement_options: pick(json, ["settlement_options", "settlementOptions"]) || [],
         error: pick(json, ["error", "reason"])

--- a/packages/raxol_payments/test/property/signing_boundary_property_test.exs
+++ b/packages/raxol_payments/test/property/signing_boundary_property_test.exs
@@ -133,11 +133,19 @@ defmodule Raxol.Payments.SigningBoundaryPropertyTest do
       #   CreateMandate       -- signs a struct-derived Mandate digest (sign_hash),
       #                          not an arbitrary hash; gated at LLM tool dispatch
       #                          by `sensitive: true` (see ToolGateTest)
+      #   ExecuteDepositRoute -- verify-only; never signs. It fetches a Tron-origin
+      #                          quote and verifies the deposit_attestation, then
+      #                          returns the deposit instructions. raxol has no Tron
+      #                          tx stack and moves no funds; the agent funds the
+      #                          verified address externally. `sensitive: true`
+      #                          gates it at LLM dispatch since acting on its output
+      #                          moves real funds.
       known_sensitive =
         MapSet.new([
           Payments.Transfer,
           Payments.ExecuteXochiIntent,
           Payments.ExecuteRelayTransfer,
+          Payments.ExecuteDepositRoute,
           Payments.CreateMandate
         ])
 

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/execute_deposit_route_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/execute_deposit_route_test.exs
@@ -1,0 +1,132 @@
+defmodule Raxol.Payments.Actions.Payments.ExecuteDepositRouteTest do
+  # #400: the deposit-route action fetches a Tron-origin quote and verifies its
+  # deposit_attestation before returning the deposit instructions. raxol never
+  # sends the funds; the agent's own Tron wallet funds the verified address.
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.Actions.Payments
+  alias Raxol.Payments.Actions.Payments.ExecuteDepositRoute
+  alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Xochi.Capabilities
+  alias Raxol.Payments.Xochi.DepositAttestation
+
+  @tron_usdt "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+  @tron_wallet "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7"
+  @deposit_addr "TWd4WrZ9wn84f5x1hZhL4DHvk738ns5jwb"
+  @evm_recipient "0x" <> String.duplicate("ab", 20)
+
+  @intent_id "xi_dep_1"
+  @quote_id "xq_dep_1"
+  @amount "1000000"
+  @priv <<9::256>>
+
+  defp params(overrides \\ %{}) do
+    Map.merge(
+      %{
+        wallet: @tron_wallet,
+        from_chain_id: 728_126_428,
+        to_chain_id: 8453,
+        from_token: @tron_usdt,
+        to_token: @evm_recipient,
+        amount_atomic: @amount,
+        recipient_address: @evm_recipient,
+        slippage_bps: 50
+      },
+      overrides
+    )
+  end
+
+  defp signer_address do
+    {:ok, <<_prefix::8, xy::binary-size(64)>>} = ExSecp256k1.create_public_key(@priv)
+    <<_first12::binary-size(12), addr::binary-size(20)>> = ExKeccak.hash_256(xy)
+    "0x" <> Base.encode16(addr, case: :lower)
+  end
+
+  defp attestation do
+    msg =
+      DepositAttestation.message(%{
+        intent_id: @intent_id,
+        quote_id: @quote_id,
+        from_chain_id: 728_126_428,
+        from_token: @tron_usdt,
+        from_amount: @amount,
+        deposit_address: @deposit_addr
+      })
+
+    digest =
+      ("\x19Ethereum Signed Message:\n" <> Integer.to_string(byte_size(msg)) <> msg)
+      |> ExKeccak.hash_256()
+
+    {:ok, sig} = ExSecp256k1.sign(digest, @priv)
+    "0x" <> Base.encode16(EIP712.pack_signature(sig), case: :lower)
+  end
+
+  defp config do
+    body = %{
+      "intent_id" => @intent_id,
+      "quote_id" => @quote_id,
+      "can_solve" => true,
+      "to_amount" => "995000",
+      "deposit_address" => @deposit_addr,
+      "deposit_attestation" => attestation(),
+      "deposit_deadline" => 1_900_000_000
+    }
+
+    plug = fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(body))
+    end
+
+    %{base_url: "https://xochi.test", req_options: [plug: plug]}
+  end
+
+  describe "run/2" do
+    test "verifies the attestation and returns the deposit instructions" do
+      ctx = %{xochi_config: config(), deposit_attestation_signer: signer_address()}
+
+      assert {:ok, result} = ExecuteDepositRoute.run(params(), ctx)
+      assert result.intent_id == @intent_id
+      assert result.deposit_address == @deposit_addr
+      assert result.deposit_deadline == 1_900_000_000
+      assert result.from_amount == @amount
+      assert result.recipient_address == @evm_recipient
+    end
+
+    test "fails closed when the attestation does not recover to the pinned signer" do
+      ctx = %{
+        xochi_config: config(),
+        deposit_attestation_signer: "0x000000000000000000000000000000000000dead"
+      }
+
+      assert {:error, :attestation_mismatch} = ExecuteDepositRoute.run(params(), ctx)
+    end
+
+    test "fails closed when no signer is pinned" do
+      ctx = %{xochi_config: config(), capabilities: Capabilities.fallback()}
+      assert {:error, :deposit_signer_unavailable} = ExecuteDepositRoute.run(params(), ctx)
+    end
+
+    test "rejects an EVM origin (deposit routes are non-EVM only)" do
+      ctx = %{xochi_config: config(), deposit_attestation_signer: signer_address()}
+
+      assert {:error, {:unsupported_origin_vm, _}} =
+               ExecuteDepositRoute.run(params(%{from_chain_id: 8453}), ctx)
+    end
+
+    test "errors when :xochi_config is absent from the context" do
+      assert {:error, {:missing_context, :xochi_config}} =
+               ExecuteDepositRoute.run(params(), %{})
+    end
+  end
+
+  describe "registration" do
+    test "is registered in the payment action set" do
+      assert ExecuteDepositRoute in Payments.actions()
+    end
+
+    test "exposes the payment_execute_deposit_route tool name" do
+      assert ExecuteDepositRoute.__action_meta__().name == "payment_execute_deposit_route"
+    end
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/protocols/xochi_deposit_route_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/xochi_deposit_route_test.exs
@@ -1,0 +1,174 @@
+defmodule Raxol.Payments.Protocols.XochiDepositRouteTest do
+  # #400: a Tron-origin deposit-route quote returns a bare deposit_address; raxol
+  # verifies the deposit_attestation against the pinned signer before surfacing
+  # it, and fails closed otherwise. raxol never sends the Tron funds.
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Xochi.Capabilities
+  alias Raxol.Payments.Xochi.DepositAttestation
+  alias Raxol.Payments.Xochi.Schemas.{DepositRouteRequest, QuoteResponse}
+  alias Raxol.Payments.Protocols.Xochi
+
+  @tron_usdt "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+  @tron_wallet "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7"
+  @deposit_addr "TWd4WrZ9wn84f5x1hZhL4DHvk738ns5jwb"
+  @evm_recipient "0x" <> String.duplicate("ab", 20)
+
+  @intent_id "xi_dep_1"
+  @quote_id "xq_dep_1"
+  @from_amount "1000000"
+
+  @priv <<7::256>>
+
+  defp request do
+    %DepositRouteRequest{
+      wallet: @tron_wallet,
+      from_chain_id: 728_126_428,
+      to_chain_id: 8453,
+      from_token: @tron_usdt,
+      to_token: @evm_recipient,
+      from_amount: @from_amount,
+      recipient_address: @evm_recipient
+    }
+  end
+
+  defp signer_address do
+    {:ok, <<_prefix::8, xy::binary-size(64)>>} = ExSecp256k1.create_public_key(@priv)
+    <<_first12::binary-size(12), addr::binary-size(20)>> = ExKeccak.hash_256(xy)
+    "0x" <> Base.encode16(addr, case: :lower)
+  end
+
+  # Sign the deposit attestation over the exact binding fields, as Riddler does.
+  defp attestation(deposit_address \\ @deposit_addr) do
+    msg =
+      DepositAttestation.message(%{
+        intent_id: @intent_id,
+        quote_id: @quote_id,
+        from_chain_id: 728_126_428,
+        from_token: @tron_usdt,
+        from_amount: @from_amount,
+        deposit_address: deposit_address
+      })
+
+    digest =
+      ("\x19Ethereum Signed Message:\n" <> Integer.to_string(byte_size(msg)) <> msg)
+      |> ExKeccak.hash_256()
+
+    {:ok, sig} = ExSecp256k1.sign(digest, @priv)
+    "0x" <> Base.encode16(EIP712.pack_signature(sig), case: :lower)
+  end
+
+  # Stub /api/intent/quote with a deposit-route quote body.
+  defp quote_plug(body) do
+    fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, Jason.encode!(body))
+    end
+  end
+
+  defp config(body) do
+    %{base_url: "https://xochi.test", req_options: [plug: quote_plug(body)]}
+  end
+
+  defp deposit_quote_body(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "intent_id" => @intent_id,
+        "quote_id" => @quote_id,
+        "can_solve" => true,
+        "to_amount" => "995000",
+        "deposit_address" => @deposit_addr,
+        "deposit_attestation" => attestation(),
+        "deposit_deadline" => 1_900_000_000
+      },
+      overrides
+    )
+  end
+
+  describe "deposit_route_quote/3" do
+    test "verifies the attestation and returns deposit instructions" do
+      opts = [deposit_attestation_signer: signer_address()]
+
+      assert {:ok, instructions} =
+               Xochi.deposit_route_quote(config(deposit_quote_body()), request(), opts)
+
+      assert instructions.intent_id == @intent_id
+      assert instructions.deposit_address == @deposit_addr
+      assert instructions.deposit_deadline == 1_900_000_000
+      assert instructions.from_chain_id == 728_126_428
+      assert instructions.from_token == @tron_usdt
+      assert instructions.from_amount == @from_amount
+      assert instructions.recipient_address == @evm_recipient
+      assert instructions.to_amount == "995000"
+    end
+
+    test "fails closed when the deposit_address was swapped (attestation over the real one)" do
+      # The endpoint serves a different deposit address than the one the signer
+      # attested -- the attestation no longer recovers to the pinned signer.
+      body = deposit_quote_body(%{"deposit_address" => "TXswapped000000000000000000000000000"})
+      opts = [deposit_attestation_signer: signer_address()]
+
+      assert {:error, :attestation_mismatch} =
+               Xochi.deposit_route_quote(config(body), request(), opts)
+    end
+
+    test "fails closed when the attestation is from a different signer" do
+      other = "0x000000000000000000000000000000000000dead"
+
+      assert {:error, :attestation_mismatch} =
+               Xochi.deposit_route_quote(config(deposit_quote_body()), request(),
+                 deposit_attestation_signer: other
+               )
+    end
+
+    test "fails closed when no signer is pinned (capabilities publishes none)" do
+      assert {:error, :deposit_signer_unavailable} =
+               Xochi.deposit_route_quote(config(deposit_quote_body()), request(),
+                 capabilities: Capabilities.fallback()
+               )
+    end
+
+    test "fails closed when the quote carries no attestation" do
+      body = deposit_quote_body(%{"deposit_attestation" => nil})
+
+      assert {:error, :missing_attestation} =
+               Xochi.deposit_route_quote(config(body), request(),
+                 deposit_attestation_signer: signer_address()
+               )
+    end
+
+    test "rejects a non-deposit-route quote (an EVM pull quote has no deposit_address)" do
+      body =
+        deposit_quote_body(%{"deposit_address" => nil, "eip712" => %{"domain" => %{}}})
+
+      assert {:error, :not_a_deposit_route} =
+               Xochi.deposit_route_quote(config(body), request(),
+                 deposit_attestation_signer: signer_address()
+               )
+    end
+
+    test "surfaces an unsolvable quote as an error" do
+      body = deposit_quote_body(%{"can_solve" => false, "reason" => "no liquidity"})
+
+      assert {:error, {:not_solvable, "no liquidity"}} =
+               Xochi.deposit_route_quote(config(body), request(),
+                 deposit_attestation_signer: signer_address()
+               )
+    end
+  end
+
+  describe "verify_deposit_route/4 (pure verify over a fetched quote)" do
+    test "returns instructions for a valid attestation" do
+      quote = QuoteResponse.from_json(deposit_quote_body())
+
+      assert {:ok, instructions} =
+               Xochi.verify_deposit_route(%{base_url: "https://xochi.test"}, request(), quote,
+                 deposit_attestation_signer: signer_address()
+               )
+
+      assert instructions.deposit_address == @deposit_addr
+    end
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/xochi/capabilities_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/capabilities_test.exs
@@ -121,6 +121,52 @@ defmodule Raxol.Payments.Xochi.CapabilitiesTest do
         assert Assets.known?(chain, address)
       end
     end
+
+    test "publishes no deposit attestation signer (fails a deposit-route verify closed)" do
+      assert Capabilities.deposit_attestation_signer(Capabilities.fallback()) == nil
+    end
+  end
+
+  describe "deposit_attestation_signer/1 (#400)" do
+    @signer "0x000000000000000000000000000000000000dead"
+
+    test "parses the published signer (bare and worker-wrapped)" do
+      wire = Map.put(@wire_evm, "deposit_attestation_signer", @signer)
+
+      assert {:ok, caps} = Capabilities.parse(wire)
+      assert Capabilities.deposit_attestation_signer(caps) == @signer
+
+      assert {:ok, wrapped} = Capabilities.parse(%{"source" => "live", "capabilities" => wire})
+      assert Capabilities.deposit_attestation_signer(wrapped) == @signer
+    end
+
+    test "normalizes the signer to lowercase 0x" do
+      wire =
+        Map.put(
+          @wire_evm,
+          "deposit_attestation_signer",
+          "  0x000000000000000000000000000000000000DEAD  "
+        )
+
+      assert {:ok, caps} = Capabilities.parse(wire)
+      assert Capabilities.deposit_attestation_signer(caps) == @signer
+    end
+
+    test "is nil when the matrix omits it" do
+      assert {:ok, caps} = Capabilities.parse(@wire_evm)
+      assert Capabilities.deposit_attestation_signer(caps) == nil
+    end
+
+    test "treats a malformed signer as absent (verify then fails closed)" do
+      wire = Map.put(@wire_evm, "deposit_attestation_signer", "not-an-address")
+      assert {:ok, caps} = Capabilities.parse(wire)
+      assert Capabilities.deposit_attestation_signer(caps) == nil
+    end
+
+    test "accessor returns nil for a caps map predating the field" do
+      assert Capabilities.deposit_attestation_signer(%{source: :fallback, chains: [], tokens: []}) ==
+               nil
+    end
   end
 
   describe "fillable?/4" do

--- a/packages/raxol_payments/test/raxol/payments/xochi/deposit_attestation_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/deposit_attestation_test.exs
@@ -1,0 +1,124 @@
+defmodule Raxol.Payments.Xochi.DepositAttestationTest do
+  # #400: a deposit-route quote returns a bare deposit_address; the client must
+  # verify the deposit_attestation recovers to the pinned signer before sending
+  # funds. The signed message must be byte-exact with the Riddler signer.
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Xochi.DepositAttestation
+
+  @fields %{
+    intent_id: "xi_abc123",
+    quote_id: "xq_def456",
+    from_chain_id: 728_126_428,
+    from_token: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+    from_amount: "1000000",
+    deposit_address: "TJYeasTPa6gpEEfYGfp5LQjWXmdZQBpLzX"
+  }
+
+  # A deterministic secp256k1 key: the "signer". Real crypto, no mocks -- the
+  # signature is produced with ExSecp256k1 exactly as a wallet would.
+  @priv <<1::256>>
+
+  defp signer_address do
+    {:ok, <<_prefix::8, xy::binary-size(64)>>} = ExSecp256k1.create_public_key(@priv)
+    <<_first12::binary-size(12), addr::binary-size(20)>> = ExKeccak.hash_256(xy)
+    "0x" <> Base.encode16(addr, case: :lower)
+  end
+
+  defp sign(fields) do
+    digest =
+      ("\x19Ethereum Signed Message:\n" <>
+         Integer.to_string(byte_size(DepositAttestation.message(fields))) <>
+         DepositAttestation.message(fields))
+      |> ExKeccak.hash_256()
+
+    {:ok, sig} = ExSecp256k1.sign(digest, @priv)
+    "0x" <> Base.encode16(EIP712.pack_signature(sig), case: :lower)
+  end
+
+  describe "message/1 (byte-exact Riddler parity)" do
+    test "matches the v1 spec byte-for-byte" do
+      assert DepositAttestation.message(@fields) ==
+               "xochi-deposit-attestation:v1\n" <>
+                 "xi_abc123\n" <>
+                 "xq_def456\n" <>
+                 "728126428\n" <>
+                 "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t\n" <>
+                 "1000000\n" <>
+                 "TJYeasTPa6gpEEfYGfp5LQjWXmdZQBpLzX"
+    end
+
+    test "lowercases an EVM (0x-hex) address; leaves base58 verbatim" do
+      msg =
+        DepositAttestation.message(%{
+          @fields
+          | from_token: "0xAbCdEf0000000000000000000000000000000001"
+        })
+
+      assert msg =~ "0xabcdef0000000000000000000000000000000001"
+      assert msg =~ "TJYeasTPa6gpEEfYGfp5LQjWXmdZQBpLzX"
+    end
+
+    test "accepts an integer from_amount" do
+      assert DepositAttestation.message(%{@fields | from_amount: 1_000_000}) ==
+               DepositAttestation.message(@fields)
+    end
+  end
+
+  describe "recover/2 and verify/3" do
+    test "an attestation recovers to the signing address" do
+      assert {:ok, recovered} = DepositAttestation.recover(@fields, sign(@fields))
+      assert recovered == signer_address()
+    end
+
+    test "verify/3 accepts a signature that recovers to the pinned signer" do
+      assert :ok = DepositAttestation.verify(@fields, sign(@fields), signer_address())
+    end
+
+    test "verify/3 is case-insensitive on the pinned signer" do
+      assert :ok =
+               DepositAttestation.verify(@fields, sign(@fields), String.upcase(signer_address()))
+    end
+
+    test "a tampered deposit_address no longer recovers to the signer (MITM swap)" do
+      sig = sign(@fields)
+      tampered = %{@fields | deposit_address: "TTamperedAddr00000000000000000000000"}
+
+      assert {:ok, recovered} = DepositAttestation.recover(tampered, sig)
+      refute recovered == signer_address()
+
+      assert {:error, :attestation_mismatch} =
+               DepositAttestation.verify(tampered, sig, signer_address())
+    end
+
+    test "verify/3 rejects an attestation from a different signer" do
+      other = "0x000000000000000000000000000000000000dead"
+
+      assert {:error, :attestation_mismatch} =
+               DepositAttestation.verify(@fields, sign(@fields), other)
+    end
+
+    test "verify/3 fails closed on a missing attestation" do
+      assert {:error, :missing_attestation} =
+               DepositAttestation.verify(@fields, nil, signer_address())
+
+      assert {:error, :missing_attestation} =
+               DepositAttestation.verify(@fields, "", signer_address())
+    end
+
+    test "verify/3 fails closed when no signer is pinned" do
+      assert {:error, :signer_unavailable} =
+               DepositAttestation.verify(@fields, sign(@fields), nil)
+
+      assert {:error, :signer_unavailable} = DepositAttestation.verify(@fields, sign(@fields), "")
+    end
+
+    test "verify/3 rejects a malformed signature" do
+      assert {:error, :invalid_signature} =
+               DepositAttestation.verify(@fields, "0xdeadbeef", signer_address())
+
+      assert {:error, :invalid_signature} = DepositAttestation.recover(@fields, "not-a-sig")
+    end
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/schemas_test.exs
@@ -2,6 +2,7 @@ defmodule Raxol.Payments.Xochi.SchemasTest do
   use ExUnit.Case, async: true
 
   alias Raxol.Payments.Xochi.Schemas.{
+    DepositRouteRequest,
     QuoteRequest,
     QuoteResponse,
     ExecuteRequest,
@@ -394,6 +395,113 @@ defmodule Raxol.Payments.Xochi.SchemasTest do
       resp = QuoteResponse.from_json(json)
       assert resp.can_solve == false
       assert resp.error == "no liquidity"
+    end
+
+    test "parses deposit-route fields (snake_case and camelCase) (#400)" do
+      for {addr, att, deadline} <- [
+            {"deposit_address", "deposit_attestation", "deposit_deadline"},
+            {"depositAddress", "depositAttestation", "depositDeadline"}
+          ] do
+        json = %{
+          "intent_id" => "xi_1",
+          "quote_id" => "xq_1",
+          "can_solve" => true,
+          addr => "TJYeasTPa6gpEEfYGfp5LQjWXmdZQBpLzX",
+          att => "0x" <> String.duplicate("ab", 65),
+          deadline => 1_900_000_000
+        }
+
+        resp = QuoteResponse.from_json(json)
+        assert resp.deposit_address == "TJYeasTPa6gpEEfYGfp5LQjWXmdZQBpLzX"
+        assert resp.deposit_attestation == "0x" <> String.duplicate("ab", 65)
+        assert resp.deposit_deadline == 1_900_000_000
+        assert QuoteResponse.deposit_route?(resp)
+      end
+    end
+
+    test "deposit_route? is false for an EVM pull quote (no deposit_address)" do
+      resp = QuoteResponse.from_json(%{"intent_id" => "i", "quote_id" => "q", "eip712" => %{}})
+      assert resp.deposit_address == nil
+      refute QuoteResponse.deposit_route?(resp)
+    end
+  end
+
+  describe "DepositRouteRequest" do
+    @tron_usdt "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+    @tron_wallet "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7"
+    @evm_addr "0x" <> String.duplicate("ab", 20)
+
+    defp deposit_route(overrides \\ %{}) do
+      struct(
+        %DepositRouteRequest{
+          wallet: @tron_wallet,
+          from_chain_id: 728_126_428,
+          to_chain_id: 8453,
+          from_token: @tron_usdt,
+          to_token: @evm_addr,
+          from_amount: "1000000",
+          recipient_address: @evm_addr
+        },
+        overrides
+      )
+    end
+
+    test "a Tron origin -> EVM destination request validates" do
+      assert :ok = DepositRouteRequest.validate(deposit_route())
+    end
+
+    test "to_json serializes the /api/intent/quote wire keys" do
+      json = DepositRouteRequest.to_json(deposit_route(%{trust_score: 40}))
+      assert json["wallet"] == @tron_wallet
+      assert json["from_chain_id"] == 728_126_428
+      assert json["to_chain_id"] == 8453
+      assert json["from_token"] == @tron_usdt
+      assert json["to_token"] == @evm_addr
+      assert json["from_amount"] == "1000000"
+      assert json["recipient_address"] == @evm_addr
+      assert json["settlement_preference"] == "public"
+      assert json["trust_score"] == 40
+    end
+
+    test "omits trust_score when nil" do
+      json = DepositRouteRequest.to_json(deposit_route())
+      refute Map.has_key?(json, "trust_score")
+    end
+
+    test "rejects an EVM origin (that path signs an intent, it does not deposit)" do
+      assert {:error, {:unsupported_origin_vm, _}} =
+               DepositRouteRequest.validate(deposit_route(%{from_chain_id: 8453}))
+    end
+
+    test "rejects a non-base58 origin wallet" do
+      assert {:error, {:invalid_wallet, _}} =
+               DepositRouteRequest.validate(deposit_route(%{wallet: @evm_addr}))
+    end
+
+    test "rejects a non-base58 origin token" do
+      assert {:error, {:invalid_from_token, _}} =
+               DepositRouteRequest.validate(deposit_route(%{from_token: @evm_addr}))
+    end
+
+    test "rejects a non-EVM destination token" do
+      assert {:error, {:invalid_to_token, _}} =
+               DepositRouteRequest.validate(deposit_route(%{to_token: @tron_usdt}))
+    end
+
+    test "requires an EVM recipient (the Tron wallet cannot receive on EVM)" do
+      assert {:error, {:invalid_recipient_address, _}} =
+               DepositRouteRequest.validate(deposit_route(%{recipient_address: nil}))
+
+      assert {:error, {:invalid_recipient_address, _}} =
+               DepositRouteRequest.validate(deposit_route(%{recipient_address: @tron_wallet}))
+    end
+
+    test "rejects a non-positive base-unit amount" do
+      assert {:error, {:invalid_from_amount, _}} =
+               DepositRouteRequest.validate(deposit_route(%{from_amount: "0"}))
+
+      assert {:error, {:invalid_from_amount, _}} =
+               DepositRouteRequest.validate(deposit_route(%{from_amount: "1.5"}))
     end
   end
 


### PR DESCRIPTION
## What

Implements the verify + poll layer of #400: a Tron-origin (non-EVM) Xochi
deposit-route quote returns a bare `deposit_address`; raxol now verifies the
quote's `deposit_attestation` recovers to the pinned signer BEFORE surfacing the
address, failing closed otherwise -- so an agent never funds a deposit address a
MITM or compromised quote endpoint could have swapped.

## Scope decision (verify + poll, external deposit)

The origin-side TRC-20 send is deliberately **not** in this PR. raxol has zero
Tron-send capability (wallets are EVM-only; the Relay rail explicitly refuses a
Tron source leg at `execute_relay_transfer.ex`), so "raxol sends the TRC-20"
would mean building an entire Tron transaction stack (protobuf
`triggerSmartContract`, Tron signing, TronGrid broadcaster, Tron wallet) -- money
on a new VM, external-blocked. All three of #400's acceptance criteria live in
the verify + poll layer, which is what this PR delivers:

- [x] **Deposit-route quotes verified against the pinned attestation signer
  before any funds move.**
- [x] **Happy path: deposit -> status resolves `completed`** (poll via the
  existing `payment_poll_xochi_status`).
- [x] **Refund path: a rejected deposit resolves `refunded` with a
  machine-readable reason** (the existing poll already parses `:refunded` +
  `refund_reason`).

The agent funds the verified `deposit_address` from its own Tron wallet
(external, "path C") and polls with the existing status action.

## What's here

- `Raxol.Payments.Xochi.DepositAttestation` -- `message/1` / `recover/2` /
  `verify/3`, **byte-exact parity** with the Riddler signer
  (`Riddler.Integrations.Xochi.DepositAttestation`): the golden message vector
  and EIP-191 recovery are pinned in tests against Riddler's own fixture. Reuses
  the package's `ExKeccak`/`ExSecp256k1` primitives.
- `QuoteResponse` parses `deposit_address` / `deposit_attestation` /
  `deposit_deadline` (+ a `deposit_route?/1` predicate); `DepositRouteRequest`
  expresses a Tron-origin -> EVM-destination quote (per-VM address validation).
- `Capabilities` parses + exposes `deposit_attestation_signer` (the published
  pin), `nil` in fallback.
- `Protocols.Xochi.deposit_route_quote/3` -- fetch + verify + return deposit
  instructions. Signer resolution, in precedence: `opts` pin ->
  `config :raxol_payments, :xochi_deposit_attestation_signer` -> the live
  capability matrix. Fails closed when none is pinned or the attestation does not
  verify.
- `payment_execute_deposit_route` Agent Action (registered; `sensitive: true`,
  classified in the signing-boundary guard as verify-only/never-signs).

## Tests (RED-proven; no mocks -- real ExSecp256k1 signatures)

- `deposit_attestation_test` -- byte-exact message vs the Riddler golden literal
  (teeth-proven: a prefix drift fails it), recover/verify, MITM-swap rejection,
  fail-closed on missing signer/attestation/malformed sig.
- `schemas_test` -- deposit-field parsing (snake + camel), `DepositRouteRequest`
  validation (Tron-origin only, EVM recipient required) + `to_json`.
- `capabilities_test` -- signer parse/normalize/omit/malformed, fallback nil.
- `xochi_deposit_route_test` -- the gate end to end over a stubbed quote:
  verified pass, deposit-address swap, wrong signer, no signer, missing
  attestation, non-deposit-route quote, unsolvable quote.
- `execute_deposit_route_test` -- the action: verified pass + fail-closed +
  missing-config + registration.

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` -> 1051 passed, 0
      failures.
- [x] `cd packages/raxol_acp && MIX_ENV=test mix test` -> 527 passed (downstream
      package unaffected by the Capabilities/schema additions).
- [x] Scoped `mix format` + `--check-formatted` on all changed files -> clean.
- [x] `MIX_ENV=test mix compile --force` -> 0 warnings from the changed files.
- [x] Message construction verified byte-for-byte against Riddler's
      `deposit_attestation_test.exs` golden vector.

## Not in this PR

- The Tron origin **broadcaster** (Tron tx builder + signing + TronGrid + Tron
  wallet). It's a from-scratch Tron transaction stack, money on a new VM,
  external-blocked (needs live TronGrid + a real Tron key) -- a separate,
  larger build. Until then the agent funds the verified deposit address itself.
- No change to the EVM `QuoteRequest` sign/execute path.

## CI note

Root CI does not build `raxol_payments` -- the package suite
(`cd packages/raxol_payments && MIX_ENV=test mix test`) is the gate, and it is
green.
