### PR TITLE
ci: fork-safe PR comment + case-aware singleton guard

### DIFF
--- a/.github/workflows/regression-testing.yml
+++ b/.github/workflows/regression-testing.yml
@@ -493,7 +493,9 @@ jobs:
         retention-days: 90
 
     - name: Comment unified results on PR
-      if: github.event_name == 'pull_request' && always()
+      # Fork PRs get a read-only GITHUB_TOKEN, so commenting is impossible and
+      # would fail the job. Only comment on same-repo PRs.
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/github-script@v9
       with:
         script: |
@@ -582,31 +584,36 @@ jobs:
           reportContent += "- Render: <1ms average\n";
           reportContent += "- Memory: <3MB per session\n";
 
-          // Find existing comment
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number
-          });
-
-          const existingComment = comments.find(comment =>
-            comment.body.includes('Unified Regression Test Results')
-          );
-
-          if (existingComment) {
-            await github.rest.issues.updateComment({
+          // Commenting needs a write token. Warn instead of failing the job if
+          // the token is restricted (e.g. a same-repo run with reduced perms).
+          try {
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: existingComment.id,
-              body: reportContent
+              issue_number: context.issue.number
             });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: reportContent
-            });
+
+            const existingComment = comments.find(comment =>
+              comment.body.includes('Unified Regression Test Results')
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: reportContent
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: reportContent
+              });
+            }
+          } catch (error) {
+            core.warning(`Could not post regression results comment: ${error.message}`);
           }
 
   # Nightly comprehensive analysis

--- a/scripts/check_singletons.sh
+++ b/scripts/check_singletons.sh
@@ -15,9 +15,11 @@ if [[ ! -f "$ALLOWLIST" ]]; then
   exit 2
 fi
 
-# Match real start_link calls (require start_link at line start modulo
-# whitespace) -- this skips comment lines like "# Usage: ... start_link(name: __MODULE__)".
-pattern='^[[:space:]]*(GenServer|Agent|Supervisor|DynamicSupervisor)\.start_link.*name: __MODULE__'
+# Match real start_link calls. The call must be at line start modulo whitespace,
+# with an optional `case ` or `{...} =`/`{...} <-` binding prefix so idempotent
+# wrappers still register -- this skips comment lines like
+# "# Usage: ... start_link(name: __MODULE__)".
+pattern='^[[:space:]]*(case[[:space:]]+|\{[^}]*\}[[:space:]]*[=<-]+[[:space:]]*)?(GenServer|Agent|Supervisor|DynamicSupervisor)\.start_link.*name: __MODULE__'
 
 # First-party paths only -- skip vendored deps and _build.
 roots=(


### PR DESCRIPTION
Two CI-infra fixes that unblock fork PRs (e.g. #442, #443). Neither PR modifies
these files; both are pre-existing guard/workflow issues that fork PRs trip.

## Changes

**`scripts/check_singletons.sh`: case-aware singleton detection.** The guard's
regex required `Supervisor.start_link(..., name: __MODULE__)` at line start, so an
idempotent wrapper (`case Supervisor.start_link(...) do`) hid the call. The file
then dropped out of the detected set and its allowlist entry looked stale, failing
the `Format Check` job. The pattern now accepts an optional `case ` or
`{...} =` / `{...} <-` binding prefix. Comment lines stay skipped; the bare form
still matches, so `master` stays green.

**`.github/workflows/regression-testing.yml`: fork-safe PR comment.** The
`consolidate-results` "Comment unified results on PR" step called
`issues.createComment`, which needs a write token. `pull_request` runs from a fork
get a read-only `GITHUB_TOKEN` regardless of the `permissions:` block, so the call
403'd and failed the whole job on every fork PR. The step now runs only on same-repo
PRs (`head.repo.full_name == github.repository`), and the API calls are wrapped in
try/catch that warns instead of failing if a token is ever restricted.

## Manual testing

- [x] `bash scripts/check_singletons.sh` on this branch -> "33 allowed registrations, all accounted for", exit 0
- [x] Simulated #442's `case`-wrap on the agent supervisor -> new regex still detects it (PASS); old regex does not (would fail CI)
- [x] Binding form (`{:ok, pid} = Supervisor.start_link(...)`) detected; comment line still skipped
- [x] `shellcheck -x scripts/check_singletons.sh` clean
- [x] `regression-testing.yml` parses as valid YAML
- [ ] After merge: update-branch #442/#443 -> `Format Check`, `CI Status`, `consolidate-results` go green
