### PR TITLE
Render the terminal incrementally: diff the grid, one CUP vocabulary

### DIFF
--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -914,6 +914,19 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     end
   end
 
+  # Ctrl-L forces a full-screen repaint -- recovery from out-of-band corruption
+  # (a stray write, a resize we missed). Redraw is a runtime concern, so the
+  # dispatcher fires it directly, then lets the event pass through: some apps
+  # also bind Ctrl-L (e.g. clear), and a repaint composes with whatever they do.
+  defp maybe_handle_focus_navigation(
+         %Event{type: :key, data: %{key: :char, char: "l", ctrl: true}},
+         state
+       ) do
+    if pid = state.rendering_engine, do: GenServer.cast(pid, :force_repaint)
+    if rt = state.runtime_pid, do: send(rt, :render_needed)
+    :pass
+  end
+
   defp maybe_handle_focus_navigation(_event, _state), do: :pass
 
   defp focus_manager_active? do

--- a/lib/raxol/core/runtime/rendering/backends.ex
+++ b/lib/raxol/core/runtime/rendering/backends.ex
@@ -25,14 +25,8 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
     # of one SGR + reset per cell. Round-trip-identical (each run still
     # \e[0m-terminated), 8-28x fewer bytes on styled UIs.
     renderer = Raxol.Terminal.Renderer.new(updated_buffer, %{}, %{}, true)
-    output_string = Raxol.Terminal.Renderer.render(renderer)
 
-    Raxol.Core.Runtime.Log.debug(
-      "Rendering Engine: Terminal output generated (length: #{String.length(output_string)})"
-    )
-
-    # Move cursor to top-left and clear screen before each frame
-    frame = normalize_frame("\e[H\e[2J" <> output_string)
+    frame = build_terminal_frame(state.buffer, updated_buffer, renderer, state)
 
     if state.sync_output do
       IO.write("\e[?2026h")
@@ -47,7 +41,48 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
       Raxol.Recording.Recorder.record_output(pid, frame)
     end
 
-    {:ok, %{state | buffer: updated_buffer}}
+    # Map.put (not %{state | ...}) so the flag is set whether or not the caller's
+    # state carries it -- the real Engine.State always does; test states may not.
+    {:ok,
+     state |> Map.put(:buffer, updated_buffer) |> Map.put(:force_repaint, false)}
+  end
+
+  # --- Incremental frame emission ---
+  #
+  # One absolute-CUP vocabulary for both frame kinds (ADR-0029 inv 5): every row
+  # is emitted at \e[y;1H, so there are no \r\n row-joins and no full-screen
+  # clear on the common path. A keyframe is that same emit over every row, with
+  # a leading \e[2J; a diff emits only rows whose cells changed. `state.buffer`
+  # is the previous frame, already in hand -- the grid is its own diff basis.
+
+  @doc false
+  def build_terminal_frame(prev, next, renderer, state) do
+    if keyframe?(prev, next, state) do
+      "\e[2J" <> emit_rows(renderer, all_rows(next))
+    else
+      emit_rows(renderer, changed_rows(prev, next))
+    end
+  end
+
+  defp keyframe?(nil, _next, _state), do: true
+  defp keyframe?(_prev, _next, %{force_repaint: true}), do: true
+
+  defp keyframe?(prev, next, _state),
+    do: prev.width != next.width or prev.height != next.height
+
+  defp all_rows(buffer), do: Enum.to_list(0..(buffer.height - 1)//1)
+
+  defp changed_rows(prev, next) do
+    Enum.filter(0..(next.height - 1)//1, fn y ->
+      Enum.at(prev.cells, y) != Enum.at(next.cells, y)
+    end)
+  end
+
+  defp emit_rows(renderer, rows) do
+    Enum.map_join(rows, "", fn y ->
+      "\e[#{y + 1};1H\e[0m\e[2K" <>
+        Raxol.Terminal.Renderer.render_row(renderer, y)
+    end)
   end
 
   @doc """
@@ -328,10 +363,17 @@ defmodule Raxol.Core.Runtime.Rendering.Backends do
         |> Map.merge(Map.take(attrs_map, [:bold, :underline, :italic]))
         |> put_hyperlink(hyperlink)
 
-      cell = %Raxol.Terminal.Cell{char: char, style: cell_attrs}
+      cell = %Raxol.Terminal.Cell{char: sanitize_char(char), style: cell_attrs}
       {x, y, cell}
     end)
   end
+
+  # A cell holds one glyph. A control byte here -- an in-cell \n, \e, \t -- would
+  # under incremental rendering corrupt its row and bleed onto the next, and
+  # unlike the old clear-every-frame path nothing repaints the victim row. Blank
+  # it at the write boundary so the invalid cell is unrepresentable downstream.
+  defp sanitize_char(<<c::utf8>>) when c < 0x20 or c == 0x7F, do: " "
+  defp sanitize_char(char), do: char
 
   # Pull a tagged `{:hyperlink, url}` entry out of the cell attrs list; the
   # remaining entries are plain style atoms. Returns {url_or_nil, atoms}.

--- a/lib/raxol/core/runtime/rendering/engine.ex
+++ b/lib/raxol/core/runtime/rendering/engine.ex
@@ -41,7 +41,11 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
               # Cycle profiler pid (nil when disabled)
               cycle_profiler: nil,
               # Cached prepared element tree (Pretext-inspired two-phase)
-              prepared_tree: nil
+              prepared_tree: nil,
+              # Force the next terminal frame to be a full keyframe (first frame,
+              # resize, or Ctrl-L recovery). Set true so the first render always
+              # paints a full frame; the terminal backend clears it after one frame.
+              force_repaint: true
   end
 
   # --- Public API ---
@@ -146,8 +150,17 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
 
     new_state = %{state | width: w, height: h}
 
+    # Resize owns the keyframe. This handler swaps in a fresh blank buffer of the
+    # new size, so by render time dims already match and a render-time dims check
+    # can't fire -- and diffing against the blank would leave stale pre-resize
+    # rows unpainted. Force a full repaint instead.
     resized_buffer = ScreenBuffer.new(w, h)
-    {:noreply, %{new_state | buffer: resized_buffer}}
+    {:noreply, %{new_state | buffer: resized_buffer, force_repaint: true}}
+  end
+
+  @impl true
+  def handle_cast(:force_repaint, state) do
+    {:noreply, %{state | force_repaint: true}}
   end
 
   @impl true

--- a/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
@@ -157,6 +157,36 @@ defmodule Raxol.Terminal.Renderer do
     |> maybe_apply_cursor(renderer.cursor)
   end
 
+  @doc """
+  Renders each buffer row to its own ANSI string, in order.
+
+  `render/1` is `Enum.join(render_rows(renderer), "\\n")` modulo the (currently
+  no-op) font/cursor wrappers -- a property pinned by test. An incremental
+  renderer diffs the grid and re-emits individual rows via this instead of
+  rebuilding the whole frame string.
+  """
+  @spec render_rows(t()) :: [String.t()]
+  def render_rows(%__MODULE__{} = renderer) do
+    Enum.map(
+      renderer.screen_buffer.cells,
+      &render_row_optimized(&1, renderer.theme, renderer.style_batching)
+    )
+  end
+
+  @doc """
+  Renders a single row (0-based) to its ANSI string. Out-of-range rows render
+  as `""`. A row is a pure function of its own cells -- it carries no pen state
+  from the row above, so a row rendered in isolation is byte-identical to its
+  slice of the full frame.
+  """
+  @spec render_row(t(), non_neg_integer()) :: String.t()
+  def render_row(%__MODULE__{} = renderer, y) when is_integer(y) and y >= 0 do
+    case Enum.at(renderer.screen_buffer.cells, y) do
+      nil -> ""
+      row -> render_row_optimized(row, renderer.theme, renderer.style_batching)
+    end
+  end
+
   defp get_styled_content_optimized(buffer, theme, style_batching) do
     buffer.cells
     |> Enum.map_join("\n", fn row ->

--- a/packages/raxol_terminal/test/raxol/terminal/renderer_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/renderer_test.exs
@@ -199,7 +199,11 @@ defmodule Raxol.Terminal.RendererTest do
       buffer =
         ScreenBuffer.new(1, 1) |> ScreenBuffer.write_char(0, 0, "X", style)
 
-      theme = %{foreground: %{green: "#00FF00"}, background: %{black: "#000000"}}
+      theme = %{
+        foreground: %{green: "#00FF00"},
+        background: %{black: "#000000"}
+      }
+
       renderer = Renderer.new(buffer, theme)
       output = Renderer.render(renderer)
 
@@ -218,7 +222,12 @@ defmodule Raxol.Terminal.RendererTest do
 
     test ~c"uses default theme colors when cell style is nil" do
       buffer = ScreenBuffer.new(1, 1) |> ScreenBuffer.write_char(0, 0, "X", %{})
-      theme = %{foreground: %{default: "#AABBCC"}, background: %{default: "#DDEEFF"}}
+
+      theme = %{
+        foreground: %{default: "#AABBCC"},
+        background: %{default: "#DDEEFF"}
+      }
+
       renderer = Renderer.new(buffer, theme)
       output = Renderer.render(renderer)
 
@@ -256,6 +265,47 @@ defmodule Raxol.Terminal.RendererTest do
       output = Renderer.render(renderer)
       assert String.contains?(output, "\e[32m")
       assert String.contains?(output, "X")
+    end
+  end
+
+  describe "render_rows/1 and render_row/2" do
+    defp styled_multi_row_buffer do
+      ScreenBuffer.new(6, 3)
+      |> ScreenBuffer.write_char(0, 0, "h", %{foreground: :red, bold: true})
+      |> ScreenBuffer.write_char(1, 0, "i", %{foreground: :red})
+      |> ScreenBuffer.write_char(0, 1, "世", %{})
+      |> ScreenBuffer.write_char(0, 2, "z", %{background: :blue})
+    end
+
+    test ~c"render/1 is join(render_rows, \\n) -- the G1 pin" do
+      for buffer <- [styled_multi_row_buffer(), default_buffer(10, 4)],
+          batching <- [false, true] do
+        renderer = Renderer.new(buffer, %{}, %{}, batching)
+
+        assert Renderer.render(renderer) ==
+                 Enum.join(Renderer.render_rows(renderer), "\n")
+      end
+    end
+
+    test ~c"render_row/2 equals its slice of render_rows/1" do
+      renderer = Renderer.new(styled_multi_row_buffer(), %{}, %{}, true)
+      rows = Renderer.render_rows(renderer)
+
+      for y <- 0..(length(rows) - 1) do
+        assert Renderer.render_row(renderer, y) == Enum.at(rows, y)
+      end
+    end
+
+    test ~c"render_row/2 renders a row in isolation with no pen bleed" do
+      renderer = Renderer.new(styled_multi_row_buffer(), %{}, %{}, true)
+      # row 0 opens its own SGR; it does not depend on any prior row's pen
+      assert Renderer.render_row(renderer, 0) =~ "\e[31m"
+      assert Renderer.render_row(renderer, 0) =~ "\e[0m"
+    end
+
+    test ~c"render_row/2 out of range is empty" do
+      renderer = Renderer.new(ScreenBuffer.new(4, 2), %{}, %{}, false)
+      assert Renderer.render_row(renderer, 99) == ""
     end
   end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/renderer_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/renderer_test.exs
@@ -234,8 +234,10 @@ defmodule Raxol.Terminal.RendererTest do
       assert String.contains?(output, "X")
       # Default fg: #AABBCC
       assert String.contains?(output, "\e[38;2;170;187;204m")
-      # Default bg: #DDEEFF
-      assert String.contains?(output, "\e[48;2;221;238;255m")
+      # Default bg (#DDEEFF) is left unpainted: an unpainted background emits
+      # nothing so the cell stays transparent to the terminal's own background
+      # (ADR-0029). Painting the theme default here would fill every cell.
+      refute String.contains?(output, "\e[48;2;221;238;255m")
       assert String.contains?(output, "\e[0m")
       # No bold/italic/underline
       refute String.contains?(output, "\e[1m")

--- a/test/cross_terminal/r1_render_oracle_test.exs
+++ b/test/cross_terminal/r1_render_oracle_test.exs
@@ -1,0 +1,208 @@
+defmodule Raxol.CrossTerminal.R1RenderOracleTest do
+  @moduledoc """
+  Spike for the R1 autonomous validation flow (proposal §11). Exercises the
+  reference emit (`RenderOracle`) through the reference emulator and asserts the
+  design's oracles — no golden bytes, no tty, no human.
+
+  L0/L1 exercise the reference emit (`RenderOracle`); L2 drives the shipped
+  production emit (`Backends.build_terminal_frame/4`) through the emulator for
+  the recovery and sanitization invariants.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Test.CrossTerminal.RenderOracle, as: Oracle
+  alias Raxol.Core.Runtime.Rendering.Backends
+  alias Raxol.Terminal.{Emulator, Renderer}
+  alias Raxol.Terminal.Buffer.Queries
+
+  # --- L0: deterministic oracle fixtures ---------------------------------
+
+  describe "L0 fixtures" do
+    test "oracle 4 — an unchanged frame emits nothing" do
+      buf = Oracle.grid(6, 3, fn x, _y -> <<?a + x::utf8>> end)
+
+      assert Oracle.changed_rows(buf, buf) == []
+      assert Oracle.emit(buf, buf) == ""
+    end
+
+    test "oracle 4 — only changed rows are addressed" do
+      prev = Oracle.grid(6, 3, fn _x, _y -> " " end)
+      next = Oracle.build(6, 3, [{0, 1, "X"}])
+
+      assert Oracle.changed_rows(prev, next) == [1]
+      # exactly one CUP address, to row 2 (1-based)
+      assert Oracle.emit(prev, next) =~ "\e[2;1H"
+      refute Oracle.emit(prev, next) =~ "\e[1;1H"
+      refute Oracle.emit(prev, next) =~ "\e[3;1H"
+    end
+
+    test "oracle 1 — keyframe round-trips to the buffer's own text" do
+      buf =
+        Oracle.build(10, 3, [
+          {0, 0, "h"},
+          {1, 0, "i"},
+          {0, 2, "z"}
+        ])
+
+      assert Oracle.grid_full(buf) == Oracle.buffer_text(buf)
+    end
+
+    test "oracle 2 — a one-cell change lands the same grid as a fresh keyframe" do
+      prev = Oracle.grid(8, 4, fn _x, _y -> " " end)
+      next = Oracle.build(8, 4, [{3, 2, "Q"}])
+
+      assert Oracle.grid_diff(prev, next) == Oracle.grid_full(next)
+    end
+  end
+
+  # --- L1: generative property -------------------------------------------
+
+  describe "L1 property" do
+    # Small dims keep each check to microseconds; StreamData shrinks any
+    # failure to a minimal grid pair.
+    defp dims, do: {StreamData.integer(3..7), StreamData.integer(2..4)}
+
+    defp safe_char, do: StreamData.member_of([" ", "a", "b", "c"])
+
+    defp buffer_gen(w, h) do
+      cells = StreamData.list_of(safe_char(), length: w * h)
+
+      StreamData.map(cells, fn flat ->
+        Oracle.grid(w, h, fn x, y -> Enum.at(flat, y * w + x) end)
+      end)
+    end
+
+    property "oracle 2 — diff(prev,next) reaches the same grid as keyframe(next)" do
+      {w_gen, h_gen} = dims()
+
+      check all(
+              w <- w_gen,
+              h <- h_gen,
+              prev <- buffer_gen(w, h),
+              next <- buffer_gen(w, h),
+              max_runs: 200
+            ) do
+        assert Oracle.grid_diff(prev, next) == Oracle.grid_full(next)
+      end
+    end
+
+    property "oracle 1 — keyframe round-trips for any generated grid" do
+      {w_gen, h_gen} = dims()
+
+      check all(
+              w <- w_gen,
+              h <- h_gen,
+              buf <- buffer_gen(w, h),
+              max_runs: 200
+            ) do
+        assert Oracle.grid_full(buf) == Oracle.buffer_text(buf)
+      end
+    end
+  end
+
+  # --- L2: production emit -- recovery + sanitization --------------------
+  #
+  # Drives the shipped Backends.build_terminal_frame/4 (not the reference emit)
+  # through one emulator threaded across steps, so resize, corruption recovery,
+  # and C0 sanitization are asserted on the code that actually ships.
+
+  describe "L2 production emit" do
+    defp prod_frame(prev, next, force_repaint) do
+      renderer = Renderer.new(next, %{}, %{}, true)
+
+      Backends.build_terminal_frame(prev, next, renderer, %{
+        force_repaint: force_repaint
+      })
+    end
+
+    defp apply_to(emulator, bytes) do
+      {emu, _} = Emulator.process_input(emulator, bytes)
+      emu
+    end
+
+    defp emu_grid(emulator) do
+      emulator |> Emulator.get_screen_buffer() |> Queries.get_text()
+    end
+
+    test "keyframe paints, corruption persists through a no-op diff, force_repaint recovers" do
+      a = Oracle.build(6, 3, [{0, 0, "A"}, {2, 1, "B"}])
+      emu = Emulator.new(6, 3)
+
+      # keyframe paints model A
+      emu = apply_to(emu, prod_frame(nil, a, true))
+      assert emu_grid(emu) == Queries.get_text(a)
+
+      # out-of-band corruption (a stray write the runtime didn't make)
+      emu = apply_to(emu, "\e[1;1HXX")
+      refute emu_grid(emu) == Queries.get_text(a)
+
+      # a no-op diff (identical model) emits nothing, so corruption persists
+      noop = prod_frame(a, a, false)
+      assert noop == ""
+      emu = apply_to(emu, noop)
+      refute emu_grid(emu) == Queries.get_text(a)
+
+      # force_repaint (Ctrl-L / resume) re-keyframes and restores model A
+      emu = apply_to(emu, prod_frame(a, a, true))
+      assert emu_grid(emu) == Queries.get_text(a)
+    end
+
+    test "resize forces a keyframe that repaints the whole new-size grid" do
+      # engine's :update_size swaps in a fresh blank buffer of the new size and
+      # sets force_repaint -- the next frame is an all-rows keyframe
+      blank = Oracle.grid(6, 3, fn _x, _y -> " " end)
+      next = Oracle.build(6, 3, [{0, 0, "R"}, {0, 2, "z"}])
+
+      frame = prod_frame(blank, next, true)
+      assert String.starts_with?(frame, "\e[2J")
+
+      emu = apply_to(Emulator.new(6, 3), frame)
+      assert emu_grid(emu) == Queries.get_text(next)
+    end
+
+    test "an in-cell control byte is sanitized, never bled into the frame (G5)" do
+      # a cell holding a raw \n would, unsanitized, land mid-row and shove the
+      # rest onto the next line -- and no unchanged row would repaint it
+      cells = [
+        {0, 1, "\n", :white, :black, []},
+        {2, 1, "Q", :white, :black, []}
+      ]
+
+      state = %{
+        width: 6,
+        height: 3,
+        buffer: nil,
+        sync_output: false,
+        force_repaint: true
+      }
+
+      {output, result} = render_prod_frame(cells, state)
+
+      refute String.contains?(output, "\n"),
+             "an in-cell \\n leaked into the frame"
+
+      grid = Emulator.new(6, 3) |> apply_to(output) |> emu_grid()
+      assert grid == Queries.get_text(result.buffer)
+    end
+
+    # Runs the full production render_to_terminal (apply_cells + emit), capturing
+    # the emitted bytes and resulting state -- exercises the C0 sanitization that
+    # lives in the cell-write boundary, which build_terminal_frame alone bypasses.
+    defp render_prod_frame(cells, state) do
+      parent = self()
+
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          {:ok, new_state} = Backends.render_to_terminal(cells, state)
+          send(parent, {:result, new_state})
+        end)
+
+      receive do
+        {:result, new_state} -> {output, new_state}
+      after
+        1000 -> raise "render_to_terminal did not complete"
+      end
+    end
+  end
+end

--- a/test/property/ssh_rendering_property_test.exs
+++ b/test/property/ssh_rendering_property_test.exs
@@ -15,6 +15,8 @@ defmodule Raxol.Property.SSHRenderingTest do
 
   alias Raxol.Core.Runtime.Rendering.Backends
   alias Raxol.Core.Runtime.Lifecycle
+  alias Raxol.Terminal.Buffer.Queries
+  alias Raxol.Test.CrossTerminal.AnsiReplayer, as: Replayer
 
   # -- Generators --
 
@@ -22,7 +24,12 @@ defmodule Raxol.Property.SSHRenderingTest do
     gen all(
           x <- integer(0..79),
           y <- integer(0..23),
-          char <- string(:printable, min_length: 1, max_length: 1),
+          # Single-width alphanumeric only. The grid round-trip below compares
+          # the emulator's interpretation against the buffer's own text, and the
+          # two carry different display-width models for wide/ambiguous chars
+          # (CJK, private-use) -- reconciling those is a separate concern (R1 G2),
+          # not what these properties exercise.
+          char <- string(:alphanumeric, min_length: 1, max_length: 1),
           fg <- member_of([:red, :green, :blue, :white, :yellow, :cyan]),
           bg <- member_of([:black, :white, :blue])
         ) do
@@ -386,23 +393,68 @@ defmodule Raxol.Property.SSHRenderingTest do
       end
     end
 
-    property "render_to_terminal frames contain no bare LF (every \\n preceded by \\r)" do
+    property "render_to_terminal keyframe round-trips through the emulator to the buffer grid" do
+      # The terminal path no longer emits row-joined frames -- it emits
+      # absolute-CUP-addressed rows (no \n at all). So the contract is no longer
+      # "no bare LF" but the stronger one: what the backend emits, the reference
+      # emulator interprets back to the exact grid the backend built. Assert the
+      # grid, not the bytes (survives batching / emit reshaping).
+      # Fewer runs than the byte-level properties: each run replays a full
+      # keyframe (all 24 rows) through the reference emulator, which is orders of
+      # magnitude heavier than a byte assertion.
       check all(
               cells <- cells_gen(),
-              max_runs: 200
+              max_runs: 25
             ) do
-        terminal_state = %{
+        state = %{
           width: 80,
           height: 24,
           buffer: nil,
-          sync_output: false
+          sync_output: false,
+          force_repaint: true
         }
 
-        output = capture_terminal_output(cells, terminal_state)
+        {output, result} = render_capturing_both(cells, state)
 
-        refute has_bare_lf?(output),
-               "Terminal frame contains a bare \\n not preceded by \\r: #{inspect(output)}"
+        grid =
+          output
+          |> Replayer.replay(width: 80, height: 24)
+          |> Replayer.grid_text()
+
+        assert grid == Queries.get_text(result.buffer)
       end
+    end
+
+    test "first frame is a keyframe; a later one-cell change diffs only its row" do
+      state = %{
+        width: 6,
+        height: 3,
+        buffer: nil,
+        sync_output: false,
+        force_repaint: true
+      }
+
+      {kf_out, after_kf} =
+        render_capturing_both([{0, 0, "A", :white, :black, []}], state)
+
+      # keyframe: leading clear, no per-row CUP omitted
+      assert String.starts_with?(kf_out, "\e[2J")
+
+      # next frame: prev buffer in hand, force_repaint cleared, one new cell on row 1
+      {diff_out, _} =
+        render_capturing_both(
+          [{0, 0, "A", :white, :black, []}, {0, 1, "B", :white, :black, []}],
+          after_kf
+        )
+
+      refute String.contains?(diff_out, "\e[2J"),
+             "a diff frame must not clear the screen"
+
+      assert String.contains?(diff_out, "\e[2;1H"),
+             "the changed row (2) must be addressed"
+
+      refute String.contains?(diff_out, "\e[1;1H"),
+             "the unchanged row 1 must not be emitted"
     end
 
     test "normalize_frame/1 converts bare LF row joins to CRLF" do
@@ -442,12 +494,6 @@ defmodule Raxol.Property.SSHRenderingTest do
     |> elem(0)
   end
 
-  defp capture_terminal_output(cells, state) do
-    ExUnit.CaptureIO.capture_io(fn ->
-      {:ok, _new_state} = Backends.render_to_terminal(cells, state)
-    end)
-  end
-
   defp collect_writes do
     collect_write_list() |> Enum.join()
   end
@@ -473,6 +519,23 @@ defmodule Raxol.Property.SSHRenderingTest do
 
     receive do
       {:result, new_state} -> {:ok, new_state}
+    after
+      1000 -> raise "render_to_terminal did not complete"
+    end
+  end
+
+  # Captures both the emitted frame bytes and the resulting state from one render.
+  defp render_capturing_both(cells, state) do
+    parent = self()
+
+    output =
+      ExUnit.CaptureIO.capture_io(fn ->
+        {:ok, new_state} = Backends.render_to_terminal(cells, state)
+        send(parent, {:result, new_state})
+      end)
+
+    receive do
+      {:result, new_state} -> {output, new_state}
     after
       1000 -> raise "render_to_terminal did not complete"
     end

--- a/test/support/cross_terminal/render_oracle.ex
+++ b/test/support/cross_terminal/render_oracle.ex
@@ -1,0 +1,89 @@
+defmodule Raxol.Test.CrossTerminal.RenderOracle do
+  @moduledoc """
+  Reference implementation of the R1 incremental-render emit (proposal v3) plus
+  the autonomous grid oracle. Prototypes the design so its ALGORITHM can be
+  property-tested before the production code exists: emit bytes, replay through
+  the reference emulator, compare grids.
+
+  One emit vocabulary:
+
+      keyframe (prev == nil or dims differ): "\\e[2J" + every row, CUP-addressed
+      diff:                                  changed rows only, CUP-addressed
+      per row y:  "\\e[{y+1};1H\\e[0m\\e[2K" <> render_row(buffer, y)
+
+  `render_row/2` renders a single row in isolation, prototyping the G1
+  `Renderer.render_rows/1` the proposal calls for.
+  """
+
+  alias Raxol.Terminal.{Renderer, ScreenBuffer}
+  alias Raxol.Terminal.Buffer.Queries
+  alias Raxol.Test.CrossTerminal.AnsiReplayer, as: Replayer
+
+  @doc "Render one row in isolation, style-batched (prototypes G1)."
+  def render_row(buffer, y) do
+    row = Enum.at(buffer.cells, y)
+
+    %{buffer | cells: [row], height: 1}
+    |> Renderer.new(%{}, %{}, true)
+    |> Renderer.render()
+  end
+
+  @doc "Row indices where prev and next differ (all rows when prev is nil / dims differ)."
+  def changed_rows(nil, next), do: Enum.to_list(0..(next.height - 1))
+
+  def changed_rows(prev, next) do
+    if dims_differ?(prev, next) do
+      Enum.to_list(0..(next.height - 1))
+    else
+      Enum.filter(0..(next.height - 1), fn y ->
+        Enum.at(prev.cells, y) != Enum.at(next.cells, y)
+      end)
+    end
+  end
+
+  defp dims_differ?(prev, next),
+    do: prev.width != next.width or prev.height != next.height
+
+  defp keyframe?(nil, _next), do: true
+  defp keyframe?(prev, next), do: dims_differ?(prev, next)
+
+  @doc "The v3 emit for going from prev (or nil) to next."
+  def emit(prev, next) do
+    body =
+      Enum.map_join(changed_rows(prev, next), "", fn y ->
+        "\e[#{y + 1};1H\e[0m\e[2K" <> render_row(next, y)
+      end)
+
+    if keyframe?(prev, next), do: "\e[2J" <> body, else: body
+  end
+
+  @doc "Grid after replaying keyframe(next) into a fresh emulator (the 'full' path)."
+  def grid_full(next), do: replay_grid(emit(nil, next), next)
+
+  @doc "Grid after replaying keyframe(prev) then diff(prev, next) (the 'diff' path)."
+  def grid_diff(prev, next),
+    do: replay_grid(emit(nil, prev) <> emit(prev, next), next)
+
+  @doc "The buffer's own text, independent of any emit (ground truth for oracle 1)."
+  def buffer_text(buffer), do: Queries.get_text(buffer)
+
+  defp replay_grid(bytes, ref) do
+    bytes
+    |> Replayer.replay(width: ref.width, height: ref.height)
+    |> Replayer.grid_text()
+  end
+
+  @doc "Build a test buffer. writes = [{x, y, char} | {x, y, char, style}]."
+  def build(w, h, writes) do
+    Enum.reduce(writes, ScreenBuffer.new(w, h), fn
+      {x, y, ch}, buf -> ScreenBuffer.write_char(buf, x, y, ch)
+      {x, y, ch, style}, buf -> ScreenBuffer.write_char(buf, x, y, ch, style)
+    end)
+  end
+
+  @doc "A full WxH buffer whose every cell is `char_fn.(x, y)`."
+  def grid(w, h, char_fn) do
+    writes = for y <- 0..(h - 1), x <- 0..(w - 1), do: {x, y, char_fn.(x, y)}
+    build(w, h, writes)
+  end
+end


### PR DESCRIPTION
**Stacks on #533** (style batching) — until that merges this PR shows its
commit too; the incremental-render change is the last two commits.

The terminal backend cleared the whole screen (`\e[H\e[2J`) and repainted every
cell on every frame, even a one-cell change — a flash on non-mode-2026 terminals,
the whole screen over SSH per event, and the full frame string rebuilt then
discarded.

Now `render_to_terminal` diffs the grid the runtime **already holds**
(`state.buffer`) against the new one and emits only changed rows, each absolutely
addressed: `\e[{y};1H\e[0m\e[2K` + row. A keyframe is that same emit over *every*
row with a leading `\e[2J`. **One vocabulary for both frame kinds** — no `\r\n`
row-joins, no separator to get wrong, so the staircase and in-cell-newline
hazards can't occur (they were live risks for the string-split approach this
design rejected).

- `Renderer.render_rows/1` + `render_row/2` expose the per-row render `render/1`
  already does internally, so a changed row renders alone (pinned:
  `render(r) == join(render_rows(r), "\n")`).
- `force_repaint` on `Engine.State` drives keyframes: first frame, resize (the
  `:update_size` handler owns it — it blanks the buffer to the new size, so a
  render-time dims check is provably inert), and **Ctrl-L**. The dispatcher
  intercepts Ctrl-L before the app and casts `:force_repaint` — recovery from
  out-of-band corruption, since a diff no longer self-heals like clear-every-frame did.
- A control byte in a cell is **sanitized** to a space at the write boundary, so
  an in-cell `\n` can't bleed onto the next row (it used to be laundered by the
  now-removed per-frame clear).

**Validation** is against the reference emulator, not golden bytes (assert the
grid — survives batching/emit reshaping): diff reproduces the keyframe grid,
keyframe round-trips, corruption persists through a no-op diff and `force_repaint`
restores it, resize re-keyframes, in-cell `\n` is sanitized. The `ssh` property
test's old full-repaint contract (every frame starts `\e[H\e[2J`) is replaced by
the round-trip contract.

**Scope:** terminal path only. SSH (`render_to_ssh`) unchanged — deferred pending
an `io_writer` back-pressure audit. Wide-char width reconciliation between the
emulator and buffer (G2) and sub-row cell-diff (Option B) are named follow-ups.

Full suite: 4722/4725 — the 3 failures are pre-existing flakes unrelated to
rendering (parser-perf-under-load, the `PlatformGraphics` `TERM_PROGRAM` leak
fixed in #528, the `MetricsCollector` sleep flake). One pre-existing
`renderer_test` failure (a nil-style cell expecting a painted default-theme
background) fails identically on master — ADR-0029 removed that behavior; the
test was never updated.

