### PR TITLE
Release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,38 @@
 ## [Unreleased]
 
-### Removed
+## [2.6.0] - 2026-07-11
 
-- **`raxol_acp`: v1 memo model retired (seller-stack migration Phases 1-4, #385/#390/#388/#389/#391)**. Deleted `Raxol.ACP.Job.{Server, Supervisor, Registry, Workflow, StateMachine, MemoType, FeeType, Store}`, `Raxol.ACP.ContractClient` (+ `Onchain` + `InMemory`), the memo `Raxol.ACP.Directive`s + their executor, `Raxol.ACP.Onchain.LogDecoder`, and the `acp_version` / `ACP_VERSION` switch. The v2 hook/event model (`Raxol.ACP.JobSession` + `Raxol.ACP.HookClient` -> `AgenticCommerceV3` via `Raxol.ACP.ProviderAdapter`) is now the only runtime. `raxol_acp` bumped `0.2.0-pre.0 -> 0.2.0-rc.0`. Supersedes ADR-0016/0017. See `packages/raxol_acp/MIGRATION_V2.md`.
+### Added
+
+- **LiveView accessibility: ARIA roles + announcement live region (#431)**. The LiveView terminal surface now emits ARIA roles and an `aria-live` region so screen readers announce state changes.
+- **Accessibility projection + MCP a11y fields (#428)**. The model exposes an accessibility projection; MCP screenshots carry a11y fields describing focus, roles, and announcements.
+- **OpenRouter backend harness with app attribution (#414)**. `Backend.Selector`'s `:openrouter` harness targets OpenRouter (OpenAI-compatible) and attaches app-attribution headers (HTTP-Referer, X-OpenRouter-Title, X-OpenRouter-Categories) so Raxol appears on openrouter.ai/rankings.
+- **`raxol_payments`: `recipient_address` on the Xochi `QuoteRequest` (#416)**, and stealth fields surfaced in the ACP Xochi deliverable so buyers can settle to a stealth meta-address.
+- **Property tests for the money-adjacent paths (#392/#393)**: `router_property_test` (trust-score totality / monotonicity / clamp / tier_override bounds), `ledger_release_property_test` (`Ledger.release/4` refund netting), `jsonrpc_nonce_test` (concurrent-send nonce distinctness), `job_session/telemetry_test` (pins the `[:raxol, :acp, :job_session, :transition]` cross-package contract with `raxol_symphony`), and an exhaustive `JobSession.Status.validate/2` matrix.
+
+### Changed
+
+- **Toolchain: Elixir 1.20 / OTP 29, zero warnings (#398)**.
+- **`raxol_payments`: MPP amounts pinned to atomic integer units (#413)**; Xochi Tron deposit-route quotes verified.
+- **Web surface hardening (#427/#418/#426)**: web deploy gained a CI gate, health check, SSH, and warnings-as-errors; the raxol.io agent surface was tightened; the landing demo is interactive (forwards keydown).
 
 ### Fixed
 
 - **`raxol_acp`: EOA nonce race in `ProviderAdapter.JSONRPC` (#392)**. `send_calls/3` fetched the pending nonce inline, so two concurrent sends for one EOA signed the same nonce and the RPC silently dropped one (fund loss on retry). Nonce assignment now routes through the mailbox-serialized `Raxol.ACP.Wallet.NonceServer`; a failed send resyncs to re-fetch and re-fill the gap. The SCA/UserOp path is unaffected.
 - **`raxol_payments`: negative trust score crashed the router (#393)**. `Raxol.Payments.Router` clamped only the upper trust-score bound, so a negative `:trust_score` hit `PrivacyTier.from_trust_score/2` (no negative clause) and raised `FunctionClauseError` on the settlement path. Now clamped to `[0,100]` at the boundary.
+- **`raxol_payments`: x402 auto-pay budget leak and value binding (#403)**; refunded status now handled and the session budget reconciled on refund (#402); `Ledger` reservation tags are bounded with a TTL sweep (#407).
+- **`raxol_acp`: write-confirmation correctness**. EOA transactions confirm the receipt before reporting write success (#412); a reverted UserOp is rejected as a failed SCA write (#409); `accept_request` (#408) and seller delivery (#406) are idempotent.
+- **Web release stability**: fixed a raxol.io release boot crash (#424), restored web PubSub + SSH for minimal-mode Raxol (#425), set ssh/public_key to `:permanent` (#420), and excluded nested build artifacts from the Docker context (#422).
+- **CI: de-flaked two timing-sensitive property tests (#432)** (parser performance budget, process-isolation link race) that failed seed-dependently on the nightly and macOS matrices.
 
-### Added
+### Security
 
-- **Property tests for the money-adjacent paths above (#392/#393)**: `router_property_test` (trust-score totality / monotonicity / clamp / tier_override bounds), `ledger_release_property_test` (`Ledger.release/4` refund netting), `jsonrpc_nonce_test` (concurrent-send nonce distinctness), `job_session/telemetry_test` (pins the `[:raxol, :acp, :job_session, :transition]` cross-package contract with `raxol_symphony`), and an exhaustive `JobSession.Status.validate/2` matrix.
+- **`raxol_payments`: wallet private key guarded from crash-report leak (#404)**. Keys are wrapped so they cannot surface in `Inspect` output or crash reports.
+- **Dependencies: pruned orphaned lockfile deps, dropping the Tesla CVEs (#415)**; dropped the earmark dependency (#396).
+
+### Removed
+
+- **`raxol_acp`: v1 memo model retired (seller-stack migration Phases 1-4, #385/#390/#388/#389/#391)**. Deleted `Raxol.ACP.Job.{Server, Supervisor, Registry, Workflow, StateMachine, MemoType, FeeType, Store}`, `Raxol.ACP.ContractClient` (+ `Onchain` + `InMemory`), the memo `Raxol.ACP.Directive`s + their executor, `Raxol.ACP.Onchain.LogDecoder`, and the `acp_version` / `ACP_VERSION` switch. The v2 hook/event model (`Raxol.ACP.JobSession` + `Raxol.ACP.HookClient` -> `AgenticCommerceV3` via `Raxol.ACP.ProviderAdapter`) is now the only runtime. `raxol_acp` graduated `0.2.0-pre.0 -> 0.2.0`. Supersedes ADR-0016/0017. See `packages/raxol_acp/MIGRATION_V2.md`.
 
 ## [2.5.0] - 2026-07-07
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Multi-surface application runtime for Elixir. One TEA module, four render targets.
 
-## Current Version: v2.5.0
+## Current Version: v2.6.0
 
 ### What's Done
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Raxol.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_acp/mix.exs
+++ b/packages/raxol_acp/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolAcp.MixProject do
   use Mix.Project
 
-  @version "0.2.0-rc.0"
+  @version "0.2.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_agent/mix.exs
+++ b/packages/raxol_agent/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolAgent.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_core/mix.exs
+++ b/packages/raxol_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCore.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_liveview/mix.exs
+++ b/packages/raxol_liveview/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolLiveView.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_mcp/mix.exs
+++ b/packages/raxol_mcp/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolMcp.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_payments/CHANGELOG.md
+++ b/packages/raxol_payments/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-11
+
 ### Added
 
 - `Raxol.Payments.Mandate` -- Xochi delegation envelope. EIP-712-signed

--- a/packages/raxol_payments/mix.exs
+++ b/packages/raxol_payments/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolPayments.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_plugin/mix.exs
+++ b/packages/raxol_plugin/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolPlugin.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_sensor/mix.exs
+++ b/packages/raxol_sensor/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolSensor.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_terminal/mix.exs
+++ b/packages/raxol_terminal/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolTerminal.MixProject do
   use Mix.Project
 
-  @version "2.5.0"
+  @version "2.6.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/web/lib/raxol_playground/capabilities.ex
+++ b/web/lib/raxol_playground/capabilities.ex
@@ -60,7 +60,7 @@ defmodule RaxolPlayground.Capabilities do
   def version do
     case :application.get_key(:raxol, :vsn) do
       {:ok, vsn} -> to_string(vsn)
-      _ -> "2.5.0"
+      _ -> "2.6.0"
     end
   end
 


### PR DESCRIPTION
Cuts the **2.6.0** release for the lockstep family and graduates the
independently-versioned payments/ACP packages.

## Version bumps

| Package | From | To |
|---------|------|----|
| `raxol` (+ core, terminal, agent, mcp, liveview, plugin, sensor) | 2.5.0 | **2.6.0** |
| `raxol_payments` | 0.1.0 | **0.2.0** |
| `raxol_acp` | 0.2.0-rc.0 | **0.2.0** (graduate) |

The eight lockstep packages move together per the shared version line. Cross-package
constraints (`~> 2.4`, `~> 0.1`) already absorb the bumps, so no dependency lines
changed. `mix deps.get` resolves unchanged; mix.lock untouched.

## Changelog

- Main `CHANGELOG.md`: `[Unreleased]` promoted to `[2.6.0] - 2026-07-11`. The section
  was stale (only #385-#393); backfilled the ~25 commits since v2.5.0 — LiveView ARIA
  (#431), accessibility projection + MCP a11y (#428), Elixir 1.20 / OTP 29 (#398),
  OpenRouter harness (#414), payments/ACP hardening, web-release fixes, the Tesla-CVE
  prune (#415), and the two de-flaked property tests (#432).
- `raxol_payments/CHANGELOG.md`: accumulated `[Unreleased]` entries attributed to `[0.2.0]`.

Also updated the `ROADMAP.md` current-version header and the build-time version
fallback in `web/lib/raxol_playground/capabilities.ex`.

## After merge

- Tag `v2.6.0` (lockstep) and `raxol-acp-v0.2.0` (fires `release-raxol-acp.yml` Docker build).
- Publish to Hex in dependency order (acp excluded, pre-alpha).

## Manual testing

- [x] `mix deps.get` -> resolves unchanged, exit 0
- [x] Pre-commit lock-consistency guard passed
- [x] Diff limited to 10 `@version` bumps + 2 changelogs + ROADMAP + version fallback
