### PR TITLE
Enable style batching on the terminal render path

### DIFF
--- a/lib/raxol/core/runtime/rendering/backends.ex
+++ b/lib/raxol/core/runtime/rendering/backends.ex
@@ -21,7 +21,10 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
 
     updated_buffer = apply_cells_to_buffer(cells, state)
 
-    renderer = Raxol.Terminal.Renderer.new(updated_buffer)
+    # style_batching: merge adjacent same-style cells into one SGR run instead
+    # of one SGR + reset per cell. Round-trip-identical (each run still
+    # \e[0m-terminated), 8-28x fewer bytes on styled UIs.
+    renderer = Raxol.Terminal.Renderer.new(updated_buffer, %{}, %{}, true)
     output_string = Raxol.Terminal.Renderer.render(renderer)
 
     Raxol.Core.Runtime.Log.debug(
@@ -163,7 +166,10 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
   def render_to_ssh(cells, state) do
     updated_buffer = apply_cells_to_buffer(cells, state)
 
-    renderer = Raxol.Terminal.Renderer.new(updated_buffer)
+    # style_batching: merge adjacent same-style cells into one SGR run instead
+    # of one SGR + reset per cell. Round-trip-identical (each run still
+    # \e[0m-terminated), 8-28x fewer bytes on styled UIs.
+    renderer = Raxol.Terminal.Renderer.new(updated_buffer, %{}, %{}, true)
     output_string = Raxol.Terminal.Renderer.render(renderer)
 
     # Home cursor and clear screen before each frame, matching render_to_terminal


### PR DESCRIPTION
`Raxol.Terminal.Renderer.new/4` defaults `style_batching` to `false`, so the
terminal (and SSH) render path emits one SGR prefix **plus a `\e[0m` reset per
cell**. Run-merging adjacent same-style cells into a single SGR is:

- **round-trip-identical** — each run still `\e[0m`-terminates, so ADR-0029
  invariant 2 (transparency) holds; the reference-emulator round-trip yields a
  byte-for-byte identical grid.
- **8-28x fewer bytes** on run-structured styled UIs (measured: 8.15x at 80-col,
  17x at 300-col, 28x on flat panels; 1.0x only on per-cell-unique gradients,
  where nothing is shared).

This is the companion change that re-prices the incremental-render work (R1): the
"~19 KB frame" and "a row repaint is cheap" premises are artifacts of this
off-by-default flag on the exact call site R1 rewrites. Flipping it first makes
those numbers honest and is independently valuable.

Scope: one flag at the two `backends.ex` render sites (`render_to_terminal`,
`render_to_ssh`). The only other production `Terminal.Renderer.render` caller
constructs its own renderer with the `false` default and is untouched.

Full suite: 4720/4721 (the one failure is the pre-existing sleep-based
`MetricsCollectorTest` flake, `:skip_on_ci`, unrelated). Round-trip + SSH
full-repaint contract properties stay green.