### PR TITLE
Cross-terminal characterization net (ANSI-stream differential pins)

### DIFF
--- a/test/cross_terminal/emulator_replay_test.exs
+++ b/test/cross_terminal/emulator_replay_test.exs
@@ -1,0 +1,114 @@
+defmodule Raxol.CrossTerminal.EmulatorReplayTest do
+  @moduledoc """
+  Pins TerminalParser + Emulator behavior, via AnsiReplayer, for the ANSI
+  sequence families the renderer emits.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Test.CrossTerminal.AnsiReplayer, as: Replayer
+
+  describe "text placement" do
+    test "plain text lands at origin" do
+      emulator = Replayer.replay("hello")
+      assert Replayer.visible_text(emulator) == "hello"
+      # emulator cursor tuples are {row, col}
+      assert Replayer.cursor(emulator) == {0, 5}
+    end
+
+    test "CUP positions text (1-based params, 0-based grid)" do
+      emulator = Replayer.replay("\e[3;5Hx")
+      cell = Replayer.cell_at(emulator, 4, 2)
+      assert cell.char == "x"
+    end
+
+    test "newline + carriage return advance lines" do
+      emulator = Replayer.replay("one\r\ntwo")
+      assert Replayer.visible_text(emulator) == "one\ntwo"
+    end
+
+    test "ED 2J clears the screen" do
+      emulator = Replayer.replay("garbage\e[2J\e[HX")
+      assert Replayer.visible_text(emulator) == "X"
+    end
+  end
+
+  describe "SGR styling" do
+    test "16-color foreground reaches the cell style" do
+      emulator = Replayer.replay("\e[31mr\e[0m")
+      cell = Replayer.cell_at(emulator, 0, 0)
+      assert cell.char == "r"
+      assert cell.style.foreground != nil
+    end
+
+    test "truecolor foreground reaches the cell style" do
+      emulator = Replayer.replay("\e[38;2;255;100;0mT\e[0m")
+      cell = Replayer.cell_at(emulator, 0, 0)
+      assert cell.char == "T"
+      assert cell.style.foreground != nil
+    end
+
+    test "256-color foreground reaches the cell style" do
+      emulator = Replayer.replay("\e[38;5;196mC\e[0m")
+      cell = Replayer.cell_at(emulator, 0, 0)
+      assert cell.char == "C"
+      assert cell.style.foreground != nil
+    end
+
+    test "reset stops style bleed" do
+      emulator = Replayer.replay("\e[1;31mbold\e[0m plain")
+      styled = Replayer.cell_at(emulator, 0, 0)
+      plain = Replayer.cell_at(emulator, 5, 0)
+      assert styled.style != plain.style
+    end
+  end
+
+  describe "alt screen (mode 1049)" do
+    test "content written on alt screen does not survive exit" do
+      emulator = Replayer.replay("main\e[?1049halt-only\e[?1049l")
+      text = Replayer.visible_text(emulator)
+      refute text =~ "alt-only"
+      assert text =~ "main"
+    end
+  end
+
+  describe "streaming resume" do
+    test "sequence split across chunks equals single-shot" do
+      single = Replayer.replay("\e[38;2;10;20;30mX")
+      chunked = Replayer.replay_chunks(["\e[38;2;1", "0;20;3", "0mX"])
+
+      assert Replayer.grid_text(single) == Replayer.grid_text(chunked)
+
+      assert Replayer.cell_at(single, 0, 0).style ==
+               Replayer.cell_at(chunked, 0, 0).style
+    end
+
+    test "CUP split across chunks equals single-shot" do
+      single = Replayer.replay("\e[5;10Hy")
+      chunked = Replayer.replay_chunks(["\e[5;1", "0Hy"])
+      assert Replayer.grid_text(single) == Replayer.grid_text(chunked)
+    end
+  end
+
+  describe "wide characters" do
+    test "CJK char occupies two cells" do
+      emulator = Replayer.replay("你a")
+      first = Replayer.cell_at(emulator, 0, 0)
+      second = Replayer.cell_at(emulator, 1, 0)
+      third = Replayer.cell_at(emulator, 2, 0)
+
+      assert first.char == "你"
+      # Placeholder cell content isn't asserted; what matters is the next
+      # narrow char lands at x=2, not x=1.
+      assert third.char == "a"
+      refute second.char == "a"
+    end
+  end
+
+  describe "mode 2026 (synchronized output)" do
+    test "emulator currently does not track mode 2026 (pin until implemented)" do
+      # Mode 2026 not tracked; sequence must not corrupt grid.
+      emulator = Replayer.replay("\e[?2026hhello\e[?2026l")
+      assert Replayer.visible_text(emulator) == "hello"
+    end
+  end
+end

--- a/test/cross_terminal/headless_golden_test.exs
+++ b/test/cross_terminal/headless_golden_test.exs
@@ -1,0 +1,99 @@
+defmodule Raxol.CrossTerminal.HeadlessGoldenTest do
+  @moduledoc """
+  Boots a real TEA app headless and pins its rendered text grid across
+  boot, key events, and re-render — an end-to-end pipeline regression net.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Headless
+
+  defmodule GoldenApp do
+    use Raxol.Core.Runtime.Application
+
+    @impl true
+    def init(_context), do: %{count: 0, panel: :a}
+
+    @impl true
+    def update(message, model) do
+      case message do
+        %Raxol.Core.Events.Event{type: :key, data: %{key: :tab}} ->
+          {%{model | panel: :b}, []}
+
+        %Raxol.Core.Events.Event{type: :key, data: %{key: :char, char: "+"}} ->
+          {%{model | count: model.count + 1}, []}
+
+        _ ->
+          {model, []}
+      end
+    end
+
+    @impl true
+    def view(model) do
+      Raxol.Core.Renderer.View.column(
+        children: [
+          Raxol.Core.Renderer.View.text("Count: #{model.count}"),
+          Raxol.Core.Renderer.View.text("Panel: #{model.panel}")
+        ]
+      )
+    end
+
+    @impl true
+    def subscriptions(_model), do: []
+  end
+
+  setup do
+    pid =
+      case Process.whereis(Headless) do
+        nil -> start_supervised!({Headless, [name: Headless]})
+        existing -> existing
+      end
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        for id <- GenServer.call(pid, :list_sessions) do
+          try do
+            GenServer.call(pid, {:stop_session, id}, 2_000)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  test "initial render matches golden" do
+    {:ok, id} = Headless.start(GoldenApp, id: :golden_initial)
+    {:ok, text} = Headless.screenshot(id)
+
+    assert text =~ "Count: 0"
+    assert text =~ "Panel: a"
+    :ok = Headless.stop(id)
+  end
+
+  test "key event updates model and re-renders" do
+    {:ok, id} = Headless.start(GoldenApp, id: :golden_keys)
+
+    {:ok, text} = Headless.send_key_and_screenshot(id, :tab)
+    assert text =~ "Panel: b"
+
+    {:ok, text} = Headless.send_key_and_screenshot(id, "+")
+    assert text =~ "Count: 1"
+
+    :ok = Headless.stop(id)
+  end
+
+  test "model state matches what the screen shows" do
+    {:ok, id} = Headless.start(GoldenApp, id: :golden_model)
+    {:ok, _} = Headless.send_key_and_screenshot(id, "+")
+    {:ok, _} = Headless.send_key_and_screenshot(id, "+")
+
+    {:ok, model} = Headless.get_model(id)
+    {:ok, text} = Headless.screenshot(id)
+
+    assert model.count == 2
+    assert text =~ "Count: 2"
+    :ok = Headless.stop(id)
+  end
+end

--- a/test/cross_terminal/mouse_characterization_test.exs
+++ b/test/cross_terminal/mouse_characterization_test.exs
@@ -1,0 +1,100 @@
+defmodule Raxol.CrossTerminal.MouseCharacterizationTest do
+  # Pin InputParser (1-based) vs MouseHandler (0-based) SGR decode.
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.ANSI.InputParser
+  alias Raxol.Terminal.Input.MouseHandler
+  alias Raxol.Core.Events.Event
+
+  # SGR: ESC [ < button ; x ; y (M=press|m=release), 1-based coords
+  @sgr_left_press "\e[<0;10;5M"
+  @sgr_left_release "\e[<0;10;5m"
+  @sgr_wheel_up "\e[<64;3;4M"
+  @sgr_ctrl_left "\e[<16;2;2M"
+  @sgr_motion "\e[<32;7;8M"
+
+  describe "InputParser (driver path) SGR decoding" do
+    test "left press keeps 1-based coordinates" do
+      assert [%Event{type: :mouse, data: data}] =
+               InputParser.parse(@sgr_left_press)
+
+      assert data.button == :left
+      assert data.action == :press
+      assert data.x == 10
+      assert data.y == 5
+      assert data.ctrl == false
+    end
+
+    test "release variant" do
+      assert [%Event{type: :mouse, data: %{action: :release, button: :left}}] =
+               InputParser.parse(@sgr_left_release)
+    end
+
+    test "wheel up decodes as wheel_up press" do
+      assert [%Event{type: :mouse, data: %{button: :wheel_up}}] =
+               InputParser.parse(@sgr_wheel_up)
+    end
+
+    test "ctrl modifier decodes" do
+      assert [%Event{type: :mouse, data: %{ctrl: true, button: :left}}] =
+               InputParser.parse(@sgr_ctrl_left)
+    end
+
+    test "motion bit decodes as move" do
+      assert [%Event{type: :mouse, data: %{action: :move}}] =
+               InputParser.parse(@sgr_motion)
+    end
+
+    test "X10 encoding: coords are byte minus 32 (1-based preserved)" do
+      # button 0 (+32), x=11 (+32=43), y=6 (+32=38)
+      assert [%Event{type: :mouse, data: data}] =
+               InputParser.parse(<<27, 91, 77, 32, 43, 38>>)
+
+      assert data.button == :left
+      assert data.action == :press
+      assert data.x == 11
+      assert data.y == 6
+    end
+
+    test "mouse event embedded in key stream parses in order" do
+      events = InputParser.parse("a" <> @sgr_left_press <> "\e[A")
+
+      assert [%Event{type: :key}, %Event{type: :mouse}, %Event{type: :key}] =
+               events
+    end
+  end
+
+  describe "MouseHandler (parallel module) SGR decoding" do
+    test "left press converts to 0-based coordinates — DIVERGES from InputParser" do
+      assert {:ok, event} = MouseHandler.parse_mouse_event(@sgr_left_press)
+
+      assert event.button == :left
+      assert event.type == :press
+      assert event.protocol == :sgr
+      # Same sequence, different origin convention than InputParser:
+      assert event.x == 9
+      assert event.y == 4
+    end
+
+    test "wheel event maps type to :scroll" do
+      assert {:ok, event} = MouseHandler.parse_mouse_event(@sgr_wheel_up)
+      assert event.type == :scroll
+      assert event.button == :wheel_up
+    end
+
+    test "unknown sequence rejected" do
+      assert {:error, :unknown_mouse_sequence} =
+               MouseHandler.parse_mouse_event("\e[Znope")
+    end
+  end
+
+  describe "tracking-mode enable sequences" do
+    test "MouseHandler emits documented enable sequences" do
+      # Pins exact bytes; nothing else catches a broken tracking sequence.
+      assert MouseHandler.enable_mouse_tracking(:x11) =~ "\e[?1000h"
+      assert MouseHandler.enable_mouse_tracking(:button_event) =~ "\e[?1002h"
+      assert MouseHandler.enable_mouse_tracking(:any_event) =~ "\e[?1003h"
+      assert MouseHandler.enable_mouse_tracking(:sgr) =~ "\e[?1006h"
+    end
+  end
+end

--- a/test/cross_terminal/parser_characterization_test.exs
+++ b/test/cross_terminal/parser_characterization_test.exs
@@ -1,0 +1,69 @@
+defmodule Raxol.CrossTerminal.ParserCharacterizationTest do
+  @moduledoc """
+  Characterizes the two ANSI parsers — `TerminalParser` (stateful,
+  canonical) and `ANSI.Parser` (stateless tokenizer) — against a shared
+  corpus, asserting observable outcomes only.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Test.CrossTerminal.AnsiReplayer, as: Replayer
+  alias Raxol.Terminal.ANSI.Parser, as: StatelessParser
+
+  @corpus [
+    {"plain text", "hello world"},
+    {"16-color SGR", "\e[31mred\e[0m"},
+    {"truecolor SGR", "\e[38;2;255;0;0mR\e[0m"},
+    {"cursor position", "\e[10;20Hx"},
+    {"erase display", "before\e[2J\e[Hafter"},
+    {"alt screen", "\e[?1049halt\e[?1049l"},
+    {"osc title", "\e]0;my-title\abody"},
+    {"bracketed paste enable", "\e[?2004htext"}
+  ]
+
+  describe "stateful pipeline (canonical): corpus must not crash the emulator" do
+    for {name, input} <- @corpus do
+      test "#{name}" do
+        emulator = Replayer.replay(unquote(input))
+        # grid must be a well-formed string, cursor a coordinate tuple
+        assert is_binary(Replayer.grid_text(emulator))
+        assert {x, y} = Replayer.cursor(emulator)
+        assert is_integer(x) and is_integer(y)
+      end
+    end
+  end
+
+  describe "stateless parser: corpus must return token lists without crashing" do
+    for {name, input} <- @corpus do
+      test "#{name}" do
+        result = StatelessParser.parse(unquote(input))
+        assert is_list(result)
+      end
+    end
+  end
+
+  describe "pinned grid outcomes (drift detectors)" do
+    test "16-color SGR leaves only text on the grid" do
+      assert "\e[31mred\e[0m" |> Replayer.replay() |> Replayer.visible_text() ==
+               "red"
+    end
+
+    test "OSC title does not leak into the grid" do
+      text =
+        "\e]0;my-title\abody" |> Replayer.replay() |> Replayer.visible_text()
+
+      assert text == "body"
+      refute text =~ "my-title"
+    end
+
+    test "private mode toggles leave no residue on the grid" do
+      assert "\e[?2004htext" |> Replayer.replay() |> Replayer.visible_text() ==
+               "text"
+    end
+
+    test "cursor lands after written text, not at sequence start" do
+      emulator = Replayer.replay("\e[10;20Hx")
+      # CUP is 1-based, grid is 0-based; cursor sits after "x" as {row, col}.
+      assert Replayer.cursor(emulator) == {9, 20}
+    end
+  end
+end

--- a/test/cross_terminal/renderer_roundtrip_test.exs
+++ b/test/cross_terminal/renderer_roundtrip_test.exs
@@ -1,0 +1,106 @@
+defmodule Raxol.CrossTerminal.RendererRoundtripTest do
+  @moduledoc """
+  Differential test: what the renderer emits, the reference emulator
+  must interpret back to the identical text grid.
+
+      Core.Buffer --Renderer.render_diff--> ANSI bytes
+                 --AnsiReplayer/Emulator--> grid
+      grid == Core.Buffer.to_string
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Buffer
+  alias Raxol.Core.Renderer
+  alias Raxol.Test.CrossTerminal.AnsiReplayer, as: Replayer
+  alias Raxol.Test.CrossTerminal.SequenceScanner, as: Scanner
+
+  defp render_to_ansi(buffer, width, height) do
+    blank = Buffer.create_blank_buffer(width, height)
+
+    blank
+    |> Renderer.render_diff(buffer)
+    |> Renderer.apply_diff()
+  end
+
+  defp roundtrip(buffer, width \\ 40, height \\ 10) do
+    ansi = render_to_ansi(buffer, width, height)
+    emulator = Replayer.replay(ansi, width: width, height: height)
+    {ansi, emulator}
+  end
+
+  defp normalized(text) do
+    text
+    |> String.split("\n")
+    |> Enum.map(&String.trim_trailing/1)
+    |> Enum.reverse()
+    |> Enum.drop_while(&(&1 == ""))
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+
+  test "plain text buffer roundtrips through emulator" do
+    buffer =
+      Buffer.create_blank_buffer(40, 10)
+      |> Buffer.write_at(0, 0, "top-left")
+      |> Buffer.write_at(10, 5, "middle")
+      |> Buffer.write_at(0, 9, "bottom")
+
+    {_ansi, emulator} = roundtrip(buffer)
+
+    assert normalized(Replayer.grid_text(emulator)) ==
+             normalized(Buffer.to_string(buffer))
+  end
+
+  test "styled text roundtrips: chars intact, styles land on cells" do
+    buffer =
+      Buffer.create_blank_buffer(40, 10)
+      |> Buffer.write_at(2, 1, "styled", %{fg_color: :red, bold: true})
+      |> Buffer.write_at(2, 3, "plain")
+
+    {_ansi, emulator} = roundtrip(buffer)
+
+    assert normalized(Replayer.grid_text(emulator)) ==
+             normalized(Buffer.to_string(buffer))
+
+    styled_cell = Replayer.cell_at(emulator, 2, 1)
+    plain_cell = Replayer.cell_at(emulator, 2, 3)
+    assert styled_cell.char == "s"
+    assert plain_cell.char == "p"
+  end
+
+  test "box-drawing characters roundtrip intact" do
+    buffer =
+      Buffer.create_blank_buffer(20, 5)
+      |> Buffer.write_at(0, 0, "┌──────┐")
+      |> Buffer.write_at(0, 1, "│ box  │")
+      |> Buffer.write_at(0, 2, "└──────┘")
+
+    {_ansi, emulator} = roundtrip(buffer, 20, 5)
+
+    assert normalized(Replayer.grid_text(emulator)) ==
+             normalized(Buffer.to_string(buffer))
+  end
+
+  test "renderer output contains no sequences a modern terminal cannot interpret" do
+    buffer =
+      Buffer.create_blank_buffer(40, 10)
+      |> Buffer.write_at(0, 0, "text", %{fg_color: :cyan})
+
+    {ansi, _emulator} = roundtrip(buffer)
+
+    assert Scanner.violations(ansi, :modern) == []
+  end
+
+  test "sequence scanner sees only known token types in renderer output" do
+    buffer =
+      Buffer.create_blank_buffer(40, 10)
+      |> Buffer.write_at(0, 0, "abc", %{bold: true})
+      |> Buffer.write_at(5, 5, "def")
+
+    ansi = render_to_ansi(buffer, 40, 10)
+
+    for token <- Scanner.scan(ansi) do
+      assert elem(token, 0) in [:csi, :osc, :dcs, :esc, :text]
+    end
+  end
+end

--- a/test/support/cross_terminal/ansi_replayer.ex
+++ b/test/support/cross_terminal/ansi_replayer.ex
@@ -1,0 +1,105 @@
+defmodule Raxol.Test.CrossTerminal.AnsiReplayer do
+  @moduledoc """
+  Feeds a raw ANSI byte stream into the reference terminal emulator
+  (`Raxol.Terminal.Emulator`) and exposes the resulting text grid.
+
+  This is the missing link between `Raxol.Recording` (which captures the
+  real ANSI frames an app emits) and grid-level assertions: any `.cast`
+  file or ANSI string can be replayed headlessly and compared cell by cell.
+  """
+
+  alias Raxol.Terminal.Emulator
+  alias Raxol.Terminal.Buffer.Queries
+  alias Raxol.Terminal.ScreenBuffer
+
+  @default_width 80
+  @default_height 24
+
+  @doc "Replays a single ANSI binary into a fresh emulator."
+  def replay(bytes, opts \\ []) when is_binary(bytes) do
+    replay_chunks([bytes], opts)
+  end
+
+  @doc """
+  Replays a list of ANSI chunks sequentially through one emulator,
+  exercising the parser's ability to resume mid-sequence across chunks.
+  """
+  def replay_chunks(chunks, opts \\ []) when is_list(chunks) do
+    width = Keyword.get(opts, :width, @default_width)
+    height = Keyword.get(opts, :height, @default_height)
+
+    Enum.reduce(chunks, Emulator.new(width, height), fn chunk, emulator ->
+      {emulator, _output} = Emulator.process_input(emulator, chunk)
+      emulator
+    end)
+  end
+
+  @doc """
+  Replays an asciinema v2 `.cast` file (as produced by `Raxol.Recording`),
+  concatenating all output ("o") events. Returns the emulator.
+  """
+  def replay_cast(path, opts \\ []) do
+    [header_line | event_lines] =
+      path
+      |> File.read!()
+      |> String.split("\n", trim: true)
+
+    header = Jason.decode!(header_line)
+
+    bytes =
+      event_lines
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.filter(fn [_ts, type, _data] -> type == "o" end)
+      |> Enum.map_join("", fn [_ts, _type, data] -> data end)
+
+    opts =
+      Keyword.merge(
+        [
+          width: header["width"] || @default_width,
+          height: header["height"] || @default_height
+        ],
+        opts
+      )
+
+    replay(bytes, opts)
+  end
+
+  @doc "Full text grid, one string per line, padded to buffer width."
+  def grid_text(emulator) do
+    emulator
+    |> Emulator.get_screen_buffer()
+    |> Queries.get_text()
+  end
+
+  @doc """
+  Text grid trimmed for golden comparisons: trailing whitespace stripped
+  per line, trailing blank lines dropped.
+  """
+  def visible_text(emulator) do
+    emulator
+    |> grid_text()
+    |> String.split("\n")
+    |> Enum.map(&String.trim_trailing/1)
+    |> Enum.reverse()
+    |> Enum.drop_while(&(&1 == ""))
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+
+  @doc "Cell struct at (x, y) — zero-based."
+  def cell_at(emulator, x, y) do
+    emulator
+    |> Emulator.get_screen_buffer()
+    |> ScreenBuffer.get_cell_at(x, y)
+  end
+
+  @doc """
+  Cursor position of the replayed emulator.
+
+  NOTE: the emulator returns `{row, col}` (y first), not `{x, y}`.
+  Pinned as-is by the characterization tests.
+  """
+  def cursor(emulator) do
+    Emulator.get_cursor_position(emulator)
+  end
+end

--- a/test/support/cross_terminal/sequence_scanner.ex
+++ b/test/support/cross_terminal/sequence_scanner.ex
@@ -1,0 +1,151 @@
+defmodule Raxol.Test.CrossTerminal.SequenceScanner do
+  @moduledoc """
+  Minimal ANSI sequence linter. Scans a raw output byte stream, extracts
+  escape sequences, classifies them, and checks them against a terminal
+  capability profile.
+
+  Purpose: assert that what Raxol *emits* stays within what a target
+  terminal can *interpret* — without needing the terminal.
+  """
+
+  @type token ::
+          {:csi, params :: String.t(), final :: String.t()}
+          | {:osc, String.t()}
+          | {:dcs, String.t()}
+          | {:esc, String.t()}
+          | {:text, String.t()}
+
+  @doc "Tokenizes a binary into text runs and escape sequences."
+  @spec scan(binary()) :: [token()]
+  def scan(bytes) when is_binary(bytes), do: scan(bytes, [])
+
+  defp scan(<<>>, acc), do: Enum.reverse(acc)
+
+  defp scan(<<0x1B, ?[, rest::binary>>, acc) do
+    {params, final, rest} = take_csi(rest, "")
+    scan(rest, [{:csi, params, final} | acc])
+  end
+
+  defp scan(<<0x1B, ?], rest::binary>>, acc) do
+    {body, rest} = take_until_st(rest, "")
+    scan(rest, [{:osc, body} | acc])
+  end
+
+  defp scan(<<0x1B, ?P, rest::binary>>, acc) do
+    {body, rest} = take_until_st(rest, "")
+    scan(rest, [{:dcs, body} | acc])
+  end
+
+  defp scan(<<0x1B, char, rest::binary>>, acc) do
+    scan(rest, [{:esc, <<char>>} | acc])
+  end
+
+  defp scan(bytes, acc) do
+    case :binary.match(bytes, <<0x1B>>) do
+      :nomatch ->
+        scan(<<>>, [{:text, bytes} | acc])
+
+      {pos, _} ->
+        <<text::binary-size(^pos), rest::binary>> = bytes
+        scan(rest, [{:text, text} | acc])
+    end
+  end
+
+  defp take_csi(<<char, rest::binary>>, acc) when char in 0x40..0x7E do
+    {acc, <<char>>, rest}
+  end
+
+  defp take_csi(<<char, rest::binary>>, acc),
+    do: take_csi(rest, acc <> <<char>>)
+
+  defp take_csi(<<>>, acc), do: {acc, "", <<>>}
+
+  defp take_until_st(<<0x07, rest::binary>>, acc), do: {acc, rest}
+  defp take_until_st(<<0x1B, ?\\, rest::binary>>, acc), do: {acc, rest}
+
+  defp take_until_st(<<char, rest::binary>>, acc),
+    do: take_until_st(rest, acc <> <<char>>)
+
+  defp take_until_st(<<>>, acc), do: {acc, <<>>}
+
+  @doc """
+  Classifies a token into a capability requirement, or `:basic` when any
+  VT100-era terminal handles it.
+  """
+  def capability({:csi, params, "m"}) do
+    cond do
+      String.contains?(params, "38;2;") or String.contains?(params, "48;2;") ->
+        :truecolor
+
+      String.contains?(params, "38;5;") or String.contains?(params, "48;5;") ->
+        :color256
+
+      true ->
+        :basic
+    end
+  end
+
+  def capability({:csi, "?" <> params, final}) when final in ["h", "l"] do
+    modes = params |> String.split(";") |> Enum.map(&String.trim/1)
+
+    cond do
+      Enum.any?(modes, &(&1 in ~w(1000 1002 1003 1005 1006 1015))) -> :mouse
+      "1049" in modes or "47" in modes -> :alt_screen
+      "2004" in modes -> :bracketed_paste
+      "2026" in modes -> :synchronized_output
+      "25" in modes -> :basic
+      true -> :private_mode
+    end
+  end
+
+  def capability({:osc, "52;" <> _}), do: :osc52_clipboard
+  def capability({:osc, _}), do: :osc
+  def capability({:dcs, _}), do: :dcs
+  def capability(_), do: :basic
+
+  @profiles %{
+    # Bare VT100/dumb-ish: no color extensions, no mouse, no modes beyond basics
+    vt100: MapSet.new([:basic]),
+    # xterm-256color without truecolor (Terminal.app)
+    xterm_256color:
+      MapSet.new([
+        :basic,
+        :color256,
+        :mouse,
+        :alt_screen,
+        :bracketed_paste,
+        :osc
+      ]),
+    # Modern terminal (iTerm2, kitty, WezTerm, Ghostty, Windows Terminal)
+    modern:
+      MapSet.new([
+        :basic,
+        :color256,
+        :truecolor,
+        :mouse,
+        :alt_screen,
+        :bracketed_paste,
+        :synchronized_output,
+        :osc,
+        :osc52_clipboard,
+        :dcs,
+        :private_mode
+      ])
+  }
+
+  @doc "Known capability profiles."
+  def profiles, do: Map.keys(@profiles)
+
+  @doc """
+  Returns the list of `{token, capability}` violations: sequences in the
+  stream that the given profile's terminal cannot interpret.
+  """
+  def violations(bytes, profile) when is_atom(profile) do
+    allowed = Map.fetch!(@profiles, profile)
+
+    bytes
+    |> scan()
+    |> Enum.map(&{&1, capability(&1)})
+    |> Enum.reject(fn {_token, cap} -> MapSet.member?(allowed, cap) end)
+  end
+end


### PR DESCRIPTION
Atomic slice of the flex-convergence layout work (decomposing the closed #448). Off master, no dependencies — box-sizing (#456) has merged.

An ANSI-stream-to-grid differential test harness (`ansi_replayer`, `sequence_scanner`) plus pins for emulator replay, mouse/parser decode, and renderer round-trips. A tripwire for the flex rework: a changed number here is either an intended re-pin or a regression.

This net already earned its keep — during the decomposition it caught the render-diff `{:write}`/`{:move}` ordering bug (fixed in #456) and the flexbox tuple-arity bug (fixed in the solver PR).
