### PR TITLE
Harness UI: pty test harness (signals, capture, recovery) [TP]

### DIFF
--- a/test/harness/tp_pty_test.exs
+++ b/test/harness/tp_pty_test.exs
@@ -1,0 +1,353 @@
+defmodule Raxol.Harness.TpPtyTest do
+  @moduledoc """
+  Unit TP smoke test (`docs/proposals/in-flight/harness-ui-roadmap.md`,
+  design in `harness-ui-testing/03-lifecycle.md` §1.2-1.3): proves the pty
+  harness itself -- spawn-under-pty, real signal delivery to the BEAM's
+  child, and post-mortem `stty -a` capture -- before any T2d/T2a/T25 test
+  builds on it.
+
+  Tier B (real kernel pty). Independent of `SKIP_TERMBOX2_TESTS` (no
+  termbox anywhere in this path); requires only `python3` + `sh` + `stty`,
+  all present on any Unix CI image. Skips cleanly (not a failure) when
+  `python3` is absent.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Test.PtyHarness
+
+  @moduletag :pty
+  @moduletag :unix_only
+
+  # `trap ... TERM` intercepts SIGTERM: the shell prints CLEANUP, then exits
+  # via a normal `exit()` syscall (WIFEXITED true) -- verified empirically
+  # under this harness with `sh` as pty session leader, exit code 143
+  # (128+SIGTERM, the shell's own convention for "died to a trapped fatal
+  # signal", not the kernel forcibly killing it). SIGKILL bypasses the trap
+  # entirely -- the kernel just ends the process (WIFSIGNALED true, signal
+  # 9), so CLEANUP is never printed. WIFEXITED-vs-WIFSIGNALED is the load
+  # bearing distinction here, not the exact exit code.
+  @trap_script ~s(trap "echo CLEANUP" TERM; echo READY; sleep 30)
+
+  setup_all do
+    if PtyHarness.available?() do
+      :ok
+    else
+      {:skip, "python3 not found on PATH"}
+    end
+  end
+
+  # Stops the wrapper (killing anything still running under it) and removes
+  # the capture file, so a green run leaves nothing behind in `TMPDIR`.
+  defp cleanup(session) do
+    PtyHarness.stop(session)
+    File.rm(session.capture_path)
+  end
+
+  # `stty -a` renders each mode as a bare token ("icanon") when set and a
+  # minus-prefixed token ("-icanon") when clear. Exact token membership
+  # avoids the substring trap ("-echo" contains "echo").
+  defp stty_tokens(output), do: String.split(output, ~r/[\s;]+/, trim: true)
+
+  describe "signal delivery + post-mortem" do
+    test "SIGTERM: trap fires (CLEANUP captured), exits (not signaled), post-mortem stty readable" do
+      {:ok, session} = PtyHarness.start(["sh", "-c", @trap_script])
+      on_exit(fn -> cleanup(session) end)
+
+      assert :ok = PtyHarness.await_capture(session, "READY", 3_000)
+
+      assert :ok = PtyHarness.signal(session, :term)
+      # WIFEXITED, not WIFSIGNALED: the trap ran to completion. Exit code
+      # follows the shell's 128+signum convention (see @trap_script above).
+      assert {:ok, {:exit, 143}} = PtyHarness.await(session, 3_000)
+
+      assert :ok = PtyHarness.await_capture(session, "CLEANUP", 2_000)
+      {:ok, output} = PtyHarness.read_output(session)
+      assert output =~ "READY"
+      assert output =~ "CLEANUP"
+
+      assert {:ok, stty_output} = PtyHarness.post_mortem(session)
+      assert is_binary(stty_output)
+      assert byte_size(stty_output) > 0
+    end
+
+    test "SIGKILL: no trap run (no CLEANUP), exit reported as signaled" do
+      {:ok, session} = PtyHarness.start(["sh", "-c", @trap_script])
+      on_exit(fn -> cleanup(session) end)
+
+      assert :ok = PtyHarness.await_capture(session, "READY", 3_000)
+
+      assert :ok = PtyHarness.signal(session, :kill)
+      assert {:ok, {:signaled, 9}} = PtyHarness.await(session, 3_000)
+
+      {:ok, output} = PtyHarness.read_output(session)
+      assert output =~ "READY"
+      refute output =~ "CLEANUP"
+
+      # The pty slave outlives the child (the wrapper still owns the
+      # master), so post-mortem inspection after a SIGKILL is exactly the
+      # "documented residual is a tested fact" case from the design doc.
+      assert {:ok, stty_output} = PtyHarness.post_mortem(session)
+      assert is_binary(stty_output)
+      assert byte_size(stty_output) > 0
+    end
+
+    # Signals go to the process GROUP, not just the direct child pid: a
+    # backgrounded grandchild must die with the group, or `sh -c` chains
+    # leave orphan processes behind every interrupt.
+    test "SIGTERM reaches the whole process group, not just the shell pid" do
+      script =
+        ~s[trap "echo CLEANUP" TERM; (sleep 30)& echo BGPID=$!; echo READY; wait]
+
+      {:ok, session} = PtyHarness.start(["sh", "-c", script])
+      on_exit(fn -> cleanup(session) end)
+
+      assert :ok = PtyHarness.await_capture(session, "READY", 3_000)
+
+      {:ok, output} = PtyHarness.read_output(session)
+      [_, bgpid] = Regex.run(~r/BGPID=(\d+)/, output)
+
+      assert :ok = PtyHarness.signal(session, :term)
+      assert {:ok, {:exit, _}} = PtyHarness.await(session, 3_000)
+      assert :ok = PtyHarness.await_capture(session, "CLEANUP", 2_000)
+
+      # the backgrounded grandchild must be gone too -- no orphan sleep
+      assert :ok = await_process_death(bgpid, 2_000)
+    end
+  end
+
+  # Polls `kill -0 pid` until the process is gone (exit status != 0) or the
+  # deadline passes. kill -0 delivers nothing; it only probes existence.
+  defp await_process_death(pid_str, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    poll_process_death(pid_str, deadline)
+  end
+
+  defp poll_process_death(pid_str, deadline) do
+    {_, status} = System.cmd("kill", ["-0", pid_str], stderr_to_stdout: true)
+
+    cond do
+      status != 0 ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:error, :still_alive}
+
+      true ->
+        Process.sleep(20)
+        poll_process_death(pid_str, deadline)
+    end
+  end
+
+  describe "spawn/inspect/exit round-trip" do
+    test "a trivial script's exit code round-trips through WAIT" do
+      {:ok, session} = PtyHarness.start(["sh", "-c", "echo hi; exit 5"])
+      on_exit(fn -> cleanup(session) end)
+
+      assert :ok = PtyHarness.await_capture(session, "hi", 3_000)
+      assert {:ok, {:exit, 5}} = PtyHarness.await(session, 3_000)
+    end
+
+    test "WRITE injects input bytes into the pty master" do
+      # `cat` echoes stdin back out; sending Ctrl-D (EOT) via WRITE should
+      # let it see EOF and exit cleanly once its own input is closed.
+      {:ok, session} = PtyHarness.start(["cat"])
+      on_exit(fn -> cleanup(session) end)
+
+      assert :ok = PtyHarness.write(session, "hello\n")
+      assert :ok = PtyHarness.await_capture(session, "hello", 2_000)
+
+      assert :ok = PtyHarness.write(session, <<4>>)
+      assert {:ok, {:exit, 0}} = PtyHarness.await(session, 3_000)
+    end
+
+    # (A RECOVER-after-kill smoke test used to live here; it was vacuous --
+    # it passed even with a no-op recover. PTY-SELF-3 below is the real
+    # assertion: recover on a deliberately-stuck slave restores sane.)
+
+    # DRAIN BARRIER: a successful await must guarantee capture
+    # completeness -- the wrapper joins the pump thread (drain to EOF +
+    # close) before replying to WAIT. Without it, the last bytes written
+    # right at exit can race the reply, which is exactly the truncation
+    # LC-P-SIGTERM exists to detect. Looped to catch the race, which is
+    # timing-dependent by nature.
+    test "drain barrier: burst-then-exit output is fully captured after await (20x)" do
+      burst_script =
+        "i=0; while [ $i -lt 100 ]; do echo LINE$i; i=$((i+1)); done; " <>
+          "echo FINAL_MARKER; exit 0"
+
+      for round <- 1..20 do
+        {:ok, session} = PtyHarness.start(["sh", "-c", burst_script])
+
+        assert {:ok, {:exit, 0}} = PtyHarness.await(session, 5_000)
+        {:ok, output} = PtyHarness.read_output(session)
+
+        assert output =~ "LINE0", "round #{round}: head of burst missing"
+        assert output =~ "LINE99", "round #{round}: tail of burst missing"
+
+        assert output =~ "FINAL_MARKER",
+               "round #{round}: trailing bytes lost to the reply race"
+
+        cleanup(session)
+      end
+    end
+  end
+
+  describe "harness self-tests (03-lifecycle §3.3)" do
+    # PTY-SELF-2: the STTY probe must decisively distinguish a raw-mode
+    # slave from a default (sane-ish) one, or every raw/sane assertion
+    # built on it is meaningless.
+    test "PTY-SELF-2: STTY probe distinguishes raw-mode slave from default" do
+      {:ok, raw_session} =
+        PtyHarness.start(["sh", "-c", "stty raw -echo; echo ARMED; sleep 30"])
+
+      on_exit(fn -> cleanup(raw_session) end)
+
+      {:ok, sane_session} =
+        PtyHarness.start(["sh", "-c", "echo IDLE; sleep 30"])
+
+      on_exit(fn -> cleanup(sane_session) end)
+
+      assert :ok = PtyHarness.await_capture(raw_session, "ARMED", 3_000)
+      assert :ok = PtyHarness.await_capture(sane_session, "IDLE", 3_000)
+
+      {:ok, raw_stty} = PtyHarness.post_mortem(raw_session)
+      {:ok, sane_stty} = PtyHarness.post_mortem(sane_session)
+
+      raw_tokens = stty_tokens(raw_stty)
+      sane_tokens = stty_tokens(sane_stty)
+
+      # raw slave: icanon and echo are CLEAR
+      assert "-icanon" in raw_tokens
+      assert "-echo" in raw_tokens
+
+      # untouched slave: icanon and echo are SET
+      assert "icanon" in sane_tokens
+      assert "echo" in sane_tokens
+    end
+
+    # PTY-SELF-3: RECOVER resets a DELIBERATELY-stuck slave. The child puts
+    # the tty into raw -echo and then hangs (a frozen/hung app in raw mode
+    # -- pinned as stuck by SIGSTOP so it can't interfere); the documented
+    # one-liner must bring the line discipline back to sane while the app
+    # is still holding the tty. This is the "recovery is a passing test"
+    # fact from the design doc, not a smoke assertion on a never-stuck tty.
+    #
+    # Measured constraint (macOS): once the child -- the pty's SESSION
+    # LEADER -- dies and the last slave fd closes, the kernel resets the
+    # pty's termios, so a reopened-slave probe after SIGKILL shows fresh
+    # defaults, not residual raw. Residual-after-kill therefore can't be
+    # asserted through this probe; residual-while-hung is the honest
+    # cross-platform fact, and the byte-stream absence of teardown tokens
+    # after SIGKILL stays covered by Oracle A in the T2d suite.
+    test "PTY-SELF-3: RECOVER resets a deliberately-stuck slave to sane" do
+      {:ok, session} =
+        PtyHarness.start(["sh", "-c", "stty raw -echo; echo ARMED; sleep 30"])
+
+      on_exit(fn -> cleanup(session) end)
+
+      assert :ok = PtyHarness.await_capture(session, "ARMED", 3_000)
+
+      # freeze the app mid-raw-mode: stuck AND unresponsive
+      assert :ok = PtyHarness.signal(session, :stop)
+      assert {:ok, {:stopped, _}} = PtyHarness.await(session, 3_000)
+
+      {:ok, stuck_stty} = PtyHarness.post_mortem(session)
+      stuck_tokens = stty_tokens(stuck_stty)
+      assert "-icanon" in stuck_tokens
+      assert "-echo" in stuck_tokens
+
+      # the documented recovery one-liner (ESC[r + stty sane)
+      assert :ok = PtyHarness.recover(session)
+
+      {:ok, recovered_stty} = PtyHarness.post_mortem(session)
+      recovered_tokens = stty_tokens(recovered_stty)
+      assert "icanon" in recovered_tokens
+      assert "echo" in recovered_tokens
+    end
+  end
+
+  describe "job control (WUNTRACED)" do
+    # A stopped child must be observable as {:stopped, sig} -- distinct
+    # from {:error, :timeout} -- for T25's Ctrl-Z/fg tests. SIGSTOP is used
+    # here because the spawned child's process group is ORPHANED (session
+    # leader, parent in another session) and POSIX discards default-action
+    # SIGTSTP to orphaned process groups (measured: `signal(s, :tstp)` on
+    # this `sh` never stops it). Real T25 targets HANDLE SIGTSTP (release
+    # raw+region, then re-raise), and handled signals are not discarded --
+    # so the discard rule doesn't weaken T25; it just makes plain-`sh`
+    # smoke tests use the uncatchable stop signal.
+    test "stopped child reports {:stopped, sig}; SIGCONT resumes; exit still observable" do
+      {:ok, session} = PtyHarness.start(["sh", "-c", "echo READY; sleep 30"])
+      on_exit(fn -> cleanup(session) end)
+
+      assert :ok = PtyHarness.await_capture(session, "READY", 3_000)
+
+      assert :ok = PtyHarness.signal(session, :stop)
+      assert {:ok, {:stopped, stop_sig}} = PtyHarness.await(session, 3_000)
+      assert stop_sig > 0
+
+      # resume, then terminate: the stop did NOT reap the child, so the
+      # eventual death is still observable through a later await.
+      assert :ok = PtyHarness.signal(session, :cont)
+      assert :ok = PtyHarness.signal(session, :kill)
+      assert {:ok, {:signaled, 9}} = PtyHarness.await(session, 3_000)
+    end
+  end
+
+  describe "start/2 consumer options" do
+    test "winsize, env, and cwd reach the child" do
+      cwd_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol_pty_cwd_#{:erlang.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(cwd_dir)
+      on_exit(fn -> File.rm_rf!(cwd_dir) end)
+
+      {:ok, session} =
+        PtyHarness.start(
+          ["sh", "-c", "stty size; echo MARKER=$TP_MARKER; pwd"],
+          winsize: {40, 100},
+          env: %{"TP_MARKER" => "tp_env_ok"},
+          cwd: cwd_dir
+        )
+
+      on_exit(fn -> cleanup(session) end)
+
+      assert {:ok, {:exit, 0}} = PtyHarness.await(session, 3_000)
+      {:ok, output} = PtyHarness.read_output(session)
+
+      # TIOCSWINSZ: `stty size` prints "rows cols"
+      assert output =~ "40 100"
+      # env merge
+      assert output =~ "MARKER=tp_env_ok"
+      # cwd (compare by unique basename -- /tmp may resolve to /private/tmp)
+      assert output =~ Path.basename(cwd_dir)
+    end
+  end
+
+  describe "dead-wrapper guard" do
+    test "commands after stop/1 return {:error, :wrapper_exited}, not a crash" do
+      {:ok, session} = PtyHarness.start(["sh", "-c", "echo BYE"])
+      assert :ok = PtyHarness.await_capture(session, "BYE", 3_000)
+      assert {:ok, {:exit, 0}} = PtyHarness.await(session, 3_000)
+
+      :ok = PtyHarness.stop(session)
+      on_exit(fn -> File.rm(session.capture_path) end)
+
+      assert {:error, :wrapper_exited} = PtyHarness.signal(session, :term)
+      assert {:error, :wrapper_exited} = PtyHarness.write(session, "x")
+      assert {:error, :wrapper_exited} = PtyHarness.post_mortem(session)
+      assert {:error, :wrapper_exited} = PtyHarness.await(session, 100)
+    end
+  end
+
+  describe "availability guard" do
+    test "available?/0 reflects whether python3 is on PATH" do
+      assert PtyHarness.available?() ==
+               (System.find_executable("python3") != nil)
+    end
+  end
+end

--- a/test/support/harness/pty/pty_harness.ex
+++ b/test/support/harness/pty/pty_harness.ex
@@ -1,0 +1,441 @@
+defmodule Raxol.Test.PtyHarness do
+  @moduledoc """
+  Elixir wrapper around the vendored `pty_spawn.py` helper (unit TP,
+  `docs/proposals/in-flight/harness-ui-roadmap.md`).
+
+  Canonical location: `test/support/harness/pty/` (this directory). The
+  03-lifecycle design doc's earlier draft said `test/support/pty/`; this
+  path is the one that shipped -- consumers (T2d/T2a/T25 suites) should
+  `alias Raxol.Test.PtyHarness` and not care about the directory.
+
+  Spawns a command under a fresh pty via a `Port`, delivers signals to its
+  process group, tees its combined stdout/stderr byte stream to a capture
+  file, and takes a post-mortem `stty -a` snapshot of the pty's kernel line
+  discipline. This is Tier B of
+  `docs/proposals/in-flight/harness-ui-testing/03-lifecycle.md` -- the tier
+  reserved for facts that need a *real* controlling tty (signal delivery,
+  kernel line-discipline residual, kill-9 recovery, job control) that a pure
+  byte-capture harness cannot observe.
+
+  Requires `python3` on `PATH`. Call `available?/0` from a test's
+  `setup_all` and return `{:skip, reason}` when it's absent so CI images
+  without python3 skip cleanly instead of failing:
+
+      setup_all do
+        if Raxol.Test.PtyHarness.available?() do
+          :ok
+        else
+          {:skip, "python3 not found on PATH"}
+        end
+      end
+
+  ## Example
+
+      {:ok, session} = PtyHarness.start(["sh", "-c", "echo READY; sleep 30"])
+      :ok = PtyHarness.await_capture(session, "READY", 2_000)
+      :ok = PtyHarness.signal(session, :term)
+      {:ok, {:exit, 143}} = PtyHarness.await(session)
+      {:ok, output} = PtyHarness.read_output(session)
+      :ok = PtyHarness.stop(session)
+
+  ## Capture completeness
+
+  A successful `await/2` exit result (`{:exit, _}` / `{:signaled, _}`) is a
+  DRAIN BARRIER: the wrapper drains the pty master to EOF and closes the
+  capture file before replying, so `read_output/1` after such an `await`
+  sees the complete byte stream including trailing teardown bytes. Do not
+  assert capture completeness without an intervening successful `await`.
+
+  ## Failure taxonomy
+
+  Every public function returns `:ok`/`{:ok, value}` or `{:error, reason}`
+  where `reason` is an atom or a `{atom, detail}` tuple -- never a bare
+  string:
+
+    * `:python3_not_found` -- `start/2` only; no `python3` on PATH
+    * `:spawn_timeout` -- wrapper never sent its `SPAWNED` handshake
+    * `:timeout` -- the wrapper didn't reply in time, or `await/2`'s child
+      didn't change state within its bound
+    * `:wrapper_exited` -- command attempted on a closed/dead wrapper port
+    * `{:wrapper_exited, exit_status}` -- wrapper died mid-command
+    * `{:wrapper_error, message}` -- the wrapper replied `ERR <message>`
+      (e.g. no such process, bad signal, stty failure)
+    * `:bad_protocol` -- a wrapper reply failed to parse (malformed number)
+    * `:short_write` -- `write/2` reported fewer bytes than sent (should
+      not happen; the wrapper loops until drained)
+    * `{:unexpected_response, line}` -- reply outside the protocol grammar
+    * `File.read/1` posix reasons pass through from `read_output/1`
+
+  ## Concurrency contract
+
+  A session is NOT reentrant: one in-flight command at a time, from the
+  process that called `start/2` (the Port owner -- replies are delivered
+  to it, so cross-process calls hang). Calling `stop/1` while another
+  command (e.g. a long `await/2`) is in flight is undefined behavior --
+  sequence your commands.
+  """
+
+  defstruct [:port, :capture_path, :os_pid]
+
+  @type t :: %__MODULE__{
+          port: port(),
+          capture_path: Path.t(),
+          os_pid: pos_integer()
+        }
+
+  @type signal ::
+          :term | :int | :kill | :tstp | :stop | :cont | :hup | :usr1 | :usr2
+  @type wait_result ::
+          {:exit, non_neg_integer()}
+          | {:signaled, non_neg_integer()}
+          | {:stopped, non_neg_integer()}
+
+  @wrapper_path Path.join(__DIR__, "pty_spawn.py")
+  @spawn_timeout_ms 5_000
+  @default_command_timeout_ms 5_000
+
+  @doc """
+  Is `python3` on `PATH`? Use from `setup_all` to skip Tier B tests cleanly
+  (via `{:skip, reason}`) rather than failing on images without it.
+  """
+  @spec available? :: boolean()
+  def available? do
+    System.find_executable("python3") != nil
+  end
+
+  @doc """
+  Spawn `argv` (a non-empty list, `argv` head is the executable resolved via
+  the child's own `PATH` lookup) under a fresh pty.
+
+  Options:
+    * `:capture_path` -- where the tee'd byte stream is written. Defaults to
+      a fresh path under `System.tmp_dir!/0`.
+    * `:spawn_timeout_ms` -- how long to wait for the wrapper's initial
+      `SPAWNED <pid>` handshake. Defaults to #{@spawn_timeout_ms}.
+    * `:winsize` -- `{rows, cols}` pty window size, applied via TIOCSWINSZ
+      before exec. Defaults to `{24, 80}` (never the kernel's 0x0 default).
+    * `:cwd` -- child working directory.
+    * `:env` -- map of extra child environment variables (string keys and
+      values), merged over the inherited environment.
+  """
+  @spec start([String.t()], keyword()) :: {:ok, t()} | {:error, term()}
+  def start(argv, opts \\ [])
+
+  def start(argv, opts) when is_list(argv) and argv != [] do
+    case System.find_executable("python3") do
+      nil ->
+        {:error, :python3_not_found}
+
+      python3 ->
+        capture_path =
+          Keyword.get_lazy(opts, :capture_path, &tmp_capture_path/0)
+
+        spawn_timeout = Keyword.get(opts, :spawn_timeout_ms, @spawn_timeout_ms)
+
+        wrapper_args =
+          Enum.concat([
+            ["--capture", capture_path],
+            winsize_args(opts),
+            cwd_args(opts),
+            env_args(opts),
+            ["--" | argv]
+          ])
+
+        port =
+          Port.open({:spawn_executable, python3}, [
+            :binary,
+            :exit_status,
+            {:line, 65_536},
+            args: [@wrapper_path | wrapper_args]
+          ])
+
+        handle_spawn_handshake(port, capture_path, spawn_timeout)
+    end
+  end
+
+  defp handle_spawn_handshake(port, capture_path, timeout) do
+    case receive_line(port, timeout) do
+      {:ok, "SPAWNED " <> pid_str} ->
+        case parse_int(pid_str) do
+          {:ok, os_pid} ->
+            {:ok,
+             %__MODULE__{
+               port: port,
+               capture_path: capture_path,
+               os_pid: os_pid
+             }}
+
+          :error ->
+            safe_close(port)
+            {:error, :bad_protocol}
+        end
+
+      {:ok, "ERR " <> reason} ->
+        safe_close(port)
+        {:error, {:wrapper_error, reason}}
+
+      {:error, :timeout} ->
+        safe_close(port)
+        {:error, :spawn_timeout}
+
+      {:error, other} ->
+        safe_close(port)
+        {:error, other}
+    end
+  end
+
+  @doc """
+  Deliver `sig` to the child's process group (covers `sh -c` subshell
+  chains).
+
+  Job-control caveat: the spawned child is a session leader whose process
+  group is orphaned (its parent -- the wrapper -- lives in another session),
+  and POSIX discards default-action stop signals (SIGTSTP/SIGTTIN/SIGTTOU)
+  sent to orphaned process groups. So `:tstp` only stops a child that
+  handles the signal -- which real inline apps do (03-lifecycle §1.3
+  requires the app to catch SIGTSTP, release raw+region, then re-raise).
+  Use `:stop` (SIGSTOP, uncatchable and undiscardable) to stop an
+  arbitrary child unconditionally.
+  """
+  @spec signal(t(), signal()) :: :ok | {:error, term()}
+  def signal(session, sig)
+      when sig in [:term, :int, :kill, :tstp, :stop, :cont, :hup, :usr1, :usr2] do
+    case command(session, "SIG #{sig}") do
+      {:ok, "OK SIG " <> _} -> :ok
+      {:ok, "ERR " <> reason} -> {:error, {:wrapper_error, reason}}
+      {:error, _} = err -> err
+      {:ok, other} -> {:error, {:unexpected_response, other}}
+    end
+  end
+
+  @doc "Inject `bytes` into the pty master, as if typed (e.g. `<<3>>` for Ctrl-C)."
+  @spec write(t(), binary()) :: :ok | {:error, term()}
+  def write(session, bytes) when is_binary(bytes) do
+    hex = Base.encode16(bytes, case: :lower)
+    expected = byte_size(bytes)
+
+    case command(session, "WRITE #{hex}") do
+      {:ok, "OK WRITE " <> count} ->
+        case parse_int(count) do
+          {:ok, ^expected} -> :ok
+          {:ok, _short} -> {:error, :short_write}
+          :error -> {:error, :bad_protocol}
+        end
+
+      {:ok, "ERR " <> reason} ->
+        {:error, {:wrapper_error, reason}}
+
+      {:error, _} = err ->
+        err
+
+      {:ok, other} ->
+        {:error, {:unexpected_response, other}}
+    end
+  end
+
+  @doc """
+  Post-mortem `stty -a` against the pty *slave* -- kernel line-discipline
+  state, independent of whether the child process is still alive.
+  """
+  @spec post_mortem(t()) :: {:ok, String.t()} | {:error, term()}
+  def post_mortem(session) do
+    case command(session, "STTY") do
+      {:ok, "STTY " <> b64} -> Base.decode64(b64) |> wrap_decode_result()
+      {:ok, "ERR " <> reason} -> {:error, {:wrapper_error, reason}}
+      {:error, _} = err -> err
+      {:ok, other} -> {:error, {:unexpected_response, other}}
+    end
+  end
+
+  defp wrap_decode_result({:ok, bin}), do: {:ok, bin}
+  defp wrap_decode_result(:error), do: {:error, :bad_base64}
+
+  @doc """
+  The documented kill-9 recovery one-liner: `ESC [ r` (reset scroll region)
+  then `stty sane`, run directly against the pty slave.
+  """
+  @spec recover(t()) :: :ok | {:error, term()}
+  def recover(session) do
+    case command(session, "RECOVER") do
+      {:ok, "OK RECOVER"} -> :ok
+      {:ok, "ERR " <> reason} -> {:error, {:wrapper_error, reason}}
+      {:error, _} = err -> err
+      {:ok, other} -> {:error, {:unexpected_response, other}}
+    end
+  end
+
+  @doc """
+  Block (bounded by `timeout_ms`) until the child changes state.
+
+  A SIGTSTP/SIGSTOP-stopped child reports as `{:stopped, signum}` (WUNTRACED)
+  -- distinct from `{:error, :timeout}` -- so job-control tests (T25 Ctrl-Z /
+  `fg`) can observe the stop. Each stop transition is reported once; the
+  child is NOT reaped by it, so a later `await/2` still observes the eventual
+  exit after `signal(session, :cont)`. Exit results are idempotent: calling
+  again after a reap returns the same status instead of erroring.
+  """
+  @spec await(t(), non_neg_integer()) :: {:ok, wait_result()} | {:error, term()}
+  def await(session, timeout_ms \\ @default_command_timeout_ms) do
+    # The wrapper's WAIT drain-joins the capture pump for +5s max on exit,
+    # so give the port reply 6s of headroom beyond the child-state bound.
+    case command(session, "WAIT #{timeout_ms}", timeout_ms + 6_000) do
+      {:ok, "EXIT " <> code} -> tag_int(:exit, code)
+      {:ok, "SIGNALED " <> sig} -> tag_int(:signaled, sig)
+      {:ok, "STOPPED " <> sig} -> tag_int(:stopped, sig)
+      {:ok, "TIMEOUT"} -> {:error, :timeout}
+      {:ok, "ERR " <> reason} -> {:error, {:wrapper_error, reason}}
+      {:error, _} = err -> err
+      {:ok, other} -> {:error, {:unexpected_response, other}}
+    end
+  end
+
+  defp tag_int(tag, str) do
+    case parse_int(str) do
+      {:ok, n} -> {:ok, {tag, n}}
+      :error -> {:error, :bad_protocol}
+    end
+  end
+
+  @doc "Read everything captured from the child's pty output so far."
+  @spec read_output(t()) :: {:ok, binary()} | {:error, term()}
+  def read_output(session), do: File.read(session.capture_path)
+
+  @doc """
+  Poll `read_output/1` (bounded by `timeout_ms`) until `substring` appears --
+  the "no sleeps" way to know a child has reached an armed/ready state before
+  driving the next step (e.g. waiting for a `READY` sentinel before sending
+  a signal).
+  """
+  @spec await_capture(t(), binary(), non_neg_integer()) ::
+          :ok | {:error, :timeout}
+  def await_capture(session, substring, timeout_ms \\ 3_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    poll_capture(session, substring, deadline)
+  end
+
+  defp poll_capture(session, substring, deadline) do
+    case read_output(session) do
+      {:ok, content} ->
+        if String.contains?(content, substring),
+          do: :ok,
+          else: retry_or_timeout(session, substring, deadline)
+
+      {:error, _} ->
+        retry_or_timeout(session, substring, deadline)
+    end
+  end
+
+  defp retry_or_timeout(session, substring, deadline) do
+    if System.monotonic_time(:millisecond) >= deadline do
+      {:error, :timeout}
+    else
+      Process.sleep(20)
+      poll_capture(session, substring, deadline)
+    end
+  end
+
+  @doc """
+  Stop the harness: closes the port, which signals EOF to the wrapper's
+  stdin. The wrapper best-effort SIGKILLs the child's process group before
+  exiting, so nothing is left running even if the test never reaped it.
+  """
+  @spec stop(t()) :: :ok
+  def stop(session), do: safe_close(session.port)
+
+  # -- protocol plumbing --
+
+  defp command(session, line, timeout \\ @default_command_timeout_ms) do
+    # A closed/exited wrapper port must surface as an error tuple, not an
+    # ArgumentError crash (Port.command to a dead port raises badarg). The
+    # Port.info check catches the common case; the rescue closes the
+    # alive-at-check-dead-at-command race.
+    if Port.info(session.port) == nil do
+      {:error, :wrapper_exited}
+    else
+      Port.command(session.port, line <> "\n")
+      receive_line(session.port, timeout)
+    end
+  rescue
+    ArgumentError -> {:error, :wrapper_exited}
+  end
+
+  defp receive_line(port, timeout) do
+    receive do
+      {^port, {:data, {:eol, line}}} ->
+        {:ok, line}
+
+      {^port, {:data, {:noeol, partial}}} ->
+        accumulate_line(port, partial, timeout)
+
+      {^port, {:exit_status, status}} ->
+        {:error, {:wrapper_exited, status}}
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp accumulate_line(port, acc, timeout) do
+    receive do
+      {^port, {:data, {:eol, line}}} ->
+        {:ok, acc <> line}
+
+      {^port, {:data, {:noeol, more}}} ->
+        accumulate_line(port, acc <> more, timeout)
+
+      {^port, {:exit_status, status}} ->
+        {:error, {:wrapper_exited, status}}
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp safe_close(port) do
+    if Port.info(port), do: Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp parse_int(str) do
+    case Integer.parse(str) do
+      {n, ""} -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp tmp_capture_path do
+    unique =
+      "#{:erlang.unique_integer([:positive, :monotonic])}_#{System.os_time(:microsecond)}"
+
+    Path.join(System.tmp_dir!(), "raxol_pty_capture_#{unique}.bin")
+  end
+
+  # -- start/2 option -> wrapper argv translation --
+
+  defp winsize_args(opts) do
+    {rows, cols} = Keyword.get(opts, :winsize, {24, 80})
+
+    if is_integer(rows) and is_integer(cols) and rows > 0 and cols > 0 do
+      ["--winsize", "#{rows}x#{cols}"]
+    else
+      raise ArgumentError,
+            ":winsize must be {rows, cols} positive integers, got: " <>
+              inspect(Keyword.get(opts, :winsize))
+    end
+  end
+
+  defp cwd_args(opts) do
+    case Keyword.get(opts, :cwd) do
+      nil -> []
+      cwd when is_binary(cwd) -> ["--cwd", cwd]
+    end
+  end
+
+  defp env_args(opts) do
+    opts
+    |> Keyword.get(:env, %{})
+    |> Enum.flat_map(fn {key, val} ->
+      ["--env", "#{key}=#{val}"]
+    end)
+  end
+end

--- a/test/support/harness/pty/pty_spawn.py
+++ b/test/support/harness/pty/pty_spawn.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Vendored pty spawn/control wrapper for Raxol's Tier B lifecycle tests.
+
+Stdlib only (pty/os/signal/termios/fcntl/subprocess) -- no third-party deps,
+so it runs on any CI image with python3 and nothing else.
+
+Usage:
+    python3 pty_spawn.py --capture PATH [--winsize ROWSxCOLS] [--cwd DIR]
+                         [--env KEY=VAL ...] -- CMD [ARG ...]
+
+Spawns CMD under a fresh pty (child becomes session leader + controlling-tty
+owner, mirroring `os.login_tty`), tees everything the child writes to PATH,
+and then speaks a one-command-per-line protocol on its own stdin/stdout.
+
+Options:
+    --winsize ROWSxCOLS  pty window size, set via TIOCSWINSZ before exec
+                         (default 24x80 -- never the kernel's 0x0 default,
+                         which breaks anything that consults `stty size`).
+    --cwd DIR            child working directory (chdir after fork).
+    --env KEY=VAL        extra child environment (repeatable; merged over
+                         the inherited environment).
+
+Protocol:
+
+    SIG <term|int|kill|tstp|stop|cont|hup|usr1|usr2>
+        Deliver the named signal to the child's *process group* (not just
+        the child pid, so a `sh -c` subshell chain is covered). NOTE: the
+        spawned child is a session leader whose process group is ORPHANED
+        (its parent lives in another session), and POSIX discards
+        default-action job-control stop signals (SIGTSTP/SIGTTIN/SIGTTOU)
+        sent to orphaned process groups -- so `SIG tstp` only stops a child
+        that HANDLES the signal (as real inline apps do, per the
+        03-lifecycle design). `SIG stop` (SIGSTOP) cannot be caught or
+        discarded and always stops.
+        -> "OK SIG <name>" | "ERR <reason>"
+
+    WRITE <hexbytes>
+        Write raw bytes (hex-encoded on the wire) to the pty master, i.e.
+        inject them as if typed (e.g. "03" for Ctrl-C, "1a" for Ctrl-Z).
+        -> "OK WRITE <n>" | "ERR <reason>"
+
+    STTY
+        Run `stty -a` against the pty *slave* (kernel line-discipline
+        probe, independent of anything the child itself has done to fd 0).
+        -> "STTY <base64>" | "ERR <reason>"
+
+    RECOVER
+        The documented kill-9 recovery one-liner: write `ESC [ r` (reset
+        scroll region) to the slave, then `stty sane` against it.
+        -> "OK RECOVER" | "ERR <reason>"
+
+    WAIT <timeout_ms>
+        Block (bounded by timeout_ms) until the child changes state. Uses
+        WUNTRACED, so a SIGTSTP-stopped child reports as STOPPED (once per
+        stop -- the child is NOT reaped, so a later WAIT can still observe
+        the eventual exit after SIGCONT).
+
+        DRAIN BARRIER: when the state change is an exit (EXIT/SIGNALED,
+        not STOPPED), the wrapper joins the capture pump thread -- draining
+        the pty master to EOF and closing the capture file -- BEFORE
+        replying. A successful WAIT therefore guarantees the capture file
+        is complete; without this, a reply racing the last pump write
+        could make truncation tests (LC-P-SIGTERM) flaky. The join is
+        bounded (5s): if an orphaned grandchild keeps the slave open the
+        master never EOFs, and WAIT replies anyway after the bound.
+        -> "EXIT <code>" | "SIGNALED <signum>" | "STOPPED <signum>"
+           | "TIMEOUT" | "ERR <reason>"
+
+On EOF of its own stdin (the Elixir side closing the port), the wrapper
+best-effort SIGKILLs the child's process group so nothing is left running,
+then exits.
+
+The very first line written to stdout, before the command loop starts, is
+either "SPAWNED <pid>" or "ERR <reason>" (spawn failure).
+"""
+
+import base64
+import fcntl
+import os
+import signal
+import struct
+import subprocess
+import sys
+import termios
+import threading
+import time
+
+_SIGNAL_MAP = {
+    "term": signal.SIGTERM,
+    "int": signal.SIGINT,
+    "kill": signal.SIGKILL,
+    "tstp": signal.SIGTSTP,
+    "stop": signal.SIGSTOP,
+    "cont": signal.SIGCONT,
+    "hup": signal.SIGHUP,
+    "usr1": signal.SIGUSR1,
+    "usr2": signal.SIGUSR2,
+}
+
+
+class PtyChild:
+    """Owns the forked child + its pty pair and answers control commands."""
+
+    def __init__(self, capture_path, argv, winsize=(24, 80), cwd=None, env=None):
+        self.capture_path = capture_path
+        self.argv = argv
+        self.winsize = winsize
+        self.cwd = cwd
+        self.env_overrides = env or {}
+        self.pid = None
+        self.master_fd = None
+        self.slave_name = None
+        self._reaped_status = None  # (kind, value) once WAIT has reaped it
+        self._capture_lock = threading.Lock()
+        self._capture_file = None
+        self._pump_thread = None
+
+    def spawn(self):
+        master_fd, slave_fd = os.openpty()
+        slave_name = os.ttyname(slave_fd)
+
+        rows, cols = self.winsize
+        fcntl.ioctl(
+            slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0)
+        )
+
+        child_env = dict(os.environ)
+        child_env.update(self.env_overrides)
+
+        pid = os.fork()
+        if pid == 0:
+            # --- child ---
+            try:
+                os.close(master_fd)
+                os.setsid()
+                fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+                os.dup2(slave_fd, 0)
+                os.dup2(slave_fd, 1)
+                os.dup2(slave_fd, 2)
+                if slave_fd > 2:
+                    os.close(slave_fd)
+                if self.cwd is not None:
+                    os.chdir(self.cwd)
+                os.execvpe(self.argv[0], self.argv, child_env)
+            except Exception:
+                os._exit(127)
+            os._exit(127)  # unreachable; guards against execvpe fallthrough
+
+        # --- parent ---
+        os.close(slave_fd)
+        self.pid = pid
+        self.master_fd = master_fd
+        self.slave_name = slave_name
+        self._capture_file = open(self.capture_path, "wb", buffering=0)
+
+        self._pump_thread = threading.Thread(
+            target=self._pump_capture, daemon=True
+        )
+        self._pump_thread.start()
+
+    def _pump_capture(self):
+        while True:
+            try:
+                chunk = os.read(self.master_fd, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            with self._capture_lock:
+                if self._capture_file is not None:
+                    self._capture_file.write(chunk)
+                    self._capture_file.flush()
+        with self._capture_lock:
+            if self._capture_file is not None:
+                self._capture_file.close()
+                self._capture_file = None
+
+    # -- commands --
+
+    def do_sig(self, name):
+        signum = _SIGNAL_MAP.get(name)
+        if signum is None:
+            return "ERR unknown signal: {}".format(name)
+        try:
+            os.killpg(self.pid, signum)
+        except ProcessLookupError:
+            return "ERR no such process"
+        except PermissionError as exc:
+            return "ERR permission denied: {}".format(exc)
+        return "OK SIG {}".format(name)
+
+    def do_write(self, hex_bytes):
+        try:
+            data = bytes.fromhex(hex_bytes)
+        except ValueError as exc:
+            return "ERR bad hex: {}".format(exc)
+        # os.write can short-write on a pty; loop until fully drained so
+        # the reported count always equals len(data) on success.
+        total = 0
+        try:
+            while total < len(data):
+                total += os.write(self.master_fd, data[total:])
+        except OSError as exc:
+            return "ERR write failed after {} bytes: {}".format(total, exc)
+        return "OK WRITE {}".format(total)
+
+    def do_stty(self):
+        try:
+            fd = os.open(self.slave_name, os.O_RDWR | os.O_NOCTTY)
+        except OSError as exc:
+            return "ERR open slave failed: {}".format(exc)
+        try:
+            result = subprocess.run(
+                ["stty", "-a"],
+                stdin=fd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=5,
+            )
+            if result.returncode != 0:
+                return "ERR stty exited {}: {}".format(
+                    result.returncode,
+                    result.stdout.decode("utf-8", "replace").strip(),
+                )
+            payload = base64.b64encode(result.stdout).decode("ascii")
+            return "STTY {}".format(payload)
+        except (OSError, subprocess.SubprocessError) as exc:
+            return "ERR stty failed: {}".format(exc)
+        finally:
+            os.close(fd)
+
+    def do_recover(self):
+        try:
+            fd = os.open(self.slave_name, os.O_RDWR | os.O_NOCTTY)
+        except OSError as exc:
+            return "ERR open slave failed: {}".format(exc)
+        try:
+            os.write(fd, b"\x1b[r")
+            subprocess.run(["stty", "sane"], stdin=fd, timeout=5, check=False)
+            return "OK RECOVER"
+        except (OSError, subprocess.SubprocessError) as exc:
+            return "ERR recover failed: {}".format(exc)
+        finally:
+            os.close(fd)
+
+    def do_wait(self, timeout_ms_str):
+        try:
+            timeout_ms = int(timeout_ms_str)
+        except ValueError:
+            return "ERR bad timeout: {}".format(timeout_ms_str)
+
+        if self._reaped_status is not None:
+            return self._format_status(self._reaped_status)
+
+        deadline = time.monotonic() + (timeout_ms / 1000.0)
+        while True:
+            try:
+                wpid, status = os.waitpid(self.pid, os.WNOHANG | os.WUNTRACED)
+            except ChildProcessError:
+                return "ERR already reaped elsewhere"
+            if wpid == self.pid:
+                decoded = self._decode_status(status)
+                if decoded[0] == "stopped":
+                    # A stopped child is NOT reaped: don't cache, so a later
+                    # WAIT still observes the eventual exit after SIGCONT.
+                    # (The kernel reports each stop transition once; a WAIT
+                    # issued while the child stays stopped returns TIMEOUT.)
+                    return self._format_status(decoded)
+                self._reaped_status = decoded
+                # DRAIN BARRIER: the child is dead, so the pty master will
+                # hit EOF once buffered output is drained. Join the pump
+                # thread (which drains + closes the capture file) BEFORE
+                # replying, so a successful WAIT guarantees the capture is
+                # complete -- no reply/last-write race.
+                self._drain_capture()
+                return self._format_status(decoded)
+            if time.monotonic() >= deadline:
+                return "TIMEOUT"
+            time.sleep(0.01)
+
+    @staticmethod
+    def _decode_status(status):
+        if os.WIFSTOPPED(status):
+            return ("stopped", os.WSTOPSIG(status))
+        if os.WIFEXITED(status):
+            return ("exit", os.WEXITSTATUS(status))
+        if os.WIFSIGNALED(status):
+            return ("signaled", os.WTERMSIG(status))
+        return ("exit", -1)
+
+    @staticmethod
+    def _format_status(decoded):
+        kind, value = decoded
+        if kind == "exit":
+            return "EXIT {}".format(value)
+        if kind == "stopped":
+            return "STOPPED {}".format(value)
+        return "SIGNALED {}".format(value)
+
+    def _drain_capture(self, timeout=5.0):
+        # Bounded: if an orphaned grandchild still holds the slave open the
+        # master never EOFs; reply anyway after the bound rather than hang.
+        t = self._pump_thread
+        if t is not None and t.is_alive():
+            t.join(timeout=timeout)
+        with self._capture_lock:
+            if self._capture_file is not None:
+                self._capture_file.flush()
+
+    def shutdown(self):
+        try:
+            os.killpg(self.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        # Reap until gone (bounded) so no zombie outlives the wrapper.
+        if self._reaped_status is None:
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                try:
+                    wpid, status = os.waitpid(
+                        self.pid, os.WNOHANG | os.WUNTRACED
+                    )
+                except ChildProcessError:
+                    break
+                if wpid == self.pid and not os.WIFSTOPPED(status):
+                    self._reaped_status = self._decode_status(status)
+                    break
+                time.sleep(0.01)
+        # Close the master so the pump thread hits EBADF/EOF and terminates
+        # deterministically even if a grandchild kept the slave open.
+        try:
+            os.close(self.master_fd)
+        except OSError:
+            pass
+        self._drain_capture(timeout=2.0)
+
+
+_USAGE = (
+    "usage: pty_spawn.py --capture PATH [--winsize ROWSxCOLS] [--cwd DIR] "
+    "[--env KEY=VAL ...] -- CMD [ARG ...]"
+)
+
+
+def _parse_args(argv):
+    capture_path = None
+    winsize = (24, 80)
+    cwd = None
+    env = {}
+    child_argv = None
+
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--":
+            child_argv = argv[i + 1 :]
+            break
+        if arg == "--capture" and i + 1 < len(argv):
+            capture_path = argv[i + 1]
+            i += 2
+        elif arg == "--winsize" and i + 1 < len(argv):
+            try:
+                rows_s, cols_s = argv[i + 1].split("x", 1)
+                winsize = (int(rows_s), int(cols_s))
+            except ValueError:
+                raise SystemExit("bad --winsize (want ROWSxCOLS): {}".format(argv[i + 1]))
+            i += 2
+        elif arg == "--cwd" and i + 1 < len(argv):
+            cwd = argv[i + 1]
+            i += 2
+        elif arg == "--env" and i + 1 < len(argv):
+            key, sep, val = argv[i + 1].partition("=")
+            if not sep or not key:
+                raise SystemExit("bad --env (want KEY=VAL): {}".format(argv[i + 1]))
+            env[key] = val
+            i += 2
+        else:
+            raise SystemExit(_USAGE)
+
+    if capture_path is None or not child_argv:
+        raise SystemExit(_USAGE)
+    return capture_path, child_argv, winsize, cwd, env
+
+
+def main():
+    out = sys.stdout
+    try:
+        capture_path, child_argv, winsize, cwd, env = _parse_args(sys.argv[1:])
+    except SystemExit as exc:
+        out.write("ERR {}\n".format(exc))
+        out.flush()
+        return 2
+
+    child = PtyChild(capture_path, child_argv, winsize=winsize, cwd=cwd, env=env)
+    try:
+        child.spawn()
+    except OSError as exc:
+        out.write("ERR spawn failed: {}\n".format(exc))
+        out.flush()
+        return 1
+
+    out.write("SPAWNED {}\n".format(child.pid))
+    out.flush()
+
+    try:
+        for raw_line in sys.stdin:
+            line = raw_line.rstrip("\n")
+            if not line:
+                continue
+            parts = line.split(" ", 1)
+            cmd = parts[0]
+            rest = parts[1] if len(parts) > 1 else ""
+
+            if cmd == "SIG":
+                reply = child.do_sig(rest.strip())
+            elif cmd == "WRITE":
+                reply = child.do_write(rest.strip())
+            elif cmd == "STTY":
+                reply = child.do_stty()
+            elif cmd == "RECOVER":
+                reply = child.do_recover()
+            elif cmd == "WAIT":
+                reply = child.do_wait(rest.strip())
+            else:
+                reply = "ERR unknown command: {}".format(cmd)
+
+            out.write(reply + "\n")
+            out.flush()
+    finally:
+        child.shutdown()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Unit **TP** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): the pty test harness — Tier B substrate for every lifecycle/signal test in the lane (T2d inline driver, T2a scroll-region manager, T25 $EDITOR handoff).

## What
- `test/support/harness/pty/pty_spawn.py` — stdlib-only pty wrapper: fork under a fresh pty (setsid + TIOCSCTTY), tee child output to a capture file, line protocol for signals/stty/recover/wait, group-SIGKILL on EOF.
- `Raxol.Test.PtyHarness` — Port wrapper: `start/2` (env, cwd, winsize via TIOCSWINSZ), `signal/2` (incl. undiscardable `:stop`), `await/2` (WUNTRACED — exit/signaled/stopped distinct), `post_mortem/1` (stty -a), `recover/1`, capture readers. One documented failure taxonomy; dead wrapper never raises.
- **Capture-completeness contract**: the wrapper drains the pty to EOF and closes the capture *before* answering WAIT — a successful `await` guarantees the full byte stream. Proven load-bearing by fault injection: with an artificially slowed pump, the barrier-less variant lost the final marker 5/5 runs; with barrier 0/5.
- Oracle self-tests per the 03-lifecycle design: stty probe distinguishes raw from sane; RECOVER resets a deliberately-stuck, SIGSTOP-frozen slave; SIGTERM-to-pgid kills backgrounded grandchildren (no orphans).

## Measured POSIX facts (documented in-test, they shaped the API)
- Trapped `sh` exits 143 after SIGTERM (WIFEXITED vs WIFSIGNALED is the discriminating fact, not the code).
- macOS resets pty termios when the session leader dies and the last slave fd closes — post-SIGKILL residual is asserted while-hung, not post-mortem.
- Default-action SIGTSTP to an orphaned process group is kernel-discarded — hence `:stop` (SIGSTOP) in the signal map.

## Evidence
12 tests green (`:pty` + `:unix_only`, independent of SKIP_TERMBOX2_TESTS, clean skip without python3); 20/20 drain-barrier rounds; compile --warnings-as-errors / format / credo --strict clean.

## Review trail
Opus adversarial review (approve-with-yellows) → self-tests + dead-port guard + consumer API round; three-lens advisory (grok-4.5 invariants / grok-composer quality / longcat conceptual) → drain barrier, pgid test, wire hardening, taxonomy normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
