### PR TITLE
Verify ZKSAR attestations before they buy trust

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/privacy_tier.ex
+++ b/packages/raxol_payments/lib/raxol/payments/privacy_tier.ex
@@ -6,6 +6,16 @@ defmodule Raxol.Payments.PrivacyTier do
   unlock deeper privacy at lower fees. Users can always opt into less
   privacy than their score allows.
 
+  ## Attestations are pre-verified
+
+  The `:attestations` this module reads for tier-requirement gating must already
+  be **verified** -- the output of `Raxol.Payments.Zksar.verify/2` (which carries
+  `valid: true`). `Raxol.Payments.Router` is the verification choke point: it runs
+  `Zksar.verify_batch/2` against the operator-pinned issuer allowlist and passes
+  only the verified subset here. Do not call `from_trust_score/2` with raw,
+  caller-supplied attestations expecting them to be trusted; a self-asserted
+  `%{valid: true}` map is not a proof.
+
   ## Tiers
 
   | Score | Tier      | Fee (bps) | Settlement |
@@ -101,6 +111,10 @@ defmodule Raxol.Payments.PrivacyTier do
 
   # -- Private --
 
+  # Consumes PRE-VERIFIED attestations (Zksar.verify output; Router verifies
+  # before calling here). The `valid: true` filter is a guard, not the trust
+  # decision -- a raw caller-supplied `valid: true` is meaningless here because it
+  # never passed through the Router's `Zksar.verify_batch/2`. See the moduledoc.
   defp extract_attestation_types(opts) do
     case Keyword.get(opts, :attestations) do
       nil ->

--- a/packages/raxol_payments/lib/raxol/payments/router.ex
+++ b/packages/raxol_payments/lib/raxol/payments/router.ex
@@ -34,7 +34,24 @@ defmodule Raxol.Payments.Router do
   - `:privacy` -- `:public`, `:stealth`, `:shielded`, or `:auto` (default: `:auto`)
   - `:protocol` -- force a specific protocol (overrides routing)
   - `:trust_score` -- trust score for privacy tier resolution (used by `settlement_for/1`)
-  - `:attestations` -- list of verified ZKSAR proofs (computes trust score if `:trust_score` absent)
+  - `:attestations` -- list of raw ZKSAR proofs (`type_code`/`signature`/`issuer`/...).
+    They are verified here (see below) before buying any trust; unverified proofs
+    are dropped. Computes the trust score when `:trust_score` is absent.
+
+  ## Attestation trust (fail closed)
+
+  Callers supply *raw, signed* attestations; the router verifies each via
+  `Raxol.Payments.Zksar.verify_batch/2` against the operator-pinned issuer
+  allowlist BEFORE any proof counts toward the trust score or a privacy-tier
+  requirement. This runs on every path (computed-score and explicit-`trust_score`),
+  so a self-asserted `%{valid: true}` map with no signature -- or a proof from a
+  non-allowlisted issuer -- buys nothing.
+
+      config :raxol_payments, :zksar_allowed_issuers, ["0xoracle..."]
+
+  When the allowlist is unset (the default), no attestation can be verified, so
+  none buys trust. An explicit `:trust_score` integer is a separate, caller-owned
+  hint and is clamped, not attestation-derived.
   """
   @spec select(keyword()) :: atom()
   def select(opts \\ []) do
@@ -122,6 +139,11 @@ defmodule Raxol.Payments.Router do
   @max_trust_score 100
 
   defp maybe_compute_trust_score(opts) do
+    # Verify attestations up front, on every path: the verified subset replaces
+    # the caller-supplied list so nothing unverified reaches the score
+    # aggregation OR the PrivacyTier tier-requirement check downstream.
+    opts = replace_with_verified_attestations(opts)
+
     case {Keyword.get(opts, :trust_score), Keyword.get(opts, :attestations)} do
       {nil, attestations} when is_list(attestations) and attestations != [] ->
         score = Zksar.TrustScore.aggregate(attestations)
@@ -133,6 +155,39 @@ defmodule Raxol.Payments.Router do
       _ ->
         opts
     end
+  end
+
+  # Replace `:attestations` with only the proofs that recover to an allowlisted
+  # issuer. A self-asserted map (no signature / not a raw proof) or a proof from
+  # an unpinned issuer verifies to nothing, so it cannot buy trust -- fail closed.
+  defp replace_with_verified_attestations(opts) do
+    case Keyword.get(opts, :attestations) do
+      list when is_list(list) and list != [] ->
+        Keyword.put(opts, :attestations, verify_attestations(list))
+
+      _ ->
+        opts
+    end
+  end
+
+  defp verify_attestations(attestations) do
+    case allowed_issuers() do
+      [] ->
+        # No trusted-issuer allowlist configured: trust cannot be established, so
+        # no attestation is credited (rather than trusting a caller's `valid`).
+        []
+
+      issuers ->
+        {verified, _errors} = Zksar.verify_batch(attestations, allowed_issuers: issuers)
+        verified
+    end
+  end
+
+  defp allowed_issuers do
+    :raxol_payments
+    |> Application.get_env(:zksar_allowed_issuers, [])
+    |> List.wrap()
+    |> Enum.filter(&(is_binary(&1) and &1 != ""))
   end
 
   # A trust score is a non-negative 0..100 value, but callers can pass any

--- a/packages/raxol_payments/test/raxol/payments/router_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/router_test.exs
@@ -1,7 +1,73 @@
 defmodule Raxol.Payments.RouterTest do
-  use ExUnit.Case, async: true
+  # async: false -- the attestation tests set the :zksar_allowed_issuers app env.
+  use ExUnit.Case, async: false
 
   alias Raxol.Payments.Router
+  alias Raxol.Payments.Zksar
+
+  # anvil account 0/1 keys -- real secp256k1 scalars. account 0's address is the
+  # trusted attestation issuer; account 1 signs "wrong issuer" proofs.
+  @issuer_key Base.decode16!(
+                "AC0974BEC39A17E36BA4A6B4D238FF944BACB478CBED5EFCAE784D7BF4F2FF80",
+                case: :mixed
+              )
+  @rogue_key Base.decode16!(
+               "59C6995E998F97A5A0044966F0945389DC9E86DAE88C7A8412F4603B6B78690D",
+               case: :mixed
+             )
+
+  @issuer (
+            {:ok, pub} = ExSecp256k1.create_public_key(@issuer_key)
+            <<_prefix::8, body::binary-size(64)>> = pub
+            <<_first_12::binary-size(12), addr::binary-size(20)>> = ExKeccak.hash_256(body)
+            "0x" <> Base.encode16(addr, case: :lower)
+          )
+
+  @type_codes %{compliance: 0x01, risk_score: 0x02, non_membership: 0x06}
+
+  setup do
+    prior = Application.get_env(:raxol_payments, :zksar_allowed_issuers)
+    Application.put_env(:raxol_payments, :zksar_allowed_issuers, [@issuer])
+
+    on_exit(fn ->
+      case prior do
+        nil -> Application.delete_env(:raxol_payments, :zksar_allowed_issuers)
+        value -> Application.put_env(:raxol_payments, :zksar_allowed_issuers, value)
+      end
+    end)
+
+    :ok
+  end
+
+  # A raw ZKSAR proof of `type` signed by `key`, valid at real system time (the
+  # Router verifies with no `now:` override): far-future expiry, past issue.
+  defp signed(type, key \\ @issuer_key) do
+    proof = %{
+      type_code: Map.fetch!(@type_codes, type),
+      issuer: address_for(key),
+      subject: "0x00000000000000000000000000000000000000ff",
+      issued_at: 1_000_000_000,
+      expires_at: 4_000_000_000,
+      signature: "",
+      payload: <<1, 2, 3, 4>>
+    }
+
+    digest = Zksar.attestation_digest(proof)
+    {:ok, {r, s, v}} = ExSecp256k1.sign(digest, key)
+
+    %{
+      proof
+      | signature:
+          "0x" <> Base.encode16(<<r::binary-size(32), s::binary-size(32), v::8>>, case: :lower)
+    }
+  end
+
+  defp address_for(key) do
+    {:ok, pub} = ExSecp256k1.create_public_key(key)
+    <<_prefix::8, body::binary-size(64)>> = pub
+    <<_first_12::binary-size(12), addr::binary-size(20)>> = ExKeccak.hash_256(body)
+    "0x" <> Base.encode16(addr, case: :lower)
+  end
 
   describe "select/1" do
     test "defaults to x402 for same-chain" do
@@ -63,53 +129,53 @@ defmodule Raxol.Payments.RouterTest do
     end
   end
 
-  describe "attestation-aware routing" do
-    @verified_non_membership %{
-      type: :non_membership,
-      subject: "0x",
-      issuer: "0x",
-      issued_at: 0,
-      expires_at: 0,
-      valid: true
-    }
-    @verified_compliance %{
-      type: :compliance,
-      subject: "0x",
-      issuer: "0x",
-      issued_at: 0,
-      expires_at: 0,
-      valid: true
-    }
+  describe "attestation-aware routing (verified, fail closed) (#337)" do
+    # A caller-fabricated attestation: the verified shape, but no raw proof to
+    # verify (no type_code / signature). It must buy nothing.
+    @self_asserted %{type: :non_membership, valid: true}
 
-    test "attestations compute trust score when trust_score absent" do
-      # non_membership (25) + compliance (20/ln(3) ~= 18) = ~43 -> stealth tier -> xochi
-      assert Router.select(attestations: [@verified_non_membership, @verified_compliance]) ==
-               :xochi
+    test "verified attestations compute a trust score" do
+      # signed non_membership (25) + compliance (~18) = ~43 -> stealth -> xochi
+      assert Router.select(attestations: [signed(:non_membership), signed(:compliance)]) == :xochi
     end
 
-    test "trust_score takes precedence over attestations" do
-      # Explicit score 10 -> standard -> x402, even though attestations would yield higher
-      assert Router.select(
-               trust_score: 10,
-               attestations: [@verified_non_membership, @verified_compliance]
-             ) == :x402
+    test "a single verified attestation of sufficient weight routes to xochi" do
+      # signed non_membership = 25 -> stealth -> xochi
+      assert Router.select(attestations: [signed(:non_membership)]) == :xochi
     end
 
-    test "attestations with high aggregate score route to xochi" do
-      # non_membership alone = 25 -> stealth -> xochi
-      assert Router.select(attestations: [@verified_non_membership]) == :xochi
+    test "trust_score_for aggregates only verified proofs" do
+      assert Router.trust_score_for(attestations: [signed(:non_membership)]) == 25
     end
 
-    test "trust_score_for/1 with attestations" do
-      score = Router.trust_score_for(attestations: [@verified_non_membership])
-      assert score == 25
+    test "a self-asserted attestation (no signature) buys no trust -- fail closed" do
+      # The core #337 vulnerability: valid: true with no proof behind it.
+      assert Router.select(attestations: [@self_asserted]) == :x402
+      assert Router.trust_score_for(attestations: [@self_asserted]) == 0
+      assert Router.settlement_for(attestations: [@self_asserted]) == :public
     end
 
-    test "trust_score_for/1 prefers explicit trust_score" do
+    test "a proof from a non-allowlisted issuer buys no trust" do
+      rogue = signed(:non_membership, @rogue_key)
+      assert Router.select(attestations: [rogue]) == :x402
+      assert Router.trust_score_for(attestations: [rogue]) == 0
+    end
+
+    test "no configured allowlist means no attestation buys trust" do
+      Application.put_env(:raxol_payments, :zksar_allowed_issuers, [])
+      assert Router.select(attestations: [signed(:non_membership)]) == :x402
+      assert Router.trust_score_for(attestations: [signed(:non_membership)]) == 0
+    end
+
+    test "an explicit trust_score wins over (would-be) attestation trust" do
+      assert Router.select(trust_score: 10, attestations: [signed(:non_membership)]) == :x402
+    end
+
+    test "trust_score_for prefers an explicit trust_score" do
       assert Router.trust_score_for(trust_score: 42) == 42
     end
 
-    test "trust_score_for/1 returns 0 with no inputs" do
+    test "trust_score_for returns 0 with no inputs" do
       assert Router.trust_score_for() == 0
     end
   end
@@ -145,35 +211,35 @@ defmodule Raxol.Payments.RouterTest do
       assert Router.settlement_for(trust_score: 999) == :shielded
     end
 
-    test "attestations with valid: false do not count for tier requirements" do
-      invalid_compliance = %{
-        type: :compliance,
-        subject: "0x",
-        issuer: "0x",
-        issued_at: 0,
-        expires_at: 0,
-        valid: false
-      }
-
-      invalid_non_membership = %{
-        type: :non_membership,
-        subject: "0x",
-        issuer: "0x",
-        issued_at: 0,
-        expires_at: 0,
-        valid: false
-      }
-
-      # Score 80 qualifies for sovereign, but invalid attestations should
-      # cause downgrade since they don't satisfy requirements.
-      # Downgrades to stealth (first tier with no attestation requirements).
+    test "verified attestations satisfy a high tier's requirement (no downgrade) (#337)" do
+      # Sovereign (score 75+) requires compliance + non_membership; both verified
+      # and present, so the tier stands -> shielded.
       settlement =
         Router.settlement_for(
           trust_score: 80,
-          attestations: [invalid_compliance, invalid_non_membership]
+          attestations: [signed(:compliance), signed(:non_membership)]
         )
 
+      assert settlement == :shielded
+    end
+
+    test "verified attestations that miss a tier's required types force a downgrade (#337)" do
+      # Score 80 is sovereign, but the only verified proof is risk_score, so the
+      # compliance/non_membership requirement is unmet -> downgrade to stealth.
+      settlement = Router.settlement_for(trust_score: 80, attestations: [signed(:risk_score)])
       assert settlement == :stealth
+    end
+
+    test "unverified attestations are dropped, not credited, so they do not downgrade (#337)" do
+      # Self-asserted proofs verify to nothing, so an explicit high score resolves
+      # by score alone -- as if no attestations were supplied.
+      settlement =
+        Router.settlement_for(
+          trust_score: 80,
+          attestations: [%{type: :compliance, valid: true}, %{type: :non_membership, valid: true}]
+        )
+
+      assert settlement == :shielded
     end
 
     test "empty attestation list does not affect routing" do


### PR DESCRIPTION
## What

Closes #337. Wires `Raxol.Payments.Zksar.verify_batch/2` into the live trust
pipeline so attestations are cryptographically verified against a pinned issuer
allowlist BEFORE they buy any trust. Previously the verification code existed but
had **zero production callers**, so `Router` credited unverified, self-asserted
attestations.

## The vulnerability (HIGH)

A caller -- or a prompt-injected agent assembling `Router` opts -- could pass:

    Router.select(attestations: [%{type: :compliance, valid: true},
                                 %{type: :non_membership, valid: true}])

with no signature and no issuer, and obtain max trust score -> `:sovereign` /
`:shielded` tier -> the lowest fee tier. `Router.maybe_compute_trust_score/1`
called `TrustScore.aggregate/1` directly on caller maps, and `PrivacyTier` gated
tiers on a caller-settable `:valid` boolean. The signature verification added in
the origin-pull hardening pass never executed.

## Why it's safe to wire now (the deferral was stale)

The issue was pinned "deferred until a tested ZKSAR issuer exists." Verified
against the code, that rationale no longer holds: `Zksar.verify_batch` has zero
production callers, every live/E2E/property flow resolves trust via an explicit
`trust_score` (never attestations), and only self-asserted *test* fixtures
exercised the attestation path. Wiring verification is therefore pure hardening
with no functional regression -- and since no issuer is pinned by default, the
fail-closed default is strictly safer than crediting fakes.

## The fix (fail closed)

- `Router.maybe_compute_trust_score/1` now verifies attestations up front and
  replaces `:attestations` with only the verified subset -- so nothing unverified
  reaches EITHER the score aggregation OR the `PrivacyTier` tier-requirement
  check. This runs on every path (computed-score and explicit-`trust_score`).
- Issuers are pinned via `config :raxol_payments, :zksar_allowed_issuers, [...]`.
  Unset (the default) => no attestation can be verified => none buys trust.
- Callers now supply *raw, signed* proofs (`type_code`/`signature`/`issuer`/...);
  `verify_batch` requires the signature recover to an allowlisted issuer.
- `PrivacyTier` documents that it consumes pre-verified attestations (Router is
  the verification choke point); a self-asserted `%{valid: true}` map is not a
  proof.

An explicit `:trust_score` integer is a separate, caller-owned hint (clamped),
unchanged by this PR.

## Tests (RED-proven; real ExSecp256k1 signatures, no mocks)

`router_test.exs` reworked (now `async: false` -- it sets the allowlist app env):

- Positive: real signed proofs from the allowlisted issuer compute a score and
  route to `:xochi`; a verified compliance+non_membership pair satisfies the
  sovereign requirement; a verified proof that misses a tier's required types
  still forces a downgrade.
- Fail closed (each was RED before the fix): a self-asserted proof (no signature)
  buys nothing (`:x402` / score 0 / `:public`); a proof from a non-allowlisted
  issuer buys nothing; no configured allowlist means no attestation buys trust;
  unverified attestations are dropped, not credited.

`privacy_tier_test` / `trust_score_test` are unchanged -- they exercise the
pre-verified contract (feeding verified-shaped maps directly), which is exactly
what Router now guarantees.

## Manual testing

- [x] `cd packages/raxol_payments && MIX_ENV=test mix test` -> 1013 passed, 0
      failures.
- [x] Scoped `mix format` + `--check-formatted` on changed files -> clean.
- [x] `MIX_ENV=test mix compile --force` -> 0 warnings from the changed files.
- [x] Confirmed the self-asserted attestation fixtures fail RED before the fix,
      then pass GREEN after (fail-closed).

## Not in this PR (issue point 5, lower severity)

- Binding a per-use nonce / chain id / intent id into `attestation_digest/1` to
  prevent cross-settlement replay of a valid attestation until expiry. This
  changes the signed message and must be coordinated with the issuer
  (cross-repo), so it is a separate change.
- Enforcing low-`s` canonicalization in `recover_signer`.

## CI note

Root CI does not build `raxol_payments` -- the package suite
(`cd packages/raxol_payments && MIX_ENV=test mix test`) is the gate, and it is
green.
