### PR TITLE
feat(harness): SS — Session.Supervisor + session registry (per-session OTP tree)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/session.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session.ex
@@ -18,7 +18,8 @@ defmodule Raxol.Agent.Session do
     :team_id,
     :session_id,
     :emit_bridge,
-    bridge_opts: []
+    bridge_opts: [],
+    owns_bridge?: true
   ]
 
   @type t :: %__MODULE__{
@@ -28,7 +29,8 @@ defmodule Raxol.Agent.Session do
           team_id: term() | nil,
           session_id: String.t() | nil,
           emit_bridge: pid() | nil,
-          bridge_opts: keyword()
+          bridge_opts: keyword(),
+          owns_bridge?: boolean()
         }
 
   @spec child_spec(keyword()) :: Supervisor.child_spec()
@@ -46,9 +48,7 @@ defmodule Raxol.Agent.Session do
   def start_link(opts) do
     id = Keyword.fetch!(opts, :id)
 
-    GenServer.start_link(__MODULE__, opts,
-      name: {:via, Registry, {Raxol.Agent.Registry, id}}
-    )
+    GenServer.start_link(__MODULE__, opts, name: {:via, Registry, {Raxol.Agent.Registry, id}})
   end
 
   @doc "Send a message into the agent's TEA loop."
@@ -106,11 +106,31 @@ defmodule Raxol.Agent.Session do
       |> maybe_put(:journal, Keyword.get(opts, :journal))
       |> maybe_put(:journal_opts, Keyword.get(opts, :journal_opts))
 
-    emit_bridge = start_emit_bridge(session_id, bridge_opts)
-    # The session OWNS its bridge: monitor it so a bridge death is observed
-    # (:DOWN → log + restart-or-degrade), never linked so a bridge crash can
-    # never take the session down.
-    if emit_bridge, do: Process.monitor(emit_bridge)
+    # Two bridge-ownership modes:
+    #
+    #   * standalone `Session.start_link` (default): the session OWNS its
+    #     bridge — starts it, monitors it (:DOWN → log + restart-or-degrade;
+    #     never linked so a bridge crash can never take the session down), and
+    #     stops it in terminate/2.
+    #   * under `Raxol.Agent.Session.Supervisor` (`start_emit_bridge: false`):
+    #     the TREE owns the bridge (started before this session,
+    #     `:rest_for_one`). The session only looks it up — no monitor, no
+    #     restart, no stop; supervision handles all of that.
+    owns_bridge? = Keyword.get(opts, :start_emit_bridge, true)
+
+    emit_bridge =
+      if owns_bridge? do
+        bridge = start_emit_bridge(session_id, bridge_opts)
+        if bridge, do: Process.monitor(bridge)
+        bridge
+      else
+        lookup_emit_bridge(session_id)
+      end
+
+    # session_id → pid resolution seam (SS): registered in both ownership
+    # modes so `Raxol.Agent.Session.Supervisor.whereis/1` resolves supervised
+    # and standalone sessions alike. Registry cleans the key up on death.
+    register_session(session_id, id, app_module)
 
     lifecycle_pid = start_or_reattach_lifecycle(app_module, id, session_id)
     Process.monitor(lifecycle_pid)
@@ -127,7 +147,8 @@ defmodule Raxol.Agent.Session do
        team_id: team_id,
        session_id: session_id,
        emit_bridge: emit_bridge,
-       bridge_opts: bridge_opts
+       bridge_opts: bridge_opts,
+       owns_bridge?: owns_bridge?
      }}
   end
 
@@ -255,14 +276,21 @@ defmodule Raxol.Agent.Session do
 
   @impl GenServer
   def terminate(_reason, state) do
-    if state.lifecycle_pid && Process.alive?(state.lifecycle_pid) do
-      Raxol.Core.Runtime.Lifecycle.stop(state.lifecycle_pid)
-    end
+    # Stop the lifecycle SYNCHRONOUSLY (wait for it to actually die). Lifecycle
+    # runs under a stable name (`agent_lifecycle_<id>`); under Session.Supervisor
+    # a `:rest_for_one` restart re-enters `start_or_reattach_lifecycle` with the
+    # same name, so if we only cast `:shutdown` (async) the restarted session can
+    # reattach to the still-dying old lifecycle and immediately lose it. Freeing
+    # the name before we return makes the restart deterministic.
+    stop_lifecycle_sync(state.lifecycle_pid)
 
     # Gracefully stop the per-session sink so its journal handle is flushed and
     # closed (its terminate/2 does this). Best-effort — never block session
-    # shutdown on it.
-    stop_emit_bridge(state.emit_bridge)
+    # shutdown on it. ONLY when the session OWNS the bridge (standalone mode):
+    # under Session.Supervisor the TREE owns it, and stopping it here would tear
+    # down a sink the supervisor is responsible for (and, on a session-only
+    # `:rest_for_one` restart, orphan the journal writer).
+    if state.owns_bridge?, do: stop_emit_bridge(state.emit_bridge)
 
     :ok
   end
@@ -320,7 +348,12 @@ defmodule Raxol.Agent.Session do
   # A session_id is also the durable journal's on-disk directory name, so it
   # must be a safe filename. Coerce the (arbitrary term) agent id into the
   # journal's charset and suffix a unique token so restarts never collide.
-  defp derive_session_id(id) do
+  #
+  # Public (not `defp`) so `Raxol.Agent.Session.Supervisor.start_session/2` can
+  # mint the same shape of id up-front when the caller omits `:session_id`.
+  @doc false
+  @spec derive_session_id(term()) :: String.t()
+  def derive_session_id(id) do
     base =
       id
       |> to_id_string()
@@ -334,6 +367,48 @@ defmodule Raxol.Agent.Session do
   defp to_id_string(id) when is_binary(id), do: id
   defp to_id_string(id) when is_atom(id), do: Atom.to_string(id)
   defp to_id_string(id), do: inspect(id)
+
+  # The `session_id → pid` resolution seam (SS). The session is already
+  # registered by its agent `id` (its `{:via, ...}` name); this ADDS a second
+  # key, `{:session, session_id}`, so `Raxol.Agent.Session.Supervisor.whereis/1`
+  # and `list_sessions/0` resolve every session — supervised or standalone —
+  # by its harness session_id. `:unique` Registry allows one process under many
+  # keys; each key stays unique. The Registry auto-removes the key on death.
+  #
+  # Best-effort: an unexpectedly duplicate session_id (two standalone sessions
+  # with distinct agent ids but the same session_id) just skips the secondary
+  # registration rather than crashing the session — the primary `id` identity
+  # is untouched. Registry is always up here (the `{:via, ...}` name requires
+  # it), but guard defensively.
+  defp register_session(session_id, id, app_module) do
+    if Process.whereis(Raxol.Agent.Registry) do
+      case Registry.register(
+             Raxol.Agent.Registry,
+             {:session, session_id},
+             %{id: id, app_module: app_module}
+           ) do
+        {:ok, _} -> :ok
+        {:error, {:already_registered, _}} -> :ok
+      end
+    end
+
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  # Resolve the tree-owned sink for `session_id` (supervised mode). The bridge
+  # child of `Session.Supervisor` starts BEFORE this session under
+  # `:rest_for_one` and registers its `{:via, ...}` name synchronously, so by
+  # the time the session inits the key is already present.
+  defp lookup_emit_bridge(session_id) do
+    case Registry.lookup(Raxol.Agent.Registry, {:emit_bridge, session_id}) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
 
   # Start the per-session sink under the agent DynamicSupervisor when available
   # (so it is not crash-coupled to this Session); fall back to an unlinked
@@ -368,8 +443,7 @@ defmodule Raxol.Agent.Session do
   defp bridge_name_opts(session_id) do
     if Process.whereis(Raxol.Agent.Registry) do
       [
-        name:
-          {:via, Registry, {Raxol.Agent.Registry, {:emit_bridge, session_id}}}
+        name: {:via, Registry, {Raxol.Agent.Registry, {:emit_bridge, session_id}}}
       ]
     else
       []
@@ -399,6 +473,28 @@ defmodule Raxol.Agent.Session do
 
   defp maybe_put(kw, _key, nil), do: kw
   defp maybe_put(kw, key, value), do: Keyword.put(kw, key, value)
+
+  # Stop the lifecycle and block until it is truly gone (or 2s elapses), so its
+  # stable process name is free for a same-id restart. `Lifecycle.stop/1` casts
+  # `:shutdown`, so we monitor + await the `:DOWN` ourselves.
+  defp stop_lifecycle_sync(nil), do: :ok
+
+  defp stop_lifecycle_sync(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      ref = Process.monitor(pid)
+      Raxol.Core.Runtime.Lifecycle.stop(pid)
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+      after
+        2_000 ->
+          Process.demonitor(ref, [:flush])
+          :ok
+      end
+    end
+
+    :ok
+  end
 
   defp stop_emit_bridge(nil), do: :ok
 

--- a/packages/raxol_agent/lib/raxol/agent/session.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session.ex
@@ -42,7 +42,17 @@ defmodule Raxol.Agent.Session do
     %{
       id: {__MODULE__, id},
       start: {__MODULE__, :start_link, [opts]},
-      restart: :permanent
+      restart: :permanent,
+      # The child-spec shutdown budget must STRICTLY EXCEED `stop_lifecycle_sync`'s
+      # total wait (`shutdown_timeout_ms() + 1_000`, see ~640). A standalone
+      # Session traps exits and drains its owned lifecycle in `terminate/2`; on a
+      # parent shutdown (e.g. `Raxol.Agent.Team`'s `:rest_for_one`), the parent
+      # must give `terminate/2` long enough to reach its `Process.exit(:kill)`
+      # fallback. If this budget were <= the drain budget the parent would
+      # brutal-kill the Session mid-drain, BEFORE the kill-fallback runs —
+      # orphaning the lifecycle (the exact failure the sync drain exists to
+      # prevent). +2_000 keeps a 1s margin over the +1_000 drain budget.
+      shutdown: Raxol.Core.Defaults.shutdown_timeout_ms() + 2_000
     }
   end
 
@@ -303,6 +313,22 @@ defmodule Raxol.Agent.Session do
     end
   end
 
+  # A LINKED process exited abnormally. Standalone mode traps exits, so a link
+  # exit lands here as `{:EXIT, pid, reason}`. gen_server intercepts the PARENT's
+  # exit before it reaches this callback (it drives `terminate/2`), so this only
+  # fires for a NON-parent link. Nothing links to the Session today (the lifecycle
+  # and bridge are unlinked + monitored), but if a future linked helper dies
+  # abnormally, log it rather than let the catch-all below swallow it silently.
+  def handle_manager_info({:EXIT, pid, reason}, state)
+      when reason not in [:normal, :shutdown] do
+    Logger.warning(
+      "[Agent.Session] linked process #{inspect(pid)} for #{inspect(state.id)} " <>
+        "exited abnormally: #{inspect(reason)}"
+    )
+
+    {:noreply, state}
+  end
+
   def handle_manager_info(_msg, state), do: {:noreply, state}
 
   @impl GenServer
@@ -408,6 +434,16 @@ defmodule Raxol.Agent.Session do
   # and the session in `Raxol.Agent.Session.Supervisor`'s `:rest_for_one` tree.
   # The tree owns the lifecycle: a `stop_session` (or any restart) tears it down
   # with the subtree — it can neither leak nor be reattached-to while dead.
+  #
+  # NOTE on `shutdown`: `Raxol.Core.Runtime.Lifecycle` does NOT trap exits, so on
+  # a supervised teardown it dies immediately on the `:shutdown` signal WITHOUT
+  # running its `handle_cast(:shutdown)` dispatcher-drain or `terminate/2` — this
+  # budget only bounds how long the supervisor waits before brutal-kill (it
+  # rarely engages). The durable-tail drain is therefore NOT done here; it is
+  # done up-front by `Raxol.Agent.Session.Supervisor.stop_session/1`, which flushes
+  # the dispatcher -> bridge -> journal Writer via FIFO barriers BEFORE tearing
+  # the tree down. The journal Writer traps exits and datasyncs in its own
+  # `terminate/2`, so once flushed the tail survives this hard teardown.
   @spec lifecycle_child_spec(keyword()) :: Supervisor.child_spec()
   def lifecycle_child_spec(opts) do
     %{
@@ -533,7 +569,23 @@ defmodule Raxol.Agent.Session do
         Process.sleep(5)
         do_register_session(key, meta, attempts - 1)
 
-      {:error, {:already_registered, _pid}} ->
+      {:error, {:already_registered, holder}} ->
+        # Retry budget exhausted: a genuinely-live foreign holder still owns the
+        # key. Proceed (the primary `id` identity is intact) but LOUDLY — an
+        # unregistered live session is invisible to `whereis/1`, `list_sessions/0`
+        # and `stop_session/1` by session_id, and a silent `:ok` would hide that.
+        Logger.warning(
+          "[Agent.Session] session_id seam registration for #{inspect(key)} timed " <>
+            "out (held by #{inspect(holder)}); proceeding UNREGISTERED — this " <>
+            "session won't resolve by session_id via whereis/list_sessions/stop_session"
+        )
+
+        :telemetry.execute(
+          [:raxol, :agent, :session, :register_timeout],
+          %{count: 1},
+          Map.put(meta, :key, key)
+        )
+
         :ok
     end
   end
@@ -648,6 +700,15 @@ defmodule Raxol.Agent.Session do
 
   defp stop_emit_bridge(pid) do
     if Process.alive?(pid) do
+      # FIFO barrier: drain the bridge's mailbox so durable events the lifecycle
+      # drain (`stop_lifecycle_sync`, run just before this) published are appended
+      # to the journal BEFORE we stop the bridge. This matters on the DynSup path:
+      # a plain `GenServer.stop` would trip the bridge's permanent-child restart,
+      # so we must `terminate_child` — which brutal-kills without a mailbox drain.
+      # The journal Writer (linked, exit-trapping) datasyncs in its own
+      # `terminate/2`, so once appended the tail survives the kill.
+      drain_mailbox(pid)
+
       case Process.whereis(Raxol.Agent.DynSup) do
         nil ->
           GenServer.stop(pid, :normal, 1_000)
@@ -663,6 +724,18 @@ defmodule Raxol.Agent.Session do
     end
 
     :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  # A synchronous system message is a FIFO barrier: it returns only after every
+  # message enqueued before it has been handled. Best-effort/bounded — a slow or
+  # dead process just short-circuits and teardown proceeds.
+  defp drain_mailbox(pid) do
+    _ = :sys.get_state(pid, Raxol.Core.Defaults.shutdown_timeout_ms())
+    :ok
+  rescue
+    _ -> :ok
   catch
     :exit, _ -> :ok
   end

--- a/packages/raxol_agent/lib/raxol/agent/session.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session.ex
@@ -19,7 +19,8 @@ defmodule Raxol.Agent.Session do
     :session_id,
     :emit_bridge,
     bridge_opts: [],
-    owns_bridge?: true
+    owns_bridge?: true,
+    owns_lifecycle?: true
   ]
 
   @type t :: %__MODULE__{
@@ -30,7 +31,8 @@ defmodule Raxol.Agent.Session do
           session_id: String.t() | nil,
           emit_bridge: pid() | nil,
           bridge_opts: keyword(),
-          owns_bridge?: boolean()
+          owns_bridge?: boolean(),
+          owns_lifecycle?: boolean()
         }
 
   @spec child_spec(keyword()) :: Supervisor.child_spec()
@@ -47,6 +49,14 @@ defmodule Raxol.Agent.Session do
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
     id = Keyword.fetch!(opts, :id)
+
+    # Deterministic (re)start: a `:rest_for_one` restart can race Registry's
+    # async cleanup of the dead predecessor's `{:via, ...}` name. Wait for the
+    # stale key to clear before we register, so the start can't lose the race
+    # and fail with `{:already_started, dead_pid}` (YELLOW 3). Only the
+    # single restarter competes for this unique key, and cleanup only REMOVES
+    # it, so once it reads empty our registration cannot collide.
+    await_free(id)
 
     GenServer.start_link(__MODULE__, opts, name: {:via, Registry, {Raxol.Agent.Registry, id}})
   end
@@ -106,17 +116,27 @@ defmodule Raxol.Agent.Session do
       |> maybe_put(:journal, Keyword.get(opts, :journal))
       |> maybe_put(:journal_opts, Keyword.get(opts, :journal_opts))
 
-    # Two bridge-ownership modes:
+    # Two ownership modes, one flag pair:
     #
-    #   * standalone `Session.start_link` (default): the session OWNS its
-    #     bridge — starts it, monitors it (:DOWN → log + restart-or-degrade;
-    #     never linked so a bridge crash can never take the session down), and
-    #     stops it in terminate/2.
-    #   * under `Raxol.Agent.Session.Supervisor` (`start_emit_bridge: false`):
-    #     the TREE owns the bridge (started before this session,
-    #     `:rest_for_one`). The session only looks it up — no monitor, no
-    #     restart, no stop; supervision handles all of that.
+    #   * standalone `Session.start_link` (default): the session OWNS both its
+    #     bridge and its lifecycle — starts them (unlinked so their crashes can
+    #     never take the session down), monitors them, and stops them in
+    #     `terminate/2`. To make `terminate/2` actually run on a graceful
+    #     `GenServer.stop`/parent-shutdown, this mode traps exits (BaseManager
+    #     does NOT — unlike BaseServer). Without trapping, the cleanup below
+    #     would be dead code and the lifecycle would leak.
+    #   * under `Raxol.Agent.Session.Supervisor`
+    #     (`start_emit_bridge: false`, `manage_lifecycle: false`): the TREE owns
+    #     both — the bridge and the lifecycle are sibling supervised children
+    #     started BEFORE this session under `:rest_for_one`. The session only
+    #     looks them up; supervision owns start/restart/stop. This is what makes
+    #     the lifecycle leak + reattach-to-dead structurally impossible: a
+    #     `stop_session` tears the whole subtree down (fresh lifecycle on any
+    #     restart, never an orphan), so no `terminate/2` cleanup is needed here.
     owns_bridge? = Keyword.get(opts, :start_emit_bridge, true)
+    owns_lifecycle? = Keyword.get(opts, :manage_lifecycle, true)
+
+    if owns_bridge? or owns_lifecycle?, do: Process.flag(:trap_exit, true)
 
     emit_bridge =
       if owns_bridge? do
@@ -132,8 +152,18 @@ defmodule Raxol.Agent.Session do
     # and standalone sessions alike. Registry cleans the key up on death.
     register_session(session_id, id, app_module)
 
-    lifecycle_pid = start_or_reattach_lifecycle(app_module, id, session_id)
-    Process.monitor(lifecycle_pid)
+    lifecycle_pid =
+      if owns_lifecycle? do
+        pid = start_or_reattach_lifecycle(app_module, id, session_id)
+        Process.monitor(pid)
+        pid
+      else
+        # Tree-owned lifecycle: it started before us under `:rest_for_one` and
+        # registered its `{:lifecycle, session_id}` via-name synchronously, so
+        # the key is present by the time we init. No monitor: if it crashes,
+        # `:rest_for_one` restarts us too, so we always re-resolve a fresh pid.
+        lookup_lifecycle(session_id)
+      end
 
     Logger.info(
       "[Agent.Session] Started agent #{inspect(id)} (#{inspect(app_module)}) session=#{session_id}"
@@ -148,7 +178,8 @@ defmodule Raxol.Agent.Session do
        session_id: session_id,
        emit_bridge: emit_bridge,
        bridge_opts: bridge_opts,
-       owns_bridge?: owns_bridge?
+       owns_bridge?: owns_bridge?,
+       owns_lifecycle?: owns_lifecycle?
      }}
   end
 
@@ -276,20 +307,19 @@ defmodule Raxol.Agent.Session do
 
   @impl GenServer
   def terminate(_reason, state) do
-    # Stop the lifecycle SYNCHRONOUSLY (wait for it to actually die). Lifecycle
-    # runs under a stable name (`agent_lifecycle_<id>`); under Session.Supervisor
-    # a `:rest_for_one` restart re-enters `start_or_reattach_lifecycle` with the
-    # same name, so if we only cast `:shutdown` (async) the restarted session can
-    # reattach to the still-dying old lifecycle and immediately lose it. Freeing
-    # the name before we return makes the restart deterministic.
-    stop_lifecycle_sync(state.lifecycle_pid)
+    # Standalone mode only. Under `Session.Supervisor` the tree owns both the
+    # lifecycle and the bridge as supervised siblings, so `owns_lifecycle?` and
+    # `owns_bridge?` are false here and this is a no-op — supervision tears the
+    # subtree down in dependency order, and no cleanup depends on this callback
+    # (which BaseManager only reaches because standalone init sets `trap_exit`).
+    #
+    # Stop the lifecycle SYNCHRONOUSLY (block until it is truly dead) so its
+    # `{:lifecycle, session_id}` via-name is free and no orphaned runtime leaks.
+    if state.owns_lifecycle?, do: stop_lifecycle_sync(state.lifecycle_pid)
 
     # Gracefully stop the per-session sink so its journal handle is flushed and
     # closed (its terminate/2 does this). Best-effort — never block session
-    # shutdown on it. ONLY when the session OWNS the bridge (standalone mode):
-    # under Session.Supervisor the TREE owns it, and stopping it here would tear
-    # down a sink the supervisor is responsible for (and, on a session-only
-    # `:rest_for_one` restart, orphan the journal writer).
+    # shutdown on it.
     if state.owns_bridge?, do: stop_emit_bridge(state.emit_bridge)
 
     :ok
@@ -321,28 +351,117 @@ defmodule Raxol.Agent.Session do
     end
   end
 
-  defp start_or_reattach_lifecycle(app_module, id, session_id) do
-    opts = [
+  # The lifecycle's registered name. A `{:via, Registry, ...}` name keyed by the
+  # (unique-suffixed) session_id — NOT a `:"agent_lifecycle_#{id}"` atom. Bare
+  # atoms are never garbage-collected, so minting one per session marches a
+  # long-running node toward the ~1M atom limit; a Registry key has no such cost
+  # and is auto-removed when the lifecycle dies.
+  defp lifecycle_name(session_id),
+    do: {:via, Registry, {Raxol.Agent.Registry, {:lifecycle, session_id}}}
+
+  defp lifecycle_opts(app_module, id, session_id) do
+    [
       environment: :agent,
       width: Raxol.Core.Defaults.terminal_width(),
       height: Raxol.Core.Defaults.terminal_height(),
-      name: :"agent_lifecycle_#{inspect(id)}",
+      name: lifecycle_name(session_id),
       command_interceptor: build_command_interceptor(app_module, id),
       # Harness keystone: makes the Dispatcher publish typed events to EmitBus.
       session_id: session_id
     ]
+  end
 
-    case Raxol.Core.Runtime.Lifecycle.start_link(app_module, opts) do
+  # Standalone ownership: the session starts the lifecycle itself, unlinked so a
+  # lifecycle crash can't cascade into the session (the session monitors it
+  # instead). `terminate/2` stops it synchronously, so a graceful stop leaves no
+  # orphan. The `{:already_started, _}` branch only fires if a prior standalone
+  # incarnation leaked a lifecycle under the same session_id (e.g. a brutal
+  # kill, which skips terminate); reattach rather than fail to start.
+  defp start_or_reattach_lifecycle(app_module, id, session_id) do
+    case Raxol.Core.Runtime.Lifecycle.start_link(
+           app_module,
+           lifecycle_opts(app_module, id, session_id)
+         ) do
       {:ok, lifecycle_pid} ->
-        # A fresh lifecycle is linked to us; unlink so its crashes don't cascade.
         Process.unlink(lifecycle_pid)
         lifecycle_pid
 
       {:error, {:already_started, lifecycle_pid}} ->
-        # A prior session was killed before its lifecycle was cleaned up.
-        # Reattach to the running runtime instead of failing to restart.
         lifecycle_pid
     end
+  end
+
+  # Resolve the tree-owned lifecycle for `session_id` (supervised mode). It
+  # starts before this session under `:rest_for_one` and registers its via-name
+  # synchronously, so the key is present when we look it up.
+  defp lookup_lifecycle(session_id) do
+    case Registry.lookup(Raxol.Agent.Registry, {:lifecycle, session_id}) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc false
+  # Supervised child spec for the per-session lifecycle, placed BETWEEN the sink
+  # and the session in `Raxol.Agent.Session.Supervisor`'s `:rest_for_one` tree.
+  # The tree owns the lifecycle: a `stop_session` (or any restart) tears it down
+  # with the subtree — it can neither leak nor be reattached-to while dead.
+  @spec lifecycle_child_spec(keyword()) :: Supervisor.child_spec()
+  def lifecycle_child_spec(opts) do
+    %{
+      id: :lifecycle,
+      start: {__MODULE__, :start_supervised_lifecycle, [opts]},
+      restart: :permanent,
+      shutdown: Raxol.Core.Defaults.shutdown_timeout_ms()
+    }
+  end
+
+  @doc false
+  # Start the lifecycle as a linked, supervised child (NOT unlinked — the tree
+  # supervises it). Waits for the dead predecessor's via-name to clear first so
+  # a `:rest_for_one` restart is deterministic (YELLOW 3).
+  @spec start_supervised_lifecycle(keyword()) :: GenServer.on_start()
+  def start_supervised_lifecycle(opts) do
+    app_module = Keyword.fetch!(opts, :app_module)
+    id = Keyword.fetch!(opts, :id)
+    session_id = Keyword.fetch!(opts, :session_id)
+
+    await_free({:lifecycle, session_id})
+
+    Raxol.Core.Runtime.Lifecycle.start_link(
+      app_module,
+      lifecycle_opts(app_module, id, session_id)
+    )
+  end
+
+  @doc false
+  # Block (bounded) until a Registry key is unregistered. Used before a
+  # same-name (re)start so it never loses the race against Registry's async
+  # cleanup of a dead predecessor. Only the single restarter competes for these
+  # unique per-session keys, and cleanup only removes entries, so once this
+  # reads empty a fresh registration cannot collide. Bounded so a genuinely
+  # live holder (pathological) just falls through to a normal already_started.
+  @spec await_free(term(), non_neg_integer()) :: :ok
+  def await_free(key, attempts \\ 200) do
+    case safe_lookup(key) do
+      [] ->
+        :ok
+
+      _ when attempts > 0 ->
+        Process.sleep(5)
+        await_free(key, attempts - 1)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp safe_lookup(key) do
+    Registry.lookup(Raxol.Agent.Registry, key)
+  rescue
+    ArgumentError -> []
   end
 
   # A session_id is also the durable journal's on-disk directory name, so it
@@ -382,19 +501,41 @@ defmodule Raxol.Agent.Session do
   # it), but guard defensively.
   defp register_session(session_id, id, app_module) do
     if Process.whereis(Raxol.Agent.Registry) do
-      case Registry.register(
-             Raxol.Agent.Registry,
-             {:session, session_id},
-             %{id: id, app_module: app_module}
-           ) do
-        {:ok, _} -> :ok
-        {:error, {:already_registered, _}} -> :ok
-      end
+      do_register_session(
+        {:session, session_id},
+        %{id: id, app_module: app_module}
+      )
     end
 
     :ok
   rescue
     ArgumentError -> :ok
+  end
+
+  # Don't silently skip on `:already_registered`. A `{:session, session_id}` key
+  # can briefly outlive its dead owner (Registry cleanup lag on a fast
+  # `:rest_for_one` restart); skipping then would leave a LIVE session
+  # unregistered once the stale key is swept — `whereis/1`, `list_sessions/0`
+  # and standalone `stop_session/1` would all lose it (YELLOW 2). Instead retry
+  # (bounded) until the stale predecessor's key clears and ours lands. A key
+  # already held by self() is fine. A genuinely-live foreign holder
+  # (pathological duplicate session_id) exhausts the budget and is skipped — the
+  # primary `id` identity is untouched.
+  defp do_register_session(key, meta, attempts \\ 200) do
+    case Registry.register(Raxol.Agent.Registry, key, meta) do
+      {:ok, _} ->
+        :ok
+
+      {:error, {:already_registered, pid}} when pid == self() ->
+        :ok
+
+      {:error, {:already_registered, _pid}} when attempts > 0 ->
+        Process.sleep(5)
+        do_register_session(key, meta, attempts - 1)
+
+      {:error, {:already_registered, _pid}} ->
+        :ok
+    end
   end
 
   # Resolve the tree-owned sink for `session_id` (supervised mode). The bridge
@@ -474,9 +615,15 @@ defmodule Raxol.Agent.Session do
   defp maybe_put(kw, _key, nil), do: kw
   defp maybe_put(kw, key, value), do: Keyword.put(kw, key, value)
 
-  # Stop the lifecycle and block until it is truly gone (or 2s elapses), so its
-  # stable process name is free for a same-id restart. `Lifecycle.stop/1` casts
-  # `:shutdown`, so we monitor + await the `:DOWN` ourselves.
+  # Stop the lifecycle and block until it is truly gone, so its via-name is free
+  # for a same-session_id restart. `Lifecycle.stop/1` casts `:shutdown`, so we
+  # monitor + await the `:DOWN` ourselves. The wait budget matches the
+  # lifecycle's own shutdown budget (`Defaults.shutdown_timeout_ms/0`) plus a
+  # margin — a shorter timeout could fire spuriously under load and return while
+  # the lifecycle is still sinking. If it DOES time out we hard-kill it before
+  # returning: returning with a still-alive lifecycle would let a restart
+  # reattach to a dying runtime whose dispatcher then vanishes, silently
+  # dropping every `send_message`.
   defp stop_lifecycle_sync(nil), do: :ok
 
   defp stop_lifecycle_sync(pid) when is_pid(pid) do
@@ -487,8 +634,9 @@ defmodule Raxol.Agent.Session do
       receive do
         {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
       after
-        2_000 ->
+        Raxol.Core.Defaults.shutdown_timeout_ms() + 1_000 ->
           Process.demonitor(ref, [:flush])
+          Process.exit(pid, :kill)
           :ok
       end
     end

--- a/packages/raxol_agent/lib/raxol/agent/session/supervisor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session/supervisor.ex
@@ -1,0 +1,252 @@
+defmodule Raxol.Agent.Session.Supervisor do
+  @moduledoc """
+  One supervised OTP subtree per harness session, plus the `session_id → pid`
+  registry the Wave 2 units resolve against (U4 reattach, U5/U6 turn
+  kill/steer, U9 pointer records).
+
+  ## Tree shape
+
+  `:rest_for_one`, children in dependency order:
+
+    1. `Raxol.Agent.EmitBridge` — the per-session sink. Owns the durable
+       journal handle (opened lazily on the first durable event) and the
+       EmitBus subscription.
+    2. `Raxol.Agent.Session` — the Lifecycle wrapper (dispatcher). Started
+       with `start_emit_bridge: false`: the tree owns the bridge, the session
+       must not start a second one.
+
+  Why this order: the journal/sink is the resource the session *depends on*
+  (durable events must have somewhere to land), so it starts first and stops
+  last. Under `:rest_for_one`:
+
+    * a **bridge crash** restarts the bridge *and then* the session — the
+      whole tree recovers in dependency order, and the restarted bridge
+      re-registers under `{:emit_bridge, session_id}` (exactly one bridge; the
+      journal Writer survives via its own `:global` single-writer discipline
+      and is re-joined on the next durable append, so offsets stay monotonic);
+    * a **session crash** restarts *only* the session — the sink is never
+      orphaned and never duplicated, and the restarted session finds the
+      running bridge via the registry.
+
+  ## Registry keys (all in `Raxol.Agent.Registry`)
+
+    * `{:session_supervisor, session_id}` → this subtree supervisor
+    * `{:session, session_id}` → the live `Raxol.Agent.Session` process
+      (registered by the session itself, in both supervised and standalone
+      modes, so `whereis/1` resolves either)
+    * `{:emit_bridge, session_id}` → the sink (pre-existing key, unchanged)
+
+  Session ids are unique: a second `start_session/2` with the same
+  `session_id` returns `{:error, {:already_started, pid}}`.
+
+  ## Placement
+
+  Subtrees run under the existing `Raxol.Agent.DynSup` (the agent package's
+  DynamicSupervisor, supervised by `Raxol.Agent.Supervisor`), so a session
+  tree is crash-isolated from every other session and from the caller.
+  `start_session/2` therefore requires `Raxol.Agent.Registry` and
+  `Raxol.Agent.DynSup` to be running (boot `Raxol.Agent.Supervisor`, or start
+  both directly in tests).
+
+  Note: the journal `FileStore.Writer` keeps its `:global` name (keyed by the
+  physical journal *directory*, not by session) — that registration enforces
+  the single-writer-per-dir invariant across sessions, base dirs and (on
+  shared storage) nodes, which a per-session Registry key cannot express.
+  See `Raxol.Agent.Journal.FileStore.Writer.global_name/1`.
+  """
+
+  use Supervisor
+
+  alias Raxol.Agent.EmitBridge
+  alias Raxol.Agent.Session
+
+  @registry Raxol.Agent.Registry
+  @dynsup Raxol.Agent.DynSup
+
+  # --- public API --------------------------------------------------------------
+
+  @doc """
+  Start a session as one supervised subtree under `Raxol.Agent.DynSup`.
+
+  Returns `{:ok, pid}` where `pid` is the subtree supervisor (resolve the
+  session process itself with `whereis/1`). A second call with the same
+  `session_id` returns `{:error, {:already_started, pid}}`.
+
+  Options (all `Raxol.Agent.Session` options are accepted and forwarded):
+
+    * `:session_id` — the harness session key (default: derived from `:id`
+      or the app module, filename-safe + unique suffix)
+    * `:id` — the agent id for `Raxol.Agent.Registry` discovery (default:
+      `{:harness_session, session_id}`)
+    * `:journal` / `:journal_opts` — forwarded to the tree-owned
+      `Raxol.Agent.EmitBridge`
+  """
+  @spec start_session(module(), keyword()) ::
+          {:ok, pid()} | {:error, {:already_started, pid()} | term()}
+  def start_session(app_module, opts \\ []) when is_atom(app_module) do
+    with :ok <- ensure_infrastructure() do
+      opts = normalize_opts(app_module, opts)
+
+      DynamicSupervisor.start_child(@dynsup, tree_spec(opts))
+    end
+  end
+
+  @doc """
+  Stop a session's whole subtree (session first, then the sink — the reverse
+  of start order — so the bridge's `terminate/2` flushes and closes the
+  journal handle last). Also stops bare `Raxol.Agent.Session.start_link`
+  sessions that registered under `{:session, session_id}`.
+  """
+  @spec stop_session(term()) :: :ok | {:error, :not_found}
+  def stop_session(session_id) do
+    case lookup({:session_supervisor, session_id}) do
+      pid when is_pid(pid) -> stop_tree(pid)
+      nil -> stop_standalone(session_id)
+    end
+  end
+
+  @doc """
+  Resolve `session_id` to the live `Raxol.Agent.Session` pid, or `nil`.
+  """
+  @spec whereis(term()) :: pid() | nil
+  def whereis(session_id), do: lookup({:session, session_id})
+
+  @doc """
+  All live sessions as `{session_id, session_pid}` — supervised subtrees and
+  standalone `Session.start_link` sessions alike.
+  """
+  @spec list_sessions() :: [{term(), pid()}]
+  def list_sessions do
+    Registry.select(@registry, [
+      {{{:session, :"$1"}, :"$2", :_}, [], [{{:"$1", :"$2"}}]}
+    ])
+  rescue
+    # Registry not running — no sessions.
+    ArgumentError -> []
+  end
+
+  # --- supervisor --------------------------------------------------------------
+
+  @doc false
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    session_id = Keyword.fetch!(opts, :session_id)
+
+    Supervisor.start_link(__MODULE__, opts,
+      name: {:via, Registry, {@registry, {:session_supervisor, session_id}}}
+    )
+  end
+
+  @impl Supervisor
+  def init(opts) do
+    session_id = Keyword.fetch!(opts, :session_id)
+
+    bridge_opts =
+      [
+        session_id: session_id,
+        name: {:via, Registry, {@registry, {:emit_bridge, session_id}}}
+      ]
+      |> copy_opt(:journal, opts)
+      |> copy_opt(:journal_opts, opts)
+
+    # The tree owns the bridge; the session must not start (or stop) its own.
+    session_opts = Keyword.put(opts, :start_emit_bridge, false)
+
+    children = [
+      %{
+        id: :emit_bridge,
+        start: {EmitBridge, :start_link, [bridge_opts]},
+        restart: :permanent
+      },
+      %{
+        id: :session,
+        start: {Session, :start_link, [session_opts]},
+        restart: :permanent
+      }
+    ]
+
+    # max_restarts is slightly generous: an immediate restart of the session
+    # child can transiently lose the Registry-cleanup race for its via name
+    # and need another attempt.
+    Supervisor.init(children,
+      strategy: :rest_for_one,
+      max_restarts: 5,
+      max_seconds: 5
+    )
+  end
+
+  # --- helpers -----------------------------------------------------------------
+
+  defp normalize_opts(app_module, opts) do
+    session_id =
+      Keyword.get(opts, :session_id) ||
+        Session.derive_session_id(Keyword.get(opts, :id, app_module))
+
+    opts
+    |> Keyword.put(:app_module, app_module)
+    |> Keyword.put(:session_id, session_id)
+    |> Keyword.put_new(:id, {:harness_session, session_id})
+  end
+
+  defp tree_spec(opts) do
+    %{
+      id: {__MODULE__, Keyword.fetch!(opts, :session_id)},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :transient,
+      type: :supervisor
+    }
+  end
+
+  defp ensure_infrastructure do
+    cond do
+      is_nil(Process.whereis(@registry)) -> {:error, :registry_not_running}
+      is_nil(Process.whereis(@dynsup)) -> {:error, :dynsup_not_running}
+      true -> :ok
+    end
+  end
+
+  defp lookup(key) do
+    case Registry.lookup(@registry, key) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  # Prefer terminate_child (synchronous, removes the DynSup child); fall back
+  # to a direct stop for a tree that was not started under DynSup.
+  defp stop_tree(sup) do
+    case Process.whereis(@dynsup) do
+      nil ->
+        stop_process(sup)
+
+      _ ->
+        case DynamicSupervisor.terminate_child(@dynsup, sup) do
+          :ok -> :ok
+          {:error, :not_found} -> stop_process(sup)
+        end
+    end
+  end
+
+  defp stop_standalone(session_id) do
+    case lookup({:session, session_id}) do
+      nil -> {:error, :not_found}
+      pid -> stop_process(pid)
+    end
+  end
+
+  defp stop_process(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal, 5_000)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp copy_opt(target, key, source) do
+    case Keyword.fetch(source, key) do
+      {:ok, value} -> Keyword.put(target, key, value)
+      :error -> target
+    end
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/session/supervisor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session/supervisor.ex
@@ -113,14 +113,94 @@ defmodule Raxol.Agent.Session.Supervisor do
   of start order — so the bridge's `terminate/2` flushes and closes the
   journal handle last). Also stops bare `Raxol.Agent.Session.start_link`
   sessions that registered under `{:session, session_id}`.
+
+  ## Journal-tail completeness guarantee (graceful stop)
+
+  Before tearing the tree down, `stop_session/1` drains the durable tail so a
+  graceful stop never silently truncates the journal. The runtime `Lifecycle`
+  does NOT trap exits, so a plain subtree teardown would kill the dispatcher
+  (and the events queued in its mailbox) with no drain. Instead we flush in
+  dependency order using synchronous FIFO barriers — a `:sys.get_state/2` call
+  returns only after every message enqueued before it has been handled:
+
+    1. barrier on the **session** — `send_message` is a cast the session forwards
+       (also a cast) to the dispatcher, so this drains queued inbound messages
+       out of the session's mailbox into the dispatcher's first;
+    2. barrier on the **dispatcher** — it processes its whole mailbox, publishing
+       each queued durable event to `EmitBus`, which `send`s it (synchronously)
+       into the bridge's mailbox;
+    3. barrier on the **bridge** — it processes its whole mailbox, `append`ing
+       each durable event to the journal `Writer` (a synchronous call).
+
+  Neither barrier stops a process, so no `:rest_for_one` restart is triggered.
+  Only then do we tear the subtree down; the journal `Writer` (which traps exits)
+  datasyncs and closes in its own `terminate/2`.
+
+  GUARANTEED: every durable event enqueued to the dispatcher at the moment the
+  drain begins is appended to the journal and datasynced before teardown.
+  NOT guaranteed: events emitted *concurrently* by a still-running async turn
+  after the barriers pass — they race the teardown. For the harness's
+  synchronous one-message-one-turn model, once inbound `send_message`s stop the
+  tail is captured in full. The drain is bounded (best-effort) and never blocks
+  teardown on a slow/dead process.
   """
   @spec stop_session(term()) :: :ok | {:error, :not_found}
   def stop_session(session_id) do
     case lookup({:session_supervisor, session_id}) do
-      pid when is_pid(pid) -> stop_tree(pid)
-      nil -> stop_standalone(session_id)
+      pid when is_pid(pid) ->
+        drain_durable_tail(session_id)
+        stop_tree(pid)
+
+      nil ->
+        # Standalone sessions drain themselves: `Session.terminate/2` runs
+        # `stop_lifecycle_sync` (drains the dispatcher) then stops the bridge
+        # (which flushes the journal), so no extra drain is needed here.
+        stop_standalone(session_id)
     end
   end
+
+  # Flush dispatcher -> bridge -> journal via FIFO barriers so a graceful stop
+  # captures the full durable tail before the tree is torn down. See the
+  # `stop_session/1` doc for the completeness guarantee. Best-effort and bounded:
+  # any missing/slow/dead process just short-circuits — teardown proceeds either
+  # way, and a hard teardown is still safe (the Writer datasyncs on its own exit).
+  defp drain_durable_tail(session_id) do
+    flush_barrier(lookup({:session, session_id}))
+    flush_barrier(dispatcher_for(session_id))
+    flush_barrier(lookup({:emit_bridge, session_id}))
+    :ok
+  end
+
+  defp dispatcher_for(session_id) do
+    with pid when is_pid(pid) <- lookup({:lifecycle, session_id}),
+         %{dispatcher_pid: dispatcher} <-
+           GenServer.call(pid, :get_full_state, drain_timeout()) do
+      dispatcher
+    else
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  catch
+    :exit, _ -> nil
+  end
+
+  # A synchronous system message is a FIFO barrier: it returns only after every
+  # message enqueued before it has been handled, draining the mailbox into the
+  # process's side effects (dispatcher: publish to EmitBus; bridge: append to
+  # journal) WITHOUT stopping it (so no `:rest_for_one` restart fires).
+  defp flush_barrier(pid) when is_pid(pid) do
+    _ = :sys.get_state(pid, drain_timeout())
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp flush_barrier(_), do: :ok
+
+  defp drain_timeout, do: Raxol.Core.Defaults.shutdown_timeout_ms()
 
   @doc """
   Resolve `session_id` to the live `Raxol.Agent.Session` pid, or `nil`.

--- a/packages/raxol_agent/lib/raxol/agent/session/supervisor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session/supervisor.ex
@@ -11,22 +11,39 @@ defmodule Raxol.Agent.Session.Supervisor do
     1. `Raxol.Agent.EmitBridge` — the per-session sink. Owns the durable
        journal handle (opened lazily on the first durable event) and the
        EmitBus subscription.
-    2. `Raxol.Agent.Session` — the Lifecycle wrapper (dispatcher). Started
-       with `start_emit_bridge: false`: the tree owns the bridge, the session
-       must not start a second one.
+    2. `Raxol.Core.Runtime.Lifecycle` — the per-session TEA runtime (dispatcher
+       + model). A **supervised sibling**, not something the session spawns and
+       orphans. It emits durable events onto EmitBus, so it must start AFTER the
+       sink is subscribed (dependency order). Registered under
+       `{:lifecycle, session_id}`.
+    3. `Raxol.Agent.Session` — the thin API/forwarder. Started with
+       `start_emit_bridge: false` AND `manage_lifecycle: false`: the tree owns
+       both the sink and the runtime; the session only looks them up and
+       forwards `send_message` / `get_model` to the runtime's dispatcher.
 
-  Why this order: the journal/sink is the resource the session *depends on*
-  (durable events must have somewhere to land), so it starts first and stops
-  last. Under `:rest_for_one`:
+  Why the runtime is a supervised child (not session-spawned): if the session
+  owned an unlinked lifecycle, a `stop_session` (or any `:rest_for_one` restart,
+  which kills the non-trapping session WITHOUT running `terminate/2`) would
+  leave the runtime running forever — a leak — and a later same-`session_id`
+  start would reattach to that dead session's stale model. As a tree child the
+  runtime is torn down with the subtree and started fresh on every restart:
+  the leak and the reattach-to-dead are structurally impossible.
 
-    * a **bridge crash** restarts the bridge *and then* the session — the
-      whole tree recovers in dependency order, and the restarted bridge
-      re-registers under `{:emit_bridge, session_id}` (exactly one bridge; the
-      journal Writer survives via its own `:global` single-writer discipline
-      and is re-joined on the next durable append, so offsets stay monotonic);
-    * a **session crash** restarts *only* the session — the sink is never
-      orphaned and never duplicated, and the restarted session finds the
-      running bridge via the registry.
+  Why this order: the sink is the resource the runtime *depends on* (durable
+  events must have somewhere to land), so it starts first and stops last; the
+  runtime depends on it and the session depends on the runtime. Under
+  `:rest_for_one`:
+
+    * a **bridge crash** restarts the bridge, THEN the lifecycle, THEN the
+      session — the whole tree recovers in dependency order (a FRESH lifecycle,
+      so no durable event is ever emitted into a dead-sink gap), and the
+      restarted bridge re-registers under `{:emit_bridge, session_id}` (exactly
+      one bridge; the journal Writer survives via its own `:global`
+      single-writer discipline and is re-joined on the next durable append, so
+      offsets stay monotonic);
+    * a **session crash** restarts *only* the session — the sink and the
+      lifecycle are never orphaned or duplicated, and the restarted session
+      re-resolves the SAME running lifecycle (model preserved) via the registry.
 
   ## Registry keys (all in `Raxol.Agent.Registry`)
 
@@ -149,15 +166,21 @@ defmodule Raxol.Agent.Session.Supervisor do
       |> copy_opt(:journal, opts)
       |> copy_opt(:journal_opts, opts)
 
-    # The tree owns the bridge; the session must not start (or stop) its own.
-    session_opts = Keyword.put(opts, :start_emit_bridge, false)
+    # The tree owns the sink AND the lifecycle; the session starts (and stops)
+    # neither — it only looks them up and forwards to the runtime's dispatcher.
+    session_opts =
+      opts
+      |> Keyword.put(:start_emit_bridge, false)
+      |> Keyword.put(:manage_lifecycle, false)
 
     children = [
       %{
         id: :emit_bridge,
-        start: {EmitBridge, :start_link, [bridge_opts]},
-        restart: :permanent
+        start: {__MODULE__, :start_bridge, [session_id, bridge_opts]},
+        restart: :permanent,
+        shutdown: 5_000
       },
+      Session.lifecycle_child_spec(opts),
       %{
         id: :session,
         start: {Session, :start_link, [session_opts]},
@@ -165,14 +188,27 @@ defmodule Raxol.Agent.Session.Supervisor do
       }
     ]
 
-    # max_restarts is slightly generous: an immediate restart of the session
-    # child can transiently lose the Registry-cleanup race for its via name
-    # and need another attempt.
+    # Restarts are made deterministic (each via-named child waits for its dead
+    # predecessor's Registry key to clear before re-registering — see
+    # `start_bridge/2`, `Session.start_supervised_lifecycle/1`,
+    # `Session.start_link/1`), so `max_restarts` no longer has to absorb a lost
+    # cleanup race. Keep a small budget purely as a genuine crash-loop backstop.
     Supervisor.init(children,
       strategy: :rest_for_one,
       max_restarts: 5,
       max_seconds: 5
     )
+  end
+
+  @doc false
+  # Start the per-session sink, waiting for a dead predecessor's
+  # `{:emit_bridge, session_id}` via-name to clear first so a `:rest_for_one`
+  # restart is deterministic (YELLOW 3) rather than depending on winning the
+  # race against Registry's async cleanup.
+  @spec start_bridge(term(), keyword()) :: GenServer.on_start()
+  def start_bridge(session_id, bridge_opts) do
+    Session.await_free({:emit_bridge, session_id})
+    EmitBridge.start_link(bridge_opts)
   end
 
   # --- helpers -----------------------------------------------------------------

--- a/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
@@ -238,6 +238,126 @@ defmodule Raxol.Agent.Session.SupervisorTest do
     end
   end
 
+  describe "lifecycle ownership (RED 1 — no leak, no reattach-to-dead)" do
+    test "stop_session tears down the tree-owned lifecycle — no orphaned runtime" do
+      base = tmp_base()
+      sid = "ss-lifeleak-#{uniq()}"
+
+      {:ok, sup} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_ll_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      # The lifecycle is a supervised sibling, registered by session_id.
+      lifecycle = lifecycle_pid(sid)
+      assert is_pid(lifecycle) and Process.alive?(lifecycle)
+
+      # Under BaseManager the session does NOT trap exits, so stop_session kills
+      # it WITHOUT running terminate/2. If the lifecycle were a session-spawned
+      # orphan it would leak here; as a tree child it dies with the subtree.
+      assert :ok = Session.Supervisor.stop_session(sid)
+      wait_until(fn -> not Process.alive?(sup) end)
+      wait_until(fn -> not Process.alive?(lifecycle) end)
+      refute Process.alive?(lifecycle)
+      wait_until(fn -> lifecycle_pid(sid) == nil end)
+    end
+
+    test "restarting the same session_id yields a FRESH lifecycle + init model (never reattaches to the dead one)" do
+      base = tmp_base()
+      sid = "ss-reattach-#{uniq()}"
+
+      {:ok, sup1} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_ra_a_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      session1 = Session.Supervisor.whereis(sid)
+      life1 = lifecycle_pid(sid)
+      assert is_pid(life1)
+
+      # Accumulate model state so a reattach would be observable.
+      :ok = Session.send_message(agent_id(session1), {:say, "one"})
+      wait_until(fn -> get_model(session1) == {:ok, %{seen: ["one"]}} end)
+
+      assert :ok = Session.Supervisor.stop_session(sid)
+      wait_until(fn -> not Process.alive?(sup1) and lifecycle_pid(sid) == nil end)
+      refute Process.alive?(life1)
+
+      # Same session_id again: a fresh subtree, a fresh lifecycle, and — the
+      # crux — the app's INIT model, not the dead session's accumulated one.
+      {:ok, sup2} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_ra_b_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn -> Session.Supervisor.stop_session(sid) end)
+
+      session2 = Session.Supervisor.whereis(sid)
+      life2 = lifecycle_pid(sid)
+
+      assert is_pid(life2) and Process.alive?(life2)
+      assert life2 != life1
+      assert is_pid(sup2) and sup2 != sup1
+      assert {:ok, %{seen: []}} = get_model(session2)
+    end
+
+    test "lifecycle is REUSED after a session-only crash but FRESH after a bridge crash" do
+      base = tmp_base()
+      sid = "ss-lifeid-#{uniq()}"
+
+      {:ok, _sup} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_li_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn -> Session.Supervisor.stop_session(sid) end)
+
+      life0 = lifecycle_pid(sid)
+      session0 = Session.Supervisor.whereis(sid)
+      assert is_pid(life0)
+
+      # Session-only crash: rest_for_one restarts only the child at/after the
+      # session (the session is last), so the lifecycle before it is untouched.
+      Process.exit(session0, :kill)
+
+      wait_until(fn ->
+        s = Session.Supervisor.whereis(sid)
+        is_pid(s) and s != session0 and Process.alive?(s)
+      end)
+
+      # REUSED — same pid, and the restarted session re-resolved it.
+      assert lifecycle_pid(sid) == life0
+      session1 = Session.Supervisor.whereis(sid)
+      assert %{lifecycle_pid: ^life0} = :sys.get_state(session1)
+
+      # Bridge crash: the bridge is first, so bridge + lifecycle + session all
+      # restart — a FRESH lifecycle (no durable event is emitted into a dead
+      # sink), which the restarted session re-resolves.
+      [{bridge1, _}] = registry_lookup({:emit_bridge, sid})
+      Process.exit(bridge1, :kill)
+
+      wait_until(fn ->
+        l = lifecycle_pid(sid)
+        is_pid(l) and l != life0 and Process.alive?(l)
+      end)
+
+      life2 = lifecycle_pid(sid)
+      assert life2 != life0
+
+      wait_until(fn ->
+        match?(%{lifecycle_pid: ^life2}, :sys.get_state(Session.Supervisor.whereis(sid)))
+      end)
+    end
+  end
+
   describe "whereis / list_sessions" do
     test "whereis resolves a live session and returns nil for an unknown id" do
       assert Session.Supervisor.whereis("ss-unknown-#{uniq()}") == nil
@@ -344,6 +464,21 @@ defmodule Raxol.Agent.Session.SupervisorTest do
   defp agent_id(session) do
     %{id: id} = :sys.get_state(session)
     id
+  end
+
+  # The tree-owned lifecycle for a session_id (nil if none). It registers under
+  # {:lifecycle, session_id} in Raxol.Agent.Registry.
+  defp lifecycle_pid(sid) do
+    case Registry.lookup(Raxol.Agent.Registry, {:lifecycle, sid}) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+  defp get_model(session) when is_pid(session) do
+    GenServer.call(session, :get_model)
+  catch
+    :exit, _ -> {:error, :down}
   end
 
   defp registry_lookup(key), do: Registry.lookup(Raxol.Agent.Registry, key)

--- a/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
@@ -1,0 +1,399 @@
+defmodule Raxol.Agent.Session.SupervisorTest do
+  @moduledoc """
+  SS — the per-session OTP tree + `session_id → pid` registry that the Wave 2
+  units (U4 reattach, U5/U6 turn kill/steer, U9 pointer records) resolve
+  against.
+
+  Proves:
+
+    1. `start_session/2` brings up one supervised subtree (sink + session), both
+       registered; `stop_session/1` tears it down cleanly and closes the journal.
+    2. A bridge (journal-owner) crash restarts the tree in DEPENDENCY ORDER
+       under `:rest_for_one` (sink first, then session) — asserted via the
+       restarted session resolving the ALREADY-restarted sink.
+    3. A session crash recovers with exactly one bridge and one writer, and a
+       durable event round-trips (emit → journal → live tail) post-recovery.
+    4. `whereis/1`, `list_sessions/0`, and duplicate-id rejection behave.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Journal.FileStore
+  alias Raxol.Agent.Session
+  alias Raxol.Agent.SessionStreamer
+  alias Raxol.Core.Runtime.EmitBus
+
+  # A synchronous, headless agent: one inbound message = one fold = one turn.
+  defmodule EchoAgent do
+    use Raxol.Agent
+
+    def init(_context), do: %{seen: []}
+
+    def update({:agent_message, _from, {:say, text}}, model),
+      do: {%{model | seen: [text | model.seen]}, []}
+
+    def update(_msg, model), do: {model, []}
+
+    def view(model), do: text("seen: #{length(model.seen)}")
+  end
+
+  setup do
+    # App-level singletons: tolerate an already-running instance.
+    ensure_registry(:duplicate, EmitBus.registry_name())
+
+    ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
+
+    # The lifecycle's own DynamicSupervisor (used by Lifecycle.start_link).
+    ensure_running({DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one})
+
+    # Per-test singletons owned by ExUnit (auto-stopped at test end): the agent
+    # Registry, the DynSup the session trees run under, and the named
+    # SessionStreamer the sink emits into.
+    start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
+
+    start_supervised!({DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one})
+
+    start_supervised!(Raxol.Agent.SessionStreamer)
+
+    :ok
+  end
+
+  describe "start_session / stop_session (one supervised subtree)" do
+    test "start brings the whole tree up and registers it; stop tears it down and closes the journal" do
+      base = tmp_base()
+      sid = "ss-start-#{uniq()}"
+
+      {:ok, sup} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_start_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      # The subtree supervisor is registered and is the returned pid.
+      assert is_pid(sup)
+      assert [{^sup, _}] = registry_lookup({:session_supervisor, sid})
+
+      # Both children are up and registered.
+      session = Session.Supervisor.whereis(sid)
+      assert is_pid(session) and Process.alive?(session)
+      assert [{bridge, _}] = registry_lookup({:emit_bridge, sid})
+      assert Process.alive?(bridge)
+
+      # Drive one durable turn so the journal actually opens, then grab the
+      # writer pid to prove it closes on teardown.
+      :ok = SessionStreamer.subscribe(sid)
+      :ok = Session.send_message(agent_id(session), {:say, "hi"})
+      assert_receive {:session_event, ^sid, %Event{type: :turn_completed}}, 1_000
+
+      %{journal: %FileStore{writer: writer}} = :sys.get_state(bridge)
+      assert Process.alive?(writer)
+
+      # Teardown: whole subtree gone, registry clean, journal writer closed.
+      assert :ok = Session.Supervisor.stop_session(sid)
+      wait_until(fn -> not Process.alive?(sup) end)
+
+      refute Process.alive?(session)
+      refute Process.alive?(bridge)
+      wait_until(fn -> not Process.alive?(writer) end)
+      refute Process.alive?(writer)
+
+      # Registry keys clear on each process's DOWN (just after termination).
+      wait_until(fn ->
+        Session.Supervisor.whereis(sid) == nil and
+          registry_lookup({:session_supervisor, sid}) == [] and
+          registry_lookup({:emit_bridge, sid}) == []
+      end)
+
+      assert Session.Supervisor.list_sessions() == []
+    end
+
+    test "duplicate start_session with the same session_id returns {:error, {:already_started, _}}" do
+      sid = "ss-dup-#{uniq()}"
+      base = tmp_base()
+
+      {:ok, sup1} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_dup_a_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn -> Session.Supervisor.stop_session(sid) end)
+
+      assert {:error, {:already_started, ^sup1}} =
+               Session.Supervisor.start_session(EchoAgent,
+                 id: :"ss_dup_b_#{uniq()}",
+                 session_id: sid,
+                 journal_opts: [base_dir: base]
+               )
+    end
+
+    test "stop_session on an unknown id returns {:error, :not_found}" do
+      assert {:error, :not_found} =
+               Session.Supervisor.stop_session("ss-nope-#{uniq()}")
+    end
+  end
+
+  describe "rest_for_one dependency order (bridge crash)" do
+    test "a sink crash restarts the sink FIRST, then the session — the restarted session resolves the new sink" do
+      base = tmp_base()
+      sid = "ss-bridgecrash-#{uniq()}"
+
+      {:ok, _sup} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_bc_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn -> Session.Supervisor.stop_session(sid) end)
+
+      session1 = Session.Supervisor.whereis(sid)
+      [{bridge1, _}] = registry_lookup({:emit_bridge, sid})
+      assert %{emit_bridge: ^bridge1} = :sys.get_state(session1)
+
+      # Brutally kill the sink (the journal owner, first in the tree).
+      Process.exit(bridge1, :kill)
+
+      # rest_for_one restarts the sink AND everything after it (the session).
+      # Wait until both are fresh, live pids.
+      wait_until(fn ->
+        s = Session.Supervisor.whereis(sid)
+        b = registry_lookup({:emit_bridge, sid})
+
+        match?([{p, _}] when is_pid(p) and p != bridge1, b) and
+          is_pid(s) and s != session1 and Process.alive?(s)
+      end)
+
+      session2 = Session.Supervisor.whereis(sid)
+      [{bridge2, _}] = registry_lookup({:emit_bridge, sid})
+
+      # The sink was restarted (new pid).
+      assert bridge2 != bridge1
+      # rest_for_one (not one_for_one): the SESSION restarted too.
+      assert session2 != session1
+      # DEPENDENCY ORDER: the restarted session resolved the ALREADY-restarted
+      # sink — proving the sink came up before the session.
+      assert %{emit_bridge: ^bridge2} = :sys.get_state(session2)
+
+      # Exactly one sink for the session_id — no orphan/duplicate.
+      assert [{^bridge2, _}] = registry_lookup({:emit_bridge, sid})
+    end
+  end
+
+  describe "session crash recovery (sink not orphaned or duplicated)" do
+    test "a killed session recovers with one sink + one writer; a durable event round-trips post-recovery" do
+      base = tmp_base()
+      sid = "ss-sesscrash-#{uniq()}"
+
+      {:ok, _sup} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_sc_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn -> Session.Supervisor.stop_session(sid) end)
+
+      session1 = Session.Supervisor.whereis(sid)
+      [{bridge1, _}] = registry_lookup({:emit_bridge, sid})
+
+      # Brutal session kill — terminate/2 never runs, so the (unlinked) sink and
+      # lifecycle survive.
+      Process.exit(session1, :kill)
+
+      wait_until(fn ->
+        s = Session.Supervisor.whereis(sid)
+        is_pid(s) and s != session1 and Process.alive?(s)
+      end)
+
+      session2 = Session.Supervisor.whereis(sid)
+
+      # The sink survived the session crash (session-only restart) — same pid,
+      # exactly one registered, and its single writer is unchanged.
+      assert Process.alive?(bridge1)
+      assert [{^bridge1, _}] = registry_lookup({:emit_bridge, sid})
+
+      # A durable turn round-trips through the recovered tree: emit → journal →
+      # live tail, and a duplicate sink would emit a second turn_started.
+      :ok = SessionStreamer.subscribe(sid)
+      :ok = Session.send_message(agent_id(session2), {:say, "after"})
+
+      assert_receive {:session_event, ^sid, %Event{type: :turn_started}}, 1_000
+      assert_receive {:session_event, ^sid, %Event{type: :turn_completed}}, 1_000
+
+      refute_receive {:session_event, ^sid, %Event{type: :turn_started}}, 200
+
+      # Journal on disk holds the durable trace with monotonic offsets.
+      {:ok, j} = FileStore.open(sid, base_dir: base)
+      {:ok, records} = FileStore.read(j)
+      FileStore.close(j)
+
+      ids = Enum.map(records, & &1["id"])
+      assert ids == Enum.sort(ids)
+      assert length(ids) >= 3
+    end
+  end
+
+  describe "whereis / list_sessions" do
+    test "whereis resolves a live session and returns nil for an unknown id" do
+      assert Session.Supervisor.whereis("ss-unknown-#{uniq()}") == nil
+
+      sid = "ss-whereis-#{uniq()}"
+      base = tmp_base()
+
+      {:ok, _sup} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_wi_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn -> Session.Supervisor.stop_session(sid) end)
+
+      session = Session.Supervisor.whereis(sid)
+      assert is_pid(session) and Process.alive?(session)
+    end
+
+    test "list_sessions is accurate across starts, stops, and crashes" do
+      base = tmp_base()
+      sid_a = "ss-list-a-#{uniq()}"
+      sid_b = "ss-list-b-#{uniq()}"
+
+      {:ok, _a} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_la_#{uniq()}",
+          session_id: sid_a,
+          journal_opts: [base_dir: base]
+        )
+
+      {:ok, _b} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_lb_#{uniq()}",
+          session_id: sid_b,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn ->
+        Session.Supervisor.stop_session(sid_a)
+        Session.Supervisor.stop_session(sid_b)
+      end)
+
+      listed = fn -> Session.Supervisor.list_sessions() |> Map.new() end
+
+      m = listed.()
+      assert Map.has_key?(m, sid_a)
+      assert Map.has_key?(m, sid_b)
+
+      # After a crash, the (restarted) session still lists — under its session_id.
+      Process.exit(Session.Supervisor.whereis(sid_a), :kill)
+
+      wait_until(fn ->
+        s = Session.Supervisor.whereis(sid_a)
+        is_pid(s) and Process.alive?(s)
+      end)
+
+      m2 = listed.()
+      assert Map.has_key?(m2, sid_a)
+      assert Map.has_key?(m2, sid_b)
+
+      # After a stop, only the survivor remains.
+      assert :ok = Session.Supervisor.stop_session(sid_a)
+      wait_until(fn -> Session.Supervisor.whereis(sid_a) == nil end)
+
+      m3 = listed.()
+      refute Map.has_key?(m3, sid_a)
+      assert Map.has_key?(m3, sid_b)
+    end
+  end
+
+  describe "standalone sessions still resolve through the seam" do
+    test "a bare Session.start_link registers under {:session, session_id} and stop_session stops it" do
+      sid = "ss-standalone-#{uniq()}"
+      base = tmp_base()
+
+      {:ok, session} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"ss_standalone_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      on_exit(fn -> if Process.alive?(session), do: GenServer.stop(session) end)
+
+      # Resolvable via the shared seam even though it was NOT started under the
+      # tree (no {:session_supervisor, _} key exists for it).
+      assert Session.Supervisor.whereis(sid) == session
+      assert registry_lookup({:session_supervisor, sid}) == []
+
+      # stop_session falls back to stopping the standalone session directly.
+      assert :ok = Session.Supervisor.stop_session(sid)
+      wait_until(fn -> not Process.alive?(session) end)
+      # Registry removes the {:session, _} key on the process's DOWN, which lands
+      # just after GenServer.stop returns — wait for the key to clear.
+      wait_until(fn -> Session.Supervisor.whereis(sid) == nil end)
+    end
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  defp agent_id(session) do
+    %{id: id} = :sys.get_state(session)
+    id
+  end
+
+  defp registry_lookup(key), do: Registry.lookup(Raxol.Agent.Registry, key)
+
+  defp uniq, do: System.unique_integer([:positive])
+
+  defp wait_until(fun, timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("wait_until timed out")
+
+      true ->
+        Process.sleep(20)
+        do_wait_until(fun, deadline)
+    end
+  end
+
+  defp tmp_base do
+    base = Path.join(System.tmp_dir!(), "ss_journal_#{uniq()}")
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf(base) end)
+    base
+  end
+
+  defp ensure_registry(keys, name) do
+    case Registry.start_link(keys: keys, name: name) do
+      {:ok, pid} -> Process.unlink(pid)
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+
+  defp ensure_running({DynamicSupervisor, opts}) do
+    case DynamicSupervisor.start_link(opts) do
+      {:ok, pid} -> Process.unlink(pid)
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+
+  defp ensure_running({mod, opts}) do
+    case mod.start_link(opts) do
+      {:ok, pid} -> Process.unlink(pid)
+      {:error, {:already_started, _}} -> :ok
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
@@ -338,6 +338,12 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       session1 = Session.Supervisor.whereis(sid)
       assert %{lifecycle_pid: ^life0} = :sys.get_state(session1)
 
+      # Accumulate model state on the REUSED lifecycle so a "fresh model" claim
+      # after the bridge crash is observable at the MODEL level, not just via a
+      # new pid: a reattach-to-dead would carry this state forward.
+      :ok = Session.send_message(agent_id(session1), {:say, "kept"})
+      wait_until(fn -> get_model(session1) == {:ok, %{seen: ["kept"]}} end)
+
       # Bridge crash: the bridge is first, so bridge + lifecycle + session all
       # restart — a FRESH lifecycle (no durable event is emitted into a dead
       # sink), which the restarted session re-resolves.
@@ -355,6 +361,113 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       wait_until(fn ->
         match?(%{lifecycle_pid: ^life2}, :sys.get_state(Session.Supervisor.whereis(sid)))
       end)
+
+      # The crux: the fresh lifecycle carries the app's INIT model, NOT the
+      # accumulated ["kept"] — proving it did not reattach to the dead runtime.
+      session2 = Session.Supervisor.whereis(sid)
+      wait_until(fn -> get_model(session2) == {:ok, %{seen: []}} end)
+    end
+  end
+
+  describe "graceful stop drains the durable tail (YELLOW 2 — no journal-tail loss)" do
+    test "durable events queued at stop_session all reach the journal" do
+      base = tmp_base()
+      sid = "ss-drain-#{uniq()}"
+
+      {:ok, _sup} =
+        Session.Supervisor.start_session(EchoAgent,
+          id: :"ss_drain_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      session = Session.Supervisor.whereis(sid)
+      aid = agent_id(session)
+
+      # Fire several turns WITHOUT awaiting their round-trip, so their durable
+      # events are still in-flight (session/dispatcher/bridge mailboxes) at stop
+      # time. Each turn journals turn_started, item_completed, turn_completed.
+      n = 5
+      for i <- 1..n, do: :ok = Session.send_message(aid, {:say, "m#{i}"})
+
+      # Graceful stop must flush the whole queued tail before teardown.
+      assert :ok = Session.Supervisor.stop_session(sid)
+      wait_until(fn -> Session.Supervisor.whereis(sid) == nil end)
+
+      # Reopen from disk: all N turns present — none lost to a truncated tail.
+      {:ok, j} = FileStore.open(sid, base_dir: base)
+      {:ok, records} = FileStore.read(j)
+      FileStore.close(j)
+
+      assert Enum.count(records, &(&1["type"] == "turn_completed")) == n
+      ids = Enum.map(records, & &1["id"])
+      assert ids == Enum.sort(ids)
+    end
+  end
+
+  describe "standalone Session under a rest_for_one parent (YELLOW 1 — no orphaned lifecycle)" do
+    test "a Team-style parent shutdown honors terminate/2 and leaves no orphaned lifecycle" do
+      base = tmp_base()
+      sid = "ss-teardown-#{uniq()}"
+
+      # Mirror Raxol.Agent.Team exactly: a :rest_for_one supervisor over a
+      # standalone Session child spec (Session.child_spec).
+      children = [
+        {Session,
+         [
+           app_module: EchoAgent,
+           id: :"ss_td_#{uniq()}",
+           session_id: sid,
+           journal_opts: [base_dir: base]
+         ]}
+      ]
+
+      {:ok, parent} = Supervisor.start_link(children, strategy: :rest_for_one)
+
+      session = Session.Supervisor.whereis(sid)
+      assert is_pid(session) and Process.alive?(session)
+
+      lifecycle = lifecycle_pid(sid)
+      assert is_pid(lifecycle) and Process.alive?(lifecycle)
+
+      # Tear the parent down. The child-spec shutdown budget (drain + margin) must
+      # give the Session's terminate/2 long enough to run stop_lifecycle_sync to
+      # completion — incl. its Process.exit(:kill) fallback — so the owned
+      # lifecycle can never be orphaned by a premature parent brutal-kill.
+      Supervisor.stop(parent)
+
+      refute Process.alive?(session)
+      wait_until(fn -> not Process.alive?(lifecycle) end)
+      refute Process.alive?(lifecycle)
+      wait_until(fn -> lifecycle_pid(sid) == nil end)
+    end
+
+    test "a graceful standalone GenServer.stop drains its durable tail" do
+      base = tmp_base()
+      sid = "ss-standalone-drain-#{uniq()}"
+
+      {:ok, session} =
+        Session.start_link(
+          app_module: EchoAgent,
+          id: :"ss_sad_#{uniq()}",
+          session_id: sid,
+          journal_opts: [base_dir: base]
+        )
+
+      aid = agent_id(session)
+      n = 4
+      for i <- 1..n, do: :ok = Session.send_message(aid, {:say, "s#{i}"})
+
+      # Standalone traps exits: terminate/2 runs, draining the lifecycle
+      # (dispatcher) then the bridge (which flushes the journal) — no tail loss.
+      :ok = GenServer.stop(session)
+      wait_until(fn -> not Process.alive?(session) end)
+
+      {:ok, j} = FileStore.open(sid, base_dir: base)
+      {:ok, records} = FileStore.read(j)
+      FileStore.close(j)
+
+      assert Enum.count(records, &(&1["type"] == "turn_completed")) == n
     end
   end
 


### PR DESCRIPTION
## What

Adds the per-session OTP topology unit **SS**:

- **`Raxol.Agent.Session.Supervisor`** — one supervised subtree per harness session, started under the existing `Raxol.Agent.DynSup`. `:rest_for_one`, children in dependency order:
  1. `Raxol.Agent.EmitBridge` (the sink — owns the durable journal handle + EmitBus subscription)
  2. `Raxol.Agent.Session` (the Lifecycle/dispatcher wrapper), started with `start_emit_bridge: false` so it does **not** start a second sink.
- **`session_id → pid` registry** in `Raxol.Agent.Registry`:
  - `{:session_supervisor, session_id}` → subtree supervisor
  - `{:session, session_id}` → the live `Session` (registered by the session in **both** supervised and standalone modes, so resolution works either way)
  - `{:emit_bridge, session_id}` → the sink (pre-existing key, unchanged)
- **Public API**: `start_session/2`, `stop_session/1`, `whereis/1`, `list_sessions/0`. Duplicate `session_id` → `{:error, {:already_started, pid}}` (enforced by the subtree supervisor's `:via` name).
- **Migrated `Agent.Session`'s bridge wiring into the tree**: under the supervisor the session *looks up* the sink instead of owning it. The bare `Session.start_link` path is untouched (back-compat).

## Why

Three plan reviewers independently flagged that four upcoming Wave 2 units — **U4** reattach (resolve a session), **U5/U6** turn kill/steer (find the turn process), **U9** pointer records (tag by session) — all assume a per-session OTP tree that nobody owned. Wave 1.5 left journal-open, bridge-start, and `session_id` as ad-hoc wiring spread across `Agent.Session`; without SS each Wave 2 unit reinvents that wiring and they collide. SS is the seam they resolve against.

## `:rest_for_one` order rationale

The sink is the resource the session *depends on* (durable events must have somewhere to land), so it starts **first** and stops **last**:

- **sink crash** → `:rest_for_one` restarts the sink *and then* the session; the restarted session resolves the already-restarted sink (dependency order), exactly one sink registered — no orphan, no duplicate.
- **session crash** → only the session restarts; the (unlinked) sink and its single journal writer survive and are re-resolved.

Two correctness fixes to `Agent.Session` that the tree requires:
- `terminate/2` stops the sink **only** when the session owns it (standalone mode). Under the tree the supervisor owns the sink's lifecycle.
- The lifecycle is now stopped **synchronously** in `terminate/2` (it runs under a stable name; `Lifecycle.stop/1` is a cast, so a `:rest_for_one` restart could otherwise reattach to the still-dying old lifecycle).

## Writer-migration decision: DEFERRED (keep `:global`)

The journal `FileStore.Writer` keeps its `:global` registration. It is keyed by the physical journal **directory**, not by session, so it enforces single-writer-per-dir across sessions, base dirs, and (on shared storage) nodes — an invariant a per-session `Registry` key cannot express. Migrating it would weaken that guarantee for no benefit. See `Raxol.Agent.Journal.FileStore.Writer.global_name/1`.

## Accepts (8 tests, all green)

- `start_session` brings the whole tree up + registered; `stop_session` tears it down cleanly, registry keys clear, journal writer closed.
- Sink crash → `:rest_for_one` restarts in dependency order (asserted via the restarted session resolving the already-restarted sink); one sink, no orphan.
- Session crash → recovers with exactly one sink + one writer; a durable event round-trips (emit → journal → live tail) post-recovery; no duplicate emits.
- `whereis/1` resolves live sessions and returns `nil` for unknown ids; `list_sessions/0` accurate across starts/stops/crashes.
- Duplicate `start_session` same id → `{:error, {:already_started, _}}`.
- Standalone `Session.start_link` sessions resolve through the same seam and are stoppable via `stop_session/1`.

Existing suites unbroken: `keystone_close_test`, `streaming_turn_attribution_test`, `journal_test`, `emit_bridge_test`, `session_test` all green. Full `raxol_agent` suite: **987 passed, 0 failures**. Clean `mix compile --warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7