### PR TITLE
Auto-ellipsis overflowing text and cursor-follow list scrolling

### DIFF
--- a/lib/raxol/playground/app.ex
+++ b/lib/raxol/playground/app.ex
@@ -21,6 +21,7 @@ defmodule Raxol.Playground.App do
   use Raxol.Core.Runtime.Application
 
   alias Raxol.Playground.Catalog
+  alias Raxol.UI.ScrollWindow
 
   @categories [nil] ++ Catalog.list_categories()
   @complexities [nil, :basic, :intermediate, :advanced]
@@ -29,6 +30,13 @@ defmodule Raxol.Playground.App do
   @help_key_pad 18
   @unknown_category_order 99
   @default_terminal_width 80
+  @default_terminal_height 24
+  # header_bar + status_bar rows consumed outside the sidebar box
+  @chrome_lines 2
+  # box top/bottom border rows
+  @box_border_lines 2
+  # Matches Viewport's @subtle_thumb_bg (rationale there).
+  @scrollbar_thumb_bg {110, 140, 180}
 
   @category_order %{
     input: 0,
@@ -42,13 +50,19 @@ defmodule Raxol.Playground.App do
   }
 
   @impl true
-  def init(_context) do
+  def init(context) do
     components = Catalog.list_components() |> sort_by_category()
-    terminal_width = detect_terminal_width()
+
+    terminal_width =
+      context_dimension(context, :width, &detect_terminal_width/0)
+
+    terminal_height =
+      context_dimension(context, :height, &detect_terminal_height/0)
 
     %{
       components: components,
       cursor: 0,
+      scroll_top: 0,
       selected: List.first(components),
       focus: :sidebar,
       search: nil,
@@ -59,6 +73,7 @@ defmodule Raxol.Playground.App do
       complexity_filter: nil,
       show_help: false,
       terminal_width: terminal_width,
+      terminal_height: terminal_height,
       available_width: demo_available_width(terminal_width)
     }
     |> init_demo()
@@ -70,16 +85,17 @@ defmodule Raxol.Playground.App do
       :tick ->
         forward_tick_to_demo(model)
 
-      %Raxol.Core.Events.Event{type: :resize, data: %{width: w}} ->
+      %Raxol.Core.Events.Event{type: :resize, data: %{width: w, height: h}} ->
         new_avail = demo_available_width(w)
 
         model =
           model
           |> Map.put(:terminal_width, w)
+          |> Map.put(:terminal_height, h)
           |> Map.put(:available_width, new_avail)
           |> inject_width_into_demo()
 
-        {model, []}
+        {%{model | scroll_top: sidebar_window(model).scroll_top}, []}
 
       _ ->
         cond do
@@ -248,7 +264,6 @@ defmodule Raxol.Playground.App do
   end
 
   defp sidebar_panel(model) do
-    items = build_sidebar_items(model)
     border_fg = if model.focus == :sidebar, do: :cyan, else: :white
     total = length(Catalog.list_components())
     showing = length(model.components)
@@ -271,24 +286,51 @@ defmodule Raxol.Playground.App do
 
     box style: %{border: :rounded, fg: border_fg, width: @sidebar_width} do
       column style: %{gap: 0} do
-        count_line ++ filter_lines ++ search_line ++ items
+        count_line ++ filter_lines ++ search_line ++ sidebar_item_lines(model)
       end
     end
   end
 
-  defp build_sidebar_items(%{components: []} = _model) do
+  # Window items only (not header rows) so one cursor step never scrolls
+  # more than one row; headers render only while the full list still fits.
+  defp sidebar_item_lines(%{components: []}) do
     [text("   No matches", style: [:dim], fg: :yellow)]
   end
 
-  defp build_sidebar_items(model) do
-    {_last_cat, items_rev} =
+  defp sidebar_item_lines(model) do
+    if sidebar_fits?(model) do
+      sidebar_full_lines(model)
+    else
+      sidebar_windowed_lines(model)
+    end
+  end
+
+  defp sidebar_fits?(model) do
+    sidebar_total_lines(model.components) <= sidebar_visible_height(model)
+  end
+
+  # items + one header row per distinct category run
+  defp sidebar_total_lines(components) do
+    {_last_cat, header_count} =
+      Enum.reduce(components, {nil, 0}, fn comp, {last_cat, count} ->
+        if comp.category != last_cat,
+          do: {comp.category, count + 1},
+          else: {comp.category, count}
+      end)
+
+    length(components) + header_count
+  end
+
+  defp sidebar_full_lines(model) do
+    {_last_cat, lines_rev} =
       model.components
       |> Enum.with_index()
       |> Enum.reduce({nil, []}, fn {comp, idx}, {last_cat, acc} ->
-        is_current = idx == model.cursor
-        marker = if is_current, do: " ▸ ", else: "   "
-        item_opts = if is_current, do: [style: [:bold], fg: :green], else: []
-        item = text(marker <> comp.name, item_opts)
+        item =
+          text(
+            sidebar_item_label(model, comp, idx),
+            sidebar_item_opts(model, idx)
+          )
 
         if comp.category != last_cat do
           hdr =
@@ -300,7 +342,79 @@ defmodule Raxol.Playground.App do
         end
       end)
 
-    Enum.reverse(items_rev)
+    Enum.reverse(lines_rev)
+  end
+
+  # Each visible line is its own row: item text padded to a fixed width,
+  # plus a trailing 1-column scrollbar cell. Fixed-width padding (rather
+  # than flex layout) guarantees the scrollbar cell lands in the box's
+  # true rightmost column regardless of how short an item's label is.
+  defp sidebar_windowed_lines(model) do
+    window = sidebar_window(model)
+    item_width = @sidebar_width - @sidebar_border_overhead - 1
+    # thumb is nil when the item count alone fits the row budget even
+    # though items+headers together didn't (the case that routed us into
+    # this windowed branch) -- {0, 0} renders a track with no thumb cell.
+    {thumb_start, thumb_size} = window.thumb || {0, 0}
+
+    window.visible
+    |> Enum.with_index()
+    |> Enum.map(fn {comp, row_idx} ->
+      idx = window.scroll_top + row_idx
+      label = pad_to_width(sidebar_item_label(model, comp, idx), item_width)
+      item_text = text(label, sidebar_item_opts(model, idx))
+
+      row style: %{gap: 0} do
+        [item_text, scrollbar_cell(row_idx, thumb_start, thumb_size)]
+      end
+    end)
+  end
+
+  defp sidebar_item_label(model, comp, idx) do
+    marker = if idx == model.cursor, do: " ▸ ", else: "   "
+    marker <> comp.name
+  end
+
+  defp sidebar_item_opts(model, idx) do
+    if idx == model.cursor, do: [style: [:bold], fg: :green], else: []
+  end
+
+  defp scrollbar_cell(row_idx, thumb_start, thumb_size) do
+    if row_idx >= thumb_start and row_idx < thumb_start + thumb_size do
+      text(" ", bg: @scrollbar_thumb_bg)
+    else
+      text(" ")
+    end
+  end
+
+  defp pad_to_width(content, width) do
+    {fit, _rest} = Raxol.UI.TextMeasure.split_at_display_width(content, width)
+    visible_width = Raxol.UI.TextMeasure.display_width(fit)
+    fit <> String.duplicate(" ", max(width - visible_width, 0))
+  end
+
+  defp sidebar_window(model) do
+    ScrollWindow.window(
+      model.components,
+      model.cursor,
+      sidebar_visible_height(model),
+      model.scroll_top
+    )
+  end
+
+  defp sidebar_chrome_lines(model) do
+    1 + length(active_filters(model)) +
+      if(model.focus == :search, do: 1, else: 0)
+  end
+
+  defp sidebar_visible_height(model) do
+    total_height = model.terminal_height || @default_terminal_height
+
+    max(
+      total_height - @chrome_lines - @box_border_lines -
+        sidebar_chrome_lines(model),
+      1
+    )
   end
 
   defp active_filters(model) do
@@ -473,7 +587,8 @@ defmodule Raxol.Playground.App do
   defp move_cursor(model, delta) do
     max_idx = length(model.components) - 1
     new_cursor = Raxol.Core.Utils.Math.clamp(model.cursor + delta, 0, max_idx)
-    %{model | cursor: new_cursor}
+    model = %{model | cursor: new_cursor}
+    %{model | scroll_top: sidebar_window(model).scroll_top}
   end
 
   defp select_current(model) do
@@ -515,7 +630,10 @@ defmodule Raxol.Playground.App do
       )
       |> sort_by_category()
 
-    %{model | components: components, cursor: 0}
+    # Jump-to-top, not a step: reset scroll_top directly rather than
+    # threading it through ScrollWindow, so the first category's header
+    # is guaranteed visible instead of merely "cursor is visible".
+    %{model | components: components, cursor: 0, scroll_top: 0}
   end
 
   defp forward_to_demo(model, event) do
@@ -539,6 +657,23 @@ defmodule Raxol.Playground.App do
     case :io.columns() do
       {:ok, cols} -> cols
       _ -> @default_terminal_width
+    end
+  end
+
+  defp detect_terminal_height do
+    case :io.rows() do
+      {:ok, rows} -> rows
+      _ -> @default_terminal_height
+    end
+  end
+
+  # Lifecycle passes `%{width:, height:, options:}` as init/1's context;
+  # prefer it over live TTY detection so headless/agent sessions (no TTY)
+  # get their configured size immediately instead of the 80x24 fallback.
+  defp context_dimension(context, key, fallback) do
+    case context do
+      %{^key => value} when is_integer(value) and value > 0 -> value
+      _ -> fallback.()
     end
   end
 

--- a/lib/raxol/ui/components/display/viewport.ex
+++ b/lib/raxol/ui/components/display/viewport.ex
@@ -14,7 +14,12 @@ defmodule Raxol.UI.Components.Display.Viewport do
   @behaviour Raxol.MCP.ToolProvider
   @behaviour Raxol.Core.Accessibility.Provider
 
+  alias Raxol.UI.ScrollWindow
   alias Raxol.View.Components
+
+  # Pale pastel blue, low-intensity so it reads as a subtle wash rather
+  # than a bright highlight against a dark terminal background.
+  @subtle_thumb_bg {110, 140, 180}
 
   @type t :: %{
           id: any(),
@@ -28,6 +33,7 @@ defmodule Raxol.UI.Components.Display.Viewport do
           style: map(),
           theme: map(),
           show_scrollbar: boolean(),
+          scrollbar_style: :glyph | :subtle,
           focused: boolean()
         }
 
@@ -58,6 +64,7 @@ defmodule Raxol.UI.Components.Display.Viewport do
       style: Map.get(props, :style, %{}),
       theme: Map.get(props, :theme, %{}),
       show_scrollbar: Map.get(props, :show_scrollbar, true),
+      scrollbar_style: Map.get(props, :scrollbar_style, :glyph),
       focused: Map.get(props, :focused, false),
       # :auto pins to bottom when at end (follow mode); :none freezes scroll_top.
       overflow_anchor: Map.get(props, :overflow_anchor, :auto)
@@ -133,6 +140,7 @@ defmodule Raxol.UI.Components.Display.Viewport do
       |> maybe_update(:visible_height, props)
       |> maybe_update(:visible_width, props)
       |> maybe_update(:show_scrollbar, props)
+      |> maybe_update(:scrollbar_style, props)
       |> maybe_update(:style, props)
       |> maybe_update(:theme, props)
 
@@ -244,23 +252,42 @@ defmodule Raxol.UI.Components.Display.Viewport do
     total = state.content_height
     visible = state.visible_height
 
-    thumb_size = max(1, div(visible * visible, max(total, 1)))
-    scrollable = max_scroll(total, visible)
-
-    thumb_pos =
-      if scrollable > 0,
-        do: div(state.scroll_top * (visible - thumb_size), scrollable),
-        else: 0
+    {thumb_start, thumb_size} =
+      ScrollWindow.thumb(state.scroll_top, visible, total) || {0, 0}
 
     track =
-      Enum.map(0..(visible - 1), fn i ->
-        char =
-          if i >= thumb_pos and i < thumb_pos + thumb_size, do: "█", else: "░"
-
-        Components.text(content: char, style: %{fg: :white})
-      end)
+      render_scrollbar_track(
+        state.scrollbar_style,
+        visible,
+        thumb_start,
+        thumb_size
+      )
 
     %{type: :column, style: %{}, children: track}
+  end
+
+  # :glyph -- solid/light block characters mark the thumb against the track,
+  # foreground-colored (works without truecolor support).
+  defp render_scrollbar_track(:glyph, visible, thumb_start, thumb_size) do
+    Enum.map(0..(visible - 1), fn i ->
+      char =
+        if i >= thumb_start and i < thumb_start + thumb_size, do: "█", else: "░"
+
+      Components.text(content: char, style: %{fg: :white})
+    end)
+  end
+
+  # :subtle -- no glyphs at all; only the thumb rows get a pale pastel-blue
+  # background wash, the track is otherwise blank. Reads as a hint rather
+  # than a hard UI chrome element.
+  defp render_scrollbar_track(:subtle, visible, thumb_start, thumb_size) do
+    Enum.map(0..(visible - 1), fn i ->
+      if i >= thumb_start and i < thumb_start + thumb_size do
+        Components.text(content: " ", bg: @subtle_thumb_bg)
+      else
+        Components.text(content: " ")
+      end
+    end)
   end
 
   defp scroll(state, delta) do

--- a/lib/raxol/ui/element_renderer.ex
+++ b/lib/raxol/ui/element_renderer.ex
@@ -256,14 +256,32 @@ defmodule Raxol.UI.ElementRenderer do
     fg = resolve_fg(style)
     bg = resolve_bg(style)
     attrs = extract_text_attrs(style) ++ hyperlink_attrs(style)
+    max_width = Map.get(style, :max_paint_width)
+    overflow_mode = Map.get(style, :text_overflow, :ellipsis)
 
-    # split \n; never emit a newline cell (resets cursor to col 0)
+    # Multi-line content: each line restarts at the ELEMENT's x on the
+    # next row. Newlines must never become buffer cells — a literal "\n"
+    # in a cell linefeeds the terminal to column 0, dragging the rest of
+    # the text outside the element's layout box. Each line is bounded
+    # independently, so a multi-line element inside a bordered box gets
+    # an ellipsis on every overflowing line, not just the first.
     text
     |> String.split("\n")
     |> Enum.with_index()
     |> Enum.flat_map(fn {line, row_offset} ->
-      render_text_line(line, x, y + row_offset, fg, bg, attrs)
+      line
+      |> bound_line(max_width, overflow_mode)
+      |> render_text_line(x, y + row_offset, fg, bg, attrs)
     end)
+  end
+
+  # Only truncates when the layout engine stamped `:max_paint_width`
+  # (definite-boundary box); `TextLayout.truncate/3` is a no-op if the
+  # line already fits.
+  defp bound_line(line, nil, _mode), do: line
+
+  defp bound_line(line, max_width, mode) when is_integer(max_width) do
+    Raxol.UI.TextLayout.truncate(line, max_width, mode)
   end
 
   # Width-aware text rendering - CJK/fullwidth chars advance x by 2

--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -221,18 +221,20 @@ defmodule Raxol.UI.Layout.Engine do
     # Create a text element at the given position
     style_map = style_to_map(Map.get(attrs_map, :style, %{}))
 
-    text_element = %{
-      type: :text,
-      x: space.x,
-      y: space.y,
-      text: Map.get(attrs_map, :content, Map.get(attrs_map, :text, "")),
-      fg: Map.get(attrs_map, :fg),
-      bg: Map.get(attrs_map, :bg),
-      style: style_map,
-      link: Map.get(attrs_map, :link),
-      # Pass original attributes through, let Renderer handle styling
-      attrs: Map.put(attrs_map, :original_type, type)
-    }
+    text_element =
+      %{
+        type: :text,
+        x: space.x,
+        y: space.y,
+        text: Map.get(attrs_map, :content, Map.get(attrs_map, :text, "")),
+        fg: Map.get(attrs_map, :fg),
+        bg: Map.get(attrs_map, :bg),
+        style: style_map,
+        link: Map.get(attrs_map, :link),
+        # Pass original attributes through, let Renderer handle styling
+        attrs: Map.put(attrs_map, :original_type, type)
+      }
+      |> stamp_paint_bound(space)
 
     [text_element | acc]
   end
@@ -252,31 +254,33 @@ defmodule Raxol.UI.Layout.Engine do
         _ -> {0, 0}
       end
 
-    text_element = %{
-      type: :text,
-      # Carry the declaration id and explicit geometry at the top level so
-      # accessibility surfaces can map this cell span back to the source node
-      # (Browser data-raxol-id, ARIA). The renderer already honors an explicit
-      # width/height, so setting them here is behavior-preserving.
-      id: Map.get(element, :id),
-      x: space.x + dx,
-      y: space.y + dy,
-      width: Raxol.UI.TextMeasure.display_width(content),
-      # Match measure_element's line count: the renderer paints one row per
-      # `\n`-split line, so layout must reserve the same rows or later
-      # siblings get painted over.
-      height: content |> String.split("\n") |> length(),
-      text: content,
-      fg: Map.get(element, :fg),
-      bg: Map.get(element, :bg),
-      style: style_map,
-      link: Map.get(element, :link),
-      attrs: %{
-        style: style_map,
+    text_element =
+      %{
+        type: :text,
+        # Carry the declaration id and explicit geometry at the top level so
+        # accessibility surfaces can map this cell span back to the source node
+        # (Browser data-raxol-id, ARIA). The renderer already honors an explicit
+        # width/height, so setting them here is behavior-preserving.
         id: Map.get(element, :id),
-        original_type: :text
+        x: space.x + dx,
+        y: space.y + dy,
+        width: Raxol.UI.TextMeasure.display_width(content),
+        # Match measure_element's line count: the renderer paints one row per
+        # `\n`-split line, so layout must reserve the same rows or later
+        # siblings get painted over.
+        height: content |> String.split("\n") |> length(),
+        text: content,
+        fg: Map.get(element, :fg),
+        bg: Map.get(element, :bg),
+        style: style_map,
+        link: Map.get(element, :link),
+        attrs: %{
+          style: style_map,
+          id: Map.get(element, :id),
+          original_type: :text
+        }
       }
-    }
+      |> stamp_paint_bound(space)
 
     [text_element | acc]
   end
@@ -420,6 +424,9 @@ defmodule Raxol.UI.Layout.Engine do
     box_space = %{space | width: width, height: height}
     inner_space = box_inner_space(box_space, border, padding)
 
+    children_space =
+      stamp_text_paint_bound(inner_space, style, border, explicit_w)
+
     box_style = Map.get(box, :style, %{})
     animation_hints = Map.get(box, :animation_hints, [])
 
@@ -440,7 +447,7 @@ defmodule Raxol.UI.Layout.Engine do
 
     children_acc =
       children
-      |> process_children(inner_space, [])
+      |> process_children(children_space, [])
       |> apply_overflow_clip(style, inner_space, space)
 
     [box_element | children_acc] ++ acc
@@ -1178,6 +1185,41 @@ defmodule Raxol.UI.Layout.Engine do
   defp intersect_bounds({ax1, ay1, ax2, ay2}, {bx1, by1, bx2, by2}) do
     {max(ax1, bx1), max(ay1, by1), min(ax2, bx2), min(ay2, by2)}
   end
+
+  # Stamp `:text_paint_bound` for text inside a definite-boundary box
+  # (visible border or explicit/fill width) so `ElementRenderer` can
+  # ellipsize (or clip, via `text_overflow: :clip`) at paint time instead
+  # of painting past the border. Unbounded boxes don't stamp -- text
+  # stays unconstrained (existing behavior). A nested box's own stamp
+  # wins for its own subtree.
+  defp stamp_text_paint_bound(inner_space, style, border, explicit_w) do
+    if definite_box_bound?(border, explicit_w) do
+      Map.put(inner_space, :text_paint_bound, text_overflow_mode(style))
+    else
+      inner_space
+    end
+  end
+
+  defp definite_box_bound?(border, explicit_w) do
+    border not in [:none, false] or explicit_w == :fill or
+      is_integer(explicit_w)
+  end
+
+  defp text_overflow_mode(style) do
+    case Map.get(style, :text_overflow, :ellipsis) do
+      :clip -> :clip
+      _ellipsis_or_other -> :ellipsis
+    end
+  end
+
+  defp stamp_paint_bound(text_element, %{text_paint_bound: mode, width: width})
+       when mode in [:ellipsis, :clip] do
+    text_element
+    |> Map.put(:max_paint_width, max(width, 0))
+    |> Map.put(:text_overflow, mode)
+  end
+
+  defp stamp_paint_bound(text_element, _space), do: text_element
 
   defp enrich_flex_attrs(%{type: :flex} = flex) do
     existing = Map.get(flex, :attrs, %{})

--- a/lib/raxol/ui/scroll_window.ex
+++ b/lib/raxol/ui/scroll_window.ex
@@ -1,0 +1,96 @@
+defmodule Raxol.UI.ScrollWindow do
+  @moduledoc """
+  Pure cursor-follow scroll windowing for vertical selection lists.
+
+  Keeps the cursor inside a fixed-height visible window: when the cursor
+  would step outside the window, `scroll_top` moves by exactly the amount
+  needed to bring it back in, so the item under the cursor lands on the
+  same screen row it approached the edge from (edge-anchored scrolling,
+  not page-jump scrolling). Also derives a proportional scrollbar thumb
+  position/size for the windowed content, `nil` when everything fits.
+
+  Consumers own `scroll_top` as persistent state (e.g. in a TEA model)
+  and thread it back in as `prev_scroll_top` on the next call -- this
+  function never mutates anything, it only computes the next frame.
+  """
+
+  alias Raxol.Core.Utils.Math
+
+  @type thumb :: {start_row :: non_neg_integer(), size :: pos_integer()}
+
+  @type t :: %{
+          visible: list(),
+          scroll_top: non_neg_integer(),
+          cursor_row: non_neg_integer(),
+          overflown?: boolean(),
+          thumb: thumb() | nil
+        }
+
+  @doc """
+  Windows `items` around `cursor`, given a `visible_height` row budget and
+  the previous `scroll_top` (for edge-anchored continuity).
+
+  `cursor` is clamped to `items`' bounds. `scroll_top` is clamped so the
+  window never runs past either end of `items`, regardless of what
+  `prev_scroll_top` was (stale or out-of-range inputs self-heal).
+
+  ## Examples
+
+      iex> w = Raxol.UI.ScrollWindow.window(Enum.to_list(1..20), 0, 10, 0)
+      iex> w.scroll_top
+      0
+      iex> w.cursor_row
+      0
+
+      iex> # cursor steps onto the last visible row -> window scrolls by 1,
+      iex> # cursor stays pinned to the same screen row
+      iex> w = Raxol.UI.ScrollWindow.window(Enum.to_list(1..20), 10, 10, 0)
+      iex> {w.scroll_top, w.cursor_row}
+      {1, 9}
+  """
+  @spec window(list(), integer(), pos_integer(), integer()) :: t()
+  def window(items, cursor, visible_height, prev_scroll_top) do
+    total = length(items)
+    visible_height = max(visible_height, 1)
+    max_index = max(total - 1, 0)
+    cursor = Math.clamp(cursor, 0, max_index)
+    max_scroll = max(total - visible_height, 0)
+
+    scroll_top =
+      cursor
+      |> Math.scroll_into_view(prev_scroll_top, visible_height)
+      |> Math.clamp(0, max_scroll)
+
+    %{
+      visible: Enum.slice(items, scroll_top, visible_height),
+      scroll_top: scroll_top,
+      cursor_row: cursor - scroll_top,
+      overflown?: total > visible_height,
+      thumb: thumb(scroll_top, visible_height, total)
+    }
+  end
+
+  @doc """
+  Proportional scrollbar thumb `{start_row, size}` for `total` rows of
+  content in a `visible_height`-row track scrolled to `scroll_top`.
+  `nil` when content fits without scrolling (nothing to indicate).
+  """
+  @spec thumb(non_neg_integer(), pos_integer(), non_neg_integer()) ::
+          thumb() | nil
+  def thumb(_scroll_top, visible_height, total) when total <= visible_height,
+    do: nil
+
+  def thumb(scroll_top, visible_height, total) do
+    thumb_size = max(1, div(visible_height * visible_height, total))
+    max_scroll = max(total - visible_height, 0)
+
+    thumb_start =
+      if max_scroll > 0 do
+        div(scroll_top * (visible_height - thumb_size), max_scroll)
+      else
+        0
+      end
+
+    {thumb_start, thumb_size}
+  end
+end

--- a/lib/raxol/ui/ui_renderer.ex
+++ b/lib/raxol/ui/ui_renderer.ex
@@ -183,7 +183,9 @@ defmodule Raxol.UI.Renderer do
          parent_style
        ) do
     merged_style =
-      StyleProcessor.flatten_merged_style(parent_style, text_element, theme)
+      parent_style
+      |> StyleProcessor.flatten_merged_style(text_element, theme)
+      |> put_paint_bound(text_element)
 
     cells = ElementRenderer.render_text(x, y, text_content, merged_style, theme)
     CellManager.clip_cells_to_bounds(cells, Map.get(text_element, :clip_bounds))
@@ -331,4 +333,14 @@ defmodule Raxol.UI.Renderer do
 
   defp add_clip_bounds(child, clip_bounds),
     do: Map.put(child, :clip_bounds, clip_bounds)
+
+  # Copy layout's paint bounds onto style so ElementRenderer (style-only) sees them.
+  defp put_paint_bound(style, %{max_paint_width: w} = text_element)
+       when is_integer(w) do
+    style
+    |> Map.put(:max_paint_width, w)
+    |> Map.put(:text_overflow, Map.get(text_element, :text_overflow, :ellipsis))
+  end
+
+  defp put_paint_bound(style, _text_element), do: style
 end

--- a/test/cross_terminal/text_auto_ellipsis_test.exs
+++ b/test/cross_terminal/text_auto_ellipsis_test.exs
@@ -1,0 +1,188 @@
+defmodule Raxol.CrossTerminal.TextAutoEllipsisTest do
+  @moduledoc """
+  Text that would paint past a box's own boundary (a visible border or an
+  explicit/fill width) gets a grapheme-safe ellipsis backstop at paint
+  time instead of bleeding through the border. Mechanism:
+  `Raxol.UI.Layout.Engine` stamps `:text_paint_bound` on the space handed
+  to a definite-boundary box's children, which becomes `:max_paint_width`
+  + `:text_overflow` on positioned `:text` elements; `Raxol.UI.ElementRenderer`
+  truncates each line via `Raxol.UI.TextLayout.truncate/3` before emitting
+  cells.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Renderer.View, as: V
+  alias Raxol.UI.Layout.Engine
+  alias Raxol.UI.TextLayout
+  alias Raxol.UI.TextMeasure
+
+  defp bordered_box(text, opts \\ []) do
+    width = Keyword.get(opts, :width, 20)
+    height = Keyword.get(opts, :height, 3)
+    extra_style = Keyword.get(opts, :style, %{})
+
+    V.box(
+      style:
+        Map.merge(%{border: :single, width: width, height: height}, extra_style),
+      children: [V.text(text)]
+    )
+  end
+
+  defp render(view, dims) do
+    view
+    |> Engine.apply_layout(dims)
+    |> then(&{&1, Raxol.UI.Renderer.render_to_cells(&1, nil)})
+  end
+
+  # Reconstructs the painted line at row `y` across `x_from..x_to` by
+  # sorting cells in x-order; last-write-wins per x reproduces the real
+  # compositing since this bypasses CellManager.merge_cells/2.
+  defp reconstruct(cells, y, x_from, x_to) do
+    cells
+    |> Enum.filter(fn {x, cy, _c, _fg, _bg, _a} ->
+      cy == y and x >= x_from and x <= x_to
+    end)
+    |> Enum.reduce(%{}, fn {x, _y, c, _fg, _bg, _a}, acc ->
+      Map.put(acc, x, c)
+    end)
+    |> Enum.sort_by(fn {x, _c} -> x end)
+    |> Enum.map_join(fn {_x, c} -> c end)
+  end
+
+  describe "bordered fixed-width box: overlong text" do
+    test "renders an ellipsis at the last inner cell and nothing past the border" do
+      text = "The quick brown fox jumps over the lazy dog"
+      {elements, cells} = render(bordered_box(text), %{width: 40, height: 10})
+
+      box = Enum.find(elements, &(&1.type == :box))
+      inner_left = box.x + 1
+      inner_right = box.x + box.width - 2
+      border_right = box.x + box.width - 1
+      text_row = box.y + 1
+
+      ellipsis_cell =
+        Enum.find(cells, fn {x, y, _c, _fg, _bg, _a} ->
+          x == inner_right and y == text_row
+        end)
+
+      assert {^inner_right, ^text_row, "…", _fg, _bg, _attrs} = ellipsis_cell
+
+      # Screenshot-shaped repro proof: nothing text-shaped painted at or
+      # past the border column on the text row.
+      refute Enum.any?(cells, fn {x, y, c, _fg, _bg, _a} ->
+               y == text_row and x >= border_right and c =~ ~r/[A-Za-z]/
+             end)
+
+      expected = TextLayout.truncate(text, box.width - 2, :ellipsis)
+      assert reconstruct(cells, text_row, inner_left, inner_right) == expected
+    end
+  end
+
+  describe "CJK boundary" do
+    test "never splits a double-width grapheme; ellipsis moves one cell earlier" do
+      text = "中文测试ABCDEFGHIJKLMNOP"
+      {elements, cells} =
+        render(bordered_box(text, width: 14), %{width: 40, height: 10})
+
+      box = Enum.find(elements, &(&1.type == :box))
+      inner_left = box.x + 1
+      inner_right = box.x + box.width - 2
+      text_row = box.y + 1
+      inner_width = box.width - 2
+
+      actual = reconstruct(cells, text_row, inner_left, inner_right)
+      expected = TextLayout.truncate(text, inner_width, :ellipsis)
+
+      assert actual == expected
+      assert TextMeasure.display_width(actual) <= inner_width
+      assert String.last(actual) == "…"
+    end
+  end
+
+  describe "text_overflow: :clip opt-out" do
+    test "hard-clips without an ellipsis" do
+      text = "The quick brown fox jumps over the lazy dog"
+
+      {elements, cells} =
+        render(
+          bordered_box(text, style: %{text_overflow: :clip}),
+          %{width: 40, height: 10}
+        )
+
+      box = Enum.find(elements, &(&1.type == :box))
+      inner_left = box.x + 1
+      inner_right = box.x + box.width - 2
+      border_right = box.x + box.width - 1
+      text_row = box.y + 1
+
+      actual = reconstruct(cells, text_row, inner_left, inner_right)
+      expected = TextLayout.truncate(text, box.width - 2, :clip)
+
+      assert actual == expected
+      refute actual =~ "…"
+
+      refute Enum.any?(cells, fn {x, y, c, _fg, _bg, _a} ->
+               y == text_row and x >= border_right and c =~ ~r/[A-Za-z]/
+             end)
+    end
+  end
+
+  describe "non-overflowing text" do
+    test "byte-identical to unbounded rendering -- untouched by the backstop" do
+      text = "short"
+      {elements, cells} = render(bordered_box(text), %{width: 40, height: 10})
+
+      box = Enum.find(elements, &(&1.type == :box))
+      inner_left = box.x + 1
+      inner_right = box.x + box.width - 2
+      text_row = box.y + 1
+
+      actual = reconstruct(cells, text_row, inner_left, inner_right)
+
+      assert actual == text
+      refute actual =~ "…"
+    end
+  end
+
+  describe "multi-line text" do
+    test "each line truncates independently" do
+      text = "short\nThe quick brown fox jumps over the lazy dog\nok"
+
+      {elements, cells} =
+        render(bordered_box(text, height: 5), %{width: 40, height: 10})
+
+      box = Enum.find(elements, &(&1.type == :box))
+      inner_left = box.x + 1
+      inner_right = box.x + box.width - 2
+      inner_width = box.width - 2
+
+      [line1, line2, line3] = String.split(text, "\n")
+      first_row = box.y + 1
+
+      for {expected_source, row_offset} <- [{line1, 0}, {line2, 1}, {line3, 2}] do
+        row = first_row + row_offset
+        expected = TextLayout.truncate(expected_source, inner_width, :ellipsis)
+        assert reconstruct(cells, row, inner_left, inner_right) == expected
+      end
+
+      # The long middle line actually needed truncation; the short lines
+      # didn't -- confirms per-line independence rather than a single
+      # element-wide decision.
+      assert reconstruct(cells, first_row + 1, inner_left, inner_right) =~ "…"
+      refute reconstruct(cells, first_row, inner_left, inner_right) =~ "…"
+      refute reconstruct(cells, first_row + 2, inner_left, inner_right) =~ "…"
+    end
+  end
+
+  describe "boxes without a definite boundary stay unconstrained" do
+    test "no border, no explicit width: overflowing text is left untouched" do
+      text = "The quick brown fox jumps over the lazy dog"
+      view = V.box(style: %{}, children: [V.text(text)])
+      {_elements, cells} = render(view, %{width: 15, height: 10})
+
+      actual = reconstruct(cells, 0, 0, 999)
+      assert actual == text
+      refute actual =~ "…"
+    end
+  end
+end

--- a/test/raxol/playground/sidebar_scroll_test.exs
+++ b/test/raxol/playground/sidebar_scroll_test.exs
@@ -1,0 +1,229 @@
+defmodule Raxol.Playground.SidebarScrollTest do
+  @moduledoc """
+  End-to-end coverage, via `Raxol.Headless`, for cursor-follow sidebar
+  scrolling and the subtle background-only scrollbar; chrome-aware
+  windowing complements `Raxol.UI.ScrollWindowTest`'s pure math coverage.
+  """
+
+  use ExUnit.Case, async: false
+  @moduletag capture_log: true
+
+  alias Raxol.Headless
+  alias Raxol.Playground.App
+  alias Raxol.Playground.Catalog
+
+  @width 80
+  @height 20
+  @sidebar_width 28
+  # Box border occupies column 0; last interior column (where the
+  # scrollbar cell lands) is at this absolute index.
+  @scrollbar_col @sidebar_width - 2
+
+  setup_all do
+    case start_supervised({Headless, []}) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    :ok
+  end
+
+  setup do
+    id = :"sidebar_scroll_#{System.unique_integer([:positive])}"
+    on_exit(fn -> safe_stop(id) end)
+    {:ok, id: id}
+  end
+
+  describe "App.init/1 and App.update/2 (model-level)" do
+    test "picks up context width/height instead of the 80x24 fallback" do
+      model = App.init(%{width: 80, height: @height})
+      assert model.terminal_width == 80
+      assert model.terminal_height == @height
+    end
+
+    test "cursor-follow: scroll_top advances by at most 1 per step as the cursor walks off the bottom edge" do
+      model = App.init(%{width: 80, height: @height})
+      total = length(Catalog.list_components())
+
+      {_final_model, scroll_tops} =
+        Enum.reduce(1..(total - 1), {model, [model.scroll_top]}, fn _,
+                                                                    {m, acc} ->
+          {m2, []} = App.update(key_event("j"), m)
+          {m2, [m2.scroll_top | acc]}
+        end)
+
+      scroll_tops = Enum.reverse(scroll_tops)
+
+      scroll_tops
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.each(fn [a, b] -> assert abs(b - a) <= 1 end)
+    end
+
+    test "cursor never runs past the last component" do
+      model = App.init(%{width: 80, height: @height})
+      total = length(Catalog.list_components())
+
+      final =
+        Enum.reduce(1..(total + 10), model, fn _, m ->
+          {m2, []} = App.update(key_event("j"), m)
+          m2
+        end)
+
+      assert final.cursor == total - 1
+    end
+
+    test "k mirrors j back to scroll_top 0 at the top" do
+      model = App.init(%{width: 80, height: @height})
+
+      scrolled =
+        Enum.reduce(1..15, model, fn _, m ->
+          {m2, []} = App.update(key_event("j"), m)
+          m2
+        end)
+
+      assert scrolled.scroll_top > 0
+
+      back_at_top =
+        Enum.reduce(1..15, scrolled, fn _, m ->
+          {m2, []} = App.update(key_event("k"), m)
+          m2
+        end)
+
+      assert back_at_top.cursor == 0
+      assert back_at_top.scroll_top == 0
+    end
+  end
+
+  describe "headless render: short terminal forces the sidebar to scroll" do
+    test "initial frame shows the first widget with the cursor marker", %{
+      id: id
+    } do
+      assert {:ok, ^id} =
+               Headless.start(App, id: id, width: @width, height: @height)
+
+      Process.sleep(150)
+
+      {:ok, text} = Headless.screenshot(id)
+      sidebar = sidebar_text(text)
+
+      assert sidebar =~ "▸ Button"
+      assert sidebar =~ "30 widgets"
+    end
+
+    test "scrolling past the visible window keeps the marker on screen and scrolls the top items out",
+         %{id: id} do
+      assert {:ok, ^id} =
+               Headless.start(App, id: id, width: @width, height: @height)
+
+      Process.sleep(150)
+
+      # Walk far enough down to guarantee the window has scrolled (visible
+      # height is well under 30 components + 8 category headers at h=20).
+      for _ <- 1..20, do: Headless.send_key(id, "j")
+      Process.sleep(100)
+
+      {:ok, text} = Headless.screenshot(id)
+      sidebar = sidebar_text(text)
+
+      # the cursor marker is still visible somewhere in the (bounded) sidebar
+      assert sidebar =~ "▸"
+      # the first item has scrolled out of the sidebar's own column range
+      # (it may still legitimately appear in the right-hand demo panel,
+      # which tracks `selected`, not `cursor` -- so we only check the
+      # sidebar's own text slice)
+      refute sidebar =~ "Button"
+
+      # the box border stays intact -- windowing never grows the sidebar
+      # past its allotted height
+      assert length(String.split(text, "\n")) <= @height + 1
+    end
+
+    test "the sidebar box never exceeds the terminal height while scrolling", %{
+      id: id
+    } do
+      assert {:ok, ^id} =
+               Headless.start(App, id: id, width: @width, height: @height)
+
+      Process.sleep(150)
+
+      total = length(Catalog.list_components())
+
+      Enum.each(1..(total - 1), fn _ ->
+        Headless.send_key(id, "j")
+        {:ok, text} = Headless.screenshot(id)
+        lines = String.split(text, "\n", trim: false)
+        assert length(lines) <= @height + 1
+      end)
+    end
+
+    test "the scrollbar thumb paints the rightmost sidebar column with the pastel-blue background, proportionally",
+         %{id: id} do
+      assert {:ok, ^id} =
+               Headless.start(App, id: id, width: @width, height: @height)
+
+      Process.sleep(150)
+
+      for _ <- 1..10, do: Headless.send_key(id, "j")
+      Process.sleep(100)
+
+      {:ok, buffer} = Headless.get_buffer(id)
+      backgrounds = thumb_column_backgrounds(buffer, @scrollbar_col)
+
+      thumb_rows = Enum.count(backgrounds, &(&1 == {110, 140, 180}))
+
+      # some rows carry the thumb color, but not the entire column (a
+      # proportional thumb, not a full-height bar)
+      assert thumb_rows > 0
+      assert thumb_rows < length(backgrounds)
+    end
+
+    test "no scrollbar coloring appears when the filtered list fits entirely",
+         %{id: id} do
+      assert {:ok, ^id} =
+               Headless.start(App, id: id, width: @width, height: @height)
+
+      Process.sleep(150)
+
+      # Filter down to a category small enough to fit without scrolling.
+      Headless.send_key(id, "f")
+      Process.sleep(50)
+
+      {:ok, buffer} = Headless.get_buffer(id)
+      backgrounds = thumb_column_backgrounds(buffer, @scrollbar_col)
+
+      refute Enum.any?(backgrounds, &(&1 == {110, 140, 180}))
+    end
+  end
+
+  # --- Helpers ---
+
+  defp key_event(char) do
+    %Raxol.Core.Events.Event{type: :key, data: %{key: :char, char: char}}
+  end
+
+  # Slices every line down to just the sidebar box's own columns so
+  # assertions don't accidentally match text from the demo panel on the
+  # right (which tracks `selected`, independent of sidebar scroll).
+  defp sidebar_text(screenshot) do
+    screenshot
+    |> String.split("\n")
+    |> Enum.map_join("\n", &String.slice(&1, 0, @sidebar_width))
+  end
+
+  defp thumb_column_backgrounds(buffer, col) do
+    buffer.cells
+    |> Enum.map(&Enum.at(&1, col))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(& &1.style.background)
+  end
+
+  defp safe_stop(id) do
+    try do
+      Headless.stop(id)
+    catch
+      :exit, _ -> :ok
+    end
+
+    :ok
+  end
+end

--- a/test/raxol/ui/components/display/viewport_test.exs
+++ b/test/raxol/ui/components/display/viewport_test.exs
@@ -68,7 +68,10 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
     test "renders from scroll offset" do
       children = make_children(20)
-      state = init_viewport(children: children, visible_height: 3, scroll_top: 5)
+
+      state =
+        init_viewport(children: children, visible_height: 3, scroll_top: 5)
+
       rendered = Viewport.render(state, %{})
 
       [content_col | _] = rendered.children
@@ -97,10 +100,75 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
     test "hides scrollbar when show_scrollbar is false" do
       children = make_children(20)
-      state = init_viewport(children: children, visible_height: 5, show_scrollbar: false)
+
+      state =
+        init_viewport(
+          children: children,
+          visible_height: 5,
+          show_scrollbar: false
+        )
+
       rendered = Viewport.render(state, %{})
 
       assert length(rendered.children) == 1
+    end
+
+    test "defaults to the :glyph scrollbar style" do
+      children = make_children(20)
+      state = init_viewport(children: children, visible_height: 5)
+      assert state.scrollbar_style == :glyph
+
+      rendered = Viewport.render(state, %{})
+      [_content, scrollbar] = rendered.children
+      contents = Enum.map(scrollbar.children, & &1.content)
+      assert Enum.all?(contents, &(&1 in ["█", "░"]))
+    end
+
+    test ":subtle scrollbar style paints the thumb as a background wash, no glyphs" do
+      children = make_children(20)
+
+      state =
+        init_viewport(
+          children: children,
+          visible_height: 5,
+          scrollbar_style: :subtle
+        )
+
+      rendered = Viewport.render(state, %{})
+      [_content, scrollbar] = rendered.children
+
+      assert length(scrollbar.children) == 5
+      # every track cell is a blank space -- no block glyphs anywhere
+      assert Enum.all?(scrollbar.children, &(&1.content == " "))
+      # exactly one cell (the thumb) carries the pastel-blue background;
+      # the rest are unstyled track
+      bgs = Enum.map(scrollbar.children, & &1.bg)
+      assert Enum.count(bgs, &(&1 != nil)) == 1
+      assert Enum.find(bgs, &(&1 != nil)) == {110, 140, 180}
+    end
+
+    test ":subtle style renders no scrollbar at all when content fits" do
+      children = make_children(3)
+
+      state =
+        init_viewport(
+          children: children,
+          visible_height: 5,
+          scrollbar_style: :subtle
+        )
+
+      rendered = Viewport.render(state, %{})
+      assert length(rendered.children) == 1
+    end
+
+    test "scrollbar_style is updatable via :update_props" do
+      children = make_children(20)
+      state = init_viewport(children: children, visible_height: 5)
+
+      {new_state, _} =
+        Viewport.update({:update_props, %{scrollbar_style: :subtle}}, state)
+
+      assert new_state.scrollbar_style == :subtle
     end
 
     test "renders empty viewport" do
@@ -124,7 +192,10 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
     test "arrow up scrolls by -1" do
       children = make_children(20)
-      state = init_viewport(children: children, visible_height: 5, scroll_top: 5)
+
+      state =
+        init_viewport(children: children, visible_height: 5, scroll_top: 5)
+
       event = %Event{type: :key, data: %{key: :up}}
 
       {updated, []} = Viewport.handle_event(event, state, %{})
@@ -142,7 +213,10 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
     test "page up scrolls by visible_height" do
       children = make_children(20)
-      state = init_viewport(children: children, visible_height: 5, scroll_top: 10)
+
+      state =
+        init_viewport(children: children, visible_height: 5, scroll_top: 10)
+
       event = %Event{type: :key, data: %{key: :page_up}}
 
       {updated, []} = Viewport.handle_event(event, state, %{})
@@ -151,7 +225,10 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
     test "home scrolls to top" do
       children = make_children(20)
-      state = init_viewport(children: children, visible_height: 5, scroll_top: 10)
+
+      state =
+        init_viewport(children: children, visible_height: 5, scroll_top: 10)
+
       event = %Event{type: :key, data: %{key: :home}}
 
       {updated, []} = Viewport.handle_event(event, state, %{})
@@ -169,7 +246,10 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
     test "does not scroll past bottom" do
       children = make_children(20)
-      state = init_viewport(children: children, visible_height: 5, scroll_top: 15)
+
+      state =
+        init_viewport(children: children, visible_height: 5, scroll_top: 15)
+
       event = %Event{type: :key, data: %{key: :down}}
 
       {updated, []} = Viewport.handle_event(event, state, %{})
@@ -178,7 +258,10 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
     test "does not scroll past top" do
       children = make_children(20)
-      state = init_viewport(children: children, visible_height: 5, scroll_top: 0)
+
+      state =
+        init_viewport(children: children, visible_height: 5, scroll_top: 0)
+
       event = %Event{type: :key, data: %{key: :up}}
 
       {updated, []} = Viewport.handle_event(event, state, %{})
@@ -189,10 +272,22 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
       children = make_children(20)
       state = init_viewport(children: children, visible_height: 5)
 
-      {updated, []} = Viewport.handle_event(%Event{type: :key, data: %{key: "Down"}}, state, %{})
+      {updated, []} =
+        Viewport.handle_event(
+          %Event{type: :key, data: %{key: "Down"}},
+          state,
+          %{}
+        )
+
       assert updated.scroll_top == 1
 
-      {updated, []} = Viewport.handle_event(%Event{type: :key, data: %{key: "PageDown"}}, updated, %{})
+      {updated, []} =
+        Viewport.handle_event(
+          %Event{type: :key, data: %{key: "PageDown"}},
+          updated,
+          %{}
+        )
+
       assert updated.scroll_top == 6
     end
 
@@ -206,7 +301,13 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
 
   describe "update/2" do
     test "set_children updates content and clamps scroll" do
-      state = init_viewport(children: make_children(20), visible_height: 5, scroll_top: 15)
+      state =
+        init_viewport(
+          children: make_children(20),
+          visible_height: 5,
+          scroll_top: 15
+        )
+
       new_children = make_children(8)
       {updated, []} = Viewport.update({:set_children, new_children}, state)
 
@@ -227,19 +328,37 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
     end
 
     test "scroll_by adds delta" do
-      state = init_viewport(children: make_children(20), visible_height: 5, scroll_top: 3)
+      state =
+        init_viewport(
+          children: make_children(20),
+          visible_height: 5,
+          scroll_top: 3
+        )
+
       {updated, []} = Viewport.update({:scroll_by, 4}, state)
       assert updated.scroll_top == 7
     end
 
     test "scroll_by negative" do
-      state = init_viewport(children: make_children(20), visible_height: 5, scroll_top: 10)
+      state =
+        init_viewport(
+          children: make_children(20),
+          visible_height: 5,
+          scroll_top: 10
+        )
+
       {updated, []} = Viewport.update({:scroll_by, -3}, state)
       assert updated.scroll_top == 7
     end
 
     test "set_visible_height adjusts and clamps" do
-      state = init_viewport(children: make_children(20), visible_height: 5, scroll_top: 15)
+      state =
+        init_viewport(
+          children: make_children(20),
+          visible_height: 5,
+          scroll_top: 15
+        )
+
       {updated, []} = Viewport.update({:set_visible_height, 10}, state)
       assert updated.visible_height == 10
       assert updated.scroll_top == 10
@@ -248,7 +367,13 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
     test "update_props merges multiple fields" do
       state = init_viewport(children: make_children(5), visible_height: 5)
       new_children = make_children(30)
-      {updated, []} = Viewport.update({:update_props, %{children: new_children, visible_height: 8}}, state)
+
+      {updated, []} =
+        Viewport.update(
+          {:update_props, %{children: new_children, visible_height: 8}},
+          state
+        )
+
       assert updated.content_height == 30
       assert updated.visible_height == 8
     end
@@ -263,13 +388,19 @@ defmodule Raxol.UI.Components.Display.ViewportTest do
   describe "focus events" do
     test "focus event sets focused" do
       state = init_viewport()
-      {updated, []} = Viewport.handle_event(%Event{type: :focus, data: %{}}, state, %{})
+
+      {updated, []} =
+        Viewport.handle_event(%Event{type: :focus, data: %{}}, state, %{})
+
       assert updated.focused == true
     end
 
     test "blur event clears focused" do
       state = %{init_viewport() | focused: true}
-      {updated, []} = Viewport.handle_event(%Event{type: :blur, data: %{}}, state, %{})
+
+      {updated, []} =
+        Viewport.handle_event(%Event{type: :blur, data: %{}}, state, %{})
+
       assert updated.focused == false
     end
   end

--- a/test/raxol/ui/scroll_window_test.exs
+++ b/test/raxol/ui/scroll_window_test.exs
@@ -1,0 +1,186 @@
+defmodule Raxol.UI.ScrollWindowTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.ScrollWindow
+
+  describe "window/4" do
+    test "fits entirely: no scroll, not overflown, no thumb" do
+      items = Enum.to_list(1..5)
+      w = ScrollWindow.window(items, 2, 10, 0)
+
+      assert w.visible == items
+      assert w.scroll_top == 0
+      assert w.cursor_row == 2
+      refute w.overflown?
+      assert w.thumb == nil
+    end
+
+    test "cursor at top of an overflowing list: no scroll needed" do
+      items = Enum.to_list(1..20)
+      w = ScrollWindow.window(items, 0, 10, 0)
+
+      assert w.visible == Enum.to_list(1..10)
+      assert w.scroll_top == 0
+      assert w.cursor_row == 0
+      assert w.overflown?
+      assert w.thumb != nil
+    end
+
+    test "cursor within the current window: scroll position unchanged" do
+      items = Enum.to_list(1..20)
+      w = ScrollWindow.window(items, 8, 10, 5)
+
+      assert w.scroll_top == 5
+      assert w.cursor_row == 3
+      assert w.visible == Enum.to_list(6..15)
+    end
+
+    test "cursor steps onto the last visible row: scroll advances by exactly 1, cursor stays on the same screen row" do
+      items = Enum.to_list(1..20)
+      # cursor 9 is the last visible row when scroll_top is 0 (rows 0..9)
+      before = ScrollWindow.window(items, 9, 10, 0)
+      assert before.scroll_top == 0
+      assert before.cursor_row == 9
+
+      after_ = ScrollWindow.window(items, 10, 10, before.scroll_top)
+      assert after_.scroll_top == 1
+      assert after_.cursor_row == 9
+      assert after_.visible == Enum.to_list(2..11)
+    end
+
+    test "cursor steps onto the first visible row scrolling up: mirrors the down case" do
+      items = Enum.to_list(1..20)
+      before = ScrollWindow.window(items, 10, 10, 1)
+      assert before.scroll_top == 1
+      assert before.cursor_row == 9
+
+      after_ = ScrollWindow.window(items, 9, 10, before.scroll_top)
+      assert after_.scroll_top == 1
+      assert after_.cursor_row == 8
+
+      up_again = ScrollWindow.window(items, 0, 10, 1)
+      assert up_again.scroll_top == 0
+      assert up_again.cursor_row == 0
+    end
+
+    test "cursor jump far outside the window (e.g. Home/End) resets scroll rather than crawling" do
+      items = Enum.to_list(1..100)
+      w = ScrollWindow.window(items, 0, 10, 80)
+      assert w.scroll_top == 0
+      assert w.cursor_row == 0
+
+      w2 = ScrollWindow.window(items, 99, 10, 0)
+      assert w2.scroll_top == 90
+      assert w2.cursor_row == 9
+    end
+
+    test "cursor is clamped to item bounds" do
+      items = Enum.to_list(1..5)
+      w = ScrollWindow.window(items, 999, 10, 0)
+      assert w.cursor_row == 4
+
+      w2 = ScrollWindow.window(items, -5, 10, 0)
+      assert w2.cursor_row == 0
+    end
+
+    test "stale/out-of-range prev_scroll_top self-heals" do
+      items = Enum.to_list(1..20)
+      w = ScrollWindow.window(items, 0, 10, -50)
+      assert w.scroll_top == 0
+
+      w2 = ScrollWindow.window(items, 0, 10, 999)
+      assert w2.scroll_top == 0
+    end
+
+    test "empty items list never crashes" do
+      w = ScrollWindow.window([], 0, 10, 0)
+      assert w.visible == []
+      assert w.cursor_row == 0
+      refute w.overflown?
+      assert w.thumb == nil
+    end
+
+    test "visible_height of 0 or negative is treated as 1" do
+      items = Enum.to_list(1..5)
+      w = ScrollWindow.window(items, 0, 0, 0)
+      assert length(w.visible) == 1
+    end
+  end
+
+  describe "thumb/3" do
+    test "nil when content fits" do
+      assert ScrollWindow.thumb(0, 10, 10) == nil
+      assert ScrollWindow.thumb(0, 10, 5) == nil
+    end
+
+    test "thumb spans the track proportionally to scroll position" do
+      # 20 rows of content in a 5-row track: thumb_size = max(1, div(25,20)) = 1
+      assert ScrollWindow.thumb(0, 5, 20) == {0, 1}
+      # at max scroll (15), thumb sits at the last row of the track
+      assert ScrollWindow.thumb(15, 5, 20) == {4, 1}
+    end
+
+    test "thumb size grows with the visible fraction of content" do
+      # 10 rows of content in an 8-row track: thumb_size = max(1, div(64,10)) = 6
+      {_start, size} = ScrollWindow.thumb(0, 8, 10)
+      assert size == 6
+    end
+  end
+
+  describe "property: cursor-follow invariants" do
+    property "cursor_row always lands within the visible window" do
+      check all(
+              total <- integer(0..60),
+              visible_height <- integer(1..20),
+              cursor <- integer(-10..70),
+              prev_scroll_top <- integer(-10..70),
+              max_runs: 300
+            ) do
+        items = Enum.to_list(1..total//1)
+        w = ScrollWindow.window(items, cursor, visible_height, prev_scroll_top)
+
+        assert w.cursor_row >= 0
+        assert w.cursor_row < visible_height
+        assert length(w.visible) <= visible_height
+        assert w.scroll_top >= 0
+        assert w.scroll_top <= max(total - visible_height, 0)
+      end
+    end
+
+    property "thumb is nil exactly when the list fits, and set exactly when overflown" do
+      check all(
+              total <- integer(0..60),
+              visible_height <- integer(1..20),
+              cursor <- integer(0..60),
+              prev_scroll_top <- integer(0..60),
+              max_runs: 300
+            ) do
+        items = Enum.to_list(1..total//1)
+        w = ScrollWindow.window(items, cursor, visible_height, prev_scroll_top)
+
+        assert w.overflown? == total > visible_height
+        assert w.thumb == nil == not w.overflown?
+      end
+    end
+
+    property "scroll_top moves by at most 1 when the cursor advances one step at a time from 0" do
+      check all(
+              total <- integer(1..40),
+              visible_height <- integer(1..15),
+              max_runs: 200
+            ) do
+        items = Enum.to_list(1..total//1)
+        max_index = total - 1
+
+        Enum.reduce(0..max_index, 0, fn cursor, prev_scroll_top ->
+          w =
+            ScrollWindow.window(items, cursor, visible_height, prev_scroll_top)
+
+          assert abs(w.scroll_top - prev_scroll_top) <= 1
+          w.scroll_top
+        end)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two related overflow behaviours:

- **Text auto-ellipsis**: text inside a definite-boundary box (visible border or explicit/fill width) is stamped a paint bound so `ElementRenderer` ellipsizes (or clips, via `text_overflow: :clip`) at paint time instead of painting past the border. Unbounded boxes leave text unconstrained.
- **Cursor-follow list scrolling**: adds `Raxol.UI.ScrollWindow` — a cursor-following window over a list with a subtle scrollbar — and wires `Viewport` and the playground sidebar to it so the selection stays visible.

Independent of the modal PRs.