### PR TITLE
Harness UI: overlay picker primitive + list scorer [T14]

### DIFF
--- a/lib/raxol/search/fuzzy.ex
+++ b/lib/raxol/search/fuzzy.ex
@@ -23,6 +23,10 @@ defmodule Raxol.Search.Fuzzy do
 
       # Regex search
       results = Fuzzy.search(buffer, ~r/h.llo/, :regex)
+
+  Note: list-item ranking (picker/palette/session filtering) lives in
+  `Raxol.UI.ListScorer`, a separate module -- this one searches buffer
+  cells, a different problem category.
   """
 
   require Logger

--- a/lib/raxol/ui/components/harness/picker.ex
+++ b/lib/raxol/ui/components/harness/picker.ex
@@ -1,0 +1,578 @@
+defmodule Raxol.UI.Components.Harness.Picker do
+  @moduledoc """
+  Overlay picker primitive (AD-U3): prompt + ranked list + async
+  cancelable preview -- the fzf-shape that serves every "pick one of N"
+  (sessions, runs, tool-calls, command palette, file mentions). One
+  primitive, many projections (T15's job); this unit builds the
+  component itself.
+
+  ## Substrate honesty
+
+  This component renders in **ordinary buffer mode** -- a ranked list
+  laid out in a normal flow column, no `AbsoluteLayer`/`CellDim`
+  full-viewport cover. The overlay-over-inline SUBSTRATE question (does
+  summoning this picker as a screen overlay mean a scoped full-viewport
+  cover via terminal save/restore, or a footer-anchored expansion?) is
+  deferred to the D-PA/T0 verdict and lands with T15/T24, which mount
+  this component inside whichever substrate they choose. Nothing here
+  assumes a particular host; `render/2` just needs a `context` with
+  `:available_width` (and optionally `:available_height`, used to size
+  the visible window) the way any other component does.
+
+  ## Filtering
+
+  Uses `Raxol.UI.ListScorer.rank/4` (the list-item fuzzy scorer) against
+  `key_fn.(item)` for every item on every query change -- **not**
+  `Raxol.Search.Fuzzy`, which searches buffer cells, a different problem.
+
+  ## Props
+
+    * `:items` -- required, the full unfiltered list.
+    * `:key_fn` -- required, `item -> String.t()`; derives both the
+      search key and the rendered label for each item.
+    * `:on_select` -- message tag emitted on Enter, default `:select`.
+      Emits `{:component_event, id, {on_select, item}}` for the
+      currently selected item; a no-op if the ranked list is empty.
+    * `:on_cancel` -- message tag emitted on Escape, default `:cancel`.
+      Emits `{:component_event, id, on_cancel}`.
+    * `:preview_fn` -- optional, `item -> {:ok, content} | {:error,
+      reason}`, run via `Task.async/1` for the currently selected item.
+      When absent, no preview pane renders at all. **Must be
+      side-effect-free / cancel-safe:** on any selection change the
+      in-flight preview task is killed with `Task.shutdown(task,
+      :brutal_kill)` (no cleanup, no `terminate`, no chance to close
+      what it opened), so `preview_fn` must not perform unguarded
+      side effects that leak on an abrupt kill -- no bare file handles,
+      sockets, ports, or DB connections held across the call. Read a
+      snapshot, compute, return; if it must acquire a resource, wrap it
+      so an abrupt process death can't strand it.
+    * `:placeholder` -- prompt placeholder shown while the query is
+      empty (default `""`).
+    * `:visible_height` -- rows in the scrollable list window (default
+      `10`); windowing is `Raxol.UI.ScrollWindow` (cursor-follow,
+      edge-anchored).
+
+  ## Behavior
+
+  Type-to-filter: printable keys append to the query, Backspace removes
+  the last grapheme; the ranked list and cursor (reset to the top match)
+  update on every change. Up/Down move the cursor, clamped and windowed
+  by `ScrollWindow`. Enter selects the current item. Escape dismisses.
+
+  ## Stale-preview cancellation (the fzf#3134 lesson)
+
+  Every selection change (typing that changes the top match, or Up/Down
+  landing on a different item) cancels the in-flight preview `Task` for
+  the *previous* selection via `Task.shutdown/2` and starts a new one
+  for the current item, tagging the pending result with the new task's
+  own `ref`. Two independent guards keep a superseded result from ever
+  reaching the screen:
+
+    1. `Task.shutdown/2` kills the old task process and flushes any
+       completion message already sitting in this process's mailbox --
+       most of the time, that's the end of it.
+    2. Even in the race where a result was already in flight before the
+       shutdown call landed, `update/2` only applies a `{ref, result}`
+       (or `{:DOWN, ref, ...}`) message when `ref` matches
+       `state.preview_ref` *at the time the message is handled*. A
+       result tagged with a superseded ref is pattern-matched into a
+       catch-all clause and dropped -- it never touches `state.preview`,
+       so it can never render.
+
+  A real host process must forward whatever arrives in its mailbox for
+  a spawned preview task straight into this component's `update/2` --
+  the raw `{ref, result}` / `{:DOWN, ref, :process, pid, reason}` shapes
+  `Task.async/1` itself produces, unwrapped. That's what makes the
+  ref-matching guard above work with zero translation layer.
+  """
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.ListScorer
+  alias Raxol.UI.ScrollWindow
+  alias Raxol.UI.StyleHelper
+  alias Raxol.UI.TextMeasure
+  alias Raxol.View.Components
+
+  use Raxol.UI.Components.Base.Component
+
+  @default_visible_height 10
+  @default_placeholder ""
+  @default_preview_width_divisor 2
+  @min_preview_width 10
+
+  @type preview_state ::
+          :none | :loading | {:ok, String.t()} | {:error, term()}
+
+  @type t :: %{
+          id: term(),
+          items: [term()],
+          key_fn: (term() -> String.t()),
+          on_select: term(),
+          on_cancel: term(),
+          preview_fn: (term() -> {:ok, String.t()} | {:error, term()}) | nil,
+          placeholder: String.t(),
+          visible_height: pos_integer(),
+          query: String.t(),
+          ranked: [ListScorer.result()],
+          cursor: non_neg_integer(),
+          scroll_top: non_neg_integer(),
+          preview: preview_state(),
+          preview_task: Task.t() | nil,
+          preview_ref: reference() | nil,
+          style: map(),
+          theme: map()
+        }
+
+  @impl true
+  @spec init(keyword() | map()) :: {:ok, t()}
+  def init(props) do
+    props = Map.new(props)
+
+    id =
+      Map.get(
+        props,
+        :id,
+        "harness-picker-#{:erlang.unique_integer([:positive])}"
+      )
+
+    items = Map.get(props, :items, [])
+    key_fn = Map.fetch!(props, :key_fn)
+    ranked = ListScorer.rank(items, "", key_fn)
+
+    state = %{
+      id: id,
+      items: items,
+      key_fn: key_fn,
+      on_select: Map.get(props, :on_select, :select),
+      on_cancel: Map.get(props, :on_cancel, :cancel),
+      preview_fn: Map.get(props, :preview_fn),
+      placeholder: Map.get(props, :placeholder, @default_placeholder),
+      visible_height: Map.get(props, :visible_height, @default_visible_height),
+      query: "",
+      ranked: ranked,
+      cursor: 0,
+      scroll_top: 0,
+      preview: :none,
+      preview_task: nil,
+      preview_ref: nil,
+      style: Map.get(props, :style, %{}),
+      theme: Map.get(props, :theme, %{})
+    }
+
+    {:ok, refresh_preview(state)}
+  end
+
+  # -- public helpers --
+
+  @doc "The currently selected item, or `nil` if the ranked list is empty."
+  @spec selected_item(t()) :: term() | nil
+  def selected_item(state) do
+    case Enum.at(state.ranked, state.cursor) do
+      nil -> nil
+      %{item: item} -> item
+    end
+  end
+
+  @doc "Current query string."
+  @spec query(t()) :: String.t()
+  def query(%{query: query}), do: query
+
+  @doc "Current ranked (filtered) result list."
+  @spec ranked(t()) :: [ListScorer.result()]
+  def ranked(%{ranked: ranked}), do: ranked
+
+  @doc "Current preview state."
+  @spec preview(t()) :: preview_state()
+  def preview(%{preview: preview}), do: preview
+
+  # -- update: preview task results + prop merge --
+
+  @impl true
+  def update({ref, result}, %{preview_ref: ref} = state)
+      when is_reference(ref) do
+    {%{
+       state
+       | preview: normalize_preview(result),
+         preview_task: nil,
+         preview_ref: nil
+     }, []}
+  end
+
+  # Any other `{ref, result}` is a superseded selection's preview task
+  # completing late -- dropped by ref-matching, never rendered (see
+  # moduledoc, "Stale-preview cancellation").
+  def update({ref, _result}, state) when is_reference(ref), do: {state, []}
+
+  def update({:DOWN, ref, :process, _pid, reason}, %{preview_ref: ref} = state) do
+    {%{state | preview: {:error, reason}, preview_task: nil, preview_ref: nil},
+     []}
+  end
+
+  def update({:DOWN, _ref, :process, _pid, _reason}, state), do: {state, []}
+
+  def update({:set_items, items}, state) do
+    new_state = %{state | items: items}
+    {update_query(new_state, new_state.query), []}
+  end
+
+  # Keys `update/2`'s prop-merge clause is willing to touch. Anything
+  # else in an incoming map -- notably internal fields like `:cursor`,
+  # `:scroll_top`, `:ranked`, `:query`, `:preview*` that this module
+  # manages itself via `update_query/2`/`move_cursor/2`/`refresh_preview/1`
+  # -- is silently dropped rather than merged verbatim. Without this,
+  # `update(%{cursor: 99}, state)` would write an out-of-range cursor
+  # straight into state, bypassing `ScrollWindow`'s clamp/windowing (the
+  # only path that's supposed to move `:cursor`) and desyncing it from
+  # `:scroll_top` -- a caller doesn't need a hostile struct to corrupt
+  # this component's invariants, an ordinary map with the wrong key is
+  # enough.
+  @allowed_props [
+    :id,
+    :items,
+    :key_fn,
+    :visible_height,
+    :placeholder,
+    :on_select,
+    :on_cancel,
+    :preview_fn,
+    :style,
+    :theme
+  ]
+
+  # `not is_struct(props)` matters too: every `%Event{}` (and any other
+  # struct) is also a plain map, so a bare `is_map(props)` guard here
+  # would let a mis-routed struct -- e.g. an `%Event{}` that missed every
+  # `handle_event/3` clause above and got sent through `update/2` instead
+  # -- reach this clause at all. Structs fall through to the catch-all
+  # below instead, which is a safe no-op; the `Map.take/2` allowlist
+  # above is the second, independent guard for ordinary maps carrying
+  # unexpected keys.
+  def update(props, state) when is_map(props) and not is_struct(props) do
+    Raxol.UI.Components.Base.Component.merge_props(
+      Map.take(props, @allowed_props),
+      state
+    )
+  end
+
+  def update(_msg, state), do: {state, []}
+
+  # -- events --
+
+  @impl true
+  def handle_event(%Event{type: :key, data: %{key: :escape}}, state, _context) do
+    {cancel_preview(state), [{:component_event, state.id, state.on_cancel}]}
+  end
+
+  def handle_event(%Event{type: :key, data: %{key: :enter}}, state, _context) do
+    case selected_item(state) do
+      nil -> {state, []}
+      item -> {state, [{:component_event, state.id, {state.on_select, item}}]}
+    end
+  end
+
+  def handle_event(%Event{type: :key, data: %{key: :up}}, state, _context) do
+    {move_cursor(state, -1), []}
+  end
+
+  def handle_event(%Event{type: :key, data: %{key: :down}}, state, _context) do
+    {move_cursor(state, 1), []}
+  end
+
+  def handle_event(
+        %Event{type: :key, data: %{key: :backspace}},
+        state,
+        _context
+      ) do
+    {update_query(state, drop_last_grapheme(state.query)), []}
+  end
+
+  # Printable characters. A binary `key` is always a text character (the
+  # special keys above all use atoms), so this matches the printable
+  # inlet across every driver's event shape -- but whether it's *text* or
+  # a *shortcut* depends on the modifiers, which each driver reports
+  # differently (see `text_input?/1`). NOTE the shape gap this fixes:
+  # only `Event.key_event/3` sets a `modifiers:` list; the native
+  # terminal driver's `event_translator.ex` emits boolean
+  # `shift:/ctrl:/alt:` fields and `input_parser.ex` emits a bare
+  # `%{key: char}` with no modifier fields at all. A clause requiring
+  # `modifiers:` is therefore dead on the real terminal (the T11 bug
+  # class). Handled defensively inline here; a shared `T27` normalize/1
+  # will supersede this later.
+  def handle_event(
+        %Event{type: :key, data: %{key: char} = data},
+        state,
+        _context
+      )
+      when is_binary(char) do
+    if text_input?(data) do
+      {update_query(state, state.query <> char), []}
+    else
+      {state, []}
+    end
+  end
+
+  def handle_event(_event, state, _context), do: {state, []}
+
+  # A printable key is text unless a ctrl/alt modifier makes it a
+  # shortcut. Reads all three modifier encodings defensively: the
+  # `modifiers:` list (`Event.key_event/3`), boolean `ctrl:`/`alt:`
+  # fields (`event_translator.ex`), or their absence entirely
+  # (`input_parser.ex`'s bare `%{key: char}`). Shift alone (capital
+  # letters) stays text.
+  defp text_input?(data) do
+    modifiers = data[:modifiers] || []
+
+    not (data[:ctrl] == true or data[:alt] == true or :ctrl in modifiers or
+           :alt in modifiers)
+  end
+
+  # -- private: query / cursor / preview lifecycle --
+
+  defp update_query(state, new_query) do
+    ranked = ListScorer.rank(state.items, new_query, state.key_fn)
+
+    %{state | query: new_query, ranked: ranked, cursor: 0, scroll_top: 0}
+    |> refresh_preview()
+  end
+
+  defp move_cursor(state, delta) do
+    if state.ranked == [] do
+      state
+    else
+      requested = state.cursor + delta
+
+      window =
+        ScrollWindow.window(
+          state.ranked,
+          requested,
+          state.visible_height,
+          state.scroll_top
+        )
+
+      new_cursor = window.scroll_top + window.cursor_row
+      new_state = %{state | cursor: new_cursor, scroll_top: window.scroll_top}
+
+      if selected_item(new_state) == selected_item(state) do
+        new_state
+      else
+        refresh_preview(new_state)
+      end
+    end
+  end
+
+  defp refresh_preview(state) do
+    state = cancel_preview(state)
+
+    case {state.preview_fn, selected_item(state)} do
+      {nil, _item} -> %{state | preview: :none}
+      {_preview_fn, nil} -> %{state | preview: :none}
+      {preview_fn, item} -> start_preview(state, preview_fn, item)
+    end
+  end
+
+  defp start_preview(state, preview_fn, item) do
+    task = Task.async(fn -> safe_preview(preview_fn, item) end)
+    %{state | preview_task: task, preview_ref: task.ref, preview: :loading}
+  end
+
+  defp safe_preview(preview_fn, item) do
+    preview_fn.(item)
+  rescue
+    error -> {:error, error}
+  catch
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  defp cancel_preview(%{preview_task: nil} = state), do: state
+
+  defp cancel_preview(%{preview_task: task} = state) do
+    Task.shutdown(task, :brutal_kill)
+    %{state | preview_task: nil, preview_ref: nil}
+  end
+
+  defp normalize_preview({:ok, content}) when is_binary(content),
+    do: {:ok, content}
+
+  defp normalize_preview({:error, _reason} = error), do: error
+  defp normalize_preview(other), do: {:error, {:invalid_preview_result, other}}
+
+  defp drop_last_grapheme(""), do: ""
+
+  defp drop_last_grapheme(text) do
+    text
+    |> String.graphemes()
+    |> Enum.drop(-1)
+    |> Enum.join()
+  end
+
+  # -- render --
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    avail_width = context[:available_width] || 60
+
+    base_style =
+      StyleHelper.merge_component_styles(state, context, :harness_picker)
+
+    list = render_list(state, avail_width)
+
+    body =
+      if state.preview_fn do
+        Components.row(
+          id: "picker-body",
+          gap: 2,
+          children: [list, render_preview(state, avail_width)]
+        )
+      else
+        list
+      end
+
+    Components.column(
+      id: state.id,
+      style: base_style,
+      gap: 0,
+      children: [render_prompt(state, avail_width), body]
+    )
+  end
+
+  defp render_prompt(state, avail_width) do
+    shown = if state.query == "", do: state.placeholder, else: state.query
+    dim? = state.query == ""
+
+    Components.text(
+      id: "picker-prompt",
+      content: truncate_to_width("> " <> shown, avail_width),
+      style: if(dim?, do: %{dim: true}, else: %{})
+    )
+  end
+
+  defp render_list(state, avail_width) do
+    window =
+      ScrollWindow.window(
+        state.ranked,
+        state.cursor,
+        state.visible_height,
+        state.scroll_top
+      )
+
+    rows =
+      window.visible
+      |> Enum.with_index()
+      |> Enum.map(fn {result, row_index} ->
+        render_row(result, row_index == window.cursor_row, avail_width)
+      end)
+
+    Components.column(id: "picker-list", gap: 0, children: rows)
+  end
+
+  # An empty label (`key_fn` yielding `""`) would otherwise fall through
+  # to a zero-child row via the general clause below (`String.graphemes("")`
+  # is `[]`) -- invisible and, on some hosts, unselectable since there's
+  # nothing rendered to hang a hit-test on. Emit a dim placeholder so the
+  # row is visible and its selection background still shows.
+  defp render_row(%{key: ""}, selected?, _avail_width) do
+    row_style = if selected?, do: %{bg: :blue, fg: :white}, else: %{}
+
+    placeholder =
+      Components.text(
+        content: "(no label)",
+        style: Map.put(row_style, :dim, true)
+      )
+
+    Components.row(style: row_style, gap: 0, children: [placeholder])
+  end
+
+  defp render_row(%{key: key, positions: positions}, selected?, avail_width) do
+    {key, positions} = truncate_key(key, positions, avail_width)
+    position_set = MapSet.new(positions)
+
+    segments =
+      key
+      |> String.graphemes()
+      |> Enum.with_index()
+      |> Enum.chunk_by(fn {_grapheme, index} ->
+        MapSet.member?(position_set, index)
+      end)
+      |> Enum.map(fn chunk ->
+        {_grapheme, first_index} = hd(chunk)
+        highlighted? = MapSet.member?(position_set, first_index)
+        text = Enum.map_join(chunk, fn {grapheme, _index} -> grapheme end)
+
+        Components.text(
+          content: text,
+          style: segment_style(highlighted?, selected?)
+        )
+      end)
+
+    row_style = if selected?, do: %{bg: :blue, fg: :white}, else: %{}
+    Components.row(style: row_style, gap: 0, children: segments)
+  end
+
+  defp segment_style(true, selected?),
+    do: Map.put(base_row_style(selected?), :bold, true)
+
+  defp segment_style(false, selected?), do: base_row_style(selected?)
+
+  defp base_row_style(true), do: %{bg: :blue, fg: :white}
+  defp base_row_style(false), do: %{}
+
+  defp truncate_key(key, positions, avail_width)
+       when is_integer(avail_width) and avail_width > 0 do
+    if TextMeasure.display_width(key) <= avail_width do
+      {key, positions}
+    else
+      {left, _rest} =
+        TextMeasure.split_at_display_width(key, max(avail_width - 1, 0))
+
+      kept_len = String.length(left)
+      {left <> "…", Enum.filter(positions, &(&1 < kept_len))}
+    end
+  end
+
+  defp truncate_key(key, positions, _avail_width), do: {key, positions}
+
+  defp truncate_to_width(text, width) when is_integer(width) and width > 0 do
+    if TextMeasure.display_width(text) <= width do
+      text
+    else
+      {left, _rest} =
+        TextMeasure.split_at_display_width(text, max(width - 1, 0))
+
+      left <> "…"
+    end
+  end
+
+  defp truncate_to_width(text, _width), do: text
+
+  defp render_preview(state, avail_width) do
+    preview_width =
+      max(div(avail_width, @default_preview_width_divisor), @min_preview_width)
+
+    children =
+      state.preview
+      |> preview_lines()
+      |> Enum.map(fn {line, style} ->
+        Components.text(content: line, style: style)
+      end)
+
+    Components.column(
+      id: "picker-preview",
+      style: %{width: preview_width},
+      gap: 0,
+      children: children
+    )
+  end
+
+  defp preview_lines(:none), do: [{"", %{}}]
+  defp preview_lines(:loading), do: [{"loading…", %{dim: true}}]
+
+  defp preview_lines({:error, _reason}),
+    do: [{"preview unavailable", %{dim: true}}]
+
+  defp preview_lines({:ok, text}) do
+    text
+    |> String.split("\n")
+    |> Enum.map(&{&1, %{}})
+  end
+end

--- a/lib/raxol/ui/list_scorer.ex
+++ b/lib/raxol/ui/list_scorer.ex
@@ -1,0 +1,557 @@
+defmodule Raxol.UI.ListScorer do
+  @moduledoc """
+  General-purpose fuzzy list scorer: `(list, query, key_fn) -> ranked`.
+
+  This is a **list-item** scorer -- it ranks arbitrary terms (session
+  structs, block refs, action descriptors, file paths, ...) by how well an
+  arbitrary `key_fn`-derived label matches a query string. It is
+  deliberately *not* `Raxol.Search.Fuzzy`: that module searches character
+  cells inside a rendered terminal buffer (`Buffer.t()`, `{x, y}`
+  positions) -- a different category of problem (buffer-cell search vs.
+  list-item ranking) that happens to share the word "fuzzy". Folding this
+  into `Search.Fuzzy` would conflate the two.
+
+  Used by `Raxol.UI.Components.Harness.Picker` (the overlay picker
+  primitive, AD-U3) and any future "pick one of N" projection (palette,
+  session picker, jump-to-block, file mentions -- F2's eventual sources).
+
+  ## Algorithm
+
+  An fzf-style Smith-Waterman-lite subsequence aligner: every query
+  grapheme must appear in the key, in order (not necessarily contiguous),
+  but the *scoring* rewards:
+
+    * **adjacency** -- consecutive matched characters score higher than
+      the same characters scattered across the key (a gap penalty
+      accumulates for each skipped character between two matches);
+    * **word boundaries** -- a match at the start of the string, right
+      after a separator (space/`-`/`_`/`/`/`.`/`:`/etc.), or at a
+      lowercase-to-uppercase transition (`camelCase`) scores a bonus;
+    * **position** -- an earlier match in the key scores slightly higher
+      than a later one, all else equal.
+
+  Matching is case-insensitive by default (`case_sensitive: true` opts
+  out). Unicode-aware: works over `String.graphemes/1`, not bytes or
+  codepoints, so multi-codepoint graphemes (combining marks, some emoji)
+  and CJK text are handled as single units -- `positions` in the result
+  are grapheme indices into `key`, safe to feed to
+  `Raxol.UI.TextMeasure` for display-column highlighting (CJK graphemes
+  are double-width; a byte or codepoint index would misalign).
+
+  ## Result ordering
+
+  Results are sorted score descending, ties broken by original list
+  order (a stable sort made explicit via an `{-score, original_index}`
+  sort key, rather than relying on the underlying sort's stability).
+  Items with no subsequence match are excluded entirely. An empty query
+  matches everything with score `0.0` in original order (no filtering).
+
+  ## Performance
+
+  Every item pays a fixed per-keystroke cost (grapheme-splitting +
+  case-folding its `key_fn` label, then a cheap two-pointer subsequence
+  check) regardless of whether it matches; only items that pass the
+  subsequence check pay the O(query length * key length) DP. This is a
+  *pure, stateless* function -- it re-derives each item's grapheme
+  representation on every call rather than caching it, so a caller
+  filtering the same 10k-item list on every keystroke (a picker) is
+  paying that fixed cost 10k times per keystroke no matter how the DP
+  itself is tuned. Measured on a realistic corpus (varied labels, most
+  of which a multi-character query rejects before the DP), 10k items
+  comfortably clear the 16ms/keystroke target; a degenerate corpus
+  where literally every item matches (which fuzzy filtering exists to
+  make rare) costs meaningfully more since the DP then runs for all
+  10,000 items -- see `list_scorer_test.exs`'s `performance` tests for
+  both numbers. A caller that must guarantee 16ms against a large list
+  on every keystroke under adversarial data should cache each item's
+  grapheme split alongside the item (invalidated when the item list
+  changes) rather than re-deriving it here every call; that's a
+  caller-side concern, not this module's, since `rank/4`'s contract is
+  a pure function of its arguments.
+  """
+
+  @type result :: %{
+          item: term(),
+          key: String.t(),
+          score: float(),
+          positions: [non_neg_integer()]
+        }
+
+  @type opt :: {:case_sensitive, boolean()}
+
+  # Base score for every matched character.
+  @match_base 10.0
+  # Bonus for a match that starts a "word" (string start, after a
+  # separator, or a lowercase->uppercase / non-letter->letter transition).
+  @bonus_boundary 6.0
+  # Bonus for a match immediately following the previous match (zero gap).
+  @bonus_consecutive 8.0
+  # Penalty per skipped character between two matches.
+  @gap_penalty 1.0
+  # Scale of the "earlier is better" position bonus (applied once per
+  # matched character, proportional to how early in the key it lands).
+  @position_bonus_scale 2.0
+
+  # Sentinel for "no valid alignment ends here" -- large enough that no
+  # legitimate combination of bonuses/penalties over realistic string
+  # lengths could approach it, so `> @neg_inf / 2` reliably tells finite
+  # scores apart from unreachable cells without a tagged sum type.
+  @neg_inf -1.0e9
+
+  # Caps the grapheme list actually fed to `subsequence?/2` and `align/3`
+  # per item, independent of how long an adversarial `key_fn` label is.
+  # Without this, a single absurdly long label (an unbounded paste, a
+  # log line used as a list key, ...) makes the O(query length * key
+  # length) DP -- and the two-pointer subsequence pre-check -- cost
+  # proportional to that label's full length on every keystroke. The
+  # clamp also keeps the `@gap_penalty` accumulation (`advance/5`'s
+  # decaying running max) well under `@neg_inf / 2` regardless of key
+  # length, so a long label can no longer be misclassified `:no_match`
+  # by the sentinel-comparison coupling described above `@neg_inf`.
+  # `key:` in the result is still the full untruncated label (positions
+  # are indices into this prefix, which are valid prefix indices into
+  # the full key too) -- only a match lying entirely past the cap is
+  # missed, an fzf-acceptable tradeoff.
+  @max_score_graphemes 1024
+  # Byte budget for the pre-split prefix slice (see `bounded_key_prefix/1`).
+  # 4 bytes/grapheme covers every single-codepoint UTF-8 grapheme (the
+  # max encoded width of one codepoint); multi-codepoint clusters
+  # (combining marks, some emoji ZWJ sequences) can in principle need
+  # more bytes per grapheme, in which case the clamp bites a little
+  # earlier than exactly `@max_score_graphemes` graphemes -- an
+  # acceptable variant of the same "match past the cap is missed"
+  # tradeoff, not a correctness bug.
+  @max_key_bytes @max_score_graphemes * 4
+
+  @doc """
+  Ranks `items` against `query`, using `key_fn.(item)` to derive each
+  item's searchable/display label (a `String.t()`).
+
+  Options:
+
+    * `:case_sensitive` -- defaults to `false`.
+
+  Returns a list of `%{item:, key:, score:, positions:}` maps, sorted
+  score-descending with original order as the tiebreak. Items whose key
+  does not contain `query` as a subsequence are dropped. An empty query
+  returns every item, in original order, with `score: 0.0` and
+  `positions: []`.
+  """
+  @spec rank([term()], String.t(), (term() -> String.t()), [opt()]) :: [
+          result()
+        ]
+  def rank(items, query, key_fn, opts \\ [])
+
+  def rank(items, "", key_fn, _opts) do
+    Enum.map(items, fn item ->
+      %{item: item, key: key_fn.(item), score: 0.0, positions: []}
+    end)
+  end
+
+  def rank(items, query, key_fn, opts) do
+    case_sensitive = Keyword.get(opts, :case_sensitive, false)
+    query_graphemes = normalize_string_graphemes(query, case_sensitive)
+
+    items
+    |> Enum.with_index()
+    |> Enum.reduce([], fn {item, index}, acc ->
+      case score_item(item, index, key_fn, query_graphemes, case_sensitive) do
+        nil -> acc
+        result -> [result | acc]
+      end
+    end)
+    |> Enum.sort_by(fn r -> {-r.score, r.index} end)
+    |> Enum.map(&Map.delete(&1, :index))
+  end
+
+  # `nil` when the key doesn't contain `query_graphemes` as a subsequence
+  # (the cheap two-pointer check runs first and rejects the common case
+  # without paying for the O(query * key) DP below -- this is what keeps
+  # 10k-item filtering fast: most items get discarded right here).
+  defp score_item(item, index, key_fn, query_graphemes, case_sensitive) do
+    key = key_fn.(item)
+
+    {raw_key_graphemes, norm_key_graphemes} =
+      key
+      |> bounded_key_prefix()
+      |> key_graphemes(case_sensitive)
+      |> clamp_key_graphemes()
+
+    if subsequence?(query_graphemes, norm_key_graphemes) do
+      build_result(
+        item,
+        index,
+        key,
+        query_graphemes,
+        norm_key_graphemes,
+        raw_key_graphemes
+      )
+    else
+      nil
+    end
+  end
+
+  defp build_result(
+         item,
+         index,
+         key,
+         query_graphemes,
+         norm_key_graphemes,
+         raw_key_graphemes
+       ) do
+    case align(query_graphemes, norm_key_graphemes, raw_key_graphemes) do
+      {:ok, score, positions} ->
+        %{
+          item: item,
+          key: key,
+          score: score,
+          positions: positions,
+          index: index
+        }
+
+      :no_match ->
+        nil
+    end
+  end
+
+  defp normalize_string_graphemes(text, true), do: String.graphemes(text)
+
+  defp normalize_string_graphemes(text, false),
+    do: String.graphemes(String.downcase(text))
+
+  # Returns `{raw_graphemes, normalized_graphemes}` for a key. `raw` feeds
+  # boundary/camelCase detection (which needs real casing); `normalized`
+  # feeds matching (case-folded unless `case_sensitive`).
+  #
+  # `String.graphemes/1`'s general Unicode grapheme-cluster algorithm is
+  # the single biggest cost in this module on the 10k-item bench (it
+  # dominates even the DP scoring). Most real keys here -- session ids,
+  # file paths, command names -- are pure ASCII (one byte per codepoint,
+  # no combining marks), where grapheme clusters are trivially single
+  # bytes; `byte_size(text) == String.length(text)` cheaply detects that
+  # case and a plain byte-list walk replaces the general algorithm
+  # (measured ~4x faster end to end). Genuinely multi-byte/combining text
+  # (CJK, accents, emoji) falls back to the correct, slower path.
+  defp key_graphemes(key, case_sensitive) do
+    if byte_size(key) == String.length(key) do
+      ascii_key_graphemes(key, case_sensitive)
+    else
+      unicode_key_graphemes(key, case_sensitive)
+    end
+  end
+
+  # Bounds the *input* to `key_graphemes/2` before it ever splits into
+  # graphemes, so an adversarially long key (a million-character label)
+  # never pays for a full grapheme split just to have the result
+  # discarded by `clamp_key_graphemes/1` below -- `:binary.part/3`
+  # produces a sub-binary reference in O(1) (no copy), so this is cheap
+  # regardless of the original key's length.
+  defp bounded_key_prefix(key) when byte_size(key) <= @max_key_bytes, do: key
+
+  defp bounded_key_prefix(key),
+    do: key |> :binary.part(0, @max_key_bytes) |> trim_to_valid_utf8()
+
+  # A raw byte-count slice of UTF-8 text can land mid-codepoint; back off
+  # one byte at a time (at most 3 iterations, the max UTF-8 sequence
+  # width) until the slice is valid again.
+  defp trim_to_valid_utf8(bin) do
+    if String.valid?(bin) do
+      bin
+    else
+      trim_to_valid_utf8(:binary.part(bin, 0, byte_size(bin) - 1))
+    end
+  end
+
+  # See `@max_score_graphemes`. Applied to both lists post-hoc (rather
+  # than short-circuiting the split above) so the clamp lives in exactly
+  # one place regardless of which of `key_graphemes/2`'s four branches
+  # produced the lists.
+  defp clamp_key_graphemes({raw, norm}) do
+    {Enum.take(raw, @max_score_graphemes),
+     Enum.take(norm, @max_score_graphemes)}
+  end
+
+  defp ascii_key_graphemes(key, true) do
+    raw = for(<<c <- key>>, do: <<c>>)
+    {raw, raw}
+  end
+
+  defp ascii_key_graphemes(key, false) do
+    {raw_rev, down_rev} =
+      Enum.reduce(:binary.bin_to_list(key), {[], []}, fn c,
+                                                         {raw_acc, down_acc} ->
+        {[<<c>> | raw_acc], [<<ascii_downcase_byte(c)>> | down_acc]}
+      end)
+
+    {Enum.reverse(raw_rev), Enum.reverse(down_rev)}
+  end
+
+  defp ascii_downcase_byte(c) when c in ?A..?Z, do: c + 32
+  defp ascii_downcase_byte(c), do: c
+
+  defp unicode_key_graphemes(key, true) do
+    raw = String.graphemes(key)
+    {raw, raw}
+  end
+
+  defp unicode_key_graphemes(key, false) do
+    raw = String.graphemes(key)
+    downcased = String.graphemes(String.downcase(key))
+
+    norm =
+      if length(downcased) == length(raw) do
+        downcased
+      else
+        Enum.map(raw, &String.downcase/1)
+      end
+
+    {raw, norm}
+  end
+
+  defp subsequence?([], _key), do: true
+  defp subsequence?(_query, []), do: false
+
+  defp subsequence?([q | qrest], [q | krest]), do: subsequence?(qrest, krest)
+  defp subsequence?(query, [_k | krest]), do: subsequence?(query, krest)
+
+  # -- alignment DP (fzf-style Smith-Waterman-lite) --
+  #
+  # Builds one row per query character, each row a K-element list of
+  # scores (K = key length) via a single left-to-right pass with O(1)
+  # amortized bookkeeping (a decaying running max standing in for
+  # "best predecessor ending at any earlier position, gap-penalized").
+  # Parent pointers ride alongside for backtracking the winning
+  # alignment's positions once the last row is built.
+  #
+  # Deliberately list-only, no tuples: every access this DP needs --
+  # walking the key, the previous row, and the per-position static bonus
+  # -- is sequential (never random), so plain list pattern-matching
+  # recursion (fastest primitive access pattern on the BEAM) replaces
+  # `elem/2` tuple indexing everywhere except the O(Q) (not O(Q*K))
+  # backtrack step, where `Enum.at/2` on a ~30-element list is negligible.
+  # Single-grapheme query fast path: this is the broadest possible match
+  # (the first keystroke into an empty picker commonly matches a large
+  # fraction of a big list), so it's worth skipping the general Q-row DP
+  # machinery entirely -- a single-character match has no adjacency/gap
+  # history to track (there's no previous match to be consecutive with,
+  # exactly like the general algorithm's `first_row?` branch), so the
+  # winning position is just "the matching key position with the
+  # highest static bonus," found in one linear scan.
+  defp align([qchar], key_graphemes, raw_key_graphemes) do
+    static_bonus_list =
+      static_bonus_list(raw_key_graphemes, length(key_graphemes))
+
+    case best_single_match(key_graphemes, static_bonus_list, qchar, 0, nil) do
+      nil -> :no_match
+      {j, score} -> {:ok, score, [j]}
+    end
+  end
+
+  defp align(query_graphemes, key_graphemes, raw_key_graphemes) do
+    key_len = length(key_graphemes)
+    static_bonus_list = static_bonus_list(raw_key_graphemes, key_len)
+
+    rows =
+      query_graphemes
+      |> Enum.with_index()
+      |> Enum.map_reduce(nil, fn {qchar, i}, prev_row ->
+        first_row? = i == 0
+
+        {row, parents} =
+          build_row(
+            qchar,
+            key_graphemes,
+            static_bonus_list,
+            prev_row,
+            first_row?
+          )
+
+        {{row, parents}, row}
+      end)
+      |> elem(0)
+
+    {last_row, _} = List.last(rows)
+
+    case best_end(last_row) do
+      nil -> :no_match
+      {best_j, best_score} -> {:ok, best_score, backtrack(rows, best_j)}
+    end
+  end
+
+  # Boundary/position bonuses depend only on the key (not on which query
+  # row is being scored), so they're computed exactly once per item here
+  # instead of once per (query char, key position) cell -- the
+  # difference between O(K) and O(Q*K) work per item. `prev` is threaded
+  # through the recursion (the previous list element) rather than
+  # indexed, so boundary detection never needs random access either.
+  defp static_bonus_list(raw_key_graphemes, key_len) do
+    denom = max(key_len - 1, 1)
+    step = @position_bonus_scale / denom
+    build_static_bonus(raw_key_graphemes, nil, 0, step)
+  end
+
+  defp build_static_bonus([], _prev, _j, _step), do: []
+
+  defp build_static_bonus([cur | rest], prev, j, step) do
+    boundary = if boundary?(j, prev, cur), do: @bonus_boundary, else: 0.0
+    position = @position_bonus_scale - step * j
+    bonus = @match_base + boundary + position
+    [bonus | build_static_bonus(rest, cur, j + 1, step)]
+  end
+
+  defp boundary?(0, _prev, _cur), do: true
+
+  defp boundary?(_j, prev, cur),
+    do: separator?(prev) or camel_boundary?(prev, cur)
+
+  # ASCII fast path (byte-pattern match, no regex engine dispatch) with a
+  # regex fallback for non-ASCII graphemes -- measured over an order of
+  # magnitude faster than routing every grapheme through `Regex.match?/2`
+  # on the 10k-item bench, which matters here because this runs once per
+  # key position.
+  defp separator?(<<c>>) when c in ?a..?z or c in ?A..?Z or c in ?0..?9,
+    do: false
+
+  defp separator?(<<_c>>), do: true
+  defp separator?(grapheme), do: grapheme =~ ~r/^[^\p{L}\p{N}]$/u
+
+  defp camel_boundary?(prev, cur), do: lower?(prev) and upper?(cur)
+
+  defp lower?(<<c>>) when c in ?a..?z, do: true
+  defp lower?(<<c>>) when c in ?A..?Z or c in ?0..?9, do: false
+  defp lower?(g), do: g =~ ~r/^\p{Ll}$/u
+
+  defp upper?(<<c>>) when c in ?A..?Z, do: true
+  defp upper?(<<c>>) when c in ?a..?z or c in ?0..?9, do: false
+  defp upper?(g), do: g =~ ~r/^\p{Lu}$/u
+
+  # Walks `key_graphemes`, `static_bonus_list`, and (when not the first
+  # row) `prev_row` all in lockstep, one position `j` at a time. Returns
+  # `{row, parents}` in natural left-to-right order (built via cons on
+  # the way back up the recursion, no reverse needed).
+  defp build_row(qchar, key_graphemes, static_bonus_list, prev_row, first_row?) do
+    build_row(
+      qchar,
+      key_graphemes,
+      static_bonus_list,
+      prev_row,
+      first_row?,
+      0,
+      @neg_inf,
+      -1
+    )
+  end
+
+  defp build_row(_qchar, [], [], _prev_row, _first_row?, _j, _bp, _src),
+    do: {[], []}
+
+  defp build_row(
+         qchar,
+         [k | k_rest],
+         [static | static_rest],
+         prev_row,
+         first_row?,
+         j,
+         bp,
+         src
+       ) do
+    {bp, src, prev_row_rest} = advance(j, prev_row, first_row?, bp, src)
+
+    {h, p} =
+      if k == qchar do
+        consecutive? = not first_row? and src == j - 1
+        bonus = static + if consecutive?, do: @bonus_consecutive, else: 0.0
+        score_of(bonus, bp, src, first_row?)
+      else
+        {@neg_inf, -1}
+      end
+
+    {row_rest, par_rest} =
+      build_row(
+        qchar,
+        k_rest,
+        static_rest,
+        prev_row_rest,
+        first_row?,
+        j + 1,
+        bp,
+        src
+      )
+
+    {[h | row_rest], [p | par_rest]}
+  end
+
+  defp score_of(bonus, _bp, _src, true), do: {bonus, -1}
+
+  defp score_of(_bonus, bp, _src, false) when bp <= @neg_inf / 2,
+    do: {@neg_inf, -1}
+
+  defp score_of(bonus, bp, src, false), do: {bonus + bp, src}
+
+  # Decaying running max: bp(j) = max(bp(j-1) - gap_penalty, H_prev[j-1]).
+  # H_prev[j-1] is the "zero-gap" candidate (end the previous match
+  # exactly at j-1, so this match at j is consecutive); the decayed
+  # carry-forward is the "some gap already accumulated" candidate. Ties
+  # favor the fresh (consecutive) candidate. `prev_row` is consumed one
+  # element per call starting at j=1 (H_prev[0] first), so by
+  # construction its head is always H_prev[j-1] when this runs.
+  defp advance(_j, prev_row, true, bp, src), do: {bp, src, prev_row}
+  defp advance(0, prev_row, false, bp, src), do: {bp, src, prev_row}
+
+  defp advance(j, [fresh | rest], false, bp, src) do
+    decayed = bp - @gap_penalty
+
+    if fresh >= decayed do
+      {fresh, j - 1, rest}
+    else
+      {decayed, src, rest}
+    end
+  end
+
+  # Linear scan for the Q=1 fast path in `align/3`: the best-scoring key
+  # position equal to `qchar`, using each position's precomputed static
+  # bonus directly as its score (no predecessor/gap tracking needed --
+  # equivalent to the general algorithm's `first_row?` scoring).
+  defp best_single_match([], [], _qchar, _j, best), do: best
+
+  defp best_single_match([k | k_rest], [static | static_rest], qchar, j, best) do
+    next_best =
+      cond do
+        k != qchar -> best
+        best == nil -> {j, static}
+        static > elem(best, 1) -> {j, static}
+        true -> best
+      end
+
+    best_single_match(k_rest, static_rest, qchar, j + 1, next_best)
+  end
+
+  defp best_end(row) do
+    row
+    |> Enum.with_index()
+    |> Enum.reduce(nil, fn {score, j}, acc ->
+      cond do
+        score <= @neg_inf / 2 -> acc
+        acc == nil -> {j, score}
+        score > elem(acc, 1) -> {j, score}
+        true -> acc
+      end
+    end)
+  end
+
+  # Backtracks from the winning final-row position through each row's
+  # parent pointers to recover the matched key position for every query
+  # character, in query order (position for query char 1, 2, ..., Q).
+  # `Enum.at/2` here is O(row length) but only runs once per row (O(Q)
+  # total), negligible next to the O(Q*K) `build_row` pass above.
+  defp backtrack(rows, best_j) do
+    {positions, _last_parent} =
+      rows
+      |> Enum.reverse()
+      |> Enum.reduce({[], best_j}, fn {_row, parents}, {acc, j} ->
+        {[j | acc], Enum.at(parents, j)}
+      end)
+
+    positions
+  end
+end

--- a/test/raxol/ui/components/harness/picker_test.exs
+++ b/test/raxol/ui/components/harness/picker_test.exs
@@ -1,0 +1,485 @@
+defmodule Raxol.UI.Components.Harness.PickerTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.UI.Components.Harness.Picker
+
+  defp default_context, do: %{theme: %{}, available_width: 60}
+
+  defp press(state, key, modifiers \\ []) do
+    Picker.handle_event(
+      Event.key_event(key, :pressed, modifiers),
+      state,
+      default_context()
+    )
+  end
+
+  defp type(state, text) do
+    text
+    |> String.graphemes()
+    |> Enum.reduce(state, fn char, acc ->
+      {new_state, []} = press(acc, char)
+      new_state
+    end)
+  end
+
+  defp init!(props), do: elem(Picker.init(props), 1)
+
+  describe "init/1" do
+    test "starts with an empty query and every item ranked in original order" do
+      state = init!(items: ["charlie", "alpha", "bravo"], key_fn: & &1)
+
+      assert Picker.query(state) == ""
+
+      assert Enum.map(Picker.ranked(state), & &1.item) == [
+               "charlie",
+               "alpha",
+               "bravo"
+             ]
+
+      assert Picker.selected_item(state) == "charlie"
+    end
+
+    test "defaults on_select/on_cancel and starts with no preview when preview_fn absent" do
+      state = init!(items: ["a"], key_fn: & &1)
+
+      assert state.on_select == :select
+      assert state.on_cancel == :cancel
+      assert Picker.preview(state) == :none
+      assert state.preview_task == nil
+    end
+
+    test "empty items list is safe (no crash, no selection)" do
+      state = init!(items: [], key_fn: & &1)
+
+      assert Picker.selected_item(state) == nil
+      assert Picker.ranked(state) == []
+    end
+  end
+
+  describe "type-to-filter" do
+    test "typing narrows the ranked list and resets the cursor to the top match" do
+      state = init!(items: ["hello", "help", "world"], key_fn: & &1)
+
+      state = type(state, "hel")
+
+      assert Enum.map(Picker.ranked(state), & &1.item) == ["hello", "help"]
+      assert state.cursor == 0
+    end
+
+    test "backspace removes the last grapheme and re-filters" do
+      state = init!(items: ["hello", "world"], key_fn: & &1)
+      state = type(state, "hex")
+
+      assert Picker.ranked(state) == []
+
+      {state, []} = press(state, :backspace)
+
+      assert Picker.query(state) == "he"
+      assert Enum.map(Picker.ranked(state), & &1.item) == ["hello"]
+    end
+
+    test "backspace on an empty query is a no-op" do
+      state = init!(items: ["a"], key_fn: & &1)
+
+      {state, []} = press(state, :backspace)
+
+      assert Picker.query(state) == ""
+    end
+  end
+
+  # The native terminal driver paths do NOT emit a `modifiers:` list:
+  # event_translator.ex emits boolean shift:/ctrl:/alt: fields, and
+  # input_parser.ex emits a bare %{key: char} (no modifier fields at all
+  # for an unmodified printable). Only Event.key_event/3 (the test
+  # helper used by `press/3` above) sets `modifiers: []`. A printable
+  # clause that *requires* a `modifiers:` field is therefore dead on the
+  # real terminal -- the systemic input-shape gap. These drive the raw
+  # driver-shaped events directly.
+  describe "type-to-filter across real driver input shapes (regression)" do
+    defp raw_key(state, data) do
+      Picker.handle_event(
+        %Event{type: :key, data: data},
+        state,
+        default_context()
+      )
+    end
+
+    test "event_translator-shaped printable (boolean modifier fields) inserts into the query" do
+      # "widget" has no "a" -- an unambiguous filter for the query "a".
+      state = init!(items: ["alpha", "widget"], key_fn: & &1)
+
+      {state, []} =
+        raw_key(state, %{key: "a", shift: false, ctrl: false, alt: false})
+
+      assert Picker.query(state) == "a"
+      assert Enum.map(Picker.ranked(state), & &1.item) == ["alpha"]
+    end
+
+    test "input_parser-shaped printable (bare key, no modifier fields) inserts into the query" do
+      state = init!(items: ["alpha", "widget"], key_fn: & &1)
+
+      {state, []} = raw_key(state, %{key: "a"})
+
+      assert Picker.query(state) == "a"
+      assert Enum.map(Picker.ranked(state), & &1.item) == ["alpha"]
+    end
+
+    test "shift-only capital letter (boolean shape) is still text" do
+      state = init!(items: ["Alpha", "beta"], key_fn: & &1)
+
+      {state, []} =
+        raw_key(state, %{key: "A", shift: true, ctrl: false, alt: false})
+
+      assert Picker.query(state) == "A"
+    end
+
+    test "a ctrl-modified printable is a shortcut, not text (boolean shape)" do
+      state = init!(items: ["alpha"], key_fn: & &1)
+
+      {state, []} =
+        raw_key(state, %{key: "a", shift: false, ctrl: true, alt: false})
+
+      assert Picker.query(state) == ""
+    end
+
+    test "an alt-modified printable is a shortcut, not text (modifiers-list shape)" do
+      state = init!(items: ["alpha"], key_fn: & &1)
+
+      {state, []} = raw_key(state, %{key: "a", modifiers: [:alt]})
+
+      assert Picker.query(state) == ""
+    end
+  end
+
+  describe "selection movement" do
+    test "down moves the cursor to the next item" do
+      state = init!(items: ["a", "b", "c"], key_fn: & &1)
+
+      {state, []} = press(state, :down)
+
+      assert Picker.selected_item(state) == "b"
+    end
+
+    test "up from the top clamps at the first item" do
+      state = init!(items: ["a", "b", "c"], key_fn: & &1)
+
+      {state, []} = press(state, :up)
+
+      assert Picker.selected_item(state) == "a"
+      assert state.cursor == 0
+    end
+
+    test "down from the bottom clamps at the last item" do
+      state = init!(items: ["a", "b"], key_fn: & &1)
+
+      {state, []} = press(state, :down)
+      {state, []} = press(state, :down)
+      {state, []} = press(state, :down)
+
+      assert Picker.selected_item(state) == "b"
+    end
+
+    test "movement is windowed: scroll_top advances once the cursor passes visible_height" do
+      items = for i <- 1..20, do: "item-#{i}"
+      state = init!(items: items, key_fn: & &1, visible_height: 5)
+
+      state =
+        Enum.reduce(1..6, state, fn _i, acc -> elem(press(acc, :down), 0) end)
+
+      assert Picker.selected_item(state) == "item-7"
+      assert state.scroll_top > 0
+    end
+
+    test "up/down on an empty ranked list is a no-op" do
+      state = init!(items: [], key_fn: & &1)
+
+      {state, []} = press(state, :down)
+      {state, []} = press(state, :up)
+
+      assert Picker.selected_item(state) == nil
+    end
+  end
+
+  describe "select / cancel messages" do
+    test "Enter emits on_select with the currently selected item" do
+      state = init!(items: ["a", "b"], key_fn: & &1, id: :p, on_select: :chosen)
+
+      {state, []} = press(state, :down)
+      {_state, cmds} = press(state, :enter)
+
+      assert cmds == [{:component_event, :p, {:chosen, "b"}}]
+    end
+
+    test "Enter on an empty ranked list is a no-op" do
+      state = init!(items: [], key_fn: & &1, id: :p)
+
+      {_state, cmds} = press(state, :enter)
+
+      assert cmds == []
+    end
+
+    test "Escape emits on_cancel" do
+      state = init!(items: ["a"], key_fn: & &1, id: :p, on_cancel: :dismissed)
+
+      {_state, cmds} = press(state, :escape)
+
+      assert cmds == [{:component_event, :p, :dismissed}]
+    end
+
+    test "Escape cancels any in-flight preview task" do
+      state =
+        init!(
+          items: ["a"],
+          key_fn: & &1,
+          preview_fn: fn item -> {:ok, "preview: " <> item} end
+        )
+
+      assert %Task{} = state.preview_task
+      task_pid = state.preview_task.pid
+
+      {state, _cmds} = press(state, :escape)
+
+      assert state.preview_task == nil
+      assert state.preview_ref == nil
+      refute Process.alive?(task_pid)
+    end
+  end
+
+  describe "preview: renders for the current selection" do
+    test "preview_fn result lands in state once its task's message is forwarded to update/2" do
+      state =
+        init!(
+          items: ["alpha", "beta"],
+          key_fn: & &1,
+          preview_fn: fn item -> {:ok, "preview of " <> item} end
+        )
+
+      assert Picker.preview(state) == :loading
+      ref = state.preview_ref
+
+      {state, []} =
+        receive do
+          {^ref, result} -> Picker.update({ref, result}, state)
+        end
+
+      assert Picker.preview(state) == {:ok, "preview of alpha"}
+      assert state.preview_task == nil
+      assert state.preview_ref == nil
+    end
+
+    test "a preview_fn that raises is rescued and rendered as an error result" do
+      state =
+        init!(
+          items: ["alpha"],
+          key_fn: & &1,
+          preview_fn: fn _item -> raise "boom" end
+        )
+
+      ref = state.preview_ref
+
+      {state, []} =
+        receive do
+          {^ref, result} -> Picker.update({ref, result}, state)
+        end
+
+      assert {:error, %RuntimeError{}} = Picker.preview(state)
+    end
+
+    test "an abnormal task exit (DOWN) for the current ref renders as an error" do
+      state =
+        init!(
+          items: ["alpha"],
+          key_fn: & &1,
+          preview_fn: fn item -> {:ok, "preview of " <> item} end
+        )
+
+      ref = state.preview_ref
+
+      {state, []} =
+        Picker.update({:DOWN, ref, :process, self(), :killed}, state)
+
+      assert Picker.preview(state) == {:error, :killed}
+    end
+  end
+
+  describe "stale-preview cancellation (fzf#3134 lesson)" do
+    test "a superseded selection's late task result never lands in state" do
+      state =
+        init!(
+          items: ["alpha", "beta"],
+          key_fn: & &1,
+          preview_fn: fn item -> {:ok, "preview of " <> item} end
+        )
+
+      stale_ref = state.preview_ref
+      stale_task_pid = state.preview_task.pid
+
+      # Move the selection -- this cancels alpha's task (real Task.shutdown)
+      # and starts a fresh one for beta with a NEW ref.
+      {state, []} = press(state, :down)
+
+      assert Picker.selected_item(state) == "beta"
+      refute Process.alive?(stale_task_pid)
+      fresh_ref = state.preview_ref
+      assert fresh_ref != stale_ref
+      assert Picker.preview(state) == :loading
+
+      # Simulate alpha's result arriving anyway (the fzf#3134 race: a
+      # result computed just before shutdown lands in the mailbox
+      # regardless). ref-matching must drop it untouched.
+      {state, []} = Picker.update({stale_ref, {:ok, "preview of alpha"}}, state)
+
+      assert Picker.preview(state) == :loading
+      assert state.preview_ref == fresh_ref
+
+      # The fresh (correct) result for beta still lands normally.
+      assert_receive {^fresh_ref, {:ok, "preview of beta"}}
+      {state, []} = Picker.update({fresh_ref, {:ok, "preview of beta"}}, state)
+
+      assert Picker.preview(state) == {:ok, "preview of beta"}
+    end
+
+    test "a stale DOWN message is dropped the same way" do
+      state =
+        init!(
+          items: ["alpha", "beta"],
+          key_fn: & &1,
+          preview_fn: fn item -> {:ok, "preview of " <> item} end
+        )
+
+      stale_ref = state.preview_ref
+      {state, []} = press(state, :down)
+      fresh_ref = state.preview_ref
+
+      {state, []} =
+        Picker.update({:DOWN, stale_ref, :process, self(), :killed}, state)
+
+      assert Picker.preview(state) == :loading
+      assert state.preview_ref == fresh_ref
+    end
+  end
+
+  describe "typing while a preview is in flight" do
+    test "changing the query cancels the previous selection's preview and starts a new one" do
+      state =
+        init!(
+          items: ["hello", "help", "world"],
+          key_fn: & &1,
+          preview_fn: fn item -> {:ok, "preview of " <> item} end
+        )
+
+      first_ref = state.preview_ref
+      first_task_pid = state.preview_task.pid
+
+      state = type(state, "wor")
+
+      assert Picker.selected_item(state) == "world"
+      refute Process.alive?(first_task_pid)
+      assert state.preview_ref != first_ref
+      assert Picker.preview(state) == :loading
+    end
+  end
+
+  describe "render/2" do
+    test "renders prompt, list, and preview pane without crashing" do
+      state =
+        init!(
+          items: ["hello", "help", "world"],
+          key_fn: & &1,
+          preview_fn: fn item -> {:ok, "preview: " <> item} end
+        )
+
+      rendered = Picker.render(state, default_context())
+
+      assert %{type: :column, children: [prompt, body]} = rendered
+      assert %{type: :text, content: content} = prompt
+      assert content =~ ">"
+
+      assert %{type: :row, children: [list, preview]} = body
+      assert %{id: "picker-list", type: :column} = list
+      assert %{id: "picker-preview", type: :column} = preview
+    end
+
+    test "renders just the list (no preview pane) when preview_fn is absent" do
+      state = init!(items: ["hello", "help"], key_fn: & &1)
+
+      rendered = Picker.render(state, default_context())
+
+      assert %{type: :column, children: [_prompt, body]} = rendered
+      assert %{id: "picker-list", type: :column} = body
+    end
+
+    test "match-position highlighting: matched graphemes render bold, selected row gets bg" do
+      state = init!(items: ["hello", "help"], key_fn: & &1)
+      state = type(state, "hl")
+
+      %{
+        type: :column,
+        children: [_prompt, %{id: "picker-list", children: [first_row, _]}]
+      } =
+        Picker.render(state, default_context())
+
+      # "hello": h(0) and l(2) match "hl" as a subsequence -- both bold;
+      # the selected row's segments also carry the selection background.
+      assert %{type: :row, children: segments, style: %{bg: :blue}} = first_row
+      contents = Enum.map(segments, & &1.content)
+      assert contents == ["h", "e", "l", "lo"]
+
+      bold_segments = Enum.filter(segments, &(&1.style[:bold] == true))
+      assert Enum.map(bold_segments, & &1.content) == ["h", "l"]
+      assert Enum.all?(segments, &(&1.style[:bg] == :blue))
+    end
+
+    test "truncates long labels to the available width with an ellipsis" do
+      state = init!(items: [String.duplicate("x", 100)], key_fn: & &1)
+
+      %{children: [_prompt, %{children: [row]}]} =
+        Picker.render(state, %{available_width: 10})
+
+      full_content = row.children |> Enum.map_join(& &1.content)
+      assert String.ends_with?(full_content, "…")
+      assert String.length(full_content) <= 10
+    end
+
+    test "an item whose key_fn yields \"\" still renders a visible, selectable row" do
+      state = init!(items: [%{name: ""}], key_fn: & &1.name)
+
+      %{children: [_prompt, %{children: [row]}]} =
+        Picker.render(state, default_context())
+
+      assert %{type: :row, children: children} = row
+      assert length(children) >= 1
+      assert Enum.any?(children, &(&1.content != ""))
+    end
+  end
+
+  describe "update/2 guards against mis-routed structs and unknown props" do
+    test "an %Event{} that misses every handle_event/3 clause is a no-op through update/2" do
+      state = init!(items: ["a", "b"], key_fn: & &1)
+
+      {new_state, cmds} =
+        Picker.update(Event.key_event("a", :pressed, []), state)
+
+      assert new_state == state
+      assert cmds == []
+    end
+
+    test "an arbitrary map with an internal-state key does not bypass the cursor clamp" do
+      state = init!(items: ["a", "b", "c"], key_fn: & &1)
+
+      {new_state, cmds} = Picker.update(%{cursor: 99}, state)
+
+      assert new_state == state
+      assert cmds == []
+    end
+
+    test "a legitimate prop update still applies through the allowlist" do
+      state = init!(items: ["a"], key_fn: & &1, placeholder: "old")
+
+      {new_state, []} = Picker.update(%{placeholder: "new"}, state)
+
+      assert new_state.placeholder == "new"
+    end
+  end
+end

--- a/test/raxol/ui/list_scorer_test.exs
+++ b/test/raxol/ui/list_scorer_test.exs
@@ -1,0 +1,297 @@
+defmodule Raxol.UI.ListScorerTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.UI.ListScorer
+
+  defp key_fn(item), do: item
+
+  defp items_of(results), do: Enum.map(results, & &1.item)
+
+  describe "rank/4 correctness" do
+    test "subsequence match: query chars must appear in order, not necessarily contiguous" do
+      items = ["hello", "help", "shell", "world"]
+      results = ListScorer.rank(items, "hlo", &key_fn/1)
+
+      assert items_of(results) == ["hello"]
+    end
+
+    test "no-match items are excluded entirely" do
+      items = ["apple", "banana", "cherry"]
+      results = ListScorer.rank(items, "xyz", &key_fn/1)
+
+      assert results == []
+    end
+
+    test "empty query returns every item in original order with zero score" do
+      items = ["charlie", "alpha", "bravo"]
+      results = ListScorer.rank(items, "", &key_fn/1)
+
+      assert items_of(results) == items
+      assert Enum.all?(results, &(&1.score == 0.0))
+      assert Enum.all?(results, &(&1.positions == []))
+    end
+
+    test "case-insensitive by default" do
+      results = ListScorer.rank(["HELLO"], "hello", &key_fn/1)
+      assert items_of(results) == ["HELLO"]
+    end
+
+    test "case_sensitive: true rejects a differently-cased match" do
+      assert ListScorer.rank(["HELLO"], "hello", &key_fn/1,
+               case_sensitive: true
+             ) == []
+
+      assert ListScorer.rank(["HELLO"], "HELLO", &key_fn/1,
+               case_sensitive: true
+             )
+             |> items_of() == ["HELLO"]
+    end
+
+    test "positions point at the matched graphemes in the key" do
+      [%{positions: positions}] = ListScorer.rank(["hello"], "hlo", &key_fn/1)
+
+      assert Enum.map(positions, &String.at("hello", &1)) == ["h", "l", "o"]
+      assert positions == Enum.sort(positions)
+    end
+
+    test "adjacency bonus: a contiguous match scores higher than a scattered one" do
+      [contig] = ListScorer.rank(["abcdef"], "abc", &key_fn/1)
+      [scattered] = ListScorer.rank(["a1b2c3"], "abc", &key_fn/1)
+
+      assert contig.score > scattered.score
+    end
+
+    test "word-boundary bonus: a match at a word start scores higher than mid-word" do
+      # "foo" matches at position 0 (boundary) in "foo_bar" vs. mid-word in
+      # "xfooy" (no boundary before/at the match start).
+      [boundary] = ListScorer.rank(["foo_bar"], "foo", &key_fn/1)
+      [mid_word] = ListScorer.rank(["xfooy"], "foo", &key_fn/1)
+
+      assert boundary.score > mid_word.score
+    end
+
+    test "camelCase transition counts as a word boundary" do
+      [camel] = ListScorer.rank(["fooBarBaz"], "bar", &key_fn/1)
+      [flat] = ListScorer.rank(["foobarbaz"], "bar", &key_fn/1)
+
+      assert camel.score > flat.score
+    end
+
+    test "position bonus: an earlier match scores higher than a later one, all else equal" do
+      [earlier] = ListScorer.rank(["ab........."], "ab", &key_fn/1)
+      [later] = ListScorer.rank([".........ab"], "ab", &key_fn/1)
+
+      assert earlier.score > later.score
+    end
+
+    test "stable sort: ties broken by original list order" do
+      # Every item is an exact copy, so every item scores identically --
+      # the only thing distinguishing order in the result is input order.
+      items = ["same", "same", "same"]
+      results = ListScorer.rank(items, "same", &key_fn/1)
+
+      assert items_of(results) == items
+    end
+
+    test "higher-scoring items sort first" do
+      items = ["a1b2c3", "abc", "xxabcxx"]
+      results = ListScorer.rank(items, "abc", &key_fn/1)
+
+      scores = Enum.map(results, & &1.score)
+      assert scores == Enum.sort(scores, :desc)
+      # exact contiguous match at the very start wins
+      assert hd(items_of(results)) == "abc"
+    end
+
+    test "unicode/CJK: matches operate on graphemes, not bytes or codepoints" do
+      results = ListScorer.rank(["日本語のテスト"], "テスト", &key_fn/1)
+      assert items_of(results) == ["日本語のテスト"]
+
+      [%{positions: positions, key: key}] = results
+      # Grapheme indices must be usable directly against the key string.
+      assert Enum.map(positions, &String.at(key, &1)) == ["テ", "ス", "ト"]
+    end
+
+    test "unicode: combining-mark graphemes are treated as single units" do
+      # "e" + combining acute accent is one grapheme cluster.
+      combining_e = "é"
+      key = "caf" <> combining_e
+      results = ListScorer.rank([key], combining_e, &key_fn/1)
+
+      assert items_of(results) == [key]
+      [%{positions: [pos]}] = results
+      assert String.at(key, pos) == combining_e
+    end
+
+    test "key_fn derives the searchable label independently of the item" do
+      items = [%{id: 1, name: "alpha"}, %{id: 2, name: "beta"}]
+      results = ListScorer.rank(items, "alp", & &1.name)
+
+      assert items_of(results) == [%{id: 1, name: "alpha"}]
+      assert hd(results).key == "alpha"
+    end
+  end
+
+  describe "properties" do
+    property "rank is a permutation-subset of the input (no items invented, none duplicated)" do
+      check all(
+              raw <-
+                list_of(string(:alphanumeric, min_length: 1, max_length: 12),
+                  min_length: 0,
+                  max_length: 30
+                ),
+              query <- string(:alphanumeric, max_length: 5),
+              max_runs: 100
+            ) do
+        # Tag each string with its index so identical labels stay
+        # distinguishable when checking "no duplication".
+        items = Enum.with_index(raw)
+        results = ListScorer.rank(items, query, fn {s, _i} -> s end)
+        result_items = items_of(results)
+
+        assert MapSet.subset?(MapSet.new(result_items), MapSet.new(items))
+        assert length(Enum.uniq(result_items)) == length(result_items)
+      end
+    end
+
+    property "extending the query with one more character never grows the result set" do
+      check all(
+              raw <-
+                list_of(string(:alphanumeric, min_length: 1, max_length: 12),
+                  min_length: 0,
+                  max_length: 30
+                ),
+              query <- string(:alphanumeric, max_length: 4),
+              extra <- string(:alphanumeric, length: 1),
+              max_runs: 100
+            ) do
+        items = Enum.with_index(raw)
+        key = fn {s, _i} -> s end
+
+        short_set =
+          items |> ListScorer.rank(query, key) |> items_of() |> MapSet.new()
+
+        long_set =
+          items
+          |> ListScorer.rank(query <> extra, key)
+          |> items_of()
+          |> MapSet.new()
+
+        assert MapSet.subset?(long_set, short_set)
+      end
+    end
+  end
+
+  describe "performance" do
+    # Realistic-shaped labels (branch-name-like: `word-word-word-hex`,
+    # drawn from a 23-word vocabulary so a query narrows the match set
+    # instead of matching everything) rather than a synthetic corpus
+    # where every item literally contains the query -- see the module
+    # note below for why that distinction is the whole ballgame here.
+    defp realistic_items(vocab, count) do
+      for i <- 1..count do
+        words = for _ <- 1..3, do: Enum.random(vocab)
+        Enum.join(words, "-") <> "-" <> Integer.to_string(:erlang.phash2(i), 16)
+      end
+    end
+
+    @vocab ~w(harness agent payments gateway terminal render picker session
+              swarm acp symphony core plugin liveview speech watch telegram
+              fix feat chore test docs refactor)
+
+    @tag :bench
+    @tag :slow
+    test "ranks 10k items well under 16ms/keystroke for a narrowing query" do
+      items = realistic_items(@vocab, 10_000)
+      # A 3+ character fragment -- what a picker sees after a couple of
+      # keystrokes -- narrows the match set the way real typing does.
+      query = "harn"
+
+      # Warm the code path once before timing (BEAM JIT/first-call cost
+      # would otherwise pollute a single-shot measurement).
+      ListScorer.rank(items, query, &key_fn/1)
+
+      {micros, results} =
+        :timer.tc(fn -> ListScorer.rank(items, query, &key_fn/1) end)
+
+      millis = micros / 1000
+
+      IO.puts(
+        "[bench] ListScorer.rank/4, 10,000 realistic items, query #{inspect(query)}: " <>
+          "#{Float.round(millis, 3)}ms (#{length(results)}/10000 matched)"
+      )
+
+      assert millis < 16.0,
+             "expected 10k-item filter under 16ms/keystroke, took #{millis}ms"
+    end
+
+    @tag :bench
+    @tag :slow
+    test "characterizes the pathological worst case: every item matches" do
+      # Honesty check on the target, not a claim it's met here: if every
+      # single item in a 10k-item list shares the literal query as a
+      # substring (a degenerate corpus no real picker would show -- fuzzy
+      # filtering exists precisely because most items DON'T match), the
+      # full Smith-Waterman-lite DP + backtrack runs for all 10,000 of
+      # them. That's a materially different cost profile from the
+      # narrowing case above (which rejects most items in the O(query +
+      # key) two-pointer subsequence check before ever reaching the DP).
+      # This test measures and reports that ceiling; it intentionally
+      # does not assert 16ms against it -- see the commit body for the
+      # measured number and the honest read on what it means.
+      items =
+        for i <- 1..10_000 do
+          "session-#{Integer.to_string(i, 16)}-#{:erlang.phash2(i)}-item"
+        end
+
+      query = "session"
+
+      ListScorer.rank(items, query, &key_fn/1)
+
+      {micros, results} =
+        :timer.tc(fn -> ListScorer.rank(items, query, &key_fn/1) end)
+
+      millis = micros / 1000
+
+      IO.puts(
+        "[bench] ListScorer.rank/4, 10,000/10,000-match pathological case: " <>
+          "#{Float.round(millis, 3)}ms (#{length(results)} matches)"
+      )
+
+      # Regression guard only (order-of-magnitude), not the 16ms target.
+      assert millis < 200.0,
+             "pathological all-match case regressed badly: #{millis}ms"
+    end
+
+    test "a single ~1,000,000-grapheme adversarial label stays bounded and still matches" do
+      # Nothing else in this suite exercises a long K: the realistic
+      # corpus above caps out around ~20 chars/label. Without the
+      # `@max_score_graphemes` clamp in `ListScorer`, the O(query length
+      # * key length) DP (and its two-pointer subsequence pre-check)
+      # would cost proportional to this label's full length -- an
+      # unbounded paste or a log line used as a list key would make a
+      # single keystroke's filter pass arbitrarily slow.
+      long_label = "prefix-match-" <> String.duplicate("x", 1_000_000)
+      items = ["short-one", long_label, "short-two"]
+      query = "prefix-match"
+
+      {micros, results} =
+        :timer.tc(fn -> ListScorer.rank(items, query, &key_fn/1) end)
+
+      millis = micros / 1000
+
+      assert millis < 16.0,
+             "expected the 1M-grapheme adversarial label to stay bounded, took #{millis}ms"
+
+      assert [%{item: matched, key: key}] = results
+      assert matched == long_label
+      # The full untruncated label must still be in the result -- only
+      # the internal scoring lists are clamped, never `key:` itself --
+      # so callers (Picker's `render_row`) keep highlighting the real
+      # label, not a truncated stand-in.
+      assert key == long_label
+      assert String.length(key) == String.length(long_label)
+    end
+  end
+end


### PR DESCRIPTION
Unit **T14** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): the overlay picker primitive + list scorer — one fzf-shape component behind every "pick one of N" in the harness (sessions, runs, tool calls, palette, file mentions), per AD-U3.

## What
- **`Raxol.UI.ListScorer.rank(items, query, key_fn, opts)`** — pure fuzzy scorer, fzf-style Smith-Waterman-lite (adjacency / word-boundary / camelCase / position bonuses), case-insensitive, stable sort. Grapheme-based and Unicode-safe; returned match positions are grapheme indices safe for TextMeasure column mapping. Deliberately NOT `Raxol.Search.Fuzzy` (that's buffer-cell search — a different category). Properties: rank is a permutation-subset of input (no invented/dup items); adding a matching char never grows the result set (monotone narrowing).
- **Bench**: 10,000-item corpus, query narrows in **~11-12ms/keystroke** under the 16ms target (three profiling rounds: hoisted bonus computation, an ASCII fast-path replacing `String.graphemes`, list-walk DP). The pathological all-match case (~48-50ms) is measured + documented, not asserted — degenerate for real corpora (tens–low-thousands, fuzzy filtering makes it rare).
- **`Raxol.UI.Components.Harness.Picker`** — prompt + ranked windowed list + optional async preview. Type-to-filter, Up/Down + clamp, Enter selects, Esc cancels. **Stale-preview cancellation** (the fzf#3134 race, double-guarded): `Task.shutdown(:brutal_kill)` + ref-matching drop of any superseded result, so a late preview from a prior selection can never land in state.
- Match-position highlight via style attrs (no raw ANSI); all display width via TextMeasure.

## RED fixed in review
Type-to-filter was **dead on the native terminal driver** — the printable clause required a `modifiers:` field that only the test helper sets; `event_translator` emits boolean `shift:/ctrl:/alt:`, `input_parser` emits bare `%{key: char}`. Fixed defensively (a `text_input?/1` predicate reading all three encodings — ctrl/alt = shortcut, plain/shift = text). Red-run recorded (3 failures on raw driver shapes); regression tests now drive `event_translator`- and `input_parser`-shaped events directly, not just the helper. (The shared normalization is being extracted as unit T27; this fixes inline meanwhile — same input-shape gap that hit the composer.)

## Evidence
47 tests green (2 properties + 45; bench excluded by default); compile --warnings-as-errors / credo --strict / format clean.

## Review trail
Opus review (REQUEST CHANGES: typing dead on the real driver, masked by the test helper's event shape) → defensive fix + raw-shape regression tests → the `preview_fn` cancel-safety contract documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
