### PR TITLE
Accessibility projection + MCP a11y fields (#305)

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -126,6 +126,45 @@ a Component.
 
 ---
 
+## Accessibility
+
+The accessibility layer projects the semantic Element tree into a
+role/label/state form that Surfaces serialize for assistive technology.
+
+| Term                       | Definition                                                                                                                                                    | Aliases to avoid                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **Accessibility tree**     | The projection of the Element tree into role/label/state descriptors, consumed by Surfaces to drive assistive technology.                                      | a11y tree, ARIA tree, semantic tree |
+| **Accessibility node**     | One entry in the Accessibility tree: `%{role, label, state, value, children, live?}`. Derived from an Element.                                                 | a11y node, ARIA node                |
+| **Accessibility Provider** | The `Raxol.Core.Accessibility.Provider` behaviour a Component implements (`a11y_node/1`) to describe itself. Parallels ToolProvider.                           | a11y provider                       |
+| **Role**                   | The ARIA role of an Accessibility node: button, textbox, checkbox, grid, dialog, and so on.                                                                    | type, kind                          |
+| **Announcement**           | A prioritized message pushed to assistive technology via the Accessibility facade (`:high`, `:medium`, `:low`, with optional interrupt). Consumed by the Speech surface (TTS) and the Browser live region. | notification, alert  |
+| **Live region**            | A Surface construct that speaks Announcements as they arrive (Browser: a visually hidden `aria-live` region; Speech: TTS).                                     | announcer                           |
+
+### Relationships
+
+- One Element yields zero or one Accessibility node (1:0..1).
+- The Projection walks the Element tree once; MCP and Browser both consume its
+  output (1:N).
+- A Component that implements the Accessibility Provider behaviour is
+  authoritative for its own node.
+
+### Example dialogue
+
+> "The checkbox's Accessibility Provider reports `role: :checkbox` with `state: %{checked?: true}`, and the Browser surface renders `aria-checked` from it."
+> NOT: "The checkbox widget sets its ARIA node so the frontend can show the checked state."
+
+### Flagged ambiguities
+
+- **Accessibility node** vs **Element**: an Element is what `view/1` returns; an
+  Accessibility node is the descriptor projected from it. Never call the
+  projected descriptor an Element.
+- **Role** (ARIA) vs Button's visual **variant** (`:primary`, `:danger`): the
+  variant is styling. It becomes `state.variant`, never the ARIA Role.
+- **Announcement** vs **Message** (TEA): a Message drives `update/2`; an
+  Announcement is an outbound accessibility string. Unrelated.
+
+---
+
 ## Agents
 
 | Term                    | Definition                                                                                            | Aliases to avoid                       |

--- a/lib/raxol/ui/charts/bar_chart.ex
+++ b/lib/raxol/ui/charts/bar_chart.ex
@@ -11,6 +11,7 @@ defmodule Raxol.UI.Charts.BarChart do
 
   @compile {:no_warn_undefined, Raxol.MCP.ToolProvider}
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type cell :: ChartUtils.cell()
 
@@ -562,4 +563,21 @@ defmodule Raxol.UI.Charts.BarChart do
   @impl Raxol.MCP.ToolProvider
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    %{
+      role: :img,
+      label:
+        node[:aria_label] || node[:title] || a11y_chart_id(node[:id]) ||
+          "bar chart"
+    }
+  end
+
+  defp a11y_chart_id(id) when is_binary(id), do: id
+
+  defp a11y_chart_id(id) when is_atom(id) and not is_nil(id),
+    do: Atom.to_string(id)
+
+  defp a11y_chart_id(_id), do: nil
 end

--- a/lib/raxol/ui/charts/line_chart.ex
+++ b/lib/raxol/ui/charts/line_chart.ex
@@ -11,6 +11,7 @@ defmodule Raxol.UI.Charts.LineChart do
 
   @compile {:no_warn_undefined, Raxol.MCP.ToolProvider}
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type cell :: ChartUtils.cell()
 
@@ -248,4 +249,21 @@ defmodule Raxol.UI.Charts.LineChart do
   @impl Raxol.MCP.ToolProvider
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    %{
+      role: :img,
+      label:
+        node[:aria_label] || node[:title] || a11y_chart_id(node[:id]) ||
+          "line chart"
+    }
+  end
+
+  defp a11y_chart_id(id) when is_binary(id), do: id
+
+  defp a11y_chart_id(id) when is_atom(id) and not is_nil(id),
+    do: Atom.to_string(id)
+
+  defp a11y_chart_id(_id), do: nil
 end

--- a/lib/raxol/ui/charts/scatter_chart.ex
+++ b/lib/raxol/ui/charts/scatter_chart.ex
@@ -11,6 +11,7 @@ defmodule Raxol.UI.Charts.ScatterChart do
 
   @compile {:no_warn_undefined, Raxol.MCP.ToolProvider}
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type cell :: ChartUtils.cell()
 
@@ -198,6 +199,23 @@ defmodule Raxol.UI.Charts.ScatterChart do
   @impl Raxol.MCP.ToolProvider
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    %{
+      role: :img,
+      label:
+        node[:aria_label] || node[:title] || a11y_chart_id(node[:id]) ||
+          "scatter chart"
+    }
+  end
+
+  defp a11y_chart_id(id) when is_binary(id), do: id
+
+  defp a11y_chart_id(id) when is_atom(id) and not is_nil(id),
+    do: Atom.to_string(id)
+
+  defp a11y_chart_id(_id), do: nil
 
   defp series_cluster_stats(s) do
     points = ChartUtils.normalize_data_2d(s[:data] || [])

--- a/lib/raxol/ui/components/display/tree.ex
+++ b/lib/raxol/ui/components/display/tree.ex
@@ -21,6 +21,7 @@ defmodule Raxol.UI.Components.Display.Tree do
 
   use Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type tree_node :: %{
           id: atom(),
@@ -393,4 +394,44 @@ defmodule Raxol.UI.Components.Display.Tree do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    %{
+      role: :tree,
+      label: node[:aria_label] || node[:label],
+      children: a11y_tree_items(node[:nodes] || [], node[:expanded])
+    }
+  end
+
+  defp a11y_tree_items(nodes, expanded) do
+    Enum.map(nodes, fn tree_node ->
+      children = tree_node[:children] || []
+      is_expanded = a11y_expanded?(expanded, tree_node[:id])
+
+      %{
+        role: :treeitem,
+        label: a11y_cell_text(tree_node[:label]),
+        id: a11y_atom_id(tree_node[:id]),
+        state: if(children == [], do: %{}, else: %{expanded?: is_expanded}),
+        children:
+          if(is_expanded, do: a11y_tree_items(children, expanded), else: [])
+      }
+    end)
+  end
+
+  defp a11y_expanded?(%MapSet{} = set, id), do: MapSet.member?(set, id)
+  defp a11y_expanded?(list, id) when is_list(list), do: id in list
+  defp a11y_expanded?(_expanded, _id), do: false
+
+  defp a11y_atom_id(id) when is_binary(id), do: id
+
+  defp a11y_atom_id(id) when is_atom(id) and not is_nil(id),
+    do: Atom.to_string(id)
+
+  defp a11y_atom_id(_id), do: nil
+
+  defp a11y_cell_text(text) when is_binary(text), do: text
+  defp a11y_cell_text(nil), do: nil
+  defp a11y_cell_text(text), do: to_string(text)
 end

--- a/lib/raxol/ui/components/display/viewport.ex
+++ b/lib/raxol/ui/components/display/viewport.ex
@@ -12,6 +12,7 @@ defmodule Raxol.UI.Components.Display.Viewport do
 
   @behaviour Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   alias Raxol.View.Components
 
@@ -303,4 +304,10 @@ defmodule Raxol.UI.Components.Display.Viewport do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    # Children omitted: the projection recurses the viewport's content Elements.
+    %{role: :region, label: node[:aria_label] || node[:label], state: %{}}
+  end
 end

--- a/lib/raxol/ui/components/input/button.ex
+++ b/lib/raxol/ui/components/input/button.ex
@@ -5,6 +5,7 @@ defmodule Raxol.UI.Components.Input.Button do
 
   use Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
   @default_max_width Raxol.Core.Defaults.terminal_width()
 
   defstruct [
@@ -284,6 +285,21 @@ defmodule Raxol.UI.Components.Input.Button do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    attrs = Map.get(node, :attrs, %{})
+
+    %{
+      role: :button,
+      label: attrs[:label],
+      state: %{
+        disabled?: attrs[:disabled] == true,
+        focused?: attrs[:focused] == true,
+        variant: attrs[:role]
+      }
+    }
+  end
 
   # Add validation for invalid roles
   def errors(button) do

--- a/lib/raxol/ui/components/input/checkbox.ex
+++ b/lib/raxol/ui/components/input/checkbox.ex
@@ -12,6 +12,7 @@ defmodule Raxol.UI.Components.Input.Checkbox do
 
   use Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type t :: %{
           id: String.t(),
@@ -199,4 +200,21 @@ defmodule Raxol.UI.Components.Input.Checkbox do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    attrs = Map.get(node, :attrs, %{})
+
+    %{
+      role: :checkbox,
+      label:
+        node[:aria_label] || attrs[:aria_label] || node[:label] || attrs[:label],
+      state: %{
+        checked?: (node[:checked] || attrs[:checked]) == true,
+        required?: (node[:required] || attrs[:required]) == true,
+        disabled?: (node[:disabled] || attrs[:disabled]) == true,
+        focused?: (node[:focused] || attrs[:focused]) == true
+      }
+    }
+  end
 end

--- a/lib/raxol/ui/components/input/menu.ex
+++ b/lib/raxol/ui/components/input/menu.ex
@@ -28,6 +28,7 @@ defmodule Raxol.UI.Components.Input.Menu do
 
   use Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type menu_item :: %{
           id: atom(),
@@ -402,6 +403,34 @@ defmodule Raxol.UI.Components.Input.Menu do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    %{
+      role: :menu,
+      label: node[:aria_label] || node[:label],
+      children: a11y_menu_items(node[:items] || [])
+    }
+  end
+
+  defp a11y_menu_items(items) do
+    Enum.map(items, fn item ->
+      %{
+        role: :menuitem,
+        label: item[:label],
+        id: a11y_atom_id(item[:id]),
+        state: %{disabled?: item[:disabled] == true},
+        children: a11y_menu_items(item[:children] || [])
+      }
+    end)
+  end
+
+  defp a11y_atom_id(id) when is_binary(id), do: id
+
+  defp a11y_atom_id(id) when is_atom(id) and not is_nil(id),
+    do: Atom.to_string(id)
+
+  defp a11y_atom_id(_id), do: nil
 
   defp collect_item_labels(items, depth) do
     Enum.flat_map(items, fn item ->

--- a/lib/raxol/ui/components/input/password_field.ex
+++ b/lib/raxol/ui/components/input/password_field.ex
@@ -9,6 +9,7 @@ defmodule Raxol.UI.Components.Input.PasswordField do
 
   @behaviour Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @impl Raxol.UI.Components.Base.Component
   def init(props) do
@@ -69,4 +70,21 @@ defmodule Raxol.UI.Components.Input.PasswordField do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    attrs = Map.get(node, :attrs, %{})
+
+    %{
+      role: :textbox,
+      label:
+        node[:aria_label] || attrs[:aria_label] || node[:label] || attrs[:label] ||
+          node[:placeholder] || attrs[:placeholder],
+      value: nil,
+      state: %{
+        focused?: (node[:focused] || attrs[:focused]) == true,
+        required?: (node[:required] || attrs[:required]) == true
+      }
+    }
+  end
 end

--- a/lib/raxol/ui/components/input/select_list.ex
+++ b/lib/raxol/ui/components/input/select_list.ex
@@ -22,6 +22,7 @@ defmodule Raxol.UI.Components.Input.SelectList do
 
   @behaviour Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @key_mapping %{
     "Down" => :navigation_down,
@@ -703,4 +704,33 @@ defmodule Raxol.UI.Components.Input.SelectList do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    options = node[:options] || node[:filtered_options] || []
+    selected = node[:selected_index] || node[:focused_index]
+
+    children =
+      options
+      |> Enum.with_index()
+      |> Enum.map(fn {opt, index} ->
+        %{
+          role: :option,
+          label: a11y_option_label(opt),
+          state: %{selected?: index == selected}
+        }
+      end)
+
+    %{
+      role: :listbox,
+      label: node[:aria_label] || node[:label],
+      state: %{focused?: node[:focused] == true},
+      children: children
+    }
+  end
+
+  defp a11y_option_label({label, _value}) when is_binary(label), do: label
+  defp a11y_option_label(%{} = opt), do: opt[:label] || opt[:name]
+  defp a11y_option_label(label) when is_binary(label), do: label
+  defp a11y_option_label(other), do: inspect(other)
 end

--- a/lib/raxol/ui/components/input/tabs.ex
+++ b/lib/raxol/ui/components/input/tabs.ex
@@ -15,6 +15,7 @@ defmodule Raxol.UI.Components.Input.Tabs do
 
   use Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type tab :: %{id: atom() | String.t(), label: String.t()}
 
@@ -220,4 +221,35 @@ defmodule Raxol.UI.Components.Input.Tabs do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    tabs = node[:tabs] || []
+    active = node[:active_index] || 0
+
+    children =
+      tabs
+      |> Enum.with_index()
+      |> Enum.map(fn {tab, index} ->
+        %{
+          role: :tab,
+          label: tab[:label],
+          id: a11y_tab_id(tab[:id]),
+          state: %{selected?: index == active}
+        }
+      end)
+
+    %{
+      role: :tablist,
+      label: node[:aria_label] || node[:label],
+      children: children
+    }
+  end
+
+  defp a11y_tab_id(id) when is_binary(id), do: id
+
+  defp a11y_tab_id(id) when is_atom(id) and not is_nil(id),
+    do: Atom.to_string(id)
+
+  defp a11y_tab_id(_id), do: nil
 end

--- a/lib/raxol/ui/components/input/text_area.ex
+++ b/lib/raxol/ui/components/input/text_area.ex
@@ -9,6 +9,7 @@ defmodule Raxol.UI.Components.Input.TextArea do
 
   @behaviour Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @impl Raxol.UI.Components.Base.Component
   def init(props), do: MultiLineInput.init(props)
@@ -74,4 +75,21 @@ defmodule Raxol.UI.Components.Input.TextArea do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    attrs = Map.get(node, :attrs, %{})
+
+    %{
+      role: :textbox,
+      label:
+        node[:aria_label] || attrs[:aria_label] || node[:label] || attrs[:label] ||
+          node[:placeholder] || attrs[:placeholder],
+      value: node[:value] || attrs[:value],
+      state: %{
+        focused?: (node[:focused] || attrs[:focused]) == true,
+        required?: (node[:required] || attrs[:required]) == true
+      }
+    }
+  end
 end

--- a/lib/raxol/ui/components/input/text_input.ex
+++ b/lib/raxol/ui/components/input/text_input.ex
@@ -9,6 +9,7 @@ defmodule Raxol.UI.Components.Input.TextInput do
 
   @behaviour Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @type props :: %{
           optional(:id) => String.t(),
@@ -222,6 +223,23 @@ defmodule Raxol.UI.Components.Input.TextInput do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    attrs = Map.get(node, :attrs, %{})
+
+    %{
+      role: :textbox,
+      label:
+        node[:aria_label] || attrs[:aria_label] || node[:label] || attrs[:label] ||
+          node[:placeholder] || attrs[:placeholder],
+      value: node[:value] || attrs[:value],
+      state: %{
+        focused?: (node[:focused] || attrs[:focused]) == true,
+        required?: (node[:required] || attrs[:required]) == true
+      }
+    }
+  end
 end
 
 defmodule Raxol.UI.Components.Input.TextInput.KeyHandler do

--- a/lib/raxol/ui/components/modal.ex
+++ b/lib/raxol/ui/components/modal.ex
@@ -31,6 +31,7 @@ defmodule Raxol.UI.Components.Modal do
   # Use standard component behaviour
   use Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   # Require view macros and components
   # require Raxol.View.Elements  # Removed
@@ -339,4 +340,10 @@ defmodule Raxol.UI.Components.Modal do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    # Children omitted: the projection recurses the modal's own content Elements.
+    %{role: :dialog, label: node[:title] || node[:aria_label], state: %{}}
+  end
 end

--- a/lib/raxol/ui/components/table.ex
+++ b/lib/raxol/ui/components/table.ex
@@ -109,6 +109,7 @@ defmodule Raxol.UI.Components.Table do
 
   @behaviour Raxol.UI.Components.Base.Component
   @behaviour Raxol.MCP.ToolProvider
+  @behaviour Raxol.Core.Accessibility.Provider
 
   @doc """
   Initializes the table component with the given props.
@@ -811,4 +812,37 @@ defmodule Raxol.UI.Components.Table do
 
   def handle_tool_call(action, _args, _ctx),
     do: {:error, "Unknown action: #{action}"}
+
+  @impl Raxol.Core.Accessibility.Provider
+  def a11y_node(node) do
+    columns = node[:columns] || []
+    data = node[:data] || []
+
+    rows =
+      Enum.map(data, fn row ->
+        cells =
+          Enum.map(columns, fn column ->
+            %{
+              role: :gridcell,
+              label: a11y_cell_text(a11y_cell(row, column[:id]))
+            }
+          end)
+
+        %{role: :row, children: cells}
+      end)
+
+    %{role: :grid, label: node[:aria_label] || node[:label], children: rows}
+  end
+
+  defp a11y_cell(row, key) when is_map(row), do: Map.get(row, key)
+  defp a11y_cell(_row, _key), do: nil
+
+  defp a11y_cell_text(nil), do: nil
+  defp a11y_cell_text(value) when is_binary(value), do: value
+
+  defp a11y_cell_text(value)
+       when is_integer(value) or is_float(value) or is_atom(value),
+       do: to_string(value)
+
+  defp a11y_cell_text(value), do: inspect(value)
 end

--- a/packages/raxol_core/lib/raxol/core/accessibility/projection.ex
+++ b/packages/raxol_core/lib/raxol/core/accessibility/projection.ex
@@ -1,0 +1,310 @@
+defmodule Raxol.Core.Accessibility.Projection do
+  @moduledoc """
+  Projects a declaration Element tree into an accessibility tree.
+
+  The accessibility tree is a role/label/state descriptor tree that Surfaces
+  (MCP, Browser) serialize to drive assistive technology. It is derived from the
+  same Element tree that `Raxol.MCP.TreeWalker` walks (the `view/1` output synced
+  to the Dispatcher), so a node here carries the discrete Component props.
+
+  For each Element the projection either calls the Component's
+  `Raxol.Core.Accessibility.Provider.a11y_node/1` (for the ~15 Components that
+  implement it) or falls back to a default extraction driven by
+  `Raxol.Core.Accessibility.Roles`. The projection is **total**: it never raises
+  for any input, defaulting unknown types to `:generic` and rescuing a Provider
+  that itself raises.
+
+  ## Dependency direction
+
+  This lives in raxol_core (which Browser and MCP both depend on, but which does
+  NOT depend on main raxol). The `type -> module` map names Component modules in
+  main raxol; they are resolved at runtime only when loaded, guarded by
+  `Provider.provider?/1`, so raxol_core stays free of a main-raxol dependency.
+  """
+
+  require Logger
+
+  alias Raxol.Core.Accessibility.{Provider, Roles}
+
+  @type accessibility_node :: %{
+          role: atom(),
+          label: String.t() | nil,
+          state: %{optional(atom()) => boolean() | atom()},
+          value: term() | nil,
+          children: [accessibility_node()],
+          live?: boolean(),
+          id: String.t() | nil
+        }
+
+  # Mirrors Raxol.MCP.TreeWalker's @default_type_map. Declaration type -> the
+  # Component module that implements the Provider behaviour.
+  @compile {:no_warn_undefined,
+            [
+              Raxol.UI.Components.Input.Button,
+              Raxol.UI.Components.Input.TextInput,
+              Raxol.UI.Components.Input.TextArea,
+              Raxol.UI.Components.Input.PasswordField,
+              Raxol.UI.Components.Input.SelectList,
+              Raxol.UI.Components.Input.Checkbox,
+              Raxol.UI.Components.Input.Menu,
+              Raxol.UI.Components.Input.Tabs,
+              Raxol.UI.Components.Modal,
+              Raxol.UI.Components.Table,
+              Raxol.UI.Components.Display.Tree,
+              Raxol.UI.Components.Display.Viewport,
+              Raxol.UI.Charts.BarChart,
+              Raxol.UI.Charts.LineChart,
+              Raxol.UI.Charts.ScatterChart
+            ]}
+
+  @default_type_map %{
+    button: Raxol.UI.Components.Input.Button,
+    text_input: Raxol.UI.Components.Input.TextInput,
+    text_area: Raxol.UI.Components.Input.TextArea,
+    password_field: Raxol.UI.Components.Input.PasswordField,
+    select_list: Raxol.UI.Components.Input.SelectList,
+    checkbox: Raxol.UI.Components.Input.Checkbox,
+    menu: Raxol.UI.Components.Input.Menu,
+    tabs: Raxol.UI.Components.Input.Tabs,
+    modal: Raxol.UI.Components.Modal,
+    table: Raxol.UI.Components.Table,
+    tree: Raxol.UI.Components.Display.Tree,
+    viewport: Raxol.UI.Components.Display.Viewport,
+    bar_chart: Raxol.UI.Charts.BarChart,
+    line_chart: Raxol.UI.Charts.LineChart,
+    scatter_chart: Raxol.UI.Charts.ScatterChart
+  }
+
+  # State keys whose `false` is meaningful (aria-checked=false differs from
+  # absent); all other keys are dropped when false.
+  @keep_false [:checked?, :selected?, :expanded?, :pressed?]
+
+  @doc """
+  Projects an Element (or list of Elements) into an accessibility node (or list).
+
+  ## Options
+
+    * `:type_map` - override the declaration-type -> Component-module map
+      (defaults to the built-in 15-Component map). Mirrors
+      `Raxol.MCP.TreeWalker`'s `context.type_map`.
+  """
+  @spec project(map() | [map()] | nil, keyword()) ::
+          accessibility_node() | [accessibility_node()] | nil
+  def project(tree, opts \\ [])
+
+  def project(nil, _opts), do: []
+
+  def project(nodes, opts) when is_list(nodes) do
+    Enum.map(nodes, &project(&1, opts))
+  end
+
+  def project(node, opts) when is_map(node) do
+    type_map = Keyword.get(opts, :type_map, @default_type_map)
+    build_node(node, type_map, opts)
+  end
+
+  def project(_other, _opts), do: nil
+
+  @doc """
+  Projects a single Element's own descriptor -- role/label/state/value/live?/id
+  -- WITHOUT recursing its children (children is always `[]`).
+
+  For Surfaces that walk the Element tree themselves (e.g. MCP
+  `StructuredScreenshot`) and only need per-node a11y fields folded in.
+  """
+  @spec descriptor(map(), keyword()) :: accessibility_node() | nil
+  def descriptor(node, opts \\ [])
+
+  def descriptor(node, opts) when is_map(node) do
+    type_map = Keyword.get(opts, :type_map, @default_type_map)
+    type = Map.get(node, :type)
+
+    raw =
+      case provider_for(type, type_map) do
+        {:ok, module} -> safe_provider(module, node)
+        :none -> default_extract(node, type)
+      end
+
+    finalize(raw, [], node_id(node))
+  end
+
+  def descriptor(_node, _opts), do: nil
+
+  @doc """
+  Flat `id -> accessibility_node` map for Surfaces that key ARIA by Element id.
+
+  Only nodes with a non-empty binary id are included.
+  """
+  @spec by_id(map() | [map()] | nil, keyword()) ::
+          %{optional(String.t()) => accessibility_node()}
+  def by_id(tree, opts \\ []) do
+    tree
+    |> project(opts)
+    |> List.wrap()
+    |> collect_by_id(%{})
+  end
+
+  # -- tree walk ---------------------------------------------------------------
+
+  defp build_node(node, type_map, opts) do
+    type = Map.get(node, :type)
+
+    raw =
+      case provider_for(type, type_map) do
+        {:ok, module} -> safe_provider(module, node)
+        :none -> default_extract(node, type)
+      end
+
+    # A Provider may synthesize its own children (SelectList options, Tabs, Table
+    # rows); otherwise the projection recurses the Element's own children.
+    children =
+      case Map.fetch(raw, :children) do
+        {:ok, kids} when is_list(kids) -> finalize_supplied(kids)
+        _ -> project_children(Map.get(node, :children), type_map, opts)
+      end
+
+    finalize(raw, children, node_id(node))
+  end
+
+  # Normalizes a raw node (from a Provider or default extraction) into a complete
+  # accessibility node, filling missing keys.
+  defp finalize(raw, children, id) do
+    role = Map.get(raw, :role, Roles.default_role())
+
+    %{
+      role: role,
+      label: normalize_label(Map.get(raw, :label)),
+      state: compact_state(Map.get(raw, :state, %{})),
+      value: Map.get(raw, :value),
+      children: children,
+      live?: Map.get(raw, :live?, Roles.live?(role)),
+      id: id
+    }
+  end
+
+  # Provider-supplied children are terse maps; normalize each (recursively) so a
+  # Provider can return %{role: :option, label: "x", state: %{selected?: true}}.
+  defp finalize_supplied(kids) when is_list(kids) do
+    kids |> Enum.map(&finalize_supplied_node/1) |> Enum.reject(&is_nil/1)
+  end
+
+  defp finalize_supplied_node(child) when is_map(child) do
+    grandkids =
+      case Map.fetch(child, :children) do
+        {:ok, kids} when is_list(kids) -> finalize_supplied(kids)
+        _ -> []
+      end
+
+    finalize(child, grandkids, node_id(child))
+  end
+
+  defp finalize_supplied_node(_child), do: nil
+
+  defp project_children(kids, type_map, opts) when is_list(kids) do
+    opts = Keyword.put(opts, :type_map, type_map)
+    kids |> Enum.map(&project(&1, opts)) |> Enum.reject(&is_nil/1)
+  end
+
+  defp project_children(_other, _type_map, _opts), do: []
+
+  defp collect_by_id(nodes, acc) when is_list(nodes) do
+    Enum.reduce(nodes, acc, &collect_by_id/2)
+  end
+
+  defp collect_by_id(%{} = node, acc) do
+    acc =
+      case node[:id] do
+        id when is_binary(id) and id != "" -> Map.put(acc, id, node)
+        _ -> acc
+      end
+
+    collect_by_id(node[:children] || [], acc)
+  end
+
+  defp collect_by_id(_other, acc), do: acc
+
+  # -- provider dispatch -------------------------------------------------------
+
+  defp provider_for(type, type_map) when is_atom(type) do
+    case Map.get(type_map, type) do
+      nil -> :none
+      module -> if Provider.provider?(module), do: {:ok, module}, else: :none
+    end
+  end
+
+  defp provider_for(_type, _type_map), do: :none
+
+  defp safe_provider(module, node) do
+    module.a11y_node(node)
+  rescue
+    error ->
+      Logger.debug("a11y_node/1 raised in #{inspect(module)}: #{inspect(error)}")
+      default_extract(node, Map.get(node, :type))
+  end
+
+  # -- default extraction ------------------------------------------------------
+
+  defp default_extract(node, type) do
+    role = Roles.role_for(type)
+
+    %{
+      role: role,
+      label: default_label(node),
+      state: default_state(node),
+      value: default_value(node, role),
+      live?: Roles.live?(role)
+    }
+  end
+
+  defp default_label(node) do
+    node[:label] || node[:aria_label] || fetch_attr(node, :label) ||
+      fetch_attr(node, :aria_label) || node[:content] || fetch_attr(node, :content)
+  end
+
+  # Default extraction surfaces only flags that are literally true; it never
+  # invents `selected?: false` on Elements with no selection concept. Tri-state
+  # `false` (aria-checked/selected) is the Provider's job, not the fallback's.
+  defp default_state(node) do
+    %{}
+    |> put_flag(:disabled?, node[:disabled] || fetch_attr(node, :disabled))
+    |> put_flag(:focused?, node[:focused] || fetch_attr(node, :focused))
+    |> put_flag(:required?, node[:required] || fetch_attr(node, :required))
+    |> put_flag(:selected?, node[:selected] || fetch_attr(node, :selected))
+  end
+
+  defp put_flag(state, key, true), do: Map.put(state, key, true)
+  defp put_flag(state, _key, _value), do: state
+
+  defp default_value(node, :textbox),
+    do: node[:value] || fetch_attr(node, :value) || node[:content]
+
+  defp default_value(node, :progressbar),
+    do: node[:value] || fetch_attr(node, :value)
+
+  defp default_value(_node, _role), do: nil
+
+  # -- helpers -----------------------------------------------------------------
+
+  defp fetch_attr(%{attrs: %{} = attrs}, key), do: Map.get(attrs, key)
+  defp fetch_attr(_node, _key), do: nil
+
+  defp node_id(node) do
+    case Map.get(node, :id) do
+      id when is_binary(id) -> id
+      _ -> nil
+    end
+  end
+
+  defp normalize_label(label) when is_binary(label), do: label
+  defp normalize_label(_label), do: nil
+
+  defp compact_state(state) when is_map(state) do
+    Enum.reduce(state, %{}, fn
+      {_k, nil}, acc -> acc
+      {k, false}, acc -> if k in @keep_false, do: Map.put(acc, k, false), else: acc
+      {k, v}, acc -> Map.put(acc, k, v)
+    end)
+  end
+
+  defp compact_state(_state), do: %{}
+end

--- a/packages/raxol_core/lib/raxol/core/accessibility/provider.ex
+++ b/packages/raxol_core/lib/raxol/core/accessibility/provider.ex
@@ -1,0 +1,54 @@
+defmodule Raxol.Core.Accessibility.Provider do
+  @moduledoc """
+  Behaviour a Component implements to describe itself to assistive technology.
+
+  Parallels `Raxol.MCP.ToolProvider`: the callback receives the Component's
+  declaration Element (the same map `mcp_tools/1` receives) and returns an
+  accessibility node. `Raxol.Core.Accessibility.Projection` walks the Element
+  tree and calls this callback for Components that implement it, falling back to
+  a default role/label extraction otherwise.
+
+  A Component knows where its own fields live (field locations are heterogeneous
+  across the codebase), so co-locating the extractor here keeps each Component
+  authoritative about its own shape.
+
+  ## Returning children
+
+  Omit `:children` for leaf Components (Button, TextInput, Checkbox) -- the
+  projection recurses the Element's own children. Set `:children` only when the
+  Component *synthesizes* semantic children not present as Element children
+  (e.g. SelectList options built from an `:options` attr, Tabs, Table rows).
+
+  ## Example
+
+      @impl Raxol.Core.Accessibility.Provider
+      def a11y_node(node) do
+        %{role: :checkbox, label: node[:label], id: node[:id],
+          state: %{checked?: node[:checked] || false}}
+      end
+  """
+
+  @doc """
+  Builds an accessibility node from a Component's declaration Element.
+
+  Returned maps are normalized by `Raxol.Core.Accessibility.Projection`:
+  missing keys are filled (`role` -> `:generic`, `state` -> `%{}`, `live?`
+  derived from the role), so a Provider only needs to supply what it knows.
+  """
+  @callback a11y_node(element :: map()) ::
+              Raxol.Core.Accessibility.Projection.accessibility_node()
+
+  @doc """
+  Returns true when `module` implements this behaviour.
+
+  Guarded with `Code.ensure_loaded?/1` so raxol_core can dispatch to Component
+  modules that live in main raxol (loaded only when main is present) without a
+  compile-time dependency.
+  """
+  @spec provider?(module()) :: boolean()
+  def provider?(module) when is_atom(module) do
+    Code.ensure_loaded?(module) and function_exported?(module, :a11y_node, 1)
+  end
+
+  def provider?(_module), do: false
+end

--- a/packages/raxol_core/lib/raxol/core/accessibility/roles.ex
+++ b/packages/raxol_core/lib/raxol/core/accessibility/roles.ex
@@ -1,0 +1,93 @@
+defmodule Raxol.Core.Accessibility.Roles do
+  @moduledoc """
+  The ARIA role vocabulary for the accessibility tree.
+
+  Maps a declaration Element `:type` to a standard ARIA role and answers which
+  roles are live regions. This is the single source of truth for the default
+  `type -> role` mapping; Components that implement
+  `Raxol.Core.Accessibility.Provider` may override the role for their own node,
+  but the values here are the vocabulary they should draw from.
+
+  Interactive and structural Components map to standard ARIA roles. Tables map
+  to `:grid` (arrow-navigable, focusable cells) rather than the static `:table`.
+  Layout containers map to `:group`; bare text maps to `:text`. Unknown types
+  fall back to `:generic` so the projection is total.
+  """
+
+  # Declaration Element type -> ARIA role. Provider Components plus the DSL
+  # primitives the projection may encounter when no Provider is present.
+  @type_role %{
+    # interactive Components
+    button: :button,
+    text_input: :textbox,
+    text_area: :textbox,
+    textarea: :textbox,
+    password_field: :textbox,
+    multi_line_input: :textbox,
+    select_list: :listbox,
+    checkbox: :checkbox,
+    radio: :radio,
+    radio_group: :radiogroup,
+    menu: :menu,
+    tabs: :tablist,
+    modal: :dialog,
+    # structural Components
+    table: :grid,
+    tree: :tree,
+    viewport: :region,
+    progress: :progressbar,
+    # charts render as a single labeled image
+    bar_chart: :img,
+    line_chart: :img,
+    scatter_chart: :img,
+    heatmap: :img,
+    # layout primitives
+    row: :group,
+    column: :group,
+    box: :group,
+    panel: :group,
+    container: :group,
+    flex: :group,
+    grid: :group,
+    # text primitives + live announcers
+    text: :text,
+    label: :text,
+    alert: :alert,
+    status: :status,
+    log: :log
+  }
+
+  # Role a container's semantic children should carry. Convenience for Provider
+  # impls that synthesize children (e.g. SelectList options); the projection
+  # does not apply these automatically.
+  @child_role %{
+    listbox: :option,
+    menu: :menuitem,
+    tablist: :tab,
+    grid: :row,
+    tree: :treeitem,
+    radiogroup: :radio
+  }
+
+  @live_roles [:alert, :status, :log, :progressbar]
+
+  @default_role :generic
+
+  @doc "The ARIA role for a declaration Element type. Unknown types -> `:generic`."
+  @spec role_for(term()) :: atom()
+  def role_for(type) when is_atom(type), do: Map.get(@type_role, type, @default_role)
+  def role_for(_type), do: @default_role
+
+  @doc "The conventional child role for a container role, or `nil`."
+  @spec child_role(atom()) :: atom() | nil
+  def child_role(role) when is_atom(role), do: Map.get(@child_role, role)
+  def child_role(_role), do: nil
+
+  @doc "Whether a role denotes a live region (announced as it changes)."
+  @spec live?(atom()) :: boolean()
+  def live?(role), do: role in @live_roles
+
+  @doc "The fallback role for Elements with no mapping."
+  @spec default_role() :: atom()
+  def default_role, do: @default_role
+end

--- a/packages/raxol_core/test/raxol/core/accessibility/projection_test.exs
+++ b/packages/raxol_core/test/raxol/core/accessibility/projection_test.exs
@@ -1,0 +1,166 @@
+defmodule Raxol.Core.Accessibility.ProjectionTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Accessibility.Projection
+
+  # Stub Providers for the injected type_map. The real Components live in main
+  # raxol and are not loaded in raxol_core's suite; their integration is covered
+  # by Raxol.UI.Accessibility.ComponentA11yTest in the main app.
+  defmodule StubButton do
+    @behaviour Raxol.Core.Accessibility.Provider
+    @impl true
+    def a11y_node(node) do
+      %{role: :button, label: node[:label], state: %{disabled?: node[:disabled] == true}}
+    end
+  end
+
+  defmodule StubList do
+    @behaviour Raxol.Core.Accessibility.Provider
+    @impl true
+    def a11y_node(node) do
+      children = Enum.map(node[:options] || [], fn opt -> %{role: :option, label: opt} end)
+      %{role: :listbox, label: node[:label], children: children}
+    end
+  end
+
+  defmodule StubRaises do
+    @behaviour Raxol.Core.Accessibility.Provider
+    @impl true
+    def a11y_node(_node), do: raise("boom")
+  end
+
+  @stub_map %{stub_button: StubButton, stub_list: StubList, stub_raises: StubRaises}
+
+  defp project(node), do: Projection.project(node, type_map: @stub_map)
+
+  describe "Provider dispatch" do
+    test "calls a11y_node/1 for a mapped Provider and normalizes the node" do
+      node = %{type: :stub_button, id: "b1", label: "Save", disabled: false}
+
+      assert %{
+               role: :button,
+               label: "Save",
+               id: "b1",
+               children: [],
+               value: nil,
+               live?: false,
+               state: state
+             } = project(node)
+
+      # disabled? false is dropped (its absence means false)
+      refute Map.has_key?(state, :disabled?)
+    end
+
+    test "keeps disabled? when true" do
+      node = %{type: :stub_button, id: "b1", label: "Save", disabled: true}
+      assert %{state: %{disabled?: true}} = project(node)
+    end
+
+    test "uses Provider-supplied children, normalizing each terse child" do
+      node = %{type: :stub_list, id: "l1", label: "Pick", options: ["a", "b"]}
+
+      assert %{role: :listbox, label: "Pick", children: [c1, c2]} = project(node)
+
+      assert %{
+               role: :option,
+               label: "a",
+               children: [],
+               state: %{},
+               value: nil,
+               live?: false,
+               id: nil
+             } =
+               c1
+
+      assert %{role: :option, label: "b"} = c2
+    end
+  end
+
+  describe "totality" do
+    test "a Provider that raises falls back to default extraction" do
+      node = %{type: :stub_raises, id: "x", content: "hi"}
+      assert %{role: :generic, label: "hi", id: "x"} = project(node)
+    end
+
+    @adversarial [
+      nil,
+      %{},
+      %{type: :text},
+      %{type: nil},
+      %{type: "string-type"},
+      %{type: :row, children: nil},
+      %{type: :row, children: "not a list"},
+      %{type: :row, children: [nil, "x", 42, %{type: :text, content: "ok"}]},
+      %{type: :checkbox, checked: nil, attrs: nil},
+      %{type: :button, attrs: %{label: 123}},
+      %{type: :text, content: 42},
+      %{type: :unknown_xyz, foo: :bar},
+      [%{type: :button}, %{type: :text, content: "y"}],
+      "just a string",
+      42,
+      :an_atom
+    ]
+
+    test "project/1 never raises for adversarial input" do
+      for input <- @adversarial do
+        result = Projection.project(input)
+        assert is_nil(result) or is_map(result) or is_list(result)
+      end
+    end
+  end
+
+  describe "default extraction (no Provider loaded)" do
+    # The default type_map names main-raxol Components not loaded here, so these
+    # exercise the fallback path the projection uses for un-opted Elements.
+    test "bare text -> :text with content as label" do
+      assert %{role: :text, label: "hello", children: []} =
+               Projection.project(%{type: :text, content: "hello"})
+    end
+
+    test "row -> :group and recurses Element children" do
+      tree = %{
+        type: :row,
+        children: [%{type: :text, content: "a"}, %{type: :text, content: "b"}]
+      }
+
+      assert %{role: :group, children: [%{label: "a"}, %{label: "b"}]} = Projection.project(tree)
+    end
+
+    test "unknown type -> :generic" do
+      assert %{role: :generic} = Projection.project(%{type: :frobnicate})
+    end
+
+    test "button-shaped Element falls back to :button + attrs label when unloaded" do
+      node = %{type: :button, id: "b", attrs: %{label: "Go", disabled: true}}
+
+      assert %{role: :button, label: "Go", id: "b", state: %{disabled?: true}} =
+               Projection.project(node)
+    end
+
+    test "non-string labels normalize to nil" do
+      assert %{label: nil} = Projection.project(%{type: :text, content: 42})
+    end
+  end
+
+  describe "by_id/2" do
+    test "flattens nodes with binary ids into a map" do
+      tree = %{
+        type: :row,
+        children: [
+          %{type: :stub_button, id: "b1", label: "A"},
+          %{type: :stub_button, id: "b2", label: "B"}
+        ]
+      }
+
+      map = Projection.by_id(tree, type_map: @stub_map)
+
+      assert %{"b1" => %{role: :button, label: "A"}, "b2" => %{label: "B"}} = map
+      assert map_size(map) == 2
+    end
+
+    test "skips nodes without a binary id" do
+      tree = %{type: :row, children: [%{type: :text, content: "x"}]}
+      assert Projection.by_id(tree) == %{}
+    end
+  end
+end

--- a/packages/raxol_core/test/raxol/core/accessibility/roles_test.exs
+++ b/packages/raxol_core/test/raxol/core/accessibility/roles_test.exs
@@ -1,0 +1,80 @@
+defmodule Raxol.Core.Accessibility.RolesTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Accessibility.Roles
+
+  describe "role_for/1" do
+    test "maps interactive Component types to ARIA roles" do
+      assert Roles.role_for(:button) == :button
+      assert Roles.role_for(:text_input) == :textbox
+      assert Roles.role_for(:text_area) == :textbox
+      assert Roles.role_for(:password_field) == :textbox
+      assert Roles.role_for(:checkbox) == :checkbox
+      assert Roles.role_for(:select_list) == :listbox
+      assert Roles.role_for(:menu) == :menu
+      assert Roles.role_for(:tabs) == :tablist
+      assert Roles.role_for(:modal) == :dialog
+    end
+
+    test "maps Table to :grid (interactive-grid variant)" do
+      assert Roles.role_for(:table) == :grid
+    end
+
+    test "maps structural + chart types" do
+      assert Roles.role_for(:tree) == :tree
+      assert Roles.role_for(:viewport) == :region
+      assert Roles.role_for(:progress) == :progressbar
+      assert Roles.role_for(:bar_chart) == :img
+      assert Roles.role_for(:line_chart) == :img
+      assert Roles.role_for(:scatter_chart) == :img
+    end
+
+    test "maps layout primitives to :group and text to :text" do
+      assert Roles.role_for(:row) == :group
+      assert Roles.role_for(:column) == :group
+      assert Roles.role_for(:box) == :group
+      assert Roles.role_for(:text) == :text
+      assert Roles.role_for(:label) == :text
+    end
+
+    test "unknown or non-atom types fall back to :generic" do
+      assert Roles.role_for(:frobnicate) == :generic
+      assert Roles.role_for("button") == :generic
+      assert Roles.role_for(nil) == :generic
+      assert Roles.role_for(42) == :generic
+    end
+  end
+
+  describe "live?/1" do
+    test "true for live-region roles" do
+      assert Roles.live?(:alert)
+      assert Roles.live?(:status)
+      assert Roles.live?(:log)
+      assert Roles.live?(:progressbar)
+    end
+
+    test "false otherwise" do
+      refute Roles.live?(:button)
+      refute Roles.live?(:grid)
+      refute Roles.live?(:generic)
+    end
+  end
+
+  describe "child_role/1" do
+    test "returns the conventional child role for a container" do
+      assert Roles.child_role(:listbox) == :option
+      assert Roles.child_role(:menu) == :menuitem
+      assert Roles.child_role(:tablist) == :tab
+      assert Roles.child_role(:tree) == :treeitem
+    end
+
+    test "nil when no convention" do
+      assert Roles.child_role(:button) == nil
+      assert Roles.child_role(nil) == nil
+    end
+  end
+
+  test "default_role/0" do
+    assert Roles.default_role() == :generic
+  end
+end

--- a/packages/raxol_mcp/lib/raxol/mcp/structured_screenshot.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/structured_screenshot.ex
@@ -7,27 +7,46 @@ defmodule Raxol.MCP.StructuredScreenshot do
   widget nodes to a consistent shape.
   """
 
+  alias Raxol.Core.Accessibility.Projection
+
   @type widget_summary :: %{
           required(:type) => atom(),
           required(:id) => String.t() | nil,
           required(:children) => [widget_summary()],
           optional(:content) => String.t(),
-          optional(:animation_hints) => [map()]
+          optional(:animation_hints) => [map()],
+          optional(:role) => atom(),
+          optional(:label) => String.t(),
+          optional(:state) => %{optional(atom()) => boolean() | atom()},
+          optional(:value) => term(),
+          optional(:focused) => boolean(),
+          optional(:live) => boolean()
         }
 
   @doc """
   Convert a view tree map to a list of widget summaries.
 
   Each node retains `:type`, `:id`, `:content` (if text), and recursed
-  `:children`. All callbacks and style details are stripped.
+  `:children`. All callbacks and style details are stripped. Accessibility
+  fields (`:role`, `:label`, `:state`, `:value`, `:focused`, `:live`) are folded
+  in per node via `Raxol.Core.Accessibility.Projection` so agents get a
+  machine-readable role/state alongside the structural tree.
+
+  ## Options
+
+    * `:focused_id` - Element id currently focused; marks that node `focused: true`
+      in addition to any Component-reported focus.
+    * `:type_map` - override the projection's declaration-type -> Component map.
   """
-  @spec from_view_tree(map() | list() | nil) :: [widget_summary()]
-  def from_view_tree(nil), do: []
+  @spec from_view_tree(map() | list() | nil, keyword()) :: [widget_summary()]
+  def from_view_tree(tree, opts \\ [])
 
-  def from_view_tree(nodes) when is_list(nodes),
-    do: Enum.map(nodes, &summarize_node/1)
+  def from_view_tree(nil, _opts), do: []
 
-  def from_view_tree(node) when is_map(node), do: [summarize_node(node)]
+  def from_view_tree(nodes, opts) when is_list(nodes),
+    do: Enum.map(nodes, &summarize_node(&1, opts))
+
+  def from_view_tree(node, opts) when is_map(node), do: [summarize_node(node, opts)]
 
   @doc """
   Encode a widget summary list to a JSON string.
@@ -42,11 +61,11 @@ defmodule Raxol.MCP.StructuredScreenshot do
 
   # -- Private -----------------------------------------------------------------
 
-  defp summarize_node(node) when is_map(node) do
+  defp summarize_node(node, opts) when is_map(node) do
     children =
       case Map.get(node, :children) do
         nil -> []
-        kids when is_list(kids) -> Enum.map(kids, &summarize_node/1)
+        kids when is_list(kids) -> Enum.map(kids, &summarize_node(&1, opts))
         _ -> []
       end
 
@@ -57,9 +76,43 @@ defmodule Raxol.MCP.StructuredScreenshot do
     }
     |> maybe_put_content(Map.get(node, :content))
     |> maybe_put_hints(Map.get(node, :animation_hints))
+    |> put_a11y(node, opts)
   end
 
-  defp summarize_node(_), do: %{type: :unknown, id: nil, children: []}
+  defp summarize_node(_node, _opts), do: %{type: :unknown, id: nil, children: []}
+
+  # Folds the per-node accessibility descriptor into the summary. Additive: only
+  # meaningful fields are attached (role always, others when present/truthy).
+  defp put_a11y(summary, node, opts) do
+    case Projection.descriptor(node, Keyword.take(opts, [:type_map])) do
+      nil ->
+        summary
+
+      desc ->
+        focused_id = Keyword.get(opts, :focused_id)
+
+        focused =
+          desc.state[:focused?] == true or
+            (is_binary(focused_id) and desc.id == focused_id)
+
+        summary
+        |> Map.put(:role, desc.role)
+        |> maybe_put(:label, desc.label)
+        |> put_state(desc.state)
+        |> maybe_put(:value, desc.value)
+        |> maybe_put_focused(focused)
+        |> maybe_put_live(desc.live?)
+    end
+  end
+
+  defp put_state(summary, state) when map_size(state) == 0, do: summary
+  defp put_state(summary, state), do: Map.put(summary, :state, state)
+
+  defp maybe_put_focused(summary, true), do: Map.put(summary, :focused, true)
+  defp maybe_put_focused(summary, _focused), do: summary
+
+  defp maybe_put_live(summary, true), do: Map.put(summary, :live, true)
+  defp maybe_put_live(summary, _live), do: summary
 
   defp maybe_put_content(summary, content) when is_binary(content),
     do: Map.put(summary, :content, content)

--- a/packages/raxol_mcp/test/raxol/mcp/structured_screenshot_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/structured_screenshot_test.exs
@@ -271,6 +271,80 @@ defmodule Raxol.MCP.StructuredScreenshotTest do
     end
   end
 
+  describe "accessibility fields" do
+    # The Component Providers live in main raxol and are not loaded here, so
+    # these exercise the projection's default (Roles-driven) extraction path.
+    # The Provider path is covered by the main app's ComponentA11y tests.
+    test "adds role/label/state for an interactive node" do
+      node = %{type: :button, id: "save", attrs: %{label: "Save", disabled: true}}
+      [summary] = StructuredScreenshot.from_view_tree(node)
+
+      assert summary.role == :button
+      assert summary.label == "Save"
+      assert summary.state == %{disabled?: true}
+    end
+
+    test "role always present; static text gets :text with content label" do
+      node = %{type: :text, id: "t", content: "Hello"}
+      [summary] = StructuredScreenshot.from_view_tree(node)
+
+      assert summary.role == :text
+      assert summary.label == "Hello"
+      refute Map.has_key?(summary, :state)
+    end
+
+    test "unknown types get role :generic" do
+      [summary] = StructuredScreenshot.from_view_tree(%{type: :frobnicate, id: "x"})
+      assert summary.role == :generic
+    end
+
+    test "marks live regions" do
+      [summary] = StructuredScreenshot.from_view_tree(%{type: :progress, id: "p"})
+      assert summary.role == :progressbar
+      assert summary.live == true
+    end
+
+    test "omits :live and :focused when not applicable" do
+      [summary] = StructuredScreenshot.from_view_tree(%{type: :text, id: "t", content: "x"})
+      refute Map.has_key?(summary, :live)
+      refute Map.has_key?(summary, :focused)
+    end
+
+    test "reports focus from the Component's own focused field" do
+      node = %{type: :text_input, id: "n", attrs: %{focused: true}}
+      [summary] = StructuredScreenshot.from_view_tree(node)
+      assert summary.focused == true
+    end
+
+    test "marks focus via the :focused_id option" do
+      node = %{type: :text_input, id: "search", attrs: %{value: "hi"}}
+      [summary] = StructuredScreenshot.from_view_tree(node, focused_id: "search")
+      assert summary.focused == true
+    end
+
+    test "enriches nested children" do
+      tree = %{
+        type: :panel,
+        id: "root",
+        children: [%{type: :button, id: "b", attrs: %{label: "Go"}}]
+      }
+
+      [summary] = StructuredScreenshot.from_view_tree(tree)
+      [child] = summary.children
+      assert child.role == :button
+      assert child.label == "Go"
+    end
+
+    test "a11y fields survive JSON serialization" do
+      node = %{type: :button, id: "b", attrs: %{label: "Save", disabled: true}}
+      json = node |> StructuredScreenshot.from_view_tree() |> StructuredScreenshot.to_json()
+
+      assert json =~ "role"
+      assert json =~ "button"
+      assert json =~ "disabled?"
+    end
+  end
+
   describe "to_json/1" do
     test "serializes summaries to JSON string" do
       summaries = [%{type: :button, id: "btn", children: []}]

--- a/test/raxol/mcp/structured_screenshot_a11y_test.exs
+++ b/test/raxol/mcp/structured_screenshot_a11y_test.exs
@@ -1,0 +1,63 @@
+defmodule Raxol.MCP.StructuredScreenshotA11yTest do
+  @moduledoc """
+  End-to-end: the MCP `StructuredScreenshot` folds real Component a11y_node
+  Providers (loaded here in the main app) into the widget summary. The raxol_mcp
+  suite only sees the fallback path; this covers the Provider path.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.MCP.StructuredScreenshot
+
+  test "Provider-derived role/label/state surface through the screenshot" do
+    tree = %{
+      type: :column,
+      id: "form",
+      children: [
+        %{type: :checkbox, id: "agree", label: "Agree", checked: true},
+        %{
+          type: :button,
+          id: "submit",
+          attrs: %{label: "Submit", disabled: true}
+        }
+      ]
+    }
+
+    [summary] = StructuredScreenshot.from_view_tree(tree)
+    [checkbox, button] = summary.children
+
+    assert checkbox.role == :checkbox
+    assert checkbox.label == "Agree"
+    assert checkbox.state == %{checked?: true}
+
+    assert button.role == :button
+    assert button.label == "Submit"
+    assert button.state == %{disabled?: true}
+  end
+
+  test "nested Provider dispatch: modal dialog wraps its content controls" do
+    tree = %{
+      type: :modal,
+      id: "confirm",
+      title: "Delete?",
+      children: [%{type: :button, id: "yes", attrs: %{label: "Yes"}}]
+    }
+
+    [summary] = StructuredScreenshot.from_view_tree(tree)
+
+    assert summary.role == :dialog
+    assert summary.label == "Delete?"
+    assert [%{role: :button, label: "Yes"}] = summary.children
+  end
+
+  test "the whole tree serializes to JSON with a11y fields" do
+    tree = %{type: :checkbox, id: "agree", label: "Agree", checked: true}
+
+    json =
+      tree
+      |> StructuredScreenshot.from_view_tree()
+      |> StructuredScreenshot.to_json()
+
+    assert json =~ "checkbox"
+    assert json =~ "checked?"
+  end
+end

--- a/test/raxol/ui/accessibility/component_a11y_test.exs
+++ b/test/raxol/ui/accessibility/component_a11y_test.exs
@@ -1,0 +1,234 @@
+defmodule Raxol.UI.Accessibility.ComponentA11yTest do
+  @moduledoc """
+  Exercises the real Component `a11y_node/1` Providers through
+  `Raxol.Core.Accessibility.Projection` (default 15-Component type_map). This
+  runs in the main app where the Component modules are loaded, so it covers the
+  provider-dispatch path the raxol_core suite cannot.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Accessibility.Projection
+
+  test "Button -> :button with label, disabled state, and visual variant" do
+    node = %{
+      type: :button,
+      id: "save",
+      attrs: %{label: "Save", disabled: true, focused: false, role: :primary}
+    }
+
+    assert %{role: :button, label: "Save", id: "save", state: state} =
+             Projection.project(node)
+
+    assert state[:disabled?] == true
+    assert state[:variant] == :primary
+    refute Map.has_key?(state, :focused?)
+  end
+
+  test "Checkbox reads top-level checked (View.Components shape)" do
+    node = %{type: :checkbox, id: "agree", label: "Agree", checked: true}
+
+    assert %{role: :checkbox, label: "Agree", state: %{checked?: true}} =
+             Projection.project(node)
+  end
+
+  test "Checkbox reads attrs.checked (MCP fixture shape), keeps checked? false" do
+    node = %{
+      type: :checkbox,
+      id: "agree",
+      attrs: %{checked: false, label: "Agree"}
+    }
+
+    assert %{role: :checkbox, label: "Agree", state: %{checked?: false}} =
+             Projection.project(node)
+  end
+
+  test "TextInput -> :textbox with value and placeholder-derived label" do
+    node = %{
+      type: :text_input,
+      id: "name",
+      attrs: %{value: "Alice"},
+      placeholder: "Name"
+    }
+
+    assert %{role: :textbox, value: "Alice", label: "Name"} =
+             Projection.project(node)
+  end
+
+  test "TextInput reflects focused?" do
+    node = %{type: :text_input, id: "n", focused: true}
+
+    assert %{role: :textbox, state: %{focused?: true}} =
+             Projection.project(node)
+  end
+
+  test "PasswordField -> :textbox but never exposes value" do
+    node = %{
+      type: :password_field,
+      id: "pw",
+      value: "hunter2",
+      placeholder: "Password"
+    }
+
+    assert %{role: :textbox, value: nil, label: "Password"} =
+             Projection.project(node)
+  end
+
+  test "SelectList synthesizes :option children with aria-selected on all" do
+    node = %{
+      type: :select_list,
+      id: "s",
+      options: ["x", "y"],
+      selected_index: 1
+    }
+
+    assert %{
+             role: :listbox,
+             children: [
+               %{role: :option, label: "x", state: %{selected?: false}},
+               %{role: :option, label: "y", state: %{selected?: true}}
+             ]
+           } = Projection.project(node)
+  end
+
+  test "Tabs synthesizes :tab children with the active tab selected" do
+    node = %{
+      type: :tabs,
+      id: "t",
+      tabs: [%{id: :a, label: "A"}, %{id: :b, label: "B"}],
+      active_index: 0
+    }
+
+    assert %{
+             role: :tablist,
+             children: [
+               %{role: :tab, label: "A", id: "a", state: %{selected?: true}},
+               %{role: :tab, label: "B", id: "b", state: %{selected?: false}}
+             ]
+           } = Projection.project(node)
+  end
+
+  test "Modal -> :dialog with title label and recursed content children" do
+    node = %{
+      type: :modal,
+      id: "m",
+      title: "Confirm",
+      children: [%{type: :button, id: "ok", attrs: %{label: "OK"}}]
+    }
+
+    assert %{role: :dialog, label: "Confirm", children: [child]} =
+             Projection.project(node)
+
+    assert %{role: :button, label: "OK", id: "ok"} = child
+  end
+
+  test "Table -> :grid with :row and :gridcell children" do
+    node = %{
+      type: :table,
+      id: "tbl",
+      columns: [%{id: :name, label: "Name"}, %{id: :age, label: "Age"}],
+      data: [%{name: "Alice", age: 30}]
+    }
+
+    assert %{role: :grid, children: [row]} = Projection.project(node)
+
+    assert %{
+             role: :row,
+             children: [
+               %{role: :gridcell, label: "Alice"},
+               %{role: :gridcell, label: "30"}
+             ]
+           } = row
+  end
+
+  test "Tree -> :tree/:treeitem with expanded? and nested items" do
+    node = %{
+      type: :tree,
+      id: "tr",
+      nodes: [
+        %{
+          id: :root,
+          label: "Root",
+          children: [%{id: :child, label: "Child", children: []}]
+        }
+      ],
+      expanded: MapSet.new([:root])
+    }
+
+    assert %{role: :tree, children: [root]} = Projection.project(node)
+
+    assert %{
+             role: :treeitem,
+             label: "Root",
+             id: "root",
+             state: %{expanded?: true},
+             children: [%{role: :treeitem, label: "Child", id: "child"}]
+           } = root
+  end
+
+  test "collapsed Tree node hides its children" do
+    node = %{
+      type: :tree,
+      id: "tr",
+      nodes: [
+        %{
+          id: :root,
+          label: "Root",
+          children: [%{id: :child, label: "Child", children: []}]
+        }
+      ],
+      expanded: MapSet.new()
+    }
+
+    assert %{children: [%{state: %{expanded?: false}, children: []}]} =
+             Projection.project(node)
+  end
+
+  test "Charts -> :img with id-derived or default label" do
+    assert %{role: :img, label: "cpu"} =
+             Projection.project(%{type: :bar_chart, id: "cpu"})
+
+    assert %{role: :img, label: "line chart"} =
+             Projection.project(%{type: :line_chart})
+
+    assert %{role: :img, label: "scatter chart"} =
+             Projection.project(%{type: :scatter_chart})
+  end
+
+  test "Viewport -> :region and recurses its content Elements" do
+    node = %{
+      type: :viewport,
+      id: "vp",
+      children: [%{type: :text, content: "row 1"}]
+    }
+
+    assert %{
+             role: :region,
+             id: "vp",
+             children: [%{role: :text, label: "row 1"}]
+           } =
+             Projection.project(node)
+  end
+
+  test "Menu -> :menu with nested :menuitem children" do
+    node = %{
+      type: :menu,
+      id: "menu",
+      items: [
+        %{
+          id: :file,
+          label: "File",
+          children: [%{id: :open, label: "Open", children: []}]
+        }
+      ]
+    }
+
+    assert %{role: :menu, children: [file]} = Projection.project(node)
+
+    assert %{
+             role: :menuitem,
+             label: "File",
+             id: "file",
+             children: [%{role: :menuitem, label: "Open", id: "open"}]
+           } = file
+  end
+end


### PR DESCRIPTION
## Summary

First slice of accessibility / screen-reader support (#305). Raxol already has a
rich accessibility layer in `raxol_core` (announcements, per-Component metadata,
focus, preferences) and `raxol_speech` consumes announcements end to end, but the
semantic Element tree was never projected into a role/label/state form that
Surfaces could serialize. This PR builds that projection once and wires it into
the MCP surface.

### Projection (raxol_core)

- `Raxol.Core.Accessibility.Roles` -- the ARIA role vocabulary (`type -> role`),
  broad standard roles, Table maps to `grid`, unknown types to `generic`.
- `Raxol.Core.Accessibility.Provider` -- a per-Component behaviour (`a11y_node/1`)
  mirroring `Raxol.MCP.ToolProvider`. A Component describes itself; co-location
  absorbs the heterogeneous (and internally inconsistent) field locations across
  Components.
- `Raxol.Core.Accessibility.Projection` -- walks the declaration Element tree (the
  same tree `TreeWalker`/`StructuredScreenshot` already consume) and produces an
  accessibility tree. Dispatches to the 15 Component Providers via the same
  `type -> module` pattern as `TreeWalker`, and falls back to a default
  role/label/state extraction for un-opted Elements. **Total**: never raises for
  any input (rescues a Provider that raises, defaults unknown types), covered by
  a totality test over an adversarial corpus.
- All 15 Components that implement `ToolProvider` now implement `a11y_node/1`
  (Button, TextInput, TextArea, PasswordField, SelectList, Checkbox, Menu, Tabs,
  Modal, Table, Tree, Viewport, Bar/Line/Scatter charts). PasswordField never
  exposes its value; Button's visual variant (`:primary`/`:danger`) becomes
  `state.variant`, never the ARIA role.

### MCP enrichment (raxol_mcp)

- `StructuredScreenshot` folds the per-node descriptor into every widget summary:
  `role`, `label`, `state`, `value`, `focused`, `live` (additive -- the existing
  `type`/`id`/`children`/`content`/`animation_hints` are unchanged, and the
  `raxol://session/{id}/widgets` resource wiring is untouched). `focused` comes
  from the Component's own focus, or an optional `:focused_id` option.

### Glossary

- New Accessibility section in `UBIQUITOUS_LANGUAGE.md` (Accessibility tree /
  node / Provider, Role, Announcement, Live region) with flagged ambiguities
  (Accessibility node vs Element, Role vs Button variant, Announcement vs Message).

## Tests

- raxol_core: `roles_test.exs`, `projection_test.exs` (Provider dispatch,
  provider-supplied child normalization, default fallback, totality property,
  `by_id`). Full suite 795 passed.
- raxol_mcp: `structured_screenshot_test.exs` extended with a11y-field cases
  (fallback path). Full suite 291 passed.
- main raxol: `component_a11y_test.exs` (each of the 15 real Providers through the
  Projection, incl. the checkbox top-level-vs-`attrs.checked` divergence) and
  `structured_screenshot_a11y_test.exs` (real Providers surfacing through the MCP
  screenshot). Full suite 4235 passed.
- Every new assertion was RED-proven before GREEN.

## Manual testing

- [ ] `mix mcp.server`, start a session, read the `raxol://session/{id}/widgets`
      resource, confirm `role`/`label`/`state` appear on interactive nodes.
- [ ] Toggle a checkbox in a headless session; confirm the screenshot reports
      `state.checked?`.
- [ ] Confirm a plain `text()` node projects to `role: :text` with its content as
      the label (fallback path).

## Not in this PR

- Phase 2 (LiveView ARIA on spans + configurable `aria_mode` + a visually-hidden
  `aria-live` announcement region) -- follow-up PR `a11y/liveview-aria`.
- Phase 3 (Terminal/SSH structured-announcement sidecar for external readers) --
  to be filed as a separate issue.
