### PR TITLE
Make DCS parsing total; never crash on unparsable input

### DIFF
--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/state_machine.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/state_machine.ex
@@ -172,6 +172,15 @@ defmodule Raxol.Terminal.ANSI.StateMachine do
   defp handle_byte(%{state: :osc_string_maybe_st} = state, byte),
     do: handle_osc_string_maybe_st_state(state, byte)
 
+  defp handle_byte(%{state: :dcs_entry} = state, byte),
+    do: handle_dcs_entry_state(state, byte)
+
+  defp handle_byte(%{state: :dcs_passthrough} = state, byte),
+    do: handle_dcs_passthrough_state(state, byte)
+
+  defp handle_byte(%{state: :dcs_passthrough_maybe_st} = state, byte),
+    do: handle_dcs_passthrough_maybe_st_state(state, byte)
+
   defp handle_byte(%{state: :designate_charset} = state, byte),
     do: handle_designate_charset_state(state, byte)
 
@@ -403,6 +412,56 @@ defmodule Raxol.Terminal.ANSI.StateMachine do
            | state: :osc_string,
              payload_buffer: state.payload_buffer <> <<0x1B, b>>
          }}
+    end
+  end
+
+  # DCS (Device Control String) payloads are not parsed or emitted; we only
+  # need to consume them whole so unsupported/unparsable DCS never crashes
+  # the machine or leaks its bytes as ground-state text/keystrokes.
+  defp handle_dcs_entry_state(state, byte) do
+    case byte do
+      0x1B ->
+        {:continue, %{state | state: :dcs_passthrough_maybe_st}}
+
+      b when cancel_byte?(b) ->
+        {:continue, %{state | state: :ground}}
+
+      _ ->
+        {:continue, %{state | state: :dcs_passthrough}}
+    end
+  end
+
+  defp handle_dcs_passthrough_state(state, byte) do
+    case byte do
+      0x1B ->
+        {:continue, %{state | state: :dcs_passthrough_maybe_st}}
+
+      b when cancel_byte?(b) ->
+        {:continue, %{state | state: :ground}}
+
+      _ ->
+        {:continue, state}
+    end
+  end
+
+  defp handle_dcs_passthrough_maybe_st_state(state, byte) do
+    case byte do
+      ?\\ ->
+        Raxol.Core.Runtime.Log.debug_with_context(
+          "Discarded unparsable DCS sequence",
+          %{}
+        )
+
+        {:continue, %{state | state: :ground}}
+
+      0x1B ->
+        {:continue, state}
+
+      b when cancel_byte?(b) ->
+        {:continue, %{state | state: :ground}}
+
+      _ ->
+        {:continue, %{state | state: :dcs_passthrough}}
     end
   end
 

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/state_machine_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/state_machine_test.exs
@@ -85,6 +85,58 @@ defmodule Raxol.Terminal.ANSI.StateMachineTest do
       assert sequence.text == "title"
     end
 
+    test ~c"handles a well-formed DCS sequence without crashing or leaking text" do
+      state = StateMachine.new()
+
+      {new_state, sequences} =
+        StateMachine.process(state, "\eP1;2q$q\"p\e\\")
+
+      assert new_state.state == :ground
+      assert Enum.empty?(sequences)
+    end
+
+    test ~c"handles an empty DCS sequence" do
+      state = StateMachine.new()
+      {new_state, sequences} = StateMachine.process(state, "\eP\e\\")
+      assert new_state.state == :ground
+      assert Enum.empty?(sequences)
+    end
+
+    test ~c"handles CAN/SUB inside a DCS sequence" do
+      state = StateMachine.new()
+      {new_state, sequences} = StateMachine.process(state, "\eP1;2\x18")
+      assert new_state.state == :ground
+      assert Enum.empty?(sequences)
+    end
+
+    test ~c"handles unparsable DCS payload without raising" do
+      state = StateMachine.new()
+
+      payload = <<0x1B, ?P, 200, 150, 90, 0xF0, 0x9F, 0x92, 0xA9, 0x1B, ?\\>>
+
+      {new_state, sequences} = StateMachine.process(state, payload)
+      assert new_state.state == :ground
+      assert Enum.empty?(sequences)
+    end
+
+    test ~c"handles a DCS sequence followed by more input" do
+      state = StateMachine.new()
+
+      {new_state, sequences} =
+        StateMachine.process(state, "\eP1qdata\e\\Hello")
+
+      assert new_state.state == :ground
+      assert Enum.map(sequences, & &1.type) == [:text, :text, :text, :text, :text]
+      assert Enum.map(sequences, & &1.text) == ["H", "e", "l", "l", "o"]
+    end
+
+    test ~c"handles an unterminated DCS sequence without raising" do
+      state = StateMachine.new()
+      {new_state, sequences} = StateMachine.process(state, "\eP1;2qsome data")
+      assert new_state.state in [:dcs_entry, :dcs_passthrough, :dcs_passthrough_maybe_st]
+      assert Enum.empty?(sequences)
+    end
+
     test ~c"handles multiple sequences" do
       state = StateMachine.new()
 

--- a/test/property/dcs_parsing_property_test.exs
+++ b/test/property/dcs_parsing_property_test.exs
@@ -1,0 +1,122 @@
+defmodule Raxol.Property.DcsParsingTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Terminal.ANSI.StateMachine
+
+  # Mirrors StateMachine.state()/0 -- kept in sync manually since the type
+  # itself isn't introspectable at runtime.
+  @valid_states [
+    :ground,
+    :escape,
+    :csi_entry,
+    :csi_param,
+    :csi_intermediate,
+    :csi_final,
+    :osc_string,
+    :osc_string_maybe_st,
+    :dcs_entry,
+    :dcs_passthrough,
+    :dcs_passthrough_maybe_st,
+    :designate_charset,
+    :ignore
+  ]
+
+  defp assert_sane_result({new_state, sequences}) do
+    assert new_state.state in @valid_states
+    assert is_list(sequences)
+    Enum.each(sequences, &assert(is_map(&1)))
+  end
+
+  # Regression coverage for the FunctionClauseError originally hit fuzzing
+  # the state machine with random unicode inside a DCS string, e.g.
+  # `"\eP��...\e\\"`.
+  describe "DCS totality" do
+    property "never raises on DCS strings wrapping arbitrary bytes" do
+      check all(
+              payload <- binary(max_length: 64),
+              max_runs: 500
+            ) do
+        input = <<0x1B, ?P>> <> payload <> <<0x1B, ?\\>>
+
+        StateMachine.process(StateMachine.new(), input)
+        |> assert_sane_result()
+      end
+    end
+
+    property "never raises on DCS strings wrapping arbitrary unicode" do
+      check all(
+              codepoints <-
+                list_of(
+                  one_of([
+                    integer(0..0xD7FF),
+                    integer(0xE000..0x10FFFF)
+                  ]),
+                  max_length: 24
+                ),
+              max_runs: 500
+            ) do
+        payload = Enum.map_join(codepoints, fn cp -> <<cp::utf8>> end)
+        input = "\eP" <> payload <> "\e\\"
+
+        StateMachine.process(StateMachine.new(), input)
+        |> assert_sane_result()
+      end
+    end
+
+    property "never raises on unterminated or truncated DCS strings" do
+      check all(
+              payload <- binary(max_length: 64),
+              max_runs: 500
+            ) do
+        input = <<0x1B, ?P>> <> payload
+
+        StateMachine.process(StateMachine.new(), input)
+        |> assert_sane_result()
+      end
+    end
+
+    property "a DCS closed with ST and no control bytes always returns to :ground" do
+      check all(
+              payload <- list_of(integer(0x20..0x7E), max_length: 40),
+              max_runs: 500
+            ) do
+        payload_bin = :erlang.list_to_binary(payload)
+        input = <<0x1B, ?P>> <> payload_bin <> <<0x1B, ?\\>>
+
+        {new_state, sequences} = StateMachine.process(StateMachine.new(), input)
+
+        assert new_state.state == :ground
+        assert Enum.empty?(sequences)
+      end
+    end
+
+    property "a DCS cancelled with CAN/SUB always returns to :ground" do
+      check all(
+              prefix <- list_of(integer(0x20..0x7E), max_length: 40),
+              cancel_byte <- member_of([0x18, 0x1A]),
+              max_runs: 500
+            ) do
+        prefix_bin = :erlang.list_to_binary(prefix)
+        input = <<0x1B, ?P>> <> prefix_bin <> <<cancel_byte>>
+
+        {new_state, sequences} = StateMachine.process(StateMachine.new(), input)
+
+        assert new_state.state == :ground
+        assert Enum.empty?(sequences)
+      end
+    end
+  end
+
+  describe "whole-machine totality (broad fuzz)" do
+    property "never raises on arbitrary binary input" do
+      check all(
+              input <- binary(max_length: 128),
+              max_runs: 1000
+            ) do
+        StateMachine.process(StateMachine.new(), input)
+        |> assert_sane_result()
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Bug

`Raxol.Terminal.ANSI.StateMachine.handle_byte/2` had no clauses for `:dcs_entry`, `:dcs_passthrough`, or `:dcs_passthrough_maybe_st` — three states declared in the module's own `@type state()` but never wired up. Any DCS (`\eP…`) input that advanced past the first byte raised `FunctionClauseError`. This was caught for real by a property test fuzzing the state machine with random unicode:

```
[warning] ANSI Parse Error: %FunctionClauseError{module: Raxol.Terminal.ANSI.StateMachine, function: :handle_byte, arity: 2, ...} | Context: %{input: "\"\\eP...\\e\\\\\""}
```

CSI parsing was made total previously; DCS never got the same treatment.

## Fix

Mirror the existing CSI/OSC pattern: unknown bytes are consumed rather than crashing, and CAN/SUB (0x18/0x1A) aborts back to `:ground`. Since this module never parses or emits DCS content as a `sequence` (there's no `:dcs` `sequence_type`), the simplest correct fix is total consumption — an unparsable/unsupported DCS payload is now swallowed whole and discarded until its `ST` (`ESC \`) terminator or a cancel byte, instead of crashing or leaking its bytes into `:ground` as stray text/keystrokes. Logs once per discarded sequence at `:debug` (no per-byte spam).

Checked OSC and APC (`ESC _`) for the same hole per the task: OSC already has dedicated `:osc_string`/`:osc_string_maybe_st` consuming states with full catch-alls, and APC/PM/SOS fall through to the existing catch-all 2-byte escape clause (`create_escape_sequence`/`:ignore`), so neither was actually crashing — no change needed there.

## Tests

- Unit tests: well-formed DCS with params/intermediates, empty DCS (`\eP\e\\`), CAN/SUB abort mid-DCS, unparsable/invalid-UTF8 payload, DCS followed by trailing ground-state text, unterminated DCS.
- New property test suite (`test/property/dcs_parsing_property_test.exs`) fuzzing:
  - DCS-wrapped arbitrary bytes and arbitrary Unicode codepoints (the actual repro shape)
  - unterminated/truncated DCS
  - DCS closed with ST / cancelled with CAN/SUB always lands in `:ground`
  - a broad whole-machine fuzz of arbitrary binaries (regression net, same shape as the fuzzer that found the bug)

All assert the machine never raises and always lands in a state from the declared `@type state()`.

Verified by reverting the fix locally and re-running the new property tests: they reproduce the exact `FunctionClauseError` reported above (6/6 failing), and pass with the fix applied (6/6 passing).

## Verification

- `MIX_ENV=test mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` on touched files — clean
- `TMPDIR=/tmp SKIP_TERMBOX2_TESTS=true MIX_ENV=test mix test packages/raxol_terminal/test/raxol/terminal/ansi/ test/property/dcs_parsing_property_test.exs` — 428 passed, 0 failed
