### PR TITLE
Min-content measurement + exact justify spacing

### DIFF
--- a/lib/raxol/ui/layout/flexbox/positioner.ex
+++ b/lib/raxol/ui/layout/flexbox/positioner.ex
@@ -11,7 +11,7 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
     total_gaps = gap_size * max(0, length(sized_children) - 1)
     available_space = get_dimension(space, main_axis) - total_size - total_gaps
 
-    {start_pos, item_gap} =
+    {start_pos, item_gaps} =
       calculate_justify_positioning(
         flex_props.justify_content,
         available_space,
@@ -24,7 +24,7 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
       space,
       main_axis,
       get_coord(space, main_axis) + start_pos,
-      item_gap
+      item_gaps
     )
   end
 
@@ -34,18 +34,24 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
     end)
   end
 
+  # `item_gaps` has `length(sized_children) - 1` values (gap after each item
+  # but the last); padded with a trailing 0 so `Enum.zip/2` doesn't truncate.
   defp place_children_on_main_axis(
          sized_children,
          space,
          main_axis,
          start_coord,
-         item_gap
+         item_gaps
        ) do
+    gaps = item_gaps ++ [0]
+
     {_, positioned} =
-      Enum.reduce(sized_children, {start_coord, []}, fn {child, dims, flex},
-                                                        {current_pos, acc} ->
+      sized_children
+      |> Enum.zip(gaps)
+      |> Enum.reduce({start_coord, []}, fn {{child, dims, flex}, gap},
+                                           {current_pos, acc} ->
         child_space = build_child_space(space, dims, main_axis, current_pos)
-        next_pos = current_pos + get_dimension(dims, main_axis) + item_gap
+        next_pos = current_pos + get_dimension(dims, main_axis) + gap
         {next_pos, [{child, child_space, flex} | acc]}
       end)
 
@@ -90,30 +96,30 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # justify-content positioning
-  # ---------------------------------------------------------------------------
+  # Every clause returns `{start, gaps}`; `gaps` sums exactly to
+  # `available_space` (largest-remainder/Bresenham, not `div/2` truncation).
 
   def calculate_justify_positioning(
         :flex_start,
         _available_space,
-        _item_count,
+        item_count,
         gap
       ) do
-    {0, gap}
+    {0, uniform_gaps(gap, item_count)}
   end
 
   def calculate_justify_positioning(
         :flex_end,
         available_space,
-        _item_count,
+        item_count,
         gap
       ) do
-    {available_space, gap}
+    {available_space, uniform_gaps(gap, item_count)}
   end
 
-  def calculate_justify_positioning(:center, available_space, _item_count, gap) do
-    {div(available_space, 2), gap}
+  def calculate_justify_positioning(:center, available_space, item_count, gap) do
+    # Floor division biases a 1-cell remainder right; matches CSS, not a bug.
+    {div(available_space, 2), uniform_gaps(gap, item_count)}
   end
 
   def calculate_justify_positioning(
@@ -123,7 +129,7 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
         _gap
       )
       when item_count > 1 do
-    {0, div(available_space, item_count - 1)}
+    {0, largest_remainder_split(available_space, item_count - 1)}
   end
 
   def calculate_justify_positioning(
@@ -131,9 +137,23 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
         available_space,
         item_count,
         _gap
-      ) do
-    space_per_item = div(available_space, item_count)
-    {div(space_per_item, 2), space_per_item}
+      )
+      when item_count > 0 do
+    # Model as 2*item_count half-units (each item owns one per side); adjacent
+    # half-units merge into an inter-item gap, outermost ones become the
+    # margins. Bresenham split, not largest-remainder: front-loading the
+    # remainder would clump "+1" half-units at the start, so a merged gap
+    # there could differ from one near the end by up to 2 cells.
+    halves = bresenham_split(available_space, item_count * 2)
+    [start | _] = halves
+
+    middles =
+      halves
+      |> Enum.slice(1, item_count * 2 - 2)
+      |> Enum.chunk_every(2)
+      |> Enum.map(&Enum.sum/1)
+
+    {start, middles}
   end
 
   def calculate_justify_positioning(
@@ -141,13 +161,43 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
         available_space,
         item_count,
         _gap
-      ) do
-    space_per_gap = div(available_space, item_count + 1)
-    {space_per_gap, space_per_gap}
+      )
+      when item_count > 0 do
+    # item_count + 1 slots: leading margin, item_count - 1 gaps, trailing margin (unused).
+    [start | rest] = largest_remainder_split(available_space, item_count + 1)
+    middles = Enum.slice(rest, 0, item_count - 1)
+    {start, middles}
   end
 
-  def calculate_justify_positioning(_, _available_space, _item_count, gap) do
-    {0, gap}
+  def calculate_justify_positioning(_, _available_space, item_count, gap) do
+    {0, uniform_gaps(gap, item_count)}
+  end
+
+  # `item_count - 1` copies of the declared gap (never negative-length).
+  defp uniform_gaps(gap, item_count),
+    do: List.duplicate(gap, max(item_count - 1, 0))
+
+  # Splits `total` into `count` parts summing exactly to `total`; the first
+  # `rem(total, count)` entries get one extra cell (deterministic, left-to-right).
+  defp largest_remainder_split(_total, count) when count <= 0, do: []
+
+  defp largest_remainder_split(total, count) do
+    base = Integer.floor_div(total, count)
+    extra = Integer.mod(total, count)
+
+    Enum.map(0..(count - 1), fn i -> if i < extra, do: base + 1, else: base end)
+  end
+
+  # Rasterization split: part(i) = floor((i+1)*total/count) - floor(i*total/count).
+  # Sums to `total`, extra cells spread evenly (not clumped) so adjacent pairs
+  # never differ by more than 1 -- unlike `largest_remainder_split/2`.
+  defp bresenham_split(_total, count) when count <= 0, do: []
+
+  defp bresenham_split(total, count) do
+    Enum.map(0..(count - 1), fn i ->
+      Integer.floor_div((i + 1) * total, count) -
+        Integer.floor_div(i * total, count)
+    end)
   end
 
   # ---------------------------------------------------------------------------
@@ -167,7 +217,7 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
     gap_size = get_gap_size(flex_props.gap, cross_axis)
     total_gaps = gap_size * max(0, length(lines_with_layout) - 1)
 
-    {start_pos, line_gap} =
+    {start_pos, line_gaps} =
       calculate_align_content_positioning(
         flex_props.align_content,
         available_space - total_gaps,
@@ -180,7 +230,7 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
       line_heights,
       cross_axis,
       get_coord(space, cross_axis) + start_pos,
-      line_gap
+      line_gaps
     )
   end
 
@@ -192,17 +242,22 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
     end)
   end
 
+  # `line_gaps` has `length(lines_with_layout) - 1` values, same convention
+  # as `place_children_on_main_axis/5`.
   defp place_lines_cross(
          lines_with_layout,
          line_heights,
          cross_axis,
          start_coord,
-         line_gap
+         line_gaps
        ) do
+    gaps = line_gaps ++ [0]
+
     {_, positioned_lines} =
       lines_with_layout
       |> Enum.zip(line_heights)
-      |> Enum.reduce({start_coord, []}, fn {line, line_height},
+      |> Enum.zip(gaps)
+      |> Enum.reduce({start_coord, []}, fn {{line, line_height}, line_gap},
                                            {current_pos, acc} ->
         positioned_line =
           Enum.map(line, &set_item_cross_pos(&1, cross_axis, current_pos))
@@ -214,31 +269,34 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
     positioned_lines
   end
 
+  # Same `{start, gaps}` contract as `calculate_justify_positioning/4`; no
+  # `:space_evenly` clause -- align-content never supported one.
+
   def calculate_align_content_positioning(
         :flex_start,
         _available_space,
-        _line_count,
+        line_count,
         gap
       ) do
-    {0, gap}
+    {0, uniform_gaps(gap, line_count)}
   end
 
   def calculate_align_content_positioning(
         :flex_end,
         available_space,
-        _line_count,
+        line_count,
         gap
       ) do
-    {available_space, gap}
+    {available_space, uniform_gaps(gap, line_count)}
   end
 
   def calculate_align_content_positioning(
         :center,
         available_space,
-        _line_count,
+        line_count,
         gap
       ) do
-    {div(available_space, 2), gap}
+    {div(available_space, 2), uniform_gaps(gap, line_count)}
   end
 
   def calculate_align_content_positioning(
@@ -248,7 +306,7 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
         _gap
       )
       when line_count > 1 do
-    {0, div(available_space, line_count - 1)}
+    {0, largest_remainder_split(available_space, line_count - 1)}
   end
 
   def calculate_align_content_positioning(
@@ -256,13 +314,22 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
         available_space,
         line_count,
         _gap
-      ) do
-    space_per_line = div(available_space, line_count)
-    {div(space_per_line, 2), space_per_line}
+      )
+      when line_count > 0 do
+    halves = bresenham_split(available_space, line_count * 2)
+    [start | _] = halves
+
+    middles =
+      halves
+      |> Enum.slice(1, line_count * 2 - 2)
+      |> Enum.chunk_every(2)
+      |> Enum.map(&Enum.sum/1)
+
+    {start, middles}
   end
 
-  def calculate_align_content_positioning(_, _available_space, _line_count, gap) do
-    {0, gap}
+  def calculate_align_content_positioning(_, _available_space, line_count, gap) do
+    {0, uniform_gaps(gap, line_count)}
   end
 
   # ---------------------------------------------------------------------------
@@ -284,12 +351,23 @@ defmodule Raxol.UI.Layout.Flexbox.Positioner do
   def set_cross_dimension(space, :horizontal, val), do: %{space | width: val}
   def set_cross_dimension(space, :vertical, val), do: %{space | height: val}
 
+  # Merge to preserve extra keys on `space` (e.g. `:prepared_cache`).
   def build_child_space(space, dims, :horizontal, main_pos) do
-    %{x: main_pos, y: space.y, width: dims.width, height: dims.height}
+    Map.merge(space, %{
+      x: main_pos,
+      y: space.y,
+      width: dims.width,
+      height: dims.height
+    })
   end
 
   def build_child_space(space, dims, :vertical, main_pos) do
-    %{x: space.x, y: main_pos, width: dims.width, height: dims.height}
+    Map.merge(space, %{
+      x: space.x,
+      y: main_pos,
+      width: dims.width,
+      height: dims.height
+    })
   end
 
   def item_space({_child, child_space, _flex}), do: child_space

--- a/lib/raxol/ui/layout/min_content.ex
+++ b/lib/raxol/ui/layout/min_content.ex
@@ -1,0 +1,185 @@
+defmodule Raxol.UI.Layout.MinContent do
+  @moduledoc """
+  Min-content inline (width) measurement.
+
+  The min-content width of an element is the smallest width it can occupy
+  without losing content: the longest unbreakable segment for text, the
+  declared width for fixed boxes, aggregates for containers.
+
+  Pure and unwired: nothing in the live path calls this yet. Intended as
+  `FlexItem`'s automatic `min-width: auto`. A full-width divider's
+  min-content is 1 cell, so it won't inflate measured container widths or
+  rob fixed-width siblings during shrink.
+
+  Widths via `Raxol.UI.TextMeasure` exclusively (CJK double-width).
+  Unknown element types measure 0.
+  """
+
+  alias Raxol.UI.TextMeasure
+
+  @doc "Min-content width of an element, in cells."
+  def width(element)
+
+  def width(%{type: :text} = el), do: longest_segment(text_of(el))
+  def width(%{type: :label} = el), do: longest_segment(text_of(el))
+
+  def width(%{type: :divider}), do: 1
+  def width(%{type: :spacer}), do: 0
+
+  def width(%{type: :box} = box) do
+    case explicit_width(box) do
+      w when is_integer(w) and w >= 0 ->
+        w
+
+      _ ->
+        children_min(children_of(box), :max) + box_overhead(box)
+    end
+  end
+
+  def width(%{type: :flex} = flex) do
+    case explicit_width(flex) do
+      w when is_integer(w) and w >= 0 ->
+        w
+
+      _ ->
+        children = children_of(flex)
+
+        case direction_of(flex) do
+          :row ->
+            gap = gap_of(flex)
+            children_min(children, :sum) + gap * max(0, length(children) - 1)
+
+          :column ->
+            children_min(children, :max)
+        end
+    end
+  end
+
+  def width(%{type: type} = el) when type in [:row, :column] do
+    width(
+      Map.put(el, :type, :flex)
+      |> Map.put_new(:direction, container_direction(type))
+    )
+  end
+
+  def width(%{type: :view} = el), do: children_min(children_of(el), :max)
+
+  # Components that render a fixed-ish chrome around text
+  def width(%{type: :button} = el),
+    do: TextMeasure.display_width(text_of(el)) + 4
+
+  def width(%{type: :checkbox} = el),
+    do: TextMeasure.display_width(text_of(el)) + 4
+
+  def width(_unknown), do: 0
+
+  # -- helpers ----------------------------------------------------------------
+
+  @doc "Longest unbreakable segment of a text, by display width; break opportunities mirror TextLayout (spaces, after hyphens, between CJK ideographs)."
+  def longest_segment(nil), do: 0
+  def longest_segment(""), do: 0
+
+  def longest_segment(text) when is_binary(text) do
+    text
+    |> String.split(~r/[\s\x{200B}]+/u, trim: true)
+    |> Enum.flat_map(&split_after_hyphens/1)
+    |> Enum.flat_map(&split_cjk/1)
+    |> Enum.map(&TextMeasure.display_width/1)
+    |> Enum.max(fn -> 0 end)
+  end
+
+  defp split_after_hyphens(word) do
+    word
+    |> String.split(~r/(?<=-)/u, trim: true)
+  end
+
+  # CJK graphemes are break opportunities between each other, so each is its own segment.
+  defp split_cjk(segment) do
+    segment
+    |> String.graphemes()
+    |> Enum.chunk_by(&cjk?/1)
+    |> Enum.flat_map(fn
+      [g | _] = run ->
+        if cjk?(g), do: run, else: [Enum.join(run)]
+    end)
+  end
+
+  defp cjk?(<<cp::utf8, _rest::binary>>) do
+    cp in 0x1100..0x115F or cp in 0x2E80..0x9FFF or cp in 0xAC00..0xD7A3 or
+      cp in 0xF900..0xFAFF or cp in 0xFF00..0xFF60 or cp in 0x20000..0x2FFFD
+  end
+
+  defp cjk?(_), do: false
+
+  defp text_of(el), do: Map.get(el, :text) || Map.get(el, :content) || ""
+
+  defp children_of(el) do
+    case Map.get(el, :children) do
+      nil -> []
+      %{} = child -> [child]
+      list when is_list(list) -> list
+      other -> [other]
+    end
+  end
+
+  defp children_min([], _), do: 0
+
+  defp children_min(children, :max),
+    do: children |> Enum.map(&width/1) |> Enum.max(fn -> 0 end)
+
+  defp children_min(children, :sum),
+    do: children |> Enum.map(&width/1) |> Enum.sum()
+
+  defp explicit_width(el) do
+    style = style_of(el)
+
+    Map.get(el, :width) || Map.get(style, :width) ||
+      case Map.get(el, :size) do
+        {w, _h} -> w
+        _ -> nil
+      end
+  end
+
+  defp style_of(el) do
+    case Map.get(el, :style) do
+      s when is_map(s) -> s
+      _ -> %{}
+    end
+  end
+
+  defp box_overhead(box) do
+    style = style_of(box)
+    border = Map.get(box, :border) || Map.get(style, :border, :none)
+    border_cells = if border in [:none, false, nil], do: 0, else: 2
+
+    {_t, r, _b, l} =
+      case Map.get(box, :padding) || Map.get(style, :padding, 0) do
+        n when is_integer(n) -> {n, n, n, n}
+        {h, v} -> {v, h, v, h}
+        {t, r, b, l} -> {t, r, b, l}
+        _ -> {0, 0, 0, 0}
+      end
+
+    border_cells + l + r
+  end
+
+  defp direction_of(flex) do
+    Map.get(flex, :direction) ||
+      flex |> Map.get(:attrs, %{}) |> Map.get(:flex_direction, :row)
+  end
+
+  defp gap_of(flex) do
+    raw =
+      Map.get(style_of(flex), :gap) || Map.get(flex, :gap) ||
+        flex |> Map.get(:attrs, %{}) |> Map.get(:gap, 0)
+
+    case raw do
+      n when is_integer(n) and n >= 0 -> n
+      %{column: c} when is_integer(c) -> c
+      _ -> 0
+    end
+  end
+
+  defp container_direction(:row), do: :row
+  defp container_direction(:column), do: :column
+end

--- a/test/raxol/ui/layout/flexbox/positioner_test.exs
+++ b/test/raxol/ui/layout/flexbox/positioner_test.exs
@@ -1,0 +1,392 @@
+defmodule Raxol.UI.Layout.Flexbox.PositionerTest do
+  @moduledoc """
+  Regression coverage for `Raxol.UI.Layout.Flexbox.Positioner`:
+
+    * `calculate_justify_positioning/4` (and its cross-axis twin
+      `calculate_align_content_positioning/4`) used `div/2` for `:center`,
+      `:space_between`, `:space_around`, `:space_evenly`, truncating up to
+      `n - 1` cells of distributed spacing. Both now return
+      `{start, gaps :: [int]}`, with `gaps` computed via exact
+      (largest-remainder / Bresenham) integer splits summing exactly to
+      `available_space`.
+
+    * `build_child_space/4` rebuilt a fresh `%{x, y, width, height}` map,
+      dropping any extra keys on the incoming container space (e.g.
+      `:prepared_cache`). Now `Map.merge`-based.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.Layout.Flexbox.Positioner
+
+  describe "calculate_justify_positioning/4 -- evenly-divisible fixture (regression parity)" do
+    # available_space 24 divides evenly by every mode's divisor; matches layout_characterization_test.exs byte-for-byte.
+    test "flex_start" do
+      assert Positioner.calculate_justify_positioning(:flex_start, 24, 3, 0) ==
+               {0, [0, 0]}
+    end
+
+    test "flex_end" do
+      assert Positioner.calculate_justify_positioning(:flex_end, 24, 3, 0) ==
+               {24, [0, 0]}
+    end
+
+    test "center -- floor division, leftover goes right (spec-consistent, not a bug)" do
+      assert Positioner.calculate_justify_positioning(:center, 24, 3, 0) ==
+               {12, [0, 0]}
+    end
+
+    test "space_between" do
+      assert Positioner.calculate_justify_positioning(:space_between, 24, 3, 0) ==
+               {0, [12, 12]}
+    end
+
+    test "space_around" do
+      assert Positioner.calculate_justify_positioning(:space_around, 24, 3, 0) ==
+               {4, [8, 8]}
+    end
+
+    test "space_evenly" do
+      assert Positioner.calculate_justify_positioning(:space_evenly, 24, 3, 0) ==
+               {6, [6, 6]}
+    end
+  end
+
+  describe "calculate_justify_positioning/4 -- center leftover-right pin" do
+    test "odd available_space biases the 1-cell remainder to the right (unchanged behavior)" do
+      # CSS-consistent: leftover cell biases right, not a bug.
+      assert Positioner.calculate_justify_positioning(:center, 25, 3, 0) ==
+               {12, [0, 0]}
+    end
+  end
+
+  describe "calculate_justify_positioning/4 -- exact-sum fix on a non-divisible fixture" do
+    # 3 items width 1 each, container width 10, gap 0: available_space = 7.
+    test "space_between: 7 does not divide evenly by 2 gaps -- old code lost a cell" do
+      assert Positioner.calculate_justify_positioning(:space_between, 7, 3, 0) ==
+               {0, [4, 3]}
+
+      {start, gaps} =
+        Positioner.calculate_justify_positioning(:space_between, 7, 3, 0)
+
+      assert start + Enum.sum(gaps) == 7
+    end
+
+    test "space_around: 8 half-units for 4 items over available_space 10" do
+      {start, gaps} =
+        Positioner.calculate_justify_positioning(:space_around, 10, 4, 0)
+
+      assert length(gaps) == 3
+      assert Enum.max(gaps) - Enum.min(gaps) <= 1
+      # start + gaps + implied trailing (derived) must reconstruct exactly.
+      trailing = 10 - start - Enum.sum(gaps)
+      assert trailing >= 0
+      assert abs(trailing - start) <= 1
+    end
+
+    test "space_evenly: 25 does not divide evenly by 4 slots (3 items)" do
+      {start, gaps} =
+        Positioner.calculate_justify_positioning(:space_evenly, 25, 3, 0)
+
+      assert length(gaps) == 2
+      trailing = 25 - start - Enum.sum(gaps)
+      all = [start | gaps] ++ [trailing]
+      assert Enum.max(all) - Enum.min(all) <= 1
+      assert start + Enum.sum(gaps) + trailing == 25
+    end
+  end
+
+  describe "calculate_justify_positioning/4 -- degenerate item counts don't crash" do
+    test "space_between with 1 item falls through to the uniform-gap catch-all" do
+      assert Positioner.calculate_justify_positioning(:space_between, 10, 1, 2) ==
+               {0, []}
+    end
+
+    test "space_around with 0 items falls through without dividing by zero" do
+      assert Positioner.calculate_justify_positioning(:space_around, 10, 0, 0) ==
+               {0, []}
+    end
+
+    test "space_evenly with 0 items falls through without dividing by zero" do
+      assert Positioner.calculate_justify_positioning(:space_evenly, 10, 0, 0) ==
+               {0, []}
+    end
+  end
+
+  describe "properties: calculate_justify_positioning/4 exact-sum + bounded-difference" do
+    property "space_between: gaps sum exactly to available_space; length item_count - 1; differ by <= 1" do
+      check all(
+              item_count <- StreamData.integer(2..12),
+              available_space <- StreamData.integer(0..500)
+            ) do
+        {start, gaps} =
+          Positioner.calculate_justify_positioning(
+            :space_between,
+            available_space,
+            item_count,
+            0
+          )
+
+        assert start == 0
+        assert length(gaps) == item_count - 1
+        assert Enum.sum(gaps) == available_space
+        assert Enum.max(gaps) - Enum.min(gaps) <= 1
+      end
+    end
+
+    property "space_evenly: start/gaps/trailing all reconstruct exactly and differ by <= 1" do
+      check all(
+              item_count <- StreamData.integer(1..12),
+              available_space <- StreamData.integer(0..500)
+            ) do
+        {start, gaps} =
+          Positioner.calculate_justify_positioning(
+            :space_evenly,
+            available_space,
+            item_count,
+            0
+          )
+
+        assert length(gaps) == item_count - 1
+        trailing = available_space - start - Enum.sum(gaps)
+        assert start + Enum.sum(gaps) + trailing == available_space
+
+        all_slots = [start | gaps] ++ [trailing]
+        assert Enum.max(all_slots) - Enum.min(all_slots) <= 1
+      end
+    end
+
+    property "space_around: exact reconstruction, symmetric edges within 1, middle gaps differ by <= 1" do
+      check all(
+              item_count <- StreamData.integer(1..12),
+              available_space <- StreamData.integer(0..500)
+            ) do
+        {start, gaps} =
+          Positioner.calculate_justify_positioning(
+            :space_around,
+            available_space,
+            item_count,
+            0
+          )
+
+        assert length(gaps) == item_count - 1
+        trailing = available_space - start - Enum.sum(gaps)
+        assert start + Enum.sum(gaps) + trailing == available_space
+        assert abs(trailing - start) <= 1
+
+        if length(gaps) > 1 do
+          assert Enum.max(gaps) - Enum.min(gaps) <= 1
+        end
+      end
+    end
+
+    property "center/flex_start/flex_end always return item_count - 1 uniform gaps" do
+      check all(
+              mode <- StreamData.member_of([:flex_start, :flex_end, :center]),
+              item_count <- StreamData.integer(0..12),
+              available_space <- StreamData.integer(0..500),
+              gap <- StreamData.integer(0..10)
+            ) do
+        {_start, gaps} =
+          Positioner.calculate_justify_positioning(
+            mode,
+            available_space,
+            item_count,
+            gap
+          )
+
+        assert gaps == List.duplicate(gap, max(item_count - 1, 0))
+      end
+    end
+  end
+
+  describe "calculate_align_content_positioning/4 -- same exact-sum treatment" do
+    test "space_between: non-divisible available_space loses no cells" do
+      {start, gaps} =
+        Positioner.calculate_align_content_positioning(:space_between, 7, 3, 0)
+
+      assert start == 0
+      assert Enum.sum(gaps) == 7
+      assert Enum.max(gaps) - Enum.min(gaps) <= 1
+    end
+
+    test "space_around: exact reconstruction" do
+      {start, gaps} =
+        Positioner.calculate_align_content_positioning(:space_around, 10, 4, 0)
+
+      trailing = 10 - start - Enum.sum(gaps)
+      assert start + Enum.sum(gaps) + trailing == 10
+      assert abs(trailing - start) <= 1
+    end
+
+    test "no :space_evenly clause -- falls through to the uniform-gap catch-all (unsupported, as before)" do
+      assert Positioner.calculate_align_content_positioning(
+               :space_evenly,
+               10,
+               3,
+               2
+             ) ==
+               {0, [2, 2]}
+    end
+  end
+
+  describe "position_main_axis/4 -- end-to-end exactness" do
+    defp sized_children(widths) do
+      Enum.map(widths, fn w -> {%{}, %{width: w, height: 1}, %{}} end)
+    end
+
+    defp flex_props(justify_content) do
+      %{
+        justify_content: justify_content,
+        gap: %{row: 0, column: 0}
+      }
+    end
+
+    test "space_between: last item's end reaches exactly the container's far edge" do
+      space = %{x: 0, y: 0, width: 10, height: 1}
+
+      result =
+        Positioner.position_main_axis(
+          sized_children([1, 1, 1]),
+          space,
+          flex_props(:space_between),
+          :horizontal
+        )
+
+      [{_, s0, _}, {_, s1, _}, {_, s2, _}] = result
+      assert s0.x == 0
+      assert s1.x == 5
+      assert s2.x == 9
+      assert s2.x + s2.width == 10
+    end
+
+    property "space_between: last item's end always reaches the container's far edge (gap 0)" do
+      check all(
+              widths <-
+                StreamData.list_of(StreamData.integer(1..10),
+                  min_length: 2,
+                  max_length: 8
+                ),
+              extra <- StreamData.integer(0..50)
+            ) do
+        container_width = Enum.sum(widths) + extra
+        space = %{x: 0, y: 0, width: container_width, height: 1}
+
+        result =
+          Positioner.position_main_axis(
+            sized_children(widths),
+            space,
+            flex_props(:space_between),
+            :horizontal
+          )
+
+        {_, last_space, _} = List.last(result)
+        assert last_space.x + last_space.width == container_width
+
+        # Gaps between consecutive items never differ by more than one cell.
+        gaps =
+          result
+          |> Enum.zip(Enum.drop(result, 1))
+          |> Enum.map(fn {{_, a, _}, {_, b, _}} -> b.x - (a.x + a.width) end)
+
+        assert Enum.all?(gaps, &(&1 >= 0))
+
+        if length(gaps) > 1 do
+          assert Enum.max(gaps) - Enum.min(gaps) <= 1
+        end
+      end
+    end
+  end
+
+  describe "build_child_space/4 -- key preservation" do
+    test "horizontal axis: extra keys on the container space survive onto the child space" do
+      space = %{
+        x: 1,
+        y: 2,
+        width: 99,
+        height: 99,
+        prepared_cache: :some_cache,
+        custom: :flag
+      }
+
+      dims = %{width: 5, height: 3}
+
+      child_space = Positioner.build_child_space(space, dims, :horizontal, 7)
+
+      assert child_space == %{
+               x: 7,
+               y: 2,
+               width: 5,
+               height: 3,
+               prepared_cache: :some_cache,
+               custom: :flag
+             }
+    end
+
+    test "vertical axis: extra keys on the container space survive onto the child space" do
+      space = %{x: 1, y: 2, width: 99, height: 99, prepared_cache: :some_cache}
+      dims = %{width: 5, height: 3}
+
+      child_space = Positioner.build_child_space(space, dims, :vertical, 9)
+
+      assert child_space == %{
+               x: 1,
+               y: 9,
+               width: 5,
+               height: 3,
+               prepared_cache: :some_cache
+             }
+    end
+
+    test "no extra keys: behaves identically to the pre-fix literal-map construction" do
+      space = %{x: 1, y: 2, width: 99, height: 99}
+      dims = %{width: 5, height: 3}
+
+      assert Positioner.build_child_space(space, dims, :horizontal, 7) ==
+               %{x: 7, y: 2, width: 5, height: 3}
+
+      assert Positioner.build_child_space(space, dims, :vertical, 9) ==
+               %{x: 1, y: 9, width: 5, height: 3}
+    end
+
+    property "geometry keys always reflect dims/main_pos regardless of extra container keys" do
+      check all(
+              extra <-
+                StreamData.map_of(
+                  StreamData.atom(:alphanumeric),
+                  StreamData.term(),
+                  max_length: 3
+                ),
+              width <- StreamData.integer(0..50),
+              height <- StreamData.integer(0..50),
+              main_pos <- StreamData.integer(0..50)
+            ) do
+        space =
+          Map.merge(%{x: 0, y: 0, width: 999, height: 999}, extra)
+
+        dims = %{width: width, height: height}
+
+        horiz = Positioner.build_child_space(space, dims, :horizontal, main_pos)
+        assert horiz.x == main_pos
+        assert horiz.y == space.y
+        assert horiz.width == width
+        assert horiz.height == height
+
+        for {k, v} <- extra, k not in [:x, :y, :width, :height] do
+          assert Map.get(horiz, k) == v
+        end
+
+        vert = Positioner.build_child_space(space, dims, :vertical, main_pos)
+        assert vert.x == space.x
+        assert vert.y == main_pos
+        assert vert.width == width
+        assert vert.height == height
+
+        for {k, v} <- extra, k not in [:x, :y, :width, :height] do
+          assert Map.get(vert, k) == v
+        end
+      end
+    end
+  end
+end

--- a/test/raxol/ui/layout/min_content_test.exs
+++ b/test/raxol/ui/layout/min_content_test.exs
@@ -1,0 +1,98 @@
+defmodule Raxol.UI.Layout.MinContentTest do
+  @moduledoc "Contract tests for min-content measurement."
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Layout.MinContent
+
+  describe "text: longest unbreakable segment" do
+    test "longest word wins" do
+      assert MinContent.width(%{type: :text, text: "a bb characterization dd"}) ==
+               16
+    end
+
+    test "hyphens are break opportunities" do
+      # segments: "cross-" (6) and "terminal" (8)
+      assert MinContent.width(%{type: :text, text: "cross-terminal"}) == 8
+    end
+
+    test "CJK breaks between ideographs: min is one double-width cell pair" do
+      assert MinContent.width(%{type: :text, text: "你好世界"}) == 2
+    end
+
+    test "mixed latin + CJK" do
+      assert MinContent.width(%{type: :text, text: "abc 你好 defgh"}) == 5
+    end
+
+    test "empty and nil" do
+      assert MinContent.width(%{type: :text, text: ""}) == 0
+      assert MinContent.width(%{type: :text}) == 0
+    end
+  end
+
+  describe "L6 root cause" do
+    test "divider min-content is 1 cell, not container width" do
+      assert MinContent.width(%{type: :divider}) == 1
+    end
+  end
+
+  describe "boxes" do
+    test "explicit width wins" do
+      assert MinContent.width(%{type: :box, style: %{width: 28}, children: []}) ==
+               28
+    end
+
+    test "auto box: max child + border + horizontal padding" do
+      box = %{
+        type: :box,
+        style: %{border: :single, padding: 1},
+        children: [%{type: :text, text: "hello world"}]
+      }
+
+      # longest word 5 + border 2 + padding 2
+      assert MinContent.width(box) == 9
+    end
+  end
+
+  describe "flex containers" do
+    test "row: sum of children mins plus gaps" do
+      flex = %{
+        type: :flex,
+        direction: :row,
+        gap: 2,
+        children: [
+          %{type: :text, text: "ab cd"},
+          %{type: :divider},
+          %{type: :text, text: "xyz"}
+        ]
+      }
+
+      # 2 + 1 + 3 + 2 gaps * 2
+      assert MinContent.width(flex) == 10
+    end
+
+    test "column: max of children mins" do
+      flex = %{
+        type: :flex,
+        direction: :column,
+        children: [%{type: :text, text: "looooooong"}, %{type: :divider}]
+      }
+
+      assert MinContent.width(flex) == 10
+    end
+
+    test "literal :row/:column types route like flex" do
+      assert MinContent.width(%{
+               type: :column,
+               children: [%{type: :text, text: "abcde"}]
+             }) == 5
+    end
+  end
+
+  test "unknown types impose no minimum" do
+    assert MinContent.width(%{type: :mystery_widget}) == 0
+  end
+
+  test "button chrome" do
+    assert MinContent.width(%{type: :button, text: "OK"}) == 6
+  end
+end


### PR DESCRIPTION
Split of #459. **Depends on the solver-modules PR — review after it.**

- `MinContent` — min-content width measurement.
- `Flexbox.Positioner` — exact justify/align spacing (largest-remainder, sums exactly to the container).
