### PR TITLE
CSS-style text layout modes (white-space, ellipsis, line-clamp, pretty-wrap)

### DIFF
--- a/lib/raxol/ui/components/display/text.ex
+++ b/lib/raxol/ui/components/display/text.ex
@@ -7,14 +7,34 @@ defmodule Raxol.UI.Components.Display.Text do
   Props:
   - `content` (string) -- text to display
   - `wrap` (`:word | :char | :none`) -- wrapping mode, default `:none`
+  - `white_space` (`:normal | :nowrap | :pre | :pre_wrap | :pre_line`) --
+    CSS `white-space`-following collapse/preserve/wrap semantics, default
+    `:normal`. Only takes effect when set to a value other than `:normal`;
+    at the default it defers entirely to the legacy `wrap` prop so existing
+    callers see zero behavior change. See `Raxol.UI.TextLayout` for the
+    unified wrapping implementation.
   - `align` (`:left | :center | :right`) -- alignment within width, default `:left`
   - `width` (integer | nil) -- constraint for wrapping/alignment/truncation
   - `truncate` (boolean) -- truncate with ellipsis when exceeding width, default `false`
+  - `text_overflow` (`:clip | :ellipsis`) -- CSS `text-overflow`-following
+    single-line truncation, default `:clip` (a no-op; existing rendering
+    already visually clips at the buffer edge). Only takes effect when
+    `white_space` is `:nowrap` or `:pre` (the CSS-spec-following
+    non-wrapping cases) and set to `:ellipsis`; at any other combination
+    it defers entirely, so existing callers see zero behavior change. See
+    `Raxol.UI.TextLayout.truncate/3`.
+  - `line_clamp` (`pos_integer | nil`) -- CSS Overflow Module Level 4
+    `line-clamp`: caps wrapped output at this many lines, block-ellipsing
+    the last kept line, default `nil` (a no-op). When set, it overrides
+    the legacy `wrap`/`truncate` dispatch entirely and wraps via
+    `white_space` (default `:normal`) through
+    `Raxol.UI.TextLayout.clamp/4`.
   - `style`, `theme`, `id` -- standard
   """
 
   alias Raxol.UI.Components.Input.TextWrapping
   alias Raxol.UI.StyleHelper
+  alias Raxol.UI.TextLayout
 
   use Raxol.UI.Components.Base.Component
 
@@ -22,9 +42,13 @@ defmodule Raxol.UI.Components.Display.Text do
           id: String.t() | atom(),
           content: String.t(),
           wrap: :word | :char | :none,
+          white_space: TextLayout.white_space(),
           align: :left | :center | :right,
           width: non_neg_integer() | nil,
           truncate: boolean(),
+          text_overflow: :clip | :ellipsis,
+          line_clamp: pos_integer() | nil,
+          text_wrap: :auto | :pretty,
           style: map(),
           theme: map()
         }
@@ -37,9 +61,13 @@ defmodule Raxol.UI.Components.Display.Text do
         Keyword.get(props, :id, "text-#{:erlang.unique_integer([:positive])}"),
       content: Keyword.get(props, :content, ""),
       wrap: Keyword.get(props, :wrap, :none),
+      white_space: Keyword.get(props, :white_space, :normal),
       align: Keyword.get(props, :align, :left),
       width: Keyword.get(props, :width),
       truncate: Keyword.get(props, :truncate, false),
+      text_overflow: Keyword.get(props, :text_overflow, :clip),
+      line_clamp: Keyword.get(props, :line_clamp),
+      text_wrap: Keyword.get(props, :text_wrap, :auto),
       style: Keyword.get(props, :style, %{}),
       theme: Keyword.get(props, :theme, %{})
     }
@@ -55,8 +83,25 @@ defmodule Raxol.UI.Components.Display.Text do
   def render(state, context) do
     style = StyleHelper.merge_component_styles(state, context, :text)
 
+    # `text_wrap: :pretty` replaces the greedy break-point choice for
+    # plain wrapped text; `line_clamp` (which does its own wrapping) and
+    # non-:normal white-space modes take priority and ignore it.
     lines =
-      process_content(state.content, state.width, state.wrap, state.truncate)
+      if Map.get(state, :text_wrap, :auto) == :pretty and
+           state.white_space == :normal and is_integer(state.width) and
+           is_nil(state.line_clamp) and state.content != "" do
+        TextLayout.wrap(state.content, state.width, :normal, :pretty)
+      else
+        process_content(
+          state.content,
+          state.width,
+          state.white_space,
+          state.wrap,
+          state.truncate,
+          state.text_overflow,
+          state.line_clamp
+        )
+      end
 
     lines = align_lines(lines, state.width, state.align)
 
@@ -76,28 +121,129 @@ defmodule Raxol.UI.Components.Display.Text do
             )
           end)
 
-        %{type: :column, style: style, children: children}
+        %{type: :column, style: style, children: children, gap: 0}
     end
   end
 
   # --- Content processing ---
 
-  defp process_content(content, nil, _wrap, _truncate), do: [content]
+  defp process_content(
+         content,
+         nil,
+         _white_space,
+         _wrap,
+         _truncate,
+         _text_overflow,
+         _line_clamp
+       ),
+       do: [content]
 
-  defp process_content(content, _width, _wrap, _truncate) when content == "",
-    do: [""]
+  defp process_content(
+         content,
+         _width,
+         _white_space,
+         _wrap,
+         _truncate,
+         _text_overflow,
+         _line_clamp
+       )
+       when content == "",
+       do: [""]
 
-  defp process_content(content, width, :none, true) do
+  # `line_clamp` overrides the legacy `wrap`/`truncate` dispatch entirely
+  # (and takes priority over `white_space`, which it passes through to
+  # TextLayout.clamp/4 as the wrapping mode) whenever it's set.
+  defp process_content(
+         content,
+         width,
+         white_space,
+         _wrap,
+         _truncate,
+         _text_overflow,
+         line_clamp
+       )
+       when is_integer(line_clamp) do
+    TextLayout.clamp(content, width, line_clamp, white_space: white_space)
+  end
+
+  # `text-overflow: ellipsis` only applies to the non-wrapping CSS
+  # `white-space` cases (`:nowrap`, `:pre`); `:clip` (the default) is a
+  # no-op here since rendering already clips visually at the buffer edge.
+  defp process_content(
+         content,
+         width,
+         white_space,
+         _wrap,
+         _truncate,
+         :ellipsis,
+         _line_clamp
+       )
+       when white_space in [:nowrap, :pre] do
+    content
+    |> TextLayout.wrap(width, white_space)
+    |> Enum.map(&TextLayout.truncate(&1, width, :ellipsis))
+  end
+
+  # CSS `white-space` takes over the whole collapse/preserve/wrap decision
+  # whenever it's set to anything other than the default -- at :normal we
+  # fall through to the legacy `wrap`-prop dispatch below unchanged.
+  defp process_content(
+         content,
+         width,
+         white_space,
+         _wrap,
+         _truncate,
+         _text_overflow,
+         _line_clamp
+       )
+       when white_space != :normal do
+    TextLayout.wrap(content, width, white_space)
+  end
+
+  defp process_content(
+         content,
+         width,
+         :normal,
+         :none,
+         true,
+         _text_overflow,
+         _line_clamp
+       ) do
     [truncate_line(content, width)]
   end
 
-  defp process_content(content, _width, :none, false), do: [content]
+  defp process_content(
+         content,
+         _width,
+         :normal,
+         :none,
+         false,
+         _text_overflow,
+         _line_clamp
+       ),
+       do: [content]
 
-  defp process_content(content, width, :word, _truncate) do
-    TextWrapping.wrap_line_by_word(content, width)
+  defp process_content(
+         content,
+         width,
+         :normal,
+         :word,
+         _truncate,
+         _text_overflow,
+         _line_clamp
+       ) do
+    TextLayout.wrap(content, width, :normal)
   end
 
-  defp process_content(content, width, :char, _truncate) do
+  defp process_content(
+         content,
+         width,
+         :normal,
+         :char,
+         _truncate,
+         _text_overflow,
+         _line_clamp
+       ) do
     TextWrapping.wrap_line_by_char(content, width)
   end
 

--- a/lib/raxol/ui/text_layout.ex
+++ b/lib/raxol/ui/text_layout.ex
@@ -1,0 +1,366 @@
+defmodule Raxol.UI.TextLayout do
+  @moduledoc """
+  Canonical text-wrapping entry point implementing the CSS `white-space`
+  property (CSS Text Module Level 3) for monospace/terminal text. Call
+  `wrap/3` with one of the five values below instead of hand-rolling
+  collapsing/wrapping logic.
+
+  | Value       | Newlines  | Space/tab collapsing | Wraps at width? |
+  |-------------|-----------|------------------------|------------------|
+  | `:normal`   | collapse  | collapse               | yes              |
+  | `:nowrap`   | collapse  | collapse               | no               |
+  | `:pre`      | preserve  | preserve               | no               |
+  | `:pre_wrap` | preserve  | preserve               | yes              |
+  | `:pre_line` | preserve  | collapse               | yes              |
+
+  `:normal` delegates to `TextWrapping.wrap_line_by_word/2` and is
+  deliberately bit-identical to it, including its character-count-based
+  (not display-width) line-fit check — so `:normal` is not CJK-width-safe.
+  This is an intentionally preserved divergence; the other four modes are
+  display-width safe via `Raxol.UI.TextMeasure`.
+
+  Word-vs-character break granularity (CSS `word-break`/`overflow-wrap`) is
+  a separate axis not modeled here; see
+  `Raxol.UI.Components.Input.TextWrapping.wrap_line_by_char/2`.
+  """
+
+  alias Raxol.UI.Components.Input.TextWrapping
+  alias Raxol.UI.TextLayout.Pretty
+  alias Raxol.UI.TextMeasure
+
+  @type white_space :: :normal | :nowrap | :pre | :pre_wrap | :pre_line
+
+  @doc """
+  Wraps `text` to `width` display columns according to `white_space`.
+
+  Returns a list of lines (each a `String.t()`). An empty input string
+  always yields `[""]` (one empty line), matching how callers such as
+  `Raxol.UI.Components.Display.Text` already special-case blank content
+  before ever reaching a wrap function.
+
+  A single grapheme wider than `width` is never split -- it is emitted on
+  its own line even though it exceeds `width` (this applies to the
+  width-aware modes: `:nowrap` is not width-constrained at all, `:pre` is
+  never split, and `:normal` also never splits inside a grapheme).
+  """
+  @spec wrap(String.t(), integer(), white_space()) :: [String.t()]
+  def wrap(text, width, white_space \\ :normal)
+
+  def wrap("", _width, _white_space), do: [""]
+
+  def wrap(text, width, :normal) when is_binary(text) and is_integer(width) do
+    if width <= 0 do
+      [text]
+    else
+      TextWrapping.wrap_line_by_word(text, width)
+    end
+  end
+
+  def wrap(text, _width, :nowrap) when is_binary(text) do
+    case collapse_whitespace(text) do
+      "" -> [""]
+      collapsed -> [collapsed]
+    end
+  end
+
+  def wrap(text, _width, :pre) when is_binary(text) do
+    String.split(text, "\n")
+  end
+
+  def wrap(text, width, :pre_wrap) when is_binary(text) and is_integer(width) do
+    text
+    |> String.split("\n")
+    |> Enum.flat_map(&wrap_preserve_segment(&1, width))
+  end
+
+  def wrap(text, width, :pre_line) when is_binary(text) and is_integer(width) do
+    text
+    |> String.split("\n")
+    |> Enum.flat_map(&wrap_collapsed_segment(&1, width))
+  end
+
+  @doc """
+  `wrap/3` with a CSS `text-wrap` style: `:auto` (greedy, identical to
+  `wrap/3`) or `:pretty` (Knuth-Plass DP via `TextLayout.Pretty` —
+  minimizes raggedness, avoids single-word orphan lines).
+
+  `:pretty` applies only to `white_space: :normal` (the sole mode where
+  break points are freely chosen); other modes ignore it.
+  """
+  @spec wrap(String.t(), integer(), white_space(), :auto | :pretty) :: [
+          String.t()
+        ]
+  def wrap(text, width, white_space, :auto), do: wrap(text, width, white_space)
+
+  def wrap("", _width, _white_space, :pretty), do: [""]
+
+  def wrap(text, width, :normal, :pretty)
+      when is_binary(text) and is_integer(width) do
+    if width <= 0 do
+      [text]
+    else
+      Pretty.wrap(text, width)
+    end
+  end
+
+  def wrap(text, width, white_space, :pretty),
+    do: wrap(text, width, white_space)
+
+  # --- :pre_wrap: preserve whitespace runs, wrap at width ---
+
+  defp wrap_preserve_segment("", _width), do: [""]
+
+  defp wrap_preserve_segment(segment, width) when width <= 0, do: [segment]
+
+  defp wrap_preserve_segment(segment, width) do
+    segment
+    |> tokenize_preserve()
+    |> do_wrap_preserve(width, "", [])
+  end
+
+  defp tokenize_preserve(text) do
+    ~r/(\s+)/
+    |> Regex.split(text, include_captures: true)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp do_wrap_preserve([], _width, "", acc), do: Enum.reverse(acc)
+
+  defp do_wrap_preserve([], _width, current, acc),
+    do: Enum.reverse([current | acc])
+
+  defp do_wrap_preserve([token | rest], width, current, acc) do
+    if whitespace_token?(token) do
+      do_wrap_preserve_whitespace(token, rest, width, current, acc)
+    else
+      do_wrap_preserve_word(token, rest, width, current, acc)
+    end
+  end
+
+  defp do_wrap_preserve_word(token, rest, width, current, acc) do
+    cond do
+      TextMeasure.display_width(current <> token) <= width ->
+        do_wrap_preserve(rest, width, current <> token, acc)
+
+      current != "" ->
+        do_wrap_preserve([token | rest], width, "", [current | acc])
+
+      TextMeasure.display_width(token) > width ->
+        {chunks, remainder} = split_overlong(token, width)
+        do_wrap_preserve(rest, width, remainder, Enum.reverse(chunks) ++ acc)
+
+      true ->
+        do_wrap_preserve(rest, width, token, acc)
+    end
+  end
+
+  # Whitespace is preserved, but (unlike CSS's box-model "hang" allowance,
+  # which has no monospace-grid equivalent) it never pushes a line past
+  # `width`: if it still fits, it's appended; if it doesn't and the current
+  # line already has content, the whitespace is dropped at the wrap point
+  # (the line breaks there instead); if the line is empty and even the
+  # whitespace alone is overlong (e.g. a long run of tabs), it is
+  # force-split like an overlong word.
+  defp do_wrap_preserve_whitespace(token, rest, width, current, acc) do
+    cond do
+      TextMeasure.display_width(current <> token) <= width ->
+        do_wrap_preserve(rest, width, current <> token, acc)
+
+      current != "" ->
+        do_wrap_preserve(rest, width, "", [current | acc])
+
+      true ->
+        {chunks, remainder} = split_overlong(token, width)
+        do_wrap_preserve(rest, width, remainder, Enum.reverse(chunks) ++ acc)
+    end
+  end
+
+  defp whitespace_token?(token), do: token != "" and String.trim(token) == ""
+
+  # --- :pre_line: collapse whitespace within a segment, wrap at width ---
+
+  defp wrap_collapsed_segment(segment, width) do
+    wrap_collapsed(collapse_whitespace(segment), width)
+  end
+
+  defp wrap_collapsed("", _width), do: [""]
+  defp wrap_collapsed(text, width) when width <= 0, do: [text]
+
+  defp wrap_collapsed(text, width) do
+    text
+    |> String.split(" ")
+    |> do_wrap_collapsed(width, "", [])
+  end
+
+  defp do_wrap_collapsed([], _width, "", acc), do: Enum.reverse(acc)
+
+  defp do_wrap_collapsed([], _width, current, acc),
+    do: Enum.reverse([current | acc])
+
+  defp do_wrap_collapsed([word | rest], width, current, acc) do
+    candidate = join_word(current, word)
+
+    cond do
+      TextMeasure.display_width(candidate) <= width ->
+        do_wrap_collapsed(rest, width, candidate, acc)
+
+      current != "" ->
+        do_wrap_collapsed([word | rest], width, "", [current | acc])
+
+      true ->
+        do_wrap_collapsed_overlong(word, rest, width, acc)
+    end
+  end
+
+  defp do_wrap_collapsed_overlong(word, rest, width, acc) do
+    if TextMeasure.display_width(word) > width do
+      {chunks, remainder} = split_overlong(word, width)
+      do_wrap_collapsed(rest, width, remainder, Enum.reverse(chunks) ++ acc)
+    else
+      do_wrap_collapsed(rest, width, word, acc)
+    end
+  end
+
+  defp join_word("", word), do: word
+  defp join_word(current, word), do: current <> " " <> word
+
+  # --- shared helpers ---
+
+  # Breaks `word` into display-width-bounded chunks. Returns
+  # `{full_chunks_in_order, remainder}` where `remainder` fits within
+  # `width` and is meant to become the caller's new in-progress line. Never
+  # splits a grapheme in half; if a single grapheme is wider than `width`
+  # it is emitted alone (the documented exception to the width bound).
+  defp split_overlong(word, width) do
+    do_split_overlong(word, width, [])
+  end
+
+  defp do_split_overlong("", _width, chunks), do: {Enum.reverse(chunks), ""}
+
+  defp do_split_overlong(word, width, chunks) do
+    if TextMeasure.display_width(word) <= width do
+      {Enum.reverse(chunks), word}
+    else
+      {chunk, rest} = split_one_overlong_chunk(word, width)
+      do_split_overlong(rest, width, [chunk | chunks])
+    end
+  end
+
+  # Splits one width-bounded chunk off the front of `word`. Falls back to
+  # force-taking a single grapheme when `width` is narrower than the
+  # widest single grapheme in `word` (so we always make progress).
+  defp split_one_overlong_chunk(word, width) do
+    case TextMeasure.split_at_display_width(word, width) do
+      {"", _rest} ->
+        case String.next_grapheme(word) do
+          {grapheme, rest} -> {grapheme, rest}
+          nil -> {word, ""}
+        end
+
+      {left, rest} ->
+        {left, rest}
+    end
+  end
+
+  defp collapse_whitespace(text) do
+    text
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+  end
+
+  # --- text-overflow: single-line truncation -----------------------------
+
+  @ellipsis "…"
+
+  @doc """
+  Truncates a single line to `width` display columns per CSS
+  `text-overflow` (`:ellipsis`) or a plain hard clip (`:clip`).
+
+  Never splits a double-width grapheme in half -- the cut always lands one
+  column earlier instead. Output display width is always `<= width`.
+
+  - `:clip` -- hard cut at `width`, no indicator appended.
+  - `:ellipsis` -- cut to make room for a trailing single-cell `"…"`
+    (U+2026 HORIZONTAL ELLIPSIS). At `width == 1` the whole line collapses
+    to just the ellipsis character.
+
+  `width <= 0` always yields `""`. A line that already fits within `width`
+  is returned unchanged (no ellipsis appended, even in `:ellipsis` mode).
+  """
+  @spec truncate(String.t(), integer(), :ellipsis | :clip) :: String.t()
+  def truncate(line, width, mode)
+      when is_binary(line) and is_integer(width) and mode in [:ellipsis, :clip] do
+    cond do
+      width <= 0 -> ""
+      TextMeasure.display_width(line) <= width -> line
+      mode == :clip -> clip_to_width(line, width)
+      mode == :ellipsis -> fit_with_ellipsis(line, width)
+    end
+  end
+
+  defp clip_to_width(line, width) do
+    {left, _rest} = TextMeasure.split_at_display_width(line, width)
+    left
+  end
+
+  # Assumes `width >= 1` (callers guard `width <= 0` separately).
+  defp fit_with_ellipsis(_line, width) when width <= 1, do: @ellipsis
+
+  defp fit_with_ellipsis(line, width) do
+    {left, _rest} = TextMeasure.split_at_display_width(line, width - 1)
+    left <> @ellipsis
+  end
+
+  # --- line-clamp: multi-line block truncation ----------------------------
+
+  @doc """
+  Wraps `text` to `width` columns (per `white_space`, default `:normal`)
+  and keeps at most `max_lines` lines, implementing CSS Overflow Module
+  Level 4 `line-clamp`.
+
+  If wrapping produces `max_lines` or fewer lines, the result is returned
+  unchanged -- no ellipsis is added when nothing was actually clamped.
+
+  If wrapping produces more lines than `max_lines`, the excess lines are
+  dropped and the kept last line gets a block-ellipsis: a trailing
+  single-cell `"…"` is appended, re-truncating that line first if
+  appending it would push the line past `width`. The block-ellipsed line's
+  display width never exceeds `width`.
+
+  `max_lines <= 0` yields `[]`.
+
+  ## Options
+
+  - `:white_space` -- one of `Raxol.UI.TextLayout.white_space/0`, default
+    `:normal`.
+  """
+  @spec clamp(String.t(), integer(), integer(), keyword()) :: [String.t()]
+  def clamp(text, width, max_lines, opts \\ [])
+
+  def clamp(text, width, max_lines, opts) when is_integer(max_lines) do
+    if max_lines <= 0 do
+      []
+    else
+      white_space = Keyword.get(opts, :white_space, :normal)
+      lines = wrap(text, width, white_space)
+
+      if length(lines) <= max_lines do
+        lines
+      else
+        lines
+        |> Enum.take(max_lines)
+        |> List.update_at(-1, &block_ellipsis(&1, width))
+      end
+    end
+  end
+
+  defp block_ellipsis(_line, width) when width <= 0, do: ""
+
+  defp block_ellipsis(line, width) do
+    if TextMeasure.display_width(line) + 1 <= width do
+      line <> @ellipsis
+    else
+      fit_with_ellipsis(line, width)
+    end
+  end
+end

--- a/lib/raxol/ui/text_layout/pretty.ex
+++ b/lib/raxol/ui/text_layout/pretty.ex
@@ -1,0 +1,463 @@
+defmodule Raxol.UI.TextLayout.Pretty do
+  @moduledoc """
+  `text-wrap: pretty` -- a Knuth-Plass-style dynamic program for the
+  monospace grid.
+
+  Unlike greedy wrapping (packs each line until the next token overflows,
+  often stranding one "orphan" word on the final line), this considers
+  every legal way to break a paragraph and picks the one minimizing total
+  raggedness (squared slack) plus an orphan penalty, subject to no line
+  exceeding `width` (a single overlong token is force-broken).
+
+  Break opportunities (UAX #14 subset): whitespace runs, after a
+  hyphen-minus inside a word, and between any two CJK ideographs/kana.
+
+  All display-width math goes through `Raxol.UI.TextMeasure` (never
+  `String.length/1`). Pure and self-contained -- no dependency on
+  `Raxol.UI.TextLayout`; callers cache if needed.
+  """
+
+  alias Raxol.UI.TextMeasure
+
+  @type token_kind :: :word | :space | :cjk | :hyphen_piece | :split_piece
+
+  @type token :: %{
+          text: String.t(),
+          width: non_neg_integer(),
+          kind: token_kind(),
+          word_id: non_neg_integer() | nil
+        }
+
+  @default_orphan_threshold 2
+  @default_badness_exponent 2
+
+  @doc """
+  Wraps `text` to `width` display columns using the pretty (Knuth-Plass-style)
+  algorithm.
+
+  Paragraphs (separated by `"\\n"`) are wrapped independently and their
+  resulting lines concatenated in order. A blank paragraph produces a single
+  empty line, so the number of `"\\n"`-delimited input paragraphs is a lower
+  bound on the number of output lines.
+
+  ## Options
+
+    * `:orphan_penalty` - integer cost added when a paragraph's last line
+      would contain a single word while the paragraph has more than
+      `:orphan_threshold` words total. Defaults to `width * width`.
+    * `:orphan_threshold` - word count above which the orphan penalty
+      applies. Defaults to `2` (i.e. the penalty applies once a paragraph
+      has more than 2 words).
+    * `:badness_exponent` - exponent used in the raggedness cost
+      `abs(width - line_width) ** exponent`. Defaults to `2`. An exponent of
+      `0` makes every non-perfect line cost `1`, which degenerates the DP
+      toward "minimize line count" (useful as a greedy-ish reference).
+  """
+  @spec wrap(String.t(), pos_integer()) :: [String.t()]
+  @spec wrap(String.t(), pos_integer(), keyword()) :: [String.t()]
+  def wrap(text, width, opts \\ [])
+
+  def wrap(text, width, opts)
+      when is_binary(text) and is_integer(width) and width > 0 do
+    text
+    |> String.split("\n", trim: false)
+    |> Enum.flat_map(&wrap_paragraph(&1, width, opts))
+  end
+
+  def wrap(_text, width, _opts) when is_integer(width) do
+    raise ArgumentError,
+          "width must be a positive integer, got: #{inspect(width)}"
+  end
+
+  # -- Paragraph wrapping -----------------------------------------------------
+
+  @spec wrap_paragraph(String.t(), pos_integer(), keyword()) :: [String.t()]
+  defp wrap_paragraph(paragraph, width, opts) do
+    trimmed = String.trim(paragraph)
+
+    if trimmed == "" do
+      [""]
+    else
+      trimmed
+      |> tokenize()
+      |> force_split_wide(width)
+      |> dp_wrap(width, opts)
+    end
+  end
+
+  # -- Tokenization -------------------------------------------------------
+
+  @cjk_ranges [
+    # Hiragana
+    {0x3040, 0x309F},
+    # Katakana
+    {0x30A0, 0x30FF},
+    # CJK Unified Ideographs Extension A
+    {0x3400, 0x4DBF},
+    # CJK Unified Ideographs
+    {0x4E00, 0x9FFF},
+    # CJK Compatibility Ideographs
+    {0xF900, 0xFAFF}
+  ]
+
+  @spec tokenize(String.t()) :: [token()]
+  defp tokenize(text) do
+    ~r/(\s+)/u
+    |> Regex.split(text, include_captures: true)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.reduce({0, []}, fn part, {word_id, tokens} ->
+      if whitespace?(part) do
+        token = %{text: " ", width: 1, kind: :space, word_id: nil}
+        {word_id, [token | tokens]}
+      else
+        word_tokens = tokenize_word(part, word_id)
+        {word_id + 1, Enum.reverse(word_tokens) ++ tokens}
+      end
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+  end
+
+  defp whitespace?(part), do: String.trim(part) == ""
+
+  @spec tokenize_word(String.t(), non_neg_integer()) :: [token()]
+  defp tokenize_word(word, word_id) do
+    {buffer, tokens} =
+      word
+      |> String.graphemes()
+      |> Enum.reduce({[], []}, fn grapheme, {buffer, tokens} ->
+        cond do
+          cjk_grapheme?(grapheme) ->
+            tokens = flush_buffer(buffer, word_id, tokens)
+
+            cjk = %{
+              text: grapheme,
+              width: TextMeasure.display_width(grapheme),
+              kind: :cjk,
+              word_id: word_id
+            }
+
+            {[], [cjk | tokens]}
+
+          grapheme == "-" ->
+            text = buffer |> Enum.reverse() |> Enum.join() |> Kernel.<>("-")
+
+            piece = %{
+              text: text,
+              width: TextMeasure.display_width(text),
+              kind: :hyphen_piece,
+              word_id: word_id
+            }
+
+            {[], [piece | tokens]}
+
+          true ->
+            {[grapheme | buffer], tokens}
+        end
+      end)
+
+    buffer
+    |> flush_buffer(word_id, tokens)
+    |> Enum.reverse()
+  end
+
+  defp flush_buffer([], _word_id, tokens), do: tokens
+
+  defp flush_buffer(buffer, word_id, tokens) do
+    text = buffer |> Enum.reverse() |> Enum.join()
+
+    token = %{
+      text: text,
+      width: TextMeasure.display_width(text),
+      kind: :word,
+      word_id: word_id
+    }
+
+    [token | tokens]
+  end
+
+  defp cjk_grapheme?(grapheme) do
+    case String.to_charlist(grapheme) do
+      [cp | _] ->
+        Enum.any?(@cjk_ranges, fn {lo, hi} -> cp >= lo and cp <= hi end)
+
+      _ ->
+        false
+    end
+  end
+
+  # -- Force-splitting overlong tokens ---------------------------------------
+
+  # A single :word or :hyphen_piece token whose width exceeds the container
+  # is broken into grapheme-safe pieces via TextMeasure. :cjk tokens are
+  # already single graphemes and cannot be split further; if a CJK grapheme
+  # itself is wider than `width` it is the permitted "single overlong token"
+  # exception to the hard width constraint.
+  @spec force_split_wide([token()], pos_integer()) :: [token()]
+  defp force_split_wide(tokens, width) do
+    Enum.flat_map(tokens, fn
+      %{kind: kind, width: w, text: text, word_id: word_id}
+      when kind in [:word, :hyphen_piece] and w > width ->
+        split_into_pieces(text, width, word_id)
+
+      token ->
+        [token]
+    end)
+  end
+
+  defp split_into_pieces(text, width, word_id),
+    do: split_into_pieces(text, width, word_id, [])
+
+  defp split_into_pieces("", _width, _word_id, acc), do: Enum.reverse(acc)
+
+  defp split_into_pieces(text, width, word_id, acc) do
+    {piece, rest} =
+      case TextMeasure.split_at_display_width(text, width) do
+        {"", _right} ->
+          # Even a single grapheme doesn't fit (e.g. a double-width
+          # grapheme against width=1). Force-take it alone; this is the
+          # unavoidable "single token wider than width" exception.
+          {grapheme, remainder} = String.next_grapheme(text)
+          {grapheme, remainder}
+
+        {left, right} ->
+          {left, right}
+      end
+
+    token = %{
+      text: piece,
+      width: TextMeasure.display_width(piece),
+      kind: :split_piece,
+      word_id: word_id
+    }
+
+    split_into_pieces(rest, width, word_id, [token | acc])
+  end
+
+  # -- Dynamic program --------------------------------------------------------
+
+  # `kind`s after which a line break is legally allowed.
+  defp breakable_kind?(kind),
+    do: kind in [:space, :cjk, :hyphen_piece, :split_piece]
+
+  @spec dp_wrap([token()], pos_integer(), keyword()) :: [String.t()]
+  defp dp_wrap([], _width, _opts), do: [""]
+
+  defp dp_wrap(tokens, width, opts) do
+    n = length(tokens)
+    tokens_t = List.to_tuple(tokens)
+    prefix = build_prefix(tokens)
+    breaks = legal_breaks(tokens_t, n)
+    breaks_t = List.to_tuple(breaks)
+    m = tuple_size(breaks_t)
+
+    total_words =
+      tokens
+      |> Enum.map(& &1.word_id)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> length()
+
+    orphan_threshold =
+      Keyword.get(opts, :orphan_threshold, @default_orphan_threshold)
+
+    orphan_penalty = Keyword.get(opts, :orphan_penalty, width * width)
+    exponent = Keyword.get(opts, :badness_exponent, @default_badness_exponent)
+
+    ctx = %{
+      tokens_t: tokens_t,
+      prefix: prefix,
+      width: width,
+      exponent: exponent,
+      orphan_penalty: orphan_penalty,
+      orphan_threshold: orphan_threshold,
+      total_words: total_words
+    }
+
+    {costs, prevs} = run_dp(breaks_t, m, ctx)
+
+    if elem(costs, m - 1) == :infinity do
+      # Should be unreachable given tokenization guarantees (every token is
+      # individually <= width after force-splitting, and every token is
+      # adjacent to at least one legally-breakable neighbor). Fall back to a
+      # single-token-per-line split so callers never crash on pathological
+      # input (e.g. mixed-script tokens not covered by the break rules).
+      fallback_wrap(tokens_t, n)
+    else
+      breaks_t
+      |> backtrack(prevs, m - 1)
+      |> build_lines(tokens_t)
+    end
+  end
+
+  defp build_prefix(tokens) do
+    [0 | Enum.scan(tokens, 0, fn t, acc -> acc + t.width end)]
+    |> List.to_tuple()
+  end
+
+  defp legal_breaks(_tokens_t, 0), do: [0]
+
+  defp legal_breaks(tokens_t, n) do
+    interior =
+      if n < 2 do
+        []
+      else
+        for g <- 1..(n - 1), breakable_kind?(elem(tokens_t, g - 1).kind), do: g
+      end
+
+    [0] ++ interior ++ [n]
+  end
+
+  defp run_dp(breaks_t, m, ctx) do
+    init_costs = 0 |> then(&(Tuple.duplicate(:infinity, m) |> put_elem(0, &1)))
+    init_prevs = Tuple.duplicate(nil, m)
+
+    Enum.reduce(1..(m - 1), {init_costs, init_prevs}, fn idx, {costs, prevs} ->
+      is_last = idx == m - 1
+
+      {best_cost, best_prev} =
+        Enum.reduce(0..(idx - 1), {:infinity, nil}, fn jdx, acc ->
+          consider_transition(breaks_t, jdx, idx, costs, is_last, ctx, acc)
+        end)
+
+      {put_elem(costs, idx, best_cost), put_elem(prevs, idx, best_prev)}
+    end)
+  end
+
+  defp consider_transition(
+         breaks_t,
+         jdx,
+         idx,
+         costs,
+         is_last,
+         ctx,
+         {best_cost, best_prev} = acc
+       ) do
+    prev_cost = elem(costs, jdx)
+
+    if prev_cost == :infinity do
+      acc
+    else
+      case line_cost(breaks_t, jdx, idx, ctx, is_last) do
+        :invalid ->
+          acc
+
+        cost ->
+          total = prev_cost + cost
+
+          if better?(total, best_cost) do
+            {total, jdx}
+          else
+            {best_cost, best_prev}
+          end
+      end
+    end
+  end
+
+  defp better?(_a, :infinity), do: true
+  defp better?(a, b), do: a < b
+
+  defp line_cost(breaks_t, jdx, idx, ctx, is_last) do
+    start_idx = elem(breaks_t, jdx)
+    end_idx = end_index(ctx.tokens_t, elem(breaks_t, idx))
+
+    if end_idx < start_idx do
+      :invalid
+    else
+      line_width = elem(ctx.prefix, end_idx + 1) - elem(ctx.prefix, start_idx)
+      token_count = end_idx - start_idx + 1
+
+      if line_width > ctx.width and token_count > 1 do
+        :invalid
+      else
+        compute_cost(ctx, start_idx, end_idx, line_width, is_last)
+      end
+    end
+  end
+
+  defp compute_cost(ctx, _start_idx, _end_idx, line_width, false) do
+    diff = abs(ctx.width - line_width)
+    pow_int(diff, ctx.exponent)
+  end
+
+  defp compute_cost(ctx, start_idx, end_idx, _line_width, true) do
+    orphan_cost(
+      ctx.tokens_t,
+      start_idx,
+      end_idx,
+      ctx.total_words,
+      ctx.orphan_penalty,
+      ctx.orphan_threshold
+    )
+  end
+
+  defp orphan_cost(
+         tokens_t,
+         start_idx,
+         end_idx,
+         total_words,
+         penalty,
+         threshold
+       ) do
+    word_ids =
+      start_idx..end_idx
+      |> Enum.map(&elem(tokens_t, &1).word_id)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    if length(word_ids) == 1 and total_words > threshold do
+      penalty
+    else
+      0
+    end
+  end
+
+  defp pow_int(0, _exp), do: 0
+  defp pow_int(_diff, 0), do: 1
+  defp pow_int(diff, exp), do: Integer.pow(diff, exp)
+
+  # Given a legal break gap `g` (the boundary immediately before token index
+  # `g`), returns the index of the last token INCLUDED in the line that ends
+  # at this gap. A gap caused by a :space token drops that space (it belongs
+  # to neither line); any other breakable kind is kept on the earlier line.
+  defp end_index(_tokens_t, 0), do: -1
+
+  defp end_index(tokens_t, g) do
+    case elem(tokens_t, g - 1).kind do
+      :space -> g - 2
+      _ -> g - 1
+    end
+  end
+
+  defp backtrack(breaks_t, prevs, idx), do: backtrack(breaks_t, prevs, idx, [])
+
+  defp backtrack(breaks_t, _prevs, 0, acc), do: [elem(breaks_t, 0) | acc]
+
+  defp backtrack(breaks_t, prevs, idx, acc) do
+    prev_idx = elem(prevs, idx)
+    backtrack(breaks_t, prevs, prev_idx, [elem(breaks_t, idx) | acc])
+  end
+
+  defp build_lines(break_gaps, tokens_t) do
+    break_gaps
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.map(fn [g_start, g_end] ->
+      start_idx = g_start
+      end_idx = end_index(tokens_t, g_end)
+
+      if end_idx < start_idx do
+        ""
+      else
+        start_idx..end_idx
+        |> Enum.map_join("", &elem(tokens_t, &1).text)
+      end
+    end)
+  end
+
+  defp fallback_wrap(tokens_t, n) do
+    0..(n - 1)
+    |> Enum.map(&elem(tokens_t, &1))
+    |> Enum.reject(&(&1.kind == :space))
+    |> Enum.map(& &1.text)
+  end
+end

--- a/test/raxol/ui/components/display/text_test.exs
+++ b/test/raxol/ui/components/display/text_test.exs
@@ -58,7 +58,9 @@ defmodule Raxol.UI.Components.Display.TextTest do
 
   describe "render/2 - truncation" do
     test "truncates long text with ellipsis" do
-      {:ok, state} = Text.init(content: "hello world", width: 8, truncate: true, id: "t")
+      {:ok, state} =
+        Text.init(content: "hello world", width: 8, truncate: true, id: "t")
+
       result = Text.render(state, @context)
       assert result.type == :text
       assert result.content == "hello..."
@@ -66,19 +68,25 @@ defmodule Raxol.UI.Components.Display.TextTest do
     end
 
     test "does not truncate text that fits" do
-      {:ok, state} = Text.init(content: "hi", width: 10, truncate: true, id: "t")
+      {:ok, state} =
+        Text.init(content: "hi", width: 10, truncate: true, id: "t")
+
       result = Text.render(state, @context)
       assert result.content == "hi"
     end
 
     test "does not truncate when no width set" do
-      {:ok, state} = Text.init(content: "a long string", truncate: true, id: "t")
+      {:ok, state} =
+        Text.init(content: "a long string", truncate: true, id: "t")
+
       result = Text.render(state, @context)
       assert result.content == "a long string"
     end
 
     test "handles very small widths" do
-      {:ok, state} = Text.init(content: "hello", width: 3, truncate: true, id: "t")
+      {:ok, state} =
+        Text.init(content: "hello", width: 3, truncate: true, id: "t")
+
       result = Text.render(state, @context)
       assert String.length(result.content) == 3
     end
@@ -86,7 +94,14 @@ defmodule Raxol.UI.Components.Display.TextTest do
 
   describe "render/2 - word wrapping" do
     test "produces column with wrapped lines" do
-      {:ok, state} = Text.init(content: "one two three four", width: 10, wrap: :word, id: "t")
+      {:ok, state} =
+        Text.init(
+          content: "one two three four",
+          width: 10,
+          wrap: :word,
+          id: "t"
+        )
+
       result = Text.render(state, @context)
       assert result.type == :column
       contents = Enum.map(result.children, & &1.content)
@@ -95,7 +110,9 @@ defmodule Raxol.UI.Components.Display.TextTest do
     end
 
     test "single word that fits returns text element" do
-      {:ok, state} = Text.init(content: "hello", width: 10, wrap: :word, id: "t")
+      {:ok, state} =
+        Text.init(content: "hello", width: 10, wrap: :word, id: "t")
+
       result = Text.render(state, @context)
       assert result.type == :text
       assert result.content == "hello"
@@ -104,7 +121,9 @@ defmodule Raxol.UI.Components.Display.TextTest do
 
   describe "render/2 - char wrapping" do
     test "produces column with char-wrapped lines" do
-      {:ok, state} = Text.init(content: "abcdefghij", width: 4, wrap: :char, id: "t")
+      {:ok, state} =
+        Text.init(content: "abcdefghij", width: 4, wrap: :char, id: "t")
+
       result = Text.render(state, @context)
       assert result.type == :column
       contents = Enum.map(result.children, & &1.content)
@@ -126,7 +145,9 @@ defmodule Raxol.UI.Components.Display.TextTest do
     end
 
     test "center alignment pads both sides" do
-      {:ok, state} = Text.init(content: "hi", width: 10, align: :center, id: "t")
+      {:ok, state} =
+        Text.init(content: "hi", width: 10, align: :center, id: "t")
+
       result = Text.render(state, @context)
       assert String.length(result.content) == 10
       assert String.trim(result.content) == "hi"
@@ -142,7 +163,13 @@ defmodule Raxol.UI.Components.Display.TextTest do
   describe "render/2 - wrapping + alignment" do
     test "each wrapped line is aligned independently" do
       {:ok, state} =
-        Text.init(content: "ab cd ef", width: 5, wrap: :word, align: :right, id: "t")
+        Text.init(
+          content: "ab cd ef",
+          width: 5,
+          wrap: :word,
+          align: :right,
+          id: "t"
+        )
 
       result = Text.render(state, @context)
       assert result.type == :column
@@ -153,10 +180,302 @@ defmodule Raxol.UI.Components.Display.TextTest do
     end
   end
 
+  describe "init/1 - white_space" do
+    test "defaults to :normal" do
+      {:ok, state} = Text.init([])
+      assert state.white_space == :normal
+    end
+
+    test "accepts provided white_space" do
+      {:ok, state} = Text.init(white_space: :pre_wrap)
+      assert state.white_space == :pre_wrap
+    end
+  end
+
+  describe "render/2 - white_space :normal is a no-op over the legacy wrap prop" do
+    test "wrap: :word output is unchanged whether white_space is set or omitted" do
+      {:ok, without} =
+        Text.init(
+          content: "one two three four",
+          width: 10,
+          wrap: :word,
+          id: "t"
+        )
+
+      {:ok, with_normal} =
+        Text.init(
+          content: "one two three four",
+          width: 10,
+          wrap: :word,
+          white_space: :normal,
+          id: "t"
+        )
+
+      assert Text.render(without, @context) ==
+               Text.render(with_normal, @context)
+    end
+  end
+
+  describe "render/2 - white_space overrides wrap dispatch when non-default" do
+    test ":pre preserves whitespace and only breaks on explicit newlines" do
+      {:ok, state} =
+        Text.init(
+          content: "a  b\nc  d",
+          width: 3,
+          white_space: :pre,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      assert result.type == :column
+      contents = Enum.map(result.children, & &1.content)
+      assert contents == ["a  b", "c  d"]
+    end
+
+    test ":nowrap collapses whitespace into a single line regardless of width" do
+      {:ok, state} =
+        Text.init(
+          content: "line one\nline two",
+          width: 4,
+          white_space: :nowrap,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      assert result.type == :text
+      assert result.content == "line one line two"
+    end
+
+    test ":pre_line collapses spaces but preserves newlines, wraps at width" do
+      {:ok, state} =
+        Text.init(
+          content: "a   b\nc d",
+          width: 10,
+          white_space: :pre_line,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      assert result.type == :column
+      contents = Enum.map(result.children, & &1.content)
+      assert contents == ["a b", "c d"]
+    end
+  end
+
+  describe "init/1 - text_overflow / line_clamp" do
+    test "defaults to :clip and nil" do
+      {:ok, state} = Text.init([])
+      assert state.text_overflow == :clip
+      assert state.line_clamp == nil
+    end
+
+    test "accepts provided text_overflow and line_clamp" do
+      {:ok, state} = Text.init(text_overflow: :ellipsis, line_clamp: 3)
+      assert state.text_overflow == :ellipsis
+      assert state.line_clamp == 3
+    end
+  end
+
+  describe "render/2 - text_overflow default (:clip) is a no-op" do
+    test ":nowrap output is unchanged whether text_overflow is set to :clip or omitted" do
+      {:ok, without} =
+        Text.init(
+          content: "hello world foo",
+          width: 8,
+          white_space: :nowrap,
+          id: "t"
+        )
+
+      {:ok, with_clip} =
+        Text.init(
+          content: "hello world foo",
+          width: 8,
+          white_space: :nowrap,
+          text_overflow: :clip,
+          id: "t"
+        )
+
+      assert Text.render(without, @context) == Text.render(with_clip, @context)
+    end
+
+    test ":pre output is unchanged whether text_overflow is set to :clip or omitted" do
+      {:ok, without} =
+        Text.init(
+          content: "a  b\nc  d looooong",
+          width: 5,
+          white_space: :pre,
+          id: "t"
+        )
+
+      {:ok, with_clip} =
+        Text.init(
+          content: "a  b\nc  d looooong",
+          width: 5,
+          white_space: :pre,
+          text_overflow: :clip,
+          id: "t"
+        )
+
+      assert Text.render(without, @context) == Text.render(with_clip, @context)
+    end
+
+    test "text_overflow: :ellipsis has no effect on :normal/:pre_wrap/:pre_line (spec-scoped to :nowrap/:pre only)" do
+      {:ok, without} =
+        Text.init(
+          content: "one two three four",
+          width: 10,
+          white_space: :pre_wrap,
+          id: "t"
+        )
+
+      {:ok, with_ellipsis} =
+        Text.init(
+          content: "one two three four",
+          width: 10,
+          white_space: :pre_wrap,
+          text_overflow: :ellipsis,
+          id: "t"
+        )
+
+      assert Text.render(without, @context) ==
+               Text.render(with_ellipsis, @context)
+    end
+
+    test "legacy truncate: true prop is unaffected by the new text_overflow default" do
+      {:ok, state} =
+        Text.init(content: "hello world", width: 8, truncate: true, id: "t")
+
+      result = Text.render(state, @context)
+      assert result.content == "hello..."
+    end
+  end
+
+  describe "render/2 - line_clamp default (nil) is a no-op" do
+    test "word-wrapped output is unchanged whether line_clamp is nil or omitted" do
+      {:ok, without} =
+        Text.init(
+          content: "one two three four five six",
+          width: 10,
+          wrap: :word,
+          id: "t"
+        )
+
+      {:ok, with_nil} =
+        Text.init(
+          content: "one two three four five six",
+          width: 10,
+          wrap: :word,
+          line_clamp: nil,
+          id: "t"
+        )
+
+      assert Text.render(without, @context) == Text.render(with_nil, @context)
+    end
+  end
+
+  describe "render/2 - text_overflow: :ellipsis applied to :nowrap / :pre" do
+    test ":nowrap truncates the collapsed single line with a real ellipsis" do
+      {:ok, state} =
+        Text.init(
+          content: "hello world foo",
+          width: 8,
+          white_space: :nowrap,
+          text_overflow: :ellipsis,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      assert result.type == :text
+      assert result.content == "hello w…"
+      assert Raxol.UI.TextMeasure.display_width(result.content) <= 8
+    end
+
+    test ":pre truncates each preserved line independently" do
+      {:ok, state} =
+        Text.init(
+          content: "a  b\nc  d looooong",
+          width: 5,
+          white_space: :pre,
+          text_overflow: :ellipsis,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      assert result.type == :column
+      contents = Enum.map(result.children, & &1.content)
+      assert contents == ["a  b", "c  d…"]
+    end
+  end
+
+  describe "render/2 - line_clamp" do
+    test "clamps :normal wrap to max_lines with block-ellipsis on the last line" do
+      {:ok, state} =
+        Text.init(
+          content: "one two three four five six",
+          width: 10,
+          line_clamp: 2,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      assert result.type == :column
+      contents = Enum.map(result.children, & &1.content)
+      assert contents == ["one two", "three fou…"]
+    end
+
+    test "overrides the legacy wrap prop when set" do
+      {:ok, state} =
+        Text.init(
+          content: "one two three four five six",
+          width: 10,
+          wrap: :char,
+          line_clamp: 2,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      contents = Enum.map(result.children, & &1.content)
+      assert contents == ["one two", "three fou…"]
+    end
+
+    test "combined with :pre_line white_space" do
+      {:ok, state} =
+        Text.init(
+          content: "a\nb\nc\nd",
+          width: 10,
+          white_space: :pre_line,
+          line_clamp: 2,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      contents = Enum.map(result.children, & &1.content)
+      assert contents == ["a", "b…"]
+    end
+
+    test "content fitting entirely within max_lines is unchanged, no ellipsis" do
+      {:ok, state} =
+        Text.init(
+          content: "one two",
+          width: 10,
+          line_clamp: 5,
+          id: "t"
+        )
+
+      result = Text.render(state, @context)
+      assert result.type == :text
+      assert result.content == "one two"
+    end
+  end
+
   describe "update/2" do
     test "merges style and theme" do
-      {:ok, state} = Text.init(style: %{bold: true}, theme: %{fg: :red}, id: "t")
-      {updated, []} = Text.update(%{style: %{italic: true}, theme: %{bg: :blue}}, state)
+      {:ok, state} =
+        Text.init(style: %{bold: true}, theme: %{fg: :red}, id: "t")
+
+      {updated, []} =
+        Text.update(%{style: %{italic: true}, theme: %{bg: :blue}}, state)
+
       assert updated.style == %{bold: true, italic: true}
       assert updated.theme == %{fg: :red, bg: :blue}
     end

--- a/test/raxol/ui/text_layout/pretty_test.exs
+++ b/test/raxol/ui/text_layout/pretty_test.exs
@@ -1,0 +1,264 @@
+defmodule Raxol.UI.TextLayout.PrettyTest do
+  @moduledoc """
+  Tests for `Raxol.UI.TextLayout.Pretty`, the Knuth-Plass-style `text-wrap:
+  pretty` dynamic program. Self-contained: does not import
+  `Raxol.UI.TextLayout`; uses a private greedy reference wrap for
+  comparison in property/cost-sanity tests.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.TextLayout.Pretty
+  alias Raxol.UI.TextMeasure
+
+  # ---------------------------------------------------------------------
+  # Private greedy reference (word-list based, no hyphenation/CJK
+  # splitting -- used only for comparison in property/cost-sanity tests).
+  # ---------------------------------------------------------------------
+
+  defp greedy_wrap([], _width), do: [""]
+
+  defp greedy_wrap(words, width) do
+    words
+    |> Enum.reduce([], fn word, lines ->
+      case lines do
+        [] ->
+          [word]
+
+        [current | rest] ->
+          candidate_width =
+            TextMeasure.display_width(current) + 1 +
+              TextMeasure.display_width(word)
+
+          if candidate_width <= width do
+            [current <> " " <> word | rest]
+          else
+            [word, current | rest]
+          end
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp line_word_count(line),
+    do: line |> String.split(" ", trim: true) |> length()
+
+  # Cost function mirroring Pretty's default DP cost: sum of squared slack
+  # for all but the last line, plus an orphan penalty (width^2) if the
+  # last line is a single word while the paragraph has more than 2 words.
+  defp total_cost(lines, width, total_words) do
+    {body, [last]} = Enum.split(lines, length(lines) - 1)
+
+    body_cost =
+      Enum.reduce(body, 0, fn line, acc ->
+        diff = width - TextMeasure.display_width(line)
+        acc + diff * diff
+      end)
+
+    orphan_cost =
+      if line_word_count(last) == 1 and total_words > 2 do
+        width * width
+      else
+        0
+      end
+
+    body_cost + orphan_cost
+  end
+
+  describe "goldens" do
+    test "classic raggedness case: pretty balances the orphan, greedy doesn't" do
+      words = ~w(The quick brown fox jumps over the lazy dog today)
+      text = Enum.join(words, " ")
+      width = 15
+
+      greedy = greedy_wrap(words, width)
+      pretty = Pretty.wrap(text, width)
+
+      # Greedy leaves a single-word orphan on the last line.
+      assert greedy == [
+               "The quick brown",
+               "fox jumps over",
+               "the lazy dog",
+               "today"
+             ]
+
+      assert line_word_count(List.last(greedy)) == 1
+
+      # Pretty pulls a second word down onto the last line instead.
+      assert pretty == [
+               "The quick",
+               "brown fox jumps",
+               "over the lazy",
+               "dog today"
+             ]
+
+      assert line_word_count(List.last(pretty)) == 2
+
+      for line <- pretty, do: assert(TextMeasure.display_width(line) <= width)
+    end
+
+    test "CJK paragraph breaks between ideographs with no spaces" do
+      text = "日本語のテキストです今日はとても良い天気ですね"
+      width = 10
+
+      assert Pretty.wrap(text, width) == [
+               "日本語のテキス",
+               "トです今日はとて",
+               "も良い天気です",
+               "ね"
+             ]
+    end
+
+    test "hyphenated word breaks after the hyphen" do
+      text = "a well-known algorithm for wrapping text"
+      width = 12
+
+      assert Pretty.wrap(text, width) == [
+               "a well-known",
+               "algorithm",
+               "for wrapping",
+               "text"
+             ]
+    end
+
+    test "single word wider than width is force-broken grapheme-safe" do
+      text = "supercalifragilisticexpialidocious"
+      width = 10
+
+      lines = Pretty.wrap(text, width)
+
+      assert lines == ["supercalif", "ragilistic", "expialidoc", "ious"]
+      assert Enum.join(lines) == text
+    end
+
+    test "empty string wraps to a single empty line" do
+      assert Pretty.wrap("", 10) == [""]
+    end
+
+    test "width 1 forces one character per line" do
+      lines = Pretty.wrap("cat sat", 1)
+
+      assert lines == ["c", "a", "t", "s", "a", "t"]
+      assert Enum.all?(lines, &(TextMeasure.display_width(&1) <= 1))
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Unit tests: extra behavior not covered by the goldens
+  # ---------------------------------------------------------------------
+
+  describe "multi-paragraph handling" do
+    test "paragraphs separated by \\n are wrapped independently and concatenated" do
+      text = "para one here\n\npara two here also long enough"
+
+      lines = Pretty.wrap(text, 12)
+
+      # blank paragraph between the two produces a blank line
+      assert "" in lines
+      assert Enum.join(lines, " ") |> String.contains?("para one here")
+      assert Enum.join(lines, " ") |> String.contains?("para two")
+    end
+
+    test "single-word paragraph is never penalized for being alone (total_words <= 2)" do
+      assert Pretty.wrap("hi", 20) == ["hi"]
+      assert Pretty.wrap("hi there", 20) == ["hi there"]
+    end
+  end
+
+  describe "argument validation" do
+    test "raises for non-positive width" do
+      assert_raise ArgumentError, fn -> Pretty.wrap("hello", 0) end
+      assert_raise ArgumentError, fn -> Pretty.wrap("hello", -5) end
+    end
+  end
+
+  describe "options" do
+    test "orphan_penalty: 0 disables the orphan-avoidance behavior" do
+      words = ~w(The quick brown fox jumps over the lazy dog today)
+      text = Enum.join(words, " ")
+      width = 15
+
+      pretty_default = Pretty.wrap(text, width)
+      pretty_no_orphan = Pretty.wrap(text, width, orphan_penalty: 0)
+      greedy = greedy_wrap(words, width)
+
+      # With the default orphan penalty, the single-word orphan is avoided.
+      assert line_word_count(List.last(pretty_default)) == 2
+
+      # With the penalty disabled, minimizing squared slack alone reverts
+      # to the same maximal packing greedy finds -- the orphan returns.
+      assert line_word_count(List.last(pretty_no_orphan)) == 1
+      assert pretty_no_orphan == greedy
+    end
+  end
+
+  describe "cost sanity" do
+    test "DP picks a lower total badness than greedy on the classic example" do
+      words = ~w(The quick brown fox jumps over the lazy dog today)
+      text = Enum.join(words, " ")
+      width = 15
+
+      greedy = greedy_wrap(words, width)
+      pretty = Pretty.wrap(text, width)
+
+      greedy_cost = total_cost(greedy, width, length(words))
+      pretty_cost = total_cost(pretty, width, length(words))
+
+      assert pretty_cost < greedy_cost
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Properties
+  # ---------------------------------------------------------------------
+
+  # Words are bounded to <= width so the "single overlong token" exception
+  # never triggers; every line must respect width exactly.
+  defp bounded_word(width) do
+    StreamData.string(:alphanumeric, min_length: 1, max_length: width)
+  end
+
+  defp width_and_words_gen do
+    StreamData.bind(StreamData.integer(3..25), fn width ->
+      StreamData.bind(
+        StreamData.list_of(bounded_word(width), min_length: 1, max_length: 15),
+        fn words -> StreamData.constant({width, words}) end
+      )
+    end)
+  end
+
+  property "every output line fits within width when no single token exceeds it" do
+    check all({width, words} <- width_and_words_gen(), max_runs: 100) do
+      text = Enum.join(words, " ")
+      lines = Pretty.wrap(text, width)
+
+      assert Enum.all?(lines, fn line ->
+               TextMeasure.display_width(line) <= width
+             end)
+    end
+  end
+
+  property "output reconstructs the input words in order" do
+    check all({width, words} <- width_and_words_gen(), max_runs: 100) do
+      text = Enum.join(words, " ")
+      lines = Pretty.wrap(text, width)
+
+      reconstructed =
+        lines
+        |> Enum.flat_map(&String.split(&1, " ", trim: true))
+
+      assert reconstructed == words
+    end
+  end
+
+  property "pretty never produces more lines than greedy + 1 (safety bound)" do
+    check all({width, words} <- width_and_words_gen(), max_runs: 100) do
+      text = Enum.join(words, " ")
+      pretty_lines = Pretty.wrap(text, width)
+      greedy_lines = greedy_wrap(words, width)
+
+      assert length(pretty_lines) <= length(greedy_lines) + 1
+    end
+  end
+end

--- a/test/raxol/ui/text_layout_test.exs
+++ b/test/raxol/ui/text_layout_test.exs
@@ -1,0 +1,454 @@
+defmodule Raxol.UI.TextLayoutTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.Components.Input.TextWrapping
+  alias Raxol.UI.TextLayout
+
+  # Pin wrap_line_by_word/2 output (incl. CJK String.length fit,
+  # intentionally not display-width safe).
+  describe "characterization: TextWrapping.wrap_line_by_word/2 (pre-refactor pins)" do
+    test "collapses nothing -- internal double spaces pass through untouched" do
+      assert TextWrapping.wrap_line_by_word("a  b  c", 10) == ["a  b  c"]
+    end
+
+    test "basic word wrap" do
+      assert TextWrapping.wrap_line_by_word("one two three four", 10) ==
+               ["one two", "three four"]
+    end
+
+    test "overlong single word breaks by character count" do
+      assert TextWrapping.wrap_line_by_word(
+               "supercalifragilisticexpialidocious",
+               10
+             ) == ["supercalif", "ragilistic", "expialidoc", "ious"]
+    end
+
+    test "CJK: fit-check is character-count based, not display-width based (known divergence)" do
+      # 5 graphemes passes the <=6 length check despite a display width of
+      # 10 -- pre-existing behavior preserved bit-for-bit.
+      assert TextWrapping.wrap_line_by_word("中文字符串 test", 6) ==
+               ["中文字符串", "test"]
+    end
+
+    test "trailing spaces are trimmed off the final line" do
+      assert TextWrapping.wrap_line_by_word("trailing spaces   ", 10) ==
+               ["trailing", "spaces"]
+    end
+  end
+
+  # --- :normal ---------------------------------------------------------
+
+  describe "wrap/3 :normal (default)" do
+    test "delegates to TextWrapping.wrap_line_by_word/2 bit-for-bit" do
+      for {text, width} <- [
+            {"a  b  c", 10},
+            {"one two three four", 10},
+            {"supercalifragilisticexpialidocious", 10},
+            {"中文字符串 test", 6},
+            {"trailing spaces   ", 10},
+            {"hello world", 5},
+            {"emoji 🎉🎉 party", 8},
+            {"word", 4},
+            {"ab", 1}
+          ] do
+        assert TextLayout.wrap(text, width, :normal) ==
+                 TextWrapping.wrap_line_by_word(text, width),
+               "mismatch for #{inspect(text)} @ #{width}"
+      end
+    end
+
+    test "default white_space arg is :normal" do
+      assert TextLayout.wrap("one two three four", 10) ==
+               TextLayout.wrap("one two three four", 10, :normal)
+    end
+
+    test "empty string yields a single empty line" do
+      assert TextLayout.wrap("", 10, :normal) == [""]
+    end
+
+    test "width <= 0 returns text unchanged" do
+      assert TextLayout.wrap("hello world", 0, :normal) == ["hello world"]
+      assert TextLayout.wrap("hello world", -1, :normal) == ["hello world"]
+    end
+  end
+
+  # --- :nowrap ------------------------------------------------------------
+
+  describe "wrap/3 :nowrap" do
+    test "collapses whitespace runs (including newlines) to a single space, one line" do
+      assert TextLayout.wrap("hello   world", 5, :nowrap) == ["hello world"]
+
+      assert TextLayout.wrap("line one\nline two", 5, :nowrap) ==
+               ["line one line two"]
+    end
+
+    test "trims leading/trailing whitespace" do
+      assert TextLayout.wrap("  padded  ", 20, :nowrap) == ["padded"]
+    end
+
+    test "ignores width entirely -- never wraps" do
+      assert TextLayout.wrap("this is a long line of text", 4, :nowrap) ==
+               ["this is a long line of text"]
+    end
+
+    test "empty string" do
+      assert TextLayout.wrap("", 10, :nowrap) == [""]
+    end
+
+    test "all-whitespace collapses to a single empty line" do
+      assert TextLayout.wrap("   \n  \t ", 10, :nowrap) == [""]
+    end
+
+    test "CJK/emoji pass through uncollapsed content unchanged" do
+      assert TextLayout.wrap("中文  emoji 🎉", 4, :nowrap) == ["中文 emoji 🎉"]
+    end
+  end
+
+  # --- :pre -----------------------------------------------------------
+
+  describe "wrap/3 :pre" do
+    test "preserves whitespace exactly, only splits on explicit newlines" do
+      assert TextLayout.wrap("a  b\tc", 10, :pre) == ["a  b\tc"]
+    end
+
+    test "splits on newlines, ignoring width" do
+      assert TextLayout.wrap("line one\nline two\nline three", 4, :pre) ==
+               ["line one", "line two", "line three"]
+    end
+
+    test "preserves blank lines" do
+      assert TextLayout.wrap("a\n\nb", 10, :pre) == ["a", "", "b"]
+    end
+
+    test "empty string" do
+      assert TextLayout.wrap("", 10, :pre) == [""]
+    end
+
+    test "never wraps even a very long line" do
+      long = String.duplicate("x", 50)
+      assert TextLayout.wrap(long, 5, :pre) == [long]
+    end
+  end
+
+  # --- :pre_wrap ------------------------------------------------------
+
+  describe "wrap/3 :pre_wrap" do
+    test "wraps at width but preserves internal whitespace runs" do
+      assert TextLayout.wrap("one  two three", 8, :pre_wrap) ==
+               ["one  two", "three"]
+    end
+
+    test "whitespace that would itself overflow the wrap point is dropped, not hung" do
+      # "one  two " would be 9 wide (over the width-8 budget) -- the space
+      # itself doesn't fit, so it's dropped and the break happens there.
+      # The next break ("three four" doesn't fit) is *word*-caused, so the
+      # already-attached single space before "four" is preserved as-is.
+      assert TextLayout.wrap("one  two three four", 8, :pre_wrap) ==
+               ["one  two", "three ", "four"]
+    end
+
+    test "preserves explicit newlines as hard breaks" do
+      assert TextLayout.wrap("ab cd\nef gh", 8, :pre_wrap) ==
+               ["ab cd", "ef gh"]
+    end
+
+    test "preserves blank lines" do
+      assert TextLayout.wrap("a\n\nb", 10, :pre_wrap) == ["a", "", "b"]
+    end
+
+    test "empty string" do
+      assert TextLayout.wrap("", 10, :pre_wrap) == [""]
+    end
+
+    test "overlong single word breaks by display width, CJK/emoji-safe" do
+      # each 中 is 2 columns wide; width 6 fits exactly 3 of them
+      assert TextLayout.wrap("中中中中中", 6, :pre_wrap) == ["中中中", "中中"]
+    end
+
+    test "trailing spaces are preserved (not trimmed)" do
+      lines = TextLayout.wrap("trailing spaces   ", 30, :pre_wrap)
+      assert lines == ["trailing spaces   "]
+    end
+
+    test "single grapheme wider than width is emitted alone, exceeding width" do
+      assert TextLayout.wrap("中", 1, :pre_wrap) == ["中"]
+    end
+  end
+
+  # --- :pre_line ------------------------------------------------------
+
+  describe "wrap/3 :pre_line" do
+    test "collapses spaces within a line but preserves newlines" do
+      assert TextLayout.wrap("a   b\nc     d", 10, :pre_line) ==
+               ["a b", "c d"]
+    end
+
+    test "wraps collapsed content at width" do
+      assert TextLayout.wrap("one   two three   four", 10, :pre_line) ==
+               ["one two", "three four"]
+    end
+
+    test "preserves blank lines" do
+      assert TextLayout.wrap("a\n\nb", 10, :pre_line) == ["a", "", "b"]
+    end
+
+    test "empty string" do
+      assert TextLayout.wrap("", 10, :pre_line) == [""]
+    end
+
+    test "CJK-aware overlong word breaking (display-width safe, unlike :normal)" do
+      assert TextLayout.wrap("中文字符串", 6, :pre_line) == ["中文字", "符串"]
+    end
+
+    test "trailing spaces on a segment collapse away" do
+      assert TextLayout.wrap("trailing spaces   ", 30, :pre_line) ==
+               ["trailing spaces"]
+    end
+  end
+
+  # --- Properties -------------------------------------------------------
+
+  describe "property: :normal never exceeds width in character count" do
+    # Scoped to ASCII/character count since :normal's fit-check is
+    # String.length-based, not display-width-based.
+    property "output lines never exceed width in grapheme count, except a single overlong grapheme" do
+      check all(
+              width <- integer(1..40),
+              words <-
+                list_of(string(?a..?z, min_length: 1, max_length: 60),
+                  min_length: 0,
+                  max_length: 12
+                ),
+              text = Enum.join(words, " "),
+              max_runs: 200
+            ) do
+        lines = TextLayout.wrap(text, width, :normal)
+
+        Enum.each(lines, fn line ->
+          len = String.length(line)
+
+          assert len <= width or len == 1,
+                 "line #{inspect(line)} (len #{len}) exceeds width #{width}"
+        end)
+      end
+    end
+  end
+
+  describe "property: :pre_wrap and :pre_line never exceed display width except a single overlong grapheme" do
+    property "display width bound holds for the width-aware, display-width-safe modes" do
+      check all(
+              width <- integer(1..40),
+              words <-
+                list_of(
+                  string([?a..?z, ?中, ?文, ?🎉],
+                    min_length: 1,
+                    max_length: 8
+                  ),
+                  min_length: 0,
+                  max_length: 10
+                ),
+              mode <- member_of([:pre_wrap, :pre_line]),
+              text = Enum.join(words, " "),
+              max_runs: 200
+            ) do
+        lines = TextLayout.wrap(text, width, mode)
+
+        Enum.each(lines, fn line ->
+          w = Raxol.UI.TextMeasure.display_width(line)
+          graphemes = String.graphemes(line)
+
+          single_overlong_grapheme? =
+            length(graphemes) == 1 and
+              Raxol.UI.TextMeasure.char_display_width(hd(graphemes)) > width
+
+          assert w <= width or single_overlong_grapheme?,
+                 "line #{inspect(line)} (width #{w}) exceeds width #{width} for mode #{mode}"
+        end)
+      end
+    end
+  end
+
+  # --- truncate/3 (text-overflow) ----------------------------------------
+
+  describe "truncate/3 :ellipsis" do
+    test "ASCII: cuts to make room for a trailing single-cell ellipsis" do
+      assert TextLayout.truncate("hello world", 8, :ellipsis) == "hello w…"
+    end
+
+    test "CJK at cut boundary: never splits a double-width grapheme" do
+      # "abc你好": "abc"=3, 你=2 (total 5, fits exactly), 好=2 (would be 7).
+      # width 5 forces the cut before 你 fits alongside the ellipsis: only
+      # "abc" (3 cols) + "…" (1 col) = 4 cols fit within the width-5 budget.
+      assert TextLayout.truncate("abc你好", 5, :ellipsis) == "abc…"
+    end
+
+    test "emoji: fits whole emoji graphemes, never splits" do
+      assert TextLayout.truncate("🎉🎉🎉", 3, :ellipsis) == "🎉…"
+      assert TextLayout.truncate("🎉🎉🎉", 5, :ellipsis) == "🎉🎉…"
+    end
+
+    test "width 0: empty string" do
+      assert TextLayout.truncate("hello", 0, :ellipsis) == ""
+    end
+
+    test "negative width: empty string, no crash" do
+      assert TextLayout.truncate("hello", -3, :ellipsis) == ""
+    end
+
+    test "width 1 with overflow: just the ellipsis" do
+      assert TextLayout.truncate("ab", 1, :ellipsis) == "…"
+      assert TextLayout.truncate("中", 1, :ellipsis) == "…"
+    end
+
+    test "line already fits: returned unchanged, no ellipsis appended" do
+      assert TextLayout.truncate("hi", 10, :ellipsis) == "hi"
+      assert TextLayout.truncate("hi", 2, :ellipsis) == "hi"
+    end
+  end
+
+  describe "truncate/3 :clip" do
+    test "ASCII: hard cut at width, no ellipsis" do
+      assert TextLayout.truncate("hello world", 8, :clip) == "hello wo"
+    end
+
+    test "CJK: never splits a double-width grapheme, cuts one column early" do
+      assert TextLayout.truncate("abc你好", 5, :clip) == "abc你"
+    end
+
+    test "width 1 with an overlong double-width grapheme yields empty" do
+      assert TextLayout.truncate("中", 1, :clip) == ""
+    end
+
+    test "width 1 with a narrow grapheme yields that grapheme" do
+      assert TextLayout.truncate("ab", 1, :clip) == "a"
+    end
+
+    test "width 0: empty string" do
+      assert TextLayout.truncate("hello", 0, :clip) == ""
+    end
+
+    test "line already fits: returned unchanged" do
+      assert TextLayout.truncate("hi", 10, :clip) == "hi"
+    end
+  end
+
+  describe "property: truncate/3 output display width never exceeds the requested width" do
+    property "holds for both :ellipsis and :clip across ASCII/CJK/emoji input" do
+      check all(
+              width <- integer(0..40),
+              mode <- member_of([:ellipsis, :clip]),
+              graphemes <-
+                list_of(member_of(["a", "b", " ", "中", "文", "🎉"]),
+                  min_length: 0,
+                  max_length: 30
+                ),
+              line = Enum.join(graphemes),
+              max_runs: 200
+            ) do
+        result = TextLayout.truncate(line, width, mode)
+
+        assert Raxol.UI.TextMeasure.display_width(result) <= width,
+               "truncate(#{inspect(line)}, #{width}, #{mode}) => #{inspect(result)} exceeds width"
+      end
+    end
+
+    property "never crashes for any width, including negative" do
+      check all(
+              text <- string(:printable, max_length: 40),
+              width <- integer(-10..40),
+              mode <- member_of([:ellipsis, :clip]),
+              max_runs: 200
+            ) do
+        result = TextLayout.truncate(text, width, mode)
+        assert is_binary(result)
+      end
+    end
+  end
+
+  # --- clamp/4 (line-clamp) -----------------------------------------------
+
+  describe "clamp/4" do
+    test "content fits entirely within max_lines: unchanged, no ellipsis" do
+      assert TextLayout.clamp("one two", 10, 2) == ["one two"]
+    end
+
+    test "exact line count match: unchanged, no ellipsis" do
+      assert TextLayout.clamp("one two three four five six", 10, 3) ==
+               ["one two", "three four", "five six"]
+    end
+
+    test "clamps with block-ellipsis on the last kept line" do
+      assert TextLayout.clamp("one two three four five six", 10, 2) ==
+               ["one two", "three fou…"]
+    end
+
+    test "max_lines 1" do
+      assert TextLayout.clamp("one two three", 10, 1) == ["one two…"]
+    end
+
+    test "last kept line exactly fills width: re-truncates to make room for the ellipsis" do
+      assert TextLayout.clamp("abcdefghij klmno", 10, 1) == ["abcdefghi…"]
+    end
+
+    test ":pre_line white_space combination: collapses/wraps then clamps" do
+      assert TextLayout.clamp("a\nb\nc\nd", 10, 2, white_space: :pre_line) ==
+               ["a", "b…"]
+    end
+
+    test "max_lines <= 0 yields an empty list" do
+      assert TextLayout.clamp("anything", 10, 0) == []
+      assert TextLayout.clamp("anything", 10, -1) == []
+    end
+
+    test "empty text yields a single empty line, matching wrap/3" do
+      assert TextLayout.clamp("", 10, 2) == [""]
+    end
+
+    test "default white_space is :normal" do
+      assert TextLayout.clamp("one two three four five six", 10, 2) ==
+               TextLayout.clamp("one two three four five six", 10, 2,
+                 white_space: :normal
+               )
+    end
+  end
+
+  describe "property: clamp/4 output line count never exceeds max_lines" do
+    property "holds across white_space modes and widths" do
+      check all(
+              width <- integer(1..20),
+              max_lines <- integer(1..6),
+              white_space <-
+                member_of([:normal, :nowrap, :pre, :pre_wrap, :pre_line]),
+              words <-
+                list_of(string(?a..?z, min_length: 1, max_length: 8),
+                  min_length: 0,
+                  max_length: 15
+                ),
+              text = Enum.join(words, " "),
+              max_runs: 200
+            ) do
+        lines =
+          TextLayout.clamp(text, width, max_lines, white_space: white_space)
+
+        assert length(lines) <= max_lines
+      end
+    end
+  end
+
+  describe "property: no mode ever crashes and every mode round-trips to a list of strings" do
+    property "wrap/3 always returns a list of binaries for any text/width/mode" do
+      check all(
+              text <- string(:printable, max_length: 60),
+              width <- integer(-5..40),
+              white_space <-
+                member_of([:normal, :nowrap, :pre, :pre_wrap, :pre_line]),
+              max_runs: 300
+            ) do
+        lines = TextLayout.wrap(text, width, white_space)
+        assert is_list(lines)
+        assert Enum.all?(lines, &is_binary/1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Atomic slice of the flex-convergence layout work (decomposing #448). Off master, independent of the flex engine — mergeable on its own.

CSS-style text handling as a standalone `TextLayout` module + `Text` component props:
- `white_space` modes
- `text_overflow` (grapheme-safe ellipsis; CJK never split)
- `line_clamp` (multi-line ellipsis)
- `text_wrap: :pretty` (Knuth-Plass)

No coupling to the flexbox solver (`min_content` and the solver live in the dependent flex PRs).
