### PR TITLE
Read :border, not the dead :border_style key, when picking box glyphs

### DIFF
--- a/lib/raxol/ui/element_renderer.ex
+++ b/lib/raxol/ui/element_renderer.ex
@@ -217,7 +217,10 @@ defmodule Raxol.UI.ElementRenderer do
          style
        ) do
     border_chars =
-      BorderRenderer.get_border_chars(Map.get(style, :border_style, :single))
+      style
+      |> Map.get(:border, :single)
+      |> normalize_border_variant()
+      |> BorderRenderer.get_border_chars()
 
     BorderRenderer.render_box_borders(
       clip_x,
@@ -246,6 +249,17 @@ defmodule Raxol.UI.ElementRenderer do
       style
     )
   end
+
+  # `:border` doubles as the enable flag (checked above) and the variant
+  # selector; by the time we're here it is guaranteed truthy and non-:none.
+  # Map anything BorderRenderer.get_border_chars/1 has no glyph set for
+  # (:bold, :dashed, a stray `true`) to a visible default instead of letting
+  # its catch-all fall through to :none, whose horizontal run is a space.
+  defp normalize_border_variant(variant)
+       when variant in [:single, :double, :rounded, :ascii],
+       do: variant
+
+  defp normalize_border_variant(_), do: :single
 
   defp render_text_if_valid_coordinates(x, y, _text, _style)
        when x < 0 or y < 0,


### PR DESCRIPTION
\`render_clipped_box/5\` reads \`:border\` to decide whether to draw a border.
The very next clause, \`render_box_with_border_option/6\`, read a different
key -- \`:border_style\` -- to decide which glyph set. Nothing in the box
pipeline ever sets \`:border_style\`, so it always fell back to \`:single\`:
a box declaring \`border: :rounded\` rendered square corners regardless.

Same shape as the divider background default (#526) and the whole ADR-0029
catalog: two names doing one job, and the wrong one wins silently because
the failure only shows up once you're looking at the actual glyph.

\`:border\` can also legitimately hold \`:bold\`/\`:dashed\` (documented variants
with no glyph set in \`BorderRenderer\`) -- routed to \`:single\` rather than
falling through \`BorderRenderer\`'s own catch-all to \`:none\`, whose
horizontal run is a space (an invisible border, worse than a square one).

No test asserted a specific square-corner glyph; the two tests that touch
this path (\`theme_handling_test.exs\`, \`demo_render_test.exs\`) check
fg/bg/attrs and a regex that already matches both box-drawing sets.

Full suite: 4713/4715 -- the 2 failures are pre-existing env-leak/timing
flakes, present on master, unrelated.

**Found, not fixed here** (same audit, separate concern): the layout engine
nests a top-level-declared \`:border\` under \`:attrs\` (\`engine.ex:464\`) and
nothing lifts it back into \`:style\` before render -- a box whose variant is
declared outside the \`:style\` map renders no border at all. Flagging for a
follow-up.