### PR TITLE
feat(harness): U2a — journal core (framed JSONL, torn-tail recovery)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/journal.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal.ex
@@ -1,0 +1,72 @@
+defmodule Raxol.Agent.Journal do
+  @moduledoc """
+  Behaviour for a session's durable append-only journal — the source of truth
+  for the durable tier of harness events (harness-spec-backend §4).
+
+  A journal is an ordered, append-only log of events. Each appended event is
+  assigned a monotonic `offset` (= the event's id) and framed as one complete,
+  self-delimited JSON object per line. Replaying a journal yields the events
+  back in offset order.
+
+  The behaviour exists so alternate storage backends (S3, a database, ...) can
+  slot in later behind the same contract. The concrete file-backed
+  implementation is `Raxol.Agent.Journal.FileStore` — one directory per session,
+  size-capped JSONL segments, torn-tail recovery on replay.
+
+  ## Callbacks
+
+    * `open/2`    — open (creating if needed) the journal for a session, returning an opaque handle.
+    * `append/2`  — append one event, returning `{:ok, offset}`.
+    * `read/2`    — replay durable events in offset order.
+    * `close/2`   — release the handle (flush + stop the writer).
+    * `status/1`  — `:ok` for a healthy journal, `:damaged` if interior corruption was detected.
+
+  ## Durability & recovery
+
+  Only *complete* records are ever returned. On replay a parse failure on the
+  final line of the last segment is treated as a torn tail (a crash mid-write)
+  and truncated away — everything before it is recovered and `status/1` stays
+  `:ok`. A parse failure anywhere interior marks the session `:damaged`, raises a
+  hard alarm, deletes nothing, and never returns the damaged content downstream.
+  """
+
+  @typedoc "Stable identifier for a session (also the on-disk directory name)."
+  @type session_id :: String.t()
+
+  @typedoc "Opaque, backend-specific handle returned by `open/2`."
+  @type handle :: term()
+
+  @typedoc "An event to append — any JSON-encodable map."
+  @type event :: map()
+
+  @typedoc "A durable record read back from the journal (a decoded map with an `\"id\"`)."
+  @type journal_record :: map()
+
+  @typedoc "Monotonic offset assigned to an appended event (= its id)."
+  @type offset :: non_neg_integer()
+
+  @doc "Open (creating if needed) the journal for `session_id`. Returns an opaque handle."
+  @callback open(session_id, opts :: keyword()) :: {:ok, handle} | {:error, term()}
+
+  @doc "Append one event. Returns the assigned monotonic offset."
+  @callback append(handle, event) :: {:ok, offset} | {:error, term()}
+
+  @doc """
+  Replay durable events in offset order.
+
+  Returns `{:ok, records}` for a healthy (or torn-tail-recovered) journal, or
+  `{:error, :damaged}` when interior corruption was detected — in which case the
+  damaged content is never returned.
+
+  Options:
+
+    * `:from_offset` — only return records whose id is `>=` this value.
+  """
+  @callback read(handle, opts :: keyword()) :: {:ok, [journal_record]} | {:error, term()}
+
+  @doc "Release the handle (flush pending writes and stop the writer)."
+  @callback close(handle) :: :ok
+
+  @doc "`:ok` for a healthy journal, `:damaged` if interior corruption was detected."
+  @callback status(handle) :: :ok | :damaged
+end

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store.ex
@@ -32,6 +32,11 @@ defmodule Raxol.Agent.Journal.FileStore do
   @env_base "RAXOL_SESSIONS_DIR"
   @default_base "~/.raxol/sessions"
 
+  # A session_id is also the on-disk directory name, so it must not be able to
+  # escape the base dir. Allow only a conservative filename charset (no `/`, no
+  # NUL, no empty string) and reject the `.`/`..` traversal names explicitly.
+  @session_id_re ~r/\A[A-Za-z0-9._-]+\z/
+
   @doc """
   Open (creating if needed) the journal for `session_id`.
 
@@ -46,12 +51,22 @@ defmodule Raxol.Agent.Journal.FileStore do
   """
   @impl Raxol.Agent.Journal
   def open(session_id, opts \\ []) when is_binary(session_id) do
-    dir = Path.join(base_dir(opts), session_id)
-    writer_opts = Keyword.merge(opts, dir: dir, session_id: session_id)
+    with :ok <- validate_session_id(session_id) do
+      dir = Path.join(base_dir(opts), session_id)
+      writer_opts = Keyword.merge(opts, dir: dir, session_id: session_id)
 
-    case Writer.start_link(writer_opts) do
-      {:ok, pid} -> {:ok, %__MODULE__{session_id: session_id, dir: dir, writer: pid}}
-      {:error, _} = err -> err
+      case Writer.start_link(writer_opts) do
+        {:ok, pid} ->
+          {:ok, %__MODULE__{session_id: session_id, dir: dir, writer: pid}}
+
+        # Single-writer invariant: a Writer already owns this session's journal.
+        # Reuse the live one rather than spawning a second writer on the segment.
+        {:error, {:already_started, pid}} ->
+          {:ok, %__MODULE__{session_id: session_id, dir: dir, writer: pid}}
+
+        {:error, _} = err ->
+          err
+      end
     end
   end
 
@@ -87,6 +102,16 @@ defmodule Raxol.Agent.Journal.FileStore do
   end
 
   # --- helpers ---------------------------------------------------------------
+
+  defp validate_session_id(id) when id in [".", ".."], do: {:error, :invalid_session_id}
+
+  defp validate_session_id(id) do
+    if Regex.match?(@session_id_re, id) do
+      :ok
+    else
+      {:error, :invalid_session_id}
+    end
+  end
 
   defp flush(pid) do
     if Process.alive?(pid), do: Writer.flush(pid)

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store.ex
@@ -1,0 +1,107 @@
+defmodule Raxol.Agent.Journal.FileStore do
+  @moduledoc """
+  File-backed `Raxol.Agent.Journal` — one directory per session, the directory
+  *is* the session (portable, tar-able, rsync-able, grep-able).
+
+      <base>/<session_id>/
+      ├── meta.json          # created_at, cwd, git branch, title, schema_version
+      ├── HEAD               # sidecar: current durable offset + config
+      ├── journal/
+      │   ├── 000001.jsonl   # framed JSONL, size-capped ascending segments
+      │   └── 000002.jsonl
+      └── snapshots/         # checkpoint payloads (populated by a later unit)
+
+  The base directory defaults to `~/.raxol/sessions/`, overridable via the
+  `:base_dir` option or the `RAXOL_SESSIONS_DIR` env var.
+
+  Storage splits into a single-writer GenServer
+  (`Raxol.Agent.Journal.FileStore.Writer`) and a tolerant replay reader
+  (`Raxol.Agent.Journal.FileStore.Reader`). See those modules and
+  `Raxol.Agent.Journal` for the durability and torn-tail-recovery contract.
+  """
+
+  @behaviour Raxol.Agent.Journal
+
+  alias Raxol.Agent.Journal.FileStore.{Reader, Writer}
+
+  @enforce_keys [:session_id, :dir, :writer]
+  defstruct [:session_id, :dir, :writer]
+
+  @type t :: %__MODULE__{session_id: String.t(), dir: Path.t(), writer: pid()}
+
+  @env_base "RAXOL_SESSIONS_DIR"
+  @default_base "~/.raxol/sessions"
+
+  @doc """
+  Open (creating if needed) the journal for `session_id`.
+
+  Options:
+
+    * `:base_dir` — base directory (defaults to `$RAXOL_SESSIONS_DIR` or `~/.raxol/sessions`).
+    * `:segment_cap` — segment size cap in bytes before rotation (default 8 MiB).
+    * `:immediate_sync_types` — event `type`s that force an immediate datasync
+      (default `["tool_result", "approval"]`).
+    * `:sync_ceiling_ms` — batched-sync ceiling in ms (default 200).
+    * `:schema_version`, `:cwd`, `:git_branch`, `:title` — recorded in `meta.json` on first open.
+  """
+  @impl Raxol.Agent.Journal
+  def open(session_id, opts \\ []) when is_binary(session_id) do
+    dir = Path.join(base_dir(opts), session_id)
+    writer_opts = Keyword.merge(opts, dir: dir, session_id: session_id)
+
+    case Writer.start_link(writer_opts) do
+      {:ok, pid} -> {:ok, %__MODULE__{session_id: session_id, dir: dir, writer: pid}}
+      {:error, _} = err -> err
+    end
+  end
+
+  @impl Raxol.Agent.Journal
+  def append(%__MODULE__{writer: pid}, event) when is_map(event) do
+    Writer.append(pid, event)
+  end
+
+  @impl Raxol.Agent.Journal
+  def read(%__MODULE__{dir: dir, writer: pid}, opts \\ []) do
+    flush(pid)
+
+    case Reader.scan(dir) do
+      {:ok, records} -> {:ok, filter(records, opts)}
+      {:damaged, _partial} -> {:error, :damaged}
+    end
+  end
+
+  @impl Raxol.Agent.Journal
+  def close(%__MODULE__{writer: pid}) do
+    if Process.alive?(pid), do: GenServer.stop(pid)
+    :ok
+  end
+
+  @impl Raxol.Agent.Journal
+  def status(%__MODULE__{dir: dir, writer: pid}) do
+    flush(pid)
+
+    case Reader.scan(dir) do
+      {:ok, _} -> :ok
+      {:damaged, _} -> :damaged
+    end
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  defp flush(pid) do
+    if Process.alive?(pid), do: Writer.flush(pid)
+    :ok
+  end
+
+  defp filter(records, opts) do
+    case Keyword.get(opts, :from_offset) do
+      nil -> records
+      from -> Enum.filter(records, fn %{"id" => id} -> id >= from end)
+    end
+  end
+
+  defp base_dir(opts) do
+    (Keyword.get(opts, :base_dir) || System.get_env(@env_base) || @default_base)
+    |> Path.expand()
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store/reader.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store/reader.ex
@@ -97,6 +97,10 @@ defmodule Raxol.Agent.Journal.FileStore.Reader do
           |> Enum.map(fn {line, i} ->
             %{path: path, raw: line, terminated: i < n - 1 or terminated_file?}
           end)
+          # A stray blank line is not a record and not corruption — drop it, as
+          # the moduledoc promises. (`terminated` on the survivors is unaffected:
+          # only the file's true last line can ever be unterminated.)
+          |> Enum.reject(&(&1.raw == ""))
       end
     end)
   end
@@ -108,17 +112,26 @@ defmodule Raxol.Agent.Journal.FileStore.Reader do
       {:ok, record} ->
         replay(rest, [record | acc], dir)
 
-      {:error, _} when rest == [] ->
-        # Final line of the last segment failed to parse: torn tail. Truncate
-        # the incomplete bytes and recover everything before.
-        truncate_torn(entry)
-        {:ok, Enum.reverse(acc)}
-
       {:error, _} ->
-        # Interior corruption: alarm, mark damaged, delete nothing, leak nothing.
-        alarm(dir, entry)
-        {:damaged, Enum.reverse(acc)}
+        handle_bad_line(entry, rest, acc, dir)
     end
+  end
+
+  # Torn tail (Ra policy): the *final* line of the *last* segment has NO trailing
+  # newline — a crash mid-`:file.write`. Truncate the incomplete bytes, recover
+  # everything before, session stays healthy.
+  defp handle_bad_line(%{terminated: false} = entry, [], acc, _dir) do
+    truncate_torn(entry)
+    {:ok, Enum.reverse(acc)}
+  end
+
+  # Everything else is real data loss, not a torn write: an interior bad line, OR
+  # a fully-flushed newline-terminated but corrupt final record. Mark damaged —
+  # alarm, delete nothing, leak nothing. Silently truncating a terminated record
+  # would mask genuine corruption behind a healthy `:ok`.
+  defp handle_bad_line(entry, _rest, acc, dir) do
+    alarm(dir, entry)
+    {:damaged, Enum.reverse(acc)}
   end
 
   defp truncate_torn(%{path: path, raw: raw, terminated: terminated}) do

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store/reader.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store/reader.ex
@@ -1,0 +1,151 @@
+defmodule Raxol.Agent.Journal.FileStore.Reader do
+  @moduledoc """
+  Tolerant replay of a session's JSONL journal segments (harness-spec-backend
+  §4, component 2 — the Reader).
+
+  Segments are replayed in ascending order into an ordered record stream. Two
+  failure policies, per the spec:
+
+    * **Torn tail (Ra policy).** A parse failure on the *final* line of the *last*
+      segment is a crash mid-write. The torn bytes are truncated away, everything
+      before is recovered, and the session stays healthy (`{:ok, records}`).
+
+    * **Interior corruption.** A parse failure anywhere else marks the session
+      damaged. A hard alarm fires (`Logger.error` + a telemetry event), **nothing
+      is deleted**, and the damaged content is **never** returned — `scan/2`
+      returns `{:damaged, records_before}` and callers must not surface it.
+  """
+
+  require Logger
+
+  @telemetry_damaged [:raxol, :agent, :journal, :damaged]
+
+  @typedoc "Result of a replay scan."
+  @type result :: {:ok, [map()]} | {:damaged, [map()]}
+
+  @doc """
+  Replay all journal segments under `dir` in ascending order.
+
+  Returns `{:ok, records}` for a healthy or torn-tail-recovered journal (the
+  torn tail is physically truncated as a side effect), or `{:damaged, records}`
+  when interior corruption was detected. In the damaged case `records` are only
+  the complete records preceding the corruption and MUST NOT be surfaced
+  downstream — callers map this to an error.
+  """
+  @spec scan(Path.t(), keyword()) :: result
+  def scan(dir, _opts \\ []) do
+    dir
+    |> Path.join("journal")
+    |> list_segments()
+    |> build_entries()
+    |> replay([], dir)
+  end
+
+  @doc "Highest offset (id) present in a healthy replay, or 0 if empty/damaged."
+  @spec last_offset(Path.t()) :: non_neg_integer()
+  def last_offset(dir) do
+    case scan(dir) do
+      {:ok, records} -> records |> List.last() |> record_id()
+      {:damaged, _} -> 0
+    end
+  end
+
+  defp record_id(nil), do: 0
+  defp record_id(%{"id" => id}) when is_integer(id), do: id
+  defp record_id(_), do: 0
+
+  # --- segment discovery -----------------------------------------------------
+
+  @segment_re ~r/^\d{6}\.jsonl$/
+
+  @doc false
+  @spec list_segments(Path.t()) :: [Path.t()]
+  def list_segments(journal_dir) do
+    case File.ls(journal_dir) do
+      {:ok, names} ->
+        names
+        |> Enum.filter(&Regex.match?(@segment_re, &1))
+        |> Enum.sort()
+        |> Enum.map(&Path.join(journal_dir, &1))
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  # --- replay ----------------------------------------------------------------
+
+  # Flatten every segment into an ordered list of line entries, dropping empty
+  # segments/lines. Each entry records whether its line was newline-terminated,
+  # which is needed to compute the truncation offset for a torn tail.
+  defp build_entries(segments) do
+    Enum.flat_map(segments, fn path ->
+      raw = File.read!(path)
+
+      case raw do
+        "" ->
+          []
+
+        _ ->
+          terminated_file? = String.ends_with?(raw, "\n")
+          parts = String.split(raw, "\n")
+          lines = if terminated_file?, do: Enum.drop(parts, -1), else: parts
+          n = length(lines)
+
+          lines
+          |> Enum.with_index()
+          |> Enum.map(fn {line, i} ->
+            %{path: path, raw: line, terminated: i < n - 1 or terminated_file?}
+          end)
+      end
+    end)
+  end
+
+  defp replay([], acc, _dir), do: {:ok, Enum.reverse(acc)}
+
+  defp replay([entry | rest], acc, dir) do
+    case Jason.decode(entry.raw) do
+      {:ok, record} ->
+        replay(rest, [record | acc], dir)
+
+      {:error, _} when rest == [] ->
+        # Final line of the last segment failed to parse: torn tail. Truncate
+        # the incomplete bytes and recover everything before.
+        truncate_torn(entry)
+        {:ok, Enum.reverse(acc)}
+
+      {:error, _} ->
+        # Interior corruption: alarm, mark damaged, delete nothing, leak nothing.
+        alarm(dir, entry)
+        {:damaged, Enum.reverse(acc)}
+    end
+  end
+
+  defp truncate_torn(%{path: path, raw: raw, terminated: terminated}) do
+    size = File.stat!(path).size
+    newline = if terminated, do: 1, else: 0
+    keep = max(size - byte_size(raw) - newline, 0)
+
+    {:ok, io} = :file.open(path, [:read, :write, :binary])
+
+    try do
+      {:ok, _} = :file.position(io, keep)
+      :ok = :file.truncate(io)
+      :ok = :file.datasync(io)
+    after
+      :file.close(io)
+    end
+
+    :ok
+  end
+
+  defp alarm(dir, %{path: path}) do
+    Logger.error(
+      "[Journal] interior corruption detected in #{path}; session marked :damaged. " <>
+        "Nothing deleted, damaged content withheld from replay."
+    )
+
+    :telemetry.execute(@telemetry_damaged, %{count: 1}, %{dir: dir, segment: path})
+    :ok
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
@@ -45,8 +45,16 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
   # --- API -------------------------------------------------------------------
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
+    dir = Keyword.fetch!(opts, :dir)
+    # Single-writer invariant: at most one Writer per physical journal dir,
+    # globally (survives across processes and — on shared storage — nodes).
+    # A second `start_link` for the same dir returns `{:error, {:already_started, pid}}`
+    # so the opener can reuse the live Writer instead of racing a second one.
+    GenServer.start_link(__MODULE__, opts, name: global_name(dir))
   end
+
+  @doc false
+  def global_name(dir), do: {:global, {__MODULE__, dir}}
 
   @spec append(pid(), map()) :: {:ok, non_neg_integer()} | {:error, term()}
   def append(pid, event), do: GenServer.call(pid, {:append, event})
@@ -66,6 +74,7 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
 
     File.mkdir_p!(journal_dir)
     File.mkdir_p!(Path.join(dir, "snapshots"))
+    sweep_tmp_files(dir)
 
     schema_version = Keyword.get(opts, :schema_version, @default_schema_version)
     seg_cap = Keyword.get(opts, :segment_cap, @default_segment_cap)
@@ -104,14 +113,22 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
     offset = state.offset + 1
     record = stamp(event, offset, state.schema_version)
     line = [Jason.encode_to_iodata!(record), ?\n]
-    :ok = :file.write(state.io, line)
 
-    state =
-      %{state | offset: offset, seg_size: state.seg_size + IO.iodata_length(line)}
-      |> maybe_rotate()
-      |> sync_after_append(immediate?(record, state))
+    # A write can fail (e.g. `:enospc` on a full disk). Surface it as an error
+    # instead of MatchError-crashing the Writer: the offset is NOT advanced, the
+    # fd/state stay intact, and the caller can retry once space frees up.
+    case :file.write(state.io, line) do
+      :ok ->
+        state =
+          %{state | offset: offset, seg_size: state.seg_size + IO.iodata_length(line)}
+          |> maybe_rotate()
+          |> sync_after_append(immediate?(record, state))
 
-    {:reply, {:ok, offset}, state}
+        {:reply, {:ok, offset}, state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
   end
 
   @impl GenServer
@@ -130,6 +147,10 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
   def terminate(_reason, state) do
     state = flush_now(state)
     if state.io, do: :file.close(state.io)
+    # Free the global name synchronously (before the process exits) so a
+    # close-then-reopen on the same dir never races the async :global cleanup
+    # and gets handed the corpse of the writer we just stopped.
+    if state.dir, do: :global.unregister_name({__MODULE__, state.dir})
     :ok
   end
 
@@ -214,10 +235,19 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
 
   # --- meta.json / HEAD (atomic writes only) ---------------------------------
 
+  # HEAD is only rewritten on flush (≤200ms / datasync), but `:file.write`
+  # already reached the OS ahead of it — so after a crash HEAD can lag the real
+  # journal. Trusting HEAD alone would reuse an already-written offset (duplicate
+  # id, non-monotonic, id ≠ offset). Resume from the max of HEAD and the reader's
+  # torn-tail-recovered real last offset, so id stays monotonic and == offset.
   defp resume_offset(dir) do
+    max(head_offset(dir), Reader.last_offset(dir))
+  end
+
+  defp head_offset(dir) do
     case read_head(dir) do
       {:ok, %{"offset" => offset}} when is_integer(offset) -> offset
-      _ -> Reader.last_offset(dir)
+      _ -> 0
     end
   end
 
@@ -275,6 +305,36 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
     end)
 
     File.rename!(tmp, path)
+    # Durability of the rename itself needs the *directory* entry flushed, else
+    # a power loss can lose the newly-renamed name. Best-effort (some platforms
+    # reject datasync on a dir fd — that's fine, the rename still stands).
+    sync_dir(Path.dirname(path))
     :ok
+  end
+
+  defp sync_dir(dir) do
+    case :file.open(dir, [:read, :raw]) do
+      {:ok, io} ->
+        _ = :file.datasync(io)
+        :file.close(io)
+
+      _ ->
+        :ok
+    end
+
+    :ok
+  end
+
+  # Remove stray `*.tmp.*` files left by a crash mid-atomic-write on a prior run.
+  defp sweep_tmp_files(dir) do
+    case File.ls(dir) do
+      {:ok, names} ->
+        Enum.each(names, fn name ->
+          if String.contains?(name, ".tmp."), do: File.rm(Path.join(dir, name))
+        end)
+
+      _ ->
+        :ok
+    end
   end
 end

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
@@ -1,0 +1,280 @@
+defmodule Raxol.Agent.Journal.FileStore.Writer do
+  @moduledoc """
+  The single-writer GenServer for one session's journal (harness-spec-backend
+  §4, component 1 — the Writer).
+
+  Exactly one Writer per session enforces the single-writer invariant. It:
+
+    * appends framed JSONL (one complete self-delimited JSON object per line),
+      assigning each event a monotonic `offset` = the event's id;
+    * batches `:file.datasync` on mailbox drain with a `≤200ms` ceiling, but syncs
+      **immediately** for side-effect events (`tool_result`, `approval`, ...);
+    * never uses `delayed_write`;
+    * rotates to the next `NNNNNN.jsonl` segment when one passes the size cap;
+    * writes `meta.json` and `HEAD` **atomically only** (temp + fsync + rename).
+
+  `HEAD` records the last *durable* offset (+ config) and is persisted together
+  with each datasync, never in place.
+  """
+
+  use GenServer
+
+  alias Raxol.Agent.Journal.FileStore.Reader
+
+  @default_segment_cap 8 * 1024 * 1024
+  @default_sync_ceiling_ms 200
+  @default_immediate_types ["tool_result", "approval"]
+  @default_schema_version "1.0.0"
+
+  defstruct [
+    :session_id,
+    :dir,
+    :journal_dir,
+    :io,
+    :seg_num,
+    :seg_size,
+    :seg_cap,
+    :offset,
+    :schema_version,
+    :immediate_types,
+    :sync_ceiling_ms,
+    :sync_timer,
+    dirty: false
+  ]
+
+  # --- API -------------------------------------------------------------------
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @spec append(pid(), map()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def append(pid, event), do: GenServer.call(pid, {:append, event})
+
+  @spec flush(pid()) :: :ok
+  def flush(pid), do: GenServer.call(pid, :flush)
+
+  # --- lifecycle -------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    dir = Keyword.fetch!(opts, :dir)
+    session_id = Keyword.fetch!(opts, :session_id)
+    journal_dir = Path.join(dir, "journal")
+
+    File.mkdir_p!(journal_dir)
+    File.mkdir_p!(Path.join(dir, "snapshots"))
+
+    schema_version = Keyword.get(opts, :schema_version, @default_schema_version)
+    seg_cap = Keyword.get(opts, :segment_cap, @default_segment_cap)
+
+    immediate_types =
+      opts
+      |> Keyword.get(:immediate_sync_types, @default_immediate_types)
+      |> MapSet.new(&to_string/1)
+
+    write_meta(dir, opts, schema_version)
+
+    offset = resume_offset(dir)
+    {seg_num, seg_size} = current_segment(journal_dir, seg_cap)
+    io = open_segment(journal_dir, seg_num)
+
+    state = %__MODULE__{
+      session_id: session_id,
+      dir: dir,
+      journal_dir: journal_dir,
+      io: io,
+      seg_num: seg_num,
+      seg_size: seg_size,
+      seg_cap: seg_cap,
+      offset: offset,
+      schema_version: schema_version,
+      immediate_types: immediate_types,
+      sync_ceiling_ms: Keyword.get(opts, :sync_ceiling_ms, @default_sync_ceiling_ms)
+    }
+
+    write_head(state)
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:append, event}, _from, state) do
+    offset = state.offset + 1
+    record = stamp(event, offset, state.schema_version)
+    line = [Jason.encode_to_iodata!(record), ?\n]
+    :ok = :file.write(state.io, line)
+
+    state =
+      %{state | offset: offset, seg_size: state.seg_size + IO.iodata_length(line)}
+      |> maybe_rotate()
+      |> sync_after_append(immediate?(record, state))
+
+    {:reply, {:ok, offset}, state}
+  end
+
+  @impl GenServer
+  def handle_call(:flush, _from, state) do
+    {:reply, :ok, flush_now(state)}
+  end
+
+  @impl GenServer
+  def handle_info(:flush_sync, state) do
+    {:noreply, flush_now(%{state | sync_timer: nil})}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    state = flush_now(state)
+    if state.io, do: :file.close(state.io)
+    :ok
+  end
+
+  # --- append helpers --------------------------------------------------------
+
+  defp stamp(event, offset, default_schema) when is_map(event) do
+    event
+    |> Map.new(fn {k, v} -> {to_string(k), v} end)
+    |> Map.put("id", offset)
+    |> Map.put_new("schema_version", default_schema)
+  end
+
+  defp immediate?(record, state) do
+    type = Map.get(record, "type")
+    is_binary(type) and MapSet.member?(state.immediate_types, type)
+  end
+
+  # Batched datasync: side-effect events sync immediately; otherwise flush as
+  # soon as the mailbox is drained, bounded by the ≤200ms ceiling timer.
+  defp sync_after_append(state, true), do: flush_now(state)
+
+  defp sync_after_append(state, false) do
+    state = %{state | dirty: true}
+
+    case Process.info(self(), :message_queue_len) do
+      {:message_queue_len, 0} -> flush_now(state)
+      _ -> ensure_timer(state)
+    end
+  end
+
+  defp ensure_timer(%{sync_timer: nil} = state) do
+    ref = Process.send_after(self(), :flush_sync, state.sync_ceiling_ms)
+    %{state | sync_timer: ref}
+  end
+
+  defp ensure_timer(state), do: state
+
+  defp flush_now(%{dirty: false, sync_timer: nil} = state), do: state
+
+  defp flush_now(state) do
+    if state.io, do: :ok = :file.datasync(state.io)
+    if state.sync_timer, do: Process.cancel_timer(state.sync_timer)
+    state = %{state | dirty: false, sync_timer: nil}
+    write_head(state)
+    state
+  end
+
+  # --- segment rotation ------------------------------------------------------
+
+  defp maybe_rotate(%{seg_size: size, seg_cap: cap} = state) when size >= cap do
+    :ok = :file.datasync(state.io)
+    :ok = :file.close(state.io)
+    seg_num = state.seg_num + 1
+    %{state | io: open_segment(state.journal_dir, seg_num), seg_num: seg_num, seg_size: 0}
+  end
+
+  defp maybe_rotate(state), do: state
+
+  defp open_segment(journal_dir, seg_num) do
+    path = Path.join(journal_dir, segment_name(seg_num))
+    # :raw + :append, never :delayed_write (durability guarantees depend on it).
+    {:ok, io} = :file.open(path, [:append, :raw, :binary])
+    io
+  end
+
+  defp current_segment(journal_dir, seg_cap) do
+    case Reader.list_segments(journal_dir) do
+      [] ->
+        {1, 0}
+
+      segments ->
+        path = List.last(segments)
+        num = path |> Path.basename() |> String.slice(0, 6) |> String.to_integer()
+        size = File.stat!(path).size
+        if size >= seg_cap, do: {num + 1, 0}, else: {num, size}
+    end
+  end
+
+  defp segment_name(seg_num) do
+    :io_lib.format(~c"~6..0B.jsonl", [seg_num]) |> List.to_string()
+  end
+
+  # --- meta.json / HEAD (atomic writes only) ---------------------------------
+
+  defp resume_offset(dir) do
+    case read_head(dir) do
+      {:ok, %{"offset" => offset}} when is_integer(offset) -> offset
+      _ -> Reader.last_offset(dir)
+    end
+  end
+
+  defp read_head(dir) do
+    with {:ok, body} <- File.read(Path.join(dir, "HEAD")) do
+      Jason.decode(body)
+    end
+  end
+
+  defp write_head(state) do
+    head = %{
+      "offset" => state.offset,
+      "segment" => state.seg_num,
+      "segment_cap" => state.seg_cap,
+      "schema_version" => state.schema_version
+    }
+
+    atomic_write!(Path.join(state.dir, "HEAD"), Jason.encode_to_iodata!(head))
+  end
+
+  defp write_meta(dir, opts, schema_version) do
+    path = Path.join(dir, "meta.json")
+
+    unless File.exists?(path) do
+      cwd = Keyword.get(opts, :cwd) || File.cwd!()
+
+      meta = %{
+        "created_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+        "cwd" => cwd,
+        "git_branch" => Keyword.get(opts, :git_branch) || git_branch(cwd),
+        "title" => Keyword.get(opts, :title),
+        "schema_version" => schema_version
+      }
+
+      atomic_write!(path, Jason.encode_to_iodata!(meta))
+    end
+  end
+
+  # Best-effort current branch from <cwd>/.git/HEAD; nil if not a git repo.
+  defp git_branch(cwd) do
+    with {:ok, body} <- File.read(Path.join([cwd, ".git", "HEAD"])),
+         "ref: refs/heads/" <> branch <- String.trim(body) do
+      branch
+    else
+      _ -> nil
+    end
+  end
+
+  defp atomic_write!(path, data) do
+    tmp = path <> ".tmp." <> Integer.to_string(System.unique_integer([:positive]))
+
+    File.open!(tmp, [:write, :raw, :binary], fn io ->
+      :ok = :file.write(io, data)
+      :ok = :file.datasync(io)
+    end)
+
+    File.rename!(tmp, path)
+    :ok
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/journal_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/journal_test.exs
@@ -251,6 +251,155 @@ defmodule Raxol.Agent.JournalTest do
     end
   end
 
+  describe "single-writer invariant" do
+    test "a second open on the same session reuses the one writer, offsets never collide",
+         %{base: base, session: session} do
+      {:ok, j1} = FileStore.open(session, base_dir: base)
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+
+      # Same session dir -> the exact same Writer process, not a second one.
+      assert j1.writer == j2.writer
+
+      # Interleave appends through both handles: the single writer serializes
+      # them, so ids are unique, ascending, and never collide.
+      offsets =
+        Enum.map([j1, j2, j1, j2, j1], fn h ->
+          {:ok, off} = FileStore.append(h, %{"type" => "chunk"})
+          off
+        end)
+
+      assert offsets == [1, 2, 3, 4, 5]
+      assert offsets == Enum.uniq(offsets)
+
+      {:ok, records} = FileStore.read(j1)
+      assert Enum.map(records, & &1["id"]) == [1, 2, 3, 4, 5]
+
+      # Closing either handle stops the shared writer once.
+      FileStore.close(j1)
+      refute Process.alive?(j2.writer)
+    end
+  end
+
+  describe "stale-HEAD offset resume (crash before HEAD flush)" do
+    test "resume ignores a stale HEAD and continues from the real last record",
+         %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      {:ok, 1} = FileStore.append(j, %{"type" => "a"})
+      FileStore.close(j)
+
+      # HEAD now records offset 1. Simulate `:file.write` having reached the OS
+      # for records 2 and 3 while the crash beat the next HEAD flush -- so the
+      # journal on disk is ahead of a stale HEAD.
+      [seg] = segments(base, session)
+      File.write!(seg, ~s({"id":2,"type":"b"}\n{"id":3,"type":"c"}\n), [:append])
+
+      {:ok, head} = Path.join([base, session, "HEAD"]) |> File.read!() |> Jason.decode()
+      assert head["offset"] == 1, "precondition: HEAD is stale behind the journal"
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      # Next id must be 4 (not a reused 2/3): monotonic, no duplicate, id == offset.
+      assert {:ok, 4} = FileStore.append(j2, %{"type" => "d"})
+
+      {:ok, records} = FileStore.read(j2)
+      ids = Enum.map(records, & &1["id"])
+      assert ids == [1, 2, 3, 4]
+      assert ids == Enum.uniq(ids), "no duplicate ids after a stale-HEAD resume"
+      assert ids == Enum.sort(ids), "ids strictly ascending"
+      FileStore.close(j2)
+    end
+  end
+
+  describe "session_id validation (path traversal)" do
+    test "rejects ids that escape the base dir, are empty, or contain NUL",
+         %{base: base} do
+      for bad <- ["../foo", "a/b", "", "a\0b", "..", ".", "../../etc/x"] do
+        assert {:error, :invalid_session_id} = FileStore.open(bad, base_dir: base),
+               "expected #{inspect(bad)} to be rejected"
+      end
+    end
+
+    test "accepts ordinary safe ids", %{base: base} do
+      for good <- ["sess-1", "abc_DEF.123", "a-b_c", "session"] do
+        assert {:ok, j} = FileStore.open(good, base_dir: base)
+        FileStore.close(j)
+      end
+    end
+  end
+
+  describe "terminated-but-corrupt final record (not a torn tail)" do
+    test "a newline-terminated corrupt final line is :damaged, never silently truncated",
+         %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      for n <- 1..3, do: FileStore.append(j, %{"type" => "chunk", "n" => n})
+      FileStore.close(j)
+
+      [seg] = segments(base, session)
+      # Fully flushed (has a trailing newline) but corrupt final record: this is
+      # real data loss, NOT a crash mid-write, so it must NOT be truncated away.
+      File.write!(seg, ~s({corrupt but terminated}\n), [:append])
+      before = File.read!(seg)
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+
+      log =
+        capture_log(fn ->
+          assert {:error, :damaged} = FileStore.read(j2)
+          assert FileStore.status(j2) == :damaged
+        end)
+
+      assert log =~ "interior corruption"
+      # Nothing deleted or truncated: the corrupt bytes are still on disk.
+      assert File.read!(seg) == before
+      FileStore.close(j2)
+    end
+  end
+
+  describe "blank interior line" do
+    test "a stray blank line is skipped and the session stays healthy",
+         %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      for n <- 1..3, do: FileStore.append(j, %{"type" => "chunk", "n" => n})
+      FileStore.close(j)
+
+      [seg] = segments(base, session)
+      [first | rest] = String.split(File.read!(seg), "\n", trim: true)
+      # Inject a stray blank line between the first and second records.
+      File.write!(seg, Enum.join([first, "" | rest], "\n") <> "\n")
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      assert {:ok, records} = FileStore.read(j2)
+      assert Enum.map(records, & &1["id"]) == [1, 2, 3]
+      assert FileStore.status(j2) == :ok
+      FileStore.close(j2)
+    end
+  end
+
+  describe "write error handling (disk full)" do
+    test "a failing write returns {:error, reason} and keeps the writer alive",
+         %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      {:ok, 1} = FileStore.append(j, %{"type" => "a"})
+
+      # Simulate a failing fd (e.g. :enospc): swap a closed, writer-owned handle
+      # into the writer's state so the next :file.write returns {:error, _}. The
+      # fd is opened+closed *inside* the writer process (the replace_state fun
+      # runs there) so the writer owns it and terminate can close it cleanly.
+      scratch = Path.join(base, "scratch")
+
+      :sys.replace_state(j.writer, fn state ->
+        {:ok, dead_io} = :file.open(scratch, [:write, :raw, :binary])
+        :ok = :file.close(dead_io)
+        %{state | io: dead_io}
+      end)
+
+      assert {:error, _reason} = FileStore.append(j, %{"type" => "b"})
+      # The writer survives the error (state/fd intact, offset not advanced).
+      assert Process.alive?(j.writer)
+
+      FileStore.close(j)
+    end
+  end
+
   defp attach_damaged_telemetry do
     ref = "journal-damaged-#{System.unique_integer([:positive])}"
     test_pid = self()

--- a/packages/raxol_agent/test/raxol/agent/journal_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/journal_test.exs
@@ -1,0 +1,269 @@
+defmodule Raxol.Agent.JournalTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Raxol.Agent.Journal.FileStore
+  alias Raxol.Agent.Journal.FileStore.Reader
+
+  setup do
+    # NEVER touch the real home: every test gets its own tmp base dir.
+    base =
+      Path.join(System.tmp_dir!(), "raxol_journal_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf(base) end)
+    {:ok, base: base, session: "sess-#{System.unique_integer([:positive])}"}
+  end
+
+  defp segments(base, session) do
+    Reader.list_segments(Path.join([base, session, "journal"]))
+  end
+
+  describe "directory layout" do
+    test "creates the per-session directory skeleton", %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      dir = Path.join(base, session)
+
+      assert File.dir?(Path.join(dir, "journal"))
+      assert File.dir?(Path.join(dir, "snapshots"))
+      assert File.exists?(Path.join(dir, "meta.json"))
+      assert File.exists?(Path.join(dir, "HEAD"))
+
+      FileStore.close(j)
+    end
+  end
+
+  describe "append + replay round-trip" do
+    test "append N, close, reopen, read returns the full trace in order", %{
+      base: base,
+      session: session
+    } do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+
+      offsets =
+        for n <- 1..10 do
+          {:ok, off} = FileStore.append(j, %{"type" => "chunk", "n" => n})
+          off
+        end
+
+      assert offsets == Enum.to_list(1..10)
+      assert :ok = FileStore.close(j)
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      assert {:ok, records} = FileStore.read(j2)
+
+      assert length(records) == 10
+      assert Enum.map(records, & &1["id"]) == Enum.to_list(1..10)
+      assert Enum.map(records, & &1["n"]) == Enum.to_list(1..10)
+      assert Enum.all?(records, &(&1["type"] == "chunk"))
+      assert FileStore.status(j2) == :ok
+
+      FileStore.close(j2)
+    end
+
+    test "offset = the event id, monotonic and continued across reopen", %{
+      base: base,
+      session: session
+    } do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      {:ok, 1} = FileStore.append(j, %{"type" => "a"})
+      {:ok, 2} = FileStore.append(j, %{"type" => "b"})
+      FileStore.close(j)
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      assert {:ok, 3} = FileStore.append(j2, %{"type" => "c"})
+
+      {:ok, records} = FileStore.read(j2)
+      assert Enum.map(records, & &1["id"]) == [1, 2, 3]
+      FileStore.close(j2)
+    end
+
+    test "from_offset filters the replay", %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      for n <- 1..5, do: FileStore.append(j, %{"type" => "e", "n" => n})
+
+      {:ok, records} = FileStore.read(j, from_offset: 3)
+      assert Enum.map(records, & &1["id"]) == [3, 4, 5]
+      FileStore.close(j)
+    end
+
+    test "schema_version passes through and defaults", %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base, schema_version: "2.0.0")
+      FileStore.append(j, %{"type" => "x"})
+      FileStore.append(j, %{"type" => "y", "schema_version" => "9.9.9"})
+
+      {:ok, [a, b]} = FileStore.read(j)
+      assert a["schema_version"] == "2.0.0"
+      assert b["schema_version"] == "9.9.9"
+      FileStore.close(j)
+    end
+  end
+
+  describe "torn-tail recovery (crash mid-write)" do
+    test "truncating the last segment mid-final-line recovers all complete records", %{
+      base: base,
+      session: session
+    } do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      for n <- 1..5, do: FileStore.append(j, %{"type" => "chunk", "n" => n})
+      FileStore.close(j)
+
+      [seg] = segments(base, session)
+
+      # Simulate a crash: append a partial, unterminated final line.
+      File.write!(seg, ~s({"id":6,"type":"chunk","n":6,), [:append])
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      assert {:ok, records} = FileStore.read(j2)
+
+      assert length(records) == 5
+      assert Enum.map(records, & &1["id"]) == Enum.to_list(1..5)
+      assert FileStore.status(j2) == :ok
+
+      # The torn bytes were physically truncated; the file is clean now.
+      assert String.ends_with?(File.read!(seg), "\n")
+      FileStore.close(j2)
+    end
+
+    test "torn tail is dropped, not surfaced, and appends continue cleanly", %{
+      base: base,
+      session: session
+    } do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      FileStore.append(j, %{"type" => "chunk", "n" => 1})
+      FileStore.close(j)
+
+      [seg] = segments(base, session)
+      File.write!(seg, ~s({"id":2,"type":"cho), [:append])
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      {:ok, [only]} = FileStore.read(j2)
+      assert only["id"] == 1
+
+      # Next append gets id 2 again (the torn one never committed).
+      assert {:ok, 2} = FileStore.append(j2, %{"type" => "chunk", "n" => 2})
+      {:ok, records} = FileStore.read(j2)
+      assert Enum.map(records, & &1["id"]) == [1, 2]
+      FileStore.close(j2)
+    end
+  end
+
+  describe "interior corruption (hard alarm, damaged)" do
+    test "corrupting a middle line marks damaged, fires an alarm, deletes nothing, leaks nothing",
+         %{base: base, session: session} do
+      # Force multiple small segments so corruption lands in a non-last segment.
+      {:ok, j} = FileStore.open(session, base_dir: base, segment_cap: 64)
+      for n <- 1..8, do: FileStore.append(j, %{"type" => "chunk", "n" => n})
+      FileStore.close(j)
+
+      segs = segments(base, session)
+      assert length(segs) > 1
+
+      first_seg = List.first(segs)
+      before_bytes = File.read!(first_seg)
+
+      # Corrupt a middle (non-final, terminated) line of a non-last segment.
+      lines = String.split(before_bytes, "\n", trim: true)
+      assert length(lines) >= 2
+      corrupted = List.replace_at(lines, 1, "{not valid json")
+      File.write!(first_seg, Enum.join(corrupted, "\n") <> "\n")
+
+      telemetry_ref = attach_damaged_telemetry()
+      {:ok, j2} = FileStore.open(session, base_dir: base, segment_cap: 64)
+
+      log =
+        capture_log(fn ->
+          # Interior corruption never returns the damaged content downstream.
+          assert {:error, :damaged} = FileStore.read(j2)
+          assert FileStore.status(j2) == :damaged
+        end)
+
+      assert log =~ "interior corruption"
+
+      assert_received {:journal_damaged, %{dir: _}, %{segment: _}},
+                      "expected a damaged telemetry alarm"
+
+      # NOTHING deleted: every segment file still on disk.
+      assert segments(base, session) == segs
+      assert Enum.all?(segs, &File.exists?/1)
+
+      :telemetry.detach(telemetry_ref)
+      FileStore.close(j2)
+    end
+  end
+
+  describe "meta.json / HEAD atomicity" do
+    test "meta.json is written once and is valid JSON", %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base, cwd: "/tmp/wd", title: "hello")
+      meta_path = Path.join([base, session, "meta.json"])
+      {:ok, meta} = meta_path |> File.read!() |> Jason.decode()
+
+      assert meta["cwd"] == "/tmp/wd"
+      assert meta["title"] == "hello"
+      assert is_binary(meta["created_at"])
+      assert meta["schema_version"] == "1.0.0"
+
+      created = meta["created_at"]
+      FileStore.append(j, %{"type" => "x"})
+      FileStore.close(j)
+
+      # Reopen must not clobber meta.json (created_at preserved).
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      {:ok, meta2} = meta_path |> File.read!() |> Jason.decode()
+      assert meta2["created_at"] == created
+      FileStore.close(j2)
+    end
+
+    test "HEAD tracks the durable offset and is valid JSON", %{base: base, session: session} do
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      for _ <- 1..3, do: FileStore.append(j, %{"type" => "x"})
+      FileStore.close(j)
+
+      {:ok, head} = Path.join([base, session, "HEAD"]) |> File.read!() |> Jason.decode()
+      assert head["offset"] == 3
+      assert is_integer(head["segment"])
+
+      # No stray temp files left behind by atomic writes.
+      names = File.ls!(Path.join(base, session))
+      refute Enum.any?(names, &String.contains?(&1, ".tmp."))
+    end
+  end
+
+  describe "segment rotation" do
+    test "rotates to a new segment past the size cap, offsets stay ascending", %{
+      base: base,
+      session: session
+    } do
+      {:ok, j} = FileStore.open(session, base_dir: base, segment_cap: 128)
+
+      for n <- 1..20,
+          do: FileStore.append(j, %{"type" => "chunk", "n" => n, "pad" => "xxxxxxxxxx"})
+
+      FileStore.close(j)
+
+      assert length(segments(base, session)) > 1
+
+      {:ok, j2} = FileStore.open(session, base_dir: base)
+      {:ok, records} = FileStore.read(j2)
+      assert Enum.map(records, & &1["id"]) == Enum.to_list(1..20)
+      FileStore.close(j2)
+    end
+  end
+
+  defp attach_damaged_telemetry do
+    ref = "journal-damaged-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      ref,
+      [:raxol, :agent, :journal, :damaged],
+      fn _event, _measurements, metadata, _ ->
+        send(test_pid, {:journal_damaged, %{dir: metadata.dir}, %{segment: metadata.segment}})
+      end,
+      nil
+    )
+
+    ref
+  end
+end


### PR DESCRIPTION
## What

A durable, append-only **journal** — the source of truth for a session's durable-tier events. One directory per session; the directory *is* the session (portable, tar-able, rsync-able, grep-able):

```
<base>/<session_id>/
├── meta.json          # created_at, cwd, git branch, title, schema_version — atomic writes only
├── HEAD               # sidecar: current durable offset + config — atomic writes only, never model state
├── journal/
│   ├── 000001.jsonl   # framed JSONL, size-capped ascending segments
│   └── 000002.jsonl
└── snapshots/         # empty for now; checkpoint payloads land here in a later unit
```

Base dir defaults to `~/.raxol/sessions/`, overridable via `:base_dir` opt or `RAXOL_SESSIONS_DIR`.

- **`Raxol.Agent.Journal`** — behaviour (`open`/`append`/`read`/`close`/`status`) so S3/DB impls can slot in later behind the same seam.
- **`Journal.FileStore`** — the concrete file impl (handle struct + facade).
- **`FileStore.Writer`** — ONE single-writer GenServer per session. Framed JSONL (one self-delimited JSON object per line), monotonic `offset` = event id. Batched `:file.datasync` on mailbox drain with a ≤200ms ceiling; **immediate** sync for side-effect events (`tool_result`/`approval`); never `delayed_write`. Segment rotation past the size cap (default 8 MiB). `meta.json`/`HEAD` written atomically (temp + fsync + rename), never in place.
- **`FileStore.Reader`** — tolerant replay in ascending offset order. Parse failure on the **final line of the last segment** → torn tail (Ra policy): truncate it, recover everything before, `status == :ok`. Parse failure **anywhere interior** → session `:damaged`, hard alarm (`Logger.error` + `[:raxol, :agent, :journal, :damaged]` telemetry), **nothing deleted**, damaged content **never** returned downstream.

## Why

The storage spine for harness resume: durable source of truth so a session survives a BEAM kill and can be replayed/reattached from offset. Files-only (round-2 research AD-9/NC-7 rejected DETS/Mnesia/SQLite as primary; a derived SQLite index may come later behind the behaviour). v0 session listing is just readdir + `meta.json`.

## Acceptance (all covered by `test/raxol/agent/journal_test.exs`, 11 tests green)

- Append N → close → reopen → `read` returns the full trace in order, ids ascending; offset continues across reopen.
- Crash sim: truncate last segment mid-final-line → `read` recovers all complete records, drops the torn tail, `status == :ok`, file physically cleaned, appends resume at the reused id.
- Interior corruption: corrupt a middle line of a non-last segment → `read` returns `{:error, :damaged}`, `status == :damaged`, `Logger.error`/telemetry alarm fired, NO file deleted, damaged content absent from output.
- `meta.json`/`HEAD` written atomically, valid JSON, no stray `.tmp` files; reopen does not clobber `meta.json`.

## Scope note

The **trust layer (U2b: SemVer upcast / retention / redaction / export)** is intentionally a **separate later unit** — not built here. This unit is the storage spine only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7