### PR TITLE
Harness UI: DECRQM capability slice (scanner, probe, ladder) [T1]

### DIFF
--- a/packages/raxol_terminal/lib/raxol/terminal/capabilities/capabilities_record.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/capabilities/capabilities_record.ex
@@ -1,0 +1,139 @@
+defmodule Raxol.Terminal.Capabilities do
+  @moduledoc """
+  Session-immutable terminal capability record (F0 §5, T1 slice).
+
+  Filled once at startup by the probe pass
+  (`Raxol.Terminal.Capabilities.Probe` -> `Classifier`), cached in
+  `:persistent_term`, and never mutated for the rest of the session.
+
+  Provenance discipline: every detected capability records *where* the
+  answer came from in `source` (`:decrqm`, `:xtversion`, `:xtgettcap`,
+  `:env`, `:tmux_clamp`, `:default`). Env sniffing (`$TERM_PROGRAM` et
+  al.) is only ever a free first-pass seed -- it can never claim a
+  probe-able capability like mode 2026 (the fail-first anchor of the T1
+  unit).
+
+  `sync_output?/0` is the single public emit-gate for mode-2026 framing;
+  render paths consult it and nothing else.
+  """
+
+  @type tier :: :core_minus | :core | :modern | :rich
+  @type unicode_axis :: :none | :wide | :grapheme
+  @type grapheme_width :: :mode_2027 | :measured | :assumed
+  @type multiplexer :: :none | :tmux | :screen
+  @type identity :: {String.t(), String.t() | nil} | nil
+  @type provenance ::
+          :decrqm
+          | :xtversion
+          | :da1
+          | :da2
+          | :xtgettcap
+          | :env
+          | :tmux_clamp
+          | :platform
+          | :default
+
+  @type t :: %__MODULE__{
+          identity: identity(),
+          tier: tier(),
+          unicode: unicode_axis(),
+          truecolor: boolean(),
+          sixel: boolean(),
+          sixel_regs: non_neg_integer() | nil,
+          kitty_graphics: boolean(),
+          kitty_keyboard: non_neg_integer() | nil,
+          sync_output: boolean(),
+          grapheme_width: grapheme_width(),
+          in_band_resize: boolean(),
+          lr_margins: boolean(),
+          theme_events: boolean(),
+          cell_px: {pos_integer(), pos_integer()} | nil,
+          styled_underline: boolean(),
+          multiplexer: multiplexer(),
+          quirks: [atom()],
+          source: %{optional(atom()) => provenance()}
+        }
+
+  defstruct identity: nil,
+            tier: :core,
+            unicode: :wide,
+            truecolor: false,
+            sixel: false,
+            sixel_regs: nil,
+            kitty_graphics: false,
+            kitty_keyboard: nil,
+            sync_output: false,
+            grapheme_width: :assumed,
+            in_band_resize: false,
+            lr_margins: false,
+            theme_events: false,
+            cell_px: nil,
+            styled_underline: false,
+            multiplexer: :none,
+            quirks: [],
+            source: %{}
+
+  @record_key {__MODULE__, :record}
+  @mode_key {__MODULE__, :mode_replies}
+
+  # ---- session cache (:persistent_term, write-once) ----
+
+  @doc """
+  Caches the classified record for the session. Write-once: the first
+  cached record wins; later calls are no-ops (session immutability,
+  CAP-P-13).
+  """
+  @spec cache(t()) :: :ok
+  def cache(%__MODULE__{} = caps) do
+    case :persistent_term.get(@record_key, :undefined) do
+      :undefined -> :persistent_term.put(@record_key, caps)
+      _existing -> :ok
+    end
+  end
+
+  @doc "Returns the cached session record, if any."
+  @spec cached() :: {:ok, t()} | :error
+  def cached do
+    case :persistent_term.get(@record_key, :undefined) do
+      :undefined -> :error
+      %__MODULE__{} = caps -> {:ok, caps}
+    end
+  end
+
+  @doc """
+  THE mode-2026 emit gate. Render paths consult this one function before
+  emitting `CSI ? 2026 h/l` sync frames.
+
+  Truth order: cached session record -> raw DECRQM mode replies noted by
+  the driver's reply scan -> `false`. Env is never consulted.
+  """
+  @spec sync_output?() :: boolean()
+  def sync_output? do
+    case cached() do
+      {:ok, caps} ->
+        caps.sync_output
+
+      :error ->
+        Map.get(mode_replies(), 2026) in [1, 2]
+    end
+  end
+
+  @doc false
+  @spec note_mode_reply(non_neg_integer(), integer() | nil) :: :ok
+  def note_mode_reply(mode, value) when is_integer(mode) do
+    replies = :persistent_term.get(@mode_key, %{})
+    :persistent_term.put(@mode_key, Map.put_new(replies, mode, value))
+  end
+
+  @doc false
+  @spec mode_replies() :: %{optional(non_neg_integer()) => integer() | nil}
+  def mode_replies, do: :persistent_term.get(@mode_key, %{})
+
+  @doc false
+  @spec reset_cache() :: :ok
+  def reset_cache do
+    :persistent_term.erase(@record_key)
+    :persistent_term.erase(@mode_key)
+    :ok
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/capabilities/classifier.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/capabilities/classifier.ex
@@ -1,0 +1,145 @@
+defmodule Raxol.Terminal.Capabilities.Classifier do
+  @moduledoc """
+  Pure classifier: scanner accumulator + env seed -> `%Capabilities{}`
+  (04 design §1c).
+
+  The env seed is a *free first pass only* -- it can set `multiplexer`
+  and seed `truecolor` (marked `source: :env`), but a probe-able
+  capability like mode 2026 is only ever set from a DECRQM reply
+  (`source: :decrqm`). The quirk table runs after the naive parse.
+  """
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Capabilities.{QuirkTable, ReplyScanner}
+
+  @truecolor_env ["truecolor", "24bit"]
+
+  @doc """
+  Classifies a scan accumulator into a capability record.
+
+  Options:
+
+    * `:tty?` -- `false` forces the Core-minus non-TTY path (CAP-P-12)
+    * `:platform` -- `:windows` applies the platform gates (CAP-N-12)
+  """
+  @spec classify(ReplyScanner.t(), map(), keyword()) :: Capabilities.t()
+  def classify(%ReplyScanner{} = acc, env, opts \\ []) when is_map(env) do
+    tty? = Keyword.get(opts, :tty?, true)
+
+    multiplexer = detect_multiplexer(env)
+    {sync_output, sync_source} = decide_mode(acc.mode, 2026)
+    {resize, resize_source} = decide_mode(acc.mode, 2048)
+    {lr_margins, lr_source} = decide_mode(acc.mode, 69)
+    {theme_events, theme_source} = decide_mode(acc.mode, 2031)
+    {grapheme_2027, _} = decide_mode(acc.mode, 2027)
+    {truecolor, truecolor_source} = decide_truecolor(acc, env)
+    {identity, identity_source} = decide_identity(acc)
+
+    %Capabilities{
+      identity: identity,
+      tier: tier(acc, tty?),
+      unicode: if(grapheme_2027, do: :grapheme, else: :wide),
+      truecolor: truecolor,
+      sixel: sixel?(acc),
+      sixel_regs: acc.sixel_regs,
+      kitty_graphics: acc.kitty_graphics == true,
+      kitty_keyboard: acc.kitty_kbd,
+      sync_output: sync_output,
+      grapheme_width: if(grapheme_2027, do: :mode_2027, else: :assumed),
+      in_band_resize: resize,
+      lr_margins: lr_margins,
+      theme_events: theme_events,
+      cell_px: acc.cell_px,
+      styled_underline: Map.has_key?(acc.xtgettcap, "Smulx"),
+      multiplexer: multiplexer,
+      source: %{
+        identity: identity_source,
+        sync_output: sync_source,
+        in_band_resize: resize_source,
+        lr_margins: lr_source,
+        theme_events: theme_source,
+        truecolor: truecolor_source
+      }
+    }
+    |> QuirkTable.apply(acc, env, opts)
+  end
+
+  # ---- DECRQM value semantics (F0 §3): {1,2} supported, else not ----
+
+  defp decide_mode(modes, mode) do
+    case Map.fetch(modes, mode) do
+      {:ok, value} when value in [1, 2] -> {true, :decrqm}
+      {:ok, _other} -> {false, :decrqm}
+      :error -> {false, :default}
+    end
+  end
+
+  # ---- truecolor priority: XTGETTCAP RGB (probed) > $COLORTERM (seed) ----
+
+  defp decide_truecolor(acc, env) do
+    cond do
+      Map.has_key?(acc.xtgettcap, "RGB") -> {true, :xtgettcap}
+      Map.get(env, "COLORTERM") in @truecolor_env -> {true, :env}
+      true -> {false, :default}
+    end
+  end
+
+  # ---- identity: XTVERSION, DA2 fallback (no static DA2 table yet) ----
+
+  defp decide_identity(%{xtversion: {_, _} = identity}),
+    do: {identity, :xtversion}
+
+  defp decide_identity(%{da2: params}) when is_list(params), do: {nil, :da2}
+  defp decide_identity(_acc), do: {nil, :default}
+
+  # ---- tier bucketing (output labels per terminfo.dev, F0 §5) ----
+
+  defp tier(_acc, false), do: :core_minus
+
+  defp tier(%{sentinel_seen?: false, da1: nil}, _tty?), do: :core_minus
+
+  defp tier(acc, _tty?) do
+    cond do
+      rich?(acc) -> :rich
+      modern?(acc) -> :modern
+      true -> :core
+    end
+  end
+
+  defp rich?(acc) do
+    is_integer(acc.kitty_kbd) or acc.kitty_graphics == true
+  end
+
+  defp modern?(acc) do
+    acc.mode[2026] in [1, 2] or acc.xtversion != nil or
+      Map.has_key?(acc.xtgettcap, "RGB")
+  end
+
+  # ---- sixel: DA1 attribute 4 or reported color registers ----
+
+  defp sixel?(%{da1: [_level | attrs]} = acc) when is_list(attrs) do
+    4 in attrs or (is_integer(acc.sixel_regs) and acc.sixel_regs > 0)
+  end
+
+  defp sixel?(acc) do
+    is_integer(acc.sixel_regs) and acc.sixel_regs > 0
+  end
+
+  # ---- multiplexer detection ($TERM=screen never trusted to widen) ----
+
+  defp detect_multiplexer(env) do
+    cond do
+      present?(env, "TMUX") -> :tmux
+      String.starts_with?(Map.get(env, "TERM") || "", "screen") -> :screen
+      true -> :none
+    end
+  end
+
+  defp present?(env, key) do
+    case Map.get(env, key) do
+      nil -> false
+      "" -> false
+      _ -> true
+    end
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/capabilities/ladder.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/capabilities/ladder.ex
@@ -1,0 +1,144 @@
+defmodule Raxol.Terminal.Capabilities.Ladder do
+  @moduledoc """
+  Degradation ladder: pure tier selection over the capability record
+  (roadmap T3 seam, 04 design §1c / §7).
+
+  Modes:
+
+    * `:inline_log` -- the inline hybrid (scroll-region history + pinned
+      footer). Requires a real terminal, no multiplexer, and either a
+      Modern/Rich tier or Core with verified sync-output.
+    * `:tmux_conservative` -- inside tmux/screen: clamped caps, no OSC
+      marks assumed consumed.
+    * `:flat` -- append-only + plain prompt, zero regions/cursor jumps.
+      The screen-reader answer, the CI/pipe answer. Always safe.
+
+  Env overrides: `RAXOL_FORCE_FLAT=1` forces `:flat` (downgrade is always
+  safe; a forced downgrade on a capable terminal emits the
+  `[:raxol, :degradation, :forced_downgrade]` telemetry so it is at least
+  observable). `RAXOL_FORCE_MODE=inline_log` on an *incapable* record is
+  REFUSED -- `select/2` returns `{:error, :incapable}` and
+  `assert_capable!/2` raises `IncapableModeError`. Fail loud, never emit
+  inline sequences to a terminal that cannot host them (LAD-N-01).
+  """
+
+  alias Raxol.Terminal.Capabilities
+
+  defmodule IncapableModeError do
+    defexception [:message]
+
+    @impl true
+    def exception(opts) do
+      mode = Keyword.get(opts, :mode)
+      caps = Keyword.get(opts, :caps)
+
+      %__MODULE__{
+        message:
+          "refusing to run #{inspect(mode)} on an incapable terminal " <>
+            "(tier=#{inspect(caps && caps.tier)} " <>
+            "sync_output=#{inspect(caps && caps.sync_output)} " <>
+            "multiplexer=#{inspect(caps && caps.multiplexer)}); " <>
+            "falling back would corrupt the host -- fix the override"
+      }
+    end
+  end
+
+  @type mode :: :inline_log | :tmux_conservative | :flat
+  @modes [:inline_log, :tmux_conservative, :flat]
+
+  @truthy ["1", "true", "TRUE", "yes"]
+
+  @doc "The three ladder modes."
+  @spec modes() :: [mode()]
+  def modes, do: @modes
+
+  @doc """
+  Selects the rendering mode for a capability record. Total: always
+  `{:ok, mode}` or `{:error, reason}`, never raises (LAD-P-02).
+  """
+  @spec select(Capabilities.t(), map()) :: {:ok, mode()} | {:error, term()}
+  def select(caps, env \\ %{})
+
+  def select(%Capabilities{} = caps, env) when is_map(env) do
+    cond do
+      forced?(env, "RAXOL_FORCE_FLAT") or
+          Map.get(env, "RAXOL_FORCE_MODE") == "flat" ->
+        emit_downgrade_telemetry(caps)
+        {:ok, :flat}
+
+      Map.get(env, "RAXOL_FORCE_MODE") == "tmux_conservative" ->
+        {:ok, :tmux_conservative}
+
+      Map.get(env, "RAXOL_FORCE_MODE") == "inline_log" ->
+        case guard(:inline_log, caps) do
+          :ok -> {:ok, :inline_log}
+          {:error, _} = error -> error
+        end
+
+      caps.tier == :core_minus ->
+        {:ok, :flat}
+
+      caps.multiplexer in [:tmux, :screen] ->
+        {:ok, :tmux_conservative}
+
+      capable?(:inline_log, caps) ->
+        {:ok, :inline_log}
+
+      true ->
+        {:ok, :flat}
+    end
+  end
+
+  def select(_caps, _env), do: {:error, :invalid_capabilities}
+
+  @doc """
+  Can this record host the given mode? Downgrades are always safe;
+  `:inline_log` needs the scroll-region floor (proxy until T0's verdict:
+  tier + sync_output -- 04 §10 Q5) and no multiplexer.
+  """
+  @spec capable?(mode(), Capabilities.t()) :: boolean()
+  def capable?(:flat, %Capabilities{}), do: true
+  def capable?(:tmux_conservative, %Capabilities{}), do: true
+
+  def capable?(:inline_log, %Capabilities{} = caps) do
+    caps.multiplexer == :none and
+      (caps.tier in [:modern, :rich] or
+         (caps.tier == :core and caps.sync_output))
+  end
+
+  @doc "Non-raising guard: `:ok` or `{:error, :incapable}`."
+  @spec guard(mode(), Capabilities.t()) :: :ok | {:error, :incapable}
+  def guard(mode, %Capabilities{} = caps) do
+    if capable?(mode, caps), do: :ok, else: {:error, :incapable}
+  end
+
+  @doc """
+  Fail-loud guard: raises `IncapableModeError` when the mode cannot be
+  hosted (LAD-N-01). Never proceed and corrupt.
+  """
+  @spec assert_capable!(mode(), Capabilities.t()) :: :ok
+  def assert_capable!(mode, %Capabilities{} = caps) do
+    case guard(mode, caps) do
+      :ok -> :ok
+      {:error, :incapable} -> raise IncapableModeError, mode: mode, caps: caps
+    end
+  end
+
+  # ---- internals ----
+
+  defp forced?(env, key), do: Map.get(env, key) in @truthy
+
+  # LAD-N-02: forcing :flat on a capable terminal is allowed (downgrade
+  # is safe) but observable -- never a silent product downgrade.
+  defp emit_downgrade_telemetry(caps) do
+    if capable?(:inline_log, caps) do
+      :telemetry.execute(
+        [:raxol, :degradation, :forced_downgrade],
+        %{},
+        %{tier: caps.tier, multiplexer: caps.multiplexer}
+      )
+    end
+
+    :ok
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/capabilities/probe.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/capabilities/probe.ex
@@ -1,0 +1,223 @@
+defmodule Raxol.Terminal.Capabilities.Probe do
+  @moduledoc """
+  Pure probe reducer -- the clock seam (04 design §1b).
+
+  `step(state, event)` where `event` is `{:input, bytes}`, `{:clock,
+  monotonic_ms}`, or `:start`. **No time is read inside `step`** and no
+  process sleeps anywhere: the silence timeout is driven entirely by
+  injected clock events, so every timing case is a table row, not a
+  flake. The real driver wraps this with a `receive/after` loop feeding
+  `System.monotonic_time(:millisecond)` as `{:clock, now}` events.
+
+  Sentinel discipline (F0 §2): the batched query ends with Primary DA
+  (`CSI c`). Every VT-class terminal answers DA1, so read-to-sentinel
+  converts "did it ignore me?" into a bounded wait -- any wanted reply
+  that did not arrive before the sentinel is unsupported. Silence past
+  the deadline is the failure mode, answered with a conservative default.
+
+  Deadline policy (F0 §7 step 3): ~100 ms local, ~1 s when `$SSH_*` is
+  present; extended AT MOST ONCE when a first byte is seen but the
+  sentinel is not. After the sentinel, one drain window stays open until
+  the next clock event so reordered replies (a documented terminal bug)
+  are still parsed; after `:done`, late replies are drained, never
+  reclassified, and never leaked as keystrokes.
+  """
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Capabilities.{Classifier, ReplyScanner}
+
+  @local_budget_ms 100
+  @ssh_budget_ms 1000
+  @ssh_env_keys ["SSH_TTY", "SSH_CONNECTION", "SSH_CLIENT"]
+
+  # One batched write (F0 §3 order, 2026 slice), DA1 sentinel LAST:
+  # OSC 11 background - kitty keyboard - DECRQM 2026 - XTVERSION - DA1.
+  @query "\e]11;?\a\e[?u\e[?2026$p\e[>0q\e[c"
+
+  # tmux passthrough payload (F0 §7 step 4): identity + color queries
+  # only, kept well under the ~60 char truncation limit.
+  @passthrough_payload "\e]11;?\a\e[>0q"
+
+  @type event :: :start | {:input, binary()} | {:clock, integer()}
+  @type action ::
+          {:write, iodata()}
+          | {:passthrough, iodata()}
+          | {:extend_deadline, non_neg_integer()}
+          | {:leak_free, binary()}
+          | {:done, Capabilities.t()}
+
+  @type phase :: :init | :awaiting | :draining | :done
+
+  @type t :: %__MODULE__{
+          scanner: ReplyScanner.t(),
+          env: map(),
+          opts: keyword(),
+          phase: phase(),
+          budget_ms: pos_integer(),
+          extend_ms: pos_integer(),
+          deadline: integer() | nil,
+          extended?: boolean(),
+          seen_input?: boolean(),
+          tty?: boolean(),
+          now0: integer(),
+          caps: Capabilities.t() | nil
+        }
+
+  defstruct scanner: nil,
+            env: %{},
+            opts: [],
+            phase: :init,
+            budget_ms: @local_budget_ms,
+            extend_ms: @local_budget_ms,
+            deadline: nil,
+            extended?: false,
+            seen_input?: false,
+            tty?: true,
+            now0: 0,
+            caps: nil
+
+  @doc "The exact batched query the probe emits on `:start`."
+  @spec query_sequence() :: binary()
+  def query_sequence, do: @query
+
+  @doc """
+  Builds a probe from the env seed.
+
+  Options:
+
+    * `:budget_ms` -- override the silence deadline (default ~100 ms
+      local, ~1 s when any `$SSH_*` var is present)
+    * `:extend_ms` -- the one-time extension budget (default = budget)
+    * `:now_ms` -- clock origin the deadline is computed from (default 0;
+      the driver passes `System.monotonic_time(:millisecond)`)
+    * `:tty?` -- `false` = non-TTY path: Core-minus, ZERO queries emitted
+    * `:tmux_passthrough?` -- re-issue identity/color queries wrapped for
+      the outer terminal (only meaningful when `$TMUX` is set)
+    * `:platform` -- forwarded to the classifier (`:windows` gates)
+  """
+  @spec new(map(), keyword()) :: t()
+  def new(env, opts \\ []) when is_map(env) do
+    budget = Keyword.get(opts, :budget_ms, default_budget(env))
+
+    %__MODULE__{
+      scanner: ReplyScanner.new(),
+      env: env,
+      opts: opts,
+      budget_ms: budget,
+      extend_ms: Keyword.get(opts, :extend_ms, budget),
+      tty?: Keyword.get(opts, :tty?, true),
+      now0: Keyword.get(opts, :now_ms, 0)
+    }
+  end
+
+  @doc "Probe outcome: `:pending` or `{:done, %Capabilities{}}`."
+  @spec result(t()) :: :pending | {:done, Capabilities.t()}
+  def result(%__MODULE__{phase: :done, caps: caps}), do: {:done, caps}
+  def result(%__MODULE__{}), do: :pending
+
+  @doc """
+  Advances the reducer by one event. Returns `{state, actions}`.
+  """
+  @spec step(t(), event()) :: {t(), [action()]}
+  def step(%__MODULE__{phase: :init} = p, :start) do
+    if p.tty? do
+      actions = [{:write, @query} | passthrough_actions(p)]
+      {%{p | phase: :awaiting, deadline: p.now0 + p.budget_ms}, actions}
+    else
+      # CAP-P-12: not a TTY -> Core-minus from the env seed alone,
+      # zero bytes written (F0 §7 step 0).
+      finalize(%{p | phase: :awaiting}, [])
+    end
+  end
+
+  # an empty chunk is not a "first byte": no scan, no extension
+  def step(%__MODULE__{} = p, {:input, <<>>}), do: {p, []}
+
+  def step(%__MODULE__{phase: :awaiting} = p, {:input, bytes}) do
+    {scanner, leak} = ReplyScanner.scan(bytes, p.scanner)
+    p = %{p | scanner: scanner}
+
+    {p, extend_actions} =
+      if not p.seen_input? and not scanner.sentinel_seen? and not p.extended? do
+        {%{
+           p
+           | seen_input?: true,
+             extended?: true,
+             deadline: p.deadline + p.extend_ms
+         }, [{:extend_deadline, p.extend_ms}]}
+      else
+        {%{p | seen_input?: true}, []}
+      end
+
+    p = if scanner.sentinel_seen?, do: %{p | phase: :draining}, else: p
+    {p, leak_actions(leak) ++ extend_actions}
+  end
+
+  def step(%__MODULE__{phase: :awaiting} = p, {:clock, now}) do
+    if now >= p.deadline, do: finalize(p, []), else: {p, []}
+  end
+
+  # Drain window: replies arriving after the sentinel (same window) are
+  # still parsed by grammar -- reorder is a documented terminal bug
+  # (CAP-N-02). The window closes on the next clock event.
+  def step(%__MODULE__{phase: :draining} = p, {:input, bytes}) do
+    {scanner, leak} = ReplyScanner.scan(bytes, p.scanner)
+    {%{p | scanner: scanner}, leak_actions(leak)}
+  end
+
+  def step(%__MODULE__{phase: :draining} = p, {:clock, _now}) do
+    finalize(p, [])
+  end
+
+  # After :done: late replies are drained (classification is immutable),
+  # interleaved keystrokes still pass through (CAP-N-03).
+  def step(%__MODULE__{phase: :done} = p, {:input, bytes}) do
+    {_scanner, leak} = ReplyScanner.scan(bytes, ReplyScanner.new())
+    {p, leak_actions(leak)}
+  end
+
+  def step(%__MODULE__{phase: :done} = p, _event), do: {p, []}
+
+  # a stray :start in any later phase is a no-op (idempotence)
+  def step(%__MODULE__{} = p, :start), do: {p, []}
+
+  # ---- internals ----
+
+  defp finalize(p, extra_actions) do
+    caps =
+      Classifier.classify(p.scanner, p.env,
+        tty?: p.tty?,
+        platform: Keyword.get(p.opts, :platform)
+      )
+
+    # the parked partial (if any) is dropped here: a half-reply at
+    # timeout is DRAINED, never leaked to the key parser (CAP-N-08)
+    p = %{p | phase: :done, caps: caps}
+    {p, extra_actions ++ [{:done, caps}]}
+  end
+
+  defp leak_actions(""), do: []
+  defp leak_actions(leak), do: [{:leak_free, leak}]
+
+  defp passthrough_actions(p) do
+    if tmux?(p.env) and Keyword.get(p.opts, :tmux_passthrough?, false) do
+      [{:passthrough, wrap_passthrough(@passthrough_payload)}]
+    else
+      []
+    end
+  end
+
+  # DCS tmux ; <ESC-doubled payload> ST (F0 §7 step 4)
+  defp wrap_passthrough(payload) do
+    "\ePtmux;" <> String.replace(payload, "\e", "\e\e") <> "\e\\"
+  end
+
+  defp tmux?(env), do: (Map.get(env, "TMUX") || "") != ""
+
+  defp default_budget(env) do
+    ssh? =
+      Enum.any?(@ssh_env_keys, fn key -> (Map.get(env, key) || "") != "" end)
+
+    if ssh?, do: @ssh_budget_ms, else: @local_budget_ms
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/capabilities/quirk_table.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/capabilities/quirk_table.ex
@@ -1,0 +1,89 @@
+defmodule Raxol.Terminal.Capabilities.QuirkTable do
+  @moduledoc """
+  Per-terminal quirk corrections applied *after* the naive grammar parse
+  (F0 §3 catalog, 04 design §1c).
+
+  Quirks in the 2026 slice:
+
+    * **Alacritty stuck-at-2** -- Alacritty answers DECRQM 2026 with
+      `Pm = 2` and the value never flips to `1` after a set. `2` ("mode
+      recognized, currently reset") already classifies as supported under
+      the generic rule; the quirk records `:no_verify_2026` so callers
+      never do a set-then-requery verification (04 §10 Q1: `no_verify`,
+      not a value override).
+    * **tmux/screen conservative clamp** -- passthrough is off by default
+      since tmux 3.3a (F0 §7.4); replies observed inside a multiplexer
+      describe the *inner* terminal at best and garble at worst. Clamp:
+      `sync_output: false`, tier capped at `:modern`, kitty caps cleared.
+      `$TERM=screen` is never trusted to widen anything.
+    * **Windows platform gates** -- no XTVERSION / pixel geometry / 2048
+      on Windows Terminal; gate those caps by *platform*, not by DECRQM
+      absence (F0 §9).
+  """
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Capabilities.ReplyScanner
+
+  @doc "Applies the quirk table to a naively-classified record."
+  @spec apply(Capabilities.t(), ReplyScanner.t(), map(), keyword()) ::
+          Capabilities.t()
+  def apply(%Capabilities{} = caps, %ReplyScanner{} = acc, env, opts \\ []) do
+    caps
+    |> alacritty_stuck_at_2(acc)
+    |> multiplexer_clamp(env)
+    |> windows_platform_gate(Keyword.get(opts, :platform))
+  end
+
+  # Alacritty reports 2026 but its DECRQM value is stuck at 2: supported,
+  # but never verify by set-then-requery (CAP-N-05).
+  defp alacritty_stuck_at_2(caps, acc) do
+    if identity_name(caps) =~ ~r/alacritty/i and acc.mode[2026] == 2 do
+      add_quirk(caps, :no_verify_2026)
+    else
+      caps
+    end
+  end
+
+  defp multiplexer_clamp(%{multiplexer: :none} = caps, _env), do: caps
+
+  defp multiplexer_clamp(caps, _env) do
+    %{
+      caps
+      | sync_output: false,
+        tier: cap_tier(caps.tier),
+        kitty_keyboard: nil,
+        kitty_graphics: false,
+        source: Map.put(caps.source, :sync_output, :tmux_clamp)
+    }
+    |> add_quirk(:multiplexer_conservative_clamp)
+  end
+
+  defp cap_tier(:rich), do: :modern
+  defp cap_tier(tier), do: tier
+
+  defp windows_platform_gate(caps, :windows) do
+    %{
+      caps
+      | in_band_resize: false,
+        cell_px: nil,
+        source:
+          caps.source
+          |> Map.put(:in_band_resize, :platform)
+          |> Map.put(:cell_px, :platform)
+    }
+    |> add_quirk(:windows_platform_gates)
+  end
+
+  defp windows_platform_gate(caps, _platform), do: caps
+
+  defp add_quirk(caps, quirk) do
+    if quirk in caps.quirks do
+      caps
+    else
+      %{caps | quirks: caps.quirks ++ [quirk]}
+    end
+  end
+
+  defp identity_name(%{identity: {name, _}}), do: name
+  defp identity_name(_), do: ""
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/capabilities/reply_scanner.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/capabilities/reply_scanner.ex
@@ -1,0 +1,393 @@
+defmodule Raxol.Terminal.Capabilities.ReplyScanner do
+  @moduledoc """
+  Pure reply scanner: raw input chunk in, `{parsed_replies_acc,
+  leak_free_residual}` out (test-suite design 04 §1a).
+
+  Generalizes `Raxol.Terminal.Driver.BackgroundQuery.scan/1` to all F0 §3
+  reply framings. Replies are classified **by grammar and echoed
+  parameters** (`?2026` in `CSI ? 2026 ; 1 $ y`), never by position.
+
+  Invariants (pinned by the CAP-F fuzz suite):
+
+    * **Conservation** -- every input byte is either consumed as a
+      recognized reply/control frame or returned in `leak_free`, in the
+      original order. User keystrokes are never eaten; reply bytes never
+      leak to the key parser.
+    * **Both terminators** -- OSC/DCS/APC close on BEL (`0x07`) *or* ST
+      (`ESC \\`).
+    * **Chunk-split invariance** -- a chunk ending mid-reply parks the
+      fragment in `partial`; the next `scan/2` resumes byte-identically.
+
+  The scanner is a pure function; it has no process, no clock, and no
+  side effects. The driver-facing shim (`BackgroundQuery`) and the probe
+  reducer (`Probe`) compose it.
+  """
+
+  alias Raxol.Terminal.Driver.BackgroundQuery
+
+  @type mode_value :: integer() | nil
+
+  @type t :: %__MODULE__{
+          osc11: {:ok, BackgroundQuery.rgb()} | {:invalid, binary()} | nil,
+          kitty_kbd: non_neg_integer() | nil,
+          mode: %{optional(non_neg_integer()) => mode_value()},
+          xtversion: {String.t(), String.t() | nil} | nil,
+          xtversion_raw: String.t() | nil,
+          xtgettcap: %{optional(String.t()) => String.t() | true},
+          da1: [non_neg_integer()] | nil,
+          da2: [non_neg_integer()] | nil,
+          cpr: {pos_integer(), pos_integer()} | nil,
+          cell_px: {pos_integer(), pos_integer()} | nil,
+          sixel_regs: non_neg_integer() | nil,
+          kitty_graphics: boolean() | nil,
+          sentinel_seen?: boolean(),
+          partial: binary()
+        }
+
+  defstruct osc11: nil,
+            kitty_kbd: nil,
+            mode: %{},
+            xtversion: nil,
+            xtversion_raw: nil,
+            xtgettcap: %{},
+            da1: nil,
+            da2: nil,
+            cpr: nil,
+            cell_px: nil,
+            sixel_regs: nil,
+            kitty_graphics: nil,
+            sentinel_seen?: false,
+            partial: <<>>
+
+  @doc "Fresh scanner accumulator."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Scans a raw input chunk, resuming from any parked partial reply.
+
+  Returns `{acc, leak_free}` where `leak_free` is safe to hand to the
+  key-event parser.
+  """
+  @spec scan(binary(), t()) :: {t(), binary()}
+  def scan(chunk, %__MODULE__{} = acc) when is_binary(chunk) do
+    data = acc.partial <> chunk
+    do_scan(data, %{acc | partial: <<>>}, [])
+  end
+
+  defp do_scan(<<>>, acc, leak), do: {acc, flush_leak(leak)}
+
+  defp do_scan(<<0x1B, _::binary>> = data, acc, leak) do
+    case match_reply(data) do
+      {:reply, kind, payload, rest} ->
+        do_scan(rest, absorb(acc, kind, payload), leak)
+
+      {:drain, rest} ->
+        do_scan(rest, acc, leak)
+
+      :partial ->
+        {%{acc | partial: data}, flush_leak(leak)}
+
+      {:leak, n} ->
+        <<leaked::binary-size(^n), rest::binary>> = data
+        do_scan(rest, acc, [leaked | leak])
+    end
+  end
+
+  defp do_scan(<<byte, rest::binary>>, acc, leak) do
+    do_scan(rest, acc, [<<byte>> | leak])
+  end
+
+  defp flush_leak(leak), do: leak |> Enum.reverse() |> IO.iodata_to_binary()
+
+  # ---- grammar dispatch (by opening framing) ----
+
+  defp match_reply(<<0x1B>>), do: :partial
+  defp match_reply(<<0x1B, ?], rest::binary>>), do: match_osc(rest)
+  defp match_reply(<<0x1B, ?P, rest::binary>>), do: match_string(rest, :dcs)
+  defp match_reply(<<0x1B, ?_, rest::binary>>), do: match_string(rest, :apc)
+  defp match_reply(<<0x1B, ?[, rest::binary>>), do: match_csi(rest)
+  # ESC followed by anything else (Alt+key, SS3, ...) is input: leak the
+  # ESC byte alone; the loop leaks the following bytes individually, so
+  # the concatenated leak_free is byte-identical to the input.
+  defp match_reply(_data), do: {:leak, 1}
+
+  # ---- CSI replies: ESC [ <marker?> <params> <intermediates?> <final> ----
+
+  defp match_csi(rest) do
+    case take_csi_body(rest, [], []) do
+      :partial -> :partial
+      :abort -> {:leak, 1}
+      {body, final, after_seq} -> classify_csi(body, final, after_seq, rest)
+    end
+  end
+
+  # Walk the CSI body: params 0x30-0x3F, intermediates 0x20-0x2F,
+  # final 0x40-0x7E. Any other byte aborts (stray ESC / control byte).
+  defp take_csi_body(<<>>, _body, _inter), do: :partial
+
+  defp take_csi_body(<<byte, rest::binary>>, body, inter)
+       when byte in 0x30..0x3F do
+    take_csi_body(rest, [byte | body], inter)
+  end
+
+  defp take_csi_body(<<byte, rest::binary>>, body, inter)
+       when byte in 0x20..0x2F do
+    take_csi_body(rest, body, [byte | inter])
+  end
+
+  defp take_csi_body(<<final, rest::binary>>, body, inter)
+       when final in 0x40..0x7E do
+    {%{
+       raw: body |> Enum.reverse() |> :erlang.list_to_binary(),
+       intermediates: inter |> Enum.reverse() |> :erlang.list_to_binary()
+     }, final, rest}
+  end
+
+  defp take_csi_body(<<_other, _::binary>>, _body, _inter), do: :abort
+
+  defp classify_csi(%{raw: raw, intermediates: inter}, final, rest, whole) do
+    marker_and_params = split_marker(raw)
+
+    case {marker_and_params, inter, final} do
+      # DECRQM reply: CSI ? <mode> ; <value> $ y
+      {{"?", params}, "$", ?y} ->
+        {:reply, :decrqm, parse_decrqm_params(params), rest}
+
+      # our own DECRQM *query* echoed back verbatim: CSI ? <mode> $ p --
+      # recognized as a non-reply, drained (CAP-N-07)
+      {{"?", _params}, "$", ?p} ->
+        {:drain, rest}
+
+      # DA1 reply (THE sentinel): CSI ? <params> c
+      {{"?", params}, "", ?c} ->
+        {:reply, :da1, parse_int_params(params), rest}
+
+      # kitty keyboard flags reply: CSI ? <flags> u  (a bare echoed
+      # "CSI ? u" query carries no digits and is drained, not a reply)
+      {{"?", params}, "", ?u} ->
+        if params =~ ~r/\d/ do
+          {:reply, :kitty_kbd, params |> parse_int_params() |> List.first(0), rest}
+        else
+          {:drain, rest}
+        end
+
+      # XTSMGRAPHICS reply: CSI ? <Pi> ; <Ps> ; <Pv> S
+      {{"?", params}, "", ?S} ->
+        {:reply, :xtsmgraphics, parse_int_params(params), rest}
+
+      # DA2 reply: CSI > <params> c
+      {{">", params}, "", ?c} ->
+        {:reply, :da2, parse_int_params(params), rest}
+
+      # cursor position report: CSI <row> ; <col> R. Consumed here
+      # because CPR is wire-ambiguous with xterm's modified-F3 key
+      # encoding (CSI 1 ; mod R): during a probe window the reply must
+      # be stripped before it can masquerade as a keypress.
+      {{"", params}, "", ?R} ->
+        case parse_int_params(params) do
+          [row, col] -> {:reply, :cpr, {row, col}, rest}
+          _ -> leak_whole(whole, rest)
+        end
+
+      # window/cell-size report: CSI 4|6|8 ; <h> ; <w> t
+      {{"", params}, "", ?t} ->
+        case parse_int_params(params) do
+          [kind | _] = ints when kind in [4, 6, 8] ->
+            {:reply, :size_report, ints, rest}
+
+          _ ->
+            leak_whole(whole, rest)
+        end
+
+      # anything else (arrow keys, mouse, focus, unknown) is input --
+      # leak the whole sequence untouched for the key parser
+      _ ->
+        leak_whole(whole, rest)
+    end
+  end
+
+  # leak "ESC [" + everything up to and including the final byte
+  defp leak_whole(body_and_rest, rest) do
+    {:leak, 2 + byte_size(body_and_rest) - byte_size(rest)}
+  end
+
+  defp split_marker(<<marker, params::binary>>) when marker in ~c"<=>?" do
+    {<<marker>>, params}
+  end
+
+  defp split_marker(params), do: {"", params}
+
+  defp parse_decrqm_params(params) do
+    case String.split(params, ";") do
+      [mode] -> {to_int(mode, nil), nil}
+      [mode, value | _] -> {to_int(mode, nil), to_int(value, nil)}
+    end
+  end
+
+  defp parse_int_params(""), do: []
+
+  defp parse_int_params(params) do
+    params
+    |> String.split(";")
+    |> Enum.map(&to_int(&1, 0))
+  end
+
+  defp to_int(s, default) do
+    case Integer.parse(s) do
+      {n, ""} -> n
+      _ -> default
+    end
+  end
+
+  # ---- OSC replies: ESC ] <payload> (BEL | ST) ----
+
+  defp match_osc(rest) do
+    case take_string_body(rest, []) do
+      :partial ->
+        :partial
+
+      :abort ->
+        {:leak, 1}
+
+      {payload, after_seq} ->
+        case payload do
+          "11;" <> color -> {:reply, :osc11, color, after_seq}
+          _ -> {:drain, after_seq}
+        end
+    end
+  end
+
+  # ---- DCS / APC replies: ESC P|_ <payload> (ST | BEL) ----
+
+  defp match_string(rest, kind) do
+    case take_string_body(rest, []) do
+      :partial -> :partial
+      :abort -> {:leak, 1}
+      {payload, after_seq} -> classify_string(kind, payload, after_seq)
+    end
+  end
+
+  defp classify_string(:dcs, ">|" <> version, rest),
+    do: {:reply, :xtversion, version, rest}
+
+  defp classify_string(:dcs, "1+r" <> pairs, rest),
+    do: {:reply, :xtgettcap, {:ok, pairs}, rest}
+
+  defp classify_string(:dcs, "0+r" <> _, rest),
+    do: {:reply, :xtgettcap, :invalid, rest}
+
+  defp classify_string(:dcs, _payload, rest), do: {:drain, rest}
+
+  defp classify_string(:apc, "G" <> body, rest),
+    do: {:reply, :kitty_graphics, String.contains?(body, ";OK"), rest}
+
+  defp classify_string(:apc, _payload, rest), do: {:drain, rest}
+
+  # Collect a string-frame body up to BEL or ST. A stray ESC not followed
+  # by `\\` aborts; ESC as the last byte stays :partial (could become ST).
+  defp take_string_body(<<>>, _seen), do: :partial
+  defp take_string_body(<<0x07, rest::binary>>, seen), do: finish(seen, rest)
+
+  defp take_string_body(<<0x1B, ?\\, rest::binary>>, seen),
+    do: finish(seen, rest)
+
+  defp take_string_body(<<0x1B>>, _seen), do: :partial
+  defp take_string_body(<<0x1B, _, _::binary>>, _seen), do: :abort
+
+  defp take_string_body(<<byte, rest::binary>>, seen),
+    do: take_string_body(rest, [byte | seen])
+
+  defp finish(seen, rest),
+    do: {seen |> Enum.reverse() |> :erlang.list_to_binary(), rest}
+
+  # ---- absorb parsed replies into the accumulator ----
+
+  defp absorb(acc, :decrqm, {nil, _value}), do: acc
+
+  defp absorb(acc, :decrqm, {mode, value}),
+    do: %{acc | mode: Map.put(acc.mode, mode, value)}
+
+  defp absorb(acc, :da1, params),
+    do: %{acc | da1: params, sentinel_seen?: true}
+
+  defp absorb(acc, :da2, params), do: %{acc | da2: params}
+
+  defp absorb(acc, :cpr, {row, col}), do: %{acc | cpr: {row, col}}
+
+  defp absorb(acc, :kitty_kbd, flags), do: %{acc | kitty_kbd: flags}
+
+  defp absorb(acc, :xtsmgraphics, [1, 0, regs | _]),
+    do: %{acc | sixel_regs: regs}
+
+  defp absorb(acc, :xtsmgraphics, _params), do: acc
+
+  defp absorb(acc, :size_report, [6, h, w | _]) when h > 0 and w > 0,
+    do: %{acc | cell_px: {w, h}}
+
+  defp absorb(acc, :size_report, _params), do: acc
+
+  defp absorb(acc, :osc11, color) do
+    case BackgroundQuery.parse_color(color) do
+      {:ok, rgb} -> %{acc | osc11: {:ok, rgb}}
+      :error -> %{acc | osc11: {:invalid, color}}
+    end
+  end
+
+  defp absorb(acc, :xtversion, version) do
+    %{acc | xtversion_raw: version, xtversion: parse_identity(version)}
+  end
+
+  defp absorb(acc, :xtgettcap, {:ok, pairs}) do
+    %{acc | xtgettcap: Map.merge(acc.xtgettcap, decode_tcap_pairs(pairs))}
+  end
+
+  defp absorb(acc, :xtgettcap, :invalid), do: acc
+
+  defp absorb(acc, :kitty_graphics, ok?), do: %{acc | kitty_graphics: ok?}
+
+  # ---- XTVERSION identity: "kitty(0.32.2)" | "iTerm2 3.5.0" | "name" ----
+
+  defp parse_identity(raw) do
+    trimmed = String.trim(raw)
+
+    case Regex.run(~r/^(.+?)\(([^)]*)\)$/, trimmed) do
+      [_, name, version] ->
+        {String.trim(name), version}
+
+      nil ->
+        case String.split(trimmed, " ", parts: 2) do
+          [name, version] -> {name, version}
+          [name] -> {name, nil}
+        end
+    end
+  end
+
+  # ---- XTGETTCAP payload: hex(name)=hex(value) pairs joined by ';' ----
+
+  defp decode_tcap_pairs(pairs) do
+    pairs
+    |> String.split(";")
+    |> Enum.reduce(%{}, fn pair, out ->
+      case String.split(pair, "=", parts: 2) do
+        [name_hex, value_hex] ->
+          with {:ok, name} <- decode_hex(name_hex),
+               {:ok, value} <- decode_hex(value_hex) do
+            Map.put(out, name, value)
+          else
+            _ -> out
+          end
+
+        [name_hex] ->
+          case decode_hex(name_hex) do
+            {:ok, name} -> Map.put(out, name, true)
+            _ -> out
+          end
+      end
+    end)
+  end
+
+  defp decode_hex(hex) do
+    Base.decode16(hex, case: :mixed)
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/background_query.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/background_query.ex
@@ -1,25 +1,36 @@
 defmodule Raxol.Terminal.Driver.BackgroundQuery do
   @moduledoc """
-  OSC 11 terminal background-color detection.
+  OSC 11 terminal background-color detection + DECRQM 2026 probe.
 
-  Emits an OSC 11 query (`ESC ] 11 ; ? BEL`) followed by a primary Device
-  Attributes probe (`CSI c`). Every terminal answers DA, so a DA reply that
-  arrives without an OSC 11 reply means the terminal does not support
-  dynamic-color queries and callers should fall back to an assumed ground.
+  Emits an OSC 11 query (`ESC ] 11 ; ? BEL`) and a DECRQM query for mode
+  2026 (`CSI ? 2026 $ p`, synchronized output), followed by a primary
+  Device Attributes probe (`CSI c`) as the sentinel. Every terminal
+  answers DA, so a DA reply that arrives without a wanted reply means the
+  terminal does not support that query and callers fall back conservative
+  (silence is the failure mode, F0 §2).
 
   Replies arrive asynchronously on the input stream, interleaved with
-  keystrokes. `scan/1` extracts (and strips) the OSC 11 / DA replies from a
-  raw input chunk so they never leak into key-event parsing.
+  keystrokes. `scan/1` routes the chunk through
+  `Raxol.Terminal.Capabilities.ReplyScanner` (grammar dispatch, both
+  OSC terminators, leak-free residual) so reply bytes never leak into
+  key-event parsing. A parsed DECRQM 2026 reply is noted on
+  `Raxol.Terminal.Capabilities` -- `Capabilities.sync_output?/0` is the
+  one public emit-gate render paths consult. `scan/1` keeps its original
+  `{result, cleaned}` contract for the driver.
 
   The detected background is stored in `:persistent_term` and readable via
   `detected_background/0`; higher layers (e.g. salience theming) convert it
   to a ground lightness.
   """
 
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Capabilities.ReplyScanner
+
   @pt_key {__MODULE__, :background}
 
-  # OSC 11 query (BEL-terminated) + primary DA probe.
-  @query "\e]11;?\a\e[c"
+  # OSC 11 query (BEL-terminated) + DECRQM 2026 probe + primary DA
+  # sentinel LAST (F0 §2: read-to-sentinel bounds every unanswered query).
+  @query "\e]11;?\a\e[?2026$p\e[c"
 
   @type rgb :: {0..255, 0..255, 0..255}
 
@@ -28,7 +39,8 @@ defmodule Raxol.Terminal.Driver.BackgroundQuery do
   def query_sequence, do: @query
 
   @doc """
-  Scans a raw input chunk for OSC 11 / DA replies while a query is pending.
+  Scans a raw input chunk for OSC 11 / DECRQM / DA replies while a query
+  is pending.
 
   Returns `{result, cleaned}` where `cleaned` is the chunk with any reply
   bytes removed (safe to hand to the key-event parser) and `result` is:
@@ -39,21 +51,30 @@ defmodule Raxol.Terminal.Driver.BackgroundQuery do
   """
   @spec scan(binary()) :: {{:ok, rgb()} | :unsupported | :pending, binary()}
   def scan(data) when is_binary(data) do
-    case extract_osc11(data) do
-      {payload, cleaned} ->
-        cleaned = strip_da_reply(cleaned)
+    {acc, leak_free} = ReplyScanner.scan(data, ReplyScanner.new())
 
-        case parse_color(payload) do
-          {:ok, rgb} -> {{:ok, rgb}, cleaned}
-          :error -> {:unsupported, cleaned}
-        end
+    # scan/1 is stateless per chunk (the driver's contract): a trailing
+    # partial reply is handed back untouched so the next chunk re-scans it.
+    cleaned = leak_free <> acc.partial
 
-      :none ->
-        case strip_da_reply_if_present(data) do
-          {:stripped, cleaned} -> {:unsupported, cleaned}
-          :absent -> {:pending, data}
-        end
+    note_mode_replies(acc)
+
+    case {acc.osc11, acc.sentinel_seen?} do
+      {{:ok, rgb}, _} -> {{:ok, rgb}, cleaned}
+      {{:invalid, _payload}, _} -> {:unsupported, cleaned}
+      {nil, true} -> {:unsupported, cleaned}
+      {nil, false} -> {:pending, cleaned}
     end
+  end
+
+  # Route parsed DECRQM replies (e.g. mode 2026) to the session
+  # capability record so `Capabilities.sync_output?/0` -- the one public
+  # emit-gate -- answers from the wire, never from env sniffing.
+  defp note_mode_replies(%ReplyScanner{mode: mode}) when map_size(mode) == 0,
+    do: :ok
+
+  defp note_mode_replies(%ReplyScanner{mode: mode}) do
+    Enum.each(mode, fn {m, value} -> Capabilities.note_mode_reply(m, value) end)
   end
 
   @doc "Stores a detected background color for later lookup."
@@ -66,72 +87,6 @@ defmodule Raxol.Terminal.Driver.BackgroundQuery do
     case :persistent_term.get(@pt_key, :undefined) do
       :undefined -> :error
       rgb -> {:ok, rgb}
-    end
-  end
-
-  # ---- OSC 11 reply extraction ----
-  # Reply shape: ESC ] 11 ; <payload> terminated by BEL or ST (ESC \).
-
-  defp extract_osc11(data) do
-    case :binary.match(data, "\e]11;") do
-      :nomatch ->
-        :none
-
-      {start, prefix_len} ->
-        rest_start = start + prefix_len
-        rest = binary_part(data, rest_start, byte_size(data) - rest_start)
-
-        case find_osc_terminator(rest) do
-          :none ->
-            :none
-
-          {payload_len, term_len} ->
-            payload = binary_part(rest, 0, payload_len)
-
-            cleaned =
-              binary_part(data, 0, start) <>
-                binary_part(
-                  data,
-                  rest_start + payload_len + term_len,
-                  byte_size(data) - rest_start - payload_len - term_len
-                )
-
-            {payload, cleaned}
-        end
-    end
-  end
-
-  defp find_osc_terminator(rest) do
-    bel = :binary.match(rest, "\a")
-    st = :binary.match(rest, "\e\\")
-
-    case {bel, st} do
-      {:nomatch, :nomatch} -> :none
-      {{pos, len}, :nomatch} -> {pos, len}
-      {:nomatch, {pos, len}} -> {pos, len}
-      {{b, bl}, {s, _}} when b < s -> {b, bl}
-      {_, {s, sl}} -> {s, sl}
-    end
-  end
-
-  # ---- DA reply stripping: ESC [ ? <params> c ----
-
-  defp strip_da_reply(data) do
-    case strip_da_reply_if_present(data) do
-      {:stripped, cleaned} -> cleaned
-      :absent -> data
-    end
-  end
-
-  defp strip_da_reply_if_present(data) do
-    case Regex.run(~r/\e\[\?[\d;]*c/, data, return: :index) do
-      [{start, len}] ->
-        {:stripped,
-         binary_part(data, 0, start) <>
-           binary_part(data, start + len, byte_size(data) - start - len)}
-
-      nil ->
-        :absent
     end
   end
 

--- a/packages/raxol_terminal/test/fixtures/capability/capture/alacritty-bare.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/alacritty-bare.json
@@ -1,0 +1,34 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": "truecolor",
+    "SSH_TTY": null,
+    "TERM": "alacritty",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": [
+      "Alacritty",
+      "0.13.2"
+    ],
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "modern",
+    "truecolor": true,
+    "unicode": "wide"
+  },
+  "expected_tier": "inline_log",
+  "notes": "DECRQM 2026 value stuck at 2 (never flips to 1 after set). Generic rule classifies 2 as supported; quirk table adds :no_verify_2026 -- never set-then-requery (CAP-N-05).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5d31313b7267623a316431642f316631662f32313231071b5b3f323032363b3224791b503e7c416c6163726974747920302e31332e321b5c1b5b3f3663",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "alacritty",
+  "terminal_version": "0.13.2"
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/apple-terminal-bare.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/apple-terminal-bare.json
@@ -1,0 +1,31 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": null,
+    "SSH_TTY": null,
+    "TERM": "xterm-256color",
+    "TERM_PROGRAM": "Apple_Terminal",
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": null,
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": false,
+    "theme_events": false,
+    "tier": "core",
+    "truecolor": false,
+    "unicode": "wide"
+  },
+  "expected_tier": "flat",
+  "notes": "Silence for everything except the DA1 sentinel: no OSC 11, no DECRQM, no XTVERSION. Missing reply before the sentinel = unsupported (F0 §2).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5b3f313b3263",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "Apple_Terminal",
+  "terminal_version": "455"
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/ghostty-bare.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/ghostty-bare.json
@@ -1,0 +1,34 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": "truecolor",
+    "SSH_TTY": null,
+    "TERM": "xterm-ghostty",
+    "TERM_PROGRAM": "ghostty",
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": [
+      "ghostty",
+      "1.0.1"
+    ],
+    "in_band_resize": false,
+    "kitty_keyboard": 31,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "rich",
+    "truecolor": true,
+    "unicode": "wide"
+  },
+  "expected_tier": "inline_log",
+  "notes": "Synthetic plausible capture. Kitty keyboard flags 31.",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5d31313b7267623a323232322f323232322f323232321b5c1b5b3f3331751b5b3f323032363b3124791b503e7c67686f7374747920312e302e311b5c1b5b3f36323b323263",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "ghostty",
+  "terminal_version": "1.0.1"
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/iterm2-bare.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/iterm2-bare.json
@@ -1,0 +1,34 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": "truecolor",
+    "SSH_TTY": null,
+    "TERM": "xterm-256color",
+    "TERM_PROGRAM": "iTerm.app",
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": [
+      "iTerm2",
+      "3.5.0"
+    ],
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": true,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "modern",
+    "truecolor": true,
+    "unicode": "wide"
+  },
+  "expected_tier": "inline_log",
+  "notes": "Synthetic plausible capture. BEL-terminated OSC; DA1 advertises sixel (attr 4).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5d31313b7267623a666666662f666666662f66666666071b5b3f323032363b3124791b503e7c695465726d3220332e352e301b5c1b5b3f36323b3463",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "iTerm2",
+  "terminal_version": "3.5.0"
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/kitty-bare.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/kitty-bare.json
@@ -1,0 +1,34 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": "truecolor",
+    "SSH_TTY": null,
+    "TERM": "xterm-kitty",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": [
+      "kitty",
+      "0.32.2"
+    ],
+    "in_band_resize": false,
+    "kitty_keyboard": 1,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "rich",
+    "truecolor": true,
+    "unicode": "wide"
+  },
+  "expected_tier": "inline_log",
+  "notes": "Synthetic plausible capture (schema-stable placeholder until T0 lands real bytes). ST-terminated OSC; DECRQM 2026 answers 2.",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5d31313b7267623a316531652f323032302f323632361b5c1b5b3f31751b5b3f323032363b3224791b503e7c6b6974747928302e33322e32291b5c1b5b3f36323b63",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "kitty",
+  "terminal_version": "0.32.2"
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-echo-leak.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-echo-leak.json
@@ -1,0 +1,32 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": null,
+    "SSH_TTY": null,
+    "TERM": "vt52-like",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": null,
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": false,
+    "theme_events": false,
+    "tier": "core_minus",
+    "truecolor": false,
+    "unicode": "wide"
+  },
+  "expected_leak_hex": "1b5b3e30711b5b63",
+  "expected_tier": "flat",
+  "notes": "A terminal that echoes the whole query back verbatim. The echoed DECRQM query ($p, not $y) and bare 'CSI ? u' are recognized as non-replies and drained; the echoed XTVERSION/DA queries leak as well-formed CSI that the InputParser consumes without key events; no cap is falsely set (CAP-N-07).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "synthetic",
+  "terminal_version": null
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-keystroke-interleave.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-keystroke-interleave.json
@@ -1,0 +1,32 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": null,
+    "SSH_TTY": null,
+    "TERM": "xterm-256color",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": null,
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "modern",
+    "truecolor": false,
+    "unicode": "wide"
+  },
+  "expected_leak_hex": "6c730d",
+  "expected_tier": "inline_log",
+  "notes": "User typed 'l', 's', Enter while replies were in flight. The replies are parsed AND the keystrokes survive, in order (CAP-N-04).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "6c1b5b3f323032363b3124791b5b3f36323b63730d",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "synthetic",
+  "terminal_version": null
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-partial-then-eof.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-partial-then-eof.json
@@ -1,0 +1,32 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": null,
+    "SSH_TTY": null,
+    "TERM": "xterm-256color",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": null,
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": false,
+    "theme_events": false,
+    "tier": "core_minus",
+    "truecolor": false,
+    "unicode": "wide"
+  },
+  "expected_leak_hex": "",
+  "expected_tier": "flat",
+  "notes": "Reply truncated mid-sequence, then nothing (EOF/timeout). The fragment is parked, then DRAINED at finalize -- never leaked as keystrokes; the cap stays unsupported (CAP-N-08).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5b3f323032363b31",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "synthetic",
+  "terminal_version": null
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-reorder.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-reorder.json
@@ -1,0 +1,31 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": null,
+    "SSH_TTY": null,
+    "TERM": "xterm-256color",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": null,
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "modern",
+    "truecolor": false,
+    "unicode": "wide"
+  },
+  "expected_tier": "inline_log",
+  "notes": "OSC 11 reply reordered AFTER the DA1 sentinel (documented terminal bug). Grammar dispatch still parses it inside the drain window (CAP-N-02).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5b3f323032363b3124791b5b3f36323b631b5d31313b7267623a303030302f303030302f3030303007",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "synthetic",
+  "terminal_version": null
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-silence.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-silence.json
@@ -1,0 +1,31 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": null,
+    "SSH_TTY": null,
+    "TERM": "dumb",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": null,
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": false,
+    "theme_events": false,
+    "tier": "core_minus",
+    "truecolor": false,
+    "unicode": "wide"
+  },
+  "expected_tier": "flat",
+  "notes": "Total silence: not even the DA1 sentinel. The probe finalizes on the clock deadline with the conservative default (CAP-N-01).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "synthetic",
+  "terminal_version": null
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-tmux-garble.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/synthetic-tmux-garble.json
@@ -1,0 +1,31 @@
+{
+  "context": "tmux",
+  "env": {
+    "COLORTERM": null,
+    "SSH_TTY": null,
+    "TERM": "screen-256color",
+    "TERM_PROGRAM": null,
+    "TMUX": "/private/tmp/tmux-501/default,32768,0"
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": null,
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "tmux",
+    "sixel": false,
+    "sync_output": false,
+    "theme_events": false,
+    "tier": "core",
+    "truecolor": false,
+    "unicode": "wide"
+  },
+  "expected_tier": "tmux_conservative",
+  "notes": "Inside tmux with passthrough off (default since 3.3a): DA1 from tmux itself plus a truncated/garbled DCS fragment. Clamp to the conservative tier; $TERM=screen is NOT trusted (CAP-N-06).",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5b3f313b32631b503e7c746d",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "synthetic",
+  "terminal_version": null
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/vte-bare.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/vte-bare.json
@@ -1,0 +1,34 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": "truecolor",
+    "SSH_TTY": null,
+    "TERM": "xterm-256color",
+    "TERM_PROGRAM": null,
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": [
+      "VTE",
+      "7600"
+    ],
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": false,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "modern",
+    "truecolor": true,
+    "unicode": "wide"
+  },
+  "expected_tier": "inline_log",
+  "notes": "Synthetic plausible capture. Older VTE answers no XTVERSION; this models 0.76+.",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5d31313b7267623a326432642f326432642f32643264071b5b3f323032363b3224791b503e7c5654452837363030291b5c1b5b3f36353b313b3963",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "gnome-terminal (VTE)",
+  "terminal_version": "0.76"
+}

--- a/packages/raxol_terminal/test/fixtures/capability/capture/wezterm-bare.json
+++ b/packages/raxol_terminal/test/fixtures/capability/capture/wezterm-bare.json
@@ -1,0 +1,34 @@
+{
+  "context": "bare",
+  "env": {
+    "COLORTERM": "truecolor",
+    "SSH_TTY": null,
+    "TERM": "wezterm",
+    "TERM_PROGRAM": "WezTerm",
+    "TMUX": null
+  },
+  "expected": {
+    "grapheme_width": "assumed",
+    "identity": [
+      "WezTerm",
+      "20240203-110809-5046fc22"
+    ],
+    "in_band_resize": false,
+    "kitty_keyboard": null,
+    "lr_margins": false,
+    "multiplexer": "none",
+    "sixel": true,
+    "sync_output": true,
+    "theme_events": false,
+    "tier": "modern",
+    "truecolor": true,
+    "unicode": "wide"
+  },
+  "expected_tier": "inline_log",
+  "notes": "Synthetic plausible capture.",
+  "query_hex": "1b5d31313b3f071b5b3f751b5b3f3230323624701b5b3e30711b5b63",
+  "reply_hex": "1b5d31313b7267623a323832382f326332632f333433341b5c1b5b3f323032363b3124791b503e7c57657a5465726d2032303234303230332d3131303830392d35303436666332321b5c1b5b3f36353b343b363b31383b323263",
+  "schema": "raxol.capability.capture/1",
+  "terminal": "WezTerm",
+  "terminal_version": "20240203-110809-5046fc22"
+}

--- a/packages/raxol_terminal/test/property/capability_slice_ladder_property_test.exs
+++ b/packages/raxol_terminal/test/property/capability_slice_ladder_property_test.exs
@@ -1,0 +1,68 @@
+defmodule Raxol.Terminal.CapabilitySliceLadderPropertyTest do
+  @moduledoc """
+  Ladder fuzz: CAP-F-07 / LAD-P-02 -- `select/2` is total over the
+  `%Capabilities{}` state space: always `{:ok, mode}` in the three-mode
+  set or `{:error, _}`, never a raise.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Capabilities.Ladder
+  alias Raxol.Test.CapabilitySliceGen, as: Gen
+
+  @runs 1000
+
+  # note: no RAXOL_FORCE_FLAT-on-capable case here -- that combination
+  # emits the forced-downgrade telemetry asserted (with an attached
+  # handler) in the ladder matrix suite; keeping it out avoids
+  # cross-test telemetry noise. Totality of the forced-flat branch is
+  # covered there.
+  @envs [
+    %{},
+    %{"RAXOL_FORCE_MODE" => "inline_log"},
+    %{"RAXOL_FORCE_MODE" => "tmux_conservative"},
+    %{"RAXOL_FORCE_MODE" => "garbage"}
+  ]
+
+  test "CAP-F-07: select/2 is total over the record state space" do
+    modes = Ladder.modes()
+
+    for i <- 1..@runs do
+      Gen.seed(i)
+
+      caps = %Capabilities{
+        identity: Enum.random([nil, {"kitty", "0.32.2"}, {"x", nil}]),
+        tier: Enum.random([:core_minus, :core, :modern, :rich]),
+        unicode: Enum.random([:none, :wide, :grapheme]),
+        truecolor: Enum.random([true, false]),
+        sixel: Enum.random([true, false]),
+        kitty_graphics: Enum.random([true, false]),
+        kitty_keyboard: Enum.random([nil, 0, 1, 31]),
+        sync_output: Enum.random([true, false]),
+        grapheme_width: Enum.random([:mode_2027, :measured, :assumed]),
+        in_band_resize: Enum.random([true, false]),
+        lr_margins: Enum.random([true, false]),
+        theme_events: Enum.random([true, false]),
+        cell_px: Enum.random([nil, {10, 20}]),
+        styled_underline: Enum.random([true, false]),
+        multiplexer: Enum.random([:none, :tmux, :screen]),
+        quirks: Enum.take_random([:no_verify_2026], :rand.uniform(2) - 1)
+      }
+
+      env = Enum.random(@envs)
+
+      case Ladder.select(caps, env) do
+        {:ok, mode} ->
+          assert mode in modes, "iteration #{i}: unknown mode #{mode}"
+
+          # a selected mode is always capable (select never proposes a
+          # mode that assert_capable! would refuse)
+          assert Ladder.assert_capable!(mode, caps) == :ok,
+                 "iteration #{i}: select proposed an incapable mode"
+
+        {:error, reason} ->
+          assert reason == :incapable, "iteration #{i}: #{inspect(reason)}"
+      end
+    end
+  end
+end

--- a/packages/raxol_terminal/test/property/capability_slice_parser_property_test.exs
+++ b/packages/raxol_terminal/test/property/capability_slice_parser_property_test.exs
@@ -1,0 +1,50 @@
+defmodule Raxol.Terminal.CapabilitySliceParserPropertyTest do
+  @moduledoc """
+  InputParser fuzz over reply shapes: CAP-F-05 (a DECRQM/CPR/DA reply
+  never yields a key/char event -- locks the `input_parser.ex`
+  consume-unmapped path) and CAP-F-06 (totality with a reply prefix).
+
+  CPR is generated with row >= 2: `CSI 1 ; <n> R` is byte-identical to
+  xterm's modified-F3 key encoding, so the key parser *cannot*
+  distinguish them -- which is why the ReplyScanner consumes CPR before
+  the key parser during probe windows (see the scanner suite).
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.ANSI.InputParser
+  alias Raxol.Test.CapabilitySliceGen, as: Gen
+
+  @runs 500
+
+  test "CAP-F-05: DECRQM/CPR/DA replies never become key events" do
+    for i <- 1..@runs do
+      Gen.seed(i)
+
+      {reply, kind} =
+        case :rand.uniform(3) do
+          1 -> Gen.decrqm()
+          2 -> Gen.da1()
+          3 -> Gen.cpr()
+        end
+
+      events = InputParser.parse(reply)
+
+      key_events = Enum.filter(events, &(&1.type == :key))
+
+      assert key_events == [],
+             "iteration #{i} (#{kind}): #{inspect(reply)} leaked " <>
+               "#{inspect(key_events)}"
+    end
+  end
+
+  test "CAP-F-06: parse(reply <> noise) never raises" do
+    for i <- 1..@runs do
+      Gen.seed(i)
+      {reply, _kind} = Gen.reply()
+      noise = Gen.noise(64)
+
+      events = InputParser.parse(reply <> noise)
+      assert is_list(events), "iteration #{i}"
+    end
+  end
+end

--- a/packages/raxol_terminal/test/property/capability_slice_probe_property_test.exs
+++ b/packages/raxol_terminal/test/property/capability_slice_probe_property_test.exs
@@ -1,0 +1,57 @@
+defmodule Raxol.Terminal.CapabilitySliceProbePropertyTest do
+  @moduledoc """
+  Probe fuzz: CAP-F-04 -- termination. For any finite event list mixing
+  `{:input, bytes}` with monotonic `{:clock, _}` events, the reducer is
+  `{:done, _}` after the first clock past the (at-most-once extended)
+  deadline, stays done (idempotent), and never requests a second
+  extension. No real clock, no sleeps.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities.Probe
+  alias Raxol.Test.CapabilitySliceGen, as: Gen
+
+  @runs 500
+  @budget 100
+
+  test "CAP-F-04: termination, single extension, idempotence" do
+    for i <- 1..@runs do
+      Gen.seed(i)
+
+      probe = Probe.new(%{}, budget_ms: @budget, extend_ms: @budget)
+      {probe, _} = Probe.step(probe, :start)
+
+      # a random prefix of input events (noise or well-formed replies)
+      # and interior clock events below the maximum possible deadline
+      events =
+        for _ <- 1..(:rand.uniform(6) - 1)//1 do
+          case :rand.uniform(3) do
+            1 -> {:input, Gen.noise(32)}
+            2 -> {:input, elem(Gen.reply(), 0)}
+            3 -> {:clock, :rand.uniform(@budget * 2)}
+          end
+        end
+
+      {probe, all_actions} =
+        Enum.reduce(events, {probe, []}, fn event, {p, actions} ->
+          {p, new_actions} = Probe.step(p, event)
+          {p, actions ++ new_actions}
+        end)
+
+      # the reducer never grants a second extension
+      extension_count =
+        Enum.count(all_actions, &match?({:extend_deadline, _}, &1))
+
+      assert extension_count <= 1, "iteration #{i}: multiple extensions"
+
+      # one clock past the maximum possible deadline forces :done
+      {probe, _} = Probe.step(probe, {:clock, @budget * 2 + 1})
+      assert {:done, caps} = Probe.result(probe)
+
+      # done is a fixed point: further events cannot change the outcome
+      {probe, _} = Probe.step(probe, {:input, Gen.noise(16)})
+      {probe, _} = Probe.step(probe, {:clock, @budget * 10})
+      assert {:done, ^caps} = Probe.result(probe)
+    end
+  end
+end

--- a/packages/raxol_terminal/test/property/capability_slice_scanner_property_test.exs
+++ b/packages/raxol_terminal/test/property/capability_slice_scanner_property_test.exs
@@ -1,0 +1,87 @@
+defmodule Raxol.Terminal.CapabilitySliceScannerPropertyTest do
+  @moduledoc """
+  ReplyScanner fuzz: CAP-F-01 (totality), CAP-F-02 (conservation),
+  CAP-F-03 (chunk-split invariance), CAP-F-08 (two-sided keystroke
+  property). Deterministic seeded generators (see
+  `Raxol.Test.CapabilitySliceGen` -- stream_data is not a raxol_terminal
+  dependency); every failure reports the iteration to replay.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities.ReplyScanner
+  alias Raxol.Test.CapabilitySliceGen, as: Gen
+
+  @runs 500
+
+  test "CAP-F-01: totality -- scan/2 never raises on arbitrary bytes" do
+    Enum.reduce(1..@runs, ReplyScanner.new(), fn i, carried_acc ->
+      Gen.seed(i)
+      noise = Gen.noise()
+
+      # fresh accumulator
+      {acc, leak} = ReplyScanner.scan(noise, ReplyScanner.new())
+      assert %ReplyScanner{} = acc
+      assert is_binary(leak)
+
+      # and an accumulator carried across iterations (partials chain)
+      {carried, leak2} = ReplyScanner.scan(noise, carried_acc)
+      assert %ReplyScanner{} = carried
+      assert is_binary(leak2)
+      carried
+    end)
+  end
+
+  test "CAP-F-02: conservation -- leak_free = input minus parsed replies" do
+    for i <- 1..@runs do
+      Gen.seed(i)
+      {input, expected_leak} = Gen.interleave()
+
+      {acc, leak} = ReplyScanner.scan(input, ReplyScanner.new())
+
+      assert leak == expected_leak,
+             "iteration #{i}: leak mismatch for #{inspect(input)}"
+
+      # replies are complete in G-interleave: nothing may stay parked
+      assert acc.partial == "", "iteration #{i}: unexpected partial"
+    end
+  end
+
+  test "CAP-F-03: chunk-split invariance at an arbitrary index" do
+    for i <- 1..@runs do
+      Gen.seed(i)
+      {input, _leak} = Gen.interleave()
+
+      {acc_one, leak_one} = ReplyScanner.scan(input, ReplyScanner.new())
+
+      split = :rand.uniform(byte_size(input) + 1) - 1
+      <<part_a::binary-size(^split), part_b::binary>> = input
+
+      {acc_a, leak_a} = ReplyScanner.scan(part_a, ReplyScanner.new())
+      {acc_two, leak_b} = ReplyScanner.scan(part_b, acc_a)
+
+      assert acc_two == acc_one,
+             "iteration #{i}: acc diverged at split #{split}"
+
+      assert leak_a <> leak_b == leak_one,
+             "iteration #{i}: leak diverged at split #{split}"
+    end
+  end
+
+  test "CAP-F-08: no-leak-of-replies AND no-eat-of-input" do
+    for i <- 1..@runs do
+      Gen.seed(i)
+      keys_before = Gen.printable()
+      {reply, kind} = Gen.reply()
+      keys_after = Gen.printable()
+
+      {_acc, leak} =
+        ReplyScanner.scan(
+          keys_before <> reply <> keys_after,
+          ReplyScanner.new()
+        )
+
+      assert leak == keys_before <> keys_after,
+             "iteration #{i} (#{kind}): keystrokes eaten or reply leaked"
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_anchor_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_anchor_test.exs
@@ -1,0 +1,57 @@
+defmodule Raxol.Terminal.Capabilities.CapabilitySliceAnchorTest do
+  @moduledoc """
+  T1 fail-first anchor (harness-ui-roadmap §4, suite 04: "env-sniff vs
+  DECRQM (hardcoded false)").
+
+  Mode-2026 (synchronized output) support must be decided by parsing a
+  DECRQM reply (`CSI ? 2026 ; Ps $ y`) off the wire -- never by
+  `$TERM_PROGRAM` sniffing. Today `advanced_features.ex` sniffs
+  `$TERM_PROGRAM` and its `query_synchronized_output_support/0` is
+  hardcoded `false`; no DECRQM reply parser exists anywhere. These tests
+  are red on master and go green with the T1 capability slice.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities.Probe
+
+  test "2026 detection comes from a DECRQM reply, not env sniffing" do
+    # env deliberately says NOTHING that an env-sniffer would recognize
+    # as a 2026-capable terminal:
+    env = %{"TERM" => "xterm-256color"}
+
+    probe = Probe.new(env, budget_ms: 100)
+    {probe, actions} = Probe.step(probe, :start)
+
+    # the probe must actually ASK via DECRQM
+    assert Enum.any?(actions, fn
+             {:write, iodata} ->
+               IO.iodata_to_binary(iodata) =~ "\e[?2026$p"
+
+             _ ->
+               false
+           end)
+
+    # the terminal answers DECRQM 2026 = set (1), then the DA1 sentinel
+    {probe, _actions} = Probe.step(probe, {:input, "\e[?2026;1$y\e[?62;4c"})
+    {probe, _actions} = Probe.step(probe, {:clock, 10})
+
+    assert {:done, caps} = Probe.result(probe)
+    assert caps.sync_output == true
+    # provenance: the cap was set by the DECRQM reply, not the env seed
+    assert caps.source.sync_output == :decrqm
+  end
+
+  test "env sniffing alone can never claim 2026 support" do
+    # $TERM_PROGRAM screams kitty (the exact string the current
+    # env-sniff trusts), but the wire stays SILENT -> unsupported.
+    env = %{"TERM" => "xterm-kitty", "TERM_PROGRAM" => "kitty"}
+
+    probe = Probe.new(env, budget_ms: 100)
+    {probe, _actions} = Probe.step(probe, :start)
+    {probe, _actions} = Probe.step(probe, {:clock, 101})
+
+    assert {:done, caps} = Probe.result(probe)
+    assert caps.sync_output == false
+    assert caps.source.sync_output != :env
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_cache_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_cache_test.exs
@@ -1,0 +1,96 @@
+defmodule Raxol.Terminal.Capabilities.CapabilitySliceCacheTest do
+  @moduledoc """
+  CAP-P-13: `:persistent_term` cache round-trip + session immutability,
+  and the driver-facing wiring: `BackgroundQuery` emits the DECRQM 2026
+  query in its batched write (DA1 sentinel LAST), routes replies through
+  the ReplyScanner, and `Capabilities.sync_output?/0` -- the ONE public
+  emit-gate -- answers from the wire.
+
+  `async: false`: `:persistent_term` is process-global.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Driver.BackgroundQuery
+
+  setup do
+    Capabilities.reset_cache()
+    on_exit(fn -> Capabilities.reset_cache() end)
+    :ok
+  end
+
+  describe "CAP-P-13: cache round-trip and immutability" do
+    test "classify once; second read identical; re-cache no-ops" do
+      caps = %Capabilities{tier: :modern, sync_output: true}
+
+      assert Capabilities.cached() == :error
+      assert Capabilities.cache(caps) == :ok
+      assert Capabilities.cached() == {:ok, caps}
+
+      # session-immutable: a second cache write is a no-op
+      other = %Capabilities{tier: :core, sync_output: false}
+      assert Capabilities.cache(other) == :ok
+      assert Capabilities.cached() == {:ok, caps}
+    end
+
+    test "sync_output?/0 answers from the cached record" do
+      refute Capabilities.sync_output?()
+
+      Capabilities.cache(%Capabilities{sync_output: true})
+      assert Capabilities.sync_output?()
+    end
+
+    test "sync_output?/0 falls back to noted DECRQM replies" do
+      refute Capabilities.sync_output?()
+      Capabilities.note_mode_reply(2026, 2)
+      assert Capabilities.sync_output?()
+    end
+
+    test "a negative DECRQM reply never reads as support" do
+      Capabilities.note_mode_reply(2026, 0)
+      refute Capabilities.sync_output?()
+    end
+  end
+
+  describe "batched write (T1 extension of the existing driver query)" do
+    test "query includes DECRQM 2026 with the DA1 sentinel LAST" do
+      query = BackgroundQuery.query_sequence()
+
+      assert query =~ "\e]11;?\a"
+      assert query =~ "\e[?2026$p"
+      assert String.ends_with?(query, "\e[c")
+    end
+  end
+
+  describe "reply routing through the ReplyScanner" do
+    test "a DECRQM 2026 reply in the driver stream feeds the gate" do
+      refute Capabilities.sync_output?()
+
+      {result, cleaned} = BackgroundQuery.scan("\e[?2026;1$y")
+
+      # the reply is stripped from the stream (never a keystroke) ...
+      assert cleaned == ""
+      # ... the OSC 11 outcome is still pending (no color, no sentinel) ...
+      assert result == :pending
+      # ... and the 2026 gate now answers true, from the wire
+      assert Capabilities.mode_replies() == %{2026 => 1}
+      assert Capabilities.sync_output?()
+    end
+
+    test "full driver read: color + DECRQM + sentinel + keystrokes" do
+      {result, cleaned} =
+        BackgroundQuery.scan("a\e]11;rgb:2b2b/2b2b/2b2b\a\e[?2026;2$y\e[?62;cb")
+
+      assert result == {:ok, {43, 43, 43}}
+      assert cleaned == "ab"
+      assert Capabilities.sync_output?()
+    end
+
+    test "sentinel without a DECRQM reply leaves the gate closed" do
+      {result, cleaned} = BackgroundQuery.scan("\e[?1;2c")
+      assert result == :unsupported
+      assert cleaned == ""
+      refute Capabilities.sync_output?()
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_classifier_matrix_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_classifier_matrix_test.exs
@@ -1,0 +1,168 @@
+defmodule Raxol.Terminal.Capabilities.CapabilitySliceClassifierMatrixTest do
+  @moduledoc """
+  CAP-P-01: the fixture golden matrix. Every
+  `test/fixtures/capability/capture/*.json` replays end-to-end through
+  Probe/Classifier and is asserted byte-exactly against its `expected`
+  record and `expected_tier` ladder golden. Dropping in a new T0 capture
+  adds a regression with zero code (04 design §2).
+
+  Plus classifier-level cases: CAP-P-08/09, CAP-N-05/06/12.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities.{Classifier, Ladder, Probe, ReplyScanner}
+  alias Raxol.Test.CapabilityFixtures
+
+  for path <- CapabilityFixtures.all() do
+    @path path
+    test "CAP-P-01 matrix golden: #{Path.basename(path, ".json")}" do
+      fixture = CapabilityFixtures.load!(@path)
+      env = CapabilityFixtures.env(fixture)
+
+      probe = Probe.new(env, budget_ms: 100)
+      {probe, _actions} = Probe.step(probe, :start)
+      {probe, input_actions} = Probe.step(probe, {:input, fixture["reply"]})
+      # one clock far past deadline + extension closes every window
+      {probe, _actions} = Probe.step(probe, {:clock, 1_000})
+
+      assert {:done, caps} = Probe.result(probe)
+
+      for {field, expected} <- CapabilityFixtures.expected_assertions(fixture) do
+        actual = Map.fetch!(caps, field)
+
+        assert actual == expected,
+               "#{Path.basename(@path)}: expected #{field}=" <>
+                 "#{inspect(expected)}, got #{inspect(actual)}"
+      end
+
+      assert Ladder.select(caps, env) ==
+               {:ok, CapabilityFixtures.expected_tier(fixture)}
+
+      case fixture["expected_leak"] do
+        nil ->
+          :ok
+
+        expected_leak ->
+          leaked =
+            for {:leak_free, bytes} <- input_actions, into: "", do: bytes
+
+          assert leaked == expected_leak,
+                 "#{Path.basename(@path)}: leak mismatch"
+      end
+    end
+  end
+
+  defp classify(reply, env, opts \\ []) do
+    {acc, _leak} = ReplyScanner.scan(reply, ReplyScanner.new())
+    Classifier.classify(acc, env, opts)
+  end
+
+  describe "CAP-P-08: identity fallback" do
+    test "no XTVERSION, DA1-only -> nil identity, core tier, no crash" do
+      caps = classify("\e[?1;2c", %{"TERM" => "xterm-256color"})
+      assert caps.identity == nil
+      assert caps.tier == :core
+    end
+
+    test "DA2 without XTVERSION records DA2 provenance" do
+      caps = classify("\e[>1;10;0c\e[?62;c", %{})
+      assert caps.identity == nil
+      assert caps.source.identity == :da2
+    end
+  end
+
+  describe "CAP-P-09: truecolor priority order" do
+    test "XTGETTCAP RGB outranks the env seed" do
+      # 524742 = hex("RGB"); reply carries a value -> confirmed truecolor
+      reply = "\eP1+r524742=382f382f38\e\\\e[?62;c"
+      caps = classify(reply, %{})
+      assert caps.truecolor == true
+      assert caps.source.truecolor == :xtgettcap
+    end
+
+    test "$COLORTERM alone is trusted only as a seed" do
+      caps = classify("\e[?62;c", %{"COLORTERM" => "truecolor"})
+      assert caps.truecolor == true
+      assert caps.source.truecolor == :env
+    end
+
+    test "neither -> false" do
+      caps = classify("\e[?62;c", %{})
+      assert caps.truecolor == false
+      assert caps.source.truecolor == :default
+    end
+  end
+
+  describe "CAP-N-05: the Alacritty lie" do
+    test "2026 stuck at 2 + Alacritty identity -> supported, no_verify" do
+      reply = "\e[?2026;2$y\eP>|Alacritty 0.13.2\e\\\e[?6c"
+      caps = classify(reply, %{"TERM" => "alacritty"})
+
+      assert caps.sync_output == true
+      assert caps.source.sync_output == :decrqm
+      assert :no_verify_2026 in caps.quirks
+    end
+
+    test "2026=2 on a non-Alacritty terminal carries no quirk" do
+      reply = "\e[?2026;2$y\eP>|kitty(0.32.2)\e\\\e[?62;c"
+      caps = classify(reply, %{})
+      assert caps.sync_output == true
+      refute :no_verify_2026 in caps.quirks
+    end
+  end
+
+  describe "CAP-N-06: tmux conservative clamp" do
+    test "inside tmux: clamped record, $TERM=screen never trusted" do
+      env = %{"TMUX" => "/tmp/tmux-501/default,1,0", "TERM" => "screen"}
+      # even a (forwarded/garbled) positive 2026 reply is clamped
+      caps = classify("\e[?2026;1$y\e[?62;c", env)
+
+      assert caps.multiplexer == :tmux
+      assert caps.sync_output == false
+      assert caps.source.sync_output == :tmux_clamp
+      assert :multiplexer_conservative_clamp in caps.quirks
+    end
+
+    test "$TERM=screen without $TMUX still clamps (GNU screen)" do
+      caps = classify("\e[?62;c", %{"TERM" => "screen-256color"})
+      assert caps.multiplexer == :screen
+      assert :multiplexer_conservative_clamp in caps.quirks
+    end
+
+    test "rich caps inside tmux are capped to modern" do
+      env = %{"TMUX" => "/tmp/tmux-501/default,1,0"}
+      caps = classify("\e[?31u\e[?2026;1$y\e[?62;c", env)
+      assert caps.tier == :modern
+      assert caps.kitty_keyboard == nil
+      assert caps.kitty_graphics == false
+    end
+  end
+
+  describe "CAP-N-12: Windows platform gate" do
+    test "2048/pixel gated by platform, not by DECRQM absence" do
+      # the wire even claims 2048 support -- the platform gate wins
+      reply = "\e[?2048;1$y\e[6;20;10t\e[?62;c"
+      caps = classify(reply, %{}, platform: :windows)
+
+      assert caps.in_band_resize == false
+      assert caps.source.in_band_resize == :platform
+      assert caps.cell_px == nil
+      assert :windows_platform_gates in caps.quirks
+    end
+
+    test "same wire on unix keeps the caps" do
+      reply = "\e[?2048;1$y\e[6;20;10t\e[?62;c"
+      caps = classify(reply, %{})
+      assert caps.in_band_resize == true
+      assert caps.cell_px == {10, 20}
+    end
+  end
+
+  describe "mode 2027 -> unicode axis" do
+    test "2027 supported flips grapheme_width to :mode_2027" do
+      caps = classify("\e[?2027;1$y\e[?62;c", %{})
+      assert caps.grapheme_width == :mode_2027
+      assert caps.unicode == :grapheme
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_input_parser_regression_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_input_parser_regression_test.exs
@@ -1,0 +1,49 @@
+defmodule Raxol.Terminal.Capabilities.CapabilitySliceInputParserRegressionTest do
+  @moduledoc """
+  CAP-N-11: reply bytes must never surface as key events. This locks the
+  `InputParser` consume-unmapped path (the #443 hardening) that the
+  capability probe's leak-free residual relies on: even if a reply
+  reaches the key parser, it is consumed whole, silently.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.ANSI.InputParser
+
+  test "a DECRQM reply parses to ZERO events" do
+    assert InputParser.parse("\e[?2026;1$y") == []
+  end
+
+  test "every DECRQM value shape parses to zero events" do
+    for value <- 0..4 do
+      assert InputParser.parse("\e[?2026;#{value}$y") == []
+    end
+  end
+
+  test "DA replies parse to zero events" do
+    assert InputParser.parse("\e[?62;4c") == []
+    assert InputParser.parse("\e[?1;2c") == []
+    assert InputParser.parse("\e[>1;10;0c") == []
+  end
+
+  test "a cursor position report parses to zero events" do
+    assert InputParser.parse("\e[12;40R") == []
+  end
+
+  test "echoed probe queries parse to zero events" do
+    # the scanner leaks these as well-formed non-reply CSI (CAP-N-07);
+    # the key parser must swallow them silently
+    assert InputParser.parse("\e[>0q") == []
+    assert InputParser.parse("\e[c") == []
+    assert InputParser.parse("\e[?2026$p") == []
+  end
+
+  test "keystrokes around a reply survive; the reply does not" do
+    events = InputParser.parse("l\e[?2026;1$ys\r")
+
+    assert [
+             %{type: :key, data: %{key: :char, char: "l"}},
+             %{type: :key, data: %{key: :char, char: "s"}},
+             %{type: :key, data: %{key: :enter}}
+           ] = events
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_ladder_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_ladder_test.exs
@@ -1,0 +1,145 @@
+defmodule Raxol.Terminal.Capabilities.CapabilitySliceLadderTest do
+  @moduledoc """
+  T3 ladder matrix (04 design §7): LAD-P-01 table, LAD-P-04 tmux tier,
+  LAD-N-01 fail-loud misdetection guard, LAD-N-02 forced-downgrade
+  telemetry.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Capabilities.Ladder
+  alias Raxol.Terminal.Capabilities.Ladder.IncapableModeError
+
+  defp caps(overrides) do
+    struct!(Capabilities, overrides)
+  end
+
+  describe "LAD-P-01: caps x mode matrix" do
+    @matrix [
+      # {description, caps overrides, env, expected}
+      {"core-minus (not a tty / TERM=dumb)", [tier: :core_minus], %{}, {:ok, :flat}},
+      {"tmux, any caps", [tier: :rich, sync_output: true, multiplexer: :tmux], %{},
+       {:ok, :tmux_conservative}},
+      {"GNU screen", [tier: :modern, multiplexer: :screen], %{}, {:ok, :tmux_conservative}},
+      {"Core with verified sync (scroll-region floor proxy), no tmux",
+       [tier: :core, sync_output: true], %{}, {:ok, :inline_log}},
+      {"Modern, sync, no tmux", [tier: :modern, sync_output: true], %{}, {:ok, :inline_log}},
+      {"Rich, no tmux", [tier: :rich], %{}, {:ok, :inline_log}},
+      {"Core WITHOUT sync: no inline floor", [tier: :core], %{}, {:ok, :flat}},
+      {"capable but RAXOL_FORCE_FLAT", [tier: :modern, sync_output: true],
+       %{"RAXOL_FORCE_FLAT" => "1"}, {:ok, :flat}},
+      {"capable, RAXOL_FORCE_MODE=flat", [tier: :rich], %{"RAXOL_FORCE_MODE" => "flat"},
+       {:ok, :flat}},
+      {"forced inline on capable caps", [tier: :modern], %{"RAXOL_FORCE_MODE" => "inline_log"},
+       {:ok, :inline_log}},
+      {"forced inline UNDER TMUX: rejected", [tier: :modern, multiplexer: :tmux],
+       %{"RAXOL_FORCE_MODE" => "inline_log"}, {:error, :incapable}},
+      {"forced inline on core-minus: rejected", [tier: :core_minus],
+       %{"RAXOL_FORCE_MODE" => "inline_log"}, {:error, :incapable}}
+    ]
+
+    for {{desc, overrides, env, expected}, i} <- Enum.with_index(@matrix) do
+      @row {overrides, env, expected}
+      test "row #{i}: #{desc}" do
+        {overrides, env, expected} = @row
+        assert Ladder.select(caps(overrides), env) == expected
+      end
+    end
+  end
+
+  describe "LAD-P-04: tmux fixture ends conservative" do
+    test "clamped record selects :tmux_conservative" do
+      clamped =
+        caps(
+          tier: :modern,
+          sync_output: false,
+          multiplexer: :tmux,
+          quirks: [:multiplexer_conservative_clamp]
+        )
+
+      assert Ladder.select(clamped) == {:ok, :tmux_conservative}
+    end
+  end
+
+  describe "LAD-N-01: misdetection consequences -- fail loud, never corrupt" do
+    test "inline mode forced on incapable caps REFUSES" do
+      incapable =
+        caps(tier: :core, sync_output: false, multiplexer: :none)
+
+      assert_raise IncapableModeError, fn ->
+        Ladder.assert_capable!(:inline_log, incapable)
+      end
+
+      # and the non-raising surface returns an error, never proceeds
+      assert {:error, :incapable} = Ladder.guard(:inline_log, incapable)
+    end
+
+    test "the raise names the offending caps" do
+      incapable = caps(tier: :core_minus)
+
+      error =
+        assert_raise IncapableModeError, fn ->
+          Ladder.assert_capable!(:inline_log, incapable)
+        end
+
+      assert error.message =~ "inline_log"
+      assert error.message =~ "core_minus"
+    end
+
+    test "downgrades are always capable" do
+      rich = caps(tier: :rich, sync_output: true)
+      assert Ladder.assert_capable!(:flat, rich) == :ok
+      assert Ladder.assert_capable!(:tmux_conservative, rich) == :ok
+    end
+  end
+
+  describe "LAD-N-02: forced downgrade is observable" do
+    test "forcing :flat on a capable terminal emits telemetry" do
+      handler_id = {__MODULE__, :forced_downgrade}
+      parent = self()
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:raxol, :degradation, :forced_downgrade],
+          fn _event, _measurements, metadata, _config ->
+            send(parent, {:forced_downgrade, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      capable = caps(tier: :rich, sync_output: true)
+
+      assert {:ok, :flat} =
+               Ladder.select(capable, %{"RAXOL_FORCE_FLAT" => "1"})
+
+      assert_receive {:forced_downgrade, %{tier: :rich}}
+    end
+
+    test "forcing :flat on an incapable terminal is silent (no downgrade)" do
+      handler_id = {__MODULE__, :no_downgrade}
+      parent = self()
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:raxol, :degradation, :forced_downgrade],
+          fn _event, _measurements, metadata, _config ->
+            send(parent, {:forced_downgrade_2, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      incapable = caps(tier: :core_minus)
+
+      assert {:ok, :flat} =
+               Ladder.select(incapable, %{"RAXOL_FORCE_FLAT" => "1"})
+
+      refute_receive {:forced_downgrade_2, %{tier: :core_minus}}, 10
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_probe_clock_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_probe_clock_test.exs
@@ -1,0 +1,204 @@
+defmodule Raxol.Terminal.Capabilities.CapabilitySliceProbeClockTest do
+  @moduledoc """
+  Probe reducer timing suite -- the fake-clock pattern (04 design §3).
+  Time is an injected event; there is NO `Process.sleep` anywhere in this
+  file. Covers CAP-N-01, CAP-P-03, the extend-once rule, the SSH-widened
+  deadline, CAP-N-02/03, CAP-P-12, CAP-P-14.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities.Probe
+
+  describe "CAP-N-01: silence" do
+    test "no reply -> conservative default within one budget, no waiting" do
+      p = Probe.new(%{"TERM" => "dumb"}, budget_ms: 100)
+      {p, [{:write, _query}]} = Probe.step(p, :start)
+
+      # advance the fake clock straight past the deadline; ZERO input
+      {p, actions} = Probe.step(p, {:clock, 101})
+
+      assert {:done, caps} = Probe.result(p)
+      assert caps.sync_output == false
+      assert caps.tier == :core_minus
+      refute Enum.any?(actions, &match?({:extend_deadline, _}, &1))
+    end
+
+    test "clock before the deadline stays pending" do
+      p = Probe.new(%{}, budget_ms: 100)
+      {p, _} = Probe.step(p, :start)
+      {p, []} = Probe.step(p, {:clock, 99})
+      assert Probe.result(p) == :pending
+    end
+  end
+
+  describe "CAP-P-03: missing reply before the sentinel" do
+    test "unanswered DECRQM is unsupported the moment DA1 drains" do
+      p = Probe.new(%{}, budget_ms: 100)
+      {p, _} = Probe.step(p, :start)
+
+      # OSC 11 answered, DECRQM 2026 NOT, then the sentinel
+      {p, actions} =
+        Probe.step(p, {:input, "\e]11;rgb:1111/1111/1111\a\e[?62;c"})
+
+      # sentinel arrived in the same chunk: no deadline extension
+      refute Enum.any?(actions, &match?({:extend_deadline, _}, &1))
+
+      # drain window closes on the next clock tick -- no timeout burned
+      {p, _} = Probe.step(p, {:clock, 10})
+
+      assert {:done, caps} = Probe.result(p)
+      assert caps.sync_output == false
+      assert caps.source.sync_output == :default
+    end
+  end
+
+  describe "extend-once rule (F0 §7 step 3)" do
+    test "first byte without sentinel extends the deadline exactly once" do
+      p = Probe.new(%{}, budget_ms: 100, extend_ms: 100)
+      {p, _} = Probe.step(p, :start)
+
+      {p, actions} = Probe.step(p, {:input, "\e[?2026;1"})
+
+      assert [{:extend_deadline, 100}] =
+               Enum.filter(actions, &match?({:extend_deadline, _}, &1))
+
+      # a second partial chunk must NOT extend again
+      {p, actions2} = Probe.step(p, {:input, "$"})
+      refute Enum.any?(actions2, &match?({:extend_deadline, _}, &1))
+
+      # original deadline passed -- still pending (extension applies)
+      {p, []} = Probe.step(p, {:clock, 150})
+      assert Probe.result(p) == :pending
+
+      # extended deadline passed -- done
+      {p, _} = Probe.step(p, {:clock, 201})
+      assert {:done, caps} = Probe.result(p)
+      # the fragment never completed: unsupported, drained
+      assert caps.sync_output == false
+    end
+  end
+
+  describe "SSH-widened deadline" do
+    test "same clock tick: local probe is done, SSH probe still pending" do
+      local = Probe.new(%{"TERM" => "xterm-256color"})
+      ssh = Probe.new(%{"TERM" => "xterm-256color", "SSH_TTY" => "/dev/tty1"})
+
+      {local, _} = Probe.step(local, :start)
+      {ssh, _} = Probe.step(ssh, :start)
+
+      {local, _} = Probe.step(local, {:clock, 500})
+      {ssh, []} = Probe.step(ssh, {:clock, 500})
+
+      assert {:done, _} = Probe.result(local)
+      assert Probe.result(ssh) == :pending
+
+      {ssh, _} = Probe.step(ssh, {:clock, 1001})
+      assert {:done, _} = Probe.result(ssh)
+    end
+  end
+
+  describe "CAP-N-02: reordered reply inside the drain window" do
+    test "OSC 11 arriving after DA1 (later chunk, same window) is parsed" do
+      p = Probe.new(%{}, budget_ms: 100)
+      {p, _} = Probe.step(p, :start)
+      {p, _} = Probe.step(p, {:input, "\e[?2026;1$y\e[?62;c"})
+      # the window is still open until the next clock tick
+      {p, _} = Probe.step(p, {:input, "\e]11;rgb:0000/0000/0000\a"})
+      {p, _} = Probe.step(p, {:clock, 10})
+
+      assert {:done, caps} = Probe.result(p)
+      assert caps.sync_output == true
+      assert p.scanner.osc11 == {:ok, {0, 0, 0}}
+    end
+  end
+
+  describe "CAP-N-03: late reply after :done" do
+    test "classification immutable; late reply drained; keys still flow" do
+      p = Probe.new(%{}, budget_ms: 100)
+      {p, _} = Probe.step(p, :start)
+      {p, _} = Probe.step(p, {:input, "\e[?62;c"})
+      {p, [{:done, caps}]} = Probe.step(p, {:clock, 10})
+
+      # a late OSC 11 reply: drained, never leaked, never reclassified
+      {p, actions} = Probe.step(p, {:input, "\e]11;rgb:ffff/ffff/ffff\a"})
+      assert actions == []
+      assert {:done, ^caps} = Probe.result(p)
+
+      # real keystrokes after :done still pass through
+      {p, [{:leak_free, "x"}]} = Probe.step(p, {:input, "x"})
+      assert {:done, ^caps} = Probe.result(p)
+    end
+  end
+
+  describe "CAP-P-12: non-TTY path" do
+    test "stdout not a tty -> Core-minus, ZERO queries emitted" do
+      p = Probe.new(%{"TERM" => "xterm-256color"}, tty?: false)
+      {p, actions} = Probe.step(p, :start)
+
+      refute Enum.any?(actions, &match?({:write, _}, &1))
+      refute Enum.any?(actions, &match?({:passthrough, _}, &1))
+
+      assert {:done, caps} = Probe.result(p)
+      assert caps.tier == :core_minus
+      assert caps.sync_output == false
+    end
+  end
+
+  describe "CAP-P-14: tmux passthrough re-issue" do
+    test "passthrough wrap emitted, payload bounded, outer identity parsed" do
+      env = %{"TMUX" => "/tmp/tmux-501/default,1,0", "TERM" => "screen"}
+      p = Probe.new(env, budget_ms: 100, tmux_passthrough?: true)
+
+      {p, actions} = Probe.step(p, :start)
+
+      assert [{:passthrough, wrapped}] =
+               Enum.filter(actions, &match?({:passthrough, _}, &1))
+
+      wrapped = IO.iodata_to_binary(wrapped)
+      assert String.starts_with?(wrapped, "\ePtmux;")
+      assert String.ends_with?(wrapped, "\e\\")
+
+      # inner payload: ESC-doubled, and well under the ~60 char truncation
+      "\ePtmux;" <> inner_st = wrapped
+      inner = String.replace_suffix(inner_st, "\e\\", "")
+      payload = String.replace(inner, "\e\e", "\e")
+      assert String.length(payload) < 60
+
+      # outer terminal's forwarded XTVERSION still parses
+      {p, _} = Probe.step(p, {:input, "\eP>|kitty(0.32.2)\e\\\e[?62;c"})
+      {p, _} = Probe.step(p, {:clock, 10})
+
+      assert {:done, caps} = Probe.result(p)
+      assert caps.identity == {"kitty", "0.32.2"}
+      # ... but the conservative clamp still applies inside tmux
+      assert caps.multiplexer == :tmux
+      assert caps.sync_output == false
+    end
+
+    test "no passthrough action without opt-in" do
+      env = %{"TMUX" => "/tmp/tmux-501/default,1,0"}
+      p = Probe.new(env, budget_ms: 100)
+      {_p, actions} = Probe.step(p, :start)
+      refute Enum.any?(actions, &match?({:passthrough, _}, &1))
+    end
+  end
+
+  describe "reducer hygiene" do
+    test "empty input chunk is a no-op (no scan, no extension)" do
+      p = Probe.new(%{}, budget_ms: 100)
+      {p, _} = Probe.step(p, :start)
+      {p, []} = Probe.step(p, {:input, ""})
+      {_p, actions} = Probe.step(p, {:input, "\e[?62;c"})
+      # the sentinel chunk is genuinely the first byte -- and since the
+      # sentinel arrived with it, still no extension
+      refute Enum.any?(actions, &match?({:extend_deadline, _}, &1))
+    end
+
+    test "stray :start after :start is a no-op" do
+      p = Probe.new(%{}, budget_ms: 100)
+      {p, _} = Probe.step(p, :start)
+      {p, []} = Probe.step(p, :start)
+      assert Probe.result(p) == :pending
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_reply_scanner_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/capabilities/capability_slice_reply_scanner_test.exs
@@ -1,0 +1,238 @@
+defmodule Raxol.Terminal.Capabilities.CapabilitySliceReplyScannerTest do
+  @moduledoc """
+  ReplyScanner positives + negatives (04 design §5/§6):
+  CAP-P-02, CAP-P-04..07, CAP-P-10, CAP-P-11 and CAP-N-04, CAP-N-07..10.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Capabilities.ReplyScanner
+
+  defp scan(bytes), do: ReplyScanner.scan(bytes, ReplyScanner.new())
+
+  describe "CAP-P-02: sentinel discipline" do
+    test "all replies before DA1 are parsed, sentinel flagged" do
+      {acc, leak} =
+        scan(
+          "\e]11;rgb:1e1e/1e1e/1e1e\a" <>
+            "\e[?2026;1$y" <> "\e[?2048;1$y" <> "\e[?62;4c"
+        )
+
+      assert leak == ""
+      assert acc.osc11 == {:ok, {30, 30, 30}}
+      assert acc.mode == %{2026 => 1, 2048 => 1}
+      assert acc.da1 == [62, 4]
+      assert acc.sentinel_seen?
+    end
+  end
+
+  describe "CAP-P-04: both OSC/DCS terminators" do
+    test "BEL-terminated and ST-terminated replies parse identically" do
+      {bel, ""} = scan("\e]11;rgb:8080/8080/8080\a")
+      {st, ""} = scan("\e]11;rgb:8080/8080/8080\e\\")
+
+      assert bel.osc11 == st.osc11
+      assert bel.osc11 == {:ok, {128, 128, 128}}
+    end
+
+    test "DCS accepts BEL too" do
+      {acc, ""} = scan("\eP>|kitty(0.32.2)\a")
+      assert acc.xtversion == {"kitty", "0.32.2"}
+    end
+  end
+
+  describe "CAP-P-05: grammar dispatch, not position" do
+    test "scrambled reply order attributes each cap by echoed params" do
+      # XTVERSION first, DECRQM in the middle, OSC 11 late, kbd, DA1
+      {acc, leak} =
+        scan(
+          "\eP>|kitty(0.32.2)\e\\" <>
+            "\e[?2026;1$y" <>
+            "\e]11;rgb:1111/2222/3333\a" <> "\e[?1u" <> "\e[?62;c"
+        )
+
+      assert leak == ""
+      assert acc.xtversion == {"kitty", "0.32.2"}
+      assert acc.mode[2026] == 1
+      assert acc.osc11 == {:ok, {17, 34, 51}}
+      assert acc.kitty_kbd == 1
+      assert acc.sentinel_seen?
+    end
+  end
+
+  describe "CAP-P-06: DECRQM value capture" do
+    test "every Ps value is stored verbatim for the classifier" do
+      for value <- 0..4 do
+        {acc, ""} = scan("\e[?2026;#{value}$y")
+        assert acc.mode[2026] == value
+      end
+    end
+  end
+
+  describe "CAP-P-07: XTVERSION identity parse" do
+    test "name(version) form" do
+      {acc, ""} = scan("\eP>|kitty(0.32.2)\e\\")
+      assert acc.xtversion == {"kitty", "0.32.2"}
+    end
+
+    test "name version form" do
+      {acc, ""} = scan("\eP>|iTerm2 3.5.0\e\\")
+      assert acc.xtversion == {"iTerm2", "3.5.0"}
+    end
+
+    test "bare name form" do
+      {acc, ""} = scan("\eP>|foot\e\\")
+      assert acc.xtversion == {"foot", nil}
+    end
+  end
+
+  describe "CAP-P-10: cell-px and sixel register replies" do
+    test "CSI 6 ; h ; w t yields cell_px {w, h}" do
+      {acc, ""} = scan("\e[6;20;10t")
+      assert acc.cell_px == {10, 20}
+    end
+
+    test "XTSMGRAPHICS color registers" do
+      {acc, ""} = scan("\e[?1;0;256S")
+      assert acc.sixel_regs == 256
+    end
+  end
+
+  describe "CPR consumption (the modified-F3 wire ambiguity)" do
+    test "a cursor position report is consumed, never leaked" do
+      {acc, leak} = scan("\e[12;40R")
+      assert acc.cpr == {12, 40}
+      assert leak == ""
+    end
+
+    test "row-1 CPR (byte-identical to xterm modified-F3) is consumed too" do
+      # during a probe window this MUST be stripped: InputParser would
+      # otherwise read it as a modified function key
+      {acc, leak} = scan("\e[1;83R")
+      assert acc.cpr == {1, 83}
+      assert leak == ""
+    end
+
+    test "single-param CSI R is not a CPR and leaks" do
+      {acc, leak} = scan("\e[5R")
+      assert acc.cpr == nil
+      assert leak == "\e[5R"
+    end
+  end
+
+  describe "CAP-P-11: kitty keyboard flags" do
+    test "flags reply parses" do
+      {acc, ""} = scan("\e[?31u")
+      assert acc.kitty_kbd == 31
+    end
+
+    test "absent reply stays nil" do
+      {acc, _} = scan("\e[?62;c")
+      assert acc.kitty_kbd == nil
+    end
+
+    test "a bare echoed 'CSI ? u' query (no digits) is not a flags reply" do
+      {acc, leak} = scan("\e[?u")
+      assert acc.kitty_kbd == nil
+      assert leak == ""
+    end
+  end
+
+  describe "CAP-N-04: interleaved user keystrokes" do
+    test "replies parsed AND keystrokes preserved in order" do
+      {acc, leak} = scan("l\e[?2026;1$y" <> "\e[?62;c" <> "s\r")
+
+      assert acc.mode[2026] == 1
+      assert acc.sentinel_seen?
+      assert leak == "ls\r"
+    end
+  end
+
+  describe "CAP-N-07: echo-leak (terminal echoes the query verbatim)" do
+    test "echoed queries never become caps; residual is InputParser-safe" do
+      query = Raxol.Terminal.Capabilities.Probe.query_sequence()
+      {acc, leak} = scan(query)
+
+      # nothing was mistaken for a reply
+      assert acc.mode == %{}
+      assert acc.kitty_kbd == nil
+      refute acc.sentinel_seen?
+      # the echoed OSC query is captured as an invalid color, never a cap
+      assert acc.osc11 == {:invalid, "?"}
+      # residual is only well-formed CSI the key parser consumes silently
+      assert leak == "\e[>0q\e[c"
+    end
+  end
+
+  describe "CAP-N-08/09: partial replies" do
+    test "chunk ending mid-reply parks the fragment (nothing leaks)" do
+      {acc, leak} = scan("\e[?2026;1")
+      assert leak == ""
+      assert acc.partial == "\e[?2026;1"
+      assert acc.mode == %{}
+    end
+
+    test "continuation chunk resumes the parked fragment (CAP-N-09)" do
+      {acc, ""} = scan("\e[?2026;1")
+      {acc, ""} = ReplyScanner.scan("$y\e[?62;c", acc)
+
+      assert acc.mode[2026] == 1
+      assert acc.sentinel_seen?
+      assert acc.partial == ""
+    end
+
+    test "trailing lone ESC is parked, then resolves as input" do
+      {acc, ""} = scan("\e")
+      assert acc.partial == "\e"
+
+      {acc, leak} = ReplyScanner.scan("[A", acc)
+      assert leak == "\e[A"
+      assert acc.partial == ""
+    end
+  end
+
+  describe "CAP-N-10: malformed replies never crash, never support" do
+    test "empty DECRQM value" do
+      {acc, ""} = scan("\e[?2026;$y")
+      assert acc.mode[2026] == nil
+      assert Map.has_key?(acc.mode, 2026)
+    end
+
+    test "out-of-range DECRQM value is stored for the classifier to reject" do
+      {acc, ""} = scan("\e[?2026;9$y")
+      assert acc.mode[2026] == 9
+    end
+
+    test "DECRQM with no mode param is dropped" do
+      {acc, ""} = scan("\e[?;1$y")
+      assert acc.mode == %{}
+    end
+
+    test "truncated DCS parks as partial" do
+      {acc, ""} = scan("\eP>|kit")
+      assert acc.partial == "\eP>|kit"
+      assert acc.xtversion == nil
+    end
+
+    test "stray ESC inside a CSI aborts and re-scans, losing no input" do
+      {_acc, leak} = scan("\e[?20\e[A")
+      # aborted reply candidate: all bytes surface as leak, in order
+      assert leak == "\e[?20\e[A"
+    end
+  end
+
+  describe "leak discipline for non-reply sequences" do
+    test "arrow keys, mouse, and focus events pass through untouched" do
+      input = "\e[A\e[<0;10;5M\e[I\e[1;5C"
+      {acc, leak} = scan(input)
+      assert leak == input
+      assert acc == %{ReplyScanner.new() | partial: acc.partial}
+      assert acc.partial == ""
+    end
+
+    test "unrelated OSC frames are drained, not leaked as Alt+] keys" do
+      {acc, leak} = scan("\e]0;window title\ax")
+      assert leak == "x"
+      assert acc.osc11 == nil
+    end
+  end
+end

--- a/packages/raxol_terminal/test/support/capability_slice_fixtures.ex
+++ b/packages/raxol_terminal/test/support/capability_slice_fixtures.ex
@@ -1,0 +1,95 @@
+defmodule Raxol.Test.CapabilityFixtures do
+  @moduledoc """
+  Loader for `test/fixtures/capability/capture/*.json` (schema
+  `raxol.capability.capture/1`, shared contract with T0 -- 04 design §2).
+
+  `reply_hex` is the WHOLE raw read exactly as the tty delivered it,
+  lowercase hex; the loader decodes `*_hex` fields to binaries. One
+  table-driven test iterates `all/0`; dropping a new T0 capture into the
+  directory adds a regression test with zero code.
+  """
+
+  @dir Path.expand("../fixtures/capability/capture", __DIR__)
+
+  @atom_fields ~w(tier unicode grapheme_width multiplexer)
+
+  @doc "Fixture directory."
+  def dir, do: @dir
+
+  @doc "All fixture paths, sorted."
+  def all do
+    @dir |> Path.join("*.json") |> Path.wildcard() |> Enum.sort()
+  end
+
+  @doc """
+  Loads one fixture by path or bare name. Decodes `query_hex`,
+  `reply_hex`, and `expected_leak_hex` into `"query"`, `"reply"`, and
+  `"expected_leak"` binaries.
+  """
+  def load!(path_or_name) do
+    path =
+      if String.contains?(path_or_name, "/") do
+        path_or_name
+      else
+        Path.join(@dir, ensure_ext(path_or_name))
+      end
+
+    fixture = path |> File.read!() |> Jason.decode!()
+
+    fixture
+    |> decode_hex_field("query_hex", "query")
+    |> decode_hex_field("reply_hex", "reply")
+    |> decode_hex_field("expected_leak_hex", "expected_leak")
+  end
+
+  @doc """
+  Environment seed for the probe: the fixture `env` map with unset (null)
+  vars dropped, mirroring a real process environment.
+  """
+  def env(fixture) do
+    fixture
+    |> Map.fetch!("env")
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+  end
+
+  @doc """
+  The fixture's `expected` golden as `{atom_field, expected_value}` pairs
+  directly comparable against a `%Raxol.Terminal.Capabilities{}` record.
+  """
+  def expected_assertions(fixture) do
+    fixture
+    |> Map.fetch!("expected")
+    |> Enum.map(fn {key, value} ->
+      {String.to_atom(key), convert_expected(key, value)}
+    end)
+  end
+
+  @doc "The fixture's expected ladder mode, as an atom."
+  def expected_tier(fixture) do
+    fixture |> Map.fetch!("expected_tier") |> String.to_atom()
+  end
+
+  defp convert_expected("identity", nil), do: nil
+  defp convert_expected("identity", [name, version]), do: {name, version}
+
+  defp convert_expected(field, value)
+       when field in @atom_fields and is_binary(value),
+       do: String.to_atom(value)
+
+  defp convert_expected(_field, value), do: value
+
+  defp decode_hex_field(fixture, hex_key, bin_key) do
+    case Map.fetch(fixture, hex_key) do
+      {:ok, hex} when is_binary(hex) ->
+        Map.put(fixture, bin_key, Base.decode16!(hex, case: :lower))
+
+      _ ->
+        fixture
+    end
+  end
+
+  defp ensure_ext(name) do
+    if String.ends_with?(name, ".json"), do: name, else: name <> ".json"
+  end
+end

--- a/packages/raxol_terminal/test/support/capability_slice_gen.ex
+++ b/packages/raxol_terminal/test/support/capability_slice_gen.ex
@@ -1,0 +1,110 @@
+defmodule Raxol.Test.CapabilitySliceGen do
+  @moduledoc """
+  Deterministic seeded generators for the T1 capability fuzz suite
+  (CAP-F-*, 04 design §4).
+
+  raxol_terminal does not depend on `stream_data` (and the package
+  `mix.exs` is outside the T1 write-set), so the fuzz properties are
+  driven by an explicit seeded PRNG: same properties, same generator
+  shapes (`G-noise`, `G-reply`, `G-interleave`), fully reproducible runs.
+  Each iteration seeds `:rand` with `{@seed_a, @seed_b, i}` so a failure
+  reports the exact iteration to replay.
+  """
+
+  @seed_a 1337
+  @seed_b 424_242
+
+  @doc "Seeds the PRNG for iteration `i` (call at the top of each run)."
+  def seed(i), do: :rand.seed(:exsss, {@seed_a, @seed_b, i})
+
+  @doc "G-noise: arbitrary bytes, length 0..max."
+  def noise(max_len \\ 128) do
+    len = :rand.uniform(max_len + 1) - 1
+    for _ <- 1..len//1, into: <<>>, do: <<:rand.uniform(256) - 1>>
+  end
+
+  @doc "Printable keystroke run (0x20..0x7E -- never contains ESC)."
+  def printable do
+    len = :rand.uniform(12)
+    for _ <- 1..len, into: <<>>, do: <<0x1F + :rand.uniform(0x5F)>>
+  end
+
+  @doc """
+  G-reply: one well-formed reply from the bank. Returns `{bytes, tag}`.
+  """
+  def reply do
+    case :rand.uniform(6) do
+      1 -> decrqm()
+      2 -> osc11()
+      3 -> xtversion()
+      4 -> da1()
+      5 -> kitty_kbd()
+      6 -> cpr()
+    end
+  end
+
+  @doc "DECRQM reply: CSI ? <mode> ; <0..4> $ y."
+  def decrqm do
+    mode = Enum.random([2026, 2027, 2048, 69, 2031, :rand.uniform(9999)])
+    value = :rand.uniform(5) - 1
+    {"\e[?#{mode};#{value}$y", :decrqm}
+  end
+
+  @doc "OSC 11 color reply, BEL- or ST-terminated."
+  def osc11 do
+    hex = fn -> Enum.map_join(1..4, fn _ -> Enum.random(~w(0 4 8 a f)) end) end
+
+    {"\e]11;rgb:#{hex.()}/#{hex.()}/#{hex.()}" <> terminator(), :osc11}
+  end
+
+  @doc "XTVERSION DCS reply."
+  def xtversion do
+    name = Enum.random(~w(kitty WezTerm ghostty Alacritty iTerm2 VTE))
+    {"\eP>|#{name}(#{:rand.uniform(99)}.#{:rand.uniform(99)})" <> "\e\\", :xtversion}
+  end
+
+  @doc "DA1 reply (the sentinel)."
+  def da1 do
+    attrs = Enum.take_random([1, 2, 4, 6, 9, 15, 18, 21, 22], :rand.uniform(4))
+    {"\e[?#{Enum.join([62 | attrs], ";")}c", :da1}
+  end
+
+  @doc "Kitty keyboard flags reply."
+  def kitty_kbd, do: {"\e[?#{:rand.uniform(31)}u", :kitty_kbd}
+
+  @doc """
+  Cursor position report. Row is always >= 2: `CSI 1 ; <n> R` is
+  wire-ambiguous with xterm's modified-F3 key encoding, which is exactly
+  why the ReplyScanner consumes CPR before the key parser ever sees it.
+  """
+  def cpr, do: {"\e[#{1 + :rand.uniform(59)};#{:rand.uniform(200)}R", :cpr}
+
+  defp terminator, do: Enum.random(["\a", "\e\\"])
+
+  @doc """
+  G-interleave: replies interleaved with printable keystrokes. Returns
+  `{full_binary, expected_leak_free}` -- the leak is exactly the
+  concatenated keystroke segments; every reply (CPR included) is
+  consumed by the scanner.
+  """
+  def interleave do
+    segments =
+      for _ <- 1..:rand.uniform(8) do
+        if :rand.uniform(2) == 1 do
+          {:keys, printable()}
+        else
+          {bytes, kind} = reply()
+          {kind, bytes}
+        end
+      end
+
+    full = Enum.map_join(segments, fn {_kind, bytes} -> bytes end)
+
+    expected_leak =
+      segments
+      |> Enum.filter(fn {kind, _} -> kind == :keys end)
+      |> Enum.map_join(fn {_kind, bytes} -> bytes end)
+
+    {full, expected_leak}
+  end
+end


### PR DESCRIPTION
Unit **T1** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): the capability-detection slice — real DECRQM probing replacing env-sniffing, and the degradation ladder that gates every renderer emitter.

## What (all in `packages/raxol_terminal`, additive)
- **`Capabilities.ReplyScanner`** — pure grammar-dispatch scanner (CSI/OSC/DCS/APC, BEL-or-ST termination): parses probe replies, leaks everything else byte-identically, parks partial tails. Total over arbitrary bytes (seeded fuzz, 500 runs/property, 0 failures).
- **`Capabilities.Probe`** — pure reducer, clock-as-injected-event (no sleeps anywhere in tests): batched query `OSC 11 · CSI ?u · CSI ?2026$p · XTVERSION · DA1-sentinel`, read-to-sentinel discipline, one deadline extension max, SSH-widened budget, tmux passthrough wrapping, non-TTY → zero bytes written.
- **`Capabilities.Classifier` + `QuirkTable`** — DECRQM `{1,2}` = supported; Alacritty stuck-at-2 → `:no_verify_2026` (supported, skip set-requery); tmux/screen conservative clamp (`$TERM=screen` never widens); Windows platform gates.
- **`Capabilities.Ladder`** — total `select/2` → `:inline_log | :tmux_conservative | :flat`; `assert_capable!/2` **raises** on forced-inline-with-incapable-caps (misdetection fails loud, never corrupts); forced downgrades emit telemetry.
- **`Capabilities` record** — session-immutable, per-cap provenance (`:decrqm | :env | :tmux_clamp | ...`), one public 2026 emit-gate (`sync_output?/0`).
- 13 terminal fixtures (kitty/iTerm2/WezTerm/Ghostty/Alacritty/VTE/Apple + silence/reorder/keystroke-interleave/echo-leak/partial-EOF/tmux-garble) replaying end-to-end Probe→Classifier→Ladder; T0's Ring B captures drop in with zero code.

## Fail-first anchor (recorded in commit body)
The suite's anchor tests were run against master first: **red** — `query_synchronized_output_support/0` is hardcoded `false` behind `$TERM_PROGRAM` sniffing. Green post-implementation with provenance asserted (`source.sync_output == :decrqm`).

## Fuzz trophy
Property iteration 109 caught a real wire ambiguity: **CPR `CSI 1;n R` is byte-identical to xterm's modified-F3 key encoding** — the parser emitted a phantom shift+alt+ctrl-F3 for a row-1 cursor report. Scanner now consumes CPR before the key parser; regression-locked.

## Evidence
All 129 capability/driver/parser tests green; package suite 2123/2126 (3 failures proven pre-existing on pristine master, untouched files). Reviewer independently verified fixture byte-plausibility against documented terminal reply formats.

## Review trail
Opus adversarial review: **approve-with-yellows** — both yellows are T2a integration notes (absolute-deadline driver loop; clamped-record as emit-gate authority), recorded in the lane STATE doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
