### PR TITLE
Exclude nested build artifacts from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,13 @@
 .git/
 .gitignore
 
-# Build artifacts
+# Build artifacts. Recursive because web/ is a separate mix project: the
+# top-level _build/deps rules do not match web/_build or web/deps, so host
+# build artifacts (including a macOS-built NIF) leaked into the Linux image.
 _build/
 deps/
+**/_build/
+**/deps/
 .fetch
 
 # Test and development
@@ -31,16 +35,21 @@ docs/
 /tmp/
 erl_crash.dump
 
-# NIF build artifacts (must not leak host-platform binaries into Docker)
+# NIF build artifacts (must not leak host-platform binaries into Docker).
+# Recursive so nested build dirs are caught, e.g.
+# web/_build/prod/lib/raxol_terminal/priv/termbox2_nif.so.
 *.so
 *.o
+**/*.so
+**/*.o
 priv/termbox2_nif.so
 packages/raxol_terminal/lib/termbox2_nif/c_src/*.o
 packages/raxol_terminal/lib/termbox2_nif/c_src/*.so
 packages/raxol_terminal/lib/termbox2_nif/priv/*.so
 
-# Node modules (in case they exist at root)
+# Node modules (root or nested)
 node_modules/
+**/node_modules/
 
 # Docker files themselves
 Dockerfile*


### PR DESCRIPTION
## Problem

`flyctl deploy` produced an image that crash-loops on boot:

```
[termbox2_nif] NIF load failed: ... termbox2_nif.so: invalid ELF header
WARNING The app is not listening on 0.0.0.0:8080
```

A **macOS-built** `termbox2_nif.so` ended up in the **Linux** image. On boot the NIF fails to load, the runtime terminates during `ensure_all_started`, and the machine reboots in a loop (raxol.io went down).

## Root cause

`.dockerignore` patterns `_build/`, `deps/`, `*.so`, `*.o`, `node_modules/` only match at the **context root**. `web/` is a separate mix project, so `web/_build/`, `web/deps/`, and nested NIF binaries (`web/_build/prod/lib/raxol_terminal/priv/termbox2_nif.so`) were **not** excluded and leaked host artifacts into the build. The container reused the host `.so` instead of compiling a Linux one. (This also bloated the context to ~1.8GB.)

## Fix

Make the exclusions recursive with `**/`:
- `**/_build/`, `**/deps/`
- `**/*.so`, `**/*.o`
- `**/node_modules/`

`web/priv/static/` (fonts, favicons, llms.txt, skill.md) is intentionally left included; only the root `priv/static/` rule is unchanged.

## Verification

- Pattern check: `**/_build/` and `**/*.so` exclude `web/_build/prod/lib/raxol_terminal/priv/termbox2_nif.so`; the old `_build/`/`*.so` rules do not.
- True verification is a fresh `flyctl deploy`: the container now compiles the NIF for Linux and boots. (If it fails, the v44 image remains the fallback.)

## Manual testing

- [x] `.dockerignore` patterns confirmed to match the leaked path
- [ ] Fresh `flyctl deploy` boots (Phoenix listening on 0.0.0.0:8080, health check passing)