### PR TITLE
Layer 2 oracle: termbox2 NIF vs pure reference

### DIFF
--- a/.github/workflows/fate-selfhosted.yml
+++ b/.github/workflows/fate-selfhosted.yml
@@ -59,8 +59,10 @@ jobs:
             cd packages/raxol_terminal
             MIX_ENV=test mix deps.get
             script -qec "MIX_ENV=test mix test --include docker \
+              test/termbox2_nif/termbox_model_test.exs \
               test/termbox2_nif/termbox2_loading_test.exs \
-              test/termbox2_nif/termbox2_nif_test.exs --no-deps-check" /dev/null
+              test/termbox2_nif/termbox2_nif_test.exs \
+              test/termbox2_nif/oracle_equivalence_test.exs --no-deps-check" /dev/null
           '
 
       - name: Platform :requires_terminal suite (under a pseudo-terminal)

--- a/docs/testing/FATE_BENCH.md
+++ b/docs/testing/FATE_BENCH.md
@@ -20,7 +20,8 @@ then compares the golden render hashes against `priv/fate/golden.refs`.
 carrying the `self-hosted`, `linux`, arch, and `raxol` labels. Each job, inside
 `nix develop` (so the toolchain is flake-pinned and identical on every host):
 
-1. Builds the NIF and runs the `:docker` suite under a pseudo-terminal.
+1. Builds the NIF and runs the `:docker` suite under a pseudo-terminal (loading
+   tests, the direct NIF tests, and the oracle equivalence test below).
 2. Runs the platform `:requires_terminal` suite under a pseudo-terminal.
 3. Runs the FATE golden render (pure, no terminal) to compare this architecture's
    hashes against the committed references.
@@ -37,6 +38,27 @@ Two mechanics matter:
   (from `util-linux`, present in the devShell) gives the process both a tty on stdin/stdout
   (so `:io.columns/0` succeeds) and a controlling terminal (so `tb_init` can open
   `/dev/tty`). `TERM=xterm-256color` plus the `ncurses` terminfo let cap loading succeed.
+
+### Reference-oracle equivalence
+
+The oracle half of Layer 2 is the checkasm analogue: the termbox2 NIF (the optimized
+path) must produce the same back buffer as a pure reference for the same op stream.
+
+- `Raxol.Terminal.Termbox.Model` (in `packages/raxol_terminal/test/support/`) is the
+  reference oracle: a small pure model of termbox2's cell semantics (cleared cell
+  `{0x20, 0, 0}`, `set_cell` in-bounds writes, `print` lead-cell writes and advance).
+  `termbox_model_test.exs` verifies the model independently, with no NIF or terminal,
+  so it runs anywhere.
+- A `tb_cell_buffer/0` NIF reads the back buffer back as a row-major list of
+  `{ch, fg, bg}`. `oracle_equivalence_test.exs` applies each fixture op stream to the
+  NIF and to the model and asserts the grids are identical, covering the explicit
+  edges FATE requires: empty, wide CJK codepoints, attribute saturation, out-of-bounds
+  writes, print clipping, and newlines. It needs `tb_init`, so it runs on the runners
+  under the pseudo-terminal alongside the other `:docker` tests.
+
+A failure names the fixture and the first few diverging cell indices. Print fixtures use
+printable ASCII (advance is one column per cell); wide characters are covered through
+`set_cell` storage, so the model never has to replicate `tb_wcwidth`.
 
 ### Security
 

--- a/packages/raxol_terminal/lib/termbox2_nif/c_src/termbox2_nif.c
+++ b/packages/raxol_terminal/lib/termbox2_nif/c_src/termbox2_nif.c
@@ -154,6 +154,37 @@ static ERL_NIF_TERM nif_tb_print(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
   return enif_make_int(env, result);
 }
 
+// tb_cell_buffer/0 -> row-major list of {ch, fg, bg} for the back buffer.
+// Lets Elixir read back rendered cells for reference-oracle equivalence tests.
+static ERL_NIF_TERM nif_tb_cell_buffer(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+  (void)argc;
+  (void)argv;
+  int w = tb_width();
+  int h = tb_height();
+  struct tb_cell *buf = tb_cell_buffer();
+  if (w <= 0 || h <= 0 || buf == NULL)
+  {
+    return enif_make_list(env, 0);
+  }
+  int n = w * h;
+  ERL_NIF_TERM *cells = (ERL_NIF_TERM *)malloc(sizeof(ERL_NIF_TERM) * n);
+  if (cells == NULL)
+  {
+    return enif_make_badarg(env);
+  }
+  for (int i = 0; i < n; i++)
+  {
+    ERL_NIF_TERM ch = enif_make_uint(env, (unsigned int)buf[i].ch);
+    ERL_NIF_TERM fg = enif_make_uint64(env, (ErlNifUInt64)buf[i].fg);
+    ERL_NIF_TERM bg = enif_make_uint64(env, (ErlNifUInt64)buf[i].bg);
+    cells[i] = enif_make_tuple3(env, ch, fg, bg);
+  }
+  ERL_NIF_TERM list = enif_make_list_from_array(env, cells, n);
+  free(cells);
+  return list;
+}
+
 // Platform-specific implementation for setting terminal title
 static ERL_NIF_TERM tb_set_title(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -276,6 +307,7 @@ static ErlNifFunc nif_funcs[] = {
     {"tb_set_input_mode", 1, nif_tb_set_input_mode, 0},
     {"tb_set_output_mode", 1, nif_tb_set_output_mode, 0},
     {"tb_print", 5, nif_tb_print, 0},
+    {"tb_cell_buffer", 0, nif_tb_cell_buffer, 0},
     {"tb_set_title", 1, tb_set_title, 0},
     {"tb_set_position", 2, tb_set_position, 0}};
 

--- a/packages/raxol_terminal/lib/termbox2_nif/lib/termbox2_nif.ex
+++ b/packages/raxol_terminal/lib/termbox2_nif/lib/termbox2_nif.ex
@@ -139,6 +139,15 @@ defmodule :termbox2_nif do
   def tb_print(_x, _y, _fg, _bg, _str), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
+  Read back the back buffer as a row-major list of `{ch, fg, bg}` tuples.
+
+  One tuple per cell, `tb_width() * tb_height()` in total, indexed
+  `(y * width) + x`. Reflects drawing calls (`tb_set_cell`, `tb_print`) before
+  `tb_present`. Used by the reference-oracle equivalence tests.
+  """
+  def tb_cell_buffer, do: :erlang.nif_error(:nif_not_loaded)
+
+  @doc """
   Set the terminal title.
   Returns {:ok, "set"} on success, {:error, reason} on failure.
   """

--- a/packages/raxol_terminal/test/support/termbox_model.ex
+++ b/packages/raxol_terminal/test/support/termbox_model.ex
@@ -1,0 +1,96 @@
+defmodule Raxol.Terminal.Termbox.Model do
+  @moduledoc """
+  Pure reference model of termbox2's back-buffer cell semantics.
+
+  This is the reference oracle for the NIF equivalence test: apply the same op
+  stream here and to the termbox2 NIF, then compare the resulting cell grids.
+  The model mirrors `termbox2.h` for the operations it supports:
+
+    * the initial and cleared cell is `{0x20, 0, 0}` (space, default fg, default bg)
+    * `set_cell` writes one cell when in bounds; out of bounds is a no-op
+    * `print` writes the lead cell for each printable codepoint and advances x by
+      one column, with `\\n` returning to the start column and moving down
+
+  Width note: `print` advances one column per codepoint. That is exact for ASCII
+  strings and for a single wide character (whose trailing advance does not affect
+  the grid). Multi-codepoint strings containing wide characters are out of scope;
+  cover wide characters with `set_cell` instead.
+
+  Grid format matches `:termbox2_nif.tb_cell_buffer/0`: a row-major list of
+  `{ch, fg, bg}` tuples, length `width * height`, indexed `(y * width) + x`.
+  """
+
+  @space 0x20
+  @default_fg 0
+  @default_bg 0
+  @replacement 0xFFFD
+
+  @type cell :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}
+  @type op ::
+          {:set_cell, integer(), integer(), non_neg_integer(), non_neg_integer(),
+           non_neg_integer()}
+          | {:print, integer(), integer(), non_neg_integer(), non_neg_integer(), binary()}
+          | :clear
+
+  @doc """
+  Render `ops` onto a fresh `width` x `height` grid.
+
+  Returns the row-major cell list in the same shape as
+  `:termbox2_nif.tb_cell_buffer/0`.
+  """
+  @spec render([op()], pos_integer(), pos_integer()) :: [cell()]
+  def render(ops, width, height) when width > 0 and height > 0 do
+    ops
+    |> Enum.reduce(blank(width, height), &apply_op(&1, &2, width, height))
+    |> to_list(width, height)
+  end
+
+  defp blank(width, height) do
+    for y <- 0..(height - 1), x <- 0..(width - 1), into: %{} do
+      {{x, y}, {@space, @default_fg, @default_bg}}
+    end
+  end
+
+  defp apply_op(:clear, _grid, width, height), do: blank(width, height)
+
+  defp apply_op({:set_cell, x, y, ch, fg, bg}, grid, width, height) do
+    put_cell(grid, x, y, {ch, fg, bg}, width, height)
+  end
+
+  defp apply_op({:print, x, y, fg, bg, string}, grid, width, height) do
+    print(grid, x, y, fg, bg, string, width, height)
+  end
+
+  # Mirrors tb_print_ex: an out-of-bounds start position is a no-op.
+  defp print(grid, x, y, _fg, _bg, _string, width, height)
+       when x < 0 or x >= width or y < 0 or y >= height,
+       do: grid
+
+  defp print(grid, x0, y0, fg, bg, string, width, height) do
+    string
+    |> String.to_charlist()
+    |> Enum.reduce({grid, x0, y0}, fn
+      ?\n, {grid, _x, y} ->
+        {grid, x0, y + 1}
+
+      cp, {grid, x, y} ->
+        {put_cell(grid, x, y, {printable(cp), fg, bg}, width, height), x + 1, y}
+    end)
+    |> elem(0)
+  end
+
+  # Printable ASCII passes through; anything else becomes U+FFFD, matching
+  # termbox2 for control characters. Print fixtures use printable ASCII and `\n`.
+  defp printable(cp) when cp >= 0x20 and cp <= 0x7E, do: cp
+  defp printable(_cp), do: @replacement
+
+  defp put_cell(grid, x, y, cell, width, height)
+       when x >= 0 and x < width and y >= 0 and y < height,
+       do: Map.put(grid, {x, y}, cell)
+
+  defp put_cell(grid, _x, _y, _cell, _width, _height), do: grid
+
+  defp to_list(grid, width, height) do
+    for y <- 0..(height - 1), x <- 0..(width - 1), do: Map.fetch!(grid, {x, y})
+  end
+end

--- a/packages/raxol_terminal/test/termbox2_nif/oracle_equivalence_test.exs
+++ b/packages/raxol_terminal/test/termbox2_nif/oracle_equivalence_test.exs
@@ -1,0 +1,109 @@
+if !Raxol.Terminal.TerminalUtils.real_tty?() do
+  defmodule Raxol.Terminal.OracleEquivalenceTest do
+    use ExUnit.Case
+    @moduletag :docker
+    @tag skip: "requires a real TTY (self-hosted FATE runner under a PTY)"
+    test "oracle equivalence skipped without a TTY" do
+      assert true
+    end
+  end
+else
+  defmodule Raxol.Terminal.OracleEquivalenceTest do
+    @moduledoc """
+    checkasm-style equivalence: the termbox2 NIF (the optimized path) must produce
+    the same back buffer as the pure `Raxol.Terminal.Termbox.Model` (the reference
+    oracle) for the same op stream, including explicit edges (empty, wide CJK,
+    attribute saturation, out-of-bounds writes, print clipping, newlines).
+
+    Needs a real terminal (`tb_init` opens the controlling tty), so it runs on the
+    self-hosted FATE runners under a pseudo-terminal, not on GitHub-hosted CI.
+    """
+    use ExUnit.Case
+
+    @moduletag :docker
+
+    alias Raxol.Terminal.Termbox.Model
+
+    @nif :termbox2_nif
+
+    setup do
+      assert @nif.tb_init() == 0
+      on_exit(fn -> @nif.tb_shutdown() end)
+
+      w = @nif.tb_width()
+      h = @nif.tb_height()
+      assert is_integer(w) and w > 0
+      assert is_integer(h) and h > 0
+      %{w: w, h: h}
+    end
+
+    test "NIF back buffer matches the reference oracle", %{w: w, h: h} do
+      for {name, ops} <- fixtures(w, h) do
+        actual = render_nif(ops)
+        expected = Model.render(ops, w, h)
+
+        assert length(actual) == length(expected),
+               "#{name}: NIF returned #{length(actual)} cells, model #{length(expected)} (#{w}x#{h})"
+
+        assert divergence(actual, expected) == [],
+               "#{name}: NIF diverged from reference at #{inspect(Enum.take(divergence(actual, expected), 5))}"
+      end
+    end
+
+    defp fixtures(w, h) do
+      [
+        {"empty", []},
+        {"single set_cell", [{:set_cell, 0, 0, ?A, 1, 2}]},
+        {"multiple set_cells",
+         [
+           {:set_cell, 0, 0, ?A, 1, 2},
+           {:set_cell, 1, 0, ?B, 3, 4},
+           {:set_cell, 0, 1, ?C, 5, 6}
+         ]},
+        {"overwrite same cell", [{:set_cell, 2, 2, ?X, 1, 1}, {:set_cell, 2, 2, ?Y, 2, 2}]},
+        {"wide CJK codepoints",
+         [{:set_cell, 0, 0, 0x65E5, 3, 4}, {:set_cell, 1, 0, 0x672C, 5, 6}]},
+        {"attribute saturation", [{:set_cell, 0, 0, ?Z, 0xFFFFFFFF, 0xFFFFFFFF}]},
+        {"out-of-bounds no-ops",
+         [
+           {:set_cell, -1, 0, ?A, 1, 1},
+           {:set_cell, 0, -1, ?B, 1, 1},
+           {:set_cell, w, 0, ?C, 1, 1},
+           {:set_cell, 0, h, ?D, 1, 1},
+           {:set_cell, w + 5, h + 5, ?E, 1, 1}
+         ]},
+        {"far corner boundary", [{:set_cell, w - 1, h - 1, ?Z, 4, 5}]},
+        {"print ASCII run", [{:print, 0, 0, 7, 0, "Hello"}]},
+        {"print clips at right edge", [{:print, w - 3, 0, 7, 0, "ABCDE"}]},
+        {"print newline", [{:print, 0, 0, 7, 0, "AB\nCD"}]},
+        {"print out-of-bounds start", [{:print, w, 0, 7, 0, "zz"}]},
+        {"mixed ops",
+         [
+           {:set_cell, 0, 0, ?*, 1, 1},
+           {:print, 1, 0, 2, 3, "xy"},
+           {:set_cell, 0, 1, ?#, 4, 5}
+         ]}
+      ]
+    end
+
+    defp render_nif(ops) do
+      @nif.tb_clear()
+
+      Enum.each(ops, fn
+        {:set_cell, x, y, ch, fg, bg} -> @nif.tb_set_cell(x, y, ch, fg, bg)
+        {:print, x, y, fg, bg, str} -> @nif.tb_print(x, y, fg, bg, str)
+        :clear -> @nif.tb_clear()
+      end)
+
+      @nif.tb_cell_buffer()
+    end
+
+    # Row-major indices where the NIF and the reference disagree.
+    defp divergence(actual, expected) do
+      actual
+      |> Enum.zip(expected)
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {{a, e}, i} -> if a == e, do: [], else: [{i, e, a}] end)
+    end
+  end
+end

--- a/packages/raxol_terminal/test/termbox2_nif/termbox_model_test.exs
+++ b/packages/raxol_terminal/test/termbox2_nif/termbox_model_test.exs
@@ -1,0 +1,95 @@
+defmodule Raxol.Terminal.Termbox.ModelTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  Unit tests for the pure termbox2 reference model. These run everywhere (no NIF,
+  no terminal); the model must be independently correct for the equivalence test
+  in oracle_equivalence_test.exs to mean anything.
+  """
+
+  alias Raxol.Terminal.Termbox.Model
+
+  @space 0x20
+  @blank {@space, 0, 0}
+
+  describe "baseline" do
+    test "a fresh grid is all blank cells, row-major, length w*h" do
+      assert Model.render([], 3, 2) == List.duplicate(@blank, 6)
+    end
+
+    test "clear resets every written cell" do
+      ops = [{:set_cell, 0, 0, ?X, 5, 6}, {:set_cell, 2, 1, ?Y, 7, 8}, :clear]
+      assert Model.render(ops, 3, 2) == List.duplicate(@blank, 6)
+    end
+  end
+
+  describe "set_cell" do
+    test "writes one cell in row-major position (y*w + x)" do
+      grid = Model.render([{:set_cell, 1, 0, ?A, 1, 2}], 3, 2)
+      assert Enum.at(grid, 1) == {?A, 1, 2}
+      assert Enum.at(grid, 0) == @blank
+      assert Enum.at(grid, 2) == @blank
+    end
+
+    test "last write to a coordinate wins" do
+      ops = [{:set_cell, 0, 0, ?A, 1, 1}, {:set_cell, 0, 0, ?B, 2, 2}]
+      assert Model.render(ops, 2, 1) == [{?B, 2, 2}, @blank]
+    end
+
+    test "out-of-bounds writes are no-ops (negative and beyond edges)" do
+      ops = [
+        {:set_cell, -1, 0, ?A, 1, 1},
+        {:set_cell, 0, -1, ?B, 1, 1},
+        {:set_cell, 3, 0, ?C, 1, 1},
+        {:set_cell, 0, 2, ?D, 1, 1}
+      ]
+
+      assert Model.render(ops, 3, 2) == List.duplicate(@blank, 6)
+    end
+
+    test "the far corner cell is in bounds" do
+      grid = Model.render([{:set_cell, 2, 1, ?Z, 4, 5}], 3, 2)
+      assert List.last(grid) == {?Z, 4, 5}
+    end
+
+    test "stores a wide CJK codepoint verbatim" do
+      # U+65E5 (日). set_cell stores the codepoint; display width is irrelevant.
+      grid = Model.render([{:set_cell, 0, 0, 0x65E5, 3, 4}], 2, 1)
+      assert grid == [{0x65E5, 3, 4}, @blank]
+    end
+
+    test "stores saturated 32-bit attributes" do
+      max = 0xFFFFFFFF
+      grid = Model.render([{:set_cell, 0, 0, ?Z, max, max}], 1, 1)
+      assert grid == [{?Z, max, max}]
+    end
+  end
+
+  describe "print (ASCII)" do
+    test "writes a run of cells advancing x by one" do
+      assert Model.render([{:print, 0, 0, 7, 0, "AB"}], 3, 1) ==
+               [{?A, 7, 0}, {?B, 7, 0}, @blank]
+    end
+
+    test "clips characters past the right edge" do
+      # width 3, start x=1: X at 1, Y at 2, Z at 3 (dropped).
+      assert Model.render([{:print, 1, 0, 7, 0, "XYZ"}], 3, 1) ==
+               [@blank, {?X, 7, 0}, {?Y, 7, 0}]
+    end
+
+    test "newline returns to the start column and moves down" do
+      grid = Model.render([{:print, 0, 0, 7, 0, "A\nB"}], 2, 2)
+      # (0,0)=A, (0,1)=B, others blank.
+      assert grid == [{?A, 7, 0}, @blank, {?B, 7, 0}, @blank]
+    end
+
+    test "an out-of-bounds start is a no-op" do
+      assert Model.render([{:print, 5, 5, 7, 0, "hi"}], 3, 2) ==
+               List.duplicate(@blank, 6)
+    end
+
+    test "an empty string writes nothing" do
+      assert Model.render([{:print, 0, 0, 7, 0, ""}], 2, 1) == [@blank, @blank]
+    end
+  end
+end


### PR DESCRIPTION
## What

The oracle half of Layer 2 (the checkasm analogue): the termbox2 NIF (the optimized path) must produce the same back buffer as a pure reference for the same op stream. Builds on the golden half already shipped in #441.

## Why a readback NIF

The NIF renders to a real terminal and exposed no way to read cells back, so its rendered content was verified against nothing. `termbox2.h` has `tb_cell_buffer()`; this adds a thin `tb_cell_buffer/0` NIF that returns the back buffer as a row-major list of `{ch, fg, bg}`, making the rendered grid observable from Elixir.

## Changes

- `packages/raxol_terminal/lib/termbox2_nif/c_src/termbox2_nif.c`: `nif_tb_cell_buffer` (+ registration). Compiles clean locally (`-std=c99 -Wall -Wextra`).
- `.../lib/termbox2_nif/lib/termbox2_nif.ex`: `tb_cell_buffer/0` stub.
- `.../test/support/termbox_model.ex`: `Raxol.Terminal.Termbox.Model`, a pure reference model of termbox2 cell semantics (cleared cell `{0x20, 0, 0}`, in-bounds `set_cell`, `print` lead-cell writes + advance). Semantics taken directly from `termbox2.h`.
- `.../test/termbox2_nif/termbox_model_test.exs`: unit tests for the model (no NIF, no terminal) so the oracle is independently correct.
- `.../test/termbox2_nif/oracle_equivalence_test.exs`: applies each fixture op stream to the NIF and the model, asserts identical grids. Explicit edges: empty, wide CJK, attribute saturation, out-of-bounds writes, print clipping, newlines. Tty-gated via `real_tty?/0` (self-skips off-runner).
- `.github/workflows/fate-selfhosted.yml`: runs the model + oracle tests in the NIF step.
- `docs/testing/FATE_BENCH.md`: documents the oracle layer.

## Soundness

The reference is independently correct, not a second production path: print fixtures use printable ASCII (advance is one column per cell) and wide characters are covered through `set_cell` storage, so the model never replicates `tb_wcwidth`. A failure names the fixture and the first diverging cell indices.

## Verification status

- **Verified locally:** the C compiles (built the `.so` via the Makefile, no warnings); `termbox_model_test.exs` passes (13 tests); `oracle_equivalence_test.exs` compiles and self-skips without a tty.
- **Homelab/CI-gated:** the NIF-vs-model equivalence needs `tb_init` + a real terminal, so it runs on the self-hosted FATE runners under the pseudo-terminal. Not runnable in the authoring sandbox.

## Manual testing

- [x] `cd packages/raxol_terminal && MIX_ENV=test mix test test/termbox2_nif/termbox_model_test.exs` -> 13 passed
- [x] NIF builds: `make` in `lib/termbox2_nif/c_src` -> `termbox2_nif.so`, no warnings
- [x] `oracle_equivalence_test.exs` compiles + skips without a tty
- [ ] `fate-selfhosted` green on ARM64/X64: oracle equivalence passes on real hardware
