### PR TITLE
Fix OSC 9 clipboard mis-route; add OSC 9;4 progress and OSC 22 pointer shape

### DIFF
--- a/lib/raxol/playground/catalog.ex
+++ b/lib/raxol/playground/catalog.ex
@@ -326,6 +326,16 @@ defmodule Raxol.Playground.Catalog do
       tags: ["effects", "focus", "ring", "accessibility"],
       code_snippet: ~s'FocusRing.render(content, FocusRing.init(style: :solid))'
     },
+    %{
+      name: "OSC Ambient",
+      module: Demos.OscAmbientDemo,
+      category: :effects,
+      description:
+        "Host-terminal desktop notification, taskbar progress, and pointer shape",
+      complexity: :intermediate,
+      tags: ["effects", "osc", "notification", "progress", "pointer"],
+      code_snippet: ~s'IO.write(AdvancedFeatures.report_progress(:set, 42))'
+    },
     # --- REPL & VFS ---
     %{
       name: "Virtual FS",

--- a/lib/raxol/playground/demos/osc_ambient_demo.ex
+++ b/lib/raxol/playground/demos/osc_ambient_demo.ex
@@ -1,0 +1,189 @@
+defmodule Raxol.Playground.Demos.OscAmbientDemo do
+  @moduledoc """
+  Playground demo: OSC 9 desktop notification, OSC 9;4 taskbar/dock
+  progress, and OSC 22 pointer shape.
+
+  These are host-terminal features, not something Raxol renders itself.
+  Ghostty, iTerm2, WezTerm, and Windows Terminal draw the dock/taskbar
+  progress bar from OSC 9;4; most other terminals (including many Linux
+  emulators) silently ignore all three sequences. This demo always emits
+  them and trusts the terminal to honor or drop them -- there is no
+  capability detection here.
+  """
+  use Raxol.Core.Runtime.Application
+
+  alias Raxol.Playground.DemoHelpers
+  alias Raxol.Terminal.AdvancedFeatures
+
+  @tick_ms 200
+  @step 4
+  @max_progress 100
+  @bar_width 30
+  @pointer_shapes ["default", "text", "pointer", "wait", "crosshair"]
+
+  @impl true
+  def init(_context) do
+    %{status: :idle, progress: 0, pointer_idx: 0}
+  end
+
+  @impl true
+  def update(message, model) do
+    case message do
+      key_match(" ") ->
+        toggle_running(model)
+
+      key_match("r") ->
+        {reset(model), [clear_progress_command()]}
+
+      key_match("e") ->
+        set_status(model, :error)
+
+      key_match("w") ->
+        set_status(model, :warning)
+
+      key_match("c") ->
+        cycle_pointer(model)
+
+      :tick when model.status == :running ->
+        advance(model)
+
+      _ ->
+        {model, []}
+    end
+  end
+
+  @impl true
+  def view(model) do
+    filled = round(model.progress / @max_progress * @bar_width)
+    empty = @bar_width - filled
+    bar = String.duplicate("#", filled) <> String.duplicate(".", empty)
+    shape = Enum.at(@pointer_shapes, model.pointer_idx)
+
+    column style: %{gap: 1} do
+      [
+        text("OSC Ambient Demo", style: [:bold]),
+        text("Desktop notification + taskbar progress + pointer shape",
+          style: [:dim]
+        ),
+        divider(),
+        progress(value: model.progress, max: @max_progress),
+        text("[#{bar}] #{model.progress}%"),
+        text("Task: #{status_label(model.status)}",
+          fg: status_color(model.status)
+        ),
+        text("Pointer shape: #{shape}"),
+        divider(),
+        box style: %{border: :single, padding: 1, width: 56} do
+          column style: %{gap: 0} do
+            [
+              text("Host-terminal features -- may do nothing here.",
+                style: [:bold]
+              ),
+              text("OSC 9;4 taskbar progress: Ghostty, iTerm2, WezTerm,"),
+              text("Windows Terminal. Most other terminals ignore it."),
+              text("No capability detection is performed.")
+            ]
+          end
+        end,
+        text(
+          "[space] start/pause  [e] error  [w] warning  [c] pointer  [r] reset",
+          style: [:dim]
+        )
+      ]
+    end
+  end
+
+  @impl true
+  def subscribe(model) do
+    if model.status == :running do
+      [subscribe_interval(@tick_ms, :tick)]
+    else
+      []
+    end
+  end
+
+  defp toggle_running(%{status: :done} = model), do: {model, []}
+
+  defp toggle_running(%{status: :running} = model) do
+    {%{model | status: :paused}, []}
+  end
+
+  defp toggle_running(model) do
+    new_model = %{model | status: :running}
+    {new_model, [progress_command(new_model)]}
+  end
+
+  defp set_status(%{status: :done} = model, _status), do: {model, []}
+
+  defp set_status(model, status) do
+    new_model = %{model | status: status}
+    {new_model, [progress_command(new_model)]}
+  end
+
+  defp cycle_pointer(model) do
+    new_idx = DemoHelpers.cycle_next(model.pointer_idx, length(@pointer_shapes))
+    shape = Enum.at(@pointer_shapes, new_idx)
+    {%{model | pointer_idx: new_idx}, [pointer_command(shape)]}
+  end
+
+  defp reset(model), do: %{model | status: :idle, progress: 0}
+
+  defp advance(model) do
+    new_progress = min(model.progress + @step, @max_progress)
+
+    if new_progress >= @max_progress do
+      new_model = %{model | progress: @max_progress, status: :done}
+      {new_model, [progress_command(new_model), notify_command()]}
+    else
+      new_model = %{model | progress: new_progress}
+      {new_model, [progress_command(new_model)]}
+    end
+  end
+
+  defp progress_command(model) do
+    state = progress_state(model.status)
+
+    Directive.spawn_task(fn ->
+      IO.write(AdvancedFeatures.report_progress(state, model.progress))
+      :ok
+    end)
+  end
+
+  defp clear_progress_command do
+    Directive.spawn_task(fn ->
+      IO.write(AdvancedFeatures.clear_progress())
+      :ok
+    end)
+  end
+
+  defp notify_command do
+    Directive.spawn_task(fn ->
+      IO.write(AdvancedFeatures.notify("Playground task complete"))
+      :ok
+    end)
+  end
+
+  defp pointer_command(shape) do
+    Directive.spawn_task(fn ->
+      IO.write(AdvancedFeatures.set_pointer_shape(shape))
+      :ok
+    end)
+  end
+
+  defp progress_state(:error), do: :error
+  defp progress_state(:warning), do: :warning
+  defp progress_state(_), do: :set
+
+  defp status_label(:idle), do: "idle"
+  defp status_label(:running), do: "running"
+  defp status_label(:paused), do: "paused"
+  defp status_label(:error), do: "error"
+  defp status_label(:warning), do: "warning"
+  defp status_label(:done), do: "done"
+
+  defp status_color(:error), do: :red
+  defp status_color(:warning), do: :yellow
+  defp status_color(:done), do: :green
+  defp status_color(:running), do: :cyan
+  defp status_color(_), do: :white
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/advanced_features.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/advanced_features.ex
@@ -4,6 +4,8 @@ defmodule Raxol.Terminal.AdvancedFeatures do
 
   This module provides support for:
   - OSC 8 Hyperlinks - Clickable links in terminal output
+  - OSC 9 / 9;4 Ambient signals - Desktop notifications and taskbar/dock progress
+  - OSC 22 Pointer shape - Mouse cursor shape hints
   - Synchronized Output (DEC 2026) - Flicker-free rendering
   - Focus Events - Terminal focus/blur detection
   - Enhanced Bracketed Paste - Improved paste handling
@@ -12,7 +14,6 @@ defmodule Raxol.Terminal.AdvancedFeatures do
   These features enable rich, interactive terminal applications with modern UX patterns.
   """
 
-
   @type hyperlink_id :: String.t()
   @type url :: String.t()
   @type hyperlink_params :: %{
@@ -20,6 +21,7 @@ defmodule Raxol.Terminal.AdvancedFeatures do
           optional(:tooltip) => String.t(),
           optional(:params) => map()
         }
+  @type progress_state :: :remove | :set | :error | :indeterminate | :warning
 
   # OSC 8 Hyperlink Implementation
 
@@ -107,6 +109,71 @@ defmodule Raxol.Terminal.AdvancedFeatures do
         # Try to detect by querying terminal capabilities
         query_hyperlink_support()
     end
+  end
+
+  # OSC 9 / 9;4 Ambient Signal Implementation
+
+  @doc """
+  Sends a desktop notification using OSC 9.
+
+  ## Examples
+
+      iex> AdvancedFeatures.notify("Build finished")
+      "\\e]9;Build finished\\e\\\\"
+  """
+  @spec notify(String.t()) :: String.t()
+  def notify(message) do
+    "\e]9;#{message}\e\\"
+  end
+
+  @doc """
+  Reports progress on the host terminal's dock/taskbar icon using OSC 9;4.
+
+  `state` is one of `:remove`, `:set`, `:error`, `:indeterminate`, or `:warning`.
+  `value` is the progress percentage (0-100), ignored by most terminals for
+  `:remove` and `:indeterminate`.
+
+  ## Examples
+
+      iex> AdvancedFeatures.report_progress(:set, 42)
+      "\\e]9;4;1;42\\e\\\\"
+
+      iex> AdvancedFeatures.report_progress(:remove)
+      "\\e]9;4;0;0\\e\\\\"
+  """
+  @spec report_progress(progress_state(), 0..100) :: String.t()
+  def report_progress(state, value \\ 0) do
+    "\e]9;4;#{progress_state_code(state)};#{value}\e\\"
+  end
+
+  @doc """
+  Clears any taskbar/dock progress previously set via `report_progress/2`.
+  """
+  @spec clear_progress() :: String.t()
+  def clear_progress, do: report_progress(:remove, 0)
+
+  defp progress_state_code(:remove), do: 0
+  defp progress_state_code(:set), do: 1
+  defp progress_state_code(:error), do: 2
+  defp progress_state_code(:indeterminate), do: 3
+  defp progress_state_code(:warning), do: 4
+
+  # OSC 22 Pointer Shape Implementation
+
+  @doc """
+  Sets the mouse pointer shape using OSC 22.
+
+  `shape` is a CSS-style cursor keyword, e.g. `"default"`, `"text"`,
+  `"pointer"`, `"wait"`, `"crosshair"`.
+
+  ## Examples
+
+      iex> AdvancedFeatures.set_pointer_shape("pointer")
+      "\\e]22;pointer\\e\\\\"
+  """
+  @spec set_pointer_shape(String.t()) :: String.t()
+  def set_pointer_shape(shape) do
+    "\e]22;#{shape}\e\\"
   end
 
   # Synchronized Output (DEC 2026) Implementation

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/osc_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/osc_handler.ex
@@ -19,6 +19,9 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
       {:clipboard, cmd} ->
         handle_clipboard_ops(emulator, cmd, data)
 
+      {:notification, cmd} ->
+        handle_notification_ops(emulator, cmd, data)
+
       {:color, cmd} ->
         handle_color_ops(emulator, cmd, data)
 
@@ -37,9 +40,12 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
   defp get_command_group(command) do
     command_groups = [
       {[0, 1, 2, 7, 8, 1337], :window},
-      {[9, 52], :clipboard},
+      {[52], :clipboard},
+      # OSC 9: desktop notification (iTerm2/growl); OSC 9;4 (data-prefixed):
+      # taskbar/dock progress (ConEmu)
+      {[9], :notification},
       {[10, 11, 17, 19], :color},
-      {[12, 50, 112], :cursor},
+      {[12, 22, 50, 112], :cursor},
       {[4, 51], :standalone}
     ]
 
@@ -74,8 +80,13 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
 
   defp handle_clipboard_ops(emulator, command, data) do
     case command do
-      9 -> __MODULE__.Clipboard.handle_9(emulator, data)
       52 -> __MODULE__.Clipboard.handle_52(emulator, data)
+    end
+  end
+
+  defp handle_notification_ops(emulator, command, data) do
+    case command do
+      9 -> __MODULE__.Notification.handle_9(emulator, data)
     end
   end
 
@@ -88,10 +99,12 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
     end
   end
 
-  defp handle_cursor_ops(emulator, command, _data) do
+  defp handle_cursor_ops(emulator, command, data) do
     case command do
       # Set cursor color
       12 -> {:ok, emulator}
+      # Set pointer/cursor shape
+      22 -> __MODULE__.Pointer.handle_22(emulator, data)
       # Set cursor shape
       50 -> {:ok, emulator}
       # Reset cursor color
@@ -113,21 +126,6 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
     """
 
     alias Raxol.Terminal.Clipboard
-
-    def handle_9(emulator, data) do
-      case data do
-        "?" ->
-          content = Clipboard.get_content(emulator.clipboard)
-          response = format_clipboard_response(9, content)
-          {:ok, %{emulator | output_buffer: response}}
-
-        content ->
-          {:ok, new_clipboard} =
-            Clipboard.set_content(emulator.clipboard, content)
-
-          {:ok, %{emulator | clipboard: new_clipboard}}
-      end
-    end
 
     def handle_52(emulator, data) do
       case parse_52_command(data) do
@@ -178,6 +176,72 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
     defp format_clipboard_response(command, content) do
       encoded = Base.encode64(content)
       "\e]#{command};c;#{encoded}\e\\"
+    end
+  end
+
+  # Notification sub-module
+  defmodule Notification do
+    @moduledoc """
+    Handles OSC 9 desktop notifications and OSC 9;4 taskbar/dock progress.
+    """
+
+    def handle_9(emulator, "4;" <> rest), do: handle_progress(emulator, rest)
+    def handle_9(emulator, data), do: {:ok, %{emulator | notification: data}}
+
+    defp handle_progress(emulator, rest) do
+      case parse_progress(rest) do
+        {:ok, state, value} ->
+          {:ok, %{emulator | progress: %{state: state, value: value}}}
+
+        {:error, _reason} ->
+          {:error, :invalid_progress, emulator}
+      end
+    end
+
+    defp parse_progress(rest) do
+      case String.split(rest, ";", parts: 2) do
+        [state_str, progress_str] ->
+          parse_state_and_progress(state_str, progress_str)
+
+        [state_str] ->
+          parse_state_and_progress(state_str, "0")
+
+        _ ->
+          {:error, :invalid_format}
+      end
+    end
+
+    defp parse_state_and_progress(state_str, progress_str) do
+      with {state_code, ""} <- Integer.parse(state_str),
+           {:ok, state} <- progress_state(state_code),
+           {value, ""} <- Integer.parse(progress_str),
+           true <- value >= 0 and value <= 100 do
+        {:ok, state, value}
+      else
+        _ -> {:error, :invalid_progress}
+      end
+    end
+
+    defp progress_state(0), do: {:ok, :remove}
+    defp progress_state(1), do: {:ok, :set}
+    defp progress_state(2), do: {:ok, :error}
+    defp progress_state(3), do: {:ok, :indeterminate}
+    defp progress_state(4), do: {:ok, :warning}
+    defp progress_state(_), do: {:error, :invalid_state}
+  end
+
+  # Pointer sub-module
+  defmodule Pointer do
+    @moduledoc """
+    Handles OSC 22 pointer/cursor shape.
+    """
+
+    def handle_22(emulator, "") do
+      {:error, :invalid_pointer_shape, emulator}
+    end
+
+    def handle_22(emulator, shape) do
+      {:ok, %{emulator | pointer_shape: shape}}
     end
   end
 
@@ -355,7 +419,6 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
     Handles color palette OSC commands.
     """
 
-
     def handle_4(emulator, data) do
       case parse_palette_command(data) do
         {:set, index, color} ->
@@ -389,7 +452,9 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
               if color_spec == "" do
                 {:reset, index}
               else
-                case Raxol.Terminal.Commands.OSCHandler.ColorParser.parse(color_spec) do
+                case Raxol.Terminal.Commands.OSCHandler.ColorParser.parse(
+                       color_spec
+                     ) do
                   {:ok, color} -> {:set, index, color}
                   error -> error
                 end
@@ -474,7 +539,6 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
     Handles window-related OSC commands.
     """
 
-
     def handle_0(emulator, data) do
       # Set icon name and window title
       emulator = %{emulator | icon_name: data, window_title: data}
@@ -541,7 +605,6 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
     Handles selection-related OSC commands.
     """
 
-
     def handle_51(emulator, data) do
       case data do
         "?" ->
@@ -591,7 +654,8 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
         [family, size, style] ->
           case Integer.parse(size) do
             {size_val, ""} ->
-              {:ok, %{family: family, size: size_val, style: parse_style(style)}}
+              {:ok,
+               %{family: family, size: size_val, style: parse_style(style)}}
 
             _ ->
               {:error, :invalid_size}

--- a/packages/raxol_terminal/lib/raxol/terminal/emulator.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/emulator.ex
@@ -117,6 +117,9 @@ defmodule Raxol.Terminal.Emulator do
             color_palette: %{},
             last_key_event: nil,
             current_hyperlink: nil,
+            notification: nil,
+            progress: nil,
+            pointer_shape: nil,
             active_buffer: nil,
             alternate_screen_buffer: nil,
             sixel_state: nil,
@@ -198,6 +201,14 @@ defmodule Raxol.Terminal.Emulator do
           color_palette: map(),
           last_key_event: any(),
           current_hyperlink: any(),
+          notification: String.t() | nil,
+          progress:
+            %{
+              state: :remove | :set | :error | :indeterminate | :warning,
+              value: 0..100
+            }
+            | nil,
+          pointer_shape: String.t() | nil,
           active_buffer: any(),
           alternate_screen_buffer: any(),
           sixel_state: any(),
@@ -274,47 +285,61 @@ defmodule Raxol.Terminal.Emulator do
 
   # Erase operations - delegated to Operations.ScreenOperations
   @doc "Clears the entire screen."
-  defdelegate clear_screen(emulator), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate clear_screen(emulator),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Clears the specified line."
-  defdelegate clear_line(emulator, line), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate clear_line(emulator, line),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Erases display content based on mode (0=to end, 1=from start, 2=entire)."
-  defdelegate erase_display(emulator, mode), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate erase_display(emulator, mode),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Erases content within the display."
-  defdelegate erase_in_display(emulator, mode), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate erase_in_display(emulator, mode),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Erases line content based on mode."
-  defdelegate erase_line(emulator, mode), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate erase_line(emulator, mode),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Erases content within the current line."
-  defdelegate erase_in_line(emulator, mode), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate erase_in_line(emulator, mode),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Erases from cursor position to end of screen."
-  defdelegate erase_from_cursor_to_end(emulator), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate erase_from_cursor_to_end(emulator),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Erases from start of screen to cursor position."
-  defdelegate erase_from_start_to_cursor(emulator), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate erase_from_start_to_cursor(emulator),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   @doc "Erases the specified number of characters."
-  defdelegate erase_chars(emulator, count), to: Raxol.Terminal.Operations.ScreenOperations
+  defdelegate erase_chars(emulator, count),
+    to: Raxol.Terminal.Operations.ScreenOperations
 
   # Text operations - delegated to Operations.TextOperations
   @doc "Inserts a character at the cursor position."
-  defdelegate insert_char(emulator, char), to: Raxol.Terminal.Operations.TextOperations
+  defdelegate insert_char(emulator, char),
+    to: Raxol.Terminal.Operations.TextOperations
 
   @doc "Inserts the specified number of blank characters."
-  defdelegate insert_chars(emulator, count), to: Raxol.Terminal.Operations.TextOperations
+  defdelegate insert_chars(emulator, count),
+    to: Raxol.Terminal.Operations.TextOperations
 
   @doc "Deletes the character at the cursor position."
-  defdelegate delete_char(emulator), to: Raxol.Terminal.Operations.TextOperations
+  defdelegate delete_char(emulator),
+    to: Raxol.Terminal.Operations.TextOperations
 
   @doc "Deletes the specified number of characters."
-  defdelegate delete_chars(emulator, count), to: Raxol.Terminal.Operations.TextOperations
+  defdelegate delete_chars(emulator, count),
+    to: Raxol.Terminal.Operations.TextOperations
 
   @doc "Writes text to the terminal at the cursor position."
-  defdelegate write_text(emulator, text), to: Raxol.Terminal.Operations.TextOperations
+  defdelegate write_text(emulator, text),
+    to: Raxol.Terminal.Operations.TextOperations
 
   # Selection operations
   @doc "Starts text selection at the specified coordinates."
@@ -488,7 +513,8 @@ defmodule Raxol.Terminal.Emulator do
   # Screen buffer accessor
   @doc "Gets the active screen buffer."
   @impl Raxol.Terminal.EmulatorBehaviour
-  def get_screen_buffer(emulator), do: BufferOperations.get_screen_buffer(emulator)
+  def get_screen_buffer(emulator),
+    do: BufferOperations.get_screen_buffer(emulator)
 
   @doc "Sets terminal dimensions after validation."
   def set_dimensions(emulator, width, height) do

--- a/packages/raxol_terminal/test/raxol/terminal/advanced_features_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/advanced_features_test.exs
@@ -1,0 +1,53 @@
+defmodule Raxol.Terminal.AdvancedFeaturesTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.AdvancedFeatures
+
+  describe "notify/1" do
+    test "emits an OSC 9 notification sequence" do
+      assert AdvancedFeatures.notify("Build finished") ==
+               "\e]9;Build finished\e\\"
+    end
+  end
+
+  describe "report_progress/2" do
+    test "emits OSC 9;4 with the set state code" do
+      assert AdvancedFeatures.report_progress(:set, 42) == "\e]9;4;1;42\e\\"
+    end
+
+    test "emits OSC 9;4 for the remove state" do
+      assert AdvancedFeatures.report_progress(:remove) == "\e]9;4;0;0\e\\"
+    end
+
+    test "emits OSC 9;4 for the error state" do
+      assert AdvancedFeatures.report_progress(:error, 100) == "\e]9;4;2;100\e\\"
+    end
+
+    test "emits OSC 9;4 for the indeterminate state" do
+      assert AdvancedFeatures.report_progress(:indeterminate) ==
+               "\e]9;4;3;0\e\\"
+    end
+
+    test "emits OSC 9;4 for the warning state" do
+      assert AdvancedFeatures.report_progress(:warning, 75) == "\e]9;4;4;75\e\\"
+    end
+  end
+
+  describe "clear_progress/0" do
+    test "emits a remove-state progress sequence" do
+      assert AdvancedFeatures.clear_progress() == "\e]9;4;0;0\e\\"
+    end
+  end
+
+  describe "set_pointer_shape/1" do
+    test "emits an OSC 22 sequence for a named shape" do
+      assert AdvancedFeatures.set_pointer_shape("pointer") ==
+               "\e]22;pointer\e\\"
+    end
+
+    test "emits an OSC 22 sequence for the default shape" do
+      assert AdvancedFeatures.set_pointer_shape("default") ==
+               "\e]22;default\e\\"
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/commands/osc_handler_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/commands/osc_handler_test.exs
@@ -1,0 +1,139 @@
+defmodule Raxol.Terminal.Commands.OSCHandlerTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Clipboard
+  alias Raxol.Terminal.Commands.OSCHandler
+
+  defp emulator(overrides \\ %{}) do
+    Map.merge(
+      %{
+        clipboard: Clipboard.Manager.new(),
+        output_buffer: nil,
+        notification: nil,
+        progress: nil,
+        pointer_shape: nil
+      },
+      overrides
+    )
+  end
+
+  describe "OSC 9 notification" do
+    test "stores a plain notification message" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "Build finished")
+      assert result.notification == "Build finished"
+    end
+
+    test "leaves clipboard state untouched" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "hello")
+      assert result.clipboard == Clipboard.Manager.new()
+    end
+  end
+
+  describe "OSC 9;4 progress" do
+    test "parses set state with a value" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "4;1;42")
+      assert result.progress == %{state: :set, value: 42}
+    end
+
+    test "parses remove state, defaulting value to 0" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "4;0")
+      assert result.progress == %{state: :remove, value: 0}
+    end
+
+    test "parses error state" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "4;2;100")
+      assert result.progress == %{state: :error, value: 100}
+    end
+
+    test "parses indeterminate state" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "4;3;0")
+      assert result.progress == %{state: :indeterminate, value: 0}
+    end
+
+    test "parses warning state" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "4;4;75")
+      assert result.progress == %{state: :warning, value: 75}
+    end
+
+    test "rejects an unknown state code without crashing" do
+      assert {:error, :invalid_progress, _emulator} =
+               OSCHandler.handle(emulator(), 9, "4;9;10")
+    end
+
+    test "rejects an out-of-range progress value without crashing" do
+      assert {:error, :invalid_progress, _emulator} =
+               OSCHandler.handle(emulator(), 9, "4;1;101")
+    end
+
+    test "rejects a negative progress value without crashing" do
+      assert {:error, :invalid_progress, _emulator} =
+               OSCHandler.handle(emulator(), 9, "4;1;-5")
+    end
+
+    test "rejects non-numeric input without crashing" do
+      assert {:error, :invalid_progress, _emulator} =
+               OSCHandler.handle(emulator(), 9, "4;abc;def")
+    end
+
+    test "rejects an empty progress payload without crashing" do
+      assert {:error, :invalid_progress, _emulator} =
+               OSCHandler.handle(emulator(), 9, "4;")
+    end
+  end
+
+  describe "OSC 22 pointer shape" do
+    test "sets a named pointer shape" do
+      {:ok, result} = OSCHandler.handle(emulator(), 22, "pointer")
+      assert result.pointer_shape == "pointer"
+    end
+
+    test "accepts the default shape" do
+      {:ok, result} = OSCHandler.handle(emulator(), 22, "default")
+      assert result.pointer_shape == "default"
+    end
+
+    test "accepts arbitrary CSS-style cursor keywords" do
+      {:ok, result} = OSCHandler.handle(emulator(), 22, "crosshair")
+      assert result.pointer_shape == "crosshair"
+    end
+
+    test "rejects an empty shape without crashing" do
+      assert {:error, :invalid_pointer_shape, _emulator} =
+               OSCHandler.handle(emulator(), 22, "")
+    end
+  end
+
+  describe "OSC 52 clipboard (regression)" do
+    test "sets clipboard content from base64" do
+      {:ok, result} = OSCHandler.handle(emulator(), 52, "c;SGVsbG8=")
+      assert Clipboard.get_content(result.clipboard) == "Hello"
+    end
+
+    test "queries clipboard content" do
+      {:ok, seeded} = Clipboard.set_content(Clipboard.Manager.new(), "Hi")
+
+      {:ok, result} =
+        OSCHandler.handle(emulator(%{clipboard: seeded}), 52, "c;?")
+
+      assert result.output_buffer == "\e]52;c;#{Base.encode64("Hi")}\e\\"
+    end
+
+    test "sets selection content from base64" do
+      {:ok, result} = OSCHandler.handle(emulator(), 52, "s;U2VsZWN0ZWQ=")
+      assert {:ok, "Selected"} = Clipboard.get_selection(result.clipboard)
+    end
+
+    test "rejects a malformed command without crashing" do
+      assert {:error, :invalid_clipboard_command, _emulator} =
+               OSCHandler.handle(emulator(), 52, "bogus")
+    end
+  end
+
+  describe "OSC 9 no longer mis-routes to clipboard" do
+    test "clipboard-shaped payloads on OSC 9 are treated as notification text" do
+      {:ok, result} = OSCHandler.handle(emulator(), 9, "c;SGVsbG8=")
+      assert result.clipboard == Clipboard.Manager.new()
+      assert result.notification == "c;SGVsbG8="
+    end
+  end
+end

--- a/test/raxol/playground/app_test.exs
+++ b/test/raxol/playground/app_test.exs
@@ -14,7 +14,7 @@ defmodule Raxol.Playground.AppTest do
   describe "init/1" do
     test "initializes with components and first selected" do
       model = App.init(nil)
-      assert length(model.components) == 30
+      assert length(model.components) == 31
       assert model.cursor == 0
       assert model.selected != nil
       assert model.focus == :sidebar
@@ -189,7 +189,7 @@ defmodule Raxol.Playground.AppTest do
       # After cycling through all categories, next press returns to nil
       {model, []} = App.update(key_event("f"), model)
       assert model.category_filter == nil
-      assert length(model.components) == 30
+      assert length(model.components) == 31
     end
 
     test "f resets cursor to 0" do

--- a/test/raxol/playground/catalog_test.exs
+++ b/test/raxol/playground/catalog_test.exs
@@ -6,7 +6,7 @@ defmodule Raxol.Playground.CatalogTest do
   describe "list_components/0" do
     test "returns all registered components" do
       components = Catalog.list_components()
-      assert length(components) == 30
+      assert length(components) == 31
       assert Enum.all?(components, &is_map/1)
     end
 

--- a/test/raxol/playground/demos/osc_ambient_demo_test.exs
+++ b/test/raxol/playground/demos/osc_ambient_demo_test.exs
@@ -1,0 +1,143 @@
+defmodule Raxol.Playground.Demos.OscAmbientDemoTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Runtime.Directive.Spawn
+  alias Raxol.Playground.Demos.OscAmbientDemo
+
+  defp key_event(char) do
+    %Raxol.Core.Events.Event{type: :key, data: %{key: :char, char: char}}
+  end
+
+  # A returned Spawn directive's fun is only invoked by the runtime executor,
+  # never by these tests, so asserting its shape (and never calling `.fun`)
+  # is what keeps this suite from writing real OSC escape sequences to stdout.
+  defp assert_spawn_commands(commands, count) do
+    assert length(commands) == count
+    assert Enum.all?(commands, &match?(%Spawn{fun: fun} when is_function(fun, 0), &1))
+  end
+
+  describe "init/1" do
+    test "starts idle at zero progress" do
+      model = OscAmbientDemo.init(nil)
+      assert model.status == :idle
+      assert model.progress == 0
+      assert model.pointer_idx == 0
+    end
+  end
+
+  describe "start/pause" do
+    test "space starts the task and emits a progress command" do
+      model = OscAmbientDemo.init(nil)
+      {model, commands} = OscAmbientDemo.update(key_event(" "), model)
+      assert model.status == :running
+      assert_spawn_commands(commands, 1)
+    end
+
+    test "space again pauses without emitting a command" do
+      model = %{OscAmbientDemo.init(nil) | status: :running}
+      {model, []} = OscAmbientDemo.update(key_event(" "), model)
+      assert model.status == :paused
+    end
+
+    test "space is a no-op once done" do
+      model = %{OscAmbientDemo.init(nil) | status: :done, progress: 100}
+      {result, []} = OscAmbientDemo.update(key_event(" "), model)
+      assert result == model
+    end
+  end
+
+  describe "error/warning" do
+    test "e sets error status and emits a progress command" do
+      model = %{OscAmbientDemo.init(nil) | status: :running, progress: 40}
+      {model, commands} = OscAmbientDemo.update(key_event("e"), model)
+      assert model.status == :error
+      assert_spawn_commands(commands, 1)
+    end
+
+    test "w sets warning status and emits a progress command" do
+      model = %{OscAmbientDemo.init(nil) | status: :running, progress: 40}
+      {model, commands} = OscAmbientDemo.update(key_event("w"), model)
+      assert model.status == :warning
+      assert_spawn_commands(commands, 1)
+    end
+
+    test "e/w are no-ops once done" do
+      model = %{OscAmbientDemo.init(nil) | status: :done, progress: 100}
+      {result, []} = OscAmbientDemo.update(key_event("e"), model)
+      assert result == model
+    end
+  end
+
+  describe "pointer shape" do
+    test "c cycles the pointer index and emits a command" do
+      model = OscAmbientDemo.init(nil)
+      {model, commands} = OscAmbientDemo.update(key_event("c"), model)
+      assert model.pointer_idx == 1
+      assert_spawn_commands(commands, 1)
+    end
+
+    test "c wraps around" do
+      model = %{OscAmbientDemo.init(nil) | pointer_idx: 4}
+      {model, _commands} = OscAmbientDemo.update(key_event("c"), model)
+      assert model.pointer_idx == 0
+    end
+  end
+
+  describe "reset" do
+    test "r resets status and progress and clears taskbar progress" do
+      model = %{status: :error, progress: 88, pointer_idx: 2}
+      {model, commands} = OscAmbientDemo.update(key_event("r"), model)
+      assert model.status == :idle
+      assert model.progress == 0
+      assert model.pointer_idx == 2
+      assert_spawn_commands(commands, 1)
+    end
+  end
+
+  describe "tick" do
+    test "tick advances progress while running" do
+      model = %{OscAmbientDemo.init(nil) | status: :running, progress: 0}
+      {model, commands} = OscAmbientDemo.update(:tick, model)
+      assert model.progress == 4
+      assert model.status == :running
+      assert_spawn_commands(commands, 1)
+    end
+
+    test "tick reaching 100 marks done and fires notify + progress commands" do
+      model = %{OscAmbientDemo.init(nil) | status: :running, progress: 98}
+      {model, commands} = OscAmbientDemo.update(:tick, model)
+      assert model.progress == 100
+      assert model.status == :done
+      assert_spawn_commands(commands, 2)
+    end
+
+    test "tick is ignored when not running" do
+      model = OscAmbientDemo.init(nil)
+      {result, []} = OscAmbientDemo.update(:tick, model)
+      assert result == model
+    end
+  end
+
+  describe "subscribe/1" do
+    test "subscribes to tick only while running" do
+      running = %{OscAmbientDemo.init(nil) | status: :running}
+      assert [_ | _] = OscAmbientDemo.subscribe(running)
+      assert OscAmbientDemo.subscribe(OscAmbientDemo.init(nil)) == []
+    end
+  end
+
+  describe "view/1" do
+    test "returns element tree" do
+      model = OscAmbientDemo.init(nil)
+      assert is_map(OscAmbientDemo.view(model))
+    end
+  end
+
+  describe "unknown events" do
+    test "unknown events pass through" do
+      model = OscAmbientDemo.init(nil)
+      {result, []} = OscAmbientDemo.update(:unknown, model)
+      assert result == model
+    end
+  end
+end

--- a/test/raxol/playground/sidebar_scroll_test.exs
+++ b/test/raxol/playground/sidebar_scroll_test.exs
@@ -107,7 +107,7 @@ defmodule Raxol.Playground.SidebarScrollTest do
       sidebar = sidebar_text(text)
 
       assert sidebar =~ "▸ Button"
-      assert sidebar =~ "30 widgets"
+      assert sidebar =~ "31 widgets"
     end
 
     test "scrolling past the visible window keeps the marker on screen and scrolls the top items out",


### PR DESCRIPTION
## OSC 9 routing fix

`OSCHandler` routed OSC 9 to `Clipboard.handle_9`. That's wrong: OSC 9 is the
iTerm2/growl desktop notification sequence, not clipboard. OSC 52 is the
correct clipboard sequence and was already implemented separately and
untouched by this PR.

**Investigation / back-compat**: grepped the repo for any caller or test
depending on OSC-9-as-clipboard (`handle_9`, direct `OSCHandler.handle(_, 9,
_)` calls, fixtures). Found none — `executor.ex` is the only real caller and
it dispatches by parsed command code with no OSC-9-specific handling. The
test fixture at `test/fixtures/ansi_sequences.exs` already labels OSC 9 as
`notification`, not clipboard, confirming the routing was a bug rather than
an intentional (if nonstandard) extension. So this removes the OSC-9 →
clipboard path outright instead of keeping it for back-compat.

## New ambient OSC support

- **OSC 9** (plain payload): desktop notification, stored on
  `emulator.notification`.
- **OSC 9;4;<state>;<progress>**: taskbar/dock progress (ConEmu-origin, now
  also supported by Ghostty, iTerm2, Windows Terminal, WezTerm). `state` is
  0=remove, 1=set, 2=error, 3=indeterminate, 4=warning; `progress` is 0-100
  (defaults to 0 if omitted). Stored on `emulator.progress` as
  `%{state:, value:}`. Malformed input (bad state code, out-of-range or
  non-numeric progress) returns `{:error, :invalid_progress, emulator}`
  rather than crashing.
- **OSC 22;<shape>**: pointer/cursor shape (CSS-style keyword, e.g.
  `default`, `text`, `pointer`, `wait`, `crosshair`). Stored on
  `emulator.pointer_shape`. Empty payload returns
  `{:error, :invalid_pointer_shape, emulator}`.

Emit-side API added to `Raxol.Terminal.AdvancedFeatures` (alongside the
existing OSC 8 hyperlink emitters): `notify/1`, `report_progress/2`,
`clear_progress/0`, `set_pointer_shape/1` — all pure functions returning the
escape sequence, matching `create_hyperlink/3`'s style.

`Raxol.Terminal.Emulator` gains three new struct fields (`notification`,
`progress`, `pointer_shape`, all defaulting to `nil`) alongside the existing
`current_hyperlink` field, following the same pattern.

## Tests

- `packages/raxol_terminal/test/raxol/terminal/commands/osc_handler_test.exs`
  (new): parse tests for OSC 9 notification, OSC 9;4 progress (all five
  states, malformed/out-of-range/non-numeric input), OSC 22 pointer shape
  (including empty-payload rejection), and an OSC 52 clipboard regression
  suite that also asserts OSC 9 no longer touches clipboard state.
- `packages/raxol_terminal/test/raxol/terminal/advanced_features_test.exs`
  (new): emit tests asserting exact byte sequences for `notify/1`,
  `report_progress/2`, `clear_progress/0`, `set_pointer_shape/1`.

## Test plan

- [x] `MIX_ENV=test mix compile --warnings-as-errors` (exit 0)
- [x] `mix format --check-formatted` (exit 0)
- [x] `TMPDIR=/tmp SKIP_TERMBOX2_TESTS=true MIX_ENV=test mix test` on the new
      OSC/advanced-features test files: 30 passed
- [x] Broader terminal `commands/` + renderer/output-manager suite for
      regressions: 366 passed, 5 excluded, 0 failed