### PR TITLE
Harness UI: approval prompt + blast-radius preview

### DIFF
--- a/lib/raxol/playground/catalog.ex
+++ b/lib/raxol/playground/catalog.ex
@@ -460,6 +460,29 @@ defmodule Raxol.Playground.Catalog do
       ])
       WorktracksPanel.render(state, %{})
       """
+    },
+    %{
+      name: "Harness Approval",
+      module: Demos.HarnessApprovalDemo,
+      category: :overlay,
+      description:
+        "Agent-harness approval gate: blast-radius preview and keyboard-driven allow/deny scope choice",
+      complexity: :intermediate,
+      tags: ["harness", "approval", "overlay", "blast-radius"],
+      code_snippet: """
+      {:ok, approval} =
+        ApprovalPrompt.init(
+          id: "harness-approval",
+          action: %{description: "Clear stale build cache", tool: "shell.exec"},
+          blast_radius: %{deletes: ["/tmp/build/artifact.tar"], reversible: false}
+        )
+
+      AbsoluteLayer.dialog_overlay(
+        approval.width,
+        ApprovalPrompt.estimate_height(approval),
+        ApprovalPrompt.render(approval, %{})
+      )
+      """
     }
   ]
 

--- a/lib/raxol/playground/demos/harness_approval_demo.ex
+++ b/lib/raxol/playground/demos/harness_approval_demo.ex
@@ -1,0 +1,152 @@
+defmodule Raxol.Playground.Demos.HarnessApprovalDemo do
+  @moduledoc """
+  Playground demo: the agent-harness approval gate.
+
+  Triggers an `approval_requested` for a risky action (a file delete plus a
+  shell command, marked irreversible) and exercises
+  `Raxol.UI.Components.Harness.ApprovalPrompt` end to end: blast-radius
+  preview with the `IRREVERSIBLE` marker, arrow/number-key navigation
+  across the four scope options, and the emitted `approval_decision`
+  command once the user confirms with Enter.
+  """
+  use Raxol.Core.Runtime.Application
+
+  alias Raxol.UI.Components.AbsoluteLayer
+  alias Raxol.UI.Components.Harness.ApprovalPrompt
+
+  import Raxol.Playground.DemoHelpers, only: [effective_width: 2]
+
+  @stats_box_width 46
+
+  @risky_action %{
+    description: "Clear stale build cache and session db",
+    tool: "shell.exec"
+  }
+
+  @risky_blast_radius %{
+    deletes: ["/var/cache/app/session_12.db", "/tmp/build/artifact.tar"],
+    commands: ["rm -rf /tmp/build"],
+    writes: ["/var/log/app/cleanup.log"],
+    network: [],
+    reversible: false
+  }
+
+  @impl true
+  def init(_context) do
+    %{show: false, approval: nil, last_decision: nil}
+  end
+
+  @impl true
+  def update(message, model) do
+    case message do
+      key_match("o") -> {open_prompt(model), []}
+      _ -> route_to_prompt(message, model)
+    end
+  end
+
+  defp open_prompt(model) do
+    {:ok, approval} =
+      ApprovalPrompt.init(
+        id: "harness-approval-demo",
+        action: @risky_action,
+        blast_radius: @risky_blast_radius
+      )
+
+    %{model | show: true, approval: approval, last_decision: nil}
+  end
+
+  # While the prompt is open, every message (arrow keys, digit keys, Enter,
+  # ...) is forwarded straight to the component's own handle_event/3 -- the
+  # same thing a real dispatcher does for a focused widget. Anything the
+  # component doesn't recognize is a safe no-op (see its catch-all clause),
+  # so no filtering is needed here.
+  defp route_to_prompt(message, %{show: true, approval: approval} = model) do
+    {new_approval, commands} =
+      ApprovalPrompt.handle_event(message, approval, %{})
+
+    apply_commands(commands, %{model | approval: new_approval})
+  end
+
+  defp route_to_prompt(_message, model), do: {model, []}
+
+  defp apply_commands([], model), do: {model, []}
+
+  defp apply_commands([{:approval_decision, decision} | _rest], model) do
+    {%{model | show: false, approval: nil, last_decision: decision}, []}
+  end
+
+  defp apply_commands([_unknown | rest], model), do: apply_commands(rest, model)
+
+  @impl true
+  def view(model) do
+    overlays =
+      if model.show do
+        width = effective_width(model, model.approval.width)
+        height = ApprovalPrompt.estimate_height(model.approval)
+
+        [
+          AbsoluteLayer.dialog_overlay(
+            width,
+            height,
+            ApprovalPrompt.render(model.approval, %{})
+          )
+        ]
+      else
+        []
+      end
+
+    AbsoluteLayer.absolute_layer(background_view(model), overlays)
+  end
+
+  # Flow child is laid out the same open or closed; the prompt is overlay-only.
+  defp background_view(model) do
+    column style: %{gap: 1} do
+      [
+        text("Harness Approval Demo", style: [:bold]),
+        divider(),
+        static_panel(),
+        divider(),
+        box style: %{
+              border: :rounded,
+              padding: 1,
+              width: effective_width(model, @stats_box_width)
+            } do
+          column style: %{gap: 0} do
+            [
+              text("Prompt: #{if model.show, do: "OPEN", else: "closed"}"),
+              text("Decision: #{format_decision(model.last_decision)}")
+            ]
+          end
+        end,
+        footer(model)
+      ]
+    end
+  end
+
+  defp static_panel do
+    column style: %{gap: 0} do
+      [
+        text("Background content (does not move):"),
+        text("- item one"),
+        text("- item two"),
+        text("[o] Trigger a risky approval request", style: [:dim])
+      ]
+    end
+  end
+
+  defp format_decision(nil), do: "none yet"
+
+  defp format_decision(%{decision: decision, scope: scope}),
+    do: "#{decision} / #{scope}"
+
+  defp footer(%{show: true}) do
+    text("[up/down or 1-4] choose  [Enter] confirm", style: [:dim])
+  end
+
+  defp footer(_model) do
+    text("[o] trigger approval prompt", style: [:dim])
+  end
+
+  @impl true
+  def subscribe(_model), do: []
+end

--- a/lib/raxol/ui/components/harness/approval_prompt.ex
+++ b/lib/raxol/ui/components/harness/approval_prompt.ex
@@ -177,7 +177,14 @@ defmodule Raxol.UI.Components.Harness.ApprovalPrompt do
       | option_rows(state)
     ]
 
-    content_column = %{type: :column, style: %{width: :fill}, children: content}
+    # gap: 0 is load-bearing: the layout engine defaults an unset gap to 1,
+    # which doubles every row and overflows the fixed-height dialog surface.
+    content_column = %{
+      type: :column,
+      style: %{width: :fill},
+      gap: 0,
+      children: content
+    }
 
     ModalRendering.dialog_surface(
       state.width,

--- a/lib/raxol/ui/components/harness/approval_prompt.ex
+++ b/lib/raxol/ui/components/harness/approval_prompt.ex
@@ -1,0 +1,302 @@
+defmodule Raxol.UI.Components.Harness.ApprovalPrompt do
+  @moduledoc """
+  The agent-harness approval gate: shows what an action wants to do, its
+  blast radius, and a keyboard-driven choice of how far to trust it.
+
+  Render-dual of the harness protocol's approval exchange (see
+  `docs/proposals/in-flight/harness-spec-frontend.md`, §4 row A6):
+
+    * Payload in — `approval_requested{action, blast_radius, options}`,
+      read by `init/1` as the `:action`, `:blast_radius`, `:options` props.
+    * Emitted out — `approval_decision{decision, scope}`, returned as a
+      command from `handle_event/3` in the shape
+      `{:approval_decision, %{decision: :allow | :deny, scope: :once |
+      :session | :root}}` once the user confirms with Enter.
+
+  Built on `Raxol.UI.Components.Modal.Rendering.dialog_surface/4` -- the
+  same one-box overlay shell `Modal` itself renders into -- rather than a
+  second modal implementation. `render/2` embeds a
+  `Raxol.UI.Components.Harness.BlastRadiusPreview` for the safety-critical
+  part of the surface. The overlay *positioning* (centering, dimming the
+  background) is the caller's job, same as `Modal`'s own demo: wrap this
+  component's `render/2` result with
+  `Raxol.UI.Components.AbsoluteLayer.dialog_overlay/3`, sized with
+  `estimate_height/1`.
+
+  ## Keyboard
+
+  Up/Down arrows and digit keys (`1`-`9`) move the selection; digits jump
+  straight to that option's index rather than acting as a shortcut, so
+  Enter is always the one and only way to confirm (a mis-timed digit key
+  can't fire off a decision by itself). Enter emits the decision for
+  whichever option is currently selected.
+
+  ## Default options
+
+  Four choices, matching the harness spec's `:once/:session/:root` scopes
+  (Devin's three-button pattern) plus deny:
+
+    * Allow once     -> `%{decision: :allow, scope: :once}`
+    * Allow session   -> `%{decision: :allow, scope: :session}`
+    * Allow subtree   -> `%{decision: :allow, scope: :root}` -- `:root`
+      covers this whole agent spawn subtree, not just the current agent.
+    * Deny            -> `%{decision: :deny, scope: :once}` -- denial is
+      inherently a single-decision act; there is no persistent "deny for
+      session/subtree" concept in this gate, so it always carries the
+      narrowest scope.
+
+  None of the options carry inherent color-by-danger -- the only visual
+  differentiator between rows is which one currently holds keyboard focus
+  (reverse video, one row, per the `tui-design-science` skill's "one
+  anchor per screen" rule). Danger lives entirely in the embedded
+  `BlastRadiusPreview`, not in how "Deny" or "Allow" are painted, so the
+  safe default is never visually fighting the destructive one.
+  """
+
+  alias Raxol.UI.Components.Harness.BlastRadiusPreview
+  alias Raxol.UI.Components.Modal.Rendering, as: ModalRendering
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type scope :: :once | :session | :root
+  @type option :: %{
+          key: atom(),
+          label: String.t(),
+          decision: :allow | :deny,
+          scope: scope()
+        }
+
+  @type t :: %{
+          id: String.t() | atom(),
+          action: term(),
+          blast_radius: BlastRadiusPreview.blast_radius(),
+          options: [option()],
+          selected_index: non_neg_integer(),
+          width: pos_integer(),
+          style: map(),
+          theme: map()
+        }
+
+  @default_options [
+    %{key: :allow_once, label: "Allow once", decision: :allow, scope: :once},
+    %{
+      key: :allow_session,
+      label: "Allow for session",
+      decision: :allow,
+      scope: :session
+    },
+    %{
+      key: :allow_root,
+      label: "Allow for agent subtree",
+      decision: :allow,
+      scope: :root
+    },
+    %{key: :deny, label: "Deny", decision: :deny, scope: :once}
+  ]
+
+  @default_width 60
+  @frame_rows 4
+
+  @nav_keys %{
+    "Up" => :up,
+    :up => :up,
+    "Down" => :down,
+    :down => :down,
+    "Enter" => :enter,
+    :enter => :enter
+  }
+
+  @digit_chars ~w(1 2 3 4 5 6 7 8 9)
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "approval-prompt-#{:erlang.unique_integer([:positive])}"
+        ),
+      action: Keyword.get(props, :action, nil),
+      blast_radius: Keyword.get(props, :blast_radius, %{}),
+      options: Keyword.get(props, :options, @default_options),
+      selected_index: 0,
+      width: Keyword.get(props, :width, @default_width),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(%{__struct__: _} = event, state, context),
+    do: handle_event(Map.from_struct(event), state, context)
+
+  def handle_event(%{type: :key, data: data}, state, _context)
+      when is_map(data) do
+    case classify_key(data) do
+      :up -> {move_selection(state, -1), []}
+      :down -> {move_selection(state, 1), []}
+      {:jump, index} -> {select_index(state, index), []}
+      :enter -> emit_decision(state)
+      :noop -> {state, []}
+    end
+  end
+
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    {:ok, blast_radius_state} =
+      BlastRadiusPreview.init(
+        id: "#{state.id}-blast-radius",
+        blast_radius: state.blast_radius
+      )
+
+    blast_radius_view = BlastRadiusPreview.render(blast_radius_state, context)
+
+    content = [
+      Components.text(
+        id: "#{state.id}-action",
+        content: action_description(state.action),
+        style: %{bold: true}
+      ),
+      blank_line(),
+      blast_radius_view,
+      blank_line(),
+      Components.text(
+        id: "#{state.id}-options-header",
+        content: "Choose a response:",
+        style: %{dim: true}
+      )
+      | option_rows(state)
+    ]
+
+    content_column = %{type: :column, style: %{width: :fill}, children: content}
+
+    ModalRendering.dialog_surface(
+      state.width,
+      estimate_height(state),
+      box_style(state, context),
+      [content_column]
+    )
+  end
+
+  @doc """
+  Structural line-count estimate of the prompt's total footprint height
+  (frame + content), used to size the `dialog_surface/4` box this
+  component renders into and, standalone, by callers positioning the
+  overlay before calling `render/2` (e.g. `AbsoluteLayer.dialog_overlay/3`
+  needs a matching height to center correctly). Generous by design, like
+  `Raxol.UI.Components.Modal.Rendering.estimate_height/1`.
+  """
+  @spec estimate_height(t()) :: pos_integer()
+  def estimate_height(state) do
+    action_rows = 1
+    options_header_rows = 1
+    blast_rows = BlastRadiusPreview.estimate_rows(state.blast_radius)
+    options_rows = length(state.options)
+    # blank line after the action line, blank line after the blast radius
+    spacer_rows = 2
+
+    @frame_rows + action_rows + spacer_rows + blast_rows + options_header_rows +
+      options_rows
+  end
+
+  # -- Rendering helpers --
+
+  defp box_style(state, context) do
+    base = StyleHelper.merge_component_styles(state, context, :approval_prompt)
+    Map.merge(%{border: :double, align: :center}, base)
+  end
+
+  defp option_rows(state) do
+    state.options
+    |> Enum.with_index()
+    |> Enum.map(fn {option, index} ->
+      render_option(state.id, option, index, state.selected_index)
+    end)
+  end
+
+  defp render_option(id, option, index, selected_index) do
+    selected? = index == selected_index
+    marker = if selected?, do: "▸", else: " "
+
+    Components.text(
+      id: "#{id}-option-#{index}",
+      content: "#{marker} #{index + 1}. #{option_label(option)}",
+      style: %{reverse: selected?}
+    )
+  end
+
+  defp option_label(%{label: label}) when is_binary(label), do: label
+  defp option_label(option), do: inspect(option)
+
+  defp action_description(action) when is_binary(action) do
+    case String.trim(action) do
+      "" -> "Approval requested"
+      trimmed -> trimmed
+    end
+  end
+
+  defp action_description(%{} = action) do
+    description =
+      case Map.get(action, :description) do
+        d when is_binary(d) and d != "" -> d
+        _ -> "Approval requested"
+      end
+
+    case Map.get(action, :tool) do
+      tool when is_binary(tool) and tool != "" -> "#{description} (via #{tool})"
+      _ -> description
+    end
+  end
+
+  defp action_description(_action), do: "Approval requested"
+
+  defp blank_line, do: Components.text(content: "")
+
+  # -- Keyboard handling --
+
+  defp classify_key(%{key: :char, char: char}) when char in @digit_chars,
+    do: {:jump, String.to_integer(char) - 1}
+
+  defp classify_key(%{key: key}) when is_binary(key) and key in @digit_chars,
+    do: {:jump, String.to_integer(key) - 1}
+
+  defp classify_key(%{key: key}), do: Map.get(@nav_keys, key, :noop)
+  defp classify_key(_data), do: :noop
+
+  defp move_selection(state, delta) do
+    last_index = max(length(state.options) - 1, 0)
+    new_index = (state.selected_index + delta) |> max(0) |> min(last_index)
+    %{state | selected_index: new_index}
+  end
+
+  defp select_index(state, index) do
+    if index >= 0 and index < length(state.options) do
+      %{state | selected_index: index}
+    else
+      state
+    end
+  end
+
+  defp emit_decision(state) do
+    case Enum.at(state.options, state.selected_index) do
+      nil ->
+        {state, []}
+
+      option ->
+        {state,
+         [
+           {:approval_decision,
+            %{decision: option.decision, scope: option.scope}}
+         ]}
+    end
+  end
+end

--- a/lib/raxol/ui/components/harness/blast_radius_preview.ex
+++ b/lib/raxol/ui/components/harness/blast_radius_preview.ex
@@ -115,7 +115,10 @@ defmodule Raxol.UI.Components.Harness.BlastRadiusPreview do
           list |> Enum.intersperse(blank_line()) |> List.flatten()
       end
 
-    %{type: :column, style: base_style, children: children}
+    # gap: 0 is load-bearing: the layout engine defaults an unset gap to 1,
+    # which would double every row; section spacing is the explicit
+    # interspersed blank lines, counted by estimate_rows/1.
+    %{type: :column, style: base_style, gap: 0, children: children}
   end
 
   @doc """

--- a/lib/raxol/ui/components/harness/blast_radius_preview.ex
+++ b/lib/raxol/ui/components/harness/blast_radius_preview.ex
@@ -1,0 +1,232 @@
+defmodule Raxol.UI.Components.Harness.BlastRadiusPreview do
+  @moduledoc """
+  Renders the blast radius of an agent-harness action: everything it will
+  touch, grouped by effect kind, with destructive/irreversible effects made
+  impossible to miss.
+
+  Render-dual of the `blast_radius` field carried by the harness's
+  `approval_requested` payload (see
+  `docs/proposals/in-flight/harness-spec-frontend.md`, §4 row A6). Typically
+  embedded inside `Raxol.UI.Components.Harness.ApprovalPrompt`, but stands
+  alone for the playground and for testing.
+
+  ## Props
+
+    * `:blast_radius` - `%{writes: [path], deletes: [path], commands:
+      [string], network: [host], reversible: boolean}`. Every key is
+      optional; missing lists default to `[]`, missing `:reversible`
+      defaults to `true` (a missing/absent flag is not itself a danger
+      signal -- but deletes are still shown loud regardless, see below).
+
+  ## Visual hierarchy
+
+  Per the `tui-design-science` skill: hue carries *identity* (what kind of
+  effect this is), weight carries *importance* (how much attention it
+  needs) -- kept independent so red stays reserved for the one thing it
+  means.
+
+    * `:deletes` are always red + bold. Deleting earns a second look even
+      inside an otherwise-reversible action.
+    * `:commands` are yellow (caution -- unpredictable side effects),
+      `:network` is cyan (informational -- reaching outside the sandbox),
+      `:writes` carry no hue, just weight.
+    * When `blast_radius.reversible == false`, every group loses its
+      dim/default weight and renders bold -- nothing here is a "minor"
+      effect anymore -- and a standalone `IRREVERSIBLE` marker leads the
+      list, in red (the one other case the alarm hue is reserved for).
+    * When `blast_radius.reversible == true`, `:commands` / `:network` /
+      `:writes` render dim -- present, but not competing with the deletes
+      group for attention.
+
+  Every group is glyph-prefixed, not color-only, so the hierarchy survives
+  for colorblind readers: `✗` delete, `▲` run, `ℹ` network, `•` write.
+  """
+
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type blast_radius :: %{
+          optional(:writes) => [String.t()],
+          optional(:deletes) => [String.t()],
+          optional(:commands) => [String.t()],
+          optional(:network) => [String.t()],
+          optional(:reversible) => boolean()
+        }
+
+  @type t :: %{
+          id: String.t() | atom(),
+          blast_radius: blast_radius(),
+          style: map(),
+          theme: map()
+        }
+
+  @groups [
+    {:deletes, "Delete", "✗", :red, true},
+    {:commands, "Run", "▲", :yellow, false},
+    {:network, "Network", "ℹ", :cyan, false},
+    {:writes, "Write", "•", nil, false}
+  ]
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "blast-radius-preview-#{:erlang.unique_integer([:positive])}"
+        ),
+      blast_radius: Keyword.get(props, :blast_radius, %{}),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :blast_radius_preview)
+
+    br = state.blast_radius
+    reversible = Map.get(br, :reversible, true)
+
+    sections =
+      [
+        marker_section(state.id, reversible)
+        | group_sections(state.id, br, reversible)
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    children =
+      case sections do
+        [] ->
+          [Components.text(content: "No tracked effects.", style: %{dim: true})]
+
+        list ->
+          list |> Enum.intersperse(blank_line()) |> List.flatten()
+      end
+
+    %{type: :column, style: base_style, children: children}
+  end
+
+  @doc """
+  Structural row-count estimate of this preview's rendered height (content
+  rows only -- no outer frame/padding), for callers that need to size an
+  enclosing overlay before `render/2` has run (see
+  `Raxol.UI.Components.Harness.ApprovalPrompt.estimate_height/1`). Generous
+  by design, mirroring `Raxol.UI.Components.Modal.Rendering.estimate_height/1`.
+  """
+  @spec estimate_rows(blast_radius()) :: pos_integer()
+  def estimate_rows(blast_radius) do
+    reversible = Map.get(blast_radius, :reversible, true)
+    marker? = not reversible
+
+    groups =
+      Enum.map(@groups, fn {key, _label, _glyph, _color, _always} ->
+        Map.get(blast_radius, key, [])
+      end)
+
+    non_empty = Enum.count(groups, &(&1 != []))
+    item_rows = Enum.reduce(groups, 0, fn items, acc -> acc + length(items) end)
+    section_count = non_empty + bool_to_int(marker?)
+    gap_rows = max(section_count - 1, 0)
+
+    case section_count do
+      0 -> 1
+      _ -> bool_to_int(marker?) + non_empty + item_rows + gap_rows
+    end
+  end
+
+  defp bool_to_int(true), do: 1
+  defp bool_to_int(false), do: 0
+
+  defp marker_section(_id, true), do: nil
+
+  defp marker_section(id, false) do
+    [
+      Components.text(
+        id: "#{id}-irreversible",
+        content: "⚠ IRREVERSIBLE — this action cannot be undone",
+        fg: :red,
+        style: %{bold: true}
+      )
+    ]
+  end
+
+  defp group_sections(id, blast_radius, reversible) do
+    Enum.map(@groups, fn {key, label, glyph, color, always_loud} ->
+      group_section(
+        id,
+        key,
+        label,
+        glyph,
+        color,
+        Map.get(blast_radius, key, []),
+        always_loud,
+        reversible
+      )
+    end)
+  end
+
+  defp group_section(
+         _id,
+         _key,
+         _label,
+         _glyph,
+         _color,
+         [],
+         _always_loud,
+         _reversible
+       ),
+       do: nil
+
+  defp group_section(
+         id,
+         key,
+         label,
+         glyph,
+         color,
+         items,
+         always_loud,
+         reversible
+       ) do
+    loud? = always_loud or not reversible
+
+    header =
+      Components.text(
+        id: "#{id}-#{key}-header",
+        content: "#{glyph} #{label} (#{length(items)})",
+        fg: color,
+        style: %{bold: loud?}
+      )
+
+    item_nodes =
+      items
+      |> Enum.with_index()
+      |> Enum.map(fn {item, index} ->
+        render_item(id, key, item, index, color, loud?)
+      end)
+
+    [header | item_nodes]
+  end
+
+  defp render_item(id, key, item, index, color, loud?) do
+    Components.text(
+      id: "#{id}-#{key}-#{index}",
+      content: "  #{item}",
+      fg: if(loud?, do: color, else: nil),
+      style: %{dim: not loud?}
+    )
+  end
+
+  defp blank_line, do: Components.text(content: "")
+end

--- a/test/raxol/playground/app_test.exs
+++ b/test/raxol/playground/app_test.exs
@@ -14,7 +14,7 @@ defmodule Raxol.Playground.AppTest do
   describe "init/1" do
     test "initializes with components and first selected" do
       model = App.init(nil)
-      assert length(model.components) == 37
+      assert length(model.components) == 38
       assert model.cursor == 0
       assert model.selected != nil
       assert model.focus == :sidebar
@@ -189,7 +189,7 @@ defmodule Raxol.Playground.AppTest do
       # After cycling through all categories, next press returns to nil
       {model, []} = App.update(key_event("f"), model)
       assert model.category_filter == nil
-      assert length(model.components) == 37
+      assert length(model.components) == 38
     end
 
     test "f resets cursor to 0" do

--- a/test/raxol/playground/catalog_test.exs
+++ b/test/raxol/playground/catalog_test.exs
@@ -6,7 +6,7 @@ defmodule Raxol.Playground.CatalogTest do
   describe "list_components/0" do
     test "returns all registered components" do
       components = Catalog.list_components()
-      assert length(components) == 37
+      assert length(components) == 38
       assert Enum.all?(components, &is_map/1)
     end
 

--- a/test/raxol/playground/sidebar_scroll_test.exs
+++ b/test/raxol/playground/sidebar_scroll_test.exs
@@ -107,7 +107,7 @@ defmodule Raxol.Playground.SidebarScrollTest do
       sidebar = sidebar_text(text)
 
       assert sidebar =~ "▸ Button"
-      assert sidebar =~ "37 widgets"
+      assert sidebar =~ "38 widgets"
     end
 
     test "scrolling past the visible window keeps the marker on screen and scrolls the top items out",

--- a/test/raxol/ui/components/harness/approval_prompt_test.exs
+++ b/test/raxol/ui/components/harness/approval_prompt_test.exs
@@ -237,4 +237,48 @@ defmodule Raxol.UI.Components.Harness.ApprovalPromptTest do
                ApprovalPrompt.handle_event(enter, state, %{})
     end
   end
+
+  describe "layout regression: explicit gaps" do
+    # The layout engine defaults an unset column gap to 1, which doubles
+    # every row and overflows the fixed-height dialog surface (content
+    # spilled past the bottom border). Every column this component renders
+    # must carry an explicit gap.
+    test "every column in the rendered tree has an explicit gap" do
+      {:ok, state} =
+        ApprovalPrompt.init(
+          action: %{description: "Clear cache", tool: "shell.exec"},
+          blast_radius: %{
+            deletes: ["/a", "/b"],
+            commands: ["rm -rf /tmp/x"],
+            writes: ["/log"],
+            reversible: false
+          }
+        )
+
+      rendered = ApprovalPrompt.render(state, %{})
+
+      for column <- collect_columns(rendered) do
+        assert is_integer(Map.get(column, :gap)) or
+                 is_integer(get_in(column, [:style, :gap])),
+               "column without explicit gap: #{inspect(Map.drop(column, [:children]))}"
+      end
+    end
+
+    defp collect_columns(%{type: :column} = node) do
+      [node | Enum.flat_map(children_of(node), &collect_columns/1)]
+    end
+
+    defp collect_columns(%{} = node),
+      do: Enum.flat_map(children_of(node), &collect_columns/1)
+
+    defp collect_columns(_other), do: []
+
+    defp children_of(node) do
+      case Map.get(node, :children) do
+        list when is_list(list) -> List.flatten(list)
+        %{} = one -> [one]
+        _ -> []
+      end
+    end
+  end
 end

--- a/test/raxol/ui/components/harness/approval_prompt_test.exs
+++ b/test/raxol/ui/components/harness/approval_prompt_test.exs
@@ -1,0 +1,240 @@
+defmodule Raxol.UI.Components.Harness.ApprovalPromptTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.ApprovalPrompt
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  defp find_by_id(children, id), do: Enum.find(children, &(&1[:id] == id))
+
+  describe "init/1" do
+    test "defaults to the four standard options, none selected but the first" do
+      assert {:ok, state} = ApprovalPrompt.init(id: :ap1)
+
+      assert state.action == nil
+      assert state.blast_radius == %{}
+      assert state.selected_index == 0
+      assert state.width == 60
+
+      assert [
+               %{key: :allow_once, decision: :allow, scope: :once},
+               %{key: :allow_session, decision: :allow, scope: :session},
+               %{key: :allow_root, decision: :allow, scope: :root},
+               %{key: :deny, decision: :deny, scope: :once}
+             ] = state.options
+    end
+
+    test "honors a custom :options list instead of the defaults" do
+      custom = [%{key: :yes, label: "Yes", decision: :allow, scope: :once}]
+      assert {:ok, state} = ApprovalPrompt.init(id: :ap2, options: custom)
+      assert state.options == custom
+    end
+
+    test "honors :action and :blast_radius props" do
+      assert {:ok, state} =
+               ApprovalPrompt.init(
+                 id: :ap3,
+                 action: %{description: "Delete stale cache", tool: "shell"},
+                 blast_radius: %{deletes: ["/tmp/a"]}
+               )
+
+      assert state.action == %{description: "Delete stale cache", tool: "shell"}
+      assert state.blast_radius == %{deletes: ["/tmp/a"]}
+    end
+  end
+
+  describe "render/2" do
+    setup do
+      {:ok, state} =
+        ApprovalPrompt.init(
+          id: "ap-render",
+          action: "Delete the stale cache",
+          blast_radius: %{deletes: ["/tmp/a"], reversible: false}
+        )
+
+      %{state: state}
+    end
+
+    test "renders a dialog_surface box built on Modal.Rendering", %{
+      state: state
+    } do
+      rendered = ApprovalPrompt.render(state, default_context())
+
+      assert rendered.type == :box
+      assert rendered.border == :double
+      assert rendered.width == state.width
+      assert rendered.height == ApprovalPrompt.estimate_height(state)
+      assert rendered.padding == 1
+      assert rendered.style.align == :center
+    end
+
+    test "shows the action description and embeds the blast radius preview", %{
+      state: state
+    } do
+      rendered = ApprovalPrompt.render(state, default_context())
+      [content_column] = rendered.children
+      assert content_column.type == :column
+
+      action_line = find_by_id(content_column.children, "ap-render-action")
+      assert action_line.content == "Delete the stale cache"
+      assert action_line.style == %{bold: true}
+
+      blast_radius_view =
+        Enum.find(content_column.children, &(&1.type == :column))
+
+      assert blast_radius_view != nil
+
+      marker =
+        Enum.find(
+          blast_radius_view.children,
+          &(&1[:content] == "⚠ IRREVERSIBLE — this action cannot be undone")
+        )
+
+      assert marker != nil
+      assert marker.fg == :red
+    end
+
+    test "renders the option rows with the first one marked as selected", %{
+      state: state
+    } do
+      rendered = ApprovalPrompt.render(state, default_context())
+      [content_column] = rendered.children
+
+      option0 = find_by_id(content_column.children, "ap-render-option-0")
+      assert option0.content == "▸ 1. Allow once"
+      assert option0.style == %{reverse: true}
+
+      option1 = find_by_id(content_column.children, "ap-render-option-1")
+      assert option1.content == "  2. Allow for session"
+      assert option1.style == %{reverse: false}
+
+      option3 = find_by_id(content_column.children, "ap-render-option-3")
+      assert option3.content == "  4. Deny"
+    end
+  end
+
+  describe "estimate_height/1" do
+    test "sums frame, action, spacers, blast radius rows, and options" do
+      {:ok, state} = ApprovalPrompt.init(id: :ap_height)
+
+      # frame(4) + action(1) + spacers(2) + blast_radius("no effects" line = 1) +
+      # options_header(1) + options(4) = 13
+      assert ApprovalPrompt.estimate_height(state) == 13
+    end
+  end
+
+  describe "handle_event/3 — navigation" do
+    setup do
+      {:ok, state} = ApprovalPrompt.init(id: :ap_nav)
+      %{state: state}
+    end
+
+    test "Down (string form) moves the selection forward", %{state: state} do
+      event = %{type: :key, data: %{key: "Down"}}
+      assert {new_state, []} = ApprovalPrompt.handle_event(event, state, %{})
+      assert new_state.selected_index == 1
+    end
+
+    test "down (atom form) moves the selection forward", %{state: state} do
+      event = %{type: :key, data: %{key: :down}}
+      assert {new_state, []} = ApprovalPrompt.handle_event(event, state, %{})
+      assert new_state.selected_index == 1
+    end
+
+    test "Up clamps at 0 instead of going negative", %{state: state} do
+      event = %{type: :key, data: %{key: "Up"}}
+      assert {new_state, []} = ApprovalPrompt.handle_event(event, state, %{})
+      assert new_state.selected_index == 0
+    end
+
+    test "Down clamps at the last option", %{state: state} do
+      down = %{type: :key, data: %{key: :down}}
+
+      final_state =
+        Enum.reduce(1..10, state, fn _, acc ->
+          {next, []} = ApprovalPrompt.handle_event(down, acc, %{})
+          next
+        end)
+
+      assert final_state.selected_index == 3
+    end
+
+    test "a digit key (:char form) jumps straight to that option", %{
+      state: state
+    } do
+      event = %{type: :key, data: %{key: :char, char: "3"}}
+      assert {new_state, []} = ApprovalPrompt.handle_event(event, state, %{})
+      assert new_state.selected_index == 2
+    end
+
+    test "a digit key (bare single-char form) jumps straight to that option", %{
+      state: state
+    } do
+      event = %{type: :key, data: %{key: "3"}}
+      assert {new_state, []} = ApprovalPrompt.handle_event(event, state, %{})
+      assert new_state.selected_index == 2
+    end
+
+    test "an out-of-range digit key is a no-op", %{state: state} do
+      event = %{type: :key, data: %{key: "9"}}
+      assert {new_state, []} = ApprovalPrompt.handle_event(event, state, %{})
+      assert new_state.selected_index == 0
+    end
+
+    test "accepts a wrapped %Event{} struct the same as a plain map", %{
+      state: state
+    } do
+      event = %Event{type: :key, data: %{key: :down}}
+      assert {new_state, []} = ApprovalPrompt.handle_event(event, state, %{})
+      assert new_state.selected_index == 1
+    end
+
+    test "an unrelated event is a no-op", %{state: state} do
+      event = %Event{type: :resize, data: %{width: 80, height: 24}}
+      assert {^state, []} = ApprovalPrompt.handle_event(event, state, %{})
+    end
+  end
+
+  describe "handle_event/3 — confirming a decision" do
+    setup do
+      {:ok, state} = ApprovalPrompt.init(id: :ap_confirm)
+      %{state: state}
+    end
+
+    test "Enter on the default selection emits allow/once", %{state: state} do
+      event = %{type: :key, data: %{key: "Enter"}}
+
+      assert {^state, [{:approval_decision, %{decision: :allow, scope: :once}}]} =
+               ApprovalPrompt.handle_event(event, state, %{})
+    end
+
+    test "Enter after navigating to Deny emits deny/once", %{state: state} do
+      down = %{type: :key, data: %{key: :down}}
+      {state, []} = ApprovalPrompt.handle_event(down, state, %{})
+      {state, []} = ApprovalPrompt.handle_event(down, state, %{})
+      {state, []} = ApprovalPrompt.handle_event(down, state, %{})
+      assert state.selected_index == 3
+
+      enter = %{type: :key, data: %{key: :enter}}
+
+      assert {^state, [{:approval_decision, %{decision: :deny, scope: :once}}]} =
+               ApprovalPrompt.handle_event(enter, state, %{})
+    end
+
+    test "Enter after jumping to 'Allow for agent subtree' emits allow/root", %{
+      state: state
+    } do
+      jump = %{type: :key, data: %{key: "3"}}
+      {state, []} = ApprovalPrompt.handle_event(jump, state, %{})
+      assert state.selected_index == 2
+
+      enter = %{type: :key, data: %{key: :enter}}
+
+      assert {_state, [{:approval_decision, %{decision: :allow, scope: :root}}]} =
+               ApprovalPrompt.handle_event(enter, state, %{})
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/blast_radius_preview_test.exs
+++ b/test/raxol/ui/components/harness/blast_radius_preview_test.exs
@@ -1,0 +1,155 @@
+defmodule Raxol.UI.Components.Harness.BlastRadiusPreviewTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.BlastRadiusPreview
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  defp find_by_id(children, id), do: Enum.find(children, &(&1[:id] == id))
+
+  describe "init/1" do
+    test "defaults to an empty blast radius" do
+      assert {:ok, state} = BlastRadiusPreview.init(id: :bp1)
+      assert state.id == :bp1
+      assert state.blast_radius == %{}
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "keeps the provided blast radius as-is" do
+      br = %{deletes: ["/tmp/a"], reversible: false}
+      assert {:ok, state} = BlastRadiusPreview.init(id: :bp2, blast_radius: br)
+      assert state.blast_radius == br
+    end
+  end
+
+  describe "render/2 — empty blast radius" do
+    test "renders a calm placeholder line, no marker" do
+      {:ok, state} = BlastRadiusPreview.init(id: :bp_empty)
+      rendered = BlastRadiusPreview.render(state, default_context())
+
+      assert rendered.type == :column
+      assert [line] = rendered.children
+      assert line.content == "No tracked effects."
+      assert line.style == %{dim: true}
+    end
+  end
+
+  describe "render/2 — deletes" do
+    test "always renders deletes red and bold, even when reversible" do
+      {:ok, state} =
+        BlastRadiusPreview.init(
+          id: :bp_del,
+          blast_radius: %{deletes: ["/tmp/a", "/tmp/b"], reversible: true}
+        )
+
+      rendered = BlastRadiusPreview.render(state, default_context())
+
+      header = find_by_id(rendered.children, "bp_del-deletes-header")
+      assert header.content == "✗ Delete (2)"
+      assert header.fg == :red
+      assert header.style == %{bold: true}
+
+      item0 = find_by_id(rendered.children, "bp_del-deletes-0")
+      assert item0.content == "  /tmp/a"
+      assert item0.fg == :red
+      assert item0.style == %{dim: false}
+
+      # No IRREVERSIBLE marker when reversible: true
+      refute find_by_id(rendered.children, "bp_del-irreversible")
+    end
+  end
+
+  describe "render/2 — reversible: false" do
+    test "shows the IRREVERSIBLE marker and escalates every group to loud" do
+      {:ok, state} =
+        BlastRadiusPreview.init(
+          id: :bp_irr,
+          blast_radius: %{
+            deletes: ["/tmp/a"],
+            writes: ["/tmp/b"],
+            reversible: false
+          }
+        )
+
+      rendered = BlastRadiusPreview.render(state, default_context())
+
+      marker = find_by_id(rendered.children, "bp_irr-irreversible")
+      assert marker.content == "⚠ IRREVERSIBLE — this action cannot be undone"
+      assert marker.fg == :red
+      assert marker.style == %{bold: true}
+
+      # writes is not always_loud, but reversible: false escalates it anyway
+      write_header = find_by_id(rendered.children, "bp_irr-writes-header")
+      assert write_header.style == %{bold: true}
+
+      write_item = find_by_id(rendered.children, "bp_irr-writes-0")
+      assert write_item.style == %{dim: false}
+    end
+
+    test "reversible: true keeps non-delete groups dim" do
+      {:ok, state} =
+        BlastRadiusPreview.init(
+          id: :bp_dim,
+          blast_radius: %{commands: ["rm -rf /tmp/x"], reversible: true}
+        )
+
+      rendered = BlastRadiusPreview.render(state, default_context())
+
+      header = find_by_id(rendered.children, "bp_dim-commands-header")
+      assert header.content == "▲ Run (1)"
+      assert header.fg == :yellow
+      assert header.style == %{bold: false}
+
+      item = find_by_id(rendered.children, "bp_dim-commands-0")
+      assert item.fg == nil
+      assert item.style == %{dim: true}
+    end
+
+    test "missing :reversible defaults to true (non-delete groups stay dim)" do
+      {:ok, state} =
+        BlastRadiusPreview.init(
+          id: :bp_default,
+          blast_radius: %{network: ["api.example.com"]}
+        )
+
+      rendered = BlastRadiusPreview.render(state, default_context())
+
+      header = find_by_id(rendered.children, "bp_default-network-header")
+      assert header.style == %{bold: false}
+    end
+  end
+
+  describe "estimate_rows/1" do
+    test "is 1 for an empty blast radius (the placeholder line)" do
+      assert BlastRadiusPreview.estimate_rows(%{}) == 1
+    end
+
+    test "counts header + items with no gap for a single group" do
+      assert BlastRadiusPreview.estimate_rows(%{deletes: ["a"]}) == 2
+    end
+
+    test "accounts for the marker row and inter-group gaps" do
+      br = %{reversible: false, deletes: ["a", "b"], writes: ["c"]}
+
+      # marker(1) + delete header+items(1+2) + write header+items(1+1) + gaps(2) = 8
+      assert BlastRadiusPreview.estimate_rows(br) == 8
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged (non-interactive)" do
+      {:ok, state} =
+        BlastRadiusPreview.init(
+          id: :bp_evt,
+          blast_radius: %{deletes: ["/tmp/a"]}
+        )
+
+      event = %Event{type: :key, data: %{key: :enter}}
+      assert {^state, []} = BlastRadiusPreview.handle_event(event, state, %{})
+    end
+  end
+end


### PR DESCRIPTION
Renders `approval_requested` → emits `approval_decision`:
- `BlastRadiusPreview` — what an action touches; deletes/irreversible LOUD red, IRREVERSIBLE marker.
- `ApprovalPrompt` — built on Modal; allow once/session/root or deny (`:root` covers a spawn subtree).
Catalog registration added this pass (crashed agent had skipped it).

Part of the agent-harness UI (`docs/proposals/in-flight/harness-spec-frontend.md`). Pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP5gp9w9LBHU6nSXMc6kc1