### PR TITLE
Stop the divider defaulting its background to black

### DIFF
--- a/lib/raxol/ui/ui_renderer.ex
+++ b/lib/raxol/ui/ui_renderer.ex
@@ -264,7 +264,7 @@ defmodule Raxol.UI.Renderer do
        ) do
     style = Map.get(element, :style, %{})
     fg = Map.get(style, :fg, :white)
-    bg = Map.get(style, :bg, :black)
+    bg = Map.get(style, :bg)
     ch = String.at(char || "-", 0) || "-"
 
     for col <- 0..(w - 1), do: {x + col, y, ch, fg, bg, []}


### PR DESCRIPTION
One-line fix, same class as #520.

`render_visible_element(%{type: :divider, ...})` in `ui_renderer.ex` defaulted
`bg` to `:black` when no style was set. Every other element in the paint path
(`element_renderer`, `border_renderer`) went through this fix in #520; the
divider clause was outside that sweep and kept the old default.

Visible effect: a divider inside a modal punches an opaque black cell through
the modal's `:surface` fill, instead of showing it — see ADR-0029 rule 2 (an
unpainted background means "show what is beneath", not "paint black").

```elixir
bg = Map.get(style, :bg, :black)   # before
bg = Map.get(style, :bg)           # after -- nil, inherits the fill beneath
```

No test pinned the old default. Full suite: 4712/4715 — the 3 failures are
pre-existing env-leak flakes (`TERM`/metrics timing), unrelated and present
on master too.