### PR TITLE
Fix chart height under-allocation and wrapper box sizing

### DIFF
--- a/lib/raxol/ui/charts/view_bridge.ex
+++ b/lib/raxol/ui/charts/view_bridge.ex
@@ -19,7 +19,7 @@ defmodule Raxol.UI.Charts.ViewBridge do
   def cells_to_view(cells, opts \\ [])
 
   def cells_to_view([], opts) do
-    Components.box(style: Keyword.get(opts, :style, %{}), children: [])
+    Components.box(style: chart_box_style(opts), children: [])
   end
 
   def cells_to_view(cells, opts) do
@@ -29,7 +29,25 @@ defmodule Raxol.UI.Charts.ViewBridge do
       |> Enum.chunk_by(fn {_x, y, _c, fg, bg, _a} -> {y, fg, bg} end)
       |> Enum.map(&group_to_text_element/1)
 
-    Components.box(style: Keyword.get(opts, :style, %{}), children: children)
+    Components.box(style: chart_box_style(opts), children: children)
+  end
+
+  # The wrapper box must hug the chart's render region — a dimensionless
+  # box fills all available space, framing a small chart with a huge empty
+  # rectangle. Caller-provided style dimensions win over the region's.
+  defp chart_box_style(opts) do
+    style = Keyword.get(opts, :style, %{})
+
+    case Keyword.get(opts, :region) do
+      {_x, _y, w, h} ->
+        style
+        |> Map.put_new(:width, w)
+        |> Map.put_new(:height, h)
+        |> Map.put_new(:overflow, :hidden)
+
+      _ ->
+        style
+    end
   end
 
   defp group_to_text_element(group) do

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -751,6 +751,13 @@ defmodule Raxol.UI.Layout.Engine do
     Inputs.measure(:text_input, attrs_map, available_space)
   end
 
+  # charts are :box under a discovery type alias; measure must mirror the
+  # layout-side rewrite or charts measure 0x0 and siblings paint over them
+  def measure_element(%{type: type} = element, available_space)
+      when type in [:line_chart, :bar_chart, :scatter_chart, :heatmap] do
+    measure_element(Map.put(element, :type, :box), available_space)
+  end
+
   # Box with single map child (View DSL produces map, not list, for single child)
   def measure_element(
         %{type: :box, children: %{} = child} = element,

--- a/lib/raxol/view/components.ex
+++ b/lib/raxol/view/components.ex
@@ -544,7 +544,11 @@ defmodule Raxol.View.Components do
           )
       end
 
-    view = Raxol.UI.Charts.ViewBridge.cells_to_view(cells, style: style)
+    view =
+      Raxol.UI.Charts.ViewBridge.cells_to_view(cells,
+        style: style,
+        region: region
+      )
 
     # Preserve chart type, series, and render opts so MCP ToolProvider
     # can expose chart data as read-only tools via TreeWalker.

--- a/test/cross_terminal/chart_measurement_test.exs
+++ b/test/cross_terminal/chart_measurement_test.exs
@@ -1,0 +1,53 @@
+defmodule Raxol.CrossTerminal.ChartMeasurementTest do
+  @moduledoc """
+  Regression: chart widget types (:line_chart etc. — :box elements with an
+  overridden :type for MCP discovery) must measure through the same :box
+  rewrite as layout, or they measure 0x0 and siblings paint over them.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Layout.Engine
+
+  test "chart element measures its content height, not zero" do
+    chart = %{
+      type: :line_chart,
+      style: %{},
+      children: Enum.map(1..12, &%{type: :text, content: "row #{&1} braille"})
+    }
+
+    assert %{height: 12} =
+             Engine.measure_element(chart, %{x: 0, y: 0, width: 80, height: 40})
+  end
+
+  test "siblings after a chart in a column land below the chart rows" do
+    tree = %{
+      type: :flex,
+      direction: :column,
+      gap: 0,
+      children: [
+        %{
+          type: :bar_chart,
+          style: %{},
+          children: Enum.map(1..8, &%{type: :text, content: "bar row #{&1}"})
+        },
+        %{type: :text, content: "legend below"}
+      ]
+    }
+
+    elements = Engine.apply_layout(tree, %{width: 80, height: 30})
+
+    box = Enum.find(elements, &(&1.type == :box))
+
+    legend =
+      Enum.find(
+        elements,
+        &(Map.get(&1, :content) == "legend below" or
+            Map.get(&1, :text) == "legend below")
+      )
+
+    assert box.height == 8
+
+    assert legend.y >= box.y + box.height,
+           "legend (y=#{legend.y}) overlaps chart box (y=#{box.y}, h=#{box.height})"
+  end
+end

--- a/test/raxol/view/chart_components_test.exs
+++ b/test/raxol/view/chart_components_test.exs
@@ -56,7 +56,10 @@ defmodule Raxol.View.ChartComponentsTest do
           style: %{border: :single}
         )
 
-      assert view.style == %{border: :single}
+      # wrapper hugs region w/h; caller style keys still win
+      assert view.style.border == :single
+      assert view.style.width == 40
+      assert view.style.height == 10
     end
   end
 
@@ -94,7 +97,9 @@ defmodule Raxol.View.ChartComponentsTest do
 
   describe "scatter_chart/1" do
     test "returns a box with chart content" do
-      view = Components.scatter_chart(series: @scatter_series, width: 20, height: 8)
+      view =
+        Components.scatter_chart(series: @scatter_series, width: 20, height: 8)
+
       assert view.type in [:line_chart, :bar_chart, :scatter_chart, :heatmap]
       assert is_list(view.children)
     end


### PR DESCRIPTION
- Chart widgets (`:line_chart`/`:bar_chart`/`:scatter_chart`/`:heatmap`) are `:box` elements with an overridden `:type` for MCP discovery. `measure_element` fell through to unknown-type and measured 0x0, so siblings (legend, key hints) were placed at the chart's top edge and braille rows painted over them. Measure now mirrors the layout-side type rewrite.
- The chart wrapper box now hugs the chart region instead of filling all available space.

Part of the render-fixes wave; independent, mergeable on its own.