### PR TITLE
Fix multiline text rendering escaping element layout box

### DIFF
--- a/lib/raxol/ui/element_renderer.ex
+++ b/lib/raxol/ui/element_renderer.ex
@@ -257,8 +257,18 @@ defmodule Raxol.UI.ElementRenderer do
     bg = resolve_bg(style)
     attrs = extract_text_attrs(style) ++ hyperlink_attrs(style)
 
-    # Width-aware text rendering - CJK/fullwidth chars advance x by 2
+    # split \n; never emit a newline cell (resets cursor to col 0)
     text
+    |> String.split("\n")
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {line, row_offset} ->
+      render_text_line(line, x, y + row_offset, fg, bg, attrs)
+    end)
+  end
+
+  # Width-aware text rendering - CJK/fullwidth chars advance x by 2
+  defp render_text_line(line, x, y, fg, bg, attrs) do
+    line
     |> String.graphemes()
     |> Enum.reduce({[], x}, fn char, {cells, cur_x} ->
       w = Raxol.UI.TextMeasure.char_display_width(char)

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -262,7 +262,10 @@ defmodule Raxol.UI.Layout.Engine do
       x: space.x + dx,
       y: space.y + dy,
       width: Raxol.UI.TextMeasure.display_width(content),
-      height: 1,
+      # Match measure_element's line count: the renderer paints one row per
+      # `\n`-split line, so layout must reserve the same rows or later
+      # siblings get painted over.
+      height: content |> String.split("\n") |> length(),
       text: content,
       fg: Map.get(element, :fg),
       bg: Map.get(element, :bg),

--- a/test/cross_terminal/multiline_text_render_test.exs
+++ b/test/cross_terminal/multiline_text_render_test.exs
@@ -1,0 +1,156 @@
+defmodule Raxol.CrossTerminal.MultilineTextRenderTest do
+  @moduledoc """
+  Regression: text elements containing embedded newlines must render each
+  line at the ELEMENT's x on consecutive rows — never emit a literal "\\n"
+  cell (which linefeeds the terminal to column 0, dragging content outside
+  its layout box), and layout must reserve one row per line.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Headless
+  alias Raxol.Terminal.Buffer.Queries
+
+  defmodule CodePanelApp do
+    use Raxol.Core.Runtime.Application
+
+    @impl true
+    def init(_context), do: %{}
+
+    @impl true
+    def update(_message, model), do: {model, []}
+
+    @impl true
+    def view(_model) do
+      require Raxol.Core.Renderer.View
+      alias Raxol.Core.Renderer.View, as: V
+
+      V.row style: %{gap: 0} do
+        [
+          V.box(
+            style: %{border: :single, width: 12},
+            children: [V.text("side1\nside2\nside3")]
+          ),
+          V.column style: %{gap: 0} do
+            [V.text("code:\n  line_one(\n    arg\n  )")]
+          end
+        ]
+      end
+    end
+
+    @impl true
+    def subscribe(_model), do: []
+  end
+
+  defmodule StackedSiblingApp do
+    use Raxol.Core.Runtime.Application
+
+    @impl true
+    def init(_context), do: %{}
+
+    @impl true
+    def update(_message, model), do: {model, []}
+
+    @impl true
+    def view(_model) do
+      require Raxol.Core.Renderer.View
+      alias Raxol.Core.Renderer.View, as: V
+
+      V.column style: %{gap: 0} do
+        [V.text("line1\nline2\nline3"), V.text("MARKER")]
+      end
+    end
+
+    @impl true
+    def subscribe(_model), do: []
+  end
+
+  setup do
+    pid =
+      case Process.whereis(Headless) do
+        nil -> start_supervised!({Headless, [name: Headless]})
+        existing -> existing
+      end
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        for id <- GenServer.call(pid, :list_sessions) do
+          try do
+            GenServer.call(pid, {:stop_session, id}, 2_000)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  test "multiline text lines all start at the element's x column" do
+    {:ok, id} =
+      Headless.start(CodePanelApp, id: :ml_text, width: 60, height: 20)
+
+    Process.sleep(300)
+    {:ok, buffer} = Headless.get_buffer(id)
+    text = Queries.get_text(buffer)
+    lines = String.split(text, "\n")
+
+    # The second element sits at x=12 (after the 12-wide box). Every one
+    # of its four lines must start at column 12, none may leak to column 0
+    # inside the sidebar box or to the row below the layout.
+    code_rows =
+      lines
+      |> Enum.filter(
+        &(String.contains?(&1, "code:") or String.contains?(&1, "line_one") or
+            String.contains?(&1, "arg") or String.trim(&1) == ")")
+      )
+
+    assert length(code_rows) >= 3
+
+    for row <- code_rows do
+      # nothing before column 12 except the sidebar box's own content
+      prefix = String.slice(row, 0, 12)
+
+      refute prefix =~ "code",
+             "code content leaked into sidebar columns: #{inspect(row)}"
+
+      refute prefix =~ "line_one",
+             "code content leaked into sidebar columns: #{inspect(row)}"
+    end
+
+    # No literal newline characters stored as cells
+    refute text =~ <<0>>
+
+    # Sidebar's own multiline text also stays inside its box (x=1, border)
+    side_rows = Enum.filter(lines, &(&1 =~ "side"))
+    assert length(side_rows) == 3
+
+    for row <- side_rows do
+      assert row =~ ~r/^│side\d/,
+             "sidebar line escaped its box: #{inspect(row)}"
+    end
+
+    :ok = Headless.stop(id)
+  end
+
+  test "layout reserves a row per line so a following sibling isn't overlapped" do
+    {:ok, id} =
+      Headless.start(StackedSiblingApp, id: :ml_stack, width: 40, height: 20)
+
+    Process.sleep(300)
+    {:ok, buffer} = Headless.get_buffer(id)
+    text = Queries.get_text(buffer)
+    lines = String.split(text, "\n")
+
+    line1_row = Enum.find_index(lines, &(&1 =~ "line1"))
+    line3_row = Enum.find_index(lines, &(&1 =~ "line3"))
+    marker_row = Enum.find_index(lines, &(&1 =~ "MARKER"))
+
+    assert line1_row && line3_row && marker_row
+    assert line3_row == line1_row + 2
+    # MARKER must land below all three reserved rows, not on top of line2/line3.
+    assert marker_row == line3_row + 1
+
+    :ok = Headless.stop(id)
+  end
+end


### PR DESCRIPTION
- ElementRenderer paints one row per `\n`-split line, but layout reserved height 1, so multiline text (playground code panel, LineChart braille scatter) linefeeds to column 0 and bleeds into sibling columns.
- Layout now reserves the same line count the renderer paints; renderer splits on newline and renders each line at the element's own x.
- Adds a regression test asserting no leak into sibling columns and no stored control chars.

Part of the render-fixes wave; independent, mergeable on its own.