### PR TITLE
Harness UI: streaming markdown body (provisional close, seal parse, GFM tables) [T26]

### DIFF
--- a/lib/raxol/ui/components/harness/block.ex
+++ b/lib/raxol/ui/components/harness/block.ex
@@ -88,24 +88,32 @@ defmodule Raxol.UI.Components.Harness.Block do
   `exit_code`, `duration_ms`, and `cost` are all `nil`; otherwise it renders
   only the fields that are present.
 
-  ## Prominence (T8)
+  ## Prominence
 
   `context[:prominence]` (`0.0..1.0`) resolves the header/content/outcome
-  text colors through `Raxol.UI.Harness.Prominence` -- the H-K salience
-  solver, ground-aware. `context[:ground]` overrides the ground lightness
-  (default: OSC-11-detected, see
-  `Raxol.UI.Theming.SalienceTheme.detect_ground/0`).
+  text colours through `Raxol.UI.Harness.Prominence` -- a salience solver
+  that fades a colour toward the background as prominence drops.
+  `context[:ground]` overrides the background lightness (default:
+  terminal-detected, see `Raxol.UI.Theming.SalienceTheme.detect_ground/0`).
   `context[:legibility_floor]` (default `false`) is threaded through to
-  `Prominence.resolve/3`: the default is the **pure salience-gradient
-  fade** (context text recedes, legible on promotion); T9 sets it `true`
-  only for acting / interactive tiers where blind-reading risk lives (see
-  the `Prominence` moduledoc's "Two modes"). **Default is neutral**: when
-  `:prominence` is absent from `context`, or is `1.0`, no style is touched
-  -- the render is byte-identical to a pre-T8 render (no `:fg` added to any
-  style map). This is deliberate (roadmap unit T8's regression guard,
-  SAL-P-06): existing callers that never pass `:prominence` see zero change.
+  `Prominence.resolve/3`: the default is a pure fade (context text recedes,
+  becoming legible again as it is promoted); set it `true` for interactive
+  tiers where a minimum legibility must be preserved (see the `Prominence`
+  moduledoc's "Two modes").
+
+  When `context[:markdown]` is enabled, the Markdown body is faded to the
+  same resolved colour as the header, so the whole block dims together.
+
+  **Default is neutral**: when `:prominence` is absent from `context`, or
+  is `1.0`, no style is touched -- the render is byte-identical to a render
+  without prominence (no `:fg` added to any style map), so existing callers
+  that never pass `:prominence` see zero change.
+
+  The colour is resolved once per `render/2` call and threaded into every
+  branch, so a multi-line body never re-runs the solver per line.
   """
 
+  alias Raxol.UI.Components.Harness.MarkdownBody
   alias Raxol.UI.Harness.Prominence
   alias Raxol.UI.TextLayout
   alias Raxol.UI.TextMeasure
@@ -343,6 +351,19 @@ defmodule Raxol.UI.Components.Harness.Block do
   @doc """
   Renders `block` as a plain view map. `context[:width]` sets the wrap/
   truncation budget (defaults to `Raxol.Core.Defaults.terminal_width/0`).
+
+  `context[:markdown]` (default `false`, additive/opt-in) routes a
+  `:message`/`:reasoning` block's text content through
+  `Raxol.UI.Components.Harness.MarkdownBody` instead of the plain
+  line-split body: `:sealed` mode while the block is `:sealed`, `:streaming`
+  (provisional-close) while it is still `:live`. Every other kind, and
+  every block when the option is omitted, renders exactly as before.
+
+  `context[:prominence]` (see the moduledoc's "Prominence" section) fades
+  the header, content, and outcome to one resolved colour. A Markdown body
+  fades in lockstep -- its text nodes carry the same colour as the header,
+  so a faded header never sits above a bright body.
+
   Never raises: any unexpected internal shape falls back to a one-line
   placeholder rather than crashing the caller.
   """
@@ -359,13 +380,18 @@ defmodule Raxol.UI.Components.Harness.Block do
   end
 
   defp build_render(block, width, context) do
-    header = header_view(block, width, context)
-    outcome_children = outcome_row_view(block.outcome, context)
+    # Resolve the prominence fade colour ONCE per render (nil = neutral,
+    # no fade), then thread it into every text-producing branch --
+    # header, content, and outcome all carry the SAME `:fg`, and the
+    # per-line content map never re-runs the H-K solver.
+    fg = prominence_fg(context)
+    header = header_view(block, width, fg)
+    outcome_children = outcome_row_view(block.outcome, fg)
 
     body_children =
       case block.fold do
         :folded -> [header]
-        :expanded -> [header | content_lines_view(block, context)]
+        :expanded -> [header | content_lines_view(block, width, context, fg)]
       end
 
     Components.column(gap: 0, children: body_children ++ outcome_children)
@@ -383,28 +409,27 @@ defmodule Raxol.UI.Components.Harness.Block do
     )
   end
 
-  defp header_view(block, width, context) do
+  defp header_view(block, width, fg) do
     prefix = "#{fold_icon(block.fold)} #{kind_glyph(block.kind)} "
     budget = max(width - TextMeasure.display_width(prefix), 1)
     summary_text = block |> summary() |> TextLayout.truncate(budget, :ellipsis)
 
     Components.text(
       content: prefix <> summary_text,
-      style: prominence_style(header_style(block.kind), context)
+      style: apply_fg(header_style(block.kind), fg)
     )
   end
 
-  # Chrome neutral baseline (matches DiffViewer's `@chrome_base_fg`) faded
-  # per `context[:prominence]` through the T8 mapping layer. Absent or 1.0
-  # prominence is a no-op (see moduledoc "Prominence (T8)" -- SAL-P-06).
+  # Chrome neutral baseline (matches DiffViewer's neutral chrome colour)
+  # faded per `context[:prominence]`. Absent or 1.0 prominence resolves to
+  # a nil fade colour (see `prominence_fg/1`), which `apply_fg/2` leaves
+  # the style untouched for -- neutral by default.
   @chrome_fg "#B4B4B4"
 
-  defp prominence_style(style, context) do
-    case prominence_fg(context) do
-      nil -> style
-      fg -> Map.put(style, :fg, fg)
-    end
-  end
+  # Applies an already-resolved fade colour to a style map. `nil` (the
+  # neutral / no-prominence case) leaves the style byte-identical.
+  defp apply_fg(style, nil), do: style
+  defp apply_fg(style, fg), do: Map.put(style, :fg, fg)
 
   defp prominence_fg(context) do
     case Map.get(context, :prominence, 1.0) do
@@ -510,7 +535,59 @@ defmodule Raxol.UI.Components.Harness.Block do
   defp format_args([]), do: ""
   defp format_args(args), do: "(#{inspect(args)})"
 
-  defp content_lines_view(block, context) do
+  # Opt-in Markdown wire-in per `context[:markdown]`, message/reasoning
+  # kinds only. When enabled, the block's text content is rendered by
+  # `MarkdownBody` (`:sealed` full parse while sealed, `:streaming`
+  # provisional-close while live) and then FADED to the same resolved
+  # prominence colour as the header, so a faded header never sits above a
+  # bright Markdown body. Every other combination -- markdown disabled,
+  # or a non-message/reasoning kind -- falls through to the plain
+  # per-line rendering unchanged.
+  defp content_lines_view(
+         %__MODULE__{kind: kind, content: %{text: _}} = block,
+         width,
+         context,
+         fg
+       )
+       when kind in [:message, :reasoning] do
+    if Map.get(context, :markdown, false) do
+      body =
+        MarkdownBody.render(markdown_source(block), %{
+          width: width,
+          mode: markdown_mode(block)
+        })
+
+      [fade_view(body, fg)]
+    else
+      plain_content_lines(block, fg)
+    end
+  end
+
+  defp content_lines_view(block, _width, _context, fg),
+    do: plain_content_lines(block, fg)
+
+  defp markdown_source(%__MODULE__{content: %{text: text}}),
+    do: to_display_text(text)
+
+  defp markdown_mode(%__MODULE__{seal: :sealed}), do: :sealed
+  defp markdown_mode(%__MODULE__{seal: :live}), do: :streaming
+
+  # Recursively applies the resolved prominence colour to every text node
+  # in a rendered view tree (the MarkdownBody result), so the Markdown
+  # body fades in lockstep with the header/outcome. `nil` fg is the
+  # neutral case -- the tree is returned byte-identical, so a
+  # no-prominence markdown render is untouched.
+  defp fade_view(view, nil), do: view
+
+  defp fade_view(%{type: :text, style: style} = node, fg),
+    do: %{node | style: apply_fg(style, fg)}
+
+  defp fade_view(%{children: children} = node, fg),
+    do: %{node | children: Enum.map(children, &fade_view(&1, fg))}
+
+  defp fade_view(node, _fg), do: node
+
+  defp plain_content_lines(block, fg) do
     block
     |> body_lines()
     |> Enum.with_index()
@@ -518,7 +595,7 @@ defmodule Raxol.UI.Components.Harness.Block do
       Components.text(
         id: line_id(block, idx),
         content: line,
-        style: prominence_style(content_style(block.kind), context)
+        style: apply_fg(content_style(block.kind), fg)
       )
     end)
   end
@@ -558,7 +635,7 @@ defmodule Raxol.UI.Components.Harness.Block do
   defp split_lines(""), do: []
   defp split_lines(text), do: text |> to_display_text() |> String.split("\n")
 
-  defp outcome_row_view(outcome, context) do
+  defp outcome_row_view(outcome, fg) do
     case outcome_parts(outcome) do
       [] ->
         []
@@ -567,7 +644,7 @@ defmodule Raxol.UI.Components.Harness.Block do
         [
           Components.text(
             content: Enum.join(parts, " · "),
-            style: prominence_style(%{dim: true}, context)
+            style: apply_fg(%{dim: true}, fg)
           )
         ]
     end

--- a/lib/raxol/ui/components/harness/markdown_body.ex
+++ b/lib/raxol/ui/components/harness/markdown_body.ex
@@ -1,0 +1,557 @@
+defmodule Raxol.UI.Components.Harness.MarkdownBody do
+  @moduledoc """
+  Renders a message/reasoning block's Markdown content for the harness
+  transcript.
+
+  Extends `Raxol.UI.Components.MarkdownRenderer` (does not change its
+  existing behavior -- see that module's own additive GFM table support)
+  with a streaming-aware render policy: while a message is still being
+  typed/streamed, its trailing text may contain an incomplete construct,
+  and this module renders a provisional, closed-up view of that tail
+  without ever touching the real (still-growing) source buffer.
+
+  ## Two modes
+
+  - `:sealed` -- the block's `item_completed` content is final; render it
+    through a plain full parse (`Raxol.UI.Components.MarkdownRenderer`, no
+    transformation).
+  - `:streaming` -- the block is still live; the accumulated tail text may
+    contain an incomplete construct (an unclosed fence, an unpaired
+    `**`/`_`/`` ` ``, a half-written link). `provisional_close/1` computes
+    a RENDER-ONLY closed copy of the text -- the caller's source buffer is
+    never touched, this module takes a string by value and returns a view,
+    nothing more. Discarded on the next delta / at seal: the sealed render
+    is always a full parse of the true final content, never a leftover of
+    a provisional close.
+
+  ## Provisional-close constructs handled
+
+  A single left-to-right scan of the "prose" portion of the text (fenced
+  code content is excluded -- markdown markers inside a code span/block
+  are literal, never auto-closed as emphasis) tracks a stack of open
+  constructs and appends whatever is still open, in LIFO order, at the
+  very end of the text:
+
+  - fenced code block (an odd count of ```` ``` ````/`~~~` fence lines --
+    closed by appending a fence line of the SAME marker type that opened
+    it; a fence only closes on a matching marker, so a stray `~~~` line
+    inside a ```` ``` ```` block never prematurely ends it, and vice
+    versa; nothing else is scanned once the buffer ends inside an
+    unterminated fence)
+  - inline code span (a single `` ` ``)
+  - bold (`**` / `__`)
+  - italic (`*` / `_`)
+  - link text (`[` without a matching `]`) and link URL (`](url` without a
+    matching `)`)
+
+  The renderer this module hands off to uses a flat (non-recursive)
+  regex grammar -- it can represent at most ONE active emphasis/code/link
+  run at a time, never genuine parent-child nesting of different marker
+  kinds. So when the truncation point falls inside real nesting (e.g. a
+  bold span containing an unfinished italic run), only the OUTERMOST
+  still-open construct is closed; any INNER opener that never got a
+  chance to close before the cut has its own marker characters stripped
+  from the render-only copy -- the real text it introduced is preserved,
+  now attributed to the surviving outer construct. Emitting a closer for
+  every open frame (LIFO, unconditionally) would produce a marker
+  sequence -- like `***`, `___`, or `` `* `` -- the flat grammar can't
+  parse back out, which is exactly the raw-marker leak this guards
+  against. This is the same "strip a dangling opener rather than leak
+  it" idea the module already applies to a content-free opener, just
+  widened to cover an un-nestable one too.
+
+  A half-written **table row** needs no closer here.
+  `Raxol.UI.Components.MarkdownRenderer`'s table detector fires only once
+  a header line and a separator-shaped line (`|---|...`) both exist as
+  complete lines in the buffer, so a lone in-progress header renders as
+  plain text (harmless literal `|` characters, not a broken frame). Two
+  benign streaming shapes follow from that: a partial separator on the
+  still-streaming last line (e.g. `|--`, which the lenient detector
+  accepts) renders a *premature but well-formed* frame -- header +
+  separator, no body rows yet; and a still-in-progress last body row
+  renders with a short/ragged final cell. Neither is a broken frame, and
+  a narrow width never collapses a column to zero (columns clamp to a
+  minimum and the row overflows/wraps like any long line -- see
+  `MarkdownRenderer`'s table renderer).
+
+  ## Known limitation
+
+  Backslash-escaped markers (e.g. `\\*`) are not treated as CommonMark
+  escapes -- the backslash is scanned as ordinary text and the following
+  marker character still toggles/opens its construct normally. Full
+  escape handling would need to thread an "escaped" flag through the
+  scan; left as a documented gap rather than expanded scope here.
+  """
+
+  alias Raxol.UI.Components.MarkdownRenderer
+  alias Raxol.View.Components
+
+  @type mode :: :sealed | :streaming
+
+  # Above this byte size, both the provisional-close scan and the
+  # downstream render/parse skip their normal work and fall back to a
+  # cheap identity/plain-text path. Pure insurance: the scan is
+  # single-pass O(n) so it stays fast well past this, but a
+  # multi-hundred-KB single streamed message is degenerate -- the
+  # incomplete-construct-flash risk (for the scan) and the repeated-
+  # full-reparse cost (for the render, paid again on every delta) are
+  # both negligible against the ceiling this trades them for. Never
+  # reached by normal deltas.
+  @render_byte_cap 256 * 1024
+
+  @doc """
+  Renders `markdown_text` per `context[:mode]` (`:sealed` default) and
+  `context[:width]` (defaults to `Raxol.Core.Defaults.terminal_width/0`).
+  Never raises -- arbitrary/garbage/invalid-UTF-8 input always yields
+  some safe view.
+  """
+  @spec render(term(), map()) :: map()
+  def render(markdown_text, context \\ %{}) do
+    width = Map.get(context, :width, Raxol.Core.Defaults.terminal_width())
+
+    case Map.get(context, :mode, :sealed) do
+      :streaming -> render_streaming(markdown_text, width)
+      _sealed -> render_sealed(markdown_text, width)
+    end
+  rescue
+    _ -> fallback_view(to_text(markdown_text))
+  end
+
+  @doc """
+  Full parse -- the seal-time render. `markdown_text` is trusted to be
+  the item's final, complete content (`item_completed.content`, never a
+  concatenation of deltas).
+  """
+  @spec render_sealed(term(), pos_integer()) :: map()
+  def render_sealed(markdown_text, width) do
+    markdown_text |> to_text() |> render_via(width)
+  end
+
+  @doc """
+  Streaming render: `provisional_close/1` on a copy of `markdown_text`,
+  then a full parse of THAT -- never the original. The caller's buffer is
+  untouched; this function takes a value and returns a value.
+  """
+  @spec render_streaming(term(), pos_integer()) :: map()
+  def render_streaming(markdown_text, width) do
+    markdown_text |> to_text() |> provisional_close() |> render_via(width)
+  end
+
+  # Above this byte size, rendering skips the parse entirely and falls
+  # back to a single plain-text view. It guards the EXPENSIVE side of the
+  # pipeline (a full re-parse of the whole buffer, paid on every
+  # streaming delta) the same way `@render_byte_cap`'s check in
+  # `provisional_close/1` guards the cheap scan -- without this, a
+  # multi-hundred-KB message would re-run a full parse on every single
+  # delta even though the provisional-close scan itself was skipped.
+  defp render_via(text, width) do
+    if byte_size(text) > @render_byte_cap do
+      fallback_view(text)
+    else
+      {:ok, state} = MarkdownRenderer.init(%{markdown_text: text, width: width})
+      MarkdownRenderer.render(state, %{})
+    end
+  rescue
+    _ -> fallback_view(text)
+  end
+
+  defp fallback_view(text) do
+    %{
+      type: :column,
+      gap: 0,
+      style: %{},
+      children: [Components.text(content: text)]
+    }
+  end
+
+  defp to_text(text) when is_binary(text) do
+    text |> ensure_valid_utf8() |> sanitize_controls()
+  end
+
+  defp to_text(other), do: other |> inspect() |> sanitize_controls()
+
+  defp ensure_valid_utf8(text) do
+    if String.valid?(text), do: text, else: recover_utf8(text)
+  end
+
+  # A streamed delta can arrive mid multi-byte grapheme (an "e" + a
+  # combining accent, a CJK character, an emoji codepoint -- all split
+  # across a chunk boundary), so `text` may be invalid UTF-8 purely
+  # because its TAIL is an incomplete codepoint that will complete once
+  # the next delta arrives. Naively reinterpreting the WHOLE buffer as
+  # Latin-1 in that case mojibakes every already-committed, already-valid
+  # character too (a leading "cafe" + valid multi-byte accent becomes
+  # "cafe" + two garbage Latin-1 glyphs, and that garbled render can flash
+  # onto the transcript for a frame before the next delta fixes it -- a
+  # regression, not just cosmetic noise). Instead: keep the longest valid
+  # UTF-8 prefix untouched, and only fall back to a lossy re-encoding for
+  # the trailing bytes -- and only when those bytes could NEVER become
+  # valid no matter what follows (i.e. they are not merely truncated).
+  defp recover_utf8(binary) do
+    {valid_prefix, rest} = longest_valid_utf8_prefix(binary)
+
+    cond do
+      rest == "" -> valid_prefix
+      plausibly_truncated_utf8?(rest) -> valid_prefix
+      true -> valid_prefix <> latin1_fallback(rest)
+    end
+  end
+
+  defp longest_valid_utf8_prefix(binary),
+    do: longest_valid_utf8_prefix(binary, [])
+
+  defp longest_valid_utf8_prefix(<<codepoint::utf8, rest::binary>>, acc),
+    do: longest_valid_utf8_prefix(rest, [<<codepoint::utf8>> | acc])
+
+  defp longest_valid_utf8_prefix(rest, acc),
+    do: {acc |> Enum.reverse() |> IO.iodata_to_binary(), rest}
+
+  # A leftover 1-3 byte tail is "plausibly truncated" (as opposed to
+  # genuinely malformed) iff padding it out with SOME small number of
+  # UTF-8 continuation bytes (`0x80..0xBF`, and `0xBF` is a valid
+  # continuation byte for every multi-byte lead) makes it valid -- i.e.
+  # it really was the start of a longer codepoint, just cut short.
+  defp plausibly_truncated_utf8?(tail) when byte_size(tail) in 1..3 do
+    Enum.any?(1..3, fn n -> String.valid?(tail <> :binary.copy(<<0xBF>>, n)) end)
+  end
+
+  defp plausibly_truncated_utf8?(_tail), do: false
+
+  # Genuinely-invalid bytes (arbitrary garbage, e.g. `StreamData.binary()`
+  # in the fuzz suite) still need a total, never-raising fallback --
+  # reinterpreted as Latin-1 (total over all 256 byte values), falling
+  # back to `inspect/1` only if even that somehow fails.
+  defp latin1_fallback(binary) do
+    case :unicode.characters_to_binary(binary, :latin1) do
+      converted when is_binary(converted) -> converted
+      _ -> inspect(binary)
+    end
+  end
+
+  # Untrusted (e.g. LLM-generated) markdown must never carry a raw C0/C1
+  # control byte, DEL, or -- critically -- an ESC (`\e`) out of this
+  # module: an embedded ESC/OSC sequence would reach the terminal
+  # renderer as if it were a real control sequence (cursor move, screen
+  # clear, a fake window-title write), which is exactly the "never embed
+  # raw ANSI in text()" rule this codebase enforces at the View-DSL
+  # boundary. `\n` and `\t` are the only control characters that are
+  # ever meaningful here, so both are kept; everything else in C0
+  # (`0x00-0x1F` minus those two), DEL (`0x7F`), and C1 (`0x80-0x9F`) is
+  # removed.
+  @control_chars_pattern ~r/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\x{0080}-\x{009F}]/u
+
+  defp sanitize_controls(text),
+    do: String.replace(text, @control_chars_pattern, "")
+
+  # --- provisional close (render-only closing of incomplete constructs) ----
+
+  @doc """
+  Render-only provisional close of incomplete Markdown constructs in
+  `text`. Pure: returns a NEW string, never mutates or reads any external
+  state. Safe on arbitrary input (garbage, invalid UTF-8, empty string) --
+  never raises. Runs in a single pass, time linear in `byte_size(text)`
+  (above `#{@render_byte_cap}` bytes the scan is skipped and `text` is
+  returned unchanged -- a degradation ceiling, not the bound).
+  """
+  @spec provisional_close(String.t()) :: String.t()
+  def provisional_close(text) when is_binary(text) do
+    text = to_text(text)
+
+    if byte_size(text) > @render_byte_cap do
+      text
+    else
+      do_provisional_close(text)
+    end
+  rescue
+    _ -> to_text(text)
+  end
+
+  defp do_provisional_close(text) do
+    # A still-in-progress last line consisting of ONLY 1-2 backticks (not
+    # yet the 3 that make a real fence -- see `fence_marker_of/1`),
+    # possibly followed by a partial language tag, is ambiguous: it might
+    # become a ``` fence on the next delta, or it might not. Either way
+    # it must never be scanned as inline code -- "``" alone is a code
+    # span whose captured content would be empty, which the renderer's
+    # regex can't match (requires >= 1 char), so it would leak as
+    # literal backticks. Stripping it from the render-only copy is the
+    # same tail-strip the inline scan below applies to a content-free
+    # opener.
+    text = strip_ambiguous_fence_opener(text)
+    lines = String.split(text, "\n")
+    {fence_marker, tagged_lines} = fence_scan(lines)
+
+    if fence_marker do
+      text <> "\n" <> fence_marker
+    else
+      prose_lines = for {:prose, line} <- tagged_lines, do: line
+      prose_text = Enum.join(prose_lines, "\n")
+      {erasures, closer} = resolve_inline_close(prose_text)
+      corrected_prose_text = apply_erasures(prose_text, erasures) <> closer
+      reassemble(tagged_lines, corrected_prose_text)
+    end
+  end
+
+  @fence_opener_ambiguous ~r/^`{1,2}\w*$/
+
+  defp strip_ambiguous_fence_opener(text) do
+    if String.ends_with?(text, "\n") do
+      text
+    else
+      last_line = text |> String.split("\n") |> List.last()
+
+      if last_line != "" and Regex.match?(@fence_opener_ambiguous, last_line) do
+        drop_last_graphemes(text, String.length(last_line))
+      else
+        text
+      end
+    end
+  end
+
+  # Toggles fence state per fence-marker line, tagging every line (in
+  # original order) as `{:fence, line}` or `{:prose, line}` so
+  # `reassemble/2` can splice a corrected prose rendering back into its
+  # original position without disturbing fenced content. A fence only
+  # closes on a line that opens with the SAME marker (```` ``` ```` vs
+  # `~~~`) it was opened with -- a stray line of the OTHER marker type
+  # while a fence is open is just fence content, not a closer. Returns
+  # the marker string that is still open (or `false` if every fence
+  # closed) as the first element.
+  defp fence_scan(lines) do
+    {fence_marker, tagged_rev} =
+      Enum.reduce(lines, {false, []}, fn line, {fence_marker, acc} ->
+        {new_marker, tag} = fence_step(fence_marker, fence_marker_of(line))
+        {new_marker, [{tag, line} | acc]}
+      end)
+
+    {fence_marker, Enum.reverse(tagged_rev)}
+  end
+
+  # One line's contribution to the fence state machine: `fence_marker` is
+  # the currently-open marker (or `false`), `line_marker` is what THIS
+  # line looks like as a fence opener/closer (or `nil` for an ordinary
+  # line). Returns `{new_fence_marker, tag}` where `tag` is `:fence` for
+  # an opener, closer, or already-inside-a-fence line, `:prose` otherwise.
+  defp fence_step(false, nil), do: {false, :prose}
+  defp fence_step(false, line_marker), do: {line_marker, :fence}
+  defp fence_step(marker, marker), do: {false, :fence}
+  defp fence_step(marker, _line_marker), do: {marker, :fence}
+
+  defp fence_marker_of(line) do
+    trimmed = String.trim_leading(line)
+
+    cond do
+      String.starts_with?(trimmed, "```") -> "```"
+      String.starts_with?(trimmed, "~~~") -> "~~~"
+      true -> nil
+    end
+  end
+
+  # Splices `corrected_prose_text` (the inline-closed rendering of just
+  # the prose lines, joined by "\n") back into `tagged_lines`' original
+  # line order, leaving every `:fence` line byte-identical to the
+  # source. Safe because inline closing/erasure never adds or removes a
+  # "\n": `String.split(corrected_prose_text, "\n")` always yields
+  # exactly as many lines as there were `:prose` entries.
+  defp reassemble(tagged_lines, corrected_prose_text) do
+    corrected_prose_lines = String.split(corrected_prose_text, "\n")
+
+    {lines, _remaining} =
+      Enum.map_reduce(tagged_lines, corrected_prose_lines, fn
+        {:fence, line}, remaining -> {line, remaining}
+        {:prose, _line}, [next | remaining] -> {next, remaining}
+        {:prose, _line}, [] -> {"", []}
+      end)
+
+    Enum.join(lines, "\n")
+  end
+
+  # Determines how the LIVE TAIL of `prose_text` (the portion after the
+  # last durable line boundary) should be provisionally closed, in a
+  # SINGLE left-to-right pass -- O(byte_size(prose_text)):
+  #
+  #   1. one scan (`scan_markers/3`) builds the open-construct stack,
+  #      each frame `{kind, opener_index}`, O(1) per grapheme;
+  #   2. one tail-walk (`unwind/3`) resolves it into a set of graphemes
+  #      to erase plus (at most) one trailing closer.
+  #
+  # Why erasure is needed at all: naively appending a closer for a
+  # construct with NO content yet (its opener is the last thing typed,
+  # e.g. "Summary of the **") produces a degenerate empty span ("****")
+  # the underlying renderer's regex won't match (it requires >= 1
+  # non-marker char between delimiters), which would leak the raw marker
+  # right back out. And the renderer's flat grammar can represent only
+  # ONE active emphasis/code/link run at a time -- so if the cut lands
+  # inside real nesting (two or more DIFFERENT kinds open at once, e.g. a
+  # bold span containing an unfinished italic run), only the outermost
+  # one can be closed; any inner opener that never closed is erased
+  # instead (its real content is kept, just no longer styled as its own
+  # separate construct). Both cases are handled by the same mechanism:
+  # `unwind/3` erases an opener's own token rather than closing it,
+  # either because there was nothing after it (content-free) or because
+  # something else still encloses it.
+  #
+  # Returns `{erasures, closer}` where `erasures` is a list of
+  # `{grapheme_index, grapheme_count}` ranges (each identifying a set of
+  # opener graphemes to drop from `prose_text`) and `closer` is the
+  # (possibly empty) string to append after erasure.
+  defp resolve_inline_close(prose_text) do
+    graphemes = String.graphemes(prose_text)
+    stack = scan_markers(graphemes, 0, [])
+    unwind(stack, length(graphemes), [])
+  end
+
+  defp unwind([], _pos, erasures), do: {erasures, ""}
+
+  defp unwind([{kind, idx} | tail], pos, erasures) do
+    len = opener_len(kind)
+
+    cond do
+      idx + len == pos ->
+        # opener flush against the tail -> content-free -> erase it and
+        # move the tail back over its token, then re-examine what's
+        # below (a chain of nested empty openers collapses fully here,
+        # no re-scan needed).
+        unwind(tail, idx, [{idx, len} | erasures])
+
+      tail == [] ->
+        # the outermost surviving frame, with genuine content after it --
+        # the one construct the flat grammar can still close.
+        {erasures, closer_for(kind)}
+
+      true ->
+        # genuine content follows, but something else still (differently)
+        # encloses this frame -- true nesting truncated mid-stream. The
+        # flat grammar can only keep one run open at a time, so this
+        # inner marker can't be honored as styling; erase just its own
+        # opener token (the real content after it is preserved,
+        # attributed to whatever encloses it) and let the enclosing
+        # frame resolve against the true tail.
+        unwind(tail, pos, [{idx, len} | erasures])
+    end
+  end
+
+  # Grapheme length of a construct's OPENING token (what `unwind/3` erases
+  # for a content-free or un-nestable frame). `:link_url`'s opener is the
+  # lone `(` -- the `]` belongs to the link text and must survive -- hence 1.
+  defp opener_len(:bold_star), do: 2
+  defp opener_len(:bold_under), do: 2
+  defp opener_len(:code), do: 1
+  defp opener_len(:italic_star), do: 1
+  defp opener_len(:italic_under), do: 1
+  defp opener_len(:link_text), do: 1
+  defp opener_len(:link_url), do: 1
+
+  defp drop_last_graphemes(text, 0), do: text
+
+  defp drop_last_graphemes(text, n) do
+    text |> String.graphemes() |> Enum.drop(-n) |> Enum.join()
+  end
+
+  # Removes every grapheme covered by `erasures` (a list of
+  # `{start_index, count}` ranges over `text`'s own grapheme list) --
+  # used to drop a stripped opener's token from wherever it sits in
+  # `text`, not just its tail.
+  defp apply_erasures(text, []), do: text
+
+  defp apply_erasures(text, erasures) do
+    erased_indices =
+      for {idx, len} <- erasures,
+          i <- idx..(idx + len - 1),
+          into: MapSet.new(),
+          do: i
+
+    text
+    |> String.graphemes()
+    |> Enum.with_index()
+    |> Enum.reject(fn {_grapheme, i} -> MapSet.member?(erased_indices, i) end)
+    |> Enum.map_join(&elem(&1, 0))
+  end
+
+  # Single left-to-right pass building a stack of `{kind, opener_index}`
+  # open constructs (top first; `opener_index` = the grapheme position of
+  # the construct's opening token). O(1) per grapheme -- push/pop plus an
+  # index bump, never any work proportional to stack depth. Whether a
+  # frame is ultimately content-free, or is un-nestable next to a
+  # different already-open kind, is NOT tracked here; `unwind/3` derives
+  # both, once, at the tail.
+  #
+  # Precedence: whenever the stack is topped by `:code`, every grapheme is
+  # literal except the matching closing backtick (CommonMark: nothing is
+  # parsed inside an inline code span). Otherwise `**`/`__` (two-grapheme
+  # lookahead) are checked before single `*`/`_` so bold is preferred over
+  # italic on a run of stars/underscores, matching common nesting.
+  defp scan_markers([], _idx, stack), do: stack
+
+  # inside a code span: every grapheme literal until the matching backtick
+  defp scan_markers([grapheme | rest], idx, [{:code, _} | tail] = stack) do
+    if grapheme == "`",
+      do: scan_markers(rest, idx + 1, tail),
+      else: scan_markers(rest, idx + 1, stack)
+  end
+
+  defp scan_markers(["*", "*" | rest], idx, stack),
+    do: toggle(:bold_star, rest, idx, 2, stack)
+
+  defp scan_markers(["_", "_" | rest], idx, stack),
+    do: toggle(:bold_under, rest, idx, 2, stack)
+
+  # `](` closes the (now-complete) link text and opens the URL. The URL's
+  # opener is the lone `(` at `idx + 1`: stripping a content-free URL then
+  # removes only `(`, leaving the `]` that terminates the link text.
+  defp scan_markers(["]", "(" | rest], idx, stack),
+    do: enter_link_url(rest, idx, stack)
+
+  defp scan_markers(["`" | rest], idx, stack),
+    do: toggle(:code, rest, idx, 1, stack)
+
+  defp scan_markers(["*" | rest], idx, stack),
+    do: toggle(:italic_star, rest, idx, 1, stack)
+
+  defp scan_markers(["_" | rest], idx, stack),
+    do: toggle(:italic_under, rest, idx, 1, stack)
+
+  defp scan_markers(["[" | rest], idx, stack),
+    do: scan_markers(rest, idx + 1, [{:link_text, idx} | stack])
+
+  defp scan_markers(["]" | rest], idx, stack),
+    do: close_marker(:link_text, rest, idx, 1, stack)
+
+  defp scan_markers([")" | rest], idx, stack),
+    do: close_marker(:link_url, rest, idx, 1, stack)
+
+  defp scan_markers([_grapheme | rest], idx, stack),
+    do: scan_markers(rest, idx + 1, stack)
+
+  defp toggle(kind, rest, idx, len, stack) do
+    case stack do
+      [{^kind, _} | tail] -> scan_markers(rest, idx + len, tail)
+      _ -> scan_markers(rest, idx + len, [{kind, idx} | stack])
+    end
+  end
+
+  defp enter_link_url(rest, idx, stack) do
+    case stack do
+      [{:link_text, _} | tail] ->
+        scan_markers(rest, idx + 2, [{:link_url, idx + 1} | tail])
+
+      _ ->
+        scan_markers(rest, idx + 2, stack)
+    end
+  end
+
+  defp close_marker(kind, rest, idx, len, stack) do
+    case stack do
+      [{^kind, _} | tail] -> scan_markers(rest, idx + len, tail)
+      _ -> scan_markers(rest, idx + len, stack)
+    end
+  end
+
+  defp closer_for(:code), do: "`"
+  defp closer_for(:bold_star), do: "**"
+  defp closer_for(:bold_under), do: "__"
+  defp closer_for(:italic_star), do: "*"
+  defp closer_for(:italic_under), do: "_"
+  defp closer_for(:link_text), do: "]"
+  defp closer_for(:link_url), do: ")"
+end

--- a/lib/raxol/ui/components/markdown_renderer.ex
+++ b/lib/raxol/ui/components/markdown_renderer.ex
@@ -24,6 +24,12 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
   @hr_width 40
   @ul_prefix "  * "
   @blockquote_prefix "| "
+  # GFM tables never shrink a column to zero width. Below this floor columns stop shrinking:
+  # cells are clipped to the floor with an ellipsis and the row as a whole
+  # is then wider than `width`, so the layout wraps/overflows that line
+  # like any other long text() -- NOT a horizontal scroll (there is no
+  # scroll surface here; "scrollable" is the aspirational end state).
+  @min_col_width 3
 
   @spec init(map()) ::
           {:ok, %{markdown_text: String.t(), width: non_neg_integer()}}
@@ -371,20 +377,39 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
 
   defp parse_blocks([], _width, acc), do: acc
 
-  # Fenced code block
+  # Fenced code block. GFM allows either ```` ``` ```` or `~~~` as the
+  # fence marker; a fence only closes on a line using the SAME marker it
+  # opened with, so a stray line of the other marker type while the fence
+  # is open is fence CONTENT, not a closer (mismatched fences never
+  # prematurely end the block).
   defp parse_blocks(["```" <> _ | rest], width, acc) do
-    {code_lines, remaining} = take_until_fence(rest, [])
+    parse_fenced_block("```", rest, width, acc)
+  end
 
-    code_elements =
-      Enum.map(code_lines, fn line ->
-        Components.text(content: "  " <> line, style: @code_style)
-      end)
+  defp parse_blocks(["~~~" <> _ | rest], width, acc) do
+    parse_fenced_block("~~~", rest, width, acc)
+  end
 
-    new_acc =
-      [Components.text(content: "") | code_elements] ++
-        [Components.text(content: "") | acc]
-
-    parse_blocks(remaining, width, new_acc)
+  # GFM table: a header row immediately followed by a separator-shaped row
+  # (`|---|---|`). Both must be present as their own lines in the buffer --
+  # a lone in-progress header (the last streamed line, no following line
+  # yet) can't satisfy this 2-line lookahead, so it renders as plain text
+  # rather than flashing a broken frame. The separator check is lenient
+  # (`separator_row?/1` accepts a partial `|--`), so complete-header +
+  # partial-separator DOES render -- a premature but well-formed frame
+  # (header + separator, body rows fill in as they stream). That is the
+  # intended benign streaming behavior, never a zero-width collapse.
+  defp parse_blocks([header, sep | rest], width, acc) do
+    if table_row?(header) and separator_row?(sep) do
+      header_cells = split_table_row(header)
+      {row_lines, remaining} = take_table_rows(rest, [], length(header_cells))
+      body_rows = Enum.map(row_lines, &split_table_row/1)
+      table_elements = render_table_rows(header_cells, body_rows, width)
+      parse_blocks(remaining, width, Enum.reverse(table_elements) ++ acc)
+    else
+      elements = parse_line(header, width)
+      parse_blocks([sep | rest], width, Enum.reverse(elements) ++ acc)
+    end
   end
 
   defp parse_blocks([line | rest], width, acc) do
@@ -536,9 +561,175 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
 
   defp slice_group(text, {start, len}), do: String.slice(text, start, len)
 
-  defp take_until_fence([], acc), do: {Enum.reverse(acc), []}
-  defp take_until_fence(["```" <> _ | rest], acc), do: {Enum.reverse(acc), rest}
+  defp parse_fenced_block(marker, rest, width, acc) do
+    {code_lines, remaining} = take_until_fence(rest, marker, [])
 
-  defp take_until_fence([line | rest], acc),
-    do: take_until_fence(rest, [line | acc])
+    code_elements =
+      Enum.map(code_lines, fn line ->
+        Components.text(content: "  " <> line, style: @code_style)
+      end)
+
+    new_acc =
+      [Components.text(content: "") | code_elements] ++
+        [Components.text(content: "") | acc]
+
+    parse_blocks(remaining, width, new_acc)
+  end
+
+  defp take_until_fence([], _marker, acc), do: {Enum.reverse(acc), []}
+
+  defp take_until_fence([line | rest], marker, acc) do
+    if String.starts_with?(line, marker) do
+      {Enum.reverse(acc), rest}
+    else
+      take_until_fence(rest, marker, [line | acc])
+    end
+  end
+
+  # --- GFM table rendering (builtin path) ---
+  #
+  # A permissive-by-design detector: any line containing "|" is a
+  # candidate row; a candidate is a separator iff every "|"-delimited cell
+  # is only dashes (optionally `:`-flanked for alignment). This is
+  # deliberately lenient about a truncated separator (`"|---|--"` still
+  # matches) -- during streaming that just renders a slightly-premature
+  # table frame one prefix earlier, never a crash or a raw-pipe flash.
+
+  defp table_row?(line) do
+    trimmed = String.trim(line)
+    trimmed != "" and String.contains?(trimmed, "|")
+  end
+
+  defp separator_row?(line) do
+    String.contains?(line, "|") and
+      line
+      |> String.trim()
+      |> String.trim("|")
+      |> String.split("|")
+      |> then(fn cells ->
+        cells != [] and Enum.all?(cells, &separator_cell?/1)
+      end)
+  end
+
+  defp separator_cell?(cell), do: Regex.match?(~r/^\s*:?-+:?\s*$/, cell)
+
+  defp split_table_row(line) do
+    line
+    |> String.trim()
+    |> String.trim("|")
+    |> String.split("|")
+    |> Enum.map(&String.trim/1)
+  end
+
+  # Consumes subsequent lines that still look like a row of THIS table: a
+  # leading "|" (the header/separator convention every existing table in
+  # this codebase follows) AND the same number of cells as the header. A
+  # blank line, a non-tabular line, or a "|"-containing line that doesn't
+  # match that shape (ordinary prose that happens to contain a stray "|"
+  # -- cell count alone isn't enough to rule this out for a 2-column
+  # table, where any single stray "|" trivially produces 2 cells) stops
+  # the row and is left in `remaining` for normal block parsing -- GFM
+  # tables don't span a blank/non-tabular-shaped line.
+  defp take_table_rows([line | rest], acc, col_count) do
+    if table_row_shaped?(line, col_count) do
+      take_table_rows(rest, [line | acc], col_count)
+    else
+      {Enum.reverse(acc), [line | rest]}
+    end
+  end
+
+  defp take_table_rows([], acc, _col_count), do: {Enum.reverse(acc), []}
+
+  defp table_row_shaped?(line, col_count) do
+    table_row?(line) and String.starts_with?(String.trim(line), "|") and
+      length(split_table_row(line)) == col_count
+  end
+
+  defp render_table_rows([], [], _width), do: []
+
+  defp render_table_rows(header_cells, body_rows, width) do
+    col_count =
+      Enum.max([length(header_cells) | Enum.map(body_rows, &length/1)])
+
+    header = pad_row(header_cells, col_count)
+    rows = Enum.map(body_rows, &pad_row(&1, col_count))
+
+    natural_widths = column_widths([header | rows], col_count)
+    final_widths = fit_widths(natural_widths, width, col_count)
+
+    header_row = table_row_text(header, final_widths)
+    separator_row = table_separator_text(final_widths)
+    body_texts = Enum.map(rows, &table_row_text(&1, final_widths))
+
+    Enum.concat([header_row, separator_row | body_texts], [
+      Components.text(content: "")
+    ])
+  end
+
+  defp pad_row(cells, col_count) do
+    cells
+    |> Kernel.++(List.duplicate("", max(col_count - length(cells), 0)))
+    |> Enum.take(col_count)
+  end
+
+  defp column_widths(rows, col_count) do
+    for i <- 0..(col_count - 1) do
+      rows
+      |> Enum.map(fn row ->
+        row |> Enum.at(i, "") |> TextMeasure.display_width()
+      end)
+      |> Enum.max()
+      |> max(@min_col_width)
+    end
+  end
+
+  # Shrinks natural column widths to fit `width` when possible; below the
+  # `@min_col_width` floor it stops shrinking and accepts a row wider than
+  # `width` (the documented "scrollable" degradation) rather than crush
+  # any column to zero.
+  defp fit_widths(widths, width, col_count) do
+    overhead = 3 * col_count + 1
+    budget = width - overhead
+    total = Enum.sum(widths)
+
+    cond do
+      total <= budget ->
+        widths
+
+      budget < col_count * @min_col_width ->
+        List.duplicate(@min_col_width, col_count)
+
+      true ->
+        shrink_proportionally(widths, budget)
+    end
+  end
+
+  defp shrink_proportionally(widths, budget) do
+    total = Enum.sum(widths)
+    Enum.map(widths, fn w -> max(@min_col_width, div(w * budget, total)) end)
+  end
+
+  defp table_row_text(cells, widths) do
+    cells_str =
+      cells
+      |> Enum.zip(widths)
+      |> Enum.map_join(" | ", fn {cell, w} -> pad_cell(cell, w) end)
+
+    Components.text(content: "| " <> cells_str <> " |")
+  end
+
+  defp table_separator_text(widths) do
+    seps = Enum.map_join(widths, "-|-", &String.duplicate("-", &1))
+    Components.text(content: "|-" <> seps <> "-|", style: @hr_style)
+  end
+
+  defp pad_cell(text, width) do
+    display_w = TextMeasure.display_width(text)
+
+    cond do
+      display_w == width -> text
+      display_w < width -> text <> String.duplicate(" ", width - display_w)
+      true -> TextLayout.truncate(text, width, :ellipsis)
+    end
+  end
 end

--- a/test/raxol/ui/components/harness/markdown_body_test.exs
+++ b/test/raxol/ui/components/harness/markdown_body_test.exs
@@ -1,0 +1,1260 @@
+defmodule Raxol.UI.Components.Harness.MarkdownBodyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Harness.Fixture
+  alias Raxol.UI.Components.Harness.{Block, MarkdownBody}
+  alias Raxol.UI.Components.MarkdownRenderer
+
+  @fixture_path "test/fixtures/harness/sessions/markdown-stream.jsonl"
+
+  # --- shared tree helpers (same conventions as markdown_renderer_test.exs
+  # and block_test.exs: a local recursive flattener over the
+  # `%{type: :column | :row | :text, ...}` element tree) ---
+
+  defp flat_texts(%{type: :text, content: content}), do: [content]
+
+  defp flat_texts(%{type: :row, children: children}),
+    do: Enum.flat_map(children, &flat_texts/1)
+
+  defp flat_texts(%{type: :column, children: children}),
+    do: Enum.flat_map(children, &flat_texts/1)
+
+  defp flat_texts(_), do: []
+
+  defp full_text(rendered), do: rendered |> flat_texts() |> Enum.join("\n")
+
+  defp assert_zero_gaps(%{type: type} = node) when type in [:column, :row] do
+    assert Map.get(node, :gap) == 0,
+           "#{type} container missing explicit gap: 0 -> #{inspect(node)}"
+
+    node |> Map.get(:children, []) |> Enum.each(&assert_zero_gaps/1)
+  end
+
+  defp assert_zero_gaps(%{children: children}) when is_list(children) do
+    Enum.each(children, &assert_zero_gaps/1)
+  end
+
+  defp assert_zero_gaps(_node), do: :ok
+
+  # A rendered view must never leak a Markdown marker character as
+  # literal text: every one of these is either consumed into a styled
+  # span (bold/italic/code) or a fence delimiter line that never appears
+  # in the output at all. Mirrors the existing suite's own convention
+  # (`refute full_text(result) =~ "*"` etc. in markdown_renderer_test.exs).
+  defp assert_no_raw_marker_leak(text) do
+    refute text =~ "```",
+           "fence marker leaked into rendered text: #{inspect(text)}"
+
+    refute text =~ "*", "'*' leaked into rendered text: #{inspect(text)}"
+    refute text =~ "_", "'_' leaked into rendered text: #{inspect(text)}"
+    refute text =~ "`", "'`' leaked into rendered text: #{inspect(text)}"
+  end
+
+  # --- the golden fixture: 17 real delta chunks + the item_completed
+  # content, loaded live from the fixture file (never hardcoded) so this
+  # suite stays in sync with the recorded session. ---
+
+  defp golden_deltas_and_final do
+    {:ok, session} = Fixture.load(@fixture_path)
+
+    chunks =
+      session
+      |> Fixture.Session.by_type(:item_delta)
+      |> Enum.map(& &1.body.payload["chunk"])
+
+    [completed] = Fixture.Session.by_type(session, :item_completed)
+    final = completed.body.payload["content"]
+
+    {chunks, final}
+  end
+
+  defp delta_prefixes(chunks), do: Enum.scan(chunks, "", &(&2 <> &1))
+
+  # --- render/2 basic dispatch ---
+
+  describe "render/2 dispatch" do
+    test "defaults to :sealed mode when context is omitted" do
+      rendered = MarkdownBody.render("**bold**")
+      assert full_text(rendered) =~ "bold"
+      refute full_text(rendered) =~ "*"
+    end
+
+    test ":sealed mode does a plain full parse (no provisional close applied)" do
+      rendered = MarkdownBody.render("**unclosed", %{mode: :sealed, width: 80})
+      # sealed trusts the content is final -- an actually-unclosed marker
+      # in already-final content passes through exactly as MarkdownRenderer
+      # would render it directly (existing "lone unmatched marker" behavior).
+      direct = MarkdownRenderer.render_with_builtin("**unclosed", 80)
+
+      assert flat_texts(%{type: :column, children: direct, gap: 0}) ==
+               flat_texts(rendered)
+    end
+
+    test ":streaming mode applies provisional close before rendering" do
+      rendered =
+        MarkdownBody.render("some **bold", %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+
+      assert text =~ "bold"
+      refute text =~ "*"
+    end
+  end
+
+  # --- P-MD-03: sealed render == full parse, provisional close discarded ---
+
+  describe "P-MD-03 — sealed render equals full parse" do
+    test "render_sealed on the golden doc's final content matches MarkdownRenderer directly" do
+      {_chunks, final} = golden_deltas_and_final()
+
+      sealed = MarkdownBody.render_sealed(final, 80)
+      direct = MarkdownRenderer.render_with_builtin(final, 80)
+
+      assert flat_texts(sealed) ==
+               flat_texts(%{type: :column, children: direct, gap: 0})
+    end
+
+    test "an incomplete construct in the LAST delta-prefix never survives into the sealed render" do
+      {chunks, final} = golden_deltas_and_final()
+      last_prefix = chunks |> delta_prefixes() |> List.last()
+
+      # the last prefix is exactly the full accumulated text; sealed
+      # render of the true final content must equal full parse, never a
+      # leftover provisional-close artifact from the streaming path.
+      assert last_prefix == final
+
+      assert full_text(MarkdownBody.render_sealed(final, 80)) ==
+               full_text(MarkdownBody.render_sealed(last_prefix, 80))
+    end
+  end
+
+  # --- P-MD-01 / P-MD-02: no raw-marker leak + never raises, at EVERY prefix ---
+
+  describe "P-MD-01/02 — no raw-marker leak, never raises, at every prefix of the golden doc" do
+    test "all 17 delta-boundary prefixes render without leaking a marker" do
+      {chunks, _final} = golden_deltas_and_final()
+      prefixes = delta_prefixes(chunks)
+      assert length(prefixes) == 17
+
+      for prefix <- prefixes do
+        rendered = MarkdownBody.render(prefix, %{mode: :streaming, width: 80})
+        assert %{type: :column} = rendered
+        assert_no_raw_marker_leak(full_text(rendered))
+      end
+    end
+
+    test "every character-granular prefix (not just chunk boundaries) renders without leaking a marker" do
+      {_chunks, final} = golden_deltas_and_final()
+      length = String.length(final)
+
+      for n <- 0..length do
+        prefix = String.slice(final, 0, n)
+        rendered = MarkdownBody.render(prefix, %{mode: :streaming, width: 80})
+        assert %{type: :column} = rendered
+        assert_no_raw_marker_leak(full_text(rendered))
+      end
+    end
+
+    property "arbitrary byte-prefixes of the golden doc never raise and never leak a fence marker" do
+      {_chunks, final} = golden_deltas_and_final()
+      byte_len = byte_size(final)
+
+      check all(cut <- integer(0..byte_len), max_runs: 200) do
+        # `binary_part` may cut mid multi-byte grapheme -- exercising
+        # exactly the "incl. mid-grapheme" axis N-MDFUZZ-02 calls for.
+        prefix = binary_part(final, 0, cut)
+
+        rendered = MarkdownBody.render(prefix, %{mode: :streaming, width: 80})
+        assert %{type: :column} = rendered
+        # a split multi-byte grapheme can legitimately alter which glyphs
+        # show up, but the fence delimiter itself is pure ASCII and must
+        # never survive as literal text regardless of the cut point.
+        refute full_text(rendered) =~ "```"
+      end
+    end
+  end
+
+  # --- P-MD-05: monotone-ish append (no from-scratch flashing of earlier lines) ---
+
+  describe "P-MD-05 — provisional-close is monotone-ish across the delta stream" do
+    test "each fully-arrived line's rendered text is never removed by a later delta" do
+      {chunks, _final} = golden_deltas_and_final()
+      prefixes = delta_prefixes(chunks)
+
+      prefixes
+      |> Enum.zip(tl(prefixes))
+      |> Enum.each(fn {before, after_} ->
+        # only meaningful right at a natural line boundary -- `before`
+        # ending mid-line means its OWN last (in-progress) line was never
+        # "fully arrived" and is expected to change.
+        if String.ends_with?(before, "\n") do
+          before_text =
+            full_text(
+              MarkdownBody.render(before, %{mode: :streaming, width: 80})
+            )
+
+          after_text =
+            full_text(
+              MarkdownBody.render(after_, %{mode: :streaming, width: 80})
+            )
+
+          assert String.starts_with?(after_text, before_text),
+                 "later render dropped/rewrote earlier committed content\nbefore: #{inspect(before_text)}\nafter: #{inspect(after_text)}"
+        end
+      end)
+    end
+  end
+
+  # --- P-MD-04 / table degradation: never a zero-width column collapse ---
+
+  describe "P-MD-04 — tables degrade to a scrollable/clipped block, never zero-width columns" do
+    defp table_lines(rendered) do
+      rendered |> flat_texts() |> Enum.filter(&(&1 =~ "|"))
+    end
+
+    defp table_cells(line) do
+      line
+      |> String.trim()
+      |> String.trim("|")
+      |> String.split("|")
+      |> Enum.map(&String.trim/1)
+    end
+
+    test "the golden doc's real table renders with no empty cell at a normal width" do
+      {_chunks, final} = golden_deltas_and_final()
+      rendered = MarkdownBody.render_sealed(final, 80)
+
+      [header, separator | rows] = table_lines(rendered)
+      assert table_cells(header) == ["check", "status", "ms"]
+      refute Enum.any?(table_cells(separator), &(&1 == ""))
+      assert length(rows) == 3
+
+      for row <- rows, cell <- table_cells(row) do
+        refute cell == "",
+               "a table cell collapsed to zero width: #{inspect(row)}"
+      end
+    end
+
+    test "an unclosed (still-streaming) table never collapses a column to zero width" do
+      partial =
+        "| check | status | ms |\n|---|---|---|\n| compile | ok | 812 "
+
+      for width <- [1, 2, 3, 5, 8, 10, 40, 80] do
+        rendered =
+          MarkdownBody.render(partial, %{mode: :streaming, width: width})
+
+        for line <- table_lines(rendered), cell <- table_cells(line) do
+          refute cell == "",
+                 "width #{width}: a table cell collapsed to zero width -> #{inspect(line)}"
+        end
+      end
+    end
+
+    test "extremely narrow width still never collapses a wide table's columns" do
+      wide =
+        "| alpha column | beta column | gamma column | delta column |\n" <>
+          "|---|---|---|---|\n" <>
+          "| one | two | three | four |\n"
+
+      rendered = MarkdownBody.render_sealed(wide, 10)
+
+      for line <- table_lines(rendered), cell <- table_cells(line) do
+        refute cell == "",
+               "column collapsed to zero width at narrow forced width"
+      end
+    end
+  end
+
+  # --- provisional_close/1: the closer for each construct named in the roadmap ---
+
+  describe "provisional_close/1 — construct-by-construct" do
+    test "does nothing to already-well-formed text" do
+      assert MarkdownBody.provisional_close("plain text, no markers") ==
+               "plain text, no markers"
+    end
+
+    test "closes an unclosed fenced code block" do
+      closed = MarkdownBody.provisional_close("```elixir\ndef foo do\n  :ok")
+      assert String.ends_with?(closed, "\n```")
+
+      rendered = closed |> then(&MarkdownRenderer.render_with_builtin(&1, 80))
+
+      full =
+        flat_texts(%{type: :column, children: rendered, gap: 0})
+        |> Enum.join("\n")
+
+      refute full =~ "```"
+      assert full =~ "def foo do"
+    end
+
+    test "closes unclosed bold (**)" do
+      closed = MarkdownBody.provisional_close("some **bold text")
+      assert closed == "some **bold text**"
+    end
+
+    test "closes unclosed bold (__)" do
+      closed = MarkdownBody.provisional_close("some __bold text")
+      assert closed == "some __bold text__"
+    end
+
+    test "closes unclosed italic (*)" do
+      closed = MarkdownBody.provisional_close("some *italic text")
+      assert closed == "some *italic text*"
+    end
+
+    test "closes unclosed italic (_)" do
+      closed = MarkdownBody.provisional_close("some _italic text")
+      assert closed == "some _italic text_"
+    end
+
+    test "closes an unclosed inline code span" do
+      closed = MarkdownBody.provisional_close("run `mix test")
+      assert closed == "run `mix test`"
+    end
+
+    test "closes nested constructs in LIFO order" do
+      # bold opened, then italic opened, then italic closed inline via **;
+      # only bold remains open by the end.
+      closed = MarkdownBody.provisional_close("**bold and *italic* still bold")
+      assert closed == "**bold and *italic* still bold**"
+    end
+
+    test "an opener with NOTHING typed after it yet is stripped, never closed into an empty span" do
+      # Naively appending "**" here would produce "Summary of the ****" --
+      # a degenerate empty bold span the underlying regex parser can't
+      # match (it requires >= 1 non-marker char between delimiters), so
+      # the raw asterisks would leak right back out. Stripping the
+      # dangling opener is the correct provisional behavior instead.
+      closed = MarkdownBody.provisional_close("Summary of the **")
+      assert closed == "Summary of the "
+      refute closed =~ "*"
+    end
+
+    test "a nested opener with nothing after it strips just the inner marker, keeping the outer's real content" do
+      closed = MarkdownBody.provisional_close("**bold *")
+      assert closed == "**bold **"
+
+      rendered = closed |> then(&MarkdownRenderer.render_with_builtin(&1, 80))
+
+      full =
+        flat_texts(%{type: :column, children: rendered, gap: 0})
+        |> Enum.join("\n")
+
+      refute full =~ "*"
+      assert full =~ "bold"
+    end
+
+    test "a lone dangling opener with nothing else in the buffer strips to empty" do
+      assert MarkdownBody.provisional_close("**") == ""
+    end
+
+    test "an unclosed link's bracket is closed" do
+      closed = MarkdownBody.provisional_close("see [the docs")
+      assert closed == "see [the docs]"
+    end
+
+    test "an unclosed link URL is closed" do
+      closed =
+        MarkdownBody.provisional_close("see [the docs](http://example.com/path")
+
+      assert closed == "see [the docs](http://example.com/path)"
+    end
+
+    test "content inside an open fence is never touched by inline-marker closing" do
+      # a single '*' is common, legitimate Python/Elixir syntax and must
+      # not trigger italic-closing INSIDE the still-open code block.
+      closed =
+        MarkdownBody.provisional_close("```python\ndef foo(*args):\n    pass")
+
+      assert closed == "```python\ndef foo(*args):\n    pass\n```"
+    end
+
+    test "is a no-op for empty text" do
+      assert MarkdownBody.provisional_close("") == ""
+    end
+
+    test "never mutates its input -- returns a new string, source untouched" do
+      source = "some **bold"
+      _closed = MarkdownBody.provisional_close(source)
+      assert source == "some **bold"
+    end
+  end
+
+  # --- N-MDFUZZ: never raise, bounded, safe on adversarial/garbage input ---
+
+  describe "N-MDFUZZ-01 — arbitrary bytes never raise" do
+    property "garbage binaries always render some safe view" do
+      check all(garbage <- binary(max_length: 300), max_runs: 200) do
+        rendered = MarkdownBody.render(garbage, %{mode: :streaming, width: 80})
+        assert %{type: :column, children: children} = rendered
+        assert is_list(children)
+      end
+    end
+  end
+
+  describe "N-MDFUZZ-02 — byte-prefix fuzz of a small corpus, never raise, no leak" do
+    @corpus [
+      "# Title\n\n**bold** and _em_ and `code` and [link](http://x.io)\n\n" <>
+        "```elixir\ndef f, do: :ok\n```\n",
+      "| a | b |\n|---|---|\n| 1 | 2 |\n",
+      "- one\n- two\n  - nested *item*\n",
+      # unicode-heavy: CJK + emoji + combining marks, exercises
+      # mid-grapheme cuts (N-MDFUZZ-02's explicit axis).
+      "日本語のテキスト **強調** と 🇯🇵👨‍👩‍👧‍👦 絵文字 and café"
+    ]
+
+    property "every byte prefix of every corpus doc renders without raising" do
+      check all(
+              doc <- member_of(@corpus),
+              cut <- integer(0..300),
+              max_runs: 300
+            ) do
+        prefix = binary_part(doc, 0, min(cut, byte_size(doc)))
+
+        rendered = MarkdownBody.render(prefix, %{mode: :streaming, width: 80})
+        assert %{type: :column} = rendered
+        refute full_text(rendered) =~ "```"
+      end
+    end
+  end
+
+  describe "N-MDFUZZ-03 — pathological nesting stays bounded, no stack blow-up" do
+    test "many unclosed fences/bold/nesting complete quickly" do
+      pathological =
+        String.duplicate("```\n", 50) <>
+          String.duplicate("**", 200) <> String.duplicate("* item\n", 200)
+
+      {elapsed_us, rendered} =
+        :timer.tc(fn ->
+          MarkdownBody.render(pathological, %{mode: :streaming, width: 80})
+        end)
+
+      assert %{type: :column} = rendered
+      # generous bound -- the point is "doesn't hang", not a perf budget
+      assert elapsed_us < 2_000_000
+    end
+
+    test "deeply nested emphasis never raises" do
+      deep =
+        String.duplicate("*", 500) <> "center" <> String.duplicate("_", 500)
+
+      rendered = MarkdownBody.render(deep, %{mode: :streaming, width: 80})
+      assert %{type: :column} = rendered
+    end
+  end
+
+  # --- N-MDFUZZ-05: large-input performance (the O(n^2)/O(n^3) regression
+  # lock). Provisional close is single-pass O(n): one scan builds the
+  # open-construct stack, one tail-walk resolves it -- no re-scan loop, no
+  # per-char full-stack sweep. These would time out under the old
+  # rescan-per-strip + mark_content-per-char design. ---
+
+  describe "N-MDFUZZ-05 — large opener runs stay bounded (single-pass O(n))" do
+    @perf_bound_us 2_000_000
+
+    test "20k unclosed brackets render well under the never-hang bound" do
+      doc = String.duplicate("[", 20_000)
+
+      {elapsed_us, rendered} =
+        :timer.tc(fn ->
+          MarkdownBody.render(doc, %{mode: :streaming, width: 80})
+        end)
+
+      assert %{type: :column} = rendered
+
+      assert elapsed_us < @perf_bound_us,
+             "20k-bracket render took #{elapsed_us}us (bound #{@perf_bound_us})"
+
+      # all openers are content-free -> stripped away, no marker leak
+      refute rendered |> flat_texts() |> Enum.join("\n") =~ "["
+    end
+
+    test "50k unclosed brackets still bounded" do
+      doc = String.duplicate("[", 50_000)
+
+      {elapsed_us, rendered} =
+        :timer.tc(fn ->
+          MarkdownBody.render(doc, %{mode: :streaming, width: 80})
+        end)
+
+      assert %{type: :column} = rendered
+
+      assert elapsed_us < @perf_bound_us,
+             "50k-bracket render took #{elapsed_us}us (bound #{@perf_bound_us})"
+    end
+
+    test "mixed 10k brackets + 5k bold openers stays bounded" do
+      # The 5k "**" pair up (open/close), so they count as content after
+      # the 10k "[" -- those brackets get closed as literal "[...]" rather
+      # than stripped. Degenerate pure-marker runs like this render
+      # literally (empty "[]"/"**" spans have no styled form); the
+      # invariant under test here is the O(n) TIME bound, not the (moot)
+      # leak shape of an all-marker input.
+      doc = String.duplicate("[", 10_000) <> String.duplicate("**", 5_000)
+
+      {elapsed_us, rendered} =
+        :timer.tc(fn ->
+          MarkdownBody.render(doc, %{mode: :streaming, width: 80})
+        end)
+
+      assert %{type: :column} = rendered
+
+      assert elapsed_us < @perf_bound_us,
+             "mixed-opener render took #{elapsed_us}us (bound #{@perf_bound_us})"
+    end
+
+    test "cumulative streaming: provisional_close on every prefix 1..n of a large opener run stays bounded" do
+      # This is the real-world risk: an operator watches a message stream
+      # in, and the projection re-renders at EVERY delta. The sum of
+      # per-prefix work is the Theta(n^3) case pre-fix (each of n prefixes
+      # cost Theta(n^2)); single-pass makes each prefix O(k), so the sum is
+      # Theta(n^2) -- comfortably bounded here.
+      n = 2_000
+      openers = String.duplicate("[", n)
+      prefixes = for k <- 1..n, do: binary_part(openers, 0, k)
+
+      {elapsed_us, _results} =
+        :timer.tc(fn ->
+          Enum.each(prefixes, &MarkdownBody.provisional_close/1)
+        end)
+
+      assert elapsed_us < @perf_bound_us,
+             "cumulative #{n}-prefix stream took #{elapsed_us}us (bound #{@perf_bound_us})"
+    end
+
+    test "the >256KB degradation ceiling returns the text unchanged (no scan)" do
+      # Above the cap, provisional_close is skipped entirely -- a pure
+      # safety belt (the single-pass O(n) scan is the actual fix). Verify
+      # the degradation path is a fast identity return.
+      huge = String.duplicate("[", 300 * 1024)
+
+      {elapsed_us, result} =
+        :timer.tc(fn -> MarkdownBody.provisional_close(huge) end)
+
+      assert result == huge
+      assert elapsed_us < @perf_bound_us
+    end
+  end
+
+  describe "N-MDFUZZ-04 — adversarial width (ZWJ, RTL, control chars), width via TextMeasure" do
+    test "a table with wide/zero-width unicode content never crashes and stays framed" do
+      adversarial =
+        "| emoji | plain |\n|---|---|\n| 👨‍👩‍👧‍👦 | ​zero​ |\n"
+
+      rendered = MarkdownBody.render_sealed(adversarial, 40)
+      assert %{type: :column} = rendered
+      assert full_text(rendered) =~ "plain"
+    end
+
+    test "control characters and RTL override marks never crash the renderer" do
+      adversarial =
+        "some \u{202E}text\u{202C} with \u{0000} control \u{200D} chars"
+
+      rendered =
+        MarkdownBody.render(adversarial, %{mode: :streaming, width: 20})
+
+      assert %{type: :column} = rendered
+    end
+  end
+
+  # --- Wire-in: Block's :message/:reasoning content via context[:markdown] ---
+
+  describe "wire-in — Block.render/2 opt-in markdown option (T26 step 5)" do
+    defp message_events(content) do
+      [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{item_type: :message, content: content}
+        }
+      ]
+    end
+
+    test "default (no :markdown key) renders exactly as before -- zero behavior change" do
+      block =
+        Block.from_events(:message, message_events("**bold** text"),
+          fold: :expanded
+        )
+
+      plain = Block.render(block, %{width: 80})
+      assert full_text(plain) =~ "**bold** text"
+    end
+
+    test "markdown: false explicitly behaves the same as omitted" do
+      block =
+        Block.from_events(:message, message_events("**bold** text"),
+          fold: :expanded
+        )
+
+      rendered = Block.render(block, %{width: 80, markdown: false})
+      assert full_text(rendered) =~ "**bold** text"
+    end
+
+    # The block HEADER always shows a raw first-line summary by design
+    # (`Block.summary/1` -- unrelated to T26, unaffected by the markdown
+    # option), so marker-leak assertions below check the CONTENT lines
+    # (everything after the header), not the whole tree.
+    defp content_only(rendered),
+      do: rendered |> flat_texts() |> tl() |> Enum.join("\n")
+
+    test "markdown: true on a SEALED message block does a full parse (no literal markers)" do
+      block =
+        Block.from_events(:message, message_events("some **bold** text"),
+          fold: :expanded
+        )
+        |> Block.seal()
+
+      rendered = Block.render(block, %{width: 80, markdown: true})
+
+      assert content_only(rendered) =~ "bold"
+      refute content_only(rendered) =~ "**"
+    end
+
+    test "markdown: true on a LIVE message block streams with provisional close" do
+      block =
+        Block.from_events(:message, message_events("some **bold"),
+          fold: :expanded
+        )
+
+      assert Block.live?(block)
+      rendered = Block.render(block, %{width: 80, markdown: true})
+
+      assert content_only(rendered) =~ "bold"
+      refute content_only(rendered) =~ "**"
+    end
+
+    test "markdown: true also applies to :reasoning blocks" do
+      events = [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{item_type: :reasoning, content: "thinking about **X**"}
+        }
+      ]
+
+      block =
+        Block.from_events(:reasoning, events, fold: :expanded) |> Block.seal()
+
+      rendered = Block.render(block, %{width: 80, markdown: true})
+
+      assert content_only(rendered) =~ "thinking about"
+      assert content_only(rendered) =~ "X"
+      refute content_only(rendered) =~ "**"
+    end
+
+    test "markdown: true does NOT affect other block kinds" do
+      events = [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{item_type: :tool_use, content: %{name: "Bash", args: %{}}}
+        },
+        %{
+          id: 2,
+          type: :item_completed,
+          payload: %{item_type: :tool_result, content: "**not markdown**"}
+        }
+      ]
+
+      block = Block.from_events(:tool_call, events, fold: :expanded)
+      rendered = Block.render(block, %{width: 80, markdown: true})
+
+      # tool_call bodies are never routed through MarkdownBody -- the
+      # literal content (including any '**') passes through unchanged.
+      assert full_text(rendered) =~ "**not markdown**"
+    end
+
+    test "folded blocks are unaffected by the markdown option (header-only render)" do
+      block =
+        Block.from_events(:message, message_events("**bold** text"),
+          fold: :folded
+        )
+
+      rendered = Block.render(block, %{width: 80, markdown: true})
+      assert length(flat_texts(rendered)) == 1
+    end
+
+    test "container gap discipline holds through the embedded MarkdownBody tree" do
+      block =
+        Block.from_events(
+          :message,
+          message_events(
+            "# Title\n\n**bold** and a table:\n\n| a | b |\n|---|---|\n| 1 | 2 |\n"
+          ),
+          fold: :expanded
+        )
+        |> Block.seal()
+
+      rendered = Block.render(block, %{width: 80, markdown: true})
+      assert_zero_gaps(rendered)
+    end
+
+    test "never raises even with markdown: true and malformed content" do
+      block = Block.from_events(:message, message_events(nil), fold: :expanded)
+      rendered = Block.render(block, %{width: 80, markdown: true})
+      assert %{type: :column} = rendered
+    end
+  end
+
+  # --- prominence fade reaches the Markdown body (the bright-body-under-
+  # faded-header gap): when a block is faded via context[:prominence], its
+  # Markdown body must fade in lockstep -- every body text node carries
+  # the same resolved :fg as the header, and a neutral (absent / 1.0)
+  # prominence leaves the body byte-identical to a no-fade markdown
+  # render. This case only exists once the T8 prominence wiring and the
+  # T26 markdown routing live in the same tree. ---
+
+  describe "markdown body fades with prominence" do
+    # every :fg value carried by a text node anywhere in the tree
+    defp text_node_fgs(%{type: :text, style: style}), do: [Map.get(style, :fg)]
+
+    defp text_node_fgs(%{children: children}),
+      do: Enum.flat_map(children, &text_node_fgs/1)
+
+    defp text_node_fgs(_), do: []
+
+    test "a faded block's markdown body text carries the SAME :fg as the header" do
+      block =
+        Block.from_events(
+          :message,
+          message_events("some **bold** and _em_ text across the body"),
+          fold: :expanded
+        )
+        |> Block.seal()
+
+      rendered =
+        Block.render(block, %{width: 80, markdown: true, prominence: 0.6})
+
+      fgs = text_node_fgs(rendered)
+
+      # the fade actually fired (a resolved colour, not neutral)...
+      assert [header_fg | _] = fgs
+      assert is_binary(header_fg)
+
+      # ...and EVERY text node (header + faded markdown body + outcome)
+      # carries that one resolved colour -- no bright body under a faded
+      # header.
+      assert Enum.all?(fgs, &(&1 == header_fg)),
+             "markdown body text did not fade to the header colour: #{inspect(fgs)}"
+    end
+
+    test "prominence 1.0 leaves the markdown body byte-identical to a no-fade render" do
+      source = "some **bold** and _em_ text"
+
+      block =
+        Block.from_events(:message, message_events(source), fold: :expanded)
+        |> Block.seal()
+
+      faded_1_0 =
+        Block.render(block, %{width: 80, markdown: true, prominence: 1.0})
+
+      neutral =
+        Block.render(block, %{width: 80, markdown: true})
+
+      # 1.0 is the neutral case: no :fg is added anywhere...
+      assert Enum.all?(text_node_fgs(faded_1_0), &is_nil/1)
+      # ...and it is identical to omitting :prominence entirely.
+      assert faded_1_0 == neutral
+
+      # the body content lines (everything past the header) match a direct
+      # MarkdownBody render of the same source -- routing untouched by the
+      # neutral prominence.
+      direct = MarkdownBody.render(source, %{width: 80, mode: :sealed})
+      assert content_only(neutral) == full_text(direct)
+    end
+
+    test "prominence fades a plain (non-markdown) body to the header colour too" do
+      # the same fade must hold on the plain path, so enabling markdown is
+      # not what makes fade work -- it is the shared resolved colour.
+      block =
+        Block.from_events(
+          :message,
+          message_events("line one\nline two\nline three"),
+          fold: :expanded
+        )
+        |> Block.seal()
+
+      rendered = Block.render(block, %{width: 80, prominence: 0.6})
+      fgs = text_node_fgs(rendered)
+
+      assert [header_fg | _] = fgs
+      assert is_binary(header_fg)
+      assert Enum.all?(fgs, &(&1 == header_fg))
+    end
+  end
+
+  # --- review round (Drew) ---------------------------------------------
+
+  # HIGH: nested-emphasis marker leak at the streaming tail. The
+  # renderer's builtin path uses a FLAT (non-recursive) regex grammar --
+  # it can represent at most one active emphasis/code/link run at a
+  # time. `provisional_close/1` used to close a genuinely nested,
+  # never-closed chain by emitting one closer per still-open frame
+  # (LIFO) -- a multi-character sequence like "***"/"___"/"`*" the flat
+  # grammar can't parse back out, so it leaked raw markers. The fix:
+  # only the OUTERMOST still-open construct gets a real closer; any
+  # inner construct that never closed has its own opening token erased
+  # instead (the real text after it is preserved, just no longer styled
+  # separately).
+  describe "review round (Drew), HIGH — nested-emphasis marker leak at the streaming tail" do
+    test "review example 1: italic containing an unfinished bold attempt never leaks '**'" do
+      rendered =
+        MarkdownBody.render("note: *very **important", %{
+          mode: :streaming,
+          width: 80
+        })
+
+      text = full_text(rendered)
+      refute text =~ "*"
+      assert text =~ "very"
+      assert text =~ "important"
+    end
+
+    test "review example 2: italic_under containing an unfinished bold_under attempt never leaks '__'" do
+      rendered =
+        MarkdownBody.render("text _a __b", %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+      refute text =~ "_"
+      assert text =~ "a"
+      assert text =~ "b"
+    end
+
+    test "review example 3: italic containing an unfinished code attempt never leaks a backtick" do
+      rendered = MarkdownBody.render("a *b `c", %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+      refute text =~ "`"
+      assert text =~ "b"
+      assert text =~ "c"
+    end
+
+    test "provisional_close itself: only the outer construct survives, the inner opener is erased" do
+      assert MarkdownBody.provisional_close("note: *very **important") ==
+               "note: *very important*"
+
+      assert MarkdownBody.provisional_close("text _a __b") == "text _a b_"
+      assert MarkdownBody.provisional_close("a *b `c") == "a *b c*"
+    end
+
+    # Generalizes the three examples above: an arbitrarily deep chain of
+    # GENUINELY nested (each level a different construct than its
+    # immediate parent), never-closed emphasis constructs, whose text
+    # leaves are letters/spaces only. Scoped to the four pure-emphasis
+    # kinds (bold/italic, star/underscore) -- `:code` and link-bracket
+    # nesting are deliberately excluded here: a code span's interior is
+    # verbatim by design (CommonMark), so another kind's marker chars
+    # legitimately surviving AS LITERAL CODE CONTENT when code is the
+    # surviving outer construct is correct behavior, not a leak; and a
+    # closed link-text bracket with no following `(url)` doesn't match
+    # the renderer's link alternative at all (it requires the URL
+    # suffix to recognize a link as a link) -- a separate, pre-existing
+    # renderer gap, not this fix's target.
+    #
+    # Each generated doc draws from only ONE star-family kind (bold_star
+    # XOR italic_star) and ONE underscore-family kind (bold_under XOR
+    # italic_under). The two kinds in a family share a delimiter
+    # character, so a byte-level cut landing mid a two-character opener
+    # (e.g. `**`) leaves a single leftover marker that the scanner reads
+    # as the OTHER, single-character member of that family -- if that
+    # sibling kind were ALSO genuinely open elsewhere on the stack, the
+    # leftover character would coincidentally (and correctly, per
+    # CommonMark) close it rather than exercise a still-open,
+    # never-closed frame. That's a real but SEPARATE, pre-existing
+    # rendering limitation (the flat grammar doesn't recursively
+    # re-parse a fully-resolved inner pair's content once it's embedded
+    # in an outer span -- see `markdown_renderer_test.exs`'s existing
+    # acceptance of "nested constructs in LIFO order"), not the
+    # never-closes-at-all leak this test targets; restricting each run
+    # to one kind per family keeps the fuzz focused on that.
+    @emphasis_openers %{
+      bold_star: "**",
+      bold_under: "__",
+      italic_star: "*",
+      italic_under: "_"
+    }
+
+    defp emphasis_leaf_gen do
+      [?a..?z, [?\s]]
+      |> Enum.concat()
+      |> StreamData.member_of()
+      |> StreamData.list_of(min_length: 1, max_length: 6)
+      |> StreamData.map(&List.to_string/1)
+    end
+
+    defp emphasis_kind_pool_gen do
+      StreamData.tuple(
+        {StreamData.member_of([:bold_star, :italic_star]),
+         StreamData.member_of([:bold_under, :italic_under])}
+      )
+      |> StreamData.map(&Tuple.to_list/1)
+    end
+
+    defp level_pair_gen(pool) do
+      StreamData.tuple({StreamData.member_of(pool), emphasis_leaf_gen()})
+    end
+
+    defp nested_never_closed_doc_gen do
+      StreamData.bind(emphasis_kind_pool_gen(), fn pool ->
+        StreamData.bind(emphasis_leaf_gen(), fn leading ->
+          StreamData.bind(
+            StreamData.list_of(level_pair_gen(pool),
+              min_length: 1,
+              max_length: 4
+            ),
+            fn levels ->
+              deduped = Enum.dedup_by(levels, fn {kind, _leaf} -> kind end)
+
+              doc =
+                leading <>
+                  Enum.map_join(deduped, fn {kind, leaf} ->
+                    Map.fetch!(@emphasis_openers, kind) <> leaf
+                  end)
+
+              StreamData.constant(doc)
+            end
+          )
+        end)
+      end)
+    end
+
+    property "every prefix of an arbitrarily nested, never-closed emphasis chain renders with no marker leak" do
+      check all(doc <- nested_never_closed_doc_gen(), max_runs: 200) do
+        len = String.length(doc)
+
+        for n <- 0..len do
+          prefix = String.slice(doc, 0, n)
+          # Exercise the builtin path directly (not `render/2`'s mode
+          # dispatch) so this stays load-bearing even if dispatch logic
+          # changes later -- EarmarkParser is a dev-only, compile-time
+          # dependency here (never present in :test or production), so
+          # the builtin regex parser is what actually ships; asserting
+          # against it directly removes any ambiguity about which
+          # parser produced the result.
+          closed = MarkdownBody.provisional_close(prefix)
+          elements = MarkdownRenderer.render_with_builtin(closed, 80)
+
+          text =
+            flat_texts(%{type: :column, children: elements, gap: 0})
+            |> Enum.join("\n")
+
+          refute text =~ ~r/[*_]/,
+                 "leaked a marker for prefix #{inspect(prefix)} -> closed #{inspect(closed)} -> #{inspect(text)}"
+        end
+      end
+    end
+  end
+
+  # MEDIUM: a delta can arrive mid multi-byte grapheme (an accented
+  # letter, CJK, or emoji split across a chunk boundary). Reinterpreting
+  # the WHOLE buffer as Latin-1 in that case mojibakes the already-valid,
+  # already-committed leading text too. The fix keeps the longest valid
+  # UTF-8 prefix untouched and only drops (or, if genuinely malformed,
+  # lossily re-encodes) the trailing incomplete bytes.
+  describe "review round (Drew), MEDIUM — mid-grapheme UTF-8 cut never mojibakes committed text" do
+    test "a cut mid 2-byte accented character drops the incomplete tail instead of corrupting it" do
+      # "café" = c,a,f + é (0xC3 0xA9). Cut after 0xC3 alone.
+      cut = binary_part("café", 0, byte_size("café") - 1)
+      rendered = MarkdownBody.render(cut, %{mode: :streaming, width: 80})
+      text = full_text(rendered)
+
+      assert text == "caf"
+      refute text =~ "Ã"
+    end
+
+    test "a cut mid 3-byte CJK character drops the incomplete tail instead of corrupting it" do
+      # "日" is E6 97 A5; cut after the first two bytes.
+      full_char = "日"
+      cut = binary_part(full_char, 0, byte_size(full_char) - 1)
+
+      rendered =
+        MarkdownBody.render("intro " <> cut, %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+
+      assert text == "intro "
+    end
+
+    test "a cut mid 4-byte emoji drops the incomplete tail instead of corrupting it" do
+      # "😀" is F0 9F 98 80; cut after the first three bytes.
+      emoji = "😀"
+      cut = binary_part(emoji, 0, byte_size(emoji) - 1)
+
+      rendered =
+        MarkdownBody.render("hi " <> cut, %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+
+      assert text == "hi "
+    end
+
+    test "every byte-prefix of a multibyte-heavy fixture renders the already-valid leading text byte-identical, never mojibaked" do
+      fixture = "café 日本語 😀 done"
+      byte_len = byte_size(fixture)
+
+      results =
+        for cut <- 0..byte_len do
+          prefix = binary_part(fixture, 0, cut)
+          full_text(MarkdownBody.render(prefix, %{mode: :streaming, width: 80}))
+        end
+
+      # monotone: each successive (by one more byte) render's text either
+      # equals the previous or extends it -- never mojibaked into
+      # something shorter/different for the already-valid leading part.
+      results
+      |> Enum.zip(tl(results))
+      |> Enum.each(fn {before, after_} ->
+        assert String.starts_with?(after_, before) or
+                 String.starts_with?(before, after_),
+               "byte-prefix render was not consistent: #{inspect(before)} -> #{inspect(after_)}"
+      end)
+
+      # the classic UTF-8-as-Latin-1 mojibake signature never appears.
+      refute Enum.any?(results, &(&1 =~ "Ã"))
+    end
+
+    test "a ZWJ family emoji split mid-sequence never crashes and never mojibakes plain ASCII around it" do
+      family = "👨‍👩‍👧‍👦"
+      doc = "before " <> family <> " after"
+      byte_len = byte_size(doc)
+
+      for cut <- 0..byte_len do
+        prefix = binary_part(doc, 0, cut)
+        rendered = MarkdownBody.render(prefix, %{mode: :streaming, width: 80})
+        assert %{type: :column} = rendered
+        text = full_text(rendered)
+        refute text =~ "Ã"
+      end
+    end
+  end
+
+  # MEDIUM: the 256KB provisional-close cap guarded the cheap scan, but
+  # the downstream full parse (re-run on every streaming delta) was
+  # uncapped. The fix applies the same ceiling to the render path: above
+  # it, render skips the parse and emits the raw buffer as plain text.
+  #
+  # These assert the ALGORITHMIC cap behavior with hard booleans (above
+  # the cap -> un-parsed plain-text fallback; below it -> the parser
+  # runs), never a wall-clock bound -- a timing assertion in the default
+  # suite passes locally but flakes on a slow/contended CI runner. The
+  # wall-clock perf check lives in the `:slow`-tagged test below, excluded
+  # from the default CI run.
+  describe "review round (Drew), MEDIUM — render path is byte-capped like provisional_close" do
+    @cap_bytes 256 * 1024
+
+    test "streaming render of a buffer ABOVE the cap takes the un-parsed plain-text fallback" do
+      huge = String.duplicate("**bold** ", 40_000)
+      assert byte_size(huge) > @cap_bytes
+
+      rendered = MarkdownBody.render(huge, %{mode: :streaming, width: 80})
+
+      # fallback = exactly one plain text node, byte-identical to the
+      # buffer (a hard structural match -- the parse path would instead
+      # have produced multiple/styled elements).
+      assert %{type: :column, children: [%{type: :text, content: ^huge}]} =
+               rendered
+
+      # and because the parser never ran, the raw markers survive
+      # verbatim -- the parse path would have consumed every "**" into a
+      # styled bold span (see the below-cap test).
+      assert full_text(rendered) =~ "**"
+    end
+
+    test "sealed render of a buffer ABOVE the cap also takes the fallback" do
+      huge = String.duplicate("| a | b |\n", 40_000)
+      assert byte_size(huge) > @cap_bytes
+
+      rendered = MarkdownBody.render_sealed(huge, 80)
+
+      assert %{type: :column, children: [%{type: :text, content: ^huge}]} =
+               rendered
+    end
+
+    test "render of a buffer BELOW the cap is fully parsed (fallback does NOT fire)" do
+      small = "**bold** and *italic*"
+      assert byte_size(small) < @cap_bytes
+
+      rendered = MarkdownBody.render(small, %{mode: :streaming, width: 80})
+
+      # NOT the single-raw-text fallback node the above-cap path emits...
+      refute match?(%{children: [%{type: :text, content: ^small}]}, rendered)
+
+      # ...and the parser consumed every marker into a styled span, so no
+      # raw marker survives in the rendered text.
+      refute full_text(rendered) =~ "*"
+      assert full_text(rendered) =~ "bold"
+      assert full_text(rendered) =~ "italic"
+    end
+
+    # Timing belongs in bench, never the default suite -- `:slow` is
+    # excluded by the repo's default `mix test` run. This is a documented
+    # perf guard (the render cap keeps per-delta re-parse work bounded
+    # even as an operator watches a large message stream in), not a CI
+    # gate.
+    @tag :slow
+    test "N incremental streaming prefixes of a large document stay within budget" do
+      doc = String.duplicate("some **bold** text and *italic* text.\n", 8_000)
+
+      prefixes =
+        for k <- 1..20, do: binary_part(doc, 0, div(byte_size(doc) * k, 20))
+
+      {elapsed_us, _results} =
+        :timer.tc(fn ->
+          Enum.each(
+            prefixes,
+            &MarkdownBody.render(&1, %{mode: :streaming, width: 80})
+          )
+        end)
+
+      assert elapsed_us < 2_000_000,
+             "20 incremental large-doc renders took #{elapsed_us}us"
+    end
+  end
+
+  # SECURITY: untrusted (e.g. LLM-generated) markdown must never carry a
+  # raw control byte -- especially ESC -- out of this module, since an
+  # embedded ANSI/OSC sequence would reach the terminal renderer as if it
+  # were real (cursor move, screen clear, a fake title write), violating
+  # the "never embed raw ANSI in text()" rule.
+  describe "review round (Drew), SECURITY — control-char/ANSI sanitization" do
+    test "ESC-based ANSI sequences (SGR color, screen clear) are stripped" do
+      adversarial = "hi \e[31mRED\e[0m bye"
+
+      rendered =
+        MarkdownBody.render(adversarial, %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+
+      refute text =~ "\e"
+      assert text =~ "hi"
+      assert text =~ "RED"
+      assert text =~ "bye"
+    end
+
+    test "an OSC title-set sequence (ESC ] 0 ; ... BEL) is stripped" do
+      adversarial = "hi \e]0;pwn\a bye"
+
+      rendered =
+        MarkdownBody.render(adversarial, %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+
+      refute text =~ "\e"
+      refute text =~ "\a"
+      assert text =~ "hi"
+      assert text =~ "bye"
+    end
+
+    test "assorted C0 controls and DEL are stripped, \\n and \\t are kept" do
+      adversarial = "a\x00b\x01c\x02\nd\te\x7ff"
+      rendered = MarkdownBody.render(adversarial, %{mode: :sealed, width: 80})
+      text = full_text(rendered)
+
+      assert Enum.all?(String.to_charlist(text), fn cp ->
+               cp >= 0x20 or cp in [?\n, ?\t]
+             end)
+
+      refute text =~ "\x7f"
+    end
+
+    test "C1 controls (0x80-0x9F) are stripped" do
+      adversarial = "a" <> <<0xC2, 0x9B>> <> "b"
+
+      rendered =
+        MarkdownBody.render(adversarial, %{mode: :streaming, width: 80})
+
+      text = full_text(rendered)
+
+      refute Enum.any?(String.to_charlist(text), &(&1 in 0x80..0x9F))
+    end
+
+    test "sanitization also applies to :sealed mode, not just :streaming" do
+      adversarial = "hi \e[2J bye"
+      rendered = MarkdownBody.render(adversarial, %{mode: :sealed, width: 80})
+      refute full_text(rendered) =~ "\e"
+    end
+  end
+
+  # LOW: table-row absorption used to swallow ANY later `|`-containing
+  # line, ragged-row-ing ordinary prose that happened to contain a pipe
+  # character. The fix stops absorption once a line's cell count no
+  # longer matches the header's.
+  describe "review round (Drew), LOW — table row absorption stops at a non-table-shaped line" do
+    test "a table followed by an unrelated prose line containing a stray '|' does not absorb it as a row" do
+      doc =
+        "| check | status |\n" <>
+          "|---|---|\n" <>
+          "| compile | ok |\n" <>
+          "the ratio a|b applies here\n"
+
+      rendered = MarkdownBody.render_sealed(doc, 80)
+      lines = flat_texts(rendered)
+
+      assert Enum.any?(lines, &(&1 =~ "ratio a|b applies"))
+      refute Enum.any?(lines, &(&1 == "| ratio a|b applies here |"))
+    end
+
+    test "a blank line still ends table-row absorption (existing GFM contiguity, unaffected)" do
+      doc =
+        "| check | status |\n" <>
+          "|---|---|\n" <>
+          "| compile | ok |\n" <>
+          "\n" <>
+          "some trailing prose\n"
+
+      rendered = MarkdownBody.render_sealed(doc, 80)
+      lines = flat_texts(rendered)
+
+      assert Enum.any?(lines, &(&1 =~ "trailing prose"))
+    end
+  end
+
+  # LOW: `fence_marker?` used to toggle on EITHER ``` or ~~~, so a
+  # mismatched pair (opened with one, "closed" with the other) was
+  # treated as a complete fence. The fix tracks the opening marker's
+  # identity and only closes on a matching marker, in both
+  # `provisional_close` and the renderer.
+  describe "review round (Drew), LOW — mixed fence markers never cross-close" do
+    test "an unclosed ~~~ fence is closed with a matching ~~~ (not ```)" do
+      closed = MarkdownBody.provisional_close("~~~elixir\ndef foo do\n  :ok")
+      assert String.ends_with?(closed, "\n~~~")
+      refute closed =~ "```"
+    end
+
+    test "a ``` fence is NOT closed by an interior ~~~ line -- it stays open through it" do
+      closed =
+        MarkdownBody.provisional_close("```elixir\ndef foo do\n~~~\n  :ok")
+
+      assert String.ends_with?(closed, "\n```")
+      # the interior ~~~ line is preserved as fence content, not consumed
+      # as a (mismatched) closer.
+      assert closed =~ "~~~\n  :ok\n```"
+    end
+
+    test "the renderer treats a mismatched ```...~~~ pair as one still-open code block" do
+      text = "```elixir\ndef foo do\n~~~\n  :ok\nend\n```\n"
+      elements = MarkdownRenderer.render_with_builtin(text, 80)
+
+      full =
+        flat_texts(%{type: :column, children: elements, gap: 0})
+        |> Enum.join("\n")
+
+      assert full =~ "def foo do"
+      assert full =~ "~~~"
+      assert full =~ ":ok"
+    end
+
+    test "the renderer supports ~~~ fences on their own, same as ```" do
+      text = "~~~\ndef foo do\n  :ok\nend\n~~~\n"
+      elements = MarkdownRenderer.render_with_builtin(text, 80)
+
+      full =
+        flat_texts(%{type: :column, children: elements, gap: 0})
+        |> Enum.join("\n")
+
+      refute full =~ "~~~"
+      assert full =~ "def foo do"
+    end
+  end
+end


### PR DESCRIPTION
Unit **T26** of the harness-UI lane (`docs/proposals/in-flight/harness-ui-roadmap.md` §2): the streaming markdown message body — renders markdown for message/reasoning blocks without the incomplete-construct flash the cohort research flagged (P2).

## What
- **`Raxol.UI.Components.Harness.MarkdownBody`**: two modes. `:sealed` = full parse via `MarkdownRenderer`. `:streaming` = `provisional_close` (the remend pattern) then parse — incomplete constructs at the live tail are provisionally closed FOR RENDERING ONLY, source never mutated, so a partial `**bold` or unclosed ``` never shows raw markers mid-stream.
- **provisional_close is O(n), single-pass** (rewritten from an O(n²)/Θ(n³)-streaming first cut): one left-to-right scan builds an open-construct stack (O(1)/grapheme — killed the per-char full-stack map), one tail-walk strips trailing content-free openers and closes the rest (no re-scan-per-strip). >256KB safety-belt degradation.
- Dangling zero-content openers are *stripped*, not closed (`****` would leak the markers back out); a chain of nested empty openers collapses in the same walk.
- **GFM tables** (additive to MarkdownRenderer's builtin path): header+separator lookahead renders an aligned table; narrow widths shrink proportionally to a 3-column floor (never zero-width collapse — the glow failure); below the floor cells clip with ellipsis.
- `block.ex` opt-in: `context[:markdown]` (default false) routes `:message`/`:reasoning` through MarkdownBody — byte-identical when omitted (T4's tests untouched-green).

## Evidence
48 markdown_body + 40 markdown_renderer + 40 block tests green. Prefix-property: all 17 delta-boundary prefixes of the markdown-stream golden + char-granular (~500) + a 200-run byte-cut property — zero raw-marker leaks; sealed render = full parse. Fuzz: never-crash/never-hang across binary/prefix/pathological-nesting/adversarial-unicode. **Large-input fuzz (N-MDFUZZ-05)**: 20k brackets = 6.5ms, 50k = 8.9ms, mixed = 131ms, cumulative-streaming (provisional_close on every prefix 1..2000, the Θ(n³) real-world case) = 149ms — all far under the 2s bound.

## Review trail
Opus review: APPROVE with two yellows → the O(n²) single-pass rewrite (concrete algorithm from a grok-4.5 tests-invariants advisory) + large-input fuzz lock; doc-overclaim corrections (table "scrollable" → clip/overflow; premature-frame behavior).

**Merge note: merge this BEFORE the T8 PR (#560)** — both touch block.ex render context; this changed `build_render/2→/3`, T8 rebases onto that signature (trivial union — each reads its own context key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
