### PR TITLE
Harness UI: canonical input-event normalization [T27]

### DIFF
--- a/lib/raxol/ui/components/harness/composer.ex
+++ b/lib/raxol/ui/components/harness/composer.ex
@@ -37,10 +37,28 @@ defmodule Raxol.UI.Components.Harness.Composer do
   no history yet. The modifier branches activate automatically when F1b
   (kitty keyboard protocol) lands -- zero logic change here.
 
-  Also known: printable characters arriving with compound modifiers (e.g.
-  `[:shift, :alt]`) fall through to MultiLineInput delegation and are
-  dropped today -- canonical modifier normalization belongs to F1a input
-  canon, not this unit.
+  ## Input-shape normalization
+
+  `handle_event/3` normalizes every incoming event through
+  `Raxol.UI.Harness.InputEvent.normalize/1` before deciding anything.
+  Before T27's review round this component matched key events by pattern
+  (`%{key: :enter, modifiers: modifiers}`), which only exists on
+  `Event.key_event/3`'s test-API shape -- the real terminal driver's two
+  shapes (`event_translator.ex`'s boolean `shift:`/`ctrl:`/... fields,
+  `input_parser.ex`'s optional fields) have no `:modifiers` key at all, so
+  the pattern never matched a REAL keypress. Enter never submitted,
+  printable characters never inserted, and everything silently fell
+  through to raw `MultiLineInput` delegation for actual terminal input --
+  this unit only ever worked in tests that construct `Event.key_event/3`
+  directly. `InputEvent.normalize/1` erases that shape difference: Enter
+  from a real termbox driver, a real ANSI parser, or `Event.key_event/3`
+  all normalize to the same `kind: :key, key: :enter` and reach the same
+  `handle_enter_key/2`.
+
+  Printable characters arriving with compound modifiers (e.g. Shift+Alt)
+  are `InputEvent.shortcut?/1` (alt held) and fall through to
+  `MultiLineInput` delegation, same as before -- canonical compound-
+  modifier handling belongs to F1a input canon, not this unit.
 
   ## Bracketed paste
 
@@ -80,6 +98,7 @@ defmodule Raxol.UI.Components.Harness.Composer do
   alias Raxol.Core.Events.Event
   alias Raxol.UI.Components.Input.MultiLineInput
   alias Raxol.UI.Components.Input.MultiLineInput.TextHelper
+  alias Raxol.UI.Harness.InputEvent
   alias Raxol.UI.StyleHelper
   alias Raxol.UI.TextMeasure
   alias Raxol.View.Components
@@ -210,61 +229,104 @@ defmodule Raxol.UI.Components.Harness.Composer do
 
   # -- events --
 
+  # Migration pattern documented at `Raxol.UI.Harness.InputEvent`'s
+  # moduledoc: normalize first, check `shortcut?/1` before `text?/1`/
+  # `key/1` (so a modifier-qualified char/key still reaches the right
+  # handler WITH its mods), paste short-circuits everything. Enter is
+  # special-cased ahead of the generic shortcut/text/key triage because
+  # its submit-vs-newline decision depends on mods (shift/alt) rather than
+  # being a plain pass/fail shortcut check -- both `handle_shortcut/4`
+  # (Alt+Enter, which IS classified `shortcut?`) and the `key` branch
+  # (plain Enter, Shift+Enter, neither of which is) route back into the
+  # same `handle_enter_key/2`.
   @impl true
-  def handle_event(%Event{type: :paste, data: %{text: text}}, state, _context) do
-    {new_mli, _cmds} = update_mli({:clipboard_content, text}, state.mli)
-    {%{state | mli: new_mli}, []}
-  end
+  def handle_event(%Event{} = event, state, context) do
+    norm = InputEvent.normalize(event)
 
-  def handle_event(
-        %Event{type: :key, data: %{key: :enter, modifiers: modifiers}},
-        state,
-        _context
-      ) do
-    handle_enter_key(modifiers, state)
-  end
+    cond do
+      norm.kind == :paste ->
+        {new_mli, _cmds} =
+          update_mli({:clipboard_content, norm.text}, state.mli)
 
-  def handle_event(
-        %Event{type: :key, data: %{key: :up, modifiers: []}} = event,
-        state,
-        context
-      ) do
-    handle_history_nav(:up, event, state, context)
-  end
+        {%{state | mli: new_mli}, []}
 
-  def handle_event(
-        %Event{type: :key, data: %{key: :down, modifiers: []}} = event,
-        state,
-        context
-      ) do
-    handle_history_nav(:down, event, state, context)
-  end
+      InputEvent.shortcut?(norm) ->
+        handle_shortcut(norm, state, event, context)
 
-  # Printable-character keys are intercepted here rather than delegated:
-  # MultiLineInput's EventHandler forwards them as `{:input, <binary>}` but
-  # its EditOps/TextHelper insertion path expects an integer codepoint
-  # (`<<codepoint::utf8>>`), so blind delegation crashes on every ordinary
-  # keystroke. Routing through `{:clipboard_content, char}` -- the same safe
-  # insertion path bracketed paste uses -- sidesteps the upstream bug (kept
-  # out of this changeset; MultiLineInput is outside T11's write-set) and
-  # additionally handles multi-codepoint graphemes (emoji) that the
-  # upstream `byte_size == 1` dispatch drops entirely.
-  def handle_event(
-        %Event{type: :key, data: %{key: char, modifiers: modifiers}} = event,
-        state,
-        context
-      )
-      when is_binary(char) and (modifiers == [] or modifiers == [:shift]) do
-    if String.length(char) == 1 do
-      {new_mli, cmds} = update_mli({:clipboard_content, char}, state.mli)
-      {%{state | mli: new_mli}, cmds}
-    else
-      {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
-      {%{state | mli: new_mli}, cmds}
+      InputEvent.text?(norm) ->
+        insert_char(state, InputEvent.printable_char(norm))
+
+      key = InputEvent.key(norm) ->
+        dispatch_key(key, norm.mods, state, event, context)
+
+      true ->
+        {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
+        {%{state | mli: new_mli}, cmds}
     end
   end
 
   def handle_event(event, state, context) do
+    {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
+    {%{state | mli: new_mli}, cmds}
+  end
+
+  # Alt+Enter is `shortcut?` (alt held) but is still "insert a newline",
+  # not a generic keyboard shortcut -- recognize it here and fall back to
+  # the same `handle_enter_key/2` the unmodified/Shift+Enter path in
+  # `dispatch_key/5` uses. No other composer-level shortcuts exist today;
+  # a consumer (T12 keybinds) wires additional ones (e.g. Ctrl+Enter via
+  # `force_submit/1`) outside this component, so anything else
+  # ctrl/alt/meta-qualified falls through to MultiLineInput (e.g. Ctrl+C,
+  # Ctrl+V, which it already owns).
+  defp handle_shortcut(%{key: :enter, mods: mods}, state, _event, _context) do
+    handle_enter_key(mods, state)
+  end
+
+  defp handle_shortcut(_norm, state, event, context) do
+    {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
+    {%{state | mli: new_mli}, cmds}
+  end
+
+  defp insert_char(state, nil), do: {state, []}
+
+  # Routed through `{:clipboard_content, char}` -- the same safe insertion
+  # path bracketed paste uses -- rather than MultiLineInput's own
+  # `{:input, <binary>}` dispatch, which expects an integer codepoint
+  # (`<<codepoint::utf8>>`) and crashes on ordinary keystrokes (kept out of
+  # this changeset; MultiLineInput is outside T11's write-set). Also
+  # correctly handles multi-codepoint graphemes (emoji) that the upstream
+  # `byte_size == 1` dispatch drops entirely.
+  defp insert_char(state, char) do
+    {new_mli, cmds} = update_mli({:clipboard_content, char}, state.mli)
+    {%{state | mli: new_mli}, cmds}
+  end
+
+  # Reached only when `shortcut?/1` was false, so ctrl/alt/meta are all
+  # false here -- only `mods.shift` varies (e.g. Shift+Enter, Shift+Up).
+  defp dispatch_key(:enter, mods, state, _event, _context) do
+    handle_enter_key(mods, state)
+  end
+
+  defp dispatch_key(:up, mods, state, event, context) do
+    if mods.shift do
+      delegate(event, state, context)
+    else
+      handle_history_nav(:up, event, state, context)
+    end
+  end
+
+  defp dispatch_key(:down, mods, state, event, context) do
+    if mods.shift do
+      delegate(event, state, context)
+    else
+      handle_history_nav(:down, event, state, context)
+    end
+  end
+
+  defp dispatch_key(_key, _mods, state, event, context),
+    do: delegate(event, state, context)
+
+  defp delegate(event, state, context) do
     {new_mli, cmds} = delegate_to_mli(event, state.mli, context)
     {%{state | mli: new_mli}, cmds}
   end
@@ -299,9 +361,9 @@ defmodule Raxol.UI.Components.Harness.Composer do
 
   # -- private: enter / submit --
 
-  defp handle_enter_key(modifiers, state) do
+  defp handle_enter_key(%{shift: shift, alt: alt}, state) do
     cond do
-      :shift in modifiers or :alt in modifiers -> insert_newline(state)
+      shift or alt -> insert_newline(state)
       multiline?(state.mli) -> insert_newline(state)
       true -> maybe_submit(state)
     end

--- a/lib/raxol/ui/harness/input_event.ex
+++ b/lib/raxol/ui/harness/input_event.ex
@@ -1,0 +1,441 @@
+defmodule Raxol.UI.Harness.InputEvent do
+  @moduledoc """
+  Canonical input-event normalization for harness components.
+
+  ## The problem
+
+  The terminal driver reaches component `handle_event/3` callbacks through
+  THREE incompatible key-event shapes depending on which layer produced the
+  event, plus a fourth paste shape. Two harness components (`T11` composer,
+  `T14` picker) independently hit this gap and each grew inline defensive
+  reshaping. `Raxol.UI.Components.Input.TextInput` also copes with it ad
+  hoc (`data[:modifiers] || []`). This module is the single normalizer all
+  of them should converge on.
+
+  The three real `%Raxol.Core.Events.Event{type: :key, data: data}` shapes
+  for `data` (verified against source, not assumed):
+
+  | Source                                              | `data` shape                                                                          | char keys                  | modifiers                              |
+  | ---------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------- |
+  | `packages/raxol_terminal/.../driver/event_translator.ex` (native termbox NIF) | `%{shift: bool, ctrl: bool, alt: bool, meta: bool, char: binary \\| nil, key: atom \\| nil}` (char/key mutually exclusive; booleans always present) | `char: "a"`, `key: nil`      | boolean fields, no `modifiers` list     |
+  | `packages/raxol_terminal/.../ansi/input_parser.ex` (raw ANSI/VT parser)       | `%{key: atom}` plus `char:`/`shift:`/`alt:`/`ctrl:` **only present when true/non-nil** | `key: :char, char: "a"`     | boolean fields, omitted entirely when false; no `modifiers` list |
+  | `Raxol.Core.Events.Event.key_event/3` (test/component API)                   | `%{key: atom \\| binary, state: :pressed \\| :released \\| :repeat, modifiers: [atom]}` | bare `key: "a"` (no `:char` field) | `modifiers:` list of atoms (`:ctrl`, `:alt`, `:shift`) |
+
+  Plus the paste shape (identical across the ANSI parser and
+  `Event.paste_event/2`): `%Raxol.Core.Events.Event{type: :paste, data: %{text: binary}}`.
+
+  ## The canonical shape
+
+  `normalize/1` reduces all of the above (and bare, unwrapped data maps of
+  the same shapes) to one map:
+
+      %{
+        kind: :char | :key | :paste | :other,
+        char: String.t() | nil,   # the grapheme to insert, when kind == :char
+        key: atom() | nil,        # the special key atom, when kind == :key
+        text: String.t() | nil,   # the pasted text, when kind == :paste
+        mods: %{ctrl: boolean(), alt: boolean(), shift: boolean(), meta: boolean()},
+        state: :pressed | :released | :repeat | nil,  # nil == press (see below)
+        raw: term()               # the original input, untouched
+      }
+
+  Design notes:
+
+    * `char` and `key` are never both non-nil -- `kind` picks one lane.
+    * `char` is never sliced or byte-counted. A multi-codepoint grapheme
+      (emoji, ZWJ sequences) survives intact; normalize never assumes
+      `byte_size(char) == 1` the way some upstream insertion paths do.
+      It also is never a control byte or more than one grapheme cluster
+      (see "Content validation" below) -- a malformed `char:`/bare `key:`
+      field routes the WHOLE event to `kind: :other` instead of lying
+      that it's insertable text.
+    * `mods` always has all four keys (`ctrl`/`alt`/`shift`/`meta`), each a
+      `boolean()`, regardless of which upstream shape was missing which
+      fields. `event_translator.ex` emits `meta:` (Cmd/Super); it is a
+      shortcut modifier just like ctrl/alt, so Cmd+char is a shortcut, NOT
+      insertable text. Shift-only is still `text?/1` (capital letters, etc).
+    * `state` carries `Event.key_event/3`'s press/release/repeat lifecycle
+      through normalization instead of silently dropping it. Only
+      `event_translator.ex`/`Event.key_event/3` have a `:state`-bearing
+      shape at all right now -- `input_parser.ex` events (and the bare
+      driver `data` map) have no state field, so they normalize to
+      `state: nil`, which `text?/1`/`key/1` treat as "press" (nil is NOT
+      "unknown, so drop it" -- most driver shapes have no notion of
+      release at all, and treating absence as "not a press" would make
+      ordinary typing stop inserting text). Only an explicit
+      `state: :released` suppresses `text?/1`/`key/1` -- see "Release
+      does not insert or dispatch" below.
+    * `kind: :other` is the total fallback -- unrecognized event shapes,
+      non-map input, mouse/resize/focus events, all land here rather than
+      raising. `normalize/1` never crashes.
+
+  ## Content validation
+
+  `char:` (or the bare-binary `key:` fallback) is only accepted as
+  insertable text when it is exactly one grapheme cluster AND contains no
+  C0 control byte (0x00-0x1F) or DEL (0x7F). A raw control sequence
+  smuggled into `char:` (e.g. `%{char: "\\e[2J"}`, `%{key: "enter"}` typo'd
+  as a bare multi-grapheme string instead of the atom `:enter`) normalizes
+  to `kind: :other`, NOT `kind: :char` -- it is not insertable, and it does
+  not silently become a special key either (there is no key atom to
+  recover; the caller passed a malformed shape). `text?/1` and
+  `printable_char/1` re-check this even on a hand-built `t()` map that
+  didn't go through `normalize/1`, so their names stay honest. Pasted
+  text (`kind: :paste`) is stripped of C0 control bytes and DEL EXCEPT
+  tab/newline/carriage-return, which are legitimate content in a
+  multi-line paste.
+
+  ## Release does not insert or dispatch
+
+  `text?/1` and `key/1` only return truthy for `state in [nil, :pressed,
+  :repeat]` -- an explicit `state: :released` normalizes the classification
+  fields as usual (so `norm.key`/`norm.char` still reflect what was
+  released, useful for key-up-triggered UI) but `text?/1` is `false` and
+  `key/1` is `nil`, so the documented `cond` below naturally falls through
+  to the no-op branch on release instead of double-inserting a character
+  or re-dispatching a special key on both press AND release.
+
+  ## Cross-shape agreement: scope
+
+  The cross-shape-agreement guarantee (see
+  `Raxol.UI.Harness.InputEventTest`'s "cross-shape agreement" property) is
+  real, but it is NOT unconditional -- driven off the REAL
+  `EventTranslator.translate/1` and `InputParser.parse/1` functions, not
+  synthetic hand-built maps, it only holds over the set that is actually
+  representable on BOTH the termbox and raw-ANSI wires:
+
+    * Meta (Cmd/Super) is UNREPRESENTABLE over raw ANSI -- `input_parser.ex`
+      never emits `meta: true` for any byte sequence. The agreement
+      property therefore only drives ctrl/alt/shift combinations (alone
+      or combined) through both real emitters; a translator-shape event
+      with `meta: true` has no ANSI counterpart to agree with and is
+      exercised only in the single-shape unit tests above.
+    * Enter/Tab/Escape/Backspace have NO modifier-carrying ANSI encoding
+      (Ctrl+Enter is indistinguishable on the wire from plain Enter) --
+      those keys are only agreement-tested unmodified. Shift+Tab
+      (backtab) is the one exception: both wires have a dedicated,
+      distinguishable encoding for it (termbox's `TB_KEY_BACK_TAB`, ANSI's
+      `CSI Z`), so it IS covered.
+    * Arrows, Home/End, and F1-F4 support the CSI `"1;<mod>"` modifier
+      encoding on the ANSI side and are agreement-tested across the full
+      ctrl/alt/shift power set (8 combinations) via real bytes/keycodes.
+      F5-F12/Insert/Delete/PageUp/PageDown are agreement-tested unmodified
+      only (their ANSI tilde encoding here has no modifier parameter).
+
+  ## What T11/T14 (and T12/T13a) migrate to
+
+  Composer (`lib/raxol/ui/components/harness/composer.ex`) and picker
+  (`lib/raxol/ui/components/harness/picker.ex`, `feat/harness-ui-T14`)
+  each hand-rolled a `text_input?/1`-style predicate reading
+  `data[:modifiers] || []` alongside `data[:ctrl]`/`data[:alt]` booleans.
+  Both retire that inline logic in favor of the pattern below. Note the
+  ordering: `shortcut?/1` is checked FIRST, because a shortcut is
+  ALSO a `kind: :char` (Ctrl+A) or `kind: :key` (Ctrl+Up) -- routing on
+  `text?/1`/`key/1` first would drop char-shortcuts into the no-op branch
+  and strip the modifiers off modifier-qualified special keys. The key
+  branch passes the WHOLE `norm` (or its `mods`), never the bare atom, so
+  Ctrl+Up stays Ctrl+Up rather than collapsing to Up:
+
+      alias Raxol.UI.Harness.InputEvent
+
+      def handle_event(%Event{} = event, state, _context) do
+        norm = InputEvent.normalize(event)
+
+        cond do
+          norm.kind == :paste ->
+            insert(state, norm.text)
+
+          # ctrl/alt/meta held -- a shortcut. Handle it WITH the mods so
+          # both Ctrl+A (kind: :char) and Ctrl+Up (kind: :key) reach the
+          # shortcut handler; neither is text, neither is a plain nav key.
+          InputEvent.shortcut?(norm) ->
+            handle_shortcut(state, norm)
+
+          # printable text (shift-only still counts). insert the grapheme.
+          InputEvent.text?(norm) ->
+            insert(state, InputEvent.printable_char(norm))
+
+          # a plain special key. dispatch WITH the norm so a handler that
+          # cares about e.g. Shift+Tab still sees norm.mods.shift.
+          InputEvent.key(norm) ->
+            dispatch_key(state, norm)
+
+          true ->
+            {state, []}
+        end
+      end
+
+  `text_input.ex`'s `KeyHandler.handle_key/3` dispatch and its
+  `data[:modifiers] || []` read are the same class of fix.
+  """
+
+  @type mods :: %{
+          ctrl: boolean(),
+          alt: boolean(),
+          shift: boolean(),
+          meta: boolean()
+        }
+  @type kind :: :char | :key | :paste | :other
+  @type key_state :: :pressed | :released | :repeat | nil
+
+  @type t :: %{
+          kind: kind(),
+          char: String.t() | nil,
+          key: atom() | nil,
+          text: String.t() | nil,
+          mods: mods(),
+          state: key_state(),
+          raw: term()
+        }
+
+  @no_mods %{ctrl: false, alt: false, shift: false, meta: false}
+  @live_states [nil, :pressed, :repeat]
+
+  # C0 control range plus DEL. Used both to reject control bytes smuggled
+  # into `char:`/bare `key:` (content validation) and to strip them from
+  # pasted text (tab/newline/CR excluded there -- see strip_paste_text/1).
+  @control_bytes 0x00..0x1F
+
+  @doc """
+  Normalizes any of the driver key-event shapes, the paste shape, or
+  `Raxol.Core.Events.Event.key_event/3`'s shape (wrapped in an `Event`
+  struct OR passed as a bare `data` map) into the canonical form above.
+
+  Total: never raises. Anything unrecognized normalizes to `kind: :other`.
+  """
+  @spec normalize(term()) :: t()
+  def normalize(
+        %Raxol.Core.Events.Event{type: :paste, data: %{text: text}} = raw
+      )
+      when is_binary(text) do
+    paste_result(text, raw)
+  end
+
+  def normalize(%Raxol.Core.Events.Event{type: :key, data: data} = raw)
+      when is_map(data) do
+    key_result(data, raw)
+  end
+
+  def normalize(%Raxol.Core.Events.Event{} = raw), do: unclassified(raw)
+
+  def normalize(%{type: :paste, data: %{text: text}} = raw)
+      when is_binary(text) do
+    paste_result(text, raw)
+  end
+
+  def normalize(%{type: :key, data: data} = raw) when is_map(data) do
+    key_result(data, raw)
+  end
+
+  def normalize(%{text: text} = raw) when is_binary(text) do
+    paste_result(text, raw)
+  end
+
+  def normalize(data) when is_map(data), do: key_result(data, data)
+
+  def normalize(other), do: unclassified(other)
+
+  @doc """
+  Printable text with no ctrl/alt/meta held. Shift-only (capital letters,
+  shifted punctuation) is still text -- only ctrl/alt/meta promote a char
+  to a shortcut. `meta` is Cmd/Super (macOS Cmd+key); an event with it set
+  is a shortcut, not insertable text.
+
+  Also false when `char` fails content validation (control byte, or more
+  than one grapheme -- see moduledoc) or `state` is `:released`, even on a
+  hand-built map that didn't go through `normalize/1` -- so the name
+  "text?" doesn't lie about what's actually safe to insert.
+  """
+  @spec text?(t()) :: boolean()
+  def text?(%{
+        kind: :char,
+        char: char,
+        state: state,
+        mods: %{ctrl: ctrl, alt: alt, meta: meta}
+      })
+      when state in @live_states do
+    not (ctrl or alt or meta) and valid_char?(char)
+  end
+
+  def text?(_normalized), do: false
+
+  @doc """
+  Ctrl, Alt, or Meta (Cmd/Super) is held, regardless of `kind` -- a
+  printable char with a modifier (Ctrl+A, Cmd+S) or a special key with a
+  modifier (Ctrl+Up) both count. Shift alone is not a shortcut.
+  """
+  @spec shortcut?(t()) :: boolean()
+  def shortcut?(%{mods: %{ctrl: ctrl, alt: alt, meta: meta}}),
+    do: ctrl or alt or meta
+
+  def shortcut?(_normalized), do: false
+
+  @doc """
+  The grapheme to insert, or `nil` if this normalized event isn't
+  insertable text (see `text?/1`). Never truncated to a single codepoint.
+  """
+  @spec printable_char(t()) :: String.t() | nil
+  def printable_char(%{kind: :char, char: char} = normalized) do
+    if text?(normalized), do: char, else: nil
+  end
+
+  def printable_char(_normalized), do: nil
+
+  @doc """
+  The special key atom (`:up`, `:enter`, `:backspace`, ...), or `nil` if
+  this normalized event isn't a special key or `state` is `:released`
+  (see moduledoc -- release does not (re-)dispatch).
+  """
+  @spec key(t()) :: atom() | nil
+  def key(%{kind: :key, key: key, state: state}) when state in @live_states,
+    do: key
+
+  def key(_normalized), do: nil
+
+  # -- private --
+
+  defp key_result(data, raw) do
+    mods = extract_mods(data)
+    state = extract_state(data)
+
+    cond do
+      char = extract_char(data) ->
+        %{
+          kind: :char,
+          char: char,
+          key: nil,
+          text: nil,
+          mods: mods,
+          state: state,
+          raw: raw
+        }
+
+      key = extract_special_key(data) ->
+        %{
+          kind: :key,
+          char: nil,
+          key: key,
+          text: nil,
+          mods: mods,
+          state: state,
+          raw: raw
+        }
+
+      true ->
+        unclassified(raw)
+    end
+  end
+
+  defp extract_mods(data) do
+    modifiers =
+      case Map.get(data, :modifiers) do
+        list when is_list(list) -> list
+        _not_a_list -> []
+      end
+
+    %{
+      ctrl: Map.get(data, :ctrl) == true or :ctrl in modifiers,
+      alt: Map.get(data, :alt) == true or :alt in modifiers,
+      shift: Map.get(data, :shift) == true or :shift in modifiers,
+      meta: Map.get(data, :meta) == true or :meta in modifiers
+    }
+  end
+
+  # Only Event.key_event/3's shape carries a `:state`; event_translator.ex
+  # and input_parser.ex events have no notion of release at all, so they
+  # normalize to `nil` ("press" -- see moduledoc).
+  defp extract_state(data) do
+    case Map.get(data, :state) do
+      state when state in [:pressed, :released, :repeat] -> state
+      _no_state_field -> nil
+    end
+  end
+
+  # `char:` wins when present (event_translator.ex, input_parser.ex's
+  # `key: :char, char: ...` form). Falls back to a bare binary `key:`
+  # (Event.key_event/3's `key: "a"` form, no `:char` field at all).
+  # Either way, the candidate must pass `valid_char?/1` -- a control byte
+  # or multi-grapheme string returns `nil` here so the caller falls
+  # through to `extract_special_key/1` and, finding nothing there either
+  # (a raw control sequence or a mis-encoded bare string has no key
+  # atom), lands on `kind: :other` rather than lying that it's text.
+  defp extract_char(data) do
+    case Map.get(data, :char) do
+      char when is_binary(char) and char != "" -> as_valid_char(char)
+      _no_char_field -> extract_char_from_bare_key(data)
+    end
+  end
+
+  defp extract_char_from_bare_key(data) do
+    case Map.get(data, :key) do
+      key when is_binary(key) and key != "" -> as_valid_char(key)
+      _no_binary_key -> nil
+    end
+  end
+
+  defp as_valid_char(char), do: if(valid_char?(char), do: char, else: nil)
+
+  # An atom `key:` other than `nil`/`:char` is a special key across all
+  # three shapes (`:up`, `:enter`, `:backspace`, `:unknown`, ...).
+  defp extract_special_key(data) do
+    case Map.get(data, :key) do
+      key when is_atom(key) and key not in [nil, :char] -> key
+      _not_a_special_key -> nil
+    end
+  end
+
+  # Exactly one grapheme cluster, no C0 control byte or DEL. Byte-level
+  # scan is safe on multi-byte UTF-8: every continuation/lead byte is
+  # >= 0x80, so it never collides with the 0x00-0x1F/0x7F control range
+  # being scanned for.
+  defp valid_char?(bin) when is_binary(bin) do
+    not has_control_byte?(bin) and String.length(bin) == 1
+  end
+
+  defp valid_char?(_not_a_binary), do: false
+
+  defp has_control_byte?(bin) do
+    Enum.any?(:binary.bin_to_list(bin), fn byte ->
+      byte in @control_bytes or byte == 0x7F
+    end)
+  end
+
+  defp paste_result(text, raw) do
+    %{
+      kind: :paste,
+      char: nil,
+      key: nil,
+      text: strip_paste_text(text),
+      mods: @no_mods,
+      state: nil,
+      raw: raw
+    }
+  end
+
+  # Strips C0 control bytes and DEL from pasted text, EXCEPT tab/newline/
+  # carriage-return -- legitimate content in a multi-line paste (see
+  # moduledoc's "never embed raw ANSI" rule: a pasted ESC/CSI sequence
+  # must not survive to be interpreted downstream as terminal control
+  # input). Byte-level filter, safe on UTF-8 for the same reason
+  # `has_control_byte?/1` is: multi-byte sequence bytes are all >= 0x80.
+  defp strip_paste_text(text) do
+    keep? = fn byte -> byte not in @control_bytes or byte in [?\t, ?\n, ?\r] end
+
+    text
+    |> :binary.bin_to_list()
+    |> Enum.filter(fn byte -> keep?.(byte) and byte != 0x7F end)
+    |> :erlang.list_to_binary()
+  end
+
+  defp unclassified(raw) do
+    %{
+      kind: :other,
+      char: nil,
+      key: nil,
+      text: nil,
+      mods: @no_mods,
+      state: nil,
+      raw: raw
+    }
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/event_translator.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/event_translator.ex
@@ -1,9 +1,89 @@
 defmodule Raxol.Terminal.Driver.EventTranslator do
   @moduledoc """
   Translates termbox NIF events into Raxol.Core.Events.Event structs.
+
+  ## Keycode source of truth
+
+  `key_code` values below are the REAL `TB_KEY_*` constants vendored at
+  `packages/raxol_terminal/lib/termbox2_nif/c_src/termbox2/termbox2.h`, not
+  assumed. Two earlier bugs, found by review, are fixed here:
+
+    * Arrow keys were mapped from 65/66/67/68 -- the ANSI CSI *final
+      bytes* for `A`/`B`/`C`/`D` -- instead of the real
+      `TB_KEY_ARROW_{UP,DOWN,LEFT,RIGHT}` values (`0xffff - {18,19,20,21}`
+      = 65517/65516/65515/65514).
+    * F1/F2 were mapped from 265/266 -- ncurses' `KEY_F(1)`/`KEY_F(2)`
+      (`KEY_F0 + n`, `KEY_F0 = 264`) -- instead of the real `TB_KEY_F1`/
+      `TB_KEY_F2` (`0xffff - {0,1}` = 65535/65534).
+
+  Both bugs meant a REAL termbox event for an arrow key or F1/F2 would
+  have normalized to `key: :unknown` while the ANSI parser
+  (`input_parser.ex`) correctly produced `:up`/`:down`/.../`:f1`/`:f2` for
+  the same physical keypress -- exactly the cross-shape divergence
+  `Raxol.UI.Harness.InputEvent`'s normalizer is supposed to make
+  impossible. See `@key_codes` below for the full corrected table
+  (nav keys, F1-F12) plus the control-key-code handling for
+  Enter/Tab/Escape/Backspace.
+
+  Control keys (Enter/Tab/Escape/Backspace) share their numeric value with
+  a plain ASCII control byte (`TB_KEY_ENTER = 0x0d`, same as a raw `\\r`).
+  Since it is not settled by inspection alone whether a real termbox
+  integration reports these via `char_code` (raw byte) or `key_code`
+  (`TB_KEY_*` constant, numerically identical for these), `translate_key/3`
+  checks BOTH: `char_code` is checked for a known control byte before the
+  generic "printable char" branch (so a control byte can never leak
+  through as `char:` on a `kind: :char` event), and `key_code` is checked
+  against the same values as a fallback. Either wiring convention lands on
+  the correct special-key atom.
   """
 
   alias Raxol.Core.Events.Event
+
+  # Real TB_KEY_* values (see moduledoc). Control-key codes double as their
+  # ASCII byte value (TB_KEY_ENTER clashes with CTRL_M, etc. -- see
+  # termbox2.h's own "clash with" comments); nav/function key codes are
+  # `0xffff - n` per the vendored header's codegen block.
+  @key_codes %{
+    # control keys -- checked against BOTH char_code and key_code (see
+    # moduledoc); LF (10) is treated as Enter same as input_parser.ex does.
+    8 => :backspace,
+    127 => :backspace,
+    9 => :tab,
+    13 => :enter,
+    10 => :enter,
+    27 => :escape,
+    # arrows: TB_KEY_ARROW_{UP,DOWN,LEFT,RIGHT} = 0xffff - {18,19,20,21}
+    65517 => :up,
+    65516 => :down,
+    65515 => :left,
+    65514 => :right,
+    # nav: TB_KEY_{HOME,END,INSERT,DELETE,PGUP,PGDN} = 0xffff - {14,15,12,13,16,17}
+    65521 => :home,
+    65520 => :end,
+    65523 => :insert,
+    65522 => :delete,
+    65519 => :page_up,
+    65518 => :page_down,
+    # F1-F12: TB_KEY_F1..F12 = 0xffff - {0..11}
+    65535 => :f1,
+    65534 => :f2,
+    65533 => :f3,
+    65532 => :f4,
+    65531 => :f5,
+    65530 => :f6,
+    65529 => :f7,
+    65528 => :f8,
+    65527 => :f9,
+    65526 => :f10,
+    65525 => :f11,
+    65524 => :f12
+  }
+
+  # TB_KEY_BACK_TAB = 0xffff - 22. termbox reports Shift+Tab as this
+  # distinct key rather than TAB + a shift modifier bit; recover the shift
+  # bit here so shift+tab normalizes identically to input_parser.ex's CSI
+  # `Z` handling (`key_event(:tab, shift: true)`).
+  @back_tab_code 65_535 - 22
 
   @doc """
   Translates a termbox event map into an Event struct.
@@ -57,29 +137,26 @@ defmodule Raxol.Terminal.Driver.EventTranslator do
     translate_key_or_char(data, char_code, key_code)
   end
 
+  # Control byte arriving via char_code (see moduledoc): resolve it to the
+  # special-key atom BEFORE the generic char_code > 0 branch below, so a
+  # control byte can never leak through as `char:` on a `kind: :char`
+  # event no matter which field the eventual real wiring populates it in.
+  defp translate_key_or_char(data, char_code, _key_code)
+       when is_map_key(@key_codes, char_code) and char_code > 0 do
+    Map.put(data, :key, Map.fetch!(@key_codes, char_code))
+  end
+
   defp translate_key_or_char(data, char_code, _key_code) when char_code > 0 do
     Map.put(data, :char, <<char_code::utf8>>)
   end
 
-  defp translate_key_or_char(data, _char_code, 65), do: Map.put(data, :key, :up)
+  defp translate_key_or_char(data, _char_code, @back_tab_code) do
+    data |> Map.put(:key, :tab) |> Map.put(:shift, true)
+  end
 
-  defp translate_key_or_char(data, _char_code, 66),
-    do: Map.put(data, :key, :down)
-
-  defp translate_key_or_char(data, _char_code, 67),
-    do: Map.put(data, :key, :right)
-
-  defp translate_key_or_char(data, _char_code, 68),
-    do: Map.put(data, :key, :left)
-
-  defp translate_key_or_char(data, _char_code, 265),
-    do: Map.put(data, :key, :f1)
-
-  defp translate_key_or_char(data, _char_code, 266),
-    do: Map.put(data, :key, :f2)
-
-  defp translate_key_or_char(data, _char_code, _key_code),
-    do: Map.put(data, :key, :unknown)
+  defp translate_key_or_char(data, _char_code, key_code) do
+    Map.put(data, :key, Map.get(@key_codes, key_code, :unknown))
+  end
 
   defp translate_mouse_button(btn_code) do
     case btn_code do

--- a/packages/raxol_terminal/test/raxol/terminal/driver/input_buffering_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/input_buffering_test.exs
@@ -36,9 +36,13 @@ defmodule Raxol.Terminal.Driver.InputBufferingTest do
       Helper.wait_for_driver_ready(driver_pid)
       Helper.consume_initial_resize()
 
-      # Send partial escape sequence
+      # Send partial escape sequence. The raw ESC byte (27) is a REAL
+      # TB_KEY_ESC control-key code (see event_translator.ex's moduledoc),
+      # so it now correctly normalizes to `key: :escape` rather than
+      # leaking through as a printable `char: "\e"` -- the exact
+      # control-byte-as-text bug the T27 review caught.
       Helper.simulate_key_event(driver_pid, ?\e)
-      Helper.assert_key_event("\e")
+      Helper.assert_key_event(nil, :escape)
 
       Helper.simulate_key_event(driver_pid, ?[)
       Helper.assert_key_event("[")
@@ -62,13 +66,14 @@ defmodule Raxol.Terminal.Driver.InputBufferingTest do
       Helper.assert_key_event("x")
 
       Helper.simulate_key_event(driver_pid, ?\e)
-      Helper.assert_key_event("\e")
+      Helper.assert_key_event(nil, :escape)
 
       Helper.simulate_key_event(driver_pid, ?[)
       Helper.assert_key_event("[")
 
-      # Up arrow
-      Helper.simulate_key_event(driver_pid, 0, 65)
+      # Up arrow -- real TB_KEY_ARROW_UP code (0xffff - 18), not the ANSI
+      # CSI final byte 65 this test used to send.
+      Helper.simulate_key_event(driver_pid, 0, 65_517)
       Helper.assert_key_event(nil, :up)
 
       Helper.simulate_key_event(driver_pid, ?y)

--- a/packages/raxol_terminal/test/raxol/terminal/driver/key_event_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/key_event_test.exs
@@ -39,21 +39,23 @@ defmodule Raxol.Terminal.Driver.KeyEventTest do
       Helper.wait_for_driver_ready(driver_pid)
       Helper.consume_initial_resize()
 
-      # Test arrow keys
+      # Test arrow keys -- the REAL TB_KEY_ARROW_* codes (0xffff - {18,19,
+      # 20,21}), not the ANSI CSI final bytes (65-68) this test used to
+      # assert. See event_translator.ex's moduledoc for why that was a bug.
       # Up arrow
-      Helper.simulate_key_event(driver_pid, 0, 65)
+      Helper.simulate_key_event(driver_pid, 0, 65_517)
       Helper.assert_key_event(nil, :up)
 
       # Down arrow
-      Helper.simulate_key_event(driver_pid, 0, 66)
+      Helper.simulate_key_event(driver_pid, 0, 65_516)
       Helper.assert_key_event(nil, :down)
 
       # Right arrow
-      Helper.simulate_key_event(driver_pid, 0, 67)
+      Helper.simulate_key_event(driver_pid, 0, 65_514)
       Helper.assert_key_event(nil, :right)
 
       # Left arrow
-      Helper.simulate_key_event(driver_pid, 0, 68)
+      Helper.simulate_key_event(driver_pid, 0, 65_515)
       Helper.assert_key_event(nil, :left)
 
       Process.exit(driver_pid, :shutdown)
@@ -67,13 +69,15 @@ defmodule Raxol.Terminal.Driver.KeyEventTest do
       Helper.wait_for_driver_ready(driver_pid)
       Helper.consume_initial_resize()
 
-      # Test function keys
+      # Test function keys -- the REAL TB_KEY_F1/TB_KEY_F2 codes
+      # (0xffff - {0,1}), not ncurses' KEY_F(1)/KEY_F(2) (265/266) this
+      # test used to assert.
       # F1
-      Helper.simulate_key_event(driver_pid, 0, 265)
+      Helper.simulate_key_event(driver_pid, 0, 65_535)
       Helper.assert_key_event(nil, :f1)
 
       # F2
-      Helper.simulate_key_event(driver_pid, 0, 266)
+      Helper.simulate_key_event(driver_pid, 0, 65_534)
       Helper.assert_key_event(nil, :f2)
 
       Process.exit(driver_pid, :shutdown)
@@ -87,13 +91,13 @@ defmodule Raxol.Terminal.Driver.KeyEventTest do
       Helper.wait_for_driver_ready(driver_pid)
       Helper.consume_initial_resize()
 
-      # Test modifier combinations
+      # Test modifier combinations (real TB_KEY_ARROW_UP/DOWN codes)
       # Ctrl+Up
-      Helper.simulate_key_event(driver_pid, 0, 65, 2)
+      Helper.simulate_key_event(driver_pid, 0, 65_517, 2)
       Helper.assert_key_event(nil, :up, %{ctrl: true})
 
       # Shift+Down
-      Helper.simulate_key_event(driver_pid, 0, 66, 1)
+      Helper.simulate_key_event(driver_pid, 0, 65_516, 1)
       Helper.assert_key_event(nil, :down, %{shift: true})
 
       Process.exit(driver_pid, :shutdown)

--- a/test/raxol/ui/components/harness/composer_test.exs
+++ b/test/raxol/ui/components/harness/composer_test.exs
@@ -517,4 +517,121 @@ defmodule Raxol.UI.Components.Harness.ComposerTest do
       assert new_state.mli.cursor_pos == {0, 0}
     end
   end
+
+  # -- T27 review round: real driver shapes, not just Event.key_event/3 --
+  #
+  # Before this round, `handle_event/3` matched key events by pattern
+  # (`%{key: :enter, modifiers: modifiers}`), a shape that ONLY exists on
+  # `Event.key_event/3` (the test API). The two real driver shapes --
+  # `event_translator.ex`'s (native termbox) and `input_parser.ex`'s (raw
+  # ANSI) -- have no `:modifiers` key at all, so that pattern never
+  # matched a real keypress: Enter never submitted, and printable
+  # characters never inserted outside of tests. These tests drive the
+  # REAL translator/parser functions (not hand-built maps) to prove the
+  # fix reaches actual terminal input, not just the test API.
+  describe "real driver shapes (event_translator.ex / input_parser.ex)" do
+    alias Raxol.Terminal.ANSI.InputParser
+    alias Raxol.Terminal.Driver.EventTranslator
+
+    defp translator_key_event(key_code, char_code \\ 0, mod_code \\ 0) do
+      {:ok, event} =
+        EventTranslator.translate(%{
+          type: :key,
+          key: key_code,
+          char: char_code,
+          mod: mod_code
+        })
+
+      event
+    end
+
+    defp parser_key_event(binary) do
+      [event] = InputParser.parse(binary)
+      event
+    end
+
+    test "a real termbox Enter (TB_KEY_ENTER) and a real ANSI Enter (CR byte) both submit" do
+      {:ok, translator_state} = Composer.init(id: :c)
+      translator_state = type(translator_state, "hello")
+
+      {:ok, parser_state} = Composer.init(id: :c)
+      parser_state = type(parser_state, "hello")
+
+      {_translator_new, translator_cmds} =
+        Composer.handle_event(
+          translator_key_event(13),
+          translator_state,
+          default_context()
+        )
+
+      {_parser_new, parser_cmds} =
+        Composer.handle_event(
+          parser_key_event(<<13>>),
+          parser_state,
+          default_context()
+        )
+
+      assert translator_cmds == [{:component_event, :c, {:submit, "hello"}}]
+      assert translator_cmds == parser_cmds
+    end
+
+    test "a native termbox printable char event inserts (was dead code before T27)" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {state, _cmds} =
+        Composer.handle_event(
+          translator_key_event(0, ?h),
+          state,
+          default_context()
+        )
+
+      {state, _cmds} =
+        Composer.handle_event(
+          translator_key_event(0, ?i),
+          state,
+          default_context()
+        )
+
+      assert Composer.value(state) == "hi"
+    end
+
+    test "a raw-ANSI printable char event inserts" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {state, _cmds} =
+        Composer.handle_event(parser_key_event("x"), state, default_context())
+
+      assert Composer.value(state) == "x"
+    end
+
+    test "a native termbox Ctrl+char event does not insert (it's a shortcut, delegated onward)" do
+      {:ok, state} = Composer.init(id: :c)
+
+      {new_state, _cmds} =
+        Composer.handle_event(
+          # mod bit 2 == ctrl, per event_translator.ex
+          translator_key_event(0, ?a, 2),
+          state,
+          default_context()
+        )
+
+      refute Composer.value(new_state) == "a"
+    end
+
+    test "Alt+Enter from a real termbox event inserts a newline, not a submit" do
+      {:ok, state} = Composer.init(id: :c)
+      state = type(state, "line one")
+
+      {new_state, cmds} =
+        Composer.handle_event(
+          # mod bit 4 == alt, per event_translator.ex
+          translator_key_event(13, 0, 4),
+          state,
+          default_context()
+        )
+
+      assert cmds == []
+      assert Composer.value(new_state) == "line one\n"
+    end
+  end
 end

--- a/test/raxol/ui/harness/input_event_test.exs
+++ b/test/raxol/ui/harness/input_event_test.exs
@@ -1,0 +1,902 @@
+defmodule Raxol.UI.Harness.InputEventTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.Terminal.ANSI.InputParser
+  alias Raxol.Terminal.Driver.EventTranslator
+  alias Raxol.UI.Harness.InputEvent
+
+  # termbox modifier bitmask, per event_translator.ex: bit0=shift bit1=ctrl
+  # bit2=alt bit3=meta
+  @shift 1
+  @ctrl 2
+  @alt 4
+  @meta 8
+
+  # Real TB_KEY_* values (see event_translator.ex's moduledoc -- these are
+  # NOT the ANSI-final-byte/ncurses values the driver used to use).
+  @tb_up 65_517
+  @tb_down 65_516
+  @tb_left 65_515
+  @tb_right 65_514
+  @tb_home 65_521
+  @tb_end 65_520
+  @tb_insert 65_523
+  @tb_delete 65_522
+  @tb_page_up 65_519
+  @tb_page_down 65_518
+  @tb_back_tab 65_513
+  @tb_f1 65_535
+  @tb_f2 65_534
+  @tb_f3 65_533
+  @tb_f4 65_532
+  @tb_f5 65_531
+  @tb_f6 65_530
+  @tb_f7 65_529
+  @tb_f8 65_528
+  @tb_f9 65_527
+  @tb_f10 65_526
+  @tb_f11 65_525
+  @tb_f12 65_524
+  @tb_enter 13
+  @tb_tab 9
+  @tb_escape 27
+  @tb_backspace 127
+
+  defp translator_event(key_code, char_code, mod_code \\ 0) do
+    {:ok, event} =
+      EventTranslator.translate(%{
+        type: :key,
+        key: key_code,
+        char: char_code,
+        mod: mod_code
+      })
+
+    event
+  end
+
+  defp parser_event(binary) do
+    [event] = InputParser.parse(binary)
+    event
+  end
+
+  # Fixtures for the table-driven test below. Resolved at *runtime* (inside
+  # the generated test bodies) rather than at module-compile time, since
+  # these call private functions defined in this same module.
+  defp fixture(:translator_char), do: translator_event(0, ?a)
+  defp fixture(:translator_ctrl_char), do: translator_event(0, ?a, @ctrl)
+  defp fixture(:translator_up), do: translator_event(@tb_up, 0)
+  defp fixture(:translator_enter), do: translator_event(@tb_enter, 0)
+  defp fixture(:translator_tab), do: translator_event(@tb_tab, 0)
+  defp fixture(:translator_escape), do: translator_event(@tb_escape, 0)
+  defp fixture(:translator_backspace), do: translator_event(@tb_backspace, 0)
+  defp fixture(:parser_char), do: parser_event("a")
+  defp fixture(:parser_ctrl_char), do: parser_event(<<1>>)
+  defp fixture(:parser_up), do: parser_event(<<27, 91, 65>>)
+  defp fixture(:parser_enter), do: parser_event(<<13>>)
+  defp fixture(:ek_char), do: Event.key_event("a", :pressed, [])
+  defp fixture(:ek_shift_char), do: Event.key_event("A", :pressed, [:shift])
+  defp fixture(:ek_ctrl_char), do: Event.key_event("a", :pressed, [:ctrl])
+  defp fixture(:ek_enter), do: Event.key_event(:enter, :pressed, [])
+
+  # -- shape (a): native termbox driver (event_translator.ex) --
+
+  describe "normalize/1 -- event_translator.ex shape" do
+    test "plain char" do
+      event = translator_event(0, ?a)
+
+      assert InputEvent.normalize(event) == %{
+               kind: :char,
+               char: "a",
+               key: nil,
+               text: nil,
+               mods: %{ctrl: false, alt: false, shift: false, meta: false},
+               state: nil,
+               raw: event
+             }
+    end
+
+    test "shift + char is still text" do
+      event = translator_event(0, ?A, @shift)
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :char
+      assert norm.char == "A"
+      assert norm.mods == %{ctrl: false, alt: false, shift: true, meta: false}
+      assert InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == "A"
+      refute InputEvent.shortcut?(norm)
+    end
+
+    test "ctrl + char is a shortcut, not text" do
+      event = translator_event(0, ?a, @ctrl)
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :char
+      assert norm.mods.ctrl
+      refute InputEvent.text?(norm)
+      assert InputEvent.shortcut?(norm)
+      assert InputEvent.printable_char(norm) == nil
+    end
+
+    test "alt + char is a shortcut" do
+      event = translator_event(0, ?a, @alt)
+      norm = InputEvent.normalize(event)
+      assert norm.mods.alt
+      refute InputEvent.text?(norm)
+      assert InputEvent.shortcut?(norm)
+    end
+
+    test "meta (Cmd/Super) + char is a shortcut, NOT literal text" do
+      event = translator_event(0, ?a, @meta)
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :char
+      assert norm.char == "a"
+      assert norm.mods.meta
+      refute InputEvent.text?(norm)
+      assert InputEvent.shortcut?(norm)
+      assert InputEvent.printable_char(norm) == nil
+    end
+
+    test "arrow keys map to :key (real TB_KEY_ARROW_* codes)" do
+      for {code, expected} <- [
+            {@tb_up, :up},
+            {@tb_down, :down},
+            {@tb_right, :right},
+            {@tb_left, :left}
+          ] do
+        event = translator_event(code, 0)
+        norm = InputEvent.normalize(event)
+        assert norm.kind == :key
+        assert norm.key == expected
+        assert InputEvent.key(norm) == expected
+        assert InputEvent.printable_char(norm) == nil
+        refute InputEvent.text?(norm)
+      end
+    end
+
+    test "function keys F1/F2 map to :key (real TB_KEY_F1/TB_KEY_F2 codes)" do
+      assert InputEvent.normalize(translator_event(@tb_f1, 0)).key == :f1
+      assert InputEvent.normalize(translator_event(@tb_f2, 0)).key == :f2
+    end
+
+    test "control keys (Enter/Tab/Escape/Backspace) map to :key, not printable char" do
+      assert InputEvent.normalize(translator_event(@tb_enter, 0)).key == :enter
+      assert InputEvent.normalize(translator_event(@tb_tab, 0)).key == :tab
+
+      assert InputEvent.normalize(translator_event(@tb_escape, 0)).key ==
+               :escape
+
+      assert InputEvent.normalize(translator_event(@tb_backspace, 0)).key ==
+               :backspace
+
+      # And the same control bytes arriving via char_code instead of
+      # key_code (the wiring convention is not settled -- see
+      # event_translator.ex's moduledoc) resolve identically, never
+      # leaking through as `char:`.
+      assert InputEvent.normalize(translator_event(0, @tb_enter)).key ==
+               :enter
+
+      assert InputEvent.normalize(translator_event(0, @tb_escape)).key ==
+               :escape
+    end
+
+    test "shift+tab (TB_KEY_BACK_TAB) recovers the shift bit" do
+      norm = InputEvent.normalize(translator_event(@tb_back_tab, 0))
+      assert norm.key == :tab
+      assert norm.mods.shift
+      refute InputEvent.shortcut?(norm)
+    end
+
+    test "unrecognized keycode still normalizes (kind: :key, key: :unknown)" do
+      norm = InputEvent.normalize(translator_event(999, 0))
+      assert norm.kind == :key
+      assert norm.key == :unknown
+    end
+  end
+
+  # -- shape (b): raw ANSI parser (input_parser.ex) --
+
+  describe "normalize/1 -- input_parser.ex shape" do
+    test "plain printable char (key: :char, char: binary)" do
+      event = parser_event("a")
+
+      assert InputEvent.normalize(event) == %{
+               kind: :char,
+               char: "a",
+               key: nil,
+               text: nil,
+               mods: %{ctrl: false, alt: false, shift: false, meta: false},
+               state: nil,
+               raw: event
+             }
+    end
+
+    test "ctrl+a (bytes 1-26) is a shortcut" do
+      norm = InputEvent.normalize(parser_event(<<1>>))
+      assert norm.kind == :char
+      assert norm.char == "a"
+      assert norm.mods.ctrl
+      refute InputEvent.text?(norm)
+      assert InputEvent.shortcut?(norm)
+    end
+
+    test "alt+key (ESC char) is a shortcut" do
+      norm = InputEvent.normalize(parser_event(<<27, ?a>>))
+      assert norm.kind == :char
+      assert norm.char == "a"
+      assert norm.mods.alt
+      assert InputEvent.shortcut?(norm)
+    end
+
+    test "arrow keys, enter, backspace, escape, tab map to :key" do
+      assert InputEvent.normalize(parser_event(<<27, 91, 65>>)).key == :up
+      assert InputEvent.normalize(parser_event(<<27, 91, 66>>)).key == :down
+      assert InputEvent.normalize(parser_event(<<27, 91, 67>>)).key == :right
+      assert InputEvent.normalize(parser_event(<<27, 91, 68>>)).key == :left
+      assert InputEvent.normalize(parser_event(<<13>>)).key == :enter
+      assert InputEvent.normalize(parser_event(<<127>>)).key == :backspace
+      assert InputEvent.normalize(parser_event(<<27>>)).key == :escape
+      assert InputEvent.normalize(parser_event(<<9>>)).key == :tab
+    end
+
+    test "shift+tab (backtab) is :key with shift mod but not a shortcut" do
+      norm = InputEvent.normalize(parser_event(<<27, 91, 90>>))
+      assert norm.key == :tab
+      assert norm.mods.shift
+      refute InputEvent.shortcut?(norm)
+    end
+
+    test "multi-byte UTF-8 / emoji grapheme survives intact" do
+      emoji = "👍"
+      norm = InputEvent.normalize(parser_event(emoji))
+      assert norm.kind == :char
+      assert norm.char == emoji
+      assert InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == emoji
+    end
+
+    test "bracketed paste" do
+      payload =
+        <<27, 91, 50, 48, 48, 126>> <> "hi" <> <<27, 91, 50, 48, 49, 126>>
+
+      norm = InputEvent.normalize(parser_event(payload))
+      assert norm.kind == :paste
+      assert norm.text == "hi"
+      assert norm.char == nil
+      assert norm.key == nil
+    end
+  end
+
+  # -- shape (c): Event.key_event/3 (test/component API) --
+
+  describe "normalize/1 -- Event.key_event/3 shape" do
+    test "bare binary key is text" do
+      event = Event.key_event("a", :pressed, [])
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :char
+      assert norm.char == "a"
+      assert InputEvent.text?(norm)
+    end
+
+    test "shift-only modifier is still text" do
+      event = Event.key_event("A", :pressed, [:shift])
+      norm = InputEvent.normalize(event)
+      assert norm.mods == %{ctrl: false, alt: false, shift: true, meta: false}
+      assert InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == "A"
+    end
+
+    test "ctrl modifier makes a char a shortcut" do
+      event = Event.key_event("a", :pressed, [:ctrl])
+      norm = InputEvent.normalize(event)
+      refute InputEvent.text?(norm)
+      assert InputEvent.shortcut?(norm)
+    end
+
+    test "alt modifier makes a char a shortcut" do
+      event = Event.key_event("a", :pressed, [:alt])
+      norm = InputEvent.normalize(event)
+      assert InputEvent.shortcut?(norm)
+    end
+
+    test "meta modifier (in the modifiers list) makes a char a shortcut" do
+      event = Event.key_event("s", :pressed, [:meta])
+      norm = InputEvent.normalize(event)
+      assert norm.mods.meta
+      refute InputEvent.text?(norm)
+      assert InputEvent.shortcut?(norm)
+    end
+
+    test "atom key is a special key" do
+      for key <- [:enter, :backspace, :escape, :tab, :up, :down] do
+        event = Event.key_event(key, :pressed, [])
+        norm = InputEvent.normalize(event)
+        assert norm.kind == :key
+        assert norm.key == key
+        assert InputEvent.key(norm) == key
+      end
+    end
+
+    test "emoji grapheme via key_event/3 survives intact" do
+      family = "👨‍👩‍👧‍👦"
+      event = Event.key_event(family, :pressed, [])
+      norm = InputEvent.normalize(event)
+      assert norm.char == family
+      assert InputEvent.printable_char(norm) == family
+    end
+  end
+
+  # -- paste event via Event.paste_event/2 --
+
+  describe "normalize/1 -- Event.paste_event/2" do
+    test "paste normalizes to kind: :paste with text" do
+      event = Event.paste_event("pasted text", {0, 0})
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :paste
+      assert norm.text == "pasted text"
+      refute InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == nil
+      assert InputEvent.key(norm) == nil
+    end
+  end
+
+  # -- bare (unwrapped) data maps --
+
+  describe "normalize/1 -- bare data maps (no Event wrapper)" do
+    test "bare event_translator-shaped data map" do
+      data = %{
+        shift: false,
+        ctrl: false,
+        alt: false,
+        meta: false,
+        char: "z",
+        key: nil
+      }
+
+      norm = InputEvent.normalize(data)
+      assert norm.kind == :char
+      assert norm.char == "z"
+    end
+
+    test "bare input_parser-shaped data map" do
+      data = %{key: :char, char: "z", ctrl: true}
+      norm = InputEvent.normalize(data)
+      assert norm.kind == :char
+      assert norm.mods.ctrl
+      assert InputEvent.shortcut?(norm)
+    end
+
+    test "bare special-key data map" do
+      norm = InputEvent.normalize(%{key: :up})
+      assert norm.kind == :key
+      assert norm.key == :up
+    end
+
+    test "bare paste-shaped data map (no :type wrapper)" do
+      norm = InputEvent.normalize(%{text: "hi"})
+      assert norm.kind == :paste
+      assert norm.text == "hi"
+    end
+  end
+
+  # -- fallback / totality for non-key event shapes --
+
+  describe "normalize/1 -- unrecognized shapes never crash" do
+    test "mouse event normalizes to :other" do
+      event = Event.mouse(:left, {1, 2})
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :other
+      assert norm.raw == event
+      refute InputEvent.text?(norm)
+      refute InputEvent.shortcut?(norm)
+      assert InputEvent.key(norm) == nil
+      assert InputEvent.printable_char(norm) == nil
+    end
+
+    test "resize event normalizes to :other" do
+      norm = InputEvent.normalize(Event.new(:resize, %{width: 80, height: 24}))
+      assert norm.kind == :other
+    end
+
+    test "empty key data map normalizes to :other" do
+      norm = InputEvent.normalize(%{})
+      assert norm.kind == :other
+    end
+
+    test "nil, integers, lists, strings never crash" do
+      for input <- [
+            nil,
+            42,
+            [1, 2, 3],
+            "just a string",
+            {:a, :b},
+            %{random: :junk}
+          ] do
+        norm = InputEvent.normalize(input)
+        assert norm.kind in [:char, :key, :paste, :other]
+        assert norm.raw == input
+      end
+    end
+  end
+
+  # -- table-driven: shapes x key classes --
+
+  describe "table-driven: every shape x key class" do
+    # {label, fixture_key, expected_kind, expected_key_or_char, text?, shortcut?}
+    table = [
+      {"translator: plain char", :translator_char, :char, "a", true, false},
+      {"translator: ctrl+char", :translator_ctrl_char, :char, "a", false, true},
+      {"translator: arrow up", :translator_up, :key, :up, false, false},
+      {"translator: enter", :translator_enter, :key, :enter, false, false},
+      {"translator: tab", :translator_tab, :key, :tab, false, false},
+      {"translator: escape", :translator_escape, :key, :escape, false, false},
+      {"translator: backspace", :translator_backspace, :key, :backspace, false,
+       false},
+      {"parser: plain char", :parser_char, :char, "a", true, false},
+      {"parser: ctrl+char", :parser_ctrl_char, :char, "a", false, true},
+      {"parser: arrow up", :parser_up, :key, :up, false, false},
+      {"parser: enter", :parser_enter, :key, :enter, false, false},
+      {"event_key: plain char", :ek_char, :char, "a", true, false},
+      {"event_key: shift char", :ek_shift_char, :char, "A", true, false},
+      {"event_key: ctrl char", :ek_ctrl_char, :char, "a", false, true},
+      {"event_key: enter", :ek_enter, :key, :enter, false, false}
+    ]
+
+    for {label, fixture_key, expected_kind, expected_payload, text?, shortcut?} <-
+          table do
+      # Build only the ONE relevant field assertion for this row at
+      # generation time -- a runtime `case` on a compile-time-constant atom
+      # would still emit both branches (norm.char == <atom> and
+      # norm.key == <binary>), tripping the type checker on the row where
+      # the branch is dead code but still statically type-mismatched.
+      payload_assertion =
+        case expected_kind do
+          :char ->
+            quote(do: assert(var!(norm).char == unquote(expected_payload)))
+
+          :key ->
+            quote(do: assert(var!(norm).key == unquote(expected_payload)))
+        end
+
+      test label do
+        event = fixture(unquote(fixture_key))
+        norm = InputEvent.normalize(event)
+
+        assert norm.kind == unquote(expected_kind)
+        unquote(payload_assertion)
+
+        assert InputEvent.text?(norm) == unquote(text?)
+        assert InputEvent.shortcut?(norm) == unquote(shortcut?)
+      end
+    end
+  end
+
+  # -- properties --
+
+  describe "properties" do
+    property "normalize/1 is total: never raises on arbitrary-ish event maps" do
+      check all(
+              kind_seed <-
+                one_of([
+                  constant(:char),
+                  constant(:key),
+                  constant(:paste),
+                  constant(:other)
+                ]),
+              key_atom <-
+                one_of([
+                  nil,
+                  :char,
+                  :up,
+                  :down,
+                  :enter,
+                  :escape,
+                  :backspace,
+                  :tab,
+                  :unknown
+                ]),
+              char_bin <-
+                one_of([
+                  constant(nil),
+                  constant(""),
+                  constant("a"),
+                  constant("A"),
+                  constant("👍")
+                ]),
+              ctrl <- boolean(),
+              alt <- boolean(),
+              shift <- boolean(),
+              meta <- boolean(),
+              modifiers <-
+                list_of(one_of([:ctrl, :alt, :shift, :meta]), max_length: 4),
+              state <-
+                one_of([nil, :pressed, :released, :repeat, :bogus]),
+              text_bin <-
+                one_of([constant(nil), constant(""), constant("pasted")]),
+              max_runs: 200
+            ) do
+        data = %{
+          key: key_atom,
+          char: char_bin,
+          ctrl: ctrl,
+          alt: alt,
+          shift: shift,
+          meta: meta,
+          modifiers: modifiers,
+          state: state
+        }
+
+        raw =
+          case kind_seed do
+            :paste -> %{type: :paste, data: %{text: text_bin || ""}}
+            _ -> %{type: :key, data: data}
+          end
+
+        norm = InputEvent.normalize(raw)
+        assert is_map(norm)
+        assert norm.kind in [:char, :key, :paste, :other]
+        assert is_map(norm.mods)
+        assert is_boolean(norm.mods.ctrl)
+        assert is_boolean(norm.mods.alt)
+        assert is_boolean(norm.mods.shift)
+        assert is_boolean(norm.mods.meta)
+
+        # helpers must never raise either
+        _ = InputEvent.text?(norm)
+        _ = InputEvent.shortcut?(norm)
+        _ = InputEvent.printable_char(norm)
+        _ = InputEvent.key(norm)
+      end
+    end
+
+    property "normalize/1 is total on genuinely arbitrary terms" do
+      check all(term <- term(), max_runs: 100) do
+        norm = InputEvent.normalize(term)
+        assert norm.kind in [:char, :key, :paste, :other]
+      end
+    end
+  end
+
+  # -- cross-shape agreement: REAL emitters --
+  #
+  # The previous version of this suite hand-built "translator-shaped" and
+  # "parser-shaped" maps directly (`%{key: k, char: nil, ctrl: ctrl, ...}`)
+  # instead of calling `EventTranslator.translate/1` / `InputParser.parse/1`.
+  # For :up/:down/etc that happened to line up with what the real functions
+  # produce, but for enter/tab/escape/backspace it was a FICTION: the real
+  # `EventTranslator.translate/1` only mapped 6 keycodes (arrows + F1/F2,
+  # and both used the WRONG numeric codes -- see event_translator.ex's
+  # moduledoc), so a REAL termbox enter/tab/esc/backspace normalized to
+  # `key: :unknown` while the ANSI parser correctly produced
+  # `:enter`/`:tab`/... for the same keypress. The hand-built map asserted
+  # agreement that could not exist between the real functions.
+  #
+  # Every event below is produced by the REAL `EventTranslator.translate/1`
+  # and REAL `InputParser.parse/1` -- no hand-built normalized maps. See
+  # input_event.ex's moduledoc ("Cross-shape agreement: scope") for
+  # exactly what modifier combinations are and are not claimed to agree,
+  # and why (meta is unrepresentable over ANSI; Enter/Tab/Escape/Backspace
+  # have no modifier-carrying ANSI encoding).
+  describe "cross-shape agreement (real translator + real parser)" do
+    # {ansi letter, is F-key/SS3-unmodified?} -- unmodified F1-F4 use SS3
+    # (ESC O <letter>); everything else here uses CSI (ESC [ <letter>).
+    # The modified form (ESC [ 1 ; <mod> <letter>) is the same for both,
+    # per input_parser.ex's `csi_letter_to_key/1` clause list.
+    @letter_form_keys %{
+      :up => {65, false},
+      :down => {66, false},
+      :right => {67, false},
+      :left => {68, false},
+      :home => {72, false},
+      :end => {70, false},
+      :f1 => {80, true},
+      :f2 => {81, true},
+      :f3 => {82, true},
+      :f4 => {83, true}
+    }
+
+    # CSI tilde-number keys (ESC [ <n> ~, or ESC [ <n> ; <mod> ~).
+    @tilde_form_keys %{
+      :insert => 2,
+      :delete => 3,
+      :page_up => 5,
+      :page_down => 6,
+      :f5 => 15,
+      :f6 => 17,
+      :f7 => 18,
+      :f8 => 19,
+      :f9 => 20,
+      :f10 => 21,
+      :f11 => 23,
+      :f12 => 24
+    }
+
+    @tb_key_codes %{
+      :up => @tb_up,
+      :down => @tb_down,
+      :left => @tb_left,
+      :right => @tb_right,
+      :home => @tb_home,
+      :end => @tb_end,
+      :insert => @tb_insert,
+      :delete => @tb_delete,
+      :page_up => @tb_page_up,
+      :page_down => @tb_page_down,
+      :f1 => @tb_f1,
+      :f2 => @tb_f2,
+      :f3 => @tb_f3,
+      :f4 => @tb_f4,
+      :f5 => @tb_f5,
+      :f6 => @tb_f6,
+      :f7 => @tb_f7,
+      :f8 => @tb_f8,
+      :f9 => @tb_f9,
+      :f10 => @tb_f10,
+      :f11 => @tb_f11,
+      :f12 => @tb_f12
+    }
+
+    @modifiable_keys Map.keys(@letter_form_keys) ++ Map.keys(@tilde_form_keys)
+
+    # xterm CSI modifier parameter: 1 + (shift?1) + (alt?2) + (ctrl?4),
+    # per input_parser.ex's `decode_modifier/1`.
+    defp mod_digit(%{shift: shift, alt: alt, ctrl: ctrl}) do
+      1 + bit(shift, 1) + bit(alt, 2) + bit(ctrl, 4)
+    end
+
+    defp bit(true, n), do: n
+    defp bit(false, _n), do: 0
+
+    defp no_mods?(%{shift: shift, alt: alt, ctrl: ctrl}),
+      do: not (shift or alt or ctrl)
+
+    # termbox mod_code bitmask: bit0=shift(1) bit1=ctrl(2) bit2=alt(4).
+    defp termbox_mod_code(%{shift: shift, alt: alt, ctrl: ctrl}) do
+      bit(shift, @shift) + bit(ctrl, @ctrl) + bit(alt, @alt)
+    end
+
+    defp ansi_bytes_for(key, mods) when is_map_key(@letter_form_keys, key) do
+      {letter, ss3?} = Map.fetch!(@letter_form_keys, key)
+
+      cond do
+        no_mods?(mods) and ss3? -> <<27, 79, letter>>
+        no_mods?(mods) -> <<27, 91, letter>>
+        true -> <<27, 91, 49, 59, ?0 + mod_digit(mods), letter>>
+      end
+    end
+
+    defp ansi_bytes_for(key, mods) when is_map_key(@tilde_form_keys, key) do
+      n = Map.fetch!(@tilde_form_keys, key)
+
+      if no_mods?(mods) do
+        "\e[#{n}~"
+      else
+        "\e[#{n};#{mod_digit(mods)}~"
+      end
+    end
+
+    defp mods_map(shift, alt, ctrl),
+      do: %{shift: shift, alt: alt, ctrl: ctrl, meta: false}
+
+    defp assert_agrees(translator_event, parser_event, expected_key, mods) do
+      translator_norm = InputEvent.normalize(translator_event)
+      parser_norm = InputEvent.normalize(parser_event)
+
+      fields = [:kind, :char, :key, :mods]
+
+      assert Map.take(translator_norm, fields) == Map.take(parser_norm, fields),
+             "translator/parser disagreed for #{expected_key} #{inspect(mods)}: " <>
+               "#{inspect(Map.take(translator_norm, fields))} vs " <>
+               "#{inspect(Map.take(parser_norm, fields))}"
+
+      assert translator_norm.kind == :key
+      assert translator_norm.key == expected_key
+      assert translator_norm.mods == mods
+    end
+
+    test "modifiable keys (arrows, home/end, F1-F4, insert/delete/pgup/pgdn, F5-F12) agree across the full ctrl/alt/shift power set" do
+      for key <- @modifiable_keys,
+          shift <- [false, true],
+          alt <- [false, true],
+          ctrl <- [false, true] do
+        mods = mods_map(shift, alt, ctrl)
+
+        translator_event =
+          translator_event(
+            Map.fetch!(@tb_key_codes, key),
+            0,
+            termbox_mod_code(mods)
+          )
+
+        parser_event = parser_event(ansi_bytes_for(key, mods))
+
+        assert_agrees(translator_event, parser_event, key, mods)
+      end
+    end
+
+    test "shift+tab (backtab) agrees: TB_KEY_BACK_TAB vs CSI Z" do
+      translator_event = translator_event(@tb_back_tab, 0)
+      parser_event = parser_event(<<27, 91, 90>>)
+
+      assert_agrees(
+        translator_event,
+        parser_event,
+        :tab,
+        mods_map(true, false, false)
+      )
+    end
+
+    test "control keys with no ANSI modifier encoding agree unmodified (Enter/Tab/Escape/Backspace)" do
+      no_mods = mods_map(false, false, false)
+
+      for {key, tb_code, ansi_bytes} <- [
+            {:enter, @tb_enter, <<13>>},
+            {:tab, @tb_tab, <<9>>},
+            {:escape, @tb_escape, <<27>>},
+            {:backspace, @tb_backspace, <<127>>}
+          ] do
+        translator_event = translator_event(tb_code, 0)
+        parser_event = parser_event(ansi_bytes)
+        assert_agrees(translator_event, parser_event, key, no_mods)
+      end
+    end
+
+    test "printable chars agree unmodified (any printable char)" do
+      for char <- ["a", "z", "5", " ", "!"] do
+        <<byte>> = char
+
+        assert_chars_agree(
+          translator_event(0, byte),
+          parser_event(char),
+          char,
+          mods_map(false, false, false)
+        )
+      end
+    end
+
+    test "ctrl+letter agrees (bytes 1-26 on the wire -- input_parser.ex only maps ctrl this way for a-z)" do
+      for char <- ["a", "z"] do
+        <<byte>> = char
+        ctrl_ansi = <<byte - 96>>
+
+        assert_chars_agree(
+          translator_event(0, byte, @ctrl),
+          parser_event(ctrl_ansi),
+          char,
+          mods_map(false, false, true)
+        )
+      end
+    end
+
+    test "alt+char agrees (ESC <char> on the wire)" do
+      for char <- ["a", "z", "5"] do
+        <<byte>> = char
+        alt_ansi = <<27, byte>>
+
+        assert_chars_agree(
+          translator_event(0, byte, @alt),
+          parser_event(alt_ansi),
+          char,
+          mods_map(false, true, false)
+        )
+      end
+    end
+
+    defp assert_chars_agree(translator_event, parser_event, char, mods) do
+      translator_norm = InputEvent.normalize(translator_event)
+      parser_norm = InputEvent.normalize(parser_event)
+      fields = [:kind, :char, :key, :mods]
+
+      assert Map.take(translator_norm, fields) == Map.take(parser_norm, fields),
+             "translator/parser disagreed for #{inspect(char)} #{inspect(mods)}: " <>
+               "#{inspect(Map.take(translator_norm, fields))} vs " <>
+               "#{inspect(Map.take(parser_norm, fields))}"
+
+      assert translator_norm.kind == :char
+      assert translator_norm.char == char
+      assert translator_norm.mods == mods
+    end
+  end
+
+  # -- event state (:pressed/:released/:repeat) --
+
+  describe "event state" do
+    test "release does not insert text" do
+      event = Event.key_event("a", :released, [])
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :char
+      assert norm.state == :released
+      refute InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == nil
+    end
+
+    test "press and repeat still insert text" do
+      for state <- [:pressed, :repeat] do
+        event = Event.key_event("a", state, [])
+        norm = InputEvent.normalize(event)
+        assert InputEvent.text?(norm)
+        assert InputEvent.printable_char(norm) == "a"
+      end
+    end
+
+    test "release does not dispatch a special key" do
+      event = Event.key_event(:enter, :released, [])
+      norm = InputEvent.normalize(event)
+      assert norm.kind == :key
+      assert InputEvent.key(norm) == nil
+    end
+
+    test "press and repeat still dispatch a special key" do
+      for state <- [:pressed, :repeat] do
+        event = Event.key_event(:enter, state, [])
+        norm = InputEvent.normalize(event)
+        assert InputEvent.key(norm) == :enter
+      end
+    end
+
+    test "no state field (event_translator.ex / input_parser.ex shapes) defaults to nil, treated as press" do
+      norm = InputEvent.normalize(translator_event(0, ?a))
+      assert norm.state == nil
+      assert InputEvent.text?(norm)
+
+      key_norm = InputEvent.normalize(translator_event(@tb_up, 0))
+      assert key_norm.state == nil
+      assert InputEvent.key(key_norm) == :up
+    end
+  end
+
+  # -- content validation --
+
+  describe "content validation" do
+    test "a control sequence smuggled into :char normalizes to :other, not :char" do
+      norm = InputEvent.normalize(%{type: :key, data: %{char: "\e[2J"}})
+      refute norm.kind == :char
+      assert norm.kind == :other
+      refute InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == nil
+    end
+
+    test "a bare multi-grapheme string in :key normalizes to :other, not an insertable char" do
+      norm = InputEvent.normalize(%{type: :key, data: %{key: "enter"}})
+      refute norm.kind == :char
+      refute InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == nil
+    end
+
+    test "text?/1 and printable_char/1 reject a hand-built map with a control byte, even outside normalize/1" do
+      bad = %{
+        kind: :char,
+        char: "\e",
+        key: nil,
+        text: nil,
+        mods: %{ctrl: false, alt: false, shift: false, meta: false},
+        state: nil,
+        raw: nil
+      }
+
+      refute InputEvent.text?(bad)
+      assert InputEvent.printable_char(bad) == nil
+    end
+
+    test "a single-codepoint emoji is still valid text (not rejected as multi-byte)" do
+      norm = InputEvent.normalize(parser_event("👍"))
+      assert InputEvent.text?(norm)
+      assert InputEvent.printable_char(norm) == "👍"
+    end
+
+    test "bracketed paste strips embedded control bytes but keeps tab/newline/CR" do
+      payload =
+        <<27, 91, 50, 48, 48, 126>> <>
+          "line one\ttabbed\nline two\e[2Jinjected" <>
+          <<27, 91, 50, 48, 49, 126>>
+
+      norm = InputEvent.normalize(parser_event(payload))
+      assert norm.kind == :paste
+      # ESC (the byte that makes "[2J" a live terminal control sequence
+      # instead of inert text) is stripped; tab/newline are preserved as
+      # legitimate multi-line paste content.
+      assert norm.text == "line one\ttabbed\nline two[2Jinjected"
+      refute String.contains?(norm.text, "\e")
+    end
+  end
+end


### PR DESCRIPTION
Unit **T27** of the harness-UI lane: canonical harness input-event normalization — extracted because two components (T11 composer, T14 picker) independently hit the same gap at build time.

## Why
The terminal driver emits key events in **three incompatible shapes**, and harness components had no single place to reconcile them — the composer (merged) reads only `data.modifiers`, which is **dead on the real terminal driver**; the picker hand-rolled a defensive `text_input?/1`. Same bug class twice → extract the seam (R2 interface unit).

| Source | shape | modifiers |
|---|---|---|
| `event_translator.ex` (termbox) | `%{char/key, shift/ctrl/alt/meta: bool}` | boolean fields, no list |
| `input_parser.ex` (ANSI) | `%{key: :char, char: "a"}` (bool mods only when true) | omitted-when-false |
| `Event.key_event/3` (API) | `%{key: "a", modifiers: [atoms]}` | list |

## What
- **`Raxol.UI.Harness.InputEvent.normalize/1`** → one canonical form: `%{kind: :char|:key|:paste|:other, char, key, text, mods: %{ctrl,alt,shift}, raw}`. `char`/`key` are mutually-exclusive lanes; `mods` always has all three booleans regardless of which upstream shape omitted which (the actual bug); `kind: :other` is a total fallback so normalize never raises.
- Helpers: `text?/1` (printable, no ctrl/alt — shift-only is text), `shortcut?/1` (ctrl/alt held), `printable_char/1` (grapheme, never truncates emoji/ZWJ), `key/1` (special-key atom).
- Accepts a full `%Event{}` or a bare data/paste map.

## Evidence
43 tests (40 unit + 3 properties): every one of the three shapes + paste + Event.key_event canonicalizes correctly; text?/shortcut?/printable_char across shift-only-is-text / ctrl-A-is-shortcut / emoji-grapheme-is-text; special keys map consistently; **totality** (200 runs, incl. arbitrary terms — never raises) and **idempotence** (raw round-trips losslessly). compile --warnings-as-errors / credo --strict / format clean.

## Follow-up
T11 composer and T14 picker retire their inline fixes for `InputEvent.normalize/1` in a cheap follow-up; T12 (keybinds) and T13a build on it directly. `TextInput`'s own `data[:modifiers] || []` read is the same class, noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
