### PR TITLE
Honor top-level gap/justify/align in row/column compat

### DIFF
--- a/lib/raxol/ui/components/markdown_renderer.ex
+++ b/lib/raxol/ui/components/markdown_renderer.ex
@@ -61,7 +61,9 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
         render_with_builtin(markdown_text, width)
       end
 
-    %{type: :column, children: elements, style: %{}}
+    # gap: 0 — block spacing is expressed by explicit blank-line elements;
+    # the :column dialect default (gap 1) would double every gap.
+    %{type: :column, children: elements, style: %{}, gap: 0}
   end
 
   # --- Earmark-based rendering ---

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -1056,16 +1056,24 @@ defmodule Raxol.UI.Layout.Engine do
     attrs = Map.get(el, :attrs, %{})
     gap_default = if mode == :layout, do: 1, else: 0
 
+    # gap/justify/align may be top-level or in attrs
+    read = fn key, default ->
+      case Map.get(attrs, key) do
+        nil -> Map.get(el, key, default)
+        v -> v
+      end
+    end
+
     %{
       type: :flex,
       attrs: %{
         flex_direction: el.type,
-        justify_content: containers_justify(Map.get(attrs, :justify, :start)),
-        align_items: containers_align(Map.get(attrs, :align, :start)),
+        justify_content: containers_justify(read.(:justify, :start)),
+        align_items: containers_align(read.(:align, :start)),
         align_content: :flex_start,
         flex_wrap: :nowrap,
-        gap: Map.get(attrs, :gap, gap_default),
-        padding: Map.get(attrs, :padding, 0)
+        gap: read.(:gap, gap_default),
+        padding: read.(:padding, 0)
       },
       style: Map.get(el, :style, %{}),
       children: el |> Map.get(:children, []) |> Enum.map(&compat_no_shrink/1)


### PR DESCRIPTION
- `Components.row/column` emit `gap`/`justify`/`align` as top-level keys, but the Containers compat map read only `attrs`, so `Components.row(gap: 0)` silently got the dialect default gap 1 (phantom blank lines between markdown list items, stray column between inline spans).
- Compat now reads attrs first, top-level second, dialect default last; MarkdownRenderer's container declares `gap: 0` (block spacing is explicit blank-line elements).

Part of the render-fixes wave; independent, mergeable on its own.