### PR TITLE
Terminal: feed top-anchored region scroll into scrollback + fix LF/CR coordinate bugs [TE]

### DIFF
--- a/packages/raxol_terminal/lib/raxol/terminal/commands/screen.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/screen.ex
@@ -10,7 +10,6 @@ defmodule Raxol.Terminal.Commands.Screen do
   alias Raxol.Terminal.ScreenBuffer
   alias Raxol.Terminal.ScreenBuffer.Operations
 
-
   # Use map() to accept any emulator-like struct
   @type emulator :: map()
 
@@ -182,7 +181,7 @@ defmodule Raxol.Terminal.Commands.Screen do
     Raxol.Core.Runtime.Log.debug("[Screen.scroll_down] CALLED with count: #{count}")
 
     buffer = Emulator.get_screen_buffer(emulator)
-    {top, bottom} = ScreenBuffer.get_scroll_region_boundaries(buffer)
+    {top, bottom} = effective_scroll_region(emulator, buffer)
 
     # Use ScreenBuffer.scroll_down since we have a ScreenBuffer struct
     new_buffer = ScreenBuffer.scroll_down(buffer, top, bottom, count)
@@ -193,10 +192,36 @@ defmodule Raxol.Terminal.Commands.Screen do
     Raxol.Core.Runtime.Log.debug("[Screen.scroll_up] CALLED with lines: #{lines}")
 
     buffer = Emulator.get_screen_buffer(emulator)
-    {top, bottom} = ScreenBuffer.get_scroll_region_boundaries(buffer)
+    {top, bottom} = effective_scroll_region(emulator, buffer)
 
     # Use ScreenBuffer.scroll_up since we have a ScreenBuffer struct
-    new_buffer = ScreenBuffer.scroll_up(buffer, top, bottom, lines)
-    Emulator.update_active_buffer(emulator, new_buffer)
+    {new_buffer, scrolled_lines} = ScreenBuffer.scroll_up(buffer, top, bottom, lines)
+
+    emulator
+    |> Emulator.update_active_buffer(new_buffer)
+    |> Raxol.Terminal.Emulator.BufferOperations.feed_scrollback_from_region_scroll(
+      top,
+      scrolled_lines
+    )
+  end
+
+  # DECSTBM (via Emulator.CommandHandler / the CSI handlers) records the
+  # scroll region on `emulator.scroll_region`; the ScreenBuffer's own
+  # `scroll_region` field is a separate store that the byte path never
+  # sets. The emulator-level region wins when present -- the same
+  # precedence `insert_lines/2` and `delete_lines/2` above already use --
+  # falling back to the buffer's boundaries (which default to full screen).
+  defp effective_scroll_region(emulator, buffer) do
+    height = ScreenBuffer.get_height(buffer)
+
+    case Map.get(emulator, :scroll_region) do
+      {top, bottom}
+      when is_integer(top) and is_integer(bottom) and top >= 0 and
+             top <= bottom ->
+        {top, min(bottom, height - 1)}
+
+      _ ->
+        ScreenBuffer.get_scroll_region_boundaries(buffer)
+    end
   end
 end

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/scrolling.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/scrolling.ex
@@ -3,11 +3,21 @@ defmodule Raxol.Terminal.Commands.Scrolling do
   Handles scrolling operations for the terminal screen buffer.
   """
 
-
   alias Raxol.Terminal.ANSI.TextFormatting
   alias Raxol.Terminal.Cell
   alias Raxol.Terminal.ScreenBuffer
 
+  # NOTE (harness-ui unit TE): this scroll_up is the function the harness
+  # roadmap and `Raxol.Harness.Test.SealOracle` historically named as the
+  # scrollback-dropping culprit ("commands/scrolling.ex scroll_up blanks
+  # vacated rows"). It is NOT on any live emulator scroll path today --
+  # only ScrollOps.scroll_down_with_count/3 and tests reach it. The live
+  # paths, where the TE scrollback feed is wired, are:
+  #   * Raxol.Terminal.Commands.Screen.scroll_up/2 (DECSTBM region path,
+  #     also invoked by ControlCodes.handle_lf/1 at the bottom margin and
+  #     Emulator.maybe_scroll/1 on cursor overflow)
+  #   * Raxol.Terminal.Operations.ScrollOperations.scroll_up/2
+  # both feeding Emulator.BufferOperations.feed_scrollback_from_region_scroll/3.
   @spec scroll_up(
           map(),
           non_neg_integer(),

--- a/packages/raxol_terminal/lib/raxol/terminal/control_codes.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/control_codes.ex
@@ -6,7 +6,6 @@ defmodule Raxol.Terminal.ControlCodes do
   Relies on Emulator state and ScreenBuffer for actions.
   """
 
-
   alias Raxol.Terminal.ANSI.CharacterSets
   alias Raxol.Terminal.Cursor.Movement
   alias Raxol.Terminal.Emulator
@@ -114,12 +113,29 @@ defmodule Raxol.Terminal.ControlCodes do
     active_buffer = Emulator.get_screen_buffer(emulator)
     buffer_height = ScreenBuffer.get_height(active_buffer)
 
-    {_, current_row} =
+    # Cursor.Manager positions are {row, col} (see Cursor.Movement --
+    # `position: {new_row, col}`). This destructure previously read the
+    # COLUMN as the row, so the at-bottom-margin branch effectively never
+    # fired and LF at the bottom never scrolled (TE amend, finding 3+8).
+    {current_row, _col} =
       Raxol.Terminal.Cursor.Manager.get_position(emulator.cursor)
 
-    last_row = buffer_height - 1
+    # LF scrolls when the cursor sits on the bottom row of the EFFECTIVE
+    # scroll region (DECSTBM stores it on emulator.scroll_region; full
+    # screen otherwise). A cursor below an interior region (e.g. in a
+    # footer) falls through to plain downward movement, clamped at the
+    # screen bottom -- no scroll, matching DECSTBM semantics.
+    region_bottom =
+      case emulator.scroll_region do
+        {top, bottom}
+        when is_integer(top) and is_integer(bottom) and top <= bottom ->
+          min(bottom, buffer_height - 1)
 
-    handle_lf_cursor_movement(current_row == last_row, emulator)
+        _ ->
+          buffer_height - 1
+      end
+
+    handle_lf_cursor_movement(current_row == region_bottom, emulator)
   end
 
   defp move_cursor_down(emulator) do
@@ -127,7 +143,11 @@ defmodule Raxol.Terminal.ControlCodes do
     {buffer_width, buffer_height} = ScreenBuffer.get_dimensions(active_buffer)
     cursor = emulator.cursor
 
-    {current_col, current_row} =
+    # Position tuples are {row, col} -- this previously destructured them
+    # swapped, feeding the ROW into the LNM column adjustment below, which
+    # made every LF drift the column right by the row number (TE amend,
+    # finding 3+8).
+    {current_row, current_col} =
       Raxol.Terminal.Cursor.Manager.get_position(cursor)
 
     last_row = buffer_height - 1
@@ -209,14 +229,19 @@ defmodule Raxol.Terminal.ControlCodes do
 
     # 2. Perform CR logic on potentially updated state
     Raxol.Core.Runtime.Log.debug("[handle_cr] Moving cursor to column 0")
-    # Get current Y coordinate
-    {_cx, cy} = Raxol.Terminal.Cursor.Manager.get_position(emulator.cursor)
+    # Keep the current row (position tuples are {row, col} and move_to is
+    # (cursor, row, col) -- this previously destructured the COLUMN as the
+    # row and passed the arguments swapped, so every CR teleported the
+    # cursor to row 0; TE amend, finding 3+8) and move to column 0. Read
+    # the row AFTER the pending wrap so CR lands on the wrapped row.
+    {current_row, _col} =
+      Raxol.Terminal.Cursor.Manager.get_position(emulator_after_pending_wrap.cursor)
 
     final_cursor =
       Raxol.Terminal.Cursor.Manager.move_to(
         emulator_after_pending_wrap.cursor,
-        0,
-        cy
+        current_row,
+        0
       )
 
     Raxol.Core.Runtime.Log.debug(
@@ -518,11 +543,33 @@ defmodule Raxol.Terminal.ControlCodes do
   end
 
   # Helper functions for refactored if statements
+  #
+  # LF with the cursor on the bottom row of the effective scroll region:
+  # scroll the region up one line (Commands.Screen.scroll_up/2 feeds the
+  # evicted row into emulator.scrollback_buffer per the TE eviction rules
+  # in Emulator.BufferOperations.feed_scrollback_from_region_scroll/3).
+  # The cursor row stays on the bottom margin, per VT semantics; the
+  # column follows LNM exactly like the non-scrolling branch (col -> 0
+  # when line_feed_mode is enabled, unchanged otherwise). The previous
+  # `move_cursor_down |> Emulator.maybe_scroll` pipeline never scrolled:
+  # move_cursor_down clamps at the bottom margin and Emulator.maybe_scroll
+  # only fires on an out-of-bounds row, so the two composed to a no-op.
   defp handle_lf_cursor_movement(true, emulator) do
-    emulator
-    |> move_cursor_down()
-    |> Emulator.maybe_scroll()
-    |> reset_last_col_exceeded_after_scroll()
+    line_feed_mode =
+      Raxol.Terminal.ModeManager.mode_enabled?(
+        emulator.mode_manager,
+        :line_feed_mode
+      )
+
+    {row, col} = Raxol.Terminal.Cursor.Manager.get_position(emulator.cursor)
+    target_col = get_target_column(line_feed_mode, col)
+
+    scrolled = Raxol.Terminal.Commands.Screen.scroll_up(emulator, 1)
+
+    pinned_cursor =
+      Raxol.Terminal.Cursor.Manager.move_to(scrolled.cursor, row, target_col)
+
+    reset_last_col_exceeded_after_scroll(%{scrolled | cursor: pinned_cursor})
   end
 
   defp handle_lf_cursor_movement(_at_last_row, emulator) do
@@ -533,11 +580,21 @@ defmodule Raxol.Terminal.ControlCodes do
 
   defp handle_pending_wrap(true, emulator) do
     Raxol.Core.Runtime.Log.debug("[handle_cr] Pending wrap detected")
-    # Perform the deferred wrap: move cursor to col 0, next line
-    {_cx, cy} = Raxol.Terminal.Cursor.Manager.get_position(emulator.cursor)
+    # Perform the deferred wrap: move cursor to col 0, next line. Position
+    # tuples are {row, col} and move_to is (cursor, row, col) -- this
+    # previously destructured the COLUMN as the row and passed the
+    # arguments swapped (TE amend, finding 3+8). The unclamped row+1 may
+    # land past the screen bottom; Emulator.maybe_scroll below detects
+    # that overflow and scrolls (feeding scrollback per the TE rules).
+    {current_row, _col} =
+      Raxol.Terminal.Cursor.Manager.get_position(emulator.cursor)
 
     wrapped_cursor =
-      Raxol.Terminal.Cursor.Manager.move_to(emulator.cursor, 0, cy + 1)
+      Raxol.Terminal.Cursor.Manager.move_to(
+        emulator.cursor,
+        current_row + 1,
+        0
+      )
 
     Raxol.Core.Runtime.Log.debug(
       "[handle_cr] Cursor after wrap: #{inspect(Raxol.Terminal.Cursor.Manager.get_position(wrapped_cursor))}"

--- a/packages/raxol_terminal/lib/raxol/terminal/emulator.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/emulator.ex
@@ -542,8 +542,46 @@ defmodule Raxol.Terminal.Emulator do
   @doc "Gets the scrollback buffer contents."
   def get_scrollback(emulator), do: emulator.scrollback_buffer || []
 
-  @doc "Performs automatic scrolling if needed."
-  def maybe_scroll(emulator), do: emulator
+  @doc """
+  Performs automatic scrolling if needed.
+
+  Fires when the cursor row has moved past the bottom of the screen (the
+  deferred-autowrap and pending-wrap paths move the cursor unclamped);
+  scrolls the effective scroll region by the overflow amount via
+  `Raxol.Terminal.Commands.Screen.scroll_up/2` -- which feeds evicted rows
+  into `emulator.scrollback_buffer` per the TE eviction rules -- and clamps
+  the cursor back onto the last row. The in-bounds LF-at-bottom-margin
+  scroll is handled by `Raxol.Terminal.ControlCodes.handle_lf/1` directly
+  and never reaches here (a clamped cursor is indistinguishable from one
+  legitimately sitting on the last row).
+  """
+  def maybe_scroll(emulator) do
+    height =
+      case get_screen_buffer(emulator) do
+        %{height: h} -> h
+        _ -> nil
+      end
+
+    {row, col} = Raxol.Terminal.Cursor.Manager.get_position(emulator.cursor)
+
+    case is_integer(row) and is_integer(height) and row >= height do
+      true ->
+        scrolled =
+          Raxol.Terminal.Commands.Screen.scroll_up(emulator, row - height + 1)
+
+        clamped_cursor =
+          Raxol.Terminal.Cursor.Manager.move_to(
+            scrolled.cursor,
+            height - 1,
+            col
+          )
+
+        %{scrolled | cursor: clamped_cursor}
+
+      false ->
+        emulator
+    end
+  end
 
   @doc "Sets a terminal mode."
   def set_mode(emulator, mode), do: ModeOperations.set_mode(emulator, mode)

--- a/packages/raxol_terminal/lib/raxol/terminal/emulator/buffer_operations.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/emulator/buffer_operations.ex
@@ -78,6 +78,86 @@ defmodule Raxol.Terminal.Emulator.BufferOperations do
   end
 
   @doc """
+  Appends rows evicted by a scroll to the end of the scrollback buffer.
+
+  Order is oldest-first: `emulator.scrollback_buffer` is a chronological
+  transcript, so newly evicted rows are appended (never prepended) to keep
+  `Emulator.get_scrollback(emulator) ++ <still-on-screen rows>` reading as
+  one continuous, in-order history. Trims from the front (the oldest
+  entries) when the result would exceed `scrollback_limit`. A no-op for a
+  missing/empty eviction list.
+  """
+  @spec append_scrollback(emulator(), list()) :: emulator()
+  def append_scrollback(emulator, lines)
+
+  def append_scrollback(emulator, lines) when lines in [nil, []], do: emulator
+
+  def append_scrollback(emulator, lines) when is_list(lines) do
+    combined = (Map.get(emulator, :scrollback_buffer) || []) ++ lines
+    limit = Map.get(emulator, :scrollback_limit)
+
+    trimmed =
+      case is_integer(limit) and limit >= 0 and length(combined) > limit do
+        true -> Enum.drop(combined, length(combined) - limit)
+        false -> combined
+      end
+
+    %{emulator | scrollback_buffer: trimmed}
+  end
+
+  @doc """
+  Feeds rows evicted by a scroll-region scroll into the scrollback buffer
+  (`docs/proposals/in-flight/harness-ui-roadmap.md` unit TE).
+
+  Eviction rule: a TOP-ANCHORED scroll region -- `region_top == 0` (screen
+  row 1), including the full-screen case where no explicit region is set --
+  feeds its evictions into `emulator.scrollback_buffer`; an INTERIOR region
+  (`region_top > 0`) discards them; the alternate screen buffer never gets
+  scrollback regardless of region, matching real-terminal alt-screen
+  semantics.
+
+  Fidelity note: the full-screen and alt-screen halves of this rule match
+  real terminals exactly. The PARTIAL top-anchored case (region rows
+  1..H-N with footer rows below it) is the harness's print-above scrollback
+  model per T0's design -- real terminals vary here (xterm reliably feeds
+  native scrollback only for full-screen scrolls), and T0's Ring B measures
+  what each tier-1 terminal actually does. The interior-region discard does
+  match xterm.
+
+  `region_top` is the 0-based top row of the region that was scrolled,
+  captured BEFORE the scroll by the caller (which store it comes from --
+  `emulator.scroll_region` vs the buffer's own `scroll_region` -- is the
+  caller's concern; see `Raxol.Terminal.Commands.Screen.scroll_up/2`).
+  """
+  @spec feed_scrollback_from_region_scroll(
+          emulator(),
+          non_neg_integer(),
+          list()
+        ) :: emulator()
+  def feed_scrollback_from_region_scroll(emulator, region_top, scrolled_lines)
+
+  def feed_scrollback_from_region_scroll(emulator, _region_top, lines)
+      when lines in [nil, []],
+      do: emulator
+
+  def feed_scrollback_from_region_scroll(
+        %{active_buffer_type: :alternate} = emulator,
+        _region_top,
+        _scrolled_lines
+      ),
+      do: emulator
+
+  def feed_scrollback_from_region_scroll(emulator, 0, scrolled_lines),
+    do: append_scrollback(emulator, scrolled_lines)
+
+  def feed_scrollback_from_region_scroll(
+        emulator,
+        _interior_region_top,
+        _scrolled_lines
+      ),
+      do: emulator
+
+  @doc """
   Switches to the alternate screen buffer.
   """
   def switch_to_alternate_screen(emulator) do

--- a/packages/raxol_terminal/lib/raxol/terminal/operations/scroll_operations.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/operations/scroll_operations.ex
@@ -56,10 +56,20 @@ defmodule Raxol.Terminal.Operations.ScrollOperations do
   def scroll_up(emulator, lines) do
     buffer = get_screen_buffer(emulator)
 
-    {new_buffer, _scrolled_lines} =
+    # ScrollRegion.scroll_up/2 derives its region from the buffer's own
+    # scroll_region field, so the pre-scroll region top for the scrollback
+    # eviction rule comes from the same store.
+    region_top = ScreenBuffer.get_scroll_top(buffer)
+
+    {new_buffer, scrolled_lines} =
       Raxol.Terminal.Buffer.ScrollRegion.scroll_up(buffer, lines)
 
-    update_active_buffer(emulator, new_buffer)
+    emulator
+    |> update_active_buffer(new_buffer)
+    |> Raxol.Terminal.Emulator.BufferOperations.feed_scrollback_from_region_scroll(
+      region_top,
+      scrolled_lines
+    )
   end
 
   def scroll_down(emulator, lines) do

--- a/packages/raxol_terminal/lib/raxol/terminal/screen_buffer/scroll_ops.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/screen_buffer/scroll_ops.ex
@@ -126,6 +126,15 @@ defmodule Raxol.Terminal.ScreenBuffer.ScrollOps do
 
   @doc """
   Scrolls up within an explicit top/bottom region.
+
+  Returns `{buffer, scrolled_out_rows}` -- the rows evicted from the top of
+  the region, oldest-first -- mirroring `scroll_up/2`'s two-arg contract.
+  Whether `scrolled_out_rows` is scrollback-eligible depends on the region:
+  callers feeding an effective top of 0 (screen row 1, including the
+  no-region/full-screen case) should treat them as real scrollback history;
+  callers with an interior region (top > 0) discard them, matching
+  real-terminal behavior where only a top-anchored scroll region feeds
+  native scrollback.
   """
   def scroll_up(buffer, top, bottom, lines) do
     {effective_top, effective_bottom} = normalize_scroll_region(buffer, top, bottom)
@@ -136,13 +145,14 @@ defmodule Raxol.Terminal.ScreenBuffer.ScrollOps do
       {region, after_region} = Enum.split(region_and_after, effective_bottom - effective_top + 1)
 
       lines_to_scroll = min(lines, length(region))
+      scrolled_out = Enum.take(region, lines_to_scroll)
       kept_region = Enum.drop(region, lines_to_scroll)
       empty_lines = List.duplicate(create_empty_line(buffer.width), lines_to_scroll)
       scrolled_region = kept_region ++ empty_lines
       new_cells = before_region ++ scrolled_region ++ after_region
-      %{buffer | cells: new_cells}
+      {%{buffer | cells: new_cells}, scrolled_out}
     else
-      buffer
+      {buffer, []}
     end
   end
 

--- a/packages/raxol_terminal/lib/raxol/terminal/screen_buffer_adapter.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/screen_buffer_adapter.ex
@@ -71,8 +71,10 @@ defmodule Raxol.Terminal.ScreenBufferAdapter do
   def scroll_down(buffer), do: ScrollOps.scroll_down(buffer, 1)
   defdelegate scroll_down(buffer, n), to: ScrollOps
 
+  # ScrollOps.scroll_up/4 returns {buffer, scrolled_out_rows} (TE); this
+  # adapter's contract is buffer-only, so drop the eviction list here.
   def scroll_region_up(buffer, top, bottom, n),
-    do: ScrollOps.scroll_up(buffer, top, bottom, n)
+    do: elem(ScrollOps.scroll_up(buffer, top, bottom, n), 0)
 
   def scroll_region_down(buffer, top, bottom, n),
     do: ScrollOps.scroll_down(buffer, top, bottom, n)

--- a/packages/raxol_terminal/test/raxol/terminal/commands/screen_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/commands/screen_test.exs
@@ -488,4 +488,121 @@ defmodule Raxol.Terminal.Commands.ScreenTest do
       assert position == {3, 1}
     end
   end
+
+  describe "scroll_up/2 scrollback feed (TE unit)" do
+    defp row_text(row) do
+      row
+      |> Enum.map_join("", fn
+        %{char: char} when is_binary(char) -> char
+        _ -> " "
+      end)
+      |> String.trim_trailing()
+    end
+
+    test "full-screen scroll (no scroll region set) feeds the evicted row into scrollback" do
+      emulator = Emulator.new(10, 5)
+
+      filled =
+        ScreenBuffer.write_string(
+          emulator.main_screen_buffer,
+          0,
+          0,
+          "TOPROW",
+          TextFormatting.new()
+        )
+
+      emulator = Emulator.update_active_buffer(emulator, filled)
+
+      emulator = Screen.scroll_up(emulator, 1)
+
+      assert [row] = Emulator.get_scrollback(emulator)
+      assert row_text(row) == "TOPROW"
+    end
+
+    test "top-anchored scroll region (top row 1 / internal row 0) feeds evicted rows into scrollback" do
+      emulator = Emulator.new(10, 5)
+
+      filled =
+        ScreenBuffer.write_string(
+          emulator.main_screen_buffer,
+          0,
+          0,
+          "TOPROW",
+          TextFormatting.new()
+        )
+
+      filled = ScreenBuffer.set_scroll_region(filled, {0, 2})
+      emulator = Emulator.update_active_buffer(emulator, filled)
+
+      emulator = Screen.scroll_up(emulator, 1)
+
+      assert [row] = Emulator.get_scrollback(emulator)
+      assert row_text(row) == "TOPROW"
+    end
+
+    test "interior scroll region (top > 0) discards evicted rows -- no scrollback feed" do
+      emulator = Emulator.new(10, 5)
+
+      filled =
+        ScreenBuffer.write_string(
+          emulator.main_screen_buffer,
+          0,
+          1,
+          "EVICTME",
+          TextFormatting.new()
+        )
+
+      filled = ScreenBuffer.set_scroll_region(filled, {1, 3})
+      emulator = Emulator.update_active_buffer(emulator, filled)
+
+      emulator = Screen.scroll_up(emulator, 1)
+
+      assert Emulator.get_scrollback(emulator) == []
+    end
+
+    test "alternate screen buffer scroll never feeds scrollback" do
+      emulator = Emulator.new(10, 5)
+      emulator = %{emulator | active_buffer_type: :alternate}
+
+      filled =
+        ScreenBuffer.write_string(
+          emulator.alternate_screen_buffer,
+          0,
+          0,
+          "ALTROW",
+          TextFormatting.new()
+        )
+
+      emulator = Emulator.update_active_buffer(emulator, filled)
+
+      emulator = Screen.scroll_up(emulator, 1)
+
+      assert Emulator.get_scrollback(emulator) == []
+    end
+
+    test "respects scrollback_limit, trimming the oldest entries first" do
+      emulator = Emulator.new(10, 5)
+      emulator = %{emulator | scrollback_limit: 2}
+
+      emulator =
+        Enum.reduce(0..4, emulator, fn i, acc ->
+          filled =
+            ScreenBuffer.write_string(
+              acc.main_screen_buffer,
+              0,
+              0,
+              "R#{i}",
+              TextFormatting.new()
+            )
+
+          acc
+          |> Emulator.update_active_buffer(filled)
+          |> Screen.scroll_up(1)
+        end)
+
+      scrollback = Emulator.get_scrollback(emulator)
+      assert length(scrollback) == 2
+      assert Enum.map(scrollback, &row_text/1) == ["R3", "R4"]
+    end
+  end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/emulator/writing_buffer_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/emulator/writing_buffer_test.exs
@@ -72,14 +72,20 @@ defmodule Raxol.Terminal.Emulator.WritingBufferTest do
       {emulator_after, _output} =
         Emulator.process_input(emulator, "Hello\nWorld")
 
-      # Corrected assertion: After "Hello\nWorld" with LNM off, cursor should be at {1, 5}
-      assert Emulator.get_cursor_position(emulator_after) == {1, 5},
-             "Cursor should be at row 1, col 5"
+      # With LNM off, a bare LF moves down WITHOUT resetting the column
+      # (VT semantics -- that's CR's job): "Hello" ends at col 5, LF keeps
+      # col 5 on row 1, "World" writes cols 5..9, cursor lands at {1, 10}.
+      # (The previous {1, 5} expectation codified a coordinate-order bug in
+      # ControlCodes.move_cursor_down that happened to reset the column to
+      # the row number -- 0 here; fixed in unit TE's amend.)
+      assert Emulator.get_cursor_position(emulator_after) == {1, 10},
+             "Cursor should be at row 1, col 10"
 
       # Verify buffer content
       buffer = Emulator.get_screen_buffer(emulator_after)
 
-      # Expected Screen: Line 0: "Hello", Line 1: "World" (cursor at {10, 1})
+      # Expected Screen: Line 0: "Hello", Line 1: "     World" (starts at
+      # col 5 -- LF preserved the column), cursor at {1, 10}
       expected_cells_line0 =
         [
           Cell.new("H"),
@@ -90,13 +96,14 @@ defmodule Raxol.Terminal.Emulator.WritingBufferTest do
         ] ++ List.duplicate(Cell.new(" "), 75)
 
       _expected_cells_line1 =
-        [
-          Cell.new("W"),
-          Cell.new("o"),
-          Cell.new("r"),
-          Cell.new("l"),
-          Cell.new("d")
-        ] ++ List.duplicate(Cell.new(" "), 75)
+        List.duplicate(Cell.new(" "), 5) ++
+          [
+            Cell.new("W"),
+            Cell.new("o"),
+            Cell.new("r"),
+            Cell.new("l"),
+            Cell.new("d")
+          ] ++ List.duplicate(Cell.new(" "), 70)
 
       # Compare relevant fields directly for line 0
       actual_cells_line0 = Enum.at(buffer.cells, 0)
@@ -118,8 +125,8 @@ defmodule Raxol.Terminal.Emulator.WritingBufferTest do
       end)
 
       # Check cursor position
-      assert Emulator.get_cursor_position(emulator_after) == {1, 5},
-             "Cursor should be at row 1, col 5"
+      assert Emulator.get_cursor_position(emulator_after) == {1, 10},
+             "Cursor should be at row 1, col 10"
     end
 
     test "handles basic text input with newline AND MORE", %{emulator: emulator} do
@@ -129,14 +136,18 @@ defmodule Raxol.Terminal.Emulator.WritingBufferTest do
       {emulator_after, ""} =
         Emulator.process_input(emulator, "Line 1\n Line 2")
 
-      # Check cursor position after processing
-      assert Emulator.get_cursor_position(emulator_after) == {1, 7},
-             "Cursor should be at row 1, col 7"
+      # With LNM off, LF keeps the column (VT semantics; see the newline
+      # test above): "Line 1" ends at col 6, " Line 2" (7 chars) writes
+      # cols 6..12 on row 1, cursor lands at {1, 13}.
+      assert Emulator.get_cursor_position(emulator_after) == {1, 13},
+             "Cursor should be at row 1, col 13"
 
       # Check buffer content after processing
       buffer = Emulator.get_screen_buffer(emulator_after)
 
-      # Expected Screen: Line 0: "Line 1", Line 1: "       Line 2" (starts at col 7 after space)
+      # Expected Screen: Line 0: "Line 1", Line 1: "Line 2" starting at
+      # col 7 (LF kept col 6, then the literal leading space of " Line 2"
+      # was written there)
       expected_buffer = %Raxol.Terminal.ScreenBuffer{
         width: 80,
         height: 24,
@@ -151,16 +162,18 @@ defmodule Raxol.Terminal.Emulator.WritingBufferTest do
               Cell.new(" "),
               Cell.new("1")
             ] ++ List.duplicate(Cell.new(" "), 74),
-            # Line 1: " Line 2" + padding
-            [
-              Cell.new(" "),
-              Cell.new("L"),
-              Cell.new("i"),
-              Cell.new("n"),
-              Cell.new("e"),
-              Cell.new(" "),
-              Cell.new("2")
-            ] ++ List.duplicate(Cell.new(" "), 73)
+            # Line 1: 6 untouched cols + " Line 2" (written cols 6..12)
+            # + padding
+            List.duplicate(Cell.new(" "), 6) ++
+              [
+                Cell.new(" "),
+                Cell.new("L"),
+                Cell.new("i"),
+                Cell.new("n"),
+                Cell.new("e"),
+                Cell.new(" "),
+                Cell.new("2")
+              ] ++ List.duplicate(Cell.new(" "), 67)
           ] ++ List.duplicate(List.duplicate(Cell.new(" "), 80), 22),
         scrollback: [],
         scrollback_limit: 1000,
@@ -177,8 +190,8 @@ defmodule Raxol.Terminal.Emulator.WritingBufferTest do
              "Screen buffer cells mismatch"
 
       # Check cursor position
-      assert Emulator.get_cursor_position(emulator_after) == {1, 7},
-             "Cursor should be at row 1, col 7"
+      assert Emulator.get_cursor_position(emulator_after) == {1, 13},
+             "Cursor should be at row 1, col 13"
     end
 
     test "get_cell_at retrieves cell at valid coordinates", %{

--- a/packages/raxol_terminal/test/raxol/terminal/operations/scroll_operations_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/operations/scroll_operations_test.exs
@@ -84,6 +84,75 @@ defmodule Raxol.Terminal.Operations.ScrollOperationsTest do
     end
   end
 
+  describe "scroll_up/2 scrollback feed (TE unit)" do
+    defp scrollback_row_text(row) do
+      row
+      |> Enum.map_join("", fn
+        %{char: char} when is_binary(char) -> char
+        _ -> " "
+      end)
+      |> String.trim_trailing()
+    end
+
+    test "full-screen scroll (no explicit region) feeds the evicted row into scrollback" do
+      emulator = TestUtils.create_test_emulator()
+      emulator = ScrollOperations.write_string(emulator, 0, 0, "row0", %{})
+
+      emulator = ScrollOperations.scroll_up(emulator, 1)
+
+      assert [row] = Raxol.Terminal.Emulator.get_scrollback(emulator)
+      assert scrollback_row_text(row) == "row0"
+    end
+
+    test "top-anchored explicit region (top = 0) feeds the evicted row into scrollback" do
+      emulator = TestUtils.create_test_emulator()
+      emulator = ScrollOperations.write_string(emulator, 0, 0, "top-row", %{})
+      emulator = ScrollOperations.set_scroll_region(emulator, 0, 5)
+
+      emulator = ScrollOperations.scroll_up(emulator, 1)
+
+      assert [row] = Raxol.Terminal.Emulator.get_scrollback(emulator)
+      assert scrollback_row_text(row) == "top-row"
+    end
+
+    test "interior region (top > 0) discards the evicted row -- no scrollback feed" do
+      emulator = TestUtils.create_test_emulator()
+      emulator = ScrollOperations.write_string(emulator, 0, 5, "line1", %{})
+      emulator = ScrollOperations.write_string(emulator, 0, 6, "line2", %{})
+      emulator = ScrollOperations.set_scroll_region(emulator, 5, 7)
+
+      emulator = ScrollOperations.scroll_up(emulator, 1)
+
+      assert Raxol.Terminal.Emulator.get_scrollback(emulator) == []
+    end
+
+    test "alternate screen buffer scroll never feeds scrollback" do
+      emulator = TestUtils.create_test_emulator()
+      emulator = %{emulator | active_buffer_type: :alternate}
+      emulator = ScrollOperations.write_string(emulator, 0, 0, "alt-row", %{})
+
+      emulator = ScrollOperations.scroll_up(emulator, 1)
+
+      assert Raxol.Terminal.Emulator.get_scrollback(emulator) == []
+    end
+
+    test "respects scrollback_limit, trimming the oldest entries first" do
+      emulator = TestUtils.create_test_emulator()
+      emulator = %{emulator | scrollback_limit: 2}
+
+      emulator =
+        Enum.reduce(0..4, emulator, fn i, acc ->
+          acc
+          |> ScrollOperations.write_string(0, 0, "r#{i}", %{})
+          |> ScrollOperations.scroll_up(1)
+        end)
+
+      scrollback = Raxol.Terminal.Emulator.get_scrollback(emulator)
+      assert length(scrollback) == 2
+      assert Enum.map(scrollback, &scrollback_row_text/1) == ["r3", "r4"]
+    end
+  end
+
   describe "scroll_down/2" do
     test "scrolls down within scroll region" do
       emulator = TestUtils.create_test_emulator()

--- a/packages/raxol_terminal/test/raxol/terminal/screen_buffer_adapter_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/screen_buffer_adapter_test.exs
@@ -1,0 +1,13 @@
+defmodule Raxol.Terminal.ScreenBufferAdapterTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.ScreenBufferAdapter
+
+  test "scroll_region_up/4 keeps its buffer-only contract (ScrollOps.scroll_up/4 returns {buffer, evictions} since TE)" do
+    buffer = ScreenBufferAdapter.new(10, 5)
+    result = ScreenBufferAdapter.scroll_region_up(buffer, 0, 4, 1)
+
+    refute is_tuple(result)
+    assert result.height == 5
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/scrollback_feed_byte_stream_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/scrollback_feed_byte_stream_test.exs
@@ -1,0 +1,99 @@
+defmodule Raxol.Terminal.ScrollbackFeedByteStreamTest do
+  @moduledoc """
+  Byte-stream ground truth for the TE scrollback feed (harness-ui roadmap
+  unit TE, amend): drives `Raxol.Terminal.Emulator.process_input/2` with
+  raw bytes -- DECSTBM via `\\e[...r`, printable text, CR/LF -- and asserts
+  on `emulator.scrollback_buffer`, the store
+  `Raxol.Harness.Test.SealOracle.history/2` reads (via
+  `Emulator.get_scrollback/1`). This is the oracle's ground truth for
+  T2b's immutable-prefix property: it must exercise BYTES, not function
+  calls, because the live write path (ControlCodes.handle_lf at the bottom
+  margin, Emulator.maybe_scroll on deferred-wrap overflow) is what a real
+  session goes through.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.Emulator
+
+  defp row_text(row) do
+    row
+    |> Enum.map_join("", fn
+      %{char: char} when is_binary(char) -> char
+      _ -> " "
+    end)
+    |> String.trim_trailing()
+  end
+
+  defp scrollback_texts(emulator) do
+    emulator |> Emulator.get_scrollback() |> Enum.map(&row_text/1)
+  end
+
+  defp grid_texts(emulator) do
+    emulator
+    |> Emulator.get_screen_buffer()
+    |> Map.fetch!(:cells)
+    |> Enum.map(&row_text/1)
+  end
+
+  test "DECSTBM 1..H-N region: print + LF past the region bottom feeds emulator.scrollback_buffer oldest-first" do
+    emulator = Emulator.new(10, 5)
+
+    # Region = wire rows 1..3 (internal 0..2, top-anchored), rows 4..5
+    # stand in for the harness footer.
+    {emulator, _} = Emulator.process_input(emulator, "\e[1;3r")
+    {emulator, _} = Emulator.process_input(emulator, "\e[1;1H")
+
+    stream = Enum.map_join(0..4, "", fn i -> "r#{i}\r\n" end)
+    {emulator, _} = Emulator.process_input(emulator, stream)
+
+    # 5 lines through a 3-row region: r0, r1, r2 evicted (in that order),
+    # r3/r4 still on screen, footer rows untouched.
+    assert scrollback_texts(emulator) == ["r0", "r1", "r2"]
+    assert grid_texts(emulator) == ["r3", "r4", "", "", ""]
+  end
+
+  test "full-screen byte stream (no DECSTBM): overflow feeds scrollback oldest-first" do
+    emulator = Emulator.new(10, 5)
+
+    stream = Enum.map_join(0..6, "", fn i -> "l#{i}\r\n" end)
+    {emulator, _} = Emulator.process_input(emulator, stream)
+
+    assert scrollback_texts(emulator) == ["l0", "l1", "l2"]
+    assert grid_texts(emulator) == ["l3", "l4", "l5", "l6", ""]
+  end
+
+  test "interior DECSTBM region: byte-stream scroll discards evictions -- scrollback stays empty" do
+    emulator = Emulator.new(10, 5)
+
+    # Region = wire rows 3..4 (internal 2..3) -- NOT top-anchored.
+    {emulator, _} = Emulator.process_input(emulator, "\e[3;4r")
+    {emulator, _} = Emulator.process_input(emulator, "\e[3;1H")
+
+    stream = Enum.map_join(0..3, "", fn i -> "i#{i}\r\n" end)
+    {emulator, _} = Emulator.process_input(emulator, stream)
+
+    assert Emulator.get_scrollback(emulator) == []
+  end
+
+  test "alternate screen byte stream never feeds scrollback" do
+    emulator = Emulator.new(10, 5)
+    emulator = %{emulator | active_buffer_type: :alternate}
+
+    stream = Enum.map_join(0..6, "", fn i -> "a#{i}\r\n" end)
+    {emulator, _} = Emulator.process_input(emulator, stream)
+
+    assert Emulator.get_scrollback(emulator) == []
+  end
+
+  test "byte-stream scroll respects scrollback_limit, trimming oldest first" do
+    emulator = Emulator.new(10, 5)
+    emulator = %{emulator | scrollback_limit: 2}
+
+    stream = Enum.map_join(0..8, "", fn i -> "s#{i}\r\n" end)
+    {emulator, _} = Emulator.process_input(emulator, stream)
+
+    # 9 lines through 5 rows evict s0..s4; limit 2 keeps the newest two.
+    assert scrollback_texts(emulator) == ["s3", "s4"]
+  end
+end


### PR DESCRIPTION
Unit **TE** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): emulator scrollback-feed — promoted from optional when TB's spike empirically pinned that no scroll path fed evicted rows into the scrollback buffer, blocking the renderer suite's flagship immutable-prefix property.

## What
- **Eviction rules** (one shared helper, `feed_scrollback_from_region_scroll/3`): scroll region with top == row 1 (incl. full-screen) feeds evicted rows into `emulator.scrollback_buffer` **oldest-first**, respecting `scrollback_limit` (front-trim); interior regions discard (xterm behavior); the alternate screen never feeds. `emulator.scrollback_buffer` is declared the authoritative transcript store (what `get_scrollback/1` and the TB oracle read). The partial top-anchored feed is honestly documented as the harness print-above model per T0's design — real-terminal behavior is what Ring B measures.
- **Four foundational coordinate-order bugs fixed** (found because the byte-stream test couldn't pass until the emulator's LF path actually worked): `{row, col}` tuples destructured/passed swapped meant the live byte stream **never scrolled at all** — LF's at-bottom branch never fired, CR teleported the cursor to row 0, pending-wrap wrapped to row 0, and LF drifted the column by the row number. Each fix commented at-site. `Emulator.maybe_scroll/1` (previously a stub) made real; LF now preserves the column with LNM off (correct VT100 — two tests that had codified the accidental column reset updated with at-site justification).

## Evidence
New bytes-only test file (DECSTBM bytes + prints + LFs through `process_input`): 5/5 — region feed oldest-first, full-screen feed, interior discard, alt-screen never, limit trim. Package suite 2031/2034 (3 = the pre-existing RendererIntegrationTest baseline, stash-verified); root cross_terminal + property 350/350; compile --warnings-as-errors clean.

## Review trail
Opus adversarial review (approve-with-yellows: the initially-fixed functions weren't the live byte-stream path; the primary path fed a different store) → live-path investigation found the four coordinate bugs → re-review **approve**, with two named follow-ups (handle_ri/handle_hts carry the same swapped-destructure bug class; the dual region-store split is latent debt).

**Merge order: this PR merges BEFORE #553 (TB)** — TB's spike test is this changeset's permanent regression net (3 assertions expected-red until this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
