### PR TITLE
Harness UI: block core (kinds, fold algebra, outcome row) [T4]

### DIFF
--- a/lib/raxol/ui/components/harness/block.ex
+++ b/lib/raxol/ui/components/harness/block.ex
@@ -1,0 +1,691 @@
+defmodule Raxol.UI.Components.Harness.Block do
+  @moduledoc """
+  The projection unit of the harness transcript: one sealed-or-live chunk of
+  a session, folded from journal events into a renderable shape.
+
+  See `docs/proposals/in-flight/harness-ui-roadmap.md` (unit T4) and
+  `docs/proposals/in-flight/harness-spec-protocol.md` (the event contract
+  this module folds). The protocol's `%Event{}` struct does not exist in
+  code yet (spec draft only) -- `from_events/3` accepts plain maps shaped
+  like it: `%{id:, turn_id:, ts:, family:, type:, tier:, scope:,
+  provenance:, payload:}`, all keys optional and read defensively. That
+  tolerance is deliberate: the contract only grows (methodology R6), and
+  this module must never crash when it meets a field it doesn't know yet.
+
+  ## Struct
+
+  - `kind` -- one of `:message | :reasoning | :tool_call | :diff |
+    :approval`, or `:opaque` for anything not in that set (forward-compat:
+    an unrecognised kind renders safely instead of crashing).
+  - `raw_kind` -- the kind exactly as given to `from_events/3`, kept even
+    when normalised to `:opaque` so the opaque render can still show a
+    meaningful label.
+  - `event_refs` -- the journal event ids this block was folded from.
+  - `fold` -- `:expanded | :folded`.
+  - `seal` -- `:live | :sealed`. A block is `:live` until `seal/1` is
+    called on it (typically when the projection observes the block's
+    owning turn/item close).
+  - `outcome` -- `%{exit_code:, duration_ms:, cost:}`, each `nil` when not
+    present in the source events.
+  - `content` -- the kind-specific projection of the source events' payloads
+    (never the raw events themselves; see the private `extract_content/2`
+    clauses for the per-kind shape).
+
+  ## Purity
+
+  `from_events/3` is a pure function: identical `kind` + `events` + `opts`
+  always produce an identical `%Block{}` (no random ids, no timestamps
+  generated here -- `duration_ms` is derived only from `ts` fields already
+  present on the source events).
+
+  ## Fold semantics and the D-PA gate
+
+  Fold state mutates freely while a block is `:live`. Once `seal/1` marks it
+  `:sealed`, whether `fold/2` / `unfold/2` may still change the fold state is
+  the paint-authority decision (D-PA, `harness-ui-roadmap.md` sec 0) --
+  undecided as of this unit. Rather than hardcode a guess, every fold
+  transition takes a `:fold_after_seal` option (`:allow | :deny`, default
+  `:deny`) so the eventual D-PA verdict plugs in as a caller-supplied policy
+  with no rewrite of this module: pass `fold_after_seal: :allow` once D-PA
+  chooses (B) soft-owned history or (C) live-region-only with a wider live
+  window; leave the default `:deny` for (A) seal-time-only.
+
+  A denied post-seal fold is a silent no-op by design (`fold/2` always
+  returns `t()`, never a tagged tuple). Callers that track fold state on
+  their side (T9 toggle sites, keybind handlers) must consult
+  `fold_allowed?/2` before toggling, so their bookkeeping never desyncs
+  from a no-op transition.
+
+  Algebraically: `fold/2` and `unfold/2` are projectors (idempotent --
+  folding an already-folded block is a no-op), not involutions;
+  `toggle_fold/2` is the involution, pre-seal. `seal/1` is monotonic and
+  one-way by design -- there is no unseal. Every transition touches only
+  its own field: `content`, `outcome`, `event_refs`, `kind`, and
+  `raw_kind` are frozen at construction and never mutated afterwards.
+
+  ## Observability
+
+  Both total-safety rescues (construction fallback to `:opaque`, render
+  fallback to the placeholder line) are observable per
+  `harness-ui-testing/06-projection.md` sec 4: each emits a
+  `Logger.warning/1` and the telemetry event
+  `[:raxol, :harness, :projection, :recovered]` with metadata
+  `%{kind:, reason:}` -- a recovery is never silent.
+
+  ## Rendering
+
+  `render/2` returns a plain view map (`%{type: :column, ...}`), no
+  interactive `Base.Component` behaviour -- this unit renders plain text
+  bodies only. T5 mounts the rich per-kind components (already merged:
+  `Harness.MessageBlock`, `Harness.ReasoningBlock`, `Harness.ToolCallBlock`,
+  `Harness.ToolResultBlock`, `Harness.DiffViewer`, `Harness.ApprovalPrompt`,
+  ...) as the fold-aware block bodies; this module is the data + text-only
+  fallback layer underneath that.
+
+  Expanded render = header line (fold glyph + kind glyph + first-line
+  summary) + full content lines + an outcome row. Folded render = the header
+  line alone + the outcome row. The outcome row is omitted entirely when
+  `exit_code`, `duration_ms`, and `cost` are all `nil`; otherwise it renders
+  only the fields that are present.
+  """
+
+  alias Raxol.UI.TextLayout
+  alias Raxol.UI.TextMeasure
+  alias Raxol.View.Components
+
+  require Logger
+
+  @recovered_telemetry_event [:raxol, :harness, :projection, :recovered]
+
+  @type kind :: :message | :reasoning | :tool_call | :diff | :approval | :opaque
+  @type fold_state :: :expanded | :folded
+  @type seal_state :: :live | :sealed
+  @type fold_after_seal_policy :: :allow | :deny
+
+  @type outcome :: %{
+          exit_code: integer() | nil,
+          duration_ms: non_neg_integer() | nil,
+          cost: number() | nil
+        }
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          raw_kind: term(),
+          event_refs: [term()],
+          fold: fold_state(),
+          seal: seal_state(),
+          outcome: outcome(),
+          content: map()
+        }
+
+  @enforce_keys [
+    :kind,
+    :raw_kind,
+    :event_refs,
+    :fold,
+    :seal,
+    :outcome,
+    :content
+  ]
+  defstruct [:kind, :raw_kind, :event_refs, :fold, :seal, :outcome, :content]
+
+  @known_kinds [:message, :reasoning, :tool_call, :diff, :approval]
+
+  @default_fold_by_kind %{
+    message: :expanded,
+    reasoning: :folded,
+    tool_call: :expanded,
+    diff: :folded,
+    approval: :expanded,
+    opaque: :expanded
+  }
+
+  @default_fold_after_seal :deny
+
+  # --- construction ---------------------------------------------------------
+
+  @doc """
+  The known block kinds (excludes `:opaque`, which is the forward-compat
+  fallback, not a kind a caller asks for).
+  """
+  @spec known_kinds() :: [kind()]
+  def known_kinds, do: @known_kinds
+
+  @doc """
+  The default fold state for `kind` (the "fold_defaults" a projection layer
+  like T7 assigns per identity sec 2 of `harness-ui-testing/06-projection.md`).
+  An unrecognised kind gets `:opaque`'s default.
+  """
+  @spec default_fold(term()) :: fold_state()
+  def default_fold(kind),
+    do: Map.fetch!(@default_fold_by_kind, normalize_kind(kind))
+
+  @doc """
+  Builds a `%Block{}` as a pure function of `kind` and its source `events`.
+
+  `events` is a list of maps shaped like the (not-yet-coded) protocol
+  `%Event{}` -- read defensively, every key optional. A `kind` outside
+  `known_kinds/0` normalises to `:opaque`; `raw_kind` keeps the original
+  value for display. Never raises: any unexpected shape in `events` falls
+  back to an opaque block rather than crashing the caller.
+
+  ## Options
+
+  - `:fold` -- initial fold state, defaults to `default_fold(kind)`.
+  - `:seal` -- initial seal state, defaults to `:live`.
+  """
+  @spec from_events(term(), [map()], keyword()) :: t()
+  def from_events(kind, events, opts \\ []) when is_list(events) do
+    normalized_kind = normalize_kind(kind)
+
+    %__MODULE__{
+      kind: normalized_kind,
+      raw_kind: kind,
+      event_refs: event_refs(events),
+      fold: Keyword.get(opts, :fold, default_fold(normalized_kind)),
+      seal: Keyword.get(opts, :seal, :live),
+      outcome: extract_outcome(events),
+      content: extract_content(normalized_kind, events)
+    }
+  rescue
+    e ->
+      emit_recovered(kind, e)
+      opaque_fallback(kind, events, opts)
+  end
+
+  defp normalize_kind(kind) when kind in @known_kinds, do: kind
+  defp normalize_kind(_kind), do: :opaque
+
+  defp emit_recovered(kind, exception) do
+    reason = Exception.message(exception)
+
+    Logger.warning(
+      "Harness.Block recovered from #{inspect(kind)} projection failure: #{reason}"
+    )
+
+    :telemetry.execute(@recovered_telemetry_event, %{}, %{
+      kind: kind,
+      reason: reason
+    })
+  end
+
+  defp opaque_fallback(kind, events, opts) do
+    %__MODULE__{
+      kind: :opaque,
+      raw_kind: kind,
+      event_refs: safe_event_refs(events),
+      fold: Keyword.get(opts, :fold, :expanded),
+      seal: Keyword.get(opts, :seal, :live),
+      outcome: %{exit_code: nil, duration_ms: nil, cost: nil},
+      content: %{text: safe_inspect(events)}
+    }
+  end
+
+  defp safe_event_refs(events) do
+    event_refs(events)
+  rescue
+    _ -> []
+  end
+
+  defp safe_inspect(term) do
+    inspect(term)
+  rescue
+    _ -> "(unrenderable events)"
+  end
+
+  # --- fold / seal transitions -----------------------------------------------
+
+  @doc """
+  Marks a block sealed. Idempotent.
+  """
+  @spec seal(t()) :: t()
+  def seal(%__MODULE__{} = block), do: %{block | seal: :sealed}
+
+  @doc """
+  Folds `block`. Always allowed while `:live`. Once `:sealed`, gated by
+  `opts[:fold_after_seal]` (`:allow | :deny`, default `:deny`) -- see the
+  moduledoc's D-PA note. Denied post-seal folds are a no-op (the block is
+  returned unchanged), never an error.
+  """
+  @spec fold(t(), keyword()) :: t()
+  def fold(block, opts \\ [])
+
+  def fold(%__MODULE__{seal: :live} = block, _opts),
+    do: %{block | fold: :folded}
+
+  def fold(%__MODULE__{seal: :sealed} = block, opts) do
+    apply_post_seal_fold(block, :folded, opts)
+  end
+
+  @doc """
+  Unfolds `block`. Same pre/post-seal semantics as `fold/2`.
+  """
+  @spec unfold(t(), keyword()) :: t()
+  def unfold(block, opts \\ [])
+
+  def unfold(%__MODULE__{seal: :live} = block, _opts),
+    do: %{block | fold: :expanded}
+
+  def unfold(%__MODULE__{seal: :sealed} = block, opts) do
+    apply_post_seal_fold(block, :expanded, opts)
+  end
+
+  @doc """
+  Toggles fold state; dispatches to `fold/2` or `unfold/2`.
+  """
+  @spec toggle_fold(t(), keyword()) :: t()
+  def toggle_fold(block, opts \\ [])
+
+  def toggle_fold(%__MODULE__{fold: :folded} = block, opts),
+    do: unfold(block, opts)
+
+  def toggle_fold(%__MODULE__{fold: :expanded} = block, opts),
+    do: fold(block, opts)
+
+  @doc """
+  Whether a fold/unfold transition on `block` would apply under the given
+  D-PA policy options -- the same `:fold_after_seal` option `fold/2` and
+  `unfold/2` take. Always `true` while `:live`; post-seal, `true` only
+  under `fold_after_seal: :allow`.
+
+  Interactive callers that keep their own fold bookkeeping (T9 toggle
+  sites) must check this before toggling, since a denied post-seal
+  `fold/2` is a silent no-op.
+  """
+  @spec fold_allowed?(t(), keyword()) :: boolean()
+  def fold_allowed?(block, opts \\ [])
+  def fold_allowed?(%__MODULE__{seal: :live}, _opts), do: true
+
+  def fold_allowed?(%__MODULE__{seal: :sealed}, opts) do
+    Keyword.get(opts, :fold_after_seal, @default_fold_after_seal) == :allow
+  end
+
+  defp apply_post_seal_fold(block, new_fold, opts) do
+    if fold_allowed?(block, opts) do
+      %{block | fold: new_fold}
+    else
+      block
+    end
+  end
+
+  @spec live?(t()) :: boolean()
+  def live?(%__MODULE__{seal: :live}), do: true
+  def live?(%__MODULE__{}), do: false
+
+  @spec sealed?(t()) :: boolean()
+  def sealed?(%__MODULE__{seal: :sealed}), do: true
+  def sealed?(%__MODULE__{}), do: false
+
+  @spec folded?(t()) :: boolean()
+  def folded?(%__MODULE__{fold: :folded}), do: true
+  def folded?(%__MODULE__{}), do: false
+
+  # --- render -----------------------------------------------------------
+
+  @doc """
+  Renders `block` as a plain view map. `context[:width]` sets the wrap/
+  truncation budget (defaults to `Raxol.Core.Defaults.terminal_width/0`).
+  Never raises: any unexpected internal shape falls back to a one-line
+  placeholder rather than crashing the caller.
+  """
+  @spec render(t(), map()) :: map()
+  def render(block, context \\ %{})
+
+  def render(%__MODULE__{} = block, context) do
+    width = Map.get(context, :width, Raxol.Core.Defaults.terminal_width())
+    build_render(block, width)
+  rescue
+    e ->
+      emit_recovered(block.kind, e)
+      render_fallback(block)
+  end
+
+  defp build_render(block, width) do
+    header = header_view(block, width)
+    outcome_children = outcome_row_view(block.outcome)
+
+    body_children =
+      case block.fold do
+        :folded -> [header]
+        :expanded -> [header | content_lines_view(block)]
+      end
+
+    Components.column(gap: 0, children: body_children ++ outcome_children)
+  end
+
+  defp render_fallback(block) do
+    Components.column(
+      gap: 0,
+      children: [
+        Components.text(
+          content: "[unrenderable #{inspect(block.kind)} block]",
+          style: %{dim: true}
+        )
+      ]
+    )
+  end
+
+  defp header_view(block, width) do
+    prefix = "#{fold_icon(block.fold)} #{kind_glyph(block.kind)} "
+    budget = max(width - TextMeasure.display_width(prefix), 1)
+    summary_text = block |> summary() |> TextLayout.truncate(budget, :ellipsis)
+
+    Components.text(
+      content: prefix <> summary_text,
+      style: header_style(block.kind)
+    )
+  end
+
+  defp fold_icon(:folded), do: "▸"
+  defp fold_icon(_fold), do: "▾"
+
+  defp kind_glyph(:message), do: "»"
+  defp kind_glyph(:reasoning), do: "∴"
+  defp kind_glyph(:tool_call), do: "⚙"
+  defp kind_glyph(:diff), do: "±"
+  defp kind_glyph(:approval), do: "⚑"
+  defp kind_glyph(_kind), do: "◆"
+
+  defp header_style(:reasoning), do: %{dim: true}
+  defp header_style(:opaque), do: %{dim: true}
+  defp header_style(_kind), do: %{}
+
+  defp content_style(:reasoning), do: %{dim: true}
+  defp content_style(:opaque), do: %{dim: true}
+  defp content_style(_kind), do: %{}
+
+  defp summary(%__MODULE__{
+         kind: :tool_call,
+         content: %{name: name, args: args}
+       }) do
+    name <> format_args(args)
+  end
+
+  defp summary(%__MODULE__{kind: :approval, content: %{action: action}}) do
+    first_line(action)
+  end
+
+  defp summary(%__MODULE__{
+         kind: :opaque,
+         raw_kind: raw_kind,
+         content: %{text: text}
+       }) do
+    "[#{kind_label(raw_kind)}] " <> first_line(text)
+  end
+
+  defp summary(%__MODULE__{content: %{text: text}}) do
+    first_line(text)
+  end
+
+  defp summary(_block), do: "(empty)"
+
+  defp kind_label(raw_kind) when is_atom(raw_kind), do: Atom.to_string(raw_kind)
+  defp kind_label(raw_kind) when is_binary(raw_kind), do: raw_kind
+  defp kind_label(raw_kind), do: inspect(raw_kind)
+
+  defp first_line(nil), do: "(empty)"
+
+  defp first_line(text) when is_binary(text) do
+    case text
+         |> String.split("\n")
+         |> Enum.find("", &(String.trim(&1) != "")) do
+      "" -> "(empty)"
+      line -> line
+    end
+  end
+
+  defp first_line(other), do: first_line(to_display_text(other))
+
+  defp format_args(nil), do: ""
+  defp format_args(args) when is_map(args) and map_size(args) == 0, do: ""
+
+  defp format_args(args) when is_map(args) do
+    body =
+      args
+      |> Enum.sort_by(fn {k, _v} -> to_string(k) end)
+      |> Enum.map_join(", ", fn {k, v} -> "#{k}: #{inspect(v)}" end)
+
+    "(#{body})"
+  end
+
+  defp format_args(""), do: ""
+  defp format_args(args) when is_binary(args), do: "(#{args})"
+  defp format_args([]), do: ""
+  defp format_args(args), do: "(#{inspect(args)})"
+
+  defp content_lines_view(block) do
+    block
+    |> body_lines()
+    |> Enum.with_index()
+    |> Enum.map(fn {line, idx} ->
+      Components.text(
+        id: line_id(block, idx),
+        content: line,
+        style: content_style(block.kind)
+      )
+    end)
+  end
+
+  defp line_id(block, idx) do
+    refs = Enum.map_join(block.event_refs, "-", &to_display_text/1)
+    "block-#{refs}-line-#{idx}"
+  end
+
+  defp body_lines(%__MODULE__{kind: :tool_call, content: %{result: result}}) do
+    split_lines(result)
+  end
+
+  defp body_lines(%__MODULE__{
+         kind: :approval,
+         content: %{blast_radius: br, options: options}
+       }) do
+    split_lines(br) ++ options_lines(options)
+  end
+
+  defp body_lines(%__MODULE__{content: %{text: text}}) do
+    split_lines(text)
+  end
+
+  defp body_lines(_block), do: []
+
+  defp options_lines(nil), do: []
+  defp options_lines([]), do: []
+
+  defp options_lines(options) when is_list(options) do
+    ["options: " <> Enum.map_join(options, ", ", &to_display_text/1)]
+  end
+
+  defp options_lines(other), do: ["options: " <> to_display_text(other)]
+
+  defp split_lines(nil), do: []
+  defp split_lines(""), do: []
+  defp split_lines(text), do: text |> to_display_text() |> String.split("\n")
+
+  defp outcome_row_view(outcome) do
+    case outcome_parts(outcome) do
+      [] ->
+        []
+
+      parts ->
+        [Components.text(content: Enum.join(parts, " · "), style: %{dim: true})]
+    end
+  end
+
+  defp outcome_parts(outcome) do
+    [
+      exit_part(Map.get(outcome, :exit_code)),
+      duration_part(Map.get(outcome, :duration_ms)),
+      cost_part(Map.get(outcome, :cost))
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp exit_part(nil), do: nil
+  defp exit_part(code) when is_integer(code), do: "exit #{code}"
+  defp exit_part(code), do: "exit #{inspect(code)}"
+
+  defp duration_part(nil), do: nil
+  defp duration_part(ms) when is_number(ms), do: format_duration(ms)
+  defp duration_part(ms), do: inspect(ms)
+
+  defp cost_part(nil), do: nil
+
+  defp cost_part(cost) when is_number(cost),
+    do: "$" <> :erlang.float_to_binary(cost / 1, decimals: 2)
+
+  defp cost_part(cost), do: inspect(cost)
+
+  defp format_duration(ms) when is_number(ms) and ms >= 1000,
+    do: :erlang.float_to_binary(ms / 1000, decimals: 1) <> "s"
+
+  defp format_duration(ms), do: "#{trunc(ms)}ms"
+
+  defp to_display_text(nil), do: ""
+  defp to_display_text(text) when is_binary(text), do: text
+  defp to_display_text(other), do: inspect(other)
+
+  # --- event/payload extraction (defensive: never assumes a key exists) -----
+
+  @exit_code_paths [[:exit_code], [:content, :exit_code]]
+  @cost_paths [[:cost], [:usage, :cost], [:content, :cost]]
+  @duration_paths [[:duration_ms], [:content, :duration_ms]]
+  @text_paths [[:content], [:text], [:output], [:diff]]
+  @name_paths [[:name], [:content, :name]]
+  @args_paths [[:args], [:content, :args]]
+  @action_paths [[:action]]
+  @blast_radius_paths [[:blast_radius]]
+  @options_paths [[:options]]
+
+  defp event_refs(events) when is_list(events) do
+    Enum.map(events, fn
+      event when is_map(event) -> Map.get(event, :id)
+      _other -> nil
+    end)
+  end
+
+  defp event_refs(_events), do: []
+
+  defp extract_outcome(events) do
+    %{
+      exit_code: find_in_events(events, @exit_code_paths),
+      duration_ms:
+        duration_from_timestamps(events) ||
+          find_in_events(events, @duration_paths),
+      cost: find_in_events(events, @cost_paths)
+    }
+  end
+
+  defp duration_from_timestamps(events) do
+    with start_ts when is_integer(start_ts) <- event_ts(events, :item_started),
+         end_ts when is_integer(end_ts) <- event_ts(events, :item_completed),
+         true <- end_ts >= start_ts do
+      div(end_ts - start_ts, 1000)
+    else
+      _ -> nil
+    end
+  end
+
+  defp event_ts(events, type) do
+    case find_event_by_type(events, type) do
+      event when is_map(event) -> Map.get(event, :ts)
+      _other -> nil
+    end
+  end
+
+  defp find_event_by_type(events, type) when is_list(events) do
+    Enum.find(events, fn
+      event when is_map(event) -> Map.get(event, :type) == type
+      _other -> false
+    end)
+  end
+
+  defp find_event_by_type(_events, _type), do: nil
+
+  defp extract_content(:tool_call, events),
+    do: extract_tool_call_content(events)
+
+  defp extract_content(:approval, events), do: extract_approval_content(events)
+  defp extract_content(_kind, events), do: %{text: extract_text(events)}
+
+  defp extract_text(events) do
+    events
+    |> preferred_events()
+    |> find_in_events(@text_paths)
+    |> to_display_text()
+  end
+
+  defp preferred_events(events) when is_list(events) do
+    events
+    |> Enum.filter(&(event_type(&1) == :item_completed))
+    |> case do
+      [] -> events
+      completed -> completed
+    end
+    |> Enum.reverse()
+  end
+
+  defp preferred_events(_events), do: []
+
+  defp event_type(event) when is_map(event), do: Map.get(event, :type)
+  defp event_type(_event), do: nil
+
+  defp extract_tool_call_content(events) do
+    name = events |> find_in_events(@name_paths) |> to_display_text()
+    args = find_in_events(events, @args_paths)
+    result = tool_result_content(events)
+    tainted? = find_taint(events)
+
+    %{name: name, args: args, result: result, tainted: tainted?}
+  end
+
+  defp tool_result_content(events) when is_list(events) do
+    events
+    |> Enum.filter(&(payload_get(&1, [:item_type]) == :tool_result))
+    |> List.last()
+    |> case do
+      nil -> nil
+      event -> event |> payload_get([:content]) |> to_display_text()
+    end
+  end
+
+  defp tool_result_content(_events), do: nil
+
+  defp find_taint(events) when is_list(events) do
+    Enum.any?(events, &(event_get(&1, [:provenance, :trust]) == :tainted))
+  end
+
+  defp find_taint(_events), do: false
+
+  defp extract_approval_content(events) do
+    action = events |> find_in_events(@action_paths) |> to_display_text()
+    blast_radius = find_in_events(events, @blast_radius_paths)
+    options = find_in_events(events, @options_paths) || []
+
+    %{action: action, blast_radius: blast_radius, options: options}
+  end
+
+  defp find_in_events(events, paths) when is_list(events) do
+    Enum.find_value(events, fn event ->
+      Enum.find_value(paths, fn path -> payload_get(event, path) end)
+    end)
+  end
+
+  defp find_in_events(_events, _paths), do: nil
+
+  defp payload_get(event, path) when is_map(event) do
+    event |> Map.get(:payload) |> safe_get_in(path)
+  end
+
+  defp payload_get(_event, _path), do: nil
+
+  defp event_get(event, path) when is_map(event), do: safe_get_in(event, path)
+  defp event_get(_event, _path), do: nil
+
+  defp safe_get_in(nil, _path), do: nil
+  defp safe_get_in(map, [key]) when is_map(map), do: Map.get(map, key)
+
+  defp safe_get_in(map, [key | rest]) when is_map(map),
+    do: safe_get_in(Map.get(map, key), rest)
+
+  defp safe_get_in(_value, _path), do: nil
+end

--- a/test/raxol/ui/components/harness/block_test.exs
+++ b/test/raxol/ui/components/harness/block_test.exs
@@ -1,0 +1,682 @@
+defmodule Raxol.UI.Components.Harness.BlockTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.Components.Harness.Block
+
+  @frozen_fields [:content, :outcome, :event_refs, :kind, :raw_kind]
+
+  defp flat_texts(%{type: :text, content: content}), do: [content]
+
+  defp flat_texts(%{type: :row, children: children}),
+    do: Enum.flat_map(children, &flat_texts/1)
+
+  defp flat_texts(%{type: :column, children: children}),
+    do: Enum.flat_map(children, &flat_texts/1)
+
+  defp flat_texts(_), do: []
+
+  # Structural gap assert: flat_texts can't see the unset-gap footgun
+  # (unset gap defaults to 1 in the layout engine), so walk the tree and
+  # require every :column/:row container to carry an explicit gap of 0.
+  defp assert_zero_gaps(%{type: type} = node) when type in [:column, :row] do
+    assert Map.get(node, :gap) == 0,
+           "#{type} container missing explicit gap: 0 -> #{inspect(node)}"
+
+    node |> Map.get(:children, []) |> Enum.each(&assert_zero_gaps/1)
+  end
+
+  defp assert_zero_gaps(%{children: children}) when is_list(children) do
+    Enum.each(children, &assert_zero_gaps/1)
+  end
+
+  defp assert_zero_gaps(_node), do: :ok
+
+  defp assert_frozen_fields(before_block, after_block, label) do
+    for field <- @frozen_fields do
+      assert Map.fetch!(before_block, field) == Map.fetch!(after_block, field),
+             "#{label} mutated frozen field #{field}"
+    end
+  end
+
+  defp attach_recovered_handler do
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+    parent = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:raxol, :harness, :projection, :recovered],
+      fn event, _measurements, metadata, _config ->
+        send(parent, {ref, event, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    ref
+  end
+
+  defp message_events(content, id \\ 1) do
+    [
+      %{
+        id: id,
+        type: :item_completed,
+        payload: %{item_type: :message, content: content}
+      }
+    ]
+  end
+
+  describe "from_events/3 purity" do
+    test "identical kind + events + opts always produce an identical block" do
+      events = message_events("hello\nworld")
+
+      assert Block.from_events(:message, events) ==
+               Block.from_events(:message, events)
+    end
+
+    test "block is a pure function of its events (different content, different block)" do
+      block_a = Block.from_events(:message, message_events("alpha"))
+      block_b = Block.from_events(:message, message_events("beta"))
+
+      refute block_a == block_b
+    end
+
+    test "event_refs reflects the source event ids" do
+      events = [
+        %{id: 1, type: :item_started, payload: %{item_type: :tool_use}},
+        %{
+          id: 2,
+          type: :item_completed,
+          payload: %{item_type: :tool_use, content: %{name: "Bash"}}
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events)
+      assert block.event_refs == [1, 2]
+    end
+  end
+
+  describe "from_events/3 kind normalization" do
+    test "known kinds pass through unchanged" do
+      for kind <- Block.known_kinds() do
+        block = Block.from_events(kind, [])
+        assert block.kind == kind
+        assert block.raw_kind == kind
+      end
+    end
+
+    test "an unknown kind normalizes to :opaque, keeping the original as raw_kind" do
+      block =
+        Block.from_events(:some_future_kind, message_events("payload text"))
+
+      assert block.kind == :opaque
+      assert block.raw_kind == :some_future_kind
+    end
+
+    test "a string kind (not even an atom) also normalizes to :opaque without raising" do
+      block = Block.from_events("weird-string-kind", message_events("x"))
+      assert block.kind == :opaque
+      assert block.raw_kind == "weird-string-kind"
+    end
+  end
+
+  describe "fold / unfold — pre-seal" do
+    test "fold and unfold round-trip on a live block" do
+      expanded_block =
+        Block.from_events(:message, message_events("hi"), fold: :expanded)
+
+      folded = Block.fold(expanded_block)
+      assert folded.fold == :folded
+      assert Block.unfold(folded) == expanded_block
+
+      folded_block =
+        Block.from_events(:message, message_events("hi"), fold: :folded)
+
+      unfolded = Block.unfold(folded_block)
+      assert unfolded.fold == :expanded
+      assert Block.fold(unfolded) == folded_block
+    end
+
+    test "toggle_fold flips state pre-seal" do
+      block = Block.from_events(:message, message_events("hi"), fold: :expanded)
+
+      toggled_once = Block.toggle_fold(block)
+      assert toggled_once.fold == :folded
+
+      toggled_twice = Block.toggle_fold(toggled_once)
+      assert toggled_twice == block
+    end
+
+    test "live?/1 and sealed?/1 reflect seal state" do
+      block = Block.from_events(:message, message_events("hi"))
+      assert Block.live?(block)
+      refute Block.sealed?(block)
+
+      sealed = Block.seal(block)
+      refute Block.live?(sealed)
+      assert Block.sealed?(sealed)
+    end
+  end
+
+  describe "fold / unfold — post-seal, D-PA policy gated" do
+    test "default policy (:deny) makes post-seal fold a no-op" do
+      block =
+        Block.from_events(:message, message_events("hi"), fold: :expanded)
+        |> Block.seal()
+
+      assert Block.fold(block) == block
+      assert Block.unfold(block) == block
+      assert Block.toggle_fold(block) == block
+    end
+
+    test "explicit fold_after_seal: :deny behaves the same as default" do
+      block =
+        Block.from_events(:message, message_events("hi"), fold: :expanded)
+        |> Block.seal()
+
+      assert Block.fold(block, fold_after_seal: :deny) == block
+    end
+
+    test "fold_after_seal: :allow lets fold state change post-seal" do
+      block =
+        Block.from_events(:message, message_events("hi"), fold: :expanded)
+        |> Block.seal()
+
+      folded = Block.fold(block, fold_after_seal: :allow)
+      assert folded.fold == :folded
+      assert Block.sealed?(folded)
+
+      unfolded = Block.unfold(folded, fold_after_seal: :allow)
+      assert unfolded.fold == :expanded
+    end
+  end
+
+  describe "render/2 — unknown kind renders opaque, never raises" do
+    test "opaque block renders without raising and shows the raw kind label" do
+      block =
+        Block.from_events(:totally_unknown, message_events("some content here"))
+
+      rendered = Block.render(block)
+      texts = flat_texts(rendered)
+
+      assert Enum.any?(texts, &(&1 =~ "totally_unknown"))
+      assert Enum.any?(texts, &(&1 =~ "some content here"))
+    end
+
+    test "malformed/garbage events never raise, in construction or render" do
+      garbage_events = [
+        %{},
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{content: %{nested: :garbage}}
+        },
+        :not_even_a_map,
+        %{id: 2, payload: nil}
+      ]
+
+      block = Block.from_events(:message, garbage_events)
+      assert %Block{} = block
+
+      rendered = Block.render(block)
+      assert %{type: :column} = rendered
+    end
+
+    test "a from_events call whose events aren't a list still can't crash the renderer" do
+      # from_events/3 requires a list (typed contract); an unknown kind with
+      # well-formed-but-minimal events must still render safely.
+      block = Block.from_events(:mystery, [])
+      assert Block.render(block).type == :column
+    end
+  end
+
+  describe "render/2 — expanded vs folded shape" do
+    test "expanded message block: header line + content lines" do
+      block =
+        Block.from_events(:message, message_events("first line\nsecond line"),
+          fold: :expanded
+        )
+
+      rendered = Block.render(block, %{width: 80})
+      texts = flat_texts(rendered)
+
+      assert length(texts) == 3
+      [header, line1, line2] = texts
+      assert header =~ "first line"
+      assert line1 == "first line"
+      assert line2 == "second line"
+    end
+
+    test "folded message block: one summary line only (no outcome present)" do
+      block =
+        Block.from_events(:message, message_events("first\nsecond"),
+          fold: :folded
+        )
+
+      rendered = Block.render(block, %{width: 80})
+      texts = flat_texts(rendered)
+
+      assert length(texts) == 1
+      assert hd(texts) =~ "first"
+    end
+  end
+
+  describe "outcome row" do
+    test "absent outcome data renders no outcome row" do
+      block = Block.from_events(:message, message_events("no outcome here"))
+      rendered = Block.render(block)
+
+      refute Enum.any?(flat_texts(rendered), &(&1 =~ "exit"))
+    end
+
+    test "partial outcome data renders only the present fields" do
+      events = [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{item_type: :tool_result, exit_code: 1}
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events)
+      rendered = Block.render(block, %{width: 80})
+      texts = flat_texts(rendered)
+
+      assert Enum.any?(texts, &(&1 == "exit 1"))
+      refute Enum.any?(texts, &(&1 =~ "$"))
+      refute Enum.any?(texts, &(&1 =~ "ms"))
+    end
+
+    test "full outcome data (exit code, duration, cost) all render" do
+      events = [
+        %{id: 1, type: :item_started, ts: 1_000_000},
+        %{
+          id: 2,
+          type: :item_completed,
+          ts: 1_250_000,
+          payload: %{item_type: :tool_result, exit_code: 0, cost: 0.02}
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events)
+      rendered = Block.render(block, %{width: 80})
+      texts = flat_texts(rendered)
+
+      outcome_line = Enum.find(texts, &(&1 =~ "exit"))
+      assert outcome_line =~ "exit 0"
+      assert outcome_line =~ "250ms"
+      assert outcome_line =~ "$0.02"
+    end
+
+    test "duration_ms is derived from item_started/item_completed ts deltas (microseconds)" do
+      events = [
+        %{id: 1, type: :item_started, ts: 0},
+        %{
+          id: 2,
+          type: :item_completed,
+          ts: 2_000_000,
+          payload: %{item_type: :tool_result}
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events)
+      assert block.outcome.duration_ms == 2_000
+    end
+  end
+
+  describe "tool_call content extraction" do
+    test "gathers name/args from the call and output from the paired result" do
+      events = [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{
+            item_type: :tool_use,
+            content: %{name: "Bash", args: %{command: "ls"}}
+          }
+        },
+        %{
+          id: 2,
+          type: :item_completed,
+          payload: %{item_type: :tool_result, content: "file1\nfile2"}
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events, fold: :expanded)
+      rendered = Block.render(block, %{width: 80})
+      texts = flat_texts(rendered)
+
+      assert Enum.any?(texts, &(&1 =~ "Bash"))
+      assert Enum.any?(texts, &(&1 =~ "command: \"ls\""))
+      assert Enum.any?(texts, &(&1 == "file1"))
+      assert Enum.any?(texts, &(&1 == "file2"))
+    end
+  end
+
+  describe "approval content extraction" do
+    test "renders action as the summary and blast radius / options as body lines" do
+      events = [
+        %{
+          id: 1,
+          type: :approval_requested,
+          payload: %{
+            action: "rm -rf /tmp/scratch",
+            blast_radius: "deletes 3 files",
+            options: [:allow, :deny]
+          }
+        }
+      ]
+
+      block = Block.from_events(:approval, events, fold: :expanded)
+      rendered = Block.render(block, %{width: 80})
+      texts = flat_texts(rendered)
+
+      assert Enum.any?(texts, &(&1 =~ "rm -rf /tmp/scratch"))
+      assert Enum.any?(texts, &(&1 == "deletes 3 files"))
+      assert Enum.any?(texts, &(&1 =~ "allow"))
+    end
+  end
+
+  describe "unicode content — width via TextMeasure, not String.length" do
+    test "CJK header truncation obeys display width (double-width chars), not codepoint count" do
+      # Each CJK char is 2 display columns; 10 chars = 20 columns, well over
+      # a narrow budget once the "▾ » " prefix (4 cols) is subtracted.
+      cjk = String.duplicate("日", 10)
+      block = Block.from_events(:message, message_events(cjk), fold: :folded)
+
+      rendered = Block.render(block, %{width: 10})
+      [line] = flat_texts(rendered)
+
+      assert Raxol.UI.TextMeasure.display_width(line) <= 10
+      assert String.ends_with?(line, "…")
+    end
+
+    test "emoji content renders without crashing and preserves the grapheme" do
+      block =
+        Block.from_events(:message, message_events("status: ✅ done"),
+          fold: :expanded
+        )
+
+      rendered = Block.render(block, %{width: 80})
+      texts = flat_texts(rendered)
+
+      assert Enum.any?(texts, &(&1 =~ "✅"))
+    end
+
+    test "unicode content lines never split a double-width grapheme in a way that raises" do
+      mixed = String.duplicate("漢字mix", 5)
+
+      block =
+        Block.from_events(:reasoning, message_events(mixed), fold: :folded)
+
+      rendered = Block.render(block, %{width: 6})
+      assert %{type: :column} = rendered
+    end
+  end
+
+  describe "block algebra invariants" do
+    # I-SEAL-MONO
+    test "seal is idempotent and changes ONLY the seal field" do
+      block = Block.from_events(:message, message_events("hi"))
+      sealed = Block.seal(block)
+
+      assert Block.seal(sealed) == sealed
+      assert sealed.seal == :sealed
+
+      assert Map.delete(Map.from_struct(sealed), :seal) ==
+               Map.delete(Map.from_struct(block), :seal)
+    end
+
+    # I-CONTENT
+    test "content, outcome, event_refs, kind, raw_kind are frozen across every transition" do
+      events = [
+        %{id: 1, type: :item_started, ts: 0},
+        %{
+          id: 2,
+          type: :item_completed,
+          ts: 500_000,
+          payload: %{
+            item_type: :tool_use,
+            content: %{name: "Bash", args: %{command: "ls"}},
+            exit_code: 0,
+            cost: 0.01
+          }
+        }
+      ]
+
+      transitions = [
+        {"fold/1", &Block.fold/1},
+        {"unfold/1", &Block.unfold/1},
+        {"toggle_fold/1", &Block.toggle_fold/1},
+        {"seal/1", &Block.seal/1},
+        {"fold allow", &Block.fold(&1, fold_after_seal: :allow)},
+        {"unfold allow", &Block.unfold(&1, fold_after_seal: :allow)},
+        {"toggle allow", &Block.toggle_fold(&1, fold_after_seal: :allow)}
+      ]
+
+      live_block = Block.from_events(:tool_call, events)
+      sealed_block = Block.seal(live_block)
+
+      for block <- [live_block, sealed_block],
+          {label, transition} <- transitions do
+        assert_frozen_fields(block, transition.(block), label)
+      end
+    end
+
+    test "the full default fold table covers every known kind plus :opaque" do
+      expected = %{
+        message: :expanded,
+        reasoning: :folded,
+        tool_call: :expanded,
+        diff: :folded,
+        approval: :expanded,
+        opaque: :expanded
+      }
+
+      kinds = [:opaque | Block.known_kinds()]
+      assert Enum.sort(kinds) == expected |> Map.keys() |> Enum.sort()
+
+      for kind <- kinds do
+        assert Block.default_fold(kind) == Map.fetch!(expected, kind),
+               "default_fold(#{kind}) diverged from the documented table"
+      end
+    end
+  end
+
+  describe "determinism of multi-arg tool_call summary" do
+    test "args render in sorted key order regardless of map construction order" do
+      args_one = %{command: "ls", cwd: "/tmp", background: false}
+      args_two = Map.new(background: false, cwd: "/tmp", command: "ls")
+
+      render_summary = fn args ->
+        events = [
+          %{
+            id: 1,
+            type: :item_completed,
+            payload: %{
+              item_type: :tool_use,
+              content: %{name: "Bash", args: args}
+            }
+          }
+        ]
+
+        block = Block.from_events(:tool_call, events, fold: :folded)
+        [header] = flat_texts(Block.render(block, %{width: 200}))
+        header
+      end
+
+      header = render_summary.(args_one)
+      assert header =~ "(background: false, command: \"ls\", cwd: \"/tmp\")"
+      assert header == render_summary.(args_two)
+    end
+
+    property "random atom-keyed arg maps summarize to the sorted join, construction-order-free" do
+      check all(
+              pairs <-
+                uniq_list_of(
+                  {atom(:alphanumeric),
+                   one_of([integer(), string(:alphanumeric), boolean()])},
+                  uniq_fun: fn {k, _v} -> k end,
+                  min_length: 1,
+                  max_length: 8
+                ),
+              max_runs: 50
+            ) do
+        expected_args =
+          pairs
+          |> Enum.sort_by(fn {k, _v} -> to_string(k) end)
+          |> Enum.map_join(", ", fn {k, v} -> "#{k}: #{inspect(v)}" end)
+
+        render_summary = fn args ->
+          events = [
+            %{
+              id: 1,
+              type: :item_completed,
+              payload: %{
+                item_type: :tool_use,
+                content: %{name: "T", args: args}
+              }
+            }
+          ]
+
+          block = Block.from_events(:tool_call, events, fold: :folded)
+          [header] = flat_texts(Block.render(block, %{width: 10_000}))
+          header
+        end
+
+        header = render_summary.(Map.new(pairs))
+
+        assert header =~ "(#{expected_args})"
+        assert header == render_summary.(pairs |> Enum.shuffle() |> Map.new())
+      end
+    end
+  end
+
+  describe "container gap discipline" do
+    test "every rendered container carries an explicit gap of 0 (expanded, full outcome)" do
+      events = [
+        %{id: 1, type: :item_started, ts: 0},
+        %{
+          id: 2,
+          type: :item_completed,
+          ts: 500_000,
+          payload: %{
+            item_type: :tool_use,
+            content: %{name: "Bash", args: %{command: "ls"}},
+            exit_code: 0,
+            cost: 0.01
+          }
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events, fold: :expanded)
+      assert_zero_gaps(Block.render(block, %{width: 80}))
+    end
+
+    test "folded and fallback renders also carry gap 0 on every container" do
+      folded = Block.from_events(:message, message_events("hi"), fold: :folded)
+      assert_zero_gaps(Block.render(folded, %{width: 80}))
+
+      # args map with an unstringable key forces the render rescue path
+      broken_events = [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{
+            item_type: :tool_use,
+            content: %{name: "X", args: %{%{} => 1}}
+          }
+        }
+      ]
+
+      broken = Block.from_events(:tool_call, broken_events)
+      assert_zero_gaps(Block.render(broken, %{width: 80}))
+    end
+  end
+
+  describe "recovery observability" do
+    test "a valid :message event set stays :message — never silently :opaque" do
+      ref = attach_recovered_handler()
+
+      block = Block.from_events(:message, message_events("perfectly fine"))
+      assert block.kind == :message
+
+      refute_received {^ref, _event, _meta}
+    end
+
+    @tag capture_log: true
+    test "a forced construction raise falls back to :opaque AND emits recovery telemetry" do
+      ref = attach_recovered_handler()
+
+      # Improper list: passes the is_list/1 guard, raises inside Enum traversal.
+      broken_events = [%{id: 1, type: :item_completed} | :improper_tail]
+
+      block = Block.from_events(:message, broken_events)
+      assert block.kind == :opaque
+      assert block.raw_kind == :message
+
+      assert_received {^ref, [:raxol, :harness, :projection, :recovered], meta}
+      assert meta.kind == :message
+      assert is_binary(meta.reason)
+    end
+
+    @tag capture_log: true
+    test "a forced render raise emits recovery telemetry and returns the fallback view" do
+      ref = attach_recovered_handler()
+
+      # Unstringable args key: construction succeeds, render's summary raises.
+      events = [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{
+            item_type: :tool_use,
+            content: %{name: "X", args: %{%{} => 1}}
+          }
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events)
+      refute_received {^ref, _event, _meta}
+
+      rendered = Block.render(block, %{width: 80})
+      assert %{type: :column} = rendered
+      assert Enum.any?(flat_texts(rendered), &(&1 =~ "unrenderable"))
+
+      assert_received {^ref, [:raxol, :harness, :projection, :recovered], meta}
+      assert meta.kind == :tool_call
+    end
+  end
+
+  describe "fold_allowed?/2" do
+    test "always true while live" do
+      block = Block.from_events(:message, message_events("hi"))
+      assert Block.fold_allowed?(block)
+      assert Block.fold_allowed?(block, fold_after_seal: :deny)
+    end
+
+    test "post-seal it encodes the same policy fold/2 applies" do
+      block = Block.from_events(:message, message_events("hi")) |> Block.seal()
+
+      refute Block.fold_allowed?(block)
+      refute Block.fold_allowed?(block, fold_after_seal: :deny)
+      assert Block.fold_allowed?(block, fold_after_seal: :allow)
+
+      # check-then-apply agreement: allowed? iff fold/2 actually changes state
+      refute Block.fold(block).fold == :folded
+      assert Block.fold(block, fold_after_seal: :allow).fold == :folded
+    end
+  end
+
+  describe "default_fold/1" do
+    test "reasoning folds by default; message expands by default" do
+      assert Block.default_fold(:reasoning) == :folded
+      assert Block.default_fold(:message) == :expanded
+    end
+
+    test "an unknown kind falls back to opaque's default" do
+      assert Block.default_fold(:something_new) == Block.default_fold(:opaque)
+    end
+  end
+end


### PR DESCRIPTION
Unit **T4** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): the HarnessBlock core — the block model under the harness surface's transcript.

## What
- `Raxol.UI.Components.Harness.Block`: kinds `:message | :reasoning | :tool_call | :diff | :approval` (+ `:opaque` forward-compat fallback with `raw_kind` preserved), journal `event_refs`, fold state, seal state, outcome row (exit/duration/cost).
- Pure `from_events/3` — block is a deterministic function of its events (tool args sorted; no ambient state). Unknown kinds/payloads never crash: total-safety rescue with **observable recovery** (`Logger.warning` + `[:raxol, :harness, :projection, :recovered]` telemetry).
- Fold algebra documented and tested: `fold`/`unfold` are idempotent projectors, `toggle_fold` the involution, `seal` monotonic one-way. Post-seal fold is D-PA-policy-gated (`fold_after_seal:` option + `fold_allowed?/2` predicate for caller bookkeeping) — plugs into the T0 paint-authority verdict without rewrites.
- Render: plain view-map bodies (T5 mounts the rich components later); explicit `gap: 0` everywhere (structurally tested); widths via `TextMeasure` only.

## Evidence
40 tests green (incl. StreamData determinism property, frozen-fields invariant across all seven transitions, structural gap walk, telemetry-fires-on-rescue). `mix compile --warnings-as-errors`, `credo --strict`, `format --check-formatted` all clean.

## Review trail
Opus adversarial review (approve-with-yellows) → observable-rescue + `fold_allowed?/2` round; grok-4.5 invariants advisory → seal-idempotence/content-freeze/default-fold-table top-up; longcat conceptual advisory → width-as-render-arg verified, integration notes recorded in the lane STATE doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
