### PR TITLE
feat(harness): U1.5 — close the keystone (session_id + journal sink + id-authority + turn vocab)

### DIFF
--- a/lib/raxol/core/runtime/emit_bus.ex
+++ b/lib/raxol/core/runtime/emit_bus.ex
@@ -4,7 +4,7 @@ defmodule Raxol.Core.Runtime.EmitBus do
 
   This is the **keystone seam** for the harness event stream. The Dispatcher
   publishes one neutral event map at each of its two model-fold sites
-  (`process_app_update/3` and `process_command_result/2`); any process that
+  (`process_app_update/3` and `process_command_result/3`); any process that
   subscribes by `session_id` receives those maps as `{:emit_bus, session_id,
   event}` messages.
 

--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -42,7 +42,12 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
               # Harness keystone: when set, both model-fold sites publish a
               # neutral event to Raxol.Core.Runtime.EmitBus keyed by this id.
               # nil (terminal/plain apps) makes emit/2 a no-op.
-              session_id: nil
+              session_id: nil,
+              # Harness loop vocabulary: the turn currently in flight. Minted at
+              # the agent-message dispatch (a prompt = a turn) and stamped onto
+              # every event emitted while it is set, so all items within one turn
+              # share a stable turn_id (U6's expected_turn_id CAS depends on it).
+              turn_id: nil
   end
 
   # BaseManager provides start_link/1 and start_link/2 automatically
@@ -412,7 +417,7 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
       "[Dispatcher] handle_cast :dispatch agent_message: #{inspect(msg)}"
     )
 
-    with_dispatch_span(fn -> dispatch_raw_message(msg, state) end)
+    with_dispatch_span(fn -> dispatch_agent_turn(msg, state) end)
   end
 
   @impl true
@@ -425,7 +430,7 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     )
 
     # Agent messages go directly to update/2, bypassing event/plugin pipeline
-    with_dispatch_span(fn -> dispatch_raw_message(msg, state) end)
+    with_dispatch_span(fn -> dispatch_agent_turn(msg, state) end)
   end
 
   @impl true
@@ -593,13 +598,42 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
   # agent Contract on the raxol_agent side.
   defp emit(%State{session_id: nil}, _type, _tier, _payload), do: :ok
 
-  defp emit(%State{session_id: session_id}, type, tier, payload) do
+  defp emit(%State{session_id: session_id, turn_id: turn_id}, type, tier, payload) do
     session_id
-    |> Raxol.Core.Runtime.EmitBus.build(type, tier, payload)
+    |> Raxol.Core.Runtime.EmitBus.build(type, tier, payload, turn_id: turn_id)
     |> Raxol.Core.Runtime.EmitBus.publish()
 
     :ok
   end
+
+  # --- Harness loop vocabulary: turn brackets ----------------------------
+  # An inbound agent message is one turn. We mint a turn_id, emit a durable
+  # `:turn_started` before the fold, run the model fold (whose own durable
+  # `:app_update` emit now carries this turn_id), then bracket with a durable
+  # `:turn_completed` on success or `:error` on failure. The turn_id persists
+  # in state so any async `:command_result` deltas that stream out of the
+  # turn's commands carry the same turn_id.
+  #
+  # NOTE (v0 limitation): turn_completed is emitted when the synchronous fold
+  # returns. Agents that stream via async commands will emit their ephemeral
+  # item_deltas after turn_completed (same turn_id). Tightening the boundary to
+  # the last async chunk is a later unit — see the module TODO.
+  defp dispatch_agent_turn(msg, state) do
+    turn_state = %{state | turn_id: mint_turn_id()}
+    emit(turn_state, :turn_started, :durable, %{message: msg})
+
+    case process_app_update(turn_state, msg, msg) do
+      {:ok, new_state, _commands} ->
+        emit(new_state, :turn_completed, :durable, %{})
+        {:noreply, new_state}
+
+      {:error, reason} ->
+        emit(turn_state, :error, :durable, %{reason: reason})
+        {:noreply, turn_state}
+    end
+  end
+
+  defp mint_turn_id, do: "turn-#{System.unique_integer([:positive])}"
 
   defp log_command_failure(:error, label, reason, context) do
     Raxol.Core.Runtime.Log.error_with_stacktrace(label, reason, nil, context)
@@ -624,7 +658,7 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     )
 
     with_dispatch_span(fn ->
-      msg |> dispatch_raw_message(state) |> to_call_reply()
+      msg |> dispatch_agent_turn(state) |> to_call_reply()
     end)
   end
 

--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -47,6 +47,8 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
               # the agent-message dispatch (a prompt = a turn) and stamped onto
               # every event emitted while it is set, so all items within one turn
               # share a stable turn_id (U6's expected_turn_id CAS depends on it).
+              # Cleared back to nil when the turn's closing bracket
+              # (turn_completed / error) is emitted — see dispatch_agent_turn/2.
               turn_id: nil
   end
 
@@ -598,7 +600,12 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
   # agent Contract on the raxol_agent side.
   defp emit(%State{session_id: nil}, _type, _tier, _payload), do: :ok
 
-  defp emit(%State{session_id: session_id, turn_id: turn_id}, type, tier, payload) do
+  defp emit(
+         %State{session_id: session_id, turn_id: turn_id},
+         type,
+         tier,
+         payload
+       ) do
     session_id
     |> Raxol.Core.Runtime.EmitBus.build(type, tier, payload, turn_id: turn_id)
     |> Raxol.Core.Runtime.EmitBus.publish()
@@ -610,14 +617,18 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
   # An inbound agent message is one turn. We mint a turn_id, emit a durable
   # `:turn_started` before the fold, run the model fold (whose own durable
   # `:app_update` emit now carries this turn_id), then bracket with a durable
-  # `:turn_completed` on success or `:error` on failure. The turn_id persists
-  # in state so any async `:command_result` deltas that stream out of the
-  # turn's commands carry the same turn_id.
+  # `:turn_completed` on success or `:error` on failure. The turn_id is
+  # CLEARED (nil) in the state returned from both arms, after the bracket
+  # event: a turn_id must never outlive its closing bracket, or any later
+  # non-agent event (tick, key, subscription) would emit a durable
+  # `:app_update` attributed to a finished turn AFTER its `turn_completed` —
+  # poisoning U6's `expected_turn_id` CAS.
   #
   # NOTE (v0 limitation): turn_completed is emitted when the synchronous fold
   # returns. Agents that stream via async commands will emit their ephemeral
-  # item_deltas after turn_completed (same turn_id). Tightening the boundary to
-  # the last async chunk is a later unit — see the module TODO.
+  # item_deltas after turn_completed, with `turn_id: nil` (the turn is closed
+  # by then). Tightening the boundary to the last async chunk is a later
+  # unit — see the module TODO.
   defp dispatch_agent_turn(msg, state) do
     turn_state = %{state | turn_id: mint_turn_id()}
     emit(turn_state, :turn_started, :durable, %{message: msg})
@@ -625,11 +636,11 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     case process_app_update(turn_state, msg, msg) do
       {:ok, new_state, _commands} ->
         emit(new_state, :turn_completed, :durable, %{})
-        {:noreply, new_state}
+        {:noreply, %{new_state | turn_id: nil}}
 
       {:error, reason} ->
         emit(turn_state, :error, :durable, %{reason: reason})
-        {:noreply, turn_state}
+        {:noreply, %{turn_state | turn_id: nil}}
     end
   end
 

--- a/lib/raxol/core/runtime/events/dispatcher.ex
+++ b/lib/raxol/core/runtime/events/dispatcher.ex
@@ -243,7 +243,13 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
       pid: self(),
       command_registry_table: state.command_registry_table,
       runtime_pid: state.runtime_pid,
-      command_interceptor: state.command_interceptor
+      command_interceptor: state.command_interceptor,
+      # Snapshot of the MINTING turn's id, taken at dispatch time. Async
+      # executors echo it back as `{:command_result, msg, %{turn_id: ...}}` so
+      # a late delta is stamped with its ORIGINATING turn's id — never with
+      # whatever `state.turn_id` happens to hold when the result lands
+      # (cross-turn contamination), and never with nil-by-timing.
+      turn_id: state.turn_id
     }
   end
 
@@ -510,10 +516,23 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     {:noreply, state}
   end
 
+  # Tagged form: async executors that snapshotted the minting turn's id into
+  # their dispatch context echo it back here. The app still sees the plain
+  # `{:command_result, msg}` shape; the tag only drives event attribution.
+  @impl true
+  def handle_manager_info({:command_result, msg, meta}, %State{} = state)
+      when is_map(meta) do
+    full_message = {:command_result, msg}
+    process_command_result(state, full_message, Map.get(meta, :turn_id))
+  end
+
+  # Untagged (legacy) form: no originating-turn snapshot travelled with the
+  # command, so fall back to `state.turn_id` — nil between turns, which is
+  # honest ("not attributable"), never another turn's id.
   @impl true
   def handle_manager_info({:command_result, msg}, %State{} = state) do
     full_message = {:command_result, msg}
-    process_command_result(state, full_message)
+    process_command_result(state, full_message, state.turn_id)
   end
 
   @impl true
@@ -538,16 +557,28 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     {:noreply, state}
   end
 
-  defp process_command_result(state, message) do
+  defp process_command_result(state, message, turn_id) do
     case Application.delegate_update(state.app_module, message, state.model) do
       {updated_model, commands}
       when is_map(updated_model) and is_list(commands) ->
         # Keystone: the async command-result fold used to update the model
         # silently. It now emits a typed event. Async chunks (LLM stream /
         # shell / ticks) are live-render-only, hence :ephemeral.
-        emit(state, :command_result, :ephemeral, %{message: message})
+        #
+        # `turn_id` is the ORIGINATING turn's id, snapshotted into the command
+        # context at dispatch — NOT `state.turn_id` read at emit time. The
+        # dispatcher is a single mailbox: by the time an async delta lands the
+        # minting turn is closed (turn_id nil'd) or a later turn may be the
+        # current one, so an emit-time read would stamp the delta with nil or
+        # with the WRONG turn — poisoning U6's expected_turn_id CAS.
+        emit(
+          %{state | turn_id: turn_id},
+          :command_result,
+          :ephemeral,
+          %{message: message}
+        )
 
-        process_command_commands(state, updated_model, commands)
+        process_command_commands(state, updated_model, commands, turn_id)
 
       {:error, reason} ->
         log_command_failure(
@@ -571,8 +602,12 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
     end
   end
 
-  defp process_command_commands(state, updated_model, commands) do
-    context = build_command_context(state)
+  defp process_command_commands(state, updated_model, commands, turn_id) do
+    # Follow-up commands minted by this result's fold belong to the same
+    # originating turn: build their context from a COPY of state carrying that
+    # turn_id. The state returned below is the original — the id must not
+    # leak into the dispatcher's persistent state (that was finding 2).
+    context = build_command_context(%{state | turn_id: turn_id})
 
     case Raxol.Core.ErrorHandling.safe_call(fn ->
            process_commands(commands, context)
@@ -626,9 +661,13 @@ defmodule Raxol.Core.Runtime.Events.Dispatcher do
   #
   # NOTE (v0 limitation): turn_completed is emitted when the synchronous fold
   # returns. Agents that stream via async commands will emit their ephemeral
-  # item_deltas after turn_completed, with `turn_id: nil` (the turn is closed
-  # by then). Tightening the boundary to the last async chunk is a later
-  # unit — see the module TODO.
+  # item_deltas after turn_completed — but each delta carries its ORIGINATING
+  # turn's id, snapshotted into the command context at dispatch and echoed
+  # back by the executor (see build_command_context/1 and the tagged
+  # `{:command_result, msg, meta}` clause). A late delta is therefore never
+  # stamped with a later turn's id or with nil-by-timing. Tightening the
+  # boundary so turn_completed follows the last async chunk is a later unit —
+  # see the module TODO.
   defp dispatch_agent_turn(msg, state) do
     turn_state = %{state | turn_id: mint_turn_id()}
     emit(turn_state, :turn_started, :durable, %{message: msg})

--- a/packages/raxol_agent/lib/raxol/agent/contract.ex
+++ b/packages/raxol_agent/lib/raxol/agent/contract.ex
@@ -78,6 +78,17 @@ defmodule Raxol.Agent.Contract do
     [Jason.encode!(sanitize(event)), "\n"]
   end
 
+  @doc """
+  Coerce a payload map into a JSON-encodable one.
+
+  Same boundary sanitization `encode_line/1` applies, exposed for the durable
+  journal sink: an event whose payload carries non-encodable terms (message
+  tuples, structs, pids) must not crash `Jason.encode!` when appended. Anything
+  Jason can't take becomes `inspect/1` text.
+  """
+  @spec sanitize_payload(map()) :: map()
+  def sanitize_payload(payload) when is_map(payload), do: sanitize_value(payload)
+
   # Payloads may carry non-JSON-encodable terms (error reasons, tuples,
   # arbitrary tool results). Sanitize at the boundary rather than crash
   # the feed: anything Jason can't take becomes `inspect/1` text.

--- a/packages/raxol_agent/lib/raxol/agent/directive.ex
+++ b/packages/raxol_agent/lib/raxol/agent/directive.ex
@@ -41,7 +41,10 @@ defmodule Raxol.Agent.Directive do
         runtime_pid: runtime_pid
       })
 
-  Result messages arrive at `context.pid` as `{:command_result, payload}`.
+  Result messages arrive at `context.pid` as
+  `{:command_result, payload, %{turn_id: turn_id}}` — the `turn_id` is a
+  snapshot of the agent turn that dispatched the directive (nil outside a
+  turn), so late async results stay attributed to their originating turn.
   """
 
   alias __MODULE__.{Async, SendAgent, Shell}

--- a/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
@@ -3,13 +3,21 @@ defimpl Raxol.Core.Runtime.Directive.Executor, for: Raxol.Agent.Directive.Async 
 
   def execute(%Async{fun: fun}, context) do
     pid = context.pid
-    sender = fn msg -> send(pid, {:command_result, msg}) end
+    # Snapshot the minting turn's id NOW (dispatch time). Results may land
+    # turns later; the tag makes each delta carry its originating turn's id
+    # instead of whatever the dispatcher's current turn happens to be.
+    meta = %{turn_id: Map.get(context, :turn_id)}
+    sender = fn msg -> send(pid, {:command_result, msg, meta}) end
 
     Task.start(fn ->
       try do
         fun.(sender)
       rescue
-        e -> send(pid, {:command_result, {:async_error, Exception.message(e)}})
+        e ->
+          send(
+            pid,
+            {:command_result, {:async_error, Exception.message(e)}, meta}
+          )
       end
     end)
   end
@@ -28,6 +36,8 @@ defimpl Raxol.Core.Runtime.Directive.Executor, for: Raxol.Agent.Directive.Shell 
 
     cd = Keyword.get(opts, :cd)
     env = Keyword.get(opts, :env, [])
+    # Originating-turn snapshot; see the Async impl above.
+    meta = %{turn_id: Map.get(context, :turn_id)}
 
     Task.start(fn ->
       charlist_env =
@@ -48,7 +58,7 @@ defimpl Raxol.Core.Runtime.Directive.Executor, for: Raxol.Agent.Directive.Shell 
 
       port = Port.open({:spawn_executable, "/bin/sh"}, port_opts)
       result = collect_port_output(port, [], timeout)
-      send(context.pid, {:command_result, {:shell_result, result}})
+      send(context.pid, {:command_result, {:shell_result, result}, meta})
     end)
   end
 
@@ -83,7 +93,8 @@ defimpl Raxol.Core.Runtime.Directive.Executor, for: Raxol.Agent.Directive.SendAg
       _ ->
         send(
           context.pid,
-          {:command_result, {:send_agent_error, :not_found, target_id}}
+          {:command_result, {:send_agent_error, :not_found, target_id},
+           %{turn_id: Map.get(context, :turn_id)}}
         )
     end
   end

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -34,12 +34,32 @@ defmodule Raxol.Agent.EmitBridge do
       reproduces exactly these ids — one identity, zero divergence.
     * **Ephemeral** events (`item_delta`): never journaled. Their id carries the
       **last durable offset** so it never masquerades as a fresh offset — a
-      delta refines the item at the current durable position.
+      delta refines the item at the current durable position. Real journal
+      offsets start at `1`; an ephemeral event emitted before any durable
+      append carries the sentinel id `0` ("pre-durable").
 
   The journal is opened lazily on the first durable event (or supplied up-front
   via the `:journal` option), scoped to `session_id` under `RAXOL_SESSIONS_DIR`
   / `~/.raxol/sessions`, and closed on `terminate/2`. It persists to disk and
   survives a BEAM kill.
+
+  ## The journal is the hard gate for durable events
+
+  When a durable append fails (journal cannot be opened, or `append/2` returns
+  `{:error, reason}` — e.g. a full disk), the durable event is **dropped from
+  the live tail**: it is NOT published with a fabricated id and `last_offset`
+  does NOT advance. Fabricating an id here would resurrect the dual-id
+  landmine — the Writer does not advance its offset on a failed append, so the
+  next successful append would reuse the fabricated number and two live-tail
+  events would share one id while replay reproduced only one. An un-journaled
+  durable event must never look durable.
+
+  Instead the bridge emits a loud, clearly-marked failure signal: an
+  **ephemeral** `:error` contract event with payload
+  `%{reason: :journal_append_failed | :journal_open_failed, original_type: t,
+  detail: ...}`, plus a `Logger.error`. If the failure was a dead Writer, the
+  stale handle is dropped so the next durable event lazily reopens the journal
+  and resumes from the on-disk offset — ids stay collision-free.
 
   ## Neutral -> contract mapping
 
@@ -56,6 +76,8 @@ defmodule Raxol.Agent.EmitBridge do
   """
 
   use Raxol.Core.Behaviours.BaseManager
+
+  require Logger
 
   alias Raxol.Agent.Contract
   alias Raxol.Agent.Contract.Event
@@ -113,6 +135,9 @@ defmodule Raxol.Agent.EmitBridge do
   end
 
   # Durable tier: the journal owns the id. Append first, take the offset, emit.
+  # The journal is the hard gate: if the append fails, the durable event is NOT
+  # published (no fabricated id, `last_offset` untouched) — a loud ephemeral
+  # `:error` event goes out instead. See the moduledoc.
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_info(
         {:emit_bus, session_id, %{tier: :durable} = neutral},
@@ -121,10 +146,27 @@ defmodule Raxol.Agent.EmitBridge do
     # Sanitize once and reuse for both the journal record and the live event so
     # the live tail and the replayed record are byte-identical, not just id-equal.
     safe = Map.put(neutral, :payload, sanitized_payload(neutral))
-    {state, offset} = append_durable(state, safe)
-    event = map_event(safe, offset, session_id)
-    SessionStreamer.emit(session_id, event, state.streamer)
-    {:noreply, %{state | last_offset: offset}}
+
+    case append_durable(state, safe) do
+      {:ok, state, offset} ->
+        event = map_event(safe, offset, session_id)
+        SessionStreamer.emit(session_id, event, state.streamer)
+        {:noreply, %{state | last_offset: offset}}
+
+      {:error, state, failure_reason, detail} ->
+        Logger.error(
+          "[EmitBridge] dropping durable event #{inspect(Map.get(safe, :type))} " <>
+            "for session #{inspect(session_id)}: #{failure_reason} (#{inspect(detail)})"
+        )
+
+        SessionStreamer.emit(
+          session_id,
+          journal_failure_event(state, safe, failure_reason, detail),
+          state.streamer
+        )
+
+        {:noreply, state}
+    end
   end
 
   # Ephemeral tier: never journaled. Id carries the last durable offset.
@@ -174,32 +216,64 @@ defmodule Raxol.Agent.EmitBridge do
   # --- durable id authority --------------------------------------------------
 
   # Append the durable event to the journal and return the assigned offset. The
-  # journal is opened lazily on first use. If no journal is available (open or
-  # append failed — e.g. a full disk), degrade to a sequential in-memory id so
-  # ids stay monotonic and the stream keeps flowing.
+  # journal is opened lazily on first use. The journal is the HARD GATE: on
+  # open/append failure no id is fabricated (the Writer did not advance its
+  # offset, so a fabricated id would collide with the next successful append —
+  # the dual-id landmine). The caller drops the event from the live tail and
+  # emits an ephemeral `:error` signal instead.
   defp append_durable(state, neutral) do
-    state = ensure_journal(state)
+    case ensure_journal(state) do
+      {:ok, state} ->
+        case FileStore.append(state.journal, durable_record(neutral)) do
+          {:ok, offset} ->
+            {:ok, state, offset}
 
-    case state.journal do
-      nil ->
-        {state, state.last_offset + 1}
-
-      handle ->
-        case FileStore.append(handle, durable_record(neutral)) do
-          {:ok, offset} -> {state, offset}
-          {:error, _reason} -> {state, state.last_offset + 1}
+          {:error, detail} ->
+            {:error, drop_dead_journal(state, detail), :journal_append_failed,
+             detail}
         end
+
+      {:error, state, detail} ->
+        {:error, state, :journal_open_failed, detail}
     end
   end
 
   defp ensure_journal(%__MODULE__{journal: nil} = state) do
     case FileStore.open(to_string(state.session_id), state.journal_opts) do
-      {:ok, handle} -> %{state | journal: handle}
-      {:error, _reason} -> state
+      {:ok, handle} -> {:ok, %{state | journal: handle}}
+      {:error, reason} -> {:error, state, reason}
     end
   end
 
-  defp ensure_journal(state), do: state
+  defp ensure_journal(state), do: {:ok, state}
+
+  # A dead Writer means the handle is stale forever; drop it so the next
+  # durable event lazily reopens the journal and resumes from the on-disk
+  # offset. Other errors (e.g. :enospc) keep the handle — the Writer is alive
+  # and a later append may succeed once the condition clears.
+  defp drop_dead_journal(state, {:writer_down, _}), do: %{state | journal: nil}
+  defp drop_dead_journal(state, _detail), do: state
+
+  # The loud failure signal that replaces a durable event the journal refused:
+  # ephemeral (it must never look durable — it has no offset), id pinned to the
+  # unchanged last durable offset.
+  defp journal_failure_event(state, neutral, failure_reason, detail) do
+    %Event{
+      v: 0,
+      id: state.last_offset,
+      session_id: state.session_id,
+      turn_id: Map.get(neutral, :turn_id),
+      ts: System.system_time(:microsecond),
+      family: Map.get(neutral, :family, :loop),
+      type: :error,
+      tier: :ephemeral,
+      payload: %{
+        reason: failure_reason,
+        original_type: contract_type(Map.get(neutral, :type), :durable),
+        detail: inspect(detail)
+      }
+    }
+  end
 
   # A plain, JSON-encodable map persisted to the journal. The Writer stamps
   # `"id"` (= offset) and stringifies keys; replaying reconstructs the same

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -1,21 +1,45 @@
 defmodule Raxol.Agent.EmitBridge do
   @moduledoc """
   Bridges the package-neutral `Raxol.Core.Runtime.EmitBus` to the agent
-  harness contract.
+  harness contract, and is the **durable-tier id authority** — the sink that
+  closes the keystone.
 
-  The Dispatcher (main `raxol` package) publishes neutral event maps at both
-  model-fold sites but knows nothing about the agent contract — it must not,
-  since `raxol` cannot depend on `raxol_agent`. This bridge lives on the
-  `raxol_agent` side, where the `raxol -> raxol_agent` direction is legal. It:
+  The Dispatcher (main `raxol` package) publishes neutral event maps at its
+  model-fold sites and turn brackets but knows nothing about the agent contract
+  — it must not, since `raxol` cannot depend on `raxol_agent`. This bridge lives
+  on the `raxol_agent` side, where the `raxol -> raxol_agent` direction is legal.
+  It:
 
     1. subscribes to `EmitBus` for a `session_id`,
-    2. maps each neutral map onto a `Raxol.Agent.Contract.Event`, and
-    3. re-emits it through `Raxol.Agent.SessionStreamer`,
+    2. for **durable** events, appends to the session `Raxol.Agent.Journal`
+       FIRST and takes the returned offset as the event id (append-before-
+       publish),
+    3. maps each neutral map onto a `Raxol.Agent.Contract.Event`, and
+    4. re-emits it through `Raxol.Agent.SessionStreamer`,
 
   so any surface already subscribed to `SessionStreamer` (the `raxol -p` CLI,
   the TUI, SSE) receives Dispatcher-originated events on the same channel as
-  `Raxol.Agent.Contract.pump/3` output. Producers differ; the contract does
-  not.
+  `Raxol.Agent.Contract.pump/3` output. Producers differ; the contract does not.
+
+  ## The id authority (kills the dual-id landmine)
+
+  The contract says `Event.id == journal offset`. Before this unit the bridge
+  stamped `Event.id` from a local per-process counter, so a durable event's live
+  id and its journal offset diverged the moment the event was journaled — two
+  ids for one event. Now the **journal is the single id authority**:
+
+    * **Durable** events (`turn_started`, `item_completed`, `turn_completed`,
+      `error`): `Journal.append/2` FIRST, take the returned `offset`, stamp
+      `Event.id = offset`, THEN `SessionStreamer.emit`. Replaying the journal
+      reproduces exactly these ids — one identity, zero divergence.
+    * **Ephemeral** events (`item_delta`): never journaled. Their id carries the
+      **last durable offset** so it never masquerades as a fresh offset — a
+      delta refines the item at the current durable position.
+
+  The journal is opened lazily on the first durable event (or supplied up-front
+  via the `:journal` option), scoped to `session_id` under `RAXOL_SESSIONS_DIR`
+  / `~/.raxol/sessions`, and closed on `terminate/2`. It persists to disk and
+  survives a BEAM kill.
 
   ## Neutral -> contract mapping
 
@@ -23,28 +47,30 @@ defmodule Raxol.Agent.EmitBridge do
   | ------------------ | ------------ | ----------------- |
   | `:command_result`  | `:ephemeral` | `:item_delta`     |
   | `:app_update`      | `:durable`   | `:item_completed` |
+  | `:turn_started`    | `:durable`   | `:turn_started`   |
+  | `:turn_completed`  | `:durable`   | `:turn_completed` |
+  | `:error`           | `:durable`   | `:error`          |
 
-  Anything else passes through as an `:item_completed` with its tier
-  preserved. `family` and `tier` carry through unchanged; `id` is a per-bridge
-  monotonic sequence (the future journal offset); `ts` is preserved.
-
-  The semantic refinement of these two coarse Dispatcher types into the full
-  `:turn_started` / `:turn_completed` / `:error` vocabulary happens once the
-  Dispatcher carries turn boundaries — see the module's TODO.
+  Anything else passes through as an `:item_completed` with its tier preserved.
+  `family` and `turn_id` carry through unchanged; `ts` is preserved.
   """
 
   use Raxol.Core.Behaviours.BaseManager
 
+  alias Raxol.Agent.Contract
   alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Journal.FileStore
   alias Raxol.Agent.SessionStreamer
   alias Raxol.Core.Runtime.EmitBus
 
-  defstruct [:session_id, :streamer, counter: 0]
+  defstruct [:session_id, :streamer, :journal, journal_opts: [], last_offset: 0]
 
   @type t :: %__MODULE__{
           session_id: term(),
           streamer: GenServer.server(),
-          counter: non_neg_integer()
+          journal: FileStore.t() | nil,
+          journal_opts: keyword(),
+          last_offset: non_neg_integer()
         }
 
   @doc """
@@ -52,8 +78,12 @@ defmodule Raxol.Agent.EmitBridge do
 
   Options:
 
-    * `:session_id` (required) — the EmitBus/SessionStreamer session key
+    * `:session_id` (required) — the EmitBus/SessionStreamer/Journal session key
     * `:streamer` — SessionStreamer server (default `Raxol.Agent.SessionStreamer`)
+    * `:journal` — a pre-opened `Raxol.Agent.Journal.FileStore` handle (default:
+      opened lazily on the first durable event)
+    * `:journal_opts` — options forwarded to `FileStore.open/2` on lazy open
+      (e.g. `:base_dir`); default `[]`
     * `:name` — process name (default anonymous)
   """
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -67,30 +97,62 @@ defmodule Raxol.Agent.EmitBridge do
   def init_manager(opts) do
     session_id = Keyword.fetch!(opts, :session_id)
     streamer = Keyword.get(opts, :streamer, SessionStreamer)
+    journal = Keyword.get(opts, :journal)
+    journal_opts = Keyword.get(opts, :journal_opts, [])
 
     EmitBus.subscribe(session_id)
 
-    {:ok, %__MODULE__{session_id: session_id, streamer: streamer, counter: 0}}
+    {:ok,
+     %__MODULE__{
+       session_id: session_id,
+       streamer: streamer,
+       journal: journal,
+       journal_opts: journal_opts,
+       last_offset: last_offset(journal)
+     }}
   end
 
+  # Durable tier: the journal owns the id. Append first, take the offset, emit.
   @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info(
+        {:emit_bus, session_id, %{tier: :durable} = neutral},
+        %__MODULE__{session_id: session_id} = state
+      ) do
+    # Sanitize once and reuse for both the journal record and the live event so
+    # the live tail and the replayed record are byte-identical, not just id-equal.
+    safe = Map.put(neutral, :payload, sanitized_payload(neutral))
+    {state, offset} = append_durable(state, safe)
+    event = map_event(safe, offset, session_id)
+    SessionStreamer.emit(session_id, event, state.streamer)
+    {:noreply, %{state | last_offset: offset}}
+  end
+
+  # Ephemeral tier: never journaled. Id carries the last durable offset.
   def handle_manager_info(
         {:emit_bus, session_id, neutral},
         %__MODULE__{session_id: session_id} = state
       ) do
-    id = state.counter + 1
-    event = map_event(neutral, id, session_id)
+    event = map_event(neutral, state.last_offset, session_id)
     SessionStreamer.emit(session_id, event, state.streamer)
-    {:noreply, %{state | counter: id}}
+    {:noreply, state}
   end
 
   def handle_manager_info(_msg, state), do: {:noreply, state}
 
+  @impl GenServer
+  def terminate(_reason, %__MODULE__{journal: nil}), do: :ok
+
+  def terminate(_reason, %__MODULE__{journal: journal}) do
+    FileStore.close(journal)
+    :ok
+  end
+
   @doc """
   Map a neutral EmitBus event map to a `Raxol.Agent.Contract.Event`.
 
-  Pure. `id` becomes the contract event's monotonic offset; `session_id`
-  overrides the neutral map's (they are the same in practice).
+  Pure. `id` becomes the contract event's offset (the journal offset for durable
+  events; the last durable offset for ephemeral ones). `session_id` overrides the
+  neutral map's (they are the same in practice).
   """
   @spec map_event(map(), non_neg_integer(), term()) :: Event.t()
   def map_event(neutral, id, session_id) when is_map(neutral) do
@@ -109,8 +171,77 @@ defmodule Raxol.Agent.EmitBridge do
     }
   end
 
+  # --- durable id authority --------------------------------------------------
+
+  # Append the durable event to the journal and return the assigned offset. The
+  # journal is opened lazily on first use. If no journal is available (open or
+  # append failed — e.g. a full disk), degrade to a sequential in-memory id so
+  # ids stay monotonic and the stream keeps flowing.
+  defp append_durable(state, neutral) do
+    state = ensure_journal(state)
+
+    case state.journal do
+      nil ->
+        {state, state.last_offset + 1}
+
+      handle ->
+        case FileStore.append(handle, durable_record(neutral)) do
+          {:ok, offset} -> {state, offset}
+          {:error, _reason} -> {state, state.last_offset + 1}
+        end
+    end
+  end
+
+  defp ensure_journal(%__MODULE__{journal: nil} = state) do
+    case FileStore.open(to_string(state.session_id), state.journal_opts) do
+      {:ok, handle} -> %{state | journal: handle}
+      {:error, _reason} -> state
+    end
+  end
+
+  defp ensure_journal(state), do: state
+
+  # A plain, JSON-encodable map persisted to the journal. The Writer stamps
+  # `"id"` (= offset) and stringifies keys; replaying reconstructs the same
+  # contract-typed event. Payload is already sanitized by the caller.
+  defp durable_record(neutral) do
+    %{
+      v: 0,
+      session_id: Map.get(neutral, :session_id),
+      turn_id: Map.get(neutral, :turn_id),
+      ts: Map.get(neutral, :ts, System.system_time(:microsecond)),
+      family: Map.get(neutral, :family, :loop),
+      type: contract_type(Map.get(neutral, :type), :durable),
+      tier: :durable,
+      payload: Map.get(neutral, :payload, %{})
+    }
+  end
+
+  defp sanitized_payload(neutral) do
+    Contract.sanitize_payload(Map.get(neutral, :payload, %{}))
+  end
+
+  # Resume the ephemeral-id watermark from a supplied journal so ephemeral ids
+  # keep referencing a real durable offset across a restart.
+  defp last_offset(nil), do: 0
+
+  defp last_offset(%FileStore{} = journal) do
+    case FileStore.read(journal) do
+      {:ok, records} -> records |> List.last() |> record_id()
+      _ -> 0
+    end
+  end
+
+  defp last_offset(_), do: 0
+
+  defp record_id(%{"id" => id}) when is_integer(id), do: id
+  defp record_id(_), do: 0
+
   # Coarse Dispatcher types -> v0 loop vocabulary.
   defp contract_type(:command_result, _tier), do: :item_delta
   defp contract_type(:app_update, _tier), do: :item_completed
+  defp contract_type(:turn_started, _tier), do: :turn_started
+  defp contract_type(:turn_completed, _tier), do: :turn_completed
+  defp contract_type(:error, _tier), do: :error
   defp contract_type(_other, _tier), do: :item_completed
 end

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store.ex
@@ -25,9 +25,14 @@ defmodule Raxol.Agent.Journal.FileStore do
   alias Raxol.Agent.Journal.FileStore.{Reader, Writer}
 
   @enforce_keys [:session_id, :dir, :writer]
-  defstruct [:session_id, :dir, :writer]
+  defstruct [:session_id, :dir, :writer, owner?: true]
 
-  @type t :: %__MODULE__{session_id: String.t(), dir: Path.t(), writer: pid()}
+  @type t :: %__MODULE__{
+          session_id: String.t(),
+          dir: Path.t(),
+          writer: pid(),
+          owner?: boolean()
+        }
 
   @env_base "RAXOL_SESSIONS_DIR"
   @default_base "~/.raxol/sessions"
@@ -57,12 +62,26 @@ defmodule Raxol.Agent.Journal.FileStore do
 
       case Writer.start_link(writer_opts) do
         {:ok, pid} ->
-          {:ok, %__MODULE__{session_id: session_id, dir: dir, writer: pid}}
+          {:ok,
+           %__MODULE__{
+             session_id: session_id,
+             dir: dir,
+             writer: pid,
+             owner?: true
+           }}
 
         # Single-writer invariant: a Writer already owns this session's journal.
         # Reuse the live one rather than spawning a second writer on the segment.
+        # This handle JOINS a shared Writer it did not start — mark it a joiner
+        # so `close/1` does not stop the Writer out from under the owner.
         {:error, {:already_started, pid}} ->
-          {:ok, %__MODULE__{session_id: session_id, dir: dir, writer: pid}}
+          {:ok,
+           %__MODULE__{
+             session_id: session_id,
+             dir: dir,
+             writer: pid,
+             owner?: false
+           }}
 
         {:error, _} = err ->
           err
@@ -73,6 +92,11 @@ defmodule Raxol.Agent.Journal.FileStore do
   @impl Raxol.Agent.Journal
   def append(%__MODULE__{writer: pid}, event) when is_map(event) do
     Writer.append(pid, event)
+  catch
+    # The Writer died underneath this handle (owner closed it, crash, ...).
+    # Surface a normal error tuple instead of exiting the caller — the handle
+    # is stale and should be reopened.
+    :exit, reason -> {:error, {:writer_down, exit_reason(reason)}}
   end
 
   @impl Raxol.Agent.Journal
@@ -85,11 +109,17 @@ defmodule Raxol.Agent.Journal.FileStore do
     end
   end
 
+  # Only the handle that STARTED the Writer may stop it. A joiner handle (one
+  # whose `open/2` found the Writer `{:already_started, _}`) shares the Writer
+  # with its owner; stopping it here would crash the owner's next append.
+  # Joiners just drop their reference.
   @impl Raxol.Agent.Journal
-  def close(%__MODULE__{writer: pid}) do
+  def close(%__MODULE__{writer: pid, owner?: true}) do
     if Process.alive?(pid), do: GenServer.stop(pid)
     :ok
   end
+
+  def close(%__MODULE__{owner?: false}), do: :ok
 
   @impl Raxol.Agent.Journal
   def status(%__MODULE__{dir: dir, writer: pid}) do
@@ -103,7 +133,8 @@ defmodule Raxol.Agent.Journal.FileStore do
 
   # --- helpers ---------------------------------------------------------------
 
-  defp validate_session_id(id) when id in [".", ".."], do: {:error, :invalid_session_id}
+  defp validate_session_id(id) when id in [".", ".."],
+    do: {:error, :invalid_session_id}
 
   defp validate_session_id(id) do
     if Regex.match?(@session_id_re, id) do
@@ -116,7 +147,14 @@ defmodule Raxol.Agent.Journal.FileStore do
   defp flush(pid) do
     if Process.alive?(pid), do: Writer.flush(pid)
     :ok
+  catch
+    :exit, _ -> :ok
   end
+
+  # Strip GenServer.call decoration ({reason, {GenServer, :call, ...}}) down to
+  # the bare exit reason.
+  defp exit_reason({reason, {GenServer, :call, _}}), do: reason
+  defp exit_reason(reason), do: reason
 
   defp filter(records, opts) do
     case Keyword.get(opts, :from_offset) do

--- a/packages/raxol_agent/lib/raxol/agent/session.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session.ex
@@ -11,13 +11,15 @@ defmodule Raxol.Agent.Session do
 
   require Logger
 
-  defstruct [:id, :app_module, :lifecycle_pid, :team_id]
+  defstruct [:id, :app_module, :lifecycle_pid, :team_id, :session_id, :emit_bridge]
 
   @type t :: %__MODULE__{
           id: term(),
           app_module: module(),
           lifecycle_pid: pid() | nil,
-          team_id: term() | nil
+          team_id: term() | nil,
+          session_id: String.t() | nil,
+          emit_bridge: pid() | nil
         }
 
   @spec child_spec(keyword()) :: Supervisor.child_spec()
@@ -80,17 +82,30 @@ defmodule Raxol.Agent.Session do
     id = Keyword.fetch!(opts, :id)
     team_id = Keyword.get(opts, :team_id)
 
-    lifecycle_pid = start_or_reattach_lifecycle(app_module, id)
+    # Harness keystone: a stable session_id makes the runtime Dispatcher emit
+    # typed events, and scopes the durable journal + event stream. Start the
+    # per-session sink (EmitBridge) BEFORE the lifecycle so it is subscribed to
+    # EmitBus in time for the first turn. The sink emits into the singleton
+    # SessionStreamer (supervised by Raxol.Agent.Supervisor); when none is
+    # running its emits are harmless no-ops.
+    session_id = Keyword.get(opts, :session_id) || derive_session_id(id)
+    emit_bridge = start_emit_bridge(session_id, opts)
+
+    lifecycle_pid = start_or_reattach_lifecycle(app_module, id, session_id)
     Process.monitor(lifecycle_pid)
 
-    Logger.info("[Agent.Session] Started agent #{inspect(id)} (#{inspect(app_module)})")
+    Logger.info(
+      "[Agent.Session] Started agent #{inspect(id)} (#{inspect(app_module)}) session=#{session_id}"
+    )
 
     {:ok,
      %__MODULE__{
        id: id,
        app_module: app_module,
        lifecycle_pid: lifecycle_pid,
-       team_id: team_id
+       team_id: team_id,
+       session_id: session_id,
+       emit_bridge: emit_bridge
      }}
   end
 
@@ -170,6 +185,11 @@ defmodule Raxol.Agent.Session do
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call(:get_session_id, _from, state) do
+    {:reply, {:ok, state.session_id}, state}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_call(_msg, _from, state),
     do: {:reply, {:error, :unknown_call}, state}
 
@@ -194,7 +214,21 @@ defmodule Raxol.Agent.Session do
       Raxol.Core.Runtime.Lifecycle.stop(state.lifecycle_pid)
     end
 
+    # Gracefully stop the per-session sink so its journal handle is flushed and
+    # closed (its terminate/2 does this). Best-effort — never block session
+    # shutdown on it.
+    stop_emit_bridge(state.emit_bridge)
+
     :ok
+  end
+
+  @doc "Read the harness session_id for a running agent (nil if not found)."
+  @spec session_id(term()) :: {:ok, String.t() | nil} | {:error, :not_found}
+  def session_id(agent_id) do
+    case Registry.lookup(Raxol.Agent.Registry, agent_id) do
+      [{pid, _}] -> GenServer.call(pid, :get_session_id)
+      [] -> {:error, :not_found}
+    end
   end
 
   # Wire the agent's permission/sandbox/audit hook chain into the runtime so it
@@ -211,13 +245,15 @@ defmodule Raxol.Agent.Session do
     end
   end
 
-  defp start_or_reattach_lifecycle(app_module, id) do
+  defp start_or_reattach_lifecycle(app_module, id, session_id) do
     opts = [
       environment: :agent,
       width: Raxol.Core.Defaults.terminal_width(),
       height: Raxol.Core.Defaults.terminal_height(),
       name: :"agent_lifecycle_#{inspect(id)}",
-      command_interceptor: build_command_interceptor(app_module, id)
+      command_interceptor: build_command_interceptor(app_module, id),
+      # Harness keystone: makes the Dispatcher publish typed events to EmitBus.
+      session_id: session_id
     ]
 
     case Raxol.Core.Runtime.Lifecycle.start_link(app_module, opts) do
@@ -231,6 +267,75 @@ defmodule Raxol.Agent.Session do
         # Reattach to the running runtime instead of failing to restart.
         lifecycle_pid
     end
+  end
+
+  # A session_id is also the durable journal's on-disk directory name, so it
+  # must be a safe filename. Coerce the (arbitrary term) agent id into the
+  # journal's charset and suffix a unique token so restarts never collide.
+  defp derive_session_id(id) do
+    base =
+      id
+      |> to_id_string()
+      |> String.replace(~r/[^A-Za-z0-9._-]/, "-")
+      |> String.trim("-")
+
+    base = if base == "", do: "agent", else: base
+    "#{base}-#{System.unique_integer([:positive])}"
+  end
+
+  defp to_id_string(id) when is_binary(id), do: id
+  defp to_id_string(id) when is_atom(id), do: Atom.to_string(id)
+  defp to_id_string(id), do: inspect(id)
+
+  # Start the per-session sink under the agent DynamicSupervisor when available
+  # (so it is not crash-coupled to this Session); fall back to a linked start
+  # otherwise, so the sink dies with the session rather than leaking. Returns
+  # the bridge pid or nil.
+  defp start_emit_bridge(session_id, opts) do
+    bridge_opts =
+      [session_id: session_id]
+      |> maybe_put(:journal, Keyword.get(opts, :journal))
+      |> maybe_put(:journal_opts, Keyword.get(opts, :journal_opts))
+
+    case Process.whereis(Raxol.Agent.DynSup) do
+      nil ->
+        start_emit_bridge_standalone(bridge_opts)
+
+      _sup ->
+        case DynamicSupervisor.start_child(
+               Raxol.Agent.DynSup,
+               {Raxol.Agent.EmitBridge, bridge_opts}
+             ) do
+          {:ok, pid} -> pid
+          {:error, {:already_started, pid}} -> pid
+          {:error, _} -> start_emit_bridge_standalone(bridge_opts)
+        end
+    end
+  end
+
+  defp start_emit_bridge_standalone(bridge_opts) do
+    case Raxol.Agent.EmitBridge.start_link(bridge_opts) do
+      {:ok, pid} -> pid
+      _ -> nil
+    end
+  end
+
+  defp maybe_put(kw, _key, nil), do: kw
+  defp maybe_put(kw, key, value), do: Keyword.put(kw, key, value)
+
+  defp stop_emit_bridge(nil), do: :ok
+
+  defp stop_emit_bridge(pid) do
+    if Process.alive?(pid) do
+      case Process.whereis(Raxol.Agent.DynSup) do
+        nil -> GenServer.stop(pid, :normal, 1_000)
+        _sup -> DynamicSupervisor.terminate_child(Raxol.Agent.DynSup, pid)
+      end
+    end
+
+    :ok
+  catch
+    :exit, _ -> :ok
   end
 
   defp get_dispatcher(lifecycle_pid) when is_pid(lifecycle_pid) do

--- a/packages/raxol_agent/lib/raxol/agent/session.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session.ex
@@ -11,7 +11,15 @@ defmodule Raxol.Agent.Session do
 
   require Logger
 
-  defstruct [:id, :app_module, :lifecycle_pid, :team_id, :session_id, :emit_bridge]
+  defstruct [
+    :id,
+    :app_module,
+    :lifecycle_pid,
+    :team_id,
+    :session_id,
+    :emit_bridge,
+    bridge_opts: []
+  ]
 
   @type t :: %__MODULE__{
           id: term(),
@@ -19,7 +27,8 @@ defmodule Raxol.Agent.Session do
           lifecycle_pid: pid() | nil,
           team_id: term() | nil,
           session_id: String.t() | nil,
-          emit_bridge: pid() | nil
+          emit_bridge: pid() | nil,
+          bridge_opts: keyword()
         }
 
   @spec child_spec(keyword()) :: Supervisor.child_spec()
@@ -37,7 +46,9 @@ defmodule Raxol.Agent.Session do
   def start_link(opts) do
     id = Keyword.fetch!(opts, :id)
 
-    GenServer.start_link(__MODULE__, opts, name: {:via, Registry, {Raxol.Agent.Registry, id}})
+    GenServer.start_link(__MODULE__, opts,
+      name: {:via, Registry, {Raxol.Agent.Registry, id}}
+    )
   end
 
   @doc "Send a message into the agent's TEA loop."
@@ -89,7 +100,17 @@ defmodule Raxol.Agent.Session do
     # SessionStreamer (supervised by Raxol.Agent.Supervisor); when none is
     # running its emits are harmless no-ops.
     session_id = Keyword.get(opts, :session_id) || derive_session_id(id)
-    emit_bridge = start_emit_bridge(session_id, opts)
+
+    bridge_opts =
+      []
+      |> maybe_put(:journal, Keyword.get(opts, :journal))
+      |> maybe_put(:journal_opts, Keyword.get(opts, :journal_opts))
+
+    emit_bridge = start_emit_bridge(session_id, bridge_opts)
+    # The session OWNS its bridge: monitor it so a bridge death is observed
+    # (:DOWN → log + restart-or-degrade), never linked so a bridge crash can
+    # never take the session down.
+    if emit_bridge, do: Process.monitor(emit_bridge)
 
     lifecycle_pid = start_or_reattach_lifecycle(app_module, id, session_id)
     Process.monitor(lifecycle_pid)
@@ -105,7 +126,8 @@ defmodule Raxol.Agent.Session do
        lifecycle_pid: lifecycle_pid,
        team_id: team_id,
        session_id: session_id,
-       emit_bridge: emit_bridge
+       emit_bridge: emit_bridge,
+       bridge_opts: bridge_opts
      }}
   end
 
@@ -193,6 +215,29 @@ defmodule Raxol.Agent.Session do
   def handle_manager_call(_msg, _from, state),
     do: {:reply, {:error, :unknown_call}, state}
 
+  # The session's emit bridge went down. Graceful stops (:normal/:shutdown)
+  # need no reaction — the session itself is usually terminating. On a crash,
+  # restart the bridge (same session_id, so it re-registers and re-subscribes)
+  # or degrade to running without a sink if the restart fails.
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info(
+        {:DOWN, _ref, :process, pid, reason},
+        %__MODULE__{emit_bridge: pid} = state
+      ) do
+    if reason in [:normal, :shutdown] do
+      {:noreply, %{state | emit_bridge: nil}}
+    else
+      Logger.warning(
+        "[Agent.Session] EmitBridge for session #{state.session_id} crashed: " <>
+          "#{inspect(reason)}; restarting"
+      )
+
+      bridge = start_emit_bridge(state.session_id, state.bridge_opts)
+      if bridge, do: Process.monitor(bridge)
+      {:noreply, %{state | emit_bridge: bridge}}
+    end
+  end
+
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_info({:DOWN, _ref, :process, pid, reason}, state) do
     if pid == state.lifecycle_pid do
@@ -241,7 +286,10 @@ defmodule Raxol.Agent.Session do
 
       hooks ->
         context = %{agent_id: id, agent_module: app_module}
-        fn commands -> Raxol.Agent.CommandHook.wrap_commands(commands, hooks, context) end
+
+        fn commands ->
+          Raxol.Agent.CommandHook.wrap_commands(commands, hooks, context)
+        end
     end
   end
 
@@ -288,14 +336,18 @@ defmodule Raxol.Agent.Session do
   defp to_id_string(id), do: inspect(id)
 
   # Start the per-session sink under the agent DynamicSupervisor when available
-  # (so it is not crash-coupled to this Session); fall back to a linked start
-  # otherwise, so the sink dies with the session rather than leaking. Returns
-  # the bridge pid or nil.
-  defp start_emit_bridge(session_id, opts) do
+  # (so it is not crash-coupled to this Session); fall back to an unlinked
+  # standalone start otherwise. Returns the bridge pid or nil.
+  #
+  # The bridge is registered by session_id in Raxol.Agent.Registry (when
+  # running) under `{:emit_bridge, session_id}`. That registration is the
+  # orphan guard: if this session crashed and its bridge survived (subscribed,
+  # journal open), a restarted session with the same session_id gets
+  # `{:already_started, pid}` here and ADOPTS the orphan instead of starting a
+  # second bridge — one bridge per session, no duplicate emits.
+  defp start_emit_bridge(session_id, extra_opts) do
     bridge_opts =
-      [session_id: session_id]
-      |> maybe_put(:journal, Keyword.get(opts, :journal))
-      |> maybe_put(:journal_opts, Keyword.get(opts, :journal_opts))
+      [session_id: session_id] ++ extra_opts ++ bridge_name_opts(session_id)
 
     case Process.whereis(Raxol.Agent.DynSup) do
       nil ->
@@ -313,10 +365,35 @@ defmodule Raxol.Agent.Session do
     end
   end
 
+  defp bridge_name_opts(session_id) do
+    if Process.whereis(Raxol.Agent.Registry) do
+      [
+        name:
+          {:via, Registry, {Raxol.Agent.Registry, {:emit_bridge, session_id}}}
+      ]
+    else
+      []
+    end
+  end
+
+  # Standalone fallback (no Raxol.Agent.DynSup). Ownership direction: the
+  # SESSION owns the bridge, never the reverse — a bridge crash must not take
+  # the session down. A raw start_link would link bidirectionally, so we
+  # immediately unlink and rely on the Process.monitor set by the caller
+  # (init_manager / the :DOWN handler): bridge death arrives as :DOWN and is
+  # answered with log + restart-or-degrade, and a crashed session's surviving
+  # bridge is found-and-adopted via its registry name by the successor.
   defp start_emit_bridge_standalone(bridge_opts) do
     case Raxol.Agent.EmitBridge.start_link(bridge_opts) do
-      {:ok, pid} -> pid
-      _ -> nil
+      {:ok, pid} ->
+        Process.unlink(pid)
+        pid
+
+      {:error, {:already_started, pid}} ->
+        pid
+
+      _ ->
+        nil
     end
   end
 
@@ -328,8 +405,16 @@ defmodule Raxol.Agent.Session do
   defp stop_emit_bridge(pid) do
     if Process.alive?(pid) do
       case Process.whereis(Raxol.Agent.DynSup) do
-        nil -> GenServer.stop(pid, :normal, 1_000)
-        _sup -> DynamicSupervisor.terminate_child(Raxol.Agent.DynSup, pid)
+        nil ->
+          GenServer.stop(pid, :normal, 1_000)
+
+        _sup ->
+          # An adopted bridge may have been started standalone by a prior
+          # session incarnation; stop it directly if DynSup doesn't own it.
+          case DynamicSupervisor.terminate_child(Raxol.Agent.DynSup, pid) do
+            :ok -> :ok
+            {:error, :not_found} -> GenServer.stop(pid, :normal, 1_000)
+          end
       end
     end
 

--- a/packages/raxol_agent/lib/raxol/agent/supervisor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/supervisor.ex
@@ -5,6 +5,8 @@ defmodule Raxol.Agent.Supervisor do
   Children:
   - `Raxol.Agent.Registry` -- unique Registry for agent discovery
   - `Raxol.Agent.DynSup` -- DynamicSupervisor for Agent.Process instances
+    (and per-session `Raxol.Agent.EmitBridge` sinks)
+  - `Raxol.Agent.SessionStreamer` -- singleton harness event stream
   - `Raxol.Agent.Orchestrator` -- multi-agent coordinator
   - `Raxol.Agent.Memory.Store.Ets` -- when configured as the memory provider
   - `Raxol.Agent.Skills.Store` -- when a skills provider is configured
@@ -36,6 +38,7 @@ defmodule Raxol.Agent.Supervisor do
       [
         {Registry, keys: :unique, name: Raxol.Agent.Registry},
         {DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one},
+        Raxol.Agent.SessionStreamer,
         Raxol.Agent.Orchestrator
       ] ++ memory_children() ++ skills_children() ++ curator_children()
 

--- a/packages/raxol_agent/test/raxol/agent/directive_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/directive_test.exs
@@ -59,11 +59,18 @@ defmodule Raxol.Agent.DirectiveTest do
           sender.({:progress, 50})
         end)
 
-      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+      Executor.execute(directive, %{
+        pid: self(),
+        runtime_pid: self(),
+        turn_id: "turn-orig"
+      })
 
-      assert_receive {:command_result, :first}, 1_000
-      assert_receive {:command_result, :second}, 1_000
-      assert_receive {:command_result, {:progress, 50}}, 1_000
+      # Results carry the originating turn's id snapshotted at dispatch.
+      assert_receive {:command_result, :first, %{turn_id: "turn-orig"}}, 1_000
+      assert_receive {:command_result, :second, %{turn_id: "turn-orig"}}, 1_000
+
+      assert_receive {:command_result, {:progress, 50}, %{turn_id: "turn-orig"}},
+                     1_000
     end
 
     test "raised exceptions are reported as :async_error" do
@@ -74,7 +81,8 @@ defmodule Raxol.Agent.DirectiveTest do
 
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:async_error, "boom"}}, 1_000
+      assert_receive {:command_result, {:async_error, "boom"}, %{turn_id: nil}},
+                     1_000
     end
   end
 
@@ -83,7 +91,8 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("echo hello-from-shell")
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:shell_result, %{exit_status: 0, output: output}}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 0, output: output}},
+                      %{turn_id: nil}},
                      5_000
 
       assert String.contains?(output, "hello-from-shell")
@@ -93,7 +102,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("exit 7")
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:shell_result, %{exit_status: 7}}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 7}}, %{turn_id: nil}},
                      5_000
     end
 
@@ -101,7 +110,8 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("sleep 5", timeout: 100)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:shell_result, %{exit_status: :timeout}}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: :timeout}},
+                      %{turn_id: nil}},
                      2_000
     end
   end
@@ -111,7 +121,8 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.send_agent("nobody", :payload)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:send_agent_error, :not_found, "nobody"}},
+      assert_receive {:command_result, {:send_agent_error, :not_found, "nobody"},
+                      %{turn_id: nil}},
                      1_000
     end
 

--- a/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
@@ -85,7 +85,10 @@ defmodule Raxol.Agent.EmitBridgeTest do
       assert event.type == :item_delta
       assert event.tier == :ephemeral
       assert event.family == :loop
-      assert event.id == 1
+      # Ephemeral events are never journaled; their id carries the last durable
+      # offset (0 here — no durable event has been journaled yet), never a fresh
+      # offset that could masquerade as a journal id.
+      assert event.id == 0
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/keystone_close_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/keystone_close_test.exs
@@ -41,7 +41,10 @@ defmodule Raxol.Agent.KeystoneCloseTest do
     # App-level singletons: tolerate an already-running instance, never leak a
     # named singleton that a later start_supervised!-based test would collide on.
     ensure_registry(:duplicate, EmitBus.registry_name())
-    ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
+
+    ensure_running(
+      {Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences}
+    )
 
     ensure_running(
       {DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one}
@@ -78,7 +81,12 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       # The live tail carried a monotonic run of durable ids.
       assert live_ids == Enum.sort(live_ids)
       assert length(live_ids) >= 3
-      assert Enum.map(durable, & &1.type) == [:turn_started, :item_completed, :turn_completed]
+
+      assert Enum.map(durable, & &1.type) == [
+               :turn_started,
+               :item_completed,
+               :turn_completed
+             ]
 
       # Reopen the journal from disk (same session dir via RAXOL_SESSIONS_DIR)
       # and replay it. One identity: replayed id == journal offset == live id.
@@ -109,13 +117,30 @@ defmodule Raxol.Agent.KeystoneCloseTest do
 
       # A full turn's worth of events, durable + one ephemeral delta.
       publish(session_id, :turn_started, :durable, %{prompt: "p"}, "t1")
-      publish(session_id, :app_update, :durable, %{message: {:agent_message, :x, :go}}, "t1")
-      publish(session_id, :command_result, :ephemeral, %{chunk: "streamed"}, "t1")
+
+      publish(
+        session_id,
+        :app_update,
+        :durable,
+        %{message: {:agent_message, :x, :go}},
+        "t1"
+      )
+
+      publish(
+        session_id,
+        :command_result,
+        :ephemeral,
+        %{chunk: "streamed"},
+        "t1"
+      )
+
       publish(session_id, :turn_completed, :durable, %{}, "t1")
 
       # Wait until the sink has emitted turn_completed — guarantees all four were
       # processed (durable ones appended before publish).
-      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed}}, 1_000
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_completed}},
+                     1_000
 
       # Simulate the BEAM going away: stop the sink, which flushes + closes the
       # journal writer in terminate/2.
@@ -155,9 +180,17 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       :ok = SessionStreamer.subscribe(session_id)
       :ok = Session.send_message(agent_id(sess), {:say, "hi"})
 
-      assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started}, 1_000
-      assert_receive {:session_event, ^session_id, %Event{type: :item_completed} = item}, 1_000
-      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed} = completed}, 1_000
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_started} = started},
+                     1_000
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :item_completed} = item},
+                     1_000
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_completed} = completed},
+                     1_000
 
       # session_id is non-nil (acceptance #4) and the turn_id is one stable value
       # across every item in the turn.
@@ -182,12 +215,211 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       :ok = SessionStreamer.subscribe(session_id)
       :ok = Session.send_message(agent_id(sess), :boom)
 
-      assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started}, 1_000
-      assert_receive {:session_event, ^session_id, %Event{type: :error} = error}, 1_000
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_started} = started},
+                     1_000
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :error} = error},
+                     1_000
 
       assert error.tier == :durable
       assert error.turn_id == started.turn_id
       assert Map.has_key?(error.payload, :reason)
+    end
+  end
+
+  describe "append failure is a hard gate (no phantom ids)" do
+    test "a failed durable append is dropped loudly: no fabricated id, offset unchanged, no collision" do
+      base = tmp_base()
+      session_id = "u15-appendfail-#{uniq()}"
+      {:ok, streamer} = SessionStreamer.start_link(name: nil)
+
+      {:ok, bridge} =
+        EmitBridge.start_link(
+          session_id: session_id,
+          streamer: streamer,
+          journal_opts: [base_dir: base]
+        )
+
+      SessionStreamer.subscribe(session_id, streamer)
+
+      # A successful durable append: offset 1.
+      publish(session_id, :turn_started, :durable, %{prompt: "p"}, "t1")
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_started, id: 1}},
+                     1_000
+
+      # Kill the journal writer underneath the bridge (stands in for disk-full /
+      # writer crash: append returns {:error, _}).
+      %{journal: %FileStore{writer: writer}} = :sys.get_state(bridge)
+      GenServer.stop(writer)
+
+      publish(session_id, :app_update, :durable, %{message: "lost"}, "t1")
+
+      # The durable event was NOT published with a fabricated id. Instead a
+      # loud ephemeral :error signal came out, pinned to the unchanged last
+      # durable offset.
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :error} = failure},
+                     1_000
+
+      assert failure.tier == :ephemeral
+      assert failure.id == 1
+      assert failure.payload.reason == :journal_append_failed
+      assert failure.payload.original_type == :item_completed
+
+      # last_offset did not advance on the failure.
+      assert %{last_offset: 1} = :sys.get_state(bridge)
+
+      # A subsequent durable event lazily reopens the journal, resumes from the
+      # on-disk offset, and takes a fresh non-colliding id (2).
+      publish(session_id, :turn_completed, :durable, %{}, "t1")
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_completed, id: 2}},
+                     1_000
+
+      GenServer.stop(bridge)
+
+      # Replay reproduces exactly the journaled events — the dropped durable
+      # event is absent from history, and no two events ever shared an id.
+      {:ok, j} = FileStore.open(session_id, base_dir: base)
+      {:ok, records} = FileStore.read(j)
+      FileStore.close(j)
+
+      assert Enum.map(records, & &1["id"]) == [1, 2]
+
+      assert Enum.map(records, & &1["type"]) == [
+               "turn_started",
+               "turn_completed"
+             ]
+    end
+  end
+
+  describe "turn_id does not bleed past turn_completed" do
+    test "a non-agent event after a finished turn emits app_update with turn_id: nil" do
+      session_id = "u15-bleed-#{uniq()}"
+
+      {:ok, sess} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"u15_bleed_#{uniq()}",
+          session_id: session_id
+        )
+
+      on_exit(fn -> stop(sess) end)
+
+      :ok = SessionStreamer.subscribe(session_id)
+      :ok = Session.send_message(agent_id(sess), {:say, "hi"})
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_started} = started},
+                     1_000
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :item_completed} = turn_item},
+                     1_000
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :turn_completed}},
+                     1_000
+
+      assert turn_item.turn_id == started.turn_id
+
+      # Fire a non-agent-message event through the same dispatcher (a
+      # subscription tick). Its durable app_update must NOT be stamped with the
+      # finished turn's id.
+      send(dispatcher(sess), {:subscription, :tick})
+
+      assert_receive {:session_event, ^session_id,
+                      %Event{type: :item_completed} = item},
+                     1_000
+
+      assert is_nil(item.turn_id)
+    end
+  end
+
+  describe "bridge survives a session crash without duplicating (orphan adoption)" do
+    test "a brutally-killed session's bridge is adopted by the restarted session — one bridge, no duplicate emits" do
+      session_id = "u15-orphan-#{uniq()}"
+      Process.flag(:trap_exit, true)
+
+      {:ok, sess1} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"u15_orphan_a_#{uniq()}",
+          session_id: session_id
+        )
+
+      assert [{bridge, _}] =
+               Registry.lookup(Raxol.Agent.Registry, {:emit_bridge, session_id})
+
+      # Brutal kill — terminate/2 never runs, so no graceful bridge cleanup.
+      Process.exit(sess1, :kill)
+      assert_receive {:EXIT, ^sess1, :killed}, 1_000
+
+      # The bridge survived the crash (session owns it via monitor, not link).
+      assert Process.alive?(bridge)
+
+      {:ok, sess2} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"u15_orphan_b_#{uniq()}",
+          session_id: session_id
+        )
+
+      on_exit(fn -> stop(sess2) end)
+
+      # Exactly one bridge for the session_id — the orphan was adopted, not
+      # doubled.
+      assert [{^bridge, _}] =
+               Registry.lookup(Raxol.Agent.Registry, {:emit_bridge, session_id})
+
+      :ok = SessionStreamer.subscribe(session_id)
+      :ok = Session.send_message(agent_id(sess2), {:say, "once"})
+
+      # One turn -> exactly one turn_started; a duplicate bridge would emit two.
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_started}},
+                     1_000
+
+      refute_receive {:session_event, ^session_id, %Event{type: :turn_started}},
+                     300
+    end
+  end
+
+  describe "shared writer close discipline (owner vs joiner)" do
+    test "closing a joiner handle leaves the owner's writer alive and appendable" do
+      base = tmp_base()
+      session_id = "u15-shared-#{uniq()}"
+
+      {:ok, owner} = FileStore.open(session_id, base_dir: base)
+      {:ok, joiner} = FileStore.open(session_id, base_dir: base)
+
+      # Both handles share the single writer; only the first is the owner.
+      assert owner.writer == joiner.writer
+      assert owner.owner?
+      refute joiner.owner?
+
+      :ok = FileStore.close(joiner)
+
+      # The shared writer survived the joiner's close; the owner still appends.
+      assert Process.alive?(owner.writer)
+      assert {:ok, 1} = FileStore.append(owner, %{"type" => "x"})
+
+      :ok = FileStore.close(owner)
+      refute Process.alive?(owner.writer)
+    end
+
+    test "an append through a handle whose writer died surfaces {:error, {:writer_down, _}}" do
+      base = tmp_base()
+      session_id = "u15-down-#{uniq()}"
+
+      {:ok, j} = FileStore.open(session_id, base_dir: base)
+      GenServer.stop(j.writer)
+
+      assert {:error, {:writer_down, _}} = FileStore.append(j, %{"type" => "x"})
     end
   end
 
@@ -221,23 +453,38 @@ defmodule Raxol.Agent.KeystoneCloseTest do
     receive do
       {:session_event, ^session_id, %Event{tier: :durable} = ev} ->
         acc = acc ++ [ev]
-        if ev.type == :turn_completed, do: acc, else: collect_until_turn_completed(session_id, acc)
+
+        if ev.type == :turn_completed,
+          do: acc,
+          else: collect_until_turn_completed(session_id, acc)
 
       {:session_event, ^session_id, %Event{}} ->
         # ephemeral — ignore for the durable-identity check
         collect_until_turn_completed(session_id, acc)
     after
-      2_000 -> flunk("timed out collecting durable turn events; got: #{inspect(acc)}")
+      2_000 ->
+        flunk("timed out collecting durable turn events; got: #{inspect(acc)}")
     end
   end
 
   defp publish(session_id, type, tier, payload, turn_id) do
-    EmitBus.publish(EmitBus.build(session_id, type, tier, payload, turn_id: turn_id))
+    EmitBus.publish(
+      EmitBus.build(session_id, type, tier, payload, turn_id: turn_id)
+    )
   end
 
   defp agent_id(sess) do
     %{id: id} = :sys.get_state(sess)
     id
+  end
+
+  defp dispatcher(sess) do
+    %{lifecycle_pid: lifecycle_pid} = :sys.get_state(sess)
+
+    %{dispatcher_pid: dispatcher_pid} =
+      GenServer.call(lifecycle_pid, :get_full_state)
+
+    dispatcher_pid
   end
 
   defp stop(pid) do
@@ -269,6 +516,8 @@ defmodule Raxol.Agent.KeystoneCloseTest do
     end
   end
 
-  defp start_child(DynamicSupervisor, opts), do: DynamicSupervisor.start_link(opts)
+  defp start_child(DynamicSupervisor, opts),
+    do: DynamicSupervisor.start_link(opts)
+
   defp start_child(mod, opts), do: mod.start_link(opts)
 end

--- a/packages/raxol_agent/test/raxol/agent/keystone_close_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/keystone_close_test.exs
@@ -1,0 +1,274 @@
+defmodule Raxol.Agent.KeystoneCloseTest do
+  @moduledoc """
+  U1.5 — close the keystone. Proves "replay-as-truth" is real and the dual-id
+  landmine is dead:
+
+    1. a durable event's live-tail id == its journal offset == its replayed id,
+    2. the durable trace survives a writer death (close/reopen), ids intact,
+    3. a turn is bracketed by `turn_started` … items … `turn_completed` with one
+       stable `turn_id`, and an errored turn emits `:error`,
+    4. `session_id` is non-nil on emitted events for a live agent session.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.EmitBridge
+  alias Raxol.Agent.Journal.FileStore
+  alias Raxol.Agent.Session
+  alias Raxol.Agent.SessionStreamer
+  alias Raxol.Core.Runtime.EmitBus
+
+  # A synchronous, headless agent: one inbound message = one fold = one turn.
+  defmodule EchoAgent do
+    use Raxol.Agent
+
+    def init(_context), do: %{seen: []}
+
+    def update({:agent_message, _from, {:say, text}}, model),
+      do: {%{model | seen: [text | model.seen]}, []}
+
+    def update({:agent_message, _from, :boom}, _model),
+      do: raise("boom in a live turn")
+
+    def update(_msg, model), do: {model, []}
+
+    def view(model), do: text("seen: #{length(model.seen)}")
+  end
+
+  setup do
+    # App-level singletons: tolerate an already-running instance, never leak a
+    # named singleton that a later start_supervised!-based test would collide on.
+    ensure_registry(:duplicate, EmitBus.registry_name())
+    ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
+
+    ensure_running(
+      {DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one}
+    )
+
+    # Per-test singletons owned by ExUnit (auto-stopped at test end): the agent
+    # Registry (matches session_test/team_test) and the named SessionStreamer the
+    # sink emits into.
+    start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
+    start_supervised!(Raxol.Agent.SessionStreamer)
+
+    :ok
+  end
+
+  describe "the dual-id regression (id authority)" do
+    test "durable live-tail ids == journal offsets == replayed ids (one identity)" do
+      session_id = "u15-dualid-#{uniq()}"
+
+      {:ok, sess} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"u15_dualid_#{uniq()}",
+          session_id: session_id
+        )
+
+      on_exit(fn -> stop(sess) end)
+
+      :ok = SessionStreamer.subscribe(session_id)
+      :ok = Session.send_message(agent_id(sess), {:say, "hello"})
+
+      durable = collect_until_turn_completed(session_id)
+      live_ids = Enum.map(durable, & &1.id)
+
+      # The live tail carried a monotonic run of durable ids.
+      assert live_ids == Enum.sort(live_ids)
+      assert length(live_ids) >= 3
+      assert Enum.map(durable, & &1.type) == [:turn_started, :item_completed, :turn_completed]
+
+      # Reopen the journal from disk (same session dir via RAXOL_SESSIONS_DIR)
+      # and replay it. One identity: replayed id == journal offset == live id.
+      {:ok, j} = FileStore.open(session_id, [])
+      {:ok, records} = FileStore.read(j)
+      FileStore.close(j)
+
+      replay_ids = Enum.map(records, & &1["id"])
+      assert replay_ids == live_ids
+      assert replay_ids == Enum.to_list(1..length(replay_ids))
+    end
+  end
+
+  describe "survives a writer death (BEAM kill)" do
+    test "durable trace is fully readable after close/reopen; ids intact and monotonic" do
+      base = tmp_base()
+      session_id = "u15-kill-#{uniq()}"
+      {:ok, streamer} = SessionStreamer.start_link(name: nil)
+
+      {:ok, bridge} =
+        EmitBridge.start_link(
+          session_id: session_id,
+          streamer: streamer,
+          journal_opts: [base_dir: base]
+        )
+
+      SessionStreamer.subscribe(session_id, streamer)
+
+      # A full turn's worth of events, durable + one ephemeral delta.
+      publish(session_id, :turn_started, :durable, %{prompt: "p"}, "t1")
+      publish(session_id, :app_update, :durable, %{message: {:agent_message, :x, :go}}, "t1")
+      publish(session_id, :command_result, :ephemeral, %{chunk: "streamed"}, "t1")
+      publish(session_id, :turn_completed, :durable, %{}, "t1")
+
+      # Wait until the sink has emitted turn_completed — guarantees all four were
+      # processed (durable ones appended before publish).
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed}}, 1_000
+
+      # Simulate the BEAM going away: stop the sink, which flushes + closes the
+      # journal writer in terminate/2.
+      GenServer.stop(bridge)
+
+      # Reopen from disk. The ephemeral delta was never journaled; the three
+      # durable events are present with monotonic offsets 1..3.
+      {:ok, j} = FileStore.open(session_id, base_dir: base)
+      {:ok, records} = FileStore.read(j)
+
+      ids = Enum.map(records, & &1["id"])
+      assert ids == [1, 2, 3]
+      assert ids == Enum.sort(ids)
+
+      assert Enum.map(records, & &1["type"]) ==
+               ["turn_started", "item_completed", "turn_completed"]
+
+      # The non-JSON tuple in the app_update payload was sanitized, not crashed.
+      assert FileStore.status(j) == :ok
+      FileStore.close(j)
+    end
+  end
+
+  describe "turn brackets (loop vocabulary)" do
+    test "a turn is turn_started{turn_id} … items … turn_completed{turn_id}, one stable turn_id" do
+      session_id = "u15-turn-#{uniq()}"
+
+      {:ok, sess} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"u15_turn_#{uniq()}",
+          session_id: session_id
+        )
+
+      on_exit(fn -> stop(sess) end)
+
+      :ok = SessionStreamer.subscribe(session_id)
+      :ok = Session.send_message(agent_id(sess), {:say, "hi"})
+
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started}, 1_000
+      assert_receive {:session_event, ^session_id, %Event{type: :item_completed} = item}, 1_000
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed} = completed}, 1_000
+
+      # session_id is non-nil (acceptance #4) and the turn_id is one stable value
+      # across every item in the turn.
+      assert started.session_id == session_id
+      assert is_binary(started.turn_id)
+      assert started.turn_id == item.turn_id
+      assert started.turn_id == completed.turn_id
+    end
+
+    test "an errored turn emits :error after turn_started" do
+      session_id = "u15-err-#{uniq()}"
+
+      {:ok, sess} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"u15_err_#{uniq()}",
+          session_id: session_id
+        )
+
+      on_exit(fn -> stop(sess) end)
+
+      :ok = SessionStreamer.subscribe(session_id)
+      :ok = Session.send_message(agent_id(sess), :boom)
+
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started}, 1_000
+      assert_receive {:session_event, ^session_id, %Event{type: :error} = error}, 1_000
+
+      assert error.tier == :durable
+      assert error.turn_id == started.turn_id
+      assert Map.has_key?(error.payload, :reason)
+    end
+  end
+
+  describe "session_id flows for a live agent session" do
+    test "emitted events carry a non-nil session_id" do
+      session_id = "u15-sid-#{uniq()}"
+
+      {:ok, sess} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"u15_sid_#{uniq()}",
+          session_id: session_id
+        )
+
+      on_exit(fn -> stop(sess) end)
+
+      assert {:ok, ^session_id} = Session.session_id(agent_id(sess))
+
+      :ok = SessionStreamer.subscribe(session_id)
+      :ok = Session.send_message(agent_id(sess), {:say, "x"})
+
+      assert_receive {:session_event, ^session_id, %Event{} = event}, 1_000
+      refute is_nil(event.session_id)
+      assert event.session_id == session_id
+    end
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  defp collect_until_turn_completed(session_id, acc \\ []) do
+    receive do
+      {:session_event, ^session_id, %Event{tier: :durable} = ev} ->
+        acc = acc ++ [ev]
+        if ev.type == :turn_completed, do: acc, else: collect_until_turn_completed(session_id, acc)
+
+      {:session_event, ^session_id, %Event{}} ->
+        # ephemeral — ignore for the durable-identity check
+        collect_until_turn_completed(session_id, acc)
+    after
+      2_000 -> flunk("timed out collecting durable turn events; got: #{inspect(acc)}")
+    end
+  end
+
+  defp publish(session_id, type, tier, payload, turn_id) do
+    EmitBus.publish(EmitBus.build(session_id, type, tier, payload, turn_id: turn_id))
+  end
+
+  defp agent_id(sess) do
+    %{id: id} = :sys.get_state(sess)
+    id
+  end
+
+  defp stop(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal, 2_000)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp uniq, do: System.unique_integer([:positive])
+
+  defp tmp_base do
+    base = Path.join(System.tmp_dir!(), "u15_journal_#{uniq()}")
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf(base) end)
+    base
+  end
+
+  defp ensure_registry(keys, name) do
+    case Registry.start_link(keys: keys, name: name) do
+      {:ok, pid} -> Process.unlink(pid)
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+
+  defp ensure_running({mod, opts}) do
+    case start_child(mod, opts) do
+      {:ok, pid} -> Process.unlink(pid)
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+
+  defp start_child(DynamicSupervisor, opts), do: DynamicSupervisor.start_link(opts)
+  defp start_child(mod, opts), do: mod.start_link(opts)
+end

--- a/packages/raxol_agent/test/raxol/agent/streaming_turn_attribution_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/streaming_turn_attribution_test.exs
@@ -1,0 +1,146 @@
+defmodule Raxol.Agent.StreamingTurnAttributionTest do
+  @moduledoc """
+  Async cross-turn contamination regression (PR #547 review, finding 3).
+
+  A streaming agent dispatches an async command in turn N whose delta lands
+  AFTER turn N+1 has started and finished. The dispatcher is a single mailbox,
+  so an emit-time read of `state.turn_id` would stamp the late delta with
+  whatever is current — nil between turns, or a later turn's id if one is in
+  flight — poisoning U6's `expected_turn_id` CAS. The fix snapshots the
+  minting turn's id into the command's own context at dispatch; the executor
+  echoes it back, so the delta carries its ORIGINATING turn's id.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Session
+  alias Raxol.Agent.SessionStreamer
+  alias Raxol.Core.Runtime.EmitBus
+
+  # A streaming agent: {:stream, coordinator} dispatches an async command
+  # whose task blocks until the test releases it — so the delta can be forced
+  # to land after a later turn has already run.
+  defmodule StreamingAgent do
+    use Raxol.Agent
+
+    def init(_context), do: %{}
+
+    def update({:agent_message, _from, {:stream, coordinator}}, model) do
+      directive =
+        Raxol.Agent.Directive.async(fn sender ->
+          send(coordinator, {:async_task_started, self()})
+
+          receive do
+            :release -> sender.({:chunk, "late"})
+          end
+        end)
+
+      {model, [directive]}
+    end
+
+    def update(_msg, model), do: {model, []}
+
+    def view(_model), do: text("streaming")
+  end
+
+  setup do
+    ensure_registry(:duplicate, EmitBus.registry_name())
+
+    ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
+
+    ensure_running({DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one})
+
+    start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
+    start_supervised!(Raxol.Agent.SessionStreamer)
+
+    :ok
+  end
+
+  test "an async delta dispatched in turn N and landing after turn N+1 carries turn N's id" do
+    session_id = "u15-stream-attr-#{uniq()}"
+
+    {:ok, sess} =
+      Session.start_link(
+        app_module: StreamingAgent,
+        id: :"u15_stream_attr_#{uniq()}",
+        session_id: session_id
+      )
+
+    on_exit(fn -> stop(sess) end)
+
+    :ok = SessionStreamer.subscribe(session_id)
+
+    # Turn N: dispatches the async command, whose task parks until released.
+    :ok = Session.send_message(agent_id(sess), {:stream, self()})
+
+    assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started_n},
+                   1_000
+
+    assert_receive {:session_event, ^session_id, %Event{type: :turn_completed}},
+                   1_000
+
+    assert_receive {:async_task_started, task}, 1_000
+    turn_n = started_n.turn_id
+    assert is_binary(turn_n)
+
+    # Turn N+1 starts AND completes while turn N's async result is still
+    # pending — the overlap Drew's finding 3 describes.
+    :ok = Session.send_message(agent_id(sess), :noop)
+
+    assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started_n1},
+                   1_000
+
+    assert_receive {:session_event, ^session_id, %Event{type: :turn_completed}},
+                   1_000
+
+    turn_n1 = started_n1.turn_id
+    refute turn_n1 == turn_n
+
+    # Release turn N's stream. The late delta must be stamped with turn N's
+    # id — not turn N+1's, not nil.
+    send(task, :release)
+
+    assert_receive {:session_event, ^session_id, %Event{type: :item_delta} = delta},
+                   1_000
+
+    assert delta.tier == :ephemeral
+    assert delta.turn_id == turn_n
+    refute delta.turn_id == turn_n1
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  defp agent_id(sess) do
+    %{id: id} = :sys.get_state(sess)
+    id
+  end
+
+  defp stop(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal, 2_000)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp uniq, do: System.unique_integer([:positive])
+
+  defp ensure_registry(keys, name) do
+    case Registry.start_link(keys: keys, name: name) do
+      {:ok, pid} -> Process.unlink(pid)
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+
+  defp ensure_running({mod, opts}) do
+    case start_child(mod, opts) do
+      {:ok, pid} -> Process.unlink(pid)
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+
+  defp start_child(DynamicSupervisor, opts),
+    do: DynamicSupervisor.start_link(opts)
+
+  defp start_child(mod, opts), do: mod.start_link(opts)
+end

--- a/packages/raxol_agent/test/test_helper.exs
+++ b/packages/raxol_agent/test/test_helper.exs
@@ -1,1 +1,16 @@
+# Journals (Raxol.Agent.Journal.FileStore, opened per live Agent.Session via the
+# EmitBridge sink) default to ~/.raxol/sessions. Redirect them to a throwaway
+# tmp dir for the whole test run so tests never write into the real home dir.
+unless System.get_env("RAXOL_SESSIONS_DIR") do
+  sessions_dir =
+    Path.join(
+      System.tmp_dir!(),
+      "raxol_agent_test_sessions_#{System.unique_integer([:positive])}"
+    )
+
+  File.mkdir_p!(sessions_dir)
+  System.put_env("RAXOL_SESSIONS_DIR", sessions_dir)
+  System.at_exit(fn _ -> File.rm_rf(sessions_dir) end)
+end
+
 ExUnit.start(exclude: [:slow, :integration, :docker])

--- a/packages/raxol_core/lib/raxol/core/runtime/directive/executor.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/directive/executor.ex
@@ -15,9 +15,16 @@ defprotocol Raxol.Core.Runtime.Directive.Executor do
     * `:pid` - process to receive `{:command_result, payload}` messages
     * `:runtime_pid` - process to receive runtime-level signals (e.g. quit)
 
-  Effect messages land at `context.pid` as `{:command_result, payload}`.
-  Consumers rely on the asynchronous result message rather than the return
-  value of `execute/2`.
+  The Dispatcher additionally supplies `:turn_id` — a snapshot of the agent
+  turn that minted the command (nil outside a turn). Implementations whose
+  results may land after the minting turn closed SHOULD echo it back using the
+  tagged form `{:command_result, payload, %{turn_id: turn_id}}` so the result
+  is attributed to its originating turn; the plain 2-tuple remains valid and
+  is attributed to the turn current at delivery time (nil between turns).
+
+  Effect messages land at `context.pid` as `{:command_result, payload}` (or
+  the tagged 3-tuple above). Consumers rely on the asynchronous result message
+  rather than the return value of `execute/2`.
   """
 
   @spec execute(t(), context :: map()) :: any()

--- a/test/raxol/core/runtime/events/dispatcher_emit_test.exs
+++ b/test/raxol/core/runtime/events/dispatcher_emit_test.exs
@@ -88,15 +88,22 @@ defmodule Raxol.Core.Runtime.Events.DispatcherEmitTest do
     assert event.payload.message == {:command_result, {:llm_chunk, "hello"}}
   end
 
-  test "process_app_update publishes a durable :app_update event",
+  test "an agent-message turn brackets a durable :app_update with turn_started/turn_completed",
        %{dispatcher: dispatcher} do
-    # agent_message casts route straight to process_app_update.
+    # agent_message casts are one turn: turn_started -> app_update -> turn_completed,
+    # all durable and sharing one minted turn_id.
     GenServer.cast(dispatcher, {:dispatch, {:agent_message, :peer, :ping}})
 
-    assert_receive {:emit_bus, @session_id, event}, 1_000
-    assert event.family == :loop
-    assert event.type == :app_update
-    assert event.tier == :durable
+    assert_receive {:emit_bus, @session_id, %{type: :turn_started} = started}, 1_000
+    assert_receive {:emit_bus, @session_id, %{type: :app_update} = updated}, 1_000
+    assert_receive {:emit_bus, @session_id, %{type: :turn_completed} = completed}, 1_000
+
+    assert Enum.all?([started, updated, completed], &(&1.family == :loop))
+    assert Enum.all?([started, updated, completed], &(&1.tier == :durable))
+
+    assert is_binary(started.turn_id)
+    assert started.turn_id == updated.turn_id
+    assert started.turn_id == completed.turn_id
   end
 
   test "no session_id means no emit (terminal apps stay silent)" do

--- a/test/raxol/core/runtime/events/dispatcher_emit_test.exs
+++ b/test/raxol/core/runtime/events/dispatcher_emit_test.exs
@@ -94,9 +94,15 @@ defmodule Raxol.Core.Runtime.Events.DispatcherEmitTest do
     # all durable and sharing one minted turn_id.
     GenServer.cast(dispatcher, {:dispatch, {:agent_message, :peer, :ping}})
 
-    assert_receive {:emit_bus, @session_id, %{type: :turn_started} = started}, 1_000
-    assert_receive {:emit_bus, @session_id, %{type: :app_update} = updated}, 1_000
-    assert_receive {:emit_bus, @session_id, %{type: :turn_completed} = completed}, 1_000
+    assert_receive {:emit_bus, @session_id, %{type: :turn_started} = started},
+                   1_000
+
+    assert_receive {:emit_bus, @session_id, %{type: :app_update} = updated},
+                   1_000
+
+    assert_receive {:emit_bus, @session_id,
+                    %{type: :turn_completed} = completed},
+                   1_000
 
     assert Enum.all?([started, updated, completed], &(&1.family == :loop))
     assert Enum.all?([started, updated, completed], &(&1.tier == :durable))
@@ -104,6 +110,44 @@ defmodule Raxol.Core.Runtime.Events.DispatcherEmitTest do
     assert is_binary(started.turn_id)
     assert started.turn_id == updated.turn_id
     assert started.turn_id == completed.turn_id
+  end
+
+  test "a tagged async command_result carries its ORIGINATING turn's id, not emit-time state",
+       %{dispatcher: dispatcher} do
+    # Cross-turn contamination regression: an async command dispatched in turn
+    # N snapshots N's turn_id into its context; its late result echoes it back
+    # as {:command_result, msg, %{turn_id: ...}}. Run a LATER full turn first,
+    # then deliver turn N's leftover delta — it must be stamped with N's id,
+    # not the later turn's and not nil.
+    GenServer.cast(dispatcher, {:dispatch, {:agent_message, :peer, :ping}})
+
+    assert_receive {:emit_bus, @session_id, %{type: :turn_completed} = later},
+                   1_000
+
+    send(
+      dispatcher,
+      {:command_result, {:llm_chunk, "late"}, %{turn_id: "turn-N"}}
+    )
+
+    assert_receive {:emit_bus, @session_id, %{type: :command_result} = delta},
+                   1_000
+
+    assert delta.tier == :ephemeral
+    assert delta.turn_id == "turn-N"
+    refute delta.turn_id == later.turn_id
+  end
+
+  test "an UNtagged command_result between turns is attributed to no turn (nil), never a stale one",
+       %{dispatcher: dispatcher} do
+    GenServer.cast(dispatcher, {:dispatch, {:agent_message, :peer, :ping}})
+    assert_receive {:emit_bus, @session_id, %{type: :turn_completed}}, 1_000
+
+    send(dispatcher, {:command_result, {:llm_chunk, "untagged"}})
+
+    assert_receive {:emit_bus, @session_id, %{type: :command_result} = delta},
+                   1_000
+
+    assert is_nil(delta.turn_id)
   end
 
   test "no session_id means no emit (terminal apps stay silent)" do
@@ -131,7 +175,9 @@ defmodule Raxol.Core.Runtime.Events.DispatcherEmitTest do
         name: nil
       )
 
-    on_exit(fn -> if Process.alive?(dispatcher), do: GenServer.stop(dispatcher) end)
+    on_exit(fn ->
+      if Process.alive?(dispatcher), do: GenServer.stop(dispatcher)
+    end)
 
     # Subscribe to a wildcard is impossible; subscribe to the id the app would
     # have used and confirm nothing arrives.


### PR DESCRIPTION
## What

Closes the harness keystone: durable agent events are now journaled with the **journal as the single id authority**, `session_id` flows end-to-end for a live agent session, and turns carry a minimal loop vocabulary. Builds on U1 (emit seam), U2a (journal), U3 (commands) — all on master.

Three jobs:

- **(a) session_id flows.** `Raxol.Agent.Session` mints a stable, filename-safe `session_id` and threads it through `Lifecycle.start_link` into the Dispatcher state (the initializer already read the opt). A running agent's fold sites now emit with a non-nil `session_id`.
- **(b) Journal-backed durable sink; journal owns `Event.id`.** `Raxol.Agent.EmitBridge` becomes the durable-tier id authority. For every **durable** event it does **append-before-publish**: `Journal.append/2` FIRST → take the returned `offset` → stamp `Contract.Event.id = offset` → THEN `SessionStreamer.emit`. **Ephemeral** deltas are never journaled and carry the *last durable offset* so they never masquerade as offsets. The journal (`FileStore`) opens lazily on the first durable event under `RAXOL_SESSIONS_DIR`/`~/.raxol/sessions`, persists to disk, and is closed on `terminate/2`. Durable payloads are sanitized (new `Contract.sanitize_payload/1`) before append so non-JSON terms (message tuples) never crash the writer. Main `raxol` still emits only neutral maps to `EmitBus` — **no back-dep on `Raxol.Agent.*`**.
- **(c) Minimal loop vocabulary.** An inbound agent message = one turn. The Dispatcher mints a `turn_id`, emits durable `turn_started` before the fold and `turn_completed` after (`error` on failure), and stamps that `turn_id` onto every event in the turn (U6's `expected_turn_id` CAS depends on this). `EmitBridge` maps the new neutral types additively.

`Raxol.Agent.SessionStreamer` is now supervised by `Raxol.Agent.Supervisor` (it previously had no home).

## Why

- **Kills the dual-id landmine.** The contract says `Event.id == journal offset`, but the bridge stamped ids from a local counter — live id and journal offset diverged the moment a durable event was journaled. The journal is now the sole id authority: one identity, zero divergence.
- **Wires the durable sink** behind the emit seam on the `raxol_agent` side, respecting the hard back-dep constraint.
- **Makes replay-as-truth real:** replaying the journal reproduces exactly the ids the live tail carried.

## Durable-id authority (append-before-publish)

Located in `Raxol.Agent.EmitBridge.handle_manager_info/2` (durable clause): append to `Journal.FileStore`, take the offset, `map_event` with that offset, emit. Ephemeral clause emits with `last_offset`, no append.

## Turn boundary

`Raxol.Core.Runtime.Events.Dispatcher.dispatch_agent_turn/2` — the agent-message cast/call handlers route here; a `turn_id` is added to `State`, `emit/4` stamps it, and the fold is bracketed.

## Acceptance tests (`packages/raxol_agent/test/raxol/agent/keystone_close_test.exs`)

1. **Dual-id regression:** live `Agent.Session` turn → durable live-tail ids == journal offsets == replayed ids (1..N).
2. **Survives BEAM kill:** durable trace close/reopen — ids intact, monotonic, ephemeral delta not journaled.
3. **Turn brackets:** `turn_started{turn_id}` … items … `turn_completed{turn_id}` with one stable `turn_id`; errored turn emits `:error`.
4. **session_id non-nil** on emitted events for a live agent session.

Full `raxol_agent` suite (973) green across seeds; main-raxol dispatcher suites green; `mix compile --warnings-as-errors` clean both packages.

## TODO / follow-ups

- v0 turn boundary limitation: `turn_completed` fires when the synchronous fold returns, so async-streaming agents emit their ephemeral `item_delta`s *after* `turn_completed` (same `turn_id`). Tightening the boundary to the last async chunk is a later unit.
- `test/test_helper.exs` now redirects journals to a throwaway tmp dir for the whole run so tests never touch `~/.raxol/sessions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7