### PR TITLE
Flex convergence: clause grouping, comment cleanup, review findings, characterization

### DIFF
--- a/docs/core/LAYOUT.md
+++ b/docs/core/LAYOUT.md
@@ -1,4 +1,10 @@
 # Flex & Text Layout
+
+<!--
+Documents the `:flex` layout path (`Raxol.UI.Layout.FlexItem` +
+`Flexbox.Solver` + `Flexbox.Positioner`) and the `Raxol.UI.TextLayout`
+wrapping API. Literal `:row`/`:column` elements run on the same flex
+engine through a compatibility translation (see section 6).
 -->
 
 This page is the supported-property reference for `:flex` containers and
@@ -23,13 +29,13 @@ present, falling back to legacy top-level/`attrs` forms. Item properties
 | `align_content`     | `:flex_start`, `:flex_end`, `:center`, `:space_between`, `:space_around` | `attrs.align_content` only                                                                  | No `style:` translation exists for this key; set it directly in `attrs` if you're not going through the `row`/`column`/`flex` builders. Only matters when wrapping (`flex_wrap: :wrap`). |
 | `flex_wrap`         | `:nowrap`, `:wrap` (anything non-`:nowrap` multi-lines)                 | `attrs.flex_wrap` only                                                                      | Default `:nowrap`. `:wrap_reverse` is accepted as a value but is not distinguished from `:wrap` -- lines are not reversed. |
 | `gap`                | integer, or `%{row: r, column: c}`                                      | `style: %{gap: ...}` or `attrs.gap`                                                         | Default `0`. Subtracted from the container's main-axis size before flexible-length resolution runs, and included in `MinContent` row aggregation (`sum(child min) + gap * (n - 1)`). |
-| `padding`            | integer, `{v, h}`, `{t, r, b, l}`, or `%{top:, right:, bottom:, left:}` | `style: %{padding: ...}` or `attrs.padding`                                                 | Parsed by `Raxol.UI.Layout.LayoutUtils.parse_padding/1`. Applied to the container's space before children are measured or laid out; `:prepared_cache` and other extra space keys are preserved through the padding step (previously dropped silently, forcing every flex child to measure uncached). |
+| `padding`            | integer, `{v, h}`, `{t, r, b, l}`, or `%{top:, right:, bottom:, left:}` | `style: %{padding: ...}` or `attrs.padding`                                                 | Parsed by `Raxol.UI.Layout.LayoutUtils.parse_padding/1`. Applied to the container's space before children are measured or laid out; `:prepared_cache` and other extra space keys are preserved through the padding step, so flex children always measure with cache intact. |
 
 ### Item (child) properties
 
 | Property                      | Values                                                                 | Where (child's `style:` map)          | Notes |
 |--------------------------------|---------------------------------------------------------------------------|------------------------------------------|-------|
-| `flex`                        | integer `n`; `{grow, shrink, basis}`; `%{grow:, shrink:, basis:}`         | `style: %{flex: ...}`                    | Integer shorthand `flex: n` expands to `grow: n, shrink: 1, basis: 0` **and** `min_main: 0` (terminal-pragmatic sugar, D2 -- see divergences). Tuple/map forms set grow/shrink/basis only, no min override. Legacy `child.attrs.flex` (map form) is honored at lowest precedence for back-compat. |
+| `flex`                        | integer `n`; `{grow, shrink, basis}`; `%{grow:, shrink:, basis:}`         | `style: %{flex: ...}`                    | Integer shorthand `flex: n` expands to `grow: n, shrink: 1, basis: 0` **and** `min_main: 0` (terminal-pragmatic sugar -- see divergences). Tuple/map forms set grow/shrink/basis only, no min override. Legacy `child.attrs.flex` (map form) is honored at lowest precedence for back-compat. |
 | `flex_grow`                   | non-negative integer                                                     | `style: %{flex_grow: ...}`               | Default `0`. Ignored if `flex:` shorthand is also set. |
 | `flex_shrink`                 | non-negative integer                                                     | `style: %{flex_shrink: ...}`             | Default `1`. |
 | `flex_basis`                  | non-negative integer, `{:pct, n}`, or `:auto`                            | `style: %{flex_basis: ...}`              | Default `:auto` -- resolves to the content main size (measured), or the explicit `width`/`height` when set. |
@@ -44,20 +50,19 @@ present, falling back to legacy top-level/`attrs` forms. Item properties
 
 These are deliberate, not bugs -- Raxol targets a monospace cell grid, not
 a pixel box model, and some CSS corners aren't worth the complexity on a
-terminal. Source: `Raxol.UI.Layout.FlexItem` moduledoc (decisions D2, D6,
-D7, D8).
+terminal. Source: `Raxol.UI.Layout.FlexItem` moduledoc.
 
 | CSS behavior | Raxol behavior | Why |
 |---|---|---|
-| `flex: 1` keeps each item's own `min-width`/`min-height: auto` (min-content) floor, so equal-`flex:1` columns don't always equalize if content differs. | `flex: n` sugar also sets `min_main: 0`, so equal-`flex` items *always* equalize -- an explicit `min_width`/`min_height` in `style:` still overrides the sugar. | Terminal-pragmatic (D2): equal columns that actually equalize is the common case terminal UIs want; the CSS min-content floor is opt-in via an explicit min. |
+| `flex: 1` keeps each item's own `min-width`/`min-height: auto` (min-content) floor, so equal-`flex:1` columns don't always equalize if content differs. | `flex: n` sugar also sets `min_main: 0`, so equal-`flex` items *always* equalize -- an explicit `min_width`/`min_height` in `style:` still overrides the sugar. | Terminal-pragmatic: equal columns that actually equalize is the common case terminal UIs want; the CSS min-content floor is opt-in via an explicit min. |
 | `row-reverse` / `column-reverse` reverse visual order and flip the start/end edges for `justify-content`. | `:row_reverse`/`:column_reverse` are accepted as `flex_direction` values but map to the *same* axis pair as `:row`/`:column` (`get_axes/1`) -- no actual reversal of child order or edges happens. | Not implemented. Documented divergence -- do not rely on reverse directions; they silently behave like the non-reversed direction. |
 | `align-items: baseline` aligns items along their text baseline. | Not implemented. `Positioner.align_cross/4` has no `:baseline` clause; passing it falls through to a no-op catch-all (the child keeps whatever cross position it already had, effectively broken, not "close enough"). | No font metrics/baseline concept on a monospace cell grid worth the complexity. Use `:center` or `:flex_start` instead. |
 | The fractional-flex-factor rule: if `sum(flex-grow) < 1`, only that fraction of free space is distributed, the rest stays unfilled. | Not implemented -- grow/shrink factors are non-negative integers, so a fractional sum can't occur; all free space is always distributed among items with non-zero factors. | Documented as N/A rather than a gap: the precondition (fractional factors) can't arise given the integer-only factor type. |
-| Percentages parse from CSS-like strings (`"50%"`) or numbers with a unit. | Only the `{:pct, n}` tuple is accepted; no string parsing. | D7 -- one unambiguous representation, no parser/locale edge cases. |
+| Percentages parse from CSS-like strings (`"50%"`) or numbers with a unit. | Only the `{:pct, n}` tuple is accepted; no string parsing. | One unambiguous representation, no parser/locale edge cases. |
 | Margin percentages resolve against the *containing block's inline-axis size* per side semantics some engines special-case. | Margin percentages always resolve against the container's **width**, for all four sides, matching the CSS spec's actual (if surprising) rule. | Explicitly called out in `FlexItem` moduledoc because it trips people up even in browsers -- Raxol matches spec here rather than "fixing" it. |
 | Pixel box model: fractional/subpixel sizes, box-sizing modes. | Everything is whole cells; sizes are non-negative integers (or `{:pct, n}` rounded to a whole cell). No box-sizing switch -- padding/border/margin math is always "content-box"-shaped in cells. | No subpixel concept on a terminal grid. |
-| Invalid CSS values are ignored (the property falls back to its previous/initial value, per CSS's error-handling rule). | Invalid values (negative sizes, negative flex factors, malformed percentages/margins) are clamped to the nearest valid value (usually `0`) and reported via the `[:raxol, :layout, :invalid_style]` telemetry event. Layout never raises on style input. | D8 -- fail-soft with observability instead of silent CSS-style ignoring; a clamp is easier to spot in a telemetry dashboard than a silently-dropped property. |
-| Overflow (`sum(min-size) > container`) is handled per `overflow` property (default `visible`, content spills out / overlaps). | Content clips at the container's main-end edge; siblings never overlap. Pairs with the text-overflow affordances in Section 4 so clipping degrades gracefully instead of silently truncating mid-glyph. | D6. |
+| Invalid CSS values are ignored (the property falls back to its previous/initial value, per CSS's error-handling rule). | Invalid values (negative sizes, negative flex factors, malformed percentages/margins) are clamped to the nearest valid value (usually `0`) and reported via the `[:raxol, :layout, :invalid_style]` telemetry event. Layout never raises on style input. | Fail-soft with observability instead of silent CSS-style ignoring; a clamp is easier to spot in a telemetry dashboard than a silently-dropped property. |
+| Overflow (`sum(min-size) > container`) is handled per `overflow` property (default `visible`, content spills out / overlaps). | Content clips at the container's main-end edge; siblings never overlap. Pairs with the text-overflow affordances in Section 4 so clipping degrades gracefully instead of silently truncating mid-glyph. | |
 
 ## 3. Automatic minimum size
 
@@ -72,23 +77,22 @@ shrinks below its own minimum content size) is implemented via
   labels break at spaces, after hyphens, and between CJK ideographs (each
   CJK grapheme is its own break opportunity), so a long sentence's
   min-content is just its longest word, not the whole sentence. A
-  `:divider` has min-content `1` (not the available width -- this was bug
-  class L6: a full-width divider used to inflate the measured container
-  width and rob fixed-width siblings during shrink). A `:spacer` has
-  min-content `0`.
+  `:divider` has min-content `1` (not the available width -- a full-width
+  divider would otherwise inflate the measured container width and rob
+  fixed-width siblings during shrink). A `:spacer` has min-content `0`.
 - **Block axis** (main axis is `:vertical`, i.e. `flex_direction: :column`):
   the automatic minimum is the item's already-measured content size on
   that axis (no separate min-content pass -- vertical wrapping isn't
   modeled, so "min content height" and "content height" coincide).
 - Items **never shrink below** their automatic minimum; if the sum of
-  minimums exceeds the container, the excess overflows per the D6 clip
+  minimums exceeds the container, the excess overflows per the clip
   rule (Section 2) rather than content vanishing or items overlapping.
 - An **explicit `min_width`/`min_height`** in `style:` always overrides the
   automatic minimum (and overrides the `flex: n` sugar's `min_main: 0`,
   per `FlexItem.resolve/5`'s `{explicit_min, flex.min_main_override}`
   precedence).
 - **`flex: n`** (the integer shorthand) opts out of the automatic minimum
-  entirely by setting `min_main: 0` directly (D2) -- use `flex: {n, s, b}`
+  entirely by setting `min_main: 0` directly -- use `flex: {n, s, b}`
   or explicit `flex_grow`/`flex_shrink`/`flex_basis` keys if you want the
   automatic-minimum floor to still apply.
 
@@ -110,8 +114,8 @@ Component logic. `Raxol.UI.Components.Display.Text` exposes it via props.
 
 `:normal` is the default and is deliberately bit-identical to the
 pre-existing greedy word-wrap (including its non-CJK-safe character-count
-line-fit check), matching existing production output exactly. The other
-four modes are new, CJK-width-safe code paths
+line-fit check), so existing callers see unchanged output. The other four
+modes are CJK-width-safe code paths
 via `Raxol.UI.TextMeasure`. A single grapheme wider than `width` is never
 split mid-grapheme; it's emitted alone on its own line even if it exceeds
 `width`.
@@ -177,28 +181,79 @@ Text.init(
 )
 ```
 
-## 5. Changes from the previous implementation
+## 5. Distribution and caching guarantees
 
-The previous `:flex` implementation silently diverged from its own stated
-behavior in several places, now corrected:
+These guarantees hold across the current `:flex` layout path:
 
-- **Default shrink now actually works.** The previous single-pass
-  distribution lost free space to integer `div/2` truncation; the new
-  `Flexbox.Solver` uses largest-remainder apportionment so every
-  round distributes cells exactly, with no silent loss.
+- **Free space distribution is exact.** `Flexbox.Solver` uses
+  largest-remainder apportionment, so grow/shrink distributes every
+  round's cells exactly, with no loss to integer truncation.
 - **Explicit box `width`/`height` on a flex child is honored** as the
   main-axis size input (via `FlexItem.resolve/5`'s `explicit_main`),
   instead of being overridden by content measurement.
 - **Padding tuples are honored end-to-end**, including through the
-  `apply_padding` step that previously dropped `:prepared_cache` (and any
-  other extra space keys) -- flex children now measure with cache intact
-  instead of falling back to an uncached path on every render.
+  `apply_padding` step, which preserves `:prepared_cache` (and any other
+  extra space keys) -- flex children measure with cache intact instead of
+  falling back to an uncached path.
 - **`gap` is included in main-axis measurement**: the container's usable
   main size is `container_main - total_gaps` before flexible-length
   resolution runs, and `MinContent`'s row aggregation adds
-  `gap * (n - 1)` to the summed child minimums -- gap no longer causes
+  `gap * (n - 1)` to the summed child minimums -- gap doesn't cause
   under- or over-fitting against the container.
+
+## 6. The `:row`/`:column` compatibility dialect
+
+Literal `%{type: :row}` / `%{type: :column}` element maps (as opposed to
+the View DSL `row`/`column` macros, which build `:flex` maps) predate the
+flex engine and carried their own conventions. They now translate onto
+the flex engine (`Engine.containers_compat_to_flex/2`) preserving those
+conventions:
+
+- `gap` defaults to **1** in layout and **0** in measurement (the old
+  dialect disagreed with itself; both behaviors are preserved so
+  auto-sized boxes keep their dimensions)
+- `justify`/`align` default to `:start` (mapped to `:flex_start`; the
+  dialect never stretched children)
+- children default to `flex_shrink: 0`: natural size, overflow instead of
+  reflow. A child that declares any flex property opts out.
+- `gap`/`justify`/`align`/`padding` are read from `attrs` first, then
+  top-level keys, then the defaults above.
+
+New code should use `:flex` (the View DSL macros) directly.
+
+## 7. Overflow and scroll anchoring
+
+- `style: %{overflow: :visible | :hidden | :clip | :auto | :scroll}` on
+  boxes and flex containers. Anything but `:visible` (the default) stamps
+  every descendant with the container's content rectangle as clip bounds;
+  the renderer drops cells outside it. Nested clips intersect.
+  `:auto`/`:scroll` clip identically -- scrolling itself is the Viewport
+  component's job; the property only guarantees containment.
+- `Raxol.UI.Components.Display.Viewport` takes
+  `overflow_anchor: :auto | :none`. `:auto` (default) is the terminal-log
+  idiom: a viewport scrolled to the bottom stays pinned to the bottom as
+  content grows; scrolling up releases the pin. `:none` never moves
+  `scroll_top` on content changes.
+- Chart wrapper boxes (`Raxol.UI.Charts.ViewBridge`) size themselves to
+  the chart's render region and default to `overflow: :hidden` -- chart
+  cells can never paint outside the declared region.
+
+## Future work
+
+- **Span-aware wrapping**: a wrapped paragraph cannot yet carry per-span
+  styles (`MarkdownRenderer` drops inline styling on lines that wrap;
+  single-line content keeps it). Requires the wrapper to thread style
+  runs through break points.
+- **`:fill` as a dimension value**: accepted by the box path but not by
+  `FlexItem` (where it clamps to `:auto` with telemetry). Candidate
+  alias: `{:pct, 100}`.
+- **`align-items: baseline`, reverse directions, `wrap-reverse`**:
+  intentionally unsupported (see section 2); revisit only with a concrete
+  consumer.
 
 ## See also
 
 - `docs/core/ARCHITECTURE.md` -- where layout sits in the render pipeline.
+- Module docs: `Raxol.UI.Layout.FlexItem` (resolved-item semantics),
+  `Raxol.UI.Layout.Flexbox.Solver` (flexible-length algorithm),
+  `Raxol.UI.Layout.MinContent` (automatic minimum measurement).

--- a/lib/raxol/core/renderer/view/components/box.ex
+++ b/lib/raxol/core/renderer/view/components/box.ex
@@ -3,10 +3,8 @@ defmodule Raxol.Core.Renderer.View.Components.Box do
   Constructs `:box`-tagged View DSL nodes (`new/1`) with content, padding,
   border, and margin metadata for the box model.
 
-  The layout-calculation half of this module (`calculate_layout/2` and its
-  private box-model algorithm) was removed as production-dead -- zero
-  callers outside tests. `new/1` survives; the live engine
-  (`Raxol.UI.Layout.Engine`) computes positions for `:box` elements
+  This module only builds the node; it does not compute layout. The live
+  engine (`Raxol.UI.Layout.Engine`) computes positions for `:box` elements
   independently of this module.
   """
 

--- a/lib/raxol/core/renderer/view/layout/flex.ex
+++ b/lib/raxol/core/renderer/view/layout/flex.ex
@@ -5,13 +5,9 @@ defmodule Raxol.Core.Renderer.View.Layout.Flex do
   `flex` macros and, transitively, `Raxol.UI.Layout.Flexbox` -- the live
   layout engine.
 
-  The layout-calculation half of this module (`calculate_layout/2` and its
-  private algorithm, ~440 LOC) was removed as production-dead -- it was
-  only reachable through the separately-deleted `Raxol.Core.Renderer.Layout`
-  coordinator and `Raxol.Core.Renderer.View.layout/2`, which zero production
-  code called. These constructors survive: they build plain
-  `%{type: :flex, ...}` maps that the live engine (`Raxol.UI.Layout.Flexbox`)
-  pattern-matches on directly, independent of this module.
+  This module only builds plain `%{type: :flex, ...}` maps; it does not
+  compute layout. The live engine (`Raxol.UI.Layout.Flexbox`)
+  pattern-matches on those maps directly, independent of this module.
   """
 
   @doc """

--- a/lib/raxol/ui/components/display/viewport.ex
+++ b/lib/raxol/ui/components/display/viewport.ex
@@ -59,9 +59,7 @@ defmodule Raxol.UI.Components.Display.Viewport do
       theme: Map.get(props, :theme, %{}),
       show_scrollbar: Map.get(props, :show_scrollbar, true),
       focused: Map.get(props, :focused, false),
-      # CSS overflow-anchor, terminal-log flavor. :auto keeps the view
-      # pinned to the bottom on new content once already scrolled there
-      # (follow mode); scrolling up releases it. :none never moves.
+      # :auto pins to bottom when at end (follow mode); :none freezes scroll_top.
       overflow_anchor: Map.get(props, :overflow_anchor, :auto)
     }
 

--- a/lib/raxol/ui/components/display/viewport.ex
+++ b/lib/raxol/ui/components/display/viewport.ex
@@ -125,6 +125,8 @@ defmodule Raxol.UI.Components.Display.Viewport do
   end
 
   def update({:update_props, props}, state) do
+    was_at_bottom = at_bottom?(state)
+
     new_state =
       state
       |> maybe_update(:children, props)
@@ -145,12 +147,17 @@ defmodule Raxol.UI.Components.Display.Viewport do
 
     new_state = %{new_state | content_height: content_height}
 
+    # overflow_anchor applies here too, not just {:set_children, ...}
     scroll_top =
-      clamp_scroll(
-        new_state.scroll_top,
-        new_state.content_height,
-        new_state.visible_height
-      )
+      if state.overflow_anchor == :auto and was_at_bottom do
+        max(0, new_state.content_height - new_state.visible_height)
+      else
+        clamp_scroll(
+          new_state.scroll_top,
+          new_state.content_height,
+          new_state.visible_height
+        )
+      end
 
     {%{new_state | scroll_top: scroll_top}, []}
   end

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -1081,6 +1081,13 @@ defmodule Raxol.UI.Layout.Engine do
   defp containers_align(:end), do: :flex_end
   defp containers_align(other), do: other
 
+  # wrap may arrive as a boolean (Flex.container defaults wrap: false);
+  # only :nowrap selects the single-line path, so booleans must normalize
+  # or `wrap: false` silently enables wrapping.
+  defp normalize_wrap(true), do: :wrap
+  defp normalize_wrap(w) when w in [false, nil], do: :nowrap
+  defp normalize_wrap(w), do: w
+
   # Default children to shrink 0 via style.flex_shrink (read by
   # FlexItem.resolve). Deliberately NOT via :attrs — several element
   # processors treat the presence of an :attrs key as "old element
@@ -1185,14 +1192,23 @@ defmodule Raxol.UI.Layout.Engine do
       flex_direction:
         Map.get(style, :flex_direction) || Map.get(flex, :direction, :row),
       justify_content:
-        Map.get(style, :justify_content) ||
-          Map.get(flex, :justify, :flex_start),
+        containers_justify(
+          Map.get(style, :justify_content) ||
+            Map.get(flex, :justify, :flex_start)
+        ),
       align_items:
-        Map.get(style, :align_items) || Map.get(flex, :align, :stretch),
+        containers_align(
+          Map.get(style, :align_items) || Map.get(flex, :align, :stretch)
+        ),
       align_content:
-        Map.get(style, :align_content) ||
-          Map.get(flex, :align_content, :flex_start),
-      flex_wrap: Map.get(style, :flex_wrap) || Map.get(flex, :wrap, :nowrap),
+        containers_align(
+          Map.get(style, :align_content) ||
+            Map.get(flex, :align_content, :stretch)
+        ),
+      flex_wrap:
+        normalize_wrap(
+          Map.get(style, :flex_wrap) || Map.get(flex, :wrap, :nowrap)
+        ),
       gap: Map.get(style, :gap) || Map.get(flex, :gap, 0),
       padding: Map.get(style, :padding) || Map.get(flex, :padding, 0)
     }

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -443,7 +443,6 @@ defmodule Raxol.UI.Layout.Engine do
     [box_element | children_acc] ++ acc
   end
 
-
   # Chart widget types are emitted by `Components.chart/1` as :box elements
   # whose `:type` is overridden to one of these atoms so MCP ToolProvider
   # can discover them. Layout-wise they behave identically to :box, so

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -178,9 +178,8 @@ defmodule Raxol.UI.Layout.Engine do
     Panels.process(panel, space, acc)
   end
 
-  # Literal :row/:column elements run on the flex engine via a compat map
-  # that preserves their old defaults: gap 1, justify/align :start, no
-  # shrink (overflow instead of reflow) — see containers_compat_to_flex/2.
+  # Literal :row/:column run on the flex engine via the old Containers
+  # dialect's compat map — see containers_compat_to_flex/2.
   def process_element(%{type: type} = el, space, acc)
       when type in [:row, :column] do
     process_element(containers_compat_to_flex(el, :layout), space, acc)
@@ -1048,14 +1047,12 @@ defmodule Raxol.UI.Layout.Engine do
   # Build :attrs from top-level keys so Flexbox.parse_flex_properties works.
   # The View DSL (Flex.row/column) puts direction/gap/etc. at the top level,
   # but Flexbox reads from the :attrs map.
-  # Translates literal %{type: :row} / %{type: :column} elements onto the
-  # flex engine, preserving their old defaults:
-  #
-  #   gap      1 in layout, 0 in measurement (both preserved as-is)
-  #   justify  :start (maps to :flex_start; :end -> :flex_end)
-  #   align    :start (NOT :stretch)
-  #   shrink   children default to shrink 0 — natural size, overflow
-  #            instead of reflow — unless they declare flex properties.
+  # Preserves the old Containers dialect: gap defaults to 1 in layout / 0
+  # in measurement (the dialect disagreed between the two), justify/align
+  # default :start (never :stretch), children default to shrink 0 unless
+  # they declare flex explicitly. Reads `attrs.gap` only — top-level/style
+  # gap is not honored here (that compat is in `build_flex_attrs`).
+  # Consumers: Viewport, box auto-sizing, Panels, Responsive.
   defp containers_compat_to_flex(el, mode) do
     attrs = Map.get(el, :attrs, %{})
     gap_default = if mode == :layout, do: 1, else: 0
@@ -1112,17 +1109,9 @@ defmodule Raxol.UI.Layout.Engine do
 
   defp compat_no_shrink(child), do: child
 
-  # ---------------------------------------------------------------------
-  # overflow (proposal Phase F1): when a box declares
-  # `style: %{overflow: :hidden | :clip | :auto | :scroll}`, every
-  # descendant element it produced is stamped with `:clip_bounds`
-  # (the box's content rectangle), which `Raxol.UI.CellManager`
-  # already honors at paint time. Nested clips intersect. `:visible`
-  # (default) stamps nothing — content may paint outside, matching CSS.
-  # `:auto`/`:scroll` clip identically here; scrolling itself is the
-  # Viewport component's job (F2), this property only guarantees the
-  # box's content can never paint outside its bounds.
-  # ---------------------------------------------------------------------
+  # Stamps clip_bounds on every descendant when overflow is not :visible;
+  # nested clips intersect. :auto/:scroll clip identically — scrolling
+  # itself is Viewport's job.
   @doc false
   # Overflow clipping for flex containers (called from Flexbox.process_flex,
   # hence public). The clip rect is the container's own space.

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -444,6 +444,7 @@ defmodule Raxol.UI.Layout.Engine do
     [box_element | children_acc] ++ acc
   end
 
+
   # Chart widget types are emitted by `Components.chart/1` as :box elements
   # whose `:type` is overridden to one of these atoms so MCP ToolProvider
   # can discover them. Layout-wise they behave identically to :box, so

--- a/lib/raxol/ui/layout/flex_item.ex
+++ b/lib/raxol/ui/layout/flex_item.ex
@@ -2,39 +2,31 @@ defmodule Raxol.UI.Layout.FlexItem do
   @moduledoc """
   A flex child resolved into the inputs the flexible-length solver needs.
 
-  This is the interface contract for the flex rework (proposal:
-  `docs/proposals/in-flight/flex-spec-convergence.md`, Phase A). One
-  `FlexItem` is resolved per child BEFORE distribution; the solver
-  (`Distributor`) then works exclusively on these — it never reads raw
-  elements or style maps.
+  This is the interface contract between element resolution and the
+  flexible-length solver. One `FlexItem` is resolved per child before
+  distribution; `Flexbox.Solver` then works exclusively on these — it
+  never reads raw elements or style maps.
 
   ## Semantics
 
-    * `base_size` — the item's flex base size (resolved `flex-basis`).
-      `:auto` basis resolves to the content main size via the measure
-      function passed to `resolve/4`.
-    * Terminal-pragmatic `flex: 1` (D2): the integer shorthand
-      `style: %{flex: n}` expands to grow n / shrink 1 / basis 0 AND
+    * `base_size` — resolved `flex-basis`; `:auto` resolves via the
+      measure function passed to `resolve/5`.
+    * `style: %{flex: n}` expands to grow n / shrink 1 / basis 0 AND
       `min_main: 0`, so equal columns actually equalize. An explicit
-      `min_width`/`min_height` in style still wins over the sugar.
-    * Percentages: `{:pct, n}`. Resolved against the container's
-      corresponding dimension when it is definite; against an indefinite
-      dimension a percentage behaves as `:auto` (spec). Margin percentages
-      resolve against the container's WIDTH regardless of side (spec).
-    * Invalid values (negative sizes, negative flex factors, malformed
-      percentages) are clamped to the nearest valid value and reported via
-      the `[:raxol, :layout, :invalid_style]` telemetry event (D8) — layout
-      never raises on style input.
-    * `margin` sides may be `:auto`; sizing math treats `:auto` as 0
-      (`outer_main/2`), positioning distributes free space into them (P3
-      auto-margin step, solver-adjacent but not solver-owned).
+      `min_width`/`min_height` still wins over the sugar.
+    * `{:pct, n}` resolves against the container's dimension when
+      definite, else behaves as `:auto` (spec). Margin percentages
+      always resolve against the container's WIDTH (spec).
+    * Invalid values (negative sizes/factors, malformed percentages)
+      clamp to the nearest valid value and emit
+      `[:raxol, :layout, :invalid_style]` — layout never raises on
+      style input.
+    * `margin` sides may be `:auto`, treated as 0 for sizing
+      (`outer_main/2`); positioning distributes free space into them.
 
-  ## Solver fields
-
-  `frozen`, `frozen_reason` (`:inflexible | :min_violation | :max_violation`)
-  and `main_size` belong to the resolve-flexible-lengths loop (N6). They are
-  defined here so the struct is the single currency between resolution,
-  distribution, and positioning.
+  `frozen`, `frozen_reason`, and `main_size` belong to the
+  resolve-flexible-lengths loop and live here so the struct is the
+  single currency across resolution, distribution, and positioning.
   """
 
   @type dimension :: non_neg_integer() | :infinity
@@ -172,7 +164,7 @@ defmodule Raxol.UI.Layout.FlexItem do
 
   Returns `%{grow, shrink, basis, min_main_override}`.
 
-    * `flex: n` (int)      -> grow n, shrink 1, basis 0, min_main_override 0  (D2)
+    * `flex: n` (int)      -> grow n, shrink 1, basis 0, min_main_override 0
     * `flex: {g, s, b}`    -> as given, no min override
     * `flex: %{...}` map   -> grow/shrink/basis keys, no min override
     * legacy `attrs.flex`  -> same as map form (lowest precedence)

--- a/lib/raxol/ui/layout/flexbox.ex
+++ b/lib/raxol/ui/layout/flexbox.ex
@@ -96,10 +96,6 @@ defmodule Raxol.UI.Layout.Flexbox do
 
   def measure_flex(_, _available_space), do: %{width: 0, height: 0}
 
-  # Legacy `new/1` + `render/1` + `calculate_layout/1` API (struct type
-  # :flexbox, never dispatched by the engine) removed — zero production
-  # callers.
-
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
@@ -193,7 +189,7 @@ defmodule Raxol.UI.Layout.Flexbox do
 
     resolved =
       Enum.map(children_with_dims, fn {child, dims} ->
-        # Automatic minimum size (spec min-width:auto = min-content, B3):
+        # Automatic minimum size (spec min-width:auto = min-content):
         # inline axis uses MinContent; block axis uses the measured content
         # size (min-content block size of unscrollable content). Items never
         # shrink below it — overflow clips instead of content vanishing.

--- a/lib/raxol/ui/layout/flexbox.ex
+++ b/lib/raxol/ui/layout/flexbox.ex
@@ -427,14 +427,29 @@ defmodule Raxol.UI.Layout.Flexbox do
   defp zero_auto(v), do: v
 
   defp measure_flex_child(child, available_space, flex_props) do
-    child_attrs = attrs_map(child)
-    flex_attrs = Map.get(child_attrs, :flex, %{})
-    flex_basis = Map.get(flex_attrs, :basis, :auto)
+    # basis must come from the same resolution layout uses (style flex
+    # shorthand/flex_basis first, legacy attrs.flex second) or measure and
+    # layout disagree for style-declared bases
+    style =
+      case Map.get(child, :style) do
+        s when is_map(s) -> s
+        _ -> %{}
+      end
+
+    flex_basis = FlexItem.lift_flex(style, attrs_map(child)).basis
 
     child_space =
       get_child_space(flex_basis, available_space, flex_props.flex_direction)
 
-    Engine.measure_element(child, child_space)
+    measured = Engine.measure_element(child, child_space)
+
+    # a definite basis IS the flex base size (spec) — content measurement
+    # only decides the main size for basis :auto
+    case {flex_basis, get_main_axis(flex_props.flex_direction)} do
+      {b, :horizontal} when is_integer(b) -> %{measured | width: b}
+      {b, :vertical} when is_integer(b) -> %{measured | height: b}
+      _ -> measured
+    end
   end
 
   # attrs may be a keyword list on legacy elements

--- a/lib/raxol/ui/layout/flexbox/calculator.ex
+++ b/lib/raxol/ui/layout/flexbox/calculator.ex
@@ -50,10 +50,6 @@ defmodule Raxol.UI.Layout.Flexbox.Calculator do
     %{width: total_width, height: total_height}
   end
 
-  # Legacy calculate_layout/distribute_flex API removed — zero production
-  # callers (served only the removed Flexbox.new/:flexbox struct API).
-  # Solver handles distribution now.
-
   # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------

--- a/lib/raxol/ui/layout/flexbox/solver.ex
+++ b/lib/raxol/ui/layout/flexbox/solver.ex
@@ -1,11 +1,8 @@
 defmodule Raxol.UI.Layout.Flexbox.Solver do
   @moduledoc """
   Resolve flexible lengths per CSS Flexbox spec section 9.7, on resolved
-  `Raxol.UI.Layout.FlexItem`s. Replaces `Distributor`'s single pass
-  (wired in by the integration node; until then this module is unreferenced
-  by the live path).
-
-  Differences from the naive pass it replaces:
+  `Raxol.UI.Layout.FlexItem`s. Called from
+  `Flexbox.calculate_single_line_layout/5` for every flex line.
 
     * free space computed from OUTER sizes (margins included; `:auto`
       margins count as 0 during sizing — positioning distributes into them)
@@ -196,7 +193,7 @@ defmodule Raxol.UI.Layout.Flexbox.Solver do
   defp apportion(exact, free) do
     floored =
       Enum.map(exact, fn {item, i, x} ->
-        base = trunc_toward_zero(x, free)
+        base = snap_candidate(x, free)
         {item, i, base, abs(x - base)}
       end)
 
@@ -214,8 +211,12 @@ defmodule Raxol.UI.Layout.Flexbox.Solver do
     |> Enum.sort_by(fn {_item, i, _s} -> i end)
   end
 
-  defp trunc_toward_zero(x, free) when free >= 0, do: trunc(:math.floor(x))
-  defp trunc_toward_zero(x, _free), do: trunc(:math.ceil(x))
+  # Floor in grow mode, ceil in shrink mode; apportion/2 then assigns the
+  # signed residue by largest remainder. The floor/ceil split is what keeps
+  # the integer accounting exact — replacing it with a plain truncation
+  # breaks the exact-sum invariant.
+  defp snap_candidate(x, free) when free >= 0, do: trunc(:math.floor(x))
+  defp snap_candidate(x, _free), do: trunc(:math.ceil(x))
 
   defp assign_residue(entries, 0, _step),
     do: Enum.map(entries, fn {item, i, s, _r} -> {item, i, s} end)

--- a/lib/raxol/ui/layout/min_content.ex
+++ b/lib/raxol/ui/layout/min_content.ex
@@ -151,7 +151,7 @@ defmodule Raxol.UI.Layout.MinContent do
     {_t, r, _b, l} =
       case Map.get(box, :padding) || Map.get(style, :padding, 0) do
         n when is_integer(n) -> {n, n, n, n}
-        {h, v} -> {v, h, v, h}
+        {h, v} -> {h, v, h, v}
         {t, r, b, l} -> {t, r, b, l}
         _ -> {0, 0, 0, 0}
       end

--- a/lib/raxol/ui/layout/min_content.ex
+++ b/lib/raxol/ui/layout/min_content.ex
@@ -1,18 +1,14 @@
 defmodule Raxol.UI.Layout.MinContent do
   @moduledoc """
-  Min-content inline (width) measurement.
+  Min-content inline (width) measurement: the smallest width an element
+  can occupy without losing content (longest unbreakable text segment,
+  declared width for fixed boxes, aggregates for containers).
 
-  The min-content width of an element is the smallest width it can occupy
-  without losing content: the longest unbreakable segment for text, the
-  declared width for fixed boxes, aggregates for containers.
-
-  Pure and unwired: nothing in the live path calls this yet. Intended as
-  `FlexItem`'s automatic `min-width: auto`. A full-width divider's
-  min-content is 1 cell, so it won't inflate measured container widths or
-  rob fixed-width siblings during shrink.
-
-  Widths via `Raxol.UI.TextMeasure` exclusively (CJK double-width).
-  Unknown element types measure 0.
+  `FlexItem` resolution adopts this as the automatic minimum size
+  (`min-width: auto`) on the inline axis — a divider's min-content is 1
+  cell (not its full width) so it can't rob fixed-width siblings during
+  shrink. Widths via `Raxol.UI.TextMeasure` (CJK double-width); unknown
+  element types measure 0.
   """
 
   alias Raxol.UI.TextMeasure

--- a/lib/raxol/ui/ui_renderer.ex
+++ b/lib/raxol/ui/ui_renderer.ex
@@ -94,8 +94,9 @@ defmodule Raxol.UI.Renderer do
         []
 
       _ ->
-        # Layout-stamped clip_bounds apply generically here; render paths
-        # that clip themselves are unaffected (intersection is idempotent).
+        # Layout-stamped overflow clipping applies to EVERY element type
+        # generically; type-specific render paths that clip themselves are
+        # unaffected (intersection is idempotent).
         element_with_dims
         |> render_visible_element(theme, parent_style)
         |> CellManager.clip_cells_to_bounds(

--- a/test/cross_terminal/layout_characterization_test.exs
+++ b/test/cross_terminal/layout_characterization_test.exs
@@ -2,25 +2,13 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
   @moduledoc """
   Characterization net for the live layout engine.
 
-  Pins the CURRENT geometry of `Raxol.UI.Layout.Engine.apply_layout/2`
-  across the two flex-like dialects still alive:
+  Pins the CURRENT geometry of `Raxol.UI.Layout.Engine.apply_layout/2` across
+  the two dialects it dispatches: View DSL `row`/`column`/`flex` (the
+  `Flexbox` path) and literal `:row`/`:column` elements (the Containers-dialect
+  compat map), which has its own gap/align/justify defaults.
 
-    1. `:flex` elements (View DSL `row`/`column`/`flex` macros) -> the real
-       `Raxol.UI.Layout.Flexbox` path.
-    2. Literal `:row`/`:column` elements -> `Raxol.UI.Layout.Containers`, a
-       different dialect with its own gap/align/justify defaults.
-
-  A third dialect, `Raxol.Core.Renderer.View.layout/2`, delegated to a
-  separate legacy stack (`Core.Renderer.View.Layout.Flex.calculate_layout/2`
-  and its coordinator); both are now deleted as production-dead (zero
-  callers outside tests). `Flex`'s `row`/`column`/`container` constructors
-  (dialect 1 above) and `Box.new/1` survive -- they feed the live engine
-  independent of the deleted calculation code.
-
-  Every value was captured by actually running the code above. Pins
-  document behavior AS-IS, including quirks and outright bugs (each quirk
-  carries a comment) -- they are a tripwire, not a correctness claim: a
-  changed number means either a deliberate re-pin or a regression.
+  Pins behavior as-is, quirks included; a changed number here is either a
+  conscious re-pin or a regression.
   """
 
   use ExUnit.Case, async: true
@@ -30,9 +18,10 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
   require Raxol.Core.Renderer.View
   alias Raxol.Core.Renderer.View, as: LegacyView
 
-  # Reduces each positioned element to type/x/y/width/height plus text
-  # content; deliberately lossy (drops style/attrs/fg/bg) so pins stay
-  # readable and focused on geometry.
+  # Reduces every positioned element to the fields these pins track:
+  # type/x/y/width/height plus text content when present. This is
+  # deliberately lossy (drops style/attrs/fg/bg) so pins stay readable and
+  # focused on geometry.
   defp simplify(elements) do
     Enum.map(elements, fn el ->
       case el do
@@ -432,11 +421,11 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
           [text("AAAA"), text("BBBB"), text("CCCC")]
         end
 
-      # build_flex_attrs lifts flex_wrap (plus flex_direction/align_content)
-      # from style. Container 10 wide, words 4 wide: two fit on line 0,
-      # third wraps to line 1. Output order is line-reversed (pre-existing
-      # Wrapper accumulation quirk, pinned elsewhere) - sort for a stable
-      # assertion.
+      # engine's build_flex_attrs lifts flex_wrap (plus
+      # flex_direction/align_content) from style. Container 10
+      # wide, words 4 wide: two fit on line 0, third wraps to line 1.
+      # Output order is line-reversed (pre-existing Wrapper accumulation
+      # quirk, pinned elsewhere) - sort for a stable assertion.
       result =
         layout(tree, %{width: 10, height: 10})
         |> Enum.sort_by(&{&1.y, &1.x})
@@ -469,14 +458,10 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
         children: [text("AAAAAA"), text("BBBBBB"), text("CCCCCC")]
       }
 
-      # Each 6-wide word alone fits (6<=10) but two together don't, so each
-      # gets its own line. Returned order is reversed (C, B, A) though Y is
-      # ascending: `Wrapper.place_lines_cross/5` prepends each line via
-      # `positioned_line ++ acc`. Pinned as-is.
-      #
-      # align-content defaults to :stretch (CSS initial value): three
-      # 1-tall lines in a 10-tall container get stretched allocations
-      # 4/3/3, so lines start at y=0/4/7.
+      # Each 6-wide word alone fits but two together don't, so each gets its
+      # own line; order comes back reversed (C, B, A) even though y is
+      # ascending (`Wrapper.place_lines_cross/5` prepends). align-content
+      # defaults to :stretch, giving allocations 4/3/3 (y = 0/4/7).
       assert layout(tree, %{width: 10, height: 10}) == [
                %{type: :text, x: 0, y: 7, text: "CCCCCC"},
                %{type: :text, x: 0, y: 4, text: "BBBBBB"},
@@ -491,13 +476,9 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
         children: [text("AAAAAAAAAAAAAAAAAAAA"), text("B")]
       }
 
-      # First item is 20 wide against a 10-wide container -- Wrapper still
-      # places it (an empty `current_line` always accepts the first item
-      # regardless of fit), then "B" can't share the line (20+0+1 > 10) so
-      # it starts its own line. Same reversed-order quirk as above.
-      #
-      # Default align-content :stretch expands the two 1-tall lines to
-      # 5/5, so line two starts at y=5.
+      # An empty line always accepts its first item regardless of fit, so the
+      # 20-wide item gets its own line; "B" can't share it and starts a new
+      # one. align-content :stretch splits the two lines 5/5 (y=5).
       assert layout(tree, %{width: 10, height: 10}) == [
                %{type: :text, x: 0, y: 5, text: "B"},
                %{type: :text, x: 0, y: 0, text: "AAAAAAAAAAAAAAAAAAAA"}
@@ -506,14 +487,11 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
   end
 
   # ---------------------------------------------------------------------
-  # Literal :row / :column element types -- Raxol.UI.Layout.Containers, a
-  # separate dialect from View DSL row/column (which build :flex maps
-  # processed by Flexbox). Containers defaults: gap 1, justify :start,
-  # align :start (Flexbox defaults: gap 0, align :stretch -- MISMATCH).
-  # Also returns children in REVERSE order (reduce prepends via
-  # `child_elements ++ elements`), same quirk as Wrapper above. Pinned as-is.
+  # Literal :row/:column route through the Containers-dialect compat map,
+  # whose defaults (gap 1, justify :start, align :start) differ from
+  # Flexbox's own defaults (gap 0, align :stretch).
   # ---------------------------------------------------------------------
-  describe "literal :row / :column (Containers dialect, D4 compat baseline)" do
+  describe "literal :row / :column (Containers-dialect compat baseline)" do
     test "literal :row uses Containers defaults: gap 1, justify :start, align :start" do
       tree = %{
         type: :row,

--- a/test/cross_terminal/layout_characterization_test.exs
+++ b/test/cross_terminal/layout_characterization_test.exs
@@ -18,10 +18,8 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
   require Raxol.Core.Renderer.View
   alias Raxol.Core.Renderer.View, as: LegacyView
 
-  # Reduces every positioned element to the fields these pins track:
-  # type/x/y/width/height plus text content when present. This is
-  # deliberately lossy (drops style/attrs/fg/bg) so pins stay readable and
-  # focused on geometry.
+  # Reduces positioned elements to type/x/y/width/height (or type/x/y/text
+  # for text cells), dropping style/attrs/fg/bg/id so pins stay focused on placement.
   defp simplify(elements) do
     Enum.map(elements, fn el ->
       case el do

--- a/test/cross_terminal/layout_characterization_test.exs
+++ b/test/cross_terminal/layout_characterization_test.exs
@@ -421,11 +421,10 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
           [text("AAAA"), text("BBBB"), text("CCCC")]
         end
 
-      # engine's build_flex_attrs lifts flex_wrap (plus
-      # flex_direction/align_content) from style. Container 10
-      # wide, words 4 wide: two fit on line 0, third wraps to line 1.
-      # Output order is line-reversed (pre-existing Wrapper accumulation
-      # quirk, pinned elsewhere) - sort for a stable assertion.
+      # Container 10 wide, words 4 wide: two fit on line 0, third wraps.
+      # align-content defaults to :stretch, splitting the two 1-tall lines
+      # 5/5 (wrapped line starts at y=5). Output order is line-reversed, so
+      # sort for stability.
       result =
         layout(tree, %{width: 10, height: 10})
         |> Enum.sort_by(&{&1.y, &1.x})
@@ -433,7 +432,7 @@ defmodule Raxol.CrossTerminal.LayoutCharacterizationTest do
       assert result == [
                %{type: :text, x: 0, y: 0, text: "AAAA"},
                %{type: :text, x: 4, y: 0, text: "BBBB"},
-               %{type: :text, x: 0, y: 1, text: "CCCC"}
+               %{type: :text, x: 0, y: 5, text: "CCCC"}
              ]
     end
 

--- a/test/cross_terminal/overflow_test.exs
+++ b/test/cross_terminal/overflow_test.exs
@@ -1,7 +1,7 @@
 defmodule Raxol.CrossTerminal.OverflowTest do
   @moduledoc """
   The `overflow` container property and Viewport `overflow_anchor`
-  bottom-follow behavior.
+  bottom-follow.
   """
   use ExUnit.Case, async: true
 
@@ -10,7 +10,7 @@ defmodule Raxol.CrossTerminal.OverflowTest do
   alias Raxol.UI.Components.Display.Viewport
   require Raxol.Core.Renderer.View
 
-  describe "overflow: :hidden stamps clip_bounds (F1)" do
+  describe "overflow: :hidden stamps clip_bounds" do
     defp overflowing_box(overflow) do
       V.box(
         style: %{border: :single, width: 10, height: 4, overflow: overflow},
@@ -80,7 +80,7 @@ defmodule Raxol.CrossTerminal.OverflowTest do
     end
   end
 
-  describe "Viewport overflow_anchor (F2)" do
+  describe "Viewport overflow_anchor" do
     defp viewport(props) do
       {:ok, state} = Viewport.init(props)
       state

--- a/test/examples/button_test.exs
+++ b/test/examples/button_test.exs
@@ -232,10 +232,6 @@ defmodule Raxol.Examples.ButtonTest do
           focused: false
         })
 
-      # test/support/raxol/visual.ex now lays out through the live
-      # Raxol.UI.Layout.Engine, whose element shape matches what
-      # Raxol.UI.Renderer.render_to_cells/2 expects -- this snapshot shows
-      # the real bordered button box instead of a blank buffer.
       assert_matches_snapshot(
         button,
         "button_submit",
@@ -265,8 +261,6 @@ defmodule Raxol.Examples.ButtonTest do
       assert Map.get(normal_view.attrs, :disabled, false) == false
       assert Map.get(disabled_view.attrs, :disabled, false) == true
 
-      # Same harness change as above -- both snapshots show real bordered
-      # boxes instead of blank buffers.
       assert_matches_snapshot(normal_button, "button_normal", context)
       assert_matches_snapshot(disabled_button, "button_disabled", context)
     end

--- a/test/property/ui_component_property_test.exs
+++ b/test/property/ui_component_property_test.exs
@@ -82,9 +82,7 @@ defmodule Raxol.Property.UIComponentTest do
     end
   end
 
-  # "Flexbox layout properties" (Flexbox.new/render/calculate_layout)
-  # removed with the legacy API. Live-path flex properties live in
-  # test/property/flex_layout_property_test.exs.
+  # Flex layout properties live in test/property/flex_layout_property_test.exs.
 
   describe "Grid layout properties" do
     property "grid places items in correct cells" do

--- a/test/raxol/core/renderer/view_test.exs
+++ b/test/raxol/core/renderer/view_test.exs
@@ -1,9 +1,7 @@
 defmodule Raxol.Core.Renderer.ViewTest do
   @moduledoc """
   Tests for the view module: creation, spacing normalization, and
-  construction-time validation. `View.layout/2` and the layout-geometry
-  tests it backed were removed along with the production-dead legacy
-  layout stack it delegated to.
+  construction-time validation.
   """
   use ExUnit.Case, async: true
   alias Raxol.Core.Renderer.View
@@ -78,11 +76,6 @@ defmodule Raxol.Core.Renderer.ViewTest do
     end
   end
 
-  # Relocated out of the deleted "layout/2" and "flex layout features"
-  # blocks: these four exercise construction-time validation
-  # (`Flex.container/1`'s direction check, `Border.wrap/2`, `Scroll.new/2`,
-  # `View.shadow/1`), not layout math, so they survive the dead-code
-  # removal that took `View.layout/2` and `View.grid`/`Grid.new` with it.
   describe "construction-time validation" do
     test "handles invalid flex direction" do
       assert_raise ArgumentError, "Invalid flex direction: :invalid", fn ->

--- a/test/raxol/ui/layout/flex_dsl_aliases_test.exs
+++ b/test/raxol/ui/layout/flex_dsl_aliases_test.exs
@@ -1,0 +1,116 @@
+defmodule Raxol.UI.Layout.FlexDslAliasesTest do
+  @moduledoc """
+  The View DSL flex path must accept the same convenience aliases the
+  row/column dialect does: `justify:`/`align:` `:start`/`:end` atoms and
+  boolean `wrap:` values. Unmapped aliases silently behave as flex-start /
+  wrapping-enabled — layouts look plausibly wrong instead of failing.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.Layout.Engine
+  alias Raxol.UI.Layout.FlexItem
+  alias Raxol.UI.Layout.Flexbox.Solver
+  require Raxol.Core.Renderer.View
+  alias Raxol.Core.Renderer.View, as: V
+
+  defp texts_of(tree, dims) do
+    tree
+    |> Engine.apply_layout(dims)
+    |> Enum.filter(&(&1.type == :text))
+    |> Enum.sort_by(&{&1.y, &1.x})
+  end
+
+  test "justify: :end positions at the main-axis end (alias of :flex_end)" do
+    tree = V.row(justify: :end, children: [V.text("aa"), V.text("bb")])
+    aliased = texts_of(tree, %{width: 20, height: 3})
+
+    canonical =
+      texts_of(
+        V.row(
+          style: %{justify_content: :flex_end},
+          children: [V.text("aa"), V.text("bb")]
+        ),
+        %{width: 20, height: 3}
+      )
+
+    assert Enum.map(aliased, & &1.x) == Enum.map(canonical, & &1.x)
+    assert List.last(aliased).x == 18
+  end
+
+  test "align: :end positions at the cross-axis end" do
+    tree = V.row(align: :end, children: [V.text("aa")])
+    [t] = texts_of(tree, %{width: 20, height: 5})
+    assert t.y == 4
+  end
+
+  test "wrap: false means no wrapping (boolean normalizes to :nowrap)" do
+    children = for _ <- 1..4, do: V.text("xx")
+    tree =
+      Raxol.Core.Renderer.View.Layout.Flex.container(
+        direction: :row,
+        wrap: false,
+        gap: 0,
+        children: children
+      )
+    positioned = texts_of(tree, %{width: 6, height: 5})
+
+    # nowrap: all on one row (overflowing), never a second line
+    assert Enum.uniq(Enum.map(positioned, & &1.y)) == [0]
+  end
+
+  test "wrap: true wraps (boolean normalizes to :wrap)" do
+    children = for _ <- 1..4, do: V.text("xx")
+    tree =
+      Raxol.Core.Renderer.View.Layout.Flex.container(
+        direction: :row,
+        wrap: true,
+        gap: 0,
+        children: children
+      )
+    positioned = texts_of(tree, %{width: 6, height: 5})
+
+    assert length(Enum.uniq(Enum.map(positioned, & &1.y))) > 1
+  end
+
+  test "measure honors style-declared flex basis like layout does" do
+    child = %{type: :text, content: "ab", style: %{flex: {0, 1, 30}}}
+
+    flex =
+      Raxol.Core.Renderer.View.Layout.Flex.container(
+        direction: :row,
+        gap: 0,
+        children: [child]
+      )
+    measured = Engine.measure_element(flex, %{x: 0, y: 0, width: 80, height: 5})
+    assert measured.width == 30
+  end
+
+  property "shrink mode: solved outer sizes exactly fill the container" do
+    check all(
+            bases <-
+              StreamData.list_of(StreamData.integer(5..30),
+                min_length: 2,
+                max_length: 6
+              ),
+            deficit <- StreamData.integer(1..15)
+          ) do
+      items =
+        for b <- bases do
+          struct!(FlexItem, %{
+            element: %{},
+            base_size: b,
+            shrink: 1,
+            min_main: 0
+          })
+        end
+
+      container = max(Enum.sum(bases) - deficit, length(bases))
+      solved = Solver.resolve_flexible_lengths(items, container, :horizontal)
+      sizes = Enum.map(solved, & &1.main_size)
+
+      assert Enum.sum(sizes) == container
+      assert Enum.all?(sizes, &(&1 >= 0))
+    end
+  end
+end

--- a/test/raxol/ui/layout/flex_dsl_aliases_test.exs
+++ b/test/raxol/ui/layout/flex_dsl_aliases_test.exs
@@ -46,6 +46,7 @@ defmodule Raxol.UI.Layout.FlexDslAliasesTest do
 
   test "wrap: false means no wrapping (boolean normalizes to :nowrap)" do
     children = for _ <- 1..4, do: V.text("xx")
+
     tree =
       Raxol.Core.Renderer.View.Layout.Flex.container(
         direction: :row,
@@ -53,6 +54,7 @@ defmodule Raxol.UI.Layout.FlexDslAliasesTest do
         gap: 0,
         children: children
       )
+
     positioned = texts_of(tree, %{width: 6, height: 5})
 
     # nowrap: all on one row (overflowing), never a second line
@@ -61,6 +63,7 @@ defmodule Raxol.UI.Layout.FlexDslAliasesTest do
 
   test "wrap: true wraps (boolean normalizes to :wrap)" do
     children = for _ <- 1..4, do: V.text("xx")
+
     tree =
       Raxol.Core.Renderer.View.Layout.Flex.container(
         direction: :row,
@@ -68,6 +71,7 @@ defmodule Raxol.UI.Layout.FlexDslAliasesTest do
         gap: 0,
         children: children
       )
+
     positioned = texts_of(tree, %{width: 6, height: 5})
 
     assert length(Enum.uniq(Enum.map(positioned, & &1.y))) > 1
@@ -82,6 +86,7 @@ defmodule Raxol.UI.Layout.FlexDslAliasesTest do
         gap: 0,
         children: [child]
       )
+
     measured = Engine.measure_element(flex, %{x: 0, y: 0, width: 80, height: 5})
     assert measured.width == 30
   end

--- a/test/raxol/ui/layout/flex_item_test.exs
+++ b/test/raxol/ui/layout/flex_item_test.exs
@@ -1,7 +1,7 @@
 defmodule Raxol.UI.Layout.FlexItemTest do
   @moduledoc """
-  Contract tests for FlexItem (flex rework N5). Downstream nodes (solver,
-  percentages, min-content) code against exactly these behaviors.
+  Contract tests for FlexItem. Downstream nodes (solver, percentages,
+  min-content) code against exactly these behaviors.
   """
   use ExUnit.Case, async: true
 
@@ -16,7 +16,7 @@ defmodule Raxol.UI.Layout.FlexItemTest do
     FlexItem.resolve(child, axis, container, content)
   end
 
-  describe "flex shorthand (D2: terminal-pragmatic)" do
+  describe "flex shorthand (terminal-pragmatic)" do
     test "flex: 1 -> grow 1, shrink 1, basis 0, min_main 0" do
       item = resolve(%{style: %{flex: 1}})
       assert %{grow: 1, shrink: 1, base_size: 0, min_main: 0} = item
@@ -42,7 +42,7 @@ defmodule Raxol.UI.Layout.FlexItemTest do
       assert c.grow == 5
     end
 
-    test "negative flex factor clamps to 0 (D8, no raise)" do
+    test "negative flex factor clamps to 0 (no raise)" do
       item = resolve(%{style: %{flex: -2}})
       assert item.grow == 0
     end
@@ -79,7 +79,7 @@ defmodule Raxol.UI.Layout.FlexItemTest do
     end
   end
 
-  describe "percentages (D7)" do
+  describe "percentages" do
     test "pct width and pct min/max resolve and round" do
       item = resolve(%{style: %{width: {:pct, 33}, max_width: {:pct, 50}}})
       assert item.base_size == 33
@@ -152,7 +152,7 @@ defmodule Raxol.UI.Layout.FlexItemTest do
     end
   end
 
-  describe "telemetry on invalid values (D8)" do
+  describe "telemetry on invalid values" do
     test "invalid style emits event and clamps" do
       ref = make_ref()
       pid = self()

--- a/test/raxol/ui/layout/flexbox/positioner_test.exs
+++ b/test/raxol/ui/layout/flexbox/positioner_test.exs
@@ -1,18 +1,13 @@
 defmodule Raxol.UI.Layout.Flexbox.PositionerTest do
   @moduledoc """
-  Regression coverage for `Raxol.UI.Layout.Flexbox.Positioner`:
+  Coverage for `Raxol.UI.Layout.Flexbox.Positioner`.
 
-    * `calculate_justify_positioning/4` (and its cross-axis twin
-      `calculate_align_content_positioning/4`) used `div/2` for `:center`,
-      `:space_between`, `:space_around`, `:space_evenly`, truncating up to
-      `n - 1` cells of distributed spacing. Both now return
-      `{start, gaps :: [int]}`, with `gaps` computed via exact
-      (largest-remainder / Bresenham) integer splits summing exactly to
-      `available_space`.
-
-    * `build_child_space/4` rebuilt a fresh `%{x, y, width, height}` map,
-      dropping any extra keys on the incoming container space (e.g.
-      `:prepared_cache`). Now `Map.merge`-based.
+  `calculate_justify_positioning/4` and its cross-axis twin
+  `calculate_align_content_positioning/4` return `{start, gaps :: [int]}`,
+  with `gaps` computed via exact largest-remainder integer splits so
+  distributed spacing always sums exactly to `available_space`.
+  `build_child_space/4` preserves extra keys (e.g. `:prepared_cache`) on
+  the container space via `Map.merge`.
   """
 
   use ExUnit.Case, async: true

--- a/test/raxol/ui/layout/flexbox/solver_test.exs
+++ b/test/raxol/ui/layout/flexbox/solver_test.exs
@@ -1,7 +1,7 @@
 defmodule Raxol.UI.Layout.Flexbox.SolverTest do
   @moduledoc """
-  Spec-example tests for the section 9.7 solver (flex rework N6).
-  Vectors hand-derived from the CSS Flexbox spec algorithm.
+  Spec-example tests for the section 9.7 solver. Vectors hand-derived
+  from the CSS Flexbox spec algorithm.
   """
   use ExUnit.Case, async: true
   use ExUnitProperties
@@ -18,7 +18,7 @@ defmodule Raxol.UI.Layout.Flexbox.SolverTest do
 
   defp sizes(items), do: Enum.map(items, & &1.main_size)
 
-  describe "flex: 1 equalization (D2 goal)" do
+  describe "flex: 1 equalization" do
     test "three flex:1 items with unequal content equalize exactly" do
       items = for _ <- 1..3, do: item(base_size: 0, grow: 1, min_main: 0)
       assert solve(items, 90) |> sizes() == [30, 30, 30]

--- a/test/raxol/ui/layout/flexbox_test.exs
+++ b/test/raxol/ui/layout/flexbox_test.exs
@@ -3,10 +3,6 @@ defmodule Raxol.UI.Layout.FlexboxTest do
 
   alias Raxol.UI.Layout.Flexbox
 
-  # Legacy API describes (new/1, render/1, calculate_layout/1) removed
-  # with the API itself (dead :flexbox struct path, zero production
-  # callers).
-
   describe "measure_flex/2" do
     test "measures flex container with children" do
       flex = %{

--- a/test/support/raxol/visual.ex
+++ b/test/support/raxol/visual.ex
@@ -123,16 +123,8 @@ defmodule Raxol.Test.Visual do
   defp ensure_list(item) when is_list(item), do: item
   defp ensure_list(item), do: [item]
 
-  # Re-pointed from the legacy layout stack (zero production callers) to
-  # the live engine, the pipeline production actually renders through.
-  # `apply_layout/3` takes a single element and recurses via
-  # `:view`/`:children`, so wrap the top-level list the same way `view/1`
-  # callbacks do -- every element in `elements` is laid out against the
-  # same full available space.
-  #
-  # The live engine returns flat `:type`/`:x`/`:y`(/`:width`/`:height`)
-  # maps instead of the legacy `:position`/`:size` tuples -- this is the
-  # shape `Raxol.UI.Renderer.render_to_cells/2` (below) actually expects.
+  # Wrap in %{type: :view, children: ...} so all elements share full space,
+  # same as `view/1` callbacks; engine emits x/y maps Renderer expects.
   defp apply_layout(elements, width, height) do
     Raxol.UI.Layout.Engine.apply_layout(
       %{type: :view, children: elements},


### PR DESCRIPTION
Final cleanup of the flex spec-convergence series. Stacks on #464.

- Regroup layout-engine function clauses (`border_beam` demo uses `TextMeasure`).
- Strip process narration from comments; dissolve the in-flight design doc into `docs/core/LAYOUT.md`.
- Review findings: DSL aliases, measure/layout parity, anchor coverage.
- Characterize text placement (not derived width) after the a11y field add — keeps the cross-terminal pins tracking geometry.

Depends on: #461, #462, #463, #464. Draft until those merge.