### PR TITLE
Flexbox §9.7 solver + FlexItem modules (unwired)

### DIFF
--- a/lib/raxol/ui/layout/flex_item.ex
+++ b/lib/raxol/ui/layout/flex_item.ex
@@ -1,0 +1,368 @@
+defmodule Raxol.UI.Layout.FlexItem do
+  @moduledoc """
+  A flex child resolved into the inputs the flexible-length solver needs.
+
+  This is the interface contract for the flex rework (proposal:
+  `docs/proposals/in-flight/flex-spec-convergence.md`, Phase A). One
+  `FlexItem` is resolved per child BEFORE distribution; the solver
+  (`Distributor`) then works exclusively on these — it never reads raw
+  elements or style maps.
+
+  ## Semantics
+
+    * `base_size` — the item's flex base size (resolved `flex-basis`).
+      `:auto` basis resolves to the content main size via the measure
+      function passed to `resolve/4`.
+    * Terminal-pragmatic `flex: 1` (D2): the integer shorthand
+      `style: %{flex: n}` expands to grow n / shrink 1 / basis 0 AND
+      `min_main: 0`, so equal columns actually equalize. An explicit
+      `min_width`/`min_height` in style still wins over the sugar.
+    * Percentages: `{:pct, n}`. Resolved against the container's
+      corresponding dimension when it is definite; against an indefinite
+      dimension a percentage behaves as `:auto` (spec). Margin percentages
+      resolve against the container's WIDTH regardless of side (spec).
+    * Invalid values (negative sizes, negative flex factors, malformed
+      percentages) are clamped to the nearest valid value and reported via
+      the `[:raxol, :layout, :invalid_style]` telemetry event (D8) — layout
+      never raises on style input.
+    * `margin` sides may be `:auto`; sizing math treats `:auto` as 0
+      (`outer_main/2`), positioning distributes free space into them (P3
+      auto-margin step, solver-adjacent but not solver-owned).
+
+  ## Solver fields
+
+  `frozen`, `frozen_reason` (`:inflexible | :min_violation | :max_violation`)
+  and `main_size` belong to the resolve-flexible-lengths loop (N6). They are
+  defined here so the struct is the single currency between resolution,
+  distribution, and positioning.
+  """
+
+  @type dimension :: non_neg_integer() | :infinity
+  @type margin_side :: non_neg_integer() | :auto
+  @type pct :: {:pct, number()}
+
+  @type t :: %__MODULE__{
+          element: map(),
+          base_size: non_neg_integer(),
+          min_main: non_neg_integer(),
+          max_main: dimension(),
+          grow: non_neg_integer(),
+          shrink: non_neg_integer(),
+          margin: {margin_side(), margin_side(), margin_side(), margin_side()},
+          cross_size: non_neg_integer() | nil,
+          min_cross: non_neg_integer(),
+          max_cross: dimension(),
+          align_self: atom() | nil,
+          frozen: boolean(),
+          frozen_reason: nil | :inflexible | :min_violation | :max_violation,
+          main_size: non_neg_integer() | nil
+        }
+
+  defstruct element: nil,
+            base_size: 0,
+            min_main: 0,
+            max_main: :infinity,
+            grow: 0,
+            shrink: 1,
+            margin: {0, 0, 0, 0},
+            cross_size: nil,
+            min_cross: 0,
+            max_cross: :infinity,
+            align_self: nil,
+            frozen: false,
+            frozen_reason: nil,
+            main_size: nil
+
+  @doc """
+  Resolves a raw child element into a `FlexItem`.
+
+    * `child` — element map (style read from `:style`, flex attrs also
+      honored from legacy `child.attrs.flex` for back-compat)
+    * `main_axis` — `:horizontal | :vertical`
+    * `container` — `%{width: definite | nil, height: definite | nil}`;
+      nil marks an indefinite dimension (percentages resolve to `:auto`)
+    * `content_size_fun` — zero-arg fun returning the content main size;
+      called ONLY when basis resolves to `:auto`
+  """
+  def resolve(child, main_axis, container, content_size_fun) do
+    style = get_style(child)
+    flex = lift_flex(style, Map.get(child, :attrs, %{}))
+
+    {main_dim, cross_dim} = axis_dims(main_axis)
+    container_main = Map.get(container, main_dim)
+    container_cross = Map.get(container, cross_dim)
+
+    explicit_main =
+      resolve_dimension(axis_style(style, child, main_dim), container_main)
+
+    base_size =
+      case resolve_basis(flex.basis, container_main) do
+        :auto ->
+          case explicit_main do
+            :auto -> non_neg(content_size_fun.())
+            n -> n
+          end
+
+        n ->
+          n
+      end
+
+    explicit_min = resolve_dimension(min_style(style, main_dim), container_main)
+
+    min_main =
+      case {explicit_min, flex.min_main_override} do
+        {:auto, nil} -> 0
+        {:auto, override} -> override
+        {n, _} -> n
+      end
+
+    max_main =
+      case resolve_dimension(max_style(style, main_dim), container_main) do
+        :auto -> :infinity
+        n -> n
+      end
+
+    cross_size =
+      case resolve_dimension(
+             axis_style(style, child, cross_dim),
+             container_cross
+           ) do
+        :auto -> nil
+        n -> n
+      end
+
+    min_cross =
+      case resolve_dimension(min_style(style, cross_dim), container_cross) do
+        :auto -> 0
+        n -> n
+      end
+
+    max_cross =
+      case resolve_dimension(max_style(style, cross_dim), container_cross) do
+        :auto -> :infinity
+        n -> n
+      end
+
+    %__MODULE__{
+      element: child,
+      base_size: base_size,
+      min_main: min_main,
+      max_main: max_main,
+      grow: flex.grow,
+      shrink: flex.shrink,
+      margin: resolve_margin(child, style, Map.get(container, :width)),
+      cross_size: cross_size,
+      min_cross: min_cross,
+      max_cross: max_cross,
+      align_self: Map.get(style, :align_self) || legacy_align_self(child)
+    }
+  end
+
+  @doc """
+  Expands the `flex` shorthand plus explicit grow/shrink/basis keys.
+
+  Returns `%{grow, shrink, basis, min_main_override}`.
+
+    * `flex: n` (int)      -> grow n, shrink 1, basis 0, min_main_override 0  (D2)
+    * `flex: {g, s, b}`    -> as given, no min override
+    * `flex: %{...}` map   -> grow/shrink/basis keys, no min override
+    * legacy `attrs.flex`  -> same as map form (lowest precedence)
+  """
+  def lift_flex(style, attrs \\ %{}) do
+    legacy = Map.get(attrs, :flex, %{})
+
+    defaults = %{
+      grow: Map.get(legacy, :grow, 0),
+      shrink: Map.get(legacy, :shrink, 1),
+      basis: Map.get(legacy, :basis, :auto),
+      min_main_override: nil
+    }
+
+    case Map.get(style, :flex) do
+      nil ->
+        read_explicit_flex_keys(style, defaults)
+
+      n when is_integer(n) ->
+        n = clamp_factor(n, :flex)
+        %{grow: n, shrink: 1, basis: 0, min_main_override: 0}
+
+      {g, s, b} ->
+        %{
+          grow: clamp_factor(g, :grow),
+          shrink: clamp_factor(s, :shrink),
+          basis: b,
+          min_main_override: nil
+        }
+
+      %{} = m ->
+        %{
+          grow: clamp_factor(Map.get(m, :grow, defaults.grow), :grow),
+          shrink: clamp_factor(Map.get(m, :shrink, defaults.shrink), :shrink),
+          basis: Map.get(m, :basis, defaults.basis),
+          min_main_override: nil
+        }
+
+      other ->
+        invalid(:flex, other)
+        defaults
+    end
+  end
+
+  @doc """
+  Resolves a single dimension value against a containing dimension.
+
+  int -> int (clamped non-negative); `{:pct, n}` -> rounded share of a
+  definite container, `:auto` against an indefinite one; nil/:auto -> :auto.
+  """
+  def resolve_dimension(nil, _container), do: :auto
+  def resolve_dimension(:auto, _container), do: :auto
+
+  def resolve_dimension(n, _container) when is_integer(n) do
+    if n < 0 do
+      invalid(:dimension, n)
+      0
+    else
+      n
+    end
+  end
+
+  def resolve_dimension({:pct, n}, container)
+      when is_number(n) and is_integer(container) do
+    if n < 0 do
+      invalid(:pct, n)
+      0
+    else
+      round(n / 100 * container)
+    end
+  end
+
+  def resolve_dimension({:pct, _n}, _indefinite), do: :auto
+
+  def resolve_dimension(other, _container) do
+    invalid(:dimension, other)
+    :auto
+  end
+
+  @doc "Outer main size: margins + size; :auto margins count as 0 here."
+  def outer_main(%__MODULE__{} = item, size, main_axis) do
+    {ms, me} = main_margins(item, main_axis)
+    margin_int(ms) + size + margin_int(me)
+  end
+
+  @doc "Clamp a candidate main size into the item's [min_main, max_main]."
+  def clamp_main(%__MODULE__{min_main: min, max_main: max}, size) do
+    size |> max(min) |> min_cap(max)
+  end
+
+  @doc "Hypothetical main size: base size clamped (spec 9.7 step 1 input)."
+  def hypothetical_main(%__MODULE__{} = item),
+    do: clamp_main(item, item.base_size)
+
+  @doc "Main-axis {start, end} margins for the given axis."
+  def main_margins(%__MODULE__{margin: {_t, r, _b, l}}, :horizontal), do: {l, r}
+  def main_margins(%__MODULE__{margin: {t, _r, b, _l}}, :vertical), do: {t, b}
+
+  @doc "Cross-axis {start, end} margins for the given MAIN axis."
+  def cross_margins(%__MODULE__{margin: {t, _r, b, _l}}, :horizontal),
+    do: {t, b}
+
+  def cross_margins(%__MODULE__{margin: {_t, r, _b, l}}, :vertical), do: {l, r}
+
+  def margin_int(:auto), do: 0
+  def margin_int(n) when is_integer(n), do: n
+
+  # -- private ----------------------------------------------------------------
+
+  defp get_style(child) do
+    case Map.get(child, :style) do
+      s when is_map(s) -> s
+      s when is_list(s) -> Map.new(s)
+      _ -> %{}
+    end
+  end
+
+  defp read_explicit_flex_keys(style, defaults) do
+    %{
+      defaults
+      | grow: clamp_factor(Map.get(style, :flex_grow, defaults.grow), :grow),
+        shrink:
+          clamp_factor(Map.get(style, :flex_shrink, defaults.shrink), :shrink),
+        basis: Map.get(style, :flex_basis, defaults.basis)
+    }
+  end
+
+  defp resolve_basis(:auto, _), do: :auto
+  defp resolve_basis(b, container), do: resolve_dimension(b, container)
+
+  defp axis_dims(:horizontal), do: {:width, :height}
+  defp axis_dims(:vertical), do: {:height, :width}
+
+  defp axis_style(style, child, dim) do
+    Map.get(style, dim) || Map.get(child, dim)
+  end
+
+  defp min_style(style, :width), do: Map.get(style, :min_width)
+  defp min_style(style, :height), do: Map.get(style, :min_height)
+  defp max_style(style, :width), do: Map.get(style, :max_width)
+  defp max_style(style, :height), do: Map.get(style, :max_height)
+
+  defp resolve_margin(child, style, container_width) do
+    raw = Map.get(style, :margin) || Map.get(child, :margin) || 0
+
+    normalized =
+      case raw do
+        n when is_integer(n) or n == :auto ->
+          {n, n, n, n}
+
+        {h, v} ->
+          {h, v, h, v}
+
+        {_t, _r, _b, _l} = m ->
+          m
+
+        other ->
+          invalid(:margin, other)
+          {0, 0, 0, 0}
+      end
+
+    normalized
+    |> Tuple.to_list()
+    |> Enum.map(&resolve_margin_side(&1, container_width))
+    |> List.to_tuple()
+  end
+
+  # Spec: margin percentages resolve against the container WIDTH for all sides.
+  defp resolve_margin_side(:auto, _), do: :auto
+
+  defp resolve_margin_side(v, container_width) do
+    case resolve_dimension(v, container_width) do
+      :auto -> 0
+      n -> n
+    end
+  end
+
+  defp legacy_align_self(child) do
+    child |> Map.get(:attrs, %{}) |> Map.get(:align_self)
+  end
+
+  defp clamp_factor(n, _key) when is_integer(n) and n >= 0, do: n
+
+  defp clamp_factor(n, key) do
+    invalid(key, n)
+    0
+  end
+
+  defp non_neg(n) when is_integer(n) and n >= 0, do: n
+  defp non_neg(_), do: 0
+
+  defp min_cap(n, :infinity), do: n
+  defp min_cap(n, max) when is_integer(max), do: min(n, max)
+
+  defp invalid(key, value) do
+    :telemetry.execute(
+      [:raxol, :layout, :invalid_style],
+      %{count: 1},
+      %{key: key, value: inspect(value)}
+    )
+  end
+end

--- a/lib/raxol/ui/layout/flexbox/solver.ex
+++ b/lib/raxol/ui/layout/flexbox/solver.ex
@@ -1,0 +1,256 @@
+defmodule Raxol.UI.Layout.Flexbox.Solver do
+  @moduledoc """
+  Resolve flexible lengths per CSS Flexbox spec section 9.7, on resolved
+  `Raxol.UI.Layout.FlexItem`s. Replaces `Distributor`'s single pass
+  (wired in by the integration node; until then this module is unreferenced
+  by the live path).
+
+  Differences from the naive pass it replaces:
+
+    * free space computed from OUTER sizes (margins included; `:auto`
+      margins count as 0 during sizing — positioning distributes into them)
+    * inflexible items and items whose clamped hypothetical size differs
+      from their base size freeze BEFORE the loop
+    * iterative clamp-freeze-redistribute until no min/max violations
+      (bounded by the item count)
+    * exact integer accounting: each round distributes whole cells via
+      largest-remainder, so no free space is silently lost to `div`
+      truncation
+
+  Not implemented (documented divergence): the fractional-flex-factor rule
+  (sum of factors < 1 leaves proportional free space undistributed) —
+  factors here are non-negative integers, so a fractional sum cannot occur.
+  """
+
+  alias Raxol.UI.Layout.FlexItem
+
+  @doc """
+  Solves main sizes for `items` inside `container_main` cells (the
+  container's content-box main size, gaps already subtracted by the caller).
+
+  Returns items in original order, each with `main_size` set and frozen.
+  """
+  def resolve_flexible_lengths(items, container_main, main_axis)
+      when is_list(items) and is_integer(container_main) do
+    indexed = Enum.with_index(items)
+
+    outer_hypo_sum =
+      Enum.reduce(items, 0, fn item, acc ->
+        acc +
+          FlexItem.outer_main(item, FlexItem.hypothetical_main(item), main_axis)
+      end)
+
+    mode = if outer_hypo_sum < container_main, do: :grow, else: :shrink
+
+    {frozen, unfrozen} =
+      Enum.split_with(indexed, fn {item, _i} ->
+        initially_frozen?(item, mode)
+      end)
+
+    frozen =
+      Enum.map(frozen, fn {item, i} ->
+        {freeze(item, FlexItem.hypothetical_main(item), :inflexible), i}
+      end)
+
+    (frozen ++
+       iterate(
+         unfrozen,
+         frozen,
+         container_main,
+         main_axis,
+         mode,
+         length(items) + 1
+       ))
+    |> Enum.sort_by(fn {_item, i} -> i end)
+    |> Enum.map(fn {item, _i} -> item end)
+  end
+
+  # -- loop ---------------------------------------------------------------
+
+  defp iterate([], _frozen, _container, _axis, _mode, _fuel), do: []
+
+  defp iterate(unfrozen, frozen, container, axis, mode, fuel) when fuel > 0 do
+    free = free_space(unfrozen, frozen, container, axis)
+
+    candidates = distribute(unfrozen, free, mode)
+
+    {violators, satisfied} =
+      Enum.split_with(candidates, fn {item, _i, candidate} ->
+        FlexItem.clamp_main(item, candidate) != candidate
+      end)
+
+    total_violation =
+      Enum.reduce(violators, 0, fn {item, _i, candidate}, acc ->
+        acc + (FlexItem.clamp_main(item, candidate) - candidate)
+      end)
+
+    cond do
+      violators == [] ->
+        Enum.map(candidates, fn {item, i, candidate} ->
+          {freeze(item, candidate, nil), i}
+        end)
+
+      total_violation > 0 ->
+        # min violations dominate: freeze items clamped UP at their min
+        freeze_and_continue(
+          violators,
+          satisfied,
+          frozen,
+          container,
+          axis,
+          mode,
+          fuel,
+          :min_violation
+        )
+
+      true ->
+        freeze_and_continue(
+          violators,
+          satisfied,
+          frozen,
+          container,
+          axis,
+          mode,
+          fuel,
+          :max_violation
+        )
+    end
+  end
+
+  # Fuel exhausted (cannot happen: every round freezes >= 1 item) — freeze
+  # everything at clamped candidates rather than looping forever.
+  defp iterate(unfrozen, _frozen, _container, _axis, _mode, _fuel) do
+    Enum.map(unfrozen, fn {item, i} ->
+      {freeze(item, FlexItem.hypothetical_main(item), :fuel_exhausted), i}
+    end)
+  end
+
+  defp freeze_and_continue(
+         violators,
+         satisfied,
+         frozen,
+         container,
+         axis,
+         mode,
+         fuel,
+         reason
+       ) do
+    reason_matches = fn {item, _i, candidate} ->
+      case reason do
+        :min_violation -> FlexItem.clamp_main(item, candidate) > candidate
+        :max_violation -> FlexItem.clamp_main(item, candidate) < candidate
+      end
+    end
+
+    {to_freeze, back} = Enum.split_with(violators, reason_matches)
+
+    newly_frozen =
+      Enum.map(to_freeze, fn {item, i, candidate} ->
+        {freeze(item, FlexItem.clamp_main(item, candidate), reason), i}
+      end)
+
+    still_unfrozen =
+      Enum.map(back ++ satisfied, fn {item, i, _candidate} -> {item, i} end)
+
+    newly_frozen ++
+      iterate(
+        still_unfrozen,
+        newly_frozen ++ frozen,
+        container,
+        axis,
+        mode,
+        fuel - 1
+      )
+  end
+
+  # -- distribution ---------------------------------------------------------
+
+  # Distributes `free` (may be negative in shrink mode) across unfrozen
+  # items proportionally, returning {item, index, candidate_size}. Whole
+  # cells only; the fractional residue is assigned by largest remainder so
+  # the distributed total is exact.
+  defp distribute(unfrozen, free, mode) do
+    weights =
+      Enum.map(unfrozen, fn {item, _i} -> weight(item, mode) end)
+
+    total_weight = Enum.sum(weights)
+
+    if total_weight == 0 do
+      Enum.map(unfrozen, fn {item, i} -> {item, i, item.base_size} end)
+    else
+      exact =
+        Enum.zip(unfrozen, weights)
+        |> Enum.map(fn {{item, i}, w} ->
+          {item, i, item.base_size + free * w / total_weight}
+        end)
+
+      apportion(exact, free)
+    end
+  end
+
+  defp weight(item, :grow), do: item.grow
+  defp weight(item, :shrink), do: item.shrink * item.base_size
+
+  # Largest-remainder rounding: floor everything, hand out the remaining
+  # cells (sign-aware) to the largest fractional parts.
+  defp apportion(exact, free) do
+    floored =
+      Enum.map(exact, fn {item, i, x} ->
+        base = trunc_toward_zero(x, free)
+        {item, i, base, abs(x - base)}
+      end)
+
+    assigned =
+      Enum.reduce(floored, 0, fn {item, _i, s, _r}, acc ->
+        acc + (s - item.base_size)
+      end)
+
+    residue = free - assigned
+    step = if residue >= 0, do: 1, else: -1
+
+    floored
+    |> Enum.sort_by(fn {_item, _i, _s, r} -> -r end)
+    |> assign_residue(abs(residue), step)
+    |> Enum.sort_by(fn {_item, i, _s} -> i end)
+  end
+
+  defp trunc_toward_zero(x, free) when free >= 0, do: trunc(:math.floor(x))
+  defp trunc_toward_zero(x, _free), do: trunc(:math.ceil(x))
+
+  defp assign_residue(entries, 0, _step),
+    do: Enum.map(entries, fn {item, i, s, _r} -> {item, i, s} end)
+
+  defp assign_residue([{item, i, s, _r} | rest], n, step),
+    do: [{item, i, s + step} | assign_residue(rest, n - 1, step)]
+
+  defp assign_residue([], _n, _step), do: []
+
+  # -- helpers ----------------------------------------------------------------
+
+  defp initially_frozen?(item, mode) do
+    hypo = FlexItem.hypothetical_main(item)
+
+    case mode do
+      :grow -> item.grow == 0 or hypo < item.base_size
+      :shrink -> item.shrink == 0 or hypo > item.base_size
+    end
+  end
+
+  defp free_space(unfrozen, frozen, container, axis) do
+    used_frozen =
+      Enum.reduce(frozen, 0, fn {item, _i}, acc ->
+        acc + FlexItem.outer_main(item, item.main_size, axis)
+      end)
+
+    used_unfrozen =
+      Enum.reduce(unfrozen, 0, fn {item, _i}, acc ->
+        acc + FlexItem.outer_main(item, item.base_size, axis)
+      end)
+
+    container - used_frozen - used_unfrozen
+  end
+
+  defp freeze(item, size, reason) do
+    %{item | frozen: true, frozen_reason: reason, main_size: max(0, size)}
+  end
+end

--- a/lib/raxol/ui/layout/layout_utils.ex
+++ b/lib/raxol/ui/layout/layout_utils.ex
@@ -14,12 +14,15 @@ defmodule Raxol.UI.Layout.LayoutUtils do
 
   ## Parameters
 
-  - `space` - Map with :x, :y, :width, :height keys
+  - `space` - Map with :x, :y, :width, :height keys. Any additional keys
+    (e.g. `:prepared_cache`, threaded through layout for text-measurement
+    caching) are preserved unchanged in the result.
   - `padding` - Map with :top, :right, :bottom, :left keys
 
   ## Returns
 
-  Map with adjusted dimensions accounting for padding.
+  The input `space` map with :x, :y, :width, :height adjusted for padding.
+  All other keys are carried through unmodified.
 
   ## Examples
 
@@ -29,12 +32,12 @@ defmodule Raxol.UI.Layout.LayoutUtils do
       %{x: 20, y: 15, width: 80, height: 40}
   """
   def apply_padding(space, padding) do
-    %{
+    Map.merge(space, %{
       x: space.x + padding.left,
       y: space.y + padding.top,
       width: max(0, space.width - padding.left - padding.right),
       height: max(0, space.height - padding.top - padding.bottom)
-    }
+    })
   end
 
   @doc """

--- a/test/raxol/ui/layout/flex_item_test.exs
+++ b/test/raxol/ui/layout/flex_item_test.exs
@@ -1,0 +1,172 @@
+defmodule Raxol.UI.Layout.FlexItemTest do
+  @moduledoc """
+  Contract tests for FlexItem (flex rework N5). Downstream nodes (solver,
+  percentages, min-content) code against exactly these behaviors.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Layout.FlexItem
+
+  @container %{width: 100, height: 40}
+
+  defp resolve(child, opts \\ []) do
+    axis = Keyword.get(opts, :axis, :horizontal)
+    container = Keyword.get(opts, :container, @container)
+    content = Keyword.get(opts, :content, fn -> 7 end)
+    FlexItem.resolve(child, axis, container, content)
+  end
+
+  describe "flex shorthand (D2: terminal-pragmatic)" do
+    test "flex: 1 -> grow 1, shrink 1, basis 0, min_main 0" do
+      item = resolve(%{style: %{flex: 1}})
+      assert %{grow: 1, shrink: 1, base_size: 0, min_main: 0} = item
+    end
+
+    test "explicit min_width beats the flex-int min override" do
+      item = resolve(%{style: %{flex: 1, min_width: 5}})
+      assert item.min_main == 5
+      assert item.base_size == 0
+    end
+
+    test "tuple form does not override min" do
+      item = resolve(%{style: %{flex: {2, 0, 30}}})
+      assert %{grow: 2, shrink: 0, base_size: 30, min_main: 0} = item
+    end
+
+    test "map form and legacy attrs.flex" do
+      a = resolve(%{style: %{flex: %{grow: 3}}})
+      b = resolve(%{style: %{}, attrs: %{flex: %{grow: 3}}})
+      assert a.grow == 3 and b.grow == 3
+      # style form wins over legacy attrs
+      c = resolve(%{style: %{flex: %{grow: 5}}, attrs: %{flex: %{grow: 1}}})
+      assert c.grow == 5
+    end
+
+    test "negative flex factor clamps to 0 (D8, no raise)" do
+      item = resolve(%{style: %{flex: -2}})
+      assert item.grow == 0
+    end
+  end
+
+  describe "basis resolution" do
+    test "auto basis measures content" do
+      item = resolve(%{style: %{}}, content: fn -> 13 end)
+      assert item.base_size == 13
+    end
+
+    test "auto basis with explicit width uses the width, not content" do
+      item =
+        resolve(%{style: %{width: 25}},
+          content: fn -> raise "must not measure" end
+        )
+
+      assert item.base_size == 25
+    end
+
+    test "percentage basis against definite container" do
+      item = resolve(%{style: %{flex: {0, 1, {:pct, 50}}}})
+      assert item.base_size == 50
+    end
+
+    test "percentage basis against indefinite container falls back to auto/content" do
+      item =
+        resolve(%{style: %{flex: {0, 1, {:pct, 50}}}},
+          container: %{width: nil, height: 40},
+          content: fn -> 9 end
+        )
+
+      assert item.base_size == 9
+    end
+  end
+
+  describe "percentages (D7)" do
+    test "pct width and pct min/max resolve and round" do
+      item = resolve(%{style: %{width: {:pct, 33}, max_width: {:pct, 50}}})
+      assert item.base_size == 33
+      assert item.max_main == 50
+    end
+
+    test "pct cross size against definite cross dimension" do
+      item = resolve(%{style: %{height: {:pct, 50}}})
+      assert item.cross_size == 20
+    end
+
+    test "negative pct clamps to 0 with telemetry, not raise" do
+      item = resolve(%{style: %{width: {:pct, -10}}}, content: fn -> 3 end)
+      assert item.base_size == 0
+    end
+  end
+
+  describe "margins" do
+    test "int, {h,v}, 4-tuple normalize; auto preserved" do
+      assert resolve(%{style: %{margin: 2}}).margin == {2, 2, 2, 2}
+      assert resolve(%{style: %{margin: {1, 3}}}).margin == {1, 3, 1, 3}
+
+      assert resolve(%{style: %{margin: {1, 2, 3, :auto}}}).margin ==
+               {1, 2, 3, :auto}
+    end
+
+    test "margin pct resolves against container WIDTH for all sides (spec)" do
+      item = resolve(%{style: %{margin: {{:pct, 10}, 0, {:pct, 10}, 0}}})
+      assert item.margin == {10, 0, 10, 0}
+    end
+
+    test "outer_main counts axis margins, auto as 0" do
+      item = resolve(%{style: %{width: 10, margin: {0, 4, 0, :auto}}})
+      assert FlexItem.outer_main(item, 10, :horizontal) == 14
+      assert FlexItem.main_margins(item, :horizontal) == {:auto, 4}
+    end
+
+    test "cross_margins maps the perpendicular sides" do
+      item = resolve(%{style: %{margin: {1, 2, 3, 4}}})
+      assert FlexItem.cross_margins(item, :horizontal) == {1, 3}
+      assert FlexItem.cross_margins(item, :vertical) == {4, 2}
+    end
+  end
+
+  describe "clamping" do
+    test "clamp_main and hypothetical_main" do
+      item = resolve(%{style: %{width: 60, min_width: 20, max_width: 50}})
+      assert FlexItem.clamp_main(item, 5) == 20
+      assert FlexItem.clamp_main(item, 200) == 50
+      assert FlexItem.hypothetical_main(item) == 50
+    end
+
+    test "max defaults to infinity" do
+      item = resolve(%{style: %{width: 10}})
+      assert FlexItem.clamp_main(item, 10_000) == 10_000
+    end
+  end
+
+  describe "vertical main axis (column)" do
+    test "height is main, width is cross; min/max follow" do
+      item =
+        resolve(%{style: %{height: 8, width: 30, min_height: 4, max_width: 35}},
+          axis: :vertical
+        )
+
+      assert item.base_size == 8
+      assert item.min_main == 4
+      assert item.cross_size == 30
+      assert item.max_cross == 35
+    end
+  end
+
+  describe "telemetry on invalid values (D8)" do
+    test "invalid style emits event and clamps" do
+      ref = make_ref()
+      pid = self()
+
+      :telemetry.attach(
+        "flex-item-test-#{inspect(ref)}",
+        [:raxol, :layout, :invalid_style],
+        fn _e, _m, meta, _ -> send(pid, {:invalid, meta.key}) end,
+        nil
+      )
+
+      resolve(%{style: %{width: -5}})
+      assert_receive {:invalid, :dimension}
+      :telemetry.detach("flex-item-test-#{inspect(ref)}")
+    end
+  end
+end

--- a/test/raxol/ui/layout/flexbox/solver_test.exs
+++ b/test/raxol/ui/layout/flexbox/solver_test.exs
@@ -1,0 +1,201 @@
+defmodule Raxol.UI.Layout.Flexbox.SolverTest do
+  @moduledoc """
+  Spec-example tests for the section 9.7 solver (flex rework N6).
+  Vectors hand-derived from the CSS Flexbox spec algorithm.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.Layout.FlexItem
+  alias Raxol.UI.Layout.Flexbox.Solver
+
+  defp item(attrs) do
+    struct!(FlexItem, Map.merge(%{element: %{}}, Map.new(attrs)))
+  end
+
+  defp solve(items, container),
+    do: Solver.resolve_flexible_lengths(items, container, :horizontal)
+
+  defp sizes(items), do: Enum.map(items, & &1.main_size)
+
+  describe "flex: 1 equalization (D2 goal)" do
+    test "three flex:1 items with unequal content equalize exactly" do
+      items = for _ <- 1..3, do: item(base_size: 0, grow: 1, min_main: 0)
+      assert solve(items, 90) |> sizes() == [30, 30, 30]
+    end
+
+    test "non-divisible container distributes remainder cells, sum exact" do
+      items = for _ <- 1..3, do: item(base_size: 0, grow: 1, min_main: 0)
+      result = solve(items, 100) |> sizes()
+      assert Enum.sum(result) == 100
+      assert Enum.max(result) - Enum.min(result) <= 1
+    end
+
+    test "grow 2:1:1 splits proportionally" do
+      items = [
+        item(base_size: 0, grow: 2, min_main: 0),
+        item(base_size: 0, grow: 1, min_main: 0),
+        item(base_size: 0, grow: 1, min_main: 0)
+      ]
+
+      assert solve(items, 100) |> sizes() == [50, 25, 25]
+    end
+  end
+
+  describe "grow mode (flex: auto behavior)" do
+    test "leftover distributed on top of base sizes" do
+      items = [
+        item(base_size: 10, grow: 1),
+        item(base_size: 30, grow: 1)
+      ]
+
+      assert solve(items, 60) |> sizes() == [20, 40]
+    end
+
+    test "grow 0 items keep hypothetical size" do
+      items = [item(base_size: 10, grow: 0), item(base_size: 10, grow: 1)]
+      assert solve(items, 50) |> sizes() == [10, 40]
+    end
+  end
+
+  describe "clamp-freeze-redistribute" do
+    test "max clamp freezes item, freed space redistributes" do
+      items = [
+        item(base_size: 0, grow: 1, min_main: 0, max_main: 10),
+        item(base_size: 0, grow: 1, min_main: 0)
+      ]
+
+      # naive: 30/30. clamped: first freezes at 10, second takes the rest.
+      assert solve(items, 60) |> sizes() == [10, 50]
+    end
+
+    test "min clamp in shrink mode freezes and pushes shortage to siblings" do
+      items = [
+        item(base_size: 40, shrink: 1, min_main: 35),
+        item(base_size: 40, shrink: 1, min_main: 0)
+      ]
+
+      # container 60, shortage 20. proportional: 10/10 -> first would hit 30 < min 35.
+      # freeze first at 35; second absorbs remaining shortage: 40 - 15 = 25.
+      assert solve(items, 60) |> sizes() == [35, 25]
+    end
+
+    test "cascading freezes terminate" do
+      items = [
+        item(base_size: 0, grow: 1, min_main: 0, max_main: 5),
+        item(base_size: 0, grow: 1, min_main: 0, max_main: 10),
+        item(base_size: 0, grow: 1, min_main: 0)
+      ]
+
+      assert solve(items, 90) |> sizes() == [5, 10, 75]
+    end
+
+    test "shrink cannot go below zero" do
+      items = [item(base_size: 10, shrink: 1, min_main: 0)]
+      result = solve(items, 0) |> sizes()
+      assert result == [0]
+    end
+  end
+
+  describe "scaled shrink factor (spec formula)" do
+    test "shrink weighted by base size" do
+      items = [
+        item(base_size: 60, shrink: 1, min_main: 0),
+        item(base_size: 20, shrink: 1, min_main: 0)
+      ]
+
+      # shortage 20; weights 60:20 -> 15:5
+      assert solve(items, 60) |> sizes() == [45, 15]
+    end
+
+    test "shrink 0 is rigid" do
+      items = [
+        item(base_size: 40, shrink: 0),
+        item(base_size: 40, shrink: 1, min_main: 0)
+      ]
+
+      assert solve(items, 60) |> sizes() == [40, 20]
+    end
+  end
+
+  describe "margins in outer sizes" do
+    test "margins consume free space before distribution" do
+      items = [
+        item(base_size: 10, grow: 1, margin: {0, 5, 0, 5}),
+        item(base_size: 10, grow: 1)
+      ]
+
+      # container 50; outer bases: 20 + 10 = 30; free 20 -> 10 each
+      assert solve(items, 50) |> sizes() == [20, 20]
+    end
+
+    test "auto margins count as zero during sizing" do
+      items = [item(base_size: 10, grow: 0, margin: {0, :auto, 0, :auto})]
+      assert solve(items, 50) |> sizes() == [10]
+    end
+  end
+
+  describe "pre-loop freezing (spec step 2)" do
+    test "item already over its max in grow mode freezes at hypothetical" do
+      items = [
+        item(base_size: 50, grow: 1, max_main: 30),
+        item(base_size: 0, grow: 1, min_main: 0)
+      ]
+
+      # first: hypo = 30 < base 50 -> frozen pre-loop at 30. free = 70 to second.
+      assert solve(items, 100) |> sizes() == [30, 70]
+    end
+  end
+
+  describe "properties" do
+    property "sizes are never negative and always within [min, max]" do
+      check all(
+              specs <-
+                StreamData.list_of(
+                  StreamData.tuple(
+                    {StreamData.integer(0..50), StreamData.integer(0..3),
+                     StreamData.integer(0..3), StreamData.integer(0..10),
+                     StreamData.integer(10..60)}
+                  ),
+                  min_length: 1,
+                  max_length: 6
+                ),
+              container <- StreamData.integer(0..200)
+            ) do
+        items =
+          for {base, grow, shrink, min, max} <- specs do
+            item(
+              base_size: base,
+              grow: grow,
+              shrink: shrink,
+              min_main: min,
+              max_main: max(min, max)
+            )
+          end
+
+        for solved <- solve(items, container) do
+          assert solved.main_size >= 0
+          assert solved.main_size >= solved.min_main
+          assert solved.main_size <= solved.max_main
+          assert solved.frozen
+        end
+      end
+    end
+
+    property "when growing with no max clamps, outer sizes exactly fill the container" do
+      check all(
+              bases <-
+                StreamData.list_of(StreamData.integer(0..20),
+                  min_length: 1,
+                  max_length: 6
+                ),
+              extra <- StreamData.integer(0..100)
+            ) do
+        items = for b <- bases, do: item(base_size: b, grow: 1, min_main: 0)
+        container = Enum.sum(bases) + extra
+        solved = solve(items, container)
+        assert Enum.sum(sizes(solved)) == container
+      end
+    end
+  end
+end

--- a/test/raxol/ui/layout/layout_utils_test.exs
+++ b/test/raxol/ui/layout/layout_utils_test.exs
@@ -1,0 +1,128 @@
+defmodule Raxol.UI.Layout.LayoutUtilsTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Layout.{Engine, LayoutUtils, PreparedElement}
+
+  describe "apply_padding/2 key preservation" do
+    test "preserves arbitrary extra keys (e.g. :prepared_cache) on the space map" do
+      space = %{
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 50,
+        prepared_cache: %{{:text, 123} => {5, 1}},
+        some_other_key: :untouched
+      }
+
+      padding = %{top: 5, right: 10, bottom: 5, left: 10}
+
+      result = LayoutUtils.apply_padding(space, padding)
+
+      # Geometry is still adjusted correctly.
+      assert result.x == 20
+      assert result.y == 15
+      assert result.width == 80
+      assert result.height == 40
+
+      # apply_padding/2 must not drop extra keys like :prepared_cache.
+      assert result.prepared_cache == %{{:text, 123} => {5, 1}}
+      assert result.some_other_key == :untouched
+    end
+
+    test "matches the documented example with only geometry keys present" do
+      space = %{x: 10, y: 10, width: 100, height: 50}
+      padding = %{top: 5, right: 10, bottom: 5, left: 10}
+
+      assert LayoutUtils.apply_padding(space, padding) == %{
+               x: 20,
+               y: 15,
+               width: 80,
+               height: 40
+             }
+    end
+
+    test "clamps width/height at zero when padding exceeds available space" do
+      space = %{x: 0, y: 0, width: 4, height: 4, prepared_cache: %{}}
+      padding = %{top: 10, right: 10, bottom: 10, left: 10}
+
+      result = LayoutUtils.apply_padding(space, padding)
+
+      assert result.width == 0
+      assert result.height == 0
+      assert result.prepared_cache == %{}
+    end
+  end
+
+  describe "prepared_cache propagation through the Flexbox path" do
+    # Row-flex container with two text children. "AB" really measures to
+    # width 2, but the prepared cache is seeded with a deliberately wrong
+    # width (50) for "AB", so a correct cache-read is directly observable
+    # in CD's x position.
+    defp two_text_flex_view do
+      %{
+        type: :flex,
+        direction: :row,
+        gap: 0,
+        padding: 0,
+        children: [
+          %{type: :text, content: "AB"},
+          %{type: :text, content: "CD"}
+        ]
+      }
+    end
+
+    test "a wrong-but-cached width for a flex child is consulted during flex sizing" do
+      dimensions = %{width: 200, height: 10}
+
+      prepared = %PreparedElement{
+        type: :text,
+        content_hash: :erlang.phash2("AB"),
+        measured_width: 50,
+        measured_height: 1,
+        children: nil
+      }
+
+      positioned =
+        Engine.apply_layout(two_text_flex_view(), dimensions, prepared)
+
+      ab = Enum.find(positioned, &(&1.text == "AB"))
+      cd = Enum.find(positioned, &(&1.text == "CD"))
+
+      refute is_nil(ab)
+      refute is_nil(cd)
+
+      assert ab.x == 0
+      # CD's x equals AB's cached width (50), not the real width (2),
+      # proving the cache reached the flex measurement path.
+      assert cd.x == 50
+    end
+
+    test "geometry is unchanged whether or not a prepared cache is supplied, when the cache matches reality (behavior-neutral)" do
+      dimensions = %{width: 200, height: 10}
+
+      real_width = Raxol.UI.TextMeasure.display_width("AB")
+
+      without_cache = Engine.apply_layout(two_text_flex_view(), dimensions, nil)
+
+      with_correct_cache =
+        Engine.apply_layout(two_text_flex_view(), dimensions, %PreparedElement{
+          type: :text,
+          content_hash: :erlang.phash2("AB"),
+          measured_width: real_width,
+          measured_height: 1,
+          children: nil
+        })
+
+      # Cache absent or present-and-correct produce identical output
+      # (behavior-neutral).
+      assert without_cache == with_correct_cache
+
+      ab = Enum.find(with_correct_cache, &(&1.text == "AB"))
+      cd = Enum.find(with_correct_cache, &(&1.text == "CD"))
+
+      assert ab.x == 0
+      assert ab.y == 0
+      assert cd.x == real_width
+    end
+  end
+end


### PR DESCRIPTION
Split of #459 per review — the §9.7 flexbox solver as pure modules, not yet wired. Off master, no deps.

- `Flexbox.Solver` — CSS-flexbox §9.7 resolve-flexible-lengths algorithm (largest-remainder integer accounting).
- `FlexItem` — resolved-item contract the solver consumes.
- `layout_utils` measurement-cache fix.

No engine behavior change yet (the modules aren't called until the wire PR). Unit-tested directly (solver/flex_item/layout_utils).
