### PR TITLE
Harness UI: composer (multiline input, paste, history, steer queue) [T11]

### DIFF
--- a/lib/raxol/ui/components/harness/composer.ex
+++ b/lib/raxol/ui/components/harness/composer.ex
@@ -1,0 +1,537 @@
+defmodule Raxol.UI.Components.Harness.Composer do
+  @moduledoc """
+  Harness prompt composer: wraps `Raxol.UI.Components.Input.MultiLineInput`
+  with harness-specific submit semantics, input history recall, bracketed
+  paste fidelity, and a queued-steer banner. Does not reimplement multi-line
+  editing -- cursor movement, selection, and text mutation stay entirely in
+  MultiLineInput; this module only decides *when* those primitives fire and
+  adds one banner above the prompt.
+
+  ## Submit semantics
+
+  Enter with no modifiers submits (`{:component_event, id, {:submit, text}}`)
+  when the buffer is a single logical line (no embedded `\\n`, regardless of
+  visual wrap) and non-empty after trimming. Enter with `:shift` or `:alt`
+  held, or Enter while the buffer already spans multiple logical lines
+  (continuation), inserts a literal newline instead via MultiLineInput's own
+  `{:enter}` message. `force_submit/1` is exposed for a consumer (T12
+  keybinds) to wire an unconditional submit key (e.g. Ctrl+Enter) that
+  bypasses the single-line gate.
+
+  **Legacy terminals and the degraded-mode inlet:** many terminals do not
+  encode Shift+Enter or Alt+Enter distinctly (Alt+Enter arrives as ESC CR
+  and the ESC is dropped in parsing -- a bare Enter is all this component
+  sees), so the modifier branches are unreachable there. The
+  modifier-independent primary inlet to a first newline is **backslash
+  continuation**: a line ending in `\\` + Enter consumes the backslash and
+  inserts a newline instead of submitting. This works over tmux/SSH/mosh
+  at any point, including creating the very first newline. Escape rule
+  (simplest that round-trips a literal trailing backslash): count the
+  trailing backslash run -- an odd run means continuation (the final
+  backslash is consumed, the rest stay as typed); an even run means submit
+  with the run halved (`\\\\` submits as `\\`). The rule applies only on
+  the Enter-submit path; `force_submit/1` and paste submit/insert content
+  verbatim. Bracketed paste and a consumer-wired `force_submit/1` remain
+  alternate inlets, and a dim hint line (`\\ continue · paste multiline ·
+  ↵ submit`) renders below the input while it is focused, empty, and has
+  no history yet. The modifier branches activate automatically when F1b
+  (kitty keyboard protocol) lands -- zero logic change here.
+
+  Also known: printable characters arriving with compound modifiers (e.g.
+  `[:shift, :alt]`) fall through to MultiLineInput delegation and are
+  dropped today -- canonical modifier normalization belongs to F1a input
+  canon, not this unit.
+
+  ## Bracketed paste
+
+  The terminal driver already parses `ESC[200~...ESC[201~` into
+  `%Raxol.Core.Events.Event{type: :paste, data: %{text: text}}`
+  (`Raxol.Terminal.Ansi.InputParser`). This component routes that event
+  straight into MultiLineInput's `{:clipboard_content, text}` message -- the
+  same path Ctrl+V system-clipboard paste already uses
+  (`MultiLineInput.SelectionOps.handle_clipboard_content/2`) -- so pasted
+  newlines are inserted verbatim in one edit and never pass through the
+  Enter/submit decision above, no matter how many lines the paste contains.
+
+  ## History recall
+
+  Up at the first (visual) line, or Down at the last (visual) line, walks a
+  bounded ring (default 100) of past submissions, newest first. The
+  in-progress draft is saved on the first Up so Down can restore it. Any
+  other cursor position forwards Up/Down to MultiLineInput unchanged (normal
+  cursor movement / shift-selection).
+
+  ## Queued-steer banner
+
+  `queued_steer: nil | %{text: String.t(), queued_at: term()}` renders (when
+  set) one dim, truncated line above the prompt, prefixed with "⏸ " --
+  `⏸ steer queued for next boundary: <text>` -- visually distinct from
+  editable content. This is AD-2's two-signal model (interrupt vs. steer)
+  made visible.
+
+  ## Resize safety
+
+  No absolute width is persisted on this struct. `render/2` derives
+  MultiLineInput's width from `context[:available_width]` on every call and
+  re-wraps the cached lines for that width, so a resized `context` produces
+  a correctly-wrapped prompt without any stored width going stale.
+  """
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Input.MultiLineInput
+  alias Raxol.UI.Components.Input.MultiLineInput.TextHelper
+  alias Raxol.UI.StyleHelper
+  alias Raxol.UI.TextMeasure
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @default_width 80
+  @default_height 3
+  @default_max_history 100
+  @steer_prefix "⏸ steer queued for next boundary: "
+  @hint_text "\\ continue · paste multiline · ↵ submit"
+
+  @type queued_steer :: %{text: String.t(), queued_at: term()} | nil
+
+  @type t :: %{
+          id: String.t() | atom(),
+          mli: MultiLineInput.t(),
+          history: [String.t()],
+          history_index: non_neg_integer() | nil,
+          draft: String.t() | nil,
+          queued_steer: queued_steer(),
+          max_history: pos_integer(),
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword() | map()) :: {:ok, t()}
+  def init(props) do
+    props = Map.new(props)
+
+    id =
+      Map.get(
+        props,
+        :id,
+        "harness-composer-#{:erlang.unique_integer([:positive])}"
+      )
+
+    {:ok, mli} =
+      MultiLineInput.init(%{
+        id: "#{id}-input",
+        value: Map.get(props, :value, ""),
+        placeholder: Map.get(props, :placeholder, ""),
+        width: Map.get(props, :width, @default_width),
+        height: Map.get(props, :height, @default_height),
+        wrap: Map.get(props, :wrap, :word),
+        focused: Map.get(props, :focused, true)
+      })
+
+    state = %{
+      id: id,
+      mli: mli,
+      history: [],
+      history_index: nil,
+      draft: nil,
+      queued_steer: Map.get(props, :queued_steer),
+      max_history: Map.get(props, :max_history, @default_max_history),
+      style: Map.get(props, :style, %{}),
+      theme: Map.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  # -- public helpers (used by consumers: T12 keybinds, T25 editor handoff) --
+
+  @doc "Current composer text (delegates to the wrapped MultiLineInput)."
+  @spec value(t()) :: String.t()
+  def value(%{mli: %{value: text}}), do: text
+
+  @doc "Replace the composer's content programmatically (e.g. after $EDITOR)."
+  @spec set_value(t(), String.t()) :: t()
+  def set_value(state, text), do: %{state | mli: set_mli_value(state.mli, text)}
+
+  @doc "Bounded, newest-first list of past submissions."
+  @spec history(t()) :: [String.t()]
+  def history(%{history: history}), do: history
+
+  @doc """
+  Unconditional submit, bypassing the single-line gate -- for a consumer
+  keybind (e.g. Ctrl+Enter) that must submit multi-line content directly.
+  Returns `{state, []}` unchanged if the trimmed buffer is empty.
+  """
+  @spec force_submit(t()) :: {t(), [term()]}
+  def force_submit(state) do
+    text = value(state)
+
+    if String.trim(text) == "" do
+      {state, []}
+    else
+      submit(state, text)
+    end
+  end
+
+  @impl true
+  def update({:set_queued_steer, queued_steer}, state) do
+    {%{state | queued_steer: queued_steer}, []}
+  end
+
+  def update(props, state) when is_map(props) do
+    # :value/:placeholder/:focused describe the embedded MultiLineInput, not
+    # the composer map itself -- forward them into the mli (buffer truth)
+    # instead of letting merge_props stamp them onto the outer state where
+    # they would silently desync from what the input actually contains.
+    {mli_props, rest} = Map.split(props, [:value, :placeholder, :focused])
+
+    state =
+      if map_size(mli_props) > 0 do
+        %{state | mli: sync_mli_props(state.mli, mli_props)}
+      else
+        state
+      end
+
+    Raxol.UI.Components.Base.Component.merge_props(rest, state)
+  end
+
+  def update(_msg, state), do: {state, []}
+
+  defp sync_mli_props(mli, props) do
+    mli =
+      case Map.fetch(props, :value) do
+        {:ok, value} -> set_mli_value(mli, value)
+        :error -> mli
+      end
+
+    struct(mli, Map.take(props, [:placeholder, :focused]))
+  end
+
+  # -- events --
+
+  @impl true
+  def handle_event(%Event{type: :paste, data: %{text: text}}, state, _context) do
+    {new_mli, _cmds} = update_mli({:clipboard_content, text}, state.mli)
+    {%{state | mli: new_mli}, []}
+  end
+
+  def handle_event(
+        %Event{type: :key, data: %{key: :enter, modifiers: modifiers}},
+        state,
+        _context
+      ) do
+    handle_enter_key(modifiers, state)
+  end
+
+  def handle_event(
+        %Event{type: :key, data: %{key: :up, modifiers: []}} = event,
+        state,
+        context
+      ) do
+    handle_history_nav(:up, event, state, context)
+  end
+
+  def handle_event(
+        %Event{type: :key, data: %{key: :down, modifiers: []}} = event,
+        state,
+        context
+      ) do
+    handle_history_nav(:down, event, state, context)
+  end
+
+  # Printable-character keys are intercepted here rather than delegated:
+  # MultiLineInput's EventHandler forwards them as `{:input, <binary>}` but
+  # its EditOps/TextHelper insertion path expects an integer codepoint
+  # (`<<codepoint::utf8>>`), so blind delegation crashes on every ordinary
+  # keystroke. Routing through `{:clipboard_content, char}` -- the same safe
+  # insertion path bracketed paste uses -- sidesteps the upstream bug (kept
+  # out of this changeset; MultiLineInput is outside T11's write-set) and
+  # additionally handles multi-codepoint graphemes (emoji) that the
+  # upstream `byte_size == 1` dispatch drops entirely.
+  def handle_event(
+        %Event{type: :key, data: %{key: char, modifiers: modifiers}} = event,
+        state,
+        context
+      )
+      when is_binary(char) and (modifiers == [] or modifiers == [:shift]) do
+    if String.length(char) == 1 do
+      {new_mli, cmds} = update_mli({:clipboard_content, char}, state.mli)
+      {%{state | mli: new_mli}, cmds}
+    else
+      {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
+      {%{state | mli: new_mli}, cmds}
+    end
+  end
+
+  def handle_event(event, state, context) do
+    {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
+    {%{state | mli: new_mli}, cmds}
+  end
+
+  # -- render --
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    avail_width = context[:available_width] || state.mli.width
+    mli = size_mli_for_render(state.mli, avail_width)
+    mli_context = Map.put_new(context, :theme, %{})
+
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :harness_composer)
+
+    children =
+      [
+        queued_steer_banner(state.queued_steer, avail_width),
+        MultiLineInput.render(mli, mli_context),
+        first_focus_hint(state)
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    %{
+      type: :column,
+      style: base_style,
+      gap: 0,
+      children: children
+    }
+  end
+
+  # -- private: enter / submit --
+
+  defp handle_enter_key(modifiers, state) do
+    cond do
+      :shift in modifiers or :alt in modifiers -> insert_newline(state)
+      multiline?(state.mli) -> insert_newline(state)
+      true -> maybe_submit(state)
+    end
+  end
+
+  defp multiline?(mli), do: String.contains?(mli.value, "\n")
+
+  defp insert_newline(state) do
+    {new_mli, cmds} = update_mli({:enter}, state.mli)
+    {%{state | mli: new_mli}, cmds}
+  end
+
+  # Enter-submit path only: backslash continuation is the
+  # modifier-independent inlet to a newline (see moduledoc). An odd trailing
+  # backslash run means "continue" (consume the final backslash, insert a
+  # newline); an even run submits with the run halved so a literal trailing
+  # backslash is expressible as `\\`.
+  defp maybe_submit(state) do
+    text = value(state)
+
+    cond do
+      String.trim(text) == "" -> {state, []}
+      continuation?(text) -> apply_continuation(state, text)
+      true -> submit(state, collapse_trailing_escapes(text))
+    end
+  end
+
+  defp continuation?(text), do: rem(trailing_backslashes(text), 2) == 1
+
+  defp collapse_trailing_escapes(text) do
+    case trailing_backslashes(text) do
+      0 -> text
+      n -> String.slice(text, 0, String.length(text) - div(n, 2))
+    end
+  end
+
+  defp trailing_backslashes(text) do
+    text
+    |> String.reverse()
+    |> String.graphemes()
+    |> Enum.take_while(&(&1 == "\\"))
+    |> length()
+  end
+
+  # Builds the continued value directly (base minus the consumed backslash,
+  # plus a newline) and derives `lines` by logical split, preserving the
+  # trailing empty line. Deliberately NOT routed through MultiLineInput's
+  # re-init/ensure_cursor_visible: its split_into_lines drops a trailing
+  # empty line (upstream bug (2) in the commit body), which would strand the
+  # cursor past the line list and lose the just-created newline on the next
+  # edit.
+  defp apply_continuation(state, text) do
+    base = String.slice(text, 0, String.length(text) - 1)
+    new_value = base <> "\n"
+    lines = String.split(new_value, "\n")
+
+    mli = %{
+      state.mli
+      | value: new_value,
+        lines: lines,
+        cursor_pos: {length(lines) - 1, 0},
+        selection_start: nil,
+        selection_end: nil
+    }
+
+    {%{state | mli: mli}, []}
+  end
+
+  defp submit(state, text) do
+    history = Enum.take([text | state.history], state.max_history)
+    fresh_mli = set_mli_value(state.mli, "")
+
+    new_state = %{
+      state
+      | mli: fresh_mli,
+        history: history,
+        history_index: nil,
+        draft: nil
+    }
+
+    {new_state, [{:component_event, state.id, {:submit, text}}]}
+  end
+
+  # -- private: history navigation --
+
+  defp handle_history_nav(:up, event, state, context) do
+    {row, _col} = state.mli.cursor_pos
+
+    if row == 0 and state.history != [] do
+      recall_older(state)
+    else
+      {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
+      {%{state | mli: new_mli}, cmds}
+    end
+  end
+
+  defp handle_history_nav(:down, event, state, context) do
+    last_row = max(length(state.mli.lines) - 1, 0)
+    {row, _col} = state.mli.cursor_pos
+
+    if row == last_row and state.history_index != nil do
+      recall_newer(state)
+    else
+      {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
+      {%{state | mli: new_mli}, cmds}
+    end
+  end
+
+  defp recall_older(state) do
+    next_index =
+      case state.history_index do
+        nil -> 0
+        idx -> min(idx + 1, length(state.history) - 1)
+      end
+
+    draft = if state.history_index == nil, do: value(state), else: state.draft
+    text = Enum.at(state.history, next_index, "")
+
+    {%{
+       state
+       | mli: set_mli_value(state.mli, text),
+         history_index: next_index,
+         draft: draft
+     }, []}
+  end
+
+  defp recall_newer(%{history_index: 0} = state) do
+    text = state.draft || ""
+
+    {%{
+       state
+       | mli: set_mli_value(state.mli, text),
+         history_index: nil,
+         draft: nil
+     }, []}
+  end
+
+  defp recall_newer(state) do
+    new_index = state.history_index - 1
+    text = Enum.at(state.history, new_index, "")
+
+    {%{state | mli: set_mli_value(state.mli, text), history_index: new_index},
+     []}
+  end
+
+  defp set_mli_value(mli, text) do
+    {:ok, new_mli} =
+      MultiLineInput.init(%{
+        id: mli.id,
+        value: text,
+        placeholder: mli.placeholder,
+        width: mli.width,
+        height: mli.height,
+        wrap: mli.wrap,
+        focused: true
+      })
+
+    last_row = max(length(new_mli.lines) - 1, 0)
+    last_line = Enum.at(new_mli.lines, last_row, "")
+    %{new_mli | cursor_pos: {last_row, String.length(last_line)}}
+  end
+
+  # -- private: delegation to the wrapped MultiLineInput --
+
+  defp delegate_to_mli(event, mli, context) do
+    case MultiLineInput.handle_event(event, mli, context) do
+      {:noreply, new_mli, cmd} -> {new_mli, wrap_cmd(cmd)}
+      _other -> {mli, []}
+    end
+  end
+
+  defp update_mli(msg, mli) do
+    case MultiLineInput.update(msg, mli) do
+      {:noreply, new_mli, cmd} -> {new_mli, wrap_cmd(cmd)}
+      _other -> {mli, []}
+    end
+  end
+
+  defp wrap_cmd(nil), do: []
+  defp wrap_cmd(cmd) when is_list(cmd), do: cmd
+  defp wrap_cmd(cmd), do: [cmd]
+
+  # -- private: render helpers --
+
+  defp size_mli_for_render(mli, avail_width)
+       when is_integer(avail_width) and avail_width > 0 and
+              avail_width != mli.width do
+    lines = TextHelper.split_into_lines(mli.value, avail_width, mli.wrap)
+    %{mli | width: avail_width, lines: lines}
+  end
+
+  defp size_mli_for_render(mli, _avail_width), do: mli
+
+  # First-focus hint: shown only while there is nothing else to look at --
+  # focused, empty buffer, no history yet. Same dim styling tier as the
+  # steer banner; disappears the moment any of the three conditions breaks.
+  defp first_focus_hint(%{mli: mli, history: history}) do
+    if mli.focused and history == [] and mli.value == "" do
+      Components.text(
+        id: "composer-hint",
+        content: @hint_text,
+        style: %{dim: true}
+      )
+    else
+      nil
+    end
+  end
+
+  defp queued_steer_banner(nil, _avail_width), do: nil
+
+  defp queued_steer_banner(%{text: text}, avail_width) do
+    content = truncate_to_width(@steer_prefix <> text, avail_width)
+
+    Components.text(
+      id: "queued-steer-banner",
+      content: content,
+      style: %{dim: true}
+    )
+  end
+
+  defp truncate_to_width(text, width) when is_integer(width) and width > 0 do
+    if TextMeasure.display_width(text) <= width do
+      text
+    else
+      {left, _rest} =
+        TextMeasure.split_at_display_width(text, max(width - 1, 0))
+
+      left <> "…"
+    end
+  end
+
+  defp truncate_to_width(text, _width), do: text
+end

--- a/test/raxol/ui/components/harness/composer_test.exs
+++ b/test/raxol/ui/components/harness/composer_test.exs
@@ -1,0 +1,520 @@
+defmodule Raxol.UI.Components.Harness.ComposerTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.Composer
+  alias Raxol.UI.TextMeasure
+
+  defp default_context, do: %{theme: %{}, available_width: 40}
+
+  # Types text one grapheme at a time via real :key events -- the path a
+  # user's keystrokes actually take (the Composer intercepts printable
+  # characters and routes them through the safe insertion path; see the
+  # module docs).
+  defp type(state, text) do
+    text
+    |> String.graphemes()
+    |> Enum.reduce(state, fn char, acc ->
+      {new_state, _cmds} = press(acc, char)
+      new_state
+    end)
+  end
+
+  defp press(state, key, modifiers \\ []) do
+    Composer.handle_event(
+      Event.key_event(key, :pressed, modifiers),
+      state,
+      default_context()
+    )
+  end
+
+  defp paste(state, text) do
+    event = %Event{type: :paste, data: %{text: text}}
+    Composer.handle_event(event, state, default_context())
+  end
+
+  defp hint_of(rendered),
+    do: Enum.find(rendered.children, &(&1[:id] == "composer-hint"))
+
+  describe "init/1" do
+    test "initializes with empty value, no history, no queued steer" do
+      {:ok, state} = Composer.init(id: :composer1)
+      assert Composer.value(state) == ""
+      assert Composer.history(state) == []
+      assert state.queued_steer == nil
+    end
+
+    test "accepts an initial value and queued_steer" do
+      {:ok, state} =
+        Composer.init(
+          id: :composer2,
+          value: "draft",
+          queued_steer: %{text: "steer this", queued_at: 123}
+        )
+
+      assert Composer.value(state) == "draft"
+      assert state.queued_steer.text == "steer this"
+    end
+  end
+
+  describe "typing + submit" do
+    test "Enter on single-line non-empty content submits and clears the buffer" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "hello")
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == [{:component_event, :c, {:submit, "hello"}}]
+      assert Composer.value(new_state) == ""
+    end
+
+    test "Enter on empty content is a no-op" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == []
+      assert Composer.value(new_state) == ""
+    end
+
+    test "Enter on whitespace-only content is a no-op" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "   ")
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == []
+      assert Composer.value(new_state) == "   "
+    end
+
+    test "Shift+Enter inserts a newline instead of submitting" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "line one")
+
+      {new_state, cmds} = press(state, :enter, [:shift])
+
+      assert cmds == []
+      assert Composer.value(new_state) == "line one\n"
+    end
+
+    test "Alt+Enter inserts a newline instead of submitting" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "line one")
+
+      {new_state, cmds} = press(state, :enter, [:alt])
+
+      assert cmds == []
+      assert Composer.value(new_state) == "line one\n"
+    end
+
+    test "plain Enter continues (inserts newline) once the buffer already spans lines" do
+      {:ok, state} = Composer.init(id: :c)
+      {state, []} = paste(state, "line one\nline two")
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == []
+      assert Composer.value(new_state) == "line one\nline two\n"
+    end
+
+    test "force_submit bypasses the single-line gate" do
+      {:ok, state} = Composer.init(id: :c)
+      {state, []} = paste(state, "line one\nline two")
+
+      {new_state, cmds} = Composer.force_submit(state)
+
+      assert cmds == [{:component_event, :c, {:submit, "line one\nline two"}}]
+      assert Composer.value(new_state) == ""
+    end
+  end
+
+  describe "bracketed paste" do
+    test "multiline paste lands verbatim as content and never submits" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {new_state, cmds} = paste(state, "first\nsecond\nthird")
+
+      assert cmds == []
+      assert Composer.value(new_state) == "first\nsecond\nthird"
+    end
+
+    test "a plain Enter after a multiline paste continues rather than submits" do
+      {:ok, state} = Composer.init(id: :c)
+      {state, []} = paste(state, "first\nsecond")
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == []
+      assert Composer.value(new_state) == "first\nsecond\n"
+    end
+
+    test "paste is a single edit even when it contains many newlines" do
+      {:ok, state} = Composer.init(id: :c)
+      big_paste = Enum.map_join(1..50, "\n", &"line #{&1}")
+
+      {new_state, cmds} = paste(state, big_paste)
+
+      assert cmds == []
+      assert Composer.value(new_state) == big_paste
+    end
+  end
+
+  describe "history recall" do
+    test "round-trips through submitted values with Up/Down" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "first")
+      {state, _} = press(state, :enter)
+      state = type(state, "second")
+      {state, _} = press(state, :enter)
+
+      assert Composer.history(state) == ["second", "first"]
+
+      # Up at the (empty) first line recalls the most recent submission.
+      {state, []} = press(state, :up)
+      assert Composer.value(state) == "second"
+
+      # Up again walks further back.
+      {state, []} = press(state, :up)
+      assert Composer.value(state) == "first"
+
+      # Down walks forward again.
+      {state, []} = press(state, :down)
+      assert Composer.value(state) == "second"
+
+      # Down at the bottom restores the saved (empty) draft.
+      {state, []} = press(state, :down)
+      assert Composer.value(state) == ""
+    end
+
+    test "saves the in-progress draft while browsing history" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "submitted")
+      {state, _} = press(state, :enter)
+      state = type(state, "unsent draft")
+
+      {state, []} = press(state, :up)
+      assert Composer.value(state) == "submitted"
+
+      {state, []} = press(state, :down)
+      assert Composer.value(state) == "unsent draft"
+    end
+
+    test "history is bounded" do
+      {:ok, state} = Composer.init(id: :c, max_history: 3)
+
+      state =
+        Enum.reduce(1..5, state, fn n, acc ->
+          acc = type(acc, "msg#{n}")
+          {acc, _} = press(acc, :enter)
+          acc
+        end)
+
+      assert Composer.history(state) == ["msg5", "msg4", "msg3"]
+    end
+
+    test "Up does nothing when there is no history" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {new_state, cmds} = press(state, :up)
+
+      assert cmds == []
+      assert Composer.value(new_state) == ""
+    end
+  end
+
+  describe "queued-steer banner" do
+    test "renders a distinct dim banner above the prompt when set" do
+      {:ok, state} =
+        Composer.init(id: :c, queued_steer: %{text: "hold on", queued_at: 1})
+
+      rendered = Composer.render(state, %{theme: %{}, available_width: 80})
+
+      assert rendered.type == :column
+      assert rendered.gap == 0
+
+      banner = hd(rendered.children)
+      assert banner.type == :text
+      assert banner.style[:dim] == true
+      assert banner.content =~ "steer queued for next boundary"
+      assert banner.content =~ "hold on"
+    end
+
+    test "is absent when queued_steer is nil" do
+      {:ok, state} = Composer.init(id: :c, value: "draft")
+
+      rendered = Composer.render(state, default_context())
+
+      assert length(rendered.children) == 1
+      assert rendered.type == :column
+      assert rendered.gap == 0
+    end
+
+    test "truncates to the available width without splitting a double-width character" do
+      {:ok, state} =
+        Composer.init(
+          id: :c,
+          queued_steer: %{text: String.duplicate("中", 20), queued_at: 1}
+        )
+
+      rendered = Composer.render(state, %{theme: %{}, available_width: 10})
+      banner = hd(rendered.children)
+
+      assert TextMeasure.display_width(banner.content) <= 10
+    end
+  end
+
+  describe "backslash continuation" do
+    test "a line ending in backslash + Enter consumes the backslash and inserts a newline" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "foo\\")
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == []
+      assert Composer.value(new_state) == "foo\n"
+    end
+
+    test "typing continues on the new line after a continuation" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "foo\\")
+      {state, []} = press(state, :enter)
+      state = type(state, "bar")
+
+      assert Composer.value(state) == "foo\nbar"
+    end
+
+    test "continuation can create the FIRST newline and Enter then submits nothing until forced" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "foo\\")
+      {state, []} = press(state, :enter)
+
+      # Buffer is now multiline: plain Enter continues, never submits.
+      {state, cmds} = press(state, :enter)
+      assert cmds == []
+
+      {_state, cmds} = Composer.force_submit(state)
+      assert [{:component_event, :c, {:submit, _text}}] = cmds
+    end
+
+    test "an escaped trailing backslash (\\\\) submits with a single backslash retained" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "foo\\\\")
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == [{:component_event, :c, {:submit, "foo\\"}}]
+      assert Composer.value(new_state) == ""
+    end
+
+    test "force_submit ignores the escape rule and submits verbatim" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "foo\\")
+
+      {_new_state, cmds} = Composer.force_submit(state)
+
+      assert cmds == [{:component_event, :c, {:submit, "foo\\"}}]
+    end
+  end
+
+  describe "first-focus hint" do
+    test "appears when focused with an empty buffer and no history" do
+      {:ok, state} = Composer.init(id: :c)
+
+      hint = hint_of(Composer.render(state, default_context()))
+
+      assert hint != nil
+      assert hint.style[:dim] == true
+      assert hint.content =~ "\\ continue"
+      assert hint.content =~ "↵ submit"
+    end
+
+    test "disappears once the buffer has content" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "x")
+
+      assert hint_of(Composer.render(state, default_context())) == nil
+    end
+
+    test "disappears once history exists" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "first")
+      {state, _} = press(state, :enter)
+
+      assert hint_of(Composer.render(state, default_context())) == nil
+    end
+
+    test "disappears when the input is not focused" do
+      {:ok, state} = Composer.init(id: :c, focused: false)
+
+      assert hint_of(Composer.render(state, default_context())) == nil
+    end
+  end
+
+  describe "unicode content" do
+    test "CJK and emoji paste round-trips without corruption" do
+      {:ok, state} = Composer.init(id: :c)
+      text = "héllo 世界 🎉 done"
+
+      {new_state, []} = paste(state, text)
+
+      assert Composer.value(new_state) == text
+    end
+
+    test "set_value/2 round-trips unicode content" do
+      {:ok, state} = Composer.init(id: :c)
+      text = "日本語のテスト 🚀"
+
+      new_state = Composer.set_value(state, text)
+
+      assert Composer.value(new_state) == text
+    end
+  end
+
+  describe "resize safety" do
+    test "render derives width from context[:available_width], not stored state" do
+      {:ok, state} = Composer.init(id: :c, value: "hello world")
+
+      narrow = Composer.render(state, %{theme: %{}, available_width: 5})
+      wide = Composer.render(state, %{theme: %{}, available_width: 80})
+
+      [input_narrow] = narrow.children
+      [input_wide] = wide.children
+
+      assert length(input_narrow.children) >= length(input_wide.children)
+    end
+  end
+
+  describe "typing via real key events" do
+    test "single-character :key events insert the characters" do
+      {:ok, state} = Composer.init(id: :c)
+
+      state =
+        Enum.reduce(String.graphemes("hi there"), state, fn char, acc ->
+          {new_state, _cmds} = press(acc, char)
+          new_state
+        end)
+
+      assert Composer.value(state) == "hi there"
+    end
+
+    test "typed characters then Enter submit the typed text" do
+      {:ok, state} = Composer.init(id: :c)
+
+      state =
+        Enum.reduce(String.graphemes("ok"), state, fn char, acc ->
+          {new_state, _cmds} = press(acc, char)
+          new_state
+        end)
+
+      {new_state, cmds} = press(state, :enter)
+
+      assert cmds == [{:component_event, :c, {:submit, "ok"}}]
+      assert Composer.value(new_state) == ""
+    end
+
+    test "typing a multi-codepoint grapheme (emoji) via a :key event inserts it intact" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {state, _cmds} = press(state, "🎉")
+
+      assert Composer.value(state) == "🎉"
+    end
+
+    test "typing a shifted character keeps working" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {state, _cmds} = press(state, "A", [:shift])
+
+      assert Composer.value(state) == "A"
+    end
+  end
+
+  describe "history reset on submit" do
+    test "submitting while browsing history resets history_index and draft" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "first")
+      {state, _} = press(state, :enter)
+      state = type(state, "unsent draft")
+
+      # Browse into history: index 0, draft saved.
+      {state, []} = press(state, :up)
+      assert Composer.value(state) == "first"
+      assert state.history_index == 0
+      assert state.draft == "unsent draft"
+
+      # Submit the recalled entry mid-browse.
+      {state, cmds} = press(state, :enter)
+      assert cmds == [{:component_event, :c, {:submit, "first"}}]
+      assert state.history_index == nil
+      assert state.draft == nil
+      assert Composer.history(state) == ["first", "first"]
+
+      # Subsequent Up starts from the newest entry again, not a stale index.
+      {state, []} = press(state, :up)
+      assert Composer.value(state) == "first"
+      assert state.history_index == 0
+    end
+  end
+
+  describe "update/2 prop sync" do
+    test "setting the :value prop updates the embedded input (no desync)" do
+      {:ok, state} = Composer.init(id: :c, value: "old")
+
+      {new_state, []} = Composer.update(%{value: "new content"}, state)
+
+      assert Composer.value(new_state) == "new content"
+      # Rendered lines follow the new value too, not a stale cache.
+      assert new_state.mli.lines == ["new content"]
+    end
+
+    test "setting :placeholder and :focused props reaches the embedded input" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {new_state, []} =
+        Composer.update(%{placeholder: "type here", focused: false}, state)
+
+      assert new_state.mli.placeholder == "type here"
+      assert new_state.mli.focused == false
+    end
+
+    test "non-mli props still merge onto the composer state" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {new_state, []} =
+        Composer.update(%{queued_steer: %{text: "s", queued_at: 1}}, state)
+
+      assert new_state.queued_steer.text == "s"
+      # No :value key ever lands on the outer composer map.
+      refute Map.has_key?(new_state, :value)
+    end
+  end
+
+  describe "typing with an active selection" do
+    test "a typed character replaces the selection and clears it" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "hello")
+
+      state = %{
+        state
+        | mli: %{state.mli | selection_start: {0, 0}, selection_end: {0, 5}}
+      }
+
+      {new_state, _cmds} = press(state, "x")
+
+      assert Composer.value(new_state) == "x"
+      assert new_state.mli.selection_start == nil
+      assert new_state.mli.selection_end == nil
+    end
+  end
+
+  describe "handle_event/3 passthrough" do
+    test "unrelated events are delegated to the wrapped MultiLineInput" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "abc")
+
+      {new_state, _cmds} = press(state, :home)
+
+      assert new_state.mli.cursor_pos == {0, 0}
+    end
+  end
+end


### PR DESCRIPTION
Unit **T11** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): the Composer — the harness surface's input component.

## What
- `Raxol.UI.Components.Harness.Composer` wrapping `MultiLineInput` (no editing rebuild): Enter submits iff single-logical-line + non-empty; Shift/Alt-Enter or Enter-on-multiline continues; `force_submit/1` escape hatch for an unconditional binding.
- Bracketed-paste fidelity: multiline paste lands verbatim as one edit, never triggers submit.
- Bounded input-history ring (Up/Down at buffer edges) with draft save/restore; submit mid-browse resets cleanly.
- Queued-steer banner (`⏸ steer queued for next boundary: …`) — AD-2's two-signal model made visible; dim via style attrs, grapheme-safe truncation.
- **Typing works around a real upstream bug**: `MultiLineInput`'s key dispatch sends 1-byte binaries where its edit ops expect codepoints (typed chars crash; multi-codepoint graphemes silently drop). The composer intercepts printable graphemes pre-delegation and routes them through the proven clipboard-insertion path — fixing ASCII, CJK, and ZWJ-emoji typing in one move. Upstream fix tracked separately in the lane STATE doc.
- `merge_props` drift fixed: `:value`/`:placeholder`/`:focused` props forward into the embedded input, so buffer truth can't desync.

## Evidence
32 tests green, including typing via real per-grapheme key events (this suite's red-run against the pre-fix commit is recorded in the commit body), typing-over-selection, history reset, prop-sync. `compile --warnings-as-errors` + `format --check-formatted` clean.

## Review trail
Opus adversarial review (needs-fixes: the typing crash, masked by a paste-only test helper) → fix + real-key-event tests → re-review **approve**; grok-composer quality advisory → merge_props sync + selection test; grok-4.5/longcat advisories → legacy-terminal modifier limitation documented; system-wide driver-input-shape gap recorded as a T13a prerequisite (F1a slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
