### PR TITLE
Terminal driver hardening: OSC 11 detection, noshell stdin, total CSI parsing, frame geometry

### DIFF
--- a/lib/raxol/core/runtime/rendering/backends.ex
+++ b/lib/raxol/core/runtime/rendering/backends.ex
@@ -29,7 +29,7 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
     )
 
     # Move cursor to top-left and clear screen before each frame
-    frame = "\e[H\e[2J" <> output_string
+    frame = normalize_frame("\e[H\e[2J" <> output_string)
 
     if state.sync_output do
       IO.write("\e[?2026h")
@@ -167,7 +167,7 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
     output_string = Raxol.Terminal.Renderer.render(renderer)
 
     # Home cursor and clear screen before each frame, matching render_to_terminal
-    frame = "\e[H\e[2J" <> output_string
+    frame = normalize_frame("\e[H\e[2J" <> output_string)
 
     write_output(state.io_writer, frame, state.sync_output)
 
@@ -175,6 +175,23 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
   end
 
   # --- Output Helpers ---
+
+  @doc """
+  Normalizes bare `\\n` row joins in a rendered frame to `\\r\\n`.
+
+  `Raxol.Terminal.Renderer.render/1` joins rows with a bare `\\n`, relying on
+  the terminal driver to cook LF into CRLF. The driver runs prim_tty in raw
+  output mode (see `Raxol.Terminal.Driver.start_stdin_reader/1`), where a
+  bare `\\n` only advances the line without returning to column 0 -- every
+  row after the first drifts one column right, and combined with DECAWM
+  autowrap on full-width rows this doubles the frame's vertical extent.
+  `\\r\\n` is mode-independent: raw mode gets a real CR+LF, and cooked
+  mode's LF->CRLF translation just turns it into a harmless `\\r\\r\\n`.
+  """
+  @spec normalize_frame(String.t()) :: String.t()
+  def normalize_frame(output_string) when is_binary(output_string) do
+    String.replace(output_string, "\n", "\r\n")
+  end
 
   @doc false
   def write_output(writer, output, true) when is_function(writer, 1) do

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/input_parser.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/input_parser.ex
@@ -34,6 +34,11 @@ defmodule Raxol.Terminal.ANSI.InputParser do
       {nil, <<>>} ->
         Enum.reverse(acc)
 
+      {:consumed, rest} ->
+        # A well-formed sequence with no event mapping (secondary DA reply,
+        # CPR, DECRQM response, ...) was consumed whole. Emit nothing.
+        parse_loop(rest, acc)
+
       {nil, _rest} ->
         # Unrecognized byte -- skip it and continue
         <<_, rest::binary>> = data
@@ -189,8 +194,18 @@ defmodule Raxol.Terminal.ANSI.InputParser do
         key = csi_letter_to_key(letter)
         {key_event(key, shift: shift, alt: alt, ctrl: ctrl), rest}
 
-      _ ->
-        {nil, data}
+      {_params, final_byte, rest} when is_integer(final_byte) ->
+        # Well-formed CSI sequence with no event mapping (secondary DA
+        # reply, cursor position report, DECRQM response, ...). Consume it
+        # whole -- {nil, data} would make parse_loop skip only the ESC and
+        # re-parse the rest as printable char keys.
+        {:consumed, rest}
+
+      {_params, nil, <<>>} ->
+        # Chunk ended mid-CSI (e.g. the input buffer flushed an incomplete
+        # sequence after its timeout). Drop the fragment rather than leak
+        # its bytes as char keys.
+        {:consumed, <<>>}
     end
   end
 
@@ -328,7 +343,16 @@ defmodule Raxol.Terminal.ANSI.InputParser do
         {event, rest}
 
       _ ->
-        {nil, data}
+        # Not a complete SGR mouse report (malformed or truncated after a
+        # buffer flush). Consume through the final byte -- or drop the
+        # fragment -- instead of leaking the bytes as char key events.
+        case parse_csi_params(data) do
+          {_params, final_byte, rest} when is_integer(final_byte) ->
+            {:consumed, rest}
+
+          _ ->
+            {:consumed, <<>>}
+        end
     end
   end
 

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/input_parser.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/input_parser.ex
@@ -221,6 +221,15 @@ defmodule Raxol.Terminal.ANSI.InputParser do
     {params ++ [num], nil, <<>>}
   end
 
+  # Catch-all for CSI parameter/intermediate bytes with no special meaning
+  # (private markers `<` `=` `>` `?` `:`, ECMA-48 intermediates 0x20-0x2F).
+  # Without this clause, an unrecognized byte is a FunctionClauseError that
+  # crashes the Driver GenServer. Skip it and keep scanning for the final
+  # byte, keeping parsing total.
+  defp parse_csi_params(<<_byte, rest::binary>>, current_digits, params) do
+    parse_csi_params(rest, current_digits, params)
+  end
+
   defp digits_to_integer([]), do: 0
 
   defp digits_to_integer(digits) do

--- a/packages/raxol_terminal/lib/raxol/terminal/driver.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver.ex
@@ -471,7 +471,7 @@ defmodule Raxol.Terminal.Driver do
 
   defp dispatch_raw_input(data, state) do
     {data, state} = handle_bg_query_reply(data, state)
-    events = InputParser.parse(data)
+    events = parse_input_safely(data)
 
     Enum.each(events, fn event ->
       case state.dispatcher_pid do
@@ -481,6 +481,32 @@ defmodule Raxol.Terminal.Driver do
     end)
 
     {:noreply, state}
+  end
+
+  # Last-resort net: InputParser.parse/1 is written to be total over the
+  # ANSI/CSI grammar, but a parser bug here must never crash the Driver --
+  # terminate/2's cleanup write can race supervisor shutdown and take stdio
+  # down before the terminal is restored. Drop this chunk rather than crash.
+  defp parse_input_safely(data) do
+    InputParser.parse(data)
+  rescue
+    error ->
+      Raxol.Core.Runtime.Log.warning_with_context(
+        "[Driver] InputParser crashed on raw input, dropping this chunk: " <>
+          inspect(error),
+        %{}
+      )
+
+      []
+  catch
+    kind, reason ->
+      Raxol.Core.Runtime.Log.warning_with_context(
+        "[Driver] InputParser raised #{inspect(kind)} on raw input, dropping this chunk: " <>
+          inspect(reason),
+        %{}
+      )
+
+      []
   end
 
   # Writes the OSC 11 background query and returns whether a reply should

--- a/packages/raxol_terminal/lib/raxol/terminal/driver.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver.ex
@@ -155,7 +155,9 @@ defmodule Raxol.Terminal.Driver do
       {_, _, nil} ->
         # No dispatcher — this is the Application supervisor's placeholder Driver.
         # Don't set up the terminal; the Lifecycle's Driver will do that.
-        Raxol.Core.Runtime.Log.info("[TerminalDriver] No dispatcher, skipping terminal setup.")
+        Raxol.Core.Runtime.Log.info(
+          "[TerminalDriver] No dispatcher, skipping terminal setup."
+        )
 
         {:ok, state}
 
@@ -271,7 +273,9 @@ defmodule Raxol.Terminal.Driver do
         {:termbox_event, event_map},
         %{termbox_state: :initialized, dispatcher_pid: dispatcher_pid} = state
       ) do
-    Raxol.Core.Runtime.Log.debug("Received termbox event: #{inspect(event_map)}")
+    Raxol.Core.Runtime.Log.debug(
+      "Received termbox event: #{inspect(event_map)}"
+    )
 
     case EventTranslator.translate(event_map) do
       {:ok, %Event{} = event} ->
@@ -285,7 +289,9 @@ defmodule Raxol.Terminal.Driver do
 
       :ignore ->
         # Event type we don't care about
-        Raxol.Core.Runtime.Log.debug("[Driver] Ignoring termbox event: #{inspect(event_map)}")
+        Raxol.Core.Runtime.Log.debug(
+          "[Driver] Ignoring termbox event: #{inspect(event_map)}"
+        )
 
         {:noreply, state}
 
@@ -366,7 +372,9 @@ defmodule Raxol.Terminal.Driver do
       "[TerminalDriver.handle_cast - :test_input] Parsed event: #{inspect(event)}"
     )
 
-    Raxol.Core.Runtime.Log.debug("[TEST] Dispatching simulated event: #{inspect(event)}")
+    Raxol.Core.Runtime.Log.debug(
+      "[TEST] Dispatching simulated event: #{inspect(event)}"
+    )
 
     _ =
       Backpressure.cast(state.dispatcher_pid, {:dispatch, event},
@@ -570,7 +578,9 @@ defmodule Raxol.Terminal.Driver do
   end
 
   def terminate(_reason, _state) do
-    Raxol.Core.Runtime.Log.info("Terminal Driver terminating (not initialized).")
+    Raxol.Core.Runtime.Log.info(
+      "Terminal Driver terminating (not initialized)."
+    )
 
     :ok
   end
@@ -613,42 +623,48 @@ defmodule Raxol.Terminal.Driver do
   # spawns a fresh reader that arms select notifications), then trace the
   # reader's sends to intercept input data before user_drv forwards it.
   defp start_stdin_reader(_driver_pid) do
-    # In -noshell mode, user_drv initializes prim_tty with tty => false,
-    # so the NIF never sets up the terminal fd for select notifications.
-    # The reader process exists but is blocked waiting for events that
-    # never arrive.
-    #
-    # Fix: call user_drv:start_shell to trigger prim_tty:reinit with
-    # tty => true, which activates the terminal fd. Then trace the
-    # reader to intercept input data before it reaches user_drv.
-    reader = Process.whereis(:user_drv_reader)
+    # `initial_shell` must be the literal atom `:noshell`, never an MFA
+    # (even a no-op one): user_drv only skips shell-spawning when
+    # initial_shell =:= :noshell. Any other value falls into
+    # init_local_shell/2, which spawns a real shell via group:start/3; that
+    # process exits immediately and drops user_drv into its JCL "User
+    # switch command" prompt, which swallows every subsequent stdin byte
+    # (including the terminal's OSC 11 / DA reply) as a job-control command
+    # instead of forwarding it, and can bring the node down before a frame
+    # ever renders.
     user_drv = Process.whereis(:user_drv)
 
     if user_drv do
-      # Activate the terminal fd by triggering prim_tty reinit.
       try do
         :gen_statem.call(
           user_drv,
-          {:start_shell, %{initial_shell: {__MODULE__, :noop_shell, []}}}
+          {:start_shell, %{initial_shell: :noshell, input: :raw}}
         )
       catch
         _, _ -> :ok
       end
     end
 
+    # Re-fetch after the reinit above: input=>raw may (re)spawn the reader.
+    reader = Process.whereis(:user_drv_reader)
+
     if reader do
       # Trace the reader's sends to intercept data before user_drv
       # forwards it. The reader sends {ref, {:data, bytes}} to user_drv.
       :erlang.trace(reader, true, [:send])
+
+      # :noshell means user_drv never issues the one-time read kick a real
+      # shell gets on startup (prim_tty:read/1 via init_shell/2), so the
+      # reader arms a select notification and then idles forever -- no
+      # crash, no keystrokes. Send the kick ourselves; :infinity makes it
+      # self-sustaining (the reader re-arms to :infinity after every read).
+      send(reader, {:read, :infinity})
     end
 
     # No spawned reader pid to track -- input arrives via trace messages
     # in handle_manager_info.
     nil
   end
-
-  @doc false
-  def noop_shell, do: :ok
 
   # --- SIGWINCH subscription ---
   # OTP's prim_tty delivers SIGWINCH from :erl_signal_server straight to

--- a/packages/raxol_terminal/lib/raxol/terminal/driver.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver.ex
@@ -188,11 +188,6 @@ defmodule Raxol.Terminal.Driver do
         # Enable terminal modes: focus reporting, bracketed paste
         IO.write("\e[?1004h\e[?2004h")
 
-        # Query the terminal background (OSC 11) with a DA probe as the
-        # unsupported-terminal sentinel; replies are extracted from the
-        # input stream in dispatch_raw_input/2.
-        IO.write(BackgroundQuery.query_sequence())
-
         # Send initial resize event if we have a dispatcher
         if dispatcher_pid,
           do: Dispatch.send_initial_resize_event(dispatcher_pid)
@@ -208,10 +203,19 @@ defmodule Raxol.Terminal.Driver do
         # and sets up trace interception of the reader's output.
         start_stdin_reader(self())
 
+        # Query the terminal background (OSC 11) with a DA probe as the
+        # unsupported-terminal sentinel; replies are extracted from the
+        # input stream in dispatch_raw_input/2. Must run after
+        # start_stdin_reader: writing it earlier races prim_tty's tty=>true
+        # reinit and can corrupt job control before a frame ever renders.
+        # Any failure here degrades to "no background detected" rather than
+        # crashing init.
+        bg_query_pending = write_background_query()
+
         state = %{
           state
           | termbox_state: :initialized,
-            bg_query_pending: true,
+            bg_query_pending: bg_query_pending,
             original_stty: original_stty,
             sigwinch_handler: sigwinch_handler,
             io_terminal_state: %{
@@ -471,8 +475,38 @@ defmodule Raxol.Terminal.Driver do
     {:noreply, state}
   end
 
+  # Writes the OSC 11 background query and returns whether a reply should
+  # be awaited. On any failure, skip the query rather than leave the driver
+  # waiting on a reply that never comes; background detection falls back to
+  # "no background detected" (BackgroundQuery.detected_background/0 :error).
+  defp write_background_query do
+    IO.write(BackgroundQuery.query_sequence())
+    true
+  rescue
+    error ->
+      Raxol.Core.Runtime.Log.warning_with_context(
+        "[Driver] Failed to write OSC 11 background query, skipping background detection: " <>
+          inspect(error),
+        %{}
+      )
+
+      false
+  catch
+    kind, reason ->
+      Raxol.Core.Runtime.Log.warning_with_context(
+        "[Driver] OSC 11 background query write raised #{inspect(kind)}, skipping background detection: " <>
+          inspect(reason),
+        %{}
+      )
+
+      false
+  end
+
   # While an OSC 11 background query is pending, extract its reply (and the
   # DA probe reply) from the input stream so they never reach the key parser.
+  # Any exception here degrades to "no background detected" and passes the
+  # chunk through untouched -- a malformed reply can't crash the driver or
+  # block real input.
   defp handle_bg_query_reply(data, %{bg_query_pending: true} = state) do
     case BackgroundQuery.scan(data) do
       {{:ok, rgb}, cleaned} ->
@@ -493,6 +527,24 @@ defmodule Raxol.Terminal.Driver do
       {:pending, data} ->
         {data, state}
     end
+  rescue
+    error ->
+      Raxol.Core.Runtime.Log.warning_with_context(
+        "[Driver] OSC 11 reply scan failed, falling back to no background detected: " <>
+          inspect(error),
+        %{}
+      )
+
+      {data, %{state | bg_query_pending: false}}
+  catch
+    kind, reason ->
+      Raxol.Core.Runtime.Log.warning_with_context(
+        "[Driver] OSC 11 reply scan raised #{inspect(kind)}, falling back to no background detected: " <>
+          inspect(reason),
+        %{}
+      )
+
+      {data, %{state | bg_query_pending: false}}
   end
 
   defp handle_bg_query_reply(data, state), do: {data, state}

--- a/packages/raxol_terminal/lib/raxol/terminal/driver.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver.ex
@@ -176,8 +176,14 @@ defmodule Raxol.Terminal.Driver do
         # Suppress Logger console output so it doesn't corrupt the TUI
         Logger.configure(level: :none)
 
-        # Enter alternate screen, hide cursor
-        IO.write("\e[?1049h\e[?25l")
+        # Enter alternate screen, hide cursor, disable DECAWM (autowrap,
+        # \e[?7l): the frame writes full-terminal-width rows via \e[H, and
+        # with autowrap on, the last cell of a full-width row advances the
+        # cursor on its own, so the frame's own newline advances a *second*
+        # time -- doubling every content row. See normalize_frame/1 in
+        # Raxol.Core.Runtime.Rendering.Backends for the LF->CRLF half of the
+        # fix. Restored in TermboxLifecycle.cleanup_terminal/1.
+        IO.write("\e[?1049h\e[?25l\e[?7l")
 
         # Reset mouse tracking (may be left over from a crashed session)
         IO.write("\e[?1003l\e[?1006l\e[?1000l")

--- a/packages/raxol_terminal/lib/raxol/terminal/driver.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver.ex
@@ -20,6 +20,7 @@ defmodule Raxol.Terminal.Driver do
   alias Raxol.Core.Events.Event
   alias Raxol.Core.Runtime.Backpressure
   alias Raxol.Terminal.ANSI.InputParser
+  alias Raxol.Terminal.Driver.BackgroundQuery
   alias Raxol.Terminal.Driver.Dispatch
   alias Raxol.Terminal.Driver.EventTranslator
   alias Raxol.Terminal.Driver.InputBuffer
@@ -57,7 +58,9 @@ defmodule Raxol.Terminal.Driver do
               init_retries: 0,
               io_terminal_state: nil,
               input_buffer: <<>>,
-              flush_timer: nil
+              flush_timer: nil,
+              sigwinch_handler: nil,
+              bg_query_pending: false
   end
 
   # --- Public API ---
@@ -152,9 +155,7 @@ defmodule Raxol.Terminal.Driver do
       {_, _, nil} ->
         # No dispatcher — this is the Application supervisor's placeholder Driver.
         # Don't set up the terminal; the Lifecycle's Driver will do that.
-        Raxol.Core.Runtime.Log.info(
-          "[TerminalDriver] No dispatcher, skipping terminal setup."
-        )
+        Raxol.Core.Runtime.Log.info("[TerminalDriver] No dispatcher, skipping terminal setup.")
 
         {:ok, state}
 
@@ -187,9 +188,19 @@ defmodule Raxol.Terminal.Driver do
         # Enable terminal modes: focus reporting, bracketed paste
         IO.write("\e[?1004h\e[?2004h")
 
+        # Query the terminal background (OSC 11) with a DA probe as the
+        # unsupported-terminal sentinel; replies are extracted from the
+        # input stream in dispatch_raw_input/2.
+        IO.write(BackgroundQuery.query_sequence())
+
         # Send initial resize event if we have a dispatcher
         if dispatcher_pid,
           do: Dispatch.send_initial_resize_event(dispatcher_pid)
+
+        # Subscribe to SIGWINCH so window resizes reach the app. Input data
+        # arrives via the prim_tty reader trace, but SIGWINCH is delivered by
+        # :erl_signal_server directly to user_drv, so we need our own handler.
+        sigwinch_handler = install_sigwinch_handler()
 
         # Activate prim_tty reader for input. In -noshell mode, prim_tty
         # was initialized with tty => false, so the reader gets no select
@@ -200,7 +211,9 @@ defmodule Raxol.Terminal.Driver do
         state = %{
           state
           | termbox_state: :initialized,
+            bg_query_pending: true,
             original_stty: original_stty,
+            sigwinch_handler: sigwinch_handler,
             io_terminal_state: %{
               input_reader: Process.whereis(:user_drv_reader),
               tty_fd: nil,
@@ -254,9 +267,7 @@ defmodule Raxol.Terminal.Driver do
         {:termbox_event, event_map},
         %{termbox_state: :initialized, dispatcher_pid: dispatcher_pid} = state
       ) do
-    Raxol.Core.Runtime.Log.debug(
-      "Received termbox event: #{inspect(event_map)}"
-    )
+    Raxol.Core.Runtime.Log.debug("Received termbox event: #{inspect(event_map)}")
 
     case EventTranslator.translate(event_map) do
       {:ok, %Event{} = event} ->
@@ -270,9 +281,7 @@ defmodule Raxol.Terminal.Driver do
 
       :ignore ->
         # Event type we don't care about
-        Raxol.Core.Runtime.Log.debug(
-          "[Driver] Ignoring termbox event: #{inspect(event_map)}"
-        )
+        Raxol.Core.Runtime.Log.debug("[Driver] Ignoring termbox event: #{inspect(event_map)}")
 
         {:noreply, state}
 
@@ -303,6 +312,19 @@ defmodule Raxol.Terminal.Driver do
       _ -> {:stop, {:termbox_error, reason}, state}
     end
   end
+
+  # SIGWINCH arrived (via SigwinchHandler on :erl_signal_server) — the
+  # terminal window was resized. Query the fresh size and dispatch a
+  # resize event so the app and rendering engine can reflow.
+  @impl true
+  def handle_manager_info(:sigwinch, %{dispatcher_pid: pid} = state)
+      when is_pid(pid) do
+    Dispatch.send_resize_event(pid)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_manager_info(:sigwinch, state), do: {:noreply, state}
 
   @impl true
   def handle_manager_info({:register_dispatcher, pid}, state)
@@ -340,9 +362,7 @@ defmodule Raxol.Terminal.Driver do
       "[TerminalDriver.handle_cast - :test_input] Parsed event: #{inspect(event)}"
     )
 
-    Raxol.Core.Runtime.Log.debug(
-      "[TEST] Dispatching simulated event: #{inspect(event)}"
-    )
+    Raxol.Core.Runtime.Log.debug("[TEST] Dispatching simulated event: #{inspect(event)}")
 
     _ =
       Backpressure.cast(state.dispatcher_pid, {:dispatch, event},
@@ -438,6 +458,7 @@ defmodule Raxol.Terminal.Driver do
   end
 
   defp dispatch_raw_input(data, state) do
+    {data, state} = handle_bg_query_reply(data, state)
     events = InputParser.parse(data)
 
     Enum.each(events, fn event ->
@@ -449,6 +470,32 @@ defmodule Raxol.Terminal.Driver do
 
     {:noreply, state}
   end
+
+  # While an OSC 11 background query is pending, extract its reply (and the
+  # DA probe reply) from the input stream so they never reach the key parser.
+  defp handle_bg_query_reply(data, %{bg_query_pending: true} = state) do
+    case BackgroundQuery.scan(data) do
+      {{:ok, rgb}, cleaned} ->
+        BackgroundQuery.store(rgb)
+
+        if state.dispatcher_pid do
+          Dispatch.send_event_to_dispatcher(
+            state.dispatcher_pid,
+            %Event{type: :terminal_background, data: %{color: rgb}}
+          )
+        end
+
+        {cleaned, %{state | bg_query_pending: false}}
+
+      {:unsupported, cleaned} ->
+        {cleaned, %{state | bg_query_pending: false}}
+
+      {:pending, data} ->
+        {data, state}
+    end
+  end
+
+  defp handle_bg_query_reply(data, state), do: {data, state}
 
   # Forward cast messages to handle_info for test_input
   @impl true
@@ -466,13 +513,12 @@ defmodule Raxol.Terminal.Driver do
 
   def terminate(_reason, %{termbox_state: :initialized} = state) do
     Raxol.Core.Runtime.Log.info("Terminal Driver terminating.")
+    remove_sigwinch_handler(state)
     TermboxLifecycle.cleanup_terminal(state)
   end
 
   def terminate(_reason, _state) do
-    Raxol.Core.Runtime.Log.info(
-      "Terminal Driver terminating (not initialized)."
-    )
+    Raxol.Core.Runtime.Log.info("Terminal Driver terminating (not initialized).")
 
     :ok
   end
@@ -509,10 +555,11 @@ defmodule Raxol.Terminal.Driver do
   end
 
   # --- Input reader ---
-  # In -noshell mode (mix run), prim_tty is initialized with tty => false,
-  # so its reader process never receives select notifications. We trigger
-  # reinit via user_drv:start_shell, then trace-intercept the reader's
-  # data messages.
+  # In -noshell mode (mix run), user_drv initializes prim_tty with
+  # tty => false, so the reader process never receives select notifications
+  # and blocks forever. Trigger a reinit via user_drv:start_shell (which
+  # spawns a fresh reader that arms select notifications), then trace the
+  # reader's sends to intercept input data before user_drv forwards it.
   defp start_stdin_reader(_driver_pid) do
     # In -noshell mode, user_drv initializes prim_tty with tty => false,
     # so the NIF never sets up the terminal fd for select notifications.
@@ -543,13 +590,51 @@ defmodule Raxol.Terminal.Driver do
       :erlang.trace(reader, true, [:send])
     end
 
-    # Return nil — no spawned reader pid to track. Input arrives via
-    # trace messages in handle_manager_info.
+    # No spawned reader pid to track -- input arrives via trace messages
+    # in handle_manager_info.
     nil
   end
 
   @doc false
   def noop_shell, do: :ok
+
+  # --- SIGWINCH subscription ---
+  # OTP's prim_tty delivers SIGWINCH from :erl_signal_server straight to
+  # user_drv (not through the reader we trace), so we install our own
+  # gen_event handler that pings this process on window resize.
+
+  defp install_sigwinch_handler do
+    handler_id = {Raxol.Terminal.Driver.SigwinchHandler, self()}
+
+    case :gen_event.add_handler(
+           :erl_signal_server,
+           handler_id,
+           %{driver: self()}
+         ) do
+      :ok ->
+        handler_id
+
+      other ->
+        Raxol.Core.Runtime.Log.warning_with_context(
+          "[Driver] Could not install SIGWINCH handler (window resize " <>
+            "events disabled): #{inspect(other)}",
+          %{}
+        )
+
+        nil
+    end
+  catch
+    _, _ -> nil
+  end
+
+  defp remove_sigwinch_handler(%{sigwinch_handler: nil}), do: :ok
+
+  defp remove_sigwinch_handler(%{sigwinch_handler: handler_id}) do
+    _ = :gen_event.delete_handler(:erl_signal_server, handler_id, :normal)
+    :ok
+  catch
+    _, _ -> :ok
+  end
 
   # --- Input buffering ---
   # Escape sequences may span multiple messages, so we buffer until complete.

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/background_query.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/background_query.ex
@@ -1,0 +1,197 @@
+defmodule Raxol.Terminal.Driver.BackgroundQuery do
+  @moduledoc """
+  OSC 11 terminal background-color detection.
+
+  Emits an OSC 11 query (`ESC ] 11 ; ? BEL`) followed by a primary Device
+  Attributes probe (`CSI c`). Every terminal answers DA, so a DA reply that
+  arrives without an OSC 11 reply means the terminal does not support
+  dynamic-color queries and callers should fall back to an assumed ground.
+
+  Replies arrive asynchronously on the input stream, interleaved with
+  keystrokes. `scan/1` extracts (and strips) the OSC 11 / DA replies from a
+  raw input chunk so they never leak into key-event parsing.
+
+  The detected background is stored in `:persistent_term` and readable via
+  `detected_background/0`; higher layers (e.g. salience theming) convert it
+  to a ground lightness.
+  """
+
+  @pt_key {__MODULE__, :background}
+
+  # OSC 11 query (BEL-terminated) + primary DA probe.
+  @query "\e]11;?\a\e[c"
+
+  @type rgb :: {0..255, 0..255, 0..255}
+
+  @doc "Escape sequence to write to the terminal to start detection."
+  @spec query_sequence() :: String.t()
+  def query_sequence, do: @query
+
+  @doc """
+  Scans a raw input chunk for OSC 11 / DA replies while a query is pending.
+
+  Returns `{result, cleaned}` where `cleaned` is the chunk with any reply
+  bytes removed (safe to hand to the key-event parser) and `result` is:
+
+    * `{:ok, {r, g, b}}` - background color reported (8-bit per channel)
+    * `:unsupported` - DA reply arrived without an OSC 11 reply
+    * `:pending` - no reply in this chunk yet
+  """
+  @spec scan(binary()) :: {{:ok, rgb()} | :unsupported | :pending, binary()}
+  def scan(data) when is_binary(data) do
+    case extract_osc11(data) do
+      {payload, cleaned} ->
+        cleaned = strip_da_reply(cleaned)
+
+        case parse_color(payload) do
+          {:ok, rgb} -> {{:ok, rgb}, cleaned}
+          :error -> {:unsupported, cleaned}
+        end
+
+      :none ->
+        case strip_da_reply_if_present(data) do
+          {:stripped, cleaned} -> {:unsupported, cleaned}
+          :absent -> {:pending, data}
+        end
+    end
+  end
+
+  @doc "Stores a detected background color for later lookup."
+  @spec store(rgb()) :: :ok
+  def store({_r, _g, _b} = rgb), do: :persistent_term.put(@pt_key, rgb)
+
+  @doc "Returns the detected background color, if any."
+  @spec detected_background() :: {:ok, rgb()} | :error
+  def detected_background do
+    case :persistent_term.get(@pt_key, :undefined) do
+      :undefined -> :error
+      rgb -> {:ok, rgb}
+    end
+  end
+
+  # ---- OSC 11 reply extraction ----
+  # Reply shape: ESC ] 11 ; <payload> terminated by BEL or ST (ESC \).
+
+  defp extract_osc11(data) do
+    case :binary.match(data, "\e]11;") do
+      :nomatch ->
+        :none
+
+      {start, prefix_len} ->
+        rest_start = start + prefix_len
+        rest = binary_part(data, rest_start, byte_size(data) - rest_start)
+
+        case find_osc_terminator(rest) do
+          :none ->
+            :none
+
+          {payload_len, term_len} ->
+            payload = binary_part(rest, 0, payload_len)
+
+            cleaned =
+              binary_part(data, 0, start) <>
+                binary_part(
+                  data,
+                  rest_start + payload_len + term_len,
+                  byte_size(data) - rest_start - payload_len - term_len
+                )
+
+            {payload, cleaned}
+        end
+    end
+  end
+
+  defp find_osc_terminator(rest) do
+    bel = :binary.match(rest, "\a")
+    st = :binary.match(rest, "\e\\")
+
+    case {bel, st} do
+      {:nomatch, :nomatch} -> :none
+      {{pos, len}, :nomatch} -> {pos, len}
+      {:nomatch, {pos, len}} -> {pos, len}
+      {{b, bl}, {s, _}} when b < s -> {b, bl}
+      {_, {s, sl}} -> {s, sl}
+    end
+  end
+
+  # ---- DA reply stripping: ESC [ ? <params> c ----
+
+  defp strip_da_reply(data) do
+    case strip_da_reply_if_present(data) do
+      {:stripped, cleaned} -> cleaned
+      :absent -> data
+    end
+  end
+
+  defp strip_da_reply_if_present(data) do
+    case Regex.run(~r/\e\[\?[\d;]*c/, data, return: :index) do
+      [{start, len}] ->
+        {:stripped,
+         binary_part(data, 0, start) <>
+           binary_part(data, start + len, byte_size(data) - start - len)}
+
+      nil ->
+        :absent
+    end
+  end
+
+  # ---- X11 color spec parsing ----
+  # Typical payloads: "rgb:2b2b/2b2b/2b2b" (widths 1-4 hex digits per
+  # channel), "rgba:.../..../..../ffff", or "#2b2b2b".
+
+  @doc false
+  @spec parse_color(binary()) :: {:ok, rgb()} | :error
+  def parse_color("rgb:" <> spec), do: parse_channels(spec)
+
+  def parse_color("rgba:" <> spec) do
+    case String.split(spec, "/") do
+      [r, g, b, _a] -> parse_channels(Enum.join([r, g, b], "/"))
+      _ -> :error
+    end
+  end
+
+  def parse_color("#" <> hex) when byte_size(hex) == 6 do
+    with {:ok, r} <- hex_channel(binary_part(hex, 0, 2)),
+         {:ok, g} <- hex_channel(binary_part(hex, 2, 2)),
+         {:ok, b} <- hex_channel(binary_part(hex, 4, 2)) do
+      {:ok, {r, g, b}}
+    end
+  end
+
+  def parse_color(_), do: :error
+
+  defp parse_channels(spec) do
+    case String.split(spec, "/") do
+      [r, g, b] ->
+        with {:ok, r} <- scale_channel(r),
+             {:ok, g} <- scale_channel(g),
+             {:ok, b} <- scale_channel(b) do
+          {:ok, {r, g, b}}
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  # Scale a 1-4 hex-digit channel to 8-bit: value / (16^w - 1) * 255.
+  defp scale_channel(digits) when byte_size(digits) in 1..4 do
+    case Integer.parse(digits, 16) do
+      {value, ""} ->
+        max = Integer.pow(16, byte_size(digits)) - 1
+        {:ok, round(value / max * 255)}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp scale_channel(_), do: :error
+
+  defp hex_channel(digits) do
+    case Integer.parse(digits, 16) do
+      {value, ""} -> {:ok, value}
+      _ -> :error
+    end
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/input_buffer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/input_buffer.ex
@@ -33,6 +33,12 @@ defmodule Raxol.Terminal.Driver.InputBuffer do
 
   # ESC O but no function key letter
   defp incomplete_csi?(<<27, 79>>), do: true
+
+  # ESC ] (OSC, e.g. an OSC 11 color reply) — incomplete until BEL or ST
+  defp incomplete_csi?(<<27, 93, rest::binary>>) do
+    not (String.contains?(rest, "\a") or String.contains?(rest, "\e\\"))
+  end
+
   defp incomplete_csi?(_), do: false
 
   defp has_csi_terminator?(<<>>), do: false

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/termbox_lifecycle.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/termbox_lifecycle.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Terminal.Driver.TermboxLifecycle do
   Termbox NIF initialization, shutdown, and recovery helpers.
   """
 
-
   alias Raxol.Core.Runtime.Log
   alias Raxol.Terminal.IOTerminal
 
@@ -54,7 +53,9 @@ defmodule Raxol.Terminal.Driver.TermboxLifecycle do
             {:noreply, state}
 
           {:error, init_reason} ->
-            Log.error("Failed to recover from termbox error: #{inspect(init_reason)}")
+            Log.error(
+              "Failed to recover from termbox error: #{inspect(init_reason)}"
+            )
 
             {:stop, {:termbox_error, reason}, state}
         end
@@ -102,8 +103,12 @@ defmodule Raxol.Terminal.Driver.TermboxLifecycle do
     if not Env.test?() and has_terminal_device?() do
       # Disable terminal modes before restoring
       IO.write("\e[?1000l\e[?1006l\e[?1004l\e[?2004l")
-      # Restore terminal: show cursor, leave alternate screen
-      IO.write("\e[?25h\e[?1049l")
+      # Restore terminal: re-enable autowrap (DECAWM, paired with the
+      # \e[?7l written at init in driver.ex's TTY-detected branch), show
+      # cursor, leave alternate screen. Autowrap is restored before the
+      # alt-screen exit so the primary screen the user returns to behaves
+      # normally.
+      IO.write("\e[?7h\e[?25h\e[?1049l")
       _ = :io.setopts(:standard_io, echo: true)
 
       # Restore original TTY settings (OS-level via /dev/tty)

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/input_parser_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/input_parser_test.exs
@@ -6,37 +6,45 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
 
   describe "arrow keys" do
     test "parses up arrow" do
-      assert [%Event{type: :key, data: %{key: :up}}] = InputParser.parse(<<27, 91, 65>>)
+      assert [%Event{type: :key, data: %{key: :up}}] =
+               InputParser.parse(<<27, 91, 65>>)
     end
 
     test "parses down arrow" do
-      assert [%Event{type: :key, data: %{key: :down}}] = InputParser.parse(<<27, 91, 66>>)
+      assert [%Event{type: :key, data: %{key: :down}}] =
+               InputParser.parse(<<27, 91, 66>>)
     end
 
     test "parses right arrow" do
-      assert [%Event{type: :key, data: %{key: :right}}] = InputParser.parse(<<27, 91, 67>>)
+      assert [%Event{type: :key, data: %{key: :right}}] =
+               InputParser.parse(<<27, 91, 67>>)
     end
 
     test "parses left arrow" do
-      assert [%Event{type: :key, data: %{key: :left}}] = InputParser.parse(<<27, 91, 68>>)
+      assert [%Event{type: :key, data: %{key: :left}}] =
+               InputParser.parse(<<27, 91, 68>>)
     end
   end
 
   describe "basic keys" do
     test "parses escape" do
-      assert [%Event{type: :key, data: %{key: :escape}}] = InputParser.parse(<<27>>)
+      assert [%Event{type: :key, data: %{key: :escape}}] =
+               InputParser.parse(<<27>>)
     end
 
     test "parses enter (CR)" do
-      assert [%Event{type: :key, data: %{key: :enter}}] = InputParser.parse(<<13>>)
+      assert [%Event{type: :key, data: %{key: :enter}}] =
+               InputParser.parse(<<13>>)
     end
 
     test "parses enter (LF)" do
-      assert [%Event{type: :key, data: %{key: :enter}}] = InputParser.parse(<<10>>)
+      assert [%Event{type: :key, data: %{key: :enter}}] =
+               InputParser.parse(<<10>>)
     end
 
     test "parses backspace" do
-      assert [%Event{type: :key, data: %{key: :backspace}}] = InputParser.parse(<<127>>)
+      assert [%Event{type: :key, data: %{key: :backspace}}] =
+               InputParser.parse(<<127>>)
     end
 
     test "parses tab" do
@@ -46,123 +54,151 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
 
   describe "printable ASCII" do
     test "parses lowercase letter" do
-      assert [%Event{type: :key, data: %{key: :char, char: "a"}}] = InputParser.parse("a")
+      assert [%Event{type: :key, data: %{key: :char, char: "a"}}] =
+               InputParser.parse("a")
     end
 
     test "parses uppercase letter" do
-      assert [%Event{type: :key, data: %{key: :char, char: "A"}}] = InputParser.parse("A")
+      assert [%Event{type: :key, data: %{key: :char, char: "A"}}] =
+               InputParser.parse("A")
     end
 
     test "parses space" do
-      assert [%Event{type: :key, data: %{key: :char, char: " "}}] = InputParser.parse(" ")
+      assert [%Event{type: :key, data: %{key: :char, char: " "}}] =
+               InputParser.parse(" ")
     end
 
     test "parses digit" do
-      assert [%Event{type: :key, data: %{key: :char, char: "5"}}] = InputParser.parse("5")
+      assert [%Event{type: :key, data: %{key: :char, char: "5"}}] =
+               InputParser.parse("5")
     end
 
     test "parses symbol" do
-      assert [%Event{type: :key, data: %{key: :char, char: "@"}}] = InputParser.parse("@")
+      assert [%Event{type: :key, data: %{key: :char, char: "@"}}] =
+               InputParser.parse("@")
     end
   end
 
   describe "UTF-8 characters" do
     test "parses multi-byte UTF-8" do
-      assert [%Event{type: :key, data: %{key: :char, char: "ñ"}}] = InputParser.parse("ñ")
+      assert [%Event{type: :key, data: %{key: :char, char: "ñ"}}] =
+               InputParser.parse("ñ")
     end
   end
 
   describe "function keys (SS3)" do
     test "parses F1 SS3" do
-      assert [%Event{type: :key, data: %{key: :f1}}] = InputParser.parse(<<27, 79, 80>>)
+      assert [%Event{type: :key, data: %{key: :f1}}] =
+               InputParser.parse(<<27, 79, 80>>)
     end
 
     test "parses F2 SS3" do
-      assert [%Event{type: :key, data: %{key: :f2}}] = InputParser.parse(<<27, 79, 81>>)
+      assert [%Event{type: :key, data: %{key: :f2}}] =
+               InputParser.parse(<<27, 79, 81>>)
     end
 
     test "parses F3 SS3" do
-      assert [%Event{type: :key, data: %{key: :f3}}] = InputParser.parse(<<27, 79, 82>>)
+      assert [%Event{type: :key, data: %{key: :f3}}] =
+               InputParser.parse(<<27, 79, 82>>)
     end
 
     test "parses F4 SS3" do
-      assert [%Event{type: :key, data: %{key: :f4}}] = InputParser.parse(<<27, 79, 83>>)
+      assert [%Event{type: :key, data: %{key: :f4}}] =
+               InputParser.parse(<<27, 79, 83>>)
     end
   end
 
   describe "function keys (CSI tilde)" do
     test "parses F1 CSI" do
-      assert [%Event{type: :key, data: %{key: :f1}}] = InputParser.parse(<<27, 91>> <> "11~")
+      assert [%Event{type: :key, data: %{key: :f1}}] =
+               InputParser.parse(<<27, 91>> <> "11~")
     end
 
     test "parses F2 CSI" do
-      assert [%Event{type: :key, data: %{key: :f2}}] = InputParser.parse(<<27, 91>> <> "12~")
+      assert [%Event{type: :key, data: %{key: :f2}}] =
+               InputParser.parse(<<27, 91>> <> "12~")
     end
 
     test "parses F3 CSI" do
-      assert [%Event{type: :key, data: %{key: :f3}}] = InputParser.parse(<<27, 91>> <> "13~")
+      assert [%Event{type: :key, data: %{key: :f3}}] =
+               InputParser.parse(<<27, 91>> <> "13~")
     end
 
     test "parses F4 CSI" do
-      assert [%Event{type: :key, data: %{key: :f4}}] = InputParser.parse(<<27, 91>> <> "14~")
+      assert [%Event{type: :key, data: %{key: :f4}}] =
+               InputParser.parse(<<27, 91>> <> "14~")
     end
 
     test "parses F5" do
-      assert [%Event{type: :key, data: %{key: :f5}}] = InputParser.parse(<<27, 91>> <> "15~")
+      assert [%Event{type: :key, data: %{key: :f5}}] =
+               InputParser.parse(<<27, 91>> <> "15~")
     end
 
     test "parses F6" do
-      assert [%Event{type: :key, data: %{key: :f6}}] = InputParser.parse(<<27, 91>> <> "17~")
+      assert [%Event{type: :key, data: %{key: :f6}}] =
+               InputParser.parse(<<27, 91>> <> "17~")
     end
 
     test "parses F7" do
-      assert [%Event{type: :key, data: %{key: :f7}}] = InputParser.parse(<<27, 91>> <> "18~")
+      assert [%Event{type: :key, data: %{key: :f7}}] =
+               InputParser.parse(<<27, 91>> <> "18~")
     end
 
     test "parses F8" do
-      assert [%Event{type: :key, data: %{key: :f8}}] = InputParser.parse(<<27, 91>> <> "19~")
+      assert [%Event{type: :key, data: %{key: :f8}}] =
+               InputParser.parse(<<27, 91>> <> "19~")
     end
 
     test "parses F9" do
-      assert [%Event{type: :key, data: %{key: :f9}}] = InputParser.parse(<<27, 91>> <> "20~")
+      assert [%Event{type: :key, data: %{key: :f9}}] =
+               InputParser.parse(<<27, 91>> <> "20~")
     end
 
     test "parses F10" do
-      assert [%Event{type: :key, data: %{key: :f10}}] = InputParser.parse(<<27, 91>> <> "21~")
+      assert [%Event{type: :key, data: %{key: :f10}}] =
+               InputParser.parse(<<27, 91>> <> "21~")
     end
 
     test "parses F11" do
-      assert [%Event{type: :key, data: %{key: :f11}}] = InputParser.parse(<<27, 91>> <> "23~")
+      assert [%Event{type: :key, data: %{key: :f11}}] =
+               InputParser.parse(<<27, 91>> <> "23~")
     end
 
     test "parses F12" do
-      assert [%Event{type: :key, data: %{key: :f12}}] = InputParser.parse(<<27, 91>> <> "24~")
+      assert [%Event{type: :key, data: %{key: :f12}}] =
+               InputParser.parse(<<27, 91>> <> "24~")
     end
   end
 
   describe "navigation keys" do
     test "parses Home (CSI H)" do
-      assert [%Event{type: :key, data: %{key: :home}}] = InputParser.parse(<<27, 91, 72>>)
+      assert [%Event{type: :key, data: %{key: :home}}] =
+               InputParser.parse(<<27, 91, 72>>)
     end
 
     test "parses End (CSI F)" do
-      assert [%Event{type: :key, data: %{key: :end}}] = InputParser.parse(<<27, 91, 70>>)
+      assert [%Event{type: :key, data: %{key: :end}}] =
+               InputParser.parse(<<27, 91, 70>>)
     end
 
     test "parses Home (CSI 1~)" do
-      assert [%Event{type: :key, data: %{key: :home}}] = InputParser.parse(<<27, 91>> <> "1~")
+      assert [%Event{type: :key, data: %{key: :home}}] =
+               InputParser.parse(<<27, 91>> <> "1~")
     end
 
     test "parses End (CSI 4~)" do
-      assert [%Event{type: :key, data: %{key: :end}}] = InputParser.parse(<<27, 91>> <> "4~")
+      assert [%Event{type: :key, data: %{key: :end}}] =
+               InputParser.parse(<<27, 91>> <> "4~")
     end
 
     test "parses Insert" do
-      assert [%Event{type: :key, data: %{key: :insert}}] = InputParser.parse(<<27, 91>> <> "2~")
+      assert [%Event{type: :key, data: %{key: :insert}}] =
+               InputParser.parse(<<27, 91>> <> "2~")
     end
 
     test "parses Delete" do
-      assert [%Event{type: :key, data: %{key: :delete}}] = InputParser.parse(<<27, 91>> <> "3~")
+      assert [%Event{type: :key, data: %{key: :delete}}] =
+               InputParser.parse(<<27, 91>> <> "3~")
     end
 
     test "parses PageUp" do
@@ -176,11 +212,13 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
     end
 
     test "parses Home (SS3 H)" do
-      assert [%Event{type: :key, data: %{key: :home}}] = InputParser.parse(<<27, 79, 72>>)
+      assert [%Event{type: :key, data: %{key: :home}}] =
+               InputParser.parse(<<27, 79, 72>>)
     end
 
     test "parses End (SS3 F)" do
-      assert [%Event{type: :key, data: %{key: :end}}] = InputParser.parse(<<27, 79, 70>>)
+      assert [%Event{type: :key, data: %{key: :end}}] =
+               InputParser.parse(<<27, 79, 70>>)
     end
   end
 
@@ -297,11 +335,13 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
     end
 
     test "Ctrl+J maps to enter (byte 10)" do
-      assert [%Event{type: :key, data: %{key: :enter}}] = InputParser.parse(<<10>>)
+      assert [%Event{type: :key, data: %{key: :enter}}] =
+               InputParser.parse(<<10>>)
     end
 
     test "Ctrl+M maps to enter (byte 13)" do
-      assert [%Event{type: :key, data: %{key: :enter}}] = InputParser.parse(<<13>>)
+      assert [%Event{type: :key, data: %{key: :enter}}] =
+               InputParser.parse(<<13>>)
     end
   end
 
@@ -393,15 +433,19 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
   describe "bracketed paste" do
     test "parses complete paste" do
       # ESC [ 200 ~ <text> ESC [ 201 ~
-      input = <<27, 91, 50, 48, 48, 126>> <> "hello world" <> <<27, 91, 50, 48, 49, 126>>
+      input =
+        <<27, 91, 50, 48, 48, 126>> <>
+          "hello world" <> <<27, 91, 50, 48, 49, 126>>
 
-      assert [%Event{type: :paste, data: %{text: "hello world"}}] = InputParser.parse(input)
+      assert [%Event{type: :paste, data: %{text: "hello world"}}] =
+               InputParser.parse(input)
     end
 
     test "parses paste without end marker" do
       input = <<27, 91, 50, 48, 48, 126>> <> "partial paste"
 
-      assert [%Event{type: :paste, data: %{text: "partial paste"}}] = InputParser.parse(input)
+      assert [%Event{type: :paste, data: %{text: "partial paste"}}] =
+               InputParser.parse(input)
     end
   end
 
@@ -413,13 +457,8 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
     test "does not crash on a secondary DA reply (CSI > Pp ; Pv ; Pc c)" do
       # Some terminals answer unsolicited (or in response to a secondary DA
       # probe raxol never sends) with `CSI > ... c`. The leading `>` byte
-      # used to hit no clause in parse_csi_params/3 and crash the whole
-      # Driver GenServer with a FunctionClauseError. Regression coverage
-      # for that crash: the parser must return *something* rather than
-      # raise. It isn't taught to recognize this sequence, so (like any
-      # other unmapped-but-well-formed CSI sequence) it degrades to
-      # per-byte printable-char events instead of bringing the process
-      # down -- not clean, but never fatal.
+      # must not hit a missing clause in parse_csi_params/3 and crash the
+      # Driver GenServer with a FunctionClauseError.
       assert is_list(InputParser.parse("\e[>0;282;0c"))
     end
 
@@ -436,6 +475,56 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
 
       assert %Event{type: :key, data: %{key: :char, char: "q"}} =
                List.last(events)
+    end
+  end
+
+  describe "unmapped terminal reports (render-storm regression)" do
+    # Well-formed CSI sequences with no event mapping must not leak: skipping
+    # only the ESC byte and re-parsing the rest as printable char keys turns
+    # one terminal report into a burst of spurious keystrokes. Terminal
+    # reports must produce ZERO events.
+
+    test "secondary DA reply produces zero events" do
+      assert [] = InputParser.parse("\e[>0;282;0c")
+    end
+
+    test "primary DA reply produces zero events" do
+      assert [] = InputParser.parse("\e[?62;4c")
+    end
+
+    test "cursor position report produces zero events" do
+      assert [] = InputParser.parse("\e[42;120R")
+    end
+
+    test "DECRQM reply (with $ intermediate byte) produces zero events" do
+      assert [] = InputParser.parse("\e[?2026;2$y")
+    end
+
+    test "kitty keyboard protocol reply produces zero events" do
+      assert [] = InputParser.parse("\e[?1u")
+    end
+
+    test "report followed by a real key yields only that key" do
+      assert [%Event{type: :key, data: %{key: :down}}] =
+               InputParser.parse("\e[>0;282;0c\e[B")
+    end
+
+    test "report between two chars yields only those chars" do
+      assert [
+               %Event{type: :key, data: %{key: :char, char: "a"}},
+               %Event{type: :key, data: %{key: :char, char: "b"}}
+             ] = InputParser.parse("a\e[42;120Rb")
+    end
+
+    test "incomplete CSI fragment at end of chunk is dropped, not leaked" do
+      # The driver's input buffer flushes incomplete escapes after a
+      # timeout; the fragment must not degrade to char key events.
+      assert [] = InputParser.parse("\e[12;3")
+      assert [] = InputParser.parse("\e[>0;28")
+    end
+
+    test "truncated SGR mouse report is dropped, not leaked" do
+      assert [] = InputParser.parse("\e[<35;10")
     end
   end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/input_parser_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/input_parser_test.exs
@@ -409,5 +409,33 @@ defmodule Raxol.Terminal.ANSI.InputParserTest do
     test "returns empty list for invalid sequence" do
       assert [] = InputParser.parse(<<128, 129, 130>>)
     end
+
+    test "does not crash on a secondary DA reply (CSI > Pp ; Pv ; Pc c)" do
+      # Some terminals answer unsolicited (or in response to a secondary DA
+      # probe raxol never sends) with `CSI > ... c`. The leading `>` byte
+      # used to hit no clause in parse_csi_params/3 and crash the whole
+      # Driver GenServer with a FunctionClauseError. Regression coverage
+      # for that crash: the parser must return *something* rather than
+      # raise. It isn't taught to recognize this sequence, so (like any
+      # other unmapped-but-well-formed CSI sequence) it degrades to
+      # per-byte printable-char events instead of bringing the process
+      # down -- not clean, but never fatal.
+      assert is_list(InputParser.parse("\e[>0;282;0c"))
+    end
+
+    test "does not crash on other CSI private-marker/intermediate bytes" do
+      for seq <- ["\e[=1c", "\e[<35;10;10M-not-sgr", "\e[:1;2m", "\e[?9999h"] do
+        assert is_list(InputParser.parse(seq))
+      end
+    end
+
+    test "keeps parsing subsequent events after an unrecognized CSI sequence" do
+      # A secondary DA reply immediately followed by a real key press must
+      # not swallow the key press (or crash trying to reach it).
+      events = InputParser.parse("\e[>0;282;0c" <> "q")
+
+      assert %Event{type: :key, data: %{key: :char, char: "q"}} =
+               List.last(events)
+    end
   end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/driver/background_query_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/background_query_test.exs
@@ -1,0 +1,88 @@
+defmodule Raxol.Terminal.Driver.BackgroundQueryTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Driver.BackgroundQuery
+
+  describe "scan/1" do
+    test "extracts a BEL-terminated 16-bit reply" do
+      {result, cleaned} = BackgroundQuery.scan("\e]11;rgb:2b2b/2b2b/2b2b\a")
+      assert result == {:ok, {43, 43, 43}}
+      assert cleaned == ""
+    end
+
+    test "extracts an ST-terminated reply" do
+      {result, cleaned} = BackgroundQuery.scan("\e]11;rgb:ffff/0000/8080\e\\")
+      assert result == {:ok, {255, 0, 128}}
+      assert cleaned == ""
+    end
+
+    test "preserves surrounding keystrokes in order" do
+      {result, cleaned} = BackgroundQuery.scan("ab\e]11;rgb:00/00/00\acd")
+      assert result == {:ok, {0, 0, 0}}
+      assert cleaned == "abcd"
+    end
+
+    test "strips the DA probe reply alongside the color reply" do
+      {result, cleaned} =
+        BackgroundQuery.scan("\e]11;rgb:1e1e/1e1e/1e1e\a\e[?62;22c" <> "x")
+
+      assert result == {:ok, {30, 30, 30}}
+      assert cleaned == "x"
+    end
+
+    test "DA reply without color reply means unsupported" do
+      {result, cleaned} = BackgroundQuery.scan("q\e[?1;2cw")
+      assert result == :unsupported
+      assert cleaned == "qw"
+    end
+
+    test "no reply at all stays pending, data untouched" do
+      {result, cleaned} = BackgroundQuery.scan("hello\e[A")
+      assert result == :pending
+      assert cleaned == "hello\e[A"
+    end
+
+    test "8-bit channels scale correctly" do
+      {result, _} = BackgroundQuery.scan("\e]11;rgb:2b/2b/2b\a")
+      assert result == {:ok, {43, 43, 43}}
+    end
+
+    test "rgba payload drops alpha" do
+      {result, _} = BackgroundQuery.scan("\e]11;rgba:ffff/8080/0000/ffff\a")
+      assert result == {:ok, {255, 128, 0}}
+    end
+
+    test "hash-hex payload parses" do
+      {result, _} = BackgroundQuery.scan("\e]11;#1a1a2e\a")
+      assert result == {:ok, {26, 26, 46}}
+    end
+
+    test "malformed payload reports unsupported, reply still stripped" do
+      {result, cleaned} = BackgroundQuery.scan("\e]11;banana\aok")
+      assert result == :unsupported
+      assert cleaned == "ok"
+    end
+  end
+
+  describe "parse_color/1 channel widths" do
+    test "scales 1, 2, 3 and 4 digit channels to 8-bit" do
+      assert BackgroundQuery.parse_color("rgb:f/f/f") == {:ok, {255, 255, 255}}
+
+      assert BackgroundQuery.parse_color("rgb:80/80/80") ==
+               {:ok, {128, 128, 128}}
+
+      assert BackgroundQuery.parse_color("rgb:fff/fff/fff") ==
+               {:ok, {255, 255, 255}}
+
+      assert BackgroundQuery.parse_color("rgb:8000/8000/8000") ==
+               {:ok, {128, 128, 128}}
+    end
+  end
+
+  describe "store/detect" do
+    test "round-trips through persistent_term" do
+      assert BackgroundQuery.store({43, 43, 43}) == :ok
+      assert BackgroundQuery.detected_background() == {:ok, {43, 43, 43}}
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/driver/terminal_report_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/terminal_report_test.exs
@@ -1,0 +1,69 @@
+defmodule Raxol.Terminal.Driver.TerminalReportTest do
+  use ExUnit.Case
+  import Mox
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.Terminal.DriverTestHelper, as: Helper
+
+  @moduledoc """
+  Regression test for the playground render storm: terminals volunteer
+  well-formed CSI reports the input parser has no event mapping for
+  (secondary DA replies, cursor position reports, DECRQM responses, ...).
+  These used to leak through `dispatch_raw_input/2` as one printable char
+  key event PER BYTE -- a single `\\e[>0;282;0c` report became 10 dispatched
+  key events, and since every app update triggers a full-frame repaint,
+  10 back-to-back clear+redraw frames (plus the leaked "c" toggling app
+  state). A terminal report chunk must produce ZERO dispatched events.
+  """
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  setup do
+    Process.flag(:trap_exit, true)
+    Helper.setup_terminal()
+  end
+
+  describe "raw terminal reports through dispatch_raw_input" do
+    test "secondary DA reply chunk produces zero key events" do
+      driver_pid = Helper.start_driver(self())
+      Helper.wait_for_driver_ready(driver_pid)
+      Helper.consume_initial_resize()
+
+      send(driver_pid, {:raw_input, "\e[>0;282;0c"})
+
+      refute_receive {:"$gen_cast", {:dispatch, %Event{type: :key}}}, 200
+
+      Process.exit(driver_pid, :shutdown)
+    end
+
+    test "CPR and DECRQM reply chunks produce zero key events" do
+      driver_pid = Helper.start_driver(self())
+      Helper.wait_for_driver_ready(driver_pid)
+      Helper.consume_initial_resize()
+
+      send(driver_pid, {:raw_input, "\e[42;120R"})
+      send(driver_pid, {:raw_input, "\e[?2026;2$y"})
+
+      refute_receive {:"$gen_cast", {:dispatch, %Event{type: :key}}}, 200
+
+      Process.exit(driver_pid, :shutdown)
+    end
+
+    test "report followed by a real key dispatches exactly that key" do
+      driver_pid = Helper.start_driver(self())
+      Helper.wait_for_driver_ready(driver_pid)
+      Helper.consume_initial_resize()
+
+      send(driver_pid, {:raw_input, "\e[>0;282;0c\e[B"})
+
+      assert_receive {:"$gen_cast",
+                      {:dispatch, %Event{type: :key, data: %{key: :down}}}},
+                     500
+
+      refute_receive {:"$gen_cast", {:dispatch, %Event{type: :key}}}, 200
+
+      Process.exit(driver_pid, :shutdown)
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/driver_init_order_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver_init_order_test.exs
@@ -86,4 +86,34 @@ defmodule Raxol.Terminal.DriverInitOrderTest do
              "caused the JCL hijack described above. If you're reintroducing a " <>
              "custom shell MFA, re-read the comment on start_stdin_reader/1 first."
   end
+
+  # With `initial_shell: :noshell`, prim_tty's OUTPUT mode is hardcoded raw
+  # and never cooks the frame's bare `\n` row joins into `\r\n`. Combined
+  # with DECAWM autowrap left on, a full-width row's last cell also triggers
+  # an autowrap advance, so the frame's own newline advances a second time,
+  # doubling every row. `normalize_frame/1` in
+  # `Raxol.Core.Runtime.Rendering.Backends` covers the missing-CR half; this
+  # test pins the driver's autowrap half.
+  test "TTY init disables autowrap (DECAWM) and cleanup restores it" do
+    source = File.read!(@driver_source)
+
+    assert source =~ ~r/IO\.write\("\\e\[\?1049h\\e\[\?25l\\e\[\?7l"\)/,
+           "TTY init must write \\e[?7l (DECAWM off) alongside entering the " <>
+             "alternate screen and hiding the cursor. Autowrap must stay off " <>
+             "for the life of the session since the frame always writes " <>
+             "full-terminal-width rows and owns its own geometry via \\e[H."
+
+    lifecycle_path =
+      @driver_source
+      |> Path.dirname()
+      |> Path.join("driver/termbox_lifecycle.ex")
+      |> Path.expand()
+
+    lifecycle_source = File.read!(lifecycle_path)
+
+    assert lifecycle_source =~
+             ~r/IO\.write\("\\e\[\?7h\\e\[\?25h\\e\[\?1049l"\)/,
+           "cleanup_terminal/1 must restore autowrap (\\e[?7h) before leaving " <>
+             "the alternate screen, undoing the \\e[?7l written at TTY init."
+  end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/driver_init_order_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver_init_order_test.exs
@@ -1,0 +1,56 @@
+defmodule Raxol.Terminal.DriverInitOrderTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Writing the OSC 11 background query before `start_stdin_reader/1` races
+  the prim_tty `tty => false` -> `tty => true` reinit that
+  `start_stdin_reader/1` triggers via `user_drv`'s `:start_shell` call; under
+  a real TTY that race can corrupt job control and crash the node before a
+  frame renders.
+
+  This lives entirely in `init_manager/1`'s TTY-detected branch, which is
+  unreachable from ExUnit (`Env.test?/0` short-circuits before that branch
+  runs, and there is no real TTY in CI). These tests assert the invariants
+  directly against the source instead of driving the GenServer.
+  """
+
+  @driver_source Path.join([
+                   Path.dirname(__ENV__.file),
+                   "..",
+                   "..",
+                   "..",
+                   "lib",
+                   "raxol",
+                   "terminal",
+                   "driver.ex"
+                 ])
+                 |> Path.expand()
+
+  test "OSC 11 background query is written after the stdin reader is activated" do
+    source = File.read!(@driver_source)
+
+    reader_index =
+      :binary.match(source, "start_stdin_reader(self())")
+      |> elem(0)
+
+    query_write_index =
+      case :binary.match(source, "write_background_query()") do
+        {index, _len} ->
+          index
+
+        :nomatch ->
+          # Fall back to the raw IO.write call in case the helper is
+          # inlined again in the future — either way, it must come after.
+          {index, _len} =
+            :binary.match(source, "BackgroundQuery.query_sequence()")
+
+          index
+      end
+
+    assert query_write_index > reader_index,
+           "The OSC 11 background query must be written after start_stdin_reader/1 " <>
+             "activates the prim_tty reader. Writing it earlier races the tty reinit " <>
+             "and can crash the whole node on startup under a real terminal (see " <>
+             "commit history around the H-K salience / OSC 11 background detection merge)."
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/driver_init_order_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver_init_order_test.exs
@@ -53,4 +53,37 @@ defmodule Raxol.Terminal.DriverInitOrderTest do
              "and can crash the whole node on startup under a real terminal (see " <>
              "commit history around the H-K salience / OSC 11 background detection merge)."
   end
+
+  # `start_stdin_reader/1`'s `:start_shell` call must pass the literal atom
+  # `:noshell`, never an MFA. Any other value makes user_drv spawn a real
+  # shell process that, if it exits immediately, drops user_drv into its JCL
+  # prompt and hijacks all subsequent stdin. Unreachable from ExUnit for the
+  # same reason as the test above, so it's asserted against the source.
+  test "start_stdin_reader's :start_shell call uses :noshell, not a shell MFA" do
+    source = File.read!(@driver_source)
+
+    # Anchor on the tuple construction itself, not just the atom — ":start_shell"
+    # alone also appears earlier in explanatory comments.
+    {start_shell_index, _len} = :binary.match(source, "{:start_shell,")
+
+    # Grab a window of source after the :start_shell call site — enough to
+    # contain the Args map literal — and confirm it pins `initial_shell` to
+    # the atom :noshell rather than any other value (MFA tuple, module
+    # capture, etc).
+    window = binary_part(source, start_shell_index, 200)
+
+    assert window =~ ~r/initial_shell:\s*:noshell/,
+           "start_stdin_reader/1's {:start_shell, Args} call must set " <>
+             "initial_shell: :noshell literally. Any other value (including a " <>
+             "custom no-op shell MFA) makes user_drv spawn a real shell process " <>
+             "that immediately exits, triggering the JCL 'User switch command' " <>
+             "prompt and hijacking all subsequent stdin — including the terminal's " <>
+             "OSC 11 / DA reply — which crashes the node. See the comment on " <>
+             "start_stdin_reader/1 in driver.ex for the full mechanism."
+
+    refute source =~ "noop_shell",
+           "noop_shell/0 should no longer exist — it was the MFA shell that " <>
+             "caused the JCL hijack described above. If you're reintroducing a " <>
+             "custom shell MFA, re-read the comment on start_stdin_reader/1 first."
+  end
 end

--- a/test/property/ssh_rendering_property_test.exs
+++ b/test/property/ssh_rendering_property_test.exs
@@ -115,7 +115,13 @@ defmodule Raxol.Property.SSHRenderingTest do
         ssh_state = ssh_state(self())
         {:ok, ssh_result} = Backends.render_to_ssh(cells, ssh_state)
 
-        terminal_state = %{width: 80, height: 24, buffer: nil, sync_output: false}
+        terminal_state = %{
+          width: 80,
+          height: 24,
+          buffer: nil,
+          sync_output: false
+        }
+
         # Capture IO to avoid writing to actual terminal
         {:ok, term_result} = capture_terminal_render(cells, terminal_state)
 
@@ -188,7 +194,13 @@ defmodule Raxol.Property.SSHRenderingTest do
   describe "Lifecycle.terminate/2 wiring" do
     property "terminate/2 delegates to terminate_manager/2" do
       check all(
-              reason <- member_of([:normal, :shutdown, :killed, {:shutdown, :user_quit}]),
+              reason <-
+                member_of([
+                  :normal,
+                  :shutdown,
+                  :killed,
+                  {:shutdown, :user_quit}
+                ]),
               max_runs: 10
             ) do
         state = %Lifecycle.State{
@@ -219,13 +231,16 @@ defmodule Raxol.Property.SSHRenderingTest do
           alternate_screen: true,
           plugin_manager: nil,
           command_registry_table: nil,
-          options: [environment: :ssh, io_writer: fn data -> send(self(), {:escape, data}) end]
+          options: [
+            environment: :ssh,
+            io_writer: fn data -> send(self(), {:escape, data}) end
+          ]
         }
 
         Lifecycle.terminate(:shutdown, state)
 
         assert_received {:escape, "\e[?1049l"},
-                         "leave-alt-screen escape not sent on terminate"
+                        "leave-alt-screen escape not sent on terminate"
       end
     end
 
@@ -264,16 +279,19 @@ defmodule Raxol.Property.SSHRenderingTest do
           alternate_screen: false,
           plugin_manager: nil,
           command_registry_table: nil,
-          options: [environment: env, io_writer: fn data -> send(self(), {:escape, data}) end]
+          options: [
+            environment: env,
+            io_writer: fn data -> send(self(), {:escape, data}) end
+          ]
         }
 
         Lifecycle.terminate(:shutdown, state)
 
         refute_received {:escape, "\e[?1049h"},
-                         "enter-alt-screen escape sent when alternate_screen is false"
+                        "enter-alt-screen escape sent when alternate_screen is false"
 
         refute_received {:escape, "\e[?1049l"},
-                         "leave-alt-screen escape sent when alternate_screen is false"
+                        "leave-alt-screen escape sent when alternate_screen is false"
       end
     end
 
@@ -288,13 +306,16 @@ defmodule Raxol.Property.SSHRenderingTest do
           alternate_screen: true,
           plugin_manager: nil,
           command_registry_table: nil,
-          options: [environment: env, io_writer: fn data -> send(self(), {:escape, data}) end]
+          options: [
+            environment: env,
+            io_writer: fn data -> send(self(), {:escape, data}) end
+          ]
         }
 
         Lifecycle.terminate(:shutdown, state)
 
         refute_received {:escape, _},
-                         "escape sequence sent for non-terminal env #{env}"
+                        "escape sequence sent for non-terminal env #{env}"
       end
     end
 
@@ -342,7 +363,90 @@ defmodule Raxol.Property.SSHRenderingTest do
     end
   end
 
+  # -- Property 7: CRLF normalization (raw-mode prim_tty doesn't cook LF) --
+  #
+  # prim_tty runs in raw OUTPUT mode and never translates a bare `\n` to
+  # `\r\n`. Renderer.render/1 joins rows with a bare `\n`, so without
+  # normalization every row after the first would drift instead of a clean
+  # line advance. Backends.normalize_frame/1 fixes this at the write site.
+
+  describe "frame CRLF normalization" do
+    property "render_to_ssh frames contain no bare LF (every \\n preceded by \\r)" do
+      check all(
+              cells <- cells_gen(),
+              max_runs: 200
+            ) do
+        state = ssh_state(self())
+        {:ok, _new_state} = Backends.render_to_ssh(cells, state)
+
+        output = collect_writes()
+
+        refute has_bare_lf?(output),
+               "SSH frame contains a bare \\n not preceded by \\r: #{inspect(output)}"
+      end
+    end
+
+    property "render_to_terminal frames contain no bare LF (every \\n preceded by \\r)" do
+      check all(
+              cells <- cells_gen(),
+              max_runs: 200
+            ) do
+        terminal_state = %{
+          width: 80,
+          height: 24,
+          buffer: nil,
+          sync_output: false
+        }
+
+        output = capture_terminal_output(cells, terminal_state)
+
+        refute has_bare_lf?(output),
+               "Terminal frame contains a bare \\n not preceded by \\r: #{inspect(output)}"
+      end
+    end
+
+    test "normalize_frame/1 converts bare LF row joins to CRLF" do
+      assert Backends.normalize_frame("row1\nrow2\nrow3") ==
+               "row1\r\nrow2\r\nrow3"
+    end
+
+    test "normalize_frame/1 leaves already-normalized \\r\\n untouched-per-LF" do
+      # Applying normalize_frame to already-\r\n content adds a redundant
+      # \r (row\r\n -> row\r\r\n) rather than corrupting it -- a redundant
+      # CR at column 0 is a no-op in both raw and cooked terminal modes, so
+      # double-normalization stays safe even if ever applied twice.
+      once = Backends.normalize_frame("row1\nrow2")
+      twice = Backends.normalize_frame(once)
+
+      assert once == "row1\r\nrow2"
+      assert twice == "row1\r\r\nrow2"
+      refute has_bare_lf?(twice)
+    end
+
+    test "normalize_frame/1 leaves LF-free content untouched" do
+      assert Backends.normalize_frame("\e[H\e[2Jno newlines here") ==
+               "\e[H\e[2Jno newlines here"
+    end
+  end
+
   # -- Helpers --
+
+  # Returns true if any \n in the string is not immediately preceded by \r.
+  defp has_bare_lf?(string) do
+    string
+    |> String.graphemes()
+    |> Enum.reduce({false, nil}, fn
+      "\n", {_found, prev} -> {prev != "\r", "\n"}
+      char, {found, _prev} -> {found, char}
+    end)
+    |> elem(0)
+  end
+
+  defp capture_terminal_output(cells, state) do
+    ExUnit.CaptureIO.capture_io(fn ->
+      {:ok, _new_state} = Backends.render_to_terminal(cells, state)
+    end)
+  end
 
   defp collect_writes do
     collect_write_list() |> Enum.join()


### PR DESCRIPTION
Part of decomposing the cross-terminal work into granular, independently-reviewable PRs. Touches only `packages/raxol_terminal/**` and `lib/raxol/core/runtime/rendering/backends.ex` — disjoint from the layout and dev-experience PRs, mergeable in any order.

Hardens the terminal driver end to end. Several of these were latent bugs that a real terminal answering escape-sequence queries could trigger at startup; found and fixed via PTY-based reproduction (expect harnesses answering OSC 11 / DA / focus / mouse reports).

## Changes (each its own commit)

**Detect terminal background via OSC 11; handle SIGWINCH resize.** The driver queries the terminal background colour (OSC 11, DA probe as the unsupported-terminal sentinel), strips the reply from the input stream before key parsing, and publishes it via `persistent_term` + a `:terminal_background` event for higher layers (e.g. theming) to consume. Also installs a SIGWINCH `gen_event` handler — prim_tty delivers the signal straight to `user_drv`, bypassing the reader we trace. `InputBuffer` holds an incomplete `ESC ]` (OSC) chunk until its BEL/ST terminator so a split colour reply is never mis-parsed as keys.

**Write the OSC 11 query only after the stdin reader is active; fail-safe.** Writing it earlier raced the prim_tty `tty => true` reinit; the whole query/scan/reply path now degrades to "no background detected" on any exception instead of crashing the driver or blocking input.

**Start `user_drv` shell-less.** `start_shell` with an MFA spawns a real shell process; ours returned immediately, so `user_drv` dropped into the job-control prompt for the whole session with all stdin still copied to it. A terminal answering the OSC 11/DA query then fed its reply into that prompt, killing stdio and the node before the first frame. `initial_shell: :noshell` spawns no shell at all; since `shell_started` stays false, `user_drv` never issues the one-time prim_tty read kick, so the driver sends `{:read, :infinity}` to the reader itself.

**Make CSI parsing total; consume unmapped sequences instead of leaking them.** `parse_csi_params` only matched digits/`;`/final bytes, so a CSI private marker (`>`, `<`, `?`) raised `FunctionClauseError` — and terminals volunteer secondary-DA reports (`CSI > Pp;Pv;Pc c`) unprompted, killing the driver right after the first frame. Unknown bytes are now skipped while scanning for the final byte, and `dispatch_raw_input` wraps the parser fail-safe. A follow-up makes well-formed-but-unmapped sequences consume whole (previously the recovery path leaked their bytes as fake keystrokes — one full-frame repaint per byte, plus the leaked `c` toggling UI state).

**Own frame geometry: CRLF row separators and DECAWM off.** With prim_tty in `output=raw` (the noshell path), nothing cooks the frame's bare-LF row joins into CRLF anymore, so full-width rows autowrapped *and* line-fed — every frame rendered double-spaced. Backends normalize LF to CRLF before writing (harmless under cooked — `\r\r\n` is still one advance) and the driver disables autowrap for the session, restoring it on cleanup.

## Verification

- PTY harnesses (BEL/ST OSC replies, kitty DA, focus-in, stray mouse SGR, single-write bursts): render + nav + `q` clean exit, no crashes, single-spaced output confirmed with a real VT100 emulator.
- `input_parser` + driver suites: 118 passed. SSH rendering property suite: 20 passed.
