### PR TITLE
liveview: emit overflow-anchor CSS for scroll-anchored elements

### DIFF
--- a/packages/raxol_liveview/lib/raxol/live_view/terminal_bridge.ex
+++ b/packages/raxol_liveview/lib/raxol/live_view/terminal_bridge.ex
@@ -199,7 +199,15 @@ defmodule Raxol.LiveView.TerminalBridge do
   a `<style>` block with CSS `transition` rules targeting `[data-raxol-id]`
   selectors, plus a `prefers-reduced-motion` media query.
 
-  Returns an empty string if no elements carry animation hints.
+  Also emits `overflow-anchor` rules for elements carrying an
+  `:overflow_anchor` field (`:auto` or `:none`) -- the browser-native
+  counterpart to the terminal `Viewport` component's `overflow_anchor`
+  scroll-pinning behavior. `:auto` lets the browser hold scroll position as
+  content grows above the fold (mirrors the terminal's follow-mode / hold
+  semantics); `:none` opts an element out entirely.
+
+  Returns an empty string if no elements carry animation hints or an
+  overflow-anchor setting.
 
   ## Examples
 
@@ -211,12 +219,17 @@ defmodule Raxol.LiveView.TerminalBridge do
       css = animation_css(elements)
       # => "<style>[data-raxol-id=\\"panel\\"] { transition: opacity 300ms cubic-bezier(...) 0ms; }\\n..."
 
+      elements = [%{id: "log", type: :box, overflow_anchor: :auto}]
+      css = animation_css(elements)
+      # => "<style>[data-raxol-id=\\"log\\"] { overflow-anchor: auto; }\\n...</style>"
+
   """
   @compile {:no_warn_undefined, Raxol.Effects.BorderBeam.CSS}
 
   @spec animation_css([map()]) :: String.t()
   def animation_css(elements) when is_list(elements) do
     hinted = collect_hinted_elements(elements, [])
+    anchored = collect_overflow_anchor_elements(elements, [])
 
     transition_rules =
       Enum.flat_map(hinted, fn {id, hints} ->
@@ -241,7 +254,12 @@ defmodule Raxol.LiveView.TerminalBridge do
         |> Enum.map(fn hint -> generate_beam_css(hint, id) end)
       end)
 
-    all_rules = transition_rules ++ beam_rules
+    anchor_rules =
+      Enum.map(anchored, fn {id, anchor} ->
+        ~s([data-raxol-id="#{id}"] { overflow-anchor: #{overflow_anchor_value(anchor)}; })
+      end)
+
+    all_rules = transition_rules ++ beam_rules ++ anchor_rules
 
     case all_rules do
       [] ->
@@ -303,6 +321,36 @@ defmodule Raxol.LiveView.TerminalBridge do
 
   defp border_beam_hint?(%{type: :border_beam}), do: true
   defp border_beam_hint?(_), do: false
+
+  # Mirrors collect_hinted_elements/2: walks the positioned element tree and
+  # pulls out {id, anchor} pairs for elements carrying a recognized
+  # `:overflow_anchor` setting.
+  defp collect_overflow_anchor_elements([], acc), do: acc
+
+  defp collect_overflow_anchor_elements([element | rest], acc) do
+    acc =
+      case element do
+        %{id: id, overflow_anchor: anchor} when is_binary(id) and anchor in [:auto, :none] ->
+          [{id, anchor} | acc]
+
+        _ ->
+          acc
+      end
+
+    children = Map.get(element, :children, [])
+
+    acc =
+      if is_list(children) do
+        collect_overflow_anchor_elements(children, acc)
+      else
+        acc
+      end
+
+    collect_overflow_anchor_elements(rest, acc)
+  end
+
+  defp overflow_anchor_value(:auto), do: "auto"
+  defp overflow_anchor_value(:none), do: "none"
 
   @beam_css_colors %{
     colorful: {"#ff0040, #ffaa00, #00ff88, #00ccff, #4400ff, #ff00cc", "#4400ff", "#ff00cc"},

--- a/packages/raxol_liveview/test/raxol/live_view/animation_css_test.exs
+++ b/packages/raxol_liveview/test/raxol/live_view/animation_css_test.exs
@@ -292,4 +292,87 @@ defmodule Raxol.LiveView.AnimationCSSTest do
       assert css =~ "conic-gradient"
     end
   end
+
+  describe "animation_css/1 overflow-anchor" do
+    test "emits overflow-anchor: auto for :auto setting" do
+      elements = [%{id: "log", type: :box, overflow_anchor: :auto}]
+
+      css = TerminalBridge.animation_css(elements)
+
+      assert css =~ ~s([data-raxol-id="log"] { overflow-anchor: auto; })
+    end
+
+    test "emits overflow-anchor: none for :none setting" do
+      elements = [%{id: "log", type: :box, overflow_anchor: :none}]
+
+      css = TerminalBridge.animation_css(elements)
+
+      assert css =~ ~s([data-raxol-id="log"] { overflow-anchor: none; })
+    end
+
+    test "emits rules for multiple elements with different anchor settings" do
+      elements = [
+        %{id: "chat", type: :box, overflow_anchor: :auto},
+        %{id: "frozen", type: :box, overflow_anchor: :none}
+      ]
+
+      css = TerminalBridge.animation_css(elements)
+
+      assert css =~ ~s([data-raxol-id="chat"] { overflow-anchor: auto; })
+      assert css =~ ~s([data-raxol-id="frozen"] { overflow-anchor: none; })
+    end
+
+    test "collects overflow-anchor settings from nested children" do
+      elements = [
+        %{
+          type: :box,
+          children: [
+            %{id: "nested-log", type: :box, overflow_anchor: :auto}
+          ]
+        }
+      ]
+
+      css = TerminalBridge.animation_css(elements)
+
+      assert css =~ ~s([data-raxol-id="nested-log"] { overflow-anchor: auto; })
+    end
+
+    test "skips elements without an id" do
+      elements = [%{type: :box, overflow_anchor: :auto}]
+
+      assert TerminalBridge.animation_css(elements) == ""
+    end
+
+    test "skips elements with an unrecognized overflow_anchor value" do
+      elements = [%{id: "weird", type: :box, overflow_anchor: :sometimes}]
+
+      assert TerminalBridge.animation_css(elements) == ""
+    end
+
+    test "emits no CSS for elements without an overflow_anchor setting" do
+      elements = [%{id: "plain", type: :box, children: []}]
+
+      assert TerminalBridge.animation_css(elements) == ""
+    end
+
+    test "coexists with animation transitions in the same style block" do
+      elements = [
+        %{
+          id: "panel",
+          type: :box,
+          animation_hints: [
+            %{property: :opacity, duration_ms: 300, easing: :linear, delay_ms: 0}
+          ]
+        },
+        %{id: "log", type: :box, overflow_anchor: :auto}
+      ]
+
+      css = TerminalBridge.animation_css(elements)
+
+      assert css =~ "opacity 300ms"
+      assert css =~ ~s([data-raxol-id="log"] { overflow-anchor: auto; })
+      assert String.starts_with?(css, "<style>")
+      assert String.ends_with?(css, "</style>")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The terminal half of scroll anchoring already shipped: `Viewport` supports `overflow_anchor: :auto | :none` (`lib/raxol/ui/components/display/viewport.ex`) — `:auto` pins to bottom while content grows (follow mode) or holds position when scrolled up; `:none` freezes `scroll_top` entirely.

This adds the browser-native counterpart. `Raxol.LiveView.TerminalBridge.animation_css/1` (which already emits `transition` and border-beam rules keyed by `[data-raxol-id]`) now also emits:

```css
[data-raxol-id="log"] { overflow-anchor: auto; }
[data-raxol-id="frozen"] { overflow-anchor: none; }
```

for any positioned element carrying an `:overflow_anchor` key (`:auto` or `:none`). This reuses the existing per-frame `<style>` broadcast (`render_to_liveview` → `{:render_update, html, animation_css}` → `TEALive`) rather than adding a new channel, so no other call sites need to change.

## Note on reachability

`animation_css/1` and its tests operate on the *positioned element* shape (`%{id:, ...}`) that `LayoutEngine.apply_layout/3` produces. Today, `Viewport.render/2` emits `type: :row`, and `:row`/`:column` containers are flattened by `containers_compat_to_flex/2` before layout — no positioned element (with `id` or otherwise) is ever emitted for the container itself. Separately, the generic `:box` clause in `lib/raxol/ui/layout/engine.ex` doesn't currently forward `:id` either. So wiring Viewport's live `overflow_anchor` state through to a real `data-raxol-id` element is a separate, cross-cutting LayoutEngine change (affecting all row/column-type components, not just Viewport) — out of scope here. This PR ships the CSS-emission half per the existing `animation_css` pattern/tests; once an element carries `%{id: ..., overflow_anchor: ...}` (the same way `animation_hints` already does for `:box`), the CSS half works with no further LiveView-side changes.

## Test plan

- [x] `MIX_ENV=test mix compile --warnings-as-errors` (root)
- [x] `mix format --check-formatted` (root; the two changed files are also individually format-clean)
- [x] `cd packages/raxol_liveview && MIX_ENV=test mix test` — 80 passed
- [x] `MIX_ENV=test mix test test/raxol/animation/ test/cross_terminal/` (root) — 203 passed