### PR TITLE
Restore web PubSub + SSH for minimal-mode Raxol

### DIFF
--- a/web/lib/raxol_playground/application.ex
+++ b/web/lib/raxol_playground/application.ex
@@ -13,14 +13,75 @@ defmodule RaxolPlayground.Application do
       [
         RaxolPlaygroundWeb.Telemetry,
         {DNSCluster,
-         query: Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
-        {Phoenix.PubSub, name: RaxolPlayground.PubSub},
-        RaxolPlaygroundWeb.Presence,
-        RaxolPlaygroundWeb.Endpoint
-      ]
+         query:
+           Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
+        {Phoenix.PubSub, name: RaxolPlayground.PubSub}
+      ] ++
+        maybe_raxol_pubsub() ++
+        [
+          RaxolPlaygroundWeb.Presence,
+          RaxolPlaygroundWeb.Endpoint
+        ] ++ maybe_ssh_playground()
 
     opts = [strategy: :one_for_one, name: RaxolPlayground.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # In production Raxol runs in :minimal mode (RAXOL_MODE=minimal), so it does
+  # not start Raxol.PubSub or the SSH playground; the web app provides them.
+  # The guard skips the child if a :full-mode Raxol already started it, avoiding
+  # an {:already_started} crash.
+  defp maybe_raxol_pubsub do
+    if Process.whereis(Raxol.PubSub) do
+      []
+    else
+      [
+        Supervisor.child_spec({Phoenix.PubSub, name: Raxol.PubSub},
+          id: :raxol_pubsub
+        )
+      ]
+    end
+  end
+
+  defp maybe_ssh_playground do
+    if System.get_env("RAXOL_SSH_PLAYGROUND") == "true" and
+         is_nil(Process.whereis(Raxol.SSH.Server)) do
+      port = String.to_integer(System.get_env("RAXOL_SSH_PORT") || "2222")
+
+      max =
+        String.to_integer(System.get_env("RAXOL_SSH_MAX_CONNECTIONS") || "50")
+
+      keys_dir = System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys"
+
+      try do
+        Application.ensure_all_started(:ssh)
+
+        # restart: :temporary so an SSH crash does not trip the parent
+        # supervisor's max_restarts and take the Phoenix endpoint down with it.
+        ssh_spec =
+          Supervisor.child_spec(
+            {Raxol.SSH.Server,
+             app_module: Raxol.Playground.App,
+             port: port,
+             host_keys_dir: keys_dir,
+             max_connections: max,
+             allow_anonymous: true},
+            restart: :temporary
+          )
+
+        [ssh_spec]
+      rescue
+        e ->
+          IO.puts("[SSH] Failed to prepare SSH: #{Exception.message(e)}")
+          []
+      catch
+        :exit, reason ->
+          IO.puts("[SSH] Failed to start :ssh app: #{inspect(reason)}")
+          []
+      end
+    else
+      []
+    end
   end
 
   @impl true


### PR DESCRIPTION
## Problem

After #424 fixed the boot crash, the app was stable but `/health` returned **503**, so Fly kept the machine `critical` and the proxy never routed to it — raxol.io stayed unreachable.

An RPC into the live node showed: `%{pubsub: false, mem_mb: 118, ssh_2222: :down}`. `Raxol.PubSub` and the SSH playground were not running.

## Root cause

`fly.toml` sets `RAXOL_MODE = 'minimal'`. In minimal mode `Raxol.Application` starts **neither** `Raxol.PubSub` **nor** the SSH playground. #424 removed `RaxolPlayground.Application`'s manual starts on the assumption `:raxol` would provide them — true in `:full` mode (which the earlier local test defaulted to), false in the `:minimal` mode production actually runs.

## Fix

Restore the web app's `Raxol.PubSub` + SSH-playground children, each guarded to no-op if a `:full`-mode `:raxol` already started it (avoids `{:already_started}`). The SSH spec now also passes `allow_anonymous: true`, required since `Raxol.SSH.Server` was hardened to fail closed on auth.

## Verification

Built and ran the prod release locally **with `RAXOL_MODE=minimal`** (matching the container, unlike the #424 test):
- `/health` -> **200**, `status: healthy`
- checks: `pubsub: ok`, `ssh: ok`, `memory: ok`

## Manual testing

- [x] `MIX_ENV=prod mix release` + run with `RAXOL_MODE=minimal`: `/health` 200, all checks ok
- [ ] `flyctl deploy` -> machine health green, raxol.io serves new landing