### PR TITLE
Harness UI: transcript blocks (message / reasoning / error)

### DIFF
--- a/lib/raxol/playground/catalog.ex
+++ b/lib/raxol/playground/catalog.ex
@@ -213,6 +213,20 @@ defmodule Raxol.Playground.Catalog do
       DiffViewer.render(state, %{})
       """
     },
+    %{
+      name: "Harness Transcript",
+      module: Demos.HarnessTranscriptDemo,
+      category: :display,
+      description:
+        "Agent-harness transcript blocks: completed message, collapsible reasoning, error",
+      complexity: :intermediate,
+      tags: ["harness", "display", "transcript", "agent", "collapsible"],
+      code_snippet: """
+      MessageBlock.render(message_state, %{})
+      ReasoningBlock.render(reasoning_state, %{})  # collapsible, Enter/Space toggles
+      ErrorBlock.render(error_state, %{})
+      """
+    },
     # --- Navigation/Layout widgets ---
     %{
       name: "Tabs",

--- a/lib/raxol/playground/demos/harness_transcript_demo.ex
+++ b/lib/raxol/playground/demos/harness_transcript_demo.ex
@@ -1,0 +1,99 @@
+defmodule Raxol.Playground.Demos.HarnessTranscriptDemo do
+  @moduledoc """
+  Playground demo: an agent-harness transcript rendered from real protocol
+  event payloads -- a completed message, collapsible reasoning, and a fault.
+
+  Exercises `Raxol.UI.Components.Harness.{MessageBlock, ReasoningBlock,
+  ErrorBlock}` directly. Only `ReasoningBlock` carries interactive state (its
+  own `expanded` flag), toggled through its real `handle_event/3` -- mirrors
+  how `ScrollAnchorDemo` forwards raw key events into `Viewport`.
+  """
+  use Raxol.Core.Runtime.Application
+
+  alias Raxol.UI.Components.Harness.{ErrorBlock, MessageBlock, ReasoningBlock}
+
+  import Raxol.Playground.DemoHelpers, only: [effective_width: 2]
+
+  @default_content_width 46
+  @border_and_padding_overhead 4
+
+  @impl true
+  def init(_context) do
+    {:ok, reasoning} =
+      ReasoningBlock.init(id: :demo_reasoning, content: reasoning_sample())
+
+    %{reasoning: reasoning}
+  end
+
+  @impl true
+  def update(message, model) do
+    case message do
+      %Raxol.Core.Events.Event{type: :key} = event ->
+        {new_reasoning, _cmds} =
+          ReasoningBlock.handle_event(event, model.reasoning, %{})
+
+        {%{model | reasoning: new_reasoning}, []}
+
+      _ ->
+        {model, []}
+    end
+  end
+
+  @impl true
+  def view(model) do
+    box_width = effective_width(model, @default_content_width)
+    content_width = max(box_width - @border_and_padding_overhead, 1)
+
+    {:ok, message_state} =
+      MessageBlock.init(
+        id: :demo_message,
+        role: :assistant,
+        content: message_sample(),
+        width: content_width
+      )
+
+    {:ok, error_state} =
+      ErrorBlock.init(
+        id: :demo_error,
+        where: "tool_call:fetch_page",
+        reason: "connection refused (ECONNREFUSED)"
+      )
+
+    reasoning_for_render = %{model.reasoning | width: content_width}
+
+    column style: %{gap: 1} do
+      [
+        text("Harness Transcript Demo", style: [:bold]),
+        divider(),
+        box style: %{border: :single, padding: 1, width: box_width} do
+          column style: %{gap: 1} do
+            [
+              MessageBlock.render(message_state, %{}),
+              ReasoningBlock.render(reasoning_for_render, %{}),
+              ErrorBlock.render(error_state, %{})
+            ]
+          end
+        end,
+        text("[Enter] or [Space] toggles the reasoning block", style: [:dim])
+      ]
+    end
+  end
+
+  @impl true
+  def subscribe(_model), do: []
+
+  defp message_sample do
+    "Here's the plan:\n\n" <>
+      "- Check the **config** file\n" <>
+      "- Run `mix test`\n" <>
+      "- Report back\n\n" <>
+      "Should be quick."
+  end
+
+  defp reasoning_sample do
+    "The user wants a summary of the failing tests.\n" <>
+      "First, check which files changed since the last green run.\n" <>
+      "Then re-run just those to confirm they're still red.\n" <>
+      "Finally, group failures by root cause before reporting back."
+  end
+end

--- a/lib/raxol/ui/components/harness/error_block.ex
+++ b/lib/raxol/ui/components/harness/error_block.ex
@@ -1,0 +1,83 @@
+defmodule Raxol.UI.Components.Harness.ErrorBlock do
+  @moduledoc """
+  Renders a fault: `error{where, reason}`.
+
+  Distinct error styling -- a red-accented, bordered box -- so a fault reads
+  as unmistakably different from a message or reasoning block in the same
+  transcript.
+  """
+
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type t :: %{
+          id: String.t() | atom(),
+          where: term(),
+          reason: term(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "harness-error-block-#{:erlang.unique_integer([:positive])}"
+        ),
+      where: Keyword.get(props, :where, ""),
+      reason: Keyword.get(props, :reason, ""),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :harness_error_block)
+
+    %{
+      type: :box,
+      style: Map.merge(%{border: :single, fg: :red, padding: 1}, base_style),
+      children: [
+        %{
+          type: :column,
+          style: %{},
+          gap: 0,
+          children: [
+            Components.text(
+              id: "#{state.id}-title",
+              content: "Error",
+              style: %{bold: true, fg: :red}
+            ),
+            Components.text(
+              id: "#{state.id}-where",
+              content: "where: #{display(state.where)}",
+              style: %{dim: true}
+            ),
+            Components.text(
+              id: "#{state.id}-reason",
+              content: "reason: #{display(state.reason)}",
+              style: %{fg: :red}
+            )
+          ]
+        }
+      ]
+    }
+  end
+
+  defp display(text) when is_binary(text), do: text
+  defp display(other), do: inspect(other)
+end

--- a/lib/raxol/ui/components/harness/message_block.ex
+++ b/lib/raxol/ui/components/harness/message_block.ex
@@ -1,0 +1,79 @@
+defmodule Raxol.UI.Components.Harness.MessageBlock do
+  @moduledoc """
+  Renders a completed transcript message: `item_completed{item_type: :message, content}`.
+
+  `content` is a Markdown string. Rendering the Markdown itself is delegated
+  entirely to `Raxol.UI.Components.MarkdownRenderer` -- this module only adds
+  a dim, accent-colored role prefix (`role: :user | :assistant`) above it so
+  turns are visually distinguishable without shouting.
+  """
+
+  alias Raxol.UI.Components.MarkdownRenderer
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type role :: :user | :assistant
+
+  @type t :: %{
+          id: String.t() | atom(),
+          role: role(),
+          content: String.t(),
+          width: pos_integer(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "harness-message-block-#{:erlang.unique_integer([:positive])}"
+        ),
+      role: Keyword.get(props, :role, :assistant),
+      content: Keyword.get(props, :content, ""),
+      width: Keyword.get(props, :width, Raxol.Core.Defaults.terminal_width()),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :harness_message_block)
+
+    {:ok, md_state} =
+      MarkdownRenderer.init(%{markdown_text: state.content, width: state.width})
+
+    %{
+      type: :column,
+      style: base_style,
+      gap: 0,
+      children: [role_header(state), MarkdownRenderer.render(md_state, context)]
+    }
+  end
+
+  defp role_header(%{id: id, role: role}) do
+    Components.text(
+      id: "#{id}-role",
+      content: "[#{role}]",
+      style: %{dim: true, fg: role_accent(role)}
+    )
+  end
+
+  defp role_accent(:user), do: :green
+  defp role_accent(:assistant), do: :cyan
+  defp role_accent(_), do: :white
+end

--- a/lib/raxol/ui/components/harness/reasoning_block.ex
+++ b/lib/raxol/ui/components/harness/reasoning_block.ex
@@ -1,0 +1,129 @@
+defmodule Raxol.UI.Components.Harness.ReasoningBlock do
+  @moduledoc """
+  Renders reasoning/thinking content: `item_completed{item_type: :reasoning, content}`.
+
+  Collapsed by default, showing a one-line summary plus a "N lines"
+  affordance. `handle_event/3` toggles expand/collapse on Enter or Space.
+  Styled dim throughout -- reasoning is secondary to the message and error
+  blocks around it in the transcript.
+  """
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.StyleHelper
+  alias Raxol.UI.TextLayout
+  alias Raxol.UI.TextMeasure
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type t :: %{
+          id: String.t() | atom(),
+          content: String.t(),
+          expanded: boolean(),
+          width: pos_integer(),
+          style: map(),
+          theme: map()
+        }
+
+  @collapsed_icon "▸"
+  @expanded_icon "▾"
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "harness-reasoning-block-#{:erlang.unique_integer([:positive])}"
+        ),
+      content: Keyword.get(props, :content, ""),
+      expanded: Keyword.get(props, :expanded, false),
+      width: Keyword.get(props, :width, Raxol.Core.Defaults.terminal_width()),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  # Enter/Space -- toggle expand/collapse (mirrors Tree's activation keys).
+  @impl true
+  def handle_event(%Event{type: :key, data: %{key: :enter}}, state, _context) do
+    {toggle(state), []}
+  end
+
+  def handle_event(%Event{type: :key, data: %{key: :space}}, state, _context) do
+    {toggle(state), []}
+  end
+
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(
+        state,
+        context,
+        :harness_reasoning_block
+      )
+
+    %{
+      type: :column,
+      style: base_style,
+      gap: 0,
+      children: body_children(state, content_lines(state.content))
+    }
+  end
+
+  defp toggle(state), do: %{state | expanded: not state.expanded}
+
+  defp content_lines(""), do: []
+  defp content_lines(content), do: String.split(content, "\n")
+
+  defp body_children(%{expanded: false} = state, lines) do
+    [collapsed_summary(state, lines)]
+  end
+
+  defp body_children(%{expanded: true} = state, lines) do
+    [expanded_header(state, lines) | expanded_lines(state, lines)]
+  end
+
+  defp collapsed_summary(%{id: id, width: width}, lines) do
+    prefix = "#{@collapsed_icon} #{line_label(length(lines))} — "
+    budget = max(width - TextMeasure.display_width(prefix), 1)
+
+    dim_text(id, "summary", prefix <> summary_text(lines, budget))
+  end
+
+  defp expanded_header(%{id: id}, lines) do
+    dim_text(id, "summary", "#{@expanded_icon} #{line_label(length(lines))}")
+  end
+
+  defp expanded_lines(%{id: id}, lines) do
+    lines
+    |> Enum.with_index()
+    |> Enum.map(fn {line, idx} -> dim_text(id, "line-#{idx}", line) end)
+  end
+
+  defp summary_text([], _budget), do: "(empty)"
+
+  defp summary_text(lines, budget) do
+    lines
+    |> Enum.find("", &(String.trim(&1) != ""))
+    |> TextLayout.truncate(budget, :ellipsis)
+  end
+
+  defp line_label(1), do: "1 line"
+  defp line_label(n), do: "#{n} lines"
+
+  defp dim_text(id, suffix, content) do
+    Components.text(
+      id: "#{id}-#{suffix}",
+      content: content,
+      style: %{dim: true}
+    )
+  end
+end

--- a/test/raxol/playground/app_test.exs
+++ b/test/raxol/playground/app_test.exs
@@ -14,7 +14,7 @@ defmodule Raxol.Playground.AppTest do
   describe "init/1" do
     test "initializes with components and first selected" do
       model = App.init(nil)
-      assert length(model.components) == 39
+      assert length(model.components) == 40
       assert model.cursor == 0
       assert model.selected != nil
       assert model.focus == :sidebar
@@ -189,7 +189,7 @@ defmodule Raxol.Playground.AppTest do
       # After cycling through all categories, next press returns to nil
       {model, []} = App.update(key_event("f"), model)
       assert model.category_filter == nil
-      assert length(model.components) == 39
+      assert length(model.components) == 40
     end
 
     test "f resets cursor to 0" do

--- a/test/raxol/playground/catalog_test.exs
+++ b/test/raxol/playground/catalog_test.exs
@@ -6,7 +6,7 @@ defmodule Raxol.Playground.CatalogTest do
   describe "list_components/0" do
     test "returns all registered components" do
       components = Catalog.list_components()
-      assert length(components) == 39
+      assert length(components) == 40
       assert Enum.all?(components, &is_map/1)
     end
 

--- a/test/raxol/playground/sidebar_scroll_test.exs
+++ b/test/raxol/playground/sidebar_scroll_test.exs
@@ -107,7 +107,7 @@ defmodule Raxol.Playground.SidebarScrollTest do
       sidebar = sidebar_text(text)
 
       assert sidebar =~ "▸ Button"
-      assert sidebar =~ "39 widgets"
+      assert sidebar =~ "40 widgets"
     end
 
     test "scrolling past the visible window keeps the marker on screen and scrolls the top items out",

--- a/test/raxol/ui/components/harness/error_block_test.exs
+++ b/test/raxol/ui/components/harness/error_block_test.exs
@@ -1,0 +1,94 @@
+defmodule Raxol.UI.Components.Harness.ErrorBlockTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.ErrorBlock
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = ErrorBlock.init(id: :e1)
+      assert state.id == :e1
+      assert state.where == ""
+      assert state.reason == ""
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "initializes with provided props" do
+      assert {:ok, state} =
+               ErrorBlock.init(
+                 id: :e2,
+                 where: "tool_call:read_file",
+                 reason: :timeout
+               )
+
+      assert state.where == "tool_call:read_file"
+      assert state.reason == :timeout
+    end
+  end
+
+  describe "render/2" do
+    test "renders a red-bordered box with title, where, and reason" do
+      {:ok, state} =
+        ErrorBlock.init(
+          id: :e_render,
+          where: "tool_call:read_file",
+          reason: "permission denied"
+        )
+
+      rendered = ErrorBlock.render(state, default_context())
+
+      assert rendered.type == :box
+      assert rendered.style.border == :single
+      assert rendered.style.fg == :red
+
+      assert [inner] = rendered.children
+      assert inner.type == :column
+
+      [title, where, reason] = inner.children
+      assert title.content == "Error"
+      assert title.style == %{bold: true, fg: :red}
+
+      assert where.content == "where: tool_call:read_file"
+      assert where.style == %{dim: true}
+
+      assert reason.content == "reason: permission denied"
+      assert reason.style == %{fg: :red}
+    end
+
+    test "formats non-binary where/reason terms via inspect" do
+      {:ok, state} =
+        ErrorBlock.init(id: :e_term, where: :boot, reason: {:timeout, 5000})
+
+      rendered = ErrorBlock.render(state, default_context())
+      [inner] = rendered.children
+      [_title, where, reason] = inner.children
+
+      assert where.content == "where: :boot"
+      assert reason.content == "reason: {:timeout, 5000}"
+    end
+
+    test "inline style overrides the default border color" do
+      {:ok, state} = ErrorBlock.init(id: :e_style, style: %{fg: :magenta})
+      rendered = ErrorBlock.render(state, default_context())
+      assert rendered.style.fg == :magenta
+      assert rendered.style.border == :single
+    end
+  end
+
+  describe "handle_event/3" do
+    test "is stateless -- passes through all events unchanged" do
+      {:ok, state} = ErrorBlock.init(id: :e_evt, reason: "boom")
+
+      event = %Event{type: :key, data: %{key: :enter}}
+      {new_state, commands} = ErrorBlock.handle_event(event, state, %{})
+
+      assert new_state == state
+      assert commands == []
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/message_block_test.exs
+++ b/test/raxol/ui/components/harness/message_block_test.exs
@@ -1,0 +1,103 @@
+defmodule Raxol.UI.Components.Harness.MessageBlockTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.MessageBlock
+  alias Raxol.UI.Components.MarkdownRenderer
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = MessageBlock.init(id: :m1)
+      assert state.id == :m1
+      assert state.role == :assistant
+      assert state.content == ""
+      assert state.width == Raxol.Core.Defaults.terminal_width()
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "initializes with provided props" do
+      assert {:ok, state} =
+               MessageBlock.init(
+                 id: :m2,
+                 role: :user,
+                 content: "**hi** there",
+                 width: 60,
+                 style: %{bg: :blue},
+                 theme: %{fg: :white}
+               )
+
+      assert state.id == :m2
+      assert state.role == :user
+      assert state.content == "**hi** there"
+      assert state.width == 60
+      assert state.style == %{bg: :blue}
+      assert state.theme == %{fg: :white}
+    end
+  end
+
+  describe "render/2" do
+    test "renders a column with a dim role prefix above the markdown body" do
+      {:ok, state} =
+        MessageBlock.init(id: :m_render, role: :assistant, content: "hello")
+
+      rendered = MessageBlock.render(state, default_context())
+
+      assert rendered.type == :column
+      assert rendered.gap == 0
+      assert length(rendered.children) == 2
+
+      [role_el, body_el] = rendered.children
+      assert role_el.content == "[assistant]"
+      assert role_el.style == %{dim: true, fg: :cyan}
+      assert body_el.type == :column
+    end
+
+    test "colors the user role prefix distinctly from assistant" do
+      {:ok, user_state} = MessageBlock.init(id: :m_user, role: :user)
+      {:ok, asst_state} = MessageBlock.init(id: :m_asst, role: :assistant)
+
+      user_rendered = MessageBlock.render(user_state, default_context())
+      asst_rendered = MessageBlock.render(asst_state, default_context())
+
+      [user_role_el | _] = user_rendered.children
+      [asst_role_el | _] = asst_rendered.children
+
+      assert user_role_el.content == "[user]"
+      assert user_role_el.style.fg == :green
+      assert asst_role_el.style.fg == :cyan
+      assert user_role_el.style.fg != asst_role_el.style.fg
+    end
+
+    test "reuses MarkdownRenderer verbatim for the message body" do
+      content = "# Title\n\nSome *text* and a [link](https://example.com)."
+      {:ok, state} = MessageBlock.init(id: :m_md, content: content, width: 40)
+
+      rendered = MessageBlock.render(state, default_context())
+      [_role_el, body_el] = rendered.children
+
+      {:ok, md_state} =
+        MarkdownRenderer.init(%{markdown_text: content, width: 40})
+
+      expected_body = MarkdownRenderer.render(md_state, default_context())
+
+      assert body_el == expected_body
+    end
+  end
+
+  describe "handle_event/3" do
+    test "is stateless -- passes through all events unchanged" do
+      {:ok, state} = MessageBlock.init(id: :m_evt, content: "hi")
+
+      event = %Event{type: :key, data: %{key: :enter}}
+      {new_state, commands} = MessageBlock.handle_event(event, state, %{})
+
+      assert new_state == state
+      assert commands == []
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/reasoning_block_test.exs
+++ b/test/raxol/ui/components/harness/reasoning_block_test.exs
@@ -1,0 +1,144 @@
+defmodule Raxol.UI.Components.Harness.ReasoningBlockTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.ReasoningBlock
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  defp key_event(key), do: %Event{type: :key, data: %{key: key}}
+
+  describe "init/1" do
+    test "initializes collapsed by default" do
+      assert {:ok, state} = ReasoningBlock.init(id: :r1)
+      assert state.id == :r1
+      assert state.content == ""
+      assert state.expanded == false
+      assert state.width == Raxol.Core.Defaults.terminal_width()
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "initializes with provided props" do
+      assert {:ok, state} =
+               ReasoningBlock.init(
+                 id: :r2,
+                 content: "line one\nline two",
+                 expanded: true,
+                 width: 30
+               )
+
+      assert state.content == "line one\nline two"
+      assert state.expanded == true
+      assert state.width == 30
+    end
+  end
+
+  describe "render/2 collapsed" do
+    test "shows a one-line summary with a line-count affordance" do
+      {:ok, state} =
+        ReasoningBlock.init(
+          id: :r_collapsed,
+          content: "Considering the tradeoffs.\nSecond line.\nThird line."
+        )
+
+      rendered = ReasoningBlock.render(state, default_context())
+
+      assert rendered.type == :column
+      assert length(rendered.children) == 1
+
+      [summary] = rendered.children
+      assert summary.style == %{dim: true}
+      assert String.starts_with?(summary.content, "▸ 3 lines — ")
+      assert summary.content =~ "Considering the tradeoffs."
+    end
+
+    test "singular line label for a single line" do
+      {:ok, state} = ReasoningBlock.init(id: :r_one, content: "Just one line.")
+      rendered = ReasoningBlock.render(state, default_context())
+      [summary] = rendered.children
+      assert String.starts_with?(summary.content, "▸ 1 line — ")
+    end
+
+    test "handles empty content without crashing" do
+      {:ok, state} = ReasoningBlock.init(id: :r_empty, content: "")
+      rendered = ReasoningBlock.render(state, default_context())
+      [summary] = rendered.children
+      assert summary.content == "▸ 0 lines — (empty)"
+    end
+
+    test "truncates a long summary to fit width, with an ellipsis" do
+      long_line = String.duplicate("a", 200)
+
+      {:ok, state} =
+        ReasoningBlock.init(id: :r_long, content: long_line, width: 20)
+
+      rendered = ReasoningBlock.render(state, default_context())
+      [summary] = rendered.children
+
+      assert Raxol.UI.TextMeasure.display_width(summary.content) <= 20
+      assert String.ends_with?(summary.content, "…")
+    end
+  end
+
+  describe "render/2 expanded" do
+    test "shows every line, dim, under a line-count header" do
+      {:ok, state} =
+        ReasoningBlock.init(
+          id: :r_expanded,
+          content: "alpha\nbeta\ngamma",
+          expanded: true
+        )
+
+      rendered = ReasoningBlock.render(state, default_context())
+      assert length(rendered.children) == 4
+
+      [header, l1, l2, l3] = rendered.children
+      assert header.content == "▾ 3 lines"
+      assert header.style == %{dim: true}
+      assert l1.content == "alpha"
+      assert l2.content == "beta"
+      assert l3.content == "gamma"
+      assert l1.style == %{dim: true}
+      assert l2.style == %{dim: true}
+      assert l3.style == %{dim: true}
+    end
+  end
+
+  describe "handle_event/3" do
+    test "Enter toggles expanded state" do
+      {:ok, state} = ReasoningBlock.init(id: :r_toggle, content: "x")
+      assert state.expanded == false
+
+      {expanded_state, []} =
+        ReasoningBlock.handle_event(key_event(:enter), state, %{})
+
+      assert expanded_state.expanded == true
+
+      {collapsed_state, []} =
+        ReasoningBlock.handle_event(key_event(:enter), expanded_state, %{})
+
+      assert collapsed_state.expanded == false
+    end
+
+    test "Space toggles expanded state" do
+      {:ok, state} = ReasoningBlock.init(id: :r_space, content: "x")
+
+      {new_state, []} =
+        ReasoningBlock.handle_event(key_event(:space), state, %{})
+
+      assert new_state.expanded == true
+    end
+
+    test "other keys pass through unchanged" do
+      {:ok, state} = ReasoningBlock.init(id: :r_other, content: "x")
+
+      {new_state, []} =
+        ReasoningBlock.handle_event(key_event(:down), state, %{})
+
+      assert new_state == state
+    end
+  end
+end


### PR DESCRIPTION
Renders the `:loop` item events into transcript blocks:
- `MessageBlock` — completed message (reuses MarkdownRenderer), role-framed.
- `ReasoningBlock` — collapsible reasoning/thinking (dimmed, expand/collapse).
- `ErrorBlock` — fault (`error{where, reason}`), boxed red.

Part of the agent-harness UI (`docs/proposals/in-flight/harness-spec-frontend.md`). Pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP5gp9w9LBHU6nSXMc6kc1