### PR TITLE
Make landing demo interactive (forward keydown)

### DIFF
--- a/web/lib/raxol_playground/application.ex
+++ b/web/lib/raxol_playground/application.ex
@@ -13,14 +13,75 @@ defmodule RaxolPlayground.Application do
       [
         RaxolPlaygroundWeb.Telemetry,
         {DNSCluster,
-         query: Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
-        {Phoenix.PubSub, name: RaxolPlayground.PubSub},
-        RaxolPlaygroundWeb.Presence,
-        RaxolPlaygroundWeb.Endpoint
-      ]
+         query:
+           Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
+        {Phoenix.PubSub, name: RaxolPlayground.PubSub}
+      ] ++
+        maybe_raxol_pubsub() ++
+        [
+          RaxolPlaygroundWeb.Presence,
+          RaxolPlaygroundWeb.Endpoint
+        ] ++ maybe_ssh_playground()
 
     opts = [strategy: :one_for_one, name: RaxolPlayground.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # In production Raxol runs in :minimal mode (RAXOL_MODE=minimal), so it does
+  # not start Raxol.PubSub or the SSH playground; the web app provides them.
+  # The guard skips the child if a :full-mode Raxol already started it, avoiding
+  # an {:already_started} crash.
+  defp maybe_raxol_pubsub do
+    if Process.whereis(Raxol.PubSub) do
+      []
+    else
+      [
+        Supervisor.child_spec({Phoenix.PubSub, name: Raxol.PubSub},
+          id: :raxol_pubsub
+        )
+      ]
+    end
+  end
+
+  defp maybe_ssh_playground do
+    if System.get_env("RAXOL_SSH_PLAYGROUND") == "true" and
+         is_nil(Process.whereis(Raxol.SSH.Server)) do
+      port = String.to_integer(System.get_env("RAXOL_SSH_PORT") || "2222")
+
+      max =
+        String.to_integer(System.get_env("RAXOL_SSH_MAX_CONNECTIONS") || "50")
+
+      keys_dir = System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys"
+
+      try do
+        Application.ensure_all_started(:ssh)
+
+        # restart: :temporary so an SSH crash does not trip the parent
+        # supervisor's max_restarts and take the Phoenix endpoint down with it.
+        ssh_spec =
+          Supervisor.child_spec(
+            {Raxol.SSH.Server,
+             app_module: Raxol.Playground.App,
+             port: port,
+             host_keys_dir: keys_dir,
+             max_connections: max,
+             allow_anonymous: true},
+            restart: :temporary
+          )
+
+        [ssh_spec]
+      rescue
+        e ->
+          IO.puts("[SSH] Failed to prepare SSH: #{Exception.message(e)}")
+          []
+      catch
+        :exit, reason ->
+          IO.puts("[SSH] Failed to start :ssh app: #{inspect(reason)}")
+          []
+      end
+    else
+      []
+    end
   end
 
   @impl true

--- a/web/lib/raxol_playground_web/live/landing_live.ex
+++ b/web/lib/raxol_playground_web/live/landing_live.ex
@@ -20,7 +20,11 @@ defmodule RaxolPlaygroundWeb.LandingLive do
 
   @raxol_version (case :application.get_key(:raxol, :vsn) do
                     {:ok, vsn} ->
-                      vsn |> to_string() |> String.split(".") |> Enum.take(2) |> Enum.join(".")
+                      vsn
+                      |> to_string()
+                      |> String.split(".")
+                      |> Enum.take(2)
+                      |> Enum.join(".")
 
                     _ ->
                       "2.4"
@@ -50,8 +54,22 @@ defmodule RaxolPlaygroundWeb.LandingLive do
 
   @impl true
   def handle_event("toggle_mobile_menu", _params, socket) do
-    {:noreply, assign(socket, :mobile_menu_open, !socket.assigns.mobile_menu_open)}
+    {:noreply,
+     assign(socket, :mobile_menu_open, !socket.assigns.mobile_menu_open)}
   end
+
+  # Forward terminal key events from the RaxolTerminal hook into the demo, so
+  # the embedded demo is interactive (same path as DemoLive).
+  def handle_event("keydown", params, socket) do
+    if socket.assigns[:lifecycle_pid] do
+      event = Raxol.LiveView.InputAdapter.translate_key_event(params)
+      {:noreply, DemoLifecycle.dispatch_event(socket, event)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   @impl true
   def handle_info({:render_update, html}, socket),


### PR DESCRIPTION
## Problem

The embedded Button demo on the raxol.io landing renders but is **frozen** — keys/clicks do nothing. (Confirmed live: renders, but not interactive; not a cache issue.)

## Root cause

`RaxolPlaygroundWeb.LandingLive` handled only `"toggle_mobile_menu"`. The `RaxolTerminal` JS hook pushes `"keydown"` events, which `LandingLive` never handled, so input never reached the demo's `Lifecycle`. `DemoLive` (the interactive `/demos` page) forwards them via `handle_event("keydown", ...)`; `LandingLive` was missing that path.

## Fix

Add the same `"keydown"` handler (translate via `Raxol.LiveView.InputAdapter`, dispatch via `DemoLifecycle.dispatch_event/2`) plus a catch-all `handle_event/3` clause. Mirrors `DemoLive` exactly.

## Verification

- `MIX_ENV=prod mix compile` clean (`InputAdapter.translate_key_event/1` and `DemoLifecycle.dispatch_event/2` already exist, used by `DemoLive`).
- Post-deploy: the Button demo responds to `1` / `2` / `r`.

Note: branched off the (now-merged) #425 fix, so the diff may also show that application.ex change; the net new change is `landing_live.ex`.