### PR TITLE
credo: resolve custom-check require by config dir

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -28,7 +28,9 @@
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
       #
-      requires: ["./.credo/checks/unguarded_test_teardown_stop.ex"],
+      requires: [
+        Path.join(__DIR__, ".credo/checks/unguarded_test_teardown_stop.ex")
+      ],
       #
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:


### PR DESCRIPTION
`.credo.exs` set `requires: ["./.credo/checks/unguarded_test_teardown_stop.ex"]`, a **cwd-relative** path. Credo resolves `requires` against the working directory, not the config file, so `mix credo` run from inside any package (`packages/raxol_*`) failed to load the custom check:

```
** (Code.LoadError) could not load .../packages/raxol_payments/.credo/checks/unguarded_test_teardown_stop.ex
```

Fix: anchor the path to the config file's own directory with `Path.join(__DIR__, ...)`. Credo eval's `.credo.exs` with the config file as `file:`, so `__DIR__` is the repo root regardless of cwd.

## Manual testing
- [x] `mix credo --strict <file>` from repo root: no issues (custom check loads)
- [x] `cd packages/raxol_payments && mix credo --strict <file>`: no issues (previously LoadError)