### PR TITLE
Fix raxol.io release boot crash

### DIFF
--- a/lib/raxol/application.ex
+++ b/lib/raxol/application.ex
@@ -400,8 +400,19 @@ defmodule Raxol.Application do
 
   defp feature_enabled?(feature) do
     features = Application.get_env(:raxol, :features, default_features())
-    Map.get(features, feature, false)
+    get_feature_flag(features, feature)
   end
+
+  # Tolerate both a map (the documented shape) and a keyword list, since config
+  # files commonly express `config :raxol, :features, key: value` as a keyword
+  # list, which Map.get would reject with a BadMapError at boot.
+  defp get_feature_flag(features, feature) when is_map(features),
+    do: Map.get(features, feature, false)
+
+  defp get_feature_flag(features, feature) when is_list(features),
+    do: Keyword.get(features, feature, false)
+
+  defp get_feature_flag(_features, _feature), do: false
 
   defp default_features do
     %{

--- a/web/config/runtime.exs
+++ b/web/config/runtime.exs
@@ -32,8 +32,9 @@ if config_env() == :prod do
     ],
     secret_key_base: secret_key_base
 
-  # Disable terminal features in production/container environments
-  config :raxol, :features,
+  # Disable terminal features in production/container environments.
+  # Must be a map: Raxol.Application.feature_enabled?/1 reads it with Map.get.
+  config :raxol, :features, %{
     terminal_driver: false,
     web_interface: true,
     database: false,
@@ -44,6 +45,7 @@ if config_env() == :prod do
     telemetry: true,
     plugins: false,
     audit: false
+  }
 
   # ## SSL Support
   #

--- a/web/lib/raxol_playground/application.ex
+++ b/web/lib/raxol_playground/application.ex
@@ -15,55 +15,12 @@ defmodule RaxolPlayground.Application do
         {DNSCluster,
          query: Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: RaxolPlayground.PubSub},
-        Supervisor.child_spec({Phoenix.PubSub, name: Raxol.PubSub},
-          id: :raxol_pubsub
-        ),
         RaxolPlaygroundWeb.Presence,
         RaxolPlaygroundWeb.Endpoint
-      ] ++ maybe_ssh_playground()
+      ]
 
     opts = [strategy: :one_for_one, name: RaxolPlayground.Supervisor]
     Supervisor.start_link(children, opts)
-  end
-
-  defp maybe_ssh_playground do
-    if System.get_env("RAXOL_SSH_PLAYGROUND") == "true" do
-      port = String.to_integer(System.get_env("RAXOL_SSH_PORT") || "2222")
-
-      max =
-        String.to_integer(System.get_env("RAXOL_SSH_MAX_CONNECTIONS") || "50")
-
-      keys_dir = System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys"
-
-      try do
-        Application.ensure_all_started(:ssh)
-
-        # Mark SSH as temporary -- if it crashes, don't restart it and don't
-        # trigger max_restarts on the parent supervisor (which would kill the
-        # Phoenix endpoint).
-        ssh_spec =
-          Supervisor.child_spec(
-            {Raxol.SSH.Server,
-             app_module: Raxol.Playground.App,
-             port: port,
-             host_keys_dir: keys_dir,
-             max_connections: max},
-            restart: :temporary
-          )
-
-        [ssh_spec]
-      rescue
-        e ->
-          IO.puts("[SSH] Failed to prepare SSH: #{Exception.message(e)}")
-          []
-      catch
-        :exit, reason ->
-          IO.puts("[SSH] Failed to start :ssh app: #{inspect(reason)}")
-          []
-      end
-    else
-      []
-    end
   end
 
   @impl true

--- a/web/mix.exs
+++ b/web/mix.exs
@@ -16,8 +16,7 @@ defmodule RaxolPlayground.MixProject do
   def application do
     [
       extra_applications: [:logger, :ssh, :public_key, :crypto],
-      mod: {RaxolPlayground.Application, []},
-      included_applications: [:raxol]
+      mod: {RaxolPlayground.Application, []}
     ]
   end
 
@@ -47,13 +46,7 @@ defmodule RaxolPlayground.MixProject do
     [
       raxol_playground: [
         include_executables_for: [:unix],
-        steps: [:assemble],
-        applications: [
-          raxol_playground: :permanent,
-          ssh: :permanent,
-          public_key: :permanent,
-          crypto: :permanent
-        ]
+        steps: [:assemble]
       ]
     ]
   end


### PR DESCRIPTION
## Problem

After the build was fixed (#422), the web release still crash-looped on boot: Phoenix bound `0.0.0.0:8080`, then the runtime terminated during `ensure_all_started`. raxol.io stayed down.

## Root causes (all pre-existing, masked by `included_applications: [:raxol]`)

The `included_applications: [:raxol]` workaround stopped `:raxol` from starting at all, hiding three real bugs. Removing it (to restore the working v44 behavior) exposed them:

1. **BadMapError** — `web/config/runtime.exs` set `config :raxol, :features` as a **keyword list**, but `Raxol.Application.feature_enabled?/1` reads it with `Map.get/3`. Fixed both sides: config is now a map, and `feature_enabled?/1` tolerates a map or keyword list.
2. **Bad release config** — `web/mix.exs` had `ssh/public_key: :load` under a `:permanent` app (breaks `mix release` on Elixir 1.17) plus `included_applications: [:raxol]`. Reverted to the v44 shape.
3. **`{:already_started}` conflicts** — once `:raxol` starts, it owns `Raxol.PubSub` and the SSH playground (`app_module: Raxol.Playground.App`). `RaxolPlayground.Application` started duplicates of both. Dropped them; `:raxol` is the single owner.

## Verification

Built and ran the **prod release locally** with `RAXOL_SSH_PLAYGROUND=true`:
- boots without crashing
- serves `GET /health` -> 200
- `/.well-known/raxol.json` reports **7 surfaces** (the new landing)

(The local `cache_manifest.json` warning is expected — `mix assets.deploy` runs in the Docker build.)

## Manual testing

- [x] `MIX_ENV=prod mix release` + run locally: boots, serves 200, SSH playground starts
- [ ] `flyctl deploy --strategy immediate` boots on Fly (health check green)