### PR TITLE
feat(harness): U22 — asciicast append + torn-tail-tolerant reader

### DIFF
--- a/lib/raxol/recording/asciicast.ex
+++ b/lib/raxol/recording/asciicast.ex
@@ -7,6 +7,16 @@ defmodule Raxol.Recording.Asciicast do
   - Remaining lines: `[elapsed_seconds, "o", "output_data"]` (newline-delimited JSON)
 
   See: https://docs.asciinema.org/manual/asciicast/v2/
+
+  ## Concurrency
+
+  `append!/2` assumes a **single writer per file**. It opens the file several
+  times (validate header, check/fix the trailing newline, append the body) with
+  no cross-process locking, so two concurrent appenders to the same path can
+  interleave their bodies or both add a trailing newline. The intended usage
+  (e.g. `Evidence.Capture` owning one `.cast` per run) already serializes writes
+  through a single process; keep that contract. Do not append to one file from
+  multiple processes concurrently.
   """
 
   require Logger
@@ -32,20 +42,23 @@ defmodule Raxol.Recording.Asciicast do
 
   Accepts either a list of `Session.event()` tuples or a `Session` (its `events`
   are appended). Raises if the file is missing or its header is not a valid
-  asciicast v2 header.
+  asciicast v2 header. Appending an empty event list is a no-op: the file is left
+  byte-for-byte untouched (no trailing-newline fixup, no header validation).
+
+  **Single-writer contract:** this is not safe against concurrent appenders to
+  the same path (see the module's Concurrency note). Call it from a single owning
+  process per file.
   """
   @spec append!([Session.event()] | Session.t(), Path.t()) :: :ok
   def append!(%Session{events: events}, path), do: append!(events, path)
+
+  def append!([], _path), do: :ok
 
   def append!(events, path) when is_list(events) do
     validate_header!(path)
     ensure_trailing_newline!(path)
 
-    body =
-      case Enum.map_join(events, "\n", &encode_event/1) do
-        "" -> ""
-        joined -> joined <> "\n"
-      end
+    body = Enum.map_join(events, "\n", &encode_event/1) <> "\n"
 
     File.write!(path, body, [:append])
   end
@@ -57,7 +70,12 @@ defmodule Raxol.Recording.Asciicast do
       {:ok, decode(content)}
     end
   rescue
-    e -> {:error, e}
+    # Only expected malformed-input exceptions become `{:error, _}`:
+    # a corrupt/empty header raises `Jason.DecodeError`, and a structurally
+    # invalid header (e.g. a non-integer `timestamp`) raises `ArgumentError`
+    # from `decode/1`. Any other exception is a genuine bug and must propagate
+    # rather than be masked as a read failure.
+    e in [Jason.DecodeError, ArgumentError, MatchError] -> {:error, e}
   end
 
   @doc "Reads a .cast file into a session. Raises on failure."
@@ -85,11 +103,13 @@ defmodule Raxol.Recording.Asciicast do
   @doc """
   Decodes an asciicast v2 format string into a session.
 
-  Torn-tail tolerant: if the file was truncated mid-write (process killed), the
-  final partial/invalid event line is dropped and every complete event preceding
-  it is recovered. An invalid *interior* line stops parsing there and returns the
-  events collected so far (with a logged warning) rather than raising. A valid
-  cast round-trips unchanged.
+  Torn-tail tolerant: if the file was truncated mid-write (process killed) so the
+  final line has no trailing newline, that torn line is dropped *silently* and
+  every complete event preceding it is recovered. A line that was fully flushed
+  (newline-terminated) but is still unparseable -- whether interior or the last
+  event line -- is committed corruption: parsing stops there, returns the events
+  collected so far, and logs a warning rather than raising. A valid cast
+  round-trips unchanged.
 
   The header line must be present and valid JSON (it is written in full before
   any event, so a truncated recording still has an intact header). A missing or
@@ -146,10 +166,17 @@ defmodule Raxol.Recording.Asciicast do
     Jason.encode!([seconds, type_str, data])
   end
 
-  # Parses event lines, tolerating a truncated/invalid final line at EOF. Stops
-  # at the first unparseable line and returns everything recovered so far. The
-  # final-line case (the common kill-mid-write outcome) is dropped quietly; an
-  # interior malformed line is logged as a warning.
+  # Parses event lines, distinguishing two failure shapes at the tail:
+  #
+  #   * `rest == []` -- the unparseable line had no trailing newline, i.e. the
+  #     writer was killed mid-write. This is a genuinely torn tail; drop it
+  #     silently and recover the complete events before it.
+  #
+  #   * anything else (an interior line, or `rest == [""]` where the final line
+  #     WAS newline-terminated and fully flushed but is still unparseable) --
+  #     that is real corruption of a committed line, so log a warning.
+  #
+  # In both cases parsing stops and everything recovered so far is returned.
   defp decode_events(lines), do: decode_events(lines, [])
 
   defp decode_events([], acc), do: Enum.reverse(acc)
@@ -164,12 +191,14 @@ defmodule Raxol.Recording.Asciicast do
           {:ok, event} ->
             decode_events(rest, [event | acc])
 
-          :error when rest == [] or rest == [""] ->
-            # Torn final line at EOF: expected when the writer was killed
-            # mid-write. Drop it and return the complete events.
+          :error when rest == [] ->
+            # No trailing newline: torn mid-write. Expected when the writer was
+            # killed; drop it silently and return the complete events.
             Enum.reverse(acc)
 
           :error ->
+            # Either an interior malformed line or a newline-terminated (fully
+            # flushed) but unparseable final line -- committed corruption, alarm.
             Logger.warning(
               "Raxol.Recording.Asciicast: malformed event line, stopping decode " <>
                 "and returning #{length(acc)} recovered event(s)"
@@ -213,31 +242,69 @@ defmodule Raxol.Recording.Asciicast do
     end
   end
 
+  # O(1): stat the size and read only the final byte, so appending to a large
+  # recording stays cheap. Reading the whole file here would make incremental
+  # append O(n^2) over a session (`Evidence.Capture` appends once per run).
   defp ensure_trailing_newline!(path) do
-    case File.read(path) do
-      {:ok, ""} ->
+    case last_byte(path) do
+      :empty ->
         :ok
 
-      {:ok, content} ->
-        maybe_append_newline!(path, content)
+      {:ok, "\n"} ->
+        :ok
+
+      {:ok, _other} ->
+        File.write!(path, "\n", [:append])
 
       {:error, reason} ->
         raise File.Error, reason: reason, action: "read file", path: path
     end
   end
 
-  defp maybe_append_newline!(path, content) do
-    unless String.ends_with?(content, "\n") do
-      File.write!(path, "\n", [:append])
-    end
+  defp last_byte(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: 0}} ->
+        :empty
 
-    :ok
+      {:ok, %File.Stat{size: size}} ->
+        pread_last_byte(path, size)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp pread_last_byte(path, size) do
+    case :file.open(path, [:read, :binary, :raw]) do
+      {:ok, io} ->
+        result = :file.pread(io, size - 1, 1)
+        :file.close(io)
+
+        case result do
+          {:ok, byte} -> {:ok, byte}
+          :eof -> :empty
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   defp parse_timestamp(nil), do: DateTime.utc_now()
 
   defp parse_timestamp(unix) when is_integer(unix) do
     DateTime.from_unix!(unix)
+  end
+
+  # The header parsed as JSON but its `timestamp` is the wrong shape (a string,
+  # float, list, ...). Raise a descriptive `ArgumentError` so `read/1` reports a
+  # structurally-invalid header distinctly, instead of leaking a
+  # `FunctionClauseError` that the old catch-all masked as a plain read failure.
+  defp parse_timestamp(other) do
+    raise ArgumentError,
+          "invalid asciicast header: timestamp must be an integer Unix time, " <>
+            "got: #{inspect(other)}"
   end
 
   defp maybe_put(map, _key, nil), do: map

--- a/lib/raxol/recording/asciicast.ex
+++ b/lib/raxol/recording/asciicast.ex
@@ -9,6 +9,8 @@ defmodule Raxol.Recording.Asciicast do
   See: https://docs.asciinema.org/manual/asciicast/v2/
   """
 
+  require Logger
+
   alias Raxol.Recording.Session
 
   @doc "Writes a session to a .cast file."
@@ -18,12 +20,44 @@ defmodule Raxol.Recording.Asciicast do
     File.write!(path, content)
   end
 
+  @doc """
+  Appends events to an existing `.cast` file without rewriting its header.
+
+  Validates the existing v2 header, then writes the new event lines to the end
+  of the file. Events carry `elapsed_us` relative to the session start (the same
+  time base the header's `timestamp` anchors), so their timestamps are preserved
+  verbatim. A defensive trailing newline is added first so a header-only file (or
+  one whose final byte is not a newline) never fuses the appended line onto the
+  previous one.
+
+  Accepts either a list of `Session.event()` tuples or a `Session` (its `events`
+  are appended). Raises if the file is missing or its header is not a valid
+  asciicast v2 header.
+  """
+  @spec append!([Session.event()] | Session.t(), Path.t()) :: :ok
+  def append!(%Session{events: events}, path), do: append!(events, path)
+
+  def append!(events, path) when is_list(events) do
+    validate_header!(path)
+    ensure_trailing_newline!(path)
+
+    body =
+      case Enum.map_join(events, "\n", &encode_event/1) do
+        "" -> ""
+        joined -> joined <> "\n"
+      end
+
+    File.write!(path, body, [:append])
+  end
+
   @doc "Reads a .cast file into a session. Returns `{:ok, session}` or `{:error, reason}`."
   @spec read(Path.t()) :: {:ok, Session.t()} | {:error, term()}
   def read(path) do
     with {:ok, content} <- File.read(path) do
       {:ok, decode(content)}
     end
+  rescue
+    e -> {:error, e}
   end
 
   @doc "Reads a .cast file into a session. Raises on failure."
@@ -48,20 +82,27 @@ defmodule Raxol.Recording.Asciicast do
     end
   end
 
-  @doc "Decodes an asciicast v2 format string into a session."
+  @doc """
+  Decodes an asciicast v2 format string into a session.
+
+  Torn-tail tolerant: if the file was truncated mid-write (process killed), the
+  final partial/invalid event line is dropped and every complete event preceding
+  it is recovered. An invalid *interior* line stops parsing there and returns the
+  events collected so far (with a logged warning) rather than raising. A valid
+  cast round-trips unchanged.
+
+  The header line must be present and valid JSON (it is written in full before
+  any event, so a truncated recording still has an intact header). A missing or
+  corrupt header raises; call `read/1` for the non-raising `{:ok, _} | {:error, _}`
+  variant.
+  """
   @spec decode(String.t()) :: Session.t()
   def decode(content) do
-    [header_line | event_lines] =
-      content
-      |> String.trim()
-      |> String.split("\n")
+    [header_line | event_lines] = String.split(content, "\n")
 
-    header = Jason.decode!(header_line)
+    header = Jason.decode!(String.trim(header_line))
 
-    events =
-      event_lines
-      |> Enum.reject(&(&1 == ""))
-      |> Enum.map(&decode_event/1)
+    events = decode_events(event_lines)
 
     %Session{
       width: header["width"],
@@ -105,18 +146,92 @@ defmodule Raxol.Recording.Asciicast do
     Jason.encode!([seconds, type_str, data])
   end
 
+  # Parses event lines, tolerating a truncated/invalid final line at EOF. Stops
+  # at the first unparseable line and returns everything recovered so far. The
+  # final-line case (the common kill-mid-write outcome) is dropped quietly; an
+  # interior malformed line is logged as a warning.
+  defp decode_events(lines), do: decode_events(lines, [])
+
+  defp decode_events([], acc), do: Enum.reverse(acc)
+
+  defp decode_events([line | rest], acc) do
+    cond do
+      blank?(line) ->
+        decode_events(rest, acc)
+
+      true ->
+        case decode_event(line) do
+          {:ok, event} ->
+            decode_events(rest, [event | acc])
+
+          :error when rest == [] or rest == [""] ->
+            # Torn final line at EOF: expected when the writer was killed
+            # mid-write. Drop it and return the complete events.
+            Enum.reverse(acc)
+
+          :error ->
+            Logger.warning(
+              "Raxol.Recording.Asciicast: malformed event line, stopping decode " <>
+                "and returning #{length(acc)} recovered event(s)"
+            )
+
+            Enum.reverse(acc)
+        end
+    end
+  end
+
+  defp blank?(line), do: String.trim(line) == ""
+
   defp decode_event(line) do
-    [seconds, type, data] = Jason.decode!(line)
-    elapsed_us = round(seconds * 1_000_000)
+    case Jason.decode(line) do
+      {:ok, [seconds, type, data]}
+      when is_number(seconds) and is_binary(type) and is_binary(data) ->
+        {:ok, {round(seconds * 1_000_000), decode_event_type(type), data}}
 
-    event_type =
-      case type do
-        "o" -> :output
-        "i" -> :input
-        _ -> :output
-      end
+      _ ->
+        :error
+    end
+  end
 
-    {elapsed_us, event_type, data}
+  defp decode_event_type("i"), do: :input
+  defp decode_event_type(_), do: :output
+
+  defp validate_header!(path) do
+    line =
+      path
+      |> File.stream!()
+      |> Enum.take(1)
+      |> List.first()
+
+    case line && Jason.decode(String.trim(line)) do
+      {:ok, %{"version" => 2}} ->
+        :ok
+
+      _ ->
+        raise ArgumentError,
+              "cannot append to #{path}: not a valid asciicast v2 file (missing or invalid header)"
+    end
+  end
+
+  defp ensure_trailing_newline!(path) do
+    case File.read(path) do
+      {:ok, ""} ->
+        :ok
+
+      {:ok, content} ->
+        maybe_append_newline!(path, content)
+
+      {:error, reason} ->
+        raise File.Error, reason: reason, action: "read file", path: path
+    end
+  end
+
+  defp maybe_append_newline!(path, content) do
+    unless String.ends_with?(content, "\n") do
+      File.write!(path, "\n", [:append])
+    end
+
+    :ok
   end
 
   defp parse_timestamp(nil), do: DateTime.utc_now()

--- a/test/raxol/recording/asciicast_test.exs
+++ b/test/raxol/recording/asciicast_test.exs
@@ -324,5 +324,216 @@ defmodule Raxol.Recording.AsciicastTest do
         Asciicast.append!([{0, :output, "x"}], path)
       end
     end
+
+    @tag :tmp_dir
+    test "appending an empty event list is a byte-for-byte no-op", %{
+      tmp_dir: dir
+    } do
+      path = Path.join(dir, "noop.cast")
+
+      Asciicast.write!(
+        %Session{
+          width: 80,
+          height: 24,
+          started_at: DateTime.from_unix!(1_700_000_000),
+          events: [{0, :output, "a"}]
+        },
+        path
+      )
+
+      before = File.read!(path)
+      assert :ok = Asciicast.append!([], path)
+      assert File.read!(path) == before
+    end
+
+    @tag :tmp_dir
+    test "an empty append neither validates nor touches the file (no-op even on a non-cast)",
+         %{tmp_dir: dir} do
+      path = Path.join(dir, "garbage_noop.cast")
+      File.write!(path, "not a cast\n")
+
+      # No header validation, no trailing-newline fixup: the file is untouched.
+      assert :ok = Asciicast.append!([], path)
+      assert File.read!(path) == "not a cast\n"
+    end
+  end
+
+  describe "append! trailing-newline handling (O(1))" do
+    @tag :tmp_dir
+    test "many sequential appends preserve order without introducing blank lines",
+         %{tmp_dir: dir} do
+      path = Path.join(dir, "many.cast")
+
+      Asciicast.write!(
+        %Session{
+          width: 80,
+          height: 24,
+          started_at: DateTime.from_unix!(1_700_000_000),
+          events: []
+        },
+        path
+      )
+
+      for i <- 0..49 do
+        Asciicast.append!([{i * 1000, :output, "e#{i}"}], path)
+      end
+
+      session = Asciicast.read!(path)
+      assert length(session.events) == 50
+
+      assert Enum.map(session.events, fn {_t, _, d} -> d end) ==
+               for(i <- 0..49, do: "e#{i}")
+
+      # The O(1) newline check must never double-insert a separator.
+      refute File.read!(path) =~ "\n\n"
+    end
+
+    @tag :tmp_dir
+    test "inserts exactly one separator when the file does not end in a newline",
+         %{tmp_dir: dir} do
+      path = Path.join(dir, "nonewline.cast")
+
+      # Header written with no trailing newline; the last-byte check must notice.
+      header = ~s({"version":2,"width":80,"height":24,"timestamp":1700000000})
+      File.write!(path, header)
+
+      Asciicast.append!([{0, :output, "x"}], path)
+
+      session = Asciicast.read!(path)
+      assert Enum.map(session.events, fn {_t, _, d} -> d end) == ["x"]
+      refute File.read!(path) =~ "\n\n"
+    end
+
+    @tag :tmp_dir
+    test "adds no separator when the file already ends in a newline", %{
+      tmp_dir: dir
+    } do
+      path = Path.join(dir, "withnewline.cast")
+
+      Asciicast.write!(
+        %Session{
+          width: 80,
+          height: 24,
+          started_at: DateTime.from_unix!(1_700_000_000),
+          events: [{0, :output, "first"}]
+        },
+        path
+      )
+
+      # write!/2 terminates the last event line with "\n".
+      assert String.ends_with?(File.read!(path), "\n")
+
+      Asciicast.append!([{1_000_000, :output, "second"}], path)
+
+      session = Asciicast.read!(path)
+
+      assert Enum.map(session.events, fn {_t, _, d} -> d end) == [
+               "first",
+               "second"
+             ]
+
+      refute File.read!(path) =~ "\n\n"
+    end
+  end
+
+  describe "torn-tail vs flushed-corrupt distinction" do
+    import ExUnit.CaptureLog
+
+    defp session_lines(path) do
+      [header | events] = String.split(File.read!(path), "\n", trim: true)
+      {header, events}
+    end
+
+    @tag :tmp_dir
+    test "a newline-terminated but unparseable final line warns (committed corruption)",
+         %{tmp_dir: dir} do
+      path = Path.join(dir, "flushed_corrupt.cast")
+      Asciicast.write!(sample_session(3), path)
+
+      {header, [e0, e1, _e2]} = session_lines(path)
+      # Replace the final event line with garbage but keep the trailing newline:
+      # the line was fully flushed, so this is real corruption.
+      File.write!(
+        path,
+        Enum.join([header, e0, e1, "garbage-final"], "\n") <> "\n"
+      )
+
+      log =
+        capture_log(fn ->
+          session = Asciicast.read!(path)
+          assert length(session.events) == 2
+        end)
+
+      assert log =~ "malformed event line"
+    end
+
+    @tag :tmp_dir
+    test "a final line with no trailing newline recovers silently (torn mid-write)",
+         %{tmp_dir: dir} do
+      path = Path.join(dir, "torn_silent.cast")
+      Asciicast.write!(sample_session(3), path)
+
+      {header, [e0, e1, _e2]} = session_lines(path)
+
+      # Final line is a torn fragment with NO trailing newline: killed mid-write.
+      File.write!(path, Enum.join([header, e0, e1, "garbage-fragmen"], "\n"))
+
+      log =
+        capture_log(fn ->
+          session = Asciicast.read!(path)
+          assert length(session.events) == 2
+        end)
+
+      refute log =~ "malformed event line"
+    end
+  end
+
+  describe "read/1 error surfacing" do
+    @tag :tmp_dir
+    test "a structurally-invalid header surfaces distinctly from a garbage/truncated file",
+         %{tmp_dir: dir} do
+      bad_ts = Path.join(dir, "bad_ts.cast")
+
+      File.write!(
+        bad_ts,
+        ~s({"version":2,"width":80,"height":24,"timestamp":"not-a-number"}) <>
+          "\n"
+      )
+
+      # Bad timestamp shape: a distinct ArgumentError, not a masked read failure.
+      assert {:error, %ArgumentError{} = err} = Asciicast.read(bad_ts)
+      assert Exception.message(err) =~ "timestamp"
+
+      # Garbage/empty header: a JSON decode error, clearly a different failure.
+      garbage = Path.join(dir, "garbage_header.cast")
+      File.write!(garbage, "this is not json\n")
+      assert {:error, %Jason.DecodeError{}} = Asciicast.read(garbage)
+    end
+
+    test "decode/1 raises ArgumentError on a bad-timestamp header" do
+      content =
+        ~s({"version":2,"width":80,"height":24,"timestamp":[1,2,3]}) <> "\n"
+
+      assert_raise ArgumentError, ~r/timestamp/, fn ->
+        Asciicast.decode(content)
+      end
+    end
+  end
+
+  describe "single-writer contract documentation" do
+    test "append!/2 and the module document the single-writer contract" do
+      {:docs_v1, _, _, _, %{"en" => moduledoc}, _, docs} =
+        Code.fetch_docs(Asciicast)
+
+      assert moduledoc =~ "single writer"
+
+      append_doc =
+        Enum.find_value(docs, fn
+          {{:function, :append!, 2}, _, _, %{"en" => doc}, _} -> doc
+          _ -> nil
+        end)
+
+      assert append_doc =~ "Single-writer"
+    end
   end
 end

--- a/test/raxol/recording/asciicast_test.exs
+++ b/test/raxol/recording/asciicast_test.exs
@@ -154,4 +154,175 @@ defmodule Raxol.Recording.AsciicastTest do
       assert length(loaded.events) == 2
     end
   end
+
+  describe "torn-tail-tolerant reader" do
+    defp sample_session(event_count) do
+      events =
+        for i <- 0..(event_count - 1) do
+          {i * 100_000, :output, "event-#{i}\r\n"}
+        end
+
+      %Session{
+        width: 80,
+        height: 24,
+        started_at: DateTime.from_unix!(1_700_000_000),
+        title: "Torn Test",
+        events: events
+      }
+    end
+
+    @tag :tmp_dir
+    test "recovers K-1 events when the final line is truncated mid-write", %{
+      tmp_dir: dir
+    } do
+      path = Path.join(dir, "torn.cast")
+      k = 6
+      Asciicast.write!(sample_session(k), path)
+
+      # Chop the file at a byte offset that lands inside the final event line.
+      content = File.read!(path)
+      lines = String.split(content, "\n", trim: true)
+      assert length(lines) == k + 1
+
+      # Keep everything up to and including the newline after the second-to-last
+      # event, then add a partial fragment of the final event line (no newline).
+      last_line = List.last(lines)
+      keep = Enum.slice(lines, 0..(k - 1)) |> Enum.join("\n")
+      fragment = String.slice(last_line, 0, div(String.length(last_line), 2))
+      File.write!(path, keep <> "\n" <> fragment)
+
+      session = Asciicast.read!(path)
+      assert length(session.events) == k - 1
+
+      texts = Enum.map(session.events, fn {_t, _type, data} -> data end)
+      assert texts == for(i <- 0..(k - 2), do: "event-#{i}\r\n")
+    end
+
+    @tag :tmp_dir
+    test "recovers all K events when truncation leaves the last line intact", %{
+      tmp_dir: dir
+    } do
+      path = Path.join(dir, "intact.cast")
+      k = 4
+      Asciicast.write!(sample_session(k), path)
+
+      # Drop only the trailing newline; every event line is complete.
+      content = File.read!(path)
+      File.write!(path, String.trim_trailing(content, "\n"))
+
+      session = Asciicast.read!(path)
+      assert length(session.events) == k
+    end
+
+    @tag :tmp_dir
+    test "returns so-far events on an interior malformed line without raising",
+         %{tmp_dir: dir} do
+      path = Path.join(dir, "interior.cast")
+      Asciicast.write!(sample_session(4), path)
+
+      [header | events] = String.split(File.read!(path), "\n", trim: true)
+      [e0, _bad, e2, e3] = events
+
+      corrupted =
+        Enum.join([header, e0, "not json at all", e2, e3], "\n") <> "\n"
+
+      File.write!(path, corrupted)
+
+      session = Asciicast.read!(path)
+      # Stops at the malformed line -> only the first event survives.
+      assert length(session.events) == 1
+      assert [{_, :output, "event-0\r\n"}] = session.events
+    end
+
+    @tag :tmp_dir
+    test "read/1 returns {:error, _} on an empty/garbage file instead of raising",
+         %{tmp_dir: dir} do
+      path = Path.join(dir, "empty.cast")
+      File.write!(path, "")
+      assert {:error, _} = Asciicast.read(path)
+
+      garbage = Path.join(dir, "garbage.cast")
+      File.write!(garbage, "this is not json\n")
+      assert {:error, _} = Asciicast.read(garbage)
+    end
+  end
+
+  describe "append!/2" do
+    @tag :tmp_dir
+    test "appends events without rewriting the header; reads back in order", %{
+      tmp_dir: dir
+    } do
+      path = Path.join(dir, "append.cast")
+
+      initial = %Session{
+        width: 80,
+        height: 24,
+        started_at: DateTime.from_unix!(1_700_000_000),
+        title: "Append Test",
+        events: [
+          {0, :output, "first"},
+          {1_000_000, :output, "second"}
+        ]
+      }
+
+      Asciicast.write!(initial, path)
+
+      # Reopen and append two more events (relative timestamps preserved).
+      Asciicast.append!(
+        [{2_000_000, :output, "third"}, {3_500_000, :output, "fourth"}],
+        path
+      )
+
+      # Exactly one header line survives.
+      lines = File.read!(path) |> String.split("\n", trim: true)
+      header = Jason.decode!(hd(lines))
+      assert header["version"] == 2
+      assert header["title"] == "Append Test"
+      assert Enum.count(lines, &String.contains?(&1, "\"version\"")) == 1
+
+      session = Asciicast.read!(path)
+      texts = Enum.map(session.events, fn {_t, _type, data} -> data end)
+      assert texts == ["first", "second", "third", "fourth"]
+
+      times = Enum.map(session.events, fn {t, _, _} -> t end)
+      assert times == [0, 1_000_000, 2_000_000, 3_500_000]
+    end
+
+    @tag :tmp_dir
+    test "accepts a Session and appends its events", %{tmp_dir: dir} do
+      path = Path.join(dir, "append_session.cast")
+
+      Asciicast.write!(
+        %Session{
+          width: 80,
+          height: 24,
+          started_at: DateTime.from_unix!(1_700_000_000),
+          events: [{0, :output, "a"}]
+        },
+        path
+      )
+
+      more = %Session{
+        width: 80,
+        height: 24,
+        started_at: DateTime.from_unix!(1_700_000_000),
+        events: [{500_000, :output, "b"}]
+      }
+
+      Asciicast.append!(more, path)
+
+      session = Asciicast.read!(path)
+      assert Enum.map(session.events, fn {_t, _, d} -> d end) == ["a", "b"]
+    end
+
+    @tag :tmp_dir
+    test "raises when appending to a file with no valid header", %{tmp_dir: dir} do
+      path = Path.join(dir, "noheader.cast")
+      File.write!(path, "garbage\n")
+
+      assert_raise ArgumentError, fn ->
+        Asciicast.append!([{0, :output, "x"}], path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Hardens the existing asciinema v2 recorder (`lib/raxol/recording/asciicast.ex`) so a truncated `.cast` file reads back cleanly, and adds an append mode.

- **Torn-tail-tolerant reader** (`decode/1`): a truncated/invalid final event line (writer killed mid-write) is dropped and every complete event before it is recovered. An interior malformed line stops the decode and returns the events collected so far with a logged warning, instead of raising. `read/1` rescues header/read failures into `{:error, _}` so an empty or garbage file never crashes the caller.
- **Append mode** (`append!/2`): reopens an existing `.cast`, validates its v2 header, and writes new event lines to the end **without duplicating or rewriting the header**. Relative timestamps are preserved verbatim; a defensive trailing newline prevents fusing an appended line onto a header-only or newline-less file. Accepts a `Session` or a list of event tuples.

## Why

The recorder was a buffered writer with no torn-tail-tolerant reader: a `.cast` whose final event line was written partially (process killed mid-write) could not be read back — the strict `Jason.decode!` path raised. This is a standalone robustness leaf fix to the existing recorder. It is **not** the harness journal (separate unit) and does not touch the v2 format.

## Acceptance

New tests in `test/raxol/recording/asciicast_test.exs` (all green, 14 passed):

- Write K events, truncate mid-final-line → reader returns K-1 complete events, no crash.
- Truncate leaving the last line intact (only trailing newline dropped) → all K events recovered.
- Interior malformed line → returns events collected so far, no raise.
- Empty / garbage file → `read/1` returns `{:error, _}`.
- Append mode: write, reopen in append, add events, read back → exactly one header + all events in order (timestamps preserved).
- Append accepts a `Session`; appending to a header-less file raises.
- Pre-existing valid-cast round-trip still passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7