### PR TITLE
ADR-0029: the terminal cell model, and the rules that follow from it

### DIFF
--- a/docs/adr/0029-the-terminal-cell-model.md
+++ b/docs/adr/0029-the-terminal-cell-model.md
@@ -1,0 +1,153 @@
+# ADR-0029: The Terminal Cell Model
+
+## Status
+
+Accepted
+
+## Context
+
+A terminal is not a canvas. It is a grid of cells, and a cell holds exactly one
+grapheme, one foreground colour, one background colour, and a few attributes.
+That is the entire vocabulary. There is no alpha channel, no sub-cell
+positioning, no layers, and no compositing step.
+
+Almost every rendering bug this project has shipped came from reasoning as if the
+terminal *were* a canvas, and every one of them shared a signature:
+
+> **They were invisible on the default configuration.**
+
+An opaque black terminal running the default theme hides a remarkable number of
+mistakes. Painting an opaque black background where you meant "leave it alone"
+looks *exactly* correct — until somebody turns on transparency. Draw a
+background around a box's border instead of inside it and, on a dark theme, the
+result is plausible. The bugs only surface when a user changes something the
+author never varied.
+
+The concrete cases, all real:
+
+| What we did | Why it looked fine | What it actually was |
+|---|---|---|
+| Defaulted an unpainted background to `:black` | black on black | every "unpainted" cell painted `\e[40m`; opaque rectangles on a transparent terminal |
+| Painted the theme's background (= the terminal's own) on every cell | identical output | destroyed transparency, overrode the user's terminal |
+| A box's background painted the border ring, never the interior | dark outline on a dark theme | `box(bg: :blue)` drew a blue *outline* around a hollow middle |
+| An unpainted cell overwrote the cell beneath it | nothing beneath, usually | a button drawn on a modal **erased** the modal and showed the desktop through itself |
+| Joined frame rows with a bare `\n` | the shell used to cook it into CRLF | in raw output mode every row drifted a column right |
+
+None of these are exotic. They are what happens when the cell model is treated as
+an implementation detail instead of the thing the whole renderer is built on.
+
+## Decision
+
+Five invariants. Everything in the paint path follows from them.
+
+### 1. The cell is the atom of paint
+
+You cannot paint half a cell. This is not a limitation to work around; it is a
+fact to design against.
+
+Its sharpest consequence is that a **border glyph occupies a whole cell**, so a
+background cannot stop halfway through it. The border cell is either inside the
+background or outside it — which is a genuine choice, and CSS already named it:
+
+- `background_clip: :border_box` **(default)** — the background extends under the
+  border. A box that declares a background is a filled panel, and its frame is
+  that panel's edge.
+- `background_clip: :padding_box` — the background stops at the border's inner
+  edge, so the fill is inset and the outline sits on whatever is behind it.
+
+`:border_box` is the default because the alternative cuts a one-cell channel
+around the box's own frame, through which the backdrop shows. No choice of
+colours fixes that; the more the box and the backdrop differ, the worse it looks.
+
+### 2. Transparency is an absence, not a value
+
+There is no alpha. A cell is transparent **precisely when we emit no background
+SGR for it**. Transparency is therefore not something you set — it is something
+you *refrain from doing*.
+
+It follows that **you must never paint a background equal to the terminal's own**.
+On an opaque terminal it is a no-op; on a transparent one it is an opaque
+rectangle. This is exactly why the bug survived: the failure is invisible in the
+configuration its author was running.
+
+The theme's `background` is an *assumption* about the terminal's background.
+Painting it is the same mistake one layer up.
+
+### 3. "Unpainted" means *show what is beneath*
+
+Cells do not composite. Writing a cell **replaces** what was there. So an
+unpainted background cannot simply be written, or it will *erase* the background
+already at that coordinate — punching a hole through a filled parent.
+
+An unpainted background therefore **inherits the background already at that
+coordinate**. One rule; both cases fall out of it:
+
+- over a filled parent → the parent's fill (a button on a modal stays on the modal)
+- at the top of the tree → nothing beneath → still unpainted → the terminal shows through
+
+Enforced at both composition points: `CellManager.merge_cells/2` and the
+cells-to-buffer write. A painted background still overrides, as always.
+
+### 4. The terminal owns the canvas; the application colours the content
+
+The user chose their terminal's background. We adapt to it rather than replace
+it. This is already the premise of the H-K colour work: `Raxol.UI.CellDim`
+detects the real ground via **OSC 11** and *solves* colours against it.
+
+So: **themes colour content** — foreground, accents, borders. They do not paint
+the canvas. Foreground keeps a theme fallback (text needs a colour); background
+does not (a background is optional). An application that genuinely wants a
+different canvas sets a background explicitly, and that still paints.
+
+### 5. The frame owns its own geometry
+
+The driver runs `prim_tty` with raw output, so nothing cooks the frame's bytes on
+our behalf:
+
+- Rows are joined with `\r\n`, never a bare `\n`. In raw mode a lone LF advances
+  the line without returning to column 0, so every row after the first drifts one
+  column right.
+- **DECAWM (autowrap) is disabled** (`\e[?7l`). With autowrap on, the last cell of
+  a full-width row advances the cursor by itself and the row separator advances
+  it *again* — every content row costs two physical lines, halving the visible
+  frame.
+- Each styled run is terminated with `\e[0m`. This is what makes invariant 2 safe:
+  emitting no background code cannot leak the previous run's background.
+
+## Consequences
+
+**Positive.** Transparent terminals work. Themes compose with the user's terminal
+instead of fighting it. A modal is a solid panel sitting on the desktop, and the
+widgets inside it sit on the modal. The rules are few and they compose.
+
+**Negative.** Contributors must internalise that *unpainted is not black*, and
+that a background is optional in a way a foreground is not. The compositing rule
+(invariant 3) means cell writes are no longer a pure overwrite, which is a small
+cost in the hot path.
+
+**Related.** The layout counterpart to this ADR is that **only `:box` produces a
+positioned element** — `:flex`/`:row`/`:column` dissolve into their children's
+positions. Anything that must be addressable (identity, bounds, clipping, CSS
+keying, an accessibility role) has to be a box. See `docs/core/LAYOUT.md`.
+
+## The failure mode this ADR exists to prevent
+
+Every bug above is an instance of one pattern:
+
+> **One name doing two jobs.**
+
+- `:black` meant *unpainted* **and** *black*
+- `nil` meant *transparent* **and** *erase what's beneath*
+- a box's `bg` meant *fill* **and** *border paint*
+- `gap` was read from `attrs` **and** the top level — but not from `style`, where
+  people naturally put it
+- a border `variant` was *a known style* **and** *silently invisible* (an
+  unrecognised value fell through to `:none`, whose horizontal run is a space)
+
+In each case the two meanings were indistinguishable by the time they reached the
+renderer, and the wrong one was *silently* wrong. The fix was always the same
+move: **split the meanings apart, and make the wrong one unrepresentable.**
+
+When adding to the paint path, the question to ask is not "does this look right?"
+— on the default configuration it will. The question is: **what is this value's
+one job, and what happens when the user's terminal is not mine?**

--- a/docs/core/LAYOUT.md
+++ b/docs/core/LAYOUT.md
@@ -251,6 +251,35 @@ New code should use `:flex` (the View DSL macros) directly.
   intentionally unsupported (see section 2); revisit only with a concrete
   consumer.
 
+## Only `:box` is addressable
+
+`Flexbox.process_flex/3` emits positioned elements for a container's *children*,
+never for the container itself. A `:flex`/`:row`/`:column` **dissolves** into its
+children's positions: it is pure layout, and it does not exist in the output.
+
+Only `:box` produces a positioned element of its own. So a box is the only thing
+that can:
+
+- carry an `:id` (and therefore an accessibility role, a `data-raxol-id` CSS
+  selector, an MCP projection, a change-stream identity)
+- bound its own width/height
+- stamp `:clip_bounds` on its descendants (i.e. clip its content)
+- paint a background or a border
+
+**A component that must be addressable has to render as a `:box`.** This is not
+a gap to be filled in later; it is the split between "paints and is addressable"
+and "positions its children and vanishes".
+
+This has bitten us twice. `Viewport` rendered as a `:row`, so it could neither
+bound nor clip its own content -- its windowed rows painted straight through the
+enclosing border and over whatever followed. The same `:row` had no id, so the
+LiveView surface had nothing to key `overflow-anchor` CSS to, and the feature
+shipped inert.
+
+If you need flex layout *and* addressability, nest them: a `:box` that carries
+the identity, bounds, clipping and background, wrapping a `:flex` that does the
+layout.
+
 ## See also
 
 - `docs/core/ARCHITECTURE.md` -- where layout sits in the render pipeline.

--- a/docs/core/RENDERING.md
+++ b/docs/core/RENDERING.md
@@ -1,0 +1,144 @@
+# Rendering: how paint works, and the rules that keep it honest
+
+The *why* lives in [ADR-0029: The Terminal Cell Model](../adr/0029-the-terminal-cell-model.md).
+This is the working reference: what to do, what not to do, and the traps that
+have actually bitten us.
+
+---
+
+## The model in one paragraph
+
+A terminal is a grid of cells. A cell is `{x, y, grapheme, fg, bg, attrs}` — one
+grapheme, one foreground, one background. No alpha. No sub-cell positioning. No
+layers. The renderer turns positioned elements into cells, composes them into a
+`ScreenBuffer`, and emits one SGR-styled run per contiguous same-style span,
+each terminated with `\e[0m`.
+
+---
+
+## The five rules
+
+### 1. A background is optional. A foreground is not.
+
+Text needs a colour, so a foreground falls back to the theme. A background does
+not fall back to anything.
+
+```elixir
+text(content: "hi", fg: :red)     # fg :red, bg unpainted
+box(border: :single)              # fully transparent, border included
+box(border: :single, bg: :blue)   # a blue panel
+```
+
+### 2. Unpainted (`nil`) means *show what is beneath* — never "black", never "erase"
+
+```elixir
+bg: nil      # transparent: the parent's fill, or the terminal
+bg: :black   # an actual, opaque black
+```
+
+Over a filled parent, an unpainted cell inherits the parent's fill. At the top of
+the tree there is nothing beneath, so the terminal shows through. Both come from
+the same rule; you do not need to special-case "transparent" widgets.
+
+> **Never** default an unpainted background to `:black`. It renders `\e[40m` — an
+> opaque black cell. It looks correct on a black terminal and punches a hole
+> through a transparent one.
+
+### 3. Never paint a background equal to the terminal's own
+
+A cell is transparent *precisely because* we emitted no background for it. So
+painting the terminal's own colour is not a no-op — it is the destruction of
+transparency, disguised as a no-op.
+
+This includes the theme's `background`, which is only an *assumption* about the
+terminal's. **Themes colour content** (fg, accents, borders); the terminal owns
+the canvas. If an app genuinely wants a different canvas, it sets a background
+explicitly.
+
+To adapt to the real background rather than assume it, use
+`Raxol.UI.CellDim` — it detects the ground via OSC 11 and solves colours against
+it.
+
+### 4. A box's background fills the whole box, border included
+
+```elixir
+box(border: :single, bg: :blue)                            # blue panel, border on the fill
+box(border: :single, bg: :blue, border_bg: :red)           # red frame around a blue panel
+box(border: :single, bg: :blue,
+    background_clip: :padding_box)                         # fill inset; outline sits on what's behind
+```
+
+A cell cannot be half-painted, so the border glyph's cell is either inside the
+background or outside it. `:border_box` (the default) puts it inside: **a frame
+is the panel's edge, not a thing floating beside it.** Leaving it unpainted cuts
+a one-cell channel around the box through which the backdrop shows — a seam no
+choice of colours can fix.
+
+### 5. The frame owns its geometry — don't hand-roll escape codes
+
+Row joins are `\r\n` (raw output does not cook a bare `\n`), autowrap is disabled
+(`\e[?7l`), and every run is `\e[0m`-terminated. If you are writing escape codes
+by hand in a component, you are almost certainly in the wrong layer.
+
+> **Never** embed raw ANSI in a string passed to `text/1` or the View DSL. Use
+> `text("hi", fg: :cyan, style: [:bold])`, never `text("\e[36mhi\e[0m")`.
+
+---
+
+## Where to put things
+
+| You want | Set it on |
+|---|---|
+| a colour for text | `fg:` |
+| a filled panel | `bg:` on a `box` |
+| a differently-coloured frame | `border_bg:` |
+| the frame to *not* be part of the fill | `background_clip: :padding_box` |
+| a colour that adapts to the user's terminal | `Raxol.UI.CellDim` / the H-K palette |
+
+---
+
+## Traps that have actually bitten us
+
+Each of these shipped. Each was invisible on an opaque black terminal with the
+default theme.
+
+**`gap` is not read from `style`.** A literal `:row`/`:column` runs through the
+Containers compat map, which reads `gap` from `:attrs` or the **top level** —
+never from `:style` — and otherwise defaults it to **1** in layout mode.
+
+```elixir
+%{type: :column, style: %{gap: 0}, children: ...}   # ignored -> gap 1, double-spaced
+%{type: :column, gap: 0, children: ...}             # correct
+```
+
+**An unknown border variant renders as a space.** `BorderRenderer`'s catch-all
+maps anything unrecognised to `:none`, whose horizontal run is `" "`. So
+`variant: :heavy` (a style that does not exist) renders an *invisible* divider
+rather than failing. Resolve unknown variants to a visible default.
+
+**Only `:box` is addressable.** `:flex`/`:row`/`:column` dissolve into their
+children's positions and never become positioned elements — they cannot carry an
+id, bound their own height, or clip their content. A component that must be
+addressable (identity, bounds, clipping, CSS keying, an a11y role) has to render
+as a `:box`. See [LAYOUT.md](LAYOUT.md).
+
+**Cells do not composite.** Writing a cell replaces what was there. This is why
+rule 2 exists; if you add a new composition point, it must inherit an unpainted
+background rather than write `nil` over a fill.
+
+---
+
+## The question to ask
+
+Every bug above passed review, passed tests, and looked right — because it was
+tested on the configuration that hides it.
+
+So the review question is not *"does this look right?"* It is:
+
+> **What is this value's one job, and what happens when the user's terminal is
+> not mine?**
+
+Every one of these bugs was **one name doing two jobs** — `:black` meaning both
+*unpainted* and *black*; `nil` meaning both *transparent* and *erase*; a box's
+`bg` meaning both *fill* and *border paint*. The fix was always to split the
+meanings apart and make the wrong one unrepresentable.


### PR DESCRIPTION
Drew asked for an ADR explaining *how* and *why* the TUI paint path works the way it does. This aggregates what the last few days of rendering bugs taught us.

## The observation the ADR is built on

A terminal is not a canvas. It is a grid of cells; a cell holds one grapheme, one foreground, one background. No alpha, no sub-cell positioning, no compositing.

Nearly every rendering bug we shipped came from reasoning as if it *were* a canvas — and every one shared a signature:

> **They were invisible on the default configuration.**

An opaque black terminal running the default theme hides a remarkable number of mistakes. Painting an opaque black background where you meant "leave it alone" looks *exactly right* — until someone turns on transparency.

| What we did | Why it looked fine | What it actually was |
|---|---|---|
| Defaulted an unpainted background to `:black` | black on black | every "unpainted" cell painted `\e[40m` |
| Painted the theme's background (= the terminal's own) | identical output | destroyed transparency, overrode the user's terminal |
| A box's background painted the border ring, never the interior | dark outline on a dark theme | `box(bg: :blue)` drew a blue *outline* around a hollow middle |
| An unpainted cell overwrote the cell beneath it | usually nothing beneath | a button on a modal **erased** the modal and showed the desktop through itself |
| Joined frame rows with a bare `\n` | the shell used to cook it to CRLF | in raw output every row drifted a column right |

## What's in it

**`docs/adr/0029-the-terminal-cell-model.md`** — five invariants and their consequences:

1. **The cell is the atom of paint.** You cannot half-paint. A border glyph fills a whole cell, so `background_clip` (`:border_box` default) is a real choice, not a detail.
2. **Transparency is an absence, not a value.** A cell is transparent *precisely because* we emitted no background for it. Therefore: never paint a background equal to the terminal's own.
3. **"Unpainted" means *show what is beneath*.** Cells don't composite, so an unpainted background must inherit, not erase.
4. **The terminal owns the canvas; the app colours the content.** Themes colour fg/accents/borders. This is already CellDim's premise (OSC 11 + H-K solving against the *real* ground) — the theme layer just contradicted it.
5. **The frame owns its geometry.** `\r\n` row joins, DECAWM off, `\e[0m`-terminated runs.

**`docs/core/RENDERING.md`** — the working reference: the rules, where to put things, and the traps that have actually bitten us (`gap` isn't read from `style`; an unknown border variant renders as a *space*; only `:box` is addressable; cells don't composite).

**`docs/core/LAYOUT.md`** — gains the layout counterpart: **only `:box` produces a positioned element**; `:flex`/`:row`/`:column` dissolve. That's why `Viewport` could neither bound nor clip its own content, and why the LiveView `overflow-anchor` CSS shipped inert.

## The pattern underneath all of it

Every bug was **one name doing two jobs**:

- `:black` = *unpainted* **and** *black*
- `nil` = *transparent* **and** *erase what's beneath*
- a box's `bg` = *fill* **and** *border paint*
- `gap` = read from `attrs` **and** top-level — but not `style`, where people put it
- a border `variant` = *a known style* **and** *silently invisible*

Each time the two meanings were indistinguishable by the time they reached the renderer, and the wrong one was *silently* wrong. The fix was always the same move: split the meanings apart and make the wrong one unrepresentable.

So the review question isn't *"does this look right?"* — on the default configuration it will. It's: **what is this value's one job, and what happens when the user's terminal is not mine?**

Docs only; no code.