### PR TITLE
Layer 1: self-hosted termbox2 NIF/FATE bench

### DIFF
--- a/.github/workflows/fate-selfhosted.yml
+++ b/.github/workflows/fate-selfhosted.yml
@@ -1,0 +1,80 @@
+name: FATE self-hosted
+
+# Builds the termbox2 NIF and exercises the tty-dependent suite on the homelab's
+# Nix-pinned self-hosted runners (aarch64-linux + x86_64-linux). GitHub-hosted CI
+# skips these via SKIP_TERMBOX2_TESTS; this workflow leaves it unset and runs the
+# NIF for real on both Linux architectures, plus a golden render comparison so the
+# aarch64-linux hash is checked against priv/fate/golden.refs.
+#
+# Security: raxol is a public repository, so these jobs must never run untrusted
+# code on the homelab. Triggers are limited to manual dispatch, pushes to master,
+# and the nightly schedule (all trusted refs). There is no pull_request trigger,
+# and the owner guard fences out forks.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [master]
+    paths:
+      - "packages/raxol_terminal/**"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/fate-selfhosted.yml"
+  schedule:
+    - cron: "0 7 * * *"
+
+concurrency:
+  group: fate-selfhosted-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  nif:
+    if: github.repository_owner == 'DROOdotFOO'
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM64, X64]
+    runs-on: [self-hosted, linux, "${{ matrix.arch }}", raxol]
+    timeout-minutes: 45
+    env:
+      TERM: xterm-256color
+      LANG: C.UTF-8
+      # SKIP_TERMBOX2_TESTS is intentionally unset so the NIF suite runs for real.
+    steps:
+      - uses: actions/checkout@v4
+
+      # `script` (from util-linux in the devShell) allocates a controlling
+      # pseudo-terminal. It wraps the whole `mix test`, not just the run: the
+      # real termbox2 tests are compiled in only when TerminalUtils.real_tty?/0
+      # is true, and that guard is evaluated at test-file compile time.
+      # --include docker un-excludes the loading tests (the package test_helper
+      # hardcodes their exclusion); the NIF-exercising tests are untagged, so
+      # naming the files runs them without --only skipping them.
+      - name: termbox2 NIF suite (built and exercised under a pseudo-terminal)
+        run: |
+          nix develop --command bash -lc '
+            cd packages/raxol_terminal
+            MIX_ENV=test mix deps.get
+            script -qec "MIX_ENV=test mix test --include docker \
+              test/termbox2_nif/termbox2_loading_test.exs \
+              test/termbox2_nif/termbox2_nif_test.exs --no-deps-check" /dev/null
+          '
+
+      - name: Platform :requires_terminal suite (under a pseudo-terminal)
+        run: |
+          nix develop --command bash -lc '
+            MIX_ENV=test mix deps.get
+            script -qec "MIX_ENV=test mix test \
+              test/platform/terminal_test.exs --no-deps-check" /dev/null
+          '
+
+      # Pure render, no pseudo-terminal needed. First comparison of the
+      # aarch64-linux golden hash against the committed references.
+      - name: FATE golden render on this architecture
+        run: |
+          nix develop --command bash -lc '
+            MIX_ENV=test mix test test/fate/golden_test.exs --no-deps-check
+          '

--- a/docs/testing/FATE_BENCH.md
+++ b/docs/testing/FATE_BENCH.md
@@ -1,0 +1,144 @@
+# FATE Cross-Platform Test Bench
+
+The FATE bench (after FFmpeg's Fast Audio Video Evaluation, plus checkasm's
+reference-oracle idea) proves Raxol behaves identically across architectures, with
+Nix pinning the toolchain so architecture is the only variable. The high-level layer
+map lives in [ROADMAP.md](../../ROADMAP.md); this guide is the operator runbook for
+Layer 1: running the `termbox2` NIF suite on self-hosted runners.
+
+## Why self-hosted
+
+GitHub-hosted CI sets `SKIP_TERMBOX2_TESTS=true` everywhere, so the `termbox2` NIF is
+never built or exercised, and there is no aarch64-linux tier at all. Self-hosted
+runners with real terminals close both gaps. The `.github/workflows/fate-selfhosted.yml`
+workflow builds the NIF and runs the tty-dependent suite on both Linux architectures,
+then compares the golden render hashes against `priv/fate/golden.refs`.
+
+## The workflow
+
+`fate-selfhosted.yml` runs one matrix job per architecture (`ARM64`, `X64`) on runners
+carrying the `self-hosted`, `linux`, arch, and `raxol` labels. Each job, inside
+`nix develop` (so the toolchain is flake-pinned and identical on every host):
+
+1. Builds the NIF and runs the `:docker` suite under a pseudo-terminal.
+2. Runs the platform `:requires_terminal` suite under a pseudo-terminal.
+3. Runs the FATE golden render (pure, no terminal) to compare this architecture's
+   hashes against the committed references.
+
+Two mechanics matter:
+
+- **`--include docker`, not `--only docker`.** The NIF-exercising tests in
+  `packages/raxol_terminal/test/termbox2_nif/termbox2_nif_test.exs` are untagged (only
+  the skip-branch placeholder carries `@moduletag :docker`). `--only docker` would skip
+  the tests that actually drive the NIF, so the workflow names the files explicitly and
+  uses `--include docker` to un-exclude the loading tests.
+- **A pseudo-terminal wraps the whole `mix test`.** `Raxol.Terminal.TerminalUtils.real_tty?/0`
+  gates the real test module, and that guard runs at compile time. `script -qec "<cmd>" /dev/null`
+  (from `util-linux`, present in the devShell) gives the process both a tty on stdin/stdout
+  (so `:io.columns/0` succeeds) and a controlling terminal (so `tb_init` can open
+  `/dev/tty`). `TERM=xterm-256color` plus the `ncurses` terminfo let cap loading succeed.
+
+### Security
+
+`raxol` is a public repository, so these jobs must never run untrusted code on the
+homelab. The workflow triggers only on `workflow_dispatch`, pushes to `master`, and the
+nightly schedule (all trusted refs). There is no `pull_request` trigger, and an
+`if: github.repository_owner == 'DROOdotFOO'` guard fences out forks. Run the runner
+under an unprivileged user with no cloud credentials on the box.
+
+## Runner hosts
+
+The homelab is 3 aarch64 Turing Pi boards, 1 x86_64 box, and 1 x86_64 NixOS laptop,
+all on a Tailscale mesh. The build toolchain is flake-pinned on every host through
+`nix develop`, so a hash divergence between architectures is a real determinism bug,
+not environment drift.
+
+### NixOS laptop
+
+Import the `nixosModules.githubRunner` flake output into the host config and provide
+the token and Tailscale key files with agenix. This is an example stanza (kept in docs
+rather than as a live `nixosConfigurations` output so the hosted flake check does not
+need this machine's hardware config):
+
+```nix
+{
+  inputs.raxol.url = "github:DROOdotFOO/raxol";
+  inputs.agenix.url = "github:ryantm/agenix";
+
+  outputs =
+    { nixpkgs, raxol, agenix, ... }:
+    {
+      nixosConfigurations.nixlaptop = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./hardware-configuration.nix
+          agenix.nixosModules.default
+          raxol.nixosModules.githubRunner
+          (
+            { config, ... }:
+            {
+              age.secrets.gh-runner-token.file = ./secrets/gh-runner-token.age;
+              age.secrets.ts-authkey.file = ./secrets/ts-authkey.age;
+
+              raxol.ci.githubRunner = {
+                enable = true;
+                tokenFile = config.age.secrets.gh-runner-token.path;
+                tailscaleAuthKeyFile = config.age.secrets.ts-authkey.path;
+                extraLabels = [ "laptop" ];
+              };
+            }
+          )
+        ];
+      };
+    };
+}
+```
+
+Apply with `nixos-rebuild switch --flake .#nixlaptop`. The module registers an ephemeral
+runner (a clean workspace per job; a PAT `tokenFile` re-registers automatically after
+each job) and joins the mesh. The runner picks up the `raxol`, `nix`, and arch labels.
+
+### Non-NixOS hosts (Turing Pi boards, x86 box)
+
+These run Nix on their base distro; the flake-pinned surface is the devShell, consumed
+via `nix develop` in the workflow.
+
+```bash
+# 1. Install Nix (this installer enables flakes)
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+
+# 2. Warm the flake so `nix develop` is fast (from a raxol checkout)
+git clone https://github.com/DROOdotFOO/raxol.git && cd raxol
+nix develop --command true
+
+# 3. Install the GitHub Actions runner as a service under an unprivileged user.
+#    Download the runner from Settings -> Actions -> Runners -> New self-hosted runner.
+./config.sh --url https://github.com/DROOdotFOO/raxol \
+  --labels raxol --unattended --token "$REGISTRATION_TOKEN"
+sudo ./svc.sh install "$RUNNER_USER"
+sudo ./svc.sh start
+
+# 4. Join the Tailscale mesh
+sudo tailscale up --auth-key "file:/etc/tailscale/authkey"
+```
+
+GitHub adds the `self-hosted`, `linux`, and arch labels (`ARM64` / `X64`) automatically;
+the `raxol` label added here is what the workflow targets.
+
+## Reproducibility
+
+Commit `flake.lock` (run `nix flake lock` on a machine with Nix). Without it, both the
+hosted flake check and the runner toolchains float on `nixos-unstable` HEAD, which
+defeats "architecture is the only variable."
+
+## Running it
+
+Trigger from the Actions tab (`Run workflow`), or let the nightly schedule run it.
+Acceptance: on both `ARM64` and `X64`, the NIF (`termbox2_nif.so`) builds, the
+`:docker` and `:requires_terminal` suites pass, and `test/fate/golden_test.exs` matches
+`priv/fate/golden.refs`.
+
+When you change rendering on purpose and the golden step fails, regenerate the
+references with `mix raxol.fate --gen` and commit them. The hashes are
+architecture-independent, so a mismatch that appears on one architecture while another
+stays green points at a determinism bug worth tracking down.

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,11 @@
                 git
                 openssl
                 ncurses
-              ]);
+              ])
+              # `script` allocates a controlling pseudo-terminal so the termbox2
+              # NIF suite runs under a real tty on Linux self-hosted runners.
+              # util-linux is Linux-only, so guard it for the Darwin systems.
+              ++ nixpkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.util-linux ];
 
             shellHook = ''
               export MIX_ENV="''${MIX_ENV:-dev}"
@@ -62,6 +66,97 @@
           };
         }
       );
+
+      # Self-hosted GitHub Actions runner for the FATE bench, as a reusable
+      # NixOS module. A host imports it and sets the token/key files (via
+      # agenix); see docs/testing/FATE_BENCH.md for a full host example. Shipped
+      # as a module rather than a nixosConfigurations entry so the hosted flake
+      # check stays green without this repo carrying a machine's hardware config.
+      nixosModules.githubRunner =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.raxol.ci.githubRunner;
+        in
+        {
+          options.raxol.ci.githubRunner = {
+            enable =
+              lib.mkEnableOption "the Raxol self-hosted GitHub Actions runner";
+
+            repoUrl = lib.mkOption {
+              type = lib.types.str;
+              default = "https://github.com/DROOdotFOO/raxol";
+              description = "Repository the runner registers against.";
+            };
+
+            tokenFile = lib.mkOption {
+              type = lib.types.path;
+              description = ''
+                File holding a GitHub runner registration token or a PAT with
+                repo scope. Keep it out of the Nix store and git; provision it
+                with agenix or sops-nix.
+              '';
+            };
+
+            tailscaleAuthKeyFile = lib.mkOption {
+              type = lib.types.nullOr lib.types.path;
+              default = null;
+              description = ''
+                Optional Tailscale auth key file for headless mesh join. Leave
+                null to join manually with `tailscale up`.
+              '';
+            };
+
+            extraLabels = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "Extra runner labels beyond raxol + the arch label.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            services.github-runners.raxol = {
+              enable = true;
+              url = cfg.repoUrl;
+              tokenFile = cfg.tokenFile;
+              # Ephemeral: a clean workspace per job, no persisted foothold. A
+              # PAT tokenFile re-registers automatically after each job.
+              ephemeral = true;
+              replace = true;
+              extraLabels =
+                [
+                  "raxol"
+                  "nix"
+                  pkgs.stdenv.hostPlatform.system
+                ]
+                ++ cfg.extraLabels;
+              extraPackages = with pkgs; [
+                util-linux
+                ncurses
+                gnumake
+                gcc
+                git
+                openssl
+              ];
+            };
+
+            services.tailscale = {
+              enable = true;
+              authKeyFile = cfg.tailscaleAuthKeyFile;
+            };
+
+            # The workflow drives the toolchain through `nix develop`, so flakes
+            # must be available system-wide.
+            nix.settings.experimental-features = [
+              "nix-command"
+              "flakes"
+            ];
+          };
+        };
 
       # Follow-up (needs a machine with nix): packages.default via
       # beam.packages.erlang_27.mixRelease + fetchMixDeps (fill the fixed-output


### PR DESCRIPTION
## What

Layer 1 of the FATE cross-platform bench: build the `termbox2` NIF and exercise the tty-dependent suite on Nix-pinned self-hosted runners (aarch64-linux + x86_64-linux), which GitHub-hosted CI skips today via `SKIP_TERMBOX2_TESTS=true`. See `docs/testing/FATE_BENCH.md` for the operator runbook.

## Changes

- `.github/workflows/fate-selfhosted.yml`: matrix `ARM64`/`X64` on `[self-hosted, linux, <arch>, raxol]`; inside `nix develop`, builds the NIF and runs `mix test --include docker` on the two NIF test files + the root `:requires_terminal` file, each wrapped in `script -qec ... /dev/null` (a controlling pseudo-terminal), then a per-arch golden compare against `priv/fate/golden.refs`.
- `flake.nix`: `util-linux` added to the devShell (Linux-guarded, provides `script`); new `nixosModules.githubRunner` output (services.github-runners + tailscale), gated by `mkIf cfg.enable` so the hosted flake check stays green.
- `docs/testing/FATE_BENCH.md`: runbook plus an example `nixosConfigurations` stanza.

### Mechanics that matter

- `--include docker`, not `--only docker`: the NIF-exercising tests are untagged, so `--only docker` would skip the very tests that prove the NIF works.
- The PTY wraps the whole `mix test`: `TerminalUtils.real_tty?/0` gates the test module at compile time, and `tb_init` needs a controlling terminal (`/dev/tty`), which `script` provides alongside a tty on stdin/stdout.

### Security

`raxol` is public. Triggers are `workflow_dispatch` + push-to-master + schedule only (no `pull_request`), with an `if: github.repository_owner == 'DROOdotFOO'` guard, so fork code never runs on the homelab.

## Verification status

Not runnable in the authoring sandbox (no `nix`, no homelab hardware).

- Hosted `nix.yml` gates the flake changes (flake eval + devShell). If it goes red on the NixOS module, switch that step to assert the devShell directly.
- The homelab runners are the gate for the NIF suite building/running green and the aarch64-linux golden matching refs.

## Operator steps (homelab)

- Commit `flake.lock` (`nix flake lock` on a nix machine).
- Register runners with the `raxol` label; wire agenix secrets (laptop) or `config.sh` + `tailscale up` (Pis/box).
- Trigger the workflow (Run workflow).

## Manual testing

- [ ] Hosted `nix.yml` green with the flake changes
- [ ] `fate-selfhosted` green on `ARM64`: NIF built, `:docker` + `:requires_terminal` pass, golden matches refs
- [ ] `fate-selfhosted` green on `X64`: same
