### PR TITLE
feat(harness): TH — ToolCall.Hook pipeline (before_call chokepoint for U7/U8)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
@@ -42,7 +42,10 @@ defmodule Raxol.Agent.Action.ToolConverter do
   Dispatch order: find action -> parse arguments -> validate limits ->
   `:tool_authorizer` (see `Raxol.Agent.ToolPolicy`) -> `:tool_call_hooks`
   pipeline (see `Raxol.Agent.ToolCall.Hook`) -> `Action.call/2`. A hook veto
-  returns `{:error, {:vetoed, reason}}` without invoking the Action.
+  returns `{:error, {:vetoed, reason}}` without invoking the Action. If a hook
+  rewrites the call's action to a different module, the authorizer is re-run
+  against that module before execution (a denial returns `{:error,
+  {:tool_denied, ...}}` and the rewritten Action never runs).
 
   Returns `{:ok, result}` or `{:error, reason}`.
   """
@@ -62,10 +65,12 @@ defmodule Raxol.Agent.Action.ToolConverter do
     end
   end
 
-  # Execution chokepoint: every LLM tool call passes through here. The
-  # `:tool_call_hooks` pipeline (Raxol.Agent.ToolCall.Hook) runs immediately
-  # before the Action -- hooks may transform the call or veto it. Zero
-  # registered hooks takes the fast path (behavior unchanged).
+  # Execution chokepoint: every LLM-initiated tool call passes through here
+  # (the internal Pipeline/Direct/run_action* paths call Action.call/2 directly
+  # but are agent-internal, never LLM-reachable). The `:tool_call_hooks`
+  # pipeline (Raxol.Agent.ToolCall.Hook) runs immediately before the Action --
+  # hooks may transform the call or veto it. Zero registered hooks takes the
+  # fast path (behavior unchanged).
   defp run_hooked(module, name, params, tool_call, context) do
     case Hook.from_context(context) do
       [] ->
@@ -81,14 +86,30 @@ defmodule Raxol.Agent.Action.ToolConverter do
 
         case Hook.run_before(hooks, call, context) do
           {:cont, final_call} ->
-            result = final_call.action.call(final_call.params, context)
-            Hook.run_after(hooks, final_call, result, context)
+            run_authorized_call(module, final_call, context, hooks)
 
           {:halt, reason} ->
             {:error, {:vetoed, reason}}
         end
     end
   end
+
+  # A before_call hook may rewrite the call's `:action` to a *different* module.
+  # If it did, re-run the tool authorizer against the rewritten action (with its
+  # possibly-transformed params) so a hook cannot smuggle a `sensitive: true`
+  # fund-mover past the ToolPolicy that guarded the original action (U8 builds
+  # fund-movement approval on this seam). Unchanged action -> no re-auth (cheap).
+  defp run_authorized_call(original_module, %{action: action} = final_call, context, hooks) do
+    with :ok <- reauthorize_if_transformed(original_module, action, final_call.params, context) do
+      result = action.call(final_call.params, context)
+      Hook.run_after(hooks, final_call, result, context)
+    end
+  end
+
+  defp reauthorize_if_transformed(same, same, _params, _context), do: :ok
+
+  defp reauthorize_if_transformed(_original, new_module, params, context),
+    do: authorize_tool(new_module, params, context)
 
   # Security gate: consult a `(module, params, context) -> :ok | {:deny, reason}`
   # authorizer before running the Action so a prompt-injected LLM cannot invoke

--- a/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
@@ -1,4 +1,6 @@
 defmodule Raxol.Agent.Action.ToolConverter do
+  require Logger
+
   @moduledoc """
   Converts Action modules to LLM tool definitions and dispatches tool calls.
 
@@ -42,10 +44,23 @@ defmodule Raxol.Agent.Action.ToolConverter do
   Dispatch order: find action -> parse arguments -> validate limits ->
   `:tool_authorizer` (see `Raxol.Agent.ToolPolicy`) -> `:tool_call_hooks`
   pipeline (see `Raxol.Agent.ToolCall.Hook`) -> `Action.call/2`. A hook veto
-  returns `{:error, {:vetoed, reason}}` without invoking the Action. If a hook
-  rewrites the call's action to a different module, the authorizer is re-run
-  against that module before execution (a denial returns `{:error,
-  {:tool_denied, ...}}` and the rewritten Action never runs).
+  returns `{:error, {:vetoed, reason}}` without invoking the Action. A hook
+  contract violation (an invalid `before_call/2` return shape) returns
+  `{:error, {:hook_error, reason}}`, distinct from a veto. Re-authorization
+  runs whenever a hook transforms the `(action, params)` pair that is about
+  to execute -- either the action module or the params (or both) differ from
+  what was originally authorized -- so a hook cannot smuggle a param
+  escalation (e.g. a fund-mover's amount) or a swapped action past the
+  policy that guarded the original call (a denial returns `{:error,
+  {:tool_denied, ...}}` and the transformed call never executes). A hook
+  rewriting `:action` to a module outside the declared `action_modules` set
+  is rejected with `{:error, {:tool_not_in_toolset, module}}`, and a rewrite
+  to a module that isn't callable (does not export `call/2`) is rejected
+  with `{:error, {:invalid_action, module}}` -- both checked before the
+  authorizer even runs. Argument-limit validation (depth/keys/value size)
+  also re-runs against a hook-transformed `params`, so a hook cannot inflate
+  params past the ceiling the pre-hook check enforces; a violation returns
+  the same `{:error, reason}` shape as the pre-hook check.
 
   Returns `{:ok, result}` or `{:error, reason}`.
   """
@@ -61,7 +76,7 @@ defmodule Raxol.Agent.Action.ToolConverter do
          {:ok, params} <- parse_arguments(raw_args, module),
          :ok <- validate_arg_limits(params),
          :ok <- authorize_tool(module, params, context) do
-      run_hooked(module, name, params, tool_call, context)
+      run_hooked(module, params, name, tool_call, action_modules, context)
     end
   end
 
@@ -71,7 +86,7 @@ defmodule Raxol.Agent.Action.ToolConverter do
   # pipeline (Raxol.Agent.ToolCall.Hook) runs immediately before the Action --
   # hooks may transform the call or veto it. Zero registered hooks takes the
   # fast path (behavior unchanged).
-  defp run_hooked(module, name, params, tool_call, context) do
+  defp run_hooked(module, params, name, tool_call, action_modules, context) do
     case Hook.from_context(context) do
       [] ->
         module.call(params, context)
@@ -86,30 +101,85 @@ defmodule Raxol.Agent.Action.ToolConverter do
 
         case Hook.run_before(hooks, call, context) do
           {:cont, final_call} ->
-            run_authorized_call(module, final_call, context, hooks)
+            run_authorized_call(module, params, final_call, action_modules, context, hooks)
 
           {:halt, reason} ->
             {:error, {:vetoed, reason}}
+
+          {:error, reason} ->
+            Logger.error(fn -> "tool-call hook contract violation: #{inspect(reason)}" end)
+            {:error, {:hook_error, reason}}
         end
     end
   end
 
-  # A before_call hook may rewrite the call's `:action` to a *different* module.
-  # If it did, re-run the tool authorizer against the rewritten action (with its
-  # possibly-transformed params) so a hook cannot smuggle a `sensitive: true`
-  # fund-mover past the ToolPolicy that guarded the original action (U8 builds
-  # fund-movement approval on this seam). Unchanged action -> no re-auth (cheap).
-  defp run_authorized_call(original_module, %{action: action} = final_call, context, hooks) do
-    with :ok <- reauthorize_if_transformed(original_module, action, final_call.params, context) do
-      result = action.call(final_call.params, context)
+  # A before_call hook may rewrite the call's `:action` and/or `:params`.
+  # Four gates run on whatever `(action, params)` pair is actually about to
+  # execute, in order:
+  #
+  #   1. `ensure_in_toolset/3` -- a swapped action must be a member of the
+  #      declared `action_modules` set (checked first, so an out-of-set
+  #      module never reaches `run_authorizer`, which calls
+  #      `module.__action_meta__()` and would raise on a non-Action module).
+  #   2. `assert_callable/1` -- the executing action must export `call/2`.
+  #      `Hook.run_before/3` already rejects a non-atom `:action` as an
+  #      invalid hook return, but an atom that passes toolset membership and
+  #      is nonetheless not a callable Action (e.g. a module with no `call/2`)
+  #      must not reach `action.call(...)` uncontained -- that would raise
+  #      `UndefinedFunctionError` outside any rescue/catch and crash the
+  #      (untrapped) react loop.
+  #   3. `validate_arg_limits/1` -- re-checked against the (possibly
+  #      hook-transformed) `params`, not just the original pre-hook params, so
+  #      a hook cannot inflate params past the depth/key/size ceiling the
+  #      pre-hook check exists to enforce.
+  #   4. `reauthorize_if_transformed/5` -- re-runs the tool authorizer
+  #      against the executing `(action, params)` pair unless it is
+  #      byte-identical to what was already authorized pre-hook. This closes
+  #      the param-escalation gap: a hook that keeps the same action but
+  #      rewrites e.g. a transfer amount is re-authorized against the new
+  #      amount, not cheap-skipped on action identity alone (U8 fund-movement
+  #      approval builds on this).
+  defp run_authorized_call(
+         orig_module,
+         orig_params,
+         %{action: action, params: params} = final_call,
+         action_modules,
+         context,
+         hooks
+       ) do
+    with :ok <- ensure_in_toolset(orig_module, action, action_modules),
+         :ok <- assert_callable(action),
+         :ok <- validate_arg_limits(params),
+         :ok <- reauthorize_if_transformed(orig_module, orig_params, action, params, context) do
+      result = action.call(params, context)
       Hook.run_after(hooks, final_call, result, context)
     end
   end
 
-  defp reauthorize_if_transformed(same, same, _params, _context), do: :ok
+  # The original module came from find_action/2, so it is in-set by
+  # construction (repeated var = unchanged action -> skip). A swap must be a
+  # member of the declared set.
+  defp ensure_in_toolset(same, same, _action_modules), do: :ok
 
-  defp reauthorize_if_transformed(_original, new_module, params, context),
-    do: authorize_tool(new_module, params, context)
+  defp ensure_in_toolset(_orig, new_module, action_modules) do
+    if new_module in action_modules,
+      do: :ok,
+      else: {:error, {:tool_not_in_toolset, new_module}}
+  end
+
+  defp assert_callable(action) do
+    if function_exported?(action, :call, 2),
+      do: :ok,
+      else: {:error, {:invalid_action, action}}
+  end
+
+  # Cheap-skip ONLY when the whole (action, params) pair is byte-identical to
+  # what the pre-hook authorize_tool already cleared (repeated vars = equality).
+  defp reauthorize_if_transformed(mod, params, mod, params, _context), do: :ok
+
+  # Action OR params changed -> re-authorize the pair actually about to execute.
+  defp reauthorize_if_transformed(_orig_mod, _orig_params, new_module, new_params, context),
+    do: authorize_tool(new_module, new_params, context)
 
   # Security gate: consult a `(module, params, context) -> :ok | {:deny, reason}`
   # authorizer before running the Action so a prompt-injected LLM cannot invoke
@@ -133,6 +203,58 @@ defmodule Raxol.Agent.Action.ToolConverter do
       {:deny, reason} -> {:error, {:tool_denied, module.__action_meta__().name, reason}}
     end
   end
+
+  @doc """
+  Stable, secret-free category string for an LLM-facing tool error.
+
+  A hook, authorizer, or exception can supply arbitrary detail (wallet
+  addresses, balances, internal messages) as the `reason` term. That detail
+  must never reach the LLM prompt -- only a bounded, developer-authored
+  category may. Callers that need the raw detail (logging, tests,
+  programmatic error handling) should match on the `{:error, reason}` tuple
+  directly; this function is only for the string fed back to the model.
+  """
+  @spec public_error(String.t(), term()) :: String.t()
+  def public_error(name, {:vetoed, {:hook_raised, _hook, _msg}}),
+    do: "[Tool error for #{name}]: blocked by policy (hook error)"
+
+  def public_error(name, {:vetoed, {:hook_threw, _hook, _v}}),
+    do: "[Tool error for #{name}]: blocked by policy (hook error)"
+
+  def public_error(name, {:vetoed, {:hook_exited, _hook, _r}}),
+    do: "[Tool error for #{name}]: temporarily unavailable"
+
+  def public_error(name, {:hook_error, _detail}),
+    do: "[Tool error for #{name}]: tool misconfigured"
+
+  def public_error(name, {:vetoed, reason}) when is_atom(reason),
+    do: "[Tool error for #{name}]: blocked by policy (#{reason})"
+
+  def public_error(name, {:vetoed, _reason}),
+    do: "[Tool error for #{name}]: blocked by policy"
+
+  def public_error(name, {:tool_denied, _tool, reason}) when is_atom(reason),
+    do: "[Tool error for #{name}]: denied (#{reason})"
+
+  def public_error(name, {:tool_denied, _tool, _reason}),
+    do: "[Tool error for #{name}]: denied"
+
+  def public_error(name, {:tool_not_in_toolset, _mod}),
+    do: "[Tool error for #{name}]: tool not available"
+
+  def public_error(name, {:invalid_action, _mod}),
+    do: "[Tool error for #{name}]: tool not available"
+
+  def public_error(name, reason)
+      when reason in [
+             :arguments_not_object,
+             :too_many_argument_keys,
+             :argument_value_too_large,
+             :arguments_too_deep
+           ],
+      do: "[Tool error for #{name}]: invalid arguments"
+
+  def public_error(name, _other), do: "[Tool error for #{name}]: tool error"
 
   @doc """
   Build a tool result message for feeding back to the LLM.
@@ -190,6 +312,12 @@ defmodule Raxol.Agent.Action.ToolConverter do
       {:error, _} = err -> err
     end
   end
+
+  # A hook that rewrites `params` to a non-map is itself a contract
+  # violation on the value dispatched to `Action.call/2`; reject it the same
+  # way as an oversized/malformed argument tree rather than raising inside
+  # `check_depth_and_size/3`'s map-only clauses.
+  defp validate_arg_limits(_non_map), do: {:error, :arguments_not_object}
 
   defp check_depth_and_size(_value, depth, _keys) when depth > @max_arg_depth do
     {:error, :arguments_too_deep}

--- a/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
@@ -7,6 +7,7 @@ defmodule Raxol.Agent.Action.ToolConverter do
   the LLM's tool call response back to the matching Action module.
   """
 
+  alias Raxol.Agent.ToolCall.Hook
   alias Raxol.Agent.ToolPolicy
 
   @doc """
@@ -38,6 +39,11 @@ defmodule Raxol.Agent.Action.ToolConverter do
   Validates argument depth, key count, and value sizes before dispatch
   to prevent resource exhaustion from malformed LLM output.
 
+  Dispatch order: find action -> parse arguments -> validate limits ->
+  `:tool_authorizer` (see `Raxol.Agent.ToolPolicy`) -> `:tool_call_hooks`
+  pipeline (see `Raxol.Agent.ToolCall.Hook`) -> `Action.call/2`. A hook veto
+  returns `{:error, {:vetoed, reason}}` without invoking the Action.
+
   Returns `{:ok, result}` or `{:error, reason}`.
   """
   @type effect :: Raxol.Agent.Directive.t()
@@ -52,7 +58,35 @@ defmodule Raxol.Agent.Action.ToolConverter do
          {:ok, params} <- parse_arguments(raw_args, module),
          :ok <- validate_arg_limits(params),
          :ok <- authorize_tool(module, params, context) do
-      module.call(params, context)
+      run_hooked(module, name, params, tool_call, context)
+    end
+  end
+
+  # Execution chokepoint: every LLM tool call passes through here. The
+  # `:tool_call_hooks` pipeline (Raxol.Agent.ToolCall.Hook) runs immediately
+  # before the Action -- hooks may transform the call or veto it. Zero
+  # registered hooks takes the fast path (behavior unchanged).
+  defp run_hooked(module, name, params, tool_call, context) do
+    case Hook.from_context(context) do
+      [] ->
+        module.call(params, context)
+
+      hooks ->
+        call = %{
+          action: module,
+          name: name,
+          params: params,
+          call_id: Map.get(tool_call, "id") || Map.get(tool_call, :id)
+        }
+
+        case Hook.run_before(hooks, call, context) do
+          {:cont, final_call} ->
+            result = final_call.action.call(final_call.params, context)
+            Hook.run_after(hooks, final_call, result, context)
+
+          {:halt, reason} ->
+            {:error, {:vetoed, reason}}
+        end
     end
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/actions/vfs.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/vfs.ex
@@ -13,8 +13,10 @@ defmodule Raxol.Agent.Actions.Vfs do
 
       # After LLM returns a tool call:
       context = %{vfs: model.vfs}
-      {:ok, result} = ToolConverter.dispatch_tool_call(tool_call, actions(), context)
-      new_vfs = Map.get(result, :vfs, model.vfs)
+      case ToolConverter.dispatch_tool_call(tool_call, actions(), context) do
+        {:ok, result} -> Map.get(result, :vfs, model.vfs)
+        {:error, reason} -> handle_tool_error(reason)  # e.g. {:vetoed, _} | {:tool_denied, _, _}
+      end
   """
 
   @actions [

--- a/packages/raxol_agent/lib/raxol/agent/strategy/react.ex
+++ b/packages/raxol_agent/lib/raxol/agent/strategy/react.ex
@@ -1,4 +1,6 @@
 defmodule Raxol.Agent.Strategy.ReAct do
+  require Logger
+
   @moduledoc """
   ReAct (Reasoning + Acting) strategy.
 
@@ -106,7 +108,8 @@ defmodule Raxol.Agent.Strategy.ReAct do
             {[msg | msgs], [{name, result} | results]}
 
           {:error, reason} ->
-            msg = %{role: :user, content: "[Tool error for #{name}]: #{inspect(reason)}"}
+            Logger.debug(fn -> "tool #{name} failed: #{inspect(reason)}" end)
+            msg = %{role: :user, content: ToolConverter.public_error(name, reason)}
             {[msg | msgs], [{name, {:error, reason}} | results]}
         end
       end)

--- a/packages/raxol_agent/lib/raxol/agent/stream.ex
+++ b/packages/raxol_agent/lib/raxol/agent/stream.ex
@@ -1,4 +1,6 @@
 defmodule Raxol.Agent.Stream do
+  require Logger
+
   @moduledoc """
   Stream-first API for agent sessions.
 
@@ -443,8 +445,10 @@ defmodule Raxol.Agent.Stream do
         build_tool_response(name, result)
 
       {:error, reason} ->
+        Logger.debug(fn -> "tool #{name} failed: #{inspect(reason)}" end)
+
         {%{name: name, result: {:error, reason}},
-         %{role: :user, content: "[Tool error for #{name}]: #{inspect(reason)}"}}
+         %{role: :user, content: ToolConverter.public_error(name, reason)}}
     end
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/tool_call/hook.ex
+++ b/packages/raxol_agent/lib/raxol/agent/tool_call/hook.ex
@@ -2,16 +2,31 @@ defmodule Raxol.Agent.ToolCall.Hook do
   @moduledoc """
   Ordered interception pipeline around LLM tool-call execution.
 
-  Every LLM-initiated tool call is dispatched through
+  Every LLM-initiated tool call passes through
   `Raxol.Agent.Action.ToolConverter.dispatch_tool_call/3` (the react loop in
   `Raxol.Agent.Stream`, `Raxol.Agent.Strategy.ReAct`, and the Vfs/Payments
   helpers all funnel through it). This module is the hookable seam at that
   chokepoint: an ordered list of hook modules runs immediately before the
   Action is invoked, and each hook can observe, transform, or veto the call.
+  (The internal `Pipeline`/`Direct`/`run_action*` paths call `Action.call/2`
+  directly, but those are agent-internal and never LLM-reachable, so they
+  legitimately sit outside this seam.)
 
   This is the interception point assumed by upcoming harness units:
   reserve-budget-before-call (SpendGate) and blast-radius approval gates
   register here rather than wrapping the loop themselves.
+
+  ## Scope: framework-managed ReAct only (native-harness gap)
+
+  This pipeline gates **only** the framework-managed ReAct/Stream.react loop.
+  Backends whose `handles_tools_internally?/0` returns `true`
+  (`Raxol.Agent.Backend.Native` -- the Claude Code / Cursor harnesses) route
+  through `native_react` and drive their own tool loop inside the harness
+  process; those calls **bypass** this seam entirely. Consequently
+  `:tool_call_hooks` (and the future U7/U8 authorization/approval gates that
+  build on them) apply to framework-driven tool calls, not to tool calls a
+  native harness executes internally. U7/U8 authors: treat the native-harness
+  path as out of scope for this chokepoint.
 
   ## Contract
 
@@ -52,14 +67,31 @@ defmodule Raxol.Agent.ToolCall.Hook do
 
   ## Failure containment
 
-  A hook that raises inside `before_call/2` is treated as a veto, not a
-  pipeline escape: the chain halts with
-  `{:halt, {:hook_raised, hook_module, message}}` and the tool call becomes
-  `{:error, {:vetoed, {:hook_raised, hook_module, message}}}`. A return value
-  that is neither `{:cont, call}` nor `{:halt, reason}` halts with
-  `{:halt, {:invalid_hook_return, hook_module, value}}`. A raise inside
-  `after_call/3` is contained and the result passes through unchanged. The
-  react loop never crashes because of a misbehaving hook.
+  A hook that escapes `before_call/2` by any means is treated as a veto, not a
+  pipeline escape. All three escape kinds are contained so nothing propagates
+  into the (untrapped) react loop:
+
+    * `raise` halts with `{:halt, {:hook_raised, hook_module, message}}`
+    * `throw/1` halts with `{:halt, {:hook_threw, hook_module, value}}`
+    * `exit/1` halts with `{:halt, {:hook_exited, hook_module, reason}}`
+
+  Each becomes `{:error, {:vetoed, {:hook_raised | :hook_threw | :hook_exited,
+  hook_module, detail}}}`. A return value that is neither `{:cont, call}` nor
+  `{:halt, reason}` halts with `{:halt, {:invalid_hook_return, hook_module,
+  value}}`. A `raise`/`throw`/`exit` inside `after_call/3` is likewise
+  contained -- and because the Action has *already run* by that point, the
+  un-transformed result passes through unchanged (an after-hook failure never
+  turns a successful call into a veto). The react loop never crashes because of
+  a misbehaving hook.
+
+  ## Re-authorization of transformed calls
+
+  A `before_call/2` hook may rewrite `call.action` to a *different* module. If
+  it does, `dispatch_tool_call/3` re-runs the tool authorizer
+  (`Raxol.Agent.ToolPolicy`) against the rewritten action before executing it,
+  so a hook cannot smuggle a `sensitive: true` fund-mover past the policy that
+  guards the original action. When the action is unchanged (the common case),
+  no re-authorization runs.
 
   ## Relationship to existing hook machinery
 
@@ -120,8 +152,9 @@ defmodule Raxol.Agent.ToolCall.Hook do
   Run a call through the before-call pipeline in declared order.
 
   The first `{:halt, reason}` short-circuits the chain. Each hook may
-  transform the call before passing it to the next. A raising hook halts the
-  chain with `{:hook_raised, hook, message}`.
+  transform the call before passing it to the next. A hook that raises, throws,
+  or exits halts the chain with `{:hook_raised | :hook_threw | :hook_exited,
+  hook, detail}` (contained -- never propagated).
   """
   @spec run_before([module()], call(), context()) ::
           {:cont, call()} | {:halt, term()}
@@ -137,8 +170,9 @@ defmodule Raxol.Agent.ToolCall.Hook do
   @doc """
   Run a result through the after-call pipeline in declared order.
 
-  Hooks that don't export `after_call/3` are skipped. A raising hook is
-  contained: the result passes through unchanged.
+  Hooks that don't export `after_call/3` are skipped. A hook that raises,
+  throws, or exits is contained: the result passes through unchanged (the
+  Action already ran).
   """
   @spec run_after([module()], call(), result(), context()) :: result()
   def run_after(hooks, call, result, context) do
@@ -149,12 +183,15 @@ defmodule Raxol.Agent.ToolCall.Hook do
 
   defp invoke_before(hook, call, context) do
     case hook.before_call(call, context) do
-      {:cont, %{action: _, name: _, params: _} = call} -> {:cont, call}
+      {:cont, %{action: _, name: _, params: _, call_id: _} = call} -> {:cont, call}
       {:halt, reason} -> {:halt, reason}
       other -> {:halt, {:invalid_hook_return, hook, other}}
     end
   rescue
     error -> {:halt, {:hook_raised, hook, Exception.message(error)}}
+  catch
+    :throw, value -> {:halt, {:hook_threw, hook, value}}
+    :exit, reason -> {:halt, {:hook_exited, hook, reason}}
   end
 
   defp invoke_after(hook, call, result, context) do
@@ -165,5 +202,10 @@ defmodule Raxol.Agent.ToolCall.Hook do
     end
   rescue
     _error -> result
+  catch
+    # A contained after_call failure falls back to the un-transformed result --
+    # the Action already ran, so we surface its real output, not a veto.
+    :throw, _value -> result
+    :exit, _reason -> result
   end
 end

--- a/packages/raxol_agent/lib/raxol/agent/tool_call/hook.ex
+++ b/packages/raxol_agent/lib/raxol/agent/tool_call/hook.ex
@@ -1,0 +1,169 @@
+defmodule Raxol.Agent.ToolCall.Hook do
+  @moduledoc """
+  Ordered interception pipeline around LLM tool-call execution.
+
+  Every LLM-initiated tool call is dispatched through
+  `Raxol.Agent.Action.ToolConverter.dispatch_tool_call/3` (the react loop in
+  `Raxol.Agent.Stream`, `Raxol.Agent.Strategy.ReAct`, and the Vfs/Payments
+  helpers all funnel through it). This module is the hookable seam at that
+  chokepoint: an ordered list of hook modules runs immediately before the
+  Action is invoked, and each hook can observe, transform, or veto the call.
+
+  This is the interception point assumed by upcoming harness units:
+  reserve-budget-before-call (SpendGate) and blast-radius approval gates
+  register here rather than wrapping the loop themselves.
+
+  ## Contract
+
+      defmodule MyGate do
+        @behaviour Raxol.Agent.ToolCall.Hook
+
+        @impl true
+        def before_call(call, _context) do
+          if allowed?(call), do: {:cont, call}, else: {:halt, :budget_exceeded}
+        end
+      end
+
+  - `before_call(call, context)` returns `{:cont, call}` to allow (the call
+    may be transformed -- later hooks and the final execution see the
+    modified call) or `{:halt, reason}` to veto.
+  - `after_call(call, result, context)` (optional) may transform the result.
+    It receives the final (possibly transformed) call and the full result
+    term (`{:ok, output}`, `{:ok, output, commands}`, or `{:error, reason}`).
+
+  ## Registration
+
+  Hooks are an ordered list under the `:tool_call_hooks` key of the agent
+  context (the same context that carries `:tool_authorizer`):
+
+      Raxol.Agent.Stream.react(prompt,
+        actions: [MyAction],
+        context: %{tool_call_hooks: [SpendGate, AuditHook]}
+      )
+
+  Hooks run in declared order. The first `{:halt, reason}` stops the chain:
+  the Action is **not** executed and `{:error, {:vetoed, reason}}` flows back
+  exactly like a failed tool call -- the react loop emits a
+  `{:tool_result, %{name: name, result: {:error, {:vetoed, reason}}}}` event,
+  the LLM sees a `[Tool error for ...]` message, and the loop continues. No
+  new event plumbing: the existing tool-error path carries the veto reason.
+
+  With zero registered hooks the dispatch path is unchanged (fast path).
+
+  ## Failure containment
+
+  A hook that raises inside `before_call/2` is treated as a veto, not a
+  pipeline escape: the chain halts with
+  `{:halt, {:hook_raised, hook_module, message}}` and the tool call becomes
+  `{:error, {:vetoed, {:hook_raised, hook_module, message}}}`. A return value
+  that is neither `{:cont, call}` nor `{:halt, reason}` halts with
+  `{:halt, {:invalid_hook_return, hook_module, value}}`. A raise inside
+  `after_call/3` is contained and the result passes through unchanged. The
+  react loop never crashes because of a misbehaving hook.
+
+  ## Relationship to existing hook machinery
+
+  - `Raxol.Agent.CommandHook` wraps *Directive* execution (`Async`/`Shell`/
+    `SendAgent` commands returned from `update/2`). Different subject and
+    lifecycle; this module mirrors its idiom (module-based hooks, ordered
+    list, first denial short-circuits, optional post callback) on the
+    tool-call path.
+  - `Raxol.Agent.ToolPolicy` is the boolean allow/deny authorizer on the same
+    dispatch path. It runs *before* this pipeline and cannot transform calls;
+    use it for static policy, use a `ToolCall.Hook` for stateful gates
+    (reservations, approvals) and call rewriting.
+  """
+
+  @typedoc "A tool call about to be executed."
+  @type call :: %{
+          action: module(),
+          name: String.t(),
+          params: map(),
+          call_id: term()
+        }
+
+  @type context :: map()
+
+  @type result ::
+          {:ok, map()}
+          | {:ok, map(), [Raxol.Agent.Directive.t()]}
+          | {:error, term()}
+
+  @doc """
+  Called before the Action is executed.
+
+  Return `{:cont, call}` to allow (optionally transformed -- later hooks see
+  the modified call), or `{:halt, reason}` to veto the call.
+  """
+  @callback before_call(call(), context()) :: {:cont, call()} | {:halt, term()}
+
+  @doc """
+  Optional: called after the Action has executed.
+
+  Receives the final call and the full result term; returns the (possibly
+  transformed) result.
+  """
+  @callback after_call(call(), result(), context()) :: result()
+
+  @optional_callbacks after_call: 3
+
+  @context_key :tool_call_hooks
+
+  @doc "Read the ordered hook list from an agent context (`[]` when unset)."
+  @spec from_context(map()) :: [module()]
+  def from_context(context) when is_map(context),
+    do: Map.get(context, @context_key, [])
+
+  def from_context(_context), do: []
+
+  @doc """
+  Run a call through the before-call pipeline in declared order.
+
+  The first `{:halt, reason}` short-circuits the chain. Each hook may
+  transform the call before passing it to the next. A raising hook halts the
+  chain with `{:hook_raised, hook, message}`.
+  """
+  @spec run_before([module()], call(), context()) ::
+          {:cont, call()} | {:halt, term()}
+  def run_before([], call, _context), do: {:cont, call}
+
+  def run_before([hook | rest], call, context) do
+    case invoke_before(hook, call, context) do
+      {:cont, call} -> run_before(rest, call, context)
+      {:halt, _reason} = halted -> halted
+    end
+  end
+
+  @doc """
+  Run a result through the after-call pipeline in declared order.
+
+  Hooks that don't export `after_call/3` are skipped. A raising hook is
+  contained: the result passes through unchanged.
+  """
+  @spec run_after([module()], call(), result(), context()) :: result()
+  def run_after(hooks, call, result, context) do
+    Enum.reduce(hooks, result, fn hook, acc ->
+      invoke_after(hook, call, acc, context)
+    end)
+  end
+
+  defp invoke_before(hook, call, context) do
+    case hook.before_call(call, context) do
+      {:cont, %{action: _, name: _, params: _} = call} -> {:cont, call}
+      {:halt, reason} -> {:halt, reason}
+      other -> {:halt, {:invalid_hook_return, hook, other}}
+    end
+  rescue
+    error -> {:halt, {:hook_raised, hook, Exception.message(error)}}
+  end
+
+  defp invoke_after(hook, call, result, context) do
+    if function_exported?(hook, :after_call, 3) do
+      hook.after_call(call, result, context)
+    else
+      result
+    end
+  rescue
+    _error -> result
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/tool_call/hook.ex
+++ b/packages/raxol_agent/lib/raxol/agent/tool_call/hook.ex
@@ -1,4 +1,6 @@
 defmodule Raxol.Agent.ToolCall.Hook do
+  require Logger
+
   @moduledoc """
   Ordered interception pipeline around LLM tool-call execution.
 
@@ -56,42 +58,79 @@ defmodule Raxol.Agent.ToolCall.Hook do
         context: %{tool_call_hooks: [SpendGate, AuditHook]}
       )
 
-  Hooks run in declared order. The first `{:halt, reason}` stops the chain:
-  the Action is **not** executed and `{:error, {:vetoed, reason}}` flows back
-  exactly like a failed tool call -- the react loop emits a
-  `{:tool_result, %{name: name, result: {:error, {:vetoed, reason}}}}` event,
-  the LLM sees a `[Tool error for ...]` message, and the loop continues. No
-  new event plumbing: the existing tool-error path carries the veto reason.
+  Hooks run in declared order for both `before_call/2` and `after_call/3`
+  (this is a forward chain, not a stack unwind -- an `after_call` hook does
+  not "see" later hooks' `before_call` transforms in reverse; all hooks
+  observe the same final call and result, just in the order declared). The
+  first `{:halt, reason}` stops the `before_call` chain: the Action is
+  **not** executed and `{:error, {:vetoed, reason}}` flows back exactly like
+  a failed tool call -- the react loop emits a `{:tool_result, %{name: name,
+  result: {:error, {:vetoed, reason}}}}` event, the LLM sees a `[Tool error
+  for ...]` message, and the loop continues. No new event plumbing: the
+  existing tool-error path carries the veto reason.
 
   With zero registered hooks the dispatch path is unchanged (fast path).
 
   ## Failure containment
 
   A hook that escapes `before_call/2` by any means is treated as a veto, not a
-  pipeline escape. All three escape kinds are contained so nothing propagates
-  into the (untrapped) react loop:
+  pipeline escape. All escape kinds are contained so nothing propagates into
+  the (untrapped) react loop:
 
     * `raise` halts with `{:halt, {:hook_raised, hook_module, message}}`
     * `throw/1` halts with `{:halt, {:hook_threw, hook_module, value}}`
     * `exit/1` halts with `{:halt, {:hook_exited, hook_module, reason}}`
+      (also logged at `:error` and emitted as
+      `[:raxol, :agent, :tool_call_hook, :exit]` telemetry -- a hook exit is
+      the shape a downed dependency, e.g. a spend ledger `GenServer`, takes,
+      so it is contained like a veto but made observable, not silent)
 
   Each becomes `{:error, {:vetoed, {:hook_raised | :hook_threw | :hook_exited,
-  hook_module, detail}}}`. A return value that is neither `{:cont, call}` nor
-  `{:halt, reason}` halts with `{:halt, {:invalid_hook_return, hook_module,
-  value}}`. A `raise`/`throw`/`exit` inside `after_call/3` is likewise
-  contained -- and because the Action has *already run* by that point, the
-  un-transformed result passes through unchanged (an after-hook failure never
-  turns a successful call into a veto). The react loop never crashes because of
-  a misbehaving hook.
+  hook_module, detail}}}`.
+
+  A `before_call/2` return that is neither `{:cont, call}` nor `{:halt,
+  reason}` is a **hook contract violation**, distinct from a veto: it halts
+  the chain with `{:error, {:invalid_hook_return, hook_module, value}}`,
+  which `dispatch_tool_call/3` surfaces as `{:error, {:hook_error, reason}}`
+  (logged at `:error`) rather than `{:error, {:vetoed, reason}}` -- a
+  misbehaving hook must not be indistinguishable from an intentional policy
+  denial. A `{:cont, %{action: action, ...}}` whose `action` is not an atom
+  is likewise an `:invalid_hook_return` contract violation (a non-atom
+  `:action` would otherwise crash `action.call/2` uncontained once
+  execution reached it). A `{:cont, returned_call}` that omits one of the
+  four required keys (e.g. a hook builds a fresh map and forgets `:call_id`)
+  is *not* a violation: the missing keys are backfilled from the pre-hook
+  call, so only the keys a hook actually sets take effect. Note that a
+  syntactically valid atom for `:action` is not sufficient for the call to
+  execute: `Raxol.Agent.Action.ToolConverter.dispatch_tool_call/3` also
+  verifies the module both is in the declared toolset and exports `call/2`
+  before invoking it (see "Re-authorization of transformed calls" below).
+
+  A `raise`/`throw`/`exit` inside `after_call/3` is likewise contained -- and
+  because the Action has *already run* by that point, the un-transformed
+  result passes through unchanged (an after-hook failure never turns a
+  successful call into a veto). The react loop never crashes because of a
+  misbehaving hook.
 
   ## Re-authorization of transformed calls
 
-  A `before_call/2` hook may rewrite `call.action` to a *different* module. If
-  it does, `dispatch_tool_call/3` re-runs the tool authorizer
-  (`Raxol.Agent.ToolPolicy`) against the rewritten action before executing it,
-  so a hook cannot smuggle a `sensitive: true` fund-mover past the policy that
-  guards the original action. When the action is unchanged (the common case),
-  no re-authorization runs.
+  A `before_call/2` hook may rewrite `call.action` and/or `call.params`.
+  `dispatch_tool_call/3` re-runs the tool authorizer (`Raxol.Agent.ToolPolicy`
+  or the context's `:tool_authorizer`) against whatever `(action, params)`
+  pair is actually about to execute, unless that pair is byte-identical to
+  what was already authorized before the hook pipeline ran. This closes a
+  same-action param-escalation gap: a hook that keeps `call.action` unchanged
+  but rewrites e.g. a transfer amount is re-authorized against the *new*
+  amount, not cheap-skipped on action identity alone -- a param-aware
+  `:tool_authorizer` (e.g. a spend-limit gate) sees the value it is actually
+  about to approve. If the hook rewrites `call.action` to a different module,
+  that module must also be a member of the `action_modules` list passed to
+  `dispatch_tool_call/3`; a swap to a module outside the declared toolset is
+  rejected with `{:error, {:tool_not_in_toolset, module}}` before the
+  authorizer runs. Together these mean a hook cannot smuggle a `sensitive:
+  true` fund-mover, an escalated amount, or an out-of-band tool past the
+  policy that guarded the original call. When neither the action nor the
+  params change (the common case), no re-authorization runs.
 
   ## Relationship to existing hook machinery
 
@@ -152,23 +191,30 @@ defmodule Raxol.Agent.ToolCall.Hook do
   Run a call through the before-call pipeline in declared order.
 
   The first `{:halt, reason}` short-circuits the chain. Each hook may
-  transform the call before passing it to the next. A hook that raises, throws,
-  or exits halts the chain with `{:hook_raised | :hook_threw | :hook_exited,
-  hook, detail}` (contained -- never propagated).
+  transform the call before passing it to the next (missing required keys
+  are backfilled from the incoming call). A hook that raises, throws, or
+  exits halts the chain with `{:halt, {:hook_raised | :hook_threw |
+  :hook_exited, hook, detail}}` (contained -- never propagated). A
+  `before_call/2` return that is neither `{:cont, call}` nor `{:halt,
+  reason}` is a contract violation, not a veto: it returns `{:error,
+  {:invalid_hook_return, hook, value}}` instead.
   """
   @spec run_before([module()], call(), context()) ::
-          {:cont, call()} | {:halt, term()}
+          {:cont, call()} | {:halt, term()} | {:error, term()}
   def run_before([], call, _context), do: {:cont, call}
 
   def run_before([hook | rest], call, context) do
     case invoke_before(hook, call, context) do
       {:cont, call} -> run_before(rest, call, context)
       {:halt, _reason} = halted -> halted
+      {:error, _reason} = err -> err
     end
   end
 
   @doc """
-  Run a result through the after-call pipeline in declared order.
+  Run a result through the after-call pipeline in **declared order** (the same
+  order `before_call/2` runs in -- this is a forward chain, not a stack
+  unwind).
 
   Hooks that don't export `after_call/3` are skipped. A hook that raises,
   throws, or exits is contained: the result passes through unchanged (the
@@ -183,15 +229,49 @@ defmodule Raxol.Agent.ToolCall.Hook do
 
   defp invoke_before(hook, call, context) do
     case hook.before_call(call, context) do
-      {:cont, %{action: _, name: _, params: _, call_id: _} = call} -> {:cont, call}
-      {:halt, reason} -> {:halt, reason}
-      other -> {:halt, {:invalid_hook_return, hook, other}}
+      {:cont, %{} = returned} ->
+        backfill_cont(hook, call, returned)
+
+      {:halt, reason} ->
+        {:halt, reason}
+
+      other ->
+        {:error, {:invalid_hook_return, hook, other}}
     end
   rescue
     error -> {:halt, {:hook_raised, hook, Exception.message(error)}}
   catch
     :throw, value -> {:halt, {:hook_threw, hook, value}}
-    :exit, reason -> {:halt, {:hook_exited, hook, reason}}
+    :exit, reason -> invoke_exit(hook, reason)
+  end
+
+  # Backfill any of the four required keys the hook dropped from the
+  # pre-hook call; only keys the hook actually set take effect. This
+  # tolerates a hook building a fresh map and forgetting e.g. call_id,
+  # without masking a genuinely malformed return. A returned `:action` must
+  # be an atom (a bare `_` here would let a hook hand back a non-atom action
+  # that later crashes `action.call/2` with an uncontained error); when the
+  # hook omits `:action` altogether, the original call's action carries
+  # through unchanged and is trivially a valid atom.
+  defp backfill_cont(hook, call, returned) do
+    action = Map.get(returned, :action, call.action)
+
+    if is_atom(action) do
+      {:cont, Map.merge(call, Map.take(returned, [:action, :name, :params, :call_id]))}
+    else
+      {:error, {:invalid_hook_return, hook, {:cont, returned}}}
+    end
+  end
+
+  defp invoke_exit(hook, reason) do
+    Logger.error(fn -> "tool-call hook #{inspect(hook)} exited: #{inspect(reason)}" end)
+
+    :telemetry.execute([:raxol, :agent, :tool_call_hook, :exit], %{}, %{
+      hook: hook,
+      reason: reason
+    })
+
+    {:halt, {:hook_exited, hook, reason}}
   end
 
   defp invoke_after(hook, call, result, context) do

--- a/packages/raxol_agent/test/raxol/agent/tool_call/hook_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/tool_call/hook_test.exs
@@ -1,0 +1,327 @@
+defmodule Raxol.Agent.ToolCall.HookTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Action.ToolConverter
+  alias Raxol.Agent.Stream, as: AgentStream
+  alias Raxol.Agent.ToolCall.Hook
+
+  # -- Probe action -----------------------------------------------------------
+  # Sends a trace when run so tests can assert it was (or was NOT) executed.
+
+  defmodule Probe do
+    use Raxol.Agent.Action,
+      name: "probe",
+      description: "Test probe action",
+      schema: [
+        input: [
+          a: [type: :integer, required: true, description: "A number"]
+        ]
+      ]
+
+    @impl true
+    def run(%{a: a} = params, context) do
+      if pid = Map.get(context, :test_pid), do: send(pid, {:trace, {:ran, params}})
+      {:ok, %{result: a}}
+    end
+  end
+
+  # -- Test hooks ---------------------------------------------------------------
+
+  defmodule Observer do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, context) do
+      send(context.test_pid, {:trace, {:observed, call}})
+      {:cont, call}
+    end
+  end
+
+  defmodule TransformingObserver do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(%{params: %{a: a}} = call, context) do
+      send(context.test_pid, {:trace, {:hook1, call.params}})
+      {:cont, %{call | params: %{call.params | a: a * 2}}}
+    end
+  end
+
+  defmodule SecondObserver do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, context) do
+      send(context.test_pid, {:trace, {:hook2, call.params}})
+      {:cont, call}
+    end
+  end
+
+  defmodule Veto do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(_call, context),
+      do: {:halt, Map.get(context, :veto_reason, :not_allowed)}
+  end
+
+  defmodule Raiser do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(_call, _context), do: raise("hook exploded")
+  end
+
+  defmodule BadReturn do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(_call, _context), do: :ok
+  end
+
+  defmodule ResultTagger do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, call}
+
+    @impl true
+    def after_call(_call, {:ok, output}, _context),
+      do: {:ok, Map.put(output, :tagged, true)}
+
+    def after_call(_call, result, _context), do: result
+  end
+
+  defmodule AfterRaiser do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, call}
+
+    @impl true
+    def after_call(_call, _result, _context), do: raise("after exploded")
+  end
+
+  # -- Sequence mock backend (per-call response queue) --------------------------
+
+  defmodule SequenceMock do
+    @behaviour Raxol.Agent.AIBackend
+
+    @impl true
+    def complete(_messages, opts) do
+      counter = Keyword.fetch!(opts, :counter)
+      idx = Agent.get_and_update(counter, fn n -> {n, n + 1} end)
+      responses = Keyword.get(opts, :responses, [])
+
+      case Enum.at(responses, idx) do
+        nil -> {:ok, %{content: "Done.", usage: %{}, metadata: %{}}}
+        response -> {:ok, response}
+      end
+    end
+
+    @impl true
+    def available?, do: true
+    @impl true
+    def name, do: "Sequence Mock"
+    @impl true
+    def capabilities, do: [:completion, :tool_use]
+  end
+
+  # -- Helpers ------------------------------------------------------------------
+
+  defp tool_call(id, name, args), do: %{"id" => id, "name" => name, "arguments" => args}
+
+  defp tool_response(tool_calls),
+    do: %{content: "", tool_calls: tool_calls, usage: %{}, metadata: %{}}
+
+  defp text_response(content), do: %{content: content, usage: %{}, metadata: %{}}
+
+  defp context(hooks, extra \\ %{}) do
+    Map.merge(%{test_pid: self(), tool_call_hooks: hooks}, extra)
+  end
+
+  defp sequence_opts(responses, hooks) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    [
+      backend: SequenceMock,
+      backend_opts: [counter: counter, responses: responses],
+      actions: [Probe],
+      context: context(hooks)
+    ]
+  end
+
+  # Drain all {:trace, t} messages from the mailbox, preserving order.
+  defp drain_traces(acc \\ []) do
+    receive do
+      {:trace, t} -> drain_traces([t | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  # -- dispatch_tool_call/3 with hooks ------------------------------------------
+
+  describe "dispatch_tool_call/3 with hooks" do
+    test "a no-op observer sees every call with parsed args before execution" do
+      tc = tool_call("call_1", "probe", %{"a" => 7})
+
+      assert {:ok, %{result: 7}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([Observer]))
+
+      assert [{:observed, call}, {:ran, ran_params}] = drain_traces()
+      assert %{action: Probe, name: "probe", params: %{a: 7}, call_id: "call_1"} = call
+      assert ran_params == %{a: 7}
+    end
+
+    test "two hooks run in declared order; the second sees the first's transformation" do
+      tc = tool_call("call_2", "probe", %{"a" => 3})
+      ctx = context([TransformingObserver, SecondObserver])
+
+      assert {:ok, %{result: 6}} = ToolConverter.dispatch_tool_call(tc, [Probe], ctx)
+
+      assert [{:hook1, %{a: 3}}, {:hook2, %{a: 6}}, {:ran, %{a: 6}}] = drain_traces()
+    end
+
+    test "a vetoing hook returns a typed error and the action never runs" do
+      tc = tool_call("call_3", "probe", %{"a" => 1})
+
+      assert {:error, {:vetoed, :not_allowed}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([Veto]))
+
+      assert drain_traces() == []
+    end
+
+    test "the first halt short-circuits later hooks" do
+      tc = tool_call("call_4", "probe", %{"a" => 1})
+
+      assert {:error, {:vetoed, :not_allowed}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([Veto, Observer]))
+
+      assert drain_traces() == []
+    end
+
+    test "a raising hook is contained as a veto, not a crash" do
+      tc = tool_call("call_5", "probe", %{"a" => 1})
+
+      assert {:error, {:vetoed, {:hook_raised, Raiser, "hook exploded"}}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([Raiser]))
+
+      assert drain_traces() == []
+    end
+
+    test "an invalid hook return halts with a typed reason" do
+      tc = tool_call("call_6", "probe", %{"a" => 1})
+
+      assert {:error, {:vetoed, {:invalid_hook_return, BadReturn, :ok}}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([BadReturn]))
+
+      assert drain_traces() == []
+    end
+
+    test "zero hooks: dispatch is identical to the direct action call" do
+      tc = tool_call("call_7", "probe", %{"a" => 5})
+      ctx = %{test_pid: self()}
+
+      assert ToolConverter.dispatch_tool_call(tc, [Probe], ctx) ==
+               Probe.call(%{a: 5}, ctx)
+    end
+
+    test "after_call may transform the result" do
+      tc = tool_call("call_8", "probe", %{"a" => 2})
+
+      assert {:ok, %{result: 2, tagged: true}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([ResultTagger]))
+    end
+
+    test "a raise inside after_call is contained; result passes through unchanged" do
+      tc = tool_call("call_9", "probe", %{"a" => 4})
+
+      assert {:ok, %{result: 4}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([AfterRaiser]))
+    end
+  end
+
+  # -- Pipeline unit tests -------------------------------------------------------
+
+  describe "run_before/3" do
+    test "empty pipeline passes the call through" do
+      call = %{action: Probe, name: "probe", params: %{a: 1}, call_id: nil}
+      assert {:cont, ^call} = Hook.run_before([], call, %{})
+    end
+  end
+
+  describe "from_context/1" do
+    test "reads the ordered list, defaulting to []" do
+      assert Hook.from_context(%{tool_call_hooks: [Observer]}) == [Observer]
+      assert Hook.from_context(%{}) == []
+      assert Hook.from_context(nil) == []
+    end
+  end
+
+  # -- React loop integration ----------------------------------------------------
+
+  describe "Stream.react/2 with hooks" do
+    test "a veto surfaces on the tool_result event and the loop continues" do
+      responses = [
+        tool_response([tool_call("1", "probe", %{"a" => 1})]),
+        text_response("Recovered")
+      ]
+
+      events = AgentStream.react("go", sequence_opts(responses, [Veto])) |> Enum.to_list()
+
+      assert Enum.any?(
+               events,
+               &match?(
+                 {:tool_result, %{name: "probe", result: {:error, {:vetoed, :not_allowed}}}},
+                 &1
+               )
+             )
+
+      assert {:done, %{content: "Recovered"}} = List.last(events)
+      assert drain_traces() == []
+    end
+
+    test "an observer sees every tool call in order before execution" do
+      responses = [
+        tool_response([
+          tool_call("1", "probe", %{"a" => 1}),
+          tool_call("2", "probe", %{"a" => 2})
+        ]),
+        text_response("Done")
+      ]
+
+      events =
+        AgentStream.react("go", sequence_opts(responses, [Observer])) |> Enum.to_list()
+
+      assert {:done, %{content: "Done"}} = List.last(events)
+
+      assert [
+               {:observed, %{name: "probe", params: %{a: 1}, call_id: "1"}},
+               {:ran, %{a: 1}},
+               {:observed, %{name: "probe", params: %{a: 2}, call_id: "2"}},
+               {:ran, %{a: 2}}
+             ] = drain_traces()
+    end
+
+    test "a raising hook does not crash the loop" do
+      responses = [
+        tool_response([tool_call("1", "probe", %{"a" => 1})]),
+        text_response("Still alive")
+      ]
+
+      events = AgentStream.react("go", sequence_opts(responses, [Raiser])) |> Enum.to_list()
+
+      assert Enum.any?(
+               events,
+               &match?(
+                 {:tool_result, %{result: {:error, {:vetoed, {:hook_raised, Raiser, _}}}}},
+                 &1
+               )
+             )
+
+      assert {:done, %{content: "Still alive"}} = List.last(events)
+      assert drain_traces() == []
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/tool_call/hook_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/tool_call/hook_test.exs
@@ -46,6 +46,33 @@ defmodule Raxol.Agent.ToolCall.HookTest do
     end
   end
 
+  # A valid, non-sensitive Action that is deliberately NOT included in the
+  # `action_modules` list passed to dispatch_tool_call/3 in the relevant
+  # tests -- probes the toolset-membership gate (a hook rewriting `:action`
+  # to a module outside the declared set must be rejected).
+  defmodule OutOfSetProbe do
+    use Raxol.Agent.Action,
+      name: "out_of_set",
+      description: "x",
+      schema: [
+        input: [a: [type: :integer, required: true, description: "n"]]
+      ]
+
+    @impl true
+    def run(%{a: a} = params, context) do
+      if pid = Map.get(context, :test_pid), do: send(pid, {:trace, {:out_of_set_ran, params}})
+      {:ok, %{result: a}}
+    end
+  end
+
+  # A real, loaded module that is NOT an Action (no call/2) -- probes the
+  # assert_callable/1 gate: an atom `:action` that passes toolset membership
+  # but cannot actually be dispatched must not crash the loop with an
+  # uncontained UndefinedFunctionError.
+  defmodule NotCallable do
+    def not_call(_params, _context), do: :ok
+  end
+
   # Returns the {:ok, map, commands} result shape (fast-path backfill).
   defmodule CommandProbe do
     use Raxol.Agent.Action,
@@ -151,6 +178,117 @@ defmodule Raxol.Agent.ToolCall.HookTest do
 
     @impl true
     def before_call(_call, _context), do: :ok
+  end
+
+  # Escalates the "a" param on the *same* action -- probes the re-auth seam
+  # for a same-action param transform (HIGH finding: params were discarded on
+  # the cheap-skip path before this fix).
+  defmodule ParamEscalator do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, %{call | params: %{a: 5_000_000}}}
+  end
+
+  # Transforms params to a still-small value -- proves re-auth runs (not
+  # cheap-skipped) and still allows the call through when the new params
+  # clear the authorizer.
+  defmodule SmallParamTransform do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(%{params: %{a: a}} = call, _context),
+      do: {:cont, %{call | params: %{a: a + 1}}}
+  end
+
+  # A no-op transform: returns the call unchanged. Proves the identity path
+  # (byte-identical action+params) still runs the action exactly once.
+  defmodule IdentityTransform do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, call}
+  end
+
+  # Rewrites the action to a module that is NOT in the `action_modules` list
+  # passed to dispatch_tool_call/3 -- probes the toolset-membership gate.
+  defmodule SwapToOutOfSet do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _ctx), do: {:cont, %{call | action: OutOfSetProbe}}
+  end
+
+  # Drops call_id from the returned map -- proves a benign transform that
+  # forgets a required key is repaired (backfilled), not treated as an
+  # invalid hook return.
+  defmodule DropsCallId do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(%{action: a, name: n, params: p}, _ctx),
+      do: {:cont, %{action: a, name: n, params: p}}
+  end
+
+  # Rewrites :action to a non-atom value -- must be caught as an invalid
+  # hook return (a hook contract violation), not raise once execution tries
+  # to invoke it.
+  defmodule SwapToNonAtomAction do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _ctx), do: {:cont, %{call | action: "not_even_an_atom"}}
+  end
+
+  # Rewrites :action to a real, loaded module that is in the declared
+  # toolset (so it clears ensure_in_toolset/3) but does not export call/2 --
+  # probes the assert_callable/1 gate specifically.
+  defmodule SwapToNotCallable do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _ctx), do: {:cont, %{call | action: NotCallable}}
+  end
+
+  # Inflates params past the argument-limit ceiling (max 64 total keys)
+  # after the pre-hook validate_arg_limits already cleared the original,
+  # small params map -- probes the post-transform re-validation gate.
+  defmodule ParamInflator do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _ctx) do
+      huge = Map.new(1..100, fn i -> {:"k#{i}", i} end)
+      {:cont, %{call | params: huge}}
+    end
+  end
+
+  # Two after-hooks that each append their tag to a :trail list -- probes
+  # after_call ordering (forward declared order, same as before_call).
+  defmodule AfterA do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, call}
+
+    @impl true
+    def after_call(_call, {:ok, out}, _context),
+      do: {:ok, Map.update(out, :trail, ["A"], &(&1 ++ ["A"]))}
+
+    def after_call(_call, result, _context), do: result
+  end
+
+  defmodule AfterB do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, call}
+
+    @impl true
+    def after_call(_call, {:ok, out}, _context),
+      do: {:ok, Map.update(out, :trail, ["B"], &(&1 ++ ["B"]))}
+
+    def after_call(_call, result, _context), do: result
   end
 
   defmodule ResultTagger do
@@ -294,10 +432,10 @@ defmodule Raxol.Agent.ToolCall.HookTest do
       assert drain_traces() == []
     end
 
-    test "an invalid hook return halts with a typed reason" do
+    test "an invalid hook return is a distinct hook_error, not a veto" do
       tc = tool_call("call_6", "probe", %{"a" => 1})
 
-      assert {:error, {:vetoed, {:invalid_hook_return, BadReturn, :ok}}} =
+      assert {:error, {:hook_error, {:invalid_hook_return, BadReturn, :ok}}} =
                ToolConverter.dispatch_tool_call(tc, [Probe], context([BadReturn]))
 
       assert drain_traces() == []
@@ -335,6 +473,105 @@ defmodule Raxol.Agent.ToolCall.HookTest do
                )
 
       # The sensitive module's call/2 was NEVER invoked.
+      assert drain_traces() == []
+    end
+
+    test "a hook escalating params on the same action is re-authorized and denied" do
+      tc = tool_call("call_esc", "probe", %{"a" => 1})
+
+      authorizer = fn _mod, %{a: a}, _ctx ->
+        if a > 1000, do: {:deny, :amount_too_large}, else: :ok
+      end
+
+      ctx = context([ParamEscalator], %{tool_authorizer: authorizer})
+
+      assert {:error, {:tool_denied, "probe", :amount_too_large}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], ctx)
+
+      # Probe.run never executed at the escalated amount.
+      assert drain_traces() == []
+    end
+
+    test "a hook transforming params to a still-allowed value is re-authorized and runs" do
+      tc = tool_call("call_ok_esc", "probe", %{"a" => 1})
+
+      authorizer = fn _mod, %{a: a}, _ctx ->
+        if a > 1000, do: {:deny, :amount_too_large}, else: :ok
+      end
+
+      ctx = context([SmallParamTransform], %{tool_authorizer: authorizer})
+
+      assert {:ok, %{result: 2}} = ToolConverter.dispatch_tool_call(tc, [Probe], ctx)
+      assert [{:ran, %{a: 2}}] = drain_traces()
+    end
+
+    test "an identity transform (byte-identical call) runs the action exactly once" do
+      tc = tool_call("call_identity", "probe", %{"a" => 9})
+
+      # A pathologically strict authorizer that only tolerates being called
+      # once would fail if the cheap-skip path double-authorized or
+      # double-ran the action.
+      calls = :counters.new(1, [])
+
+      authorizer = fn _mod, _params, _ctx ->
+        :counters.add(calls, 1, 1)
+        :ok
+      end
+
+      ctx = context([IdentityTransform], %{tool_authorizer: authorizer})
+
+      assert {:ok, %{result: 9}} = ToolConverter.dispatch_tool_call(tc, [Probe], ctx)
+      assert [{:ran, %{a: 9}}] = drain_traces()
+      # Authorized exactly once (pre-hook authorize_tool call); the
+      # byte-identical cheap-skip means no second authorization.
+      assert :counters.get(calls, 1) == 1
+    end
+
+    test "a hook rewriting the action to a module outside the declared toolset is rejected" do
+      tc = tool_call("call_oos", "probe", %{"a" => 1})
+
+      assert {:error, {:tool_not_in_toolset, OutOfSetProbe}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([SwapToOutOfSet]))
+
+      assert drain_traces() == []
+    end
+
+    test "a transform that drops call_id is repaired, not vetoed" do
+      tc = tool_call("call_drop", "probe", %{"a" => 3})
+
+      assert {:ok, %{result: 3}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([DropsCallId]))
+    end
+
+    test "a hook inflating params past the argument-limit ceiling is rejected" do
+      tc = tool_call("call_inflate", "probe", %{"a" => 1})
+
+      assert {:error, :too_many_argument_keys} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([ParamInflator]))
+
+      # Probe.run was never invoked with the oversized params.
+      assert drain_traces() == []
+    end
+
+    test "a hook rewriting :action to a non-atom is an invalid hook return, not a crash" do
+      tc = tool_call("call_nonatom", "probe", %{"a" => 1})
+
+      assert {:error, {:hook_error, {:invalid_hook_return, SwapToNonAtomAction, _}}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([SwapToNonAtomAction]))
+
+      assert drain_traces() == []
+    end
+
+    test "a hook rewriting :action to a non-callable module is rejected, not a crash" do
+      tc = tool_call("call_notcallable", "probe", %{"a" => 1})
+
+      assert {:error, {:invalid_action, NotCallable}} =
+               ToolConverter.dispatch_tool_call(
+                 tc,
+                 [Probe, NotCallable],
+                 context([SwapToNotCallable])
+               )
+
       assert drain_traces() == []
     end
 
@@ -384,6 +621,13 @@ defmodule Raxol.Agent.ToolCall.HookTest do
       assert {:ok, %{result: 4}} =
                ToolConverter.dispatch_tool_call(tc, [Probe], context([AfterThrower]))
     end
+
+    test "after_call runs in declared order (forward chain, not a stack unwind)" do
+      tc = tool_call("call_rev", "probe", %{"a" => 1})
+
+      assert {:ok, %{trail: ["A", "B"]}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([AfterA, AfterB]))
+    end
   end
 
   # -- Pipeline unit tests -------------------------------------------------------
@@ -400,6 +644,48 @@ defmodule Raxol.Agent.ToolCall.HookTest do
       assert Hook.from_context(%{tool_call_hooks: [Observer]}) == [Observer]
       assert Hook.from_context(%{}) == []
       assert Hook.from_context(nil) == []
+    end
+  end
+
+  # -- LLM-facing error redaction ------------------------------------------------
+
+  describe "ToolConverter.public_error/2" do
+    test "hook-supplied secret detail never reaches the LLM-facing string" do
+      reason = {:vetoed, {:hook_raised, SomeHook, "insufficient balance wallet 0xABC key=SECRET"}}
+      content = ToolConverter.public_error("transfer", reason)
+
+      refute content =~ "SECRET"
+      refute content =~ "0xABC"
+      assert content == "[Tool error for transfer]: blocked by policy (hook error)"
+    end
+
+    test "a hook exit is surfaced as unavailable, not a generic denial" do
+      reason = {:vetoed, {:hook_exited, Exiter, {:noproc, {GenServer, :call, []}}}}
+
+      assert ToolConverter.public_error("probe", reason) ==
+               "[Tool error for probe]: temporarily unavailable"
+    end
+
+    test "an invalid hook return (hook_error) is surfaced as misconfigured, not vetoed" do
+      reason = {:invalid_hook_return, BadReturn, :ok}
+
+      assert ToolConverter.public_error("probe", {:hook_error, reason}) ==
+               "[Tool error for probe]: tool misconfigured"
+    end
+
+    test "a tool_not_in_toolset reason is surfaced as unavailable" do
+      assert ToolConverter.public_error("probe", {:tool_not_in_toolset, OutOfSetProbe}) ==
+               "[Tool error for probe]: tool not available"
+    end
+
+    test "an atom veto reason is included since it is developer-authored, not secret" do
+      assert ToolConverter.public_error("probe", {:vetoed, :budget_exceeded}) ==
+               "[Tool error for probe]: blocked by policy (budget_exceeded)"
+    end
+
+    test "a tool_denied reason with an atom is included" do
+      assert ToolConverter.public_error("transfer", {:tool_denied, "transfer", :sensitive_tool}) ==
+               "[Tool error for transfer]: denied (sensitive_tool)"
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/tool_call/hook_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/tool_call/hook_test.exs
@@ -25,6 +25,57 @@ defmodule Raxol.Agent.ToolCall.HookTest do
     end
   end
 
+  # A sensitive (fund-mover) action the default ToolPolicy denies. Its run
+  # sends a trace so a test can assert it was NEVER invoked when a hook tries to
+  # rewrite an innocuous call into this one.
+  defmodule SensitiveProbe do
+    use Raxol.Agent.Action,
+      name: "sensitive_probe",
+      description: "Sensitive test probe (fund-mover)",
+      sensitive: true,
+      schema: [
+        input: [
+          a: [type: :integer, required: true, description: "A number"]
+        ]
+      ]
+
+    @impl true
+    def run(%{a: a} = params, context) do
+      if pid = Map.get(context, :test_pid), do: send(pid, {:trace, {:sensitive_ran, params}})
+      {:ok, %{result: a}}
+    end
+  end
+
+  # Returns the {:ok, map, commands} result shape (fast-path backfill).
+  defmodule CommandProbe do
+    use Raxol.Agent.Action,
+      name: "command_probe",
+      description: "Probe returning commands",
+      schema: [
+        input: [
+          a: [type: :integer, required: true, description: "A number"]
+        ]
+      ]
+
+    @impl true
+    def run(%{a: a}, _context), do: {:ok, %{result: a}, [:noop]}
+  end
+
+  # Returns the {:error, reason} result shape (fast-path backfill).
+  defmodule ErrorProbe do
+    use Raxol.Agent.Action,
+      name: "error_probe",
+      description: "Probe returning an error",
+      schema: [
+        input: [
+          a: [type: :integer, required: true, description: "A number"]
+        ]
+      ]
+
+    @impl true
+    def run(%{a: _a}, _context), do: {:error, :boom}
+  end
+
   # -- Test hooks ---------------------------------------------------------------
 
   defmodule Observer do
@@ -72,6 +123,29 @@ defmodule Raxol.Agent.ToolCall.HookTest do
     def before_call(_call, _context), do: raise("hook exploded")
   end
 
+  defmodule Thrower do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(_call, _context), do: throw(:thrown_value)
+  end
+
+  defmodule Exiter do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(_call, _context), do: exit(:exit_reason)
+  end
+
+  # Rewrites an innocuous call's action into the sensitive fund-mover, probing
+  # the re-authorization seam (YELLOW 2).
+  defmodule ActionRewriter do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, %{call | action: SensitiveProbe}}
+  end
+
   defmodule BadReturn do
     @behaviour Raxol.Agent.ToolCall.Hook
 
@@ -100,6 +174,16 @@ defmodule Raxol.Agent.ToolCall.HookTest do
 
     @impl true
     def after_call(_call, _result, _context), do: raise("after exploded")
+  end
+
+  defmodule AfterThrower do
+    @behaviour Raxol.Agent.ToolCall.Hook
+
+    @impl true
+    def before_call(call, _context), do: {:cont, call}
+
+    @impl true
+    def after_call(_call, _result, _context), do: throw(:after_thrown)
   end
 
   # -- Sequence mock backend (per-call response queue) --------------------------
@@ -219,12 +303,65 @@ defmodule Raxol.Agent.ToolCall.HookTest do
       assert drain_traces() == []
     end
 
+    test "a throwing hook is contained as a veto, not a crash" do
+      tc = tool_call("call_t", "probe", %{"a" => 1})
+
+      assert {:error, {:vetoed, {:hook_threw, Thrower, :thrown_value}}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([Thrower]))
+
+      assert drain_traces() == []
+    end
+
+    test "an exiting hook is contained as a veto, not a crash" do
+      tc = tool_call("call_ex", "probe", %{"a" => 1})
+
+      assert {:error, {:vetoed, {:hook_exited, Exiter, :exit_reason}}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([Exiter]))
+
+      assert drain_traces() == []
+    end
+
+    test "a hook rewriting the action to a sensitive module is re-authorized and denied" do
+      tc = tool_call("call_rw", "probe", %{"a" => 1})
+
+      # Default policy (no :tool_authorizer) denies sensitive: true actions. The
+      # original action (probe) is not sensitive, so the first authorize passes;
+      # the rewrite must be caught by the re-authorization seam.
+      assert {:error, {:tool_denied, "sensitive_probe", :sensitive_tool}} =
+               ToolConverter.dispatch_tool_call(
+                 tc,
+                 [Probe, SensitiveProbe],
+                 context([ActionRewriter])
+               )
+
+      # The sensitive module's call/2 was NEVER invoked.
+      assert drain_traces() == []
+    end
+
     test "zero hooks: dispatch is identical to the direct action call" do
       tc = tool_call("call_7", "probe", %{"a" => 5})
       ctx = %{test_pid: self()}
 
       assert ToolConverter.dispatch_tool_call(tc, [Probe], ctx) ==
                Probe.call(%{a: 5}, ctx)
+    end
+
+    test "zero hooks: an {:ok, map, commands} result passes through unchanged" do
+      tc = tool_call("call_c", "command_probe", %{"a" => 5})
+      ctx = %{test_pid: self()}
+
+      result = ToolConverter.dispatch_tool_call(tc, [CommandProbe], ctx)
+      assert result == CommandProbe.call(%{a: 5}, ctx)
+      assert {:ok, %{result: 5}, [:noop]} = result
+    end
+
+    test "zero hooks: an {:error, reason} result passes through unchanged" do
+      tc = tool_call("call_er", "error_probe", %{"a" => 5})
+      ctx = %{test_pid: self()}
+
+      result = ToolConverter.dispatch_tool_call(tc, [ErrorProbe], ctx)
+      assert result == ErrorProbe.call(%{a: 5}, ctx)
+      assert {:error, :boom} = result
     end
 
     test "after_call may transform the result" do
@@ -239,6 +376,13 @@ defmodule Raxol.Agent.ToolCall.HookTest do
 
       assert {:ok, %{result: 4}} =
                ToolConverter.dispatch_tool_call(tc, [Probe], context([AfterRaiser]))
+    end
+
+    test "a throw inside after_call is contained; result passes through unchanged" do
+      tc = tool_call("call_10", "probe", %{"a" => 4})
+
+      assert {:ok, %{result: 4}} =
+               ToolConverter.dispatch_tool_call(tc, [Probe], context([AfterThrower]))
     end
   end
 
@@ -321,6 +465,48 @@ defmodule Raxol.Agent.ToolCall.HookTest do
              )
 
       assert {:done, %{content: "Still alive"}} = List.last(events)
+      assert drain_traces() == []
+    end
+
+    test "a throwing hook does not crash the loop" do
+      responses = [
+        tool_response([tool_call("1", "probe", %{"a" => 1})]),
+        text_response("Survived throw")
+      ]
+
+      events = AgentStream.react("go", sequence_opts(responses, [Thrower])) |> Enum.to_list()
+
+      assert Enum.any?(
+               events,
+               &match?(
+                 {:tool_result,
+                  %{result: {:error, {:vetoed, {:hook_threw, Thrower, :thrown_value}}}}},
+                 &1
+               )
+             )
+
+      assert {:done, %{content: "Survived throw"}} = List.last(events)
+      assert drain_traces() == []
+    end
+
+    test "an exiting hook does not crash the loop" do
+      responses = [
+        tool_response([tool_call("1", "probe", %{"a" => 1})]),
+        text_response("Survived exit")
+      ]
+
+      events = AgentStream.react("go", sequence_opts(responses, [Exiter])) |> Enum.to_list()
+
+      assert Enum.any?(
+               events,
+               &match?(
+                 {:tool_result,
+                  %{result: {:error, {:vetoed, {:hook_exited, Exiter, :exit_reason}}}}},
+                 &1
+               )
+             )
+
+      assert {:done, %{content: "Survived exit"}} = List.last(events)
       assert drain_traces() == []
     end
   end

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments.ex
@@ -18,7 +18,10 @@ defmodule Raxol.Payments.Actions.Payments do
         policy: SpendingPolicy.dev(),
         agent_id: :my_agent
       }
-      {:ok, result} = ToolConverter.dispatch_tool_call(tool_call, actions(), context)
+      case ToolConverter.dispatch_tool_call(tool_call, actions(), context) do
+        {:ok, result} -> result
+        {:error, reason} -> handle_tool_error(reason)  # {:vetoed, _} | {:tool_denied, _, _} | {:hook_error, _}
+      end
   """
 
   @actions [


### PR DESCRIPTION
## What

Introduces `Raxol.Agent.ToolCall.Hook` — an ordered, registerable interception pipeline around LLM tool-call execution — and wires it as a `before_call` chokepoint into `ToolConverter.dispatch_tool_call/3`. No spend logic, no approval logic: just the seam.

## Why

Upcoming harness units **U7 (SpendGate: reserve-budget-before-call)** and **U8 (BlastRadiusGate: approval before write tools)** both assume a hookable interception point immediately before a tool runs. None existed. Building U7 first would fuse the seam and its first consumer into one untestable unit. TH ships the seam ALONE so U7/U8 register into it rather than each re-wrapping the react loop.

## Hook contract

```elixir
defmodule MyGate do
  @behaviour Raxol.Agent.ToolCall.Hook

  @impl true
  def before_call(call, _context) do
    # call = %{action: module, name: String.t, params: map, call_id: term}
    if allowed?(call), do: {:cont, call}, else: {:halt, :budget_exceeded}
  end
end
```

- `before_call(call, context)` → `{:cont, call}` (allow; the call may be transformed — later hooks and the final execution see the modified call) or `{:halt, reason}` (veto).
- `after_call(call, result, context)` (optional) may transform the result.
- Registered as an ordered list under `:tool_call_hooks` in the agent context (alongside `:tool_authorizer`). Hooks run in declared order; first `{:halt, _}` short-circuits.

### Chokepoint

Wired at `packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex` in `dispatch_tool_call/3` — the single point all three tool-call paths (`Stream` react loop, `Strategy.ReAct`, `Actions.Vfs` helper) funnel through. **Zero registered hooks takes the fast path — behavior byte-identical to before.**

### Veto visibility (no new event plumbing)

A veto returns `{:error, {:vetoed, reason}}`, which flows back through the **existing** tool-error path: the react loop emits `{:tool_result, %{name: name, result: {:error, {:vetoed, reason}}}}` and feeds the LLM a `[Tool error for ...]` message, so the loop continues and the model can react.

### Failure containment (documented decision: raise = veto-with-reason)

- A hook that raises in `before_call/2` → `{:halt, {:hook_raised, mod, message}}` → `{:error, {:vetoed, {:hook_raised, ...}}}`.
- A non-`{:cont,_}`/`{:halt,_}` return → `{:halt, {:invalid_hook_return, mod, value}}`.
- A raise in `after_call/3` is contained; the result passes through unchanged.
- The react loop never crashes on a misbehaving hook.

## Accepts (all green)

- No-op observer sees every call with parsed args pre-execution (order + content asserted).
- Two hooks in declared order; the second sees the first's transformation.
- Vetoing hook → typed error, the Action's `run/2` is **never** invoked (probe traces), loop continues.
- Zero hooks → dispatch identical to the direct `Action.call/2`.
- Raising hook → contained as a tool error; loop does not crash.

14 new tests in `test/raxol/agent/tool_call/hook_test.exs` (unit + `dispatch_tool_call/3` integration + `Stream.react/2` end-to-end). Full `raxol_agent` suite: **993 passed, 0 failures**. `mix compile --warnings-as-errors` clean.

## Relationship to existing hook machinery

Mirrors the established **`Raxol.Agent.CommandHook`** idiom (module-based ordered hooks, first denial short-circuits, optional post callback) — but on the *tool-call* subject rather than *Directive* execution (`Async`/`Shell`/`SendAgent` from `update/2`). Different subject and lifecycle, so a parallel behaviour rather than an extension. Complements **`Raxol.Agent.ToolPolicy`** (`:tool_authorizer`), the boolean allow/deny gate on the same dispatch path that runs *before* this pipeline and cannot transform calls: use ToolPolicy for static policy, a `ToolCall.Hook` for stateful gates (reservations, approvals) and call rewriting. The **`Raxol.Payments.SpendingHook`** (a CommandHook) gates Pay *directives*; U7's SpendGate will register here to gate *tool calls* pre-execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7