### PR TITLE
Audit playground demos under new layout/text capabilities

### DIFF
--- a/lib/raxol/playground/catalog.ex
+++ b/lib/raxol/playground/catalog.ex
@@ -152,10 +152,17 @@ defmodule Raxol.Playground.Catalog do
       name: "Text",
       module: Demos.TextDemo,
       category: :display,
-      description: "Text rendering with style variations",
+      description:
+        "Text rendering with style variations, ellipsis truncation, line clamping, and pretty wrapping",
       complexity: :basic,
-      tags: ["display", "text", "style"],
-      code_snippet: ~s'text("Hello", style: [:bold, :italic])'
+      tags: ["display", "text", "style", "wrap", "truncate", "ellipsis"],
+      code_snippet: """
+      text("Hello", style: [:bold, :italic])
+
+      # CSS-style truncation/wrapping via Raxol.UI.Components.Display.Text:
+      {:ok, state} = Text.init(content: line, width: 20, white_space: :nowrap, text_overflow: :ellipsis)
+      Text.render(state, %{})
+      """
     },
     %{
       name: "Tree",
@@ -208,10 +215,18 @@ defmodule Raxol.Playground.Catalog do
       name: "SplitPane",
       module: Demos.SplitPaneDemo,
       category: :layout,
-      description: "Resizable split pane with direction toggle",
+      description:
+        "Resizable split pane with direction toggle, proportionally sized via {:pct, n}",
       complexity: :intermediate,
-      tags: ["layout", "split", "pane", "resize"],
-      code_snippet: ~s'row do [box(left_content), box(right_content)] end'
+      tags: ["layout", "split", "pane", "resize", "pct"],
+      code_snippet: """
+      row style: %{gap: 1, width: 60} do
+        [
+          box(style: %{width: {:pct, 30}, border: :single}, do: left_content),
+          box(style: %{width: {:pct, 70}, border: :single}, do: right_content)
+        ]
+      end
+      """
     },
     %{
       name: "Container",

--- a/lib/raxol/playground/demo_helpers.ex
+++ b/lib/raxol/playground/demo_helpers.ex
@@ -45,6 +45,26 @@ defmodule Raxol.Playground.DemoHelpers do
   end
 
   @doc """
+  Renders text through `Raxol.UI.Components.Display.Text`
+  (canonical wrapping/truncation entry point, `docs/core/LAYOUT.md` §4).
+
+  Plain `Raxol.Core.Renderer.View.text/2` accepts only `fg/bg/style/align/wrap/link`.
+
+  ## Examples
+
+      rich_text("a very long line", width: 12, white_space: :nowrap, text_overflow: :ellipsis)
+      rich_text(prose, width: 20, text_wrap: :pretty)
+      rich_text(prose, width: 20, line_clamp: 2)
+  """
+  @spec rich_text(String.t(), keyword()) :: map()
+  def rich_text(content, opts \\ []) do
+    {:ok, state} =
+      Raxol.UI.Components.Display.Text.init([content: content] ++ opts)
+
+    Raxol.UI.Components.Display.Text.render(state, %{})
+  end
+
+  @doc """
   Renders `content` (Markdown text) through `Raxol.UI.Components.MarkdownRenderer`,
   the canonical Markdown-to-styled-elements renderer.
 

--- a/lib/raxol/playground/demos/code_block_demo.ex
+++ b/lib/raxol/playground/demos/code_block_demo.ex
@@ -1,11 +1,17 @@
 defmodule Raxol.Playground.Demos.CodeBlockDemo do
-  @moduledoc "Playground demo: code display with line numbers and language samples."
+  @moduledoc """
+  Playground demo: code display with line numbers and language samples.
+
+  Uses `white_space: :nowrap` + `text_overflow: :ellipsis` so long lines
+  truncate instead of reflowing mid-token.
+  """
   use Raxol.Core.Runtime.Application
 
-  import Raxol.Playground.DemoHelpers, only: [effective_width: 2]
+  import Raxol.Playground.DemoHelpers, only: [effective_width: 2, rich_text: 2]
 
   @default_code_box_width 45
   @line_number_pad 2
+  @border_and_padding_overhead 4
 
   @samples [
     %{
@@ -54,18 +60,12 @@ defmodule Raxol.Playground.Demos.CodeBlockDemo do
   def view(model) do
     sample = Enum.at(@samples, model.current)
     lines = String.split(sample.code, "\n")
+    box_width = effective_width(model, @default_code_box_width)
 
     code_lines =
       lines
       |> Enum.with_index(1)
-      |> Enum.map(fn {line, num} ->
-        if model.show_line_numbers do
-          pad = String.pad_leading(Integer.to_string(num), @line_number_pad)
-          text("#{pad} | #{line}")
-        else
-          text("  #{line}")
-        end
-      end)
+      |> Enum.map(&code_line(&1, model.show_line_numbers, box_width))
 
     ln_label = if model.show_line_numbers, do: "ON", else: "OFF"
 
@@ -77,7 +77,7 @@ defmodule Raxol.Playground.Demos.CodeBlockDemo do
         box style: %{
               border: :single,
               padding: 1,
-              width: effective_width(model, @default_code_box_width)
+              width: box_width
             } do
           column style: %{gap: 0} do
             code_lines
@@ -91,6 +91,40 @@ defmodule Raxol.Playground.Demos.CodeBlockDemo do
           ]
         end,
         text("[n] next  [p] previous  [l] toggle line numbers", style: [:dim])
+      ]
+    end
+  end
+
+  defp code_line({line, num}, true, box_width) do
+    prefix =
+      String.pad_leading(Integer.to_string(num), @line_number_pad) <> " | "
+
+    code_width =
+      max(box_width - @border_and_padding_overhead - String.length(prefix), 1)
+
+    row style: %{gap: 0} do
+      [
+        text(prefix),
+        rich_text(line,
+          width: code_width,
+          white_space: :nowrap,
+          text_overflow: :ellipsis
+        )
+      ]
+    end
+  end
+
+  defp code_line({line, _num}, false, box_width) do
+    code_width = max(box_width - @border_and_padding_overhead - 2, 1)
+
+    row style: %{gap: 0} do
+      [
+        text("  "),
+        rich_text(line,
+          width: code_width,
+          white_space: :nowrap,
+          text_overflow: :ellipsis
+        )
       ]
     end
   end

--- a/lib/raxol/playground/demos/container_demo.ex
+++ b/lib/raxol/playground/demos/container_demo.ex
@@ -1,5 +1,12 @@
 defmodule Raxol.Playground.Demos.ContainerDemo do
-  @moduledoc "Playground demo: scrollable container with viewport controls."
+  @moduledoc """
+  Playground demo: scrollable container with viewport controls.
+
+  Uses its own `Enum.slice/3` windowing instead of `Display.Viewport`:
+  box overflow clip can only clip from the main-end edge, not show an
+  arbitrary mid-list offset, and `Viewport` is a stateful `Base.Component`
+  rather than a plain View DSL element.
+  """
   use Raxol.Core.Runtime.Application
   alias Raxol.Playground.DemoHelpers
 
@@ -85,7 +92,11 @@ defmodule Raxol.Playground.Demos.ContainerDemo do
         text("Container Demo", style: [:bold]),
         divider(),
         text("Showing #{first}-#{last} of #{total}"),
-        box style: %{border: :single, padding: 1, width: @content_box_width} do
+        box style: %{
+              border: :single,
+              padding: 1,
+              width: DemoHelpers.effective_width(model, @content_box_width)
+            } do
           column style: %{gap: 0} do
             visible
           end

--- a/lib/raxol/playground/demos/modal_demo.ex
+++ b/lib/raxol/playground/demos/modal_demo.ex
@@ -2,6 +2,8 @@ defmodule Raxol.Playground.Demos.ModalDemo do
   @moduledoc "Playground demo: modal dialog with confirm and cancel actions."
   use Raxol.Core.Runtime.Application
 
+  import Raxol.Playground.DemoHelpers, only: [effective_width: 2]
+
   @stats_box_width 30
   @modal_width 40
 
@@ -51,7 +53,11 @@ defmodule Raxol.Playground.Demos.ModalDemo do
           closed_view(model)
         end,
         divider(),
-        box style: %{border: :rounded, padding: 1, width: @stats_box_width} do
+        box style: %{
+              border: :rounded,
+              padding: 1,
+              width: effective_width(model, @stats_box_width)
+            } do
           column style: %{gap: 0} do
             [
               text("Confirmed: #{model.confirmed}"),
@@ -68,8 +74,12 @@ defmodule Raxol.Playground.Demos.ModalDemo do
   @impl true
   def subscribe(_model), do: []
 
-  defp modal_view(_model) do
-    box style: %{border: :double, padding: 1, width: @modal_width} do
+  defp modal_view(model) do
+    box style: %{
+          border: :double,
+          padding: 1,
+          width: effective_width(model, @modal_width)
+        } do
       column style: %{gap: 1} do
         [
           text("Confirm Action", style: [:bold]),

--- a/lib/raxol/playground/demos/repl_demo.ex
+++ b/lib/raxol/playground/demos/repl_demo.ex
@@ -97,7 +97,12 @@ defmodule Raxol.Playground.Demos.ReplDemo do
               border: :single,
               padding: 1,
               width: effective_width(model, @default_box_width),
-              height: @box_height
+              height: @box_height,
+              # Eval output is arbitrary user code -- a long `inspect`
+              # result can exceed the box width. `overflow: :hidden`
+              # (docs/core/LAYOUT.md section 2, F1) clips it inside the
+              # border instead of bleeding past it.
+              overflow: :hidden
             } do
           column style: %{gap: 0} do
             if visible_output == [],

--- a/lib/raxol/playground/demos/split_pane_demo.ex
+++ b/lib/raxol/playground/demos/split_pane_demo.ex
@@ -1,12 +1,23 @@
 defmodule Raxol.Playground.Demos.SplitPaneDemo do
-  @moduledoc "Playground demo: resizable split pane with direction toggle."
+  @moduledoc """
+  Playground demo: resizable split pane with direction toggle.
+
+  Panes are sized via `style: %{width/height: {:pct, n}}` against an
+  explicit container width/height, since `{:pct, n}` only resolves against
+  a definite dimension. Does not override the automatic minimum size, so
+  panes refuse to shrink below their content floor at extreme ratios.
+  """
   use Raxol.Core.Runtime.Application
+
+  import Raxol.Playground.DemoHelpers, only: [effective_width: 2]
 
   @default_ratio 0.5
   @ratio_step 0.1
   @min_ratio 0.1
   @max_ratio 0.9
   @percent 100
+  @default_total_width 60
+  @stack_height 10
 
   @impl true
   def init(_context) do
@@ -49,9 +60,12 @@ defmodule Raxol.Playground.Demos.SplitPaneDemo do
     left_style = if model.focus == :left, do: [:bold], else: []
     right_style = if model.focus == :right, do: [:bold], else: []
     pct = round(model.ratio * @percent)
+    right_pct = @percent - pct
+
+    size_key = if model.direction == :horizontal, do: :width, else: :height
 
     left_pane =
-      box style: %{border: :single, padding: 1} do
+      box style: %{size_key => {:pct, pct}, border: :single, padding: 1} do
         column style: %{gap: 0} do
           [
             text("Left Pane#{left_indicator}", style: left_style),
@@ -61,22 +75,29 @@ defmodule Raxol.Playground.Demos.SplitPaneDemo do
       end
 
     right_pane =
-      box style: %{border: :single, padding: 1} do
+      box style: %{
+            size_key => {:pct, right_pct},
+            border: :single,
+            padding: 1
+          } do
         column style: %{gap: 0} do
           [
             text("Right Pane#{right_indicator}", style: right_style),
-            text("Ratio: #{@percent - pct}%")
+            text("Ratio: #{right_pct}%")
           ]
         end
       end
 
     panes =
       if model.direction == :horizontal do
-        row style: %{gap: 1} do
+        row style: %{
+              gap: 1,
+              width: effective_width(model, @default_total_width)
+            } do
           [left_pane, right_pane]
         end
       else
-        column style: %{gap: 1} do
+        column style: %{gap: 1, height: @stack_height} do
           [left_pane, right_pane]
         end
       end

--- a/lib/raxol/playground/demos/text_demo.ex
+++ b/lib/raxol/playground/demos/text_demo.ex
@@ -1,14 +1,29 @@
 defmodule Raxol.Playground.Demos.TextDemo do
-  @moduledoc "Playground demo: text rendering with style variations."
+  @moduledoc """
+  Playground demo: text rendering with style variations, plus the
+  `Raxol.UI.Components.Display.Text` wrapping/truncation affordances
+  documented in `docs/core/LAYOUT.md` section 4 (`text_overflow: :ellipsis`,
+  `line_clamp`, `text_wrap: :pretty`).
+  """
   use Raxol.Core.Runtime.Application
 
-  @styles [
-    %{label: "Bold", style: [:bold]},
-    %{label: "Italic", style: [:italic]},
-    %{label: "Underline", style: [:underline]},
-    %{label: "Bold + Italic", style: [:bold, :italic]},
-    %{label: "Dim", style: [:dim]},
-    %{label: "Bold + Underline", style: [:bold, :underline]}
+  import Raxol.Playground.DemoHelpers, only: [rich_text: 2]
+
+  @sample "The quick brown fox jumps over the lazy dog"
+  @long_line "This line is intentionally far too long to fit inside a narrow box"
+  @prose "Raxol is a multi-surface application runtime for Elixir built on OTP, covering terminal, browser, SSH, and MCP surfaces."
+  @wrap_width 24
+
+  @variants [
+    %{label: "Bold", kind: :style, style: [:bold]},
+    %{label: "Italic", kind: :style, style: [:italic]},
+    %{label: "Underline", kind: :style, style: [:underline]},
+    %{label: "Bold + Italic", kind: :style, style: [:bold, :italic]},
+    %{label: "Dim", kind: :style, style: [:dim]},
+    %{label: "Bold + Underline", kind: :style, style: [:bold, :underline]},
+    %{label: "Ellipsis (text_overflow)", kind: :ellipsis},
+    %{label: "Line clamp (2 lines)", kind: :line_clamp},
+    %{label: "Pretty wrap (Knuth-Plass)", kind: :pretty}
   ]
 
   @impl true
@@ -18,7 +33,7 @@ defmodule Raxol.Playground.Demos.TextDemo do
 
   @impl true
   def update(message, model) do
-    max_idx = length(@styles) - 1
+    max_idx = length(@variants) - 1
 
     case message do
       key_match("n") ->
@@ -34,32 +49,30 @@ defmodule Raxol.Playground.Demos.TextDemo do
 
   @impl true
   def view(model) do
-    current = Enum.at(@styles, model.style_index)
+    current = Enum.at(@variants, model.style_index)
 
-    style_list =
-      @styles
+    variant_list =
+      @variants
       |> Enum.with_index()
-      |> Enum.map(fn {s, idx} ->
+      |> Enum.map(fn {v, idx} ->
         indicator = if idx == model.style_index, do: "> ", else: "  "
-        text(indicator <> s.label)
+        text(indicator <> v.label)
       end)
 
     column style: %{gap: 1} do
       [
         text("Text Demo", style: [:bold]),
         divider(),
-        text("Current style: #{current.label}", style: [:bold]),
-        box style: %{border: :single, padding: 1, width: 40} do
-          text("The quick brown fox jumps over the lazy dog",
-            style: current.style
-          )
+        text("Current: #{current.label}", style: [:bold]),
+        box style: %{border: :single, padding: 1, width: 44} do
+          sample_for(current)
         end,
         divider(),
-        text("All styles:", style: [:underline]),
+        text("All variants:", style: [:underline]),
         column style: %{gap: 0} do
-          style_list
+          variant_list
         end,
-        text("#{model.style_index + 1}/#{length(@styles)}"),
+        text("#{model.style_index + 1}/#{length(@variants)}"),
         text("[n] next  [p] previous", style: [:dim])
       ]
     end
@@ -67,4 +80,54 @@ defmodule Raxol.Playground.Demos.TextDemo do
 
   @impl true
   def subscribe(_model), do: []
+
+  # -- Sample rendering per variant kind --
+
+  defp sample_for(%{kind: :style, style: style}) do
+    text(@sample, style: style)
+  end
+
+  defp sample_for(%{kind: :ellipsis}) do
+    column style: %{gap: 0} do
+      [
+        rich_text(@long_line,
+          width: @wrap_width,
+          white_space: :nowrap,
+          text_overflow: :ellipsis
+        ),
+        text(
+          "white_space: :nowrap, text_overflow: :ellipsis, width: #{@wrap_width}",
+          style: [:dim]
+        )
+      ]
+    end
+  end
+
+  defp sample_for(%{kind: :line_clamp}) do
+    column style: %{gap: 0} do
+      [
+        rich_text(@prose, width: @wrap_width, line_clamp: 2),
+        text("line_clamp: 2, width: #{@wrap_width}", style: [:dim])
+      ]
+    end
+  end
+
+  defp sample_for(%{kind: :pretty}) do
+    column style: %{gap: 1} do
+      [
+        column style: %{gap: 0} do
+          [
+            text("auto (greedy word-wrap):", style: [:dim]),
+            rich_text(@prose, width: @wrap_width, wrap: :word)
+          ]
+        end,
+        column style: %{gap: 0} do
+          [
+            text("pretty (Knuth-Plass, minimizes raggedness):", style: [:dim]),
+            rich_text(@prose, width: @wrap_width, text_wrap: :pretty)
+          ]
+        end
+      ]
+    end
+  end
 end

--- a/lib/raxol/playground/demos/vfs_demo.ex
+++ b/lib/raxol/playground/demos/vfs_demo.ex
@@ -75,7 +75,11 @@ defmodule Raxol.Playground.Demos.VfsDemo do
               border: :single,
               padding: 1,
               width: box_width,
-              height: @box_height
+              height: @box_height,
+              # `cat` can echo an arbitrarily wide file line; clip it
+              # inside the border instead of bleeding past it
+              # (docs/core/LAYOUT.md section 2, F1).
+              overflow: :hidden
             } do
           column style: %{gap: 0} do
             if visible == [],

--- a/test/raxol/playground/demos/split_pane_demo_test.exs
+++ b/test/raxol/playground/demos/split_pane_demo_test.exs
@@ -1,0 +1,80 @@
+defmodule Raxol.Playground.Demos.SplitPaneDemoTest do
+  @moduledoc """
+  Confirms the panes are styled with `{:pct, n}` width/height and that
+  the two percentages always sum to 100, regardless of ratio or direction.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Playground.Demos.SplitPaneDemo
+
+  defp key_event(char) do
+    %Raxol.Core.Events.Event{type: :key, data: %{key: :char, char: char}}
+  end
+
+  # Walk the view tree and collect every box's `style` map. A node's
+  # `:children` can be either a single child map or a list (the `do:`
+  # block macros don't always normalize to a list), so wrap defensively.
+  defp box_styles(%{type: :box, style: style, children: children}) do
+    [style | children |> List.wrap() |> Enum.flat_map(&box_styles/1)]
+  end
+
+  defp box_styles(%{children: children}) do
+    children |> List.wrap() |> Enum.flat_map(&box_styles/1)
+  end
+
+  defp box_styles(_), do: []
+
+  defp pane_pct_styles(model) do
+    model
+    |> SplitPaneDemo.view()
+    |> box_styles()
+    |> Enum.filter(fn style ->
+      match?({:pct, _}, style[:width]) or match?({:pct, _}, style[:height])
+    end)
+  end
+
+  describe "horizontal split (default)" do
+    test "both panes are styled with {:pct, n} width" do
+      model = SplitPaneDemo.init(nil)
+      [left, right] = pane_pct_styles(model)
+
+      assert {:pct, 50} = left[:width]
+      assert {:pct, 50} = right[:width]
+      refute Map.has_key?(left, :height)
+    end
+
+    test "resizing the ratio changes the pct split and the two halves sum to 100" do
+      model = SplitPaneDemo.init(nil)
+      {model, []} = SplitPaneDemo.update(key_event("="), model)
+
+      [left, right] = pane_pct_styles(model)
+      {:pct, left_pct} = left[:width]
+      {:pct, right_pct} = right[:width]
+
+      assert left_pct == 60
+      assert left_pct + right_pct == 100
+    end
+
+    test "extreme ratios still sum to 100" do
+      model = %{SplitPaneDemo.init(nil) | ratio: 0.1}
+      [left, right] = pane_pct_styles(model)
+      {:pct, left_pct} = left[:width]
+      {:pct, right_pct} = right[:width]
+
+      assert left_pct == 10
+      assert left_pct + right_pct == 100
+    end
+  end
+
+  describe "vertical split" do
+    test "toggling direction switches panes to {:pct, n} height" do
+      model = SplitPaneDemo.init(nil)
+      {model, []} = SplitPaneDemo.update(key_event("d"), model)
+
+      [left, right] = pane_pct_styles(model)
+      assert {:pct, 50} = left[:height]
+      assert {:pct, 50} = right[:height]
+      refute Map.has_key?(left, :width)
+    end
+  end
+end

--- a/test/raxol/playground/demos/text_demo_test.exs
+++ b/test/raxol/playground/demos/text_demo_test.exs
@@ -1,0 +1,89 @@
+defmodule Raxol.Playground.Demos.TextDemoTest do
+  @moduledoc """
+  Focused coverage for the `docs/core/LAYOUT.md` section 4 wrap/truncation
+  variants added to TextDemo (`text_overflow: :ellipsis`, `line_clamp`,
+  `text_wrap: :pretty`) on top of the pre-existing style-cycling behavior.
+  These render through `Raxol.UI.Components.Display.Text` via
+  `DemoHelpers.rich_text/2`, not the plain View DSL `text/2` used
+  elsewhere, so `demos_test.exs`'s generic `is_map(view)` check doesn't
+  exercise their actual output.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Playground.Demos.TextDemo
+
+  defp key_event(char) do
+    %Raxol.Core.Events.Event{type: :key, data: %{key: :char, char: char}}
+  end
+
+  defp advance(model, 0), do: model
+
+  defp advance(model, n) do
+    {model, []} = TextDemo.update(key_event("n"), model)
+    advance(model, n - 1)
+  end
+
+  # Collects every :text content string in the tree, depth-first. A node's
+  # `:children` can be either a single child map or a list (the `do:`
+  # block macros don't always normalize to a list), so wrap defensively.
+  defp all_text(%{type: :text, content: content}), do: [content]
+
+  defp all_text(%{children: children}) do
+    children |> List.wrap() |> Enum.flat_map(&all_text/1)
+  end
+
+  defp all_text(_), do: []
+
+  describe "style variants (0-5, pre-existing behavior)" do
+    test "index 0 renders the sample sentence in bold" do
+      model = TextDemo.init(nil)
+      lines = model |> TextDemo.view() |> all_text()
+
+      assert Enum.any?(
+               lines,
+               &(&1 == "The quick brown fox jumps over the lazy dog")
+             )
+    end
+  end
+
+  describe "ellipsis variant (text_overflow: :ellipsis)" do
+    test "long line is truncated with an ellipsis instead of wrapped" do
+      model = TextDemo.init(nil) |> advance(6)
+      lines = model |> TextDemo.view() |> all_text()
+
+      truncated = Enum.find(lines, &String.contains?(&1, "…"))
+      assert truncated
+      # nowrap + ellipsis means exactly one truncated line, not the full
+      # untruncated sentence anywhere in the tree.
+      refute Enum.any?(lines, &String.contains?(&1, "narrow box"))
+    end
+  end
+
+  describe "line_clamp variant" do
+    test "caps output at 2 lines with a trailing ellipsis" do
+      model = TextDemo.init(nil) |> advance(7)
+      lines = model |> TextDemo.view() |> all_text()
+
+      # The prose is longer than 2 lines at this width, so clamping must
+      # have cut something -- the last kept line carries the ellipsis.
+      assert Enum.any?(lines, &String.contains?(&1, "…"))
+    end
+  end
+
+  describe "pretty wrap variant" do
+    test "renders both an auto (greedy) and a pretty (Knuth-Plass) rendering" do
+      model = TextDemo.init(nil) |> advance(8)
+      lines = model |> TextDemo.view() |> all_text()
+
+      assert Enum.any?(lines, &(&1 == "auto (greedy word-wrap):"))
+      assert Enum.any?(lines, &String.contains?(&1, "pretty (Knuth-Plass"))
+      # Both wrapped renderings must fully preserve every original word.
+      assert Enum.any?(lines, &String.contains?(&1, "Raxol"))
+    end
+
+    test "n does not advance past the last variant" do
+      model = TextDemo.init(nil) |> advance(20)
+      assert model.style_index == 8
+    end
+  end
+end


### PR DESCRIPTION
- Reworks playground demos (text, code_block, container, modal, repl, split_pane, vfs, catalog) to use the canonical layout/text wrapping paths instead of hand-joined strings, with split_pane and text demo tests.
- Adds a self-contained `DemoHelpers.rich_text/2` (Display.Text bridge) that these demos need to render correctly.

Note: `DemoHelpers.rich_text/2` is also introduced by the markdown-styling PR; whichever merges first defines it, the other drops a trivial duplicate.

Part of the render-fixes wave; independent, mergeable on its own.