### PR TITLE
feat(harness): U1 — keystone emit (Dispatcher unified typed emit)

### DIFF
--- a/lib/raxol/application.ex
+++ b/lib/raxol/application.ex
@@ -127,6 +127,7 @@ defmodule Raxol.Application do
     [
       {Raxol.Performance.ETSCacheManager, []},
       {Registry, keys: :duplicate, name: :raxol_event_subscriptions},
+      Raxol.Core.Runtime.EmitBus,
       {Raxol.DynamicSupervisor, []},
       {Raxol.Core.UserPreferences, [name: Raxol.Core.UserPreferences]}
     ]
@@ -151,6 +152,7 @@ defmodule Raxol.Application do
       {Raxol.Core.UserPreferences, [name: Raxol.Core.UserPreferences]},
       {Raxol.DynamicSupervisor, []},
       {Registry, keys: :duplicate, name: :raxol_event_subscriptions},
+      Raxol.Core.Runtime.EmitBus,
       maybe_add_mcp_supervisor(),
       {Raxol.Headless, []},
       maybe_add_pubsub()
@@ -188,6 +190,7 @@ defmodule Raxol.Application do
       {Raxol.Terminal.Supervisor, []},
       maybe_add_agent_supervisor(),
       {Registry, keys: :duplicate, name: :raxol_event_subscriptions},
+      Raxol.Core.Runtime.EmitBus,
       # MCP server (registry + server, works in all environments)
       maybe_add_mcp_supervisor(),
       # Headless session manager for programmatic app interaction

--- a/lib/raxol/core/runtime/emit_bus.ex
+++ b/lib/raxol/core/runtime/emit_bus.ex
@@ -1,0 +1,128 @@
+defmodule Raxol.Core.Runtime.EmitBus do
+  @moduledoc """
+  Lightweight, package-neutral pub/sub for TEA runtime events.
+
+  This is the **keystone seam** for the harness event stream. The Dispatcher
+  publishes one neutral event map at each of its two model-fold sites
+  (`process_app_update/3` and `process_command_result/2`); any process that
+  subscribes by `session_id` receives those maps as `{:emit_bus, session_id,
+  event}` messages.
+
+  The bus deliberately knows nothing about the agent contract. It carries a
+  plain map so the **main `raxol` package never depends on `raxol_agent`**
+  (a back-dep would be circular). The `raxol_agent` side subscribes via
+  `Raxol.Agent.EmitBridge`, translates each neutral map into a
+  `Raxol.Agent.Contract.Event`, and re-emits it through
+  `Raxol.Agent.SessionStreamer`. Producer (Dispatcher) and consumer
+  (agent surfaces) meet only at this map shape.
+
+  ## Neutral event shape
+
+      %{
+        session_id: term(),
+        family: :loop | :meta,
+        type: atom(),
+        tier: :ephemeral | :durable,
+        turn_id: String.t() | nil,
+        payload: map(),
+        ts: integer()   # System.system_time(:microsecond)
+      }
+
+  ## Transport
+
+  A `:duplicate`-keyed `Registry` keyed by `session_id`. It is started as part
+  of the application supervision tree (see `Raxol.Application`). When the
+  registry is not running (e.g. a minimal/headless boot), `subscribe/1`,
+  `unsubscribe/1`, and `publish/1` degrade to `:ok` no-ops rather than crash —
+  matching the resilience of `Dispatcher.broadcast/2`.
+  """
+
+  @registry __MODULE__.Registry
+
+  @type tier :: :ephemeral | :durable
+  @type family :: :loop | :meta
+
+  @type event :: %{
+          session_id: term(),
+          family: family(),
+          type: atom(),
+          tier: tier(),
+          turn_id: String.t() | nil,
+          payload: map(),
+          ts: integer()
+        }
+
+  @doc """
+  Child spec for the backing registry. Add `Raxol.Core.Runtime.EmitBus` to a
+  supervision tree to start it.
+  """
+  @spec child_spec(term()) :: Supervisor.child_spec()
+  def child_spec(_opts) do
+    Registry.child_spec(keys: :duplicate, name: @registry)
+  end
+
+  @doc "The registered name of the backing registry."
+  @spec registry_name() :: atom()
+  def registry_name, do: @registry
+
+  @doc """
+  Subscribe the calling process to events for `session_id`.
+
+  Events arrive as `{:emit_bus, session_id, event}` messages. No-ops when the
+  registry is not running.
+  """
+  @spec subscribe(term()) :: :ok
+  def subscribe(session_id) do
+    _ = Registry.register(@registry, session_id, nil)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc "Unsubscribe the calling process from `session_id`."
+  @spec unsubscribe(term()) :: :ok
+  def unsubscribe(session_id) do
+    _ = Registry.unregister(@registry, session_id)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Publish a neutral `event` to every subscriber of its `session_id`.
+
+  No-ops when the registry is not running.
+  """
+  @spec publish(event()) :: :ok
+  def publish(%{session_id: session_id} = event) do
+    Registry.dispatch(@registry, session_id, fn entries ->
+      Enum.each(entries, fn {pid, _value} ->
+        send(pid, {:emit_bus, session_id, event})
+      end)
+    end)
+
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc """
+  Build a neutral event map.
+
+  Options: `:family` (default `:loop`) and `:turn_id` (default `nil`). `ts` is
+  stamped at build time.
+  """
+  @spec build(term(), atom(), tier(), map(), keyword()) :: event()
+  def build(session_id, type, tier, payload, opts \\ [])
+      when is_atom(type) and tier in [:ephemeral, :durable] and is_map(payload) do
+    %{
+      session_id: session_id,
+      family: Keyword.get(opts, :family, :loop),
+      type: type,
+      tier: tier,
+      turn_id: Keyword.get(opts, :turn_id),
+      payload: payload,
+      ts: System.system_time(:microsecond)
+    }
+  end
+end

--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -38,7 +38,11 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
               rendering_engine: nil,
               time_travel: nil,
               cycle_profiler: nil,
-              command_interceptor: nil
+              command_interceptor: nil,
+              # Harness keystone: when set, both model-fold sites publish a
+              # neutral event to Raxol.Core.Runtime.EmitBus keyed by this id.
+              # nil (terminal/plain apps) makes emit/2 a no-op.
+              session_id: nil
   end
 
   # BaseManager provides start_link/1 and start_link/2 automatically
@@ -74,7 +78,8 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
       current_theme_id: safe_get_theme_id(),
       time_travel: Map.get(initial_state, :time_travel),
       cycle_profiler: Map.get(initial_state, :cycle_profiler),
-      command_interceptor: Map.get(initial_state, :command_interceptor)
+      command_interceptor: Map.get(initial_state, :command_interceptor),
+      session_id: Map.get(initial_state, :session_id)
     }
 
     send(runtime_pid, {:runtime_initialized, self()})
@@ -198,6 +203,10 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
           mem_after,
           message
         )
+
+        # Keystone: the same fold site TimeTravel taps also emits a typed
+        # event. A synchronous update is a completed, durable step.
+        emit(state, :app_update, :durable, %{message: message})
 
         process_successful_update(state, updated_model, commands)
 
@@ -526,6 +535,11 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     case Application.delegate_update(state.app_module, message, state.model) do
       {updated_model, commands}
       when is_map(updated_model) and is_list(commands) ->
+        # Keystone: the async command-result fold used to update the model
+        # silently. It now emits a typed event. Async chunks (LLM stream /
+        # shell / ticks) are live-render-only, hence :ephemeral.
+        emit(state, :command_result, :ephemeral, %{message: message})
+
         process_command_commands(state, updated_model, commands)
 
       {:error, reason} ->
@@ -569,6 +583,22 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     end
 
     {:noreply, %{state | model: updated_model}}
+  end
+
+  # --- Harness keystone emit ---------------------------------------------
+  # Single typed-emit seam shared by both model-fold sites. Publishes a
+  # neutral event map to Raxol.Core.Runtime.EmitBus (main-package pub/sub, no
+  # raxol_agent dependency). No-op unless the session was started with a
+  # :session_id. Raxol.Agent.EmitBridge subscribes and maps these to the
+  # agent Contract on the raxol_agent side.
+  defp emit(%State{session_id: nil}, _type, _tier, _payload), do: :ok
+
+  defp emit(%State{session_id: session_id}, type, tier, payload) do
+    session_id
+    |> Raxol.Core.Runtime.EmitBus.build(type, tier, payload)
+    |> Raxol.Core.Runtime.EmitBus.publish()
+
+    :ok
   end
 
   defp log_command_failure(:error, label, reason, context) do

--- a/lib/raxol/core/runtime/lifecycle/initializer.ex
+++ b/lib/raxol/core/runtime/lifecycle/initializer.ex
@@ -211,7 +211,10 @@ defmodule Raxol.Core.Runtime.Lifecycle.Initializer do
       command_registry_table: registry_table,
       time_travel: Keyword.get(options, :time_travel_pid),
       cycle_profiler: Keyword.get(options, :cycle_profiler_pid),
-      command_interceptor: Keyword.get(options, :command_interceptor)
+      command_interceptor: Keyword.get(options, :command_interceptor),
+      # Harness keystone: a :session_id opt makes the Dispatcher publish typed
+      # events to Raxol.Core.Runtime.EmitBus at both model-fold sites.
+      session_id: Keyword.get(options, :session_id)
     }
 
     environment = Keyword.get(options, :environment, :terminal)

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -1,0 +1,116 @@
+defmodule Raxol.Agent.EmitBridge do
+  @moduledoc """
+  Bridges the package-neutral `Raxol.Core.Runtime.EmitBus` to the agent
+  harness contract.
+
+  The Dispatcher (main `raxol` package) publishes neutral event maps at both
+  model-fold sites but knows nothing about the agent contract — it must not,
+  since `raxol` cannot depend on `raxol_agent`. This bridge lives on the
+  `raxol_agent` side, where the `raxol -> raxol_agent` direction is legal. It:
+
+    1. subscribes to `EmitBus` for a `session_id`,
+    2. maps each neutral map onto a `Raxol.Agent.Contract.Event`, and
+    3. re-emits it through `Raxol.Agent.SessionStreamer`,
+
+  so any surface already subscribed to `SessionStreamer` (the `raxol -p` CLI,
+  the TUI, SSE) receives Dispatcher-originated events on the same channel as
+  `Raxol.Agent.Contract.pump/3` output. Producers differ; the contract does
+  not.
+
+  ## Neutral -> contract mapping
+
+  | neutral `type`     | tier         | contract `type`   |
+  | ------------------ | ------------ | ----------------- |
+  | `:command_result`  | `:ephemeral` | `:item_delta`     |
+  | `:app_update`      | `:durable`   | `:item_completed` |
+
+  Anything else passes through as an `:item_completed` with its tier
+  preserved. `family` and `tier` carry through unchanged; `id` is a per-bridge
+  monotonic sequence (the future journal offset); `ts` is preserved.
+
+  The semantic refinement of these two coarse Dispatcher types into the full
+  `:turn_started` / `:turn_completed` / `:error` vocabulary happens once the
+  Dispatcher carries turn boundaries — see the module's TODO.
+  """
+
+  use Raxol.Core.Behaviours.BaseManager
+
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.SessionStreamer
+  alias Raxol.Core.Runtime.EmitBus
+
+  defstruct [:session_id, :streamer, counter: 0]
+
+  @type t :: %__MODULE__{
+          session_id: term(),
+          streamer: GenServer.server(),
+          counter: non_neg_integer()
+        }
+
+  @doc """
+  Start a bridge for `session_id`.
+
+  Options:
+
+    * `:session_id` (required) — the EmitBus/SessionStreamer session key
+    * `:streamer` — SessionStreamer server (default `Raxol.Agent.SessionStreamer`)
+    * `:name` — process name (default anonymous)
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.get(opts, :name)
+    server_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, server_opts)
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def init_manager(opts) do
+    session_id = Keyword.fetch!(opts, :session_id)
+    streamer = Keyword.get(opts, :streamer, SessionStreamer)
+
+    EmitBus.subscribe(session_id)
+
+    {:ok, %__MODULE__{session_id: session_id, streamer: streamer, counter: 0}}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info(
+        {:emit_bus, session_id, neutral},
+        %__MODULE__{session_id: session_id} = state
+      ) do
+    id = state.counter + 1
+    event = map_event(neutral, id, session_id)
+    SessionStreamer.emit(session_id, event, state.streamer)
+    {:noreply, %{state | counter: id}}
+  end
+
+  def handle_manager_info(_msg, state), do: {:noreply, state}
+
+  @doc """
+  Map a neutral EmitBus event map to a `Raxol.Agent.Contract.Event`.
+
+  Pure. `id` becomes the contract event's monotonic offset; `session_id`
+  overrides the neutral map's (they are the same in practice).
+  """
+  @spec map_event(map(), non_neg_integer(), term()) :: Event.t()
+  def map_event(neutral, id, session_id) when is_map(neutral) do
+    tier = Map.get(neutral, :tier, :durable)
+
+    %Event{
+      v: 0,
+      id: id,
+      session_id: session_id,
+      turn_id: Map.get(neutral, :turn_id),
+      ts: Map.get(neutral, :ts, System.system_time(:microsecond)),
+      family: Map.get(neutral, :family, :loop),
+      type: contract_type(Map.get(neutral, :type), tier),
+      tier: tier,
+      payload: Map.get(neutral, :payload, %{})
+    }
+  end
+
+  # Coarse Dispatcher types -> v0 loop vocabulary.
+  defp contract_type(:command_result, _tier), do: :item_delta
+  defp contract_type(:app_update, _tier), do: :item_completed
+  defp contract_type(_other, _tier), do: :item_completed
+end

--- a/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
@@ -1,0 +1,98 @@
+defmodule Raxol.Agent.EmitBridgeTest do
+  @moduledoc """
+  Proves the bridge translates neutral `Raxol.Core.Runtime.EmitBus` maps into
+  `Raxol.Agent.Contract.Event` structs and re-emits them through
+  `Raxol.Agent.SessionStreamer`.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.EmitBridge
+  alias Raxol.Agent.SessionStreamer
+  alias Raxol.Core.Runtime.EmitBus
+
+  @session_id "sess-bridge-test"
+
+  describe "map_event/3 (pure mapping)" do
+    test "command_result -> ephemeral :item_delta" do
+      neutral = %{
+        session_id: @session_id,
+        family: :loop,
+        type: :command_result,
+        tier: :ephemeral,
+        turn_id: nil,
+        payload: %{message: {:command_result, :chunk}},
+        ts: 1234
+      }
+
+      assert %Event{
+               id: 7,
+               session_id: @session_id,
+               family: :loop,
+               type: :item_delta,
+               tier: :ephemeral,
+               ts: 1234,
+               payload: %{message: {:command_result, :chunk}}
+             } = EmitBridge.map_event(neutral, 7, @session_id)
+    end
+
+    test "app_update -> durable :item_completed" do
+      neutral = %{
+        session_id: @session_id,
+        family: :loop,
+        type: :app_update,
+        tier: :durable,
+        turn_id: "turn-1",
+        payload: %{message: :tick},
+        ts: 99
+      }
+
+      assert %Event{
+               type: :item_completed,
+               tier: :durable,
+               turn_id: "turn-1",
+               family: :loop
+             } = EmitBridge.map_event(neutral, 1, @session_id)
+    end
+  end
+
+  describe "process wiring (EmitBus -> bridge -> SessionStreamer)" do
+    setup do
+      ensure_registry(EmitBus.registry_name())
+      streamer = start_supervised!({SessionStreamer, name: :bridge_test_streamer})
+
+      bridge =
+        start_supervised!(
+          {EmitBridge, session_id: @session_id, streamer: streamer}
+        )
+
+      # Give the bridge a moment to register its EmitBus subscription.
+      _ = :sys.get_state(bridge)
+      %{streamer: streamer}
+    end
+
+    test "a neutral EmitBus event arrives at SessionStreamer as a Contract.Event",
+         %{streamer: streamer} do
+      SessionStreamer.subscribe(@session_id, streamer)
+
+      EmitBus.publish(
+        EmitBus.build(@session_id, :command_result, :ephemeral, %{
+          message: {:command_result, "hi"}
+        })
+      )
+
+      assert_receive {:session_event, @session_id, %Event{} = event}, 1_000
+      assert event.type == :item_delta
+      assert event.tier == :ephemeral
+      assert event.family == :loop
+      assert event.id == 1
+    end
+  end
+
+  defp ensure_registry(name) do
+    case Registry.start_link(keys: :duplicate, name: name) do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+end

--- a/test/raxol/core/runtime/events/dispatcher_emit_test.exs
+++ b/test/raxol/core/runtime/events/dispatcher_emit_test.exs
@@ -1,0 +1,143 @@
+defmodule Raxol.Core.Runtime.Events.DispatcherEmitTest do
+  @moduledoc """
+  Keystone-emit tests: proves the Dispatcher publishes a neutral event to
+  `Raxol.Core.Runtime.EmitBus` at BOTH model-fold sites. The async
+  command-result path used to update the model silently (the emits-nothing
+  bug); it now emits.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Core.Runtime.EmitBus
+  alias Raxol.Core.Runtime.Events.Dispatcher
+
+  @session_id "sess-emit-test"
+
+  defmodule EmitMockApp do
+    @behaviour Raxol.Core.Runtime.Application
+
+    @impl true
+    def init(_context), do: %{count: 0}
+
+    @impl true
+    def update(_msg, model), do: {%{model | count: model.count + 1}, []}
+
+    @impl true
+    def view(_model), do: []
+
+    @impl true
+    def handle_event(_), do: :ok
+    @impl true
+    def handle_message(_, _), do: :ok
+    @impl true
+    def handle_tick(_), do: :ok
+    @impl true
+    def subscriptions(_), do: []
+    @impl true
+    def terminate(_, _), do: :ok
+  end
+
+  setup do
+    case Raxol.Core.UserPreferences.start_link(
+           name: Raxol.Core.UserPreferences,
+           test_mode?: true
+         ) do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+    end
+
+    ensure_registry(:raxol_event_subscriptions, :duplicate)
+    ensure_registry(EmitBus.registry_name(), :duplicate)
+
+    table = :"cmd_reg_#{System.unique_integer([:positive])}"
+    :ets.new(table, [:set, :public, :named_table, read_concurrency: true])
+
+    initial_state = %{
+      app_module: EmitMockApp,
+      model: %{count: 0},
+      runtime_pid: self(),
+      width: 80,
+      height: 24,
+      focused: true,
+      debug_mode: false,
+      plugin_manager: nil,
+      command_registry_table: table,
+      session_id: @session_id
+    }
+
+    {:ok, dispatcher} = Dispatcher.start_link(self(), initial_state, name: nil)
+
+    on_exit(fn ->
+      if Process.alive?(dispatcher), do: GenServer.stop(dispatcher)
+    end)
+
+    EmitBus.subscribe(@session_id)
+
+    %{dispatcher: dispatcher}
+  end
+
+  test "process_command_result publishes an ephemeral :command_result event",
+       %{dispatcher: dispatcher} do
+    # Drive the previously-blind async fold site.
+    send(dispatcher, {:command_result, {:llm_chunk, "hello"}})
+
+    assert_receive {:emit_bus, @session_id, event}, 1_000
+    assert event.family == :loop
+    assert event.type == :command_result
+    assert event.tier == :ephemeral
+    assert is_integer(event.ts)
+    assert event.payload.message == {:command_result, {:llm_chunk, "hello"}}
+  end
+
+  test "process_app_update publishes a durable :app_update event",
+       %{dispatcher: dispatcher} do
+    # agent_message casts route straight to process_app_update.
+    GenServer.cast(dispatcher, {:dispatch, {:agent_message, :peer, :ping}})
+
+    assert_receive {:emit_bus, @session_id, event}, 1_000
+    assert event.family == :loop
+    assert event.type == :app_update
+    assert event.tier == :durable
+  end
+
+  test "no session_id means no emit (terminal apps stay silent)" do
+    ensure_registry(:raxol_event_subscriptions, :duplicate)
+    ensure_registry(EmitBus.registry_name(), :duplicate)
+
+    table = :"cmd_reg_#{System.unique_integer([:positive])}"
+    :ets.new(table, [:set, :public, :named_table, read_concurrency: true])
+
+    {:ok, dispatcher} =
+      Dispatcher.start_link(
+        self(),
+        %{
+          app_module: EmitMockApp,
+          model: %{count: 0},
+          runtime_pid: self(),
+          width: 80,
+          height: 24,
+          focused: true,
+          debug_mode: false,
+          plugin_manager: nil,
+          command_registry_table: table
+          # no session_id
+        },
+        name: nil
+      )
+
+    on_exit(fn -> if Process.alive?(dispatcher), do: GenServer.stop(dispatcher) end)
+
+    # Subscribe to a wildcard is impossible; subscribe to the id the app would
+    # have used and confirm nothing arrives.
+    EmitBus.subscribe(@session_id)
+    send(dispatcher, {:command_result, {:llm_chunk, "silent"}})
+
+    refute_receive {:emit_bus, _, _}, 300
+  end
+
+  defp ensure_registry(name, keys) do
+    case Registry.start_link(keys: keys, name: name) do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+end


### PR DESCRIPTION
## What

Wire ONE typed-emit seam at both Dispatcher model-fold sites (`process_app_update/3` and `process_command_result/2`) so a TEA agent run produces the same contract event stream the `raxol -p` CLI already emits via `SessionStreamer`.

- **`Raxol.Core.Runtime.EmitBus`** (main `raxol`): a `:duplicate`-keyed Registry pub/sub that publishes package-neutral event maps (`%{session_id, family, type, tier, turn_id, payload, ts}`) keyed by `session_id`. Subscribers get `{:emit_bus, session_id, event}`. No-ops when the registry isn't running (mirrors `Dispatcher.broadcast/2` resilience). Registered in the app tree (test/mcp/core modes).
- **Dispatcher**: private `emit/4` publishes at BOTH fold sites — `process_app_update/3` (durable `:app_update`) and `process_command_result/2` (ephemeral `:command_result`). The emit sits at the same fold site `Raxol.Debug.TimeTravel` taps — **one tap, two consumers**; TimeTravel snapshotting is unchanged. No-op unless a `:session_id` was set.
- **Lifecycle**: threads a `:session_id` option into the dispatcher's `initial_state`.
- **`Raxol.Agent.EmitBridge`** (`raxol_agent`): subscribes to `EmitBus`, maps neutral maps → `Raxol.Agent.Contract.Event`, re-emits via `SessionStreamer`. This is the legal `raxol → raxol_agent` direction.

## Why

- Fixes the emits-nothing async bug: `process_command_result/2` updated the model silently on async LLM chunks / shell / ticks — no observer, no render. It now emits.
- Creates the outbound event stream (the keystone) that agent surfaces consume via the existing `SessionStreamer` boundary — producers change, the contract does not.
- Probe/journal substrate: the neutral map is the single seam later producers (meta family, durable journal) attach behind.

## Hard constraint honored

Main `raxol` never references `Raxol.Agent.*`. The neutral map is the boundary; only `raxol_agent`'s `EmitBridge` knows the contract. No back-dep.

## Acceptance (all proven by tests)

- `test/raxol/core/runtime/events/dispatcher_emit_test.exs` (3 tests): the async command-result fold now publishes an ephemeral `:command_result` event to a subscriber; the sync fold publishes a durable `:app_update`; no `:session_id` ⇒ silent.
- `packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs` (3 tests): pure `map_event/3` maps `:command_result`→`:item_delta` (ephemeral) and `:app_update`→`:item_completed` (durable) with correct family/type/tier; process-level test proves EmitBus → bridge → SessionStreamer end to end.
- Existing dispatcher suite: **124 passed**, no regressions. Agent streamer/contract suite: **20 passed**.

Both packages compile clean with `--warnings-as-errors`.

## TODO (follow-up)

- Thread `:session_id` from `Raxol.Agent.Session` into `Lifecycle.start_link` opts (the Dispatcher already reads it; the Session→Lifecycle plumbing is the remaining hop).
- Auto-start an `EmitBridge` per agent session (supervise under `Agent.Session`), so live agent runs stream to `SessionStreamer` with zero caller wiring.
- Refine the coarse Dispatcher types (`:app_update` / `:command_result`) into the full v0 loop vocabulary (`:turn_started` / `:turn_completed` / `:error`) once the Dispatcher carries turn boundaries.
- Wire the neutral `:meta` family + durable journal sink behind the same seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7