### PR TITLE
Add LiveView ARIA + announcement live region (#429)

### DIFF
--- a/lib/raxol/core/runtime/rendering/backends.ex
+++ b/lib/raxol/core/runtime/rendering/backends.ex
@@ -63,9 +63,18 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
   When `positioned_elements` carry animation hints, generates a companion
   `<style>` block with CSS transitions and broadcasts it alongside the
   terminal HTML. LiveView receives `{:render_update, html, animation_css}`.
+
+  `a11y_map` is an `id -> accessibility_node` map (from
+  `Raxol.Core.Accessibility.Projection.by_id/1`) that the bridge uses to emit
+  per-element ARIA on spans whose `data-raxol-id` matches an entry.
   """
   @compile {:no_warn_undefined, [Raxol.LiveView.TerminalBridge, Phoenix.PubSub]}
-  def render_to_liveview(cells, state, positioned_elements \\ []) do
+  def render_to_liveview(
+        cells,
+        state,
+        positioned_elements \\ [],
+        a11y_map \\ %{}
+      ) do
     updated_buffer = apply_cells_to_buffer(cells, state)
 
     if Code.ensure_loaded?(Raxol.LiveView.TerminalBridge) do
@@ -74,7 +83,8 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
       html =
         Raxol.LiveView.TerminalBridge.buffer_to_html(updated_buffer,
           use_inline_styles: true,
-          element_id_map: element_id_map
+          element_id_map: element_id_map,
+          a11y_map: a11y_map
         )
 
       animation_css =

--- a/lib/raxol/core/runtime/rendering/engine.ex
+++ b/lib/raxol/core/runtime/rendering/engine.ex
@@ -252,7 +252,7 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
          :ok <- sync_dispatcher(state.dispatcher_pid, view, positioned_elements),
          :continue <- agent_short_circuit(state),
          {:ok, new_state, t5} <-
-           render_cells_to_backend(positioned_elements, theme, state) do
+           render_cells_to_backend(positioned_elements, theme, state, view) do
       maybe_record_cycle_render(
         state.cycle_profiler,
         t0,
@@ -283,13 +283,18 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
     end
   end
 
-  defp render_cells_to_backend(positioned_elements, theme, state) do
+  defp render_cells_to_backend(positioned_elements, theme, state, view) do
     with {:ok, cells} <- safe_render_to_cells(positioned_elements, theme),
          {:ok, final_cells} <- safe_apply_plugin_transforms(cells, state),
          {:ok, beamed_cells} <-
            safe_apply_border_beam(final_cells, positioned_elements),
          {:ok, new_state} <-
-           safe_render_to_backend(beamed_cells, state, positioned_elements) do
+           safe_render_to_backend(
+             beamed_cells,
+             state,
+             positioned_elements,
+             view
+           ) do
       t5 = profiler_now(state.cycle_profiler)
       {:ok, new_state, t5}
     end
@@ -478,7 +483,11 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
   # Safe backend rendering -- dispatches to Backends module.
   # positioned_elements carries the element tree with animation hints
   # for surfaces that can use them (LiveView emits CSS transitions).
-  defp safe_render_to_backend(final_cells, state, positioned_elements) do
+  # `view` is the declaration tree; the LiveView backend projects it into an
+  # accessibility map so the Browser bridge can emit per-element ARIA. The map
+  # is computed only for the LiveView environment so the terminal path pays
+  # nothing.
+  defp safe_render_to_backend(final_cells, state, positioned_elements, view) do
     Raxol.Core.Runtime.Log.debug(
       "Rendering Engine: Sending final cells to backend: #{state.environment}"
     )
@@ -491,7 +500,14 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
         Backends.render_to_vscode(final_cells, state)
 
       :liveview ->
-        Backends.render_to_liveview(final_cells, state, positioned_elements)
+        a11y_map = Raxol.Core.Accessibility.Projection.by_id(view)
+
+        Backends.render_to_liveview(
+          final_cells,
+          state,
+          positioned_elements,
+          a11y_map
+        )
 
       :ssh ->
         Backends.render_to_ssh(final_cells, state)

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -258,8 +258,15 @@ defmodule Raxol.UI.Layout.Engine do
 
     text_element = %{
       type: :text,
+      # Carry the declaration id and explicit geometry at the top level so
+      # accessibility surfaces can map this cell span back to the source node
+      # (Browser data-raxol-id, ARIA). The renderer already honors an explicit
+      # width/height, so setting them here is behavior-preserving.
+      id: Map.get(element, :id),
       x: space.x + dx,
       y: space.y + dy,
+      width: Raxol.UI.TextMeasure.display_width(content),
+      height: 1,
       text: content,
       fg: Map.get(element, :fg),
       bg: Map.get(element, :bg),
@@ -275,10 +282,12 @@ defmodule Raxol.UI.Layout.Engine do
     [text_element | acc]
   end
 
-  def process_element(%{type: :button, attrs: attrs} = _element, space, acc) do
+  def process_element(%{type: :button, attrs: attrs} = element, space, acc) do
     text = Map.get(attrs, :label, "Button")
     component_attrs = Map.put(attrs, :component_type, :button)
-    build_button_elements(text, component_attrs, space) ++ acc
+
+    build_button_elements(text, component_attrs, space, Map.get(element, :id)) ++
+      acc
   end
 
   # New-DSL form: `text_input(value: ..., placeholder: ...)` builds an
@@ -304,7 +313,7 @@ defmodule Raxol.UI.Layout.Engine do
     process_element(Map.put(element, :attrs, attrs), space, acc)
   end
 
-  def process_element(%{type: :text_input, attrs: attrs} = _element, space, acc) do
+  def process_element(%{type: :text_input, attrs: attrs} = element, space, acc) do
     # Create a text input element composed of box and text
     value = Map.get(attrs, :value, "")
     placeholder = Map.get(attrs, :placeholder, "")
@@ -316,9 +325,11 @@ defmodule Raxol.UI.Layout.Engine do
     style_map = style_to_map(Map.get(attrs, :style, %{}))
 
     text_input_elements = [
-      # Input box
+      # Input box. Carry the declaration id so accessibility surfaces can map
+      # the box's cell span back to the text_input node (data-raxol-id, ARIA).
       %{
         type: :box,
+        id: Map.get(element, :id),
         x: space.x,
         y: space.y,
         width:
@@ -348,23 +359,29 @@ defmodule Raxol.UI.Layout.Engine do
     text_input_elements ++ acc
   end
 
-  def process_element(%{type: :checkbox, attrs: attrs} = _element, space, acc) do
+  def process_element(%{type: :checkbox, attrs: attrs} = element, space, acc) do
     # Create a checkbox element (simple text for now)
     checked = Map.get(attrs, :checked, false)
     label = Map.get(attrs, :label, "")
     component_attrs = Map.put(attrs, :component_type, :checkbox)
 
     checkbox_text = get_checkbox_text(checked)
+    display_text = "#{checkbox_text} #{label}"
 
     style_map = style_to_map(Map.get(attrs, :style, %{}))
 
     checkbox_elements = [
-      # Checkbox text (box + label)
+      # Checkbox text (box + label). Carry the declaration id and explicit
+      # geometry so accessibility surfaces can map this cell span back to the
+      # checkbox node (Browser data-raxol-id, ARIA).
       %{
         type: :text,
+        id: Map.get(element, :id),
         x: space.x,
         y: space.y,
-        text: "#{checkbox_text} #{label}",
+        width: Raxol.UI.TextMeasure.display_width(display_text),
+        height: 1,
+        text: display_text,
         fg: Map.get(attrs, :fg),
         bg: Map.get(attrs, :bg),
         style: style_map,
@@ -434,7 +451,8 @@ defmodule Raxol.UI.Layout.Engine do
       style: style_map
     }
 
-    build_button_elements(text, component_attrs, space) ++ acc
+    build_button_elements(text, component_attrs, space, Map.get(button, :id)) ++
+      acc
   end
 
   def process_element(%{type: :split_pane} = split, space, acc) do
@@ -559,10 +577,11 @@ defmodule Raxol.UI.Layout.Engine do
     acc
   end
 
-  defp build_button_elements(text, component_attrs, space) do
+  defp build_button_elements(text, component_attrs, space, id) do
     [
       %{
         type: :box,
+        id: id,
         x: space.x,
         y: space.y,
         width: min(Raxol.UI.TextMeasure.display_width(text) + 4, space.width),

--- a/packages/raxol_liveview/lib/raxol/live_view/tea_live.ex
+++ b/packages/raxol_liveview/lib/raxol/live_view/tea_live.ex
@@ -30,7 +30,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
 
     use Phoenix.LiveView
 
-    @compile {:no_warn_undefined, [Raxol.Core.Runtime.Lifecycle, Phoenix.PubSub]}
+    @compile {:no_warn_undefined,
+              [
+                Raxol.Core.Runtime.Lifecycle,
+                Raxol.Core.Accessibility,
+                Phoenix.PubSub
+              ]}
 
     require Logger
 
@@ -54,6 +59,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       if connected?(socket) do
         _ = Phoenix.PubSub.subscribe(Raxol.PubSub, topic)
 
+        announce_ref = subscribe_announcements()
+
         {:ok, lifecycle_pid} =
           Lifecycle.start_link(app_module,
             environment: :liveview,
@@ -69,6 +76,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           |> assign(:topic, topic)
           |> assign(:app_module, app_module)
           |> assign(:terminal_html, "")
+          |> assign(:announce_ref, announce_ref)
+          |> assign(:announcement, nil)
 
         {:ok, socket}
       else
@@ -78,6 +87,8 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
           |> assign(:topic, topic)
           |> assign(:app_module, app_module)
           |> assign(:terminal_html, "")
+          |> assign(:announce_ref, nil)
+          |> assign(:announcement, nil)
 
         {:ok, socket}
       end
@@ -109,6 +120,11 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
     end
 
     @impl true
+    def handle_info({:announcement_added, _ref, announcement}, socket) do
+      {:noreply, assign(socket, :announcement, normalize_announcement(announcement))}
+    end
+
+    @impl true
     def handle_info(_msg, socket), do: {:noreply, socket}
 
     @impl true
@@ -117,6 +133,12 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       <%= if assigns[:animation_css] && assigns[:animation_css] != "" do %>
         <%= Phoenix.HTML.raw(assigns[:animation_css]) %>
       <% end %>
+      <div
+        class="raxol-sr-only"
+        role="status"
+        aria-live={announcement_live(assigns[:announcement])}
+        aria-atomic="true"
+      ><%= announcement_text(assigns[:announcement]) %></div>
       <div
         id="raxol-terminal"
         phx-hook="RaxolTerminal"
@@ -130,13 +152,55 @@ if Code.ensure_loaded?(Phoenix.LiveView) do
       """
     end
 
+    # The screen-reader announcement region is always present so assistive
+    # technology tracks changes to it. It reflects accessibility announcements
+    # delivered via Raxol.Core.Accessibility.subscribe_to_announcements/1:
+    # polite by default, assertive for :high-priority announcements.
+    defp announcement_live(%{priority: :high}), do: "assertive"
+    defp announcement_live(_announcement), do: "polite"
+
+    defp announcement_text(%{message: message}) when is_binary(message),
+      do: message
+
+    defp announcement_text(_announcement), do: ""
+
+    defp normalize_announcement(announcement) when is_map(announcement) do
+      %{
+        message: to_string(Map.get(announcement, :message, "")),
+        priority: Map.get(announcement, :priority, :normal)
+      }
+    end
+
+    defp normalize_announcement(_announcement), do: nil
+
+    defp subscribe_announcements do
+      ref = make_ref()
+      Raxol.Core.Accessibility.subscribe_to_announcements(ref)
+      ref
+    rescue
+      error ->
+        Logger.debug("TEALive announcement subscription failed: #{Exception.message(error)}")
+
+        nil
+    end
+
     @impl true
     def terminate(_reason, socket) do
+      if ref = socket.assigns[:announce_ref] do
+        _ = unsubscribe_announcements(ref)
+      end
+
       if socket.assigns[:lifecycle_pid] do
         Lifecycle.stop(socket.assigns.lifecycle_pid)
       end
 
       :ok
+    end
+
+    defp unsubscribe_announcements(ref) do
+      Raxol.Core.Accessibility.unsubscribe_from_announcements(ref)
+    rescue
+      _error -> :ok
     end
 
     defp dispatch_to_app(nil, _event), do: :ok

--- a/packages/raxol_liveview/lib/raxol/live_view/terminal_bridge.ex
+++ b/packages/raxol_liveview/lib/raxol/live_view/terminal_bridge.ex
@@ -70,13 +70,17 @@ defmodule Raxol.LiveView.TerminalBridge do
           | :tokyo_night
           | :catppuccin
           | :default
+  @type aria_mode :: :log | :application
+
   @type html_opts :: [
           theme: theme(),
           css_prefix: String.t(),
           use_inline_styles: boolean(),
           show_cursor: boolean(),
           cursor_position: {non_neg_integer(), non_neg_integer()} | nil,
-          cursor_style: :block | :underline | :bar
+          cursor_style: :block | :underline | :bar,
+          aria_mode: aria_mode(),
+          a11y_map: %{optional(String.t()) => map()}
         ]
 
   @doc """
@@ -90,6 +94,16 @@ defmodule Raxol.LiveView.TerminalBridge do
     - `:show_cursor` - Show cursor indicator (default: false)
     - `:cursor_position` - Cursor position {x, y} (default: nil)
     - `:cursor_style` - Cursor style (default: :block)
+    - `:aria_mode` - Coarse container semantics (default: `:log`). `:log` wraps
+      the terminal in `<pre role="log" aria-live="polite">` so screen readers
+      announce output as it changes. `:application` emits `<pre
+      role="application">` with no live region, so per-element ARIA and a
+      dedicated announcement region drive announcements instead of a
+      whole-screen re-read.
+    - `:a11y_map` - `id -> accessibility_node` map (from
+      `Raxol.Core.Accessibility.Projection.by_id/1`). Spans whose
+      `data-raxol-id` matches an entry get per-element ARIA
+      (role/aria-label/aria-disabled/aria-checked/aria-selected/aria-expanded/aria-required).
 
   ## Examples
 
@@ -110,6 +124,8 @@ defmodule Raxol.LiveView.TerminalBridge do
     cursor_pos = Keyword.get(opts, :cursor_position)
     cursor_style = Keyword.get(opts, :cursor_style, :block)
     element_id_map = Keyword.get(opts, :element_id_map, %{})
+    a11y_map = Keyword.get(opts, :a11y_map, %{})
+    aria_mode = Keyword.get(opts, :aria_mode, :log)
 
     terminal_class = "#{css_prefix}-terminal"
 
@@ -129,12 +145,21 @@ defmodule Raxol.LiveView.TerminalBridge do
           show_cursor: show_cursor,
           cursor_pos: cursor_pos,
           cursor_style: cursor_style,
-          element_id_map: element_id_map
+          element_id_map: element_id_map,
+          a11y_map: a11y_map
         })
       end)
 
-    ~s(<pre class="#{terminal_class}#{theme_class}" role="log" aria-live="polite" aria-atomic="false">#{lines_html}</pre>\n)
+    ~s(<pre class="#{terminal_class}#{theme_class}" #{container_aria(aria_mode)}>#{lines_html}</pre>\n)
   end
+
+  # Coarse container semantics. `:log` is a whole-screen live region (screen
+  # readers re-read on change); `:application` opts out so per-element ARIA and
+  # the dedicated announcement region drive announcements instead.
+  defp container_aria(:application), do: ~s(role="application")
+
+  defp container_aria(_log),
+    do: ~s(role="log" aria-live="polite" aria-atomic="false")
 
   @doc """
   Converts a buffer to HTML with diff highlighting (for debugging).
@@ -280,9 +305,7 @@ defmodule Raxol.LiveView.TerminalBridge do
   defp border_beam_hint?(_), do: false
 
   @beam_css_colors %{
-    colorful:
-      {"#ff0040, #ffaa00, #00ff88, #00ccff, #4400ff, #ff00cc", "#4400ff",
-       "#ff00cc"},
+    colorful: {"#ff0040, #ffaa00, #00ff88, #00ccff, #4400ff, #ff00cc", "#4400ff", "#ff00cc"},
     mono: {"#ffffff, #cccccc, #999999", "#ffffff", "#cccccc"},
     ocean: {"#0044ff, #00ccff, #0077ff, #00aaff", "#0077ff", "#00ccff"},
     sunset: {"#ff4400, #ffaa00, #ff6600, #ffcc00", "#ff4400", "#ffaa00"}
@@ -379,25 +402,75 @@ defmodule Raxol.LiveView.TerminalBridge do
   # with IDs get data-raxol-id attributes for CSS transition targeting.
   defp render_line_rle(cells, y, opts) do
     runs = rle_cells(cells, y, opts)
+    a11y_map = Map.get(opts, :a11y_map, %{})
 
     Enum.map_join(runs, "", fn {style_key, element_id, chars} ->
       text = Enum.join(chars)
+      aria = aria_attrs(element_id, a11y_map)
 
       case {style_key, element_id} do
         {:default, nil} ->
           escape_html_text(text)
 
         {:default, id} ->
-          ~s(<span data-raxol-id="#{id}">#{escape_html_text(text)}</span>)
+          ~s(<span data-raxol-id="#{id}"#{aria}>#{escape_html_text(text)}</span>)
 
         {style, nil} ->
           ~s(<span style="#{style}">#{escape_html_text(text)}</span>)
 
         {style, id} ->
-          ~s(<span style="#{style}" data-raxol-id="#{id}">#{escape_html_text(text)}</span>)
+          ~s(<span style="#{style}" data-raxol-id="#{id}"#{aria}>#{escape_html_text(text)}</span>)
       end
     end)
   end
+
+  # Reads the accessibility node for `id` (if any) and renders it as a leading
+  # string of ARIA attributes (e.g. ` role="button" aria-label="Save"`). The
+  # bridge only READS the projected node -- role/label/state come from
+  # `Raxol.Core.Accessibility.Projection`, never recomputed here.
+  defp aria_attrs(id, a11y_map) when is_binary(id) do
+    case Map.get(a11y_map, id) do
+      %{} = node -> build_aria(node)
+      _ -> ""
+    end
+  end
+
+  defp aria_attrs(_id, _a11y_map), do: ""
+
+  defp build_aria(node) do
+    attrs =
+      aria_role(node) ++
+        aria_label(node) ++
+        aria_state(node, :disabled?, "aria-disabled") ++
+        aria_state(node, :checked?, "aria-checked") ++
+        aria_state(node, :selected?, "aria-selected") ++
+        aria_state(node, :expanded?, "aria-expanded") ++
+        aria_state(node, :required?, "aria-required")
+
+    case attrs do
+      [] -> ""
+      parts -> " " <> Enum.join(parts, " ")
+    end
+  end
+
+  defp aria_role(%{role: role}) when is_atom(role) and not is_nil(role),
+    do: [~s(role="#{role}")]
+
+  defp aria_role(_node), do: []
+
+  defp aria_label(%{label: label}) when is_binary(label) and label != "",
+    do: [~s(aria-label="#{escape_html_text(label)}")]
+
+  defp aria_label(_node), do: []
+
+  defp aria_state(%{state: state}, key, attr) when is_map(state) do
+    case Map.fetch(state, key) do
+      {:ok, value} when is_boolean(value) -> [~s(#{attr}="#{value}")]
+      _ -> []
+    end
+  end
+
+  defp aria_state(_node, _key, _attr), do: []
 
   # Group consecutive cells by their computed inline style string AND
   # element ID. Returns [{style_string, element_id | nil, [char, ...]}, ...]
@@ -443,11 +516,18 @@ defmodule Raxol.LiveView.TerminalBridge do
   end
 
   defp escape_html_binary(<<>>, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
-  defp escape_html_binary(<<?&, rest::binary>>, acc), do: escape_html_binary(rest, ["&amp;" | acc])
+
+  defp escape_html_binary(<<?&, rest::binary>>, acc),
+    do: escape_html_binary(rest, ["&amp;" | acc])
+
   defp escape_html_binary(<<?<, rest::binary>>, acc), do: escape_html_binary(rest, ["&lt;" | acc])
   defp escape_html_binary(<<?>, rest::binary>>, acc), do: escape_html_binary(rest, ["&gt;" | acc])
-  defp escape_html_binary(<<?", rest::binary>>, acc), do: escape_html_binary(rest, ["&quot;" | acc])
-  defp escape_html_binary(<<?', rest::binary>>, acc), do: escape_html_binary(rest, ["&#39;" | acc])
+
+  defp escape_html_binary(<<?", rest::binary>>, acc),
+    do: escape_html_binary(rest, ["&quot;" | acc])
+
+  defp escape_html_binary(<<?', rest::binary>>, acc),
+    do: escape_html_binary(rest, ["&#39;" | acc])
 
   defp escape_html_binary(<<c::utf8, rest::binary>>, acc),
     do: escape_html_binary(rest, [<<c::utf8>> | acc])

--- a/packages/raxol_liveview/lib/raxol/live_view/terminal_component.ex
+++ b/packages/raxol_liveview/lib/raxol/live_view/terminal_component.ex
@@ -82,11 +82,15 @@ if Code.ensure_loaded?(Phoenix.LiveComponent) do
     end
 
     defp render_buffer(assigns) do
+      # The wrapper <div> below is the single coarse live region (role="log",
+      # aria-live). Render the inner buffer in :application mode so its <pre>
+      # is not a second, nested log region announcing the same content.
       TerminalBridge.buffer_to_html(
         assigns.buffer,
         theme: assigns.theme,
         show_cursor: assigns.show_cursor,
-        cursor_position: {assigns.cursor_x, assigns.cursor_y}
+        cursor_position: {assigns.cursor_x, assigns.cursor_y},
+        aria_mode: :application
       )
     end
   end

--- a/packages/raxol_liveview/priv/static/raxol_terminal.css
+++ b/packages/raxol_liveview/priv/static/raxol_terminal.css
@@ -122,3 +122,20 @@
   background-color: rgba(255, 255, 0, 0.25);
   outline: 1px solid rgba(255, 255, 0, 0.5);
 }
+
+/* ------------------------------------------------------------------ */
+/* Screen-reader-only announcement region                             */
+/* Visually hidden but exposed to assistive technology. Holds the     */
+/* aria-live announcement text rendered by TEALive.                   */
+/* ------------------------------------------------------------------ */
+.raxol-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/raxol_liveview/test/raxol/live_view/tea_live_test.exs
+++ b/packages/raxol_liveview/test/raxol/live_view/tea_live_test.exs
@@ -1,0 +1,55 @@
+defmodule Raxol.LiveView.TEALiveTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.LiveView.TEALive
+
+  describe "announcement live region" do
+    test "handle_info stores the latest announcement in the assign" do
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}, announcement: nil}
+      }
+
+      msg =
+        {:announcement_added, make_ref(),
+         %{message: "Saved", priority: :normal, interrupt: false, timestamp: 0}}
+
+      assert {:noreply, socket} = TEALive.handle_info(msg, socket)
+      assert socket.assigns.announcement == %{message: "Saved", priority: :normal}
+    end
+
+    test "renders a polite sr-only region for normal announcements" do
+      html = render_html(%{message: "Saved", priority: :normal})
+
+      assert html =~ ~s(class="raxol-sr-only")
+      assert html =~ ~s(role="status")
+      assert html =~ ~s(aria-live="polite")
+      assert html =~ "Saved"
+    end
+
+    test "renders an assertive sr-only region for high-priority announcements" do
+      html = render_html(%{message: "Danger", priority: :high})
+
+      assert html =~ ~s(class="raxol-sr-only")
+      assert html =~ ~s(aria-live="assertive")
+      assert html =~ "Danger"
+    end
+
+    test "renders an always-present polite region when there is no announcement" do
+      html = render_html(nil)
+
+      assert html =~ ~s(class="raxol-sr-only")
+      assert html =~ ~s(aria-live="polite")
+    end
+
+    defp render_html(announcement) do
+      assigns = %{
+        __changed__: nil,
+        terminal_html: "",
+        announcement: announcement,
+        animation_css: nil
+      }
+
+      TEALive.render(assigns) |> Phoenix.LiveViewTest.rendered_to_string()
+    end
+  end
+end

--- a/packages/raxol_liveview/test/raxol/live_view/terminal_bridge_test.exs
+++ b/packages/raxol_liveview/test/raxol/live_view/terminal_bridge_test.exs
@@ -243,4 +243,135 @@ defmodule Raxol.LiveView.TerminalBridgeTest do
       assert html =~ ">e</span>"
     end
   end
+
+  describe "per-element ARIA (a11y_map)" do
+    # Map a run of cells to an element id, then supply an accessibility node for
+    # that id. The span carrying data-raxol-id="<id>" should gain ARIA read
+    # straight from the node (the bridge never recomputes roles).
+    defp with_mapped_text(text, id, node) do
+      buffer = Buffer.write_string(Buffer.create_blank_buffer(40, 3), 0, 0, text)
+
+      id_map =
+        for x <- 0..(String.length(text) - 1), into: %{}, do: {{x, 0}, id}
+
+      a11y_map = if node, do: %{id => node}, else: %{}
+
+      TerminalBridge.buffer_to_html(buffer,
+        element_id_map: id_map,
+        a11y_map: a11y_map
+      )
+    end
+
+    test "emits role and aria-label from the node" do
+      node = %{
+        role: :button,
+        label: "Save",
+        state: %{},
+        value: nil,
+        children: [],
+        live?: false,
+        id: "save"
+      }
+
+      html = with_mapped_text("Save", "save", node)
+
+      assert html =~ ~s(data-raxol-id="save")
+      assert html =~ ~s(role="button")
+      assert html =~ ~s(aria-label="Save")
+    end
+
+    test "emits aria-disabled and aria-required from present flags" do
+      node = %{
+        role: :textbox,
+        label: "Name",
+        state: %{disabled?: true, required?: true},
+        value: nil,
+        children: [],
+        live?: false,
+        id: "name"
+      }
+
+      html = with_mapped_text("Name", "name", node)
+
+      assert html =~ ~s(aria-disabled="true")
+      assert html =~ ~s(aria-required="true")
+    end
+
+    test "emits tri-state aria-checked=false when the flag is present and false" do
+      node = %{
+        role: :checkbox,
+        label: "Agree",
+        state: %{checked?: false},
+        value: nil,
+        children: [],
+        live?: false,
+        id: "agree"
+      }
+
+      html = with_mapped_text("[ ] Agree", "agree", node)
+
+      assert html =~ ~s(aria-checked="false")
+    end
+
+    test "emits aria-selected and aria-expanded from the node state" do
+      node = %{
+        role: :option,
+        label: "Item",
+        state: %{selected?: true, expanded?: false},
+        value: nil,
+        children: [],
+        live?: false,
+        id: "opt"
+      }
+
+      html = with_mapped_text("Item", "opt", node)
+
+      assert html =~ ~s(aria-selected="true")
+      assert html =~ ~s(aria-expanded="false")
+    end
+
+    test "escapes the aria-label value" do
+      node = %{
+        role: :button,
+        label: ~s(A"<b>&),
+        state: %{},
+        value: nil,
+        children: [],
+        live?: false,
+        id: "b"
+      }
+
+      html = with_mapped_text("Btn", "b", node)
+
+      assert html =~ ~s(aria-label="A&quot;&lt;b&gt;&amp;")
+      refute html =~ ~s(aria-label="A"<b>&")
+    end
+
+    test "id with no a11y_map entry gets data-raxol-id but no ARIA" do
+      html = with_mapped_text("Plain", "plain", nil)
+
+      # The span closes immediately after data-raxol-id: no ARIA injected.
+      assert html =~ ~s(<span data-raxol-id="plain">Plain</span>)
+      refute html =~ "aria-label"
+    end
+  end
+
+  describe "aria_mode container semantics" do
+    test "defaults to :log (whole-screen live region)" do
+      buffer = Buffer.create_blank_buffer(10, 2)
+      html = TerminalBridge.buffer_to_html(buffer)
+
+      assert html =~ ~s(role="log")
+      assert html =~ ~s(aria-live="polite")
+    end
+
+    test ":application drops the live region" do
+      buffer = Buffer.create_blank_buffer(10, 2)
+      html = TerminalBridge.buffer_to_html(buffer, aria_mode: :application)
+
+      assert html =~ ~s(role="application")
+      refute html =~ ~s(role="log")
+      refute html =~ "aria-live"
+    end
+  end
 end

--- a/packages/raxol_liveview/test/raxol/live_view/terminal_component_test.exs
+++ b/packages/raxol_liveview/test/raxol/live_view/terminal_component_test.exs
@@ -1,0 +1,23 @@
+defmodule Raxol.LiveView.TerminalComponentTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Raxol.LiveView.TerminalComponent
+  alias Raxol.LiveView.Test.BufferHelper, as: Buffer
+
+  describe "coarse live-region reconciliation" do
+    test "wrapper div is the single log region; inner pre is application" do
+      buffer = Buffer.create_blank_buffer(10, 2)
+      html = render_component(TerminalComponent, id: "term", buffer: buffer)
+
+      # The wrapper div carries the sole role="log" aria-live region; the
+      # bridge's <pre> renders in :application mode so it is not a second,
+      # nested log region announcing the same content.
+      assert length(Regex.scan(~r/role="log"/, html)) == 1
+      assert html =~ ~s(aria-live="polite")
+      assert html =~ ~s(role="application")
+      refute html =~ ~r/role="log"[^>]*>\s*<pre[^>]*role="log"/
+    end
+  end
+end

--- a/test/raxol/ui/layout/engine_test.exs
+++ b/test/raxol/ui/layout/engine_test.exs
@@ -404,7 +404,14 @@ defmodule Raxol.UI.Layout.EngineTest do
     end
 
     test "measures button with new View DSL format (top-level :text key)" do
-      element = %{type: :button, text: "Click Me", id: nil, on_click: :click, style: []}
+      element = %{
+        type: :button,
+        text: "Click Me",
+        id: nil,
+        on_click: :click,
+        style: []
+      }
+
       available_space = %{width: 80, height: 24}
 
       dimensions = Engine.measure_element(element, available_space)
@@ -424,7 +431,13 @@ defmodule Raxol.UI.Layout.EngineTest do
     end
 
     test "measures text_input with new View DSL format (top-level :value key)" do
-      element = %{type: :text_input, value: "hello", placeholder: "Type...", style: []}
+      element = %{
+        type: :text_input,
+        value: "hello",
+        placeholder: "Type...",
+        style: []
+      }
+
       available_space = %{width: 80, height: 24}
 
       dimensions = Engine.measure_element(element, available_space)
@@ -434,7 +447,13 @@ defmodule Raxol.UI.Layout.EngineTest do
     end
 
     test "measures text_input with empty value uses placeholder" do
-      element = %{type: :text_input, value: "", placeholder: "Search...", style: []}
+      element = %{
+        type: :text_input,
+        value: "",
+        placeholder: "Search...",
+        style: []
+      }
+
       available_space = %{width: 80, height: 24}
 
       dimensions = Engine.measure_element(element, available_space)
@@ -472,6 +491,64 @@ defmodule Raxol.UI.Layout.EngineTest do
       # Falls through to container measurement (column-like)
       assert is_integer(dimensions.width)
       assert is_integer(dimensions.height)
+    end
+  end
+
+  describe "element id preservation (accessibility)" do
+    # Accessibility surfaces (Browser data-raxol-id, ARIA) map a rendered cell
+    # span back to its source node by the positioned element's top-level :id
+    # plus geometry. These leaf components must carry both through layout.
+    defp positioned_by_id(view, id) do
+      view
+      |> Engine.apply_layout(%{width: 80, height: 24})
+      |> Enum.find(fn el ->
+        Map.get(el, :id) == id and is_integer(Map.get(el, :width)) and
+          is_integer(Map.get(el, :height))
+      end)
+    end
+
+    test "button carries its id and geometry on the positioned box" do
+      view = %{type: :button, id: "submit", attrs: %{label: "Submit"}}
+
+      el = positioned_by_id(view, "submit")
+
+      assert el.type == :box
+      assert el.width > 0
+      assert el.height == 3
+    end
+
+    test "checkbox carries its id and geometry on the positioned text" do
+      view = %{
+        type: :checkbox,
+        id: "agree",
+        attrs: %{label: "Agree", checked: true}
+      }
+
+      el = positioned_by_id(view, "agree")
+
+      assert el.type == :text
+      assert el.width == Raxol.UI.TextMeasure.display_width("[[OK]] Agree")
+      assert el.height == 1
+    end
+
+    test "text_input carries its id and geometry on the positioned box" do
+      view = %{type: :text_input, id: "name", attrs: %{value: "Alice"}}
+
+      el = positioned_by_id(view, "name")
+
+      assert el.type == :box
+      assert el.width > 0
+      assert el.height == 3
+    end
+
+    test "content text carries its id and geometry" do
+      view = %{type: :text, id: "greeting", content: "Hello"}
+
+      el = positioned_by_id(view, "greeting")
+
+      assert el.type == :text
+      assert el.width == Raxol.UI.TextMeasure.display_width("Hello")
+      assert el.height == 1
     end
   end
 end


### PR DESCRIPTION
## Summary

Accessibility Phase 2 (#429), building on the `Raxol.Core.Accessibility` projection from #428. Gives the Browser (LiveView) surface real per-element ARIA and a dedicated announcement live region.

- **Per-element ARIA on spans.** The Engine projects the declaration `view` into an `id -> accessibility_node` map (`Projection.by_id/1`) for the LiveView environment only (terminal frames pay nothing), threads it through `render_cells_to_backend -> safe_render_to_backend -> Backends.render_to_liveview/4 -> TerminalBridge.buffer_to_html`, and the bridge emits `role`/`aria-label`/`aria-disabled`/`aria-checked`/`aria-selected`/`aria-expanded`/`aria-required` on spans whose `data-raxol-id` matches an entry. The bridge only *reads* the projected node -- roles/states come from `Raxol.Core.Accessibility.Projection`, never recomputed.
- **Configurable coarse region.** New `aria_mode: :log | :application` opt on `buffer_to_html` (default `:log`, preserving today's `<pre role="log" aria-live="polite">`). `:application` emits `<pre role="application">` with no whole-screen re-read.
- **Dedicated announcement live region.** `TEALive` subscribes to `Raxol.Core.Accessibility.subscribe_to_announcements/1` on mount, keeps the latest `{message, priority}` in an assign, and renders an always-present visually-hidden `role="status"` `aria-live` region (polite; assertive for `:high`). New `.raxol-sr-only` CSS class (structural, no colors).
- **Coarse-region dedup.** `TerminalComponent` rendered its buffer inside a `<div role="log" aria-live>` *and* the bridge `<pre>` was a second `role="log"` region. The component now renders the bridge in `aria_mode: :application`, so the wrapper div is the single log live region.

### Integration fix (verified, not assumed)

The issue assumed `data-raxol-id` already carried component ids and only container-rendering Components (Checkbox) dropped them. A scratch probe through the **real** `Engine -> LayoutEngine -> build_element_id_map` path showed the map was **empty for every view**: the layout engine expands `:button`/`:checkbox`/`:text_input` into `:box`/`:text` primitives and dropped the top-level `:id` (and text elements never carried `width`/`height`). Component `render/2` is never in this path. The existing `data-raxol-id`/`animation_css` tests only fed hand-built positioned elements, so the feature was dormant against real layout output.

Fix: the interactive-leaf `process_element` clauses now carry the declaration `:id` (+ explicit `width`/`height`) onto their primary positioned element. This is additive and behavior-preserving for the terminal path -- `Raxol.UI.Renderer` already honors an explicit `width`/`height` on text elements and ignores extra keys. Containers are intentionally left without ids (they would over-claim descendants' cells under `build_element_id_map`'s parent-first `put_new`).

## Manual testing

- [x] `MIX_ENV=test mix test` (repo root): 4239 passed, 0 failures, 26 excluded
- [x] `cd packages/raxol_liveview && MIX_ENV=test mix test`: 72 passed
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean (main + raxol_liveview)
- [x] `mix format --check-formatted` on all changed files (per package)
- [x] RED-proved every new assertion by mutating the guard, then restored:
  - layout id preservation (4 tests) -- strip `id:` -> RED
  - per-element ARIA emission (5 tests) + `aria_mode :application` -- neutralize -> RED
  - announcement assign + polite/assertive render (3 tests) -- neutralize -> RED
  - coarse-region dedup (1 test) -- `aria_mode: :log` -> two `role="log"` -> RED
- [ ] Screen-reader smoke test in a browser (VoiceOver/NVDA) -- not run here

## Not in this PR

- **Phase 3 (#430):** Terminal/SSH structured-a11y sidecar for external readers -- deferred, needs design review.
- **Focus wiring:** `aria-activedescendant` / focus management beyond per-element `focused?` -- can follow.
- **Container ARIA:** `:group` roles on `box`/`row`/`column` (their ids would over-claim descendant cells in the coordinate map) -- deferred.
