### PR TITLE
Harness UI: prominence attribute (H-K resolution, ground-aware fade, opt-in legibility clamp) [T8]

### DIFF
--- a/lib/raxol/ui/components/harness/block.ex
+++ b/lib/raxol/ui/components/harness/block.ex
@@ -87,8 +87,26 @@ defmodule Raxol.UI.Components.Harness.Block do
   line alone + the outcome row. The outcome row is omitted entirely when
   `exit_code`, `duration_ms`, and `cost` are all `nil`; otherwise it renders
   only the fields that are present.
+
+  ## Prominence (T8)
+
+  `context[:prominence]` (`0.0..1.0`) resolves the header/content/outcome
+  text colors through `Raxol.UI.Harness.Prominence` -- the H-K salience
+  solver, ground-aware. `context[:ground]` overrides the ground lightness
+  (default: OSC-11-detected, see
+  `Raxol.UI.Theming.SalienceTheme.detect_ground/0`).
+  `context[:legibility_floor]` (default `false`) is threaded through to
+  `Prominence.resolve/3`: the default is the **pure salience-gradient
+  fade** (context text recedes, legible on promotion); T9 sets it `true`
+  only for acting / interactive tiers where blind-reading risk lives (see
+  the `Prominence` moduledoc's "Two modes"). **Default is neutral**: when
+  `:prominence` is absent from `context`, or is `1.0`, no style is touched
+  -- the render is byte-identical to a pre-T8 render (no `:fg` added to any
+  style map). This is deliberate (roadmap unit T8's regression guard,
+  SAL-P-06): existing callers that never pass `:prominence` see zero change.
   """
 
+  alias Raxol.UI.Harness.Prominence
   alias Raxol.UI.TextLayout
   alias Raxol.UI.TextMeasure
   alias Raxol.View.Components
@@ -333,21 +351,21 @@ defmodule Raxol.UI.Components.Harness.Block do
 
   def render(%__MODULE__{} = block, context) do
     width = Map.get(context, :width, Raxol.Core.Defaults.terminal_width())
-    build_render(block, width)
+    build_render(block, width, context)
   rescue
     e ->
       emit_recovered(block.kind, e)
       render_fallback(block)
   end
 
-  defp build_render(block, width) do
-    header = header_view(block, width)
-    outcome_children = outcome_row_view(block.outcome)
+  defp build_render(block, width, context) do
+    header = header_view(block, width, context)
+    outcome_children = outcome_row_view(block.outcome, context)
 
     body_children =
       case block.fold do
         :folded -> [header]
-        :expanded -> [header | content_lines_view(block)]
+        :expanded -> [header | content_lines_view(block, context)]
       end
 
     Components.column(gap: 0, children: body_children ++ outcome_children)
@@ -365,16 +383,55 @@ defmodule Raxol.UI.Components.Harness.Block do
     )
   end
 
-  defp header_view(block, width) do
+  defp header_view(block, width, context) do
     prefix = "#{fold_icon(block.fold)} #{kind_glyph(block.kind)} "
     budget = max(width - TextMeasure.display_width(prefix), 1)
     summary_text = block |> summary() |> TextLayout.truncate(budget, :ellipsis)
 
     Components.text(
       content: prefix <> summary_text,
-      style: header_style(block.kind)
+      style: prominence_style(header_style(block.kind), context)
     )
   end
+
+  # Chrome neutral baseline (matches DiffViewer's `@chrome_base_fg`) faded
+  # per `context[:prominence]` through the T8 mapping layer. Absent or 1.0
+  # prominence is a no-op (see moduledoc "Prominence (T8)" -- SAL-P-06).
+  @chrome_fg "#B4B4B4"
+
+  defp prominence_style(style, context) do
+    case prominence_fg(context) do
+      nil -> style
+      fg -> Map.put(style, :fg, fg)
+    end
+  end
+
+  defp prominence_fg(context) do
+    case Map.get(context, :prominence, 1.0) do
+      p when is_number(p) and p >= 1.0 ->
+        nil
+
+      p when is_number(p) ->
+        Prominence.resolve(@chrome_fg, p, prominence_opts(context))
+
+      _other ->
+        nil
+    end
+  end
+
+  # Only pass `:ground` through when the caller actually supplied one --
+  # `Prominence.resolve/3` defaults it lazily (OSC-11-detected, else the
+  # solver's reference ground), and an explicit `ground: nil` would
+  # short-circuit that default. `:legibility_floor` is threaded through when
+  # present (T9 sets it true for acting tiers; default false = pure fade).
+  defp prominence_opts(context) do
+    []
+    |> put_opt(:ground, Map.get(context, :ground))
+    |> put_opt(:legibility_floor, Map.get(context, :legibility_floor))
+  end
+
+  defp put_opt(opts, _key, nil), do: opts
+  defp put_opt(opts, key, value), do: [{key, value} | opts]
 
   defp fold_icon(:folded), do: "▸"
   defp fold_icon(_fold), do: "▾"
@@ -453,7 +510,7 @@ defmodule Raxol.UI.Components.Harness.Block do
   defp format_args([]), do: ""
   defp format_args(args), do: "(#{inspect(args)})"
 
-  defp content_lines_view(block) do
+  defp content_lines_view(block, context) do
     block
     |> body_lines()
     |> Enum.with_index()
@@ -461,7 +518,7 @@ defmodule Raxol.UI.Components.Harness.Block do
       Components.text(
         id: line_id(block, idx),
         content: line,
-        style: content_style(block.kind)
+        style: prominence_style(content_style(block.kind), context)
       )
     end)
   end
@@ -501,13 +558,18 @@ defmodule Raxol.UI.Components.Harness.Block do
   defp split_lines(""), do: []
   defp split_lines(text), do: text |> to_display_text() |> String.split("\n")
 
-  defp outcome_row_view(outcome) do
+  defp outcome_row_view(outcome, context) do
     case outcome_parts(outcome) do
       [] ->
         []
 
       parts ->
-        [Components.text(content: Enum.join(parts, " · "), style: %{dim: true})]
+        [
+          Components.text(
+            content: Enum.join(parts, " · "),
+            style: prominence_style(%{dim: true}, context)
+          )
+        ]
     end
   end
 

--- a/lib/raxol/ui/harness/prominence.ex
+++ b/lib/raxol/ui/harness/prominence.ex
@@ -1,0 +1,277 @@
+defmodule Raxol.UI.Harness.Prominence do
+  @moduledoc """
+  Maps a continuous `prominence` (`0.0..1.0`) attribute onto a resolved hex
+  color through the `Raxol.UI.Theming.Salience` H-K solver -- the mapping
+  layer named in `docs/proposals/in-flight/harness-ui-roadmap.md` unit T8.
+
+  See `docs/proposals/in-flight/harness-ui-testing/05-salience.md` for the
+  full test design; this moduledoc summarizes the two bugs it found in the
+  DiffViewer prototype (PR `feat/harness-ui-harness_diff`) and how this
+  module fixes them for the general contract.
+
+  ## F1 -- ground-aware fade (fixed by threading `:ground` all the way through)
+
+  `DiffViewer.fade_toward_ground/2` fades toward the hardcoded dark
+  `Salience.reference_ground/0` (`0.2`) regardless of the terminal's actual
+  background. On a light theme this is backwards: fading toward `0.2`
+  moves a dark foreground *away* from a light background, so contrast rises
+  as prominence drops (the fade inverts). `resolve/3` (and `fade/3`) take
+  the real ground as an argument, threaded to `Salience.solve_lightness/3`
+  the same way `Salience.solve/4` already accepts `:ground` -- the formula
+  `faded_apparent = ground + (apparent - ground) * prominence` interpolates
+  APPARENT lightness toward the ground point, which is direction-correct on
+  either side (dark ground: fades down toward it; light ground: fades up
+  toward it) as long as `ground` is the real one, not a hardcoded reference.
+
+  ## Two modes -- pure fade (default) vs floored (opt-in)
+
+  This is the load-bearing design decision of the unit, and a **deliberate
+  correction to 05-salience.md's original "floor everywhere" sketch** (F2
+  below). The salience gradient *is the moat*: context text is *meant* to
+  recede as its prominence drops, and "faded but not lost" means
+  **recoverable when T9 promotes the block to prominence 1.0 on focus**, NOT
+  readable-at-a-glance. A universal legibility floor would fight that
+  gradient -- flattening the very tier separation the gradient exists to
+  create. So:
+
+    * **Pure fade (default).** `resolve(hex, prominence)` and `resolve(hex,
+      prominence, ground: g)` apply *only* the ground-aware fade (F1). No
+      floor. The output recedes monotonically toward the ground as
+      `prominence` drops -- the gradient T9 depends on, with no tier
+      collapse. Only guaranteed legible **on promotion** (T9 raises the
+      block to prominence 1.0 = identity = the seed), not at rest.
+
+    * **Floored (opt-in, `legibility_floor: true`).** Additionally clamps
+      the output to a WCAG-style contrast floor (F2). T9 sets this **only
+      for acting / interactive tiers** -- current-turn, needs-input,
+      composer -- where blind-reading risk actually lives (the
+      93%-blind-approve stat). Context-history tiers fade free. A floored
+      output is guaranteed legible **at rest**.
+
+  ## F2 -- the legibility clamp (opt-in), and why it is opt-in
+
+  A `prominence` scalar floors the INPUT multiplier, not the OUTPUT
+  contrast: `|faded_apparent - ground| = |apparent - ground| * prominence`,
+  which depends on how much contrast the source color started with. A
+  low-apparent-contrast source (a `:recede` tier neutral, or any near-ground
+  seed) can drop below any legibility threshold. When `legibility_floor:
+  true`, `resolve/3` clamps the *WCAG-style relative-luminance contrast
+  ratio* (`Salience.relative_luminance/1`, Rec. 709 -- an external check the
+  solver's own apparent-lightness model cannot self-certify) against
+  `FLOOR_RATIO`: if the raw fade falls short, the clamp walks *back up the
+  fade line* toward higher prominence until the floor is met, via bisection
+  (the fade-to-clamped mapping isn't analytically invertible once gamut
+  shrink is in play). "The fade line" is the one-parameter family
+  `fade_color(t) = build_hex(ground + (apparent - ground) * t, c * t, h)`
+  for `t` running from the requested `prominence` up to `1.0` -- it moves
+  BOTH apparent lightness and chroma together, so its endpoint at `t = 1.0`
+  is the **true full-chroma prominence:1.0 color** (≈ the input `hex`
+  itself, up to gamut round-trip), NOT a reduced-chroma proxy. That makes
+  the ceiling exact: the clamp never manufactures more contrast than the
+  color's own full-strength self, and the floor-reachability check is run
+  against that true ceiling. When even the full-strength color misses the
+  floor (a genuinely low-contrast seed against this ground -- a
+  palette-design gap the clamp cannot paper over without exceeding its own
+  ceiling), `resolve/3` returns that true full-chroma ceiling as documented
+  best effort.
+
+  `FLOOR_RATIO` (`#{3.0}`, `#{3.0}:1`) is a **placeholder**, pending
+  ratification by the human-eye protocol (05-salience.md sec 5) -- the
+  first playground matrix run picks the highest ratio at which every cell
+  is legible and pins it here permanently.
+
+  ## Truecolor-only floor; 256-color deferred
+
+  The clamp guarantees the floor on the **24-bit hex it emits** -- it is
+  truecolor-only. **256-color survival is out of scope for this unit and T9
+  must not assume the clamp survives quantization:** downsampling a
+  floored hex to the xterm-256 cube can drop it back under the floor (and
+  can collapse adjacent fade tiers, 05-salience.md SAL-N-01). The eventual
+  answer is a redistributed `tiers_for(ground, :color256)` ladder
+  (fewer, wider-spaced tiers chosen in-palette), not a post-hoc clamp on a
+  quantized value -- deferred here because it needs a quantization-pipeline
+  decision this unit does not make.
+
+  ## Scope
+
+  This module resolves a single foreground color; it does not decide
+  *which* prominence a block gets nor *whether* the floor is engaged for it
+  (that's T9's `policy/2` -- it owns the acting-vs-context call and passes
+  `legibility_floor:` accordingly), nor whether a sealed block may be
+  restyled at all (that's D-PA + `Block.fold_allowed?/2` territory).
+  """
+
+  alias Raxol.UI.Theming.Salience
+  alias Raxol.UI.Theming.SalienceTheme
+
+  # WCAG AA large-text / UI-component minimum, placeholder pending the
+  # human-eye ratification pass (05-salience.md sec 5.4).
+  @floor_ratio 3.0
+
+  @clamp_iterations 24
+
+  @type opts :: [
+          ground: float(),
+          legibility_floor: boolean(),
+          floor_ratio: float()
+        ]
+
+  @doc "The placeholder WCAG-style legibility floor ratio (see moduledoc)."
+  @spec floor_ratio() :: float()
+  def floor_ratio, do: @floor_ratio
+
+  @doc """
+  Resolves `hex` at `prominence` (`0.0..1.0`) against a ground.
+
+  Default is the **pure ground-aware fade** (the salience gradient, F1) --
+  no legibility floor. Pass `legibility_floor: true` to additionally clamp
+  the output to a WCAG contrast floor (F2); T9 does this only for acting /
+  interactive tiers. See the moduledoc's "Two modes" section.
+
+  ## Options
+
+    * `:ground` - ground (background) OKLCH lightness. Default: the
+      OSC-11-detected terminal background
+      (`Raxol.UI.Theming.SalienceTheme.detect_ground/0`), falling back to
+      `Salience.reference_ground/0` when detection is unavailable. Pass
+      explicitly to test against a specific ground without touching
+      `:persistent_term`.
+    * `:legibility_floor` - `true` engages the opt-in legibility clamp
+      (default `false` = pure fade).
+    * `:floor_ratio` - override the legibility floor ratio (default
+      `#{@floor_ratio}`); only consulted when `legibility_floor: true`.
+
+  `prominence >= 1.0` is the identity (byte-identical `hex` back, no ground
+  lookup, no clamp, regardless of `:legibility_floor`) -- the T8 neutrality
+  guarantee (SAL-P-06): a caller that never sets `prominence` below `1.0`
+  sees zero change.
+  """
+  @spec resolve(String.t(), number(), opts()) :: String.t()
+  def resolve(hex, prominence, opts \\ [])
+
+  def resolve(hex, prominence, _opts) when prominence >= 1.0, do: hex
+
+  def resolve(hex, prominence, opts) do
+    ground = resolve_ground(opts)
+    {l, c, h} = Salience.hex_to_oklch(hex)
+    apparent = Salience.apparent_lightness(l, c, h)
+    faded_hex = fade_color(apparent, c, h, ground, prominence)
+
+    if legibility_floor?(opts) do
+      clamp_to_floor(faded_hex, apparent, c, h, ground, prominence, opts)
+    else
+      faded_hex
+    end
+  end
+
+  @doc """
+  The raw ground-aware fade -- identical to `resolve/3`'s default (pure
+  fade) mode, and exposed as its own name so callers/tests can name the
+  intent explicitly (observe the F1 fix without any chance of the opt-in
+  floor engaging).
+  """
+  @spec fade(String.t(), number(), float()) :: String.t()
+  def fade(hex, prominence, _ground) when prominence >= 1.0, do: hex
+
+  def fade(hex, prominence, ground) do
+    {l, c, h} = Salience.hex_to_oklch(hex)
+    apparent = Salience.apparent_lightness(l, c, h)
+    fade_color(apparent, c, h, ground, prominence)
+  end
+
+  # A single point on the fade line: apparent lightness AND chroma both
+  # scaled toward the ground by `t`. At `t = 1.0` this is the true
+  # full-chroma color (≈ the original hex, up to gamut round-trip); at
+  # `t = 0.0` it collapses to the ground. Both `fade/3` and the clamp
+  # bisection walk this same line so the clamp's ceiling is exact.
+  defp fade_color(apparent, c, h, ground, t) do
+    build_hex(ground + (apparent - ground) * t, c * t, h)
+  end
+
+  @doc """
+  WCAG-style contrast ratio between two hex colors: sRGB relative luminance
+  (`Salience.relative_luminance/1`, Rec. 709), `(max(Y) + 0.05) / (min(Y) + 0.05)`.
+  This is metric M2 (05-salience.md sec 1) -- the external legibility check,
+  distinct from the solver's own apparent-lightness model (M1).
+  """
+  @spec wcag_ratio(String.t(), String.t()) :: float()
+  def wcag_ratio(hex_a, hex_b) do
+    y_a = Salience.relative_luminance(hex_a)
+    y_b = Salience.relative_luminance(hex_b)
+    (max(y_a, y_b) + 0.05) / (min(y_a, y_b) + 0.05)
+  end
+
+  defp resolve_ground(opts) do
+    Keyword.get_lazy(opts, :ground, &SalienceTheme.detect_ground/0)
+  end
+
+  defp legibility_floor?(opts), do: Keyword.get(opts, :legibility_floor, false)
+
+  defp resolve_floor_ratio(opts),
+    do: Keyword.get(opts, :floor_ratio, @floor_ratio)
+
+  defp build_hex(apparent_lightness, c, h) do
+    l = Salience.solve_lightness(apparent_lightness, c, h)
+    Salience.oklch_to_hex(l, c, h)
+  end
+
+  # The F2 guard: if the raw fade's contrast ratio against ground already
+  # meets the floor, it passes through unchanged. Otherwise walk the fade
+  # line back up toward `t = 1.0` (the TRUE full-chroma prominence:1.0
+  # color) until the floor is met -- never past `t = 1.0`, so the clamp
+  # never manufactures more contrast than the color's own full-strength
+  # self. The reachability check is run against that same true ceiling.
+  defp clamp_to_floor(faded_hex, apparent, c, h, ground, prominence, opts) do
+    floor_ratio = resolve_floor_ratio(opts)
+    ground_hex = build_hex(ground, 0.0, 0.0)
+
+    if wcag_ratio(faded_hex, ground_hex) >= floor_ratio do
+      faded_hex
+    else
+      # The true prominence:1.0 color: full chroma AND full apparent
+      # lightness, the `t = 1.0` endpoint of the fade line.
+      ceiling_hex = fade_color(apparent, c, h, ground, 1.0)
+
+      if wcag_ratio(ceiling_hex, ground_hex) < floor_ratio do
+        # Even the full-strength color misses the floor (a genuinely
+        # low-contrast seed against this ground -- a palette-design gap) --
+        # best effort: the true ceiling, the most contrast this color has
+        # to give, never more.
+        ceiling_hex
+      else
+        ctx = %{
+          apparent: apparent,
+          c: c,
+          h: h,
+          ground: ground,
+          ground_hex: ground_hex,
+          floor: floor_ratio
+        }
+
+        bisect_floor(ctx, prominence, 1.0, @clamp_iterations)
+      end
+    end
+  end
+
+  # Bisection over `t` on the fade line between the (failing) requested
+  # prominence `lo` and the (passing) full-strength `hi = 1.0` -- not
+  # solved in closed form because gamut-shrink (`Salience.oklch_to_rgb/3`'s
+  # chroma clamp) makes the WCAG ratio a non-analytic function of `t`. `hi`
+  # always denotes a `t` already verified to pass; `fade_color/5` at `hi`
+  # is the return value once the interval has collapsed to tolerance, so
+  # the result is always floor-meeting and always at `t <= 1.0` (never
+  # exceeding the true ceiling). `ctx` carries the loop invariants.
+  defp bisect_floor(ctx, _lo, hi, 0),
+    do: fade_color(ctx.apparent, ctx.c, ctx.h, ctx.ground, hi)
+
+  defp bisect_floor(ctx, lo, hi, n) do
+    mid = (lo + hi) / 2
+    hex = fade_color(ctx.apparent, ctx.c, ctx.h, ctx.ground, mid)
+
+    if wcag_ratio(hex, ctx.ground_hex) >= ctx.floor do
+      bisect_floor(ctx, lo, mid, n - 1)
+    else
+      bisect_floor(ctx, mid, hi, n - 1)
+    end
+  end
+end

--- a/lib/raxol/ui/theming/salience.ex
+++ b/lib/raxol/ui/theming/salience.ex
@@ -265,6 +265,26 @@ defmodule Raxol.UI.Theming.Salience do
     if c <= 0.04045, do: c / 12.92, else: :math.pow((c + 0.055) / 1.055, 2.4)
   end
 
+  @doc """
+  sRGB relative luminance (Rec. 709 coefficients) of a `#rrggbb` hex color,
+  per the WCAG contrast-ratio formula (`(L1 + 0.05) / (L2 + 0.05)`).
+
+  This is intentionally a different lens than `apparent_lightness/3`: the
+  H-K apparent-lightness model is the solver's *internal* notion of equal
+  brightness (used for tier uniformity/monotonicity), while relative
+  luminance is the *external*, standards-based check a caller can use for a
+  legibility floor that the solver's own model cannot self-certify.
+  """
+  @spec relative_luminance(String.t()) :: float()
+  def relative_luminance("#" <> hex), do: relative_luminance(hex)
+
+  def relative_luminance(<<r::binary-2, g::binary-2, b::binary-2>>) do
+    [r, g, b] = Enum.map([r, g, b], &(String.to_integer(&1, 16) / 255))
+
+    0.2126 * srgb_to_linear(r) + 0.7152 * srgb_to_linear(g) +
+      0.0722 * srgb_to_linear(b)
+  end
+
   defp cube(x), do: x * x * x
 
   defp cbrt(x) when x < 0, do: -:math.pow(-x, 1 / 3)

--- a/test/raxol/ui/harness/prominence_property_test.exs
+++ b/test/raxol/ui/harness/prominence_property_test.exs
@@ -1,0 +1,224 @@
+defmodule Raxol.UI.Harness.ProminencePropertyTest do
+  @moduledoc """
+  Property suite for `Raxol.UI.Harness.Prominence`, per
+  `docs/proposals/in-flight/harness-ui-testing/05-salience.md` sec 2-3.
+
+  Two distinct metrics (05-salience.md sec 1), used for different
+  properties:
+
+    * **M1** (`Salience.apparent_lightness/3`, the solver's own H-K model)
+      -- for uniformity/monotonicity properties, testing the pure fade
+      against ITS OWN model. These hold *analytically* for the fade
+      formula. The DEFAULT `resolve/3` IS the pure fade (the floor is
+      opt-in), so the gradient property tests it directly; the opt-in
+      legibility clamp (`legibility_floor: true`) is a deliberate leveler
+      that can override monotonicity when it engages (pushing several
+      under-floor colors toward the same minimal-legible point) -- that's
+      F2 doing its job, so the M1 properties never turn the floor on.
+    * **M2** (`Prominence.wcag_ratio/2`, sRGB relative luminance contrast)
+      -- for the legibility floor, testing `resolve/3` WITH
+      `legibility_floor: true`: an external check the solver's own
+      apparent-lightness model cannot self-certify.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.Harness.Prominence
+  alias Raxol.UI.Theming.Salience
+
+  @eps_quant 0.02
+  @prominences [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+  @ordered_prominence_pairs for a <- @prominences,
+                                b <- @prominences,
+                                a > b,
+                                do: {a, b}
+
+  defp hue_gen, do: integer(0..359)
+  defp chroma_gen, do: float(min: 0.0, max: 0.16)
+  defp ground_gen, do: member_of([0.2, 0.95])
+  defp prominence_gen, do: member_of(@prominences)
+  defp ordered_prominence_pair_gen, do: member_of(@ordered_prominence_pairs)
+
+  defp apparent_contrast(hex, ground) do
+    {l, c, h} = Salience.hex_to_oklch(hex)
+    ground_al = Salience.apparent_lightness(ground, 0.0, 0.0)
+    abs(Salience.apparent_lightness(l, c, h) - ground_al)
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-P-03: equal prominence => equal apparent-contrast across hues.
+  # Tests fade/3 (M1, no clamp) -- see moduledoc.
+  # ---------------------------------------------------------------------
+
+  property "equal prominence yields equal apparent-contrast across hues (SAL-P-03)" do
+    check all(
+            h1 <- hue_gen(),
+            h2 <- hue_gen(),
+            c <- chroma_gen(),
+            ground <- ground_gen(),
+            prominence <- prominence_gen()
+          ) do
+      seed1 = Salience.solve(:differentiate, c, h1, ground: ground)
+      seed2 = Salience.solve(:differentiate, c, h2, ground: ground)
+
+      faded1 = Prominence.fade(seed1, prominence, ground)
+      faded2 = Prominence.fade(seed2, prominence, ground)
+
+      contrast1 = apparent_contrast(faded1, ground)
+      contrast2 = apparent_contrast(faded2, ground)
+
+      assert_in_delta contrast1, contrast2, @eps_quant
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-P-04: per-hue monotone contrast, on BOTH grounds. Tests fade/3
+  # (M1, no clamp) -- see moduledoc.
+  # ---------------------------------------------------------------------
+
+  property "prominence a > b yields apparent-contrast a >= b, both grounds (SAL-P-04)" do
+    check all(
+            h <- hue_gen(),
+            c <- chroma_gen(),
+            ground <- ground_gen(),
+            {a, b} <- ordered_prominence_pair_gen()
+          ) do
+      seed = Salience.solve(:differentiate, c, h, ground: ground)
+
+      faded_a = Prominence.fade(seed, a, ground)
+      faded_b = Prominence.fade(seed, b, ground)
+
+      contrast_a = apparent_contrast(faded_a, ground)
+      contrast_b = apparent_contrast(faded_b, ground)
+
+      assert contrast_a >= contrast_b - @eps_quant
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # GRADIENT (the design correction): the DEFAULT resolve/3 (pure fade, no
+  # floor) is monotone per hue on both grounds -- distinct prominences do
+  # not collapse. This is the property T9 depends on for the salience
+  # ladder; the complement of SAL-P-05 (which needs the floor ON).
+  # ---------------------------------------------------------------------
+
+  property "default resolve/3 (pure fade) is monotone per hue, both grounds (gradient)" do
+    check all(
+            h <- hue_gen(),
+            c <- chroma_gen(),
+            tier <- member_of(Salience.tiers()),
+            ground <- ground_gen(),
+            {a, b} <- ordered_prominence_pair_gen()
+          ) do
+      seed = Salience.solve(tier, c, h, ground: ground)
+
+      # No legibility_floor -> pure fade -> apparent-contrast strictly
+      # tracks prominence (the leveler that would flatten it is off).
+      resolved_a = Prominence.resolve(seed, a, ground: ground)
+      resolved_b = Prominence.resolve(seed, b, ground: ground)
+
+      contrast_a = apparent_contrast(resolved_a, ground)
+      contrast_b = apparent_contrast(resolved_b, ground)
+
+      assert contrast_a >= contrast_b - @eps_quant,
+             "seed #{seed} a#{a}(#{contrast_a}) should recede no less than b#{b}(#{contrast_b})"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-P-05: floor holds against BOTH grounds when `legibility_floor:
+  # true`. Tests resolve/3 (M2, WITH the opt-in clamp) -- see moduledoc.
+  # ---------------------------------------------------------------------
+
+  property "floored resolve/3 yields WCAG ratio >= FLOOR_RATIO, both grounds (SAL-P-05)" do
+    check all(
+            h <- hue_gen(),
+            c <- chroma_gen(),
+            tier <- member_of(Salience.tiers()),
+            ground <- ground_gen(),
+            prominence <- prominence_gen()
+          ) do
+      seed = Salience.solve(tier, c, h, ground: ground)
+      ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+
+      # The clamp holds the floor for prominence < 1.0 by pushing back up
+      # the fade line AT MOST to the true full-chroma prominence:1.0 point --
+      # it never manufactures more contrast than the color's own ceiling
+      # (moduledoc). So the floor guarantee is conditional on that ceiling
+      # being reachable at all: a seed whose OWN full-strength ratio already
+      # misses FLOOR_RATIO against this ground is a palette-design gap (some
+      # low-delta tiers, e.g. `:alarm`, can be this close to ground at high
+      # chroma / extreme grounds), not something a per-call clamp can fix.
+      ceiling_ratio = Prominence.wcag_ratio(seed, ground_hex)
+
+      if ceiling_ratio >= Prominence.floor_ratio() do
+        resolved =
+          Prominence.resolve(seed, prominence,
+            ground: ground,
+            legibility_floor: true
+          )
+
+        ratio = Prominence.wcag_ratio(resolved, ground_hex)
+
+        assert ratio >= Prominence.floor_ratio() - 1.0e-6,
+               "seed #{seed} tier #{tier} ground #{ground} p#{prominence}: ratio #{ratio}"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-N-02: light ground => fade decreases contrast (F1 guard), property
+  # form. Tests fade/3 directly (byte-exact spot checks against resolve/3
+  # live in prominence_test.exs, choosing seeds that don't engage the
+  # clamp in that range).
+  # ---------------------------------------------------------------------
+
+  property "light ground: decreasing prominence never increases WCAG ratio (SAL-N-02)" do
+    check all(
+            h <- hue_gen(),
+            c <- chroma_gen(),
+            tier <- member_of(Salience.tiers()),
+            {a, b} <- ordered_prominence_pair_gen()
+          ) do
+      ground = 0.95
+      seed = Salience.solve(tier, c, h, ground: ground)
+      ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+
+      ratio_a =
+        Prominence.wcag_ratio(Prominence.fade(seed, a, ground), ground_hex)
+
+      ratio_b =
+        Prominence.wcag_ratio(Prominence.fade(seed, b, ground), ground_hex)
+
+      assert ratio_a >= ratio_b - 1.0e-6,
+             "seed #{seed} a#{a}(ratio #{ratio_a}) should be >= b#{b}(ratio #{ratio_b})"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-N-05: degenerate grounds -- stable, in-gamut, no crash. Exercises
+  # the full resolve/3 pipeline (fade + clamp) for robustness.
+  # ---------------------------------------------------------------------
+
+  property "degenerate grounds never raise and stay in-gamut, both modes (SAL-N-05)" do
+    check all(
+            h <- hue_gen(),
+            c <- chroma_gen(),
+            tier <- member_of(Salience.tiers()),
+            ground <- member_of([0.0, 0.5, 1.0]),
+            prominence <- prominence_gen(),
+            floor <- boolean()
+          ) do
+      seed = Salience.solve(tier, c, h, ground: ground)
+
+      resolved =
+        Prominence.resolve(seed, prominence,
+          ground: ground,
+          legibility_floor: floor
+        )
+
+      assert resolved =~ ~r/^#[0-9a-f]{6}$/
+    end
+  end
+end

--- a/test/raxol/ui/harness/prominence_test.exs
+++ b/test/raxol/ui/harness/prominence_test.exs
@@ -1,0 +1,414 @@
+defmodule Raxol.UI.Harness.ProminenceTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.Block
+  alias Raxol.UI.Harness.Prominence
+  alias Raxol.UI.Theming.Salience
+
+  @dark_ground 0.2
+  @light_ground 0.95
+
+  # ---------------------------------------------------------------------
+  # SAL-P-06: default 1.0 / absent prominence is a strict no-op.
+  # ---------------------------------------------------------------------
+
+  describe "resolve/3 neutrality (SAL-P-06)" do
+    test "prominence 1.0 is byte-identical for any hex, any ground" do
+      for hex <- ["#c1712c", "#abb7c3", "#717171", "#ffffff", "#000000"],
+          ground <- [@dark_ground, @light_ground, 0.5] do
+        assert Prominence.resolve(hex, 1.0, ground: ground) == hex
+      end
+    end
+
+    test "Block render with no :prominence key is byte-identical to explicit 1.0" do
+      block =
+        Block.from_events(:message, [
+          %{type: :item_completed, content: "hello world"}
+        ])
+
+      assert Block.render(block, %{}) == Block.render(block, %{prominence: 1.0})
+    end
+
+    test "Block render with no :prominence key adds no :fg to any style map" do
+      block =
+        Block.from_events(:tool_call, [
+          %{
+            type: :item_completed,
+            content: %{name: "grep", args: %{}, result: "match"}
+          }
+        ])
+
+      rendered = Block.render(block, %{})
+      refute style_fg_anywhere?(rendered)
+    end
+
+    defp style_fg_anywhere?(%{type: :text, style: style}) do
+      Map.has_key?(style, :fg)
+    end
+
+    defp style_fg_anywhere?(%{children: children}) do
+      Enum.any?(children, &style_fg_anywhere?/1)
+    end
+
+    defp style_fg_anywhere?(_other), do: false
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-P-01 analogue: byte-exact prominence-step bake (fill after first
+  # green run, same discipline as the Darcula bake in salience_test.exs).
+  # ---------------------------------------------------------------------
+
+  describe "resolve/3 byte-exact bake (SAL-P-01 analogue)" do
+    # Default = PURE FADE (no legibility floor): the salience gradient.
+    # {seed_hex, prominence, ground, expected_hex}. Light-ground rows use a
+    # dark-on-light foreground (#3b444f) so they exercise a real fade on a
+    # light ground.
+    @prominence_bake [
+      {"#c1712c", 1.0, @dark_ground, "#c1712c"},
+      {"#c1712c", 0.8, @dark_ground, "#9b5e2b"},
+      {"#c1712c", 0.6, @dark_ground, "#774b28"},
+      {"#c1712c", 0.4, @dark_ground, "#553924"},
+      {"#abb7c3", 0.8, @dark_ground, "#8a939c"},
+      {"#abb7c3", 0.6, @dark_ground, "#6a7177"},
+      {"#abb7c3", 0.4, @dark_ground, "#4c5054"},
+      {"#3b444f", 0.8, @light_ground, "#5b636c"},
+      {"#3b444f", 0.6, @light_ground, "#7e848b"},
+      {"#3b444f", 0.4, @light_ground, "#a2a6ab"}
+    ]
+
+    test "reproduces every baked hex byte-exact (pure fade default)" do
+      for {hex, prominence, ground, expected} <- @prominence_bake do
+        got = Prominence.resolve(hex, prominence, ground: ground)
+
+        assert got == expected,
+               "#{hex} p#{prominence} ground#{ground}: expected #{expected}, got #{got}"
+      end
+    end
+
+    # Floored mode (legibility_floor: true): the clamp pulls low-contrast
+    # fades back up to the floor. Note #c1712c at 0.6 and 0.4 both land on
+    # #8d562a -- the clamp deliberately levels sub-floor prominences to the
+    # minimal-legible point (the acting-tier legibility guarantee, NOT the
+    # gradient). Same seeds as above so the two modes diff cleanly.
+    @floored_bake [
+      {"#c1712c", 1.0, "#c1712c"},
+      {"#c1712c", 0.8, "#9b5e2b"},
+      {"#c1712c", 0.6, "#8d562a"},
+      {"#c1712c", 0.4, "#8d562a"},
+      {"#abb7c3", 0.4, "#5e6469"}
+    ]
+
+    test "reproduces every floored hex byte-exact (legibility_floor: true)" do
+      for {hex, prominence, expected} <- @floored_bake do
+        got =
+          Prominence.resolve(hex, prominence,
+            ground: @dark_ground,
+            legibility_floor: true
+          )
+
+        assert got == expected,
+               "#{hex} p#{prominence} floored: expected #{expected}, got #{got}"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-N-02: the F1 guard. On a light ground, decreasing prominence must
+  # DECREASE contrast (never invert).
+  # ---------------------------------------------------------------------
+
+  describe "light-ground fade direction (SAL-N-02, F1 guard)" do
+    test "on light ground, wcag ratio decreases monotonically as prominence drops" do
+      # Uses fade/3 (no legibility clamp) to isolate the F1 fade-direction
+      # fix from the F2 clamp -- the clamp is a deliberate leveler (it can
+      # push several under-floor prominences toward the same minimal-legible
+      # ratio, which would masquerade as "not strictly monotonic" here for
+      # reasons that have nothing to do with F1). SAL-P-05 below is the
+      # dedicated clamp/floor test.
+      hex = Salience.solve(:baseline, 0.022, 250, ground: @light_ground)
+      ground_hex = Salience.oklch_to_hex(@light_ground, 0.0, 0.0)
+
+      ratios =
+        for p <- [0.4, 0.6, 0.8, 1.0] do
+          faded = Prominence.fade(hex, p, @light_ground)
+          Prominence.wcag_ratio(faded, ground_hex)
+        end
+
+      [r04, r06, r08, r10] = ratios
+
+      assert r04 < r06,
+             "expected ratio to rise with prominence (0.4->0.6), got #{inspect(ratios)}"
+
+      assert r06 < r08,
+             "expected ratio to rise with prominence (0.6->0.8), got #{inspect(ratios)}"
+
+      assert r08 <= r10 + 1.0e-9,
+             "expected ratio to rise with prominence (0.8->1.0), got #{inspect(ratios)}"
+    end
+
+    test "dark and light grounds fade to opposite sides of their ground" do
+      hex = "#abb7c3"
+
+      dark_ground_hex = Salience.oklch_to_hex(@dark_ground, 0.0, 0.0)
+      light_ground_hex = Salience.oklch_to_hex(@light_ground, 0.0, 0.0)
+
+      {dark_gl, _c, _h} = Salience.hex_to_oklch(dark_ground_hex)
+      {light_gl, _c, _h} = Salience.hex_to_oklch(light_ground_hex)
+
+      faded_dark = Prominence.fade(hex, 0.5, @dark_ground)
+      faded_light = Prominence.fade(hex, 0.5, @light_ground)
+
+      {dl, _, _} = Salience.hex_to_oklch(faded_dark)
+      {ll, _, _} = Salience.hex_to_oklch(faded_light)
+
+      assert dl > dark_gl,
+             "on a dark ground, a faded foreground should stay lighter than ground"
+
+      assert ll < light_gl,
+             "on a light ground, a faded foreground should stay darker than ground"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-P-05: the F2 guard. When `legibility_floor: true`, every
+  # prominence < 1.0 must clamp to a WCAG ratio >= FLOOR_RATIO against
+  # BOTH grounds (where the true full-chroma ceiling reaches the floor).
+  # This holds for the OPT-IN floored mode, NOT the default pure fade.
+  # ---------------------------------------------------------------------
+
+  describe "legibility floor clamp (SAL-P-05, F2 guard, opt-in)" do
+    # A deliberately low-apparent-contrast seed (a `:recede`-tier neutral
+    # close to the ground) -- exactly the case 05-salience.md names as the
+    # one the raw 0.4-floor multiplier does not protect. Solved fresh
+    # against whichever ground is under test (a seed solved for one ground
+    # and reused unmodified against the other isn't a meaningful legibility
+    # scenario -- the pipeline always solves against the detected ground).
+    test "floor holds for a low-contrast source color, both grounds" do
+      for ground <- [@dark_ground, @light_ground],
+          prominence <- [0.4, 0.5, 0.6, 0.8, 1.0] do
+        seed = Salience.solve(:recede, 0.02, 250, ground: ground)
+        ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+
+        resolved =
+          Prominence.resolve(seed, prominence,
+            ground: ground,
+            legibility_floor: true
+          )
+
+        ratio = Prominence.wcag_ratio(resolved, ground_hex)
+
+        assert ratio >= Prominence.floor_ratio() - 1.0e-6,
+               "ground #{ground} p#{prominence}: ratio #{ratio} below floor #{Prominence.floor_ratio()}"
+      end
+    end
+
+    test "default (pure fade) does NOT floor -- the low-contrast seed recedes freely" do
+      # The complement of the test above: without legibility_floor:, the
+      # same low-contrast seed is allowed below the floor (that's the
+      # gradient, legible only on promotion). Guards against the floor
+      # silently becoming default again.
+      ground = @dark_ground
+      ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+      seed = Salience.solve(:recede, 0.02, 250, ground: ground)
+
+      resolved = Prominence.resolve(seed, 0.4, ground: ground)
+      ratio = Prominence.wcag_ratio(resolved, ground_hex)
+
+      assert ratio < Prominence.floor_ratio(),
+             "pure fade should let a low-contrast seed drop below the floor, got #{ratio}"
+    end
+
+    test "floor holds for the full Darcula seed set at the 0.4 floor" do
+      seeds = [
+        {0.13, 57},
+        {0.125, 77},
+        {0.022, 250},
+        {0.075, 134},
+        {0.074, 242},
+        {0.086, 314},
+        {0.16, 25}
+      ]
+
+      for {c, h} <- seeds,
+          ground <- [@dark_ground, @light_ground],
+          tier <- Salience.tiers() do
+        seed = Salience.solve(tier, c, h, ground: ground)
+        ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+        # Guard on ceiling reachability: this loop sweeps EVERY tier against
+        # EVERY hue, including combos the palette never uses (e.g. the
+        # low-delta `:alarm` tier on a green hue), some of which can't clear
+        # the floor even at full strength against a light ground -- a
+        # palette-design gap the clamp can't paper over (moduledoc). The
+        # floor is only guaranteed where the true ceiling reaches it.
+        ceiling_ratio = Prominence.wcag_ratio(seed, ground_hex)
+
+        if ceiling_ratio >= Prominence.floor_ratio() do
+          resolved =
+            Prominence.resolve(seed, 0.4,
+              ground: ground,
+              legibility_floor: true
+            )
+
+          ratio = Prominence.wcag_ratio(resolved, ground_hex)
+
+          assert ratio >= Prominence.floor_ratio() - 1.0e-6,
+                 "#{seed} (tier #{tier}) on ground #{ground}: ratio #{ratio} below floor"
+        end
+      end
+    end
+
+    # Review-round guard: the clamp's ceiling is the TRUE full-chroma
+    # prominence:1.0 color, not a reduced-chroma proxy. At MAX chroma the
+    # distinction bites -- a reduced-chroma ceiling can dip below the floor
+    # while the true full-chroma seed clears it, which would make the clamp
+    # target an unreachable ratio. These seeds sit at 0.16 (the top of the
+    # test chroma range) and a deliberately out-of-gamut-adjacent 0.30
+    # (the solver shrinks it into gamut). Two guarantees at once:
+    #   (a) the clamp never manufactures more contrast than the true
+    #       full-chroma prominence:1.0 seed (the exact-ceiling property);
+    #   (b) when that true ceiling itself clears the floor, every
+    #       prominence < 1.0 also clears it (reachable-target property).
+    test "max-chroma: clamp ceiling is the true full-chroma seed, never unreachable" do
+      high_chroma_seeds =
+        for c <- [0.16, 0.30], h <- [25, 142, 250] do
+          Salience.oklch_to_hex(0.6, c, h)
+        end
+
+      for seed <- high_chroma_seeds,
+          ground <- [@dark_ground, @light_ground],
+          prominence <- [0.4, 0.6, 0.8] do
+        ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+        # The true prominence:1.0 color is the identity (resolve short-
+        # circuits at >= 1.0), so its ratio is the exact ceiling.
+        ceiling_ratio = Prominence.wcag_ratio(seed, ground_hex)
+
+        resolved =
+          Prominence.resolve(seed, prominence,
+            ground: ground,
+            legibility_floor: true
+          )
+
+        ratio = Prominence.wcag_ratio(resolved, ground_hex)
+
+        # (a) never exceeds the true full-chroma ceiling.
+        assert ratio <= ceiling_ratio + 1.0e-6,
+               "#{seed} p#{prominence} g#{ground}: ratio #{ratio} exceeds true ceiling #{ceiling_ratio}"
+
+        # (b) if the ceiling is reachable, the floor is met.
+        if ceiling_ratio >= Prominence.floor_ratio() do
+          assert ratio >= Prominence.floor_ratio() - 1.0e-6,
+                 "#{seed} p#{prominence} g#{ground}: ratio #{ratio} below floor (ceiling #{ceiling_ratio} was reachable)"
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # SAL-N-05: degenerate grounds (solver stability at extremes).
+  # ---------------------------------------------------------------------
+
+  describe "degenerate grounds (SAL-N-05)" do
+    test "pure black, pure white, and mid-gray grounds never raise and stay in-gamut" do
+      # Both modes (pure fade default + opt-in floor) must survive the
+      # degenerate grounds where headroom -> 0 (mid-gray) / -> max (pure
+      # black/white), and the floor bisection must not diverge there.
+      for ground <- [0.0, 0.5, 1.0],
+          hex <- ["#c1712c", "#abb7c3", "#717171"],
+          prominence <- [0.4, 0.6, 0.8, 1.0],
+          floor <- [false, true] do
+        got =
+          Prominence.resolve(hex, prominence,
+            ground: ground,
+            legibility_floor: floor
+          )
+
+        assert got =~ ~r/^#[0-9a-f]{6}$/
+      end
+    end
+
+    test "mid-gray ground: floored resolve/3 never crashes, stays in-gamut, every tier" do
+      # SAL-N-05's contract at mid-gray is STABILITY, not the floor:
+      # headroom compression can shrink a tier's own full-strength
+      # (`prominence: 1.0`) contrast below FLOOR_RATIO, and the clamp never
+      # manufactures more contrast than a color's own true ceiling (see
+      # moduledoc) -- so once the floor is the binding constraint for more
+      # than one tier, several tiers converge toward the SAME
+      # minimal-legible output and tier ORDERING is not preserved through
+      # the clamp (that's the floor doing its job, not a bug). The floor
+      # guarantee itself (SAL-P-05) is scoped to dark/light grounds only.
+      ground = 0.5
+
+      for tier <- Salience.tiers(), prominence <- [0.4, 0.6, 0.8, 1.0] do
+        seed = Salience.solve(tier, 0.1, 57, ground: ground)
+
+        resolved =
+          Prominence.resolve(seed, prominence,
+            ground: ground,
+            legibility_floor: true
+          )
+
+        assert resolved =~ ~r/^#[0-9a-f]{6}$/
+      end
+    end
+
+    test "mid-gray ground: the raw fade (no clamp) preserves tier ordering" do
+      # Unlike resolve/3, fade/3 has no legibility clamp to flatten the
+      # ladder -- it scales each tier's apparent-lightness distance from
+      # ground by the same prominence factor, so relative tier ordering
+      # (established by tier_target/3's already-tested ordering) survives.
+      ground = 0.5
+      ground_al = Salience.apparent_lightness(ground, 0.0, 0.0)
+
+      distances =
+        for tier <- Salience.tiers() do
+          seed = Salience.solve(tier, 0.1, 57, ground: ground)
+          faded = Prominence.fade(seed, 0.4, ground)
+          {l, c, h} = Salience.hex_to_oklch(faded)
+          abs(Salience.apparent_lightness(l, c, h) - ground_al)
+        end
+
+      assert distances == Enum.sort(distances)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Block integration (T8 write-set): prominence in render context.
+  # ---------------------------------------------------------------------
+
+  describe "Block prominence integration" do
+    test "prominence < 1.0 in context resolves the header/content/outcome fg" do
+      events = [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{
+            item_type: :tool_use,
+            content: %{name: "grep", args: %{}},
+            exit_code: 0
+          }
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events, fold: :folded)
+
+      %{children: [header, outcome]} =
+        Block.render(block, %{prominence: 0.6, ground: 0.2})
+
+      expected_fg = Prominence.resolve("#B4B4B4", 0.6, ground: 0.2)
+
+      assert header.style.fg == expected_fg
+      assert outcome.style.fg == expected_fg
+    end
+
+    test "prominence in context defaults ground to the module's own default resolution" do
+      block =
+        Block.from_events(:message, [
+          %{type: :item_completed, content: "hi"}
+        ])
+
+      %{children: [header | _]} = Block.render(block, %{prominence: 0.6})
+
+      assert header.style.fg == Prominence.resolve("#B4B4B4", 0.6, [])
+    end
+  end
+end


### PR DESCRIPTION
Unit **T8** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): the prominence attribute — H-K salience resolution that turns a `0.0..1.0` prominence into a ground-aware color, the mechanism behind the attention-tiered transcript (the category-empty moat).

## What
- **`Raxol.UI.Harness.Prominence.resolve(hex, prominence, opts)`** — default is a **pure ground-aware fade, no floor**: the salience gradient. Context text is *meant* to recede; "faded but not lost" = legible on promotion (T9 raises a focused/approval block to prominence 1.0 = identity = the seed color), not readable-at-a-glance.
- **Opt-in legibility floor** (`legibility_floor: true`, default false): engages a WCAG-contrast clamp against the terminal ground. T9 sets it true ONLY for acting/interactive tiers (current-turn, needs-input, composer) where blind-reading risk lives; context history fades free. This is a deliberate correction to the suite-design doc's "floor everywhere," which fought the gradient.
- **Two latent bugs fixed** (found by the suite design, recorded red-runs): **F1** — the fade now threads the actual OSC-11-detected ground, so on light themes contrast *decreases* as prominence drops (a hardcoded-dark reference made it increase — the Claude-Code light-theme failure class, latent in our own DiffViewer). **F2** — a legibility clamp distinct from the prominence floor (the 0.4 floor guarded the input multiplier, not output contrast; a dim source at 0.4 could be unreadable).
- The clamp bisects along the single fade line (apparent-lightness and chroma move together), so its `t=1.0` ceiling is the **true full-chroma prominence:1.0 color**, never a reduced-chroma proxy; best-effort + documented when even full strength misses the floor.
- `block.ex` threads `prominence`/`ground`/`legibility_floor` through render context — strict no-op at prominence ≥ 1.0 or absent (T4's tests byte-identical).
- Documented: the floor is truecolor-only; 256-color survival is deferred to a redistributed `tiers_for(ground, :color256)` ladder (T9 must not assume the clamp survives quantization).

## Evidence
22/22 prominence suites (6 properties, stable across 5 seeds incl. the pure-fade monotonicity gradient property and the max-chroma ceiling test); 118/118 across prominence+salience+block+diff_viewer; 1622 across test/raxol/ui/. Red-runs for SAL-N-02 (light inversion) + SAL-P-05 (floor) recorded in the commit body. compile --warnings-as-errors / credo / format clean.

## Review trail
Opus review (approve-with-yellows: clamp ceiling used faded-chroma) → ceiling fix; longcat conceptual advisory → the pure-fade-default / opt-in-floor model correction (a hard floor on receding text fights the salience gradient that is the moat).

**Merge note: merge AFTER the T26 PR** — both touch block.ex render context; T26 changed `build_render/2→/3`, this rebases onto that signature (trivial union — each reads its own context key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
