### PR TITLE
Harness UI: projection panels (worktracks / rules / memory / residual)

### DIFF
--- a/lib/raxol/playground/catalog.ex
+++ b/lib/raxol/playground/catalog.ex
@@ -445,6 +445,21 @@ defmodule Raxol.Playground.Catalog do
       {:ok, s} = ActivityIndicator.init(state: :working, since_ms: 0, frame: 0)
       ActivityIndicator.render(s, %{})
       """
+    },
+    %{
+      name: "Harness Panels",
+      module: Demos.HarnessPanelsDemo,
+      category: :display,
+      description:
+        "Read-only harness projection panels: worktracks kanban, rules (hard vs soft), memory, residual",
+      complexity: :intermediate,
+      tags: ["harness", "display", "kanban", "rules", "memory", "projection"],
+      code_snippet: """
+      {:ok, state} = WorktracksPanel.init(lanes: [
+        %{name: "doing", items: [%{title: "Fold extract into board", status: "doing"}]}
+      ])
+      WorktracksPanel.render(state, %{})
+      """
     }
   ]
 

--- a/lib/raxol/playground/demos/harness_panels_demo.ex
+++ b/lib/raxol/playground/demos/harness_panels_demo.ex
@@ -1,0 +1,123 @@
+defmodule Raxol.Playground.Demos.HarnessPanelsDemo do
+  @moduledoc """
+  Playground demo: harness projection panels (worktracks / rules / memory /
+  residual) laid out as one dashboard.
+
+  Exercises the real `Raxol.UI.Components.Harness.*` panel modules -- each
+  `init/1` + `render/2` directly, the same way `DemoHelpers.rich_text/2`
+  mounts `Display.Text` -- with sample data shaped like the materialized
+  views these panels fold from `extract{class, op, item}` / `residual` meta
+  events (see `docs/proposals/in-flight/harness-spec-frontend.md` §3).
+  """
+  use Raxol.Core.Runtime.Application
+
+  alias Raxol.UI.Components.Harness.{
+    MemoryPanel,
+    ResidualIndicator,
+    RulesPanel,
+    WorktracksPanel
+  }
+
+  @lanes [
+    %{
+      name: "todo",
+      items: [
+        %{title: "Wire MemoryPanel to state_change stream", status: "todo"},
+        %{title: "Add reattach replay indicator", status: "todo"}
+      ]
+    },
+    %{
+      name: "doing",
+      items: [
+        %{title: "Fold extract{class: :worktracks} into board", status: "doing"}
+      ]
+    },
+    %{
+      name: "done",
+      items: [
+        %{title: "Spec projection panel props", status: "done"},
+        %{title: "Draft protocol payload table", status: "done"}
+      ]
+    }
+  ]
+
+  @rules [
+    %{
+      when: "approval_requested is pending",
+      then: "block further tool_use items until approval_decision arrives",
+      hard: true
+    },
+    %{
+      when: "steer command received mid-turn",
+      then: "inject at the next safe tool boundary, never mid-call",
+      hard: true
+    },
+    %{
+      when: "turn_completed carries usage",
+      then: "refresh the status line's cost readout",
+      hard: false
+    }
+  ]
+
+  @memory [
+    %{key: "session_id", value: "sess_8f21c"},
+    %{key: "active_gate", value: "probe_c1_gate"},
+    %{key: "turns_completed", value: 12},
+    %{key: "trust", value: "trusted"}
+  ]
+
+  @residual_text "which retry class covers a stalled probe_c2 extraction"
+
+  @impl true
+  def init(_context) do
+    %{show_residual: true}
+  end
+
+  @impl true
+  def update(message, model) do
+    case message do
+      key_match("r") ->
+        {%{model | show_residual: not model.show_residual}, []}
+
+      _ ->
+        {model, []}
+    end
+  end
+
+  @impl true
+  def view(model) do
+    column style: %{gap: 1} do
+      [
+        text("Harness Panels Demo", style: [:bold]),
+        divider(),
+        panel(WorktracksPanel, id: "demo-worktracks", lanes: @lanes),
+        row style: %{gap: 2} do
+          [
+            panel(RulesPanel, id: "demo-rules", rules: @rules),
+            panel(MemoryPanel, id: "demo-memory", items: @memory)
+          ]
+        end,
+        panel(ResidualIndicator,
+          id: "demo-residual",
+          residual: residual(model)
+        ),
+        text("[r] toggle residual", style: [:dim])
+      ]
+    end
+  end
+
+  @impl true
+  def subscribe(_model), do: []
+
+  defp residual(%{show_residual: true}), do: @residual_text
+  defp residual(_model), do: nil
+
+  # Mounts a real Harness panel component the same way
+  # `Raxol.Playground.DemoHelpers.rich_text/2` mounts `Display.Text`: a fresh
+  # `init/1` + `render/2` each frame, since these panels carry no state of
+  # their own beyond the props handed in.
+  defp panel(module, props) do
+    {:ok, state} = module.init(props)
+    module.render(state, %{})
+  end
+end

--- a/lib/raxol/ui/components/harness/memory_panel.ex
+++ b/lib/raxol/ui/components/harness/memory_panel.ex
@@ -1,0 +1,87 @@
+defmodule Raxol.UI.Components.Harness.MemoryPanel do
+  @moduledoc """
+  A read-only panel over the harness's session memory projection.
+
+  Renders the materialized view folded from `extract{class: :memory, op,
+  item}` meta events (source `:probe_c2_memory`) as an aligned key/value
+  list. Purely a projection: no interaction, no local state beyond what's
+  handed in via props.
+  """
+
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type item :: %{key: String.t(), value: term()}
+
+  @type t :: %{
+          id: String.t() | atom(),
+          title: String.t(),
+          items: [item()],
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "memory-panel-#{:erlang.unique_integer([:positive])}"
+        ),
+      title: Keyword.get(props, :title, "Memory"),
+      items: Keyword.get(props, :items, []),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :memory_panel)
+
+    Components.box(
+      id: state.id,
+      style: Map.merge(%{border: :single, padding: 1}, base_style),
+      children: [
+        Components.column(
+          style: %{gap: 0},
+          children: [
+            Components.text(
+              id: "#{state.id}-title",
+              content: state.title,
+              style: %{bold: true}
+            ),
+            memory_body(state.items)
+          ]
+        )
+      ]
+    )
+  end
+
+  defp memory_body([]) do
+    Components.text(content: "No memory yet.", style: %{dim: true})
+  end
+
+  # Reuses the `table()` layout primitive for aligned key/value columns
+  # instead of hand-padding text.
+  defp memory_body(items) do
+    rows =
+      Enum.map(items, fn %{key: key, value: value} ->
+        [key, to_string(value)]
+      end)
+
+    Components.table(headers: ["Key", "Value"], rows: rows)
+  end
+end

--- a/lib/raxol/ui/components/harness/residual_indicator.ex
+++ b/lib/raxol/ui/components/harness/residual_indicator.ex
@@ -1,0 +1,64 @@
+defmodule Raxol.UI.Components.Harness.ResidualIndicator do
+  @moduledoc """
+  A read-only indicator for the harness's residual projection.
+
+  Renders the `%{description}` payload of a `residual` meta event (source
+  `:probe_c2_residual`) -- the named unknown the probe swarm hasn't resolved
+  yet. Renders a subtle warning line when a residual is outstanding, and
+  renders nothing when it's `nil` (resolved / never raised).
+  """
+
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type t :: %{
+          id: String.t() | atom(),
+          residual: String.t() | nil,
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "residual-indicator-#{:erlang.unique_integer([:positive])}"
+        ),
+      residual: Keyword.get(props, :residual, nil),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :residual_indicator)
+
+    line(state, base_style)
+  end
+
+  defp line(%{residual: nil}, _base_style) do
+    Components.text(content: "")
+  end
+
+  defp line(%{id: id, residual: residual}, base_style) do
+    Components.text(
+      id: id,
+      content: "⚠ unresolved: #{residual}",
+      style: Map.merge(%{dim: true}, base_style)
+    )
+  end
+end

--- a/lib/raxol/ui/components/harness/rules_panel.ex
+++ b/lib/raxol/ui/components/harness/rules_panel.ex
@@ -1,0 +1,101 @@
+defmodule Raxol.UI.Components.Harness.RulesPanel do
+  @moduledoc """
+  A read-only panel over the harness's active when->then rules projection.
+
+  Renders the materialized view folded from `extract{class: :rules, op, item}`
+  meta events (source `:probe_c2_rules`). `hard: true` rules are ENFORCED
+  constraints -- the gate blocks on them -- rather than mere reminders, so
+  they render with a filled marker and bold weight; soft rules render dimmed
+  with a hollow marker. The distinction never relies on color alone (weight +
+  glyph both carry it), and avoids red/alarm styling since a rule is a
+  standing constraint, not an error.
+  """
+
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type rule :: %{when: String.t(), then: String.t(), hard: boolean()}
+
+  @type t :: %{
+          id: String.t() | atom(),
+          title: String.t(),
+          rules: [rule()],
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "rules-panel-#{:erlang.unique_integer([:positive])}"
+        ),
+      title: Keyword.get(props, :title, "Rules"),
+      rules: Keyword.get(props, :rules, []),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :rules_panel)
+
+    Components.box(
+      id: state.id,
+      style: Map.merge(%{border: :single, padding: 1}, base_style),
+      children: [
+        Components.column(
+          style: %{gap: 0},
+          children: [
+            Components.text(
+              id: "#{state.id}-title",
+              content: state.title,
+              style: %{bold: true}
+            )
+            | rule_rows(state)
+          ]
+        )
+      ]
+    )
+  end
+
+  defp rule_rows(%{rules: []}) do
+    [Components.text(content: "No active rules.", style: %{dim: true})]
+  end
+
+  defp rule_rows(%{id: id, rules: rules}) do
+    rules
+    |> Enum.with_index()
+    |> Enum.map(fn {rule, index} -> rule_row(id, rule, index) end)
+  end
+
+  defp rule_row(id, %{when: when_clause, then: then_clause, hard: true}, index) do
+    Components.text(
+      id: "#{id}-rule-#{index}",
+      content: "● HARD  when #{when_clause} → then #{then_clause}",
+      style: %{bold: true, fg: :yellow}
+    )
+  end
+
+  defp rule_row(id, %{when: when_clause, then: then_clause}, index) do
+    Components.text(
+      id: "#{id}-rule-#{index}",
+      content: "○ soft  when #{when_clause} → then #{then_clause}",
+      style: %{dim: true}
+    )
+  end
+end

--- a/lib/raxol/ui/components/harness/worktracks_panel.ex
+++ b/lib/raxol/ui/components/harness/worktracks_panel.ex
@@ -1,0 +1,118 @@
+defmodule Raxol.UI.Components.Harness.WorktracksPanel do
+  @moduledoc """
+  A read-only kanban board over the harness's worktracks projection.
+
+  Renders the materialized view folded from `extract{class: :worktracks, op,
+  item}` meta events (source `:probe_c2_worktracks`) -- one lane column per
+  entry in `:lanes` (e.g. todo / doing / done), each holding an aligned table
+  of its items. Purely a projection: no interaction, no local state beyond
+  what's handed in via props.
+  """
+
+  alias Raxol.UI.StyleHelper
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @type item :: %{title: String.t(), status: String.t()}
+  @type lane :: %{name: String.t(), items: [item()]}
+
+  @type t :: %{
+          id: String.t() | atom(),
+          title: String.t(),
+          lanes: [lane()],
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "worktracks-panel-#{:erlang.unique_integer([:positive])}"
+        ),
+      title: Keyword.get(props, :title, "Worktracks"),
+      lanes: Keyword.get(props, :lanes, []),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :worktracks_panel)
+
+    Components.box(
+      id: state.id,
+      style: Map.merge(%{border: :single, padding: 1}, base_style),
+      children: [
+        Components.column(
+          style: %{gap: 1},
+          children: [
+            Components.text(
+              id: "#{state.id}-title",
+              content: state.title,
+              style: %{bold: true}
+            ),
+            board(state)
+          ]
+        )
+      ]
+    )
+  end
+
+  defp board(%{lanes: []}) do
+    Components.text(content: "No worktracks yet.", style: %{dim: true})
+  end
+
+  defp board(%{id: id, lanes: lanes}) do
+    Components.row(
+      style: %{gap: 2},
+      children:
+        lanes
+        |> Enum.with_index()
+        |> Enum.map(fn {lane, index} -> lane_column(id, lane, index) end)
+    )
+  end
+
+  defp lane_column(id, %{name: name, items: items}, index) do
+    Components.box(
+      id: "#{id}-lane-#{index}",
+      style: %{border: :single, padding: 1},
+      children: [
+        Components.column(
+          style: %{gap: 0},
+          children: [
+            Components.text(
+              id: "#{id}-lane-#{index}-name",
+              content: "#{name} (#{length(items)})",
+              style: %{bold: true}
+            ),
+            lane_table(items)
+          ]
+        )
+      ]
+    )
+  end
+
+  # Reuses the `table()` layout primitive (Raxol.UI.Layout.Table) for aligned
+  # title/status columns instead of hand-padding text -- an empty item list
+  # still renders a clean header-only table rather than a bespoke placeholder.
+  defp lane_table(items) do
+    rows =
+      Enum.map(items, fn %{title: title, status: status} -> [title, status] end)
+
+    Components.table(headers: ["Title", "Status"], rows: rows)
+  end
+end

--- a/test/raxol/playground/app_test.exs
+++ b/test/raxol/playground/app_test.exs
@@ -14,7 +14,7 @@ defmodule Raxol.Playground.AppTest do
   describe "init/1" do
     test "initializes with components and first selected" do
       model = App.init(nil)
-      assert length(model.components) == 36
+      assert length(model.components) == 37
       assert model.cursor == 0
       assert model.selected != nil
       assert model.focus == :sidebar
@@ -189,7 +189,7 @@ defmodule Raxol.Playground.AppTest do
       # After cycling through all categories, next press returns to nil
       {model, []} = App.update(key_event("f"), model)
       assert model.category_filter == nil
-      assert length(model.components) == 36
+      assert length(model.components) == 37
     end
 
     test "f resets cursor to 0" do

--- a/test/raxol/playground/catalog_test.exs
+++ b/test/raxol/playground/catalog_test.exs
@@ -6,7 +6,7 @@ defmodule Raxol.Playground.CatalogTest do
   describe "list_components/0" do
     test "returns all registered components" do
       components = Catalog.list_components()
-      assert length(components) == 36
+      assert length(components) == 37
       assert Enum.all?(components, &is_map/1)
     end
 

--- a/test/raxol/playground/sidebar_scroll_test.exs
+++ b/test/raxol/playground/sidebar_scroll_test.exs
@@ -107,7 +107,7 @@ defmodule Raxol.Playground.SidebarScrollTest do
       sidebar = sidebar_text(text)
 
       assert sidebar =~ "▸ Button"
-      assert sidebar =~ "36 widgets"
+      assert sidebar =~ "37 widgets"
     end
 
     test "scrolling past the visible window keeps the marker on screen and scrolls the top items out",

--- a/test/raxol/ui/components/harness/memory_panel_test.exs
+++ b/test/raxol/ui/components/harness/memory_panel_test.exs
@@ -1,0 +1,107 @@
+defmodule Raxol.UI.Components.Harness.MemoryPanelTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.MemoryPanel
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  defp sample_items do
+    [
+      %{key: "session_id", value: "sess_8f21c"},
+      %{key: "turns_completed", value: 12}
+    ]
+  end
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = MemoryPanel.init(id: :mp1)
+      assert state.id == :mp1
+      assert state.title == "Memory"
+      assert state.items == []
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "initializes with provided props" do
+      items = sample_items()
+
+      assert {:ok, state} =
+               MemoryPanel.init(
+                 id: :mp2,
+                 title: "Session Memory",
+                 items: items,
+                 style: %{fg: :cyan},
+                 theme: %{bg: :blue}
+               )
+
+      assert state.id == :mp2
+      assert state.title == "Session Memory"
+      assert state.items == items
+      assert state.style == %{fg: :cyan}
+      assert state.theme == %{bg: :blue}
+    end
+
+    test "defaults id to a unique generated string" do
+      assert {:ok, state} = MemoryPanel.init([])
+      assert state.id =~ ~r/^memory-panel-\d+$/
+    end
+  end
+
+  describe "render/2" do
+    test "renders an empty-state message when items is empty" do
+      {:ok, state} = MemoryPanel.init(id: :mp_empty)
+      rendered = MemoryPanel.render(state, default_context())
+
+      assert rendered.type == :box
+      assert rendered.id == :mp_empty
+      assert rendered.style == %{border: :single, padding: 1}
+
+      [column] = rendered.children
+      assert [title_el, empty_el] = column.children
+      assert title_el.content == "Memory"
+      assert empty_el.content == "No memory yet."
+      assert empty_el.style == %{dim: true}
+    end
+
+    test "renders items as an aligned key/value table" do
+      {:ok, state} = MemoryPanel.init(id: :mp_full, items: sample_items())
+      rendered = MemoryPanel.render(state, default_context())
+
+      [column] = rendered.children
+      [title_el, table] = column.children
+
+      assert title_el.content == "Memory"
+      assert table.type == :table
+      assert table.headers == ["Key", "Value"]
+
+      assert table.rows == [
+               ["session_id", "sess_8f21c"],
+               ["turns_completed", "12"]
+             ]
+    end
+
+    test "stringifies non-binary values" do
+      {:ok, state} =
+        MemoryPanel.init(id: :mp_types, items: [%{key: "count", value: 42}])
+
+      rendered = MemoryPanel.render(state, default_context())
+      [column] = rendered.children
+      [_title_el, table] = column.children
+
+      assert table.rows == [["count", "42"]]
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = MemoryPanel.init(id: :mp_evt, items: sample_items())
+
+      event = %Event{type: :key, data: %{key: :enter}}
+      {new_state, []} = MemoryPanel.handle_event(event, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/residual_indicator_test.exs
+++ b/test/raxol/ui/components/harness/residual_indicator_test.exs
@@ -1,0 +1,78 @@
+defmodule Raxol.UI.Components.Harness.ResidualIndicatorTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.ResidualIndicator
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = ResidualIndicator.init(id: :ri1)
+      assert state.id == :ri1
+      assert state.residual == nil
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "initializes with a provided residual" do
+      assert {:ok, state} =
+               ResidualIndicator.init(
+                 id: :ri2,
+                 residual: "which retry class applies",
+                 style: %{fg: :cyan},
+                 theme: %{bg: :blue}
+               )
+
+      assert state.id == :ri2
+      assert state.residual == "which retry class applies"
+      assert state.style == %{fg: :cyan}
+      assert state.theme == %{bg: :blue}
+    end
+
+    test "defaults id to a unique generated string" do
+      assert {:ok, state} = ResidualIndicator.init([])
+      assert state.id =~ ~r/^residual-indicator-\d+$/
+    end
+  end
+
+  describe "render/2" do
+    test "renders nothing (empty text) when residual is nil" do
+      {:ok, state} = ResidualIndicator.init(id: :ri_nil, residual: nil)
+      rendered = ResidualIndicator.render(state, default_context())
+
+      assert rendered.type == :text
+      assert rendered.content == ""
+    end
+
+    test "renders a subtle warning line when residual is present" do
+      {:ok, state} =
+        ResidualIndicator.init(
+          id: :ri_some,
+          residual: "which retry class covers a stalled extraction"
+        )
+
+      rendered = ResidualIndicator.render(state, default_context())
+
+      assert rendered.type == :text
+      assert rendered.id == :ri_some
+
+      assert rendered.content ==
+               "⚠ unresolved: which retry class covers a stalled extraction"
+
+      assert rendered.style == %{dim: true}
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = ResidualIndicator.init(id: :ri_evt, residual: "x")
+
+      event = %Event{type: :key, data: %{key: :enter}}
+      {new_state, []} = ResidualIndicator.handle_event(event, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/rules_panel_test.exs
+++ b/test/raxol/ui/components/harness/rules_panel_test.exs
@@ -1,0 +1,130 @@
+defmodule Raxol.UI.Components.Harness.RulesPanelTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.RulesPanel
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  defp sample_rules do
+    [
+      %{
+        when: "approval_requested is pending",
+        then: "block until approval_decision arrives",
+        hard: true
+      },
+      %{
+        when: "turn_completed carries usage",
+        then: "refresh the cost readout",
+        hard: false
+      }
+    ]
+  end
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = RulesPanel.init(id: :rp1)
+      assert state.id == :rp1
+      assert state.title == "Rules"
+      assert state.rules == []
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "initializes with provided props" do
+      rules = sample_rules()
+
+      assert {:ok, state} =
+               RulesPanel.init(
+                 id: :rp2,
+                 title: "Active Rules",
+                 rules: rules,
+                 style: %{fg: :cyan},
+                 theme: %{bg: :blue}
+               )
+
+      assert state.id == :rp2
+      assert state.title == "Active Rules"
+      assert state.rules == rules
+      assert state.style == %{fg: :cyan}
+      assert state.theme == %{bg: :blue}
+    end
+
+    test "defaults id to a unique generated string" do
+      assert {:ok, state} = RulesPanel.init([])
+      assert state.id =~ ~r/^rules-panel-\d+$/
+    end
+  end
+
+  describe "render/2" do
+    test "renders an empty-state message when rules is empty" do
+      {:ok, state} = RulesPanel.init(id: :rp_empty)
+      rendered = RulesPanel.render(state, default_context())
+
+      assert rendered.type == :box
+      assert rendered.id == :rp_empty
+      assert rendered.style == %{border: :single, padding: 1}
+
+      [column] = rendered.children
+      assert [title_el, empty_el] = column.children
+      assert title_el.content == "Rules"
+      assert empty_el.content == "No active rules."
+      assert empty_el.style == %{dim: true}
+    end
+
+    test "renders hard rules bold+yellow with a filled marker" do
+      {:ok, state} = RulesPanel.init(id: :rp_hard, rules: sample_rules())
+      rendered = RulesPanel.render(state, default_context())
+
+      [column] = rendered.children
+      [_title_el, hard_el, _soft_el] = column.children
+
+      assert hard_el.id == "rp_hard-rule-0"
+      assert hard_el.style == %{bold: true, fg: :yellow}
+
+      assert hard_el.content ==
+               "● HARD  when approval_requested is pending → then block until approval_decision arrives"
+    end
+
+    test "renders soft rules dimmed with a hollow marker" do
+      {:ok, state} = RulesPanel.init(id: :rp_soft, rules: sample_rules())
+      rendered = RulesPanel.render(state, default_context())
+
+      [column] = rendered.children
+      [_title_el, _hard_el, soft_el] = column.children
+
+      assert soft_el.id == "rp_soft-rule-1"
+      assert soft_el.style == %{dim: true}
+
+      assert soft_el.content ==
+               "○ soft  when turn_completed carries usage → then refresh the cost readout"
+    end
+
+    test "hard rule styling is visually stronger than soft (bold vs dim, distinct markers)" do
+      {:ok, state} = RulesPanel.init(id: :rp_contrast, rules: sample_rules())
+      rendered = RulesPanel.render(state, default_context())
+
+      [column] = rendered.children
+      [_title_el, hard_el, soft_el] = column.children
+
+      assert Map.get(hard_el.style, :bold) == true
+      refute Map.get(soft_el.style, :bold)
+      assert Map.get(soft_el.style, :dim) == true
+      refute Map.get(hard_el.style, :dim)
+      assert String.starts_with?(hard_el.content, "●")
+      assert String.starts_with?(soft_el.content, "○")
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = RulesPanel.init(id: :rp_evt, rules: sample_rules())
+
+      event = %Event{type: :key, data: %{key: :enter}}
+      {new_state, []} = RulesPanel.handle_event(event, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/worktracks_panel_test.exs
+++ b/test/raxol/ui/components/harness/worktracks_panel_test.exs
@@ -1,0 +1,133 @@
+defmodule Raxol.UI.Components.Harness.WorktracksPanelTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.WorktracksPanel
+
+  defp default_context do
+    %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  end
+
+  defp sample_lanes do
+    [
+      %{
+        name: "todo",
+        items: [%{title: "Write spec", status: "todo"}]
+      },
+      %{
+        name: "doing",
+        items: []
+      },
+      %{
+        name: "done",
+        items: [
+          %{title: "Draft protocol table", status: "done"},
+          %{title: "Review", status: "done"}
+        ]
+      }
+    ]
+  end
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = WorktracksPanel.init(id: :wp1)
+      assert state.id == :wp1
+      assert state.title == "Worktracks"
+      assert state.lanes == []
+      assert state.style == %{}
+      assert state.theme == %{}
+    end
+
+    test "initializes with provided props" do
+      lanes = sample_lanes()
+
+      assert {:ok, state} =
+               WorktracksPanel.init(
+                 id: :wp2,
+                 title: "Custom Board",
+                 lanes: lanes,
+                 style: %{fg: :cyan},
+                 theme: %{bg: :blue}
+               )
+
+      assert state.id == :wp2
+      assert state.title == "Custom Board"
+      assert state.lanes == lanes
+      assert state.style == %{fg: :cyan}
+      assert state.theme == %{bg: :blue}
+    end
+
+    test "defaults id to a unique generated string" do
+      assert {:ok, state} = WorktracksPanel.init([])
+      assert state.id =~ ~r/^worktracks-panel-\d+$/
+    end
+  end
+
+  describe "render/2" do
+    test "renders an empty board when lanes is empty" do
+      {:ok, state} = WorktracksPanel.init(id: :wp_empty)
+      rendered = WorktracksPanel.render(state, default_context())
+
+      assert rendered.type == :box
+      assert rendered.id == :wp_empty
+      assert rendered.style == %{border: :single, padding: 1}
+
+      assert [column] = rendered.children
+      assert column.type == :column
+
+      assert [title_el, empty_el] = column.children
+      assert title_el.content == "Worktracks"
+      assert title_el.style == %{bold: true}
+      assert empty_el.content == "No worktracks yet."
+      assert empty_el.style == %{dim: true}
+    end
+
+    test "renders one lane column per lane, each an aligned table" do
+      {:ok, state} = WorktracksPanel.init(id: :wp_full, lanes: sample_lanes())
+      rendered = WorktracksPanel.render(state, default_context())
+
+      [column] = rendered.children
+      [_title_el, board] = column.children
+
+      assert board.type == :row
+      assert length(board.children) == 3
+
+      [todo_lane, doing_lane, done_lane] = board.children
+
+      assert todo_lane.type == :box
+      assert todo_lane.id == "wp_full-lane-0"
+      [todo_column] = todo_lane.children
+      [todo_name, todo_table] = todo_column.children
+      assert todo_name.content == "todo (1)"
+      assert todo_name.style == %{bold: true}
+      assert todo_table.type == :table
+      assert todo_table.headers == ["Title", "Status"]
+      assert todo_table.rows == [["Write spec", "todo"]]
+
+      [doing_column] = doing_lane.children
+      [doing_name, doing_table] = doing_column.children
+      assert doing_name.content == "doing (0)"
+      assert doing_table.rows == []
+      assert doing_table.headers == ["Title", "Status"]
+
+      [done_column] = done_lane.children
+      [done_name, done_table] = done_column.children
+      assert done_name.content == "done (2)"
+
+      assert done_table.rows == [
+               ["Draft protocol table", "done"],
+               ["Review", "done"]
+             ]
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = WorktracksPanel.init(id: :wp_evt, lanes: sample_lanes())
+
+      event = %Event{type: :key, data: %{key: :enter}}
+      {new_state, []} = WorktracksPanel.handle_event(event, state, %{})
+      assert new_state == state
+    end
+  end
+end


### PR DESCRIPTION
Renders the C2 materialized-view projections:
- `WorktracksPanel` — kanban board.
- `RulesPanel` — active when→then rules; hard/enforced marked distinctly.
- `MemoryPanel` — session memory key/values.
- `ResidualIndicator` — the named unknown.

Part of the agent-harness UI (`docs/proposals/in-flight/harness-spec-frontend.md`). Pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP5gp9w9LBHU6nSXMc6kc1