### PR TITLE
raxol_payments: wire AgentStream.announce into the swap execution path

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_xochi_intent.ex
@@ -111,7 +111,7 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
   alias Raxol.Payments.{Assets, Checkpoint, Failure, Router}
   alias Raxol.Payments.Protocols.Xochi
   alias Raxol.Payments.Xochi.Schemas.{QuoteRequest, QuoteResponse}
-  alias Raxol.Payments.Xochi.Stealth
+  alias Raxol.Payments.Xochi.{Stealth, SwapAnnouncer}
 
   @spec run(map(), map()) :: {:ok, map()} | {:error, Failure.t()}
   @impl true
@@ -146,6 +146,10 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteXochiIntent do
            execute(config, request, quote, wallet, context, amount, store, key),
          :ok <- assert_settlement_privacy(request, exec) do
       summary = summary(request, filled_quote, exec)
+      # Best-effort, non-blocking: emit a signed activity row to the user's live
+      # feed (and stash the route for the terminal announce). Never affects the
+      # swap; a no-op unless a capability topic_id is configured.
+      SwapAnnouncer.announce_execute(context, request, filled_quote, exec)
       Checkpoint.put(store, key, settled_record(summary))
       {:ok, summary}
     end

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -110,13 +110,17 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
     {:error, Failure.from({:settlement, status.status, reason})}
   end
 
-  defp handle_result({:error, :timeout}, _ctx, id, _budget) do
+  defp handle_result({:error, :timeout}, ctx, id, _budget) do
     # A poll that never reached a terminal status is not a clean failure: the
     # origin funds may already have been pulled while delivery stayed
     # unconfirmed, so the intent is stranded, not failed. Emit a distinct signal
     # so operator tooling can reconcile or close THIS intent, and carry the id in
     # the error so the caller does not re-execute it.
     :telemetry.execute([:raxol, :payments, :xochi, :intent_stranded], %{}, %{intent_id: id})
+    # Advance the live-feed row off "executing" to a stranded state so it does
+    # not sit unresolved. Best-effort; leaves the route in place for a later
+    # terminal announce if a re-poll resolves the intent.
+    SwapAnnouncer.announce_stranded(ctx, id)
     {:error, Failure.from({:stranded, id})}
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -52,6 +52,7 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
   alias Raxol.Payments.{Failure, Poll}
   alias Raxol.Payments.Protocols.Xochi
   alias Raxol.Payments.Xochi.Schemas.IntentStatus
+  alias Raxol.Payments.Xochi.SwapAnnouncer
 
   @spec run(map(), map()) :: {:ok, map()} | {:error, Failure.t()}
   @impl true
@@ -60,54 +61,75 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
       {:ok, config} ->
         opts = poll_opts(params)
         budget = Keyword.get(opts, :budget_ms, Poll.default_budget_ms())
-
-        case Xochi.poll_status_timed(config, intent_id, opts) do
-          {:ok, %IntentStatus{status: :completed} = status, elapsed_ms} ->
-            # Settled: the spend stands. Drop the reservation tag so the ledger's
-            # in-flight set stays bounded; nothing to release.
-            SpendGate.forget_reservation(context, intent_id)
-            {:ok, summary(status, elapsed_ms, budget)}
-
-          {:ok, %IntentStatus{status: :refunded} = status, _elapsed_ms} ->
-            # The origin funds came back. Release the execute-time budget
-            # reservation, idempotently -- a re-poll of an already-refunded intent
-            # releases nothing further -- so a refunded payment stops consuming
-            # budget. Still surfaced as an error carrying the refund reason.
-            SpendGate.release_by_intent(context, intent_id)
-            reason = status.error || status.refund_reason || status.substatus_message
-            {:error, Failure.from({:settlement, :refunded, reason})}
-
-          {:ok, %IntentStatus{} = status, _elapsed_ms} ->
-            # Terminal but not completed or refunded (failed/expired): a failed
-            # order must surface as an error, never as {:ok, ...}. The origin pull
-            # may already have moved funds, so the spend stands -- forget the tag
-            # (no release), but keep the reason (an explicit error, then the
-            # solver's substatus_message) so why it failed is never lost.
-            SpendGate.forget_reservation(context, intent_id)
-            reason = status.error || status.substatus_message
-            {:error, Failure.from({:settlement, status.status, reason})}
-
-          {:error, :timeout} ->
-            # A poll that never reached a terminal status is not a clean failure:
-            # the origin funds may already have been pulled while delivery stayed
-            # unconfirmed, so the intent is stranded, not failed. Emit a distinct
-            # signal so operator tooling can reconcile or close THIS intent, and
-            # carry the id in the error so the caller does not re-execute it.
-            :telemetry.execute(
-              [:raxol, :payments, :xochi, :intent_stranded],
-              %{},
-              %{intent_id: intent_id}
-            )
-
-            {:error, Failure.from({:stranded, intent_id})}
-
-          {:error, reason} ->
-            {:error, Failure.from(reason)}
-        end
+        result = Xochi.poll_status_timed(config, intent_id, opts)
+        handle_result(result, context, intent_id, budget)
 
       :error ->
         {:error, Failure.from({:missing_context, :xochi_config})}
     end
+  end
+
+  defp handle_result(
+         {:ok, %IntentStatus{status: :completed} = status, elapsed_ms},
+         ctx,
+         id,
+         budget
+       ) do
+    # Settled: the spend stands. Drop the reservation tag so the ledger's
+    # in-flight set stays bounded; nothing to release.
+    SpendGate.forget_reservation(ctx, id)
+    announce_terminal(ctx, id, status)
+    {:ok, summary(status, elapsed_ms, budget)}
+  end
+
+  defp handle_result(
+         {:ok, %IntentStatus{status: :refunded} = status, _elapsed_ms},
+         ctx,
+         id,
+         _budget
+       ) do
+    # The origin funds came back. Release the execute-time budget reservation,
+    # idempotently -- a re-poll of an already-refunded intent releases nothing
+    # further -- so a refunded payment stops consuming budget. Still surfaced as
+    # an error carrying the refund reason.
+    SpendGate.release_by_intent(ctx, id)
+    announce_terminal(ctx, id, status)
+    reason = status.error || status.refund_reason || status.substatus_message
+    {:error, Failure.from({:settlement, :refunded, reason})}
+  end
+
+  defp handle_result({:ok, %IntentStatus{} = status, _elapsed_ms}, ctx, id, _budget) do
+    # Terminal but not completed or refunded (failed/expired): a failed order
+    # must surface as an error, never as {:ok, ...}. The origin pull may already
+    # have moved funds, so the spend stands -- forget the tag (no release), but
+    # keep the reason (an explicit error, then the solver's substatus_message) so
+    # why it failed is never lost.
+    SpendGate.forget_reservation(ctx, id)
+    announce_terminal(ctx, id, status)
+    reason = status.error || status.substatus_message
+    {:error, Failure.from({:settlement, status.status, reason})}
+  end
+
+  defp handle_result({:error, :timeout}, _ctx, id, _budget) do
+    # A poll that never reached a terminal status is not a clean failure: the
+    # origin funds may already have been pulled while delivery stayed
+    # unconfirmed, so the intent is stranded, not failed. Emit a distinct signal
+    # so operator tooling can reconcile or close THIS intent, and carry the id in
+    # the error so the caller does not re-execute it.
+    :telemetry.execute([:raxol, :payments, :xochi, :intent_stranded], %{}, %{intent_id: id})
+    {:error, Failure.from({:stranded, id})}
+  end
+
+  defp handle_result({:error, reason}, _ctx, _id, _budget) do
+    {:error, Failure.from(reason)}
+  end
+
+  # Best-effort, non-blocking: advance the user's live-feed row to its terminal
+  # state. A no-op unless a capability topic_id is configured and the execute
+  # stashed this intent's route. Never affects the poll result.
+  defp announce_terminal(context, intent_id, status) do
+    SwapAnnouncer.announce_terminal(context, intent_id, status)
+    :ok
   end
 
   defp poll_opts(params) do

--- a/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
@@ -330,19 +330,30 @@ defmodule Raxol.Payments.Xochi.AgentStream do
     ExKeccak.hash_256(prefixed)
   end
 
+  # secp256k1 group order halved. A canonical (low-s) signature has
+  # 1 <= s <= n/2. Because (r, n - s) recovers the same key, accepting a high-s
+  # signature would let a third party malleate a posted announce into a second
+  # signature over the same event that still verifies, so the relay fans out a
+  # duplicate row. Reject high-s; our own signer (libsecp256k1) already emits
+  # low-s, and the client's viem check is over the canonical form.
+  @secp256k1_half_n 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0
+
+  # EIP-191/personal_sign is canonical: v is 27 or 28 (never the raw 0/1 recovery
+  # id here) and s is low. Enforce both so a malformed or malleated signature is
+  # rejected rather than recovered. ExSecp256k1.recover wants a 0/1 recovery id.
   defp decode_signature(hex) do
     case Base.decode16(hex, case: :mixed) do
-      {:ok, <<r::binary-size(32), s::binary-size(32), v::8>>} ->
-        {:ok, {r, s, normalize_recovery_id(v)}}
+      {:ok, <<r::binary-size(32), s::binary-size(32), v::8>>} when v in [27, 28] ->
+        if low_s?(s),
+          do: {:ok, {r, s, v - 27}},
+          else: {:error, :malleable_signature}
 
       _ ->
         {:error, :invalid_signature}
     end
   end
 
-  # EIP-191/personal_sign uses v in {27, 28}; ExSecp256k1 wants a 0/1 recovery id.
-  defp normalize_recovery_id(v) when v >= 27, do: v - 27
-  defp normalize_recovery_id(v), do: v
+  defp low_s?(<<s::unsigned-big-256>>), do: s >= 1 and s <= @secp256k1_half_n
 
   # address = last 20 bytes of keccak256(uncompressed pubkey without the 0x04 tag).
   defp address_from_pubkey(<<_prefix::8, xy::binary-size(64)>>) do

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -1,0 +1,159 @@
+defmodule Raxol.Payments.Xochi.SwapAnnouncer do
+  @moduledoc """
+  Bridge from the Xochi swap Actions to `Raxol.Payments.Xochi.AgentStream`.
+
+  When an agent runs a swap under a Mandate and the caller has configured a
+  capability `topic_id`, this emits a signed activity row to the user's live
+  feed: once on execute (non-terminal) and once at terminal status, so the row
+  advances on its own. Both emits are best-effort and non-blocking -- a failed or
+  unconfigured announce never touches the swap.
+
+  ## Configuration (per-Mandate, out of band)
+
+  The Actions read an optional `:agent_stream` key from their context:
+
+      context = %{
+        wallet: MyAgentWallet,
+        xochi_config: %{base_url: "https://api.xochi.fi", auth: {:mandate, w}},
+        agent_stream: %{topic_id: "abc...", mandate_hash: "0x..."}
+      }
+
+  Fields:
+
+    * `:topic_id` -- the capability handed to the agent out of band at Mandate
+      authorization (see the "Capability handoff" section of `AgentStream`).
+      Required; absent, every entry point here is a silent no-op.
+    * `:xochi_api_url` -- announce host. Optional; defaults to
+      `xochi_config.base_url` (the same host the swap ran against).
+    * `:mandate_hash` -- telemetry-only, never on the wire. Optional.
+    * `:jitter_ms`, `:req_options` -- forwarded to `AgentStream` when present.
+
+  The signing wallet and the on-wire `agentWallet` come from the context
+  `:wallet` (the agent's own wallet). The delegator/human wallet never appears.
+
+  The route (chains, tokens, amounts) is captured at execute and stashed in
+  `Raxol.Payments.Xochi.SwapRouteStore` keyed by intent id, so the later terminal
+  announce can rebuild the full event from only the `intent_id` it observes.
+  """
+
+  alias Raxol.Payments.Xochi.{AgentStream, SwapRouteStore}
+  alias Raxol.Payments.Xochi.Schemas.{IntentStatus, QuoteRequest, QuoteResponse}
+
+  @doc """
+  Announce the execute (non-terminal) event and stash the route for the terminal
+  announce. No-op when no `topic_id` is configured. Always returns `:ok`.
+  """
+  @spec announce_execute(map(), QuoteRequest.t(), QuoteResponse.t(), map()) ::
+          :ok
+  def announce_execute(
+        context,
+        %QuoteRequest{} = request,
+        %QuoteResponse{} = quote,
+        exec
+      ) do
+    case config(context) do
+      {:ok, cfg} ->
+        event = execute_event(request, quote, exec)
+        SwapRouteStore.remember(event.intent_id, event)
+        AgentStream.announce(cfg, event)
+        :ok
+
+      :skip ->
+        :ok
+    end
+  end
+
+  @doc """
+  Announce the terminal event, rebuilt from the stashed route plus the observed
+  terminal status. No-op when no `topic_id` is configured or no route was stashed
+  for `intent_id`. Always returns `:ok`.
+  """
+  @spec announce_terminal(map(), String.t(), IntentStatus.t()) :: :ok
+  def announce_terminal(context, intent_id, %IntentStatus{} = status) do
+    with {:ok, cfg} <- config(context),
+         {:ok, base} <- SwapRouteStore.take(intent_id) do
+      AgentStream.announce(cfg, terminal_event(base, status))
+      :ok
+    else
+      _ -> :ok
+    end
+  end
+
+  @doc """
+  Resolve the `AgentStream` config from an Action context, or `:skip` when no
+  `topic_id` (or no wallet / announce host) is available.
+  """
+  @spec config(map()) :: {:ok, map()} | :skip
+  def config(context) do
+    with %{} = stream <- Map.get(context, :agent_stream),
+         topic_id when is_binary(topic_id) and topic_id != "" <-
+           Map.get(stream, :topic_id),
+         {:ok, wallet} <- Map.fetch(context, :wallet),
+         {:ok, url} <- resolve_url(stream, context) do
+      {:ok, build_config(stream, url, topic_id, wallet)}
+    else
+      _ -> :skip
+    end
+  end
+
+  # -- Private --
+
+  defp build_config(stream, url, topic_id, wallet) do
+    %{xochi_api_url: url, topic_id: topic_id, wallet: wallet}
+    |> put_optional(:mandate_hash, Map.get(stream, :mandate_hash))
+    |> put_optional(:jitter_ms, Map.get(stream, :jitter_ms))
+    |> put_optional(:req_options, Map.get(stream, :req_options))
+  end
+
+  # An explicit announce host wins; otherwise reuse the swap's Xochi base_url.
+  defp resolve_url(stream, context) do
+    case Map.get(stream, :xochi_api_url) do
+      url when is_binary(url) and url != "" ->
+        {:ok, url}
+
+      _ ->
+        case get_in(context, [:xochi_config, :base_url]) do
+          url when is_binary(url) and url != "" -> {:ok, url}
+          _ -> :error
+        end
+    end
+  end
+
+  defp execute_event(%QuoteRequest{} = request, %QuoteResponse{} = quote, exec) do
+    %{
+      intent_id: exec.intent_id,
+      from_chain_id: request.from_chain_id,
+      to_chain_id: request.to_chain_id,
+      from_token: request.from_token,
+      to_token: request.to_token,
+      from_amount: request.from_amount,
+      to_amount: quote.to_amount,
+      status: execute_status(exec),
+      ts: now_ms()
+    }
+  end
+
+  # Rebuild the terminal event from the stashed route, overriding only the status
+  # and timestamp. The delivered amount is the quote's `to_amount` captured at
+  # execute; the status becomes the observed terminal one (completed / failed /
+  # refunded / expired).
+  defp terminal_event(base, %IntentStatus{status: status}) do
+    %{base | status: to_string(status), ts: now_ms()}
+  end
+
+  # In-doubt executes are still in flight, not terminal -- surface them as a
+  # non-terminal status so the row shows pending until polling resolves it.
+  defp execute_status(%{reconciling: true}), do: "executing"
+  defp execute_status(%{status: :completed}), do: "completed"
+
+  defp execute_status(%{status: status})
+       when status in [:executing, :settling, :pending],
+       do: to_string(status)
+
+  defp execute_status(_exec), do: "submitted"
+
+  defp put_optional(map, _key, nil), do: map
+  defp put_optional(map, key, value), do: Map.put(map, key, value)
+
+  defp now_ms, do: System.system_time(:millisecond)
+end

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -32,12 +32,33 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   `:wallet` (the agent's own wallet). The delegator/human wallet never appears.
 
   The route (chains, tokens, amounts) is captured at execute and stashed in
-  `Raxol.Payments.Xochi.SwapRouteStore` keyed by intent id, so the later terminal
-  announce can rebuild the full event from only the `intent_id` it observes.
+  `Raxol.Payments.Xochi.SwapRouteStore` keyed by the real intent id, so the later
+  terminal announce can rebuild the event from only the `intent_id` it observes.
+
+  ## Privacy: only public settlements disclose the route
+
+  Safe by default: only a `settlement_preference` of `"public"` announces the
+  full route (chains, tokens, amounts, real intent id). A `"stealth"` or
+  `"shielded"` settlement (and any unset/unknown preference) announces a
+  redacted row instead: the status and timestamp only, under a topic-salted
+  pseudo intent id, with no amounts, chains, or tokens. Announcing the exact
+  delivered amount or the real intent id of a private swap would let an observer
+  join the feed row against the on-chain stealth announcement or shielded note
+  and defeat the very unlinkability those modes exist for. The execute and
+  terminal rows share the same pseudo id so the browser still merges them into
+  one advancing row.
   """
 
   alias Raxol.Payments.Xochi.{AgentStream, SwapRouteStore}
   alias Raxol.Payments.Xochi.Schemas.{IntentStatus, QuoteRequest, QuoteResponse}
+
+  # Placeholder token for a redacted row. The wire schema requires a non-empty
+  # string (fromToken/toToken min length 1), so a private swap cannot send "".
+  @redacted_token "redacted"
+  # Chain ids and amount for a redacted row. 0 is a valid wire int; "0"/nil are
+  # valid wire amounts (toAmount is nullable). None reveal the real route.
+  @redacted_chain 0
+  @redacted_from_amount "0"
 
   @doc """
   Announce the execute (non-terminal) event and stash the route for the terminal
@@ -53,8 +74,11 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
       ) do
     case config(context) do
       {:ok, cfg} ->
-        event = execute_event(request, quote, exec)
-        SwapRouteStore.remember(event.intent_id, event)
+        event = execute_event(request, quote, exec, cfg.topic_id)
+        # Key the stash by the REAL intent id: PollXochiStatus only ever observes
+        # that. For a private swap the event's own `intent_id` is the pseudo id,
+        # so the two must not be conflated.
+        SwapRouteStore.remember(exec.intent_id, event)
         AgentStream.announce(cfg, event)
         :ok
 
@@ -70,33 +94,69 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   """
   @spec announce_terminal(map(), String.t(), IntentStatus.t()) :: :ok
   def announce_terminal(context, intent_id, %IntentStatus{} = status) do
-    with {:ok, cfg} <- config(context),
-         {:ok, base} <- SwapRouteStore.take(intent_id) do
-      AgentStream.announce(cfg, terminal_event(base, status))
-      :ok
-    else
-      _ -> :ok
+    case config(context) do
+      {:ok, cfg} ->
+        case SwapRouteStore.take(intent_id) do
+          {:ok, base} ->
+            AgentStream.announce(cfg, terminal_event(base, status))
+            :ok
+
+          # No stash for this intent: the execute never announced (unconfigured
+          # then), or the route already expired. Emitting a blank-route terminal
+          # would clobber the row, so skip and record why.
+          :error ->
+            emit_skipped(context, :no_route)
+            :ok
+        end
+
+      # config/1 already emitted the specific skip reason.
+      :skip ->
+        :ok
     end
   end
 
   @doc """
   Resolve the `AgentStream` config from an Action context, or `:skip` when no
-  `topic_id` (or no wallet / announce host) is available.
+  `topic_id` (or no wallet / announce host) is available. Emits an
+  `[:raxol, :payments, :xochi, :agent_stream, :announce_skipped]` telemetry event
+  carrying the specific reason so a misconfiguration is observable rather than a
+  silent no-op.
   """
   @spec config(map()) :: {:ok, map()} | :skip
   def config(context) do
-    with %{} = stream <- Map.get(context, :agent_stream),
-         topic_id when is_binary(topic_id) and topic_id != "" <-
-           Map.get(stream, :topic_id),
-         {:ok, wallet} <- Map.fetch(context, :wallet),
-         {:ok, url} <- resolve_url(stream, context) do
+    with {_, %{} = stream} <- {:not_configured, Map.get(context, :agent_stream)},
+         {_, topic_id} when is_binary(topic_id) and topic_id != "" <-
+           {:no_topic_id, Map.get(stream, :topic_id)},
+         {_, {:ok, wallet}} <- {:no_wallet, Map.fetch(context, :wallet)},
+         {_, {:ok, url}} <- {:no_announce_host, resolve_url(stream, context)} do
       {:ok, build_config(stream, url, topic_id, wallet)}
     else
-      _ -> :skip
+      {reason, _} ->
+        emit_skipped(context, reason)
+        :skip
     end
   end
 
   # -- Private --
+
+  # Diagnostics for the best-effort no-op paths. AgentStream emits :dropped once
+  # an announce is attempted and fails; this covers the layer above, where an
+  # announce is never attempted at all (misconfigured topic/wallet/host, or a
+  # missing/expired route). mandate_hash and the delegator wallet never appear.
+  defp emit_skipped(context, reason) do
+    :telemetry.execute(
+      [:raxol, :payments, :xochi, :agent_stream, :announce_skipped],
+      %{count: 1},
+      %{reason: reason, topic_id: topic_id_hint(context)}
+    )
+  end
+
+  defp topic_id_hint(context) do
+    case Map.get(context, :agent_stream) do
+      %{topic_id: topic_id} -> topic_id
+      _ -> nil
+    end
+  end
 
   defp build_config(stream, url, topic_id, wallet) do
     %{xochi_api_url: url, topic_id: topic_id, wallet: wallet}
@@ -119,18 +179,55 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
     end
   end
 
-  defp execute_event(%QuoteRequest{} = request, %QuoteResponse{} = quote, exec) do
+  # Public settlement: disclose the full route. Any other preference (stealth /
+  # shielded / unset) settles privately, so the row is redacted to status only.
+  defp execute_event(%QuoteRequest{} = request, %QuoteResponse{} = quote, exec, topic_id) do
+    if settlement_private?(request) do
+      redacted_event(pseudo_id(topic_id, exec.intent_id), execute_status(exec))
+    else
+      %{
+        intent_id: exec.intent_id,
+        from_chain_id: request.from_chain_id,
+        to_chain_id: request.to_chain_id,
+        from_token: request.from_token,
+        to_token: request.to_token,
+        from_amount: request.from_amount,
+        to_amount: quote.to_amount,
+        status: execute_status(exec),
+        ts: now_ms()
+      }
+    end
+  end
+
+  # Only an explicit "public" preference discloses the route. Everything else,
+  # including a nil/unknown preference, is treated as private (fail safe).
+  defp settlement_private?(%QuoteRequest{settlement_preference: "public"}), do: false
+  defp settlement_private?(%QuoteRequest{}), do: true
+
+  # A redacted row carries no amounts, chains, or tokens and a pseudo intent id.
+  # Fields are set to the least-revealing values the wire schema still accepts.
+  defp redacted_event(pseudo_intent_id, status) do
     %{
-      intent_id: exec.intent_id,
-      from_chain_id: request.from_chain_id,
-      to_chain_id: request.to_chain_id,
-      from_token: request.from_token,
-      to_token: request.to_token,
-      from_amount: request.from_amount,
-      to_amount: quote.to_amount,
-      status: execute_status(exec),
+      intent_id: pseudo_intent_id,
+      from_chain_id: @redacted_chain,
+      to_chain_id: @redacted_chain,
+      from_token: @redacted_token,
+      to_token: @redacted_token,
+      from_amount: @redacted_from_amount,
+      to_amount: nil,
+      status: status,
       ts: now_ms()
     }
+  end
+
+  # A stable, topic-salted pseudonym for the real intent id: the same real id
+  # under the same topic always yields the same pseudo id (so the execute and
+  # terminal rows merge in the browser), but without the topic secret it cannot
+  # be tied back to the real intent id or to on-chain settlement state.
+  defp pseudo_id(topic_id, intent_id) do
+    :crypto.hash(:sha256, [topic_id, "\n", to_string(intent_id)])
+    |> binary_part(0, 16)
+    |> Base.encode16(case: :lower)
   end
 
   # Rebuild the terminal event from the stashed route, overriding only the status

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -47,6 +47,28 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   and defeat the very unlinkability those modes exist for. The execute and
   terminal rows share the same pseudo id so the browser still merges them into
   one advancing row.
+
+  ## Trust boundary: where and under whose topic a signed row may go
+
+  The `topic_id` is a capability and the announce host is signature-free, so a
+  context that names a hostile host or a wrong topic would exfiltrate a signed
+  activity row to an attacker or into another user's feed. `config/1` therefore
+  fails closed on three axes before it will announce:
+
+    * The announce host must be the swap's own Xochi host, `localhost`, or a
+      host on the operator's allowlist (`config :raxol_payments,
+      :xochi_announce_hosts`). An injected `agent_stream.xochi_api_url` pointing
+      elsewhere is rejected.
+    * The `topic_id` must match the Xochi capability format
+      (`[A-Za-z0-9_-]{16,64}`), so a truncated or malformed topic never ships.
+    * The topic is bound to its authorizing Mandate. When the swap surfaces the
+      authorizing mandate hash (`context.authorizing_mandate_hash`), the topic's
+      declared `mandate_hash` must equal it. Absent that, a binding-required
+      deployment (production by default, or `config :raxol_payments,
+      :require_topic_mandate_binding`) still requires the topic to declare which
+      mandate it serves. Full cryptographic ownership is a Xochi-side check
+      (the worker verifying the signature against the mandate the topic was
+      issued for) and lands with the authorization handoff.
   """
 
   alias Raxol.Payments.Xochi.{AgentStream, SwapRouteStore}
@@ -59,6 +81,14 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   # valid wire amounts (toAmount is nullable). None reveal the real route.
   @redacted_chain 0
   @redacted_from_amount "0"
+
+  # Xochi capability topic format (mirrors TOPIC_ID_RE in the shared contract):
+  # 16-64 base64url characters. A topic that does not match never ships.
+  @topic_id_re ~r/^[A-Za-z0-9_-]{16,64}$/
+  # Announce hosts allowed in addition to the swap's own Xochi host. Localhost
+  # covers `wrangler dev`; production is added via config. The swap's own host is
+  # always allowed (it is already trusted to move the funds).
+  @default_announce_hosts ["api.xochi.fi", "localhost", "127.0.0.1"]
 
   @doc """
   Announce the execute (non-terminal) event and stash the route for the terminal
@@ -75,6 +105,7 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
     case config(context) do
       {:ok, cfg} ->
         event = execute_event(request, quote, exec, cfg.topic_id)
+
         # Key the stash by the REAL intent id: PollXochiStatus only ever observes
         # that. For a private swap the event's own `intent_id` is the pseudo id,
         # so the two must not be conflated.
@@ -116,28 +147,152 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   end
 
   @doc """
-  Resolve the `AgentStream` config from an Action context, or `:skip` when no
-  `topic_id` (or no wallet / announce host) is available. Emits an
+  Announce a `stranded` row for an intent whose poll timed out before any
+  terminal status. The row was left at its non-terminal execute state, so this
+  advances it to a distinct in-doubt state (the client keeps it out of
+  completed/failed, which is honest: the origin funds may still settle late).
+
+  Reads the route with `peek/1`, NOT `take/1`: if the intent later resolves to a
+  real terminal status on a re-poll, `announce_terminal/3` must still find its
+  route. No-op when no `topic_id` is configured or no route is stashed.
+  """
+  @spec announce_stranded(map(), String.t()) :: :ok
+  def announce_stranded(context, intent_id) do
+    case config(context) do
+      {:ok, cfg} ->
+        case SwapRouteStore.peek(intent_id) do
+          {:ok, base} ->
+            AgentStream.announce(cfg, %{base | status: "stranded", ts: now_ms()})
+            :ok
+
+          :error ->
+            emit_skipped(context, :no_route)
+            :ok
+        end
+
+      :skip ->
+        :ok
+    end
+  end
+
+  @doc """
+  Resolve the `AgentStream` config from an Action context, or `:skip` when it
+  fails a validation. Emits an
   `[:raxol, :payments, :xochi, :agent_stream, :announce_skipped]` telemetry event
-  carrying the specific reason so a misconfiguration is observable rather than a
-  silent no-op.
+  carrying the specific reason (`:not_configured`, `:no_topic_id`,
+  `:invalid_topic_id`, `:mandate_binding_required`, `:no_wallet`,
+  `:no_announce_host`, `:host_not_allowed`) so a misconfiguration or a rejected
+  host/topic is observable rather than a silent no-op. See the "Trust boundary"
+  section for the host, topic-format, and Mandate-binding rules.
   """
   @spec config(map()) :: {:ok, map()} | :skip
   def config(context) do
-    with {_, %{} = stream} <- {:not_configured, Map.get(context, :agent_stream)},
-         {_, topic_id} when is_binary(topic_id) and topic_id != "" <-
-           {:no_topic_id, Map.get(stream, :topic_id)},
-         {_, {:ok, wallet}} <- {:no_wallet, Map.fetch(context, :wallet)},
-         {_, {:ok, url}} <- {:no_announce_host, resolve_url(stream, context)} do
+    with {:ok, {stream, topic_id}} <- validate_topic(context),
+         {:ok, {wallet, url}} <- validate_target(context, stream) do
       {:ok, build_config(stream, url, topic_id, wallet)}
     else
-      {reason, _} ->
+      {:skip, reason} ->
         emit_skipped(context, reason)
         :skip
     end
   end
 
   # -- Private --
+
+  # The topic axis: a configured, well-formed topic, bound to its mandate.
+  defp validate_topic(context) do
+    with {_, %{} = stream} <- {:not_configured, Map.get(context, :agent_stream)},
+         {_, topic_id} when is_binary(topic_id) and topic_id != "" <-
+           {:no_topic_id, Map.get(stream, :topic_id)},
+         {_, true} <- {:invalid_topic_id, valid_topic_id?(topic_id)},
+         {_, :ok} <- {:mandate_binding_required, mandate_bound(stream, context)} do
+      {:ok, {stream, topic_id}}
+    else
+      {reason, _} -> {:skip, reason}
+    end
+  end
+
+  # The target axis: a signing wallet and an allowlisted announce host.
+  defp validate_target(context, stream) do
+    with {_, {:ok, wallet}} <- {:no_wallet, Map.fetch(context, :wallet)},
+         {_, {:ok, url}} <- {:no_announce_host, resolve_url(stream, context)},
+         {_, :ok} <- {:host_not_allowed, allowed_host(url, context)} do
+      {:ok, {wallet, url}}
+    else
+      {reason, _} -> {:skip, reason}
+    end
+  end
+
+  defp valid_topic_id?(topic_id), do: Regex.match?(@topic_id_re, topic_id)
+
+  # The announce host must be the swap's own Xochi host (already trusted to move
+  # the funds), or a host the operator explicitly allowlisted. A context-injected
+  # override to any other host is rejected so a signed row cannot be exfiltrated.
+  defp allowed_host(url, context) do
+    host = url_host(url)
+    base_host = url_host(get_in(context, [:xochi_config, :base_url]))
+
+    cond do
+      is_nil(host) -> :error
+      host == base_host -> :ok
+      host in configured_hosts() -> :ok
+      true -> :error
+    end
+  end
+
+  defp configured_hosts do
+    Application.get_env(
+      :raxol_payments,
+      :xochi_announce_hosts,
+      @default_announce_hosts
+    )
+  end
+
+  defp url_host(url) when is_binary(url), do: URI.parse(url).host
+  defp url_host(_url), do: nil
+
+  # Bind the topic to the mandate that authorized the swap. When the swap
+  # surfaces that mandate (`context.authorizing_mandate_hash`), the topic's
+  # declared `mandate_hash` must match it byte-for-byte (case-insensitively) so a
+  # topic issued for one mandate cannot ride a swap under another. Absent that
+  # context, a binding-required deployment still requires the topic to name a
+  # mandate; otherwise the check is a no-op.
+  defp mandate_bound(stream, context) do
+    configured = Map.get(stream, :mandate_hash)
+    authorizing = Map.get(context, :authorizing_mandate_hash)
+
+    cond do
+      is_binary(authorizing) and authorizing != "" ->
+        ok_if(is_binary(configured) and hash_eq?(configured, authorizing))
+
+      require_mandate_binding?(context) ->
+        ok_if(present?(configured))
+
+      true ->
+        :ok
+    end
+  end
+
+  defp present?(value), do: is_binary(value) and value != ""
+
+  defp ok_if(true), do: :ok
+  defp ok_if(_false), do: :error
+
+  defp require_mandate_binding?(context) do
+    case Map.get(context, :require_topic_mandate_binding) do
+      flag when is_boolean(flag) ->
+        flag
+
+      _ ->
+        Application.get_env(
+          :raxol_payments,
+          :require_topic_mandate_binding,
+          Raxol.Payments.Deployment.production?()
+        )
+    end
+  end
+
+  defp hash_eq?(a, b), do: String.downcase(a) == String.downcase(b)
 
   # Diagnostics for the best-effort no-op paths. AgentStream emits :dropped once
   # an announce is attempted and fails; this covers the layer above, where an
@@ -181,7 +336,12 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
 
   # Public settlement: disclose the full route. Any other preference (stealth /
   # shielded / unset) settles privately, so the row is redacted to status only.
-  defp execute_event(%QuoteRequest{} = request, %QuoteResponse{} = quote, exec, topic_id) do
+  defp execute_event(
+         %QuoteRequest{} = request,
+         %QuoteResponse{} = quote,
+         exec,
+         topic_id
+       ) do
     if settlement_private?(request) do
       redacted_event(pseudo_id(topic_id, exec.intent_id), execute_status(exec))
     else
@@ -201,7 +361,9 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
 
   # Only an explicit "public" preference discloses the route. Everything else,
   # including a nil/unknown preference, is treated as private (fail safe).
-  defp settlement_private?(%QuoteRequest{settlement_preference: "public"}), do: false
+  defp settlement_private?(%QuoteRequest{settlement_preference: "public"}),
+    do: false
+
   defp settlement_private?(%QuoteRequest{}), do: true
 
   # A redacted row carries no amounts, chains, or tokens and a pseudo intent id.

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
@@ -93,7 +93,10 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
         :ok
 
       nil ->
-        case start_link([]) do
+        # Register the singleton under __MODULE__ so a later `whereis` short-
+        # circuits and a concurrent starter loses cleanly with :already_started
+        # (rather than reaching init and crashing on the duplicate named table).
+        case start_link(name: __MODULE__) do
           {:ok, _pid} -> :ok
           {:error, {:already_started, _pid}} -> :ok
           {:error, _reason} -> :ok

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
@@ -1,0 +1,148 @@
+defmodule Raxol.Payments.Xochi.SwapRouteStore do
+  @moduledoc """
+  Short-lived, best-effort stash of a swap's route event, keyed by intent id.
+
+  The Xochi swap Actions are two separate calls: `ExecuteXochiIntent` has the
+  full route (chains, tokens, amounts) at execute time, while `PollXochiStatus`
+  observes the terminal status later with only the `intent_id` in hand. The
+  browser's live feed merges agent-activity rows by `intentId`, so the terminal
+  announce must still carry the full route or it would blank the row.
+
+  This store bridges that gap without threading route data through the poll
+  Action's context: `ExecuteXochiIntent` remembers the route event here at
+  execute, and `PollXochiStatus` takes it back at terminal status to build the
+  full terminal event.
+
+  ## Best-effort by design
+
+  Everything here is a no-op on failure -- the announce is telemetry, never part
+  of the swap. If the store is not running (nothing started it), `remember/3`
+  and `take/1` degrade to a silent no-op / miss, and the terminal announce is
+  simply skipped. It self-starts on the first `remember/3` so callers never have
+  to wire it into a supervision tree, though an operator may supervise it via
+  `child_spec/1`.
+
+  ## Storage
+
+  A single owner GenServer holds a named `:public` ETS table; `remember/3` and
+  `take/1` read and write it directly (no process round-trip on the hot path).
+  Entries carry a monotonic expiry and are pruned on a periodic timer; a hard
+  size cap bounds growth when terminal statuses are never polled. Keyed by
+  `intent_id`; `take/1` deletes on read so a settled intent's route does not
+  linger.
+  """
+
+  use Raxol.Core.Behaviours.BaseManager
+
+  @table :raxol_xochi_swap_routes
+  @default_ttl_ms 900_000
+  @max_entries 10_000
+  @prune_interval_ms 60_000
+
+  # -- Public API --
+
+  @doc """
+  Remember a swap's route `event` under `intent_id` for a later terminal
+  announce. Best-effort: starts the owner on first use and never raises into the
+  caller. `opts[:ttl_ms]` overrides the default retention (15 minutes).
+  """
+  @spec remember(String.t(), map(), keyword()) :: :ok
+  def remember(intent_id, event, opts \\ [])
+
+  def remember(intent_id, event, opts)
+      when is_binary(intent_id) and is_map(event) do
+    ensure_started()
+    ttl = Keyword.get(opts, :ttl_ms, @default_ttl_ms)
+    expiry = System.monotonic_time(:millisecond) + ttl
+
+    :ets.insert(@table, {intent_id, event, expiry})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  def remember(_intent_id, _event, _opts), do: :ok
+
+  @doc """
+  Take (read and delete) the route event stashed for `intent_id`. Returns
+  `{:ok, event}` when a live entry exists, or `:error` when there is none, it has
+  expired, or the store is not running.
+  """
+  @spec take(String.t()) :: {:ok, map()} | :error
+  def take(intent_id) when is_binary(intent_id) do
+    case :ets.take(@table, intent_id) do
+      [{^intent_id, event, expiry}] ->
+        if expiry >= System.monotonic_time(:millisecond),
+          do: {:ok, event},
+          else: :error
+
+      _ ->
+        :error
+    end
+  rescue
+    ArgumentError -> :error
+  end
+
+  def take(_intent_id), do: :error
+
+  @doc false
+  @spec ensure_started() :: :ok
+  def ensure_started do
+    case Process.whereis(__MODULE__) do
+      pid when is_pid(pid) ->
+        :ok
+
+      nil ->
+        case start_link([]) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+          {:error, _reason} -> :ok
+        end
+    end
+  end
+
+  # -- BaseManager callbacks --
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def init_manager(_opts) do
+    table =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    schedule_prune()
+    {:ok, %{table: table}}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info(:prune, state) do
+    prune_expired()
+    schedule_prune()
+    {:noreply, state}
+  end
+
+  def handle_manager_info(_msg, state), do: {:noreply, state}
+
+  # -- Private --
+
+  defp schedule_prune,
+    do: Process.send_after(self(), :prune, @prune_interval_ms)
+
+  # Drop expired entries, then, if still over the cap, clear the whole table
+  # rather than track insertion order: this is a best-effort cache, and an
+  # over-cap table means terminals are not being polled, so losing stale routes
+  # is harmless.
+  defp prune_expired do
+    now = System.monotonic_time(:millisecond)
+    :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:<, :"$1", now}], [true]}])
+
+    if :ets.info(@table, :size) > @max_entries,
+      do: :ets.delete_all_objects(@table)
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
@@ -1,86 +1,90 @@
 defmodule Raxol.Payments.Xochi.SwapRouteStore do
   @moduledoc """
-  Short-lived, best-effort stash of a swap's route event, keyed by intent id.
+  Short-lived, best-effort stash of a swap's announce event, keyed by intent id.
 
   The Xochi swap Actions are two separate calls: `ExecuteXochiIntent` has the
   full route (chains, tokens, amounts) at execute time, while `PollXochiStatus`
   observes the terminal status later with only the `intent_id` in hand. The
-  browser's live feed merges agent-activity rows by `intentId`, so the terminal
-  announce must still carry the full route or it would blank the row.
+  browser's live feed merges agent-activity rows by their (possibly pseudonymous)
+  id, so the terminal announce must carry the same event body or it would blank
+  the row.
 
   This store bridges that gap without threading route data through the poll
-  Action's context: `ExecuteXochiIntent` remembers the route event here at
-  execute, and `PollXochiStatus` takes it back at terminal status to build the
-  full terminal event.
+  Action's context: `ExecuteXochiIntent` remembers the event here at execute
+  (keyed by the real `intent_id`, which is all the poll observes), and
+  `PollXochiStatus` takes it back at terminal status to rebuild the event.
 
   ## Best-effort by design
 
-  Everything here is a no-op on failure -- the announce is telemetry, never part
-  of the swap. If the store is not running (nothing started it), `remember/3`
-  and `take/1` degrade to a silent no-op / miss, and the terminal announce is
-  simply skipped. It self-starts on the first `remember/3` so callers never have
-  to wire it into a supervision tree, though an operator may supervise it via
-  `child_spec/1`.
+  Every entry point is a no-op on failure: the announce is telemetry, never part
+  of the swap. If the store is not running, `remember/3` and `take/1` degrade to
+  a silent no-op or miss and the terminal announce is skipped. It self-starts on
+  first use so callers never have to wire it into a supervision tree, though an
+  operator may supervise it via `child_spec/1`.
 
-  ## Storage
+  ## Storage and access
 
-  A single owner GenServer holds a named `:public` ETS table; `remember/3` and
-  `take/1` read and write it directly (no process round-trip on the hot path).
-  Entries carry a monotonic expiry and are pruned on a periodic timer; a hard
-  size cap bounds growth when terminal statuses are never polled. Keyed by
-  `intent_id`; `take/1` deletes on read so a settled intent's route does not
-  linger.
+  A single owner GenServer holds a `:private` ETS table: only the owner reads or
+  writes it, so no other in-VM process (a co-resident agent, a loaded plugin) can
+  read a public swap's route or poison an entry to make `announce_terminal/3`
+  sign attacker-chosen values under the agent wallet. `remember/3` casts (so a
+  stash never adds latency to the swap path) and `take/1` calls (it needs the
+  reply, and deletes on read so a settled intent's route does not linger).
+  Entries carry a monotonic expiry, are pruned on a periodic timer, and are
+  bounded by a size cap that evicts the oldest entry when full.
   """
 
   use Raxol.Core.Behaviours.BaseManager
 
   @table :raxol_xochi_swap_routes
-  @default_ttl_ms 900_000
+  # Retention: a stranded or slow settlement can take many minutes to reach a
+  # terminal status, and the stash must outlive that gap for the terminal
+  # announce to find its route. One hour comfortably covers realistic
+  # strand-resolution windows without holding events indefinitely.
+  @default_ttl_ms 3_600_000
+  # Size cap: bounds memory if terminal statuses are never polled. Each event is
+  # a small map (~a few hundred bytes), so 10k entries is a couple of MB. When
+  # full, the oldest entry is evicted (never the whole table).
   @max_entries 10_000
+  # Prune cadence: sweep expired entries once a minute. Far finer than the TTL,
+  # so expired routes never linger long past their window.
   @prune_interval_ms 60_000
 
   # -- Public API --
 
   @doc """
-  Remember a swap's route `event` under `intent_id` for a later terminal
-  announce. Best-effort: starts the owner on first use and never raises into the
-  caller. `opts[:ttl_ms]` overrides the default retention (15 minutes).
+  Remember a swap's announce `event` under `intent_id` for a later terminal
+  announce. Best-effort and non-blocking: starts the owner on first use, casts
+  the write, and never raises into the caller. `opts[:ttl_ms]` overrides the
+  default retention (one hour).
   """
   @spec remember(String.t(), map(), keyword()) :: :ok
   def remember(intent_id, event, opts \\ [])
 
   def remember(intent_id, event, opts)
       when is_binary(intent_id) and is_map(event) do
-    ensure_started()
     ttl = Keyword.get(opts, :ttl_ms, @default_ttl_ms)
     expiry = System.monotonic_time(:millisecond) + ttl
-
-    :ets.insert(@table, {intent_id, event, expiry})
+    ensure_started()
+    GenServer.cast(__MODULE__, {:remember, intent_id, event, expiry})
     :ok
-  rescue
-    ArgumentError -> :ok
+  catch
+    :exit, _ -> :ok
   end
 
   def remember(_intent_id, _event, _opts), do: :ok
 
   @doc """
-  Take (read and delete) the route event stashed for `intent_id`. Returns
+  Take (read and delete) the event stashed for `intent_id`. Returns
   `{:ok, event}` when a live entry exists, or `:error` when there is none, it has
   expired, or the store is not running.
   """
   @spec take(String.t()) :: {:ok, map()} | :error
   def take(intent_id) when is_binary(intent_id) do
-    case :ets.take(@table, intent_id) do
-      [{^intent_id, event, expiry}] ->
-        if expiry >= System.monotonic_time(:millisecond),
-          do: {:ok, event},
-          else: :error
-
-      _ ->
-        :error
-    end
-  rescue
-    ArgumentError -> :error
+    ensure_started()
+    GenServer.call(__MODULE__, {:take, intent_id})
+  catch
+    :exit, _ -> :error
   end
 
   def take(_intent_id), do: :error
@@ -108,17 +112,32 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   @impl Raxol.Core.Behaviours.BaseManager
   def init_manager(_opts) do
-    table =
-      :ets.new(@table, [
-        :named_table,
-        :public,
-        :set,
-        read_concurrency: true,
-        write_concurrency: true
-      ])
-
+    table = :ets.new(@table, [:named_table, :private, :set])
     schedule_prune()
     {:ok, %{table: table}}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call({:take, intent_id}, _from, state) do
+    reply =
+      case :ets.take(@table, intent_id) do
+        [{^intent_id, event, expiry}] ->
+          if expiry >= System.monotonic_time(:millisecond),
+            do: {:ok, event},
+            else: :error
+
+        _ ->
+          :error
+      end
+
+    {:reply, reply, state}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_cast({:remember, intent_id, event, expiry}, state) do
+    evict_oldest_if_full(intent_id)
+    :ets.insert(@table, {intent_id, event, expiry})
+    {:noreply, state}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -130,22 +149,40 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   def handle_manager_info(_msg, state), do: {:noreply, state}
 
-  # -- Private --
+  # -- Private (owner process only) --
 
   defp schedule_prune,
     do: Process.send_after(self(), :prune, @prune_interval_ms)
 
-  # Drop expired entries, then, if still over the cap, clear the whole table
-  # rather than track insertion order: this is a best-effort cache, and an
-  # over-cap table means terminals are not being polled, so losing stale routes
-  # is harmless.
+  # Drop every expired entry. Runs on the owner, so a plain match spec is safe.
   defp prune_expired do
     now = System.monotonic_time(:millisecond)
     :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:<, :"$1", now}], [true]}])
+  end
 
-    if :ets.info(@table, :size) > @max_entries,
-      do: :ets.delete_all_objects(@table)
-  rescue
-    ArgumentError -> :ok
+  # Bound the table by evicting the single oldest entry (smallest expiry, which
+  # is the earliest insert since the TTL is uniform) when at capacity, rather
+  # than wiping every in-flight route. Reinserting the same `intent_id` is an
+  # update, not growth, so it never triggers eviction.
+  defp evict_oldest_if_full(intent_id) do
+    if :ets.member(@table, intent_id) or :ets.info(@table, :size) < @max_entries do
+      :ok
+    else
+      case oldest_key() do
+        nil -> :ok
+        key -> :ets.delete(@table, key)
+      end
+    end
+  end
+
+  defp oldest_key do
+    :ets.foldl(
+      fn {key, _event, expiry}, {_mk, min_exp} = acc ->
+        if expiry < min_exp, do: {key, expiry}, else: acc
+      end,
+      {nil, nil},
+      @table
+    )
+    |> elem(0)
   end
 end

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
@@ -89,6 +89,22 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   def take(_intent_id), do: :error
 
+  @doc """
+  Peek (read without deleting) the event stashed for `intent_id`. Same result as
+  `take/1` but leaves the entry in place, so a provisional read (a stranded
+  intent that may still resolve to a real terminal status later) does not consume
+  the route the eventual terminal announce needs.
+  """
+  @spec peek(String.t()) :: {:ok, map()} | :error
+  def peek(intent_id) when is_binary(intent_id) do
+    ensure_started()
+    GenServer.call(__MODULE__, {:peek, intent_id})
+  catch
+    :exit, _ -> :error
+  end
+
+  def peek(_intent_id), do: :error
+
   @doc false
   @spec ensure_started() :: :ok
   def ensure_started do
@@ -119,19 +135,20 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_call({:take, intent_id}, _from, state) do
-    reply =
-      case :ets.take(@table, intent_id) do
-        [{^intent_id, event, expiry}] ->
-          if expiry >= System.monotonic_time(:millisecond),
-            do: {:ok, event},
-            else: :error
-
-        _ ->
-          :error
-      end
-
-    {:reply, reply, state}
+    {:reply, fresh_entry(:ets.take(@table, intent_id), intent_id), state}
   end
+
+  def handle_manager_call({:peek, intent_id}, _from, state) do
+    {:reply, fresh_entry(:ets.lookup(@table, intent_id), intent_id), state}
+  end
+
+  # Shared result shape for take (delete-on-read) and peek (read-only): an entry
+  # is returned only if present and unexpired.
+  defp fresh_entry([{intent_id, event, expiry}], intent_id) do
+    if expiry >= System.monotonic_time(:millisecond), do: {:ok, event}, else: :error
+  end
+
+  defp fresh_entry(_rows, _intent_id), do: :error
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_cast({:remember, intent_id, event, expiry}, state) do

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/xochi_announce_wiring_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/xochi_announce_wiring_test.exs
@@ -25,7 +25,17 @@ defmodule Raxol.Payments.Actions.Payments.XochiAnnounceWiringTest do
 
   # Xochi worker sim: quote -> execute -> completed status. The announce POST is
   # captured on a separate plug so the swap and the announce stay decoupled.
-  defp xochi_plug do
+  @completed_status %{
+    "intentId" => "int_1",
+    "status" => "completed",
+    "txHash" => "0xabc",
+    "terminal" => true
+  }
+
+  # A status that never reaches terminal, so the poll times out (stranded).
+  @nonterminal_status %{"intentId" => "int_1", "status" => "executing", "terminal" => false}
+
+  defp xochi_plug(status_body \\ @completed_status) do
     fn conn ->
       case conn.request_path do
         "/api/intent/quote" ->
@@ -56,12 +66,7 @@ defmodule Raxol.Payments.Actions.Payments.XochiAnnounceWiringTest do
           })
 
         "/api/intent/int_1/status" ->
-          Req.Test.json(conn, %{
-            "intentId" => "int_1",
-            "status" => "completed",
-            "txHash" => "0xabc",
-            "terminal" => true
-          })
+          Req.Test.json(conn, status_body)
       end
     end
   end
@@ -157,6 +162,27 @@ defmodule Raxol.Payments.Actions.Payments.XochiAnnounceWiringTest do
                PollXochiStatus.run(%{intent_id: "int_1", timeout_ms: 2000}, ctx)
 
       body = assert_announce_verifies("completed")
+      assert body["event"]["intentId"] == "int_1"
+    end
+
+    test "PollXochiStatus fires a stranded announce when the poll times out" do
+      ctx =
+        with_stream(
+          context(%{
+            xochi_config: %{
+              base_url: "https://xochi.test",
+              req_options: [plug: xochi_plug(@nonterminal_status)]
+            }
+          })
+        )
+
+      assert {:ok, _} = ExecuteXochiIntent.run(params(), ctx)
+      assert_announce_verifies("executing")
+
+      assert {:error, %{reason: :stranded}} =
+               PollXochiStatus.run(%{intent_id: "int_1", timeout_ms: 40, interval_ms: 10}, ctx)
+
+      body = assert_announce_verifies("stranded")
       assert body["event"]["intentId"] == "int_1"
     end
   end

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/xochi_announce_wiring_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/xochi_announce_wiring_test.exs
@@ -1,0 +1,191 @@
+defmodule Raxol.Payments.Actions.Payments.XochiAnnounceWiringTest do
+  # async: false -- drives the named SwapRouteStore singleton and a real wallet.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Payments.Actions.Payments.{ExecuteXochiIntent, PollXochiStatus}
+  alias Raxol.Payments.{Ledger, SpendingPolicy}
+  alias Raxol.Payments.Xochi.AgentStream
+
+  # Anvil/foundry default account #1 -- a well-known key, not a secret. A real
+  # signing wallet (not a stub) so the announce signature actually verifies.
+  @agent_key "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+  @agent_address "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
+  @topic "verifytopicabcdef1234"
+  @usdc "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+  defmodule AgentWallet do
+    @moduledoc false
+    use Raxol.Payments.Wallets.Env, env_var: "RAXOL_ANNOUNCE_WIRING_KEY"
+  end
+
+  setup do
+    System.put_env("RAXOL_ANNOUNCE_WIRING_KEY", @agent_key)
+    :ok
+  end
+
+  # Xochi worker sim: quote -> execute -> completed status. The announce POST is
+  # captured on a separate plug so the swap and the announce stay decoupled.
+  defp xochi_plug do
+    fn conn ->
+      case conn.request_path do
+        "/api/intent/quote" ->
+          Req.Test.json(conn, %{
+            "intentId" => "int_1",
+            "quoteId" => "q_1",
+            "canSolve" => true,
+            "toAmount" => "499000",
+            "xochiFee" => "1000",
+            "eip712Data" => %{
+              "domain" => %{
+                "name" => "Xochi",
+                "version" => "1",
+                "chainId" => 8453
+              },
+              "types" => %{
+                "Intent" => [%{"name" => "amount", "type" => "uint256"}]
+              },
+              "message" => %{"amount" => 500_000}
+            }
+          })
+
+        "/api/intent/execute" ->
+          Req.Test.json(conn, %{
+            "success" => true,
+            "intentId" => "int_1",
+            "status" => "executing"
+          })
+
+        "/api/intent/int_1/status" ->
+          Req.Test.json(conn, %{
+            "intentId" => "int_1",
+            "status" => "completed",
+            "txHash" => "0xabc",
+            "terminal" => true
+          })
+      end
+    end
+  end
+
+  defp announce_plug(test_pid) do
+    fn conn ->
+      {:ok, raw, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:announce, Jason.decode!(raw)})
+      conn |> Plug.Conn.put_status(202) |> Req.Test.json(%{success: true})
+    end
+  end
+
+  defp policy do
+    %SpendingPolicy{
+      per_request_max: Decimal.new("1.00"),
+      session_max: Decimal.new("5.00"),
+      lifetime_max: Decimal.new("10.00"),
+      session_window_ms: 3_600_000,
+      approved_domains: ["xochi.test"]
+    }
+  end
+
+  defp context(overrides) do
+    Map.merge(
+      %{
+        wallet: AgentWallet,
+        xochi_config: %{
+          base_url: "https://xochi.test",
+          req_options: [plug: xochi_plug()]
+        },
+        ledger: start_supervised!({Ledger, [name: nil]}),
+        policy: policy(),
+        agent_id: "a1"
+      },
+      overrides
+    )
+  end
+
+  defp with_stream(context) do
+    Map.put(context, :agent_stream, %{
+      topic_id: @topic,
+      xochi_api_url: "https://xochi.test",
+      jitter_ms: 0,
+      req_options: [plug: announce_plug(self())]
+    })
+  end
+
+  defp params do
+    %{
+      amount: "0.50",
+      from_chain_id: 8453,
+      to_chain_id: 42_161,
+      from_token: @usdc,
+      to_token: @usdc,
+      settlement: "public",
+      recipient_address: "0x" <> String.duplicate("cc", 20)
+    }
+  end
+
+  defp assert_announce_verifies(status) do
+    assert_receive {:announce, body}, 1000
+    assert body["topicId"] == @topic
+    assert String.downcase(body["agentWallet"]) == @agent_address
+    assert body["event"]["status"] == status
+    assert body["event"]["fromChainId"] == 8453
+    assert body["event"]["toChainId"] == 42_161
+    assert body["event"]["fromAmount"] == "500000"
+
+    {:ok, recovered} =
+      AgentStream.recover_signer(@topic, event_of(body), body["agentSig"])
+
+    assert String.downcase(recovered) == @agent_address
+    body
+  end
+
+  describe "with a configured topic_id" do
+    test "ExecuteXochiIntent fires a verifiable execute announce" do
+      ctx = with_stream(context(%{}))
+
+      assert {:ok, %{intent_id: "int_1"}} =
+               ExecuteXochiIntent.run(params(), ctx)
+
+      assert_announce_verifies("executing")
+    end
+
+    test "PollXochiStatus fires a verifiable terminal announce after execute" do
+      ctx = with_stream(context(%{}))
+
+      assert {:ok, _} = ExecuteXochiIntent.run(params(), ctx)
+      assert_announce_verifies("executing")
+
+      assert {:ok, %{status: "completed"}} =
+               PollXochiStatus.run(%{intent_id: "int_1", timeout_ms: 2000}, ctx)
+
+      body = assert_announce_verifies("completed")
+      assert body["event"]["intentId"] == "int_1"
+    end
+  end
+
+  describe "without a configured topic_id" do
+    test "the swap runs and emits nothing" do
+      ctx = context(%{})
+
+      assert {:ok, %{intent_id: "int_1"}} =
+               ExecuteXochiIntent.run(params(), ctx)
+
+      assert {:ok, %{status: "completed"}} =
+               PollXochiStatus.run(%{intent_id: "int_1", timeout_ms: 2000}, ctx)
+
+      refute_receive {:announce, _}, 200
+    end
+  end
+
+  defp event_of(%{"event" => e}) do
+    %{
+      intent_id: e["intentId"],
+      from_chain_id: e["fromChainId"],
+      to_chain_id: e["toChainId"],
+      from_token: e["fromToken"],
+      to_token: e["toToken"],
+      from_amount: e["fromAmount"],
+      to_amount: e["toAmount"],
+      status: e["status"],
+      ts: e["ts"]
+    }
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/xochi/agent_stream_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/agent_stream_test.exs
@@ -96,6 +96,22 @@ defmodule Raxol.Payments.Xochi.AgentStreamTest do
     test "the test wallet derives the expected agent address" do
       assert String.downcase(AgentWallet.address()) == String.downcase(@agent_address)
     end
+
+    test "recover_signer rejects a malleated (high-s) signature" do
+      {:ok, "0x" <> hex} = AgentStream.sign_event(AgentWallet, @topic_id, event())
+      <<r::binary-size(32), s::unsigned-big-256, v::8>> = Base.decode16!(hex, case: :lower)
+
+      # The other valid root (r, n - s) with the flipped parity recovers the same
+      # key. viem may accept it; our low-s guard must not, or the relay fans out a
+      # duplicate row.
+      n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+      malleated =
+        "0x" <> Base.encode16(<<r::binary, n - s::unsigned-big-256, 55 - v::8>>, case: :lower)
+
+      assert {:error, :invalid_signature} ==
+               AgentStream.recover_signer(@topic_id, event(), malleated)
+    end
   end
 
   describe "build_body/2" do

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -1,0 +1,252 @@
+defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
+  # async: false -- SwapRouteStore is a named singleton shared across tests.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Payments.Xochi.{AgentStream, SwapAnnouncer, SwapRouteStore}
+  alias Raxol.Payments.Xochi.Schemas.{IntentStatus, QuoteRequest, QuoteResponse}
+
+  # Anvil/foundry default account #1 -- a well-known key, not a secret.
+  @agent_key "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+  @agent_address "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+  @topic "verifytopicabcdef1234"
+  @usdc "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+  defmodule AgentWallet do
+    @moduledoc false
+    use Raxol.Payments.Wallets.Env, env_var: "RAXOL_SWAP_ANNOUNCER_TEST_KEY"
+  end
+
+  setup do
+    System.put_env("RAXOL_SWAP_ANNOUNCER_TEST_KEY", @agent_key)
+    :ok
+  end
+
+  # A Req plug that captures the announce body to the test process and 202s, like
+  # the live Xochi worker.
+  defp capture_plug(test_pid) do
+    fn conn ->
+      {:ok, raw, conn} = Plug.Conn.read_body(conn)
+      send(test_pid, {:announce, conn.request_path, Jason.decode!(raw)})
+      conn |> Plug.Conn.put_status(202) |> Req.Test.json(%{success: true})
+    end
+  end
+
+  defp stream_config(overrides \\ %{}) do
+    Map.merge(
+      %{
+        topic_id: @topic,
+        xochi_api_url: "https://xochi.test",
+        jitter_ms: 0,
+        req_options: [plug: capture_plug(self())]
+      },
+      overrides
+    )
+  end
+
+  defp context(overrides \\ %{}) do
+    Map.merge(
+      %{
+        wallet: AgentWallet,
+        xochi_config: %{base_url: "https://xochi.test"},
+        agent_stream: stream_config()
+      },
+      overrides
+    )
+  end
+
+  defp request do
+    %QuoteRequest{
+      wallet: AgentWallet.address(),
+      from_chain_id: 8453,
+      to_chain_id: 42_161,
+      from_token: @usdc,
+      to_token: @usdc,
+      from_amount: "500000",
+      settlement_preference: "public"
+    }
+  end
+
+  defp quote_resp do
+    %QuoteResponse{
+      intent_id: "int_1",
+      quote_id: "q_1",
+      can_solve: true,
+      to_amount: "499000"
+    }
+  end
+
+  defp exec(overrides \\ %{}) do
+    Map.merge(
+      %{intent_id: "int_1", status: :executing, reconciling: false},
+      overrides
+    )
+  end
+
+  describe "config/1" do
+    test "resolves url, topic, and wallet from context" do
+      assert {:ok, cfg} = SwapAnnouncer.config(context())
+      assert cfg.topic_id == @topic
+      assert cfg.xochi_api_url == "https://xochi.test"
+      assert cfg.wallet == AgentWallet
+    end
+
+    test "defaults the announce url to the swap's xochi_config base_url" do
+      ctx = context(%{agent_stream: stream_config(%{xochi_api_url: nil})})
+      assert {:ok, cfg} = SwapAnnouncer.config(ctx)
+      assert cfg.xochi_api_url == "https://xochi.test"
+    end
+
+    test "carries mandate_hash when present, omits it otherwise" do
+      with_hash =
+        context(%{agent_stream: stream_config(%{mandate_hash: "0xdead"})})
+
+      assert {:ok, %{mandate_hash: "0xdead"}} = SwapAnnouncer.config(with_hash)
+
+      refute Map.has_key?(
+               elem(SwapAnnouncer.config(context()), 1),
+               :mandate_hash
+             )
+    end
+
+    test "skips when no agent_stream configured" do
+      assert :skip == SwapAnnouncer.config(%{wallet: AgentWallet})
+    end
+
+    test "skips when topic_id is missing or blank" do
+      assert :skip ==
+               SwapAnnouncer.config(context(%{agent_stream: %{xochi_api_url: "https://x"}}))
+
+      assert :skip ==
+               SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: ""})}))
+    end
+  end
+
+  describe "announce_execute/4" do
+    test "posts a signed, verifiable execute event and stashes the route" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request(),
+                 quote_resp(),
+                 exec()
+               )
+
+      assert_receive {:announce, "/api/agent/announce", body}, 1000
+      assert body["topicId"] == @topic
+
+      assert String.downcase(body["agentWallet"]) ==
+               String.downcase(@agent_address)
+
+      assert body["event"]["intentId"] == "int_1"
+      assert body["event"]["fromChainId"] == 8453
+      assert body["event"]["toChainId"] == 42_161
+      assert body["event"]["fromAmount"] == "500000"
+      assert body["event"]["toAmount"] == "499000"
+      assert body["event"]["status"] == "executing"
+
+      # The signature verifies against the agent wallet -- exactly the client's
+      # viem verifyMessage check.
+      {:ok, recovered} =
+        AgentStream.recover_signer(@topic, event_of(body), body["agentSig"])
+
+      assert String.downcase(recovered) == String.downcase(@agent_address)
+
+      # Route stashed for the terminal announce.
+      assert {:ok, stashed} = SwapRouteStore.take("int_1")
+      assert stashed.from_chain_id == 8453
+    end
+
+    test "marks an in-doubt (reconciling) execute as non-terminal" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request(),
+                 quote_resp(),
+                 exec(%{reconciling: true})
+               )
+
+      assert_receive {:announce, _path, body}, 1000
+      assert body["event"]["status"] == "executing"
+    end
+
+    test "is a silent no-op when no topic_id is configured" do
+      ctx = %{
+        wallet: AgentWallet,
+        xochi_config: %{base_url: "https://xochi.test"}
+      }
+
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 ctx,
+                 request(),
+                 quote_resp(),
+                 exec()
+               )
+
+      refute_receive {:announce, _, _}, 200
+    end
+  end
+
+  describe "announce_terminal/3" do
+    test "rebuilds the full event from the stashed route with the terminal status" do
+      # Execute first so the route is stashed.
+      SwapAnnouncer.announce_execute(context(), request(), quote_resp(), exec())
+      assert_receive {:announce, _path, _execute_body}, 1000
+
+      status = %IntentStatus{
+        intent_id: "int_1",
+        status: :completed,
+        tx_hash: "0xabc"
+      }
+
+      assert :ok == SwapAnnouncer.announce_terminal(context(), "int_1", status)
+
+      assert_receive {:announce, "/api/agent/announce", body}, 1000
+      assert body["event"]["intentId"] == "int_1"
+      assert body["event"]["fromChainId"] == 8453
+      assert body["event"]["toToken"] == @usdc
+      assert body["event"]["toAmount"] == "499000"
+      assert body["event"]["status"] == "completed"
+
+      {:ok, recovered} =
+        AgentStream.recover_signer(@topic, event_of(body), body["agentSig"])
+
+      assert String.downcase(recovered) == String.downcase(@agent_address)
+    end
+
+    test "skips when no route was stashed for the intent" do
+      status = %IntentStatus{intent_id: "never_executed", status: :failed}
+
+      assert :ok ==
+               SwapAnnouncer.announce_terminal(
+                 context(),
+                 "never_executed",
+                 status
+               )
+
+      refute_receive {:announce, _, _}, 200
+    end
+
+    test "take/1 consumes the route so it is not re-emitted" do
+      SwapAnnouncer.announce_execute(context(), request(), quote_resp(), exec())
+      assert {:ok, _} = SwapRouteStore.take("int_1")
+      assert :error == SwapRouteStore.take("int_1")
+    end
+  end
+
+  # Rebuild the snake_case event AgentStream signs from the camelCase wire body,
+  # so the test can recover the signer the same way the client does.
+  defp event_of(%{"event" => e}) do
+    %{
+      intent_id: e["intentId"],
+      from_chain_id: e["fromChainId"],
+      to_chain_id: e["toChainId"],
+      from_token: e["fromToken"],
+      to_token: e["toToken"],
+      from_amount: e["fromAmount"],
+      to_amount: e["toAmount"],
+      status: e["status"],
+      ts: e["ts"]
+    }
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -121,6 +121,92 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
     end
   end
 
+  describe "config/1 trust boundary: announce host allowlist" do
+    test "allows the swap's own Xochi host (override equals base)" do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+    end
+
+    test "allows defaulting to the swap's base_url host" do
+      ctx = context(%{agent_stream: stream_config(%{xochi_api_url: nil})})
+      assert {:ok, %{xochi_api_url: "https://xochi.test"}} = SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects a context-injected host that is not the swap host or allowlisted" do
+      ctx = context(%{agent_stream: stream_config(%{xochi_api_url: "https://attacker.example"})})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "allows a host on the operator allowlist" do
+      Application.put_env(:raxol_payments, :xochi_announce_hosts, ["relay.xochi.example"])
+      on_exit(fn -> Application.delete_env(:raxol_payments, :xochi_announce_hosts) end)
+
+      ctx =
+        context(%{agent_stream: stream_config(%{xochi_api_url: "https://relay.xochi.example"})})
+
+      assert {:ok, %{xochi_api_url: "https://relay.xochi.example"}} = SwapAnnouncer.config(ctx)
+    end
+  end
+
+  describe "config/1 trust boundary: topic_id format" do
+    test "accepts a well-formed base64url topic" do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+    end
+
+    test "rejects a too-short topic" do
+      ctx = context(%{agent_stream: stream_config(%{topic_id: "short"})})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects a topic with illegal characters" do
+      ctx = context(%{agent_stream: stream_config(%{topic_id: "has spaces and!@#chars"})})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+  end
+
+  describe "config/1 trust boundary: topic bound to authorizing Mandate" do
+    test "accepts when the authorizing mandate matches the topic's declared mandate" do
+      ctx =
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xABCDEF"}),
+          authorizing_mandate_hash: "0xabcdef"
+        })
+
+      assert {:ok, _} = SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects when the authorizing mandate does not match" do
+      ctx =
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xdead"}),
+          authorizing_mandate_hash: "0xbeef"
+        })
+
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects when the authorizing mandate is known but the topic declares none" do
+      ctx = context(%{authorizing_mandate_hash: "0xbeef"})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "when binding is required, a topic must declare its mandate" do
+      base = context(%{require_topic_mandate_binding: true})
+      assert :skip == SwapAnnouncer.config(base)
+
+      bound =
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xabc"}),
+          require_topic_mandate_binding: true
+        })
+
+      assert {:ok, _} = SwapAnnouncer.config(bound)
+    end
+
+    test "binding is a no-op when not required and no authorizing mandate is surfaced" do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+    end
+  end
+
   describe "diagnostics: announce_skipped telemetry" do
     setup do
       ref = make_ref()
@@ -160,6 +246,30 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       status = %IntentStatus{intent_id: "never_stashed", status: :completed}
       assert :ok == SwapAnnouncer.announce_terminal(context(), "never_stashed", status)
       assert_receive {:skipped, ^ref, :no_route}
+    end
+
+    test "emits :invalid_topic_id for a malformed topic", %{ref: ref} do
+      SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: "short"})}))
+      assert_receive {:skipped, ^ref, :invalid_topic_id}
+    end
+
+    test "emits :host_not_allowed for an off-allowlist host", %{ref: ref} do
+      SwapAnnouncer.config(
+        context(%{agent_stream: stream_config(%{xochi_api_url: "https://attacker.example"})})
+      )
+
+      assert_receive {:skipped, ^ref, :host_not_allowed}
+    end
+
+    test "emits :mandate_binding_required on a mandate mismatch", %{ref: ref} do
+      SwapAnnouncer.config(
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xdead"}),
+          authorizing_mandate_hash: "0xbeef"
+        })
+      )
+
+      assert_receive {:skipped, ^ref, :mandate_binding_required}
     end
 
     test "does not emit when config resolves cleanly", %{ref: ref} do
@@ -278,6 +388,35 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       SwapAnnouncer.announce_execute(context(), request(), quote_resp(), exec())
       assert {:ok, _} = SwapRouteStore.take("int_1")
       assert :error == SwapRouteStore.take("int_1")
+    end
+  end
+
+  describe "announce_stranded/2" do
+    test "announces a stranded row and leaves the route for a later terminal" do
+      SwapAnnouncer.announce_execute(context(), request(), quote_resp(), exec())
+      assert_receive {:announce, _path, _execute_body}, 1000
+
+      assert :ok == SwapAnnouncer.announce_stranded(context(), "int_1")
+
+      assert_receive {:announce, "/api/agent/announce", body}, 1000
+      assert body["event"]["intentId"] == "int_1"
+      assert body["event"]["fromChainId"] == 8453
+      assert body["event"]["status"] == "stranded"
+
+      {:ok, recovered} =
+        AgentStream.recover_signer(@topic, event_of(body), body["agentSig"])
+
+      assert String.downcase(recovered) == String.downcase(@agent_address)
+
+      # peek did not consume: a later real terminal can still announce.
+      status = %IntentStatus{intent_id: "int_1", status: :completed}
+      assert :ok == SwapAnnouncer.announce_terminal(context(), "int_1", status)
+      assert_receive {:announce, _path, %{"event" => %{"status" => "completed"}}}, 1000
+    end
+
+    test "skips when no route was stashed for the intent" do
+      assert :ok == SwapAnnouncer.announce_stranded(context(), "never_executed")
+      refute_receive {:announce, _, _}, 200
     end
   end
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -54,7 +54,7 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
     )
   end
 
-  defp request do
+  defp request(preference \\ "public") do
     %QuoteRequest{
       wallet: AgentWallet.address(),
       from_chain_id: 8453,
@@ -62,7 +62,7 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       from_token: @usdc,
       to_token: @usdc,
       from_amount: "500000",
-      settlement_preference: "public"
+      settlement_preference: preference
     }
   end
 
@@ -118,6 +118,53 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
 
       assert :skip ==
                SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: ""})}))
+    end
+  end
+
+  describe "diagnostics: announce_skipped telemetry" do
+    setup do
+      ref = make_ref()
+      test_pid = self()
+
+      handler = fn _event, _measure, meta, _cfg ->
+        send(test_pid, {:skipped, ref, meta.reason})
+      end
+
+      :telemetry.attach(
+        "skip-#{inspect(ref)}",
+        [:raxol, :payments, :xochi, :agent_stream, :announce_skipped],
+        handler,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("skip-#{inspect(ref)}") end)
+      %{ref: ref}
+    end
+
+    test "emits :not_configured when no agent_stream is set", %{ref: ref} do
+      SwapAnnouncer.config(%{wallet: AgentWallet})
+      assert_receive {:skipped, ^ref, :not_configured}
+    end
+
+    test "emits :no_topic_id when the topic is blank", %{ref: ref} do
+      SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: ""})}))
+      assert_receive {:skipped, ^ref, :no_topic_id}
+    end
+
+    test "emits :no_wallet when the wallet is absent", %{ref: ref} do
+      SwapAnnouncer.config(%{agent_stream: stream_config()})
+      assert_receive {:skipped, ^ref, :no_wallet}
+    end
+
+    test "emits :no_route when the terminal poll finds no stashed route", %{ref: ref} do
+      status = %IntentStatus{intent_id: "never_stashed", status: :completed}
+      assert :ok == SwapAnnouncer.announce_terminal(context(), "never_stashed", status)
+      assert_receive {:skipped, ^ref, :no_route}
+    end
+
+    test "does not emit when config resolves cleanly", %{ref: ref} do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+      refute_receive {:skipped, ^ref, _}, 100
     end
   end
 
@@ -231,6 +278,100 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       SwapAnnouncer.announce_execute(context(), request(), quote_resp(), exec())
       assert {:ok, _} = SwapRouteStore.take("int_1")
       assert :error == SwapRouteStore.take("int_1")
+    end
+  end
+
+  describe "privacy: only public settlements disclose the route" do
+    defp expected_pseudo(intent_id) do
+      :crypto.hash(:sha256, [@topic, "\n", intent_id])
+      |> binary_part(0, 16)
+      |> Base.encode16(case: :lower)
+    end
+
+    defp assert_redacted(body) do
+      e = body["event"]
+      assert e["fromChainId"] == 0
+      assert e["toChainId"] == 0
+      assert e["fromToken"] == "redacted"
+      assert e["toToken"] == "redacted"
+      assert e["fromAmount"] == "0"
+      assert is_nil(e["toAmount"])
+      # No real amounts/tokens/chains leaked, and the intent id is a pseudonym.
+      refute e["intentId"] == "int_1"
+      refute e["fromAmount"] == "500000"
+    end
+
+    test "a stealth execute announces a redacted row, not the route" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request("stealth"),
+                 quote_resp(),
+                 exec()
+               )
+
+      assert_receive {:announce, "/api/agent/announce", body}, 1000
+      assert_redacted(body)
+      assert body["event"]["status"] == "executing"
+      assert body["event"]["intentId"] == expected_pseudo("int_1")
+
+      # The redacted row is still a valid, verifiable signed announce.
+      {:ok, recovered} =
+        AgentStream.recover_signer(@topic, event_of(body), body["agentSig"])
+
+      assert String.downcase(recovered) == String.downcase(@agent_address)
+    end
+
+    test "an unset settlement preference is treated as private (fail safe)" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request(nil),
+                 quote_resp(),
+                 exec()
+               )
+
+      assert_receive {:announce, _path, body}, 1000
+      assert_redacted(body)
+    end
+
+    test "a shielded terminal row stays redacted and shares the execute pseudo id" do
+      SwapAnnouncer.announce_execute(
+        context(),
+        request("shielded"),
+        quote_resp(),
+        exec()
+      )
+
+      assert_receive {:announce, _path, execute_body}, 1000
+      pseudo = execute_body["event"]["intentId"]
+      assert pseudo == expected_pseudo("int_1")
+
+      status = %IntentStatus{intent_id: "int_1", status: :completed, tx_hash: "0xabc"}
+      assert :ok == SwapAnnouncer.announce_terminal(context(), "int_1", status)
+
+      assert_receive {:announce, _path, terminal_body}, 1000
+      assert_redacted(terminal_body)
+      assert terminal_body["event"]["status"] == "completed"
+      # Same pseudo id so the browser merges the two rows, without exposing the
+      # real intent id at any point.
+      assert terminal_body["event"]["intentId"] == pseudo
+    end
+
+    test "a public execute still discloses the full route" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request("public"),
+                 quote_resp(),
+                 exec()
+               )
+
+      assert_receive {:announce, _path, body}, 1000
+      assert body["event"]["intentId"] == "int_1"
+      assert body["event"]["fromChainId"] == 8453
+      assert body["event"]["fromAmount"] == "500000"
+      assert body["event"]["toAmount"] == "499000"
     end
   end
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
@@ -63,4 +63,18 @@ defmodule Raxol.Payments.Xochi.SwapRouteStoreTest do
     assert {:ok, %{v: 2}} = SwapRouteStore.take("intent_update")
     assert :error == SwapRouteStore.take("intent_update")
   end
+
+  test "peek reads without consuming" do
+    SwapRouteStore.remember("intent_peek", %{p: 1})
+    assert {:ok, %{p: 1}} = SwapRouteStore.peek("intent_peek")
+    # Still there for a later take.
+    assert {:ok, %{p: 1}} = SwapRouteStore.peek("intent_peek")
+    assert {:ok, %{p: 1}} = SwapRouteStore.take("intent_peek")
+    assert :error == SwapRouteStore.peek("intent_peek")
+  end
+
+  test "peek does not return an expired entry" do
+    SwapRouteStore.remember("intent_peek_exp", %{p: 1}, ttl_ms: -1)
+    assert :error == SwapRouteStore.peek("intent_peek_exp")
+  end
 end

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
@@ -1,0 +1,39 @@
+defmodule Raxol.Payments.Xochi.SwapRouteStoreTest do
+  # async: false -- exercises the named singleton and its ETS table.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Payments.Xochi.SwapRouteStore
+
+  test "self-starts once and registers under the module name" do
+    SwapRouteStore.remember("intent_reg", %{from_chain_id: 8453})
+    assert is_pid(Process.whereis(SwapRouteStore))
+  end
+
+  test "repeated remember does not spawn a second owner or crash" do
+    SwapRouteStore.remember("intent_a", %{a: 1})
+    pid = Process.whereis(SwapRouteStore)
+
+    # A second remember must reuse the singleton, not start (and crash) a new
+    # GenServer on the duplicate named table.
+    SwapRouteStore.remember("intent_b", %{b: 2})
+    assert Process.whereis(SwapRouteStore) == pid
+    assert Process.alive?(pid)
+  end
+
+  test "take reads then deletes the route" do
+    SwapRouteStore.remember("intent_take", %{from_token: "0xUSDC"})
+    assert {:ok, %{from_token: "0xUSDC"}} = SwapRouteStore.take("intent_take")
+    assert :error == SwapRouteStore.take("intent_take")
+  end
+
+  test "take on an unknown intent is a miss, not a crash" do
+    assert :error == SwapRouteStore.take("intent_never_seen")
+  end
+
+  test "an expired entry is not returned" do
+    # ttl_ms: -1 -> expiry is strictly before now, so any later take is past it
+    # (monotonic time has millisecond granularity, so ttl_ms: 0 could tie).
+    SwapRouteStore.remember("intent_ttl", %{x: 1}, ttl_ms: -1)
+    assert :error == SwapRouteStore.take("intent_ttl")
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
@@ -36,4 +36,31 @@ defmodule Raxol.Payments.Xochi.SwapRouteStoreTest do
     SwapRouteStore.remember("intent_ttl", %{x: 1}, ttl_ms: -1)
     assert :error == SwapRouteStore.take("intent_ttl")
   end
+
+  test "two executes in one spawned agent process settle cleanly" do
+    # Pins the singleton-registration fix: the original crash only reproduced
+    # from a spawned process running two swaps back to back (whereis -> nil ->
+    # re-start_link -> :ets.new on the existing named table raises in init and
+    # the linked crash killed the caller after funds moved). This must stay a
+    # no-op-safe stash.
+    parent = self()
+
+    spawn(fn ->
+      SwapRouteStore.remember("spawn_1", %{leg: 1})
+      SwapRouteStore.remember("spawn_2", %{leg: 2})
+      send(parent, :done)
+    end)
+
+    assert_receive :done, 1000
+    assert {:ok, %{leg: 1}} = SwapRouteStore.take("spawn_1")
+    assert {:ok, %{leg: 2}} = SwapRouteStore.take("spawn_2")
+    assert Process.alive?(Process.whereis(SwapRouteStore))
+  end
+
+  test "reinserting the same intent id updates rather than duplicates" do
+    SwapRouteStore.remember("intent_update", %{v: 1})
+    SwapRouteStore.remember("intent_update", %{v: 2})
+    assert {:ok, %{v: 2}} = SwapRouteStore.take("intent_update")
+    assert :error == SwapRouteStore.take("intent_update")
+  end
 end


### PR DESCRIPTION
Follow-up to #575 / #576. Wires the merged `Raxol.Payments.Xochi.AgentStream`
into the agent's swap execution path so a Mandate-authorized swap auto-emits a
signed activity row to the user's Xochi live feed.

## What's wired

The two agent Actions that already run a Mandate-authorized swap:

- **`ExecuteXochiIntent`** announces the **execute** (non-terminal) event -- full
  route from the quote request + response (`intent_id`, chains, tokens,
  `from_amount`, `to_amount`, `status`, `ts`).
- **`PollXochiStatus`** announces the **terminal** event (`completed` / `failed`
  / `refunded` / `expired`) so the subscriber's row advances on its own.

Both emits are **best-effort and non-blocking** -- `AgentStream.announce/2` is
fire-and-forget; a failed or unconfigured announce never touches the swap.

## Config plumbing (the crux)

New `Raxol.Payments.Xochi.SwapAnnouncer` resolves the per-Mandate config from an
optional `:agent_stream` key on the Action context:

```elixir
context = %{
  wallet: MyAgentWallet,
  xochi_config: %{base_url: "https://api.xochi.fi", auth: {:mandate, w}},
  agent_stream: %{topic_id: "abc...", mandate_hash: "0x..."}   # <- new, optional
}
```

- `topic_id` is the out-of-band capability handed to the agent at Mandate
  authorization -- never derived, never inside the signed Mandate envelope, never
  alongside the delegator wallet. **Absent it, every emit is a silent no-op.**
- `xochi_api_url` defaults to the swap's own `xochi_config.base_url`.
- `wallet` (signing + on-wire `agentWallet`) is the agent's own wallet. The
  human/delegator wallet never touches the wire.
- `mandate_hash` is telemetry-only.

## The terminal-route problem

`IntentStatus` carries no route, and the Xochi browser **merges feed rows by
`intentId`** (`localActivity.ts` `{...existing, ...item}`), so a terminal event
with a blank route would clobber the row. `PollXochiStatus` only sees the
`intent_id`. Rather than thread route data through the poll Action's LLM-tool
context, `ExecuteXochiIntent` stashes the execute-time route in
`Raxol.Payments.Xochi.SwapRouteStore` (a best-effort, self-starting, TTL-pruned,
size-capped ETS singleton) keyed by `intent_id`; the poll takes it back to
rebuild the full terminal event. If nothing was stashed, the terminal announce is
skipped.

## Tests (no mocks -- real signing wallet)

- `swap_announcer_test.exs` -- config resolution (url default, skip when no
  topic_id/wallet), execute + terminal event mapping, signature verifies via
  `AgentStream.recover_signer/3` (the exact viem `verifyMessage` check), route
  stash/take lifecycle.
- `xochi_announce_wiring_test.exs` -- drives `ExecuteXochiIntent.run` +
  `PollXochiStatus.run` through a Xochi sim with a real Anvil-key wallet:
  asserts the execute announce fires (`executing`), the terminal announce fires
  (`completed`) with a signature recovering to the agent address, and that with
  **no** `topic_id` the swap runs and emits nothing.

## Manual testing

- [x] `MIX_ENV=test mix test` in `raxol_payments` -- 1080 passed, 0 failures
- [x] Wiring + announcer suites green (62 passed across the touched action/xochi tests)
- [x] `mix format --check-formatted` (package formatter) clean on all changed files
- [x] `mix credo` clean (the one `ExecuteXochiIntent.run` ABC-33 finding is
      pre-existing on master and untouched -- my change is in `settle/8`)
- [ ] Live: point `agent_stream.xochi_api_url` at `https://api.xochi.fi` with a
      browser-subscribed `topic_id`; execute a Mandate swap and confirm a verified
      "via <label>" row appears and advances to completed.

Diff scoped to `packages/raxol_payments/`. The Xochi repo is untouched.

Closes #578
