### PR TITLE
Resolve explicit box width/height; fix render-diff cursor order

### DIFF
--- a/lib/raxol/core/renderer_compat.ex
+++ b/lib/raxol/core/renderer_compat.ex
@@ -162,7 +162,9 @@ defmodule Raxol.Core.Renderer do
     text = Enum.map_join(reversed_chars, "", & &1.char)
     style = List.first(reversed_chars) |> Map.get(:style, %{})
 
-    new_ops = [{:move, run_start, y}, {:write, text, style} | ops]
+    # ops is built reversed and flipped once at the end; prepend write
+    # before move so the final order is [{:move, ...}, {:write, ...}]
+    new_ops = [{:write, text, style}, {:move, run_start, y} | ops]
     {new_ops, nil, []}
   end
 

--- a/lib/raxol/playground/demos/text_input_demo.ex
+++ b/lib/raxol/playground/demos/text_input_demo.ex
@@ -40,7 +40,7 @@ defmodule Raxol.Playground.Demos.TextInputDemo do
         text("Input:"),
         box style: %{
               border: :single,
-              padding: 1,
+              padding: {0, 1, 0, 1},
               width: effective_width(model, @default_input_box_width)
             } do
           text(display <> "_")
@@ -49,7 +49,7 @@ defmodule Raxol.Playground.Demos.TextInputDemo do
         divider(),
         box style: %{
               border: :rounded,
-              padding: 1,
+              padding: {0, 1, 0, 1},
               width: effective_width(model, @default_input_box_width)
             } do
           column style: %{gap: 0} do

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -404,7 +404,22 @@ defmodule Raxol.UI.Layout.Engine do
     padding = Map.get(box, :padding, 0)
     border = Map.get(box, :border) || Map.get(style, :border, :none)
 
-    inner_space = box_inner_space(space, border, padding)
+    # Honor explicit width/height (style or element), clamped to available
+    # space; boxes without explicit dimensions keep filling the space.
+    {explicit_w, explicit_h} = resolve_box_dimensions(box, style, space)
+
+    width =
+      if is_integer(explicit_w),
+        do: min(explicit_w, space.width),
+        else: space.width
+
+    height =
+      if is_integer(explicit_h),
+        do: min(explicit_h, space.height),
+        else: space.height
+
+    box_space = %{space | width: width, height: height}
+    inner_space = box_inner_space(box_space, border, padding)
 
     box_style = Map.get(box, :style, %{})
     animation_hints = Map.get(box, :animation_hints, [])
@@ -413,8 +428,8 @@ defmodule Raxol.UI.Layout.Engine do
       type: :box,
       x: space.x,
       y: space.y,
-      width: space.width,
-      height: space.height,
+      width: width,
+      height: height,
       style: box_style,
       animation_hints: animation_hints,
       attrs: %{
@@ -918,36 +933,52 @@ defmodule Raxol.UI.Layout.Engine do
     end
   end
 
-  # Calculate total border + padding overhead for a box (both sides).
+  # Per-side padding as {top, right, bottom, left}. Accepts a bare integer
+  # or the tuples produced by Components.Box.normalize_spacing/1.
+  defp padding_sides(padding) do
+    case padding do
+      p when is_integer(p) and p >= 0 -> {p, p, p, p}
+      {t, r, b, l} -> {t, r, b, l}
+      {h, v} -> {h, v, h, v}
+      _ -> {0, 0, 0, 0}
+    end
+  end
+
+  # Total border + padding overhead for a box as {horizontal, vertical}.
   defp box_overhead(element, style) do
     border = Map.get(element, :border) || Map.get(style, :border, :none)
-    padding = Map.get(element, :padding, 0)
+    {top, right, bottom, left} = padding_sides(Map.get(element, :padding, 0))
     border_offset = if border in [:none, false], do: 0, else: 1
-    pad = if is_integer(padding), do: padding, else: 0
-    2 * (border_offset + pad)
+    {2 * border_offset + left + right, 2 * border_offset + top + bottom}
   end
 
   # Build inner space for a box by subtracting border and padding from outer space.
   defp box_inner_space(space, border, padding) do
     border_offset = if border in [:none, false], do: 0, else: 1
-    pad = if is_integer(padding), do: padding, else: 0
-    inset = border_offset + pad
+    {top, right, bottom, left} = padding_sides(padding)
 
     %{
-      x: space.x + inset,
-      y: space.y + inset,
-      width: max(0, space.width - 2 * inset),
-      height: max(0, space.height - 2 * inset)
+      x: space.x + border_offset + left,
+      y: space.y + border_offset + top,
+      width: max(0, space.width - 2 * border_offset - left - right),
+      height: max(0, space.height - 2 * border_offset - top - bottom)
     }
   end
 
   # Resolve explicit width/height for a box, handling :fill expansion.
   defp resolve_box_dimensions(element, style, available_space) do
-    raw_width =
-      Map.get(element, :width) || Map.get(style, :width) ||
-        Map.get(element, :size)
+    {size_w, size_h} =
+      case Map.get(element, :size) do
+        {w, h} -> {w, h}
+        s when is_integer(s) -> {s, nil}
+        _ -> {nil, nil}
+      end
 
-    raw_height = Map.get(element, :height) || Map.get(style, :height)
+    raw_width =
+      Map.get(element, :width) || Map.get(style, :width) || size_w
+
+    raw_height =
+      Map.get(element, :height) || Map.get(style, :height) || size_h
 
     width = if raw_width == :fill, do: available_space.width, else: raw_width
 
@@ -957,8 +988,8 @@ defmodule Raxol.UI.Layout.Engine do
     {width, height}
   end
 
-  # Shrink available space by a symmetric overhead amount.
-  defp shrink_space_by(available_space, overhead) do
+  # Shrink available space by {horizontal, vertical} overhead.
+  defp shrink_space_by(available_space, {overhead_w, overhead_h}) do
     avail_w =
       Map.get(available_space, :width, Raxol.Core.Defaults.terminal_width())
 
@@ -966,8 +997,8 @@ defmodule Raxol.UI.Layout.Engine do
       Map.get(available_space, :height, Raxol.Core.Defaults.terminal_height())
 
     Map.merge(available_space, %{
-      width: max(0, avail_w - overhead),
-      height: max(0, avail_h - overhead)
+      width: max(0, avail_w - overhead_w),
+      height: max(0, avail_h - overhead_h)
     })
   end
 
@@ -977,18 +1008,18 @@ defmodule Raxol.UI.Layout.Engine do
     %{width: w, height: h}
   end
 
-  defp resolve_box_size(w, _h, children, inner_space, overhead)
+  defp resolve_box_size(w, _h, children, inner_space, {_ow, oh})
        when is_integer(w) do
     child_dims = measure_children_as_column(children, inner_space)
-    %{width: w, height: child_dims.height + overhead}
+    %{width: w, height: child_dims.height + oh}
   end
 
-  defp resolve_box_size(_w, _h, children, inner_space, overhead) do
+  defp resolve_box_size(_w, _h, children, inner_space, {ow, oh}) do
     child_dims = measure_children_as_column(children, inner_space)
 
     %{
-      width: child_dims.width + overhead,
-      height: child_dims.height + overhead
+      width: child_dims.width + ow,
+      height: child_dims.height + oh
     }
   end
 
@@ -1009,7 +1040,9 @@ defmodule Raxol.UI.Layout.Engine do
     if map_size(existing) > 0 and Map.has_key?(existing, :flex_direction) do
       flex
     else
-      Map.put(flex, :attrs, build_flex_attrs(flex))
+      # Preserve caller-set attrs (e.g. %{flex: %{grow: 1}} on a child)
+      # on top of the defaults derived from top-level keys/style.
+      Map.put(flex, :attrs, Map.merge(build_flex_attrs(flex), existing))
     end
   end
 

--- a/test/cross_terminal/box_dimensions_test.exs
+++ b/test/cross_terminal/box_dimensions_test.exs
@@ -1,0 +1,107 @@
+defmodule Raxol.CrossTerminal.BoxDimensionsTest do
+  @moduledoc """
+  Regression tests for layout-engine box sizing: `box style: %{width: N}`
+  rendering full-bleed, and View DSL padding (normalized to a 4-tuple)
+  being silently dropped. Uses the real playground TextInput demo at a
+  large screen size.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Headless
+  alias Raxol.Terminal.Buffer.Queries
+
+  setup do
+    pid =
+      case Process.whereis(Headless) do
+        nil -> start_supervised!({Headless, [name: Headless]})
+        existing -> existing
+      end
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        for id <- GenServer.call(pid, :list_sessions) do
+          try do
+            GenServer.call(pid, {:stop_session, id}, 2_000)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp rendered_lines(id) do
+    {:ok, buffer} = Headless.get_buffer(id)
+
+    buffer
+    |> Queries.get_text()
+    |> String.split("\n")
+    |> Enum.map(&String.trim_trailing/1)
+  end
+
+  test "box with explicit style width stays at that width on a wide screen" do
+    {:ok, id} =
+      Headless.start(Raxol.Playground.Demos.TextInputDemo,
+        id: :box_dims,
+        width: 200,
+        height: 60
+      )
+
+    Process.sleep(300)
+    lines = rendered_lines(id)
+
+    border_lines =
+      Enum.filter(
+        lines,
+        &(String.starts_with?(&1, "┌") or String.starts_with?(&1, "└"))
+      )
+
+    # Demo declares two 40-wide boxes; the text_input component adds its own
+    # small bordered box. No bordered line may be full-bleed (200 cols), and
+    # the demo boxes must be exactly 40.
+    assert border_lines != []
+
+    for line <- border_lines do
+      assert String.length(line) < 200,
+             "border line rendered full-bleed: #{inspect(String.slice(line, 0, 50))}..."
+    end
+
+    assert Enum.count(border_lines, &(String.length(&1) == 40)) >= 2
+
+    :ok = Headless.stop(id)
+  end
+
+  test "box padding insets content from the border" do
+    {:ok, id} =
+      Headless.start(Raxol.Playground.Demos.TextInputDemo,
+        id: :box_pad,
+        width: 200,
+        height: 60
+      )
+
+    Process.sleep(300)
+    lines = rendered_lines(id)
+
+    # The input box has horizontal padding {0,1,0,1}: content line reads
+    # "│ (type to enter text)_ ..." — space between border and text.
+    content_line =
+      Enum.find(lines, &String.contains?(&1, "(type to enter text)"))
+
+    assert content_line != nil
+
+    assert content_line =~ "│ (type",
+           "padding not applied: #{inspect(String.slice(content_line, 0, 30))}"
+
+    # No vertical padding: the single-line input box is exactly 3 rows —
+    # the row above the content is the top border, not a padded blank row.
+    content_idx =
+      Enum.find_index(lines, &String.contains?(&1, "(type to enter text)"))
+
+    assert Enum.at(lines, content_idx - 1) |> String.starts_with?("┌")
+    assert Enum.at(lines, content_idx + 1) |> String.starts_with?("└")
+
+    :ok = Headless.stop(id)
+  end
+end


### PR DESCRIPTION
Atomic slice of the flex-convergence layout work (decomposing #448). Off master, no dependencies — mergeable on its own.

- The layout engine ignored a box's explicit width/height (and tuple padding); resolve them, clamped to the available space.
- Fix `render_diff` emitting `{:write}` before its `{:move}` — writes landed at the previous cursor position (public documented API, roundtrip-tested by the characterization net).
- Single-line text input uses horizontal-only padding so it's one row, not three.

Kept deliberately narrow: the flexbox rewrite, gap-inclusion, and other layout work land in the dependent flex PRs stacked on this one.
