### PR TITLE
feat(harness): MS — model snapshot contract (persistent slice, manifest, redaction)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/snapshot.ex
+++ b/packages/raxol_agent/lib/raxol/agent/snapshot.ex
@@ -1,0 +1,367 @@
+defmodule Raxol.Agent.Snapshot do
+  @moduledoc """
+  Durable serialization codec for a TEA model's **persistent slice**.
+
+  This is the JSON-safe, restorable counterpart to `Raxol.Debug.Snapshot`
+  (which captures whole in-memory `{message, before, after}` cycles for the
+  time-travel debugger). Where that snapshot lives and dies in memory, this one
+  is written to disk — it is the contract a later unit (U9 — Checkpoint) builds
+  `{journal_offset, model_snapshot}` records on. This module is the **contract +
+  codec only**: it is pure, with no GenServers and no file IO. U9 owns writing
+  envelopes into a session's `snapshots/` directory.
+
+  ## The three operations
+
+    * `dump/1` — model → a versioned, JSON-round-trippable envelope.
+    * `load/2` — envelope → the restored model (persistent fields restored,
+      everything else at struct/`init` defaults).
+    * `persistent_slice/1` — `load(dump(model))`; the durable projection of a
+      model, i.e. what survives a checkpoint round-trip.
+
+  ## The envelope
+
+      %{
+        v: 1,                       # schema version — this artifact outlives code
+        module: "Elixir.MyModel",   # struct module, or nil for a bare-map model
+        data: <json-safe encoding>, # the persistent slice
+        dropped: [%{"path" => [...], "reason" => "..."}, ...],
+        redacted: [%{"path" => [...]}, ...]
+      }
+
+  The envelope is intentionally **loud about exclusions**: every field that did
+  not make it into `data` is accounted for in `dropped` (non-persistable or
+  undeclared) or `redacted` (a secret). Nothing is silently mangled — a reviewer
+  reading the manifest sees exactly what the persistent slice omits and why.
+
+  ## The restore property
+
+  `load(dump(model))` equals the model's *persistent slice*, NOT the whole model:
+
+      load(dump(model)) == persistent_slice(model)
+
+  Equality holds on the declared slice only. Non-persistable fields (PIDs,
+  Ports, refs, functions), undeclared fields, and secrets come back at their
+  struct defaults — by design, not by accident.
+
+  ## Encoding grammar
+
+  Every persisted value maps to a self-describing, JSON-safe term:
+
+    * `nil`, booleans, numbers, binaries — encoded bare.
+    * other atoms — `%{"$a" => "name"}` (tagged strings; restored with
+      `String.to_existing_atom/1`, falling back to the raw string if the atom
+      no longer exists — safe, never a leak, never a crash).
+    * lists — JSON arrays, **all-or-nothing**: a list holding a non-serializable
+      element is dropped whole (positional partial-drop would silently reindex).
+    * plain maps — `%{"$m" => [[key, value], ...]}` (pairs preserve arbitrary
+      key types); per-key drops are recorded, the rest survive.
+    * declared structs — `%{"$s" => "Elixir.Mod", "f" => %{"field" => value}}`;
+      recursed via the struct's own `Persist.spec/1`.
+    * PIDs / Ports / refs / functions / tuples / undeclared structs — never
+      encoded; dropped into the manifest.
+
+  See `Raxol.Agent.Snapshot.Persist` for how an app declares its slice.
+  """
+
+  alias Raxol.Agent.Snapshot.Persist
+
+  @snapshot_version 1
+
+  # Name-based secret heuristic — a defence-in-depth net so an obvious secret is
+  # redacted even when an app forgot to declare it. Matches on field/key names.
+  @redact_pattern ~r/secret|password|passwd|token|api[_-]?key|private[_-]?key|credential|mnemonic|seed_phrase/i
+
+  @type envelope :: %{
+          required(:v) => pos_integer(),
+          required(:module) => String.t() | nil,
+          required(:data) => term(),
+          required(:dropped) => [map()],
+          required(:redacted) => [map()]
+        }
+
+  @doc "The schema version this codec emits."
+  @spec version() :: pos_integer()
+  def version, do: @snapshot_version
+
+  @doc """
+  Serialize `model` into a versioned, JSON-safe envelope.
+
+  Returns `{:ok, envelope}` or `{:error, reason}`. The only `dump` failure is a
+  top-level value that is itself non-persistable (e.g. handed a raw PID instead
+  of a model) — `{:error, {:not_persistable, reason}}`.
+  """
+  @spec dump(term()) :: {:ok, envelope()} | {:error, term()}
+  def dump(model) do
+    case encode(model, []) do
+      {:keep, data, dropped, redacted} ->
+        {:ok,
+         %{
+           v: @snapshot_version,
+           module: module_name(model),
+           data: data,
+           dropped: Enum.reverse(dropped),
+           redacted: Enum.reverse(redacted)
+         }}
+
+      {:drop, reason} ->
+        {:error, {:not_persistable, reason}}
+    end
+  rescue
+    e -> {:error, {:dump_failed, Exception.message(e)}}
+  end
+
+  @doc """
+  Restore a model from an `envelope`.
+
+  Accepts an envelope straight from `dump/1` (atom keys) or one that has
+  round-tripped through JSON (string keys). `module`, when given, is the target
+  struct module used to rebuild a bare-map encoding into a struct; it is ignored
+  when the envelope already carries its own `"$s"` module tag (the common case).
+
+  Returns `{:ok, model}` or a typed `{:error, reason}` — notably
+  `{:error, {:unsupported_version, v}}` for an envelope from a future codec,
+  never a crash.
+  """
+  @spec load(envelope() | map(), module() | nil) ::
+          {:ok, term()} | {:error, term()}
+  def load(envelope, module \\ nil) when is_map(envelope) do
+    with {:ok, v} <- fetch(envelope, :v),
+         :ok <- check_version(v),
+         {:ok, data} <- fetch(envelope, :data) do
+      {:ok, coerce(decode(data), module)}
+    end
+  rescue
+    e -> {:error, {:load_failed, Exception.message(e)}}
+  end
+
+  @doc """
+  The durable projection of `model`: `load(dump(model))`.
+
+  This is the slice that survives a checkpoint round-trip — the reference for
+  the restore property. Returns `{:ok, slice}` or the underlying error.
+  """
+  @spec persistent_slice(term()) :: {:ok, term()} | {:error, term()}
+  def persistent_slice(model) do
+    with {:ok, envelope} <- dump(model) do
+      load(envelope, module_atom(model))
+    end
+  end
+
+  # --- Encoding --------------------------------------------------------------
+
+  # Returns {:keep, encoded, dropped, redacted} | {:drop, reason}.
+  # `dropped`/`redacted` accumulate in reverse order (prepended); the public
+  # envelope reverses them once.
+
+  defp encode(v, _path)
+       when is_nil(v) or is_boolean(v) or is_number(v) or is_binary(v),
+       do: {:keep, v, [], []}
+
+  defp encode(v, _path) when is_atom(v),
+    do: {:keep, %{"$a" => Atom.to_string(v)}, [], []}
+
+  defp encode(v, _path) when is_pid(v), do: {:drop, :pid}
+  defp encode(v, _path) when is_port(v), do: {:drop, :port}
+  defp encode(v, _path) when is_reference(v), do: {:drop, :reference}
+  defp encode(v, _path) when is_function(v), do: {:drop, :function}
+  defp encode(v, _path) when is_tuple(v), do: {:drop, :tuple}
+  defp encode(v, path) when is_list(v), do: encode_list(v, path)
+  defp encode(%_struct{} = v, path), do: encode_struct(v, path)
+  defp encode(v, path) when is_map(v), do: encode_map(v, path)
+
+  # Lists are all-or-nothing: a non-serializable element sinks the whole list
+  # rather than silently reindexing the survivors.
+  defp encode_list(list, path) do
+    Enum.reduce_while(list, {[], [], []}, fn el, {acc, drops, reds} ->
+      case encode(el, path) do
+        {:keep, enc, d, r} ->
+          {:cont, {[enc | acc], d ++ drops, r ++ reds}}
+
+        {:drop, reason} ->
+          {:halt, {:drop, {:list_element, reason}}}
+      end
+    end)
+    |> case do
+      {:drop, reason} -> {:drop, reason}
+      {acc, drops, reds} -> {:keep, Enum.reverse(acc), drops, reds}
+    end
+  end
+
+  defp encode_map(map, path) do
+    {pairs, drops, reds} =
+      Enum.reduce(map, {[], [], []}, fn {k, val}, {pairs, drops, reds} ->
+        cond do
+          sensitive?(k) ->
+            {pairs, drops, [redacted_entry(path ++ [k]) | reds]}
+
+          true ->
+            encode_pair(k, val, path, pairs, drops, reds)
+        end
+      end)
+
+    {:keep, %{"$m" => Enum.reverse(pairs)}, drops, reds}
+  end
+
+  defp encode_pair(k, val, path, pairs, drops, reds) do
+    case {encode(k, path), encode(val, path ++ [k])} do
+      {{:keep, ek, _, _}, {:keep, ev, d, r}} ->
+        {[[ek, ev] | pairs], d ++ drops, r ++ reds}
+
+      {{:drop, reason}, _} ->
+        {pairs, [dropped_entry(path ++ [k], {:bad_key, reason}) | drops], reds}
+
+      {_, {:drop, reason}} ->
+        {pairs, [dropped_entry(path ++ [k], reason) | drops], reds}
+    end
+  end
+
+  defp encode_struct(%mod{} = struct, path) do
+    case slice_spec(struct) do
+      {:declared, %{persist: persist, redact: redact}} ->
+        redact_set = MapSet.new(redact)
+        fields = Map.from_struct(struct)
+        {fmap, drops, reds} = encode_fields(fields, persist, redact_set, path)
+        {:keep, %{"$s" => Atom.to_string(mod), "f" => fmap}, drops, reds}
+
+      :undeclared ->
+        {:drop, {:undeclared_struct, module_string(mod)}}
+    end
+  end
+
+  defp encode_fields(fields, persist, redact_set, path) do
+    Enum.reduce(fields, {%{}, [], []}, fn {k, val}, {fmap, drops, reds} ->
+      cond do
+        MapSet.member?(redact_set, k) or sensitive?(k) ->
+          {fmap, drops, [redacted_entry(path ++ [k]) | reds]}
+
+        persist != :auto and k not in persist ->
+          {fmap, [dropped_entry(path ++ [k], :undeclared_field) | drops], reds}
+
+        true ->
+          encode_field(k, val, path, fmap, drops, reds)
+      end
+    end)
+  end
+
+  defp encode_field(k, val, path, fmap, drops, reds) do
+    case encode(val, path ++ [k]) do
+      {:keep, enc, d, r} ->
+        {Map.put(fmap, Atom.to_string(k), enc), d ++ drops, r ++ reds}
+
+      {:drop, reason} ->
+        {fmap, [dropped_entry(path ++ [k], reason) | drops], reds}
+    end
+  end
+
+  # --- Decoding --------------------------------------------------------------
+
+  defp decode(%{"$a" => name}) when is_binary(name), do: safe_atom(name)
+
+  defp decode(%{"$s" => mod_str, "f" => fmap})
+       when is_binary(mod_str) and is_map(fmap) do
+    mod = String.to_existing_atom(mod_str)
+    fields = for {k, v} <- fmap, do: {safe_atom(k), decode(v)}
+    struct(mod, fields)
+  end
+
+  defp decode(%{"$m" => pairs}) when is_list(pairs) do
+    Map.new(pairs, fn [k, v] -> {decode(k), decode(v)} end)
+  end
+
+  defp decode(list) when is_list(list), do: Enum.map(list, &decode/1)
+  defp decode(v), do: v
+
+  # A bare-map encoding restores to a plain map; a caller that knows the target
+  # struct module can pass it to rebuild a struct from that map.
+  defp coerce(decoded, nil), do: decoded
+  defp coerce(%_{} = decoded, _module), do: decoded
+
+  defp coerce(decoded, module) when is_map(decoded) and is_atom(module) do
+    fields = for {k, v} <- decoded, do: {atomize(k), v}
+    struct(module, fields)
+  end
+
+  defp coerce(decoded, _module), do: decoded
+
+  # --- Manifest entries (JSON-safe) ------------------------------------------
+
+  defp dropped_entry(path, reason) do
+    %{"path" => stringify_path(path), "reason" => reason_string(reason)}
+  end
+
+  defp redacted_entry(path), do: %{"path" => stringify_path(path)}
+
+  defp stringify_path(path), do: Enum.map(path, &key_string/1)
+
+  defp key_string(k) when is_atom(k), do: Atom.to_string(k)
+  defp key_string(k) when is_binary(k), do: k
+  defp key_string(k) when is_number(k), do: to_string(k)
+  defp key_string(k), do: inspect(k)
+
+  defp reason_string(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp reason_string(reason), do: inspect(reason)
+
+  # --- Helpers ---------------------------------------------------------------
+
+  defp check_version(@snapshot_version), do: :ok
+  defp check_version(v), do: {:error, {:unsupported_version, v}}
+
+  # Envelope keys may be atoms (fresh from dump/1) or strings (post JSON).
+  defp fetch(env, key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(env, key) -> {:ok, Map.get(env, key)}
+      Map.has_key?(env, string_key) -> {:ok, Map.get(env, string_key)}
+      true -> {:error, {:missing_key, key}}
+    end
+  end
+
+  # Resolve a struct's declared slice.
+  #
+  # We look up the per-struct implementation module (`Persist.<Mod>`) directly
+  # rather than through `Persist.impl_for/1` or protocol dispatch. Both consult
+  # the *consolidated* dispatch table, which is frozen at the point the defining
+  # app is built — a struct that `@derive`s the protocol AFTER consolidation
+  # (any downstream app, and every test fixture here) would be invisible to it
+  # and silently treated as undeclared. The defimpl module itself is always
+  # generated and loadable, so probing it directly is robust to consolidation
+  # state. A struct with no such module is genuinely undeclared → auto-scan does
+  # not recurse into it; it is dropped-with-manifest.
+  defp slice_spec(%mod{} = struct) do
+    impl = Module.concat(Persist, mod)
+
+    if Code.ensure_loaded?(impl) and function_exported?(impl, :spec, 1) do
+      {:declared, impl.spec(struct)}
+    else
+      :undeclared
+    end
+  end
+
+  defp sensitive?(k) when is_atom(k) and not is_nil(k) and not is_boolean(k),
+    do: sensitive?(Atom.to_string(k))
+
+  defp sensitive?(k) when is_binary(k), do: Regex.match?(@redact_pattern, k)
+  defp sensitive?(_), do: false
+
+  # Restore an atom without risking the String.to_atom memory-leak on reload of
+  # semi-trusted on-disk data: prefer an existing atom, else keep the string.
+  defp safe_atom(name) do
+    String.to_existing_atom(name)
+  rescue
+    ArgumentError -> name
+  end
+
+  defp atomize(k) when is_atom(k), do: k
+  defp atomize(k) when is_binary(k), do: safe_atom(k)
+
+  defp module_name(model) do
+    if is_struct(model), do: module_string(model.__struct__), else: nil
+  end
+
+  defp module_atom(model) do
+    if is_struct(model), do: model.__struct__, else: nil
+  end
+
+  defp module_string(mod), do: Atom.to_string(mod)
+end

--- a/packages/raxol_agent/lib/raxol/agent/snapshot.ex
+++ b/packages/raxol_agent/lib/raxol/agent/snapshot.ex
@@ -43,14 +43,43 @@ defmodule Raxol.Agent.Snapshot do
   Ports, refs, functions), undeclared fields, and secrets come back at their
   struct defaults — by design, not by accident.
 
+  **Precise scope of the equality**: it holds *exactly* for declared struct
+  field NAMES, and for string/number/boolean/binary data. Atom *values* and
+  bare-map atom *keys* round-trip **best-effort**: an atom already interned at
+  load time restores as an atom; one that is not (e.g. an enum value first
+  introduced on a later release, loaded on an older/fresh node) restores as its
+  raw string name instead — never a crash, never `String.to_atom/1`'s
+  unbounded atom-table growth on untrusted disk data.
+
+  The larger real-world blast radius here is **struct field VALUES that are
+  atoms**, not just bare-map keys — e.g. `%Model{status: :idle}` restores
+  `:idle` as an atom only if something already interned it in the restoring
+  VM; a status/enum value first assigned at runtime (never appearing as a
+  literal anywhere in that release's source) restores as the string `"idle"`
+  instead, silently changing the field's type. Only the struct's *field
+  NAMES* are guaranteed via `resolve_struct_module/1` (the struct's module,
+  and therefore its `defstruct` field atoms, must already be loaded before
+  its `"$s"`-tagged fields are decoded) — the atom *values* it holds carry the
+  same best-effort risk as any other atom. This is a fundamental ceiling of a
+  JSON-safe, atom-table-DoS-safe codec, not a bug to "fix" by interning on
+  load.
+
   ## Encoding grammar
 
   Every persisted value maps to a self-describing, JSON-safe term:
 
-    * `nil`, booleans, numbers, binaries — encoded bare.
+    * `nil`, booleans, numbers — encoded bare.
+    * valid-UTF-8 binaries — encoded bare; a non-UTF-8 binary is not
+      JSON-encodable, so it is tagged `%{"$b64" => base64}` (round-trippable,
+      e.g. a terminal buffer or other packed bytes survives the checkpoint
+      instead of crashing `Jason.encode!/1` at write time).
     * other atoms — `%{"$a" => "name"}` (tagged strings; restored with
       `String.to_existing_atom/1`, falling back to the raw string if the atom
-      no longer exists — safe, never a leak, never a crash).
+      no longer exists — safe, never a leak, never a crash). This is the
+      best-effort restore path described in "The restore property" above:
+      struct field NAMES always resurrect, but an atom VALUE (whether a
+      struct field's value, a bare-map value, or a bare-map key) does not if
+      it was never interned at load time.
     * lists — JSON arrays, **all-or-nothing**: a list holding a non-serializable
       element is dropped whole (positional partial-drop would silently reindex).
     * plain maps — `%{"$m" => [[key, value], ...]}` (pairs preserve arbitrary
@@ -67,9 +96,19 @@ defmodule Raxol.Agent.Snapshot do
   See `Raxol.Agent.Snapshot.Persist` for how an app declares its slice.
   """
 
+  require Logger
+
   alias Raxol.Agent.Snapshot.Persist
 
   @snapshot_version 1
+
+  # Emitted when the name heuristic redacts a field that the app explicitly
+  # listed in `persist:` — i.e. a likely false positive the author didn't
+  # intend. The heuristic always wins over persist: (redaction-over-persist is
+  # the settled precedence — see encode_fields/4), but a caller relying on
+  # that field surviving the checkpoint deserves a loud signal instead of a
+  # silently-empty field on restore.
+  @telemetry_persist_redacted [:raxol, :agent, :snapshot, :persist_redacted_by_heuristic]
 
   # Name-based secret heuristic — a defence-in-depth net so an obvious secret is
   # redacted even when an app forgot to declare it. Matches on field/key names,
@@ -87,6 +126,21 @@ defmodule Raxol.Agent.Snapshot do
   #   * suffix words (`token`, the key family) redact only when the name ENDS
   #     with them, so `access_token`/`api_key` redact while `token_count`,
   #     `input_tokens`, and `api_key_id` do not.
+  #
+  # Bare `seed` is intentionally NOT in the segment list: it over-matches
+  # `random_seed`/`db_seed` and other ordinary ML/RNG state, so the
+  # false-positive cost outweighs the marginal defense-in-depth gain. A real
+  # crypto seed should be declared via an explicit `redact:`. Keep
+  # `seed_phrase`/`mnemonic` — those never name benign data.
+  #
+  # TODO(deferred — Finding 3, resolved by quorum): candidate additional
+  # spellings — creds/cred, privkey, pwd, apisecret, ssn — stay out of the
+  # heuristic. Widening this list needs an escape hatch for a field whose NAME
+  # matches but isn't secret; the heuristic winning over persist: (Finding 4,
+  # settled) means plain `persist:` is NOT that hatch. The intended hatch is a
+  # future, deliberately-ugly `allow_secret_names:` derive opt-out (warns on
+  # every dump) — not implemented yet. Until then, widening this list has no
+  # cheap rescue for a false positive.
   @redact_segment ~r/(?:^|[_-])(?:password|passwd|secret|credentials?|mnemonic|seed[_-]?phrase)(?:$|[_-])/i
   @redact_suffix ~r/(?:^|[_-])(?:token|api[_-]?key|apikey|access[_-]?key|private[_-]?key|secret[_-]?key)$/i
 
@@ -179,8 +233,17 @@ defmodule Raxol.Agent.Snapshot do
   # envelope reverses them once.
 
   defp encode(v, _path)
-       when is_nil(v) or is_boolean(v) or is_number(v) or is_binary(v),
+       when is_nil(v) or is_boolean(v) or is_number(v),
        do: {:keep, v, [], []}
+
+  # Valid-UTF-8 binaries encode bare; a non-UTF-8 binary is not JSON-encodable,
+  # so it is base64-tagged (round-trippable) rather than kept bare and crashing
+  # Jason at write time.
+  defp encode(v, _path) when is_binary(v) do
+    if String.valid?(v),
+      do: {:keep, v, [], []},
+      else: {:keep, %{"$b64" => Base.encode64(v)}, [], []}
+  end
 
   defp encode(v, _path) when is_atom(v),
     do: {:keep, %{"$a" => Atom.to_string(v)}, [], []}
@@ -253,10 +316,33 @@ defmodule Raxol.Agent.Snapshot do
     end
   end
 
+  # Precedence (settled — see @telemetry_persist_redacted above): the name
+  # heuristic redacts a secret-shaped field name UNCONDITIONALLY, even when
+  # that field is explicitly listed in `persist:`. Rationale: `persist:` is
+  # written once at declaration time and can drift as fields are added;
+  # letting it silently override the heuristic would let `persist: [:api_key]`
+  # (typo, copy-paste, or a genuinely secret field someone forgot to also
+  # `redact:`) write a real secret to cleartext disk. The heuristic winning is
+  # the safe failure mode — worst case a false positive drops a benign field,
+  # which is loud (telemetry + Logger.warning below), never a silent secret
+  # leak. A future `allow_secret_names:` derive opt-out (deliberately ugly,
+  # warns on every dump) is the intended escape hatch for a genuine false
+  # positive — not a plain `persist:` override.
+  #
+  # A field explicitly declared in BOTH persist: and redact: is redacted
+  # (proven by the PidSecretModel `api_key` fixture) — same outcome, no
+  # warning needed since the app declared the intent explicitly.
   defp encode_fields(fields, persist, redact_set, path) do
     Enum.reduce(fields, {%{}, [], []}, fn {k, val}, {fmap, drops, reds} ->
       cond do
-        MapSet.member?(redact_set, k) or sensitive?(k) ->
+        MapSet.member?(redact_set, k) ->
+          {fmap, drops, [redacted_entry(path ++ [k]) | reds]}
+
+        sensitive?(k) ->
+          if persist != :auto and k in persist do
+            warn_persist_redacted_by_heuristic(path ++ [k])
+          end
+
           {fmap, drops, [redacted_entry(path ++ [k]) | reds]}
 
         persist != :auto and k not in persist ->
@@ -266,6 +352,21 @@ defmodule Raxol.Agent.Snapshot do
           encode_field(k, val, path, fmap, drops, reds)
       end
     end)
+  end
+
+  defp warn_persist_redacted_by_heuristic(full_path) do
+    string_path = stringify_path(full_path)
+
+    Logger.warning(
+      "Raxol.Agent.Snapshot: field #{inspect(string_path)} is explicitly " <>
+        "listed in persist: but its name matches the secret-redaction " <>
+        "heuristic — it is being redacted, not persisted. If it truly holds " <>
+        "a secret, this is correct (consider also declaring it in redact: to " <>
+        "silence this warning). If it is a false positive, rename the field " <>
+        "or file a request to widen the heuristic's escape hatch."
+    )
+
+    :telemetry.execute(@telemetry_persist_redacted, %{count: 1}, %{path: string_path})
   end
 
   defp encode_field(k, val, path, fmap, drops, reds) do
@@ -281,10 +382,12 @@ defmodule Raxol.Agent.Snapshot do
   # --- Decoding --------------------------------------------------------------
 
   # A tampered/corrupt on-disk envelope is untrusted input. decode/2 threads a
-  # depth counter and refuses three shapes it will not build, throwing a typed
+  # depth counter and refuses shapes it will not build, throwing a typed
   # reason caught in load/2: nesting past @max_decode_depth, a $s struct-module
-  # tag that is not a loaded Persist implementation, and a $a/$s/$m tag with a
-  # malformed body. Unknown tags (`$x`, …) still pass through for forward-compat.
+  # tag that is not a loaded Persist implementation, and a $a/$b64/$s/$m tag
+  # with a malformed body (including a malformed $m INNER PAIR — wrong arity,
+  # not just a non-list top-level body). Unknown tags (`$x`, …) still pass
+  # through for forward-compat.
 
   # Deeper than any real model, shallow enough to stop a nesting-bomb envelope
   # before it exhausts the stack.
@@ -295,6 +398,13 @@ defmodule Raxol.Agent.Snapshot do
 
   defp decode(%{"$a" => name}, _depth) when is_binary(name), do: safe_atom(name)
 
+  defp decode(%{"$b64" => b64}, _depth) when is_binary(b64) do
+    case Base.decode64(b64) do
+      {:ok, bin} -> bin
+      :error -> throw({:snapshot_decode_error, {:malformed_tag, "$b64"}})
+    end
+  end
+
   defp decode(%{"$s" => mod_str, "f" => fmap}, depth)
        when is_binary(mod_str) and is_map(fmap) do
     mod = resolve_struct_module(mod_str)
@@ -303,9 +413,18 @@ defmodule Raxol.Agent.Snapshot do
   end
 
   defp decode(%{"$m" => pairs}, depth) when is_list(pairs) do
-    Map.new(pairs, fn [k, v] ->
-      {decode(k, depth + 1), decode(v, depth + 1)}
-    end)
+    if Enum.all?(pairs, &match?([_, _], &1)) do
+      Map.new(pairs, fn [k, v] ->
+        {decode(k, depth + 1), decode(v, depth + 1)}
+      end)
+    else
+      # An inner pair that isn't exactly a 2-element list (e.g. `["a"]` or
+      # `["a", 1, 2]`) would otherwise blow up inside the Map.new/2 callback
+      # with a raw FunctionClauseError/MatchError — caught by load/2's rescue,
+      # but as an unstructured {:load_failed, msg} instead of the same typed
+      # {:malformed_tag, "$m"} reason every other corrupt-tag case produces.
+      throw({:snapshot_decode_error, {:malformed_tag, "$m"}})
+    end
   end
 
   # A tag marker present but with a malformed body is corruption/tampering, not
@@ -313,6 +432,11 @@ defmodule Raxol.Agent.Snapshot do
   # raw map survive woven into the restored model.
   defp decode(%{"$a" => _} = v, _depth) when map_size(v) == 1,
     do: throw({:snapshot_decode_error, {:malformed_tag, "$a"}})
+
+  # A $b64 whose body is a non-binary (e.g. `%{"$b64" => 123}`); the
+  # non-base64-string case (e.g. `"!!!!"`) is handled by the :error branch above.
+  defp decode(%{"$b64" => _} = v, _depth) when map_size(v) == 1,
+    do: throw({:snapshot_decode_error, {:malformed_tag, "$b64"}})
 
   defp decode(%{"$s" => _}, _depth),
     do: throw({:snapshot_decode_error, {:malformed_tag, "$s"}})
@@ -348,9 +472,17 @@ defmodule Raxol.Agent.Snapshot do
   defp coerce(decoded, nil), do: decoded
   defp coerce(%_{} = decoded, _module), do: decoded
 
+  # Aligned with the $s decode path (resolve_struct_module/1): a bare-map
+  # envelope loaded against an explicit module must also name a currently-
+  # loaded Persist implementation before struct/2 is called, never a silently
+  # rebuilt struct of an arbitrary caller-supplied module.
   defp coerce(decoded, module) when is_map(decoded) and is_atom(module) do
-    fields = for {k, v} <- decoded, do: {atomize(k), v}
-    struct(module, fields)
+    if persist_impl?(module) do
+      fields = for {k, v} <- decoded, do: {atomize(k), v}
+      struct(module, fields)
+    else
+      throw({:snapshot_decode_error, {:unknown_struct_module, module_string(module)}})
+    end
   end
 
   defp coerce(decoded, _module), do: decoded

--- a/packages/raxol_agent/lib/raxol/agent/snapshot.ex
+++ b/packages/raxol_agent/lib/raxol/agent/snapshot.ex
@@ -56,7 +56,11 @@ defmodule Raxol.Agent.Snapshot do
     * plain maps — `%{"$m" => [[key, value], ...]}` (pairs preserve arbitrary
       key types); per-key drops are recorded, the rest survive.
     * declared structs — `%{"$s" => "Elixir.Mod", "f" => %{"field" => value}}`;
-      recursed via the struct's own `Persist.spec/1`.
+      recursed via the struct's own `Persist.spec/1`. On load the module tag is
+      validated to name a currently-loaded `Persist` implementation before
+      `struct/2` is called. Unlike an atom value or map key, a struct module is
+      **not** raw-string-fallback: an unknown or non-`Persist` module tag is a
+      typed load error (`{:unknown_struct_module, _}`), never a rebuilt struct.
     * PIDs / Ports / refs / functions / tuples / undeclared structs — never
       encoded; dropped into the manifest.
 
@@ -68,8 +72,23 @@ defmodule Raxol.Agent.Snapshot do
   @snapshot_version 1
 
   # Name-based secret heuristic — a defence-in-depth net so an obvious secret is
-  # redacted even when an app forgot to declare it. Matches on field/key names.
-  @redact_pattern ~r/secret|password|passwd|token|api[_-]?key|private[_-]?key|credential|mnemonic|seed_phrase/i
+  # redacted even when an app forgot to declare it. Matches on field/key names,
+  # anchored to whole `_`/`-`-delimited segments so normal agent state (token
+  # meters and the like) is NOT misclassified as a secret. For an agent runtime
+  # `:tokens`, `:token_count`, `:input_tokens`, `:total_tokens`, `:tokenizer`,
+  # `:api_key_id`, `:passwords_count`, `:secretary` are ordinary fields; only a
+  # field whose NAME is (or ends in) a secret word is redacted.
+  #
+  # Two rules, because the safe boundary differs by word:
+  #
+  #   * segment words redact when the word is a complete segment ANYWHERE in the
+  #     name (`client_secret`, `db_password`, `seed_phrase`) — these words never
+  #     name a benign metric;
+  #   * suffix words (`token`, the key family) redact only when the name ENDS
+  #     with them, so `access_token`/`api_key` redact while `token_count`,
+  #     `input_tokens`, and `api_key_id` do not.
+  @redact_segment ~r/(?:^|[_-])(?:password|passwd|secret|credentials?|mnemonic|seed[_-]?phrase)(?:$|[_-])/i
+  @redact_suffix ~r/(?:^|[_-])(?:token|api[_-]?key|apikey|access[_-]?key|private[_-]?key|secret[_-]?key)$/i
 
   @type envelope :: %{
           required(:v) => pos_integer(),
@@ -128,10 +147,16 @@ defmodule Raxol.Agent.Snapshot do
     with {:ok, v} <- fetch(envelope, :v),
          :ok <- check_version(v),
          {:ok, data} <- fetch(envelope, :data) do
-      {:ok, coerce(decode(data), module)}
+      {:ok, coerce(decode(data, 0), module)}
     end
   rescue
     e -> {:error, {:load_failed, Exception.message(e)}}
+  catch
+    # A tampered/corrupt on-disk envelope is untrusted input (FI-9 tamper
+    # class). decode/2 signals structured refusals — unbounded nesting, an
+    # unknown/non-Persist struct module, a malformed tag — as throws carrying a
+    # typed reason, surfaced here as a typed load error rather than a crash.
+    {:snapshot_decode_error, reason} -> {:error, {:load_failed, reason}}
   end
 
   @doc """
@@ -255,21 +280,68 @@ defmodule Raxol.Agent.Snapshot do
 
   # --- Decoding --------------------------------------------------------------
 
-  defp decode(%{"$a" => name}) when is_binary(name), do: safe_atom(name)
+  # A tampered/corrupt on-disk envelope is untrusted input. decode/2 threads a
+  # depth counter and refuses three shapes it will not build, throwing a typed
+  # reason caught in load/2: nesting past @max_decode_depth, a $s struct-module
+  # tag that is not a loaded Persist implementation, and a $a/$s/$m tag with a
+  # malformed body. Unknown tags (`$x`, …) still pass through for forward-compat.
 
-  defp decode(%{"$s" => mod_str, "f" => fmap})
+  # Deeper than any real model, shallow enough to stop a nesting-bomb envelope
+  # before it exhausts the stack.
+  @max_decode_depth 64
+
+  defp decode(_v, depth) when depth > @max_decode_depth,
+    do: throw({:snapshot_decode_error, :max_depth_exceeded})
+
+  defp decode(%{"$a" => name}, _depth) when is_binary(name), do: safe_atom(name)
+
+  defp decode(%{"$s" => mod_str, "f" => fmap}, depth)
        when is_binary(mod_str) and is_map(fmap) do
-    mod = String.to_existing_atom(mod_str)
-    fields = for {k, v} <- fmap, do: {safe_atom(k), decode(v)}
+    mod = resolve_struct_module(mod_str)
+    fields = for {k, v} <- fmap, do: {safe_atom(k), decode(v, depth + 1)}
     struct(mod, fields)
   end
 
-  defp decode(%{"$m" => pairs}) when is_list(pairs) do
-    Map.new(pairs, fn [k, v] -> {decode(k), decode(v)} end)
+  defp decode(%{"$m" => pairs}, depth) when is_list(pairs) do
+    Map.new(pairs, fn [k, v] ->
+      {decode(k, depth + 1), decode(v, depth + 1)}
+    end)
   end
 
-  defp decode(list) when is_list(list), do: Enum.map(list, &decode/1)
-  defp decode(v), do: v
+  # A tag marker present but with a malformed body is corruption/tampering, not
+  # a forward-compat unknown tag — reject it explicitly rather than letting the
+  # raw map survive woven into the restored model.
+  defp decode(%{"$a" => _} = v, _depth) when map_size(v) == 1,
+    do: throw({:snapshot_decode_error, {:malformed_tag, "$a"}})
+
+  defp decode(%{"$s" => _}, _depth),
+    do: throw({:snapshot_decode_error, {:malformed_tag, "$s"}})
+
+  defp decode(%{"$m" => _} = v, _depth) when map_size(v) == 1,
+    do: throw({:snapshot_decode_error, {:malformed_tag, "$m"}})
+
+  defp decode(list, depth) when is_list(list),
+    do: Enum.map(list, &decode(&1, depth + 1))
+
+  defp decode(v, _depth), do: v
+
+  # Validate a $s module tag before it reaches struct/2. Without this a crafted
+  # envelope could steer struct/2 at any loaded struct module and rebuild it
+  # with attacker-chosen fields (type-confusion gadget; bounded by
+  # to_existing_atom, but downstream code trusts __struct__). The module must
+  # resolve to a currently-loaded Persist implementation — the same
+  # consolidation-safe probe the dump side uses in slice_spec/1. Unlike an atom
+  # VALUE or map key, a struct module is NOT raw-string-fallback: an unknown or
+  # non-Persist name is a typed load error, never a silently rebuilt struct.
+  defp resolve_struct_module(mod_str) do
+    mod = safe_atom(mod_str)
+
+    if is_atom(mod) and persist_impl?(mod) do
+      mod
+    else
+      throw({:snapshot_decode_error, {:unknown_struct_module, mod_str}})
+    end
+  end
 
   # A bare-map encoding restores to a plain map; a caller that knows the target
   # struct module can pass it to rebuild a struct from that map.
@@ -329,19 +401,28 @@ defmodule Raxol.Agent.Snapshot do
   # state. A struct with no such module is genuinely undeclared → auto-scan does
   # not recurse into it; it is dropped-with-manifest.
   defp slice_spec(%mod{} = struct) do
-    impl = Module.concat(Persist, mod)
-
-    if Code.ensure_loaded?(impl) and function_exported?(impl, :spec, 1) do
-      {:declared, impl.spec(struct)}
+    if persist_impl?(mod) do
+      {:declared, Module.concat(Persist, mod).spec(struct)}
     else
       :undeclared
     end
   end
 
+  # The consolidation-safe Persist probe, shared by the dump side (slice_spec/1)
+  # and the load side (resolve_struct_module/1): the per-struct implementation
+  # module is always generated and loadable even when protocol consolidation
+  # froze out a late `@derive`, so probing it directly is robust.
+  defp persist_impl?(mod) when is_atom(mod) do
+    impl = Module.concat(Persist, mod)
+    Code.ensure_loaded?(impl) and function_exported?(impl, :spec, 1)
+  end
+
   defp sensitive?(k) when is_atom(k) and not is_nil(k) and not is_boolean(k),
     do: sensitive?(Atom.to_string(k))
 
-  defp sensitive?(k) when is_binary(k), do: Regex.match?(@redact_pattern, k)
+  defp sensitive?(k) when is_binary(k),
+    do: Regex.match?(@redact_segment, k) or Regex.match?(@redact_suffix, k)
+
   defp sensitive?(_), do: false
 
   # Restore an atom without risking the String.to_atom memory-leak on reload of

--- a/packages/raxol_agent/lib/raxol/agent/snapshot/persist.ex
+++ b/packages/raxol_agent/lib/raxol/agent/snapshot/persist.ex
@@ -38,7 +38,41 @@ defprotocol Raxol.Agent.Snapshot.Persist do
     * `redact:` — secret fields. Redacted values never reach the snapshot data;
       they are listed in the `redacted` manifest and restore to their struct
       default. (A name-based heuristic in the codec redacts obvious secrets —
-      `api_key`, `password`, `token`, … — even when not declared.)
+      `api_key`, `password`, `token`, … — even when not declared. See below for
+      the full word-list and how it interacts with `persist:`.)
+
+  ## Redaction: the name heuristic vs. your declaration
+
+  Beyond `redact:`, the codec runs a name-based secret heuristic (defense in
+  depth for a field you forgot to declare). It matches, on `_`/`-` segment
+  boundaries: password / passwd / secret / credential(s) / mnemonic /
+  seed_phrase, and name suffixes: token / api_key / apikey / access_key /
+  private_key / secret_key. (A few close spellings — creds/cred, privkey, pwd,
+  apisecret, ssn — are deliberately NOT included; see the TODO in
+  `Raxol.Agent.Snapshot`'s `@redact_segment`/`@redact_suffix` for why.)
+
+  Precedence (highest first) — **the heuristic wins unconditionally**, even
+  over an explicit `persist:` listing. This was reviewed and settled: letting
+  `persist:` silently override the heuristic would let a real secret, listed
+  by typo or oversight (e.g. `persist: [:api_key]`), reach cleartext disk.
+
+    1. explicit `redact:`   — always redacted
+    2. name heuristic       — redacts a secret-shaped name even if the field
+       is listed in `persist:`
+    3. explicit `persist:`  — an unlisted field drops
+    4. plain data (`:auto`) — persisted
+
+  If the heuristic redacts a field you explicitly `persist:`-listed, the codec
+  logs a `Logger.warning/1` and emits
+  `[:raxol, :agent, :snapshot, :persist_redacted_by_heuristic]` telemetry — so
+  the mismatch between your declaration and the outcome is loud, not a
+  silently-empty field on restore. If that's a genuine false positive, rename
+  the field; there is no `persist:`-side override. (The intended future
+  escape hatch is a deliberately-ugly `allow_secret_names:` derive opt-out
+  that warns on every dump — not `persist:`, and not implemented yet.)
+
+  Bare `seed` is intentionally NOT in the heuristic (it collides with RNG/data
+  seeds); redact a real crypto seed explicitly via `redact:`.
 
   ## Default (no declaration)
 

--- a/packages/raxol_agent/lib/raxol/agent/snapshot/persist.ex
+++ b/packages/raxol_agent/lib/raxol/agent/snapshot/persist.ex
@@ -1,0 +1,122 @@
+defprotocol Raxol.Agent.Snapshot.Persist do
+  @moduledoc """
+  Declares the **persistent slice** of a TEA model — which fields are durably
+  serializable and which are secrets to redact.
+
+  This is the declaration half of the model-snapshot contract; the codec lives
+  in `Raxol.Agent.Snapshot`. A snapshot is a JSON-safe, versioned envelope that
+  a later unit (U9 — Checkpoint) writes into a session's `snapshots/` directory
+  as `{journal_offset, model_snapshot}`. Arbitrary TEA models hold PIDs, Ports,
+  function refs, ETS refs, and secrets — none JSON-safe, none faithfully
+  restorable. This protocol lets an app name the slice that *is*.
+
+  ## Why a protocol (not a behaviour)
+
+  TEA models are frequently bare maps with no owning module (`init/1` commonly
+  returns `%{}`). A behaviour can only attach to a module; a protocol dispatches
+  on the *value* and — via `@fallback_to_any` — can define conservative default
+  behaviour for a map that has no module to host a callback. That is the
+  decisive reason this is a protocol with an `Any` fallback.
+
+  ## Declaring a slice
+
+  A struct-backed model opts in with `@derive`:
+
+      defmodule MyModel do
+        @derive {Raxol.Agent.Snapshot.Persist,
+                 persist: [:count, :title, :history],
+                 redact: [:api_key]}
+        defstruct [:count, :title, :history, :api_key, :socket_pid]
+      end
+
+    * `persist:` — the durable field allowlist. Any field NOT listed is
+      **explicitly excluded** — the snapshot records the exclusion in its
+      `dropped` manifest, it is never silently mangled. Omit `persist:` (or pass
+      `:auto`) for a conservative auto-scan: every field is a candidate, plain
+      data survives, non-serializable values (PIDs/Ports/refs/functions) are
+      dropped-with-manifest.
+    * `redact:` — secret fields. Redacted values never reach the snapshot data;
+      they are listed in the `redacted` manifest and restore to their struct
+      default. (A name-based heuristic in the codec redacts obvious secrets —
+      `api_key`, `password`, `token`, … — even when not declared.)
+
+  ## Default (no declaration)
+
+  Undeclared values — plain maps, and structs with no `@derive`/`defimpl` —
+  fall to the `Any` implementation: `%{persist: :auto, redact: []}`, the
+  conservative auto-scan. Note the recursion rule enforced by the codec: a
+  *nested* struct is only recursed into if it, too, declares a slice; an
+  undeclared nested struct is dropped-with-manifest, loudly.
+  """
+
+  @fallback_to_any true
+
+  @typedoc """
+  The declared slice for a model.
+
+    * `:persist` — `:auto` (scan every field) or an explicit list of field
+      names to persist.
+    * `:redact` — field names whose values must never be serialized.
+  """
+  @type spec :: %{persist: :auto | [atom()], redact: [atom()]}
+
+  @doc "Return the persistent-slice declaration for `model`."
+  @spec spec(t()) :: spec()
+  def spec(model)
+end
+
+defimpl Raxol.Agent.Snapshot.Persist, for: Any do
+  @moduledoc """
+  Fallback implementation: conservative auto-scan, no redaction.
+
+  Also hosts `__deriving__/3`, which turns
+  `@derive {Raxol.Agent.Snapshot.Persist, persist: ..., redact: ...}` into a
+  static per-struct implementation.
+  """
+
+  defmacro __deriving__(module, _struct, options) do
+    persist = Keyword.get(options, :persist, :auto)
+    redact = Keyword.get(options, :redact, [])
+
+    validate_persist!(persist, module)
+    validate_redact!(redact, module)
+
+    quote do
+      defimpl Raxol.Agent.Snapshot.Persist, for: unquote(module) do
+        def spec(_model) do
+          %{persist: unquote(persist), redact: unquote(redact)}
+        end
+      end
+    end
+  end
+
+  # Compile-time validation so a malformed @derive fails loudly at the
+  # declaration site rather than silently at snapshot time.
+  defp validate_persist!(:auto, _module), do: :ok
+
+  defp validate_persist!(list, _module) when is_list(list) do
+    if Enum.all?(list, &is_atom/1),
+      do: :ok,
+      else: raise(ArgumentError, "persist: must be :auto or a list of atoms")
+  end
+
+  defp validate_persist!(other, module) do
+    raise ArgumentError,
+          "invalid persist: #{inspect(other)} for #{inspect(module)} " <>
+            "(expected :auto or a list of field atoms)"
+  end
+
+  defp validate_redact!(list, _module) when is_list(list) do
+    if Enum.all?(list, &is_atom/1),
+      do: :ok,
+      else: raise(ArgumentError, "redact: must be a list of atoms")
+  end
+
+  defp validate_redact!(other, module) do
+    raise ArgumentError,
+          "invalid redact: #{inspect(other)} for #{inspect(module)} " <>
+            "(expected a list of field atoms)"
+  end
+
+  def spec(_model), do: %{persist: :auto, redact: []}
+end

--- a/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
@@ -1,0 +1,315 @@
+defmodule Raxol.Agent.SnapshotTest do
+  @moduledoc """
+  Contract tests for the model-snapshot codec.
+
+  The load-bearing properties: a model holding a PID + a secret dumps to a
+  JSON-safe term that restores to an EQUAL persistent slice; non-persistable
+  fields are excluded via a loud manifest, never silently mangled; secrets never
+  reach the snapshot data.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Agent.Snapshot
+
+  # --- Fixtures --------------------------------------------------------------
+
+  defmodule PidSecretModel do
+    @moduledoc false
+    # `api_key` is in BOTH persist and redact to prove redaction wins.
+    # `socket` is a declared field that holds a PID — declared-but-non-
+    # serializable must still be dropped loudly, not persisted.
+    @derive {Raxol.Agent.Snapshot.Persist,
+             persist: [:count, :label, :api_key, :socket], redact: [:api_key]}
+    defstruct [:count, :label, :api_key, :socket]
+  end
+
+  defmodule InnerDeclared do
+    @moduledoc false
+    @derive {Raxol.Agent.Snapshot.Persist, persist: [:x]}
+    defstruct [:x, :y]
+  end
+
+  defmodule InnerUndeclared do
+    @moduledoc false
+    defstruct [:z]
+  end
+
+  defmodule OuterModel do
+    @moduledoc false
+    @derive {Raxol.Agent.Snapshot.Persist, persist: [:inner, :bad]}
+    defstruct [:inner, :bad]
+  end
+
+  # --- PID + secret + plain data ---------------------------------------------
+
+  describe "dump/1 with PID + secret + plain data" do
+    setup do
+      model = %PidSecretModel{
+        count: 7,
+        label: "hello",
+        api_key: "sk-super-secret-value",
+        socket: self()
+      }
+
+      {:ok, envelope} = Snapshot.dump(model)
+      %{model: model, envelope: envelope}
+    end
+
+    test "envelope is JSON round-trippable", %{envelope: envelope} do
+      json = Jason.encode!(envelope)
+      decoded = Jason.decode!(json)
+
+      # Round-trips to an equivalent string-keyed envelope.
+      assert decoded["v"] == 1
+      assert decoded["module"] == "Elixir.Raxol.Agent.SnapshotTest.PidSecretModel"
+    end
+
+    test "the secret never reaches the snapshot (data or JSON)", %{
+      envelope: envelope
+    } do
+      refute encoded_contains?(envelope.data, "sk-super-secret-value")
+      json = Jason.encode!(envelope)
+      refute String.contains?(json, "sk-super-secret-value")
+    end
+
+    test "the PID field is listed in dropped, not persisted", %{
+      envelope: envelope
+    } do
+      assert %{"path" => ["socket"], "reason" => "pid"} in envelope.dropped
+    end
+
+    test "the secret field is listed in redacted", %{envelope: envelope} do
+      assert %{"path" => ["api_key"]} in envelope.redacted
+    end
+
+    test "plain data survives into the encoding", %{envelope: envelope} do
+      assert %{"$s" => _mod, "f" => %{"count" => 7, "label" => "hello"}} =
+               envelope.data
+    end
+
+    test "load restores the persistent slice with dropped fields at defaults", %{
+      envelope: envelope
+    } do
+      assert {:ok, restored} = Snapshot.load(envelope)
+
+      assert restored == %PidSecretModel{
+               count: 7,
+               label: "hello",
+               api_key: nil,
+               socket: nil
+             }
+    end
+
+    test "load survives a JSON round-trip (string-keyed envelope)", %{
+      envelope: envelope
+    } do
+      round = envelope |> Jason.encode!() |> Jason.decode!()
+      assert {:ok, restored} = Snapshot.load(round)
+      assert restored.count == 7
+      assert restored.label == "hello"
+      assert restored.api_key == nil
+      assert restored.socket == nil
+    end
+  end
+
+  # --- Struct-in-struct ------------------------------------------------------
+
+  describe "nested structs" do
+    setup do
+      model = %OuterModel{
+        inner: %InnerDeclared{x: 1, y: 2},
+        bad: %InnerUndeclared{z: 3}
+      }
+
+      {:ok, envelope} = Snapshot.dump(model)
+      %{model: model, envelope: envelope}
+    end
+
+    test "a declared inner struct recurses", %{envelope: envelope} do
+      assert {:ok, restored} = Snapshot.load(envelope)
+      assert %InnerDeclared{x: 1} = restored.inner
+    end
+
+    test "the declared inner struct's undeclared field is dropped loudly", %{
+      envelope: envelope
+    } do
+      assert %{"path" => ["inner", "y"], "reason" => "undeclared_field"} in envelope.dropped
+      assert {:ok, restored} = Snapshot.load(envelope)
+      assert restored.inner.y == nil
+    end
+
+    test "an undeclared inner struct is dropped-with-manifest, loudly", %{
+      envelope: envelope
+    } do
+      assert Enum.any?(envelope.dropped, fn
+               %{"path" => ["bad"], "reason" => reason} ->
+                 String.contains?(reason, "undeclared_struct")
+
+               _ ->
+                 false
+             end)
+
+      assert {:ok, restored} = Snapshot.load(envelope)
+      assert restored.bad == nil
+    end
+  end
+
+  # --- Bare-map model (the protocol's Any fallback) --------------------------
+
+  describe "bare-map model (no declaration)" do
+    test "auto-scans: plain data persists, pid dropped, secret redacted" do
+      model = %{count: 5, note: "hi", conn: self(), api_key: "leak"}
+
+      {:ok, envelope} = Snapshot.dump(model)
+
+      assert envelope.module == nil
+      assert %{"path" => ["conn"], "reason" => "pid"} in envelope.dropped
+      assert %{"path" => ["api_key"]} in envelope.redacted
+      refute encoded_contains?(envelope.data, "leak")
+
+      assert {:ok, restored} = Snapshot.load(envelope)
+      assert restored == %{count: 5, note: "hi"}
+    end
+  end
+
+  # --- Versioned envelope ----------------------------------------------------
+
+  describe "versioned envelope" do
+    test "carries the schema version" do
+      {:ok, envelope} = Snapshot.dump(%{a: 1})
+      assert envelope.v == Snapshot.version()
+      assert envelope.v == 1
+    end
+
+    test "loading an unknown future version is a typed error, not a crash" do
+      {:ok, envelope} = Snapshot.dump(%{a: 1})
+      future = %{envelope | v: 999}
+
+      assert {:error, {:unsupported_version, 999}} = Snapshot.load(future)
+    end
+
+    test "the future-version error also holds after a JSON round-trip" do
+      {:ok, envelope} = Snapshot.dump(%{a: 1})
+      future = %{envelope | v: 42} |> Jason.encode!() |> Jason.decode!()
+
+      assert {:error, {:unsupported_version, 42}} = Snapshot.load(future)
+    end
+  end
+
+  # --- Idempotence -----------------------------------------------------------
+
+  describe "round-trip idempotence" do
+    test "double dump->load is stable (struct model)" do
+      model = %PidSecretModel{count: 3, label: "x", api_key: "s", socket: self()}
+
+      {:ok, env0} = Snapshot.dump(model)
+      {:ok, m1} = Snapshot.load(env0)
+      {:ok, env1} = Snapshot.dump(m1)
+      {:ok, m2} = Snapshot.load(env1)
+
+      # Model-level idempotence: once the non-persistable fields have collapsed
+      # to their defaults, further round-trips are fixed points — including the
+      # envelope data (the first dump dropped a live PID; the second sees nil).
+      assert m1 == m2
+      assert env1.data == Snapshot.dump(m2) |> elem(1) |> Map.fetch!(:data)
+    end
+
+    test "double dump->load is stable (bare-map model)" do
+      model = %{count: 5, note: "hi", conn: self()}
+
+      {:ok, env0} = Snapshot.dump(model)
+      {:ok, m1} = Snapshot.load(env0)
+      {:ok, env1} = Snapshot.dump(m1)
+      {:ok, m2} = Snapshot.load(env1)
+
+      assert m1 == m2
+    end
+  end
+
+  # --- Non-persistable top-level ---------------------------------------------
+
+  describe "top-level errors" do
+    test "a non-persistable top-level term is a typed error" do
+      assert {:error, {:not_persistable, :pid}} = Snapshot.dump(self())
+    end
+  end
+
+  # --- Property: generated plain-data models round-trip through JSON ----------
+
+  describe "property: plain-data slice equality" do
+    property "nested plain-data models survive dump -> JSON -> load" do
+      check all(model <- map_gen(plain_data(3))) do
+        {:ok, envelope} = Snapshot.dump(model)
+
+        # Pure plain data: nothing dropped, nothing redacted.
+        assert envelope.dropped == []
+        assert envelope.redacted == []
+
+        # Full JSON round-trip, then restore, then slice-equality (== model,
+        # because for pure plain data the slice IS the whole model).
+        round = envelope |> Jason.encode!() |> Jason.decode!()
+        assert {:ok, restored} = Snapshot.load(round)
+        assert restored == model
+      end
+    end
+  end
+
+  # --- Generators ------------------------------------------------------------
+
+  # Keys drawn from a fixed pool: atom keys must already exist (so restore's
+  # to_existing_atom succeeds) and no key may match the secret heuristic.
+  defp key_gen do
+    StreamData.one_of([
+      StreamData.member_of([:a, :b, :c, :d]),
+      StreamData.member_of(["k1", "k2", "k3"])
+    ])
+  end
+
+  defp scalar do
+    StreamData.one_of([
+      StreamData.integer(),
+      StreamData.boolean(),
+      StreamData.constant(nil),
+      StreamData.string(:alphanumeric),
+      StreamData.member_of([:alpha, :beta, :gamma, :ok, :error])
+    ])
+  end
+
+  defp plain_data(0), do: scalar()
+
+  defp plain_data(depth) do
+    StreamData.one_of([
+      scalar(),
+      StreamData.list_of(plain_data(depth - 1), max_length: 4),
+      map_gen(plain_data(depth - 1))
+    ])
+  end
+
+  # Build maps from a key/value list + Map.new: keys dedup naturally, so a small
+  # key pool never starves `map_of`'s uniqueness constraint (TooManyDuplicates).
+  defp map_gen(value_gen) do
+    {key_gen(), value_gen}
+    |> StreamData.tuple()
+    |> StreamData.list_of(max_length: 5)
+    |> StreamData.map(&Map.new/1)
+  end
+
+  # --- Helpers ---------------------------------------------------------------
+
+  # Deep-scan an encoded term for a raw substring (proves a secret is absent).
+  defp encoded_contains?(term, needle) when is_binary(term),
+    do: String.contains?(term, needle)
+
+  defp encoded_contains?(term, needle) when is_map(term) do
+    Enum.any?(term, fn {k, v} ->
+      encoded_contains?(k, needle) or encoded_contains?(v, needle)
+    end)
+  end
+
+  defp encoded_contains?(term, needle) when is_list(term),
+    do: Enum.any?(term, &encoded_contains?(&1, needle))
+
+  defp encoded_contains?(_term, _needle), do: false
+end

--- a/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
@@ -42,6 +42,17 @@ defmodule Raxol.Agent.SnapshotTest do
     defstruct [:inner, :bad]
   end
 
+  defmodule ForcePersistModel do
+    @moduledoc false
+    # `client_secret_version` trips the name-heuristic segment `secret` despite
+    # being explicitly persist:-listed. The heuristic wins unconditionally
+    # (Finding 4, resolved by quorum): a field this shape is redacted, not
+    # persisted, and the mismatch is surfaced via Logger.warning + telemetry
+    # rather than silently dropping to nil.
+    @derive {Raxol.Agent.Snapshot.Persist, persist: [:client_secret_version]}
+    defstruct [:client_secret_version]
+  end
+
   # --- PID + secret + plain data ---------------------------------------------
 
   describe "dump/1 with PID + secret + plain data" do
@@ -288,6 +299,148 @@ defmodule Raxol.Agent.SnapshotTest do
     end
   end
 
+  # --- Non-UTF-8 binaries (JSON-safety) ---------------------------------------
+
+  describe "non-UTF-8 binary (JSON-safety)" do
+    test "a non-UTF-8 binary is base64-tagged ($b64), survives JSON + restore" do
+      model = %{buf: <<0xFF, 0xFE, 0x00>>, ok: "utf8"}
+      {:ok, envelope} = Snapshot.dump(model)
+      assert envelope.dropped == []
+      assert envelope.redacted == []
+      json = Jason.encode!(envelope)
+      assert {:ok, restored} = Snapshot.load(Jason.decode!(json))
+      assert restored == %{buf: <<0xFF, 0xFE, 0x00>>, ok: "utf8"}
+    end
+
+    test "a valid-UTF-8 binary stays bare (no base64 overhead)" do
+      {:ok, envelope} = Snapshot.dump(%{s: "hello"})
+      assert %{"$m" => [[_k, "hello"]]} = envelope.data
+    end
+
+    test "a non-UTF-8 binary inside a list and a struct field also survive" do
+      model = %{list: [<<0xC3, 0x28>>], nested: %{x: <<0xFF>>}}
+      {:ok, env} = Snapshot.dump(model)
+      assert {:ok, ^model} = Snapshot.load(Jason.decode!(Jason.encode!(env)))
+    end
+
+    test "a malformed $b64 tag body is a typed error, not a crash" do
+      assert {:error, {:load_failed, {:malformed_tag, "$b64"}}} =
+               Snapshot.load(tampered(%{"$b64" => 123}))
+
+      assert {:error, {:load_failed, {:malformed_tag, "$b64"}}} =
+               Snapshot.load(tampered(%{"$b64" => "!!!!"}))
+    end
+  end
+
+  # --- Finding 4 HELD: heuristic still wins over persist:, but loudly --------
+  #
+  # A second review flagged that letting persist: silently override the name
+  # heuristic could write a real secret to cleartext disk (e.g. an accidental
+  # `persist: [:api_key]`). Pending a human decision, the heuristic keeps
+  # winning unconditionally; the only change is that the mismatch is now loud
+  # (Logger.warning + telemetry) instead of a silent restore-to-nil.
+
+  describe "persist: vs. the name heuristic (precedence held, made loud)" do
+    test "a field explicitly persist:-listed is STILL redacted by the heuristic" do
+      {:ok, env} = Snapshot.dump(%ForcePersistModel{client_secret_version: 3})
+      assert %{"path" => ["client_secret_version"]} in env.redacted
+      refute match?(%{"$s" => _, "f" => %{"client_secret_version" => 3}}, env.data)
+
+      assert {:ok, r} = Snapshot.load(env)
+      assert r.client_secret_version == nil
+    end
+
+    test "redacting a persist:-listed field emits a Logger.warning and telemetry" do
+      test_pid = self()
+
+      :telemetry.attach(
+        "persist-redacted-heuristic-test",
+        [:raxol, :agent, :snapshot, :persist_redacted_by_heuristic],
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_event, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("persist-redacted-heuristic-test") end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          Snapshot.dump(%ForcePersistModel{client_secret_version: 3})
+        end)
+
+      assert log =~ "client_secret_version"
+      assert log =~ "persist:"
+
+      assert_received {:telemetry_event,
+                        [:raxol, :agent, :snapshot, :persist_redacted_by_heuristic], %{count: 1},
+                        %{path: ["client_secret_version"]}}
+    end
+
+    # explicit redact still beats explicit persist — already proven by the
+    # PidSecretModel `api_key` case above (redacted, restores to nil).
+  end
+
+  # --- Finding 3 HELD: redaction word-list unchanged --------------------------
+  #
+  # Widening the heuristic (creds/privkey/pwd/apisecret/ssn) is deferred
+  # pending the Finding 4 precedence decision — without a persist: escape
+  # hatch, a wider net has no rescue for a false positive. Confirms current
+  # behavior is unchanged (still declines these abbreviated spellings, still
+  # declines bare `seed`).
+
+  describe "redaction patterns unchanged (Finding 3 held)" do
+    test "abbreviated/alternate secret spellings are NOT yet redacted under :auto" do
+      model = %{
+        creds: "A",
+        privkey: "B",
+        pwd: "C",
+        apisecret: "D",
+        ssn: "E"
+      }
+
+      {:ok, env} = Snapshot.dump(model)
+      assert env.redacted == []
+      assert {:ok, ^model} = Snapshot.load(env)
+    end
+
+    test "benign names near the deferred patterns still survive (no over-match)" do
+      model = %{
+        credit_card: 1,
+        random_seed: 2,
+        db_seed: 3,
+        cwd: "/tmp",
+        tokens: 4,
+        token_count: 5,
+        input_tokens: 6,
+        api_key_id: "x",
+        passwords_count: 2,
+        secretary: "s"
+      }
+
+      {:ok, env} = Snapshot.dump(model)
+      assert env.redacted == []
+      assert {:ok, ^model} = Snapshot.load(env)
+    end
+  end
+
+  # --- MISS-1: $m inner-pair arity validation ---------------------------------
+
+  describe "load/2 hardening: malformed $m inner pair (MISS-1)" do
+    test "a $m inner pair with the wrong arity is a typed error, not a raw MatchError" do
+      assert {:error, {:load_failed, {:malformed_tag, "$m"}}} =
+               Snapshot.load(tampered(%{"$m" => [["a"]]}))
+
+      assert {:error, {:load_failed, {:malformed_tag, "$m"}}} =
+               Snapshot.load(tampered(%{"$m" => [["a", 1, 2]]}))
+    end
+
+    test "a well-formed $m still decodes normally" do
+      env = tampered(%{"$m" => [["a", 1], ["b", 2]]})
+      assert {:ok, %{"a" => 1, "b" => 2}} = Snapshot.load(env)
+    end
+  end
+
   # --- Load-path hardening (tampered on-disk envelopes are untrusted) --------
 
   describe "load/2 hardening against tampered envelopes" do
@@ -333,6 +486,13 @@ defmodule Raxol.Agent.SnapshotTest do
 
     test "an unknown tag still passes through (forward-compat)" do
       assert {:ok, %{"$x" => 1}} = Snapshot.load(tampered(%{"$x" => 1}))
+    end
+
+    test "load/2 with an explicit non-Persist module is a typed error (aligned with $s)" do
+      env = tampered(%{"$m" => [[%{"$a" => "scheme"}, "http"]]})
+
+      assert {:error, {:load_failed, {:unknown_struct_module, "Elixir.URI"}}} =
+               Snapshot.load(env, URI)
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
@@ -236,6 +236,106 @@ defmodule Raxol.Agent.SnapshotTest do
     end
   end
 
+  # --- Redaction name heuristic (whole-segment boundaries) -------------------
+
+  describe "redaction name heuristic" do
+    test "secret-shaped field names ARE redacted, values never reach data" do
+      model = %{
+        api_key: "AAA",
+        access_token: "BBB",
+        auth_token: "CCC",
+        password: "DDD",
+        private_key: "EEE",
+        access_key: "FFF",
+        client_secret: "GGG"
+      }
+
+      {:ok, envelope} = Snapshot.dump(model)
+      redacted_paths = Enum.map(envelope.redacted, & &1["path"])
+
+      for key <-
+            ~w(api_key access_token auth_token password private_key access_key client_secret) do
+        assert [key] in redacted_paths, "expected #{key} to be redacted"
+      end
+
+      json = Jason.encode!(envelope)
+
+      for value <- ~w(AAA BBB CCC DDD EEE FFF GGG) do
+        refute String.contains?(json, value)
+      end
+    end
+
+    test "token/metric field names are NOT redacted — normal agent state survives" do
+      # For an agent runtime these are ordinary model fields, not secrets.
+      model = %{
+        tokens: 10,
+        token_count: 20,
+        input_tokens: 30,
+        total_tokens: 40,
+        tokenizer: "gpt",
+        secretary: "alice",
+        api_key_id: "kid-123",
+        passwords_count: 2
+      }
+
+      {:ok, envelope} = Snapshot.dump(model)
+
+      assert envelope.redacted == [], "nothing here should be redacted"
+      assert envelope.dropped == []
+
+      assert {:ok, restored} = Snapshot.load(envelope)
+      assert restored == model
+    end
+  end
+
+  # --- Load-path hardening (tampered on-disk envelopes are untrusted) --------
+
+  describe "load/2 hardening against tampered envelopes" do
+    test "a $s tag naming a loaded-but-non-Persist module is a typed error" do
+      # URI is a loaded struct, but declares no Persist slice — must not be built.
+      envelope = tampered(%{"$s" => "Elixir.URI", "f" => %{"scheme" => "http"}})
+
+      assert {:error, {:load_failed, {:unknown_struct_module, "Elixir.URI"}}} =
+               Snapshot.load(envelope)
+    end
+
+    test "a $s tag naming an unknown module is a typed error, no struct built" do
+      envelope = tampered(%{"$s" => "Elixir.Nope.NotReal", "f" => %{}})
+
+      assert {:error, {:load_failed, {:unknown_struct_module, "Elixir.Nope.NotReal"}}} =
+               Snapshot.load(envelope)
+    end
+
+    test "decode nested past the max depth is a typed error, not a crash" do
+      deep =
+        Enum.reduce(1..70, %{"$m" => []}, fn _, acc ->
+          %{"$m" => [["leaf", acc]]}
+        end)
+
+      assert {:error, {:load_failed, :max_depth_exceeded}} =
+               Snapshot.load(tampered(deep))
+    end
+
+    test "a malformed $a tag body is a typed error, not a passed-through map" do
+      assert {:error, {:load_failed, {:malformed_tag, "$a"}}} =
+               Snapshot.load(tampered(%{"$a" => 127}))
+    end
+
+    test "a malformed $s tag body is a typed error" do
+      assert {:error, {:load_failed, {:malformed_tag, "$s"}}} =
+               Snapshot.load(tampered(%{"$s" => 123, "f" => %{}}))
+    end
+
+    test "a malformed $m tag body is a typed error" do
+      assert {:error, {:load_failed, {:malformed_tag, "$m"}}} =
+               Snapshot.load(tampered(%{"$m" => "not-a-list"}))
+    end
+
+    test "an unknown tag still passes through (forward-compat)" do
+      assert {:ok, %{"$x" => 1}} = Snapshot.load(tampered(%{"$x" => 1}))
+    end
+  end
+
   # --- Property: generated plain-data models round-trip through JSON ----------
 
   describe "property: plain-data slice equality" do
@@ -297,6 +397,10 @@ defmodule Raxol.Agent.SnapshotTest do
   end
 
   # --- Helpers ---------------------------------------------------------------
+
+  # A hand-built envelope with an attacker-controlled `data` payload.
+  defp tampered(data),
+    do: %{v: 1, module: nil, data: data, dropped: [], redacted: []}
 
   # Deep-scan an encoded term for a raw substring (proves a secret is absent).
   defp encoded_contains?(term, needle) when is_binary(term),


### PR DESCRIPTION
## What

The **model snapshot contract**: a declared, JSON-safe, restorable projection of a TEA model. Two modules in `raxol_agent`, plus tests:

- **`Raxol.Agent.Snapshot.Persist`** — a protocol. An app declares its durable slice with `@derive {Persist, persist: [...], redact: [...]}`. No declaration → an `Any` fallback does a conservative auto-scan.
- **`Raxol.Agent.Snapshot`** — the codec:
  - `dump/1` → `{:ok, %{v: 1, module, data, dropped, redacted}}` — a versioned, JSON-round-trippable envelope.
  - `load/2` → rebuilds the model with persistent fields restored and everything else at struct/`init` defaults.
  - `persistent_slice/1` = `load(dump(m))` — the durable projection.

Pure: no GenServers, no file IO. **U9 (Checkpoint) owns writing envelopes into a session's `snapshots/` dir** — this unit is the contract + codec only.

## Why (U9's foundation)

U9 stores checkpoints as `{journal_offset, model_snapshot}`. But arbitrary TEA models hold PIDs, Ports, function refs, ETS refs, and secrets — none JSON-safe, none faithfully restorable. Without a declared persistence boundary, U9 "will snapshot something that either can't be written or can't faithfully resume." MS defines that boundary **now**, standalone, so U9 builds on a tested contract rather than inventing serialization mid-checkpoint.

## Contract semantics

- **Declared slice.** `persist:` is the durable allowlist; any field not listed is *explicitly excluded*. Omit it (`:auto`) for auto-scan: plain data survives, non-serializable values are dropped-with-manifest.
- **Loud manifest, never silent mangling.** Every field that did not reach `data` is accounted for: PIDs / Ports / refs / functions / tuples / undeclared nested structs land in `dropped` with a reason; secrets land in `redacted`. A reviewer reading the manifest sees exactly what the slice omits and why.
- **Redaction.** `redact:` fields — plus a name heuristic (`api_key`, `password`, `token`, …) as defence-in-depth — never reach the snapshot data. Tested with a field literally named `api_key`.
- **Restore property.** `load(dump(m)) == persistent_slice(m)` — equality on the *declared slice*, explicitly NOT whole-term equality. Dropped/redacted fields come back at their struct defaults.
- **Versioned envelope.** `v: 1`; loading an unknown future `v` is a typed `{:error, {:unsupported_version, v}}`, not a crash — this artifact outlives code versions.

### Protocol, not behaviour

TEA models are frequently bare maps with no owning module (`init/1` commonly returns `%{}`). A behaviour can only attach to a module; a protocol dispatches on the *value* and, via `@fallback_to_any`, defines conservative default behaviour for a map that has no module to host a callback. Impl resolution probes the `Persist.<Mod>` module directly rather than through the *consolidated* dispatch table, so a struct that `@derive`s after its defining app is consolidated (any downstream app, and every test fixture) is seen, not silently treated as undeclared.

## Accepts (18 tests, 1 property)

- Model with PID + secret + plain data: dump → JSON-safe (Jason round-trip), PID in `dropped`, secret in `redacted` and absent from data/JSON; load → persistent slice equal, dropped fields at defaults.
- Property: generated nested plain-data models survive dump → JSON → load with slice equality.
- Struct-in-struct: declared inner recurses; undeclared inner → dropped-with-manifest, loudly.
- Versioned envelope: `v` present; unknown future `v` → typed error, not crash.
- `load(dump(m))` idempotence: double round-trip stable (struct + bare-map).

## Verify

`MIX_ENV=test mix compile --warnings-as-errors` clean; full `raxol_agent` suite green (997 passed, 5 properties). No lock committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ur4Adu4EMgNytpy7NPL5w7