### PR TITLE
Preserve :id through box and translated flex containers

### DIFF
--- a/lib/raxol/ui/layout/engine.ex
+++ b/lib/raxol/ui/layout/engine.ex
@@ -432,6 +432,10 @@ defmodule Raxol.UI.Layout.Engine do
 
     box_element = %{
       type: :box,
+      # Carry the declaration id so accessibility surfaces can map this
+      # cell span back to the source node (Browser data-raxol-id, ARIA),
+      # matching how text/button/text_input boxes already do it.
+      id: Map.get(box, :id),
       x: space.x,
       y: space.y,
       width: width,
@@ -1106,6 +1110,9 @@ defmodule Raxol.UI.Layout.Engine do
 
     %{
       type: :flex,
+      # Carry the declaration id through so it isn't silently dropped when
+      # the literal :row/:column dialect is rewritten into :flex.
+      id: Map.get(el, :id),
       attrs: %{
         flex_direction: el.type,
         justify_content: containers_justify(read.(:justify, :start)),

--- a/test/raxol/ui/layout/engine_test.exs
+++ b/test/raxol/ui/layout/engine_test.exs
@@ -550,5 +550,93 @@ defmodule Raxol.UI.Layout.EngineTest do
       assert el.width == Raxol.UI.TextMeasure.display_width("Hello")
       assert el.height == 1
     end
+
+    test "box carries its id and geometry on the positioned element" do
+      view = %{
+        type: :box,
+        id: "panel",
+        children: [%{type: :text, content: "Hi"}]
+      }
+
+      el = positioned_by_id(view, "panel")
+
+      assert el.type == :box
+      assert el.width > 0
+      assert el.height > 0
+    end
+
+    test "box without an id keeps behaving exactly as before" do
+      view = %{type: :box, children: [%{type: :text, content: "Hi"}]}
+
+      [box_el, _text_el] = Engine.apply_layout(view, %{width: 80, height: 24})
+
+      assert box_el.type == :box
+      assert box_el.id == nil
+    end
+
+    # Neither the literal :row/:column dialect nor the View DSL :flex
+    # container produce a positioned element of their own -- Flexbox lays
+    # out and emits only the children, matching pre-existing behavior. So
+    # the container's own :id has nowhere to land in `apply_layout/2`
+    # output; these tests instead pin that translating a container with an
+    # :id (compat rewrite, or a raw :flex node) does not corrupt or drop
+    # the :id carried by a child, which is the identity that IS addressable
+    # today.
+    test "a literal :row with an id preserves a child box's id through the compat rewrite" do
+      view = %{
+        type: :row,
+        id: "toolbar",
+        children: [
+          %{
+            type: :box,
+            id: "save_btn",
+            children: [%{type: :text, content: "Save"}]
+          }
+        ]
+      }
+
+      el = positioned_by_id(view, "save_btn")
+
+      assert el.type == :box
+      assert el.width > 0
+      assert el.height > 0
+    end
+
+    test "a literal :column with an id preserves a child box's id through the compat rewrite" do
+      view = %{
+        type: :column,
+        id: "sidebar",
+        children: [
+          %{
+            type: :box,
+            id: "item1",
+            children: [%{type: :text, content: "Item"}]
+          }
+        ]
+      }
+
+      el = positioned_by_id(view, "item1")
+
+      assert el.type == :box
+      assert el.width > 0
+      assert el.height > 0
+    end
+
+    test "a View DSL :flex container with an id preserves a child box's id" do
+      view = %{
+        type: :flex,
+        id: "layout_root",
+        direction: :row,
+        children: [
+          %{type: :box, id: "card", children: [%{type: :text, content: "Card"}]}
+        ]
+      }
+
+      el = positioned_by_id(view, "card")
+
+      assert el.type == :box
+      assert el.width > 0
+      assert el.height > 0
+    end
   end
 end


### PR DESCRIPTION
Text positioned elements already stamp `id: Map.get(element, :id)` in `Raxol.UI.Layout.Engine`; container elements didn't. This adds the same convention to the `:box` positioned element and fixes `containers_compat_to_flex/2` (the literal `:row`/`:column` -> `:flex` rewrite), which was dropping `:id` entirely.

## What now carries `:id`

- `:box` positioned elements (the same top-level `id:` key already used by button/text_input/text), regardless of whether the box came from a literal `box()`/`%{type: :box}` node.
- The intermediate `%{type: :flex, ...}` map produced by `containers_compat_to_flex/2` when a literal `:row`/`:column` is rewritten -- the id is no longer silently dropped during translation.
- The direct View DSL `:flex` path (`enrich_flex_attrs/1`) already preserved `:id` -- it only adds/overwrites `:attrs` via `Map.put/3` and leaves other top-level keys, `:id` included, untouched. No change needed there.

## What doesn't (and why that's out of scope here)

`Flexbox.process_flex/3` never emits a positioned element for the container itself -- only for its children (`elements ++ acc`, verified at runtime: a bare `%{type: :flex, id: "x", children: [...]}` produces zero elements carrying `"x"`). Only `:box` produces a self-standing container element. So a bare row/column/flex still has nowhere in `apply_layout/2` output to land its own `:id` -- that's unchanged by this PR and would need a separate, larger change (synthesizing a container element for flex, analogous to box) if it's needed later. Scoped this PR to not introduce that.

## Semantic keys

Grepped for `:role`, `:aria_label`, `:label`, `:live_region`, `@mcp_role` as existing conventions before touching anything -- `:aria_label`/`:aria_description` exist only on `text_input`'s `:attrs` allowlist, nothing established at the container level. Per scope, didn't invent new semantic keys; `:id` is the only thing stamped.

## Characterization tests

`test/cross_terminal/layout_characterization_test.exs`'s `simplify/1` helper already does `Map.take(el, [:type, :x, :y, :width, :height])`, deliberately excluding `:id` from pinned comparisons -- no pins needed updating.

## Tests

Extended the existing `"element id preservation (accessibility)"` describe block in `test/raxol/ui/layout/engine_test.exs`:
- box with an id -> id present on the positioned box
- box without an id -> `id: nil`, unchanged from before
- a literal `:row`/`:column` with an id, wrapping a child box with its own id -> child's id survives the compat rewrite
- a raw `:flex` container with an id, wrapping a child box with its own id -> child's id survives

## Verification

- `MIX_ENV=test mix compile --warnings-as-errors` -- exit 0
- `mix format --check-formatted` -- exit 0
- `MIX_ENV=test TMPDIR=/tmp SKIP_TERMBOX2_TESTS=true mix test test/cross_terminal/ test/raxol/ui/layout/` -- 329 passed (9 properties, 320 tests), 0 failures