### PR TITLE
Playground: span the terminal height instead of hugging content

### DIFF
--- a/lib/raxol/playground/app.ex
+++ b/lib/raxol/playground/app.ex
@@ -242,7 +242,10 @@ defmodule Raxol.Playground.App do
     column style: %{gap: 0} do
       [
         header_bar(),
-        row style: %{gap: 0} do
+        # flex: 1 -- the middle row claims the column's remaining main-axis
+        # (vertical) space between the header and status bars, so the panels
+        # span the terminal height instead of being sized to their content.
+        row style: %{gap: 0, flex: 1} do
           [
             sidebar_panel(model),
             demo_panel(model)
@@ -284,7 +287,12 @@ defmodule Raxol.Playground.App do
 
     filter_lines = active_filters(model)
 
-    box style: %{border: :rounded, fg: border_fg, width: @sidebar_width} do
+    box style: %{
+          border: :rounded,
+          fg: border_fg,
+          width: @sidebar_width,
+          height: :fill
+        } do
       column style: %{gap: 0} do
         count_line ++ filter_lines ++ search_line ++ sidebar_item_lines(model)
       end


### PR DESCRIPTION
The playground UI stopped at row 43 regardless of terminal height, leaving the rest of the screen unpainted.

**Cause:** `main_view` is `column[header_bar, row[sidebar, demo], status_bar]` with no vertical sizing — the middle row had no flex, and the sidebar box set `width:` but no `height:`. Layout fell back to content sizing: 30 widgets + 8 category headers + 1 count line + 2 borders + the two bars = **43 rows**, fixed. `sidebar_visible_height/1` already computed the correct height from `model.terminal_height`, but only fed scroll decisions — it never reached the box.

**Fix:**
- middle row gets `flex: 1` — claims the column's remaining main-axis space between the bars
- sidebar box gets `height: :fill` — spans that row

Verified on a 293x89 terminal: previously 43 rows, now fills the full height and tracks resize.

Diagnosed by rendering the app at two pty heights (89 and 60): content was 43 rows in **both**, i.e. height-independent — content-sized, not clipped. The layout engine, terminal driver, and frame emission (`\e[?7l` / CRLF row joins) were all verified correct and are untouched.