### PR TITLE
Measure absolute_layer as its flow child

### DIFF
--- a/lib/raxol/playground/catalog.ex
+++ b/lib/raxol/playground/catalog.ex
@@ -79,11 +79,10 @@ defmodule Raxol.Playground.Catalog do
       complexity: :intermediate,
       tags: ["overlay", "dialog", "focus"],
       code_snippet: """
-      modal(
-        title: "Confirm",
-        content: text("Are you sure?"),
-        visible: model.show_modal
-      )
+      overlays =
+        if model.show, do: [AbsoluteLayer.dialog_overlay(40, 17, dialog_box)], else: []
+
+      AbsoluteLayer.absolute_layer(background_view(model), overlays)
       """
     },
     %{

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -820,6 +820,16 @@ defmodule Raxol.UI.Layout.Engine do
     Map.take(measured, [:width, :height])
   end
 
+  # Absolute layer measures as its flow child measures -- overlays are
+  # non-flow (positioned independently in process_element/3) and
+  # intentionally contribute nothing to intrinsic size.
+  def measure_element(%{type: :absolute_layer} = element, available_space) do
+    case Map.get(element, :flow_child) do
+      nil -> %{width: 0, height: 0}
+      flow_child -> measure_element(flow_child, available_space)
+    end
+  end
+
   def measure_element(%{type: :spacer} = spacer, available_space) do
     size = Map.get(spacer, :size, 1)
 


### PR DESCRIPTION
`measure_element` had no `:absolute_layer` clause, so the catch-all reported 0x0. Embedded as a flex child (e.g. the playground preview panel), the layer got a zero-height slot: `process_overlay`'s `in_bounds?` check dropped every overlay, and the next flex sibling stacked on top of the still-rendered flow content.

This adds the missing clause so an absolute layer measures as its flow child, and refreshes the stale Modal catalog snippet to the AbsoluteLayer dialog API.

Independent change; no dependency on other modal PRs.