### PR TITLE
Harden web deploy: CI gate, health, SSH, warnings

### DIFF
--- a/.github/workflows/web-deploy-check.yml
+++ b/.github/workflows/web-deploy-check.yml
@@ -1,0 +1,93 @@
+name: Web Deploy Check
+
+# Builds the raxol.io web release and boots it exactly as production does
+# (RAXOL_MODE=minimal), then requires /health to return 200. The main CI never
+# builds or runs the web release, so release-config, app-boot, and service-wiring
+# bugs (the class that took raxol.io down) ship undetected until deploy. This job
+# is that missing gate.
+on:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - "web/**"
+      - "lib/raxol/application.ex"
+      - "mix.exs"
+      - "mix.lock"
+      - "docker/Dockerfile.web"
+      - ".dockerignore"
+      - ".github/workflows/web-deploy-check.yml"
+  push:
+    branches: [master, main]
+    paths:
+      - "web/**"
+      - "lib/raxol/application.ex"
+
+concurrency:
+  group: web-deploy-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-boot:
+    name: Build + boot web release (minimal mode)
+    runs-on: ubuntu-latest
+    env:
+      # Match docker/Dockerfile.web so CI reflects the production build.
+      ELIXIR_VERSION: "1.17.1"
+      OTP_VERSION: "27.0"
+      MIX_ENV: prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Cache web deps + build
+        uses: actions/cache@v4
+        with:
+          path: |
+            web/deps
+            web/_build
+          key: web-release-${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('web/mix.lock', 'mix.lock') }}
+
+      - name: Build web release
+        working-directory: web
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only prod
+          mix compile
+          mix assets.deploy
+          mix release --overwrite
+
+      - name: Boot in minimal mode and require /health 200
+        working-directory: web
+        env:
+          RAXOL_MODE: minimal
+          PHX_HOST: localhost
+          PORT: "8080"
+          RAXOL_SSH_PLAYGROUND: "true"
+          RAXOL_SSH_PORT: "2222"
+          RAXOL_SSH_HOST_KEYS_DIR: /tmp/ci_ssh_keys
+          RAXOL_SSH_MAX_CONNECTIONS: "5"
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/ci_ssh_keys
+          export SECRET_KEY_BASE="$(openssl rand -base64 48)"
+          bin=_build/prod/rel/raxol_playground/bin/raxol_playground
+          "$bin" start &
+          rel_pid=$!
+          ok=""
+          for i in $(seq 1 45); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://localhost:8080/health || true)"
+            if [ "$code" = "200" ]; then ok=1; echo "health 200 after ${i}s"; break; fi
+            if ! kill -0 "$rel_pid" 2>/dev/null; then echo "release process exited during boot"; break; fi
+            sleep 2
+          done
+          echo "health body:"; curl -s --max-time 3 http://localhost:8080/health || true; echo
+          "$bin" stop || true
+          if [ -z "$ok" ]; then
+            echo "::error::web release did not serve /health 200 in minimal mode"
+            exit 1
+          fi

--- a/lib/raxol/application.ex
+++ b/lib/raxol/application.ex
@@ -403,16 +403,18 @@ defmodule Raxol.Application do
     get_feature_flag(features, feature)
   end
 
+  @doc false
   # Tolerate both a map (the documented shape) and a keyword list, since config
   # files commonly express `config :raxol, :features, key: value` as a keyword
-  # list, which Map.get would reject with a BadMapError at boot.
-  defp get_feature_flag(features, feature) when is_map(features),
+  # list, which Map.get would reject with a BadMapError at boot. Public only so
+  # it can be unit-tested directly.
+  def get_feature_flag(features, feature) when is_map(features),
     do: Map.get(features, feature, false)
 
-  defp get_feature_flag(features, feature) when is_list(features),
+  def get_feature_flag(features, feature) when is_list(features),
     do: Keyword.get(features, feature, false)
 
-  defp get_feature_flag(_features, _feature), do: false
+  def get_feature_flag(_features, _feature), do: false
 
   defp default_features do
     %{

--- a/packages/raxol_agent/lib/raxol/agent/session_streamer.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session_streamer.ex
@@ -37,8 +37,6 @@ defmodule Raxol.Agent.SessionStreamer do
 
   use Raxol.Core.Behaviours.BaseManager
 
-  require Logger
-
   @type event ::
           {:text_delta, String.t()}
           | {:tool_use, map()}

--- a/packages/raxol_agent/lib/raxol/agent/skills/store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/skills/store.ex
@@ -519,7 +519,6 @@ defmodule Raxol.Agent.Skills.Store do
 
   defp config(key), do: Application.get_env(:raxol_agent, key)
 
-  defp expand(nil), do: nil
   defp expand(path), do: Path.expand(path)
 
   defp expand_all(paths), do: Enum.map(paths, &Path.expand/1)

--- a/test/raxol/application_test.exs
+++ b/test/raxol/application_test.exs
@@ -5,7 +5,7 @@ defmodule Raxol.ApplicationTest do
     test "determines startup mode correctly" do
       # Test mode should be detected in test environment
       assert Application.get_env(:raxol, :startup_mode) == nil ||
-             Mix.env() == :test
+               Mix.env() == :test
     end
 
     test "health_status returns valid information" do
@@ -28,20 +28,27 @@ defmodule Raxol.ApplicationTest do
       assert Raxol.Application.toggle_feature(:audit, true) == :ok
 
       # Features that require restart
-      assert Raxol.Application.toggle_feature(:web_interface, false) == {:error, :restart_required}
-      assert Raxol.Application.toggle_feature(:database, false) == {:error, :restart_required}
-      assert Raxol.Application.toggle_feature(:pubsub, false) == {:error, :restart_required}
+      assert Raxol.Application.toggle_feature(:web_interface, false) ==
+               {:error, :restart_required}
+
+      assert Raxol.Application.toggle_feature(:database, false) ==
+               {:error, :restart_required}
+
+      assert Raxol.Application.toggle_feature(:pubsub, false) ==
+               {:error, :restart_required}
     end
 
     test "add_child and remove_child handle missing dynamic supervisor" do
       # In test mode, DynamicSupervisor might not be started
       result = Raxol.Application.add_child({Task, fn -> :ok end})
+
       assert result == {:error, :dynamic_supervisor_not_started} ||
-             match?({:ok, _}, result)
+               match?({:ok, _}, result)
 
       result = Raxol.Application.remove_child(:nonexistent)
+
       assert result == {:error, :not_found} ||
-             result == {:error, :dynamic_supervisor_not_started}
+               result == {:error, :dynamic_supervisor_not_started}
     end
   end
 
@@ -57,6 +64,23 @@ defmodule Raxol.ApplicationTest do
       # Check that features is not empty
       assert map_size(features) > 0
     end
+
+    test "get_feature_flag reads maps and keyword lists (regression: keyword config crashed boot)" do
+      # Documented shape: a map.
+      assert Raxol.Application.get_feature_flag(%{database: true}, :database)
+      refute Raxol.Application.get_feature_flag(%{database: false}, :database)
+      refute Raxol.Application.get_feature_flag(%{}, :missing)
+
+      # A keyword list (what `config :raxol, :features, key: value` produces).
+      # This used to hit Map.get on a list and raise BadMapError during boot.
+      assert Raxol.Application.get_feature_flag([database: true], :database)
+      refute Raxol.Application.get_feature_flag([database: false], :database)
+      refute Raxol.Application.get_feature_flag([], :missing)
+
+      # Anything else degrades to false rather than crashing.
+      refute Raxol.Application.get_feature_flag("garbage", :database)
+      refute Raxol.Application.get_feature_flag(nil, :database)
+    end
   end
 
   describe "Memory optimization" do
@@ -67,7 +91,8 @@ defmodule Raxol.ApplicationTest do
       info = Process.info(self())
       assert info[:trap_exit] == true
       # message_queue_data might not be available in all OTP versions
-      assert info[:message_queue_data] == :off_heap || info[:message_queue_data] == nil
+      assert info[:message_queue_data] == :off_heap ||
+               info[:message_queue_data] == nil
     end
   end
 end

--- a/web/lib/raxol_playground/application.ex
+++ b/web/lib/raxol_playground/application.ex
@@ -13,18 +13,23 @@ defmodule RaxolPlayground.Application do
       [
         RaxolPlaygroundWeb.Telemetry,
         {DNSCluster,
-         query:
-           Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
+         query: Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: RaxolPlayground.PubSub}
       ] ++
         maybe_raxol_pubsub() ++
         [
           RaxolPlaygroundWeb.Presence,
           RaxolPlaygroundWeb.Endpoint
-        ] ++ maybe_ssh_playground()
+        ]
 
     opts = [strategy: :one_for_one, name: RaxolPlayground.Supervisor]
-    Supervisor.start_link(children, opts)
+
+    with {:ok, sup} <- Supervisor.start_link(children, opts) do
+      # SSH is started after the tree is up (see start_ssh_playground/1), so a
+      # failed SSH start does not abort the web app's boot.
+      start_ssh_playground(sup)
+      {:ok, sup}
+    end
   end
 
   # In production Raxol runs in :minimal mode (RAXOL_MODE=minimal), so it does
@@ -43,46 +48,44 @@ defmodule RaxolPlayground.Application do
     end
   end
 
-  defp maybe_ssh_playground do
-    if System.get_env("RAXOL_SSH_PLAYGROUND") == "true" and
-         is_nil(Process.whereis(Raxol.SSH.Server)) do
-      port = String.to_integer(System.get_env("RAXOL_SSH_PORT") || "2222")
+  # Start the SSH playground as a dynamically-added, temporary child of the
+  # already-running supervisor. Because the tree is up, Supervisor.start_child
+  # returns {:error, _} on a failed start (e.g. an unwritable host-keys dir)
+  # instead of aborting the whole boot -- an SSH problem degrades to "no SSH"
+  # rather than taking the web app down. restart: :temporary keeps a later SSH
+  # crash from tripping the parent's max_restarts.
+  defp start_ssh_playground(sup) do
+    with "true" <- System.get_env("RAXOL_SSH_PLAYGROUND"),
+         nil <- Process.whereis(Raxol.SSH.Server),
+         {:ok, _} <- Application.ensure_all_started(:ssh) do
+      spec =
+        Supervisor.child_spec(
+          {Raxol.SSH.Server,
+           app_module: Raxol.Playground.App,
+           port: ssh_port(),
+           host_keys_dir: System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys",
+           max_connections: ssh_max_connections(),
+           allow_anonymous: true},
+          restart: :temporary
+        )
 
-      max =
-        String.to_integer(System.get_env("RAXOL_SSH_MAX_CONNECTIONS") || "50")
-
-      keys_dir = System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys"
-
-      try do
-        Application.ensure_all_started(:ssh)
-
-        # restart: :temporary so an SSH crash does not trip the parent
-        # supervisor's max_restarts and take the Phoenix endpoint down with it.
-        ssh_spec =
-          Supervisor.child_spec(
-            {Raxol.SSH.Server,
-             app_module: Raxol.Playground.App,
-             port: port,
-             host_keys_dir: keys_dir,
-             max_connections: max,
-             allow_anonymous: true},
-            restart: :temporary
-          )
-
-        [ssh_spec]
-      rescue
-        e ->
-          IO.puts("[SSH] Failed to prepare SSH: #{Exception.message(e)}")
-          []
-      catch
-        :exit, reason ->
-          IO.puts("[SSH] Failed to start :ssh app: #{inspect(reason)}")
-          []
+      case Supervisor.start_child(sup, spec) do
+        {:ok, _pid} -> :ok
+        {:error, reason} -> IO.puts("[SSH] playground not started: #{inspect(reason)}")
       end
     else
-      []
+      _ -> :ok
     end
+  rescue
+    e -> IO.puts("[SSH] playground error: #{Exception.message(e)}")
+  catch
+    :exit, reason -> IO.puts("[SSH] playground exit: #{inspect(reason)}")
   end
+
+  defp ssh_port, do: String.to_integer(System.get_env("RAXOL_SSH_PORT") || "2222")
+
+  defp ssh_max_connections,
+    do: String.to_integer(System.get_env("RAXOL_SSH_MAX_CONNECTIONS") || "50")
 
   @impl true
   def config_change(changed, _new, removed) do

--- a/web/lib/raxol_playground_web/controllers/health_controller.ex
+++ b/web/lib/raxol_playground_web/controllers/health_controller.ex
@@ -11,6 +11,12 @@ defmodule RaxolPlaygroundWeb.HealthController do
       ssh: check_ssh()
     }
 
+    # Only genuinely fatal states take the machine out of rotation (503).
+    # PubSub down breaks LiveView, and critical memory is unsafe. SSH is an
+    # optional playground extra and a memory "warning" is tolerable, so neither
+    # degrades the service to 503; the JSON still reports the real state.
+    critical? = checks.pubsub in ["down", "error"] or checks.memory == "critical"
+
     all_ok = Enum.all?(checks, fn {_k, v} -> v in ["ok", "not_configured"] end)
 
     status = %{
@@ -20,7 +26,7 @@ defmodule RaxolPlaygroundWeb.HealthController do
       checks: checks
     }
 
-    http_status = if all_ok, do: 200, else: 503
+    http_status = if critical?, do: 503, else: 200
 
     conn
     |> put_status(http_status)


### PR DESCRIPTION
Post-incident hardening from the raxol.io outage this week. Each item maps to a real failure mode that took the site down or hid a bug.

## 1. Web deploy CI gate (new)
`.github/workflows/web-deploy-check.yml` builds the web release and boots it with `RAXOL_MODE=minimal` (matching prod, Elixir 1.17.1/OTP 27.0 per `Dockerfile.web`), then **requires `/health` 200**. The main CI never builds or runs the web release, so every deploy-breaking bug in the incident (features-as-keyword-list, `ssh: :load`, `included_applications`, minimal-mode service wiring) shipped undetected until the prod deploy crashed. This gate would have caught all of them. It runs on changes to `web/**`, `lib/raxol/application.ex`, deps, and the Dockerfile/.dockerignore.

## 2. Health check no longer self-inflicts an outage
`HealthController` returned **503 on a memory `"warning"` (>500MB)** and on any SSH-down — either would make Fly pull the machine. Now only `pubsub` down/error or `memory` critical return 503; a memory warning and an SSH-playground failure are `degraded` but still `200` (the JSON still reports the real per-check state).

## 3. SSH boot resilience
The SSH playground was a supervised child in the initial tree, so a failed start (e.g. an unwritable host-keys dir) aborted the **entire** app boot. It now starts via `Supervisor.start_child/2` *after* the tree is up, so a failure returns `{:error, _}` (logged) and degrades to "no SSH" instead of crash-looping the site. `restart: :temporary` keeps a later crash from tripping the parent.

## 4. Lock the features fix + clear warnings
- `get_feature_flag/2` exposed `@doc false` with a regression test covering map **and** keyword-list `:features` (a keyword-list config crashed boot with `BadMapError`).
- Removed two `--warnings-as-errors` blockers: unused `require Logger` (session_streamer) and the provably-dead `expand(nil)` clause (skills/store).

## Verification
- Web boot tested locally with the prod release in `RAXOL_MODE=minimal`:
  - normal: `/health` 200, checks `pubsub/ssh/memory` all ok
  - **SSH failure** (unwritable host-keys dir): app **stays up**, `/health` 200 with `ssh: "down"` (previously this crash-looped the whole site)
- The rest is covered by CI on this PR (main CI on `lib/**`+`packages/**`; the new web-deploy-check tests itself since it touches `web/**`).

## Manual testing
- [x] prod release boots in minimal mode, serves `/health` 200
- [x] SSH host-keys failure no longer crashes boot
- [ ] web-deploy-check job goes green on this PR