### PR TITLE
Harness contract v0 + raxol -p one-shot CLI

### DIFF
--- a/bin/raxol
+++ b/bin/raxol
@@ -1,0 +1,66 @@
+#!/bin/sh
+# raxol — one-shot headless agent CLI (v0).
+#
+#   raxol -p "what's inside my cwd"
+#   raxol -p "summarize mix.exs" --harness lm_studio 2>events.jsonl
+#
+# stdout = the answer. stderr = harness contract events as JSON lines.
+# Runs the mix task from the raxol_agent package while keeping the
+# CALLER's cwd as the agent's working directory (the fs tools are scoped
+# to it). Requires deps compiled once: (cd packages/raxol_agent && mix deps.get)
+
+set -e
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(dirname -- "$SCRIPT_DIR")
+CALLER_CWD=$(pwd)
+
+PROMPT=""
+PASSTHRU=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p)
+      shift
+      PROMPT="$1"
+      ;;
+    -h|--help)
+      echo "usage: raxol -p \"prompt\" [--harness NAME] [--model NAME] [--base-url URL] [--system TEXT] [--timeout SECONDS] [--no-tools]"
+      exit 0
+      ;;
+    *)
+      PASSTHRU="$PASSTHRU $1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$PROMPT" ]; then
+  echo "raxol: missing -p \"prompt\"" >&2
+  exit 64
+fi
+
+cd "$REPO_ROOT/packages/raxol_agent"
+
+# Compile silently first so the actual run keeps stdout clean for the
+# answer (the task boots with --no-compile).
+mix compile >/dev/null 2>&1 || {
+  echo "raxol: compile failed; run (cd packages/raxol_agent && mix compile) for details" >&2
+  exit 70
+}
+
+# RAXOL_CLI_CWD tells the fs tools which directory the user meant.
+# MAKEFLAGS=-s keeps the termbox2 NIF's per-invocation make check from
+# printing "Nothing to be done" onto the answer channel. Mix's pre-task
+# dep check still prints a constant "==> raxol_terminal" header (the
+# elixir_make dep reads as always-stale — root fix is a manifest guard in
+# raxol_terminal, out of scope here), so filter that exact line while
+# preserving the task's exit code.
+STATUS_FILE=$(mktemp)
+{
+  MAKEFLAGS=-s RAXOL_CLI_CWD="$CALLER_CWD" mix raxol.p $PASSTHRU "$PROMPT"
+  echo $? > "$STATUS_FILE"
+} | grep --line-buffered -v '^==> raxol_terminal$'
+read CODE < "$STATUS_FILE"
+rm -f "$STATUS_FILE"
+exit "$CODE"

--- a/packages/raxol_agent/lib/mix/tasks/raxol.p.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.p.ex
@@ -1,0 +1,217 @@
+defmodule Mix.Tasks.Raxol.P do
+  @shortdoc "One-shot headless agent run: prompt in, answer to stdout, events to stderr"
+
+  @moduledoc """
+  Run one agent turn headlessly — the `raxol -p` surface.
+
+      mix raxol.p "what's inside my cwd"
+      mix raxol.p --harness lm_studio --model qwen2.5-7b-instruct "summarize mix.exs"
+      bin/raxol -p "what's inside my cwd"        # repo-root wrapper
+
+  ## What it does
+
+  Boots the agent runtime (no terminal UI), starts a `SessionStreamer`,
+  subscribes to it, then pumps a `Raxol.Agent.Stream.react/2` run through
+  `Raxol.Agent.Contract` — so this command is a real consumer of the
+  harness contract, not a shortcut around it:
+
+    * **stdout** — the answer only (streamed deltas when the backend
+      streams; the final message otherwise). Pipe-safe.
+    * **stderr** — every contract event as one JSON line: `turn_started`,
+      `item_completed{tool_use/tool_result/message}`, `turn_completed`,
+      `error`. `2>events.jsonl` captures a machine-readable trace.
+
+  The agent gets read-only fs tools (`list_dir`, `read_file`, `file_stat`)
+  scoped under the current working directory.
+
+  ## Options
+
+    * `--harness`  — backend harness atom (default `lm_studio`; also
+      `anthropic`, `openai`, `ollama`, ... see `Backend.Selector`)
+    * `--model`    — model override (LM Studio uses its loaded model)
+    * `--base-url` — override the backend base URL
+    * `--system`   — system prompt override
+    * `--timeout`  — per-run timeout in seconds (default 180)
+    * `--no-tools` — plain completion, no tool loop
+
+  ## Exit codes
+
+  `0` success · `1` run error · `2` timeout · `64` usage error
+  """
+
+  use Mix.Task
+
+  alias Raxol.Agent.Contract
+  alias Raxol.Agent.SessionStreamer
+
+  @default_timeout_s 180
+
+  @switches [
+    harness: :string,
+    model: :string,
+    base_url: :string,
+    system: :string,
+    timeout: :integer,
+    tools: :boolean
+  ]
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, args, invalid} = OptionParser.parse(argv, strict: @switches)
+
+    prompt = Enum.join(args, " ") |> String.trim()
+
+    cond do
+      invalid != [] ->
+        usage_error("unknown options: #{inspect(invalid)}")
+
+      prompt == "" ->
+        usage_error("no prompt given. Usage: mix raxol.p [options] \"prompt\"")
+
+      true ->
+        run_prompt(prompt, opts)
+    end
+  end
+
+  defp usage_error(message) do
+    IO.puts(:stderr, "raxol.p: #{message}")
+    exit({:shutdown, 64})
+  end
+
+  defp run_prompt(prompt, opts) do
+    # Agent environment only — no terminal driver, no UI. stdout belongs to
+    # the answer: boot without recompiling (bin/raxol precompiles silently)
+    # and keep Logger quiet below :error.
+    System.put_env("RAXOL_SKIP_TERMINAL_INIT", "true")
+    Logger.configure(level: :error)
+
+    Mix.Task.run("app.start", [
+      "--no-compile",
+      "--no-deps-check",
+      "--no-archives-check",
+      "--no-elixir-version-check"
+    ])
+
+    ensure_streamer!()
+
+    session_id = "cli-#{System.unique_integer([:positive])}"
+    :ok = SessionStreamer.subscribe(session_id)
+
+    stream_opts = build_stream_opts(prompt, opts)
+    use_tools = Keyword.get(opts, :tools, true)
+
+    runner =
+      Task.async(fn ->
+        stream =
+          if use_tools do
+            Raxol.Agent.Stream.react(prompt, stream_opts)
+          else
+            Raxol.Agent.Stream.run(prompt, stream_opts)
+          end
+
+        Contract.pump(session_id, stream, prompt: prompt)
+      end)
+
+    timeout_ms = Keyword.get(opts, :timeout, @default_timeout_s) * 1_000
+    status = consume(session_id, runner, timeout_ms, %{wrote_stdout: false})
+    exit({:shutdown, status})
+  end
+
+  # SessionStreamer is not in any package supervision tree yet (the CLI is
+  # its first live consumer); start it idempotently.
+  defp ensure_streamer! do
+    case SessionStreamer.start_link([]) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, reason} -> raise "cannot start SessionStreamer: #{inspect(reason)}"
+    end
+  end
+
+  defp build_stream_opts(_prompt, opts) do
+    harness_name = Keyword.get(opts, :harness, "lm_studio")
+    supported = Raxol.Agent.Backend.Selector.supported_harnesses()
+
+    harness =
+      Enum.find(supported, &(Atom.to_string(&1) == harness_name)) ||
+        usage_error(
+          "unknown harness #{inspect(harness_name)}; supported: " <>
+            Enum.map_join(supported, ", ", &Atom.to_string/1)
+        )
+
+    executor_attrs =
+      [harness: harness]
+      |> maybe_put(:model, Keyword.get(opts, :model))
+
+    executor = Raxol.Agent.ExecutorConfig.new(executor_attrs)
+
+    backend_opts =
+      []
+      |> maybe_put(:base_url, Keyword.get(opts, :base_url))
+
+    system =
+      Keyword.get(
+        opts,
+        :system,
+        "You are a helpful assistant running in a terminal at the user's " <>
+          "current working directory. Use the available tools to inspect " <>
+          "files when the question is about them. Be concise."
+      )
+
+    [
+      executor: executor,
+      backend_opts: backend_opts,
+      system_prompt: system,
+      actions: Raxol.Agent.Actions.Fs.all()
+    ]
+  end
+
+  defp maybe_put(kw, _key, nil), do: kw
+  defp maybe_put(kw, key, value), do: Keyword.put(kw, key, value)
+
+  # -- Event consumption: contract events in, stdout/stderr out --------------
+
+  defp consume(session_id, runner, timeout_ms, state) do
+    receive do
+      {:session_event, ^session_id, %Contract.Event{} = event} ->
+        IO.write(:stderr, Contract.encode_line(event))
+        state = render_stdout(event, state)
+
+        case event do
+          %{type: :turn_completed, payload: %{final: true}} ->
+            Task.await(runner, 5_000)
+            if state.wrote_stdout, do: IO.write("\n")
+            0
+
+          %{type: :error} ->
+            Task.await(runner, 5_000)
+            1
+
+          _ ->
+            consume(session_id, runner, timeout_ms, state)
+        end
+    after
+      timeout_ms ->
+        IO.puts(:stderr, ~s({"type":"error","payload":{"reason":"timeout"}}))
+        Task.shutdown(runner, :brutal_kill)
+        2
+    end
+  end
+
+  # stdout carries the ANSWER only. Stream deltas as they arrive; if the
+  # run produced no deltas (non-streaming react loop), print the final
+  # message content once.
+  defp render_stdout(%{type: :item_delta, payload: %{chunk: chunk}}, state) do
+    IO.write(chunk)
+    %{state | wrote_stdout: true}
+  end
+
+  defp render_stdout(
+         %{type: :item_completed, payload: %{item_type: :message, content: content}},
+         %{wrote_stdout: false} = state
+       ) do
+    IO.write(content)
+    %{state | wrote_stdout: true}
+  end
+
+  defp render_stdout(_event, state), do: state
+end

--- a/packages/raxol_agent/lib/raxol/agent/actions/fs.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/fs.ex
@@ -1,0 +1,165 @@
+defmodule Raxol.Agent.Actions.Fs do
+  @moduledoc """
+  Read-only real-filesystem Actions for LLM tool use.
+
+  Unlike `Raxol.Agent.Actions.Vfs` (the in-memory virtual filesystem),
+  these touch the actual filesystem the BEAM runs on — scoped to the
+  current working directory and **strictly read-only** (`list_dir`,
+  `read_file`, `file_stat`). No write, delete, or shell surface here;
+  mutating tools must go through the blast-radius gate when it lands
+  (see `docs/proposals/in-flight/harness-spec-backend.md` §8).
+
+  Path discipline: every path is expanded relative to cwd and must stay
+  under cwd — `../` escapes and absolute paths outside cwd are rejected
+  with `:outside_cwd`.
+  """
+
+  defmodule ListDir do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "list_dir",
+      description:
+        "List entries of a directory (relative to the current working " <>
+          "directory). Returns names with a trailing / for directories.",
+      schema: [
+        input: [
+          path: [
+            type: :string,
+            required: false,
+            description: "Directory to list, relative to cwd. Default: \".\""
+          ]
+        ],
+        output: [
+          path: [type: :string],
+          entries: [type: {:list, :string}]
+        ]
+      ]
+
+    @impl true
+    def run(params, _context) do
+      path = Map.get(params, :path) || "."
+
+      with {:ok, abs} <- Raxol.Agent.Actions.Fs.resolve(path),
+           {:ok, names} <- File.ls(abs) do
+        entries =
+          names
+          |> Enum.sort()
+          |> Enum.map(fn name ->
+            if File.dir?(Path.join(abs, name)), do: name <> "/", else: name
+          end)
+
+        {:ok, %{path: path, entries: entries}}
+      else
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defmodule ReadFile do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "read_file",
+      description:
+        "Read a text file (relative to the current working directory). " <>
+          "Returns at most the first 16KB.",
+      schema: [
+        input: [
+          path: [type: :string, required: true, description: "File to read"]
+        ],
+        output: [
+          path: [type: :string],
+          content: [type: :string],
+          truncated: [type: :boolean]
+        ]
+      ]
+
+    @max_bytes 16_384
+
+    @impl true
+    def run(%{path: path}, _context) do
+      with {:ok, abs} <- Raxol.Agent.Actions.Fs.resolve(path),
+           {:ok, content} <- File.read(abs) do
+        truncated = byte_size(content) > @max_bytes
+
+        {:ok,
+         %{
+           path: path,
+           content: binary_part(content, 0, min(byte_size(content), @max_bytes)),
+           truncated: truncated
+         }}
+      else
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defmodule FileStat do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "file_stat",
+      description:
+        "Stat a path (relative to the current working directory): " <>
+          "type, size in bytes, and mtime.",
+      schema: [
+        input: [
+          path: [type: :string, required: true, description: "Path to stat"]
+        ],
+        output: [
+          path: [type: :string],
+          type: [type: :string],
+          size: [type: :integer],
+          mtime: [type: :string]
+        ]
+      ]
+
+    @impl true
+    def run(%{path: path}, _context) do
+      with {:ok, abs} <- Raxol.Agent.Actions.Fs.resolve(path),
+           {:ok, stat} <- File.stat(abs, time: :posix) do
+        {:ok,
+         %{
+           path: path,
+           type: to_string(stat.type),
+           size: stat.size,
+           mtime: stat.mtime |> DateTime.from_unix!() |> DateTime.to_iso8601()
+         }}
+      else
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @doc "All read-only fs actions, for passing as `actions:` to a ReAct run."
+  @spec all() :: [module()]
+  def all, do: [ListDir, ReadFile, FileStat]
+
+  @doc """
+  Expand `path` against the working directory and require the result to
+  stay under it.
+
+  The working directory is `RAXOL_CLI_CWD` when set (the `bin/raxol`
+  wrapper exports the caller's cwd before re-execing from the package
+  directory), else the BEAM's cwd.
+  """
+  @spec resolve(String.t()) :: {:ok, String.t()} | {:error, :outside_cwd}
+  def resolve(path) do
+    cwd = working_dir()
+    abs = Path.expand(path, cwd)
+
+    if abs == cwd or String.starts_with?(abs, cwd <> "/") do
+      {:ok, abs}
+    else
+      {:error, :outside_cwd}
+    end
+  end
+
+  @doc "The directory fs actions are scoped to (see `resolve/1`)."
+  @spec working_dir() :: String.t()
+  def working_dir do
+    case System.get_env("RAXOL_CLI_CWD") do
+      nil -> File.cwd!()
+      "" -> File.cwd!()
+      dir -> Path.expand(dir)
+    end
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/backend/selector.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/selector.ex
@@ -21,7 +21,15 @@ defmodule Raxol.Agent.Backend.Selector do
     ollama: {Raxol.Agent.Backend.HTTP, [provider: :ollama]},
     # LM Studio serves an OpenAI-compatible /v1/chat/completions endpoint, so
     # it reuses the :openai request/response/SSE handling in Backend.HTTP.
-    lm_studio: {Raxol.Agent.Backend.HTTP, [provider: :openai, base_url: "http://localhost:1234"]},
+    # LM Studio ignores auth; "lm-studio" is its documented placeholder key
+    # (Backend.HTTP requires an :api_key for the :openai provider).
+    lm_studio:
+      {Raxol.Agent.Backend.HTTP,
+       [
+         provider: :openai,
+         base_url: "http://localhost:1234",
+         api_key: "lm-studio"
+       ]},
     llm7: {Raxol.Agent.Backend.HTTP, [provider: :openai, base_url: "https://api.llm7.io"]},
     openrouter:
       {Raxol.Agent.Backend.HTTP,

--- a/packages/raxol_agent/lib/raxol/agent/contract.ex
+++ b/packages/raxol_agent/lib/raxol/agent/contract.ex
@@ -1,0 +1,217 @@
+defmodule Raxol.Agent.Contract do
+  @moduledoc """
+  Harness contract v0 — the typed event contract between the agent core and
+  any surface (CLI, TUI, LiveView, remote).
+
+  This is the minimal loop-family slice of the contract in
+  `docs/proposals/in-flight/harness-spec-protocol.md`: every observable step
+  of an agent run becomes a `Raxol.Agent.Contract.Event` and is published
+  through `Raxol.Agent.SessionStreamer`. Surfaces subscribe to the streamer
+  and render; they never reach into the loop.
+
+  (Distinct from `Raxol.Agent.Protocol`, which is agent-to-agent cockpit
+  messaging — this module is the core↔surface boundary.)
+
+  ## v0 vocabulary (family `:loop` only)
+
+    * `:turn_started`   — a prompt was accepted; payload `%{prompt}`
+    * `:item_delta`     — streaming text chunk; payload `%{chunk}`;
+      the one **ephemeral** event (live render only, never for replay)
+    * `:item_completed` — a finished item; payload
+      `%{item_type: :message | :tool_use | :tool_result, ...}`
+    * `:turn_completed` — a turn boundary; payload
+      `%{usage, iteration, final}` (`final: true` closes the run)
+    * `:error`          — fault; payload `%{reason}`
+
+  The meta family (probe swarm), `steer`/`approval` commands, and the
+  durable journal sink attach behind this same boundary in later steps —
+  producers change, the contract does not.
+
+  ## Producers
+
+  The v0 producer is `pump/3`: it drains a `Raxol.Agent.Stream.run/2` or
+  `Raxol.Agent.Stream.react/2` enumerable, wraps each event in the contract
+  envelope, and emits it into the streamer. The Dispatcher fold-site emit
+  (the keystone) is the next producer and plugs in behind the same
+  `SessionStreamer` boundary without surfaces changing.
+  """
+
+  alias Raxol.Agent.SessionStreamer
+
+  defmodule Event do
+    @moduledoc """
+    The contract envelope. One struct per observable step; `id` is a
+    per-run monotonic sequence (the future journal offset).
+    """
+
+    @derive Jason.Encoder
+    defstruct v: 0,
+              id: 0,
+              session_id: nil,
+              turn_id: nil,
+              ts: 0,
+              family: :loop,
+              type: nil,
+              tier: :durable,
+              payload: %{}
+
+    @type t :: %__MODULE__{
+            v: non_neg_integer(),
+            id: non_neg_integer(),
+            session_id: String.t(),
+            turn_id: String.t() | nil,
+            ts: integer(),
+            family: :loop | :meta,
+            type: atom(),
+            tier: :ephemeral | :durable,
+            payload: map()
+          }
+  end
+
+  @doc """
+  Encode an event as a JSON line (newline-terminated) for wire surfaces
+  (the CLI's stderr event feed, SSE bodies). Decoding arrives with the
+  command channel; v0 is emit-only.
+  """
+  @spec encode_line(Event.t()) :: iodata()
+  def encode_line(%Event{} = event) do
+    [Jason.encode!(sanitize(event)), "\n"]
+  end
+
+  # Payloads may carry non-JSON-encodable terms (error reasons, tuples,
+  # arbitrary tool results). Sanitize at the boundary rather than crash
+  # the feed: anything Jason can't take becomes `inspect/1` text.
+  defp sanitize(%Event{payload: payload} = event) do
+    %{event | payload: sanitize_value(payload)}
+  end
+
+  defp sanitize_value(%_struct{} = struct),
+    do: struct |> Map.from_struct() |> sanitize_value()
+
+  defp sanitize_value(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {sanitize_key(k), sanitize_value(v)} end)
+  end
+
+  defp sanitize_value(list) when is_list(list) do
+    if List.improper?(list) do
+      inspect(list)
+    else
+      Enum.map(list, &sanitize_value/1)
+    end
+  end
+
+  defp sanitize_value(value)
+       when is_binary(value) or is_number(value) or is_boolean(value) or
+              is_atom(value),
+       do: value
+
+  defp sanitize_value(other), do: inspect(other)
+
+  defp sanitize_key(key) when is_atom(key) or is_binary(key), do: key
+  defp sanitize_key(key), do: inspect(key)
+
+  @doc """
+  Drain a `Raxol.Agent.Stream` enumerable into the contract.
+
+  Emits `turn_started` first, then maps each stream event onto the v0
+  vocabulary and publishes it via `SessionStreamer.emit/2`. Returns
+  `{:ok, %{content, usage}}` on completion or `{:error, reason}`.
+
+  Blocks until the stream is done — run it in its own process (the CLI
+  uses `Task.async/1`); subscribers receive events live.
+  """
+  @spec pump(String.t(), Enumerable.t(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def pump(session_id, stream, opts \\ []) do
+    prompt = Keyword.get(opts, :prompt, "")
+    turn_id = "turn-#{System.unique_integer([:positive])}"
+    counter = :counters.new(1, [])
+
+    emit_event(session_id, turn_id, counter, :turn_started, :durable, %{
+      prompt: prompt
+    })
+
+    Enum.reduce(stream, {:error, :no_result}, fn stream_event, acc ->
+      handle_stream_event(session_id, turn_id, counter, stream_event, acc)
+    end)
+  end
+
+  defp handle_stream_event(session_id, turn_id, counter, event, acc) do
+    case event do
+      {:text_delta, chunk} ->
+        emit_event(session_id, turn_id, counter, :item_delta, :ephemeral, %{
+          chunk: chunk
+        })
+
+        acc
+
+      {:tool_use, %{name: name} = tool_use} ->
+        emit_event(session_id, turn_id, counter, :item_completed, :durable, %{
+          item_type: :tool_use,
+          name: name,
+          arguments: Map.get(tool_use, :arguments, %{}),
+          call_id: Map.get(tool_use, :id)
+        })
+
+        acc
+
+      {:tool_result, %{name: name} = tool_result} ->
+        emit_event(session_id, turn_id, counter, :item_completed, :durable, %{
+          item_type: :tool_result,
+          name: name,
+          result: Map.get(tool_result, :result)
+        })
+
+        acc
+
+      {:turn_complete, info} ->
+        emit_event(session_id, turn_id, counter, :turn_completed, :durable, %{
+          iteration: Map.get(info, :iteration, 0),
+          usage: Map.get(info, :usage, %{}),
+          final: false
+        })
+
+        acc
+
+      {:done, %{content: content} = info} ->
+        emit_event(session_id, turn_id, counter, :item_completed, :durable, %{
+          item_type: :message,
+          content: content
+        })
+
+        emit_event(session_id, turn_id, counter, :turn_completed, :durable, %{
+          usage: Map.get(info, :usage, %{}),
+          final: true
+        })
+
+        {:ok, %{content: content, usage: Map.get(info, :usage, %{})}}
+
+      {:error, reason} ->
+        emit_event(session_id, turn_id, counter, :error, :durable, %{
+          reason: reason
+        })
+
+        {:error, reason}
+
+      _other ->
+        acc
+    end
+  end
+
+  defp emit_event(session_id, turn_id, counter, type, tier, payload) do
+    :counters.add(counter, 1, 1)
+
+    event = %Event{
+      id: :counters.get(counter, 1),
+      session_id: session_id,
+      turn_id: turn_id,
+      ts: System.system_time(:microsecond),
+      family: :loop,
+      type: type,
+      tier: tier,
+      payload: payload
+    }
+
+    SessionStreamer.emit(session_id, event)
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/actions/fs_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/fs_test.exs
@@ -1,0 +1,85 @@
+defmodule Raxol.Agent.Actions.FsTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Actions.Fs
+
+  setup do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-fs-test-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(dir, "sub"))
+    File.write!(Path.join(dir, "hello.txt"), "hello world")
+
+    previous = System.get_env("RAXOL_CLI_CWD")
+    System.put_env("RAXOL_CLI_CWD", dir)
+
+    on_exit(fn ->
+      case previous do
+        nil -> System.delete_env("RAXOL_CLI_CWD")
+        value -> System.put_env("RAXOL_CLI_CWD", value)
+      end
+
+      File.rm_rf!(dir)
+    end)
+
+    %{dir: dir}
+  end
+
+  describe "resolve/1" do
+    test "accepts paths under the working dir", %{dir: dir} do
+      assert {:ok, abs} = Fs.resolve("hello.txt")
+      assert abs == Path.join(dir, "hello.txt")
+      assert {:ok, ^dir} = Fs.resolve(".")
+    end
+
+    test "rejects escapes and outside absolute paths" do
+      assert {:error, :outside_cwd} = Fs.resolve("../etc/passwd")
+      assert {:error, :outside_cwd} = Fs.resolve("/etc/passwd")
+      assert {:error, :outside_cwd} = Fs.resolve("sub/../../outside")
+    end
+
+    test "working_dir honors RAXOL_CLI_CWD", %{dir: dir} do
+      assert Fs.working_dir() == dir
+    end
+  end
+
+  describe "ListDir" do
+    test "lists sorted entries with trailing slash on directories" do
+      assert {:ok, %{entries: entries}} = Fs.ListDir.run(%{path: "."}, %{})
+      assert entries == ["hello.txt", "sub/"]
+    end
+
+    test "defaults to the working dir root" do
+      assert {:ok, %{path: ".", entries: entries}} = Fs.ListDir.run(%{}, %{})
+      assert "hello.txt" in entries
+    end
+  end
+
+  describe "ReadFile" do
+    test "reads content with truncation flag" do
+      assert {:ok, %{content: "hello world", truncated: false}} =
+               Fs.ReadFile.run(%{path: "hello.txt"}, %{})
+    end
+
+    test "errors on missing file" do
+      assert {:error, :enoent} = Fs.ReadFile.run(%{path: "nope.txt"}, %{})
+    end
+
+    test "errors outside the working dir" do
+      assert {:error, :outside_cwd} =
+               Fs.ReadFile.run(%{path: "../secrets"}, %{})
+    end
+  end
+
+  describe "FileStat" do
+    test "stats a file" do
+      assert {:ok, %{type: "regular", size: size}} =
+               Fs.FileStat.run(%{path: "hello.txt"}, %{})
+
+      assert size == byte_size("hello world")
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/contract_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/contract_test.exs
@@ -1,0 +1,124 @@
+defmodule Raxol.Agent.ContractTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Contract
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.SessionStreamer
+
+  setup do
+    start_supervised!({SessionStreamer, []})
+    :ok
+  end
+
+  defp mock_stream(response) do
+    Raxol.Agent.Stream.run("prompt",
+      backend: Raxol.Agent.Backend.Mock,
+      backend_opts: [response: response]
+    )
+  end
+
+  describe "pump/3" do
+    test "maps a completed run onto the v0 vocabulary, in order" do
+      session_id = "contract-test-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      assert {:ok, %{content: content}} =
+               Contract.pump(session_id, mock_stream("Hello!"), prompt: "hi")
+
+      assert content =~ "Hello"
+
+      events = drain_events(session_id)
+      types = Enum.map(events, & &1.type)
+
+      assert List.first(types) == :turn_started
+      assert List.last(types) == :turn_completed
+      assert :item_completed in types
+
+      # the final turn_completed closes the run
+      assert %Event{payload: %{final: true}} = List.last(events)
+
+      # ids are monotonic from 1
+      assert Enum.map(events, & &1.id) == Enum.to_list(1..length(events))
+
+      # one turn: every event shares session and turn ids
+      assert Enum.uniq(Enum.map(events, & &1.session_id)) == [session_id]
+      assert [_turn_id] = Enum.uniq(Enum.map(events, & &1.turn_id))
+    end
+
+    test "text deltas are ephemeral; completed items are durable" do
+      session_id = "contract-test-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      {:ok, _} = Contract.pump(session_id, mock_stream("chunky"), prompt: "hi")
+
+      events = drain_events(session_id)
+
+      for %Event{type: :item_delta} = event <- events do
+        assert event.tier == :ephemeral
+      end
+
+      for %Event{type: type} = event <- events, type != :item_delta do
+        assert event.tier == :durable
+      end
+    end
+
+    test "an error stream yields an :error event and error return" do
+      session_id = "contract-test-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      error_stream = [{:error, {:http, 500, "boom"}}]
+
+      assert {:error, {:http, 500, "boom"}} =
+               Contract.pump(session_id, error_stream, prompt: "hi")
+
+      events = drain_events(session_id)
+      assert Enum.any?(events, &(&1.type == :error))
+    end
+  end
+
+  describe "encode_line/1" do
+    test "produces one decodable JSON line per event" do
+      event = %Event{
+        id: 1,
+        session_id: "s",
+        turn_id: "t",
+        ts: 123,
+        type: :turn_started,
+        payload: %{prompt: "hi"}
+      }
+
+      line = event |> Contract.encode_line() |> IO.iodata_to_binary()
+      assert String.ends_with?(line, "\n")
+
+      assert {:ok, decoded} = Jason.decode(String.trim_trailing(line))
+      assert decoded["type"] == "turn_started"
+      assert decoded["payload"]["prompt"] == "hi"
+      assert decoded["tier"] == "durable"
+    end
+
+    test "sanitizes non-JSON payload terms instead of crashing" do
+      event = %Event{
+        id: 1,
+        session_id: "s",
+        turn_id: "t",
+        ts: 123,
+        type: :error,
+        payload: %{reason: {:http, 500, {:nested, :tuple}}}
+      }
+
+      line = event |> Contract.encode_line() |> IO.iodata_to_binary()
+      assert {:ok, decoded} = Jason.decode(String.trim_trailing(line))
+      assert is_binary(decoded["payload"]["reason"])
+      assert decoded["payload"]["reason"] =~ "http"
+    end
+  end
+
+  defp drain_events(session_id, acc \\ []) do
+    receive do
+      {:session_event, ^session_id, %Event{} = event} ->
+        drain_events(session_id, [event | acc])
+    after
+      100 -> Enum.reverse(acc)
+    end
+  end
+end


### PR DESCRIPTION
First end-to-end slice of the agent-harness contract, validated live against LM Studio.

## What

- **`Raxol.Agent.Contract`** — v0 of the core↔surface event contract from `docs/proposals/in-flight/harness-spec-protocol.md`: loop-family vocabulary (`turn_started` / `item_delta` / `item_completed` / `turn_completed` / `error`), ephemeral-vs-durable tiers, per-run monotonic ids (future journal offsets), JSON-line codec with payload sanitization, and `pump/3` draining any `Raxol.Agent.Stream` run into `SessionStreamer`. Surfaces subscribe to the streamer; producers swap behind the boundary (Dispatcher fold-site emit is the next producer).
- **`Raxol.Agent.Actions.Fs`** — read-only real-fs tools (`list_dir`, `read_file`, `file_stat`), strictly scoped under the caller's cwd; `../`/absolute escapes rejected. No mutating surface until the blast-radius gate.
- **`mix raxol.p` + `bin/raxol`** — the `raxol -p "prompt"` one-shot: answer on stdout (pipe-safe), one JSON contract event per line on stderr, exit 0/1/2/64.

## Live validation

```
$ bin/raxol -p "what's inside my cwd" 2>events.jsonl
Your current working directory contains:
- events.jsonl ...
$ grep -o '"type":"[a-z_]*"' events.jsonl | sort | uniq -c
   3 item_completed   2 turn_completed   1 turn_started
```
LM Studio (`qwen3.6-35b`) made a native `list_dir` tool call against the real cwd; full typed trace captured. 14 new offline tests (Mock backend) green.

## Notes
- The constant `==> raxol_terminal` header is filtered in the wrapper; root cause is the elixir_make always-stale dep check in raxol_terminal — separate fix.
- Part of the harness backend track (`harness-spec-backend.md` §10); step 2 is the Dispatcher unified emit behind this same boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7