### PR TITLE
Make View DSL tables actually render

### DIFF
--- a/lib/raxol/core/renderer/view/components.ex
+++ b/lib/raxol/core/renderer/view/components.ex
@@ -177,7 +177,9 @@ defmodule Raxol.Core.Renderer.View.Components do
   def table(opts \\ []) do
     %{
       type: :table,
-      data: Keyword.get(opts, :data, []),
+      # `rows:` and `data:` are both accepted (the sibling builder in
+      # Raxol.View.Components uses `rows:`; callers mix the two)
+      data: Keyword.get(opts, :data) || Keyword.get(opts, :rows, []),
       headers: Keyword.get(opts, :headers, []),
       style: Keyword.get(opts, :style, %{}),
       border: Keyword.get(opts, :border, :single)

--- a/lib/raxol/playground/demos/table_demo.ex
+++ b/lib/raxol/playground/demos/table_demo.ex
@@ -48,13 +48,16 @@ defmodule Raxol.Playground.Demos.TableDemo do
   def view(model) do
     rows = sorted_data(model)
 
-    rendered_rows =
+    # Real :table element (column widths computed by Raxol.UI.Layout.Table
+    # — aligned columns, not hand-joined strings). Cursor is shown by a
+    # marker column since the plain table element carries no selection
+    # state; the stateful Raxol.UI.Components.Table adds that plus
+    # pagination/filtering.
+    marked_rows =
       rows
       |> Enum.with_index()
       |> Enum.map(fn {row, idx} ->
-        prefix = DemoHelpers.cursor_prefix(idx, model.cursor)
-        style = if idx == model.cursor, do: [:bold], else: []
-        text(prefix <> Enum.join(row, "  |  "), style: style)
+        [DemoHelpers.cursor_prefix(idx, model.cursor) | row]
       end)
 
     sort_label =
@@ -70,10 +73,7 @@ defmodule Raxol.Playground.Demos.TableDemo do
       [
         text("Table Demo", style: [:bold]),
         divider(),
-        text("  " <> Enum.join(@headers, "  |  "), style: [:underline]),
-        column style: %{gap: 0} do
-          rendered_rows
-        end,
+        table(headers: ["" | @headers], rows: marked_rows),
         divider(),
         row style: %{gap: 2} do
           [

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -790,6 +790,16 @@ defmodule Raxol.UI.Layout.Engine do
     measure_element_by_type(container_type, element, %{}, available_space)
   end
 
+  # normalize DSL top-level headers/rows for measure
+  def measure_element(%{type: :table} = element, available_space) do
+    measured =
+      element
+      |> Table.normalize_table_attrs()
+      |> Table.measure(available_space)
+
+    Map.take(measured, [:width, :height])
+  end
+
   def measure_element(%{type: :spacer} = spacer, available_space) do
     size = Map.get(spacer, :size, 1)
 

--- a/lib/raxol/ui/layout/table.ex
+++ b/lib/raxol/ui/layout/table.ex
@@ -18,6 +18,43 @@ defmodule Raxol.UI.Layout.Table do
   @fallback_available_width Raxol.Core.Defaults.terminal_width()
 
   @doc """
+  Normalizes DSL top-level `headers`/`rows`/`data` into `attrs.columns`/`attrs.rows`;
+  existing `attrs.columns` wins.
+  """
+  def normalize_table_attrs(table_element) do
+    attrs = Map.get(table_element, :attrs, %{})
+
+    if Map.get(attrs, :columns) do
+      attrs
+    else
+      headers =
+        Map.get(attrs, :headers) || Map.get(table_element, :headers, [])
+
+      rows =
+        Map.get(attrs, :rows) || Map.get(attrs, :data) ||
+          Map.get(table_element, :rows) || Map.get(table_element, :data) || []
+
+      columns =
+        case headers do
+          [] ->
+            # headerless: derive column count from the widest row;
+            # downstream width inference (infer_columns_from_rows) keys
+            # off the empty-columns case, so leave columns empty and let
+            # it infer — but only when rows exist
+            []
+
+          hs ->
+            Enum.map(hs, &%{label: to_string(&1), width: :auto})
+        end
+
+      attrs
+      |> Map.put(:columns, columns)
+      |> Map.put(:rows, rows)
+      |> Map.put_new(:show_header, headers != [])
+    end
+  end
+
+  @doc """
   Measures a table element.
 
   Calculates the required dimensions for a table based on:
@@ -75,7 +112,7 @@ defmodule Raxol.UI.Layout.Table do
         _ -> %{elements: [], measurements: %{}}
       end
 
-    attrs = Map.get(table_element, :attrs, %{})
+    attrs = normalize_table_attrs(table_element)
     columns = Map.get(attrs, :columns, [])
     # Support both 'rows' and 'data' attributes
     rows = Map.get(attrs, :rows, Map.get(attrs, :data, []))
@@ -96,10 +133,9 @@ defmodule Raxol.UI.Layout.Table do
         show_borders
       )
 
-    # Build positioned elements
     positioned_elements =
       build_positioned_elements(
-        table_element,
+        Map.put(table_element, :attrs, attrs),
         cell_positions,
         measurements,
         space
@@ -283,7 +319,9 @@ defmodule Raxol.UI.Layout.Table do
   defp content_width_for_column(column, col_idx, rows) do
     case Map.get(column, :width, :auto) do
       :auto ->
-        header_text = Map.get(column, :header, "")
+        # column definitions carry :label (Components.Table convention) or
+        # :header — auto width must fit whichever is present
+        header_text = Map.get(column, :label) || Map.get(column, :header, "")
         header_width = Raxol.UI.TextMeasure.display_width(header_text)
 
         content_width =
@@ -404,19 +442,32 @@ defmodule Raxol.UI.Layout.Table do
          table_element,
          _cell_positions,
          measurements,
-         _space
+         space
        ) do
-    # Return the table element with enriched attributes
+    # Produces the _headers/_data/_col_widths contract ElementRenderer.render_table consumes.
     attrs = Map.get(table_element, :attrs, %{})
-    enriched_attrs = Map.put(attrs, :_col_widths, measurements.column_widths)
+
+    headers =
+      if Map.get(attrs, :show_header, true) do
+        attrs |> Map.get(:columns, []) |> Enum.map(&Map.get(&1, :label, ""))
+      else
+        []
+      end
+
+    enriched_attrs =
+      attrs
+      |> Map.put(:_col_widths, measurements.column_widths)
+      |> Map.put_new(:_headers, headers)
+      |> Map.put_new(:_data, Map.get(attrs, :rows, Map.get(attrs, :data, [])))
 
     enriched_table =
-      Map.put(table_element, :attrs, enriched_attrs)
+      table_element
+      |> Map.put(:attrs, enriched_attrs)
+      |> Map.put(:x, Map.get(space, :x, 0))
+      |> Map.put(:y, Map.get(space, :y, 0))
       |> Map.put(:width, measurements.width)
       |> Map.put(:height, measurements.height)
 
-    # Returns the enriched table element
-    # Cell positioning can be handled by a different layer if needed
     [enriched_table]
   end
 end


### PR DESCRIPTION
- The DSL `table()` built top-level `headers`/`rows` keys that `Layout.Table` never read (it only read `attrs.columns`/`rows`), so DSL tables laid out 0x0 and rendered zero cells.
- Normalizes top-level headers/rows/data to the attrs shape, sets x/y from allocated space and carries headers/data to the cell renderer, adds a `:table` `measure_element` clause (attrs-less tables measured 0x0 in flex containers), and fits `:label` headers in auto column widths.

Part of the render-fixes wave; independent, mergeable on its own.