### PR TITLE
Fix flaky resize-log assertion: scope it to the app under test

### DIFF
--- a/test/raxol/core/runtime/events/dispatcher_resize_test.exs
+++ b/test/raxol/core/runtime/events/dispatcher_resize_test.exs
@@ -101,7 +101,12 @@ defmodule Raxol.Core.Runtime.Events.DispatcherResizeTest do
         assert_receive :render_needed
       end)
 
-    assert log == ""
+    # `capture_log/1` captures the whole Logger output for the duration of the
+    # block, including lines emitted by unrelated async tests running
+    # concurrently (e.g. the ANSI parser property tests fuzzing with random
+    # bytes). Assert on the absence of *this* app's update error rather than on
+    # a globally empty log, which is not ours to guarantee.
+    refute log =~ "NoResizeClauseApp"
   end
 
   test "resize with nil rendering engine does not crash" do


### PR DESCRIPTION
`Test macos-latest` fails intermittently on unrelated PRs with:

```
test/raxol/core/runtime/events/dispatcher_resize_test.exs:87
Assertion with == failed
code:  assert log == ""
left:  "[warning] ANSI Parse Error: %FunctionClauseError{module: Raxol.Terminal.ANSI.StateMachine ...}"
right: ""
```

**Cause:** `capture_log/1` captures the entire Logger output for the duration of its block — not just lines produced by the code inside it. Any async test running concurrently contributes its own lines. `assert log == ""` therefore asserted something this test cannot guarantee, and broke whenever an unrelated test happened to log inside the window. In practice that's the ANSI parser property tests, which fuzz the state machine with random bytes and warn on unparsable input; whether they overlap is pure timing, hence the flake.

**Fix:** the test's real invariant is that the dispatcher stays *silent about an app whose `update/2` has no resize clause*. Assert exactly that — the app module never appears in an update-error line. `Application.log_update_error/4` logs ``"Error executing #{inspect(app_module)}.update/2"``, so a genuine regression still fails the test, while unrelated concurrent log lines can no longer break it.

No production code touched. Test passes (5/5) and no longer depends on what other tests log.

_Side note, not fixed here:_ the bled-in warnings show `Raxol.Terminal.ANSI.StateMachine.handle_byte/2` raising `FunctionClauseError` on random DCS (`\eP…`) input. CSI parsing was made total in #443; DCS apparently was not. Worth hardening separately.