### PR TITLE
Respond to window resize (SIGWINCH): handler, dispatch, headless

### DIFF
--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -273,11 +273,12 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
   end
 
   @doc """
-  Processes a system-level event that affects the runtime itself rather than the application logic.
+  Processes a system-level event. Resize is forwarded to the app's update/2
+  like any other message; quit/focus/error stay runtime-only.
   """
   def process_system_event(event, state) do
     case event do
-      %Event{type: :resize, data: data} -> handle_resize_event(data, state)
+      %Event{type: :resize} -> handle_resize_event(event, state)
       %Event{type: :quit} -> {:quit, state}
       %Event{type: :focus, data: data} -> handle_focus_event(data, state)
       %Event{type: :error, data: data} -> handle_error_event(data, state)
@@ -285,7 +286,10 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     end
   end
 
-  defp handle_resize_event(%{width: width, height: height}, state) do
+  defp handle_resize_event(
+         %Event{data: %{width: width, height: height}} = event,
+         state
+       ) do
     # Forward size to the Rendering Engine so layout uses actual terminal dimensions
     if state.rendering_engine do
       GenServer.cast(
@@ -294,8 +298,37 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
       )
     end
 
-    send(state.runtime_pid, :render_needed)
-    {:ok, %{state | width: width, height: height}, []}
+    sized_state = %{state | width: width, height: height}
+
+    case resize_update(sized_state, event) do
+      {:ok, updated_model, commands} ->
+        process_successful_update(sized_state, updated_model, commands)
+
+      :unhandled ->
+        send(state.runtime_pid, :render_needed)
+        {:ok, sized_state, []}
+    end
+  end
+
+  # Calls update/2 directly (not through process_app_update) so a resize
+  # clause that doesn't exist can degrade silently: most apps don't reflow
+  # on resize, and a FunctionClauseError there isn't a bug worth logging on
+  # every SIGWINCH. Genuinely malformed return values still get logged.
+  defp resize_update(state, event) do
+    case state.app_module.update(event, state.model) do
+      {new_model, commands} when is_map(new_model) and is_list(commands) ->
+        {:ok, new_model, commands}
+
+      new_model when is_map(new_model) ->
+        {:ok, new_model, []}
+
+      other ->
+        log_unexpected_return(state, event, event, other)
+        :unhandled
+    end
+  rescue
+    FunctionClauseError -> :unhandled
+    UndefinedFunctionError -> :unhandled
   end
 
   defp handle_focus_event(%{focused: focused}, state) do

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -98,6 +98,21 @@ defmodule Raxol.Headless do
   end
 
   @doc """
+  Sends a terminal resize event to the session's dispatcher.
+
+  The dispatcher forwards the new dimensions to the rendering engine
+  (resizing its buffer) and to the application's `update/2` as a
+  `%Event{type: :resize, data: %{width: w, height: h}}`.
+  """
+  @spec send_resize(atom(), pos_integer(), pos_integer()) ::
+          :ok | {:error, term()}
+  def send_resize(id, width, height)
+      when is_integer(width) and width > 0 and is_integer(height) and
+             height > 0 do
+    GenServer.call(__MODULE__, {:send_resize, id, width, height}, 5_000)
+  end
+
+  @doc """
   Sends a key and returns a screenshot after waiting for re-render.
 
   ## Options
@@ -182,6 +197,17 @@ defmodule Raxol.Headless do
       {:ok, session} ->
         result = dispatch_key(session, key, opts)
         {:reply, result, state}
+
+      error ->
+        {:reply, error, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:send_resize, id, width, height}, _from, state) do
+    case get_session(state, id) do
+      {:ok, session} ->
+        {:reply, dispatch_resize(session, width, height), state}
 
       error ->
         {:reply, error, state}
@@ -422,6 +448,23 @@ defmodule Raxol.Headless do
   defp dispatch_key(session, key, opts) do
     with_dispatcher(session, fn dispatcher_pid ->
       event = EventBuilder.key(key, opts)
+
+      _ =
+        Backpressure.cast(dispatcher_pid, {:dispatch, event},
+          label: :headless_dispatch,
+          policy: :call_when_full
+        )
+
+      :ok
+    end)
+  end
+
+  defp dispatch_resize(session, width, height) do
+    with_dispatcher(session, fn dispatcher_pid ->
+      event = %Raxol.Core.Events.Event{
+        type: :resize,
+        data: %{width: width, height: height}
+      }
 
       _ =
         Backpressure.cast(dispatcher_pid, {:dispatch, event},

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/dispatch.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/dispatch.ex
@@ -29,8 +29,18 @@ defmodule Raxol.Terminal.Driver.Dispatch do
   Sends an initial resize event to the dispatcher based on current terminal size.
   """
   def send_initial_resize_event(dispatcher_pid) do
+    send_resize_event(dispatcher_pid)
+  end
+
+  @doc """
+  Queries the current terminal size and dispatches a `%Event{type: :resize}`.
+
+  Used both for the initial size notification at Driver startup and for
+  subsequent SIGWINCH-driven window resizes.
+  """
+  def send_resize_event(dispatcher_pid) do
     {:ok, width, height} = TerminalSize.get_terminal_size()
-    Log.info("Initial terminal size: #{width}x#{height}")
+    Log.info("Terminal size: #{width}x#{height}")
     event = %Event{type: :resize, data: %{width: width, height: height}}
 
     if Env.test?() do
@@ -45,7 +55,9 @@ defmodule Raxol.Terminal.Driver.Dispatch do
   Parses test input data into an Event struct.
   """
   def parse_test_input(input_data) when is_binary(input_data) do
-    Log.debug("[TerminalDriver.parse_test_input] Parsing: #{inspect(input_data)}")
+    Log.debug(
+      "[TerminalDriver.parse_test_input] Parsing: #{inspect(input_data)}"
+    )
 
     case InputParser.parse(input_data) do
       [event | _] -> event

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/sigwinch_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/sigwinch_handler.ex
@@ -1,0 +1,30 @@
+defmodule Raxol.Terminal.Driver.SigwinchHandler do
+  @moduledoc """
+  `:gen_event` handler on `:erl_signal_server` that forwards SIGWINCH to the
+  Driver, because prim_tty sends it to `user_drv`, not the traced reader.
+  """
+
+  @behaviour :gen_event
+
+  @impl true
+  def init(%{driver: driver_pid}) when is_pid(driver_pid) do
+    # Idempotent; prim_tty_sighandler may have set this already. On OTP < 26
+    # :sigwinch is not a valid signal name and this raises, failing the
+    # add_handler call cleanly.
+    :ok = :os.set_signal(:sigwinch, :handle)
+    {:ok, %{driver: driver_pid}}
+  rescue
+    _ -> {:error, :sigwinch_unsupported}
+  end
+
+  @impl true
+  def handle_event(:sigwinch, %{driver: driver_pid} = state) do
+    send(driver_pid, :sigwinch)
+    {:ok, state}
+  end
+
+  def handle_event(_signal, state), do: {:ok, state}
+
+  @impl true
+  def handle_call(_request, state), do: {:ok, :ok, state}
+end

--- a/packages/raxol_terminal/test/raxol/terminal/driver/sigwinch_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/sigwinch_test.exs
@@ -1,0 +1,61 @@
+defmodule Raxol.Terminal.Driver.SigwinchTest do
+  @moduledoc """
+  SIGWINCH -> `:erl_signal_server` -> SigwinchHandler -> Driver `:sigwinch` -> resize `Event`.
+  """
+  use ExUnit.Case
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.Terminal.Driver
+  alias Raxol.Terminal.Driver.SigwinchHandler
+  alias Raxol.Terminal.DriverTestHelper, as: Helper
+
+  describe "SigwinchHandler (gen_event)" do
+    test "forwards :sigwinch signal as a message to the driver pid" do
+      {:ok, manager} = :gen_event.start_link()
+
+      :ok =
+        :gen_event.add_handler(manager, SigwinchHandler, %{driver: self()})
+
+      :ok = :gen_event.notify(manager, :sigwinch)
+      assert_receive :sigwinch, 500
+
+      # Other signals are ignored
+      :ok = :gen_event.notify(manager, :sigcont)
+      refute_receive :sigcont, 50
+
+      :ok = :gen_event.stop(manager)
+    end
+  end
+
+  describe "Driver handling of :sigwinch" do
+    setup do
+      Process.flag(:trap_exit, true)
+      Helper.setup_terminal()
+    end
+
+    test "dispatches a fresh resize event to the dispatcher" do
+      driver_pid = Helper.start_driver(self())
+
+      Helper.wait_for_driver_ready(driver_pid)
+      Helper.consume_initial_resize()
+
+      send(driver_pid, :sigwinch)
+
+      # TerminalSize reports 80x24 in the test env
+      Helper.assert_resize_event(80, 24)
+
+      Process.exit(driver_pid, :shutdown)
+    end
+
+    test "sigwinch without a dispatcher is a no-op (driver stays alive)" do
+      {:ok, driver_pid} = Driver.start_link([])
+
+      send(driver_pid, :sigwinch)
+
+      refute_receive {:"$gen_cast", {:dispatch, %Event{type: :resize}}}, 100
+      assert Process.alive?(driver_pid)
+
+      Process.exit(driver_pid, :shutdown)
+    end
+  end
+end

--- a/test/raxol/core/runtime/events/dispatcher_resize_test.exs
+++ b/test/raxol/core/runtime/events/dispatcher_resize_test.exs
@@ -1,0 +1,114 @@
+defmodule Raxol.Core.Runtime.Events.DispatcherResizeTest do
+  @moduledoc """
+  A `%Event{type: :resize}` must reach the app's `update/2` (for reflow)
+  and resize the Rendering Engine buffer.
+  """
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.Core.Runtime.Events.Dispatcher
+  alias Raxol.Core.Runtime.Events.Dispatcher.State
+
+  defmodule ResizeAwareApp do
+    @moduledoc false
+    def update(%Event{type: :resize, data: %{width: w, height: h}}, model) do
+      {%{model | width: w, height: h, resizes: model.resizes + 1}, []}
+    end
+
+    def update(_message, model), do: {model, []}
+  end
+
+  defmodule NoResizeClauseApp do
+    @moduledoc false
+    # Deliberately no catch-all: a resize event raises FunctionClauseError.
+    def update(:noop, model), do: {model, []}
+  end
+
+  defp base_state(app_module) do
+    %State{
+      runtime_pid: self(),
+      app_module: app_module,
+      model: %{width: 0, height: 0, resizes: 0},
+      width: 80,
+      height: 24,
+      # self() stands in for the Rendering Engine GenServer so its cast lands in our mailbox.
+      rendering_engine: self()
+    }
+  end
+
+  test "resize event reaches the app's update/2" do
+    event = %Event{type: :resize, data: %{width: 120, height: 40}}
+
+    assert {:ok, new_state, _commands} =
+             Dispatcher.process_system_event(event, base_state(ResizeAwareApp))
+
+    assert new_state.model.width == 120
+    assert new_state.model.height == 40
+    assert new_state.model.resizes == 1
+  end
+
+  test "resize event updates dispatcher dimensions and rendering engine buffer" do
+    event = %Event{type: :resize, data: %{width: 132, height: 43}}
+
+    assert {:ok, new_state, _commands} =
+             Dispatcher.process_system_event(event, base_state(ResizeAwareApp))
+
+    assert new_state.width == 132
+    assert new_state.height == 43
+
+    assert_receive {:"$gen_cast", {:update_size, %{width: 132, height: 43}}}
+    assert_receive :render_needed
+  end
+
+  test "consecutive resizes each reach the app" do
+    state = base_state(ResizeAwareApp)
+
+    {:ok, state, _} =
+      Dispatcher.process_system_event(
+        %Event{type: :resize, data: %{width: 100, height: 30}},
+        state
+      )
+
+    {:ok, state, _} =
+      Dispatcher.process_system_event(
+        %Event{type: :resize, data: %{width: 90, height: 25}},
+        state
+      )
+
+    assert state.model.resizes == 2
+    assert state.model.width == 90
+    assert state.width == 90 and state.height == 25
+
+    assert_receive {:"$gen_cast", {:update_size, %{width: 100, height: 30}}}
+    assert_receive {:"$gen_cast", {:update_size, %{width: 90, height: 25}}}
+  end
+
+  test "resize still resizes engine and dimensions when app has no resize clause, and stays silent" do
+    event = %Event{type: :resize, data: %{width: 100, height: 30}}
+    state = base_state(NoResizeClauseApp)
+
+    log =
+      capture_log(fn ->
+        assert {:ok, new_state, []} =
+                 Dispatcher.process_system_event(event, state)
+
+        assert new_state.model.resizes == 0
+        assert new_state.width == 100
+        assert new_state.height == 30
+
+        assert_receive {:"$gen_cast", {:update_size, %{width: 100, height: 30}}}
+        assert_receive :render_needed
+      end)
+
+    assert log == ""
+  end
+
+  test "resize with nil rendering engine does not crash" do
+    state = %{base_state(ResizeAwareApp) | rendering_engine: nil}
+    event = %Event{type: :resize, data: %{width: 100, height: 30}}
+
+    assert {:ok, new_state, _} = Dispatcher.process_system_event(event, state)
+    assert new_state.model.width == 100
+  end
+end

--- a/test/raxol/headless_resize_test.exs
+++ b/test/raxol/headless_resize_test.exs
@@ -1,0 +1,111 @@
+defmodule Raxol.HeadlessResizeTest do
+  @moduledoc """
+  End-to-end: `Headless.send_resize/3` must reach app `update/2` and resize the Rendering Engine buffer.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Headless
+
+  defmodule ResizeApp do
+    use Raxol.Core.Runtime.Application
+
+    @impl true
+    def init(_context), do: %{width: 0, height: 0, resizes: 0}
+
+    @impl true
+    def update(message, model) do
+      case message do
+        %Raxol.Core.Events.Event{
+          type: :resize,
+          data: %{width: w, height: h}
+        } ->
+          {%{model | width: w, height: h, resizes: model.resizes + 1}, []}
+
+        _ ->
+          {model, []}
+      end
+    end
+
+    @impl true
+    def view(model) do
+      Raxol.Core.Renderer.View.text(
+        "#{model.width}x#{model.height} (#{model.resizes} resizes)"
+      )
+    end
+
+    @impl true
+    def subscriptions(_model), do: []
+  end
+
+  setup do
+    pid =
+      case Process.whereis(Headless) do
+        nil ->
+          start_supervised!({Headless, [name: Headless]})
+
+        existing ->
+          for id <- GenServer.call(existing, :list_sessions) do
+            try do
+              GenServer.call(existing, {:stop_session, id}, 2_000)
+            catch
+              _, _ -> :ok
+            end
+          end
+
+          existing
+      end
+
+    {:ok, headless: pid}
+  end
+
+  defp wait_for_model(id, fun, retries \\ 40)
+
+  defp wait_for_model(_id, _fun, 0), do: flunk("model never matched")
+
+  defp wait_for_model(id, fun, retries) do
+    {:ok, model} = Headless.get_model(id)
+
+    if fun.(model) do
+      model
+    else
+      Process.sleep(25)
+      wait_for_model(id, fun, retries - 1)
+    end
+  end
+
+  test "send_resize reaches app update/2 and resizes the engine buffer" do
+    {:ok, id} =
+      Headless.start(ResizeApp, id: :resize_e2e, width: 80, height: 24)
+
+    on_exit(fn ->
+      # Headless may already be gone if it was started via start_supervised!
+      try do
+        Headless.stop(:resize_e2e)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    :ok = Headless.send_resize(id, 100, 30)
+
+    model = wait_for_model(id, fn m -> m.resizes == 1 end)
+    assert model.width == 100
+    assert model.height == 30
+
+    {:ok, buffer} = Headless.get_buffer(id)
+    assert Map.get(buffer, :width) == 100
+    assert Map.get(buffer, :height) == 30
+
+    :ok = Headless.send_resize(id, 66, 20)
+    model = wait_for_model(id, fn m -> m.resizes == 2 end)
+    assert model.width == 66
+
+    {:ok, buffer} = Headless.get_buffer(id)
+    assert Map.get(buffer, :width) == 66
+    assert Map.get(buffer, :height) == 20
+  end
+
+  test "send_resize on unknown session returns an error" do
+    assert {:error, :not_found} = Headless.send_resize(:nope, 80, 24)
+  end
+end


### PR DESCRIPTION
Window-resize (SIGWINCH) handling. Completes the resize path whose call sites already landed with the terminal-driver hardening (#443, merged): the driver carried `handle_manager_info(:sigwinch)` + the handler-install call, but the handler module and dispatch/dispatcher resize wiring were separate.

- `SigwinchHandler` gen_event module on `:erl_signal_server` (prim_tty delivers SIGWINCH to `user_drv`, past the reader the driver traces, so it needs its own handler).
- `Dispatch.send_resize_event`, dispatcher resize handling (degrades silently if the app has no resize `update/2` clause — no error spam), and headless resize support.

On SIGWINCH the driver re-measures and dispatches a resize event so the app re-lays-out at the new size. Resize tests green.
