### PR TITLE
Track lockstep dep constraints + CI guard

### DIFF
--- a/.github/workflows/lockstep-deps.yml
+++ b/.github/workflows/lockstep-deps.yml
@@ -1,0 +1,29 @@
+name: Lockstep Deps
+
+# Fails a PR if any raxol_* inter-package "~> X.Y" constraint lags the version
+# of the package it points at. Prevents the class of bug where a bumped family
+# member (e.g. raxol_core 2.6.0) is depended on with a stale "~> 2.4", so
+# HEX_BUILD publishes against the old published sibling.
+
+on:
+  pull_request:
+    paths:
+      - "**/mix.exs"
+      - "scripts/check-lockstep-deps.sh"
+      - ".github/workflows/lockstep-deps.yml"
+  push:
+    branches: [master]
+    paths:
+      - "**/mix.exs"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Constraint consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check lockstep dep constraints
+        run: ./scripts/check-lockstep-deps.sh

--- a/mix.exs
+++ b/mix.exs
@@ -195,12 +195,12 @@ defmodule Raxol.MixProject do
 
   defp modular_packages do
     [
-      raxol_dep(:raxol_core, "~> 2.4", "packages/raxol_core"),
-      raxol_dep(:raxol_terminal, "~> 2.4", "packages/raxol_terminal"),
-      raxol_dep(:raxol_sensor, "~> 2.4", "packages/raxol_sensor"),
-      raxol_dep(:raxol_mcp, "~> 2.4", "packages/raxol_mcp"),
-      raxol_dep(:raxol_liveview, "~> 2.4", "packages/raxol_liveview"),
-      raxol_dep(:raxol_plugin, "~> 2.4", "packages/raxol_plugin")
+      raxol_dep(:raxol_core, "~> 2.6", "packages/raxol_core"),
+      raxol_dep(:raxol_terminal, "~> 2.6", "packages/raxol_terminal"),
+      raxol_dep(:raxol_sensor, "~> 2.6", "packages/raxol_sensor"),
+      raxol_dep(:raxol_mcp, "~> 2.6", "packages/raxol_mcp"),
+      raxol_dep(:raxol_liveview, "~> 2.6", "packages/raxol_liveview"),
+      raxol_dep(:raxol_plugin, "~> 2.6", "packages/raxol_plugin")
     ]
   end
 

--- a/packages/raxol_acp/mix.exs
+++ b/packages/raxol_acp/mix.exs
@@ -56,9 +56,9 @@ defmodule RaxolAcp.MixProject do
 
   defp deps do
     [
-      raxol_dep(:raxol_payments, "~> 0.1", "../raxol_payments", []),
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core", []),
-      raxol_dep(:raxol_mcp, "~> 2.4", "../raxol_mcp", runtime: false),
+      raxol_dep(:raxol_payments, "~> 0.2", "../raxol_payments", []),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core", []),
+      raxol_dep(:raxol_mcp, "~> 2.6", "../raxol_mcp", runtime: false),
       {:req, "~> 0.5"},
       {:ex_keccak, "~> 0.7"},
       {:jason, "~> 1.4"},

--- a/packages/raxol_agent/mix.exs
+++ b/packages/raxol_agent/mix.exs
@@ -35,8 +35,8 @@ defmodule RaxolAgent.MixProject do
 
   defp deps do
     [
-      raxol_dep(:raxol, "~> 2.4", "../.."),
-      raxol_dep(:raxol_mcp, "~> 2.4", "../raxol_mcp"),
+      raxol_dep(:raxol, "~> 2.6", "../.."),
+      raxol_dep(:raxol_mcp, "~> 2.6", "../raxol_mcp"),
       {:circular_buffer, "~> 1.0"},
       {:jason, "~> 1.4"},
       {:yaml_elixir, "~> 2.12"},

--- a/packages/raxol_gateway/mix.exs
+++ b/packages/raxol_gateway/mix.exs
@@ -31,11 +31,11 @@ defmodule RaxolGateway.MixProject do
 
   defp deps do
     [
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
       {:telemetry, "~> 1.3"},
 
       # Per-chat durable history (optional -- only needed to record turns).
-      raxol_dep(:raxol_agent, "~> 2.4", "../raxol_agent", optional: true),
+      raxol_dep(:raxol_agent, "~> 2.6", "../raxol_agent", optional: true),
 
       # Dev/test only
       {:ex_doc, "~> 0.31", only: :dev, runtime: false},

--- a/packages/raxol_liveview/mix.exs
+++ b/packages/raxol_liveview/mix.exs
@@ -32,7 +32,7 @@ defmodule RaxolLiveView.MixProject do
   defp deps do
     [
       # Core dependency (Buffer, Events, etc.)
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
 
       # PubSub for LiveView <-> Lifecycle communication
       {:phoenix_pubsub, "~> 2.1"},

--- a/packages/raxol_mcp/mix.exs
+++ b/packages/raxol_mcp/mix.exs
@@ -31,7 +31,7 @@ defmodule RaxolMcp.MixProject do
 
   defp deps do
     [
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
       {:jason, "~> 1.4"},
       {:plug, "~> 1.16", optional: true},
 

--- a/packages/raxol_payments/mix.exs
+++ b/packages/raxol_payments/mix.exs
@@ -38,9 +38,9 @@ defmodule RaxolPayments.MixProject do
   defp deps do
     [
       # Compile-time only: Action macro, CommandHook behaviour, Command struct
-      raxol_dep(:raxol_agent, "~> 2.4", "../raxol_agent", runtime: false),
+      raxol_dep(:raxol_agent, "~> 2.6", "../raxol_agent", runtime: false),
       # Raxol.Core.Stores.Dets/Naming back Raxol.Payments.Mandate.Store
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core", []),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core", []),
       {:req, "~> 0.5"},
       {:ex_secp256k1, "~> 0.8"},
       {:ex_keccak, "~> 0.7"},

--- a/packages/raxol_plugin/mix.exs
+++ b/packages/raxol_plugin/mix.exs
@@ -32,7 +32,7 @@ defmodule RaxolPlugin.MixProject do
   defp deps do
     [
       # Core dependency - plugin behaviours and runtime
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
 
       # Dev/test only
       {:mox, "~> 1.2", only: :test},

--- a/packages/raxol_speech/mix.exs
+++ b/packages/raxol_speech/mix.exs
@@ -32,7 +32,7 @@ defmodule RaxolSpeech.MixProject do
   defp deps do
     [
       # Core dependency (Events, Accessibility, Behaviours)
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
       {:telemetry, "~> 1.3"},
 
       # Speech recognition (optional -- STT works without these)

--- a/packages/raxol_symphony/mix.exs
+++ b/packages/raxol_symphony/mix.exs
@@ -34,31 +34,31 @@ defmodule RaxolSymphony.MixProject do
 
   defp deps do
     [
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
 
       # Main raxol (Lifecycle runtime, Recording for evidence). Compile-time only --
       # runtime: false keeps :raxol out of this package's .app applications list so
       # the host (which owns raxol) controls its boot, avoiding circular OTP startup.
-      raxol_dep(:raxol, "~> 2.4", "../..", optional: true, runtime: false),
+      raxol_dep(:raxol, "~> 2.6", "../..", optional: true, runtime: false),
 
       # Agent runner backend. Optional at compile time so the orchestrator core
       # can be exercised in tests with a noop runner. Local path in dev so we
       # pick up Stream.Event / EventForwarder helpers ahead of next hex release.
-      raxol_dep(:raxol_agent, "~> 2.4", "../raxol_agent", optional: true),
+      raxol_dep(:raxol_agent, "~> 2.6", "../raxol_agent", optional: true),
 
       # raxol_acp is pulled in test env ONLY to exercise the canonical
       # cross-package auto-resume flow (Job.Server transition telemetry ->
       # Resumer -> Orchestrator.resume_run). Symphony does not depend on
       # ACP at runtime or compile time outside tests.
-      raxol_dep(:raxol_acp, "~> 0.2-pre", "../raxol_acp", only: :test),
+      raxol_dep(:raxol_acp, "~> 0.2", "../raxol_acp", only: :test),
 
       # MCP surface (optional). Local path in dev for ToolDef + register_all.
-      raxol_dep(:raxol_mcp, "~> 2.4", "../raxol_mcp", optional: true),
+      raxol_dep(:raxol_mcp, "~> 2.6", "../raxol_mcp", optional: true),
 
       # LiveView/Telegram/Watch surfaces -- all optional, gated at runtime.
-      raxol_dep(:raxol_liveview, "~> 2.4", "../raxol_liveview", optional: true),
-      raxol_dep(:raxol_telegram, "~> 0.1", "../raxol_telegram", optional: true),
-      raxol_dep(:raxol_watch, "~> 0.1", "../raxol_watch", optional: true),
+      raxol_dep(:raxol_liveview, "~> 2.6", "../raxol_liveview", optional: true),
+      raxol_dep(:raxol_telegram, "~> 0.2", "../raxol_telegram", optional: true),
+      raxol_dep(:raxol_watch, "~> 0.2", "../raxol_watch", optional: true),
 
       # YAML front matter parsing.
       {:yaml_elixir, "~> 2.12"},

--- a/packages/raxol_telegram/mix.exs
+++ b/packages/raxol_telegram/mix.exs
@@ -35,13 +35,13 @@ defmodule RaxolTelegram.MixProject do
   defp deps do
     [
       # Core dependency (Events, Behaviours)
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
       {:telemetry, "~> 1.3"},
 
       # Main raxol (Lifecycle runtime -- required for Session to start TEA apps)
       # Optional at compile time; Session guards with Code.ensure_loaded? at runtime.
       # Consumer apps must include :raxol in their deps for sessions to work.
-      {:raxol, "~> 2.4", optional: true},
+      {:raxol, "~> 2.6", optional: true},
 
       # Telegram Bot API (optional -- only needed at runtime with a bot token)
       {:telegex, "~> 1.8", optional: true, runtime: false},

--- a/packages/raxol_terminal/mix.exs
+++ b/packages/raxol_terminal/mix.exs
@@ -43,7 +43,7 @@ defmodule RaxolTerminal.MixProject do
 
   defp deps do
     [
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
       {:uuid, "~> 1.1"},
       {:jason, "~> 1.4"},
 

--- a/packages/raxol_watch/mix.exs
+++ b/packages/raxol_watch/mix.exs
@@ -34,7 +34,7 @@ defmodule RaxolWatch.MixProject do
 
   defp deps do
     [
-      raxol_dep(:raxol_core, "~> 2.4", "../raxol_core"),
+      raxol_dep(:raxol_core, "~> 2.6", "../raxol_core"),
       {:telemetry, "~> 1.3"},
 
       # Push notifications (optional -- only needed with real APNS/FCM)

--- a/scripts/check-lockstep-deps.sh
+++ b/scripts/check-lockstep-deps.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Guard against lagging inter-package version constraints.
+#
+# Every raxol_* package declares its sibling deps with a "~> X.Y" constraint.
+# When the family is bumped (say 2.5 -> 2.6) but a dependent still says
+# "~> 2.4", HEX_BUILD resolves the stale *published* sibling (2.4.0) instead of
+# the new one, so the package is built and published against incompatible code.
+# That is exactly how a 2.6.0 publish ended up compiling against raxol_core
+# 2.4.0 and failing under Elixir 1.20.
+#
+# This check fails if any raxol_* dependency constraint's minor version does not
+# match the current version of the package it points at. Run it in CI and
+# before publishing.
+#
+# Written for bash 3.2 (macOS default): no associative arrays.
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+minor_of() {
+  [[ -f "$1" ]] || return 1
+  grep -oE '@version "[0-9]+\.[0-9]+' "$1" | head -1 | grep -oE '[0-9]+\.[0-9]+$'
+}
+
+# mix.exs path that defines the given raxol package's @version.
+mixfile_for() {
+  if [[ "$1" == "raxol" ]]; then echo "mix.exs"; else echo "packages/$1/mix.exs"; fi
+}
+
+status=0
+while IFS= read -r file; do
+  while IFS= read -r match; do
+    dep="$(printf '%s' "$match" | grep -oE ':raxol[a-z_]*' | tr -d ':')"
+    cmin="$(printf '%s' "$match" | grep -oE '[0-9]+\.[0-9]+' | head -1)"
+    want="$(minor_of "$(mixfile_for "$dep")" || true)"
+    [[ -z "$want" ]] && continue
+    if [[ "$cmin" != "$want" ]]; then
+      printf 'LAG  %-34s %-16s "~> %s"  but %s is at %s\n' \
+        "$file" "$dep" "$cmin" "$dep" "$want"
+      status=1
+    fi
+  done < <(grep -oE ':raxol[a-z_]*, "~> [0-9]+\.[0-9]+' "$file")
+done < <(find . -name mix.exs -not -path '*/deps/*' -not -path '*/_build/*')
+
+if [[ "$status" -eq 0 ]]; then
+  echo "OK: every raxol_* dependency constraint tracks its package version"
+else
+  echo "" >&2
+  echo "Fix: bump the lagging \"~> X.Y\" constraints to match, then refresh" >&2
+  echo "each affected mix.lock (HEX_BUILD=1 mix deps.get)." >&2
+fi
+exit "$status"


### PR DESCRIPTION
## Problem

Every raxol_* package declared its sibling deps with a lagging `~> 2.4`
constraint while the family sits at 2.6.0, and each package's `mix.lock` pinned
those siblings to the old `2.4.0`. Under `HEX_BUILD=1 mix deps.get`, `~> 2.4`
*permits* 2.4.0 and the lock *prefers* it, so a 2.6.0 package builds and
publishes against the stale 2.4.0 sibling.

This surfaced mid-publish: `raxol_mcp` 2.6.0's doc build compiled against
`raxol_core` 2.4.0 and failed — 2.4.0's `BaseManager` reintroduces a
`start_link/1` double-default that is a hard error under Elixir 1.20 (only a
warning before). `raxol_liveview`/`raxol_plugin` 2.6.0 had already shipped,
resolved against `raxol_core` 2.4.0.

## Fix

1. Bump every inter-package constraint to track the current family version:
   `~> 2.4` -> `~> 2.6` (lockstep), `raxol_payments ~> 0.1` -> `~> 0.2`,
   `raxol_telegram`/`raxol_watch ~> 0.1` -> `~> 0.2`, `raxol_acp ~> 0.2-pre` ->
   `~> 0.2`. Now `HEX_BUILD` must resolve 2.6.0 or **fail loudly** — it can no
   longer silently use 2.4.0.
2. `scripts/check-lockstep-deps.sh`: fails if any raxol_* constraint's minor
   lags the version of the package it points at. Portable to bash 3.2 (macOS).
3. `.github/workflows/lockstep-deps.yml`: runs the guard on any PR touching a
   `mix.exs`, so a future family bump that forgets a dependent is caught in CI.

## Going forward

The release checklist gains one step: when bumping the family version, bump the
inter-package constraints too (the guard enforces it), and refresh each
`mix.lock` before publishing.

## Manual testing

- [x] `scripts/check-lockstep-deps.sh` -> OK on fixed tree
- [x] negative test (lag one constraint) -> guard fails as expected
- [x] `shellcheck` clean; `actionlint` clean
- [x] `mix deps.get` resolves clean with the new constraints (path deps)
