### PR TITLE
Render modals as dialogs over dimmed, undisturbed content

### DIFF
--- a/lib/raxol/playground/demos/modal_demo.ex
+++ b/lib/raxol/playground/demos/modal_demo.ex
@@ -2,10 +2,14 @@ defmodule Raxol.Playground.Demos.ModalDemo do
   @moduledoc "Playground demo: modal dialog with confirm and cancel actions."
   use Raxol.Core.Runtime.Application
 
+  alias Raxol.UI.Components.AbsoluteLayer
+  alias Raxol.UI.Components.Modal.Rendering, as: ModalRendering
+
   import Raxol.Playground.DemoHelpers, only: [effective_width: 2]
 
   @stats_box_width 30
   @modal_width 40
+  @modal_height 17
 
   @impl true
   def init(_context) do
@@ -41,17 +45,33 @@ defmodule Raxol.Playground.Demos.ModalDemo do
   defp do_cancel(model),
     do: %{model | show: false, cancelled: model.cancelled + 1}
 
+  # Flow child is laid out the same open or closed; dialog is overlay-only.
   @impl true
   def view(model) do
+    overlays =
+      if model.show do
+        width = effective_width(model, @modal_width)
+
+        [
+          AbsoluteLayer.dialog_overlay(
+            width,
+            @modal_height,
+            modal_box(model, width)
+          )
+        ]
+      else
+        []
+      end
+
+    AbsoluteLayer.absolute_layer(background_view(model), overlays)
+  end
+
+  defp background_view(model) do
     column style: %{gap: 1} do
       [
         text("Modal Demo", style: [:bold]),
         divider(),
-        if model.show do
-          modal_view(model)
-        else
-          closed_view(model)
-        end,
+        static_panel(),
         divider(),
         box style: %{
               border: :rounded,
@@ -71,15 +91,20 @@ defmodule Raxol.Playground.Demos.ModalDemo do
     end
   end
 
-  @impl true
-  def subscribe(_model), do: []
+  # Fixed copy so reflow tests can pin cell coords.
+  defp static_panel do
+    column style: %{gap: 0} do
+      [
+        text("Background content (does not move):"),
+        text("- item one"),
+        text("- item two"),
+        text("[o] Open Modal", style: [:dim])
+      ]
+    end
+  end
 
-  defp modal_view(model) do
-    box style: %{
-          border: :double,
-          padding: 1,
-          width: effective_width(model, @modal_width)
-        } do
+  defp modal_box(_model, width) do
+    content =
       column style: %{gap: 1} do
         [
           text("Confirm Action", style: [:bold]),
@@ -94,17 +119,17 @@ defmodule Raxol.Playground.Demos.ModalDemo do
           end
         ]
       end
-    end
+
+    ModalRendering.dialog_surface(
+      width,
+      @modal_height,
+      %{border: :double, bg: {30, 30, 45}},
+      [content]
+    )
   end
 
-  defp closed_view(_model) do
-    column style: %{gap: 1} do
-      [
-        text("No modal open."),
-        button("[o] Open Modal", on_click: :open)
-      ]
-    end
-  end
+  @impl true
+  def subscribe(_model), do: []
 
   defp footer(%{show: true}) do
     text("[y] confirm  [n] cancel  [Enter/Esc] also work", style: [:dim])

--- a/lib/raxol/ui/components/absolute_layer.ex
+++ b/lib/raxol/ui/components/absolute_layer.ex
@@ -27,7 +27,12 @@ defmodule Raxol.UI.Components.AbsoluteLayer do
     * `:left` / `:top` -- alias for `0`
     * `:right` -- last column (`width - 1`)
     * `:bottom` -- last row (`height - 1`)
-    * `:center` -- midpoint on the axis
+    * `:center` -- midpoint on the axis (the overlay's own origin lands
+      there; its bounding box is not centered unless it happens to be 1
+      cell wide/tall)
+    * `{:center_of, size}` -- centers an overlay of known `size` on that
+      axis, i.e. `origin + (length - size) / 2`. Use this to actually
+      center a fixed-width/height overlay such as a modal dialog.
 
   Overlays whose resolved coordinates fall outside the layer's space are
   clipped silently (no cells emitted).
@@ -57,11 +62,13 @@ defmodule Raxol.UI.Components.AbsoluteLayer do
           | :top
           | :bottom
           | :center
+          | {:center_of, non_neg_integer()}
 
   @type overlay :: %{
           required(:x) => axis_coord(),
           required(:y) => axis_coord(),
-          required(:element) => map()
+          required(:element) => map(),
+          optional(:dialog) => boolean()
         }
 
   @doc """
@@ -86,5 +93,28 @@ defmodule Raxol.UI.Components.AbsoluteLayer do
   @spec overlay(axis_coord(), axis_coord(), map()) :: overlay()
   def overlay(x, y, element) when is_map(element) do
     %{x: x, y: y, element: element}
+  end
+
+  @doc """
+  Builds a dialog overlay descriptor: `element` (a `width` x `height`
+  surface, e.g. a modal box) centered on both axes via `{:center_of, _}`,
+  and marked `dialog: true`.
+
+  The `:dialog` marker tells the layout engine to dim every element the
+  layer's flow content produces (pulling painted fg/bg toward the
+  background) while leaving this overlay's own cells at full color --
+  the "dialog active" / "inside active dialog" pair described in
+  `Raxol.UI.Layout.Engine`'s `:absolute_layer` handling.
+  """
+  @spec dialog_overlay(non_neg_integer(), non_neg_integer(), map()) ::
+          overlay()
+  def dialog_overlay(width, height, element)
+      when is_map(element) and is_integer(width) and is_integer(height) do
+    %{
+      x: {:center_of, width},
+      y: {:center_of, height},
+      element: element,
+      dialog: true
+    }
   end
 end

--- a/lib/raxol/ui/components/modal.ex
+++ b/lib/raxol/ui/components/modal.ex
@@ -40,6 +40,7 @@ defmodule Raxol.UI.Components.Modal do
 
   # Alias the new modules
   alias Raxol.UI.Components.Modal.{Core, Events, Rendering, State}
+  alias Raxol.UI.Components.AbsoluteLayer
 
   # Define state struct
   defstruct id: nil,
@@ -183,6 +184,38 @@ defmodule Raxol.UI.Components.Modal do
       false -> nil
     end
   end
+
+  @doc """
+  Wraps `flow_content` as an `:absolute_layer` with this modal as a
+  centered, dimmed-backdrop dialog overlay (no-op passthrough when
+  hidden). Prefer this over replacing the flow tree with
+  `Modal.render(state, %{})`, which reflows background content.
+  """
+  @spec as_dialog_overlay(t(), map()) :: map()
+  def as_dialog_overlay(%__MODULE__{visible: false}, flow_content),
+    do: flow_content
+
+  def as_dialog_overlay(%__MODULE__{visible: true} = state, flow_content) do
+    width = state.width
+    height = Rendering.estimate_height(state)
+    box_style = Rendering.get_modal_style(state)
+    # render_modal_content/1 already wraps its column with padding: 1;
+    # dialog_surface/4 adds its own padding ring, so strip this one to
+    # avoid double-padding the overlay (see dialog_surface/4 contract).
+    content_column = unpad(Rendering.render_modal_content(state).children)
+
+    surface =
+      Rendering.dialog_surface(width, height, box_style, [content_column])
+
+    AbsoluteLayer.absolute_layer(flow_content, [
+      AbsoluteLayer.dialog_overlay(width, height, surface)
+    ])
+  end
+
+  defp unpad(%{style: style} = node) when is_map(style),
+    do: %{node | style: Map.put(style, :padding, 0)}
+
+  defp unpad(node), do: node
 
   # --- Public Helper Functions (Constructors) ---
 

--- a/lib/raxol/ui/components/modal/rendering.ex
+++ b/lib/raxol/ui/components/modal/rendering.ex
@@ -77,6 +77,90 @@ defmodule Raxol.UI.Components.Modal.Rendering do
     )
   end
 
+  @doc """
+  Builds a bordered, opaque dialog surface: an inner bordered box (the
+  visible chrome) nested inside an unbordered, fully-filled outer box of
+  the same footprint -- a border only paints its ring, so without the
+  outer fill the dimmed flow content behind it would show through the
+  gaps. Outer is emitted first, inner (its child) after, so last-write-wins
+  cell composition lets the border/content win while the fill still shows
+  through any unpainted interior cells.
+
+  Both boxes set `width`/`height` as top-level keys, not just in `:style`,
+  since overlay layout has no auto-sizing fallback the way flow layout
+  does.
+  """
+  @spec dialog_surface(pos_integer(), pos_integer(), map(), [map()]) :: map()
+  def dialog_surface(width, height, box_style, children) do
+    fill_bg = Map.get(box_style, :bg) || Map.get(box_style, :background, :black)
+
+    %{
+      type: :box,
+      width: width,
+      height: height,
+      border: :none,
+      padding: 0,
+      style: %{border: :none, width: width, height: height, bg: fill_bg},
+      children: [
+        %{
+          type: :box,
+          width: width,
+          height: height,
+          border: Map.get(box_style, :border, :double),
+          padding: 1,
+          style: Map.merge(box_style, %{width: width, height: height}),
+          children: children
+        }
+      ]
+    }
+  end
+
+  @doc """
+  Structural line-count estimate of the modal's total footprint height
+  (no Preparer measurement pass for overlays); generous by design (e.g.
+  form fields budget headroom for a validation-error row) so content
+  isn't clipped.
+  """
+  @spec estimate_height(Raxol.UI.Components.Modal.t()) :: pos_integer()
+  def estimate_height(state) do
+    frame = 4
+    title_rows = if blank?(state.title), do: 0, else: 1
+    content_rows = estimate_content_rows(state)
+    button_rows = if state.buttons == [], do: 0, else: 3
+
+    spacer_rows =
+      count_true([
+        title_rows > 0 and content_rows > 0,
+        content_rows > 0 and button_rows > 0
+      ])
+
+    frame + title_rows + content_rows + spacer_rows + button_rows
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
+
+  defp count_true(conditions), do: Enum.count(conditions, & &1)
+
+  defp estimate_content_rows(%{content: content}) when is_binary(content) do
+    content |> String.split("\n") |> length()
+  end
+
+  defp estimate_content_rows(%{type: type, form_state: %{fields: fields}})
+       when type in [:prompt, :form] do
+    case length(fields) do
+      0 -> 0
+      # row per field + inter-field gaps + headroom for error rows
+      n -> 2 * n - 1 + n
+    end
+  end
+
+  defp estimate_content_rows(%{content: content}) when not is_nil(content),
+    do: 3
+
+  defp estimate_content_rows(_state), do: 0
+
   @doc "Builds modal elements with proper spacing."
   def build_modal_elements(title_element, content_element, button_elements) do
     [

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -486,8 +486,11 @@ defmodule Raxol.UI.Layout.Engine do
 
   # Absolute layer: lay out the flow child against the parent's full available
   # space (overlays consume nothing), then resolve each overlay against the
-  # same space at declared coordinates. Overlays render after flow content so
-  # they sit on top in the renderer's last-write-wins cell merge.
+  # same space at declared coordinates. Overlays are appended AFTER flow
+  # content in the returned list so they sit on top under the renderer's
+  # last-write-wins cell composition (`Backends.apply_cells_to_buffer`
+  # folds the cell list in order, later entries winning at a shared
+  # coordinate -- flow content must come first, overlays last).
   #
   # Element shape:
   #   %{
@@ -503,19 +506,38 @@ defmodule Raxol.UI.Layout.Engine do
   # Overlay coordinates are relative to the layer's space. Symbolic
   # coordinates (`:left`, `:right`, `:top`, `:bottom`, `:center`) and negative
   # integers (offset from far edge) are resolved against the current space.
+  # `{:center_of, size}` centers an overlay of known footprint `size` on that
+  # axis (unlike bare `:center`, which anchors the overlay's origin at the
+  # midpoint rather than centering its bounding box).
+  #
+  # An overlay descriptor may also carry `dialog: true` (see
+  # `Raxol.UI.Components.AbsoluteLayer.dialog_overlay/3`) to mark it as a
+  # modal dialog: every element the flow child produces is stamped with
+  # `:dim_behind_modal` so `Raxol.UI.Renderer` dims its cells toward the
+  # background, while the dialog overlay's own elements are left unstamped
+  # and render at full color on top.
   def process_element(%{type: :absolute_layer} = layer, space, acc) do
     flow_child = Map.get(layer, :flow_child)
     overlays = Map.get(layer, :overlays, [])
+    dialog_active? = Enum.any?(overlays, &Map.get(&1, :dialog, false))
 
-    flow_acc =
+    flow_elements =
       case flow_child do
-        nil -> acc
-        child -> process_element(child, space, acc)
+        nil -> []
+        child -> process_element(child, space, [])
       end
 
-    Enum.reduce(overlays, flow_acc, fn overlay, current_acc ->
-      process_overlay(overlay, space, current_acc)
-    end)
+    flow_elements =
+      if dialog_active?,
+        do: Enum.map(flow_elements, &Map.put(&1, :dim_behind_modal, true)),
+        else: flow_elements
+
+    overlay_elements =
+      Enum.reduce(overlays, [], fn overlay, current_acc ->
+        process_overlay(overlay, space, current_acc)
+      end)
+
+    flow_elements ++ overlay_elements ++ acc
   end
 
   def process_element(%{type: :table} = table_element, space, acc) do
@@ -673,6 +695,12 @@ defmodule Raxol.UI.Layout.Engine do
   defp resolve_axis(:right, origin, length), do: origin + max(length - 1, 0)
   defp resolve_axis(:bottom, origin, length), do: origin + max(length - 1, 0)
   defp resolve_axis(:center, origin, length), do: origin + div(length, 2)
+
+  # Centers an overlay of known `size` on this axis -- the origin plus half
+  # the leftover space, rather than `:center`'s bare midpoint (which anchors
+  # the overlay's own origin there, not its bounding box).
+  defp resolve_axis({:center_of, size}, origin, length) when is_integer(size),
+    do: origin + max(div(length - size, 2), 0)
 
   defp resolve_axis(value, origin, length) when is_integer(value) and value < 0,
     do: origin + max(length + value, 0)

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -121,6 +121,24 @@ defmodule Raxol.UI.Layout.Engine do
     view
     |> process_element(available_space, [])
     |> List.flatten()
+    |> dim_behind_dialog()
+  end
+
+  # Global post-pass: dim every non-`:in_dialog` element once the whole
+  # tree is flat, since dialog scope can span siblings outside the
+  # hosting `:absolute_layer` (e.g. a sidebar/header). No-op if no dialog
+  # is active.
+  defp dim_behind_dialog(elements) do
+    if Enum.any?(elements, &Map.get(&1, :in_dialog, false)) do
+      Enum.map(elements, fn element ->
+        case Map.pop(element, :in_dialog, false) do
+          {true, stripped} -> stripped
+          {false, stripped} -> Map.put(stripped, :dim_behind_modal, true)
+        end
+      end)
+    else
+      elements
+    end
   end
 
   # Build a flat map from element content hash to {measured_width, measured_height}.
@@ -510,16 +528,13 @@ defmodule Raxol.UI.Layout.Engine do
   # axis (unlike bare `:center`, which anchors the overlay's origin at the
   # midpoint rather than centering its bounding box).
   #
-  # An overlay descriptor may also carry `dialog: true` (see
-  # `Raxol.UI.Components.AbsoluteLayer.dialog_overlay/3`) to mark it as a
-  # modal dialog: every element the flow child produces is stamped with
-  # `:dim_behind_modal` so `Raxol.UI.Renderer` dims its cells toward the
-  # background, while the dialog overlay's own elements are left unstamped
-  # and render at full color on top.
+  # An overlay descriptor may carry `dialog: true` (see
+  # `Raxol.UI.Components.AbsoluteLayer.dialog_overlay/3`) to stamp its
+  # whole subtree `:in_dialog`; `dim_behind_dialog/1` dims everything else
+  # once the tree is flat (dialog scope is global, see that function).
   def process_element(%{type: :absolute_layer} = layer, space, acc) do
     flow_child = Map.get(layer, :flow_child)
     overlays = Map.get(layer, :overlays, [])
-    dialog_active? = Enum.any?(overlays, &Map.get(&1, :dialog, false))
 
     flow_elements =
       case flow_child do
@@ -527,14 +542,21 @@ defmodule Raxol.UI.Layout.Engine do
         child -> process_element(child, space, [])
       end
 
-    flow_elements =
-      if dialog_active?,
-        do: Enum.map(flow_elements, &Map.put(&1, :dim_behind_modal, true)),
-        else: flow_elements
-
     overlay_elements =
       Enum.reduce(overlays, [], fn overlay, current_acc ->
-        process_overlay(overlay, space, current_acc)
+        # Computed against `[]` (not `current_acc`) so only this overlay's
+        # own new elements get stamped, then recombined the same way
+        # `process_overlay/3` would have -- every process_element/3 clause
+        # in this module follows the `own_new(el, space) ++ acc` contract,
+        # so this is equivalent to the un-stamped call when not a dialog.
+        own_elements = process_overlay(overlay, space, [])
+
+        own_elements =
+          if Map.get(overlay, :dialog, false),
+            do: stamp_in_dialog(own_elements),
+            else: own_elements
+
+        own_elements ++ current_acc
       end)
 
     flow_elements ++ overlay_elements ++ acc
@@ -687,6 +709,17 @@ defmodule Raxol.UI.Layout.Engine do
   end
 
   defp process_overlay(_, _, acc), do: acc
+
+  # Marks a dialog overlay's elements `:in_dialog` so dim_behind_dialog/1 exempts them.
+  defp stamp_in_dialog(elements) when is_list(elements) do
+    Enum.map(elements, &stamp_in_dialog/1)
+  end
+
+  defp stamp_in_dialog(element) when is_map(element) do
+    Map.put(element, :in_dialog, true)
+  end
+
+  defp stamp_in_dialog(other), do: other
 
   # Resolve a coordinate (integer, negative offset, or symbolic atom) against
   # the parent space's origin and length on a single axis.

--- a/lib/raxol/ui/ui_renderer.ex
+++ b/lib/raxol/ui/ui_renderer.ex
@@ -94,16 +94,25 @@ defmodule Raxol.UI.Renderer do
         []
 
       _ ->
-        # Layout-stamped overflow clipping applies to EVERY element type
+        # Layout-stamped overflow clipping applies to every element type
         # generically; type-specific render paths that clip themselves are
-        # unaffected (intersection is idempotent).
+        # unaffected (intersection is idempotent). Same choke point for
+        # modal-backdrop dimming: `:dim_behind_modal` is global, stamped on
+        # every non-`:in_dialog` element while a dialog overlay is active,
+        # not just the hosting `:absolute_layer`'s flow content.
         element_with_dims
         |> render_visible_element(theme, parent_style)
         |> CellManager.clip_cells_to_bounds(
           Map.get(element_with_dims, :clip_bounds)
         )
+        |> maybe_dim(element_with_dims)
     end
   end
+
+  defp maybe_dim(cells, %{dim_behind_modal: true}),
+    do: Raxol.UI.CellDim.dim_cells(cells)
+
+  defp maybe_dim(cells, _element), do: cells
 
   # --- Element Dimension Calculation ---
 

--- a/test/cross_terminal/modal_demo_headless_test.exs
+++ b/test/cross_terminal/modal_demo_headless_test.exs
@@ -1,0 +1,104 @@
+defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
+  @moduledoc """
+  End-to-end coverage for `Raxol.Playground.Demos.ModalDemo`: boots the
+  real demo headless, opens the modal, and checks that it renders as a
+  true dialog -- centered on top, background text still present and
+  unmoved, dimmed behind it.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Headless
+
+  setup do
+    pid =
+      case Process.whereis(Headless) do
+        nil -> start_supervised!({Headless, [name: Headless]})
+        existing -> existing
+      end
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        for id <- GenServer.call(pid, :list_sessions) do
+          try do
+            GenServer.call(pid, {:stop_session, id}, 2_000)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp cell_at(buffer, x, y), do: buffer.cells |> Enum.at(y) |> Enum.at(x)
+
+  test "modal box renders centered on top, background text stays visible" do
+    {:ok, id} =
+      Headless.start(Raxol.Playground.Demos.ModalDemo, id: :modal_demo_e)
+
+    {:ok, closed_text} = Headless.screenshot(id)
+    assert closed_text =~ "Background content (does not move):"
+    assert closed_text =~ "Modal Demo"
+    refute closed_text =~ "Confirm Action"
+
+    :ok = Headless.send_key(id, "o")
+    Process.sleep(50)
+
+    {:ok, open_text} = Headless.screenshot(id)
+    # background is still present, unobstructed above/around the dialog
+    assert open_text =~ "Background content (does not move):"
+    assert open_text =~ "Modal Demo"
+    # the dialog itself rendered
+    assert open_text =~ "Confirm Action"
+    assert open_text =~ "Are you sure you want to proceed?"
+
+    :ok = Headless.stop(id)
+  end
+
+  test "background text cells are byte-identical open vs closed (no reflow)" do
+    {:ok, id} =
+      Headless.start(Raxol.Playground.Demos.ModalDemo, id: :modal_demo_reflow)
+
+    {:ok, closed_buffer} = Headless.get_buffer(id)
+
+    :ok = Headless.send_key(id, "o")
+    Process.sleep(50)
+    {:ok, open_buffer} = Headless.get_buffer(id)
+
+    for y <- 0..3, x <- 0..35 do
+      closed_cell = cell_at(closed_buffer, x, y)
+      open_cell = cell_at(open_buffer, x, y)
+
+      assert closed_cell.char == open_cell.char,
+             "cell (#{x}, #{y}) moved: #{inspect(closed_cell.char)} -> #{inspect(open_cell.char)}"
+    end
+
+    :ok = Headless.stop(id)
+  end
+
+  test "background is dimmed while the modal is open, and un-dims on close" do
+    {:ok, id} =
+      Headless.start(Raxol.Playground.Demos.ModalDemo, id: :modal_demo_dim)
+
+    {:ok, closed_buffer} = Headless.get_buffer(id)
+    closed_title_cell = cell_at(closed_buffer, 0, 0)
+    assert closed_title_cell.char == "M"
+    assert closed_title_cell.style.foreground == :white
+
+    :ok = Headless.send_key(id, "o")
+    Process.sleep(50)
+    {:ok, open_buffer} = Headless.get_buffer(id)
+    open_title_cell = cell_at(open_buffer, 0, 0)
+    assert open_title_cell.char == "M"
+    assert open_title_cell.style.foreground == {140, 140, 140}
+
+    :ok = Headless.send_key(id, "n")
+    Process.sleep(50)
+    {:ok, closed_again_buffer} = Headless.get_buffer(id)
+    closed_again_title_cell = cell_at(closed_again_buffer, 0, 0)
+    assert closed_again_title_cell.style.foreground == :white
+
+    :ok = Headless.stop(id)
+  end
+end

--- a/test/cross_terminal/modal_demo_headless_test.exs
+++ b/test/cross_terminal/modal_demo_headless_test.exs
@@ -84,7 +84,9 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
     {:ok, closed_buffer} = Headless.get_buffer(id)
     closed_title_cell = cell_at(closed_buffer, 0, 0)
     assert closed_title_cell.char == "M"
-    assert closed_title_cell.style.foreground == :white
+    # Compare against the title's own resting colour rather than a literal:
+    # the default foreground is theme-derived and not fixed across envs.
+    closed_fg = closed_title_cell.style.foreground
 
     :ok = Headless.send_key(id, "o")
     Process.sleep(50)
@@ -92,14 +94,18 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
     open_title_cell = cell_at(open_buffer, 0, 0)
     assert open_title_cell.char == "M"
 
-    assert open_title_cell.style.foreground ==
-             Raxol.UI.CellDim.dim_color(:white)
+    # The title dims while the modal is open. The exact dimmed value
+    # depends on the fg-vs-bg role and detected ground, so assert it
+    # changed (and un-dims on close) rather than recomputing it.
+    open_fg = open_title_cell.style.foreground
+    assert open_fg != nil
+    refute open_fg == closed_fg
 
     :ok = Headless.send_key(id, "n")
     Process.sleep(50)
     {:ok, closed_again_buffer} = Headless.get_buffer(id)
     closed_again_title_cell = cell_at(closed_again_buffer, 0, 0)
-    assert closed_again_title_cell.style.foreground == :white
+    assert closed_again_title_cell.style.foreground == closed_fg
 
     :ok = Headless.stop(id)
   end

--- a/test/cross_terminal/modal_demo_headless_test.exs
+++ b/test/cross_terminal/modal_demo_headless_test.exs
@@ -91,7 +91,9 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
     {:ok, open_buffer} = Headless.get_buffer(id)
     open_title_cell = cell_at(open_buffer, 0, 0)
     assert open_title_cell.char == "M"
-    assert open_title_cell.style.foreground == {140, 140, 140}
+
+    assert open_title_cell.style.foreground ==
+             Raxol.UI.CellDim.dim_color(:white)
 
     :ok = Headless.send_key(id, "n")
     Process.sleep(50)

--- a/test/cross_terminal/modal_overlay_test.exs
+++ b/test/cross_terminal/modal_overlay_test.exs
@@ -1,0 +1,207 @@
+defmodule Raxol.CrossTerminal.ModalOverlayTest do
+  @moduledoc """
+  Modal-as-true-dialog safety net: modals overlay above undisturbed,
+  dimmed background content instead of reflowing it.
+
+  Covers the mechanism at the layout/render level, independent of the
+  `Modal` component and `ModalDemo`:
+
+    a. flow content cell coordinates are identical whether a dialog
+       overlay is present or not (no reflow)
+    b. cells behind an active dialog are dimmed toward the background;
+       the dialog's own cells stay full color
+    c. dialog cells win over flow cells at overlapping coordinates under
+       the renderer's real last-write-wins cell composition
+    d. a layer with no dialog overlay is a byte-identical no-op
+
+  `test/raxol/components/modal_test.exs` covers `Modal.as_dialog_overlay/2`
+  structurally; `test/cross_terminal/modal_demo_headless_test.exs` covers
+  the playground demo end-to-end via a real headless session.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Layout.Engine
+  alias Raxol.UI.Renderer, as: UIRenderer
+  alias Raxol.UI.CellDim
+
+  import Raxol.UI.Components.AbsoluteLayer
+
+  @dimensions %{width: 40, height: 12}
+
+  defp text(content, opts) do
+    Map.merge(%{type: :text, content: content}, Map.new(opts))
+  end
+
+  defp background do
+    %{
+      type: :box,
+      children: [
+        text("FFFFFFFFFF", fg: :white, bg: {200, 100, 50})
+      ]
+    }
+  end
+
+  defp dialog_content do
+    %{type: :box, children: [text("ZZZZZZ", fg: :cyan, bg: {10, 200, 10})]}
+  end
+
+  defp positioned_signature(elements) do
+    elements
+    |> Enum.map(fn el ->
+      {Map.get(el, :type), Map.get(el, :x), Map.get(el, :y),
+       Map.get(el, :content) || Map.get(el, :text)}
+    end)
+    |> Enum.sort()
+  end
+
+  # Mirrors `Raxol.Core.Runtime.Rendering.Backends.apply_cells_to_buffer/2`'s
+  # fold: cells later in the list win at a shared coordinate. This is the
+  # real production semantics `render_to_cells`' flat cell list is composed
+  # under, so it is the correct oracle for "X painted over Y".
+  defp fold_last_write_wins(cells) do
+    Enum.reduce(cells, %{}, fn {x, y, char, fg, bg, attrs}, acc ->
+      Map.put(acc, {x, y}, {char, fg, bg, attrs})
+    end)
+  end
+
+  describe "a. no reflow: flow content positions are unaffected by an active dialog" do
+    test "flow element positions are identical open vs closed" do
+      closed = absolute_layer(background(), [])
+
+      open =
+        absolute_layer(background(), [dialog_overlay(8, 3, dialog_content())])
+
+      closed_elements = Engine.apply_layout(closed, @dimensions)
+      open_elements = Engine.apply_layout(open, @dimensions)
+
+      # Elements the flow child produced are exactly the ones stamped
+      # `:dim_behind_modal` while a dialog overlay is active.
+      open_flow_elements =
+        Enum.filter(open_elements, &Map.get(&1, :dim_behind_modal, false))
+
+      assert open_flow_elements != []
+
+      assert positioned_signature(closed_elements) ==
+               positioned_signature(open_flow_elements)
+    end
+
+    test "background text cell (x, y) set is identical open vs closed" do
+      closed = absolute_layer(background(), [])
+
+      open =
+        absolute_layer(background(), [dialog_overlay(8, 3, dialog_content())])
+
+      closed_coords =
+        Engine.apply_layout(closed, @dimensions)
+        |> UIRenderer.render_to_cells()
+        |> Enum.map(fn {x, y, _c, _fg, _bg, _a} -> {x, y} end)
+        |> MapSet.new()
+
+      open_coords =
+        Engine.apply_layout(open, @dimensions)
+        |> UIRenderer.render_to_cells()
+        |> Enum.filter(fn {x, y, _c, _fg, _bg, _a} -> y == 0 and x < 10 end)
+        |> Enum.map(fn {x, y, _c, _fg, _bg, _a} -> {x, y} end)
+        |> MapSet.new()
+
+      assert MapSet.subset?(open_coords, closed_coords)
+      assert MapSet.size(open_coords) > 0
+    end
+  end
+
+  describe "b. dim mechanics: behind-cells dim, dialog cells stay full color" do
+    test "CellDim.dim_color maps atoms to their pale equivalent" do
+      assert CellDim.dim_color(:white) == {140, 140, 140}
+      assert CellDim.dim_color(:cyan) == {90, 120, 130}
+      # unlisted atom falls back to dim gray, not a crash
+      assert CellDim.dim_color(:some_theme_color) == {90, 90, 90}
+    end
+
+    test "CellDim.dim_color scales {r, g, b} tuples toward black and clamps" do
+      assert CellDim.dim_color({200, 100, 50}) == {90, 45, 23}
+      assert CellDim.dim_color({0, 0, 0}) == {0, 0, 0}
+      assert CellDim.dim_color({255, 255, 255}) == {115, 115, 115}
+    end
+
+    test "CellDim.dim_color leaves nil and unrecognized formats untouched" do
+      assert CellDim.dim_color(nil) == nil
+      assert CellDim.dim_color(42) == 42
+      assert CellDim.dim_color("#ff0000") == "#ff0000"
+    end
+
+    test "CellDim.dim_cell only touches fg/bg, not char/coords/attrs" do
+      assert CellDim.dim_cell({3, 4, "X", :white, {200, 100, 50}, [:bold]}) ==
+               {3, 4, "X", {140, 140, 140}, {90, 45, 23}, [:bold]}
+    end
+
+    test "a background cell's painted colors are dimmed; the dialog's are not" do
+      layer =
+        absolute_layer(background(), [dialog_overlay(8, 3, dialog_content())])
+
+      cells =
+        Engine.apply_layout(layer, @dimensions) |> UIRenderer.render_to_cells()
+
+      by_char =
+        Enum.reduce(cells, %{}, fn {_x, _y, char, fg, bg, _attrs}, acc ->
+          Map.put_new(acc, char, {fg, bg})
+        end)
+
+      # background painted fg :white / bg {200,100,50} -> dimmed
+      assert by_char["F"] == {{140, 140, 140}, {90, 45, 23}}
+      # dialog painted fg :cyan / bg {10,200,10} -- full color, untouched
+      assert by_char["Z"] == {:cyan, {10, 200, 10}}
+    end
+
+    test "no dialog overlay present -> nothing is dimmed" do
+      layer = absolute_layer(background(), [overlay(0, 0, dialog_content())])
+
+      cells =
+        Engine.apply_layout(layer, @dimensions) |> UIRenderer.render_to_cells()
+
+      by_char =
+        Enum.reduce(cells, %{}, fn {_x, _y, char, fg, bg, _attrs}, acc ->
+          Map.put_new(acc, char, {fg, bg})
+        end)
+
+      assert by_char["F"] == {:white, {200, 100, 50}}
+    end
+  end
+
+  describe "c. dialog paints over flow content at overlapping coordinates" do
+    test "the dialog's cells win under the renderer's real last-write-wins fold" do
+      # Force an actual overlap: a 1x1 dialog pinned at (0, 0), exactly
+      # where the background's first character paints.
+      overlapping_dialog = %{
+        x: 0,
+        y: 0,
+        element: text("X", fg: :cyan),
+        dialog: true
+      }
+
+      layer = absolute_layer(background(), [overlapping_dialog])
+
+      cells =
+        Engine.apply_layout(layer, @dimensions)
+        |> UIRenderer.render_to_cells()
+        |> fold_last_write_wins()
+
+      assert {"X", :cyan, :black, []} = cells[{0, 0}]
+    end
+  end
+
+  describe "d. no-op when there is no dialog overlay" do
+    test "an absolute_layer with no overlays renders byte-identical cells to the bare tree" do
+      bare_cells =
+        background()
+        |> Engine.apply_layout(@dimensions)
+        |> UIRenderer.render_to_cells()
+
+      layered_cells =
+        absolute_layer(background(), [])
+        |> Engine.apply_layout(@dimensions)
+        |> UIRenderer.render_to_cells()
+
+      assert Enum.sort(bare_cells) == Enum.sort(layered_cells)
+    end
+  end
+end

--- a/test/cross_terminal/modal_overlay_test.exs
+++ b/test/cross_terminal/modal_overlay_test.exs
@@ -204,4 +204,112 @@ defmodule Raxol.CrossTerminal.ModalOverlayTest do
       assert Enum.sort(bare_cells) == Enum.sort(layered_cells)
     end
   end
+
+  describe "e. embedded as a flex child (playground preview panel shape)" do
+    # :absolute_layer measures as its flow child so flex parents give it
+    # non-zero height and overlays aren't clipped.
+
+    test "measure_element on the absolute_layer returns the flow child's size, not 0x0" do
+      available = %{width: 40, height: 20}
+
+      layer =
+        absolute_layer(background(), [dialog_overlay(8, 3, dialog_content())])
+
+      flow_size = Engine.measure_element(background(), available)
+      layer_size = Engine.measure_element(layer, available)
+
+      refute layer_size == %{width: 0, height: 0}
+      assert layer_size == flow_size
+    end
+
+    test "overlays survive and the following sibling lands below the flow content" do
+      dimensions = %{width: 40, height: 20}
+
+      layer =
+        absolute_layer(background(), [dialog_overlay(8, 3, dialog_content())])
+
+      sibling = text("SIBLING", fg: :white)
+
+      root = %{
+        type: :flex,
+        direction: :column,
+        children: [layer, sibling]
+      }
+
+      elements = Engine.apply_layout(root, dimensions)
+
+      # (a) the dialog overlay's own content made it into the output --
+      # before the fix, the layer's zero-height space clipped every overlay.
+      assert Enum.any?(elements, &(Map.get(&1, :text) == "ZZZZZZ"))
+
+      # Flow content max y, identified directly (not via `dim_behind_modal`,
+      # which now also stamps the sibling -- see the dimming tests below).
+      flow_content_elements =
+        Enum.reject(elements, &(Map.get(&1, :text) in ["SIBLING", "ZZZZZZ"]))
+
+      assert flow_content_elements != []
+
+      flow_max_y =
+        flow_content_elements
+        |> Enum.map(&Map.get(&1, :y, 0))
+        |> Enum.max()
+
+      # (c) the sibling sits strictly below the flow content -- before the
+      # fix it overlapped at y == 0 because the layer contributed no height
+      # to the flex column's main-axis allocation.
+      sibling_element = Enum.find(elements, &(Map.get(&1, :text) == "SIBLING"))
+
+      refute is_nil(sibling_element)
+      assert sibling_element.y > flow_max_y
+    end
+
+    test "a sibling outside the absolute_layer dims too when the dialog is open" do
+      dimensions = %{width: 40, height: 20}
+
+      layer =
+        absolute_layer(background(), [dialog_overlay(8, 3, dialog_content())])
+
+      sibling = text("SIBLING", fg: :white)
+
+      root = %{
+        type: :flex,
+        direction: :column,
+        children: [layer, sibling]
+      }
+
+      elements = Engine.apply_layout(root, dimensions)
+
+      sibling_element = Enum.find(elements, &(Map.get(&1, :text) == "SIBLING"))
+      refute is_nil(sibling_element)
+      assert sibling_element.dim_behind_modal == true
+
+      # The dialog's own content is never dim-stamped, even though it's a
+      # sibling produced from the same layer -- only the flow child and
+      # chrome outside the dialog subtree dim.
+      dialog_element = Enum.find(elements, &(Map.get(&1, :text) == "ZZZZZZ"))
+      refute is_nil(dialog_element)
+      refute Map.get(dialog_element, :dim_behind_modal, false)
+    end
+
+    test "no sibling dimming when there is no active dialog" do
+      dimensions = %{width: 40, height: 20}
+
+      layer = absolute_layer(background(), [overlay(0, 0, dialog_content())])
+      sibling = text("SIBLING", fg: :white)
+
+      root = %{
+        type: :flex,
+        direction: :column,
+        children: [layer, sibling]
+      }
+
+      elements = Engine.apply_layout(root, dimensions)
+
+      sibling_element = Enum.find(elements, &(Map.get(&1, :text) == "SIBLING"))
+      refute is_nil(sibling_element)
+      refute Map.get(sibling_element, :dim_behind_modal, false)
+
+      refute Enum.any?(elements, &Map.get(&1, :dim_behind_modal, false))
+    end
+  end
 end

--- a/test/cross_terminal/modal_overlay_test.exs
+++ b/test/cross_terminal/modal_overlay_test.exs
@@ -110,28 +110,28 @@ defmodule Raxol.CrossTerminal.ModalOverlayTest do
   end
 
   describe "b. dim mechanics: behind-cells dim, dialog cells stay full color" do
-    test "CellDim.dim_color maps atoms to their pale equivalent" do
-      assert CellDim.dim_color(:white) == {140, 140, 140}
-      assert CellDim.dim_color(:cyan) == {90, 120, 130}
-      # unlisted atom falls back to dim gray, not a crash
-      assert CellDim.dim_color(:some_theme_color) == {90, 90, 90}
+    test "CellDim.dim_color maps atoms through H-K apparent-lightness compression toward ground" do
+      assert CellDim.dim_color(:white) == {106, 106, 106}
+      assert CellDim.dim_color(:cyan) == {41, 97, 97}
+      # unlisted atom resolves to mid-gray before dimming, not a crash
+      assert CellDim.dim_color(:some_theme_color) == {66, 66, 66}
     end
 
-    test "CellDim.dim_color scales {r, g, b} tuples toward black and clamps" do
-      assert CellDim.dim_color({200, 100, 50}) == {90, 45, 23}
-      assert CellDim.dim_color({0, 0, 0}) == {0, 0, 0}
-      assert CellDim.dim_color({255, 255, 255}) == {115, 115, 115}
+    test "CellDim.dim_color pulls {r, g, b} tuples' apparent lightness toward ground and clamps" do
+      assert CellDim.dim_color({200, 100, 50}) == {96, 56, 38}
+      assert CellDim.dim_color({0, 0, 0}) == {4, 4, 4}
+      assert CellDim.dim_color({255, 255, 255}) == {116, 116, 116}
     end
 
-    test "CellDim.dim_color leaves nil and unrecognized formats untouched" do
+    test "CellDim.dim_color leaves nil and integer/256-color values untouched; hex strings now dim too" do
       assert CellDim.dim_color(nil) == nil
       assert CellDim.dim_color(42) == 42
-      assert CellDim.dim_color("#ff0000") == "#ff0000"
+      assert CellDim.dim_color("#ff0000") == "#78261d"
     end
 
     test "CellDim.dim_cell only touches fg/bg, not char/coords/attrs" do
       assert CellDim.dim_cell({3, 4, "X", :white, {200, 100, 50}, [:bold]}) ==
-               {3, 4, "X", {140, 140, 140}, {90, 45, 23}, [:bold]}
+               {3, 4, "X", {106, 106, 106}, {96, 56, 38}, [:bold]}
     end
 
     test "a background cell's painted colors are dimmed; the dialog's are not" do
@@ -147,7 +147,7 @@ defmodule Raxol.CrossTerminal.ModalOverlayTest do
         end)
 
       # background painted fg :white / bg {200,100,50} -> dimmed
-      assert by_char["F"] == {{140, 140, 140}, {90, 45, 23}}
+      assert by_char["F"] == {{106, 106, 106}, {96, 56, 38}}
       # dialog painted fg :cyan / bg {10,200,10} -- full color, untouched
       assert by_char["Z"] == {:cyan, {10, 200, 10}}
     end

--- a/test/cross_terminal/modal_overlay_test.exs
+++ b/test/cross_terminal/modal_overlay_test.exs
@@ -112,13 +112,13 @@ defmodule Raxol.CrossTerminal.ModalOverlayTest do
   describe "b. dim mechanics: behind-cells dim, dialog cells stay full color" do
     test "CellDim.dim_color maps atoms through H-K apparent-lightness compression toward ground" do
       assert CellDim.dim_color(:white) == {106, 106, 106}
-      assert CellDim.dim_color(:cyan) == {41, 97, 97}
+      assert CellDim.dim_color(:cyan) == {3, 100, 100}
       # unlisted atom resolves to mid-gray before dimming, not a crash
       assert CellDim.dim_color(:some_theme_color) == {66, 66, 66}
     end
 
     test "CellDim.dim_color pulls {r, g, b} tuples' apparent lightness toward ground and clamps" do
-      assert CellDim.dim_color({200, 100, 50}) == {96, 56, 38}
+      assert CellDim.dim_color({200, 100, 50}) == {108, 49, 20}
       assert CellDim.dim_color({0, 0, 0}) == {4, 4, 4}
       assert CellDim.dim_color({255, 255, 255}) == {116, 116, 116}
     end
@@ -126,12 +126,16 @@ defmodule Raxol.CrossTerminal.ModalOverlayTest do
     test "CellDim.dim_color leaves nil and integer/256-color values untouched; hex strings now dim too" do
       assert CellDim.dim_color(nil) == nil
       assert CellDim.dim_color(42) == 42
-      assert CellDim.dim_color("#ff0000") == "#78261d"
+      assert CellDim.dim_color("#ff0000") == "#8a0000"
     end
 
-    test "CellDim.dim_cell only touches fg/bg, not char/coords/attrs" do
-      assert CellDim.dim_cell({3, 4, "X", :white, {200, 100, 50}, [:bold]}) ==
-               {3, 4, "X", {106, 106, 106}, {96, 56, 38}, [:bold]}
+    test "CellDim.dim_color leaves the bg :black default/unpainted sentinel untouched" do
+      assert CellDim.dim_color(:black) == :black
+    end
+
+    test "CellDim.dim_cells only touches fg/bg, not char/coords/attrs" do
+      assert CellDim.dim_cells([{3, 4, "X", :white, {200, 100, 50}, [:bold]}]) ==
+               [{3, 4, "X", {106, 106, 106}, {108, 49, 20}, [:bold]}]
     end
 
     test "a background cell's painted colors are dimmed; the dialog's are not" do
@@ -147,7 +151,7 @@ defmodule Raxol.CrossTerminal.ModalOverlayTest do
         end)
 
       # background painted fg :white / bg {200,100,50} -> dimmed
-      assert by_char["F"] == {{106, 106, 106}, {96, 56, 38}}
+      assert by_char["F"] == {{106, 106, 106}, {108, 49, 20}}
       # dialog painted fg :cyan / bg {10,200,10} -- full color, untouched
       assert by_char["Z"] == {:cyan, {10, 200, 10}}
     end

--- a/test/cross_terminal/modal_overlay_test.exs
+++ b/test/cross_terminal/modal_overlay_test.exs
@@ -185,7 +185,9 @@ defmodule Raxol.CrossTerminal.ModalOverlayTest do
         |> UIRenderer.render_to_cells()
         |> fold_last_write_wins()
 
-      assert {"X", :cyan, :black, []} = cells[{0, 0}]
+      # The dialog char and its explicit fg win the overlap; the bg is the
+      # theme default (not fixed across envs), so it is not asserted.
+      assert {"X", :cyan, _bg, []} = cells[{0, 0}]
     end
   end
 

--- a/test/raxol/components/modal_test.exs
+++ b/test/raxol/components/modal_test.exs
@@ -573,6 +573,70 @@ defmodule Raxol.UI.Components.ModalTest do
     assert commands == [{:submit_empty, %{}}]
   end
 
+  # --- as_dialog_overlay/2 (true-dialog rendering) ---
+
+  describe "as_dialog_overlay/2" do
+    defp flow_stub,
+      do: %{type: :box, children: [%{type: :text, content: "FLOW"}]}
+
+    test "hidden modal returns flow_content unchanged" do
+      props = Modal.alert(:hidden_alert, "Alert!", "X", visible: false)
+      {:ok, state} = Modal.init(Map.new(props))
+      refute state.visible
+
+      flow = flow_stub()
+      assert Modal.as_dialog_overlay(state, flow) == flow
+    end
+
+    test "visible modal wraps flow_content in an :absolute_layer with a dialog overlay" do
+      props = Modal.alert(:my_alert, "Alert!", "Something happened")
+      {:ok, state} = Modal.init(Map.new(props))
+      assert state.visible
+
+      flow = flow_stub()
+      result = Modal.as_dialog_overlay(state, flow)
+
+      assert result.type == :absolute_layer
+      assert result.flow_child == flow
+      assert [overlay] = result.overlays
+      assert overlay.dialog == true
+      assert overlay.x == {:center_of, state.width}
+      assert is_map(overlay.element)
+    end
+
+    test "the dialog overlay's element is sized to state.width and an estimated height" do
+      props = Modal.alert(:my_alert, "Alert!", "Something happened")
+      {:ok, state} = Modal.init(Map.new(props))
+
+      result = Modal.as_dialog_overlay(state, flow_stub())
+      [overlay] = result.overlays
+      surface = overlay.element
+
+      assert surface.type == :box
+      assert surface.width == state.width
+      assert surface.height > 0
+      assert overlay.y == {:center_of, surface.height}
+      # outer surface is unbordered (it's the opaque fill); the bordered
+      # dialog chrome is nested one level in as its child.
+      assert surface.border == :none
+      assert [inner] = surface.children
+      assert inner.type == :box
+      assert inner.border == :double
+      assert inner.width == state.width
+      assert inner.height == surface.height
+    end
+
+    test "does not mutate what Modal.render/2 itself returns" do
+      props = Modal.alert(:my_alert, "Alert!", "Something happened")
+      {:ok, state} = Modal.init(Map.new(props))
+
+      plain_render = Modal.render(state, %{})
+      _ = Modal.as_dialog_overlay(state, flow_stub())
+
+      assert Modal.render(state, %{}) == plain_render
+    end
+  end
+
   test "modal without id handles focus correctly" do
     props =
       Modal.form(


### PR DESCRIPTION
Modals render through `:absolute_layer` as a centered overlay: flow content keeps identical cell coordinates whether the dialog is open or closed (no reflow), and everything behind an active dialog dims at the cell level via `Raxol.UI.CellDim` — apparent-lightness (H-K) compression toward the detected terminal ground, chroma kept separate so hues stay legible. The dialog subtree renders at full colour on top. A global post-pass dims siblings outside the hosting layer (sidebar/header), and colour assertions are theme-independent where the value is env-derived.

The final commit reconciles the describe-b dim-colour fixtures to the merged H-K solver / cell-dimming output (`dim_cells`, current dimmed bytes).

Depends on **pr/modal-absolute-layer** (#475) — stacked on it, so this PR's diff includes that commit until #475 merges.