### PR TITLE
Fix colon-subparameter SGR parsing; add styled/colored underlines

### DIFF
--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/sgr.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/sgr.ex
@@ -390,26 +390,58 @@ defmodule Raxol.Terminal.ANSI.SGR do
     """
     @spec handle_sgr(binary(), TextFormatting.t()) :: TextFormatting.t()
     def handle_sgr(params, style) do
-      # Parse SGR parameters (e.g., "31;1;4")
-      codes =
-        params
-        |> String.split(";")
-        |> Enum.map(fn code ->
-          case Integer.parse(code) do
-            {int, _} -> int
-            :error -> nil
-          end
-        end)
-        |> Enum.filter(& &1)
+      params
+      |> parse_sgr_string()
+      |> process_params(style)
+    end
 
-      # Start with current style
+    @doc """
+    Processes already-parsed SGR parameters, as produced by
+    `Raxol.Terminal.Commands.CommandsParser.parse_params/1`: a list mixing
+    plain integer codes with colon-subparameter groups (nested lists, e.g.
+    `[4, 3]` for the raw sequence `4:3`) and `nil` placeholders for empty
+    segments/slots.
+    """
+    @spec process_params(list(), TextFormatting.t()) :: TextFormatting.t()
+    def process_params(params, style) do
       style = style || TextFormatting.new()
 
-      # Process all codes
-      process_codes(codes, style)
+      params
+      |> Enum.reject(&is_nil/1)
+      |> process_codes(style)
+    end
+
+    # Parses a raw SGR parameter string, honoring colon subparameters, e.g.
+    # "1;4:3;58:2::255:0:0" -> [1, [4, 3], [58, 2, nil, 255, 0, 0]]
+    defp parse_sgr_string(params) do
+      params
+      |> String.split(";")
+      |> Enum.map(&parse_param_segment/1)
+    end
+
+    defp parse_param_segment(segment) do
+      case String.contains?(segment, ":") do
+        true -> segment |> String.split(":") |> Enum.map(&parse_int_or_nil/1)
+        false -> parse_int_or_nil(segment)
+      end
+    end
+
+    defp parse_int_or_nil(str) do
+      case Integer.parse(str) do
+        {int, _} -> int
+        :error -> nil
+      end
     end
 
     defp process_codes([], style), do: style
+
+    # Colon-subparameter group, e.g. "4:3" -> [4, 3] or
+    # "58:2::255:0:0" -> [58, 2, nil, 255, 0, 0]
+    defp process_codes([[code | subparams] | rest], style)
+         when is_integer(code) do
+      new_style = apply_sgr_colon_code(code, subparams, style)
+      process_codes(rest, new_style)
+    end
 
     defp process_codes([code | rest], style) do
       new_style = apply_sgr_code(code, style, rest)
@@ -421,6 +453,9 @@ defmodule Raxol.Terminal.ANSI.SGR do
             Enum.drop(rest, extended_color_params_count(rest))
 
           48 when length(rest) >= 2 ->
+            Enum.drop(rest, extended_color_params_count(rest))
+
+          58 when length(rest) >= 2 ->
             Enum.drop(rest, extended_color_params_count(rest))
 
           _ ->
@@ -435,6 +470,77 @@ defmodule Raxol.Terminal.ANSI.SGR do
     # 2;r;g;b format
     defp extended_color_params_count([2 | _rest]), do: 4
     defp extended_color_params_count(_), do: 0
+
+    # Underline style (colon form only): 4:0 none, 4:1 single, 4:2 double,
+    # 4:3 curly, 4:4 dotted, 4:5 dashed
+    defp apply_sgr_colon_code(4, [0 | _], style) do
+      %{style | underline: false, double_underline: false, underline_style: :none}
+    end
+
+    defp apply_sgr_colon_code(4, [1 | _], style) do
+      %{style | underline: true, double_underline: false, underline_style: :single}
+    end
+
+    defp apply_sgr_colon_code(4, [2 | _], style) do
+      %{style | underline: true, double_underline: true, underline_style: :double}
+    end
+
+    defp apply_sgr_colon_code(4, [3 | _], style) do
+      %{style | underline: true, double_underline: false, underline_style: :curly}
+    end
+
+    defp apply_sgr_colon_code(4, [4 | _], style) do
+      %{style | underline: true, double_underline: false, underline_style: :dotted}
+    end
+
+    defp apply_sgr_colon_code(4, [5 | _], style) do
+      %{style | underline: true, double_underline: false, underline_style: :dashed}
+    end
+
+    defp apply_sgr_colon_code(38, subparams, style) do
+      case parse_colon_color(subparams) do
+        {:ok, color} -> TextFormatting.set_foreground(style, color)
+        :error -> style
+      end
+    end
+
+    defp apply_sgr_colon_code(48, subparams, style) do
+      case parse_colon_color(subparams) do
+        {:ok, color} -> TextFormatting.set_background(style, color)
+        :error -> style
+      end
+    end
+
+    defp apply_sgr_colon_code(58, subparams, style) do
+      case parse_colon_color(subparams) do
+        {:ok, color} -> TextFormatting.set_underline_color(style, color)
+        :error -> style
+      end
+    end
+
+    defp apply_sgr_colon_code(_code, _subparams, style), do: style
+
+    # 5;n (256-color)
+    defp parse_colon_color([5, n])
+         when is_integer(n) and n >= 0 and n <= 255,
+         do: {:ok, {:index, n}}
+
+    # 2;colorspace;r;g;b (truecolor); colorspace slot may be empty (nil, the
+    # ECMA-48 "::" quirk) or an explicit id -- either way it's ignored here.
+    defp parse_colon_color([2, _colorspace, r, g, b])
+         when is_integer(r) and is_integer(g) and is_integer(b) and
+                r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and
+                b <= 255,
+         do: {:ok, {:rgb, r, g, b}}
+
+    # 2;r;g;b (truecolor, no colorspace slot)
+    defp parse_colon_color([2, r, g, b])
+         when is_integer(r) and is_integer(g) and is_integer(b) and
+                r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and
+                b <= 255,
+         do: {:ok, {:rgb, r, g, b}}
+
+    defp parse_colon_color(_), do: :error
 
     # Generate optimized pattern matching for SGR codes
     for code <- 0..107 do
@@ -697,6 +803,26 @@ defmodule Raxol.Terminal.ANSI.SGR do
           # Unhandled codes
           nil
       end
+    end
+
+    # Underline color (58): 256-color and truecolor semicolon forms
+    defp apply_sgr_code(58, style, [5, n | _rest])
+         when is_integer(n) and n >= 0 and n <= 255 do
+      TextFormatting.set_underline_color(style, {:index, n})
+    end
+
+    defp apply_sgr_code(58, style, [2, r, g, b | _rest])
+         when is_integer(r) and is_integer(g) and is_integer(b) and
+                r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and
+                b <= 255 do
+      TextFormatting.set_underline_color(style, {:rgb, r, g, b})
+    end
+
+    defp apply_sgr_code(58, style, _rest), do: style
+
+    # Default underline color (59)
+    defp apply_sgr_code(59, style, _rest) do
+      TextFormatting.set_underline_color(style, nil)
     end
 
     # Catch-all for unhandled codes

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/sgr_processor.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/sgr_processor.ex
@@ -78,8 +78,27 @@ defmodule Raxol.Terminal.ANSI.SGRProcessor do
   defp parse_params(params) do
     params
     |> String.split(";")
-    |> Enum.map(&parse_int/1)
+    |> Enum.map(&parse_segment/1)
     |> Enum.reject(&is_nil/1)
+  end
+
+  # A ";"-delimited segment containing ":" is a colon-subparameter group,
+  # e.g. "4:3" -> {4, [3]} or "38:2::255:0:0" -> {38, [2, nil, 255, 0, 0]}.
+  # The empty slot in "::" (ECMA-48 colorspace-id quirk) parses to nil.
+  defp parse_segment(segment) do
+    case String.contains?(segment, ":") do
+      true ->
+        case String.split(segment, ":") do
+          [code_str | subparam_strs] ->
+            case parse_int(code_str) do
+              nil -> nil
+              code -> {code, Enum.map(subparam_strs, &parse_int/1)}
+            end
+        end
+
+      false ->
+        parse_int(segment)
+    end
   end
 
   defp parse_int(str) do
@@ -91,11 +110,84 @@ defmodule Raxol.Terminal.ANSI.SGRProcessor do
 
   defp process_params([], style), do: style
 
+  defp process_params([{code, subparams} | rest], style) do
+    updated_style = apply_sgr_colon_code(code, subparams, style)
+    process_params(rest, updated_style)
+  end
+
   defp process_params([code | rest], style) do
     updated_style = apply_sgr_code(code, style, rest)
     {_consumed, remaining} = get_consumed_params(code, rest)
     process_params(remaining, updated_style)
   end
+
+  # Styled underline (colon form only): 4:0 none, 4:1 single, 4:2 double,
+  # 4:3 curly, 4:4 dotted, 4:5 dashed
+  defp apply_sgr_colon_code(4, [0 | _], style) do
+    %{style | underline: false, double_underline: false, underline_style: :none}
+  end
+
+  defp apply_sgr_colon_code(4, [1 | _], style) do
+    %{style | underline: true, double_underline: false, underline_style: :single}
+  end
+
+  defp apply_sgr_colon_code(4, [2 | _], style) do
+    %{style | underline: true, double_underline: true, underline_style: :double}
+  end
+
+  defp apply_sgr_colon_code(4, [3 | _], style) do
+    %{style | underline: true, double_underline: false, underline_style: :curly}
+  end
+
+  defp apply_sgr_colon_code(4, [4 | _], style) do
+    %{style | underline: true, double_underline: false, underline_style: :dotted}
+  end
+
+  defp apply_sgr_colon_code(4, [5 | _], style) do
+    %{style | underline: true, double_underline: false, underline_style: :dashed}
+  end
+
+  defp apply_sgr_colon_code(38, subparams, style) do
+    case parse_colon_color(subparams) do
+      {:ok, color} -> Map.put(style, :foreground, color)
+      :error -> style
+    end
+  end
+
+  defp apply_sgr_colon_code(48, subparams, style) do
+    case parse_colon_color(subparams) do
+      {:ok, color} -> Map.put(style, :background, color)
+      :error -> style
+    end
+  end
+
+  defp apply_sgr_colon_code(58, subparams, style) do
+    case parse_colon_color(subparams) do
+      {:ok, color} -> Map.put(style, :underline_color, color)
+      :error -> style
+    end
+  end
+
+  defp apply_sgr_colon_code(_code, _subparams, style), do: style
+
+  # 5;n (256-color)
+  defp parse_colon_color([5, n]) when n >= 0 and n <= 255,
+    do: {:ok, {:indexed, n}}
+
+  # 2;colorspace;r;g;b (truecolor); colorspace slot may be empty (nil) or an
+  # explicit id -- either way it's ignored here.
+  defp parse_colon_color([2, _colorspace, r, g, b])
+       when r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and
+              b <= 255,
+       do: {:ok, {:rgb, r, g, b}}
+
+  # 2;r;g;b (truecolor, no colorspace slot)
+  defp parse_colon_color([2, r, g, b])
+       when r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and
+              b <= 255,
+       do: {:ok, {:rgb, r, g, b}}
+
+  defp parse_colon_color(_), do: :error
 
   defp apply_sgr_code(0, _style, _rest), do: default_style()
 

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/text_formatting.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/text_formatting.ex
@@ -42,6 +42,9 @@ defmodule Raxol.Terminal.ANSI.TextFormatting do
           hyperlink: String.t() | nil
         }
 
+  @type underline_style ::
+          :none | :single | :double | :curly | :dotted | :dashed
+
   @type t :: %__MODULE__{
           bold: boolean(),
           italic: boolean(),
@@ -60,7 +63,9 @@ defmodule Raxol.Terminal.ANSI.TextFormatting do
           framed: boolean(),
           encircled: boolean(),
           overlined: boolean(),
-          hyperlink: String.t() | nil
+          hyperlink: String.t() | nil,
+          underline_style: underline_style(),
+          underline_color: color()
         }
 
   defstruct bold: false,
@@ -80,7 +85,9 @@ defmodule Raxol.Terminal.ANSI.TextFormatting do
             framed: false,
             encircled: false,
             overlined: false,
-            hyperlink: nil
+            hyperlink: nil,
+            underline_style: :single,
+            underline_color: nil
 
   # Core sub-module - Primary text formatting operations
   defmodule Core do
@@ -111,6 +118,19 @@ defmodule Raxol.Terminal.ANSI.TextFormatting do
 
     def get_foreground(%{} = style), do: style.foreground
     def get_background(%{} = style), do: style.background
+
+    def set_underline_color(style, color) do
+      style = ensure_text_formatting_struct(style)
+      %{style | underline_color: color}
+    end
+
+    def set_underline_style(style, underline_style) do
+      style = ensure_text_formatting_struct(style)
+      %{style | underline_style: underline_style}
+    end
+
+    def get_underline_color(%{} = style), do: style.underline_color
+    def get_underline_style(%{} = style), do: style.underline_style
 
     def set_double_width(style),
       do: %{style | double_width: true, double_height: :none}
@@ -339,6 +359,12 @@ defmodule Raxol.Terminal.ANSI.TextFormatting do
   def get_foreground(style), do: Core.get_foreground(style)
   @impl true
   def get_background(style), do: Core.get_background(style)
+  def set_underline_color(style, color), do: Core.set_underline_color(style, color)
+  def set_underline_style(style, underline_style),
+    do: Core.set_underline_style(style, underline_style)
+
+  def get_underline_color(style), do: Core.get_underline_color(style)
+  def get_underline_style(style), do: Core.get_underline_style(style)
   @impl true
   def set_double_width(style), do: Core.set_double_width(style)
   @impl true

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/csi_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/csi_handler.ex
@@ -168,8 +168,11 @@ defmodule Raxol.Terminal.Commands.CSIHandler do
   defp apply_sgr(emulator, params) do
     alias Raxol.Terminal.ANSI.SGR.Processor, as: SGRProcessor
 
-    params_string = Enum.map_join(params, ";", &Integer.to_string/1)
-    updated_style = SGRProcessor.handle_sgr(params_string, emulator.style)
+    # `params` comes from CommandsParser.parse_params/1, which already
+    # preserves colon subparameter groups as nested lists (e.g. "4:3" -> [4, 3]).
+    # Feed it straight to the processor instead of re-joining into a string --
+    # re-joining would need to reconstruct colons and can't round-trip nils.
+    updated_style = SGRProcessor.process_params(params, emulator.style)
     %{emulator | style: updated_style}
   end
 

--- a/packages/raxol_terminal/lib/raxol/terminal/parser/states/csi_param_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser/states/csi_param_state.ex
@@ -34,6 +34,11 @@ defmodule Raxol.Terminal.Parser.States.CSIParamState do
   defp dispatch_input(<<?;, rest::binary>>, emulator, parser_state),
     do: handle_separator(emulator, parser_state, rest)
 
+  # ':' is a valid CSI parameter byte (ECMA-48 0x30-0x3F) used for colon
+  # subparameters, e.g. SGR styled underline "4:3" or truecolor "38:2::r:g:b".
+  defp dispatch_input(<<?:, rest::binary>>, emulator, parser_state),
+    do: handle_colon(emulator, parser_state, rest)
+
   defp dispatch_input(
          <<intermediate_byte, rest::binary>>,
          emulator,
@@ -95,6 +100,15 @@ defmodule Raxol.Terminal.Parser.States.CSIParamState do
     # Log.debug(
     #   "CSIParamState.handle_separator: new_params=#{inspect(next_parser_state.params_buffer)}"
     # )
+
+    {:continue, emulator, next_parser_state, rest}
+  end
+
+  defp handle_colon(emulator, parser_state, rest) do
+    next_parser_state = %{
+      parser_state
+      | params_buffer: parser_state.params_buffer <> <<?:>>
+    }
 
     {:continue, emulator, next_parser_state, rest}
   end

--- a/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
@@ -267,15 +267,40 @@ defmodule Raxol.Terminal.Renderer do
         else: codes
 
     codes =
-      if Map.get(style_map, :underline, false),
-        do: [@ansi_underline | codes],
-        else: codes
+      case underline_style_ansi(Map.get(style_map, :underline_style)) do
+        nil ->
+          if Map.get(style_map, :underline, false),
+            do: [@ansi_underline | codes],
+            else: codes
+
+        code ->
+          [code | codes]
+      end
+
+    codes =
+      case underline_color_ansi(Map.get(style_map, :underline_color)) do
+        nil -> codes
+        code -> [code | codes]
+      end
 
     case codes do
       [] -> ""
       _ -> codes |> Enum.reverse() |> Enum.join("")
     end
   end
+
+  # Underline styles beyond plain/single are emitted via the colon-form SGR 4
+  # subparameter; :single, :none, and unset styles fall back to the plain
+  # boolean `:underline` handling above (byte-identical to prior behavior).
+  defp underline_style_ansi(:double), do: "\e[4:2m"
+  defp underline_style_ansi(:curly), do: "\e[4:3m"
+  defp underline_style_ansi(:dotted), do: "\e[4:4m"
+  defp underline_style_ansi(:dashed), do: "\e[4:5m"
+  defp underline_style_ansi(_), do: nil
+
+  defp underline_color_ansi({:rgb, r, g, b}), do: "\e[58;2;#{r};#{g};#{b}m"
+  defp underline_color_ansi({:index, n}), do: "\e[58;5;#{n}m"
+  defp underline_color_ansi(_), do: nil
 
   # Resolve foreground color to ANSI code
   defp resolve_fg_ansi(color, theme) when is_atom(color) do

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/sgr_processor_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/sgr_processor_test.exs
@@ -1,0 +1,167 @@
+defmodule Raxol.Terminal.ANSI.SGRProcessorTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.ANSI.SGRProcessor
+
+  describe "colon-form underline style (SGR 4:n)" do
+    test "4:0 clears underline" do
+      style = SGRProcessor.handle_sgr("4:0", nil)
+      assert style.underline == false
+      assert style.underline_style == :none
+    end
+
+    test "4:1 sets single underline" do
+      style = SGRProcessor.handle_sgr("4:1", nil)
+      assert style.underline == true
+      assert style.underline_style == :single
+    end
+
+    test "4:2 sets double underline" do
+      style = SGRProcessor.handle_sgr("4:2", nil)
+      assert style.underline == true
+      assert style.double_underline == true
+      assert style.underline_style == :double
+    end
+
+    test "4:3 sets curly underline" do
+      style = SGRProcessor.handle_sgr("4:3", nil)
+      assert style.underline == true
+      assert style.underline_style == :curly
+    end
+
+    test "4:4 sets dotted underline" do
+      style = SGRProcessor.handle_sgr("4:4", nil)
+      assert style.underline_style == :dotted
+    end
+
+    test "4:5 sets dashed underline" do
+      style = SGRProcessor.handle_sgr("4:5", nil)
+      assert style.underline_style == :dashed
+    end
+
+    test "unknown underline subparam is a no-op" do
+      style = SGRProcessor.handle_sgr("4:9", nil)
+      assert style.underline_style == :single
+      assert style.underline == false
+    end
+  end
+
+  describe "colon-form underline color (SGR 58)" do
+    test "58:5:n sets an indexed underline color" do
+      style = SGRProcessor.handle_sgr("58:5:196", nil)
+      assert style.underline_color == {:indexed, 196}
+    end
+
+    test "58:2::r:g:b (empty colorspace slot) sets an RGB underline color" do
+      style = SGRProcessor.handle_sgr("58:2::255:10:20", nil)
+      assert style.underline_color == {:rgb, 255, 10, 20}
+    end
+
+    test "58:2:r:g:b (no colorspace slot) also sets an RGB underline color" do
+      style = SGRProcessor.handle_sgr("58:2:255:10:20", nil)
+      assert style.underline_color == {:rgb, 255, 10, 20}
+    end
+
+    test "59 resets underline color" do
+      style =
+        "58:2::1:2:3"
+        |> SGRProcessor.handle_sgr(nil)
+        |> then(&SGRProcessor.handle_sgr("59", &1))
+
+      assert style.underline_color == nil
+    end
+  end
+
+  describe "colon-form 38/48 truecolor and 256-color" do
+    test "38:2::r:g:b sets RGB foreground" do
+      style = SGRProcessor.handle_sgr("38:2::10:20:30", nil)
+      assert style.foreground == {:rgb, 10, 20, 30}
+    end
+
+    test "38:5:n sets indexed foreground" do
+      style = SGRProcessor.handle_sgr("38:5:200", nil)
+      assert style.foreground == {:indexed, 200}
+    end
+
+    test "48:2::r:g:b sets RGB background" do
+      style = SGRProcessor.handle_sgr("48:2::1:2:3", nil)
+      assert style.background == {:rgb, 1, 2, 3}
+    end
+
+    test "48:5:n sets indexed background" do
+      style = SGRProcessor.handle_sgr("48:5:5", nil)
+      assert style.background == {:indexed, 5}
+    end
+  end
+
+  describe "mixed colon and semicolon params in one sequence" do
+    test "bold + curly underline + red foreground" do
+      style = SGRProcessor.handle_sgr("1;4:3;31", nil)
+      assert style.bold == true
+      assert style.underline == true
+      assert style.underline_style == :curly
+      assert style.foreground == :red
+    end
+
+    test "styled underline followed by extended color consumes its own params only" do
+      style = SGRProcessor.handle_sgr("4:3;38;5;196;1", nil)
+      assert style.underline_style == :curly
+      assert style.foreground == {:indexed, 196}
+      assert style.bold == true
+    end
+  end
+
+  describe "round trip: parse -> process_sgr_codes with pre-split codes" do
+    test "process_sgr_codes still accepts a flat integer list (unaffected by colon support)" do
+      style = SGRProcessor.process_sgr_codes([1, 4, 31, 48, 5, 196], nil)
+      assert style.bold == true
+      assert style.underline == true
+      assert style.foreground == :red
+      assert style.background == {:indexed, 196}
+    end
+  end
+
+  describe "regression: plain semicolon-form parsing is unchanged" do
+    test "basic attributes and colors" do
+      style = SGRProcessor.handle_sgr("1;4;31;48;5;196", nil)
+      assert style.bold == true
+      assert style.underline == true
+      assert style.foreground == :red
+      assert style.background == {:indexed, 196}
+      # Untouched by the plain semicolon underline (4), not a colon form
+      assert style.underline_style == :single
+      assert style.underline_color == nil
+    end
+
+    test "truecolor semicolon foreground/background" do
+      style = SGRProcessor.handle_sgr("38;2;10;20;30;48;2;40;50;60", nil)
+      assert style.foreground == {:rgb, 10, 20, 30}
+      assert style.background == {:rgb, 40, 50, 60}
+    end
+
+    test "existing semicolon-form underline color (58;5;n / 58;2;r;g;b)" do
+      style = SGRProcessor.handle_sgr("58;5;10", nil)
+      assert style.underline_color == {:indexed, 10}
+
+      style2 = SGRProcessor.handle_sgr("58;2;9;8;7", nil)
+      assert style2.underline_color == {:rgb, 9, 8, 7}
+    end
+
+    test "reset (0) clears everything, including new underline fields" do
+      style =
+        "1;4:3;58:2::1:2:3"
+        |> SGRProcessor.handle_sgr(nil)
+        |> then(&SGRProcessor.handle_sgr("0", &1))
+
+      assert style.bold == false
+      assert style.underline == false
+      assert style.underline_style == :single
+      assert style.underline_color == nil
+    end
+
+    test "empty params string defaults to reset (0)" do
+      style = SGRProcessor.handle_sgr("", nil)
+      assert style.bold == false
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/styled_underline_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/styled_underline_test.exs
@@ -1,0 +1,130 @@
+defmodule Raxol.Terminal.ANSI.StyledUnderlineTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.{Emulator, Renderer, ScreenBuffer}
+
+  # These exercise the live CSI dispatch pipeline
+  # (Emulator.process_input -> Parser -> Executor -> CSIHandler -> SGR
+  # Processor), not just the SGRProcessor module in isolation. Colon
+  # subparameters previously aborted the whole escape sequence at the
+  # byte-level CSI param parser before reaching any SGR code.
+
+  describe "live emulator dispatch: colon-form SGR" do
+    test "4:3 sets curly underline on emulator.style" do
+      {emulator, _} = Emulator.process_input(Emulator.new(), "\e[4:3m")
+      assert emulator.style.underline == true
+      assert emulator.style.underline_style == :curly
+    end
+
+    test "4:0 through 4:5 map to the expected underline styles" do
+      expected = %{
+        0 => :none,
+        1 => :single,
+        2 => :double,
+        3 => :curly,
+        4 => :dotted,
+        5 => :dashed
+      }
+
+      for {n, style} <- expected do
+        {emulator, _} = Emulator.process_input(Emulator.new(), "\e[4:#{n}m")
+        assert emulator.style.underline_style == style
+      end
+    end
+
+    test "58:2::r:g:b sets an RGB underline color" do
+      {emulator, _} =
+        Emulator.process_input(Emulator.new(), "\e[58:2::255:10:20m")
+
+      assert emulator.style.underline_color == {:rgb, 255, 10, 20}
+    end
+
+    test "58:5:n sets an indexed underline color" do
+      {emulator, _} = Emulator.process_input(Emulator.new(), "\e[58:5:196m")
+      assert emulator.style.underline_color == {:index, 196}
+    end
+
+    test "59 resets underline color" do
+      {emulator, _} =
+        Emulator.process_input(Emulator.new(), "\e[58:5:196m")
+
+      assert emulator.style.underline_color != nil
+
+      {emulator, _} = Emulator.process_input(emulator, "\e[59m")
+      assert emulator.style.underline_color == nil
+    end
+
+    test "colon and semicolon params combine in a single sequence" do
+      {emulator, _} =
+        Emulator.process_input(Emulator.new(), "\e[1;4:4;58;2;1;2;3m")
+
+      assert emulator.style.bold == true
+      assert emulator.style.underline_style == :dotted
+      assert emulator.style.underline_color == {:rgb, 1, 2, 3}
+    end
+  end
+
+  describe "regression: plain semicolon-form SGR is unaffected" do
+    test "bold + red foreground still works" do
+      {emulator, _} = Emulator.process_input(Emulator.new(), "\e[1;31m")
+      assert emulator.style.bold == true
+      assert emulator.style.foreground == :red
+      assert emulator.style.underline_style == :single
+      assert emulator.style.underline_color == nil
+    end
+
+    test "plain underline (4) toggles the boolean without touching underline_style" do
+      {emulator, _} = Emulator.process_input(Emulator.new(), "\e[4m")
+      assert emulator.style.underline == true
+      assert emulator.style.underline_style == :single
+
+      {emulator, _} = Emulator.process_input(emulator, "\e[24m")
+      assert emulator.style.underline == false
+    end
+  end
+
+  describe "round trip: parse -> render -> parse" do
+    test "curly underline survives a render round trip" do
+      {emulator, _} = Emulator.process_input(Emulator.new(), "\e[4:3m")
+
+      buffer = ScreenBuffer.new(1, 1)
+      buffer = ScreenBuffer.write_char(buffer, 0, 0, "x", emulator.style)
+      output = Renderer.new(buffer) |> Renderer.render()
+
+      assert output =~ "\e[4:3m"
+
+      # Reparse just the style prefix -- `output` also carries the trailing
+      # `\e[0m` reset emitted after the styled char, which would otherwise
+      # correctly reset the style back to defaults.
+      [prefix, _] = String.split(output, "x", parts: 2)
+      {reparsed, _} = Emulator.process_input(Emulator.new(), prefix)
+      assert reparsed.style.underline_style == :curly
+    end
+
+    test "RGB underline color survives a render round trip" do
+      {emulator, _} =
+        Emulator.process_input(Emulator.new(), "\e[58:2::9:8:7m")
+
+      buffer = ScreenBuffer.new(1, 1)
+      buffer = ScreenBuffer.write_char(buffer, 0, 0, "x", emulator.style)
+      output = Renderer.new(buffer) |> Renderer.render()
+
+      assert output =~ "\e[58;2;9;8;7m"
+
+      [prefix, _] = String.split(output, "x", parts: 2)
+      {reparsed, _} = Emulator.process_input(Emulator.new(), prefix)
+      assert reparsed.style.underline_color == {:rgb, 9, 8, 7}
+    end
+
+    test "plain underline still renders as the bare \\e[4m form" do
+      {emulator, _} = Emulator.process_input(Emulator.new(), "\e[4m")
+
+      buffer = ScreenBuffer.new(1, 1)
+      buffer = ScreenBuffer.write_char(buffer, 0, 0, "x", emulator.style)
+      output = Renderer.new(buffer) |> Renderer.render()
+
+      assert output =~ "\e[4m"
+      refute output =~ "\e[4:"
+    end
+  end
+end


### PR DESCRIPTION
## The bug

The CSI param byte parser (`csi_param_state.ex`) had no case for `:`. Any
colon-subparameter SGR sequence (styled underline `4:3`, truecolor
`38:2::r:g:b`, indexed underline color `58:5:n`, ...) hit the
unhandled-byte fallback, aborted the whole escape sequence mid-parse, and
printed the remainder as literal text. `CommandsParser.parse_params/1`
already parsed colon groups into nested lists correctly (`"4:3"` ->
`[4, 3]`) -- they just never reached it.

Downstream, `CSIHandler.apply_sgr/2` re-serialized already-parsed params
back into a `;`-joined string via `Integer.to_string/1`, which raises on
nested-list elements. It now passes the parsed list straight through
instead.

The live SGR processor (`Raxol.Terminal.ANSI.SGR.Processor`, in `sgr.ex`)
had no code-58 handling at all -- neither semicolon nor colon form -- and
no colon-subparameter support anywhere. `Raxol.Terminal.ANSI.TextFormatting`
(the struct `emulator.style` actually holds) had no `underline_style` /
`underline_color` fields.

## What's fixed

- `csi_param_state.ex`: `:` is now a valid CSI parameter byte (ECMA-48
  0x30-0x3F), appended to `params_buffer` like `;`.
- `csi_handler.ex`: `apply_sgr/2` no longer re-stringifies params; passes
  the pre-parsed list (ints + nested colon groups + nils) directly.
- `text_formatting.ex`: adds `underline_style`
  (`:none|:single|:double|:curly|:dotted|:dashed`, default `:single`) and
  `underline_color` fields + setters.
- `sgr.ex` (`SGR.Processor`, the module actually wired into
  `Emulator.process_input`): colon-subparameter support for `4:0..4:5`
  (underline style), `38:2::r:g:b` / `38:5:n`, `48:2::r:g:b` / `48:5:n`,
  `58:2::r:g:b` / `58:5:n` (underline color, colon *and* semicolon form --
  semicolon form 58/59 didn't exist before this either). Handles the
  ECMA-48 `::` empty-colorspace-slot quirk.
- `renderer.ex`: emits `\e[4:Nm` for styled underlines and
  `\e[58;2;r;g;bm` / `\e[58;5;nm` for underline color. Plain `;`-form SGR
  renders byte-identical to before.
- `sgr_processor.ex` (the standalone map-based module named in the
  original bug report): same colon parsing added. Turned out **not** to
  be reachable from `Emulator.process_input` -- it's a separate module
  from `SGR.Processor` above despite the similar name -- so the fix in
  `sgr.ex` + `csi_param_state.ex` is what actually makes this work through
  the real terminal input pipeline; this module's fix stands on its own
  since it's still directly tested and used by benchmarks.

Semicolon-only SGR sequences are unaffected -- parsing is purely additive,
confirmed via regression tests and the existing SGR test suite.

## Tests

- `sgr_processor_test.exs`: unit coverage per colon form (`4:0`-`4:5`,
  `38`/`48`/`58` with and without the empty `::` colorspace slot,
  256-color, `58`/`59`), mixed colon+semicolon sequences, and semicolon-only
  regressions.
- `styled_underline_test.exs`: same coverage through the live
  `Emulator.process_input` pipeline, plus parse -> render -> parse round
  trips confirming rendered output re-parses to the same style.
- Full existing `packages/raxol_terminal/test/raxol/terminal/{ansi,emulator,parser,commands}`
  suite plus renderer tests: 924 passed, 0 failed.