### PR TITLE
Render markdown inline styling as styled spans

### DIFF
--- a/lib/raxol/playground/demo_helpers.ex
+++ b/lib/raxol/playground/demo_helpers.ex
@@ -45,6 +45,25 @@ defmodule Raxol.Playground.DemoHelpers do
   end
 
   @doc """
+  Renders `content` (Markdown text) through `Raxol.UI.Components.MarkdownRenderer`,
+  the canonical Markdown-to-styled-elements renderer.
+
+  ## Examples
+
+      markdown("# Title\\n\\nSome **bold** text.", 40)
+  """
+  @spec markdown(String.t(), pos_integer()) :: map()
+  def markdown(content, width) do
+    {:ok, state} =
+      Raxol.UI.Components.MarkdownRenderer.init(%{
+        markdown_text: content,
+        width: width
+      })
+
+    Raxol.UI.Components.MarkdownRenderer.render(state, %{})
+  end
+
+  @doc """
   Navigate backward through input history.
 
   Expects the model to have `:input_history`, `:history_index`, `:input`, and `:cursor` fields.

--- a/lib/raxol/playground/demos/markdown_demo.ex
+++ b/lib/raxol/playground/demos/markdown_demo.ex
@@ -1,10 +1,17 @@
 defmodule Raxol.Playground.Demos.MarkdownDemo do
-  @moduledoc "Playground demo: markdown rendering with raw toggle."
+  @moduledoc """
+  Playground demo: markdown rendering with raw toggle.
+
+  Rendered mode delegates to `MarkdownRenderer` via `DemoHelpers.markdown/2`.
+  Overflowing lines fall back to greedy word-wrap with styling dropped
+  (span-aware wrapping is not implemented); raw mode shows literal source.
+  """
   use Raxol.Core.Runtime.Application
 
-  import Raxol.Playground.DemoHelpers, only: [effective_width: 2]
+  import Raxol.Playground.DemoHelpers, only: [effective_width: 2, markdown: 2]
 
   @default_content_box_width 45
+  @border_and_padding_overhead 4
 
   @documents [
     %{
@@ -52,13 +59,17 @@ defmodule Raxol.Playground.Demos.MarkdownDemo do
   def view(model) do
     doc = Enum.at(@documents, model.current)
     mode_label = if model.raw, do: "RAW", else: "RENDERED"
+    box_width = effective_width(model, @default_content_box_width)
+    prose_width = max(box_width - @border_and_padding_overhead, 1)
 
-    content_lines =
-      doc.content
-      |> String.split("\n")
-      |> Enum.map(fn line ->
-        if model.raw, do: text(line), else: render_line(line)
-      end)
+    body =
+      if model.raw do
+        doc.content
+        |> String.split("\n")
+        |> Enum.map(&text/1)
+      else
+        [markdown(doc.content, prose_width)]
+      end
 
     column style: %{gap: 1} do
       [
@@ -73,10 +84,10 @@ defmodule Raxol.Playground.Demos.MarkdownDemo do
         box style: %{
               border: :single,
               padding: 1,
-              width: effective_width(model, @default_content_box_width)
+              width: box_width
             } do
           column style: %{gap: 0} do
-            content_lines
+            body
           end
         end,
         divider(),
@@ -88,27 +99,4 @@ defmodule Raxol.Playground.Demos.MarkdownDemo do
 
   @impl true
   def subscribe(_model), do: []
-
-  defp render_line(line) do
-    cond do
-      String.starts_with?(line, "# ") ->
-        text(String.trim_leading(line, "# "), style: [:bold, :underline])
-
-      String.starts_with?(line, "- ") ->
-        body = String.trim_leading(line, "- ") |> render_inline()
-        text("  * " <> body)
-
-      line == "" ->
-        text("")
-
-      true ->
-        text(render_inline(line))
-    end
-  end
-
-  defp render_inline(str) do
-    str
-    |> String.replace(~r/\*([^*]+)\*/, "_\\1_")
-    |> String.replace(~r/`([^`]+)`/, "[\\1]")
-  end
 end

--- a/lib/raxol/ui/components/markdown_renderer.ex
+++ b/lib/raxol/ui/components/markdown_renderer.ex
@@ -5,9 +5,15 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
   Supports headings, bold, italic, code spans, code blocks, lists,
   blockquotes, horizontal rules, and links. Uses EarmarkParser when
   available, falls back to a built-in regex parser.
+
+  Inline styling does not survive a wrap boundary: a line that overflows
+  `width` falls back to plain, unstyled wrapped text, though wrapped
+  output never leaks literal Markdown marker characters.
   """
   use Raxol.UI.Components.Base.Component
 
+  alias Raxol.UI.TextLayout
+  alias Raxol.UI.TextMeasure
   alias Raxol.View.Components
 
   @default_width Raxol.Core.Defaults.terminal_width()
@@ -116,17 +122,16 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
     ]
   end
 
-  defp ast_node_to_elements({"p", _attrs, children, _meta}, _width) do
-    text = extract_inline(children)
-    [Components.text(content: text), Components.text(content: "")]
+  defp ast_node_to_elements({"p", _attrs, children, _meta}, width) do
+    lines = render_segments_line(inline_segments(children), width)
+    lines ++ [Components.text(content: "")]
   end
 
   defp ast_node_to_elements({"ul", _attrs, children, _meta}, width) do
     items =
       Enum.flat_map(children, fn
         {"li", _, li_children, _} ->
-          text = extract_inline(li_children)
-          [Components.text(content: @ul_prefix <> text)]
+          render_segments_line(inline_segments(li_children), width, @ul_prefix)
 
         other ->
           ast_node_to_elements(other, width)
@@ -142,8 +147,11 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
       |> Enum.with_index(1)
       |> Enum.flat_map(fn
         {{"li", _, li_children, _}, idx} ->
-          text = extract_inline(li_children)
-          [Components.text(content: "  #{idx}. " <> text)]
+          render_segments_line(
+            inline_segments(li_children),
+            width,
+            "  #{idx}. "
+          )
 
         {other, _idx} ->
           ast_node_to_elements(other, width)
@@ -214,32 +222,59 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
   defp extract_text(text) when is_binary(text), do: text
   defp extract_text(_), do: ""
 
-  defp extract_inline(children) when is_list(children) do
-    Enum.map_join(children, "", &extract_inline_node/1)
+  @doc """
+  Flattens Earmark AST inline children (`strong`/`em`/`code`/`a`/text
+  nodes) into a list of `{text, style}` segments, merging styles across
+  nesting (e.g. bold inside italic yields `%{bold: true, italic: true}`).
+
+  Empty-text nodes are dropped. Unknown tags recurse into their children
+  without adding style, so unsupported inline markup degrades to plain
+  text rather than being silently dropped.
+  """
+  @spec inline_segments(list() | String.t()) :: [{String.t(), map()}]
+  def inline_segments(children) when is_list(children) do
+    Enum.flat_map(children, &inline_segment_node(&1, %{}))
   end
 
-  defp extract_inline(text) when is_binary(text), do: text
-  defp extract_inline(_), do: ""
+  def inline_segments(text) when is_binary(text) do
+    if text == "", do: [], else: [{text, %{}}]
+  end
 
-  defp extract_inline_node(text) when is_binary(text), do: text
+  def inline_segments(_), do: []
 
-  defp extract_inline_node({"strong", _, inner, _}),
-    do: "*" <> extract_text(inner) <> "*"
+  defp inline_segment_node(text, style) when is_binary(text) do
+    if text == "", do: [], else: [{text, style}]
+  end
 
-  defp extract_inline_node({"em", _, inner, _}),
-    do: "_" <> extract_text(inner) <> "_"
+  defp inline_segment_node({"strong", _, inner, _}, style) do
+    merged = Map.put(style, :bold, true)
+    Enum.flat_map(inner, &inline_segment_node(&1, merged))
+  end
 
-  defp extract_inline_node({"code", _, inner, _}),
-    do: "`" <> extract_text(inner) <> "`"
+  defp inline_segment_node({"em", _, inner, _}, style) do
+    merged = Map.put(style, :italic, true)
+    Enum.flat_map(inner, &inline_segment_node(&1, merged))
+  end
 
-  defp extract_inline_node({"a", attrs, inner, _}) do
+  defp inline_segment_node({"code", _, inner, _}, style) do
+    text = extract_text(inner)
+    merged = Map.merge(style, @code_style)
+    if text == "", do: [], else: [{text, merged}]
+  end
+
+  defp inline_segment_node({"a", attrs, inner, _}, style) do
     href =
       Enum.find_value(attrs, "", fn {k, v} -> if k == "href", do: v end)
 
-    extract_text(inner) <> " (" <> href <> ")"
+    text = extract_text(inner) <> " (" <> href <> ")"
+    if text == "", do: [], else: [{text, style}]
   end
 
-  defp extract_inline_node({_tag, _, inner, _}), do: extract_inline(inner)
+  defp inline_segment_node({_tag, _, inner, _}, style) do
+    Enum.flat_map(inner, &inline_segment_node(&1, style))
+  end
+
+  defp inline_segment_node(_, _style), do: []
 
   defp extract_code_text(children) when is_list(children) do
     Enum.map_join(children, "", fn
@@ -249,9 +284,83 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
     end)
   end
 
+  # --- Shared segment rendering (fits-vs-wrapped) ---
+  #
+  # `[{text, style}, ...]` segments render as: a plain `text` element when
+  # unstyled; a `:row` of styled spans when styled and the full line fits
+  # `width`; otherwise word-wrapped plain text (styling does not survive a
+  # wrap boundary, but markers never leak since segment parsing already
+  # consumed them).
+
+  defp render_segments_line(segments, width, prefix \\ "") do
+    segments = Enum.reject(segments, fn {text, _style} -> text == "" end)
+    plain_text = Enum.map_join(segments, "", &elem(&1, 0))
+    full_text = prefix <> plain_text
+
+    cond do
+      segments == [] and prefix == "" ->
+        [Components.text(content: "")]
+
+      TextMeasure.display_width(full_text) <= width and
+          plain_segments?(segments) ->
+        [Components.text(content: full_text)]
+
+      TextMeasure.display_width(full_text) <= width ->
+        [inline_row(prefix, segments)]
+
+      true ->
+        wrap_plain_lines(prefix, plain_text, width)
+    end
+  end
+
+  defp plain_segments?(segments) do
+    Enum.all?(segments, fn {_text, style} -> style == %{} end)
+  end
+
+  defp inline_row(prefix, segments) do
+    spans = Enum.map(segments, &segment_text/1)
+
+    children =
+      if prefix == "",
+        do: spans,
+        else: [Components.text(content: prefix) | spans]
+
+    Components.row(gap: 0, children: children)
+  end
+
+  defp segment_text({text, style}) when map_size(style) == 0 do
+    Components.text(content: text)
+  end
+
+  defp segment_text({text, style}),
+    do: Components.text(content: text, style: style)
+
+  defp wrap_plain_lines(prefix, text, width) do
+    # Wrap to width minus the prefix (e.g. a list marker), or every line
+    # after the first would exceed `width` once the prefix is prepended.
+    # Continuation lines get the same amount of blank indent so wrapped
+    # text lines up under the first line's text, not the marker.
+    prefix_width = TextMeasure.display_width(prefix)
+    indent = String.duplicate(" ", prefix_width)
+    wrap_width = max(width - prefix_width, 1)
+
+    case TextLayout.wrap(text, wrap_width, :normal) do
+      [] ->
+        [Components.text(content: prefix)]
+
+      [first | rest] ->
+        [
+          Components.text(content: prefix <> first)
+          | Enum.map(rest, &Components.text(content: indent <> &1))
+        ]
+    end
+  end
+
   # --- Built-in regex-based rendering (no deps) ---
 
-  defp render_with_builtin(markdown_text, width) do
+  @doc false
+  @spec render_with_builtin(String.t(), non_neg_integer()) :: [map()]
+  def render_with_builtin(markdown_text, width) do
     markdown_text
     |> String.split("\n")
     |> parse_blocks(width, [])
@@ -276,70 +385,81 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
     parse_blocks(remaining, width, new_acc)
   end
 
-  # Heading
   defp parse_blocks([line | rest], width, acc) do
-    element = parse_line(line, width)
-    parse_blocks(rest, width, [element | acc])
+    elements = parse_line(line, width)
+    parse_blocks(rest, width, Enum.reverse(elements) ++ acc)
   end
 
   defp parse_line("# " <> text, _width) do
-    Components.text(
-      content: "# " <> strip_inline(text),
-      style: @heading_style
-    )
+    [
+      Components.text(
+        content: "# " <> strip_inline(text),
+        style: @heading_style
+      )
+    ]
   end
 
   defp parse_line("## " <> text, _width) do
-    Components.text(
-      content: "## " <> strip_inline(text),
-      style: @heading_style
-    )
+    [
+      Components.text(
+        content: "## " <> strip_inline(text),
+        style: @heading_style
+      )
+    ]
   end
 
   defp parse_line("### " <> text, _width) do
-    Components.text(
-      content: "### " <> strip_inline(text),
-      style: @heading_style
-    )
+    [
+      Components.text(
+        content: "### " <> strip_inline(text),
+        style: @heading_style
+      )
+    ]
   end
 
   defp parse_line("---" <> _, width) do
-    Components.text(
-      content: String.duplicate("-", min(@hr_width, width)),
-      style: @hr_style
-    )
+    [
+      Components.text(
+        content: String.duplicate("-", min(@hr_width, width)),
+        style: @hr_style
+      )
+    ]
   end
 
   defp parse_line("***" <> _, width) do
-    Components.text(
-      content: String.duplicate("-", min(@hr_width, width)),
-      style: @hr_style
-    )
+    [
+      Components.text(
+        content: String.duplicate("-", min(@hr_width, width)),
+        style: @hr_style
+      )
+    ]
   end
 
   defp parse_line("> " <> text, _width) do
-    Components.text(
-      content: @blockquote_prefix <> strip_inline(text),
-      style: @blockquote_style
-    )
+    [
+      Components.text(
+        content: @blockquote_prefix <> strip_inline(text),
+        style: @blockquote_style
+      )
+    ]
   end
 
-  defp parse_line("- " <> text, _width) do
-    Components.text(content: @ul_prefix <> strip_inline(text))
+  defp parse_line("- " <> text, width) do
+    render_segments_line(builtin_segments(text), width, @ul_prefix)
   end
 
-  defp parse_line("* " <> text, _width) do
-    Components.text(content: @ul_prefix <> strip_inline(text))
+  defp parse_line("* " <> text, width) do
+    render_segments_line(builtin_segments(text), width, @ul_prefix)
   end
 
-  defp parse_line(line, _width) do
+  defp parse_line(line, width) do
     # Check for ordered list: "1. text", "2. text", etc.
     case Regex.run(~r/^(\d+)\.\s+(.*)/, line) do
       [_, num, text] ->
-        Components.text(content: "  #{num}. " <> strip_inline(text))
+        render_segments_line(builtin_segments(text), width, "  #{num}. ")
 
       _ ->
-        Components.text(content: strip_inline(line))
+        render_segments_line(builtin_segments(line), width)
     end
   end
 
@@ -351,6 +471,68 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
     |> String.replace(~r/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/, "_\\1_")
     |> String.replace(~r/\[(.+?)\]\((.+?)\)/, "\\1 (\\2)")
   end
+
+  # `builtin_segments/1` mirrors `inline_segments/1` for the built-in
+  # (non-Earmark) path. Match precedence follows alternation order: code
+  # span, then bold, then em, then links. Unmatched markers pass through
+  # as literal text.
+  @builtin_pattern ~r/`([^`]+)`|\*\*([^*]+)\*\*|__([^_]+)__|\*([^*]+)\*|_([^_]+)_|\[([^\]]+)\]\(([^)]+)\)/
+
+  defp builtin_segments(text) do
+    scan_builtin_segments(text, [])
+  end
+
+  defp scan_builtin_segments("", acc), do: Enum.reverse(acc)
+
+  defp scan_builtin_segments(text, acc) do
+    case Regex.run(@builtin_pattern, text, return: :index) do
+      nil ->
+        Enum.reverse([{text, %{}} | acc])
+
+      [{whole_start, whole_len} | groups] ->
+        before = String.slice(text, 0, whole_start)
+        rest = String.slice(text, (whole_start + whole_len)..-1//1)
+        {seg_text, style} = classify_builtin_match(text, groups)
+
+        acc = if before == "", do: acc, else: [{before, %{}} | acc]
+        acc = [{seg_text, style} | acc]
+
+        scan_builtin_segments(rest, acc)
+    end
+  end
+
+  # `Regex.run/3` with `return: :index` trims trailing non-participating
+  # capture groups from the result (an Erlang `:re` quirk), so the groups
+  # list length varies depending on which alternative matched -- pad it
+  # back out to the full 7-group shape before pattern matching.
+  defp classify_builtin_match(text, groups) do
+    padded = groups ++ List.duplicate({-1, 0}, 7 - length(groups))
+    [code, bold1, bold2, em1, em2, link_text, link_url] = padded
+
+    cond do
+      code != {-1, 0} ->
+        {slice_group(text, code), @code_style}
+
+      bold1 != {-1, 0} ->
+        {slice_group(text, bold1), %{bold: true}}
+
+      bold2 != {-1, 0} ->
+        {slice_group(text, bold2), %{bold: true}}
+
+      em1 != {-1, 0} ->
+        {slice_group(text, em1), %{italic: true}}
+
+      em2 != {-1, 0} ->
+        {slice_group(text, em2), %{italic: true}}
+
+      true ->
+        link = slice_group(text, link_text)
+        url = slice_group(text, link_url)
+        {link <> " (" <> url <> ")", %{}}
+    end
+  end
+
+  defp slice_group(text, {start, len}), do: String.slice(text, start, len)
 
   defp take_until_fence([], acc), do: {Enum.reverse(acc), []}
   defp take_until_fence(["```" <> _ | rest], acc), do: {Enum.reverse(acc), rest}

--- a/test/raxol/playground/demo_render_test.exs
+++ b/test/raxol/playground/demo_render_test.exs
@@ -159,6 +159,28 @@ defmodule Raxol.Playground.DemoRenderTest do
                  "Last frame:\n\n" <>
                  numbered(String.split(union_text, "\n"))
       end
+
+      # Markdown rendered mode must not leak * _ ` markers
+      if @component.name == "Markdown" do
+        refute Regex.match?(~r/`[^`\n]+`/, initial_text),
+               header(@component.name) <>
+                 "literal backtick code markers leaked into rendered output.\n\n" <>
+                 "Rendered output:\n\n" <> numbered(lines)
+
+        refute Regex.match?(~r/\*[^*\s][^*\n]*\*/, initial_text),
+               header(@component.name) <>
+                 "literal *bold*/*em* asterisk markers leaked into rendered output " <>
+                 "(bullet prefixes like \"  * \" are fine; a closed *word* pair is not).\n\n" <>
+                 "Rendered output:\n\n" <> numbered(lines)
+
+        refute Regex.match?(
+                 ~r/(?<![[:alnum:]])_[^_\s][^_\n]*_(?![[:alnum:]])/,
+                 initial_text
+               ),
+               header(@component.name) <>
+                 "literal _em_ underscore markers leaked into rendered output.\n\n" <>
+                 "Rendered output:\n\n" <> numbered(lines)
+      end
     end
   end
 

--- a/test/raxol/ui/components/markdown_renderer_test.exs
+++ b/test/raxol/ui/components/markdown_renderer_test.exs
@@ -4,12 +4,46 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
   alias Raxol.UI.Components.MarkdownRenderer
 
   defp render_md(text, opts \\ %{}) do
-    {:ok, state} = MarkdownRenderer.init(Map.merge(%{markdown_text: text}, opts))
+    {:ok, state} =
+      MarkdownRenderer.init(Map.merge(%{markdown_text: text}, opts))
+
     MarkdownRenderer.render(state, %{})
   end
 
   defp children(result), do: result.children
-  defp contents(result), do: Enum.map(children(result), & &1.content)
+
+  # Recursively flattens `:text`/`:row` elements into their leaf text
+  # content, in document order. Needed because inline-formatted lines are
+  # now rendered as a `:row` of styled spans rather than a single `:text`
+  # element -- most content-only assertions should look through that.
+  defp flat_texts(%{type: :text, content: content}), do: [content]
+
+  defp flat_texts(%{type: :row, children: children}),
+    do: Enum.flat_map(children, &flat_texts/1)
+
+  defp flat_texts(%{type: :column, children: children}),
+    do: Enum.flat_map(children, &flat_texts/1)
+
+  defp flat_texts(_), do: []
+
+  defp contents(result), do: Enum.flat_map(children(result), &flat_texts/1)
+
+  defp full_text(result), do: Enum.join(contents(result), "")
+
+  # Recursively collects every `{content, style}` leaf pair, so tests can
+  # assert on the style attached to a specific styled span.
+  defp flat_leaves(%{type: :text, content: content, style: style}),
+    do: [{content, style}]
+
+  defp flat_leaves(%{type: :row, children: children}),
+    do: Enum.flat_map(children, &flat_leaves/1)
+
+  defp flat_leaves(%{type: :column, children: children}),
+    do: Enum.flat_map(children, &flat_leaves/1)
+
+  defp flat_leaves(_), do: []
+
+  defp leaves(result), do: Enum.flat_map(children(result), &flat_leaves/1)
 
   describe "init/1" do
     test "returns {:ok, state} with defaults" do
@@ -19,7 +53,9 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
     end
 
     test "merges custom props" do
-      assert {:ok, state} = MarkdownRenderer.init(%{markdown_text: "# Hi", width: 40})
+      assert {:ok, state} =
+               MarkdownRenderer.init(%{markdown_text: "# Hi", width: 40})
+
       assert state.markdown_text == "# Hi"
       assert state.width == 40
     end
@@ -58,8 +94,9 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
       assert is_list(result.children)
     end
 
-    test "children are text elements" do
+    test "plain (unformatted) lines stay single flat text elements" do
       result = render_md("hello")
+
       for child <- children(result) do
         assert child.type == :text
       end
@@ -93,24 +130,115 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
     end
   end
 
-  describe "inline formatting" do
-    test "converts bold markers to terminal representation" do
+  describe "inline formatting (fitting lines -> styled spans)" do
+    test "bold text becomes a styled span, not literal markers" do
       result = render_md("some **bold** text")
-      text = Enum.map_join(children(result), "", & &1.content)
-      assert text =~ "bold"
+      assert full_text(result) =~ "bold"
+      refute full_text(result) =~ "*"
+
+      assert {"bold", %{bold: true}} =
+               Enum.find(leaves(result), &(elem(&1, 0) == "bold"))
     end
 
-    test "converts italic markers to terminal representation" do
+    test "italic text becomes a styled span, not literal markers" do
       result = render_md("some _italic_ text")
-      text = Enum.map_join(children(result), "", & &1.content)
-      assert text =~ "italic"
+      assert full_text(result) =~ "italic"
+      refute full_text(result) =~ "_"
+
+      assert {"italic", %{italic: true}} =
+               Enum.find(leaves(result), &(elem(&1, 0) == "italic"))
     end
 
-    test "converts links to text with URL" do
+    test "code spans use the code style" do
+      result = render_md("run `mix test` now")
+      assert full_text(result) =~ "mix test"
+      refute full_text(result) =~ "`"
+
+      assert {"mix test", %{fg: :yellow}} =
+               Enum.find(leaves(result), &(elem(&1, 0) == "mix test"))
+    end
+
+    test "converts links to text with URL, no marker leakage" do
       result = render_md("[click](http://example.com)")
-      text = Enum.map_join(children(result), "", & &1.content)
+      text = full_text(result)
       assert text =~ "click"
       assert text =~ "http://example.com"
+      refute text =~ "["
+      refute text =~ "]("
+    end
+
+    test "a plain line with no formatting stays a single unstyled element" do
+      result = render_md("just plain text")
+      [line | _] = Enum.filter(children(result), &(&1.content != ""))
+      assert line.type == :text
+      assert line.content == "just plain text"
+    end
+
+    test "multiple spans in one line preserve order and each style" do
+      result = render_md("**bold** and _em_ and `code`")
+      leaves = leaves(result) |> Enum.reject(&(elem(&1, 0) == ""))
+
+      assert Enum.map(leaves, &elem(&1, 0)) == [
+               "bold",
+               " and ",
+               "em",
+               " and ",
+               "code"
+             ]
+
+      assert Enum.at(leaves, 0) |> elem(1) |> Map.get(:bold)
+      assert Enum.at(leaves, 2) |> elem(1) |> Map.get(:italic)
+      assert Enum.at(leaves, 4) |> elem(1) |> Map.get(:fg) == :yellow
+    end
+
+    test "a lone unmatched marker passes through as literal text" do
+      result = render_md("a * b")
+      assert full_text(result) == "a * b"
+    end
+  end
+
+  describe "inline formatting (overflowing lines -> wrapped, marker-free)" do
+    test "long formatted line wraps and drops styling but keeps no markers" do
+      long = "some **bold** words that go on and on and on and on and on and on"
+      result = render_md(long, %{width: 20})
+      lines = Enum.map(children(result), & &1.content)
+
+      assert length(lines) > 1
+      refute Enum.any?(lines, &String.contains?(&1, "*"))
+      assert Enum.any?(lines, &String.contains?(&1, "bold"))
+      assert Enum.all?(lines, &(String.length(&1) <= 20))
+    end
+
+    test "wrapped list item keeps the bullet prefix on the first line only" do
+      long =
+        "- a rather long list item body that will not fit on one narrow line at all"
+
+      result = render_md(long, %{width: 20})
+
+      lines =
+        Enum.map(children(result), & &1.content) |> Enum.reject(&(&1 == ""))
+
+      assert [first | rest] = lines
+      assert String.starts_with?(first, "  * ")
+      refute Enum.any?(rest, &String.starts_with?(&1, "  * "))
+      refute Enum.any?(lines, &String.contains?(&1, "*a "))
+      # The marker eats into the first line's budget too -- every wrapped
+      # line, including the one carrying the prefix, must fit `width`.
+      assert Enum.all?(lines, &(String.length(&1) <= 20))
+    end
+
+    test "wrapped ordered list item's prefixed line also stays within width" do
+      long =
+        "1. a rather long list item body that will not fit on one narrow line at all"
+
+      result = render_md(long, %{width: 20})
+
+      lines =
+        Enum.map(children(result), & &1.content) |> Enum.reject(&(&1 == ""))
+
+      assert [first | _rest] = lines
+      assert String.starts_with?(first, "  1. ")
+      assert Enum.all?(lines, &(String.length(&1) <= 20))
     end
   end
 
@@ -118,8 +246,13 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
     test "renders unordered list items with bullet markers" do
       result = render_md("- item one\n- item two")
       all_content = contents(result)
-      assert Enum.any?(all_content, &(&1 =~ "* item one"))
-      assert Enum.any?(all_content, &(&1 =~ "* item two"))
+      assert Enum.any?(all_content, &(&1 =~ "item one"))
+      assert Enum.any?(all_content, &(&1 =~ "item two"))
+
+      assert Enum.any?(
+               children(result),
+               &(&1.type == :text and &1.content =~ "* item one")
+             )
     end
 
     test "renders ordered list items with numbers" do
@@ -130,15 +263,28 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
       assert Enum.any?(all_content, &(&1 =~ "2."))
       assert Enum.any?(all_content, &(&1 =~ "second"))
     end
+
+    test "list item with inline formatting renders as styled spans" do
+      result = render_md("- some **bold** item")
+      assert full_text(result) =~ "bold"
+      refute full_text(result) =~ "*bold*"
+
+      row = Enum.find(children(result), &(&1.type == :row))
+      assert row != nil
+      assert Enum.any?(row.children, &(&1.content == "  * "))
+    end
   end
 
   describe "code blocks" do
     test "renders fenced code with yellow style" do
       md = "```elixir\nIO.puts(\"hi\")\n```"
       result = render_md(md)
-      code_lines = Enum.filter(children(result), fn el ->
-        el.style[:fg] == :yellow and el.content =~ "IO.puts"
-      end)
+
+      code_lines =
+        Enum.filter(children(result), fn el ->
+          el.style[:fg] == :yellow and el.content =~ "IO.puts"
+        end)
+
       assert [_ | _] = code_lines
     end
 
@@ -146,6 +292,7 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
       md = "```\nhello\nworld\n```"
       result = render_md(md)
       code_lines = Enum.filter(children(result), &(&1.style[:fg] == :yellow))
+
       for line <- code_lines do
         assert String.starts_with?(line.content, "  ")
       end
@@ -166,7 +313,7 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
     test "renders hr as dashes" do
       result = render_md("---")
       all = children(result)
-      hr = Enum.find(all, &(String.contains?(&1.content, "---")))
+      hr = Enum.find(all, &String.contains?(&1.content, "---"))
       assert hr != nil
     end
   end
@@ -183,9 +330,90 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
     test "respects width for horizontal rules" do
       result = render_md("---", %{width: 20})
       all = children(result)
-      hr = Enum.find(all, &(String.contains?(&1.content, "---")))
+      hr = Enum.find(all, &String.contains?(&1.content, "---"))
       assert hr != nil
       assert String.length(hr.content) <= 20
+    end
+  end
+
+  describe "render_with_builtin/2 (forced, EarmarkParser-independent)" do
+    test "matches the default render_md output when EarmarkParser is unavailable" do
+      # forces builtin path; default render already uses it in :test
+      direct = MarkdownRenderer.render_with_builtin("some **bold** text", 80)
+
+      {:ok, state} =
+        MarkdownRenderer.init(%{markdown_text: "some **bold** text"})
+
+      via_render = MarkdownRenderer.render(state, %{})
+
+      assert direct == via_render.children
+    end
+
+    test "produces the same span/style shape as the AST path for bold" do
+      result = %{
+        type: :column,
+        children: MarkdownRenderer.render_with_builtin("**bold**", 80)
+      }
+
+      assert {"bold", %{bold: true}} =
+               Enum.find(leaves(result), &(elem(&1, 0) == "bold"))
+    end
+
+    test "produces the same span/style shape as the AST path for code" do
+      result = %{
+        type: :column,
+        children: MarkdownRenderer.render_with_builtin("`code`", 80)
+      }
+
+      assert {"code", %{fg: :yellow}} =
+               Enum.find(leaves(result), &(elem(&1, 0) == "code"))
+    end
+  end
+
+  describe "inline_segments/2 (Earmark AST path, dependency-free)" do
+    test "plain text yields one unstyled segment" do
+      assert MarkdownRenderer.inline_segments(["hello"]) == [{"hello", %{}}]
+    end
+
+    test "strong node yields a bold segment" do
+      ast = [{"strong", [], ["bold"], %{}}]
+      assert MarkdownRenderer.inline_segments(ast) == [{"bold", %{bold: true}}]
+    end
+
+    test "em node yields an italic segment" do
+      ast = [{"em", [], ["em"], %{}}]
+      assert MarkdownRenderer.inline_segments(ast) == [{"em", %{italic: true}}]
+    end
+
+    test "code node yields a code-styled segment" do
+      ast = [{"code", [], ["code"], %{}}]
+      assert MarkdownRenderer.inline_segments(ast) == [{"code", %{fg: :yellow}}]
+    end
+
+    test "nested strong-inside-em merges both styles" do
+      ast = [{"em", [], [{"strong", [], ["both"], %{}}], %{}}]
+
+      assert MarkdownRenderer.inline_segments(ast) == [
+               {"both", %{bold: true, italic: true}}
+             ]
+    end
+
+    test "link node yields plain 'text (href)' segment" do
+      ast = [{"a", [{"href", "http://x.test"}], ["click"], %{}}]
+
+      assert MarkdownRenderer.inline_segments(ast) == [
+               {"click (http://x.test)", %{}}
+             ]
+    end
+
+    test "mixed children preserve order" do
+      ast = ["plain ", {"strong", [], ["bold"], %{}}, " tail"]
+
+      assert MarkdownRenderer.inline_segments(ast) == [
+               {"plain ", %{}},
+               {"bold", %{bold: true}},
+               {" tail", %{}}
+             ]
     end
   end
 end


### PR DESCRIPTION
- Markdown inline markers (`**bold**`, `*italic*`, ``code``) rendered as literal characters; they now become styled text spans instead of leaking the markers into output.
- Updates the markdown renderer, playground markdown demo, and demo helpers, with renderer and demo-render tests.

Part of the render-fixes wave; independent, mergeable on its own.