### PR TITLE
Harness UI: status bar + context/spend meters + activity + advisory/drift

### DIFF
--- a/lib/raxol/playground/catalog.ex
+++ b/lib/raxol/playground/catalog.ex
@@ -420,6 +420,31 @@ defmodule Raxol.Playground.Catalog do
       code_snippet: """
       Viewport.init(children: lines, visible_height: 12, overflow_anchor: :auto)
       """
+    },
+    # --- Harness widgets ---
+    %{
+      name: "Harness Status",
+      module: Demos.HarnessStatusDemo,
+      category: :feedback,
+      description:
+        "Agent harness status bar, context/spend meters, activity indicator, advisory feed, and drift gauge",
+      complexity: :intermediate,
+      tags: [
+        "harness",
+        "status",
+        "meter",
+        "activity",
+        "advisory",
+        "drift",
+        "toast"
+      ],
+      code_snippet: """
+      {:ok, s} = ContextMeter.init(used: 13_000, total: 16_000)
+      ContextMeter.render(s, %{})
+
+      {:ok, s} = ActivityIndicator.init(state: :working, since_ms: 0, frame: 0)
+      ActivityIndicator.render(s, %{})
+      """
     }
   ]
 

--- a/lib/raxol/playground/demos/harness_status_demo.ex
+++ b/lib/raxol/playground/demos/harness_status_demo.ex
@@ -1,0 +1,231 @@
+defmodule Raxol.Playground.Demos.HarnessStatusDemo do
+  @moduledoc """
+  Playground demo: harness status bar, context/spend meters, activity
+  indicator, advisory feed, drift indicator, and a toast -- the
+  status/observability surface of an agent harness (`docs/proposals/in-flight/harness-spec-frontend.md`).
+  """
+  use Raxol.Core.Runtime.Application
+
+  alias Raxol.UI.Components.Harness.{
+    ActivityIndicator,
+    AdvisoryFeed,
+    ContextMeter,
+    DriftIndicator,
+    SpendMeter,
+    StatusBar,
+    Toast
+  }
+
+  @tick_interval_ms 500
+  @context_total 16_000
+  @context_step 400
+  @spend_cap 5.0
+  @spend_step 0.03
+  @drift_step 3
+  @toast_every_ticks 10
+  @toast_ttl_ms 3_000
+
+  @advisory_entries [
+    %{
+      source: "probe:lint",
+      kind: :verdict,
+      text: "no unused aliases",
+      score: 0.98
+    },
+    %{
+      source: "probe:research",
+      kind: :research,
+      text: "similar fix landed in #521",
+      score: 0.72
+    },
+    %{
+      source: "gate:acp",
+      kind: :gate_decision,
+      text: "launch liquidity gate: pass",
+      score: nil
+    }
+  ]
+
+  @impl true
+  def init(_context) do
+    %{
+      tick: 0,
+      turn_state: :working,
+      activity_state: :working,
+      since_ms: 0,
+      context_used: 500,
+      cost: 0.12,
+      drift_score: 8,
+      toast: nil
+    }
+  end
+
+  @impl true
+  def update(message, model) do
+    case message do
+      key_match("w") ->
+        {%{model | turn_state: :working, activity_state: :working, since_ms: 0},
+         []}
+
+      key_match("i") ->
+        {%{model | turn_state: :idle, activity_state: :idle, since_ms: 0}, []}
+
+      key_match("h") ->
+        {%{model | activity_state: :working, since_ms: 12_000}, []}
+
+      :tick ->
+        {tick(model), []}
+
+      _ ->
+        {model, []}
+    end
+  end
+
+  defp tick(model) do
+    model
+    |> Map.update!(:tick, &(&1 + 1))
+    |> Map.update!(:since_ms, &(&1 + @tick_interval_ms))
+    |> advance_context()
+    |> advance_cost()
+    |> advance_drift()
+    |> advance_toast()
+  end
+
+  defp advance_context(model) do
+    %{
+      model
+      | context_used:
+          rem(model.context_used + @context_step, @context_total + 1)
+    }
+  end
+
+  defp advance_cost(model), do: %{model | cost: model.cost + @spend_step}
+
+  defp advance_drift(model) do
+    %{model | drift_score: rem(model.drift_score + @drift_step, 101)}
+  end
+
+  defp advance_toast(%{tick: tick} = model)
+       when rem(tick, @toast_every_ticks) == 0 do
+    %{
+      model
+      | toast: %{
+          message: "Checkpoint saved",
+          level: :info,
+          shown_at_tick: tick
+        }
+    }
+  end
+
+  defp advance_toast(%{toast: %{shown_at_tick: shown_at}, tick: tick} = model) do
+    if (tick - shown_at) * @tick_interval_ms >= @toast_ttl_ms do
+      %{model | toast: nil}
+    else
+      model
+    end
+  end
+
+  defp advance_toast(model), do: model
+
+  @impl true
+  def view(model) do
+    column style: %{gap: 1} do
+      [
+        text("Harness Status Demo", style: [:bold]),
+        divider(),
+        harness_status_bar(model),
+        context_meter(model),
+        spend_meter(model),
+        activity_row(model),
+        divider(),
+        advisory_feed(),
+        divider(),
+        drift_indicator(model),
+        toast_row(model),
+        text("[w] working  [i] idle  [h] simulate hung", style: [:dim])
+      ]
+    end
+  end
+
+  defp harness_status_bar(model) do
+    {:ok, state} =
+      StatusBar.init(
+        id: :harness_status_bar,
+        model: "claude-opus-4-6",
+        turn_state: model.turn_state,
+        context_pct: model.context_used / @context_total * 100,
+        cost: model.cost
+      )
+
+    StatusBar.render(state, %{})
+  end
+
+  defp context_meter(model) do
+    {:ok, state} =
+      ContextMeter.init(
+        id: :context_meter,
+        used: model.context_used,
+        total: @context_total,
+        width: 24
+      )
+
+    ContextMeter.render(state, %{})
+  end
+
+  defp spend_meter(model) do
+    {:ok, state} =
+      SpendMeter.init(
+        id: :spend_meter,
+        spent: model.cost,
+        cap: @spend_cap,
+        width: 24
+      )
+
+    SpendMeter.render(state, %{})
+  end
+
+  defp activity_row(model) do
+    {:ok, state} =
+      ActivityIndicator.init(
+        id: :activity_indicator,
+        state: model.activity_state,
+        since_ms: model.since_ms,
+        frame: model.tick
+      )
+
+    ActivityIndicator.render(state, %{})
+  end
+
+  defp advisory_feed do
+    {:ok, state} =
+      AdvisoryFeed.init(id: :advisory_feed, entries: @advisory_entries)
+
+    AdvisoryFeed.render(state, %{})
+  end
+
+  defp drift_indicator(model) do
+    {:ok, state} =
+      DriftIndicator.init(
+        id: :drift_indicator,
+        score: model.drift_score,
+        family: "claude-opus",
+        width: 24
+      )
+
+    DriftIndicator.render(state, %{})
+  end
+
+  defp toast_row(%{toast: nil}), do: text("")
+
+  defp toast_row(%{toast: toast}) do
+    {:ok, state} =
+      Toast.init(id: :toast, message: toast.message, level: toast.level)
+
+    Toast.render(state, %{})
+  end
+
+  @impl true
+  def subscribe(_model) do
+    [subscribe_interval(@tick_interval_ms, :tick)]
+  end
+end

--- a/lib/raxol/ui/components/harness/activity_indicator.ex
+++ b/lib/raxol/ui/components/harness/activity_indicator.ex
@@ -1,0 +1,115 @@
+defmodule Raxol.UI.Components.Harness.ActivityIndicator do
+  @moduledoc """
+  Working / idle / hung indicator for one harness turn.
+
+  `since_ms` is the elapsed time, in milliseconds, that the turn has spent in
+  its *current* `state` -- not a wall-clock timestamp. That keeps `render/2` a
+  pure function of props (no `System.monotonic_time/1` inside render, so the
+  component stays trivially testable); the caller's own tick/subscription
+  loop accumulates it, the same way `Raxol.Playground.Demos.StatusBarDemo`
+  accumulates `model.tick`.
+
+  When `state: :working` has run longer than `hung_threshold_ms`, the
+  indicator flips itself to the hung display even though the caller still
+  claims `:working` -- that override is the point: it catches the agent that
+  died but still *looks* like it is working.
+  """
+
+  alias Raxol.UI.Components.Progress.Spinner
+  alias Raxol.UI.StyleHelper
+
+  use Raxol.UI.Components.Base.Component
+
+  @type activity_state :: :working | :idle | :hung
+
+  @type t :: %{
+          id: String.t() | atom(),
+          state: activity_state(),
+          since_ms: number(),
+          frame: non_neg_integer(),
+          hung_threshold_ms: pos_integer(),
+          style: map(),
+          theme: map()
+        }
+
+  @default_hung_threshold_ms 10_000
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "activity-indicator-#{:erlang.unique_integer([:positive])}"
+        ),
+      state: Keyword.get(props, :state, :idle),
+      since_ms: Keyword.get(props, :since_ms, 0),
+      frame: Keyword.get(props, :frame, 0),
+      hung_threshold_ms:
+        Keyword.get(props, :hung_threshold_ms, @default_hung_threshold_ms),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :activity_indicator)
+
+    spec = display_spec(effective_state(state), state)
+
+    %{
+      type: :row,
+      style: base_style,
+      children: [
+        Raxol.View.Components.text(
+          id: "#{state.id}-indicator",
+          content: spec.content,
+          fg: spec.fg,
+          style: spec.style
+        )
+      ]
+    }
+  end
+
+  defp effective_state(%{
+         state: :working,
+         since_ms: ms,
+         hung_threshold_ms: threshold
+       })
+       when ms >= threshold,
+       do: :hung
+
+  defp effective_state(%{state: activity_state}), do: activity_state
+
+  defp display_spec(:working, state) do
+    %{
+      content: Spinner.spinner("working", state.frame, type: :dots),
+      fg: :cyan,
+      style: %{}
+    }
+  end
+
+  defp display_spec(:idle, _state) do
+    %{content: "• idle", fg: nil, style: %{dim: true}}
+  end
+
+  defp display_spec(:hung, state) do
+    %{
+      content: "HUNG? (#{elapsed_seconds(state.since_ms)}s)",
+      fg: :red,
+      style: %{bold: true}
+    }
+  end
+
+  defp elapsed_seconds(ms) when is_number(ms), do: trunc(ms / 1000)
+end

--- a/lib/raxol/ui/components/harness/activity_indicator.ex
+++ b/lib/raxol/ui/components/harness/activity_indicator.ex
@@ -70,6 +70,7 @@ defmodule Raxol.UI.Components.Harness.ActivityIndicator do
     %{
       type: :row,
       style: base_style,
+      gap: 1,
       children: [
         Raxol.View.Components.text(
           id: "#{state.id}-indicator",

--- a/lib/raxol/ui/components/harness/advisory_feed.ex
+++ b/lib/raxol/ui/components/harness/advisory_feed.ex
@@ -1,0 +1,109 @@
+defmodule Raxol.UI.Components.Harness.AdvisoryFeed do
+  @moduledoc """
+  Advisory side-channel feed: renders `gate_decision` / `verdict` /
+  `research` meta events from probes running alongside the primary
+  transcript.
+
+  Styled deliberately dim and boxed so it reads as a sidebar and never gets
+  mixed into the primary transcript -- advisory entries are context, not the
+  conversation.
+  """
+
+  alias Raxol.UI.StyleHelper
+
+  use Raxol.UI.Components.Base.Component
+
+  @type entry :: %{
+          source: String.t(),
+          kind: atom() | String.t(),
+          text: String.t(),
+          score: number() | nil
+        }
+
+  @type t :: %{
+          id: String.t() | atom(),
+          entries: [entry()],
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "advisory-feed-#{:erlang.unique_integer([:positive])}"
+        ),
+      entries: Keyword.get(props, :entries, []),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :advisory_feed)
+
+    %{
+      type: :box,
+      style: Map.merge(%{border: :single}, base_style),
+      children: [
+        %{
+          type: :column,
+          style: %{gap: 0},
+          children: [header(state.id) | entry_rows(state)]
+        }
+      ]
+    }
+  end
+
+  defp header(id) do
+    Raxol.View.Components.text(
+      id: "#{id}-header",
+      content: "ADVISORY",
+      style: %{bold: true, dim: true}
+    )
+  end
+
+  defp entry_rows(%{entries: []}) do
+    [
+      Raxol.View.Components.text(
+        content: "no advisories",
+        style: %{dim: true}
+      )
+    ]
+  end
+
+  defp entry_rows(%{entries: entries, id: id}) do
+    entries
+    |> Enum.with_index()
+    |> Enum.map(fn {entry, index} ->
+      Raxol.View.Components.text(
+        id: "#{id}-entry-#{index}",
+        content: entry_line(entry),
+        style: %{dim: true}
+      )
+    end)
+  end
+
+  defp entry_line(%{source: source, kind: kind, text: text, score: score}) do
+    "[#{to_string(kind)}] #{source}: #{text}#{score_suffix(score)}"
+  end
+
+  defp score_suffix(nil), do: ""
+
+  defp score_suffix(score) when is_float(score),
+    do: " (#{Float.round(score, 2)})"
+
+  defp score_suffix(score), do: " (#{score})"
+end

--- a/lib/raxol/ui/components/harness/context_meter.ex
+++ b/lib/raxol/ui/components/harness/context_meter.ex
@@ -66,6 +66,7 @@ defmodule Raxol.UI.Components.Harness.ContextMeter do
     %{
       type: :row,
       style: base_style,
+      gap: 1,
       children: [
         Raxol.View.Components.text(
           id: "#{state.id}-label",

--- a/lib/raxol/ui/components/harness/context_meter.ex
+++ b/lib/raxol/ui/components/harness/context_meter.ex
@@ -1,0 +1,92 @@
+defmodule Raxol.UI.Components.Harness.ContextMeter do
+  @moduledoc """
+  Compaction-proximity gauge: how much of the context window is used.
+
+  Renders a `Raxol.UI.Components.Progress.Bar` bar colored green -> yellow ->
+  red as `used` approaches `total` (the compaction threshold). Mirrors the
+  three-tier gauge idiom already used by `Raxol.Sensor.HUD.render_gauge/3`
+  (percentage thresholds, not hardcoded token counts), kept local here since
+  that module renders raw terminal cells rather than View DSL elements.
+  """
+
+  alias Raxol.UI.Components.Progress.Bar
+  alias Raxol.UI.StyleHelper
+
+  use Raxol.UI.Components.Base.Component
+
+  @type t :: %{
+          id: String.t() | atom(),
+          used: non_neg_integer(),
+          total: pos_integer(),
+          width: pos_integer(),
+          warn_threshold: float(),
+          danger_threshold: float(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "context-meter-#{:erlang.unique_integer([:positive])}"
+        ),
+      used: Keyword.get(props, :used, 0),
+      total: Keyword.get(props, :total, 1),
+      width: Keyword.get(props, :width, 20),
+      warn_threshold: Keyword.get(props, :warn_threshold, 0.75),
+      danger_threshold: Keyword.get(props, :danger_threshold, 0.9),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :context_meter)
+
+    safe_total = max(state.total, 1)
+    pct = min(state.used / safe_total, 1.0)
+    color = gauge_color(pct, state.warn_threshold, state.danger_threshold)
+
+    bar_string =
+      Bar.bar(state.used, max: safe_total, width: state.width, style: :blocks)
+
+    %{
+      type: :row,
+      style: base_style,
+      children: [
+        Raxol.View.Components.text(
+          id: "#{state.id}-label",
+          content: "Context ",
+          style: %{bold: true}
+        ),
+        Raxol.View.Components.text(
+          id: "#{state.id}-bar",
+          content: bar_string,
+          fg: color
+        ),
+        Raxol.View.Components.text(
+          id: "#{state.id}-count",
+          content: " #{state.used}/#{state.total}",
+          style: %{dim: true}
+        )
+      ]
+    }
+  end
+
+  defp gauge_color(pct, _warn, danger) when pct >= danger, do: :red
+  defp gauge_color(pct, warn, _danger) when pct >= warn, do: :yellow
+  defp gauge_color(_pct, _warn, _danger), do: :green
+end

--- a/lib/raxol/ui/components/harness/drift_indicator.ex
+++ b/lib/raxol/ui/components/harness/drift_indicator.ex
@@ -1,0 +1,88 @@
+defmodule Raxol.UI.Components.Harness.DriftIndicator do
+  @moduledoc """
+  Cross-family drift verdict gauge: how far this run has drifted from its
+  originating agent family, on a 0 (identical) to 100 (fully drifted) scale.
+
+  Uses the same green -> yellow -> red gauge idiom as
+  `Raxol.UI.Components.Harness.ContextMeter` and
+  `Raxol.UI.Components.Harness.SpendMeter`.
+  """
+
+  alias Raxol.UI.Components.Progress.Bar
+  alias Raxol.UI.StyleHelper
+
+  use Raxol.UI.Components.Base.Component
+
+  @type t :: %{
+          id: String.t() | atom(),
+          score: number(),
+          family: String.t(),
+          width: pos_integer(),
+          warn_threshold: number(),
+          danger_threshold: number(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "drift-indicator-#{:erlang.unique_integer([:positive])}"
+        ),
+      score: Keyword.get(props, :score, 0),
+      family: Keyword.get(props, :family, ""),
+      width: Keyword.get(props, :width, 20),
+      warn_threshold: Keyword.get(props, :warn_threshold, 50),
+      danger_threshold: Keyword.get(props, :danger_threshold, 75),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :drift_indicator)
+
+    clamped = state.score |> max(0) |> min(100)
+    color = gauge_color(clamped, state.warn_threshold, state.danger_threshold)
+    bar_string = Bar.bar(clamped, max: 100, width: state.width, style: :blocks)
+
+    %{
+      type: :row,
+      style: base_style,
+      children: [
+        Raxol.View.Components.text(
+          id: "#{state.id}-label",
+          content: "Drift ",
+          style: %{bold: true}
+        ),
+        Raxol.View.Components.text(
+          id: "#{state.id}-bar",
+          content: bar_string,
+          fg: color
+        ),
+        Raxol.View.Components.text(
+          id: "#{state.id}-family",
+          content: " #{state.family}",
+          style: %{dim: true}
+        )
+      ]
+    }
+  end
+
+  defp gauge_color(score, _warn, danger) when score >= danger, do: :red
+  defp gauge_color(score, warn, _danger) when score >= warn, do: :yellow
+  defp gauge_color(_score, _warn, _danger), do: :green
+end

--- a/lib/raxol/ui/components/harness/drift_indicator.ex
+++ b/lib/raxol/ui/components/harness/drift_indicator.ex
@@ -62,6 +62,7 @@ defmodule Raxol.UI.Components.Harness.DriftIndicator do
     %{
       type: :row,
       style: base_style,
+      gap: 1,
       children: [
         Raxol.View.Components.text(
           id: "#{state.id}-label",

--- a/lib/raxol/ui/components/harness/spend_meter.ex
+++ b/lib/raxol/ui/components/harness/spend_meter.ex
@@ -65,6 +65,7 @@ defmodule Raxol.UI.Components.Harness.SpendMeter do
     %{
       type: :row,
       style: base_style,
+      gap: 1,
       children: [
         Raxol.View.Components.text(
           id: "#{state.id}-label",

--- a/lib/raxol/ui/components/harness/spend_meter.ex
+++ b/lib/raxol/ui/components/harness/spend_meter.ex
@@ -1,0 +1,95 @@
+defmodule Raxol.UI.Components.Harness.SpendMeter do
+  @moduledoc """
+  Spend-vs-cap gauge: agent spend as a bar toward its session/lifetime cap,
+  colored green -> yellow -> red as spend approaches the cap.
+
+  Cost and control are the same concern -- this makes overspend visible
+  before the bill, using the same three-tier gauge idiom as
+  `Raxol.UI.Components.Harness.ContextMeter`.
+  """
+
+  alias Raxol.UI.Components.Progress.Bar
+  alias Raxol.UI.StyleHelper
+
+  use Raxol.UI.Components.Base.Component
+
+  @type t :: %{
+          id: String.t() | atom(),
+          spent: number(),
+          cap: number(),
+          width: pos_integer(),
+          warn_threshold: float(),
+          danger_threshold: float(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "spend-meter-#{:erlang.unique_integer([:positive])}"
+        ),
+      spent: Keyword.get(props, :spent, 0),
+      cap: Keyword.get(props, :cap, 1),
+      width: Keyword.get(props, :width, 20),
+      warn_threshold: Keyword.get(props, :warn_threshold, 0.75),
+      danger_threshold: Keyword.get(props, :danger_threshold, 0.9),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :spend_meter)
+
+    safe_cap = max(state.cap * 1.0, 0.01)
+    pct = min(state.spent / safe_cap, 1.0)
+    color = gauge_color(pct, state.warn_threshold, state.danger_threshold)
+
+    bar_string =
+      Bar.bar(state.spent, max: safe_cap, width: state.width, style: :blocks)
+
+    %{
+      type: :row,
+      style: base_style,
+      children: [
+        Raxol.View.Components.text(
+          id: "#{state.id}-label",
+          content: "Spend ",
+          style: %{bold: true}
+        ),
+        Raxol.View.Components.text(
+          id: "#{state.id}-bar",
+          content: bar_string,
+          fg: color
+        ),
+        Raxol.View.Components.text(
+          id: "#{state.id}-amount",
+          content: " #{format_money(state.spent)}/#{format_money(state.cap)}",
+          style: %{dim: true}
+        )
+      ]
+    }
+  end
+
+  defp gauge_color(pct, _warn, danger) when pct >= danger, do: :red
+  defp gauge_color(pct, warn, _danger) when pct >= warn, do: :yellow
+  defp gauge_color(_pct, _warn, _danger), do: :green
+
+  defp format_money(amount) when is_number(amount) do
+    "$" <> :erlang.float_to_binary(amount / 1, decimals: 2)
+  end
+end

--- a/lib/raxol/ui/components/harness/status_bar.ex
+++ b/lib/raxol/ui/components/harness/status_bar.ex
@@ -1,0 +1,84 @@
+defmodule Raxol.UI.Components.Harness.StatusBar do
+  @moduledoc """
+  Harness status line: model, turn-state, context budget, and running cost
+  for one agent turn.
+
+  This does not reimplement status-bar rendering -- it shapes harness fields
+  into the `item` list `Raxol.UI.Components.Display.StatusBar` already
+  understands and delegates the actual render to it, so separator/key/value
+  styling stays defined in exactly one place.
+  """
+
+  alias Raxol.UI.Components.Display.StatusBar, as: DisplayStatusBar
+
+  use Raxol.UI.Components.Base.Component
+
+  @type turn_state :: :working | :idle
+
+  @type t :: %{
+          id: String.t() | atom(),
+          model: String.t(),
+          turn_state: turn_state(),
+          context_pct: number(),
+          cost: number(),
+          separator: String.t(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(
+          props,
+          :id,
+          "harness-status-bar-#{:erlang.unique_integer([:positive])}"
+        ),
+      model: Keyword.get(props, :model, ""),
+      turn_state: Keyword.get(props, :turn_state, :idle),
+      context_pct: Keyword.get(props, :context_pct, 0),
+      cost: Keyword.get(props, :cost, 0),
+      separator: Keyword.get(props, :separator, " | "),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    display_state = %{
+      id: state.id,
+      items: build_items(state),
+      separator: state.separator,
+      style: state.style,
+      theme: state.theme
+    }
+
+    DisplayStatusBar.render(display_state, context)
+  end
+
+  defp build_items(state) do
+    [
+      %{key: "Model", label: state.model},
+      %{key: "Status", label: turn_state_label(state.turn_state)},
+      %{key: "Ctx", label: "#{round(state.context_pct)}%"},
+      %{key: "Cost", label: format_cost(state.cost)}
+    ]
+  end
+
+  defp turn_state_label(:working), do: "⟳ working"
+  defp turn_state_label(:idle), do: "• idle"
+  defp turn_state_label(other), do: to_string(other)
+
+  defp format_cost(cost) when is_number(cost) do
+    "$" <> :erlang.float_to_binary(cost / 1, decimals: 2)
+  end
+end

--- a/lib/raxol/ui/components/harness/toast.ex
+++ b/lib/raxol/ui/components/harness/toast.ex
@@ -1,0 +1,71 @@
+defmodule Raxol.UI.Components.Harness.Toast do
+  @moduledoc """
+  Transient notification: a small floating notice with a level-appropriate
+  glyph and color. The glyph carries the meaning too (not color alone), so
+  the toast stays legible for colorblind users and on no-color terminals.
+
+  This component renders the notice itself; corner placement and auto-dismiss
+  timing are the caller's job -- compose with
+  `Raxol.UI.Components.AbsoluteLayer.overlay/3` (e.g. `overlay(:right,
+  :bottom, toast_view)`) the same way `Raxol.UI.Components.Modal.Rendering`'s
+  dialog surface is positioned by its caller rather than positioning itself.
+  """
+
+  alias Raxol.UI.StyleHelper
+
+  use Raxol.UI.Components.Base.Component
+
+  @type level :: :info | :warn | :error
+
+  @type t :: %{
+          id: String.t() | atom(),
+          message: String.t(),
+          level: level(),
+          ttl_ms: non_neg_integer(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id:
+        Keyword.get(props, :id, "toast-#{:erlang.unique_integer([:positive])}"),
+      message: Keyword.get(props, :message, ""),
+      level: Keyword.get(props, :level, :info),
+      ttl_ms: Keyword.get(props, :ttl_ms, 4_000),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_event(_event, state, _context), do: {state, []}
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style = StyleHelper.merge_component_styles(state, context, :toast)
+    {glyph, color} = level_style(state.level)
+
+    %{
+      type: :box,
+      style: Map.merge(%{border: :rounded, padding: 1}, base_style),
+      children: [
+        Raxol.View.Components.text(
+          id: "#{state.id}-message",
+          content: "#{glyph} #{state.message}",
+          fg: color
+        )
+      ]
+    }
+  end
+
+  defp level_style(:error), do: {"✗", :red}
+  defp level_style(:warn), do: {"⚠", :yellow}
+  defp level_style(:info), do: {"ℹ", :cyan}
+  defp level_style(_level), do: {"•", :white}
+end

--- a/test/raxol/playground/app_test.exs
+++ b/test/raxol/playground/app_test.exs
@@ -14,7 +14,7 @@ defmodule Raxol.Playground.AppTest do
   describe "init/1" do
     test "initializes with components and first selected" do
       model = App.init(nil)
-      assert length(model.components) == 35
+      assert length(model.components) == 36
       assert model.cursor == 0
       assert model.selected != nil
       assert model.focus == :sidebar
@@ -189,7 +189,7 @@ defmodule Raxol.Playground.AppTest do
       # After cycling through all categories, next press returns to nil
       {model, []} = App.update(key_event("f"), model)
       assert model.category_filter == nil
-      assert length(model.components) == 35
+      assert length(model.components) == 36
     end
 
     test "f resets cursor to 0" do

--- a/test/raxol/playground/catalog_test.exs
+++ b/test/raxol/playground/catalog_test.exs
@@ -6,7 +6,7 @@ defmodule Raxol.Playground.CatalogTest do
   describe "list_components/0" do
     test "returns all registered components" do
       components = Catalog.list_components()
-      assert length(components) == 35
+      assert length(components) == 36
       assert Enum.all?(components, &is_map/1)
     end
 

--- a/test/raxol/playground/sidebar_scroll_test.exs
+++ b/test/raxol/playground/sidebar_scroll_test.exs
@@ -107,7 +107,7 @@ defmodule Raxol.Playground.SidebarScrollTest do
       sidebar = sidebar_text(text)
 
       assert sidebar =~ "▸ Button"
-      assert sidebar =~ "35 widgets"
+      assert sidebar =~ "36 widgets"
     end
 
     test "scrolling past the visible window keeps the marker on screen and scrolls the top items out",

--- a/test/raxol/ui/components/harness/activity_indicator_test.exs
+++ b/test/raxol/ui/components/harness/activity_indicator_test.exs
@@ -1,0 +1,101 @@
+defmodule Raxol.UI.Components.Harness.ActivityIndicatorTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.ActivityIndicator
+  alias Raxol.UI.Components.Progress.Spinner
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  defp indicator_el(rendered), do: Enum.at(rendered.children, 0)
+  defp dots_frame(index), do: Spinner.frames(:dots) |> Enum.at(index)
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = ActivityIndicator.init(id: :ai1)
+      assert state.state == :idle
+      assert state.since_ms == 0
+      assert state.frame == 0
+      assert state.hung_threshold_ms == 10_000
+    end
+  end
+
+  describe "render/2 working" do
+    test "renders the spinner glyph for the current frame plus a label" do
+      {:ok, state} = ActivityIndicator.init(id: :ai, state: :working, frame: 0)
+      rendered = ActivityIndicator.render(state, default_context())
+
+      assert indicator_el(rendered).content == "#{dots_frame(0)} working"
+      assert indicator_el(rendered).fg == :cyan
+    end
+
+    test "advances the spinner glyph with the frame prop" do
+      {:ok, state} = ActivityIndicator.init(id: :ai, state: :working, frame: 1)
+      rendered = ActivityIndicator.render(state, default_context())
+
+      assert indicator_el(rendered).content == "#{dots_frame(1)} working"
+    end
+
+    test "stays working just under the hung threshold" do
+      {:ok, state} =
+        ActivityIndicator.init(id: :ai, state: :working, since_ms: 9_999)
+
+      rendered = ActivityIndicator.render(state, default_context())
+      assert indicator_el(rendered).content == "#{dots_frame(0)} working"
+    end
+  end
+
+  describe "render/2 idle" do
+    test "renders a calm dot, regardless of elapsed time" do
+      {:ok, state} =
+        ActivityIndicator.init(id: :ai, state: :idle, since_ms: 999_999)
+
+      rendered = ActivityIndicator.render(state, default_context())
+
+      assert indicator_el(rendered).content == "• idle"
+      assert indicator_el(rendered).style == %{dim: true}
+    end
+  end
+
+  describe "render/2 hung" do
+    test "renders HUNG? with elapsed seconds when state is explicitly :hung" do
+      {:ok, state} =
+        ActivityIndicator.init(id: :ai, state: :hung, since_ms: 5_000)
+
+      rendered = ActivityIndicator.render(state, default_context())
+
+      assert indicator_el(rendered).content == "HUNG? (5s)"
+      assert indicator_el(rendered).fg == :red
+      assert indicator_el(rendered).style == %{bold: true}
+    end
+
+    test "self-overrides to HUNG? when :working stalls past the threshold" do
+      {:ok, state} =
+        ActivityIndicator.init(id: :ai, state: :working, since_ms: 12_000)
+
+      rendered = ActivityIndicator.render(state, default_context())
+
+      assert indicator_el(rendered).content == "HUNG? (12s)"
+      assert indicator_el(rendered).fg == :red
+    end
+
+    test "respects a custom hung_threshold_ms" do
+      {:ok, state} =
+        ActivityIndicator.init(
+          id: :ai,
+          state: :working,
+          since_ms: 2_000,
+          hung_threshold_ms: 1_000
+        )
+
+      rendered = ActivityIndicator.render(state, default_context())
+      assert indicator_el(rendered).content == "HUNG? (2s)"
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = ActivityIndicator.init(id: :ai)
+      {new_state, []} = ActivityIndicator.handle_event(:whatever, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/advisory_feed_test.exs
+++ b/test/raxol/ui/components/harness/advisory_feed_test.exs
@@ -1,0 +1,85 @@
+defmodule Raxol.UI.Components.Harness.AdvisoryFeedTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.AdvisoryFeed
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = AdvisoryFeed.init(id: :af1)
+      assert state.entries == []
+    end
+
+    test "initializes with provided entries" do
+      entries = [
+        %{source: "probe:lint", kind: :verdict, text: "ok", score: 0.9}
+      ]
+
+      assert {:ok, state} = AdvisoryFeed.init(id: :af2, entries: entries)
+      assert state.entries == entries
+    end
+  end
+
+  describe "render/2" do
+    test "renders a boxed, single-bordered column with an ADVISORY header" do
+      {:ok, state} = AdvisoryFeed.init(id: :af)
+      rendered = AdvisoryFeed.render(state, default_context())
+
+      assert rendered.type == :box
+      assert rendered.style.border == :single
+
+      [column] = rendered.children
+      assert column.type == :column
+
+      header = Enum.at(column.children, 0)
+      assert header.content == "ADVISORY"
+      assert header.style == %{bold: true, dim: true}
+    end
+
+    test "shows a placeholder line when there are no entries" do
+      {:ok, state} = AdvisoryFeed.init(id: :af, entries: [])
+      rendered = AdvisoryFeed.render(state, default_context())
+      [column] = rendered.children
+
+      assert length(column.children) == 2
+      assert Enum.at(column.children, 1).content == "no advisories"
+    end
+
+    test "renders one dim entry line per advisory, source/kind/text/score" do
+      entries = [
+        %{
+          source: "probe:lint",
+          kind: :verdict,
+          text: "no unused aliases",
+          score: 0.98
+        },
+        %{
+          source: "probe:research",
+          kind: :research,
+          text: "similar fix in #521",
+          score: nil
+        }
+      ]
+
+      {:ok, state} = AdvisoryFeed.init(id: :af, entries: entries)
+      rendered = AdvisoryFeed.render(state, default_context())
+      [column] = rendered.children
+
+      first = Enum.at(column.children, 1)
+      assert first.content == "[verdict] probe:lint: no unused aliases (0.98)"
+      assert first.style == %{dim: true}
+
+      second = Enum.at(column.children, 2)
+      assert second.content == "[research] probe:research: similar fix in #521"
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = AdvisoryFeed.init(id: :af)
+      {new_state, []} = AdvisoryFeed.handle_event(:whatever, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/context_meter_test.exs
+++ b/test/raxol/ui/components/harness/context_meter_test.exs
@@ -1,0 +1,91 @@
+defmodule Raxol.UI.Components.Harness.ContextMeterTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.ContextMeter
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+
+  defp bar_el(rendered), do: Enum.at(rendered.children, 1)
+  defp count_el(rendered), do: Enum.at(rendered.children, 2)
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = ContextMeter.init(id: :cm1)
+      assert state.used == 0
+      assert state.total == 1
+      assert state.width == 20
+      assert state.warn_threshold == 0.75
+      assert state.danger_threshold == 0.9
+    end
+
+    test "initializes with provided props" do
+      assert {:ok, state} =
+               ContextMeter.init(
+                 id: :cm2,
+                 used: 8_000,
+                 total: 16_000,
+                 width: 10,
+                 warn_threshold: 0.5,
+                 danger_threshold: 0.8
+               )
+
+      assert state.used == 8_000
+      assert state.total == 16_000
+      assert state.width == 10
+      assert state.warn_threshold == 0.5
+      assert state.danger_threshold == 0.8
+    end
+  end
+
+  describe "render/2" do
+    test "renders a row with label, bar, and token count" do
+      {:ok, state} = ContextMeter.init(id: :cm, used: 1_000, total: 16_000)
+      rendered = ContextMeter.render(state, default_context())
+
+      assert rendered.type == :row
+      assert length(rendered.children) == 3
+      assert Enum.at(rendered.children, 0).content == "Context "
+      assert count_el(rendered).content == " 1000/16000"
+    end
+
+    test "colors green below the warn threshold" do
+      {:ok, state} = ContextMeter.init(id: :cm, used: 1_000, total: 16_000)
+      rendered = ContextMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :green
+    end
+
+    test "colors yellow between warn and danger thresholds" do
+      {:ok, state} = ContextMeter.init(id: :cm, used: 13_000, total: 16_000)
+      rendered = ContextMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :yellow
+    end
+
+    test "colors red at or above the danger threshold" do
+      {:ok, state} = ContextMeter.init(id: :cm, used: 15_000, total: 16_000)
+      rendered = ContextMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :red
+    end
+
+    test "clamps display when used exceeds total" do
+      {:ok, state} = ContextMeter.init(id: :cm, used: 20_000, total: 16_000)
+      rendered = ContextMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :red
+      assert bar_el(rendered).content =~ "100%"
+    end
+
+    test "does not crash on a zero total and reads as empty/green" do
+      {:ok, state} = ContextMeter.init(id: :cm, used: 0, total: 0)
+      rendered = ContextMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :green
+      assert bar_el(rendered).content =~ "0%"
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = ContextMeter.init(id: :cm)
+      {new_state, []} = ContextMeter.handle_event(:whatever, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/drift_indicator_test.exs
+++ b/test/raxol/ui/components/harness/drift_indicator_test.exs
@@ -1,0 +1,72 @@
+defmodule Raxol.UI.Components.Harness.DriftIndicatorTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.DriftIndicator
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  defp bar_el(rendered), do: Enum.at(rendered.children, 1)
+  defp family_el(rendered), do: Enum.at(rendered.children, 2)
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = DriftIndicator.init(id: :di1)
+      assert state.score == 0
+      assert state.family == ""
+      assert state.warn_threshold == 50
+      assert state.danger_threshold == 75
+    end
+  end
+
+  describe "render/2" do
+    test "renders a row with label, bar, and family name" do
+      {:ok, state} =
+        DriftIndicator.init(id: :di, score: 10, family: "claude-opus")
+
+      rendered = DriftIndicator.render(state, default_context())
+
+      assert rendered.type == :row
+      assert Enum.at(rendered.children, 0).content == "Drift "
+      assert family_el(rendered).content == " claude-opus"
+    end
+
+    test "colors green for low drift" do
+      {:ok, state} = DriftIndicator.init(id: :di, score: 10)
+      rendered = DriftIndicator.render(state, default_context())
+      assert bar_el(rendered).fg == :green
+    end
+
+    test "colors yellow for mid drift" do
+      {:ok, state} = DriftIndicator.init(id: :di, score: 60)
+      rendered = DriftIndicator.render(state, default_context())
+      assert bar_el(rendered).fg == :yellow
+    end
+
+    test "colors red for high drift" do
+      {:ok, state} = DriftIndicator.init(id: :di, score: 90)
+      rendered = DriftIndicator.render(state, default_context())
+      assert bar_el(rendered).fg == :red
+    end
+
+    test "clamps a negative score to 0 (green)" do
+      {:ok, state} = DriftIndicator.init(id: :di, score: -20)
+      rendered = DriftIndicator.render(state, default_context())
+      assert bar_el(rendered).fg == :green
+      assert bar_el(rendered).content =~ "0%"
+    end
+
+    test "clamps a score above 100 to 100 (red)" do
+      {:ok, state} = DriftIndicator.init(id: :di, score: 250)
+      rendered = DriftIndicator.render(state, default_context())
+      assert bar_el(rendered).fg == :red
+      assert bar_el(rendered).content =~ "100%"
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = DriftIndicator.init(id: :di)
+      {new_state, []} = DriftIndicator.handle_event(:whatever, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/spend_meter_test.exs
+++ b/test/raxol/ui/components/harness/spend_meter_test.exs
@@ -1,0 +1,72 @@
+defmodule Raxol.UI.Components.Harness.SpendMeterTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.SpendMeter
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+
+  defp bar_el(rendered), do: Enum.at(rendered.children, 1)
+  defp amount_el(rendered), do: Enum.at(rendered.children, 2)
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = SpendMeter.init(id: :sm1)
+      assert state.spent == 0
+      assert state.cap == 1
+      assert state.width == 20
+      assert state.warn_threshold == 0.75
+      assert state.danger_threshold == 0.9
+    end
+  end
+
+  describe "render/2" do
+    test "renders a row with label, bar, and dollar amounts" do
+      {:ok, state} = SpendMeter.init(id: :sm, spent: 1.5, cap: 5.0)
+      rendered = SpendMeter.render(state, default_context())
+
+      assert rendered.type == :row
+      assert length(rendered.children) == 3
+      assert Enum.at(rendered.children, 0).content == "Spend "
+      assert amount_el(rendered).content == " $1.50/$5.00"
+    end
+
+    test "colors green well under the cap" do
+      {:ok, state} = SpendMeter.init(id: :sm, spent: 1.0, cap: 5.0)
+      rendered = SpendMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :green
+    end
+
+    test "colors yellow between warn and danger thresholds" do
+      {:ok, state} = SpendMeter.init(id: :sm, spent: 4.0, cap: 5.0)
+      rendered = SpendMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :yellow
+    end
+
+    test "colors red at or over the cap" do
+      {:ok, state} = SpendMeter.init(id: :sm, spent: 5.5, cap: 5.0)
+      rendered = SpendMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :red
+    end
+
+    test "does not crash on a zero cap and reads any spend as over-cap" do
+      {:ok, state} = SpendMeter.init(id: :sm, spent: 0.05, cap: 0)
+      rendered = SpendMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :red
+      assert amount_el(rendered).content == " $0.05/$0.00"
+    end
+
+    test "reads zero spend against a zero cap as green" do
+      {:ok, state} = SpendMeter.init(id: :sm, spent: 0, cap: 0)
+      rendered = SpendMeter.render(state, default_context())
+      assert bar_el(rendered).fg == :green
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = SpendMeter.init(id: :sm)
+      {new_state, []} = SpendMeter.handle_event(:whatever, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/status_bar_test.exs
+++ b/test/raxol/ui/components/harness/status_bar_test.exs
@@ -1,0 +1,102 @@
+defmodule Raxol.UI.Components.Harness.StatusBarTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.StatusBar
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = StatusBar.init(id: :hsb1)
+      assert state.id == :hsb1
+      assert state.model == ""
+      assert state.turn_state == :idle
+      assert state.context_pct == 0
+      assert state.cost == 0
+      assert state.separator == " | "
+    end
+
+    test "initializes with provided props" do
+      assert {:ok, state} =
+               StatusBar.init(
+                 id: :hsb2,
+                 model: "claude-opus-4-6",
+                 turn_state: :working,
+                 context_pct: 42,
+                 cost: 1.23
+               )
+
+      assert state.model == "claude-opus-4-6"
+      assert state.turn_state == :working
+      assert state.context_pct == 42
+      assert state.cost == 1.23
+    end
+  end
+
+  describe "render/2" do
+    test "delegates to Display.StatusBar with model/status/context/cost items" do
+      {:ok, state} =
+        StatusBar.init(
+          id: :hsb,
+          model: "claude-opus-4-6",
+          turn_state: :working,
+          context_pct: 42,
+          cost: 1.23
+        )
+
+      rendered = StatusBar.render(state, default_context())
+
+      assert rendered.type == :row
+      # 4 items * 2 elements + 3 separators
+      assert length(rendered.children) == 11
+
+      assert Enum.at(rendered.children, 0).content == "Model: "
+      assert Enum.at(rendered.children, 1).content == "claude-opus-4-6"
+      assert Enum.at(rendered.children, 3).content == "Status: "
+      assert Enum.at(rendered.children, 4).content == "⟳ working"
+      assert Enum.at(rendered.children, 6).content == "Ctx: "
+      assert Enum.at(rendered.children, 7).content == "42%"
+      assert Enum.at(rendered.children, 9).content == "Cost: "
+      assert Enum.at(rendered.children, 10).content == "$1.23"
+    end
+
+    test "renders idle turn-state with a calm glyph" do
+      {:ok, state} = StatusBar.init(id: :hsb, turn_state: :idle)
+      rendered = StatusBar.render(state, default_context())
+
+      assert Enum.at(rendered.children, 4).content == "• idle"
+    end
+
+    test "formats integer cost as two decimals" do
+      {:ok, state} = StatusBar.init(id: :hsb, cost: 2)
+      rendered = StatusBar.render(state, default_context())
+
+      assert Enum.at(rendered.children, 10).content == "$2.00"
+    end
+
+    test "rounds fractional context percentage" do
+      {:ok, state} = StatusBar.init(id: :hsb, context_pct: 41.6)
+      rendered = StatusBar.render(state, default_context())
+
+      assert Enum.at(rendered.children, 7).content == "42%"
+    end
+  end
+
+  describe "update/2" do
+    test "merges new props via the default Base.Component merge" do
+      {:ok, state} = StatusBar.init(id: :hsb)
+      {updated, []} = StatusBar.update(%{model: "opus"}, state)
+      assert updated.model == "opus"
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = StatusBar.init(id: :hsb)
+      event = %Event{type: :key, data: %{key: :enter}}
+      {new_state, []} = StatusBar.handle_event(event, state, %{})
+      assert new_state == state
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/toast_test.exs
+++ b/test/raxol/ui/components/harness/toast_test.exs
@@ -1,0 +1,72 @@
+defmodule Raxol.UI.Components.Harness.ToastTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.Toast
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  defp message_el(rendered), do: Enum.at(rendered.children, 0)
+
+  describe "init/1" do
+    test "initializes with default values" do
+      assert {:ok, state} = Toast.init(id: :t1)
+      assert state.message == ""
+      assert state.level == :info
+      assert state.ttl_ms == 4_000
+    end
+  end
+
+  describe "render/2" do
+    test "renders a rounded, padded box" do
+      {:ok, state} = Toast.init(id: :t, message: "Checkpoint saved")
+      rendered = Toast.render(state, default_context())
+
+      assert rendered.type == :box
+      assert rendered.style.border == :rounded
+      assert rendered.style.padding == 1
+    end
+
+    test "pairs the info level with an info glyph and cyan" do
+      {:ok, state} =
+        Toast.init(id: :t, message: "Checkpoint saved", level: :info)
+
+      rendered = Toast.render(state, default_context())
+
+      assert message_el(rendered).content == "ℹ Checkpoint saved"
+      assert message_el(rendered).fg == :cyan
+    end
+
+    test "pairs the warn level with a warning glyph and yellow" do
+      {:ok, state} =
+        Toast.init(id: :t, message: "Approaching cap", level: :warn)
+
+      rendered = Toast.render(state, default_context())
+
+      assert message_el(rendered).content == "⚠ Approaching cap"
+      assert message_el(rendered).fg == :yellow
+    end
+
+    test "pairs the error level with an error glyph and red" do
+      {:ok, state} = Toast.init(id: :t, message: "Turn failed", level: :error)
+      rendered = Toast.render(state, default_context())
+
+      assert message_el(rendered).content == "✗ Turn failed"
+      assert message_el(rendered).fg == :red
+    end
+
+    test "falls back to a neutral glyph for an unknown level" do
+      {:ok, state} = Toast.init(id: :t, message: "???", level: :mystery)
+      rendered = Toast.render(state, default_context())
+
+      assert message_el(rendered).content == "• ???"
+      assert message_el(rendered).fg == :white
+    end
+  end
+
+  describe "handle_event/3" do
+    test "passes through all events unchanged" do
+      {:ok, state} = Toast.init(id: :t)
+      {new_state, []} = Toast.handle_event(:whatever, state, %{})
+      assert new_state == state
+    end
+  end
+end


### PR DESCRIPTION
Status + observability widgets:
- `StatusBar` (extends Display.StatusBar), `ContextMeter` (compaction proximity), `SpendMeter` (vs cap).
- `ActivityIndicator` (working/idle/HUNG), `AdvisoryFeed` (probe side-channel, kept separate from primary), `DriftIndicator` (cross-family), `Toast`.

Part of the agent-harness UI (`docs/proposals/in-flight/harness-spec-frontend.md`). Pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP5gp9w9LBHU6nSXMc6kc1