### PR TITLE
Audit core example apps under new layout capabilities

### DIFF
--- a/examples/apps/file_browser.exs
+++ b/examples/apps/file_browser.exs
@@ -111,8 +111,11 @@ defmodule FileBrowser do
             # Tree panel
             box style: %{
                   border: if(model.panel == :tree, do: :double, else: :single),
-                  width: "40%",
-                  padding: 0
+                  # only {:pct, n} is %; "40%" becomes :auto
+                  width: {:pct, 40},
+                  padding: 0,
+                  # clip so a deeply expanded tree can't bleed past the panel
+                  overflow: :hidden
                 } do
               column do
                 tree_lines(model)
@@ -123,7 +126,9 @@ defmodule FileBrowser do
                   border:
                     if(model.panel == :preview, do: :double, else: :single),
                   flex: 1,
-                  padding: 0
+                  padding: 0,
+                  # clip so a long file preview can't bleed past the panel
+                  overflow: :hidden
                 } do
               column do
                 preview_content(model)

--- a/examples/apps/showcase_app.exs
+++ b/examples/apps/showcase_app.exs
@@ -117,7 +117,7 @@ defmodule Raxol.Examples.Showcase do
         text("Raxol Component Showcase", style: [:bold]),
         tab_bar(model.tab),
         divider(),
-        section_content(model),
+        content_region(model),
         divider(),
         footer(model)
       ]
@@ -126,6 +126,13 @@ defmodule Raxol.Examples.Showcase do
 
   @impl true
   def subscribe(_model), do: []
+
+  # flex: 1 pins the footer while tab body height changes
+  defp content_region(model) do
+    box style: %{flex: 1} do
+      section_content(model)
+    end
+  end
 
   # -- Tab bar --
 

--- a/examples/demo.exs
+++ b/examples/demo.exs
@@ -176,7 +176,8 @@ defmodule RaxolDemo do
   defp header_bar(model) do
     status = if model.paused, do: "PAUSED", else: clock()
 
-    box style: %{border: :double, width: :fill, padding: 0} do
+    # column stretch already fills width; :fill is not a real size
+    box style: %{border: :double, padding: 0} do
       row style: %{gap: 1, justify_content: :space_between} do
         [
           text("  R A X O L", style: [:bold], fg: :cyan),
@@ -379,9 +380,10 @@ defmodule RaxolDemo do
         end
       end)
 
+    # column stretch already fills width; :fill is not a real size
     panel =
       box id: "proc-panel",
-          style: %{border: panel_border(active), width: :fill, padding: 1} do
+          style: %{border: panel_border(active), padding: 1} do
         column style: %{gap: 0} do
           [
             text(panel_title("Top Processes", active),

--- a/examples/getting_started/todo_app.exs
+++ b/examples/getting_started/todo_app.exs
@@ -164,7 +164,9 @@ defmodule TodoExample do
           text("#{prefix}#{check} #{todo.text}", style: style)
         end)
 
-      box style: %{padding: 1, border: :single, width: 40} do
+      # overflow: :hidden clips gracefully once enough todos are added to
+      # exceed the box's height, instead of the list bleeding past the border.
+      box style: %{padding: 1, border: :single, width: 40, overflow: :hidden} do
         column style: %{gap: 0} do
           items
         end


### PR DESCRIPTION
- Updates file_browser, showcase_app, demo, and todo_app examples to use real layout primitives: `{:pct, 40}` widths, `overflow: :hidden` panel clipping, and a `flex: 1` footer/body split instead of `:fill`.
- No library changes; examples-only.

Part of the render-fixes wave; independent, mergeable on its own.