### PR TITLE
Add FATE golden gate to mix raxol.check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Note: `TMPDIR=/tmp` and `SKIP_TERMBOX2_TESTS=true` are set automatically via `.c
 ### Code Quality
 
 ```bash
-mix raxol.check               # All checks: format, compile, credo, dialyzer, security, test
+mix raxol.check               # All checks: format, compile, credo, dialyzer, security, docs, fate, test
 mix raxol.check --quick       # Skip dialyzer
 mix raxol.check --only format,credo  # Run specific checks only
 mix raxol.check --skip test   # Skip specific checks

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ git clone https://github.com/DROOdotFOO/raxol.git
 cd raxol
 mix deps.get
 MIX_ENV=test mix test --exclude slow --exclude integration --exclude docker
-mix raxol.check              # format, compile, credo, dialyzer, security, test
+mix raxol.check              # format, compile, credo, dialyzer, security, docs, fate, test
 mix raxol.check --quick      # skip dialyzer
 mix raxol.demo               # run built-in demos
 ```

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -41,9 +41,13 @@ mix format                    # Format code
 mix credo                     # Style check
 mix dialyzer                  # Type checking (PLT cached in priv/plts/)
 mix docs                      # Generate docs
-mix raxol.check               # Run all checks (format, compile, credo, dialyzer, test)
+mix raxol.check               # Run all checks (compile, format, credo, dialyzer, security, docs, fate, test)
 mix raxol.check --quick       # Skip dialyzer
 ```
+
+Run `mix raxol.check` before you push. It mirrors the checks CI enforces, including the
+FATE golden render gate (`mix raxol.fate`). When you change rendering on purpose,
+regenerate the references with `mix raxol.fate --gen` and commit them.
 
 ### Development
 ```bash

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -36,12 +36,22 @@ cd packages/raxol_agent    && MIX_ENV=test mix test
 
 ### All quality checks
 
+`mix raxol.check` mirrors the checks CI enforces. Run the full command before you push;
+a clean local run is the strongest signal your branch will pass CI.
+
 ```bash
-mix raxol.check                        # format, compile, credo, dialyzer, security, test
+mix raxol.check                        # lockfile, compile, format, credo, dialyzer, security, docs, fate, test
 mix raxol.check --quick                # skip dialyzer
 mix raxol.check --only format,credo   # specific checks only
 mix raxol.check --skip test            # skip specific checks
 ```
+
+The `fate` step runs the golden render harness (`mix raxol.fate`): it hashes a fixture
+corpus and compares each hash against `priv/fate/golden.refs`, failing the gate on any
+mismatch. When you change rendering on purpose, regenerate the references with
+`mix raxol.fate --gen` and commit them. The hashes are architecture-independent, so a
+mismatch that appears on one platform while another stays green points at a determinism
+bug worth tracking down.
 
 ### Coverage
 

--- a/lib/mix/tasks/raxol.check.ex
+++ b/lib/mix/tasks/raxol.check.ex
@@ -51,9 +51,10 @@ defmodule Mix.Tasks.Raxol.Check do
     :dialyzer,
     :security,
     :docs,
+    :fate,
     :test
   ]
-  @quick_checks [:lockfile, :compile, :format, :credo, :docs, :test]
+  @quick_checks [:lockfile, :compile, :format, :credo, :docs, :fate, :test]
 
   @impl Mix.Task
   def run(args) do
@@ -306,6 +307,30 @@ defmodule Mix.Tasks.Raxol.Check do
         )
 
         {:docs, :warning}
+    end
+  end
+
+  defp run_check(:fate) do
+    Mix.shell().info(Colors.subsection_header("FATE golden render"))
+
+    case Mix.shell().cmd("mix raxol.fate") do
+      0 ->
+        Mix.shell().info(
+          "    " <> Colors.format_success("Golden render hashes match")
+        )
+
+        {:fate, :ok}
+
+      _ ->
+        Mix.shell().error(
+          "    " <>
+            Colors.format_error(
+              "Golden render mismatch",
+              "inspect the diff, then run `mix raxol.fate --gen` if the change is intended"
+            )
+        )
+
+        {:fate, :error}
     end
   end
 


### PR DESCRIPTION
## What

Adds a `fate` step to `mix raxol.check`, the main quality gate. It runs the golden render harness (`mix raxol.fate`) and fails the gate (hard error) on any mismatch against `priv/fate/golden.refs`.

FATE discipline treats a reference-hash mismatch as a real render/determinism bug, so it belongs in the gate as a first-class named failure rather than buried in the test run. `test/fate/golden_test.exs` still runs inside `:test`; this makes the golden check explicit and fast, and it runs under `--quick` too.

## Changes

- `lib/mix/tasks/raxol.check.ex`: `:fate` added to `@all_checks` and `@quick_checks` (before `:test`); new `run_check(:fate)` shells `mix raxol.fate`.
- Docs tell developers CI expects a clean full `mix raxol.check`, now including the golden gate: `docs/testing/README.md`, `docs/development/README.md`, `README.md`, `CLAUDE.md`.

## Manual testing

- [x] `mix raxol.check --only fate` -> `fate: [OK]`, exit 0
- [x] Corrupt a `priv/fate/golden.refs` hash -> `fate: [FAIL]`, `Some checks failed`, exit 1; refs restored clean
- [x] `mix format --check-formatted lib/mix/tasks/raxol.check.ex` clean
- [x] `mix credo --strict lib/mix/tasks/raxol.check.ex` clean
- [x] `:fate` present in `@quick_checks` (runs under `--quick`)
