### PR TITLE
Dev-experience: auto-port endpoint, agent supervisor double-start, compile warnings

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,9 +30,42 @@ config :raxol, Raxol.Repo,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 
-# Dev endpoint for Tidewave MCP (localhost:4000/tidewave/mcp)
+# Dev endpoint for Tidewave MCP (localhost:<port>/tidewave/mcp).
+# RAXOL_DEV_PORT pins an explicit port; otherwise probe upward from 4000
+# for the first free one, so a co-resident service on 4000 (e.g. a local
+# LiteLLM) doesn't take the whole app down with :eaddrinuse. The probe
+# binds all interfaces with no SO_REUSEADDR to match how the endpoint
+# itself binds -- a truthful free/busy read, not a false positive.
+resolve_dev_port = fn ->
+  case System.get_env("RAXOL_DEV_PORT") do
+    nil ->
+      base = 4000
+
+      port =
+        Enum.find(base..(base + 50), base, fn candidate ->
+          case :gen_tcp.listen(candidate, [:binary]) do
+            {:ok, socket} -> :gen_tcp.close(socket) == :ok
+            {:error, _} -> false
+          end
+        end)
+
+      if port != base do
+        IO.puts(
+          :stderr,
+          "[raxol] port #{base} in use; serving web on #{port}. " <>
+            "Set RAXOL_DEV_PORT to pin a port."
+        )
+      end
+
+      port
+
+    explicit ->
+      String.to_integer(explicit)
+  end
+end
+
 config :raxol, Raxol.Endpoint,
-  http: [port: 4000],
+  http: [port: resolve_dev_port.()],
   server: true,
   secret_key_base: String.duplicate("dev", 22)
 

--- a/packages/raxol_agent/examples/agents/react_agent.exs
+++ b/packages/raxol_agent/examples/agents/react_agent.exs
@@ -219,7 +219,6 @@ defmodule ReactAgent do
 
   @actions [Actions.CountLines, Actions.FormatReport, Actions.Summarize]
 
-  @impl true
   def available_actions, do: @actions
 
   @impl true

--- a/packages/raxol_agent/lib/raxol/agent/backend/lumo/crypto.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/lumo/crypto.ex
@@ -115,7 +115,7 @@ defmodule Raxol.Agent.Backend.Lumo.Crypto do
         <<iv::binary-size(@iv_length), rest::binary>> = raw
         ct_len = byte_size(rest) - @tag_length
 
-        <<ciphertext::binary-size(ct_len), tag::binary-size(@tag_length)>> =
+        <<ciphertext::binary-size(^ct_len), tag::binary-size(@tag_length)>> =
           rest
 
         aad = if ad, do: ad, else: <<>>

--- a/packages/raxol_agent/lib/raxol/agent/supervisor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/supervisor.ex
@@ -17,9 +17,17 @@ defmodule Raxol.Agent.Supervisor do
 
   use Supervisor
 
+  # Idempotent: the subtree is named, and more than one caller legitimately
+  # tries to bring it up -- RaxolAgent.Application, the main `raxol` app's
+  # maybe_add_agent_supervisor, and the example/test scripts that boot it
+  # manually. Whoever wins, everyone else gets the same running subtree back
+  # instead of an :already_started crash.
   @spec start_link(keyword()) :: {:ok, pid()}
   def start_link(opts \\ []) do
-    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+    case Supervisor.start_link(__MODULE__, opts, name: __MODULE__) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+    end
   end
 
   @impl true

--- a/packages/raxol_agent/lib/raxol_agent/application.ex
+++ b/packages/raxol_agent/lib/raxol_agent/application.ex
@@ -5,9 +5,18 @@ defmodule RaxolAgent.Application do
 
   @impl true
   def start(_type, _args) do
-    children = [
-      Raxol.Agent.Supervisor
-    ]
+    # The main `raxol` app already starts Raxol.Agent.Supervisor whenever
+    # the module is compiled in (application.ex maybe_add_agent_supervisor),
+    # and raxol_agent depends on raxol -- so when raxol_agent boots as the
+    # top application the dep starts the supervisor first. Starting it again
+    # here crashes with :already_started, which took down every agent
+    # example run from the package. Only own it when nobody else has.
+    children =
+      if Process.whereis(Raxol.Agent.Supervisor) do
+        []
+      else
+        [Raxol.Agent.Supervisor]
+      end
 
     Supervisor.start_link(children,
       strategy: :one_for_one,


### PR DESCRIPTION
Part of decomposing the cross-terminal work into granular, independently-reviewable PRs. This one is fully standalone — touches only `config/dev.exs` and `packages/raxol_agent/**`, no overlap with the layout/terminal PRs, mergeable in any order.

## Changes

**Dev web endpoint auto-picks the first free port from 4000.** A co-resident service on 4000 (e.g. a local LiteLLM) made Ranch fail `:eaddrinuse` and take the whole app down at boot — so `mix run` of any example wouldn't start. `RAXOL_DEV_PORT` still pins an explicit port; absent it, the endpoint probes upward from 4000 for the first bindable port and logs which one it chose. The probe binds all interfaces with no `SO_REUSEADDR`, matching the endpoint's own bind, so it reads free/busy truthfully instead of false-positiving on a partially-bound port.

**Agent examples no longer crash on an already-started supervisor.** The main `raxol` app starts `Raxol.Agent.Supervisor` whenever the module is compiled in, and `raxol_agent` depends on `raxol` — so booting `raxol_agent` as the top app (any package example) started the supervisor twice and died with `:already_started` before the demo ran. `RaxolAgent.Application` now only owns the subtree when nobody else has started it, and the named supervisor's `start_link` is idempotent so the example/test scripts that boot it manually get the running subtree back instead of a crash.

**Two agent-path compile warnings cleared.** Pin `ct_len` in the Lumo GCM ciphertext/tag split (an unpinned var in `binary-size(...)` matches loosely and warns); drop a spurious `@impl true` on the react_agent example's `available_actions/0`, which isn't a behaviour callback.

## Verification

- `react_agent.exs` and `agent_team.exs` run to completion from the package.
- `zero_system.exs` boots from the repo root with the auto-port.
- raxol_agent package suite green; Lumo `crypto_test` 17/17.
