### PR TITLE
Fix two flaky property tests (parser perf, process isolation)

### DIFF
--- a/test/property/parser_property_test.exs
+++ b/test/property/parser_property_test.exs
@@ -129,10 +129,13 @@ defmodule Raxol.Property.ParserTest do
         # Should complete and return a list
         assert is_list(result)
 
-        # Time should scale roughly linearly (with some tolerance)
-        # Expect ~3.3 microseconds per character based on benchmarks
-        # Increase tolerance for CI/loaded systems
-        expected_max = size * 1000  # 1000 microseconds (1ms) per char as upper bound
+        # Time should scale roughly linearly. Real cost is ~3.3us/char, so the
+        # 1ms/char slope is already generous; this guards against superlinear
+        # blowups rather than enforcing a tight budget. The fixed base absorbs a
+        # one-off GC or scheduler pause on a loaded runner, which otherwise
+        # dominates the small absolute budget for tiny inputs.
+        base_overhead = 50_000
+        expected_max = base_overhead + size * 1000
         assert time < expected_max
       end
     end

--- a/test/property/process_isolation_property_test.exs
+++ b/test/property/process_isolation_property_test.exs
@@ -177,42 +177,42 @@ defmodule Raxol.Property.ProcessIsolationTest do
   end
 
   describe "anti-pattern detection" do
+    @tag capture_log: true
     property "linked child with abnormal exit kills parent (proves the bug)" do
-      # Demonstrates that WITHOUT unlink, the parent dies.
-      # We run in a spawned process to protect the test runner.
+      # Demonstrates that WITHOUT unlink, the parent dies. The victim runs in a
+      # spawned (unlinked) process so its death cannot take down the test
+      # runner; the test monitors the victim directly and treats its death as
+      # the proof.
       check all(reason <- abnormal_reason_gen(), max_runs: 50) do
-        test_pid = self()
-
-        spawn(fn ->
-          # This "victim" uses start_link WITHOUT unlink (the anti-pattern)
-          {:ok, child} = GenServer.start_link(__MODULE__.CrashableChild, nil)
-          Process.monitor(child)
-          victim_pid = self()
-
-          # Spawn a watcher to report whether victim survives
+        victim =
           spawn(fn ->
-            ref = Process.monitor(victim_pid)
-
-            receive do
-              {:DOWN, ^ref, :process, ^victim_pid, _} ->
-                send(test_pid, {:victim_status, :died})
-            after
-              1_000 -> send(test_pid, {:victim_status, :survived})
-            end
+            # Anti-pattern: start_link WITHOUT unlink, then crash the child.
+            # The propagated exit signal must kill this process.
+            {:ok, child} = GenServer.start_link(__MODULE__.CrashableChild, nil)
+            send(child, {:crash, reason})
+            # Sit here until the link kills us. With the correct pattern
+            # (unlink + monitor) we would survive until the timeout instead.
+            Process.sleep(:infinity)
           end)
 
-          # Crash the child -- the link should kill us
-          send(child, {:crash, reason})
-          Process.sleep(500)
-          send(test_pid, {:victim_status, :survived})
-        end)
+        ref = Process.monitor(victim)
 
+        # A generous timeout absorbs scheduler jitter when the child's crash is
+        # delayed under CI load. The child only has to process one message and
+        # exit, so 2s is ample. There is deliberately no short-sleep self-report
+        # in the victim: that raced the crash propagation and let a slow-to-die
+        # victim report survival before the link caught up.
         result =
           receive do
-            {:victim_status, status} -> status
+            {:DOWN, ^ref, :process, ^victim, _reason} -> :died
           after
-            2_000 -> :timeout
+            2_000 -> :survived
           end
+
+        # Keep iterations independent: drop any pending :DOWN and reap the
+        # victim if it somehow outlived the timeout.
+        Process.demonitor(ref, [:flush])
+        if Process.alive?(victim), do: Process.exit(victim, :kill)
 
         assert result == :died,
                "linked child crash (#{inspect(reason)}) must kill parent -- " <>


### PR DESCRIPTION
Two wall-clock/scheduler-sensitive property tests that flake on loaded CI
runners (the nightly and macOS matrices). Both fail "after 0 successful runs",
i.e. seed-dependently, not on a real regression.

## 1. `parser_property_test.exs` — "parser performance scales linearly"

Nightly 2026-07-09 (run 28997958175):

```
code:  assert time < expected_max
left:  19677   (us actual)
right: 16000   (us budget)
```

`expected_max = size * 1000` had no fixed-overhead term, so the smallest
generated inputs got a tiny absolute budget (size ~16 -> 16ms) while the first
`:timer.tc` call paid a one-off GC/scheduler pause. Real cost is ~3.3us/char,
so the slope is already ~300x slack; this is effectively a "not superlinear"
check. Fix: add a fixed base so tiny inputs get a floor.

```elixir
base_overhead = 50_000
expected_max = base_overhead + size * 1000
```

## 2. `process_isolation_property_test.exs` — "linked child ... kills parent"

macOS matrix (PR #432 run): failed on generated reason `:noproc`. Verified
empirically that all `abnormal_reason_gen` reasons DO propagate through links
(only `:normal` is ignored), so the reason was fine. The real race was the
victim's escape hatch: it did `send(child, {:crash, reason})` then
`Process.sleep(500)` then `send(:survived)`. Under scheduler load, if the child
GenServer didn't process the crash within 500ms, the victim finished its sleep
and reported `:survived` before the link killed it.

Fix: remove the racy self-report. The test now monitors the victim directly;
the victim `Process.sleep(:infinity)` and can only exit via the propagated
link. The sole path to `:survived` is the victim genuinely outliving a generous
2s timeout. Added `@tag capture_log: true` to silence the expected child-crash
reports, and per-iteration `demonitor(:flush)` + reap to keep runs independent.

## Manual testing

- [x] `mix test test/property/parser_property_test.exs` -> 10 passed, 0.2s
- [x] `mix test test/property/process_isolation_property_test.exs` across seeds 0/42/761215/999999/12345 -> 9 passed each
- [x] Re-ran process-isolation under two `yes` CPU hogs (scheduler stress) -> 9 passed
