### PR TITLE
Fix raxol prod release build

### DIFF
--- a/lib/raxol/workflow/node.ex
+++ b/lib/raxol/workflow/node.ex
@@ -157,9 +157,29 @@ defprotocol Raxol.Workflow.Node.Executor do
   implementing this protocol. Mirrors the
   `Raxol.Core.Runtime.Directive.Executor` shape: same callback name,
   same result tuple, same telemetry surface.
+
+  No struct is implemented in this library; the `Any` fallback raises for a
+  struct that has no implementation registered.
   """
+
+  @fallback_to_any true
 
   @spec execute(t(), state :: any(), opts :: keyword()) ::
           Raxol.Workflow.Node.result()
   def execute(node_struct, state, opts)
+end
+
+defimpl Raxol.Workflow.Node.Executor, for: Any do
+  # Reached when a TypedNode wraps a struct with no registered implementation.
+  # Raising matches the behaviour of an unimplemented protocol; the workflow
+  # runtime rescues it into an `{:error, {:exception, _}}` node result. Having a
+  # fallback also lets the compiler resolve the dispatch, so a lib-only build
+  # (the `raxol` release) does not flag the call as always-failing.
+  def execute(node_struct, _state, _opts) do
+    raise Protocol.UndefinedError,
+      protocol: Raxol.Workflow.Node.Executor,
+      value: node_struct,
+      description:
+        "register one with `defimpl Raxol.Workflow.Node.Executor, for: ...`"
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -106,15 +106,14 @@ defmodule Raxol.MixProject do
   end
 
   # The `raxol` release ships the playground TUI (`Raxol.Release.playground/0`)
-  # and the golden render smoke (`Raxol.Release.golden/0`). runtime_tools is
-  # loaded (not started) so :observer/:recon remote diagnostics work without
-  # starting anything at boot; every other application comes from the dep tree.
+  # and the golden render smoke (`Raxol.Release.golden/0`). :runtime_tools is
+  # already a started dependency (see application/0), so :observer / :recon
+  # diagnostics stay available; every other application comes from the dep tree.
   defp releases do
     [
       raxol: [
         include_executables_for: [:unix],
-        steps: [:assemble],
-        applications: [runtime_tools: :load]
+        steps: [:assemble]
       ]
     ]
   end


### PR DESCRIPTION
## Problem

`MIX_ENV=prod mix release raxol` did not build. Two latent bugs, both in the
release config added in #455, blocked any prod build of the `raxol` app itself:

1. **Unimplemented library protocol under prod `warnings_as_errors`.**
   `Raxol.Workflow.Node.Executor` is a protocol external packages implement;
   `lib/` has no implementation. On a lib-only prod compile, Elixir 1.20's type
   checker flags the dispatch in `runtime.ex` as "always fails," and
   `warnings_as_errors: Mix.env() == :prod` turns that into a hard error.

2. **`runtime_tools` mode conflict during assembly.**
   The release set `applications: [runtime_tools: :load]`, but `:raxol` is
   permanent and depends on `:runtime_tools`, so assembly refused the mode
   mismatch. The override was copied from the `raxol_acp` release template, where
   `:runtime_tools` is not an `extra_applications` entry.

This went unnoticed because the fly/web deploy builds `raxol` as a **dependency**,
which Mix compiles without `warnings_as_errors`, sidestepping (1) entirely.

## Fix

- Add `@fallback_to_any true` and an `Any` implementation to
  `Raxol.Workflow.Node.Executor`. It raises (the workflow runtime already rescues
  a raised node into an `{:error, {:exception, _}}` result, so behaviour for an
  unregistered struct is unchanged), and it gives the compiler an implementation
  to resolve the dispatch against.
- Drop `applications: [runtime_tools: :load]` from the release. `:runtime_tools`
  is already started via `application/0`, so `:observer` / `:recon` diagnostics
  stay available.

Unblocks the FATE bench cross-platform step, whose `nix` `packages.default`
builds the same prod release.

## Manual testing

- [x] `MIX_ENV=prod mix release raxol` assembles (exit 0)
- [x] `_build/prod/rel/raxol/bin/raxol eval "Raxol.Release.golden()"` exits 0 and
      its output matches `priv/fate/golden.refs` (7/7 fixtures)
- [x] `termbox2_nif.so` is bundled at `lib/raxol_terminal-2.6.0/priv/`
- [x] `mix test test/raxol/workflow/` passes (the 5 failures are Postgres-gated
      integration tests requiring `RAXOL_WORKFLOW_PG_URL`, unrelated)
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean
