### PR TITLE
H-K salience colour solver + semantic theme + truecolor SGR

### DIFF
--- a/lib/raxol/ui/theming/salience.ex
+++ b/lib/raxol/ui/theming/salience.ex
@@ -1,0 +1,272 @@
+defmodule Raxol.UI.Theming.Salience do
+  @moduledoc """
+  Salience-tier color solver: OKLCH colors leveled through a two-lobe
+  Helmholtz-Kohlrausch apparent-lightness model.
+
+  Instead of hand-picking lightness per color, a palette is expressed as
+  `(hue, chroma, tier)` seeds. Each tier is an apparent-lightness *contrast
+  delta* away from the ground (background) lightness; the solver compensates
+  for the H-K effect (chromatic colors — especially blues — read darker than
+  their nominal OKLCH `L` suggests) so every color on one tier appears equally
+  bright to the eye.
+
+  The two-lobe formulation:
+
+      apparent_L = L - 0.14 * C * hue_factor(h)
+
+  Tiers generalize to any ground: on dark grounds tiers solve *up* (lighter
+  than ground), on light grounds *down*, chosen automatically by headroom.
+  Deltas compress proportionally when the ground leaves too little headroom
+  (mid-gray grounds), preserving tier ordering.
+
+  Ground lightness is a runtime input — pair with an OSC 11 background query
+  to solve the palette against the terminal's actual background.
+  """
+
+  @hk_k 0.14
+
+  # Apparent-lightness contrast deltas per tier. At the reference ground
+  # (L = 0.2) these produce apparent-lightness targets of recede 0.55,
+  # alarm 0.53, differentiate 0.62, baseline 0.77, anchor 0.85 -- i.e.
+  # ground + delta, not the deltas themselves.
+  @tier_deltas %{
+    alarm: 0.33,
+    recede: 0.35,
+    differentiate: 0.42,
+    baseline: 0.57,
+    anchor: 0.65
+  }
+
+  @reference_ground 0.2
+  # Displayable apparent-lightness bounds used for headroom compression.
+  @al_min 0.03
+  @al_max 0.97
+  @max_delta 0.65
+
+  @type tier :: :alarm | :recede | :differentiate | :baseline | :anchor
+  @type polarity :: :auto | :up | :down
+
+  @doc "Tier names ordered by increasing contrast from ground."
+  @spec tiers() :: [tier()]
+  def tiers, do: [:alarm, :recede, :differentiate, :baseline, :anchor]
+
+  @doc """
+  The reference near-black ground OKLCH lightness the tier deltas were
+  derived against (`#{@reference_ground}`). Exposed so callers that need
+  a fallback ground (e.g. no OSC 11 detection) don't duplicate the number.
+  """
+  @spec reference_ground() :: float()
+  def reference_ground, do: @reference_ground
+
+  @doc "Apparent-lightness contrast delta for a tier."
+  @spec tier_delta(tier()) :: float()
+  def tier_delta(tier), do: Map.fetch!(@tier_deltas, tier)
+
+  @doc """
+  Two-lobe H-K hue factor: warm cosine fundamental plus a Gaussian bump
+  around blue (h = 255), clamped to [0.3, 1.2].
+  """
+  @spec hue_factor(number()) :: float()
+  def hue_factor(h) do
+    hn = h / 360
+    warm = :math.cos((hn * 3 - 1) * 2 * :math.pi()) * 0.45 + 0.75
+    blue = 0.25 * :math.exp(-:math.pow(abs(h - 255) / 35, 2))
+    min(1.2, max(0.3, warm + blue))
+  end
+
+  @doc "Apparent lightness of an OKLCH color under the two-lobe H-K model."
+  @spec apparent_lightness(number(), number(), number()) :: float()
+  def apparent_lightness(l, c, h), do: l - @hk_k * c * hue_factor(h)
+
+  @doc """
+  Nominal OKLCH `L` that lands a `(C, h)` color on a target apparent
+  lightness.
+  """
+  @spec solve_lightness(number(), number(), number()) :: float()
+  def solve_lightness(target_al, c, h),
+    do: target_al + @hk_k * c * hue_factor(h)
+
+  @doc """
+  Solves a `(C, h)` seed on a salience tier against a ground lightness and
+  returns a hex color.
+
+  ## Options
+
+    * `:ground` - ground (background) OKLCH lightness. Default `#{@reference_ground}`
+      (the reference near-black ground the tier deltas were derived against).
+    * `:polarity` - `:up` (tiers lighter than ground), `:down` (darker), or
+      `:auto` (default): whichever side of the ground has more headroom.
+
+  ## Examples
+
+      iex> Raxol.UI.Theming.Salience.solve(:differentiate, 0.13, 57)
+      "#c1712c"
+
+      iex> Raxol.UI.Theming.Salience.solve(:baseline, 0.0, 250)
+      "#b4b4b4"
+  """
+  @spec solve(tier(), number(), number(), keyword()) :: String.t()
+  def solve(tier, c, h, opts \\ []) do
+    ground = Keyword.get(opts, :ground, @reference_ground)
+    polarity = Keyword.get(opts, :polarity, :auto)
+
+    target = tier_target(tier, ground, polarity)
+    l = solve_lightness(target, c, h)
+    oklch_to_hex(l, c, h)
+  end
+
+  @doc """
+  Target apparent lightness for a tier against a ground, with headroom
+  compression: when the ground leaves less than the full delta range on the
+  chosen side, all deltas scale down proportionally (ordering preserved).
+  """
+  @spec tier_target(tier(), number(), polarity()) :: float()
+  def tier_target(tier, ground, polarity \\ :auto) do
+    sign = resolve_polarity(ground, polarity)
+
+    headroom =
+      case sign do
+        1 -> @al_max - ground
+        -1 -> ground - @al_min
+      end
+
+    scale = min(1.0, max(0.0, headroom) / @max_delta)
+    ground + sign * tier_delta(tier) * scale
+  end
+
+  defp resolve_polarity(_ground, :up), do: 1
+  defp resolve_polarity(_ground, :down), do: -1
+  defp resolve_polarity(ground, :auto), do: if(ground < 0.5, do: 1, else: -1)
+
+  @doc """
+  Solves a seed list into a palette map.
+
+  Seeds are maps with `:name`, `:h`, `:c`, `:tier` (extra keys are ignored).
+  Returns `%{name => hex}`.
+  """
+  @spec solve_palette([map()], keyword()) :: %{atom() => String.t()}
+  def solve_palette(seeds, opts \\ []) do
+    Map.new(seeds, fn %{name: name, h: h, c: c, tier: tier} ->
+      {name, solve(tier, c, h, opts)}
+    end)
+  end
+
+  # ---- OKLCH <-> sRGB ----
+
+  @doc """
+  Converts OKLCH to a gamut-mapped sRGB `{r, g, b}` tuple (0-255 per
+  channel), clamping `L` into displayable range and shrinking chroma until
+  the color fits the sRGB gamut.
+  """
+  @spec oklch_to_rgb(number(), number(), number()) ::
+          {0..255, 0..255, 0..255}
+  def oklch_to_rgb(l, c, h_deg) do
+    h = h_deg * :math.pi() / 180
+    l = min(0.999, max(0.001, l))
+    c = shrink_chroma(l, c, h)
+
+    {r, g, b} = oklab_to_linear(l, c * :math.cos(h), c * :math.sin(h))
+
+    [r, g, b]
+    |> Enum.map(fn x -> round(min(1.0, max(0.0, linear_to_srgb(x))) * 255) end)
+    |> List.to_tuple()
+  end
+
+  @doc """
+  Converts OKLCH to a sRGB hex string, clamping `L` into displayable range
+  and shrinking chroma until the color fits the sRGB gamut.
+  """
+  @spec oklch_to_hex(number(), number(), number()) :: String.t()
+  def oklch_to_hex(l, c, h_deg) do
+    {r, g, b} = oklch_to_rgb(l, c, h_deg)
+
+    [r, g, b]
+    |> Enum.map_join(fn x ->
+      x
+      |> Integer.to_string(16)
+      |> String.downcase()
+      |> String.pad_leading(2, "0")
+    end)
+    |> then(&("#" <> &1))
+  end
+
+  @doc """
+  Converts a `#rrggbb` hex string (or any struct/map with integer `r`, `g`,
+  `b` components, e.g. `Raxol.Style.Colors.Color`) to `{l, c, h}` OKLCH.
+  """
+  @spec hex_to_oklch(String.t() | %{r: 0..255, g: 0..255, b: 0..255}) ::
+          {float(), float(), float()}
+  def hex_to_oklch(%{r: r, g: g, b: b})
+      when is_integer(r) and is_integer(g) and is_integer(b) do
+    rgb_to_oklch(r / 255, g / 255, b / 255)
+  end
+
+  def hex_to_oklch("#" <> hex), do: hex_to_oklch(hex)
+
+  def hex_to_oklch(<<r::binary-2, g::binary-2, b::binary-2>>) do
+    [r, g, b] = Enum.map([r, g, b], &(String.to_integer(&1, 16) / 255))
+    rgb_to_oklch(r, g, b)
+  end
+
+  @doc """
+  Converts sRGB components in `0.0..1.0` to `{l, c, h}` OKLCH
+  (`h` in degrees, `0.0 <= h < 360.0`).
+  """
+  @spec rgb_to_oklch(number(), number(), number()) ::
+          {float(), float(), float()}
+  def rgb_to_oklch(r, g, b) do
+    [r, g, b] = Enum.map([r, g, b], &srgb_to_linear/1)
+
+    l_ = cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+    m_ = cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+    s_ = cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+
+    l = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_
+    a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_
+    b = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_
+
+    c = :math.sqrt(a * a + b * b)
+    h = :math.atan2(b, a) * 180 / :math.pi()
+    h = if h < 0, do: h + 360, else: h
+    {l, c, h}
+  end
+
+  defp shrink_chroma(l, c, h) when c > 0 do
+    rgb = oklab_to_linear(l, c * :math.cos(h), c * :math.sin(h))
+
+    if in_gamut?(rgb), do: c, else: shrink_chroma(l, c - 0.002, h)
+  end
+
+  defp shrink_chroma(_l, c, _h), do: max(c, 0.0)
+
+  defp in_gamut?({r, g, b}) do
+    Enum.all?([r, g, b], fn x -> x >= -1.0e-4 and x <= 1 + 1.0e-4 end)
+  end
+
+  defp oklab_to_linear(l, a, b) do
+    l_ = cube(l + 0.3963377774 * a + 0.2158037573 * b)
+    m_ = cube(l - 0.1055613458 * a - 0.0638541728 * b)
+    s_ = cube(l - 0.0894841775 * a - 1.291485548 * b)
+
+    {
+      4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_,
+      -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_,
+      -0.0041960863 * l_ - 0.7034186147 * m_ + 1.707614701 * s_
+    }
+  end
+
+  defp linear_to_srgb(c) do
+    if c <= 0.0031308,
+      do: 12.92 * c,
+      else: 1.055 * :math.pow(c, 1 / 2.4) - 0.055
+  end
+
+  defp srgb_to_linear(c) do
+    if c <= 0.04045, do: c / 12.92, else: :math.pow((c + 0.055) / 1.055, 2.4)
+  end
+
+  defp cube(x), do: x * x * x
+
+  defp cbrt(x) when x < 0, do: -:math.pow(-x, 1 / 3)
+  defp cbrt(x), do: :math.pow(x, 1 / 3)
+end

--- a/lib/raxol/ui/theming/salience_theme.ex
+++ b/lib/raxol/ui/theming/salience_theme.ex
@@ -1,0 +1,117 @@
+defmodule Raxol.UI.Theming.SalienceTheme do
+  @moduledoc """
+  Builds a `Raxol.UI.Theming.Theme` from salience-tier seeds solved against
+  the terminal's actual background.
+
+  Colors are expressed as `(hue, chroma, tier)` seeds — hue carries identity,
+  tier carries importance — and `Raxol.UI.Theming.Salience` solves the
+  lightness of every color so each tier reads perceptually level on the
+  detected ground. Works on dark and light terminals from one seed table.
+
+  Ground detection is optional: when `Raxol.Terminal.Driver.BackgroundQuery`
+  is loaded and has a reply, its OSC 11 background reading is used; otherwise
+  (including on this branch, which does not depend on that module) it falls
+  back to `Salience.reference_ground/0`.
+  """
+
+  alias Raxol.UI.Theming.Salience
+  alias Raxol.UI.Theming.Theme
+
+  @compile {:no_warn_undefined, Raxol.Terminal.Driver.BackgroundQuery}
+
+  # Semantic seed table. Hues follow the compensated-Darcula family:
+  # orange 57 (warning), yellow 77 (emphasis), green 134 (success),
+  # blue 242 (accent), neutral-blue 250 (text), red 25 (error).
+  @seeds [
+    %{name: :foreground, h: 250, c: 0.022, tier: :baseline},
+    %{name: :accent, h: 242, c: 0.074, tier: :differentiate},
+    %{name: :error, h: 25, c: 0.16, tier: :alarm},
+    %{name: :warning, h: 57, c: 0.13, tier: :differentiate},
+    %{name: :success, h: 134, c: 0.075, tier: :differentiate},
+    %{name: :emphasis, h: 77, c: 0.125, tier: :anchor},
+    %{name: :muted, h: 250, c: 0.0, tier: :recede},
+    %{name: :border, h: 250, c: 0.0, tier: :recede}
+  ]
+
+  @doc "The default semantic seed table."
+  @spec seeds() :: [map()]
+  def seeds, do: @seeds
+
+  @doc """
+  Detected ground lightness: OKLCH `L` of the OSC 11-reported terminal
+  background, or `Salience.reference_ground/0` when detection is
+  unavailable.
+  """
+  @spec detect_ground() :: float()
+  def detect_ground do
+    with true <- Code.ensure_loaded?(Raxol.Terminal.Driver.BackgroundQuery),
+         {:ok, {r, g, b}} <-
+           Raxol.Terminal.Driver.BackgroundQuery.detected_background() do
+      {l, _c, _h} = Salience.rgb_to_oklch(r / 255, g / 255, b / 255)
+      l
+    else
+      _ -> Salience.reference_ground()
+    end
+  end
+
+  @doc """
+  Builds a Theme with every color solved against the ground.
+
+  ## Options
+
+    * `:ground` - ground lightness override (default: `detect_ground/0`)
+    * `:seeds` - seed table override (default: `seeds/0`)
+    * `:id` / `:name` - theme identity (default `:salience`)
+  """
+  @spec build(keyword()) :: Theme.t()
+  def build(opts \\ []) do
+    ground = Keyword.get_lazy(opts, :ground, &detect_ground/0)
+    seeds = Keyword.get(opts, :seeds, @seeds)
+    palette = Salience.solve_palette(seeds, ground: ground)
+
+    background = Salience.oklch_to_hex(ground, 0.0, 0.0)
+
+    Theme.new(%{
+      id: Keyword.get(opts, :id, :salience),
+      name: Keyword.get(opts, :name, "salience"),
+      colors: %{
+        background: background,
+        foreground: palette.foreground,
+        accent: palette.accent,
+        error: palette.error,
+        warning: palette.warning,
+        success: palette.success,
+        emphasis: palette.emphasis,
+        muted: palette.muted
+      },
+      component_styles: %{
+        text_input: %{
+          background: background,
+          foreground: palette.foreground,
+          border: palette.border,
+          focus: palette.accent
+        },
+        button: %{
+          background: palette.accent,
+          foreground: background,
+          hover: palette.emphasis,
+          active: palette.accent
+        },
+        checkbox: %{
+          background: background,
+          foreground: palette.foreground,
+          border: palette.border,
+          checked: palette.accent
+        },
+        table: %{
+          border: :single,
+          header_foreground: palette.emphasis,
+          row_foreground: palette.foreground,
+          selected_row_foreground: palette.accent
+        },
+        focus: %{border: :single, border_fg: palette.accent},
+        disabled: %{fg: palette.muted}
+      }
+    })
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
@@ -72,7 +72,6 @@ defmodule Raxol.Terminal.Renderer do
     style_cache: %{}
   ]
 
-
   # ANSI escape code constants
   @ansi_reset "\e[0m"
   @ansi_bold "\e[1m"
@@ -300,6 +299,13 @@ defmodule Raxol.Terminal.Renderer do
     "\e[38;2;#{r};#{g};#{b}m"
   end
 
+  # Plain {r, g, b} tuples (UI-stack/CellDim RGB shape -- distinct from the
+  # %{r:, g:, b:} map clause above) must also resolve to truecolor SGR.
+  defp resolve_fg_ansi({r, g, b}, _theme)
+       when is_integer(r) and is_integer(g) and is_integer(b) do
+    "\e[38;2;#{r};#{g};#{b}m"
+  end
+
   defp resolve_fg_ansi(color, _theme)
        when is_integer(color) and color >= 0 and color <= 255 do
     "\e[38;5;#{color}m"
@@ -328,6 +334,12 @@ defmodule Raxol.Terminal.Renderer do
   end
 
   defp resolve_bg_ansi(%{r: r, g: g, b: b}, _theme) do
+    "\e[48;2;#{r};#{g};#{b}m"
+  end
+
+  # Same as resolve_fg_ansi/2 for {r, g, b} tuples.
+  defp resolve_bg_ansi({r, g, b}, _theme)
+       when is_integer(r) and is_integer(g) and is_integer(b) do
     "\e[48;2;#{r};#{g};#{b}m"
   end
 
@@ -380,7 +392,9 @@ defmodule Raxol.Terminal.Renderer do
   defp parse_hex_color("#" <> hex), do: parse_hex_digits(hex)
   defp parse_hex_color(hex) when is_binary(hex), do: parse_hex_digits(hex)
 
-  defp parse_hex_digits(<<r::binary-size(2), g::binary-size(2), b::binary-size(2)>>) do
+  defp parse_hex_digits(
+         <<r::binary-size(2), g::binary-size(2), b::binary-size(2)>>
+       ) do
     with {r_val, ""} <- Integer.parse(r, 16),
          {g_val, ""} <- Integer.parse(g, 16),
          {b_val, ""} <- Integer.parse(b, 16) do
@@ -390,7 +404,9 @@ defmodule Raxol.Terminal.Renderer do
     end
   end
 
-  defp parse_hex_digits(<<r::binary-size(1), g::binary-size(1), b::binary-size(1)>>) do
+  defp parse_hex_digits(
+         <<r::binary-size(1), g::binary-size(1), b::binary-size(1)>>
+       ) do
     with {r_val, ""} <- Integer.parse(r <> r, 16),
          {g_val, ""} <- Integer.parse(g <> g, 16),
          {b_val, ""} <- Integer.parse(b <> b, 16) do

--- a/packages/raxol_terminal/test/raxol/terminal/renderer_integration_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/renderer_integration_test.exs
@@ -54,7 +54,8 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
   defp parse_hex("#" <> hex), do: parse_hex(hex)
 
   defp parse_hex(<<r::binary-size(2), g::binary-size(2), b::binary-size(2)>>) do
-    {String.to_integer(r, 16), String.to_integer(g, 16), String.to_integer(b, 16)}
+    {String.to_integer(r, 16), String.to_integer(g, 16),
+     String.to_integer(b, 16)}
   end
 
   describe "integration with Manipulation module" do
@@ -243,7 +244,9 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
       text = "Red text"
 
       buffer =
-        Enum.reduce(Enum.with_index(String.graphemes(text)), buffer, fn {char, col}, acc ->
+        Enum.reduce(Enum.with_index(String.graphemes(text)), buffer, fn {char,
+                                                                         col},
+                                                                        acc ->
           ScreenBuffer.write_char(acc, col, 0, char, style)
         end)
 
@@ -256,6 +259,51 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
       assert output =~ "Red text"
       assert output =~ ansi_fg("#FF0000")
       assert output =~ @ansi_reset
+    end
+  end
+
+  describe "{r, g, b} tuple colors (Raxol.UI.CellDim / plain UI-stack RGB)" do
+    # {r,g,b} tuples must emit 38;2/48;2, not fall through to nil.
+    test "emits a 24-bit foreground escape for a tuple color", %{buffer: buffer} do
+      buffer =
+        ScreenBuffer.write_char(buffer, 0, 0, "A", %{foreground: {9, 37, 112}})
+
+      renderer = Renderer.new(buffer)
+      output = Renderer.render(renderer)
+
+      assert output =~ "\e[38;2;9;37;112m"
+    end
+
+    test "emits a 24-bit background escape for a tuple color", %{buffer: buffer} do
+      buffer =
+        ScreenBuffer.write_char(buffer, 0, 0, "A", %{background: {4, 4, 4}})
+
+      renderer = Renderer.new(buffer)
+      output = Renderer.render(renderer)
+
+      assert output =~ "\e[48;2;4;4;4m"
+    end
+
+    test "tuple and map-shaped rgb colors of the same value render identically",
+         %{
+           buffer: buffer
+         } do
+      tuple_buffer =
+        ScreenBuffer.write_char(buffer, 0, 0, "A", %{
+          foreground: {9, 37, 112},
+          background: {4, 4, 4}
+        })
+
+      map_buffer =
+        ScreenBuffer.write_char(buffer, 0, 0, "A", %{
+          foreground: %{r: 9, g: 37, b: 112},
+          background: %{r: 4, g: 4, b: 4}
+        })
+
+      tuple_output = Renderer.render(Renderer.new(tuple_buffer))
+      map_output = Renderer.render(Renderer.new(map_buffer))
+
+      assert tuple_output == map_output
     end
   end
 

--- a/test/raxol/ui/theming/salience_test.exs
+++ b/test/raxol/ui/theming/salience_test.exs
@@ -1,0 +1,142 @@
+defmodule Raxol.UI.Theming.SalienceTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Theming.Salience
+
+  # Reference fixtures (compensated Darcula bake). Must reproduce byte-exact.
+  @darcula_baked [
+    {:differentiate, 0.13, 57, "#c1712c"},
+    {:anchor, 0.125, 77, "#fec56c"},
+    {:baseline, 0.022, 250, "#abb7c3"},
+    {:differentiate, 0.075, 134, "#779465"},
+    {:differentiate, 0.074, 242, "#6190b3"},
+    {:differentiate, 0.086, 314, "#9b78ac"},
+    {:recede, 0.0, 140, "#717171"},
+    {:recede, 0.09, 140, "#58824f"},
+    {:differentiate, 0.05, 57, "#9f806a"},
+    {:recede, 0.0, 250, "#717171"},
+    {:recede, 0.04, 57, "#856d5b"},
+    {:differentiate, 0.1, 57, "#b57748"},
+    {:anchor, 0.14, 314, "#e9bdff"},
+    {:recede, 0.03, 57, "#806e61"},
+    {:baseline, 0.0, 250, "#b4b4b4"},
+    {:alarm, 0.16, 25, "#bd413f"}
+  ]
+
+  describe "darcula reference bake" do
+    test "reproduces every baked hex byte-exact" do
+      for {tier, c, h, expected} <- @darcula_baked do
+        assert Salience.solve(tier, c, h) == expected,
+               "#{tier} C#{c} h#{h}: expected #{expected}, got #{Salience.solve(tier, c, h)}"
+      end
+    end
+  end
+
+  describe "hue_factor/1" do
+    test "clamps to [0.3, 1.2]" do
+      for h <- 0..359 do
+        f = Salience.hue_factor(h)
+        assert f >= 0.3 and f <= 1.2
+      end
+    end
+
+    test "blue bump peaks near h=255" do
+      assert Salience.hue_factor(255) > Salience.hue_factor(200)
+      assert Salience.hue_factor(255) > Salience.hue_factor(310)
+    end
+  end
+
+  describe "apparent lightness leveling" do
+    test "solved colors on one tier share apparent lightness" do
+      target = Salience.tier_target(:differentiate, 0.2, :up)
+
+      for {c, h} <- [{0.13, 57}, {0.075, 134}, {0.074, 242}, {0.086, 314}] do
+        l = Salience.solve_lightness(target, c, h)
+        assert_in_delta Salience.apparent_lightness(l, c, h), target, 1.0e-9
+      end
+    end
+
+    test "achromatic solve equals the tier target" do
+      target = Salience.tier_target(:baseline, 0.2, :up)
+
+      assert_in_delta Salience.solve_lightness(target, 0.0, 250),
+                      target,
+                      1.0e-12
+    end
+  end
+
+  describe "ground adaptation" do
+    test "dark ground solves up, light ground solves down" do
+      dark = Salience.tier_target(:baseline, 0.2, :auto)
+      light = Salience.tier_target(:baseline, 0.95, :auto)
+
+      assert dark > 0.2
+      assert light < 0.95
+    end
+
+    test "reference dark ground reproduces original tier targets" do
+      assert_in_delta Salience.tier_target(:recede, 0.2), 0.55, 1.0e-12
+      assert_in_delta Salience.tier_target(:alarm, 0.2), 0.53, 1.0e-12
+      assert_in_delta Salience.tier_target(:differentiate, 0.2), 0.62, 1.0e-12
+      assert_in_delta Salience.tier_target(:baseline, 0.2), 0.77, 1.0e-12
+      assert_in_delta Salience.tier_target(:anchor, 0.2), 0.85, 1.0e-12
+    end
+
+    test "mid-gray ground compresses deltas but preserves tier ordering" do
+      targets = Enum.map(Salience.tiers(), &Salience.tier_target(&1, 0.5, :up))
+
+      assert targets == Enum.sort(targets)
+      assert List.last(targets) <= 0.97 + 1.0e-12
+    end
+
+    test "light-ground solve produces darker-than-ground colors" do
+      hex = Salience.solve(:baseline, 0.022, 250, ground: 0.95)
+      {l, _c, _h} = Salience.hex_to_oklch(hex)
+      assert l < 0.95
+    end
+  end
+
+  describe "solve_palette/2" do
+    test "resolves seeds keyed by name" do
+      seeds = [
+        %{name: :keyword, h: 57, c: 0.13, tier: :differentiate},
+        %{name: :error, h: 25, c: 0.16, tier: :alarm}
+      ]
+
+      assert Salience.solve_palette(seeds) == %{
+               keyword: "#c1712c",
+               error: "#bd413f"
+             }
+    end
+  end
+
+  describe "OKLCH <-> sRGB round-trip" do
+    test "hex_to_oklch inverts oklch_to_hex for in-gamut colors" do
+      for {l, c, h} <- [
+            {0.626, 0.13, 57.0},
+            {0.77, 0.0, 0.0},
+            {0.5, 0.05, 255.0}
+          ] do
+        hex = Salience.oklch_to_hex(l, c, h)
+        {l2, c2, _h2} = Salience.hex_to_oklch(hex)
+        # 8-bit quantization tolerance
+        assert_in_delta l, l2, 0.01
+        assert_in_delta c, c2, 0.01
+      end
+    end
+
+    test "out-of-gamut chroma shrinks instead of clipping hue" do
+      hex = Salience.oklch_to_hex(0.85, 0.4, 145)
+      assert hex =~ ~r/^#[0-9a-f]{6}$/
+      {_l, c, h} = Salience.hex_to_oklch(hex)
+      assert c < 0.4
+      assert_in_delta h, 145, 3.0
+    end
+
+    test "parses ground from a typical OSC 11 style background hex" do
+      {l, c, _h} = Salience.hex_to_oklch("#2b2b2b")
+      assert_in_delta l, 0.3, 0.05
+      assert c < 0.01
+    end
+  end
+end

--- a/test/raxol/ui/theming/salience_theme_test.exs
+++ b/test/raxol/ui/theming/salience_theme_test.exs
@@ -1,0 +1,51 @@
+defmodule Raxol.UI.Theming.SalienceThemeTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Theming.Salience
+  alias Raxol.UI.Theming.SalienceTheme
+
+  # Theme.new converts color values to Color structs; normalize to hex.
+  defp hex(%{hex: h}), do: String.downcase(h)
+  defp hex(h) when is_binary(h), do: String.downcase(h)
+
+  test "dark ground yields lighter-than-ground foreground" do
+    theme = SalienceTheme.build(ground: 0.2)
+    {l, _, _} = Salience.hex_to_oklch(theme.colors.foreground)
+    assert l > 0.2
+  end
+
+  test "light ground yields darker-than-ground foreground" do
+    theme = SalienceTheme.build(ground: 0.95)
+    {l, _, _} = Salience.hex_to_oklch(theme.colors.foreground)
+    assert l < 0.95
+  end
+
+  test "same seeds solve to different palettes on different grounds" do
+    dark = SalienceTheme.build(ground: 0.2)
+    light = SalienceTheme.build(ground: 0.95)
+    assert hex(dark.colors.accent) != hex(light.colors.accent)
+  end
+
+  test "reference ground reproduces darcula-family values" do
+    theme = SalienceTheme.build(ground: 0.2)
+    assert hex(theme.colors.warning) == "#c1712c"
+    assert hex(theme.colors.error) == "#bd413f"
+    assert hex(theme.colors.emphasis) == "#fec56c"
+    assert hex(theme.colors.success) == "#779465"
+  end
+
+  test "detection fallback uses reference ground" do
+    # No OSC 11 reply in test env -> fallback 0.2.
+    ground = SalienceTheme.detect_ground()
+    assert is_float(ground)
+    assert ground >= 0.0 and ground <= 1.0
+  end
+
+  test "theme carries salience identity and full component styles" do
+    theme = SalienceTheme.build(ground: 0.2)
+    assert theme.id == :salience
+
+    assert hex(theme.component_styles.focus.border_fg) ==
+             hex(theme.colors.accent)
+  end
+end


### PR DESCRIPTION
**Depends on #448 (flex-convergence) — review/merge after it.**

The colour foundation for adaptive theming and modal dimming:

- **Helmholtz-Kohlrausch salience solver** (`Theming.Salience`): OKLCH, two-lobe apparent-lightness model; palettes expressed as `(hue, chroma, tier)` seeds with lightness *solved* against a ground so every tier reads perceptually level. Darcula fixtures pin it byte-exact.
- **semantic salience theme** — grounds on the terminal background when detected (soft dependency; falls back to a reference ground otherwise).
- **truecolor SGR for `{r,g,b}` tuple cell colours** — the ANSI stage previously had no clause for plain integer tuples, so such cells emitted no colour escape.

Theming fixtures + renderer tests green.
