### PR TITLE
Cell-level H-K dimming toward the terminal ground

### DIFF
--- a/lib/raxol/ui/cell_dim.ex
+++ b/lib/raxol/ui/cell_dim.ex
@@ -1,0 +1,204 @@
+defmodule Raxol.UI.CellDim do
+  @moduledoc """
+  Cell-level color dimming for content sitting behind an active modal
+  dialog.
+
+  Every element type eventually becomes `{x, y, char, fg, bg, attrs}`
+  cells before paint (`Raxol.UI.Renderer`), so dimming is implemented once
+  here at that choke point instead of duplicating a "dim" branch in every
+  `render_visible_element/3` clause.
+
+  Dimming pulls a color's H-K-compensated *apparent* lightness (via
+  `Raxol.UI.Theming.Salience`), not its raw RGB channels, toward the
+  detected terminal ground -- naive `rgb * factor` scaling reads
+  chromatic colors (blues especially) darker than gray at the same
+  nominal scale, and interpolating in apparent-lightness space makes the
+  darken-on-dark-ground / wash-on-light-ground direction fall out of the
+  same formula instead of being hand-branched per theme.
+
+  `nil` fg/bg (never painted) always stays `nil`. `ElementRenderer`/
+  `BorderRenderer` default every unpainted background to the atom
+  `:black` (see their `resolve_bg/1`), so `:black` is the de facto
+  unpainted-bg sentinel and passes through undimmed for backgrounds --
+  `dim_fg/2` treats a painted `fg: :black` as a real color and dims it.
+  """
+
+  alias Raxol.UI.Theming.Colors, as: ThemeColors
+  alias Raxol.UI.Theming.Salience
+
+  # Optional cross-package dep (same pattern as SalienceTheme).
+  @compile {:no_warn_undefined, Raxol.Terminal.Driver.BackgroundQuery}
+
+  # Fraction of the ground-apparent-lightness *contrast* a dimmed color
+  # retains -- 0.45 keeps the dim/non-dim distinction unambiguous without
+  # crushing everything to near-ground.
+  @contrast_keep 0.45
+
+  # Keep more chroma than contrast so ANSI hues stay legible (not flat gray).
+  @chroma_keep 0.65
+
+  # ANSI-16 atom -> code, matching `Raxol.Core.Renderer.Color`'s private
+  # `@ansi_16_map` ordering. Only routes to `ThemeColors.ansi_to_rgb/1`'s
+  # canonical xterm RGB table below -- no hex values invented here.
+  @ansi_16_codes %{
+    black: 0,
+    red: 1,
+    green: 2,
+    yellow: 3,
+    blue: 4,
+    magenta: 5,
+    cyan: 6,
+    white: 7,
+    bright_black: 8,
+    bright_red: 9,
+    bright_green: 10,
+    bright_yellow: 11,
+    bright_blue: 12,
+    bright_magenta: 13,
+    bright_cyan: 14,
+    bright_white: 15
+  }
+
+  # Unknown atoms -> mid-gray so they still take the dim cue.
+  @unknown_atom_rgb {128, 128, 128}
+
+  @doc "Dims every cell's fg/bg in a list toward the detected terminal ground."
+  @spec dim_cells([tuple()]) :: [tuple()]
+  def dim_cells(cells) do
+    ground_al = ground_apparent_lightness()
+
+    fg_cache =
+      cells
+      |> Enum.map(fn {_x, _y, _char, fg, _bg, _attrs} -> fg end)
+      |> Enum.uniq()
+      |> Map.new(&{&1, dim_fg(&1, ground_al)})
+
+    bg_cache =
+      cells
+      |> Enum.map(fn {_x, _y, _char, _fg, bg, _attrs} -> bg end)
+      |> Enum.uniq()
+      |> Map.new(&{&1, dim_bg(&1, ground_al)})
+
+    Enum.map(cells, fn {x, y, char, fg, bg, attrs} ->
+      {x, y, char, Map.get(fg_cache, fg), Map.get(bg_cache, bg), attrs}
+    end)
+  end
+
+  @doc """
+  Dims a foreground color. Same as `dim_color/2` except a painted
+  `:black` is treated as a real color (dimmed), not the bg-only
+  unpainted sentinel -- see moduledoc.
+  """
+  @spec dim_fg(any(), float()) :: any()
+  def dim_fg(:black, ground_al) do
+    {r, g, b} = atom_to_rgb(:black)
+    dim_rgb(r, g, b, ground_al)
+  end
+
+  def dim_fg(color, ground_al), do: dim_color(color, ground_al)
+
+  @doc "Dims a background color. Alias of `dim_color/2` (bg-oriented, `:black` sentinel)."
+  @spec dim_bg(any(), float()) :: any()
+  def dim_bg(color, ground_al), do: dim_color(color, ground_al)
+
+  @doc """
+  Dims a single color value against the detected (or reference-fallback)
+  terminal ground. See `dim_color/2` for per-type behavior.
+  """
+  @spec dim_color(any()) :: any()
+  def dim_color(color), do: dim_color(color, ground_apparent_lightness())
+
+  @doc """
+  Dims a single color value against an explicit ground apparent lightness
+  (as returned by `ground_apparent_lightness/0`). Bg-oriented -- see
+  `dim_fg/2` for foregrounds.
+
+  * `nil` stays `nil`; `:black` stays `:black` (bg unpainted sentinel,
+    see moduledoc).
+  * Other ANSI-16 atoms resolve to canonical RGB first (unknown atoms,
+    including `:default` and theme-custom names, resolve to mid-gray).
+  * `{r, g, b}` tuples and `"#rrggbb"` hex strings dim via OKLCH.
+  * Integers (256-color palette indices) pass through unchanged -- there
+    is no general reverse mapping from an index to a hue without
+    inventing one.
+  """
+  @spec dim_color(any(), float()) :: any()
+  def dim_color(nil, _ground_al), do: nil
+  def dim_color(:black, _ground_al), do: :black
+
+  def dim_color({r, g, b}, ground_al)
+      when is_integer(r) and is_integer(g) and is_integer(b) do
+    dim_rgb(r, g, b, ground_al)
+  end
+
+  def dim_color(color, ground_al) when is_atom(color) do
+    {r, g, b} = atom_to_rgb(color)
+    dim_rgb(r, g, b, ground_al)
+  end
+
+  def dim_color("#" <> _ = hex, ground_al) do
+    {l, c, h} = Salience.hex_to_oklch(hex)
+    {new_l, new_c, new_h} = dim_oklch(l, c, h, ground_al)
+    Salience.oklch_to_hex(new_l, new_c, new_h)
+  end
+
+  def dim_color(other, _ground_al), do: other
+
+  @doc """
+  Apparent lightness of the current ground: the OSC 11-detected terminal
+  background when available, else `Raxol.UI.Theming.Salience`'s reference
+  ground.
+  """
+  @spec ground_apparent_lightness() :: float()
+  def ground_apparent_lightness do
+    case detected_ground_oklch() do
+      {:ok, {l, c, h}} ->
+        Salience.apparent_lightness(l, c, h)
+
+      :error ->
+        Salience.apparent_lightness(Salience.reference_ground(), 0.0, 0.0)
+    end
+  end
+
+  defp detected_ground_oklch do
+    with true <- Code.ensure_loaded?(Raxol.Terminal.Driver.BackgroundQuery),
+         true <-
+           function_exported?(
+             Raxol.Terminal.Driver.BackgroundQuery,
+             :detected_background,
+             0
+           ),
+         {:ok, {r, g, b}} <-
+           Raxol.Terminal.Driver.BackgroundQuery.detected_background() do
+      {:ok, Salience.rgb_to_oklch(r / 255, g / 255, b / 255)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp atom_to_rgb(color) do
+    case Map.fetch(@ansi_16_codes, color) do
+      {:ok, code} -> ThemeColors.ansi_to_rgb(code)
+      :error -> @unknown_atom_rgb
+    end
+  end
+
+  defp dim_rgb(r, g, b, ground_al) do
+    {l, c, h} = Salience.rgb_to_oklch(r / 255, g / 255, b / 255)
+    {new_l, new_c, new_h} = dim_oklch(l, c, h, ground_al)
+    Salience.oklch_to_rgb(new_l, new_c, new_h)
+  end
+
+  # Pull (l, c, h)'s apparent lightness toward `ground_al`, keeping
+  # `@contrast_keep` of the original contrast, and desaturate by the
+  # (larger) `@chroma_keep` factor so hue identity survives clearly rather
+  # than reading as flat gray. Solve back to a nominal `l` that lands on
+  # the new apparent lightness.
+  defp dim_oklch(l, c, h, ground_al) do
+    apparent_l = Salience.apparent_lightness(l, c, h)
+    new_apparent_l = ground_al + (apparent_l - ground_al) * @contrast_keep
+    new_c = c * @chroma_keep
+    new_l = Salience.solve_lightness(new_apparent_l, new_c, h)
+    {new_l, new_c, h}
+  end
+end

--- a/test/raxol/ui/cell_dim_test.exs
+++ b/test/raxol/ui/cell_dim_test.exs
@@ -1,0 +1,211 @@
+defmodule Raxol.UI.CellDimTest do
+  @moduledoc """
+  Coverage for `Raxol.UI.CellDim`'s H-K-compensated, apparent-lightness
+  contrast compression toward ground. No test here stores a background
+  via `Raxol.Terminal.Driver.BackgroundQuery` -- that's global
+  `:persistent_term` state shared with concurrently running async test
+  modules, so ground overrides go through `dim_color/2` instead (mirrors
+  `Raxol.UI.Theming.SalienceThemeTest`'s `ground:` override pattern).
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.CellDim
+  alias Raxol.UI.Theming.Salience
+
+  # No detection stored anywhere in this test run -> CellDim falls back to
+  # Salience's reference ground (achromatic, so its apparent lightness
+  # equals its nominal lightness exactly).
+  @dark_ground_al Salience.apparent_lightness(
+                    Salience.reference_ground(),
+                    0.0,
+                    0.0
+                  )
+  @light_ground_al Salience.apparent_lightness(0.95, 0.0, 0.0)
+
+  defp apparent_lightness_of_rgb({r, g, b}) do
+    {l, c, h} = Salience.rgb_to_oklch(r / 255, g / 255, b / 255)
+    Salience.apparent_lightness(l, c, h)
+  end
+
+  describe "dark ground (default, no detection)" do
+    test "pins the default-ground dim values" do
+      assert CellDim.dim_color(:white) == {106, 106, 106}
+      assert CellDim.dim_color(:cyan) == {3, 100, 100}
+      # unlisted atom resolves to mid-gray before dimming, not a crash
+      assert CellDim.dim_color(:some_theme_color) == {66, 66, 66}
+      assert CellDim.dim_color({200, 100, 50}) == {108, 49, 20}
+      assert CellDim.dim_color({0, 0, 0}) == {4, 4, 4}
+      assert CellDim.dim_color({255, 255, 255}) == {116, 116, 116}
+      assert CellDim.dim_color(nil) == nil
+      assert CellDim.dim_color(42) == 42
+      assert CellDim.dim_color("#ff0000") == "#8a0000"
+
+      # :black is unpainted-bg sentinel -- pass through like nil, see @moduledoc.
+      assert CellDim.dim_color(:black) == :black
+    end
+
+    test "a bright color's dimmed apparent lightness drops and moves closer to ground" do
+      original_al = apparent_lightness_of_rgb({255, 255, 255})
+      dimmed = CellDim.dim_color({255, 255, 255}, @dark_ground_al)
+      dimmed_al = apparent_lightness_of_rgb(dimmed)
+
+      assert dimmed_al < original_al
+
+      assert abs(dimmed_al - @dark_ground_al) <
+               abs(original_al - @dark_ground_al)
+    end
+  end
+
+  describe "light ground" do
+    test "a near-black color's dimmed apparent lightness rises and moves closer to ground (washes toward white)" do
+      original_al = apparent_lightness_of_rgb({10, 10, 10})
+      dimmed = CellDim.dim_color({10, 10, 10}, @light_ground_al)
+      dimmed_al = apparent_lightness_of_rgb(dimmed)
+
+      assert dimmed_al > original_al
+
+      assert abs(dimmed_al - @light_ground_al) <
+               abs(original_al - @light_ground_al)
+    end
+
+    test "direction flips relative to the same color on a dark ground" do
+      dark_dimmed = CellDim.dim_color({10, 10, 10}, @dark_ground_al)
+      light_dimmed = CellDim.dim_color({10, 10, 10}, @light_ground_al)
+
+      assert apparent_lightness_of_rgb(dark_dimmed) <
+               apparent_lightness_of_rgb(light_dimmed)
+    end
+  end
+
+  test "nil always passes through" do
+    assert CellDim.dim_color(nil) == nil
+    assert CellDim.dim_color(nil, @dark_ground_al) == nil
+    assert CellDim.dim_color(nil, @light_ground_al) == nil
+  end
+
+  test "hue is preserved within a few degrees through the OKLCH round trip" do
+    {_l, _c, h} = Salience.rgb_to_oklch(200 / 255, 100 / 255, 50 / 255)
+    dimmed = CellDim.dim_color({200, 100, 50}, @dark_ground_al)
+
+    {_dl, _dc, dh} =
+      Salience.rgb_to_oklch(
+        elem(dimmed, 0) / 255,
+        elem(dimmed, 1) / 255,
+        elem(dimmed, 2) / 255
+      )
+
+    assert_in_delta h, dh, 3.0
+  end
+
+  test "chroma is reduced" do
+    {_l, c, _h} = Salience.rgb_to_oklch(200 / 255, 100 / 255, 50 / 255)
+    dimmed = CellDim.dim_color({200, 100, 50}, @dark_ground_al)
+
+    {_dl, dc, _dh} =
+      Salience.rgb_to_oklch(
+        elem(dimmed, 0) / 255,
+        elem(dimmed, 1) / 255,
+        elem(dimmed, 2) / 255
+      )
+
+    assert dc < c
+  end
+
+  describe "dim_fg/2 and dim_bg/2 (:black role split)" do
+    test "dim_fg treats a painted :black as a real color and dims it" do
+      assert CellDim.dim_fg(:black, @dark_ground_al) ==
+               CellDim.dim_color({0, 0, 0}, @dark_ground_al)
+
+      assert CellDim.dim_fg(:black, @dark_ground_al) != :black
+    end
+
+    test "dim_bg keeps :black as the unpainted-bg sentinel" do
+      assert CellDim.dim_bg(:black, @dark_ground_al) == :black
+    end
+
+    test "both delegate to dim_color/2 for non-:black colors" do
+      assert CellDim.dim_fg(:cyan, @dark_ground_al) ==
+               CellDim.dim_color(:cyan, @dark_ground_al)
+
+      assert CellDim.dim_bg({200, 100, 50}, @dark_ground_al) ==
+               CellDim.dim_color({200, 100, 50}, @dark_ground_al)
+    end
+  end
+
+  test "dimming twice does not crash (idempotence not required)" do
+    once = CellDim.dim_color({200, 100, 50})
+    assert is_tuple(CellDim.dim_color(once))
+    assert CellDim.dim_color(CellDim.dim_color(:white)) |> is_tuple()
+  end
+
+  describe "dim_cells/1" do
+    test "dedupes and dims every cell's fg/bg, leaving char/coords/attrs untouched" do
+      cells = [
+        {0, 0, "a", :white, {200, 100, 50}, [:bold]},
+        {1, 0, "b", :white, {200, 100, 50}, []},
+        {2, 0, "c", nil, nil, []}
+      ]
+
+      dimmed = CellDim.dim_cells(cells)
+
+      assert [
+               {0, 0, "a", {106, 106, 106}, {108, 49, 20}, [:bold]},
+               {1, 0, "b", {106, 106, 106}, {108, 49, 20}, []},
+               {2, 0, "c", nil, nil, []}
+             ] = dimmed
+    end
+
+    test "empty list does not crash" do
+      assert CellDim.dim_cells([]) == []
+    end
+
+    test "bg :black sentinel passes through unchanged alongside a dimmed fg" do
+      cells = [{0, 0, "a", :cyan, :black, []}]
+
+      assert [{0, 0, "a", {3, 100, 100}, :black, []}] =
+               CellDim.dim_cells(cells)
+    end
+
+    test "fg :black dims while bg :black stays the sentinel, in the same cell" do
+      cells = [{0, 0, "a", :black, :black, []}]
+
+      assert [{0, 0, "a", {4, 4, 4}, :black, []}] = CellDim.dim_cells(cells)
+    end
+  end
+
+  describe "chroma/contrast split" do
+    test "dimmed chroma stays well above the just-noticeable threshold for saturated ANSI colors" do
+      for color <- [:blue, :cyan, :green, :red, :magenta, :yellow] do
+        {r, g, b} = CellDim.dim_color(color, @dark_ground_al)
+        {_l, c, _h} = Salience.rgb_to_oklch(r / 255, g / 255, b / 255)
+
+        assert c > 0.04,
+               "#{color} dimmed to chroma #{c}, expected > 0.04 (hue should stay legible)"
+      end
+    end
+
+    test "chroma keep factor is looser than the contrast keep factor" do
+      {l, c, h} = Salience.rgb_to_oklch(0 / 255, 0 / 255, 238 / 255)
+      apparent_l = Salience.apparent_lightness(l, c, h)
+
+      dimmed = CellDim.dim_color({0, 0, 238}, @dark_ground_al)
+
+      {dl, dc, dh} =
+        Salience.rgb_to_oklch(
+          elem(dimmed, 0) / 255,
+          elem(dimmed, 1) / 255,
+          elem(dimmed, 2) / 255
+        )
+
+      dimmed_apparent_l = Salience.apparent_lightness(dl, dc, dh)
+
+      contrast_ratio =
+        abs(dimmed_apparent_l - @dark_ground_al) /
+          abs(apparent_l - @dark_ground_al)
+
+      chroma_ratio = dc / c
+
+      assert chroma_ratio > contrast_ratio
+    end
+  end
+end


### PR DESCRIPTION
**Depends on #451 (hk-salience) — review/merge after it** (uses the salience solver). Transitively depends on #448.

Cell-level H-K modal-backdrop dimming (`Raxol.UI.CellDim`): pulls a painted colour's Helmholtz-Kohlrausch apparent lightness toward the detected terminal ground, keeping a fraction of the contrast and desaturating by the same factor. Direction falls out of "move toward ground" — dark grounds dim darker, light grounds wash lighter, no theme branching.

- ANSI atoms resolve through the canonical 16-colour table.
- `nil` (unpainted) and the `:black` **background** sentinel pass through; a painted `fg: :black` dims like any colour.
- terminal ground from OSC 11 detection when available, else a reference ground.

Pure capability module (activated by the modal PR). Unit tests green.
