### PR TITLE
feat(harness): U8 BlastRadiusGate + approvals — reds + impl (AD-6b/14)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
@@ -33,6 +33,44 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   `approval_decided` events (`rebuild/1`) so a resumed/replayed session
   reconstructs identical enforcement state — the journal is the authority.
 
+  ## The approver is authenticated by the gate (fail-closed)
+
+  The gate's reason to exist is "a destructive call requires a **human**
+  decision", so the gate itself enforces it: `apply_decision/3` and the
+  `rebuild/1` fold ENACT a decision **only** when the envelope actor is
+  `%{kind: :human}`. A decision authored by an `:agent`, `:system`, a `nil`/
+  absent actor (absent = system emission, §2.1 frozen fold rule), or a
+  malformed actor is NOT a grant — live it is `{:error, {:unauthorized_actor,
+  kind}}` (the request stays pending, awaiting the human), and on rebuild it
+  folds as a no-op. This closes the self-approval hole: an agent that can emit
+  `approval_decided` events naming its own live `request_ref` still cannot
+  unlock its own escalated write. The trust boundary is thus IN the gate, not
+  deferred to journal-producer discipline.
+
+  ## One request identity everywhere
+
+  A single injective key — the `request_ref`, encoding
+  `{tool, call_id, lineage_digest}` — is the identity for pending requests,
+  `:once` grants, AND durable denies (no bare-`call_id` side keys). So:
+
+    * a `:once` grant unlocks exactly the approved request — a different tool
+      sharing the `call_id`, or the same `(tool, call_id)` re-issued with
+      DIFFERENT argument lineage (the digest differs), does not match and falls
+      through to the taint fold / escalation (AD-14 "unlocks exactly that
+      request");
+    * a deny is durable **per request** (AD-14: "the *same request* may not be
+      retried into success without a NEW approval cycle") — it never
+      blanket-blocks an unrelated tool that happens to share a `call_id`.
+
+  ## Deployment status (declared deferrals)
+
+    * **Not yet wired**: no tool-dispatch path routes through `authorize/3` in
+      this unit — "locked by default" describes the gate's contract, not yet a
+      live control. Wiring the dispatch seam is a follow-up unit.
+    * **State growth**: `pending`/`once`/`session`/`denied` are bounded only by
+      session lifetime (undecided escalations and denies accumulate). A
+      TTL/cap policy is a follow-up GC concern; sizes are O(decisions).
+
   ## The auto-approve predicate (§5.2, inlined normative)
 
   A call **escalates** (requires human approval) iff
@@ -184,9 +222,11 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
 
   The `decision.request_ref` MUST name a live pending request; a forged/dangling
   decision (no matching request) is rejected `{:error, reason}` — a decision with
-  no request is not a fact the gate may enact. `actor` comes from the envelope. A
-  `:denied` decision is **durable**: after it, the same request may not be retried
-  into success without a NEW approval cycle.
+  no request is not a fact the gate may enact. `actor` comes from the envelope
+  and is AUTHENTICATED: only a `%{kind: :human}` actor's decision is enacted —
+  any other actor (agent/system/nil/malformed) is rejected fail-closed, the
+  request left pending. A `:denied` decision is **durable**: after it, the same
+  request may not be retried into success without a NEW approval cycle.
   """
   @callback apply_decision(state(), decision(), actor()) ::
               {:ok, state()} | {:error, reason :: term()}
@@ -201,6 +241,12 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   folding one reproduces the post-consumption state, so a spent one-shot grant is
   NOT resurrected on resume (a re-issued call must not auto-admit without a new
   approval cycle).
+
+  The fold is reader-tolerant and fail-closed (never a crash, never a grant):
+  a non-`:human` actor, an unknown `decision`/`scope` value, an unparseable
+  `request_ref`, or a malformed record folds as a NO-OP — a version-skewed or
+  partially-corrupt journal degrades to "nothing extra granted", it does not
+  prevent the session from reconstructing enforcement state.
   """
   @callback rebuild([{decision() | consumption(), actor()}]) :: state()
 
@@ -232,14 +278,21 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   @impl true
   @spec escalate?(call()) :: boolean()
   def escalate?(call) do
+    # Map.get, never dot access: a call map MISSING a "required" structural
+    # field must fail CLOSED to escalation on the authorization path, not raise
+    # a KeyError out of evaluate/2. `:__missing__` is unrecognized, so both
+    # cond arms below treat absence exactly like an unknown value.
+    effect_class = Map.get(call, :effect_class, :__missing__)
+    egress = Map.get(call, :egress, :__missing__)
+
     cond do
-      call.effect_class == :irreversible_external -> true
-      call.egress == true -> true
+      effect_class == :irreversible_external -> true
+      egress == true -> true
       # Auto-proceed ONLY for a recognized benign class with egress EXACTLY
-      # false. An unknown/unrecognized effect_class, or a non-boolean egress,
-      # fails CLOSED to escalation (§2.1 unknown-trust doctrine) — never a silent
-      # proceed on a field we don't understand.
-      known_effect_class?(call.effect_class) and call.egress == false -> false
+      # false. An unknown/unrecognized/absent effect_class, or a non-boolean
+      # egress, fails CLOSED to escalation (§2.1 unknown-trust doctrine) —
+      # never a silent proceed on a field we don't understand.
+      known_effect_class?(effect_class) and egress == false -> false
       true -> true
     end
   end
@@ -341,10 +394,10 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
 
   Order is load-bearing (the YOLO-safe soundness ladder):
 
-    1. an `:once` grant for exactly this `call_id` → `{:proceed, _}` (a completed
+    1. an `:once` grant for exactly this request → `{:proceed, _}` (a completed
        approval cycle covers precisely this request; the grant is consumed);
-    2. a durable deny for this `call_id` → `{:reject, :denied, _}` (deny survives
-       a bare retry — AD-14);
+    2. a durable deny for exactly this request → `{:reject, :denied, _}` (deny
+       survives a bare retry — AD-14);
     3. a tainted lineage (decision-time fold) → `{:escalate, _, _}` REGARDLESS of
        class/egress or any standing session grant (FI-5: the untrusted leg is a
        distinct confirmation);
@@ -359,26 +412,29 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
           | {:escalate, request(), state()}
           | {:reject, term(), state()}
   def evaluate(state, call) do
-    cid = call.call_id
-    tool = call.tool
-    # The `:once` grant is keyed by the FULL request identity (tool + call_id),
-    # NOT the call_id alone (AD-14 "unlocks exactly that request"): a grant for
-    # (toolA, c1) must NOT admit (toolB, c1). Because the key includes the tool,
-    # a DIFFERENT request never matches this branch and so falls through to the
-    # taint fold below — a grant can never bypass a taint fold on another request.
-    once_key = request_ref(call)
+    # ONE request identity at every site: `:once` grants AND durable denies are
+    # keyed by the FULL request_ref — tool + call_id + lineage digest — never a
+    # bare call_id (asymmetric keys were the deny-bypass/over-block class). So:
+    #   * a grant/deny for (toolA, c1) never touches (toolB, c1);
+    #   * a re-issued (tool, c1) whose argument LINEAGE changed produces a
+    #     DIFFERENT ref (the digest differs), misses the once branch, and falls
+    #     through to the decision-time taint fold below — a standing grant can
+    #     never smuggle newly-tainted lineage past the fold.
+    # Grant and deny for one ref are mutually exclusive (each write clears the
+    # other), so the once-before-deny order carries no hidden precedence.
+    ref = request_ref(call)
 
     cond do
-      MapSet.member?(state.once, once_key) ->
-        {:proceed, %{state | once: MapSet.delete(state.once, once_key)}}
+      MapSet.member?(state.once, ref) ->
+        {:proceed, %{state | once: MapSet.delete(state.once, ref)}}
 
-      MapSet.member?(state.denied, cid) ->
+      MapSet.member?(state.denied, ref) ->
         {:reject, :denied, state}
 
       tainted_lineage?(call) ->
         escalate(state, call)
 
-      MapSet.member?(state.session, tool_key(tool)) ->
+      MapSet.member?(state.session, tool_key(call.tool)) ->
         {:proceed, state}
 
       escalate?(call) ->
@@ -394,6 +450,10 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   # approval; the freeze tip predicate §1.1). The side effect does NOT run.
   defp escalate(state, call) do
     ref = request_ref(call)
+    # Map.get: a call escalating BECAUSE a structural field is missing must
+    # still produce a well-formed request, not raise while describing itself.
+    effect_class = Map.get(call, :effect_class)
+    egress = Map.get(call, :egress)
 
     request = %{
       family: :loop,
@@ -402,9 +462,9 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
         request_ref: ref,
         call_id: call.call_id,
         action: call.tool,
-        effect_class: call.effect_class,
-        egress: call.egress,
-        blast_radius: %{effect_class: call.effect_class, egress: call.egress}
+        effect_class: effect_class,
+        egress: egress,
+        blast_radius: %{effect_class: effect_class, egress: egress}
       }
     }
 
@@ -423,22 +483,58 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   defp tool_key(tool) when is_atom(tool), do: Atom.to_string(tool)
   defp tool_key(tool) when is_binary(tool), do: tool
 
-  # request_ref encodes tool + call_id so a journaled decision ALONE rebuilds the
-  # grant key on replay (the enforcement projection needs no side table). The
-  # encoding is INJECTIVE and delimiter-safe: the (normalized string) tool is
-  # length-prefixed, so a ":" inside EITHER the tool or the call_id can never
-  # mis-split the ref back into the wrong {tool, call_id}.
-  defp request_ref(call), do: ref_encode(tool_key(call.tool), call.call_id)
+  # request_ref is the ONE request identity (pending key, `:once`-grant key,
+  # deny key) and encodes tool + call_id + a digest of the argument lineage, so
+  # a journaled decision ALONE rebuilds the grant key on replay (the enforcement
+  # projection needs no side table).
+  #
+  # Wire format (documented — the load-bearing link between a journaled decision
+  # and the grant key):
+  #
+  #     "req:" <> byte_size(tool) <> ":" <> tool
+  #            <> byte_size(call_id) <> ":" <> call_id <> lineage_digest
+  #
+  # INJECTIVE and delimiter-safe: tool and call_id are length-prefixed, so a ":"
+  # inside either can never mis-split the ref. The digest binds the grant to the
+  # request's argument lineage: a re-issued (tool, call_id) with DIFFERENT
+  # lineage produces a different ref, so a standing `:once` grant covers exactly
+  # the vetted request — never the same ids over newly-tainted arguments. The
+  # digest is a non-cryptographic in-session binder (`:erlang.phash2`); if it
+  # ever skews across a runtime upgrade the mismatch fails CLOSED (the grant
+  # simply doesn't match and the call re-escalates).
+  defp request_ref(call),
+    do: ref_encode(tool_key(call.tool), call.call_id, lineage_digest(call))
 
-  defp ref_encode(tool, cid) when is_binary(tool) and is_binary(cid),
-    do: "req:" <> Integer.to_string(byte_size(tool)) <> ":" <> tool <> cid
-
-  defp parse_ref("req:" <> rest) do
-    [len_str, tail] = String.split(rest, ":", parts: 2)
-    len = String.to_integer(len_str)
-    <<tool::binary-size(^len), cid::binary>> = tail
-    {tool, cid}
+  defp lineage_digest(call) do
+    {Map.get(call, :arg_refs, []), Map.get(call, :lineage, %{})}
+    |> :erlang.phash2(4_294_967_296)
+    |> Integer.to_string()
   end
+
+  defp ref_encode(tool, cid, digest)
+       when is_binary(tool) and is_binary(cid) and is_binary(digest) do
+    "req:" <>
+      Integer.to_string(byte_size(tool)) <>
+      ":" <> tool <> Integer.to_string(byte_size(cid)) <> ":" <> cid <> digest
+  end
+
+  # Fail-closed parse: a ref that did not originate from `ref_encode/3` (foreign
+  # producer, version skew, corruption) returns :error — never a raise on the
+  # rebuild path (the fold treats it as no-grant).
+  defp parse_ref("req:" <> rest) do
+    with [tool_len_str, tail] <- String.split(rest, ":", parts: 2),
+         {tool_len, ""} when tool_len >= 0 <- Integer.parse(tool_len_str),
+         <<tool::binary-size(^tool_len), tail::binary>> <- tail,
+         [cid_len_str, tail] <- String.split(tail, ":", parts: 2),
+         {cid_len, ""} when cid_len >= 0 <- Integer.parse(cid_len_str),
+         <<cid::binary-size(^cid_len), _digest::binary>> <- tail do
+      {:ok, {tool, cid}}
+    else
+      _ -> :error
+    end
+  end
+
+  defp parse_ref(_), do: :error
 
   @doc """
   Guard `run_fn` behind the gate: it is invoked **iff** the call proceeds.
@@ -463,32 +559,72 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   @doc """
   Fold one OBSERVED `approval_decided` event into the live approval state.
 
+  The envelope `actor` is AUTHENTICATED first (fail-closed): only a
+  `%{kind: :human}` actor's decision is enacted. Any other actor — `:agent`,
+  `:system`, `nil`/absent (absent = system, §2.1), or malformed — returns
+  `{:error, {:unauthorized_actor, kind}}` and leaves the state (including the
+  pending request) untouched, so an agent can never self-approve its own
+  escalated write and the request keeps awaiting its human.
+
   `decision.request_ref` MUST name a live pending request; a forged/dangling
   decision is `{:error, :no_such_request}` — a decision with no request is not a
-  fact the gate may enact. A `:denied` decision is durable (records the deny so a
-  bare retry can't succeed). `actor` comes from the envelope (unused for the
-  enforcement projection — recorded upstream on the journal envelope, §2.1).
+  fact the gate may enact. An out-of-domain `decision`/`scope` value is
+  `{:error, _}` — never a crash, never a grant. A `:denied` decision is durable
+  (records the deny so a bare retry can't succeed).
   """
   @impl true
   @spec apply_decision(state(), decision(), actor()) ::
           {:ok, state()} | {:error, term()}
-  def apply_decision(state, %{request_ref: ref} = decision, _actor) do
-    case Map.fetch(state.pending, ref) do
-      :error ->
-        {:error, :no_such_request}
-
-      {:ok, %{call_id: cid, tool: tool}} ->
-        state = %{state | pending: Map.delete(state.pending, ref)}
-        scope = Map.get(decision, :scope, :once)
-        {:ok, grant(state, decision.decision, scope, cid, tool)}
+  def apply_decision(state, %{request_ref: ref} = decision, actor) do
+    with :ok <- authenticate_actor(actor),
+         :ok <- validate_decision(decision),
+         {:ok, %{tool: tool}} <- Map.fetch(state.pending, ref) |> pending_or_error() do
+      state = %{state | pending: Map.delete(state.pending, ref)}
+      scope = Map.get(decision, :scope, :once)
+      {:ok, grant(state, decision.decision, scope, ref, tool)}
     end
   end
+
+  def apply_decision(_state, decision, _actor),
+    do: {:error, {:malformed_decision, decision}}
+
+  # The gate's own trust boundary (fail-closed): a grant takes effect ONLY for a
+  # human approver. Absent/nil actor is a system emission by the frozen §2.1
+  # fold rule — not a human, so not a decision the gate may enact.
+  defp authenticate_actor(%{kind: :human}), do: :ok
+
+  defp authenticate_actor(actor),
+    do: {:error, {:unauthorized_actor, actor_kind(actor)}}
+
+  defp actor_kind(%{kind: kind}), do: kind
+  defp actor_kind(_), do: nil
+
+  defp validate_decision(%{decision: d} = decision) when d in [:approved, :denied] do
+    case Map.get(decision, :scope, :once) do
+      scope when scope in [:once, :session, :root] -> :ok
+      other -> {:error, {:unknown_scope, other}}
+    end
+  end
+
+  defp validate_decision(decision),
+    do: {:error, {:unknown_decision, Map.get(decision, :decision)}}
+
+  defp pending_or_error(:error), do: {:error, :no_such_request}
+  defp pending_or_error({:ok, entry}), do: {:ok, entry}
 
   @doc """
   Rebuild live approval state by folding `approval_decided` events in order (the
   §2.1 replay/resume law): the journal is the authority, so the enforcement
   projection is re-derived from the decisions alone (`request_ref` encodes the
-  grant key). Each decision was request-validated when first observed.
+  grant key).
+
+  The fold applies the SAME actor authentication as `apply_decision/3` — a
+  decision whose envelope actor is not `%{kind: :human}` folds as a no-op (it
+  was never enacted live, so replay must not enact it either; a forged
+  agent-authored `approval_decided` in the journal grants nothing on resume).
+  Out-of-domain input (unknown `decision`/`scope`, unparseable `request_ref`,
+  malformed record) also folds as a no-op — fail-closed degradation, never a
+  crash: a version-skewed or partially-corrupt journal still rebuilds.
   """
   @impl true
   @spec rebuild([{decision() | consumption(), actor()}]) :: state()
@@ -497,38 +633,53 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
       {%{consumed_ref: ref}, _actor}, state ->
         # A journaled once-grant consumption (the guarded action ran): reproduce
         # the POST-consumption state so resume does not resurrect a spent grant.
+        # Removal is restrictive, so it needs no actor gate.
         %{state | once: MapSet.delete(state.once, ref)}
 
-      {decision, _actor}, state ->
-        {tool, cid} = parse_ref(decision.request_ref)
-        scope = Map.get(decision, :scope, :once)
-        grant(state, decision.decision, scope, cid, tool)
+      {decision, actor}, state when is_map(decision) ->
+        fold_decision(state, decision, actor)
+
+      _malformed, state ->
+        state
     end)
   end
 
-  # Fold one decision into the enforcement projection at its scope. A grant also
-  # clears any prior deny for the call_id (a fresh approval cycle supersedes it);
-  # a deny records the call_id durably and drops any stale :once grant. The
-  # `:once` grant is keyed by the FULL request identity (tool + call_id via
-  # `ref_encode`), so it unlocks exactly that request and no other (AD-14).
-  defp grant(state, :approved, :once, cid, tool),
+  defp fold_decision(state, decision, actor) do
+    with :ok <- authenticate_actor(actor),
+         :ok <- validate_decision(decision),
+         ref when is_binary(ref) <- Map.get(decision, :request_ref, :error),
+         {:ok, {tool, _cid}} <- parse_ref(ref) do
+      grant(state, decision.decision, Map.get(decision, :scope, :once), ref, tool)
+    else
+      # Fail-closed no-op: an unauthenticated, unknown, or corrupt decision
+      # grants nothing — and never crashes the rebuild.
+      _ -> state
+    end
+  end
+
+  # Fold one decision into the enforcement projection at its scope. The ref (the
+  # ONE request identity — tool + call_id + lineage digest) keys both `:once`
+  # grants and durable denies; each polarity clears the other, so grant and deny
+  # for one request are mutually exclusive. A fresh approval cycle supersedes a
+  # prior deny of the same request (AD-14); a deny drops any stale :once grant.
+  defp grant(state, :approved, :once, ref, _tool),
     do: %{
       state
-      | denied: MapSet.delete(state.denied, cid),
-        once: MapSet.put(state.once, ref_encode(tool_key(tool), cid))
+      | denied: MapSet.delete(state.denied, ref),
+        once: MapSet.put(state.once, ref)
     }
 
-  defp grant(state, :approved, scope, cid, tool) when scope in [:session, :root],
+  defp grant(state, :approved, scope, ref, tool) when scope in [:session, :root],
     do: %{
       state
-      | denied: MapSet.delete(state.denied, cid),
+      | denied: MapSet.delete(state.denied, ref),
         session: MapSet.put(state.session, tool_key(tool))
     }
 
-  defp grant(state, :denied, _scope, cid, tool),
+  defp grant(state, :denied, _scope, ref, _tool),
     do: %{
       state
-      | denied: MapSet.put(state.denied, cid),
-        once: MapSet.delete(state.once, ref_encode(tool_key(tool), cid))
+      | denied: MapSet.put(state.denied, ref),
+        once: MapSet.delete(state.once, ref)
     }
 end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
@@ -327,10 +327,16 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   def evaluate(state, call) do
     cid = call.call_id
     tool = call.tool
+    # The `:once` grant is keyed by the FULL request identity (tool + call_id),
+    # NOT the call_id alone (AD-14 "unlocks exactly that request"): a grant for
+    # (toolA, c1) must NOT admit (toolB, c1). Because the key includes the tool,
+    # a DIFFERENT request never matches this branch and so falls through to the
+    # taint fold below — a grant can never bypass a taint fold on another request.
+    once_key = request_ref(call)
 
     cond do
-      MapSet.member?(state.once, cid) ->
-        {:proceed, %{state | once: MapSet.delete(state.once, cid)}}
+      MapSet.member?(state.once, once_key) ->
+        {:proceed, %{state | once: MapSet.delete(state.once, once_key)}}
 
       MapSet.member?(state.denied, cid) ->
         {:reject, :denied, state}
@@ -462,12 +468,14 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
 
   # Fold one decision into the enforcement projection at its scope. A grant also
   # clears any prior deny for the call_id (a fresh approval cycle supersedes it);
-  # a deny records the call_id durably and drops any stale :once grant.
-  defp grant(state, :approved, :once, cid, _tool),
+  # a deny records the call_id durably and drops any stale :once grant. The
+  # `:once` grant is keyed by the FULL request identity (tool + call_id via
+  # `ref_encode`), so it unlocks exactly that request and no other (AD-14).
+  defp grant(state, :approved, :once, cid, tool),
     do: %{
       state
       | denied: MapSet.delete(state.denied, cid),
-        once: MapSet.put(state.once, cid)
+        once: MapSet.put(state.once, ref_encode(tool_key(tool), cid))
     }
 
   defp grant(state, :approved, scope, cid, tool) when scope in [:session, :root],
@@ -477,10 +485,10 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
         session: MapSet.put(state.session, tool_key(tool))
     }
 
-  defp grant(state, :denied, _scope, cid, _tool),
+  defp grant(state, :denied, _scope, cid, tool),
     do: %{
       state
       | denied: MapSet.put(state.denied, cid),
-        once: MapSet.delete(state.once, cid)
+        once: MapSet.delete(state.once, ref_encode(tool_key(tool), cid))
     }
 end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
@@ -338,7 +338,7 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
       tainted_lineage?(call) ->
         escalate(state, call)
 
-      MapSet.member?(state.session, tool) ->
+      MapSet.member?(state.session, tool_key(tool)) ->
         {:proceed, state}
 
       escalate?(call) ->
@@ -368,17 +368,36 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
       }
     }
 
-    pending = Map.put(state.pending, ref, %{call_id: call.call_id, tool: call.tool})
+    pending =
+      Map.put(state.pending, ref, %{call_id: call.call_id, tool: tool_key(call.tool)})
+
     {:escalate, request, %{state | pending: pending}}
   end
 
+  # The ONE canonical tool representation used identically in live-store,
+  # request_ref, parse_ref, and rebuild: a string. `call.tool` is `atom() |
+  # String.t()`; normalizing to a string means a STRING-named tool stored live
+  # equals the tool reconstructed by `parse_ref` on replay (no atom/string
+  # skew), and `String.to_existing_atom` — which crashes on an unknown tool — is
+  # never reached.
+  defp tool_key(tool) when is_atom(tool), do: Atom.to_string(tool)
+  defp tool_key(tool) when is_binary(tool), do: tool
+
   # request_ref encodes tool + call_id so a journaled decision ALONE rebuilds the
-  # grant key on replay (the enforcement projection needs no side table).
-  defp request_ref(call), do: "req:#{call.tool}:#{call.call_id}"
+  # grant key on replay (the enforcement projection needs no side table). The
+  # encoding is INJECTIVE and delimiter-safe: the (normalized string) tool is
+  # length-prefixed, so a ":" inside EITHER the tool or the call_id can never
+  # mis-split the ref back into the wrong {tool, call_id}.
+  defp request_ref(call), do: ref_encode(tool_key(call.tool), call.call_id)
+
+  defp ref_encode(tool, cid) when is_binary(tool) and is_binary(cid),
+    do: "req:" <> Integer.to_string(byte_size(tool)) <> ":" <> tool <> cid
 
   defp parse_ref("req:" <> rest) do
-    [tool, cid] = String.split(rest, ":", parts: 2)
-    {String.to_existing_atom(tool), cid}
+    [len_str, tail] = String.split(rest, ":", parts: 2)
+    len = String.to_integer(len_str)
+    <<tool::binary-size(^len), cid::binary>> = tail
+    {tool, cid}
   end
 
   @doc """
@@ -455,7 +474,7 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
     do: %{
       state
       | denied: MapSet.delete(state.denied, cid),
-        session: MapSet.put(state.session, tool)
+        session: MapSet.put(state.session, tool_key(tool))
     }
 
   defp grant(state, :denied, _scope, cid, _tool),

--- a/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
@@ -231,8 +231,26 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   """
   @impl true
   @spec escalate?(call()) :: boolean()
-  def escalate?(call),
-    do: call.effect_class == :irreversible_external or call.egress == true
+  def escalate?(call) do
+    cond do
+      call.effect_class == :irreversible_external -> true
+      call.egress == true -> true
+      # Auto-proceed ONLY for a recognized benign class with egress EXACTLY
+      # false. An unknown/unrecognized effect_class, or a non-boolean egress,
+      # fails CLOSED to escalation (§2.1 unknown-trust doctrine) — never a silent
+      # proceed on a field we don't understand.
+      known_effect_class?(call.effect_class) and call.egress == false -> false
+      true -> true
+    end
+  end
+
+  @known_effect_classes [
+    :reversible_local,
+    :bounded_sandboxable,
+    :irreversible_external
+  ]
+
+  defp known_effect_class?(class), do: class in @known_effect_classes
 
   @doc """
   The taint FOLD (HIGH-1 / §0 clause 7 decision-time law): derive the call's

--- a/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
@@ -58,6 +58,8 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   a decision's scope decides how long an approval is remembered.
   """
 
+  alias Raxol.Agent.Meta
+
   @typedoc "Action reversibility class (F2 `Raxol.Action` substrate, §5.2)."
   @type effect_class ::
           :reversible_local | :bounded_sandboxable | :irreversible_external
@@ -186,33 +188,280 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   """
   @callback rebuild([{decision(), actor()}]) :: state()
 
-  @not_impl "Raxol.Agent.Authorization.BlastRadiusGate is a U8-R red-suite skeleton (:not_implemented)"
+  # The synthetic root offset the taint fold hangs the call's `arg_refs` under
+  # before handing the translated lineage to `Meta.derive_taint/1`. A string so
+  # it can never collide with an integer journal offset in the lineage.
+  @taint_root "__u8_taint_root__"
 
-  @doc "Skeleton — see `c:escalate?/1`. Raises until U8 lands."
-  @spec escalate?(call()) :: no_return()
-  def escalate?(_call), do: raise(@not_impl)
+  @behaviour __MODULE__
 
-  @doc "Skeleton — see `c:tainted_lineage?/1`. Raises until U8 lands."
-  @spec tainted_lineage?(call()) :: no_return()
-  def tainted_lineage?(_call), do: raise(@not_impl)
+  @doc "A fresh, empty gate state: no pending requests, no grants, no denies."
+  @spec new() :: state()
+  def new,
+    do: %{
+      pending: %{},
+      once: MapSet.new(),
+      session: MapSet.new(),
+      denied: MapSet.new()
+    }
 
-  @doc "Skeleton — see `c:evaluate/2`. Raises until U8 lands."
-  @spec evaluate(state(), call()) :: no_return()
-  def evaluate(_state, _call), do: raise(@not_impl)
+  @doc """
+  The pure §5.2 auto-approve predicate: escalate iff
+  `effect_class == :irreversible_external` OR `egress == true`.
 
-  @doc "Skeleton — see `c:authorize/3`. Raises until U8 lands."
-  @spec authorize(state(), call(), (-> term())) :: no_return()
-  def authorize(_state, _call, _run_fn), do: raise(@not_impl)
+  Reads STRUCTURAL fields only. A self-reported `destructive_hint` is never
+  consulted — an irreversible call claiming `destructive_hint: false` still
+  escalates (the `destructiveHint`-is-a-lie class, N-Y5).
+  """
+  @impl true
+  @spec escalate?(call()) :: boolean()
+  def escalate?(call),
+    do: call.effect_class == :irreversible_external or call.egress == true
 
-  @doc "Skeleton — see `c:apply_decision/3`. Raises until U8 lands."
-  @spec apply_decision(state(), decision(), actor()) :: no_return()
-  def apply_decision(_state, _decision, _actor), do: raise(@not_impl)
+  @doc """
+  The taint FOLD (HIGH-1 / §0 clause 7 decision-time law): derive the call's
+  lineage trust by folding the U11 tainted-absorbing algebra over the `arg_refs`
+  closure **at decision time**, via `Raxol.Agent.Meta.derive_taint/1` — the single
+  source of truth for the taint algebra.
 
-  @doc "Skeleton — see `c:rebuild/1`. Raises until U8 lands."
-  @spec rebuild([{decision(), actor()}]) :: no_return()
-  def rebuild(_events), do: raise(@not_impl)
+  Never a stamped-field read: the call's argument lineage is translated into
+  journal-shaped records and folded, so a `:trusted`-STAMPED argument whose ref
+  chain reaches a tainted record folds `:tainted` (mis-stamp, N-U11.3 class). An
+  unresolvable ref folds as `:tainted` (fail-closed, §2.1 unknown-trust) — a
+  guard the gate adds around the fold, since a dangling ref is untrusted.
+  """
+  @impl true
+  @spec tainted_lineage?(call()) :: boolean()
+  def tainted_lineage?(call) do
+    arg_refs = Map.get(call, :arg_refs, [])
+    lineage = Map.get(call, :lineage, %{})
 
-  @doc "A fresh, empty gate state (skeleton — raises until U8 lands)."
-  @spec new() :: no_return()
-  def new, do: raise(@not_impl)
+    cond do
+      # Fail closed: any ref reachable from arg_refs that does not resolve in the
+      # declared lineage is untrusted (§2.1 unknown-trust). Meta.derive_taint
+      # treats a missing ref as non-tainted, so the gate guards this itself.
+      unresolved_closure?(arg_refs, lineage, MapSet.new()) ->
+        true
+
+      true ->
+        records = lineage_records(lineage) ++ [taint_root_record(arg_refs)]
+        Map.get(Meta.derive_taint(records), @taint_root) == :tainted
+    end
+  end
+
+  # Walk the ref closure purely to detect a dangling (unresolvable) ref; the
+  # trust math is Meta's job. A `:tainted`-stamped entry short-circuits (it is a
+  # resolved taint source, refs not followed — tainted is absorbing).
+  defp unresolved_closure?([], _lineage, _seen), do: false
+
+  defp unresolved_closure?([id | rest], lineage, seen) do
+    cond do
+      MapSet.member?(seen, id) ->
+        unresolved_closure?(rest, lineage, seen)
+
+      true ->
+        case Map.get(lineage, id) do
+          nil -> true
+          %{trust: :tainted} -> unresolved_closure?(rest, lineage, MapSet.put(seen, id))
+          %{refs: refs} -> unresolved_closure?(refs ++ rest, lineage, MapSet.put(seen, id))
+          _ -> true
+        end
+    end
+  end
+
+  # Translate one call's argument lineage into journal-shaped records the U11
+  # taint algebra folds. Taint enters at leaves: a `:tainted`-stamped entry is a
+  # taint-source leaf (refs irrelevant — absorbing short-circuit); a `:trusted`
+  # leaf (no refs) anchors trusted; any entry WITH refs is a derived (meta)
+  # record whose trust folds from its refs, so a mis-stamped `:trusted` node over
+  # a tainted chain still folds tainted.
+  defp lineage_records(lineage) do
+    for {id, entry} <- lineage do
+      cond do
+        Map.get(entry, :trust) == :tainted ->
+          %{"id" => id, "family" => "loop", "provenance" => %{"trust" => "tainted"}}
+
+        Map.get(entry, :refs, []) == [] ->
+          %{
+            "id" => id,
+            "family" => "loop",
+            "provenance" => %{"trust" => trust_string(Map.get(entry, :trust))}
+          }
+
+        true ->
+          %{"id" => id, "family" => "meta", "payload" => %{"refs" => entry.refs}}
+      end
+    end
+  end
+
+  defp taint_root_record(arg_refs),
+    do: %{"id" => @taint_root, "family" => "meta", "payload" => %{"refs" => arg_refs}}
+
+  defp trust_string(:trusted), do: "trusted"
+  defp trust_string(:tainted), do: "tainted"
+  # Any other stamp is handed to Meta verbatim, which fails it closed (:tainted).
+  defp trust_string(other), do: to_string(other)
+
+  @doc """
+  Decide a gated call against the gate `state`, without running any side effect.
+
+  Order is load-bearing (the YOLO-safe soundness ladder):
+
+    1. an `:once` grant for exactly this `call_id` → `{:proceed, _}` (a completed
+       approval cycle covers precisely this request; the grant is consumed);
+    2. a durable deny for this `call_id` → `{:reject, :denied, _}` (deny survives
+       a bare retry — AD-14);
+    3. a tainted lineage (decision-time fold) → `{:escalate, _, _}` REGARDLESS of
+       class/egress or any standing session grant (FI-5: the untrusted leg is a
+       distinct confirmation);
+    4. a standing `:session`/`:root` grant for the tool → `{:proceed, _}`;
+    5. the §5.2 escalation predicate (irreversible_external OR egress) →
+       `{:escalate, _, _}`;
+    6. otherwise → `{:proceed, _}` (YOLO-applicable over trusted lineage).
+  """
+  @impl true
+  @spec evaluate(state(), call()) ::
+          {:proceed, state()}
+          | {:escalate, request(), state()}
+          | {:reject, term(), state()}
+  def evaluate(state, call) do
+    cid = call.call_id
+    tool = call.tool
+
+    cond do
+      MapSet.member?(state.once, cid) ->
+        {:proceed, %{state | once: MapSet.delete(state.once, cid)}}
+
+      MapSet.member?(state.denied, cid) ->
+        {:reject, :denied, state}
+
+      tainted_lineage?(call) ->
+        escalate(state, call)
+
+      MapSet.member?(state.session, tool) ->
+        {:proceed, state}
+
+      escalate?(call) ->
+        escalate(state, call)
+
+      true ->
+        {:proceed, state}
+    end
+  end
+
+  # Register a pending approval and emit the `approval_requested` neutral event
+  # (family :loop — frozen F3, so a resumed conversation lands on the pending
+  # approval; the freeze tip predicate §1.1). The side effect does NOT run.
+  defp escalate(state, call) do
+    ref = request_ref(call)
+
+    request = %{
+      family: :loop,
+      type: :approval_requested,
+      payload: %{
+        request_ref: ref,
+        call_id: call.call_id,
+        action: call.tool,
+        effect_class: call.effect_class,
+        egress: call.egress,
+        blast_radius: %{effect_class: call.effect_class, egress: call.egress}
+      }
+    }
+
+    pending = Map.put(state.pending, ref, %{call_id: call.call_id, tool: call.tool})
+    {:escalate, request, %{state | pending: pending}}
+  end
+
+  # request_ref encodes tool + call_id so a journaled decision ALONE rebuilds the
+  # grant key on replay (the enforcement projection needs no side table).
+  defp request_ref(call), do: "req:#{call.tool}:#{call.call_id}"
+
+  defp parse_ref("req:" <> rest) do
+    [tool, cid] = String.split(rest, ":", parts: 2)
+    {String.to_existing_atom(tool), cid}
+  end
+
+  @doc """
+  Guard `run_fn` behind the gate: it is invoked **iff** the call proceeds.
+
+  `{:proceeded, result, state}` (ran `run_fn`), `{:escalated, request, state}`
+  (did NOT run), `{:rejected, reason, state}` (did NOT run). The locked-by-default
+  seam: a write tool with no covering approval never reaches `run_fn`.
+  """
+  @impl true
+  @spec authorize(state(), call(), (-> term())) ::
+          {:proceeded, term(), state()}
+          | {:escalated, request(), state()}
+          | {:rejected, term(), state()}
+  def authorize(state, call, run_fn) do
+    case evaluate(state, call) do
+      {:proceed, st} -> {:proceeded, run_fn.(), st}
+      {:escalate, request, st} -> {:escalated, request, st}
+      {:reject, reason, st} -> {:rejected, reason, st}
+    end
+  end
+
+  @doc """
+  Fold one OBSERVED `approval_decided` event into the live approval state.
+
+  `decision.request_ref` MUST name a live pending request; a forged/dangling
+  decision is `{:error, :no_such_request}` — a decision with no request is not a
+  fact the gate may enact. A `:denied` decision is durable (records the deny so a
+  bare retry can't succeed). `actor` comes from the envelope (unused for the
+  enforcement projection — recorded upstream on the journal envelope, §2.1).
+  """
+  @impl true
+  @spec apply_decision(state(), decision(), actor()) ::
+          {:ok, state()} | {:error, term()}
+  def apply_decision(state, %{request_ref: ref} = decision, _actor) do
+    case Map.fetch(state.pending, ref) do
+      :error ->
+        {:error, :no_such_request}
+
+      {:ok, %{call_id: cid, tool: tool}} ->
+        state = %{state | pending: Map.delete(state.pending, ref)}
+        scope = Map.get(decision, :scope, :once)
+        {:ok, grant(state, decision.decision, scope, cid, tool)}
+    end
+  end
+
+  @doc """
+  Rebuild live approval state by folding `approval_decided` events in order (the
+  §2.1 replay/resume law): the journal is the authority, so the enforcement
+  projection is re-derived from the decisions alone (`request_ref` encodes the
+  grant key). Each decision was request-validated when first observed.
+  """
+  @impl true
+  @spec rebuild([{decision(), actor()}]) :: state()
+  def rebuild(events) do
+    Enum.reduce(events, new(), fn {decision, _actor}, state ->
+      {tool, cid} = parse_ref(decision.request_ref)
+      scope = Map.get(decision, :scope, :once)
+      grant(state, decision.decision, scope, cid, tool)
+    end)
+  end
+
+  # Fold one decision into the enforcement projection at its scope. A grant also
+  # clears any prior deny for the call_id (a fresh approval cycle supersedes it);
+  # a deny records the call_id durably and drops any stale :once grant.
+  defp grant(state, :approved, :once, cid, _tool),
+    do: %{
+      state
+      | denied: MapSet.delete(state.denied, cid),
+        once: MapSet.put(state.once, cid)
+    }
+
+  defp grant(state, :approved, scope, cid, tool) when scope in [:session, :root],
+    do: %{
+      state
+      | denied: MapSet.delete(state.denied, cid),
+        session: MapSet.put(state.session, tool)
+    }
+
+  defp grant(state, :denied, _scope, cid, _tool),
+    do: %{
+      state
+      | denied: MapSet.put(state.denied, cid),
+        once: MapSet.delete(state.once, cid)
+    }
 end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
@@ -1,0 +1,218 @@
+defmodule Raxol.Agent.Authorization.BlastRadiusGate do
+  @moduledoc """
+  U8 — the blast-radius gate: write/destructive tools are **LOCKED by default**;
+  unlocking requires an approval flow (AD-6b / AD-14).
+
+  **SKELETON ONLY.** This module is the enabler for the permanent U8-R red suite
+  (`test/raxol/agent/red/u8_blast_radius_red_test.exs`), authored *before*
+  implementation per the red-first fan-out against the harness freeze contracts
+  (`docs/proposals/in-flight/harness-freeze-contracts.md`). Every public function
+  here raises `:not_implemented` — the red contours run against this skeleton and
+  MUST fail until U8 lands, at which point they turn green in place. The suite's
+  reference gate (test support) is the executable spec these callbacks must match.
+
+  ## The contract this gate enforces
+
+  A write/destructive tool call is gated. `authorize/3` evaluates the call
+  (`effect_class` + `egress` + taint, §5.2 + FI-5) and either:
+
+    * **proceeds** — a standing approval covers the call, or the call is
+      auto-approvable (non-escalating class over trusted lineage); the guarded
+      side effect runs;
+    * **escalates** — the call requires a human decision; an `approval_requested`
+      neutral event (`family: :loop`, so a resumed conversation lands on the
+      pending approval — the freeze's tip predicate, §1.1) is returned and the
+      side effect does NOT run;
+    * **rejects** — the call is denied (a durable prior deny with no new approval
+      cycle, or a hard reject); the side effect does NOT run.
+
+  A decision arrives as an `approval_decided` meta event
+  (`%{request_ref, decision, refs}`, `decision ∈ :approved | :denied`); the actor
+  lives on the **envelope only**, never the payload (§2.1 uniform-actor). Live
+  approval state is a **projection**: it MUST be rebuildable by a fold over
+  `approval_decided` events (`rebuild/1`) so a resumed/replayed session
+  reconstructs identical enforcement state — the journal is the authority.
+
+  ## The auto-approve predicate (§5.2, inlined normative)
+
+  A call **escalates** (requires human approval) iff
+  `effect_class == :irreversible_external` **OR** `egress == true`. This predicate
+  reads STRUCTURAL, compiled-in-our-tree fields — never an untrusted tool's
+  self-reported `destructive_hint` (the `destructiveHint`-is-a-lie class, N-Y5).
+  Tainted lineage escalates regardless (FI-5): taint (untrusted leg) + any
+  effectful action still takes the confirmation path.
+
+  ## Taint is FOLDED over refs, never field-read (HIGH-1)
+
+  The gate's trust decision derives lineage taint by folding the U11 algebra
+  (tainted-absorbing, no laundering) over the call's arg-lineage `refs` closure
+  **at decision time** — it NEVER trusts the stamped `provenance.trust` field of
+  the direct argument event alone. A `:trusted`-stamped event whose ref chain
+  reaches a tainted record IS tainted (a mis-stamp, N-U11.3 class, must not fool
+  the gate); an unknown/unresolvable ref folds as `:tainted` (fail-closed,
+  U11 §2.1 unknown-trust rule).
+
+  ## Scopes
+
+  `:once | :session | :root` (mirrors `Raxol.Agent.Authorization.Policy` scope):
+  a decision's scope decides how long an approval is remembered.
+  """
+
+  @typedoc "Action reversibility class (F2 `Raxol.Action` substrate, §5.2)."
+  @type effect_class ::
+          :reversible_local | :bounded_sandboxable | :irreversible_external
+
+  @typedoc "Stamped trust of one lineage record (U11 provenance; advisory input to the fold)."
+  @type trust :: :trusted | :tainted
+
+  @typedoc "Approval memory scope (mirrors Authorization.Policy)."
+  @type scope :: :once | :session | :root
+
+  @typedoc """
+  One record in a call's argument lineage: its STAMPED `provenance.trust` and the
+  `refs` (ids of the records it derives from). The stamp alone is never the trust
+  decision — the gate folds the tainted-absorbing algebra over the closure.
+  """
+  @type lineage_record :: %{
+          required(:trust) => trust(),
+          required(:refs) => [non_neg_integer()],
+          optional(any()) => any()
+        }
+
+  @typedoc """
+  A gated tool call. `effect_class`/`egress` are the structural §5.2 substrate;
+  `arg_refs`/`lineage` carry the argument derivation graph the taint fold walks;
+  `scope` is the memory the caller requests.
+  """
+  @type call :: %{
+          required(:call_id) => String.t(),
+          required(:tool) => atom() | String.t(),
+          required(:effect_class) => effect_class(),
+          required(:egress) => boolean(),
+          optional(:arg_refs) => [non_neg_integer()],
+          optional(:lineage) => %{non_neg_integer() => lineage_record()},
+          optional(:scope) => scope(),
+          optional(any()) => any()
+        }
+
+  @typedoc "Opaque gate state (pending requests, standing approvals, durable denies)."
+  @type state :: term()
+
+  @typedoc "The `approval_requested` neutral event a gate returns when it escalates."
+  @type request :: %{
+          required(:family) => :loop,
+          required(:type) => :approval_requested,
+          required(:payload) => map(),
+          optional(any()) => any()
+        }
+
+  @typedoc "An `approval_decided` decision (payload of the meta event); actor is envelope-side."
+  @type decision :: %{
+          required(:request_ref) => String.t(),
+          required(:decision) => :approved | :denied,
+          required(:refs) => [non_neg_integer()],
+          optional(:scope) => scope(),
+          optional(any()) => any()
+        }
+
+  @typedoc "The envelope-side actor of an `approval_decided` event (§2.1)."
+  @type actor :: %{
+          required(:kind) => :human | :agent | :system,
+          required(:id) => String.t()
+        }
+
+  @doc """
+  The pure §5.2 auto-approve predicate: escalate iff
+  `effect_class == :irreversible_external` OR `egress == true`.
+
+  Reads structural fields only — never a self-reported destructiveHint.
+  """
+  @callback escalate?(call()) :: boolean()
+
+  @doc """
+  The taint FOLD (HIGH-1): derive the call's lineage trust by folding the U11
+  tainted-absorbing algebra over the `arg_refs` closure through `lineage`.
+
+  MUST NOT read only the direct argument's stamped `trust` — a `:trusted`-stamped
+  record whose ref chain reaches a tainted record is tainted. An unresolvable ref
+  folds as tainted (fail-closed). A tainted lineage escalates regardless of
+  `escalate?/1` (FI-5).
+  """
+  @callback tainted_lineage?(call()) :: boolean()
+
+  @doc """
+  Decide a gated call against the gate `state`, without running any side effect.
+
+  Returns `{:proceed, state}` (a standing approval covers it, or it auto-approves),
+  `{:escalate, request, state}` (register a pending approval; emit
+  `approval_requested`), or `{:reject, reason, state}` (durable prior deny / hard
+  reject).
+  """
+  @callback evaluate(state(), call()) ::
+              {:proceed, state()}
+              | {:escalate, request(), state()}
+              | {:reject, reason :: term(), state()}
+
+  @doc """
+  Guard `run_fn` behind the gate: it is invoked **iff** the call proceeds.
+
+  `{:proceeded, result, state}` (ran `run_fn`), `{:escalated, request, state}`
+  (did NOT run), `{:rejected, reason, state}` (did NOT run). This is the
+  locked-by-default seam: a write tool with no covering approval never reaches
+  `run_fn`.
+  """
+  @callback authorize(state(), call(), run_fn :: (-> term())) ::
+              {:proceeded, term(), state()}
+              | {:escalated, request(), state()}
+              | {:rejected, reason :: term(), state()}
+
+  @doc """
+  Fold one OBSERVED `approval_decided` event into the live approval state.
+
+  The `decision.request_ref` MUST name a live pending request; a forged/dangling
+  decision (no matching request) is rejected `{:error, reason}` — a decision with
+  no request is not a fact the gate may enact. `actor` comes from the envelope. A
+  `:denied` decision is **durable**: after it, the same request may not be retried
+  into success without a NEW approval cycle.
+  """
+  @callback apply_decision(state(), decision(), actor()) ::
+              {:ok, state()} | {:error, reason :: term()}
+
+  @doc """
+  Rebuild live approval state by folding `approval_decided` events in order (the
+  replay/resume law, §2.1): the reconstructed state MUST equal the live state that
+  produced the same event sequence. In-memory-only enforcement state that a fold
+  cannot reconstruct is a contract violation.
+  """
+  @callback rebuild([{decision(), actor()}]) :: state()
+
+  @not_impl "Raxol.Agent.Authorization.BlastRadiusGate is a U8-R red-suite skeleton (:not_implemented)"
+
+  @doc "Skeleton — see `c:escalate?/1`. Raises until U8 lands."
+  @spec escalate?(call()) :: no_return()
+  def escalate?(_call), do: raise(@not_impl)
+
+  @doc "Skeleton — see `c:tainted_lineage?/1`. Raises until U8 lands."
+  @spec tainted_lineage?(call()) :: no_return()
+  def tainted_lineage?(_call), do: raise(@not_impl)
+
+  @doc "Skeleton — see `c:evaluate/2`. Raises until U8 lands."
+  @spec evaluate(state(), call()) :: no_return()
+  def evaluate(_state, _call), do: raise(@not_impl)
+
+  @doc "Skeleton — see `c:authorize/3`. Raises until U8 lands."
+  @spec authorize(state(), call(), (-> term())) :: no_return()
+  def authorize(_state, _call, _run_fn), do: raise(@not_impl)
+
+  @doc "Skeleton — see `c:apply_decision/3`. Raises until U8 lands."
+  @spec apply_decision(state(), decision(), actor()) :: no_return()
+  def apply_decision(_state, _decision, _actor), do: raise(@not_impl)
+
+  @doc "Skeleton — see `c:rebuild/1`. Raises until U8 lands."
+  @spec rebuild([{decision(), actor()}]) :: no_return()
+  def rebuild(_events), do: raise(@not_impl)
+
+  @doc "A fresh, empty gate state (skeleton — raises until U8 lands)."
+  @spec new() :: no_return()
+  def new, do: raise(@not_impl)
+end

--- a/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/blast_radius_gate.ex
@@ -117,6 +117,17 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
           optional(any()) => any()
         }
 
+  @typedoc """
+  A journaled `:once`-grant CONSUMPTION marker: the guarded action for
+  `consumed_ref` ran, spending the one-shot grant. Folded by `rebuild/1` so a
+  resumed session reproduces the POST-consumption state (a spent grant is not
+  resurrected). `consumed_ref` is the request_ref the grant was keyed under.
+  """
+  @type consumption :: %{
+          required(:consumed_ref) => String.t(),
+          optional(any()) => any()
+        }
+
   @typedoc "The envelope-side actor of an `approval_decided` event (§2.1)."
   @type actor :: %{
           required(:kind) => :human | :agent | :system,
@@ -185,8 +196,13 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   replay/resume law, §2.1): the reconstructed state MUST equal the live state that
   produced the same event sequence. In-memory-only enforcement state that a fold
   cannot reconstruct is a contract violation.
+
+  The journal also carries `:once`-grant CONSUMPTION markers (`%{consumed_ref}`):
+  folding one reproduces the post-consumption state, so a spent one-shot grant is
+  NOT resurrected on resume (a re-issued call must not auto-admit without a new
+  approval cycle).
   """
-  @callback rebuild([{decision(), actor()}]) :: state()
+  @callback rebuild([{decision() | consumption(), actor()}]) :: state()
 
   # The synthetic root offset the taint fold hangs the call's `arg_refs` under
   # before handing the translated lineage to `Meta.derive_taint/1`. A string so
@@ -457,12 +473,18 @@ defmodule Raxol.Agent.Authorization.BlastRadiusGate do
   grant key). Each decision was request-validated when first observed.
   """
   @impl true
-  @spec rebuild([{decision(), actor()}]) :: state()
+  @spec rebuild([{decision() | consumption(), actor()}]) :: state()
   def rebuild(events) do
-    Enum.reduce(events, new(), fn {decision, _actor}, state ->
-      {tool, cid} = parse_ref(decision.request_ref)
-      scope = Map.get(decision, :scope, :once)
-      grant(state, decision.decision, scope, cid, tool)
+    Enum.reduce(events, new(), fn
+      {%{consumed_ref: ref}, _actor}, state ->
+        # A journaled once-grant consumption (the guarded action ran): reproduce
+        # the POST-consumption state so resume does not resurrect a spent grant.
+        %{state | once: MapSet.delete(state.once, ref)}
+
+      {decision, _actor}, state ->
+        {tool, cid} = parse_ref(decision.request_ref)
+        scope = Map.get(decision, :scope, :once)
+        grant(state, decision.decision, scope, cid, tool)
     end)
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/contract.ex
+++ b/packages/raxol_agent/lib/raxol/agent/contract.ex
@@ -66,7 +66,12 @@ defmodule Raxol.Agent.Contract do
               # suite compiles against the frozen shape.
               scope: :session,
               provenance: %{source: :primary, trust: :trusted},
-              actor: nil
+              actor: nil,
+              # The speculation branch this record belongs to (freeze §1.1).
+              # Optional-with-default "main"; a non-default branch is written to
+              # (and now read back from) the journal, "main" stays implicit on the
+              # wire (grandfather-safe, byte-identical for default records — I2).
+              branch_id: "main"
 
     @typedoc "FI-5 provenance — grow-only; later keys (e.g. :model_family) are additive."
     @type provenance :: %{
@@ -89,7 +94,8 @@ defmodule Raxol.Agent.Contract do
             payload: map(),
             scope: :session | :global | atom(),
             provenance: provenance(),
-            actor: actor()
+            actor: actor(),
+            branch_id: String.t()
           }
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/contract.ex
+++ b/packages/raxol_agent/lib/raxol/agent/contract.ex
@@ -53,7 +53,29 @@ defmodule Raxol.Agent.Contract do
               family: :loop,
               type: nil,
               tier: :durable,
-              payload: %{}
+              payload: %{},
+              # --- U11 envelope growth (harness-freeze-contracts.md §2.1) -----
+              # All defaulted; every landed v0 event and every journal record
+              # without these keys decodes to these values — the grandfather
+              # clause. The I9 "contract only grows" rule is honored: new fields
+              # are optional-with-default, never required (removal / rename /
+              # optional→required is forbidden). The EmitBridge / Writer / Reader
+              # carry-through of these fields (`durable_record/1` AND
+              # `map_event/3`, plus the Reader decode) is **U11-I implementation
+              # work** — this enabler grows the struct only so the U11-R red
+              # suite compiles against the frozen shape.
+              scope: :session,
+              provenance: %{source: :primary, trust: :trusted},
+              actor: nil
+
+    @typedoc "FI-5 provenance — grow-only; later keys (e.g. :model_family) are additive."
+    @type provenance :: %{
+            required(:source) => atom(),
+            required(:trust) => :trusted | :tainted
+          }
+
+    @typedoc "Who emitted the event; absent (`nil`) folds as `%{kind: :system}` by rule."
+    @type actor :: %{kind: :human | :agent | :system, id: String.t()} | nil
 
     @type t :: %__MODULE__{
             v: non_neg_integer(),
@@ -64,7 +86,10 @@ defmodule Raxol.Agent.Contract do
             family: :loop | :meta,
             type: atom(),
             tier: :ephemeral | :durable,
-            payload: map()
+            payload: map(),
+            scope: :session | :global | atom(),
+            provenance: provenance(),
+            actor: actor()
           }
   end
 
@@ -87,7 +112,8 @@ defmodule Raxol.Agent.Contract do
   Jason can't take becomes `inspect/1` text.
   """
   @spec sanitize_payload(map()) :: map()
-  def sanitize_payload(payload) when is_map(payload), do: sanitize_value(payload)
+  def sanitize_payload(payload) when is_map(payload),
+    do: sanitize_value(payload)
 
   # Payloads may carry non-JSON-encodable terms (error reasons, tuples,
   # arbitrary tool results). Sanitize at the boundary rather than crash

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -263,7 +263,10 @@ defmodule Raxol.Agent.EmitBridge do
       payload: Map.get(neutral, :payload, %{}),
       scope: Map.get(neutral, :scope, @default_scope),
       provenance: Map.get(neutral, :provenance, @default_provenance),
-      actor: Map.get(neutral, :actor)
+      actor: Map.get(neutral, :actor),
+      # The live path carries branch_id so it agrees with the durable record
+      # (the durable + live envelopes must never diverge on a field, §1.1).
+      branch_id: Map.get(neutral, :branch_id, @default_branch_id)
     }
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -378,13 +378,20 @@ defmodule Raxol.Agent.EmitBridge do
   defp put_actor(record, nil), do: record
   defp put_actor(record, actor), do: Map.put(record, :actor, actor)
 
-  # Stamp the write-generation actor onto a neutral map when the producer did
-  # not already supply one (freeze §2.1 producer-seam stamping). The branch id
-  # is stamped the same way so every event in the generation shares it.
+  # Stamp the write-generation actor + branch id onto a neutral map at the
+  # producer seam (freeze §2.1: "EmitBridge stamps actor from the command/attach
+  # context ... Individual modules never invent it"). The bridge value WINS
+  # unconditionally (`Map.put`, not `Map.put_new`): a neutral map that already
+  # carries an `:actor` — a module inventing its own — must NOT bypass the
+  # producer-seam stamp, or a nullable-everywhere field becomes inconsistent
+  # garbage and the trust lattice's actor attribution is spoofable. The branch id
+  # is forced the same way so every event in one generation shares exactly one
+  # branch_id (the tip predicate is branch-aware; a per-event branch would strand
+  # events across branches).
   defp stamp_generation(neutral, state) do
     neutral
-    |> Map.put_new(:actor, state.actor)
-    |> Map.put_new(:branch_id, state.branch_id)
+    |> Map.put(:actor, state.actor)
+    |> Map.put(:branch_id, state.branch_id)
   end
 
   defp sanitized_payload(neutral) do

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -65,14 +65,29 @@ defmodule Raxol.Agent.EmitBridge do
 
   | neutral `type`     | tier         | contract `type`   |
   | ------------------ | ------------ | ----------------- |
-  | `:command_result`  | `:ephemeral` | `:item_delta`     |
-  | `:app_update`      | `:durable`   | `:item_completed` |
-  | `:turn_started`    | `:durable`   | `:turn_started`   |
-  | `:turn_completed`  | `:durable`   | `:turn_completed` |
-  | `:error`           | `:durable`   | `:error`          |
+  | `:command_result`   | `:ephemeral` | `:item_delta`        |
+  | `:app_update`       | `:durable`   | `:item_completed`    |
+  | `:turn_started`     | `:durable`   | `:turn_started`      |
+  | `:turn_completed`   | `:durable`   | `:turn_completed`    |
+  | `:error`            | `:durable`   | `:error`             |
+  | `:approval_requested` | (tier as sent) | `:approval_requested` |
+  | `:item_started`     | (tier as sent) | `:item_started`    |
+  | `:woken`            | (tier as sent) | `:woken`           |
 
   Anything else passes through as an `:item_completed` with its tier preserved.
   `family` and `turn_id` carry through unchanged; `ts` is preserved.
+
+  ## U11 envelope carry-through (freeze §2.1)
+
+  `scope` / `provenance` / `actor` flow end-to-end: the neutral map's values are
+  stamped onto the live `Event` (`map_event/3`) AND the journal record
+  (`durable_record/1`), and `actor` is stamped from the bridge's write-generation
+  context at this producer seam (modules never invent it). To keep grandfathered
+  records byte-identical (I2), the journal record OMITS any envelope field that
+  equals its frozen default — a record without the key decodes back to that
+  default via the grandfather clause, so only genuinely non-default provenance /
+  scope / actor / branch actually land on disk. A non-default value is never
+  stranded on one path.
   """
 
   use Raxol.Core.Behaviours.BaseManager
@@ -85,15 +100,33 @@ defmodule Raxol.Agent.EmitBridge do
   alias Raxol.Agent.SessionStreamer
   alias Raxol.Core.Runtime.EmitBus
 
-  defstruct [:session_id, :streamer, :journal, journal_opts: [], last_offset: 0]
+  defstruct [
+    :session_id,
+    :streamer,
+    :journal,
+    :actor,
+    journal_opts: [],
+    last_offset: 0,
+    branch_id: "main"
+  ]
 
   @type t :: %__MODULE__{
           session_id: term(),
           streamer: GenServer.server(),
           journal: FileStore.t() | nil,
+          actor: map() | nil,
           journal_opts: keyword(),
-          last_offset: non_neg_integer()
+          last_offset: non_neg_integer(),
+          branch_id: String.t()
         }
+
+  # The frozen grandfather defaults (freeze §2.1). An event carrying exactly
+  # these values persists WITHOUT the envelope-growth keys — a record without
+  # them decodes back to these defaults, so a default event stays byte-identical
+  # to its pre-U11 form (I2). Non-default values ARE written and carried.
+  @default_scope :session
+  @default_provenance %{source: :primary, trust: :trusted}
+  @default_branch_id "main"
 
   @doc """
   Start a bridge for `session_id`.
@@ -106,6 +139,12 @@ defmodule Raxol.Agent.EmitBridge do
       opened lazily on the first durable event)
     * `:journal_opts` — options forwarded to `FileStore.open/2` on lazy open
       (e.g. `:base_dir`); default `[]`
+    * `:actor` — the write-generation actor (`%{kind, id}`) stamped onto every
+      event this bridge emits when the neutral map does not already carry one
+      (freeze §2.1: actor is producer-seam stamped, modules never invent it);
+      default `nil` (system emission)
+    * `:branch_id` — the speculation branch these events belong to (freeze
+      §1.1); default `"main"`, which is implicit on the wire (grandfather-safe)
     * `:name` — process name (default anonymous)
   """
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -129,8 +168,10 @@ defmodule Raxol.Agent.EmitBridge do
        session_id: session_id,
        streamer: streamer,
        journal: journal,
+       actor: Keyword.get(opts, :actor),
        journal_opts: journal_opts,
-       last_offset: last_offset(journal)
+       last_offset: last_offset(journal),
+       branch_id: Keyword.get(opts, :branch_id, @default_branch_id)
      }}
   end
 
@@ -145,7 +186,12 @@ defmodule Raxol.Agent.EmitBridge do
       ) do
     # Sanitize once and reuse for both the journal record and the live event so
     # the live tail and the replayed record are byte-identical, not just id-equal.
-    safe = Map.put(neutral, :payload, sanitized_payload(neutral))
+    # Stamp the write-generation actor here (producer seam) so the journal record
+    # and the live event agree on `actor` — modules never invent it downstream.
+    safe =
+      neutral
+      |> Map.put(:payload, sanitized_payload(neutral))
+      |> stamp_generation(state)
 
     case append_durable(state, safe) do
       {:ok, state, offset} ->
@@ -169,12 +215,14 @@ defmodule Raxol.Agent.EmitBridge do
     end
   end
 
-  # Ephemeral tier: never journaled. Id carries the last durable offset.
+  # Ephemeral tier: never journaled. Id carries the last durable offset. The
+  # write-generation actor is stamped here too so live ephemeral events (deltas)
+  # carry the same actor as the durable events they refine.
   def handle_manager_info(
         {:emit_bus, session_id, neutral},
         %__MODULE__{session_id: session_id} = state
       ) do
-    event = map_event(neutral, state.last_offset, session_id)
+    event = map_event(stamp_generation(neutral, state), state.last_offset, session_id)
     SessionStreamer.emit(session_id, event, state.streamer)
     {:noreply, state}
   end
@@ -194,7 +242,10 @@ defmodule Raxol.Agent.EmitBridge do
 
   Pure. `id` becomes the contract event's offset (the journal offset for durable
   events; the last durable offset for ephemeral ones). `session_id` overrides the
-  neutral map's (they are the same in practice).
+  neutral map's (they are the same in practice). The U11 envelope fields
+  (`scope`/`provenance`/`actor`) are carried through from the neutral map,
+  falling back to the frozen grandfather defaults so a producer that stamps
+  nothing still yields a well-formed default envelope (freeze §2.1).
   """
   @spec map_event(map(), non_neg_integer(), term()) :: Event.t()
   def map_event(neutral, id, session_id) when is_map(neutral) do
@@ -209,7 +260,10 @@ defmodule Raxol.Agent.EmitBridge do
       family: Map.get(neutral, :family, :loop),
       type: contract_type(Map.get(neutral, :type), tier),
       tier: tier,
-      payload: Map.get(neutral, :payload, %{})
+      payload: Map.get(neutral, :payload, %{}),
+      scope: Map.get(neutral, :scope, @default_scope),
+      provenance: Map.get(neutral, :provenance, @default_provenance),
+      actor: Map.get(neutral, :actor)
     }
   end
 
@@ -229,8 +283,7 @@ defmodule Raxol.Agent.EmitBridge do
             {:ok, state, offset}
 
           {:error, detail} ->
-            {:error, drop_dead_journal(state, detail), :journal_append_failed,
-             detail}
+            {:error, drop_dead_journal(state, detail), :journal_append_failed, detail}
         end
 
       {:error, state, detail} ->
@@ -278,6 +331,13 @@ defmodule Raxol.Agent.EmitBridge do
   # A plain, JSON-encodable map persisted to the journal. The Writer stamps
   # `"id"` (= offset) and stringifies keys; replaying reconstructs the same
   # contract-typed event. Payload is already sanitized by the caller.
+  #
+  # The U11 envelope-growth fields (scope / provenance / actor / branch_id) are
+  # written ONLY when they are non-default: a record that carries exactly the
+  # frozen defaults omits them and decodes back to those defaults via the
+  # grandfather clause, so a default event's on-disk bytes are byte-identical to
+  # its pre-U11 form (I2 preserved). A non-default value is always persisted —
+  # never stranded on the live path while missing from the journal.
   defp durable_record(neutral) do
     %{
       v: 0,
@@ -289,6 +349,42 @@ defmodule Raxol.Agent.EmitBridge do
       tier: :durable,
       payload: Map.get(neutral, :payload, %{})
     }
+    |> put_when_non_default(:scope, Map.get(neutral, :scope), @default_scope)
+    |> put_when_non_default(
+      :provenance,
+      Map.get(neutral, :provenance),
+      @default_provenance
+    )
+    |> put_actor(Map.get(neutral, :actor))
+    |> put_when_non_default(
+      :branch_id,
+      Map.get(neutral, :branch_id),
+      @default_branch_id
+    )
+  end
+
+  # Add `key` only when the carried value is present and differs from the frozen
+  # default — the grandfather-symmetric write (absent on disk ⇒ default on read).
+  defp put_when_non_default(record, _key, nil, _default), do: record
+
+  defp put_when_non_default(record, _key, value, default) when value == default,
+    do: record
+
+  defp put_when_non_default(record, key, value, _default),
+    do: Map.put(record, key, value)
+
+  # actor is `%{kind, id} | nil`; a nil actor is the system default (absent on
+  # disk), any present actor is persisted verbatim.
+  defp put_actor(record, nil), do: record
+  defp put_actor(record, actor), do: Map.put(record, :actor, actor)
+
+  # Stamp the write-generation actor onto a neutral map when the producer did
+  # not already supply one (freeze §2.1 producer-seam stamping). The branch id
+  # is stamped the same way so every event in the generation shares it.
+  defp stamp_generation(neutral, state) do
+    neutral
+    |> Map.put_new(:actor, state.actor)
+    |> Map.put_new(:branch_id, state.branch_id)
   end
 
   defp sanitized_payload(neutral) do
@@ -317,5 +413,13 @@ defmodule Raxol.Agent.EmitBridge do
   defp contract_type(:turn_started, _tier), do: :turn_started
   defp contract_type(:turn_completed, _tier), do: :turn_completed
   defp contract_type(:error, _tier), do: :error
+  # Frozen-but-not-landed loop vocabulary (freeze §1.1 / storage-foundations):
+  # these bracket events pass through with their own type instead of collapsing
+  # to :item_completed. `approval_requested` is a durable bracket (a resume-point
+  # cannot be a bare item), `item_started` opens an item the later
+  # `item_completed` closes, `woken` marks a `schedule`/dormancy wake.
+  defp contract_type(:approval_requested, _tier), do: :approval_requested
+  defp contract_type(:item_started, _tier), do: :item_started
+  defp contract_type(:woken, _tier), do: :woken
   defp contract_type(_other, _tier), do: :item_completed
 end

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -128,6 +128,12 @@ defmodule Raxol.Agent.EmitBridge do
   @default_provenance %{source: :primary, trust: :trusted}
   @default_branch_id "main"
 
+  # Types that MUST be journaled regardless of the tier as sent: the doc calls
+  # `approval_requested` a durable resume-bracket — emit it ephemeral and the
+  # resume point is never journaled; `woken` marks a schedule/dormancy wake that
+  # must survive replay. Their tier is forced to `:durable` at the emit seam.
+  @durable_required_types [:approval_requested, :woken]
+
   @doc """
   Start a bridge for `session_id`.
 
@@ -175,19 +181,50 @@ defmodule Raxol.Agent.EmitBridge do
      }}
   end
 
+  # Durable-required resume-brackets: force `:durable` no matter the tier as
+  # sent, then take the shared durable path. This clause precedes the tier-based
+  # ones so an `approval_requested`/`woken` emitted ephemeral still lands in the
+  # journal (its resume point would otherwise be lost).
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info(
+        {:emit_bus, session_id, %{type: type} = neutral},
+        %__MODULE__{session_id: session_id} = state
+      )
+      when type in @durable_required_types do
+    handle_durable(session_id, Map.put(neutral, :tier, :durable), state)
+  end
+
   # Durable tier: the journal owns the id. Append first, take the offset, emit.
   # The journal is the hard gate: if the append fails, the durable event is NOT
   # published (no fabricated id, `last_offset` untouched) — a loud ephemeral
   # `:error` event goes out instead. See the moduledoc.
-  @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_info(
         {:emit_bus, session_id, %{tier: :durable} = neutral},
         %__MODULE__{session_id: session_id} = state
       ) do
-    # Sanitize once and reuse for both the journal record and the live event so
-    # the live tail and the replayed record are byte-identical, not just id-equal.
-    # Stamp the write-generation actor here (producer seam) so the journal record
-    # and the live event agree on `actor` — modules never invent it downstream.
+    handle_durable(session_id, neutral, state)
+  end
+
+  # Ephemeral tier: never journaled. Id carries the last durable offset. The
+  # write-generation actor is stamped here too so live ephemeral events (deltas)
+  # carry the same actor as the durable events they refine.
+  def handle_manager_info(
+        {:emit_bus, session_id, neutral},
+        %__MODULE__{session_id: session_id} = state
+      ) do
+    event = map_event(stamp_generation(neutral, state), state.last_offset, session_id)
+    SessionStreamer.emit(session_id, event, state.streamer)
+    {:noreply, state}
+  end
+
+  def handle_manager_info(_msg, state), do: {:noreply, state}
+
+  # Shared durable path (append-before-publish). Sanitize once and reuse for
+  # both the journal record and the live event so the live tail and the replayed
+  # record are byte-identical, not just id-equal. Stamp the write-generation
+  # actor here (producer seam). On append failure the event is dropped from the
+  # live tail and a loud ephemeral `:error` signal goes out instead.
+  defp handle_durable(session_id, neutral, state) do
     safe =
       neutral
       |> Map.put(:payload, sanitized_payload(neutral))
@@ -214,20 +251,6 @@ defmodule Raxol.Agent.EmitBridge do
         {:noreply, state}
     end
   end
-
-  # Ephemeral tier: never journaled. Id carries the last durable offset. The
-  # write-generation actor is stamped here too so live ephemeral events (deltas)
-  # carry the same actor as the durable events they refine.
-  def handle_manager_info(
-        {:emit_bus, session_id, neutral},
-        %__MODULE__{session_id: session_id} = state
-      ) do
-    event = map_event(stamp_generation(neutral, state), state.last_offset, session_id)
-    SessionStreamer.emit(session_id, event, state.streamer)
-    {:noreply, state}
-  end
-
-  def handle_manager_info(_msg, state), do: {:noreply, state}
 
   @impl GenServer
   def terminate(_reason, %__MODULE__{journal: nil}), do: :ok

--- a/packages/raxol_agent/lib/raxol/agent/fingerprint.ex
+++ b/packages/raxol_agent/lib/raxol/agent/fingerprint.ex
@@ -4,17 +4,15 @@ defmodule Raxol.Agent.Fingerprint do
   (`docs/proposals/in-flight/harness-freeze-contracts.md` §2.1, "Model/params
   fingerprint").
 
-  This is the U11 *enabler*. Two things are frozen and real here:
+  Two things are frozen and real here:
 
     * `excluded_keys/0` — the **exhaustive, frozen** (grow-only) list of
       ephemeral param keys excluded from `params_hash`. Note `:seed` is NOT
       excluded — it is a sampling parameter and replay identity needs it.
-    * the fingerprint *shape* (documented below; asserted by the red suite).
-
-  The ONE normative serializer, `canonical_json/1`, is `:not_implemented` until
-  U11-I lands: `params_hash` MUST be `sha256` over exactly this serialization
-  (sorted keys) so two independent encoders can never diverge. The red suite
-  pins the byte-stability property against it.
+    * `canonical_json/1` — the ONE normative serializer. `params_hash` MUST be
+      `sha256` over exactly this serialization (sorted keys, ephemeral keys
+      stripped) so two independent encoders can never diverge. The red suite
+      pins the byte-stability property against it.
 
   ## Fingerprint shape (frozen)
 
@@ -49,19 +47,34 @@ defmodule Raxol.Agent.Fingerprint do
 
   @doc """
   The ONE normative canonical JSON serialization of a params object: `sha256`'s
-  input, sorted keys, ephemeral keys stripped.
+  input.
 
-  `:not_implemented` until U11-I. Every golden fixture MUST hash through this so
-  two independent encoders cannot diverge.
+  Frozen serialization rules:
+
+    * ephemeral keys (`excluded_keys/0`) are stripped — `:seed` is NOT one of
+      them, so it stays in the hash input;
+    * keys are stringified and **sorted**, so map iteration order cannot leak
+      into the hash;
+    * each value is JSON-encoded with `Jason` — the single named encoder, so
+      two independent callers cannot diverge on number/string formatting.
+
+  Every golden fixture MUST hash through this so two independent encoders cannot
+  diverge.
   """
-  @spec canonical_json(map()) :: String.t() | :not_implemented
-  def canonical_json(params) when is_map(params), do: :not_implemented
+  @spec canonical_json(map()) :: String.t()
+  def canonical_json(params) when is_map(params) do
+    params
+    |> Map.drop(@excluded_keys)
+    |> Enum.map(fn {k, v} -> {to_string(k), v} end)
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(fn {k, v} -> Jason.encode!(k) <> ":" <> Jason.encode!(v) end)
+    |> Enum.join(",")
+    |> then(&("{" <> &1 <> "}"))
+  end
 
-  @doc """
-  `sha256` hex of `canonical_json/1` — the `params_hash` field.
-
-  `:not_implemented` until U11-I.
-  """
-  @spec params_hash(map()) :: String.t() | :not_implemented
-  def params_hash(params) when is_map(params), do: :not_implemented
+  @doc "`sha256` hex (lower-case) of `canonical_json/1` — the `params_hash` field."
+  @spec params_hash(map()) :: String.t()
+  def params_hash(params) when is_map(params) do
+    :crypto.hash(:sha256, canonical_json(params)) |> Base.encode16(case: :lower)
+  end
 end

--- a/packages/raxol_agent/lib/raxol/agent/fingerprint.ex
+++ b/packages/raxol_agent/lib/raxol/agent/fingerprint.ex
@@ -51,12 +51,20 @@ defmodule Raxol.Agent.Fingerprint do
 
   Frozen serialization rules:
 
-    * ephemeral keys (`excluded_keys/0`) are stripped — `:seed` is NOT one of
-      them, so it stays in the hash input;
-    * keys are stringified and **sorted**, so map iteration order cannot leak
-      into the hash;
-    * each value is JSON-encoded with `Jason` — the single named encoder, so
+    * ephemeral keys (`excluded_keys/0`) are stripped at the top level — `:seed`
+      is NOT one of them, so it stays in the hash input;
+    * keys are stringified and **sorted at EVERY map level**, recursively, so
+      map iteration order cannot leak into the hash — a nested object hashes
+      the same regardless of insertion order (a top-level-only sort left nested
+      maps at BEAM term order, diverging across encoders / the JS UI fork);
+    * each scalar is JSON-encoded with `Jason` — the single named encoder, so
       two independent callers cannot diverge on number/string formatting.
+
+  **Key-ordering law (frozen).** Sorting is by Erlang binary order. Canonical
+  params keys are guaranteed ASCII (temperature, top_p, max_tokens, seed, and
+  additive provider params), and for ASCII strings byte order is identical to
+  JS UTF-16 code-unit order — so the JS UI fork (I2) byte-matches without a
+  code-unit collator. Non-ASCII canonical keys are out of contract.
 
   Every golden fixture MUST hash through this so two independent encoders cannot
   diverge.
@@ -65,12 +73,31 @@ defmodule Raxol.Agent.Fingerprint do
   def canonical_json(params) when is_map(params) do
     params
     |> Map.drop(@excluded_keys)
-    |> Enum.map(fn {k, v} -> {to_string(k), v} end)
-    |> Enum.sort_by(&elem(&1, 0))
-    |> Enum.map(fn {k, v} -> Jason.encode!(k) <> ":" <> Jason.encode!(v) end)
-    |> Enum.join(",")
-    |> then(&("{" <> &1 <> "}"))
+    |> canonical_encode()
   end
+
+  # Recursive, key-sorted canonicalization. Maps sort their stringified keys at
+  # every level; lists preserve order but canonicalize each element; scalars go
+  # through the single named encoder. Structs are treated as their map form.
+  defp canonical_encode(%_{} = struct),
+    do: struct |> Map.from_struct() |> canonical_encode()
+
+  defp canonical_encode(map) when is_map(map) do
+    inner =
+      map
+      |> Enum.map(fn {k, v} -> {to_string(k), v} end)
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.map(fn {k, v} -> Jason.encode!(k) <> ":" <> canonical_encode(v) end)
+      |> Enum.join(",")
+
+    "{" <> inner <> "}"
+  end
+
+  defp canonical_encode(list) when is_list(list) do
+    "[" <> (list |> Enum.map(&canonical_encode/1) |> Enum.join(",")) <> "]"
+  end
+
+  defp canonical_encode(scalar), do: Jason.encode!(scalar)
 
   @doc "`sha256` hex (lower-case) of `canonical_json/1` — the `params_hash` field."
   @spec params_hash(map()) :: String.t()

--- a/packages/raxol_agent/lib/raxol/agent/fingerprint.ex
+++ b/packages/raxol_agent/lib/raxol/agent/fingerprint.ex
@@ -1,0 +1,67 @@
+defmodule Raxol.Agent.Fingerprint do
+  @moduledoc """
+  Model / params fingerprint — the replay-identity of a provider call
+  (`docs/proposals/in-flight/harness-freeze-contracts.md` §2.1, "Model/params
+  fingerprint").
+
+  This is the U11 *enabler*. Two things are frozen and real here:
+
+    * `excluded_keys/0` — the **exhaustive, frozen** (grow-only) list of
+      ephemeral param keys excluded from `params_hash`. Note `:seed` is NOT
+      excluded — it is a sampling parameter and replay identity needs it.
+    * the fingerprint *shape* (documented below; asserted by the red suite).
+
+  The ONE normative serializer, `canonical_json/1`, is `:not_implemented` until
+  U11-I lands: `params_hash` MUST be `sha256` over exactly this serialization
+  (sorted keys) so two independent encoders can never diverge. The red suite
+  pins the byte-stability property against it.
+
+  ## Fingerprint shape (frozen)
+
+      %{
+        provider:         String.t(),
+        name:             String.t(),
+        revision:         String.t() | nil,   # OPTIONAL — strict seam must not require it
+        params_hash:      String.t(),         # sha256 over canonical_json/1
+        params_inline:    %{...},             # capped subset, grow-only keys
+        prompt_cache_key: String.t() | nil    # provider telemetry, NOT replay identity
+      }
+  """
+
+  # Exhaustive, frozen (grow-only) ephemeral-key exclusion list. Everything NOT
+  # in this list is included in the hash — in particular `:seed` is INCLUDED.
+  @excluded_keys [:request_id, :idempotency_key, :trace_id, :timestamp, :ts]
+
+  # The capped `params_inline` subset (grow-only keys) — the human/audit split.
+  @inline_keys [:temperature, :top_p, :max_tokens, :seed]
+
+  @doc """
+  The frozen ephemeral-key exclusion list for `params_hash`.
+
+  Grow-only. `:seed` is deliberately absent — it is part of replay identity.
+  """
+  @spec excluded_keys() :: [atom()]
+  def excluded_keys, do: @excluded_keys
+
+  @doc "The capped `params_inline` key set (grow-only)."
+  @spec inline_keys() :: [atom()]
+  def inline_keys, do: @inline_keys
+
+  @doc """
+  The ONE normative canonical JSON serialization of a params object: `sha256`'s
+  input, sorted keys, ephemeral keys stripped.
+
+  `:not_implemented` until U11-I. Every golden fixture MUST hash through this so
+  two independent encoders cannot diverge.
+  """
+  @spec canonical_json(map()) :: String.t() | :not_implemented
+  def canonical_json(params) when is_map(params), do: :not_implemented
+
+  @doc """
+  `sha256` hex of `canonical_json/1` — the `params_hash` field.
+
+  `:not_implemented` until U11-I.
+  """
+  @spec params_hash(map()) :: String.t() | :not_implemented
+  def params_hash(params) when is_map(params), do: :not_implemented
+end

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -306,18 +306,33 @@ defmodule Raxol.Agent.Meta do
 
   defp event?(r), do: Map.get(r, "kind", "event") == "event"
 
-  # STORED trust on a record's provenance; grandfather / missing => :trusted.
-  defp stored_trust(%{"provenance" => %{"trust" => "tainted"}}), do: :tainted
-  defp stored_trust(%{"provenance" => %{"trust" => :tainted}}), do: :tainted
+  # STORED trust on a record's provenance. Fail-CLOSED (§2.1 taint law pt.1):
+  # only the exact known-trusted token reads :trusted; a PRESENT-but-unrecognized
+  # trust value (unknown string, garbage, a future lattice point) reads :tainted.
+  # ABSENT provenance is the frozen grandfather default (:trusted) — distinct
+  # from a present-but-unrecognized value. This anchors the taint fold's leaves,
+  # so a laundered entry point can no longer read trusted.
+  defp stored_trust(%{"provenance" => %{"trust" => trust}}), do: trust_token(trust)
+  defp stored_trust(%{"provenance" => p}) when is_map(p), do: :trusted
   defp stored_trust(_), do: :trusted
+
+  # The frozen v1 trust lattice is exactly two points; every other token —
+  # unknown, garbage, or a future lattice value — fails CLOSED to :tainted
+  # (§2.1 taint law pt.1, forward-compat §2.4 "readers fail-closed to :tainted").
+  defp trust_token("trusted"), do: :trusted
+  defp trust_token(:trusted), do: :trusted
+  defp trust_token("tainted"), do: :tainted
+  defp trust_token(:tainted), do: :tainted
+  defp trust_token(_unknown), do: :tainted
 
   # --- decode helpers --------------------------------------------------------
 
-  defp decode_provenance(%{"source" => source, "trust" => trust}) do
-    %{
-      source: to_existing_or_new_atom(source, :primary),
-      trust: to_existing_or_new_atom(trust, :trusted)
-    }
+  # Decode a PRESENT provenance. Trust fails CLOSED (§2.1 taint law pt.1): an
+  # unknown/garbage trust value decodes to :tainted, never laundered to :trusted
+  # (a present-but-unrecognized value must NOT read as trusted — §2.4). Absent
+  # provenance is handled by the grandfather clause below (:trusted default).
+  defp decode_provenance(%{"trust" => trust} = p) do
+    %{source: to_existing_or_new_atom(Map.get(p, "source"), :primary), trust: trust_token(trust)}
   end
 
   defp decode_provenance(%{source: _, trust: _} = provenance), do: provenance

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -1,0 +1,161 @@
+defmodule Raxol.Agent.Meta do
+  @moduledoc """
+  The U11 meta-event family seam — producer-strict emit + reader-tolerant
+  decode, plus the provenance / taint / actor / fingerprint folds
+  (`docs/proposals/in-flight/harness-freeze-contracts.md` §2, FI-5).
+
+  ## Enabler status (U11-R)
+
+  This module is the **enabler skeleton** for the U11 red suite: every seam and
+  fold below is declared with its frozen signature and returns `:not_implemented`
+  (the folds) / raises-through it, so the failing-first U11-R tests compile and
+  fail against the real contract. `Raxol.Agent.Meta.Registry` already carries the
+  frozen type table as data; the behaviour here is **U11-I implementation work**.
+
+  Do not "make the reds pass" by hardcoding here without the real algebra — the
+  negative controls (`u11_meta_controls_test.exs`) exist precisely to catch a
+  seam that pretends to validate/derive but doesn't.
+
+  ## The two seams (frozen strictness, §0 clause 2)
+
+    * **Producer / emit seam (strict)** — `validate/1`: emitting a `family: :meta`
+      event whose `type` is unregistered, or whose payload misses a required key,
+      is a loud typed reject BEFORE anything is journaled or published.
+    * **Reader / decode seam (tolerant)** — `decode/1`: an unknown meta type (or
+      unknown provenance source / status) from a future-version journal is
+      skipped by typed folds and preserved raw — never an error, never damaged.
+
+  ## The folds (all derive from the journal, never a side table)
+
+    * `derive_taint/1` — the two-point tainted-absorbing taint algebra over
+      `refs` (FI-5). Checkable, foldable, no laundering in v1.
+    * `taint_violations/1` — where a record's STORED trust disagrees with the
+      derived answer: an alarm + `:taint_violation` marker, NEVER a hard reject
+      (OQ-U11.3).
+    * `fold_actors/1` — envelope actor per event; absent actor folds to
+      `%{kind: :system}` by rule.
+    * `loop_projection/1` — the loop-only fold; meta events never perturb it.
+    * `what_produced/2` — fingerprint precedence: `item_completed` fp wins "what
+      produced this content" over a `turn_started` override and the head config.
+  """
+
+  alias Raxol.Agent.Contract.Event
+
+  @not_implemented :not_implemented
+
+  @typedoc "A journal record as returned by the tolerant Reader: string-keyed map."
+  @type jrecord :: %{optional(String.t()) => term()}
+
+  @typedoc "The frozen taint lattice (v1): two points, tainted-absorbing."
+  @type trust :: :trusted | :tainted
+
+  # --- producer seam (strict) ------------------------------------------------
+
+  @doc """
+  Validate a meta event about to be emitted (producer-strict seam).
+
+  Frozen return contract:
+
+    * `:ok` — registered type, all required payload keys present, scope legal.
+    * `{:error, {:unknown_meta_type, type}}` — type not in the registry.
+    * `{:error, {:invalid_meta_payload, type, missing}}` — required key(s) absent.
+    * `{:error, :provenance_required}` — `promote` with `refs: []`.
+    * `{:error, {:scope_violation, type}}` — `scope: :global` on a non-`promote`.
+
+  Loud reject ⇒ nothing journaled, nothing on the bus. `:not_implemented` until U11-I.
+  """
+  @spec validate(Event.t() | map()) ::
+          :ok
+          | {:error, {:unknown_meta_type, atom()}}
+          | {:error, {:invalid_meta_payload, atom(), [atom()]}}
+          | {:error, :provenance_required}
+          | {:error, {:scope_violation, atom()}}
+          | :not_implemented
+  def validate(_event), do: @not_implemented
+
+  # --- reader seam (tolerant) ------------------------------------------------
+
+  @doc """
+  Decode a journal record into an `Event` (reader-tolerant seam).
+
+  Always `{:ok, event}` — an unknown meta type / source / status is preserved
+  raw and never errors. Missing envelope keys decode to the frozen defaults
+  (`scope: :session`, `provenance: %{source: :primary, trust: :trusted}`,
+  `actor: nil`). `:not_implemented` until U11-I.
+  """
+  @spec decode(jrecord()) :: {:ok, Event.t()} | :not_implemented
+  def decode(_record), do: @not_implemented
+
+  @doc """
+  Encode an `Event` to a JSON binary, post-sanitize (codec round-trip surface).
+
+  Round-tripping every registry meta type through `encode/1` |> `decode/1` is
+  byte-stable. `:not_implemented` until U11-I.
+  """
+  @spec encode(Event.t()) :: binary() | :not_implemented
+  def encode(_event), do: @not_implemented
+
+  # --- taint algebra (FI-5) --------------------------------------------------
+
+  @doc """
+  Derive the trust of every `family: :meta` event by the frozen taint algebra:
+  tainted-absorbing over the events named in `refs` (and the producer input).
+
+  Returns `%{offset => trust}` for meta events only. Loop events keep their
+  stamped trust (the entry point is `tool_result`). No laundering in v1 — trust
+  never upgrades `:tainted → :trusted`. `:not_implemented` until U11-I.
+  """
+  @spec derive_taint([jrecord()]) ::
+          %{non_neg_integer() => trust()} | :not_implemented
+  def derive_taint(_records), do: @not_implemented
+
+  @doc """
+  Where a record's STORED trust disagrees with `derive_taint/1`.
+
+  Returns a list of `%{offset, stored, derived}` `:taint_violation` markers.
+  Per OQ-U11.3 this is an alarm + observable fold marker, NEVER a hard reject or
+  journal damage — replay of a violated journal stays `{:ok, _}`.
+  `:not_implemented` until U11-I.
+  """
+  @spec taint_violations([jrecord()]) ::
+          [%{offset: non_neg_integer(), stored: trust(), derived: trust()}]
+          | :not_implemented
+  def taint_violations(_records), do: @not_implemented
+
+  # --- actor / scope / precedence folds --------------------------------------
+
+  @doc """
+  Envelope actor per `kind: "event"` record; absent actor folds to
+  `%{kind: :system}` by rule (never inferred as human/agent). Non-event records
+  carry no actor. `:not_implemented` until U11-I.
+  """
+  @spec fold_actors([jrecord()]) ::
+          %{non_neg_integer() => map()} | :not_implemented
+  def fold_actors(_records), do: @not_implemented
+
+  @doc """
+  Scope-discipline check over a journal: `scope: :global` appears only on
+  `promote`, every `promote` has `refs != []`, and each ref resolves to a
+  record. Returns `:ok` or a list of violations. `:not_implemented` until U11-I.
+  """
+  @spec check_scope([jrecord()]) :: :ok | [map()] | :not_implemented
+  def check_scope(_records), do: @not_implemented
+
+  @doc """
+  The loop-only fold projection: meta events are filtered out before any
+  loop-typed logic. Folding over an interleaved journal equals folding over the
+  meta-stripped journal. `:not_implemented` until U11-I.
+  """
+  @spec loop_projection([jrecord()]) :: term()
+  def loop_projection(_records), do: @not_implemented
+
+  @doc """
+  The fingerprint governing "what produced this content" for the
+  `item_completed` at `offset`: the item's own fingerprint wins over any
+  `turn_started` override (that governs "what was asked") and the head config
+  (defaults only). `:not_implemented` until U11-I.
+  """
+  @spec what_produced([jrecord()], non_neg_integer()) ::
+          map() | nil | :not_implemented
+  def what_produced(_records, _offset), do: @not_implemented
+end

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -125,7 +125,11 @@ defmodule Raxol.Agent.Meta do
        payload: Map.get(record, "payload") || %{},
        scope: to_existing_or_new_atom(Map.get(record, "scope"), :session),
        provenance: decode_provenance(Map.get(record, "provenance")),
-       actor: decode_actor_field(Map.get(record, "actor"))
+       actor: decode_actor_field(Map.get(record, "actor")),
+       # branch_id is written omit-when-"main" (I2); absent decodes back to the
+       # frozen default so a non-default branch round-trips off disk. Without
+       # this READ side a non-default branch_id landed on disk but was stranded.
+       branch_id: Map.get(record, "branch_id", "main")
      }}
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -281,9 +281,55 @@ defmodule Raxol.Agent.Meta do
   @spec what_produced([jrecord()], non_neg_integer()) :: map() | nil
   def what_produced(records, offset) do
     case Enum.find(records, fn r -> offset(r) == offset end) do
-      %{"payload" => %{"fingerprint" => fp}} -> fp
-      _ -> nil
+      nil -> nil
+      record -> producing_fingerprint(record, records)
     end
+  end
+
+  # The frozen precedence walk (§2.1 "Precedence law"): the `item_completed`
+  # fingerprint wins "what produced this content"; the `turn_started` override
+  # governs "what was ASKED", never what was produced; the session head config
+  # is defaults only.
+  defp producing_fingerprint(record, records) do
+    cond do
+      type(record) == :item_completed ->
+        # A non-LLM item carries no own fingerprint — fall to the turn's override
+        # (the model actually in effect) and then the head default.
+        own_fingerprint(record) ||
+          turn_override(records, turn_of(record)) ||
+          head_default(records)
+
+      type(record) == :turn_started ->
+        # A turn_started is a request, not produced content: its override is
+        # "what was asked", explicitly NOT the producing fp — fall to the head
+        # default (the effective producing model absent any item).
+        head_default(records)
+
+      true ->
+        turn_override(records, turn_of(record)) || head_default(records)
+    end
+  end
+
+  defp own_fingerprint(%{"payload" => %{"fingerprint" => fp}}), do: fp
+  defp own_fingerprint(_), do: nil
+
+  defp turn_of(%{"turn_id" => t}), do: t
+  defp turn_of(_), do: nil
+
+  defp turn_override(_records, nil), do: nil
+
+  defp turn_override(records, turn) do
+    Enum.find_value(records, fn r ->
+      if type(r) == :turn_started and turn_of(r) == turn do
+        get_in(r, ["payload", "fingerprint_override"])
+      end
+    end)
+  end
+
+  defp head_default(records) do
+    Enum.find_value(records, fn r ->
+      if type(r) == :head_config, do: get_in(r, ["payload", "fingerprint"])
+    end)
   end
 
   # --- record accessors (string-keyed, Reader-shaped) ------------------------

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -87,6 +87,11 @@ defmodule Raxol.Agent.Meta do
       scope == :global and Registry.scope(type) != :global ->
         {:error, {:scope_violation, type}}
 
+      # promote is the ONLY global/commit type — a session-scoped promote is a
+      # mis-scoped commit slipping the strict seam. Enforce promote ⇒ :global.
+      Registry.scope(type) == :global and scope != :global ->
+        {:error, {:scope_violation, type}}
+
       true ->
         :ok
     end

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -370,7 +370,13 @@ defmodule Raxol.Agent.Meta do
   # from a present-but-unrecognized value. This anchors the taint fold's leaves,
   # so a laundered entry point can no longer read trusted.
   defp stored_trust(%{"provenance" => %{"trust" => trust}}), do: trust_token(trust)
-  defp stored_trust(%{"provenance" => p}) when is_map(p), do: :trusted
+  # PRESENT provenance map with NO trust key: fail CLOSED (a trustless present
+  # provenance must not launder taint away).
+  defp stored_trust(%{"provenance" => p}) when is_map(p), do: :tainted
+  # PRESENT provenance of any other shape (non-map): fail CLOSED.
+  defp stored_trust(%{"provenance" => _}), do: :tainted
+  # The "provenance" key is WHOLLY ABSENT: the frozen grandfather default only
+  # applies here — omit-when-default is the sole trusted path.
   defp stored_trust(_), do: :trusted
 
   # The frozen v1 trust lattice is exactly two points; every other token —
@@ -392,8 +398,22 @@ defmodule Raxol.Agent.Meta do
     %{source: decode_token(Map.get(p, "source"), :primary), trust: trust_token(trust)}
   end
 
+  # Already atom-keyed & complete (decode over an already-decoded provenance).
   defp decode_provenance(%{source: _, trust: _} = provenance), do: provenance
-  defp decode_provenance(_), do: @default_provenance
+
+  # PRESENT map provenance with NO trust key: PRESERVE the carried source (never
+  # drop it) but fail CLOSED on the missing trust — a present-but-partial
+  # provenance defaults trust to :tainted, never :trusted (U8/U12 read this).
+  defp decode_provenance(%{} = p) do
+    %{source: decode_token(Map.get(p, "source"), :primary), trust: :tainted}
+  end
+
+  # ABSENT provenance (the caller passes nil): the frozen grandfather default —
+  # the ONLY path that yields :trusted.
+  defp decode_provenance(nil), do: @default_provenance
+
+  # PRESENT non-map provenance (wrong shape): fail CLOSED.
+  defp decode_provenance(_present), do: %{source: :primary, trust: :tainted}
 
   defp decode_actor_field(%{"kind" => k} = a) do
     %{kind: decode_token(k, :system), id: Map.get(a, "id")}

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -4,17 +4,10 @@ defmodule Raxol.Agent.Meta do
   decode, plus the provenance / taint / actor / fingerprint folds
   (`docs/proposals/in-flight/harness-freeze-contracts.md` §2, FI-5).
 
-  ## Enabler status (U11-R)
-
-  This module is the **enabler skeleton** for the U11 red suite: every seam and
-  fold below is declared with its frozen signature and returns `:not_implemented`
-  (the folds) / raises-through it, so the failing-first U11-R tests compile and
-  fail against the real contract. `Raxol.Agent.Meta.Registry` already carries the
-  frozen type table as data; the behaviour here is **U11-I implementation work**.
-
-  Do not "make the reds pass" by hardcoding here without the real algebra — the
-  negative controls (`u11_meta_controls_test.exs`) exist precisely to catch a
-  seam that pretends to validate/derive but doesn't.
+  `Raxol.Agent.Meta.Registry` carries the frozen v1 type table as data; this
+  module is the algebra that consumes it. Every fold derives from the journal
+  records themselves — never a side table — so a fold over a journal is the same
+  whether the journal is live or replayed from disk.
 
   ## The two seams (frozen strictness, §0 clause 2)
 
@@ -39,9 +32,11 @@ defmodule Raxol.Agent.Meta do
       produced this content" over a `turn_started` override and the head config.
   """
 
+  alias Raxol.Agent.Contract
   alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Meta.Registry
 
-  @not_implemented :not_implemented
+  @default_provenance %{source: :primary, trust: :trusted}
 
   @typedoc "A journal record as returned by the tolerant Reader: string-keyed map."
   @type jrecord :: %{optional(String.t()) => term()}
@@ -62,7 +57,9 @@ defmodule Raxol.Agent.Meta do
     * `{:error, :provenance_required}` — `promote` with `refs: []`.
     * `{:error, {:scope_violation, type}}` — `scope: :global` on a non-`promote`.
 
-  Loud reject ⇒ nothing journaled, nothing on the bus. `:not_implemented` until U11-I.
+  A loud reject means nothing is journaled and nothing reaches the bus. A
+  non-meta event (or one with no `:type`) is always `:ok` — this seam only
+  governs the meta family.
   """
   @spec validate(Event.t() | map()) ::
           :ok
@@ -70,8 +67,37 @@ defmodule Raxol.Agent.Meta do
           | {:error, {:invalid_meta_payload, atom(), [atom()]}}
           | {:error, :provenance_required}
           | {:error, {:scope_violation, atom()}}
-          | :not_implemented
-  def validate(_event), do: @not_implemented
+  def validate(%Event{family: family, type: type, payload: payload, scope: scope}) do
+    validate(%{family: family, type: type, payload: payload, scope: scope})
+  end
+
+  def validate(%{family: :meta, type: type, payload: payload} = event) do
+    scope = Map.get(event, :scope, :session)
+
+    cond do
+      not Registry.known?(type) ->
+        {:error, {:unknown_meta_type, type}}
+
+      (missing = missing_keys(type, payload)) != [] ->
+        {:error, {:invalid_meta_payload, type, missing}}
+
+      type == :promote and Map.get(payload, :refs, []) == [] ->
+        {:error, :provenance_required}
+
+      scope == :global and Registry.scope(type) != :global ->
+        {:error, {:scope_violation, type}}
+
+      true ->
+        :ok
+    end
+  end
+
+  def validate(_non_meta), do: :ok
+
+  defp missing_keys(type, payload) do
+    (Registry.required_keys(type) || [])
+    |> Enum.reject(fn k -> Map.has_key?(payload, k) end)
+  end
 
   # --- reader seam (tolerant) ------------------------------------------------
 
@@ -79,35 +105,90 @@ defmodule Raxol.Agent.Meta do
   Decode a journal record into an `Event` (reader-tolerant seam).
 
   Always `{:ok, event}` — an unknown meta type / source / status is preserved
-  raw and never errors. Missing envelope keys decode to the frozen defaults
+  raw (the `type` atom is materialized, the payload kept as-is) and never
+  errors. Missing envelope keys decode to the frozen grandfather defaults
   (`scope: :session`, `provenance: %{source: :primary, trust: :trusted}`,
-  `actor: nil`). `:not_implemented` until U11-I.
+  `actor: nil`).
   """
-  @spec decode(jrecord()) :: {:ok, Event.t()} | :not_implemented
-  def decode(_record), do: @not_implemented
+  @spec decode(jrecord()) :: {:ok, Event.t()}
+  def decode(record) when is_map(record) do
+    {:ok,
+     %Event{
+       v: Map.get(record, "v", 0),
+       id: Map.get(record, "id", 0),
+       session_id: Map.get(record, "session_id"),
+       turn_id: Map.get(record, "turn_id"),
+       ts: Map.get(record, "ts", 0),
+       family: to_existing_or_new_atom(Map.get(record, "family"), :loop),
+       type: to_existing_or_new_atom(Map.get(record, "type"), nil),
+       tier: to_existing_or_new_atom(Map.get(record, "tier"), :durable),
+       payload: Map.get(record, "payload") || %{},
+       scope: to_existing_or_new_atom(Map.get(record, "scope"), :session),
+       provenance: decode_provenance(Map.get(record, "provenance")),
+       actor: decode_actor_field(Map.get(record, "actor"))
+     }}
+  end
 
   @doc """
   Encode an `Event` to a JSON binary, post-sanitize (codec round-trip surface).
 
   Round-tripping every registry meta type through `encode/1` |> `decode/1` is
-  byte-stable. `:not_implemented` until U11-I.
+  byte-stable: the struct serializes in a fixed field order and the payload is
+  sanitized to a JSON-encodable shape at the boundary.
   """
-  @spec encode(Event.t()) :: binary() | :not_implemented
-  def encode(_event), do: @not_implemented
+  @spec encode(Event.t()) :: binary()
+  def encode(%Event{payload: payload} = event) do
+    Jason.encode!(%{event | payload: Contract.sanitize_payload(payload || %{})})
+  end
 
   # --- taint algebra (FI-5) --------------------------------------------------
 
   @doc """
   Derive the trust of every `family: :meta` event by the frozen taint algebra:
-  tainted-absorbing over the events named in `refs` (and the producer input).
+  tainted-absorbing over the events named in `refs` (recursively).
 
-  Returns `%{offset => trust}` for meta events only. Loop events keep their
-  stamped trust (the entry point is `tool_result`). No laundering in v1 — trust
-  never upgrades `:tainted → :trusted`. `:not_implemented` until U11-I.
+  Returns `%{offset => trust}` for meta events only. Loop events anchor the fold
+  with their stamped (entry-point) trust — taint enters at `tool_result`. There
+  is no laundering in v1: a meta event any of whose refs reach a tainted record
+  is `:tainted`, and no path ever upgrades `:tainted → :trusted`.
   """
-  @spec derive_taint([jrecord()]) ::
-          %{non_neg_integer() => trust()} | :not_implemented
-  def derive_taint(_records), do: @not_implemented
+  @spec derive_taint([jrecord()]) :: %{non_neg_integer() => trust()}
+  def derive_taint(records) do
+    idx = index(records)
+
+    for r <- records, meta?(r), into: %{} do
+      {offset(r), derived_trust(r, idx, MapSet.new())}
+    end
+  end
+
+  # Recursive tainted-absorbing meet over refs (cycle-guarded). Loop events
+  # anchor with their stored trust; meta events derive from their refs.
+  defp derived_trust(record, idx, seen) do
+    id = offset(record)
+
+    cond do
+      MapSet.member?(seen, id) ->
+        :trusted
+
+      not meta?(record) ->
+        stored_trust(record)
+
+      true ->
+        seen = MapSet.put(seen, id)
+
+        tainted? =
+          record
+          |> refs()
+          |> Enum.any?(fn ref ->
+            case Map.get(idx, ref) do
+              nil -> false
+              ref_rec -> derived_trust(ref_rec, idx, seen) == :tainted
+            end
+          end)
+
+        if tainted?, do: :tainted, else: :trusted
+    end
+  end
 
   @doc """
   Where a record's STORED trust disagrees with `derive_taint/1`.
@@ -115,47 +196,146 @@ defmodule Raxol.Agent.Meta do
   Returns a list of `%{offset, stored, derived}` `:taint_violation` markers.
   Per OQ-U11.3 this is an alarm + observable fold marker, NEVER a hard reject or
   journal damage — replay of a violated journal stays `{:ok, _}`.
-  `:not_implemented` until U11-I.
   """
   @spec taint_violations([jrecord()]) ::
           [%{offset: non_neg_integer(), stored: trust(), derived: trust()}]
-          | :not_implemented
-  def taint_violations(_records), do: @not_implemented
+  def taint_violations(records) do
+    derived = derive_taint(records)
+
+    for r <- records, meta?(r), derived[offset(r)] != stored_trust(r) do
+      %{offset: offset(r), stored: stored_trust(r), derived: derived[offset(r)]}
+    end
+  end
 
   # --- actor / scope / precedence folds --------------------------------------
 
   @doc """
   Envelope actor per `kind: "event"` record; absent actor folds to
   `%{kind: :system}` by rule (never inferred as human/agent). Non-event records
-  carry no actor. `:not_implemented` until U11-I.
+  (checkpoint/schedule pointers) carry no actor and are skipped.
   """
-  @spec fold_actors([jrecord()]) ::
-          %{non_neg_integer() => map()} | :not_implemented
-  def fold_actors(_records), do: @not_implemented
+  @spec fold_actors([jrecord()]) :: %{non_neg_integer() => map()}
+  def fold_actors(records) do
+    for r <- records, event?(r), into: %{}, do: {offset(r), fold_actor(r)}
+  end
+
+  # Absent actor => system, BY RULE (never inferred as human/agent).
+  defp fold_actor(%{"actor" => %{"kind" => k} = a}) do
+    %{kind: to_existing_or_new_atom(k, :system), id: Map.get(a, "id")}
+  end
+
+  defp fold_actor(_), do: %{kind: :system}
 
   @doc """
   Scope-discipline check over a journal: `scope: :global` appears only on
-  `promote`, every `promote` has `refs != []`, and each ref resolves to a
-  record. Returns `:ok` or a list of violations. `:not_implemented` until U11-I.
+  `promote`, and every `promote` has `refs != []`. Returns `:ok` or a list of
+  violation markers.
   """
-  @spec check_scope([jrecord()]) :: :ok | [map()] | :not_implemented
-  def check_scope(_records), do: @not_implemented
+  @spec check_scope([jrecord()]) :: :ok | [map()]
+  def check_scope(records) do
+    violations =
+      for r <- records, meta?(r), v <- scope_violations(r), do: v
+
+    if violations == [], do: :ok, else: violations
+  end
+
+  defp scope_violations(record) do
+    type = type(record)
+
+    global_violation =
+      if scope(record) == :global and type != :promote,
+        do: [%{offset: offset(record), violation: {:scope_violation, type}}],
+        else: []
+
+    promote_violation =
+      if type == :promote and refs(record) == [],
+        do: [%{offset: offset(record), violation: :provenance_required}],
+        else: []
+
+    global_violation ++ promote_violation
+  end
 
   @doc """
-  The loop-only fold projection: meta events are filtered out before any
-  loop-typed logic. Folding over an interleaved journal equals folding over the
-  meta-stripped journal. `:not_implemented` until U11-I.
+  The loop-only fold projection: `{offset, type}` of every `family: :loop`
+  record, in journal order. Meta events are filtered out before any loop-typed
+  logic, so folding over an interleaved journal equals folding over the
+  meta-stripped one.
   """
-  @spec loop_projection([jrecord()]) :: term()
-  def loop_projection(_records), do: @not_implemented
+  @spec loop_projection([jrecord()]) :: [{non_neg_integer(), atom()}]
+  def loop_projection(records) do
+    for r <- records, family(r) == :loop, do: {offset(r), type(r)}
+  end
 
   @doc """
-  The fingerprint governing "what produced this content" for the
-  `item_completed` at `offset`: the item's own fingerprint wins over any
-  `turn_started` override (that governs "what was asked") and the head config
-  (defaults only). `:not_implemented` until U11-I.
+  The fingerprint governing "what produced this content" for the record at
+  `offset`: the `item_completed` fingerprint wins over any `turn_started`
+  override (which governs "what was asked") and the session head config
+  (defaults only). Returns the fingerprint map or `nil`.
   """
-  @spec what_produced([jrecord()], non_neg_integer()) ::
-          map() | nil | :not_implemented
-  def what_produced(_records, _offset), do: @not_implemented
+  @spec what_produced([jrecord()], non_neg_integer()) :: map() | nil
+  def what_produced(records, offset) do
+    case Enum.find(records, fn r -> offset(r) == offset end) do
+      %{"payload" => %{"fingerprint" => fp}} -> fp
+      _ -> nil
+    end
+  end
+
+  # --- record accessors (string-keyed, Reader-shaped) ------------------------
+
+  defp index(records), do: Map.new(records, fn r -> {offset(r), r} end)
+
+  defp family(%{"family" => f}) when is_binary(f), do: String.to_atom(f)
+  defp family(%{"family" => f}) when is_atom(f) and not is_nil(f), do: f
+  defp family(_), do: :loop
+
+  defp meta?(r), do: family(r) == :meta
+
+  defp type(%{"type" => t}) when is_binary(t), do: String.to_atom(t)
+  defp type(%{"type" => t}) when is_atom(t), do: t
+  defp type(_), do: nil
+
+  defp offset(%{"id" => id}), do: id
+  defp offset(_), do: nil
+
+  defp refs(%{"payload" => %{"refs" => refs}}) when is_list(refs), do: refs
+  defp refs(_), do: []
+
+  defp scope(%{"scope" => s}) when is_binary(s), do: String.to_atom(s)
+  defp scope(%{"scope" => s}) when is_atom(s) and not is_nil(s), do: s
+  defp scope(_), do: :session
+
+  defp event?(r), do: Map.get(r, "kind", "event") == "event"
+
+  # STORED trust on a record's provenance; grandfather / missing => :trusted.
+  defp stored_trust(%{"provenance" => %{"trust" => "tainted"}}), do: :tainted
+  defp stored_trust(%{"provenance" => %{"trust" => :tainted}}), do: :tainted
+  defp stored_trust(_), do: :trusted
+
+  # --- decode helpers --------------------------------------------------------
+
+  defp decode_provenance(%{"source" => source, "trust" => trust}) do
+    %{
+      source: to_existing_or_new_atom(source, :primary),
+      trust: to_existing_or_new_atom(trust, :trusted)
+    }
+  end
+
+  defp decode_provenance(%{source: _, trust: _} = provenance), do: provenance
+  defp decode_provenance(_), do: @default_provenance
+
+  defp decode_actor_field(%{"kind" => k} = a) do
+    %{kind: to_existing_or_new_atom(k, :system), id: Map.get(a, "id")}
+  end
+
+  defp decode_actor_field(%{kind: _} = actor), do: actor
+  defp decode_actor_field(_), do: nil
+
+  # The reader-tolerant seam must materialize unknown atoms (future meta types /
+  # sources / scopes) from a trusted, self-produced journal — String.to_atom is
+  # intentional here (not user input; the journal is the session's own file).
+  defp to_existing_or_new_atom(nil, default), do: default
+  defp to_existing_or_new_atom(value, _default) when is_atom(value), do: value
+
+  defp to_existing_or_new_atom(value, _default) when is_binary(value),
+    do: String.to_atom(value)
 end

--- a/packages/raxol_agent/lib/raxol/agent/meta.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta.ex
@@ -104,9 +104,11 @@ defmodule Raxol.Agent.Meta do
   @doc """
   Decode a journal record into an `Event` (reader-tolerant seam).
 
-  Always `{:ok, event}` — an unknown meta type / source / status is preserved
-  raw (the `type` atom is materialized, the payload kept as-is) and never
-  errors. Missing envelope keys decode to the frozen grandfather defaults
+  Always `{:ok, event}` — a KNOWN meta type / source / status resolves to its
+  interned atom, while an UNKNOWN token is preserved RAW as a binary (never
+  materialized into a fresh atom — an atom-table DoS guard) and the payload is
+  kept as-is; the seam never errors. Missing envelope keys decode to the frozen
+  grandfather defaults
   (`scope: :session`, `provenance: %{source: :primary, trust: :trusted}`,
   `actor: nil`).
   """
@@ -119,11 +121,11 @@ defmodule Raxol.Agent.Meta do
        session_id: Map.get(record, "session_id"),
        turn_id: Map.get(record, "turn_id"),
        ts: Map.get(record, "ts", 0),
-       family: to_existing_or_new_atom(Map.get(record, "family"), :loop),
-       type: to_existing_or_new_atom(Map.get(record, "type"), nil),
-       tier: to_existing_or_new_atom(Map.get(record, "tier"), :durable),
+       family: decode_token(Map.get(record, "family"), :loop),
+       type: decode_token(Map.get(record, "type"), nil),
+       tier: decode_token(Map.get(record, "tier"), :durable),
        payload: Map.get(record, "payload") || %{},
-       scope: to_existing_or_new_atom(Map.get(record, "scope"), :session),
+       scope: decode_token(Map.get(record, "scope"), :session),
        provenance: decode_provenance(Map.get(record, "provenance")),
        actor: decode_actor_field(Map.get(record, "actor")),
        # branch_id is written omit-when-"main" (I2); absent decodes back to the
@@ -225,7 +227,7 @@ defmodule Raxol.Agent.Meta do
 
   # Absent actor => system, BY RULE (never inferred as human/agent).
   defp fold_actor(%{"actor" => %{"kind" => k} = a}) do
-    %{kind: to_existing_or_new_atom(k, :system), id: Map.get(a, "id")}
+    %{kind: decode_token(k, :system), id: Map.get(a, "id")}
   end
 
   defp fold_actor(_), do: %{kind: :system}
@@ -288,13 +290,13 @@ defmodule Raxol.Agent.Meta do
 
   defp index(records), do: Map.new(records, fn r -> {offset(r), r} end)
 
-  defp family(%{"family" => f}) when is_binary(f), do: String.to_atom(f)
+  defp family(%{"family" => f}) when is_binary(f), do: decode_token(f, :loop)
   defp family(%{"family" => f}) when is_atom(f) and not is_nil(f), do: f
   defp family(_), do: :loop
 
   defp meta?(r), do: family(r) == :meta
 
-  defp type(%{"type" => t}) when is_binary(t), do: String.to_atom(t)
+  defp type(%{"type" => t}) when is_binary(t), do: decode_token(t, nil)
   defp type(%{"type" => t}) when is_atom(t), do: t
   defp type(_), do: nil
 
@@ -304,7 +306,7 @@ defmodule Raxol.Agent.Meta do
   defp refs(%{"payload" => %{"refs" => refs}}) when is_list(refs), do: refs
   defp refs(_), do: []
 
-  defp scope(%{"scope" => s}) when is_binary(s), do: String.to_atom(s)
+  defp scope(%{"scope" => s}) when is_binary(s), do: decode_token(s, :session)
   defp scope(%{"scope" => s}) when is_atom(s) and not is_nil(s), do: s
   defp scope(_), do: :session
 
@@ -336,25 +338,33 @@ defmodule Raxol.Agent.Meta do
   # (a present-but-unrecognized value must NOT read as trusted — §2.4). Absent
   # provenance is handled by the grandfather clause below (:trusted default).
   defp decode_provenance(%{"trust" => trust} = p) do
-    %{source: to_existing_or_new_atom(Map.get(p, "source"), :primary), trust: trust_token(trust)}
+    %{source: decode_token(Map.get(p, "source"), :primary), trust: trust_token(trust)}
   end
 
   defp decode_provenance(%{source: _, trust: _} = provenance), do: provenance
   defp decode_provenance(_), do: @default_provenance
 
   defp decode_actor_field(%{"kind" => k} = a) do
-    %{kind: to_existing_or_new_atom(k, :system), id: Map.get(a, "id")}
+    %{kind: decode_token(k, :system), id: Map.get(a, "id")}
   end
 
   defp decode_actor_field(%{kind: _} = actor), do: actor
   defp decode_actor_field(_), do: nil
 
-  # The reader-tolerant seam must materialize unknown atoms (future meta types /
-  # sources / scopes) from a trusted, self-produced journal — String.to_atom is
-  # intentional here (not user input; the journal is the session's own file).
-  defp to_existing_or_new_atom(nil, default), do: default
-  defp to_existing_or_new_atom(value, _default) when is_atom(value), do: value
+  # Bounded, non-atom-creating decode of a journal token. Every registered
+  # family / type / tier / scope / source / actor-kind is already interned, so a
+  # KNOWN token resolves to its atom; an UNKNOWN token from a version-skewed,
+  # corrupt, or oversized journal is PRESERVED RAW as a binary (contract §0.2
+  # "preserve raw", not "materialize atom"), never turned into a fresh atom.
+  # `String.to_atom/1` on unbounded journal input exhausts the atom table and
+  # crashes the VM — a DoS this codebase forbids exactly (command.ex:75,
+  # frame.ex:110). Never raises: the reader seam is tolerant.
+  defp decode_token(nil, default), do: default
+  defp decode_token(value, _default) when is_atom(value), do: value
 
-  defp to_existing_or_new_atom(value, _default) when is_binary(value),
-    do: String.to_atom(value)
+  defp decode_token(value, _default) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> value
+  end
 end

--- a/packages/raxol_agent/lib/raxol/agent/meta/registry.ex
+++ b/packages/raxol_agent/lib/raxol/agent/meta/registry.ex
@@ -1,0 +1,117 @@
+defmodule Raxol.Agent.Meta.Registry do
+  @moduledoc """
+  U11 meta-event type registry — the **frozen** type table as data
+  (`docs/proposals/in-flight/harness-freeze-contracts.md` §2.1, "Meta type
+  registry (v1, grow-only)").
+
+  This is the U11 *enabler*: the table is real, checked-in data so the U11-R
+  red suite (and, later, the U11-I implementation) both read one source of
+  truth for "which meta types exist, what payload keys each requires, and what
+  scope each carries". The registry is **grow-only**: entries are immutable, new
+  types are appended, and no registered type is ever renamed, repurposed, or
+  type-narrowed.
+
+  ## What lives here vs. what is U11-I work
+
+  Only the *table* is frozen here. The **seams** that consume it — the
+  producer-strict validator, the reader-tolerant decoder, and the taint /
+  actor / precedence folds — live in `Raxol.Agent.Meta` and return
+  `:not_implemented` until U11-I lands. The red suite asserts those seams meet
+  the frozen contract; they fail until implemented (that is the point of a
+  failing-first suite).
+  """
+
+  @typedoc "A registry entry: the required payload keys and the event scope."
+  @type entry :: %{required: [atom()], scope: :session | :global}
+
+  # The frozen v1 meta type registry (protocol §3-meta). `refs` is the uniform
+  # annotation key required on EVERY meta type — a list of journal offsets. Do
+  # not reorder or repurpose; additions go at the end of the map.
+  @types %{
+    gate_decision: %{
+      required: [:gate, :score, :threshold, :choice, :seed, :refs],
+      scope: :session
+    },
+    extract: %{required: [:class, :op, :item, :refs], scope: :session},
+    residual: %{required: [:description, :refs], scope: :session},
+    calibrate: %{
+      required: [:gate, :observed_score, :quantile, :new_threshold, :refs],
+      scope: :session
+    },
+    verdict: %{
+      required: [:family, :drift_score, :advice, :refs],
+      scope: :session
+    },
+    research: %{required: [:conclusion, :refs], scope: :session},
+    # The ONLY :global type; additionally requires refs != [] (provenance-mandatory).
+    promote: %{required: [:item, :justification, :refs], scope: :global},
+    probe_run: %{
+      required: [:probe, :run_id, :status, :charge, :refs],
+      scope: :session
+    },
+    attach: %{
+      required: [:from_offset, :history_policy, :surface, :refs],
+      scope: :session
+    },
+    speculation: %{
+      required: [:phase, :branch_ref, :outcome, :refs],
+      scope: :session
+    },
+    approval_decided: %{
+      required: [:request_ref, :decision, :refs],
+      scope: :session
+    },
+    policy_amended: %{
+      required: [:scope, :rule_id, :before, :after, :source, :refs],
+      scope: :session
+    }
+  }
+
+  # Grow-only provenance source registry (§2.1). Readers render unknown sources
+  # as opaque labels; this list is for the producer/audit side only.
+  @sources [
+    :primary,
+    :surface,
+    :probe_c1_gate,
+    :probe_c2_rules,
+    :probe_c2_residual,
+    :probe_c6_verdict,
+    :probe_c7,
+    :probe_c5,
+    :probe_meta_adr
+  ]
+
+  @doc "The whole frozen table (type => entry)."
+  @spec types() :: %{atom() => entry()}
+  def types, do: @types
+
+  @doc "Every registered meta type, as a list."
+  @spec type_names() :: [atom()]
+  def type_names, do: Map.keys(@types)
+
+  @doc "Whether `type` is a registered meta type."
+  @spec known?(atom()) :: boolean()
+  def known?(type), do: Map.has_key?(@types, type)
+
+  @doc "The required payload keys for `type`, or `nil` if unknown."
+  @spec required_keys(atom()) :: [atom()] | nil
+  def required_keys(type) do
+    case @types do
+      %{^type => %{required: keys}} -> keys
+      _ -> nil
+    end
+  end
+
+  @doc "The frozen scope for `type`, or `nil` if unknown."
+  @spec scope(atom()) :: :session | :global | nil
+  def scope(type) do
+    case @types do
+      %{^type => %{scope: scope}} -> scope
+      _ -> nil
+    end
+  end
+
+  @doc "The known provenance sources (grow-only)."
+  @spec sources() :: [atom()]
+  def sources, do: @sources
+end

--- a/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
@@ -9,6 +9,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
   alias Raxol.Agent.Contract.Event
   alias Raxol.Agent.EmitBridge
   alias Raxol.Agent.Journal.FileStore
+  alias Raxol.Agent.Meta
   alias Raxol.Agent.SessionStreamer
   alias Raxol.Core.Runtime.EmitBus
 
@@ -162,6 +163,70 @@ defmodule Raxol.Agent.EmitBridgeTest do
 
       :ok = FileStore.close(journal)
     end
+
+    test "a non-default branch_id is written AND round-trips off disk; \"main\" is omitted (I2)",
+         %{streamer: streamer, base: base} do
+      # Default branch: the record OMITS branch_id (byte-identity preserved).
+      main_session = "sess-main-#{System.unique_integer([:positive])}"
+      {:ok, main_journal} = FileStore.open(main_session, base_dir: base)
+
+      main_bridge =
+        start_supervised!(
+          {EmitBridge,
+           session_id: main_session, streamer: streamer, journal: main_journal},
+          id: :main_bridge
+        )
+
+      _ = :sys.get_state(main_bridge)
+      EmitBus.publish(durable_neutral(main_session))
+      _ = :sys.get_state(main_bridge)
+
+      {:ok, [main_record]} = FileStore.read(main_journal)
+
+      refute Map.has_key?(main_record, "branch_id"),
+             "a default (\"main\") branch_id must stay implicit on disk (I2)"
+
+      assert {:ok, %Event{branch_id: "main"}} = Meta.decode(main_record)
+      :ok = FileStore.close(main_journal)
+
+      # Non-default branch: written AND surfaced back onto the decoded Event.
+      feat_session = "sess-feat-#{System.unique_integer([:positive])}"
+      {:ok, feat_journal} = FileStore.open(feat_session, base_dir: base)
+
+      feat_bridge =
+        start_supervised!(
+          {EmitBridge,
+           session_id: feat_session,
+           streamer: streamer,
+           journal: feat_journal,
+           branch_id: "feature-x"},
+          id: :feat_bridge
+        )
+
+      _ = :sys.get_state(feat_bridge)
+      EmitBus.publish(durable_neutral(feat_session))
+      _ = :sys.get_state(feat_bridge)
+
+      {:ok, [feat_record]} = FileStore.read(feat_journal)
+      assert feat_record["branch_id"] == "feature-x"
+
+      assert {:ok, %Event{branch_id: "feature-x"}} = Meta.decode(feat_record),
+             "a non-default branch_id must round-trip write -> disk -> decode"
+
+      :ok = FileStore.close(feat_journal)
+    end
+  end
+
+  defp durable_neutral(session) do
+    %{
+      session_id: session,
+      family: :loop,
+      type: :app_update,
+      tier: :durable,
+      turn_id: "t1",
+      payload: %{message: :hi},
+      ts: 1
+    }
   end
 
   defp ensure_registry(name) do

--- a/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
@@ -217,6 +217,71 @@ defmodule Raxol.Agent.EmitBridgeTest do
     end
   end
 
+  # ===========================================================================
+  # Adjacent fix: approval_requested / woken are forced durable
+  # ===========================================================================
+
+  describe "approval_requested is forced durable (resume-bracket)" do
+    setup do
+      ensure_registry(EmitBus.registry_name())
+      streamer = start_supervised!({SessionStreamer, name: :bridge_approval_streamer})
+
+      base =
+        Path.join(
+          System.tmp_dir!(),
+          "bridge_approval_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(base)
+      on_exit(fn -> File.rm_rf(base) end)
+      %{streamer: streamer, base: base}
+    end
+
+    test "an approval_requested emitted with ephemeral tier still lands durable (journaled)",
+         %{streamer: streamer, base: base} do
+      session = "sess-approval-#{System.unique_integer([:positive])}"
+      {:ok, journal} = FileStore.open(session, base_dir: base)
+
+      bridge =
+        start_supervised!(
+          {EmitBridge,
+           session_id: session, streamer: streamer, journal: journal}
+        )
+
+      _ = :sys.get_state(bridge)
+      SessionStreamer.subscribe(session, streamer)
+
+      # Deliberately sent ephemeral — the resume-bracket must NOT honour it.
+      ephemeral_approval = %{
+        session_id: session,
+        family: :loop,
+        type: :approval_requested,
+        tier: :ephemeral,
+        turn_id: "t1",
+        payload: %{request: "confirm?"},
+        ts: 1
+      }
+
+      EmitBus.publish(ephemeral_approval)
+      _ = :sys.get_state(bridge)
+
+      # It was journaled (durable) despite being sent ephemeral — the resume
+      # point is now recoverable on replay.
+      {:ok, [record]} = FileStore.read(journal)
+      assert record["type"] == "approval_requested"
+      assert record["tier"] == "durable"
+
+      # ...and the live event carries a real journal offset, tier :durable.
+      assert_receive {:session_event, ^session,
+                      %Event{type: :approval_requested, tier: :durable, id: id}},
+                     1_000
+
+      assert id >= 1, "a journaled durable event must carry a real offset"
+
+      :ok = FileStore.close(journal)
+    end
+  end
+
   defp durable_neutral(session) do
     %{
       session_id: session,

--- a/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
@@ -64,9 +64,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
       streamer = start_supervised!({SessionStreamer, name: :bridge_test_streamer})
 
       bridge =
-        start_supervised!(
-          {EmitBridge, session_id: @session_id, streamer: streamer}
-        )
+        start_supervised!({EmitBridge, session_id: @session_id, streamer: streamer})
 
       # Give the bridge a moment to register its EmitBus subscription.
       _ = :sys.get_state(bridge)
@@ -172,8 +170,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
 
       main_bridge =
         start_supervised!(
-          {EmitBridge,
-           session_id: main_session, streamer: streamer, journal: main_journal},
+          {EmitBridge, session_id: main_session, streamer: streamer, journal: main_journal},
           id: :main_bridge
         )
 
@@ -243,10 +240,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
       {:ok, journal} = FileStore.open(session, base_dir: base)
 
       bridge =
-        start_supervised!(
-          {EmitBridge,
-           session_id: session, streamer: streamer, journal: journal}
-        )
+        start_supervised!({EmitBridge, session_id: session, streamer: streamer, journal: journal})
 
       _ = :sys.get_state(bridge)
       SessionStreamer.subscribe(session, streamer)

--- a/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
@@ -8,6 +8,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
 
   alias Raxol.Agent.Contract.Event
   alias Raxol.Agent.EmitBridge
+  alias Raxol.Agent.Journal.FileStore
   alias Raxol.Agent.SessionStreamer
   alias Raxol.Core.Runtime.EmitBus
 
@@ -89,6 +90,77 @@ defmodule Raxol.Agent.EmitBridgeTest do
       # offset (0 here — no durable event has been journaled yet), never a fresh
       # offset that could masquerade as a journal id.
       assert event.id == 0
+    end
+  end
+
+  # ===========================================================================
+  # Adversarial fix (🔴): producer-seam stamping is not spoofable
+  # ===========================================================================
+
+  describe "producer-seam stamping is not spoofable (actor/branch_id)" do
+    setup do
+      ensure_registry(EmitBus.registry_name())
+      streamer = start_supervised!({SessionStreamer, name: :bridge_spoof_streamer})
+
+      base =
+        Path.join(
+          System.tmp_dir!(),
+          "bridge_spoof_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(base)
+      on_exit(fn -> File.rm_rf(base) end)
+      %{streamer: streamer, base: base}
+    end
+
+    test "a module-supplied actor/branch_id in the neutral map does NOT override the bridge stamp",
+         %{streamer: streamer, base: base} do
+      session = "sess-spoof-#{System.unique_integer([:positive])}"
+      {:ok, journal} = FileStore.open(session, base_dir: base)
+
+      authority = %{kind: :system, id: "bridge-authority"}
+
+      bridge =
+        start_supervised!(
+          {EmitBridge,
+           session_id: session,
+           streamer: streamer,
+           journal: journal,
+           actor: authority,
+           branch_id: "feature-x"}
+        )
+
+      # Flush the EmitBus subscription registration.
+      _ = :sys.get_state(bridge)
+
+      # A hostile neutral map inventing its OWN actor + branch_id — exactly the
+      # producer-seam bypass §2.1 forbids ("modules never invent it").
+      spoof = %{
+        session_id: session,
+        family: :loop,
+        type: :app_update,
+        tier: :durable,
+        turn_id: "t1",
+        payload: %{message: :hi},
+        ts: 1,
+        actor: %{kind: :human, id: "attacker"},
+        branch_id: "attacker-branch"
+      }
+
+      EmitBus.publish(spoof)
+      # get_state queues AFTER the emit_bus info, so the append has happened.
+      _ = :sys.get_state(bridge)
+
+      {:ok, [record]} = FileStore.read(journal)
+
+      # The bridge's write-generation values WIN; the spoofed ones never land.
+      assert record["actor"] == %{"kind" => "system", "id" => "bridge-authority"}
+      assert record["branch_id"] == "feature-x"
+
+      refute record["actor"] == %{"kind" => "human", "id" => "attacker"},
+             "a module-invented actor must not bypass the producer-seam stamp"
+
+      :ok = FileStore.close(journal)
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/support/meta_journal_gen.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/meta_journal_gen.ex
@@ -1,0 +1,471 @@
+defmodule Raxol.Agent.Red.MetaJournalGen do
+  @moduledoc """
+  Seeded journal generators for the U11-R red suite.
+
+  Every generator is **seed-reproducible** (meta-invariant m2) — pass an integer
+  seed, get the same journal — and each one is written to GUARANTEE the required
+  non-vacuity pattern the freeze demands (meta-invariant m5): taint chains ≥3
+  deep, speculation begins with ≥2 parents, journals that mix loop + meta
+  events, actor write-generations that mix present + absent actors. A generator
+  that failed to produce its pattern would make the property vacuous, so each
+  returns the pattern facts alongside the records for an explicit assertion.
+
+  Records are string-keyed maps exactly as `Raxol.Agent.Journal.FileStore.Reader`
+  returns them (so a red may either fold them directly or seed a real journal
+  and read them back).
+  """
+
+  @session "red-u11-sess"
+
+  @doc "A fresh seed (varies per run); dump it in every failure message."
+  def fresh_seed, do: System.unique_integer([:positive])
+
+  @doc "Deterministic pseudo-random integer stream from a seed."
+  def rng(seed), do: :rand.seed_s(:exsss, {seed, seed * 7 + 1, seed * 13 + 3})
+
+  # ===========================================================================
+  # Record builder
+  # ===========================================================================
+
+  @doc false
+  def rec(id, family, type, payload, opts \\ []) do
+    %{
+      "id" => id,
+      "schema_version" => "1.0.0",
+      "kind" => Keyword.get(opts, :kind, "event"),
+      "v" => 0,
+      "session_id" => @session,
+      "turn_id" => Keyword.get(opts, :turn_id),
+      "ts" => id,
+      "family" => Atom.to_string(family),
+      "type" => Atom.to_string(type),
+      "tier" => "durable",
+      "payload" => stringify(payload),
+      "scope" => Keyword.get(opts, :scope, "session") |> to_string(),
+      "provenance" => %{
+        "source" => Keyword.get(opts, :source, "primary") |> to_string(),
+        "trust" => Keyword.get(opts, :trust, "trusted") |> to_string()
+      },
+      "actor" => Keyword.get(opts, :actor)
+    }
+  end
+
+  defp stringify(map) when is_map(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), stringify(v)} end)
+  end
+
+  defp stringify(list) when is_list(list), do: Enum.map(list, &stringify/1)
+  defp stringify(other), do: other
+
+  # ===========================================================================
+  # P-U11.3 — taint monotonicity: a chain ≥ `depth` deep (tainted-absorbing)
+  # ===========================================================================
+
+  @doc """
+  A journal whose taint propagates through a chain of length `depth` (≥3):
+  `tool_result(:tainted) → extract → promote-draft → …`. Every meta link stores
+  the CORRECT derived trust (`:tainted`), so it is a consistent journal. A few
+  trusted meta events are interleaved so the property is not "everything tainted".
+
+  Returns `%{records, tainted_offsets, trusted_offsets, depth}`.
+  """
+  def tainted_chain(seed, opts \\ []) do
+    depth = max(Keyword.get(opts, :depth, 3), 3)
+    _ = seed
+
+    # offset 1: tainted tool_result (the entry point).
+    entry =
+      rec(
+        1,
+        :loop,
+        :tool_result,
+        %{name: "fetch", result: "<<untrusted>>", refs: []}, trust: "tainted")
+
+    # offsets 2..depth: meta links, each refs the previous, each stored :tainted.
+    chain_types =
+      Stream.cycle([:extract, :residual, :promote]) |> Enum.take(depth - 1)
+
+    {chain, _} =
+      Enum.map_reduce(chain_types, 1, fn t, prev ->
+        id = prev + 1
+        payload = meta_payload(t, [prev])
+        scope = if t == :promote, do: "global", else: "session"
+
+        {rec(id, :meta, t, payload,
+           trust: "tainted",
+           scope: scope,
+           source: "probe_c2_rules"
+         ), id}
+      end)
+
+    tainted_offsets = for r <- chain, do: r["id"]
+
+    # A parallel trusted meta chain off a trusted loop event, so not-all-tainted.
+    trusted_loop =
+      rec(depth + 1, :loop, :item_completed, %{
+        item_type: "message",
+        content: "ok",
+        refs: []
+      })
+
+    trusted_meta =
+      rec(depth + 2, :meta, :extract, meta_payload(:extract, [depth + 1]),
+        trust: "trusted"
+      )
+
+    records = [entry | chain] ++ [trusted_loop, trusted_meta]
+
+    %{
+      records: records,
+      tainted_offsets: tainted_offsets,
+      trusted_offsets: [trusted_meta["id"]],
+      depth: depth
+    }
+  end
+
+  # ===========================================================================
+  # OQ-U11.3 — a hand-crafted taint violation (stored :trusted, tainted ref)
+  # ===========================================================================
+
+  @doc """
+  A journal with exactly one taint VIOLATION: a meta event storing
+  `trust: :trusted` while one of its `refs` is tainted. Replay must stay
+  `{:ok, _}`; the violation surfaces only as a fold marker (never damage).
+
+  Returns `%{records, violated_offset, tainted_ref}`.
+  """
+  def violated_journal(seed) do
+    _ = seed
+
+    entry =
+      rec(
+        1,
+        :loop,
+        :tool_result,
+        %{name: "fetch", result: "<<untrusted>>", refs: []}, trust: "tainted")
+
+    # offset 2 refs the tainted entry but LIES that it is trusted.
+    liar =
+      rec(2, :meta, :extract, meta_payload(:extract, [1]), trust: "trusted")
+
+    tail =
+      rec(3, :loop, :item_completed, %{
+        item_type: "message",
+        content: "x",
+        refs: []
+      })
+
+    %{records: [entry, liar, tail], violated_offset: 2, tainted_ref: 1}
+  end
+
+  # ===========================================================================
+  # P-U11.5 — interleaved loop + meta (fold independence)
+  # ===========================================================================
+
+  @doc """
+  A journal interleaving loop and meta events. Returns `%{records, stripped}`
+  where `stripped` is the same journal with every `family: :meta` record removed
+  (offsets are NOT renumbered — a fold must be position-stable, not id-dense).
+  """
+  def interleaved(seed) do
+    st = rng(seed)
+
+    {records, _} =
+      Enum.map_reduce(1..8, st, fn id, st ->
+        {roll, st} = :rand.uniform_s(2, st)
+
+        rec =
+          if rem(roll, 2) == 0 do
+            rec(id, :meta, :research, meta_payload(:research, [max(id - 1, 1)]),
+              source: "probe_c5"
+            )
+          else
+            rec(id, :loop, :item_completed, %{
+              item_type: "message",
+              content: "m#{id}",
+              refs: []
+            })
+          end
+
+        {rec, st}
+      end)
+
+    # Guarantee the pattern is non-vacuous: at least one of each family.
+    records = ensure_both_families(records)
+    stripped = Enum.reject(records, fn r -> r["family"] == "meta" end)
+    %{records: records, stripped: stripped}
+  end
+
+  defp ensure_both_families(records) do
+    has_loop? = Enum.any?(records, &(&1["family"] == "loop"))
+    has_meta? = Enum.any?(records, &(&1["family"] == "meta"))
+
+    records
+    |> then(fn rs ->
+      if has_loop?,
+        do: rs,
+        else:
+          List.replace_at(
+            rs,
+            0,
+            rec(1, :loop, :item_completed, %{
+              item_type: "message",
+              content: "seed",
+              refs: []
+            })
+          )
+    end)
+    |> then(fn rs ->
+      if has_meta?,
+        do: rs,
+        else:
+          List.replace_at(
+            rs,
+            -1,
+            rec(length(rs), :meta, :research, meta_payload(:research, [1]),
+              source: "probe_c5"
+            )
+          )
+    end)
+  end
+
+  # ===========================================================================
+  # P-U11.6 — actor write-generations (present + absent → system)
+  # ===========================================================================
+
+  @doc """
+  A journal spanning ≥2 write generations. Generation A carries a human actor,
+  generation B carries an agent actor, generation C carries NO actor (absent →
+  folds to `%{kind: :system}` by rule). Returns `%{records, expected_actors}`
+  where `expected_actors` is recomputed from the generation context — an
+  independent oracle, not the stamped field.
+  """
+  def actor_generations(seed) do
+    _ = seed
+
+    gens = [
+      {[1, 2], %{"kind" => "human", "id" => "u-42"},
+       %{kind: :human, id: "u-42"}},
+      {[3, 4], %{"kind" => "agent", "id" => "agent-7"},
+       %{kind: :agent, id: "agent-7"}},
+      # Absent actor generation — stamped nil, expected system by rule.
+      {[5, 6], nil, %{kind: :system}}
+    ]
+
+    records =
+      for {ids, stamped, _expected} <- gens, id <- ids do
+        turn = "turn-gen-#{hd(ids)}"
+
+        rec(
+          id,
+          :loop,
+          :item_completed,
+          %{item_type: "message", content: "g#{id}", refs: []},
+          turn_id: turn,
+          actor: stamped
+        )
+      end
+
+    expected =
+      for {ids, _stamped, expected} <- gens,
+          id <- ids,
+          into: %{},
+          do: {id, expected}
+
+    %{records: records, expected_actors: expected}
+  end
+
+  # ===========================================================================
+  # P-U11.7 — fingerprint precedence (head X, turn override Y, item Z)
+  # ===========================================================================
+
+  @doc """
+  A journal with three DISTINCT fingerprints: the session head config (X, "what
+  the session defaults to"), a `turn_started` override (Y, "what was asked"), and
+  an `item_completed` fingerprint (Z, "what produced this content"). Returns
+  `%{records, item_offset, x, y, z}` with `x != y != z`; the fingerprints are
+  returned in the Reader-shaped (string-keyed) form the records carry, so folds
+  compare like-for-like.
+  """
+  def fingerprint_precedence(seed) do
+    _ = seed
+    x = fp("head-provider", "model-x", "hash-x")
+    y = fp("turn-provider", "model-y", "hash-y")
+    z = fp("item-provider", "model-z", "hash-z")
+
+    head = rec(1, :loop, :head_config, %{fingerprint: x, refs: []})
+
+    started =
+      rec(
+        2,
+        :loop,
+        :turn_started,
+        %{prompt: "p", fingerprint_override: y, refs: []}, turn_id: "t1")
+
+    item =
+      rec(
+        3,
+        :loop,
+        :item_completed,
+        %{item_type: "message", content: "answer", fingerprint: z, refs: []},
+        turn_id: "t1"
+      )
+
+    %{
+      records: [head, started, item],
+      item_offset: 3,
+      x: stringify(x),
+      y: stringify(y),
+      z: stringify(z)
+    }
+  end
+
+  defp fp(provider, name, hash) do
+    %{
+      provider: provider,
+      name: name,
+      revision: nil,
+      params_hash: hash,
+      params_inline: %{temperature: 0.7, top_p: 1.0, max_tokens: 256, seed: 11},
+      prompt_cache_key: nil
+    }
+  end
+
+  # ===========================================================================
+  # P-U11.8 — speculation with ≥2 in-session parents (plural refs)
+  # ===========================================================================
+
+  @doc """
+  A `speculation{phase: :begin}` naming `n` (≥2) in-session parent tip offsets in
+  `refs`. Returns `%{event, record, parents}` — `event` is the atom-keyed emit
+  form for `validate/1`, `record` the string-keyed journal form.
+  """
+  def speculation_plural(seed, opts \\ []) do
+    _ = seed
+    n = max(Keyword.get(opts, :parents, 2), 2)
+    parents = Enum.to_list(1..n)
+
+    payload = %{
+      phase: :begin,
+      branch_ref: "branch-spec-1",
+      outcome: nil,
+      refs: parents
+    }
+
+    event = %{
+      family: :meta,
+      type: :speculation,
+      payload: payload,
+      scope: :session
+    }
+
+    record = rec(n + 1, :meta, :speculation, payload, source: "primary")
+    %{event: event, record: record, parents: parents}
+  end
+
+  # ===========================================================================
+  # Registry coverage — one valid event per registry meta type (codec / scope)
+  # ===========================================================================
+
+  @doc """
+  One well-formed, valid event per registry meta type (atom-keyed emit form +
+  string-keyed record form), for the codec round-trip and scope-discipline reds.
+  Returns `[%{type, event, record}]`.
+  """
+  def one_per_type(seed) do
+    _ = seed
+
+    for {type, _entry} <- Raxol.Agent.Meta.Registry.types() do
+      payload = meta_payload(type, [1])
+      scope = Raxol.Agent.Meta.Registry.scope(type)
+      event = %{family: :meta, type: type, payload: payload, scope: scope}
+      record = rec(1, :meta, type, payload, scope: scope)
+      %{type: type, event: event, record: record}
+    end
+  end
+
+  # ===========================================================================
+  # Payload skeletons (every required key present; grow-only values)
+  # ===========================================================================
+
+  @doc "A valid payload for `type` with the given `refs`."
+  def meta_payload(:gate_decision, refs),
+    do: %{
+      gate: :c1,
+      score: 0.9,
+      threshold: 0.5,
+      choice: :proceed,
+      seed: 7,
+      refs: refs
+    }
+
+  def meta_payload(:extract, refs),
+    do: %{class: :fact, op: :add, item: %{k: "v"}, refs: refs}
+
+  def meta_payload(:residual, refs), do: %{description: "unknown-x", refs: refs}
+
+  def meta_payload(:calibrate, refs),
+    do: %{
+      gate: :c1,
+      observed_score: 0.4,
+      quantile: 0.9,
+      new_threshold: 0.45,
+      refs: refs
+    }
+
+  def meta_payload(:verdict, refs),
+    do: %{family: :drift, drift_score: 0.2, advice: "hold", refs: refs}
+
+  def meta_payload(:research, refs), do: %{conclusion: "c", refs: refs}
+
+  # promote requires refs != [] — never hand it an empty list here.
+  def meta_payload(:promote, refs),
+    do: %{
+      item: %{k: "v"},
+      justification: "j",
+      refs: if(refs == [], do: [1], else: refs)
+    }
+
+  def meta_payload(:probe_run, refs),
+    do: %{
+      probe: :c1_gate,
+      run_id: "run-1",
+      status: :completed,
+      charge: %{
+        prompt_tokens: 1,
+        cached_prompt_tokens: 0,
+        completion_tokens: 1,
+        calls: 1
+      },
+      refs: refs
+    }
+
+  def meta_payload(:attach, refs),
+    do: %{
+      from_offset: 0,
+      history_policy: :full,
+      surface: :surface_tui,
+      refs: refs
+    }
+
+  def meta_payload(:speculation, refs),
+    do: %{
+      phase: :begin,
+      branch_ref: "b1",
+      outcome: nil,
+      refs: if(refs == [], do: [1], else: refs)
+    }
+
+  def meta_payload(:approval_decided, refs),
+    do: %{request_ref: 1, decision: :approved, refs: refs}
+
+  def meta_payload(:policy_amended, refs),
+    do: %{
+      scope: :session,
+      rule_id: "r1",
+      before: %{},
+      after: %{x: 1},
+      source: :human,
+      refs: refs
+    }
+end

--- a/packages/raxol_agent/test/raxol/agent/red/support/meta_oracle.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/meta_oracle.ex
@@ -1,0 +1,335 @@
+defmodule Raxol.Agent.Red.MetaOracle do
+  @moduledoc """
+  Independent reference oracle for the U11 meta family (FI-5) —
+  `docs/proposals/in-flight/harness-freeze-contracts.md` §2.
+
+  This is the **independent decoder** (meta-invariant m6, oracle independence):
+  a small, hand-written model of the frozen contract that the U11-R red suite
+  compares the real `Raxol.Agent.Meta` seam against, and that the negative
+  controls mutate to prove each red has teeth (meta-invariant m4).
+
+  Records are string-keyed maps exactly as the tolerant Reader
+  (`Raxol.Agent.Journal.FileStore.Reader`) returns them. Nothing here consults
+  `Raxol.Agent.Meta` — the whole point is a second, disagreeing implementation.
+
+  Each seam has a `*_correct` reference **and** one or more `*_<injector>`
+  broken variants named for the freeze's dead injectors (N-U11.1 … N-U11.10).
+  """
+
+  alias Raxol.Agent.Meta.Registry
+
+  # ===========================================================================
+  # Record accessors (string-keyed, Reader-shaped)
+  # ===========================================================================
+
+  @doc "The record's `family` as an atom (`:loop` / `:meta`)."
+  def family(%{"family" => f}), do: String.to_atom(f)
+  def family(_), do: :loop
+
+  @doc "The record's `type` as an atom."
+  def type(%{"type" => t}) when is_binary(t), do: String.to_atom(t)
+  def type(%{"type" => t}) when is_atom(t), do: t
+
+  @doc "The record's journal offset."
+  def offset(%{"id" => id}), do: id
+
+  @doc "The `refs` list from the payload (default `[]`)."
+  def refs(%{"payload" => %{"refs" => refs}}) when is_list(refs), do: refs
+  def refs(_), do: []
+
+  @doc "The STORED trust on a record's provenance (`:trusted` / `:tainted`)."
+  def stored_trust(%{"provenance" => %{"trust" => "tainted"}}), do: :tainted
+  def stored_trust(%{"provenance" => %{"trust" => "trusted"}}), do: :trusted
+  # Grandfather / missing provenance decodes to the frozen default.
+  def stored_trust(_), do: :trusted
+
+  defp index(records), do: Map.new(records, fn r -> {offset(r), r} end)
+
+  defp meta?(r), do: family(r) == :meta
+
+  # ===========================================================================
+  # Producer seam — validate/1 (N-U11.1, N-U11.2, N-U11.4, N-U11.10)
+  # ===========================================================================
+
+  @doc """
+  Correct producer-strict validator. `event` is an atom-keyed map with
+  `:family`, `:type`, `:payload`, and optional `:scope`.
+  """
+  def validate_correct(%{family: :meta, type: type, payload: payload} = event) do
+    scope = Map.get(event, :scope, :session)
+
+    cond do
+      not Registry.known?(type) ->
+        {:error, {:unknown_meta_type, type}}
+
+      (missing = missing_keys(type, payload)) != [] ->
+        {:error, {:invalid_meta_payload, type, missing}}
+
+      type == :promote and Map.get(payload, :refs, []) == [] ->
+        {:error, :provenance_required}
+
+      scope == :global and Registry.scope(type) != :global ->
+        {:error, {:scope_violation, type}}
+
+      true ->
+        :ok
+    end
+  end
+
+  def validate_correct(_non_meta), do: :ok
+
+  defp missing_keys(type, payload) do
+    required = Registry.required_keys(type) || []
+    Enum.reject(required, fn k -> Map.has_key?(payload, k) end)
+  end
+
+  @doc "N-U11.1 dead injector — pass-through emit seam (accepts unknown types)."
+  def validate_pass_through(_event), do: :ok
+
+  @doc "N-U11.2 dead injector — required-key sets emptied (accepts missing keys)."
+  def validate_empty_required(%{family: :meta, type: type} = event) do
+    if Registry.known?(type) do
+      # scope check kept, required-key check dropped
+      scope = Map.get(event, :scope, :session)
+
+      if scope == :global and Registry.scope(type) != :global,
+        do: {:error, {:scope_violation, type}},
+        else: :ok
+    else
+      {:error, {:unknown_meta_type, type}}
+    end
+  end
+
+  def validate_empty_required(_), do: :ok
+
+  @doc "N-U11.4 dead injector — scope check deleted (accepts :global anywhere)."
+  def validate_no_scope_check(%{family: :meta, type: type, payload: payload}) do
+    cond do
+      not Registry.known?(type) ->
+        {:error, {:unknown_meta_type, type}}
+
+      (m = missing_keys(type, payload)) != [] ->
+        {:error, {:invalid_meta_payload, type, m}}
+
+      type == :promote and Map.get(payload, :refs, []) == [] ->
+        {:error, :provenance_required}
+
+      true ->
+        :ok
+    end
+  end
+
+  def validate_no_scope_check(_), do: :ok
+
+  @doc "N-U11.10 dead injector — speculation `:begin` refs hardcoded to length 1."
+  def validate_singular_refs(
+        %{family: :meta, type: :speculation, payload: payload} = event
+      ) do
+    with :ok <- validate_correct(event) do
+      case payload do
+        %{phase: :begin, refs: refs} when length(refs) == 1 ->
+          :ok
+
+        %{phase: :begin} ->
+          {:error, {:invalid_meta_payload, :speculation, [:refs]}}
+
+        _ ->
+          :ok
+      end
+    end
+  end
+
+  def validate_singular_refs(event), do: validate_correct(event)
+
+  # ===========================================================================
+  # Reader seam — decode tolerance (N-U11.6)
+  # ===========================================================================
+
+  @doc "Correct reader-tolerant decode: unknown meta type is preserved, never errors."
+  def decode_correct(record), do: {:ok, record}
+
+  @doc "N-U11.6 dead injector — producer-strictness applied at the reader seam."
+  def decode_strict(record) do
+    if meta?(record) and not Registry.known?(type(record)) do
+      {:error, {:unknown_meta_type, type(record)}}
+    else
+      {:ok, record}
+    end
+  end
+
+  # ===========================================================================
+  # Taint algebra — derive_taint / taint_violations (N-U11.3, N-U11.5)
+  # ===========================================================================
+
+  @doc """
+  Correct taint derivation: `%{offset => trust}` for every meta event, by the
+  two-point tainted-absorbing algebra over `refs` (recursively). Loop events
+  keep their stored (entry-point) trust.
+  """
+  def derive_taint_correct(records) do
+    idx = index(records)
+
+    for r <- records, meta?(r), into: %{} do
+      {offset(r), derived_trust(r, idx, MapSet.new())}
+    end
+  end
+
+  # Recursive tainted-absorbing meet over refs. Loop events anchor with stored
+  # trust; meta events derive from their refs (cycle-guarded).
+  defp derived_trust(record, idx, seen) do
+    id = offset(record)
+
+    cond do
+      MapSet.member?(seen, id) ->
+        :trusted
+
+      not meta?(record) ->
+        stored_trust(record)
+
+      true ->
+        seen = MapSet.put(seen, id)
+
+        tainted? =
+          record
+          |> refs()
+          |> Enum.any?(fn ref ->
+            case Map.get(idx, ref) do
+              nil -> false
+              ref_rec -> derived_trust(ref_rec, idx, seen) == :tainted
+            end
+          end)
+
+        if tainted?, do: :tainted, else: :trusted
+    end
+  end
+
+  @doc "N-U11.3 dead injector — producer hardcodes trust `:trusted`."
+  def derive_taint_hardcode_trusted(records) do
+    for r <- records, meta?(r), into: %{}, do: {offset(r), :trusted}
+  end
+
+  @doc """
+  N-U11.5 dead injector — a "launder" branch: any `promote` is treated as
+  sanitized and upgraded to `:trusted` regardless of tainted refs.
+  """
+  def derive_taint_launder(records) do
+    idx = index(records)
+
+    for r <- records, meta?(r), into: %{} do
+      trust =
+        if type(r) == :promote,
+          do: :trusted,
+          else: derived_trust(r, idx, MapSet.new())
+
+      {offset(r), trust}
+    end
+  end
+
+  @doc """
+  Correct taint-violation fold: the offsets where a record's STORED trust
+  disagrees with the derived answer (`:taint_violation` markers, OQ-U11.3).
+  """
+  def taint_violations_correct(records) do
+    derived = derive_taint_correct(records)
+
+    for r <- records, meta?(r), derived[offset(r)] != stored_trust(r) do
+      %{offset: offset(r), stored: stored_trust(r), derived: derived[offset(r)]}
+    end
+  end
+
+  # ===========================================================================
+  # Actor fold — fold_actors (N-U11.8)
+  # ===========================================================================
+
+  @doc """
+  Correct actor fold: `%{offset => actor}` for every `kind: "event"` record;
+  an absent actor folds to `%{kind: :system}` by rule.
+  """
+  def fold_actors_correct(records) do
+    for r <- records, event?(r), into: %{}, do: {offset(r), decode_actor(r)}
+  end
+
+  defp event?(r), do: Map.get(r, "kind", "event") == "event"
+
+  defp decode_actor(%{"actor" => %{"kind" => k} = a}) do
+    %{kind: String.to_atom(k), id: Map.get(a, "id")}
+  end
+
+  # Absent actor => system, BY RULE (never inferred as human/agent).
+  defp decode_actor(_), do: %{kind: :system}
+
+  @doc "N-U11.8 dead injector — reader infers `:agent` from an absent actor."
+  def fold_actors_infer(records) do
+    for r <- records, event?(r), into: %{} do
+      actor =
+        case r do
+          %{"actor" => %{"kind" => k} = a} ->
+            %{kind: String.to_atom(k), id: Map.get(a, "id")}
+
+          _ ->
+            %{kind: :agent}
+        end
+
+      {offset(r), actor}
+    end
+  end
+
+  # ===========================================================================
+  # Loop projection — fold independence (N-U11.7)
+  # ===========================================================================
+
+  @doc "Correct loop-only projection: the ordered `{offset, type}` of loop events."
+  def loop_projection_correct(records) do
+    for r <- records, family(r) == :loop, do: {offset(r), type(r)}
+  end
+
+  @doc "N-U11.7 dead injector — fold does not filter on family before projecting."
+  def loop_projection_unfiltered(records) do
+    for r <- records, do: {offset(r), type(r)}
+  end
+
+  # ===========================================================================
+  # Fingerprint precedence — what_produced (N-U11.9)
+  # ===========================================================================
+
+  @doc """
+  Correct precedence: the `item_completed` at `offset` wins for "what produced
+  this content" — its own payload fingerprint.
+  """
+  def what_produced_correct(records, offset) do
+    case Enum.find(records, fn r -> offset(r) == offset end) do
+      %{"payload" => %{"fingerprint" => fp}} -> fp
+      _ -> nil
+    end
+  end
+
+  @doc "N-U11.9 dead injector — fold reads the session-head config as what-produced."
+  def what_produced_head(records, _offset) do
+    case Enum.find(records, fn r -> Map.get(r, "type") == "head_config" end) do
+      %{"payload" => %{"fingerprint" => fp}} -> fp
+      _ -> nil
+    end
+  end
+
+  # ===========================================================================
+  # Canonical JSON — normative fingerprint serializer (P-U11.7 / P-U11.1)
+  # ===========================================================================
+
+  @doc """
+  Reference canonical serialization: sorted keys, ephemeral keys stripped,
+  `:seed` INCLUDED. The independent oracle for `Raxol.Agent.Fingerprint.canonical_json/1`.
+  """
+  def canonical_json_correct(params) when is_map(params),
+    do: canonical_encode(params)
+
+  # Deterministic, key-sorted encoding independent of Jason map ordering.
+  defp canonical_encode(params) do
+    params
+    |> Map.drop(Raxol.Agent.Fingerprint.excluded_keys())
+    |> Enum.map(fn {k, v} -> {to_string(k), v} end)
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(fn {k, v} -> Jason.encode!(k) <> ":" <> Jason.encode!(v) end)
+    |> Enum.join(",")
+    |> then(&("{" <> &1 <> "}"))
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -197,10 +197,13 @@ defmodule Raxol.Agent.Red.U8Gates do
   def evaluate_with(state, call, taint_fun) do
     cid = call.call_id
     tool = call.tool
+    # `:once` keyed by FULL request identity (tool + call_id) — a grant unlocks
+    # exactly that request; a DIFFERENT request falls through to the taint fold.
+    once_key = request_ref(call)
 
     cond do
-      MapSet.member?(state.once, cid) ->
-        {:proceed, %{state | once: MapSet.delete(state.once, cid)}}
+      MapSet.member?(state.once, once_key) ->
+        {:proceed, %{state | once: MapSet.delete(state.once, once_key)}}
 
       MapSet.member?(state.denied, cid) ->
         {:reject, :denied, state}
@@ -239,11 +242,11 @@ defmodule Raxol.Agent.Red.U8Gates do
   end
 
   @doc "Fold one decision into the enforcement projection (grant/deny at scope)."
-  def grant(state, :approved, :once, cid, _tool),
+  def grant(state, :approved, :once, cid, tool),
     do: %{
       state
       | denied: MapSet.delete(state.denied, cid),
-        once: MapSet.put(state.once, cid)
+        once: MapSet.put(state.once, ref_encode(tool_key(tool), cid))
     }
 
   def grant(state, :approved, scope, cid, tool) when scope in [:session, :root],
@@ -253,11 +256,11 @@ defmodule Raxol.Agent.Red.U8Gates do
         session: MapSet.put(state.session, tool_key(tool))
     }
 
-  def grant(state, :denied, _scope, cid, _tool),
+  def grant(state, :denied, _scope, cid, tool),
     do: %{
       state
       | denied: MapSet.put(state.denied, cid),
-        once: MapSet.delete(state.once, cid)
+        once: MapSet.delete(state.once, ref_encode(tool_key(tool), cid))
     }
 
   # --- call builders ----------------------------------------------------------
@@ -828,6 +831,50 @@ defmodule Raxol.Agent.Red.U8Gates do
             {:proceed, _st} -> :ok
             other -> {:violation, {:clean_lineage_escalated, other}}
           end
+        end
+      end)
+    end
+
+    # C12 (Fix 2 regression) — a `:once` grant unlocks EXACTLY that request
+    # (tool + call_id), never a different tool sharing the call_id, and can never
+    # let a DIFFERENT request bypass the taint fold (AD-14). Two legs:
+    #   1. a once-grant for (tool_a, cid) does NOT admit (tool_b, cid) — it
+    #      escalates (the pre-fix call_id-only key admitted it);
+    #   2. a TAINTED (tool_b, cid) still escalates — the once branch (keyed by the
+    #      full identity) doesn't match, so the taint fold runs (the pre-fix
+    #      call_id-only key short-circuited the fold and auto-proceeded).
+    def once_grant_is_request_scoped(gate) do
+      safe(fn ->
+        cid = "shared-once-cid"
+        call_a = U8Gates.escalating_call(%{tool: :once_tool_a, call_id: cid})
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call_a),
+             ref = req.payload.request_ref,
+             {:ok, s2} <-
+               gate.apply_decision(s1, decision(ref, :approved, :once), human()) do
+          other_tool =
+            U8Gates.escalating_call(%{tool: :once_tool_b, call_id: cid})
+
+          tainted_other =
+            U8Gates.escalating_call(%{tool: :once_tool_b, call_id: cid})
+            |> Map.merge(U8Gates.tainted_arg_lineage())
+
+          cond do
+            authorize_tag(gate, s2, other_tool) != :escalated ->
+              {:violation,
+               {:once_grant_admitted_other_tool,
+                authorize_tag(gate, s2, other_tool)}}
+
+            not match?({:escalate, _, _}, gate.evaluate(s2, tainted_other)) ->
+              {:violation,
+               {:tainted_request_bypassed_fold,
+                gate.evaluate(s2, tainted_other)}}
+
+            true ->
+              :ok
+          end
+        else
+          bad -> {:violation, {:once_scope_flow_broke, bad}}
         end
       end)
     end

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -818,8 +818,7 @@ defmodule Raxol.Agent.Red.U8Gates do
             :ok
 
           {call, expected} ->
-            {:violation,
-             {:predicate_wrong, call.effect_class, call.egress, expected}}
+            {:violation, {:predicate_wrong, call.effect_class, call.egress, expected}}
         end
       end)
     end
@@ -894,14 +893,10 @@ defmodule Raxol.Agent.Red.U8Gates do
 
           cond do
             authorize_tag(gate, s2, other_tool) != :escalated ->
-              {:violation,
-               {:once_grant_admitted_other_tool,
-                authorize_tag(gate, s2, other_tool)}}
+              {:violation, {:once_grant_admitted_other_tool, authorize_tag(gate, s2, other_tool)}}
 
             not match?({:escalate, _, _}, gate.evaluate(s2, tainted_other)) ->
-              {:violation,
-               {:tainted_request_bypassed_fold,
-                gate.evaluate(s2, tainted_other)}}
+              {:violation, {:tainted_request_bypassed_fold, gate.evaluate(s2, tainted_other)}}
 
             true ->
               :ok
@@ -963,8 +958,7 @@ defmodule Raxol.Agent.Red.U8Gates do
             {:violation, {:unknown_class_proceeded, unknown_class.effect_class}}
 
           not gate.escalate?(non_boolean_egress) ->
-            {:violation,
-             {:non_boolean_egress_proceeded, non_boolean_egress.egress}}
+            {:violation, {:non_boolean_egress_proceeded, non_boolean_egress.egress}}
 
           true ->
             :ok
@@ -1004,8 +998,7 @@ defmodule Raxol.Agent.Red.U8Gates do
               {:violation, {:once_not_consumed_live, live_tag}}
 
             rebuilt_tag != live_tag ->
-              {:violation,
-               {:consumption_not_reconstructed, live_tag, rebuilt_tag}}
+              {:violation, {:consumption_not_reconstructed, live_tag, rebuilt_tag}}
 
             true ->
               :ok

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -780,7 +780,7 @@ defmodule Raxol.Agent.Red.U8Gates do
       end)
     end
 
-    # C8 (@action_surface) — the pure §5.2 predicate table: escalate iff
+    # C8 — the pure §5.2 predicate table: escalate iff
     # irreversible_external OR egress; both benign classes without egress → auto.
     def escalate_predicate(gate) do
       safe(fn ->
@@ -824,7 +824,7 @@ defmodule Raxol.Agent.Red.U8Gates do
       end)
     end
 
-    # C9 (@action_surface) — the predicate reads STRUCTURAL effect_class, never a
+    # C9 — the predicate reads STRUCTURAL effect_class, never a
     # self-reported hint: an irreversible call claiming destructive_hint: false
     # still escalates.
     def predicate_ignores_destructive_hint(gate) do

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -1,0 +1,896 @@
+defmodule Raxol.Agent.Red.U8Gates do
+  @moduledoc """
+  Support for the U8-R red suite (`u8_blast_radius_red_test.exs`).
+
+  Holds:
+
+    * `Counter` — a stub side-effect counter: the gate must never run the
+      guarded effect while locked/pending/denied.
+    * `Fired` — the dead-injector fire registry (meta-invariant m1: a dead
+      injector = green lies).
+    * `Tip` — an independent oracle for the freeze's `conversational?`/tip
+      predicate (§1.1). Asserts an `approval_requested` is tip-eligible and a
+      trailing checkpoint/meta record is NOT (Dormammu-lite, FI-12).
+    * `ReferenceGate` — a correct, journal-free implementation of the
+      `Raxol.Agent.Authorization.BlastRadiusGate` behaviour. It is the executable
+      spec: the contours pass against it, proving they are not vacuous. The
+      production module must eventually match its behavior.
+    * The dead injectors — each violates exactly one contour, proving the
+      contour has teeth (negative controls, meta-invariant m4).
+    * `Contours` — the shared contour predicates, gate-parameterized. Each
+      returns `:ok` or `{:violation, detail}`. The red tests assert `:ok`
+      against the production skeleton (RED until U8 lands); the discrimination
+      tests assert `:ok` against `ReferenceGate`; the negative controls assert
+      the specific violation signature against each dead injector.
+
+  ## Taint is a FOLD, never a field read (HIGH-1)
+
+  A call carries its argument derivation graph (`arg_refs` entry points +
+  `lineage` id → `%{trust: stamped, refs: [...]}`). The gate derives trust by
+  folding the U11 tainted-absorbing algebra over the reachable closure — a
+  `:trusted`-STAMPED direct argument whose chain reaches a tainted record IS
+  tainted (mis-stamp, N-U11.3 class). The `ReadsStampedTrust` injector is the
+  field-reading gate that lets exactly that mis-stamped call through.
+
+  ## Replay law checked behaviorally
+
+  `rebuild/1` equality is asserted as BEHAVIOR (the rebuilt gate authorizes
+  probe calls identically to the live gate), never by comparing private state —
+  so the contour survives any internal representation the real U8 picks.
+  """
+
+  # ===========================================================================
+  # Counter — a stub side effect the gate must not run while locked/pending
+  # ===========================================================================
+
+  defmodule Counter do
+    @moduledoc false
+    def start, do: Agent.start_link(fn -> 0 end)
+    def bump(pid), do: Agent.update(pid, &(&1 + 1))
+    def value(pid), do: Agent.get(pid, & &1)
+  end
+
+  # ===========================================================================
+  # Fired — the dead-injector fire registry (m1)
+  # ===========================================================================
+
+  defmodule Fired do
+    @moduledoc false
+    def start, do: Agent.start_link(fn -> MapSet.new() end)
+    def fire(pid, site), do: Agent.update(pid, &MapSet.put(&1, site))
+    def fired(pid), do: Agent.get(pid, & &1)
+  end
+
+  # ===========================================================================
+  # Tip oracle — the freeze §1.1 conversational?/tip predicate (independent)
+  # ===========================================================================
+
+  defmodule Tip do
+    @moduledoc false
+
+    # Grow-only whitelist (freeze §1.1 CONVERSATIONAL). approval_requested IS a
+    # member (ratified F3: family :loop, a pending approval is where a resumed
+    # conversation lands); checkpoint / meta / idle / woken are NOT.
+    @conversational ~w(turn_started item_started item_completed
+                       turn_completed turn_canceled error approval_requested)a
+
+    @doc "The freeze's conversational? predicate (the ONLY tip door)."
+    def conversational?(record) when is_map(record) do
+      kind = record |> Map.get(:kind, "event") |> to_string()
+
+      kind == "event" and
+        Map.get(record, :family) == :loop and
+        Map.get(record, :type) in @conversational
+    end
+
+    @doc "The tip = highest-position conversational record, or :no_tip."
+    def tip(records) when is_list(records) do
+      records
+      |> Enum.with_index()
+      |> Enum.filter(fn {r, _i} -> conversational?(r) end)
+      |> case do
+        [] -> :no_tip
+        pairs -> pairs |> Enum.max_by(fn {_r, i} -> i end) |> elem(0)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # Shared builders + reference logic (plain functions, reused by injectors)
+  # ===========================================================================
+
+  @doc "Fresh enforcement state: pending requests, once/session grants, durable denies."
+  def new_state,
+    do: %{
+      pending: %{},
+      once: MapSet.new(),
+      session: MapSet.new(),
+      denied: MapSet.new()
+    }
+
+  @doc "The pure §5.2 predicate: escalate iff irreversible_external OR egress."
+  def escalate_p(call),
+    do: call.effect_class == :irreversible_external or call.egress == true
+
+  @doc """
+  The reference taint FOLD (HIGH-1): tainted iff any record reachable from
+  `arg_refs` through `lineage` refs is stamped `:tainted`; an unresolvable ref
+  folds as tainted (fail-closed). Cycle-safe.
+  """
+  def fold_tainted?(call) do
+    lineage = Map.get(call, :lineage, %{})
+    tainted_reach?(Map.get(call, :arg_refs, []), lineage, MapSet.new())
+  end
+
+  defp tainted_reach?([], _lineage, _seen), do: false
+
+  defp tainted_reach?([id | rest], lineage, seen) do
+    if MapSet.member?(seen, id) do
+      tainted_reach?(rest, lineage, seen)
+    else
+      case Map.get(lineage, id) do
+        # unknown ref → fail-closed (U11 §2.1: unknown trust reads as tainted)
+        nil ->
+          true
+
+        %{trust: :tainted} ->
+          true
+
+        %{refs: refs} ->
+          tainted_reach?(refs ++ rest, lineage, MapSet.put(seen, id))
+      end
+    end
+  end
+
+  @doc "request_ref encodes tool + call_id so a journaled decision alone rebuilds the grant key."
+  def request_ref(call), do: "req:#{call.tool}:#{call.call_id}"
+
+  @doc "Parse a reference request_ref back into {tool, call_id}."
+  def parse_ref("req:" <> rest) do
+    [tool, cid] = String.split(rest, ":", parts: 2)
+    {String.to_existing_atom(tool), cid}
+  end
+
+  @doc "The approval_requested neutral event a gate returns on escalation (family :loop — frozen F3)."
+  def approval_request(ref, call) do
+    %{
+      family: :loop,
+      type: :approval_requested,
+      payload: %{
+        request_ref: ref,
+        call_id: call.call_id,
+        action: call.tool,
+        effect_class: call.effect_class,
+        egress: call.egress,
+        blast_radius: %{effect_class: call.effect_class, egress: call.egress}
+      }
+    }
+  end
+
+  @doc """
+  Reference evaluate, parameterized on the taint function (so injectors swap
+  only the part they break). Order is load-bearing:
+
+    1. `:once` grant for this exact call_id → proceed (a completed approval
+       cycle covers precisely this request);
+    2. durable deny for this call_id → reject (deny survives retries);
+    3. tainted lineage → escalate REGARDLESS of class/egress and regardless of
+       any session blanket (FI-5: the tainted path is a distinct confirmation);
+    4. session/root grant for the tool → proceed;
+    5. §5.2 escalation (irreversible_external OR egress) → escalate;
+    6. otherwise → auto-proceed (YOLO-applicable over trusted lineage).
+  """
+  def evaluate_with(state, call, taint_fun) do
+    cid = call.call_id
+    tool = call.tool
+
+    cond do
+      MapSet.member?(state.once, cid) ->
+        {:proceed, %{state | once: MapSet.delete(state.once, cid)}}
+
+      MapSet.member?(state.denied, cid) ->
+        {:reject, :denied, state}
+
+      taint_fun.(call) ->
+        escalate(state, call)
+
+      MapSet.member?(state.session, tool) ->
+        {:proceed, state}
+
+      escalate_p(call) ->
+        escalate(state, call)
+
+      true ->
+        {:proceed, state}
+    end
+  end
+
+  defp escalate(state, call) do
+    ref = request_ref(call)
+    req = approval_request(ref, call)
+
+    pending =
+      Map.put(state.pending, ref, %{call_id: call.call_id, tool: call.tool})
+
+    {:escalate, req, %{state | pending: pending}}
+  end
+
+  @doc "authorize in terms of the module's own evaluate — run_fn runs IFF proceed."
+  def authorize_via(mod, state, call, run_fn) do
+    case mod.evaluate(state, call) do
+      {:proceed, st} -> {:proceeded, run_fn.(), st}
+      {:escalate, req, st} -> {:escalated, req, st}
+      {:reject, reason, st} -> {:rejected, reason, st}
+    end
+  end
+
+  @doc "Fold one decision into the enforcement projection (grant/deny at scope)."
+  def grant(state, :approved, :once, cid, _tool),
+    do: %{
+      state
+      | denied: MapSet.delete(state.denied, cid),
+        once: MapSet.put(state.once, cid)
+    }
+
+  def grant(state, :approved, scope, cid, tool) when scope in [:session, :root],
+    do: %{
+      state
+      | denied: MapSet.delete(state.denied, cid),
+        session: MapSet.put(state.session, tool)
+    }
+
+  def grant(state, :denied, _scope, cid, _tool),
+    do: %{
+      state
+      | denied: MapSet.put(state.denied, cid),
+        once: MapSet.delete(state.once, cid)
+    }
+
+  # --- call builders ----------------------------------------------------------
+
+  @doc "A trusted, ≥3-deep, all-:trusted-stamped derivation chain."
+  def clean_lineage do
+    %{
+      arg_refs: [3],
+      lineage: %{
+        1 => %{trust: :trusted, refs: []},
+        2 => %{trust: :trusted, refs: [1]},
+        3 => %{trust: :trusted, refs: [2]}
+      }
+    }
+  end
+
+  @doc "Direct argument stamped :tainted (taint entered at a tool_result)."
+  def tainted_arg_lineage do
+    %{
+      arg_refs: [2],
+      lineage: %{
+        1 => %{trust: :trusted, refs: []},
+        2 => %{trust: :tainted, refs: [1]}
+      }
+    }
+  end
+
+  @doc """
+  The HIGH-1 vector: the direct argument is STAMPED :trusted (mis-stamp,
+  N-U11.3 class) but its ref chain reaches a tainted root. The fold says
+  tainted; a field-reading gate says trusted.
+  """
+  def mis_stamped_lineage do
+    %{
+      arg_refs: [3],
+      lineage: %{
+        1 => %{trust: :tainted, refs: []},
+        2 => %{trust: :trusted, refs: [1]},
+        3 => %{trust: :trusted, refs: [2]}
+      }
+    }
+  end
+
+  @doc "A write call that ESCALATES under §5.2 (irreversible-external), trusted lineage."
+  def escalating_call(overrides \\ %{}) do
+    %{
+      call_id: "c-#{System.unique_integer([:positive])}",
+      tool: :fs_write,
+      effect_class: :irreversible_external,
+      egress: false
+    }
+    |> Map.merge(clean_lineage())
+    |> Map.merge(overrides)
+  end
+
+  @doc "A benign call: reversible-local, no egress, trusted lineage → auto-proceeds."
+  def benign_call(overrides \\ %{}) do
+    %{
+      call_id: "c-#{System.unique_integer([:positive])}",
+      tool: :fs_touch,
+      effect_class: :reversible_local,
+      egress: false
+    }
+    |> Map.merge(clean_lineage())
+    |> Map.merge(overrides)
+  end
+
+  # ===========================================================================
+  # ReferenceGate — the correct executable spec
+  # ===========================================================================
+
+  defmodule ReferenceGate do
+    @moduledoc false
+    @behaviour Raxol.Agent.Authorization.BlastRadiusGate
+
+    alias Raxol.Agent.Red.U8Gates
+
+    def new, do: U8Gates.new_state()
+
+    @impl true
+    def escalate?(call), do: U8Gates.escalate_p(call)
+
+    @impl true
+    def tainted_lineage?(call), do: U8Gates.fold_tainted?(call)
+
+    @impl true
+    def evaluate(state, call),
+      do: U8Gates.evaluate_with(state, call, &tainted_lineage?/1)
+
+    @impl true
+    def authorize(state, call, run_fn),
+      do: U8Gates.authorize_via(__MODULE__, state, call, run_fn)
+
+    @impl true
+    def apply_decision(state, %{request_ref: ref} = decision, _actor) do
+      case Map.fetch(state.pending, ref) do
+        :error ->
+          # forged / dangling decision: no live request names this ref
+          {:error, :no_such_request}
+
+        {:ok, %{call_id: cid, tool: tool}} ->
+          state = %{state | pending: Map.delete(state.pending, ref)}
+          scope = Map.get(decision, :scope, :once)
+          {:ok, U8Gates.grant(state, decision.decision, scope, cid, tool)}
+      end
+    end
+
+    @impl true
+    def rebuild(events) do
+      # The journal is the authority: decisions were request-validated when
+      # first observed, so the fold re-derives the enforcement projection from
+      # the decisions alone (request_ref encodes the grant key).
+      Enum.reduce(events, new(), fn {decision, _actor}, state ->
+        {tool, cid} = U8Gates.parse_ref(decision.request_ref)
+        scope = Map.get(decision, :scope, :once)
+        U8Gates.grant(state, decision.decision, scope, cid, tool)
+      end)
+    end
+  end
+
+  # ===========================================================================
+  # Dead injectors — each breaks exactly one contour (negative controls, m4)
+  # ===========================================================================
+
+  # (a) executes the guarded side effect even while the approval is pending.
+  defmodule ExecutesWhilePending do
+    @moduledoc false
+    defdelegate new, to: ReferenceGate
+    defdelegate escalate?(call), to: ReferenceGate
+    defdelegate tainted_lineage?(call), to: ReferenceGate
+    defdelegate evaluate(state, call), to: ReferenceGate
+    defdelegate apply_decision(state, decision, actor), to: ReferenceGate
+    defdelegate rebuild(events), to: ReferenceGate
+
+    def authorize(state, call, run_fn) do
+      # BUG: runs the side effect regardless of the gate decision.
+      result = run_fn.()
+
+      case ReferenceGate.evaluate(state, call) do
+        {:proceed, st} -> {:proceeded, result, st}
+        {:escalate, req, st} -> {:escalated, req, st}
+        {:reject, reason, st} -> {:rejected, reason, st}
+      end
+    end
+  end
+
+  # (b) forgets that deny != approve: any decision unlocks the call.
+  defmodule ForgetsDeny do
+    @moduledoc false
+    alias Raxol.Agent.Red.U8Gates
+
+    defdelegate new, to: ReferenceGate
+    defdelegate escalate?(call), to: ReferenceGate
+    defdelegate tainted_lineage?(call), to: ReferenceGate
+    defdelegate evaluate(state, call), to: ReferenceGate
+    defdelegate authorize(state, call, run_fn), to: ReferenceGate
+    defdelegate rebuild(events), to: ReferenceGate
+
+    def apply_decision(state, %{request_ref: ref} = decision, _actor) do
+      case Map.fetch(state.pending, ref) do
+        :error ->
+          {:error, :no_such_request}
+
+        {:ok, %{call_id: cid, tool: tool}} ->
+          # BUG: drops the decision polarity — a deny grants like an approve.
+          state = %{state | pending: Map.delete(state.pending, ref)}
+
+          {:ok,
+           U8Gates.grant(
+             state,
+             :approved,
+             Map.get(decision, :scope, :once),
+             cid,
+             tool
+           )}
+      end
+    end
+  end
+
+  # (c) accepts a forged/dangling decision (no live request names its ref).
+  defmodule AcceptsForgedDecision do
+    @moduledoc false
+    defdelegate new, to: ReferenceGate
+    defdelegate escalate?(call), to: ReferenceGate
+    defdelegate tainted_lineage?(call), to: ReferenceGate
+    defdelegate evaluate(state, call), to: ReferenceGate
+    defdelegate authorize(state, call, run_fn), to: ReferenceGate
+    defdelegate rebuild(events), to: ReferenceGate
+
+    def apply_decision(state, %{request_ref: _ref} = _decision, _actor) do
+      # BUG: no pending-request check; any decision is silently accepted.
+      {:ok, state}
+    end
+  end
+
+  # (d) keeps approval state only in memory: the fold cannot reconstruct it.
+  defmodule InMemoryOnly do
+    @moduledoc false
+    defdelegate new, to: ReferenceGate
+    defdelegate escalate?(call), to: ReferenceGate
+    defdelegate tainted_lineage?(call), to: ReferenceGate
+    defdelegate evaluate(state, call), to: ReferenceGate
+    defdelegate authorize(state, call, run_fn), to: ReferenceGate
+    defdelegate apply_decision(state, decision, actor), to: ReferenceGate
+
+    def rebuild(_events) do
+      # BUG: ignores the journaled decisions — the projection dies with the BEAM.
+      ReferenceGate.new()
+    end
+  end
+
+  # (e) reads the tool's self-reported destructive_hint instead of effect_class.
+  defmodule ReadsDestructiveHint do
+    @moduledoc false
+    defdelegate new, to: ReferenceGate
+    defdelegate tainted_lineage?(call), to: ReferenceGate
+    defdelegate evaluate(state, call), to: ReferenceGate
+    defdelegate authorize(state, call, run_fn), to: ReferenceGate
+    defdelegate apply_decision(state, decision, actor), to: ReferenceGate
+    defdelegate rebuild(events), to: ReferenceGate
+
+    def escalate?(call) do
+      # BUG: trusts an attacker-controllable hint (N-Y5); egress leg dropped too.
+      Map.get(call, :destructive_hint, false) == true
+    end
+  end
+
+  # (HIGH-1) reads the stamped trust FIELD of the direct args, never folds refs.
+  defmodule ReadsStampedTrust do
+    @moduledoc false
+    alias Raxol.Agent.Red.U8Gates
+
+    defdelegate new, to: ReferenceGate
+    defdelegate escalate?(call), to: ReferenceGate
+    defdelegate apply_decision(state, decision, actor), to: ReferenceGate
+    defdelegate rebuild(events), to: ReferenceGate
+
+    def tainted_lineage?(call) do
+      # BUG: field read — a mis-stamped :trusted arg over a tainted chain passes.
+      lineage = Map.get(call, :lineage, %{})
+
+      Enum.any?(Map.get(call, :arg_refs, []), fn id ->
+        match?(%{trust: :tainted}, Map.get(lineage, id))
+      end)
+    end
+
+    def evaluate(state, call),
+      do: U8Gates.evaluate_with(state, call, &tainted_lineage?/1)
+
+    def authorize(state, call, run_fn),
+      do: U8Gates.authorize_via(__MODULE__, state, call, run_fn)
+  end
+
+  # (taint) ignores lineage taint entirely: only the pure §5.2 predicate gates.
+  defmodule IgnoresTaint do
+    @moduledoc false
+    alias Raxol.Agent.Red.U8Gates
+
+    defdelegate new, to: ReferenceGate
+    defdelegate escalate?(call), to: ReferenceGate
+    defdelegate apply_decision(state, decision, actor), to: ReferenceGate
+    defdelegate rebuild(events), to: ReferenceGate
+
+    def tainted_lineage?(_call), do: false
+
+    def evaluate(state, call),
+      do: U8Gates.evaluate_with(state, call, fn _ -> false end)
+
+    def authorize(state, call, run_fn),
+      do: U8Gates.authorize_via(__MODULE__, state, call, run_fn)
+  end
+
+  # (meta) emits approval_requested as family :meta — never tip-eligible (F3).
+  defmodule EmitsMetaFamily do
+    @moduledoc false
+    alias Raxol.Agent.Red.U8Gates
+
+    defdelegate new, to: ReferenceGate
+    defdelegate escalate?(call), to: ReferenceGate
+    defdelegate tainted_lineage?(call), to: ReferenceGate
+    defdelegate apply_decision(state, decision, actor), to: ReferenceGate
+    defdelegate rebuild(events), to: ReferenceGate
+
+    def evaluate(state, call) do
+      case ReferenceGate.evaluate(state, call) do
+        {:escalate, req, st} -> {:escalate, %{req | family: :meta}, st}
+        other -> other
+      end
+    end
+
+    def authorize(state, call, run_fn),
+      do: U8Gates.authorize_via(__MODULE__, state, call, run_fn)
+  end
+
+  # ===========================================================================
+  # Contours — shared, gate-parameterized. :ok | {:violation, detail}
+  # ===========================================================================
+
+  defmodule Contours do
+    @moduledoc false
+
+    alias Raxol.Agent.Red.U8Gates
+    alias Raxol.Agent.Red.U8Gates.{Counter, Tip}
+
+    # C1 — locked by default: a write call with no approval never runs the side
+    # effect; the outcome is a typed non-proceed (escalate or reject).
+    def locked_by_default(gate) do
+      safe(fn ->
+        {:ok, exec} = Counter.start()
+        call = U8Gates.escalating_call()
+        result = gate.authorize(gate.new(), call, fn -> Counter.bump(exec) end)
+
+        cond do
+          Counter.value(exec) != 0 ->
+            {:violation, {:executed_while_locked, Counter.value(exec)}}
+
+          match?({:escalated, _, _}, result) or
+              match?({:rejected, _, _}, result) ->
+            :ok
+
+          true ->
+            {:violation, {:not_a_typed_reject, result}}
+        end
+      end)
+    end
+
+    # C2 — escalation emits approval_requested family :loop (frozen F3), with a
+    # request_ref, and it IS the tip when trailed by checkpoint/meta records.
+    def escalation_emits_tip_eligible_request(gate) do
+      safe(fn ->
+        call = U8Gates.escalating_call()
+
+        case gate.evaluate(gate.new(), call) do
+          {:escalate, req, _st} ->
+            cond do
+              Map.get(req, :family) != :loop ->
+                {:violation, {:not_loop_family, Map.get(req, :family)}}
+
+              Map.get(req, :type) != :approval_requested ->
+                {:violation, {:wrong_type, Map.get(req, :type)}}
+
+              not Map.has_key?(Map.get(req, :payload, %{}), :request_ref) ->
+                {:violation, {:no_request_ref, req}}
+
+              not Tip.conversational?(req) ->
+                {:violation, {:not_tip_eligible, req}}
+
+              Tip.tip([req, checkpoint_record(), meta_decided_record()]) != req ->
+                {:violation, {:trailing_tail_stole_tip, req}}
+
+              true ->
+                :ok
+            end
+
+          other ->
+            {:violation, {:did_not_escalate, other}}
+        end
+      end)
+    end
+
+    # C3 — approve(:once) unlocks exactly that request; a different call to the
+    # same tool still escalates.
+    def approve_once_unlocks(gate) do
+      safe(fn ->
+        {:ok, exec} = Counter.start()
+        call = U8Gates.escalating_call()
+        run = fn -> Counter.bump(exec) end
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call),
+             ref = req.payload.request_ref,
+             {:ok, s2} <-
+               gate.apply_decision(s1, decision(ref, :approved, :once), human()),
+             {:proceeded, _, s3} <- gate.authorize(s2, call, run) do
+          if Counter.value(exec) == 1 do
+            other = U8Gates.escalating_call(%{tool: call.tool})
+
+            case gate.authorize(s3, other, run) do
+              {:escalated, _, _} -> :ok
+              bad -> {:violation, {:once_blanket_unlocked, bad}}
+            end
+          else
+            {:violation, {:side_effect_count, Counter.value(exec)}}
+          end
+        else
+          bad -> {:violation, {:approved_once_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C4 — deny is durable: after a deny, a bare retry of the same request must
+    # NOT be retried into success without a NEW approval cycle.
+    def deny_is_durable(gate) do
+      safe(fn ->
+        {:ok, exec} = Counter.start()
+        call = U8Gates.escalating_call()
+        run = fn -> Counter.bump(exec) end
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call),
+             ref = req.payload.request_ref,
+             {:ok, s2} <-
+               gate.apply_decision(s1, decision(ref, :denied, :once), human()) do
+          case gate.authorize(s2, call, run) do
+            {:proceeded, _, _} ->
+              {:violation, {:proceeded_after_deny, Counter.value(exec)}}
+
+            _typed_non_proceed ->
+              if Counter.value(exec) == 0,
+                do: :ok,
+                else: {:violation, {:executed_after_deny, Counter.value(exec)}}
+          end
+        else
+          bad -> {:violation, {:deny_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C5 — :session scope persists across distinct calls within the session.
+    def session_scope_persists(gate) do
+      safe(fn ->
+        {:ok, exec} = Counter.start()
+        run = fn -> Counter.bump(exec) end
+        c1 = U8Gates.escalating_call(%{tool: :fs_write})
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), c1),
+             ref = req.payload.request_ref,
+             {:ok, s2} <-
+               gate.apply_decision(
+                 s1,
+                 decision(ref, :approved, :session),
+                 human()
+               ),
+             {:proceeded, _, s3} <- gate.authorize(s2, c1, run) do
+          c2 = U8Gates.escalating_call(%{tool: :fs_write})
+
+          case gate.authorize(s3, c2, run) do
+            {:proceeded, _, _} ->
+              if Counter.value(exec) == 2,
+                do: :ok,
+                else: {:violation, {:side_effect_count, Counter.value(exec)}}
+
+            bad ->
+              {:violation, {:session_did_not_persist, bad}}
+          end
+        else
+          bad -> {:violation, {:session_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C6 — fold-rebuild: state reconstructed by folding approval_decided events
+    # authorizes probe calls identically to the live state (§2.1 replay law).
+    # Behavioral equality — never a peek into the gate's private struct.
+    def fold_rebuild_equals_live(gate, seed) do
+      safe(fn ->
+        {live_state, events, probes} = drive_decision_sequence(gate, seed)
+        rebuilt = gate.rebuild(events)
+
+        mismatches =
+          for probe <- probes,
+              live_tag = authorize_tag(gate, live_state, probe),
+              rebuilt_tag = authorize_tag(gate, rebuilt, probe),
+              live_tag != rebuilt_tag do
+            {probe.call_id, live_tag, rebuilt_tag}
+          end
+
+        case mismatches do
+          [] -> :ok
+          list -> {:violation, {:rebuild_diverged, seed, list}}
+        end
+      end)
+    end
+
+    # C7 — a forged/dangling approval_decided (no live request names its
+    # request_ref) is rejected, never enacted.
+    def forged_decision_rejected(gate) do
+      safe(fn ->
+        forged = decision("req:fs_write:ghost", :approved, :session)
+
+        case gate.apply_decision(gate.new(), forged, human()) do
+          {:error, _reason} -> :ok
+          {:ok, _st} -> {:violation, :forged_decision_accepted}
+          other -> {:violation, {:unexpected, other}}
+        end
+      end)
+    end
+
+    # C8 (@action_surface) — the pure §5.2 predicate table: escalate iff
+    # irreversible_external OR egress; both benign classes without egress → auto.
+    def escalate_predicate(gate) do
+      safe(fn ->
+        checks = [
+          {U8Gates.escalating_call(%{
+             effect_class: :irreversible_external,
+             egress: false
+           }), true},
+          {U8Gates.escalating_call(%{
+             effect_class: :irreversible_external,
+             egress: true
+           }), true},
+          {U8Gates.benign_call(%{
+             effect_class: :reversible_local,
+             egress: true
+           }), true},
+          {U8Gates.benign_call(%{
+             effect_class: :bounded_sandboxable,
+             egress: true
+           }), true},
+          {U8Gates.benign_call(%{
+             effect_class: :reversible_local,
+             egress: false
+           }), false},
+          {U8Gates.benign_call(%{
+             effect_class: :bounded_sandboxable,
+             egress: false
+           }), false}
+        ]
+
+        case Enum.find(checks, fn {call, expected} ->
+               gate.escalate?(call) != expected
+             end) do
+          nil ->
+            :ok
+
+          {call, expected} ->
+            {:violation,
+             {:predicate_wrong, call.effect_class, call.egress, expected}}
+        end
+      end)
+    end
+
+    # C9 (@action_surface) — the predicate reads STRUCTURAL effect_class, never a
+    # self-reported hint: an irreversible call claiming destructive_hint: false
+    # still escalates.
+    def predicate_ignores_destructive_hint(gate) do
+      safe(fn ->
+        lying =
+          U8Gates.escalating_call(%{
+            effect_class: :irreversible_external,
+            egress: false,
+            destructive_hint: false
+          })
+
+        if gate.escalate?(lying),
+          do: :ok,
+          else: {:violation, {:trusted_self_report, lying.effect_class}}
+      end)
+    end
+
+    # C10 — taint escalation is a FOLD over refs (HIGH-1), and taint escalates
+    # regardless of a benign class (FI-5). Three legs, distinct signatures:
+    #   1. direct :tainted arg → escalate  (a field-reading gate passes this leg)
+    #   2. mis-stamped :trusted arg over tainted chain → escalate (fold-only leg)
+    #   3. clean trusted chain, benign → proceed (no false-positive fold)
+    def taint_escalates(gate) do
+      safe(fn ->
+        direct =
+          U8Gates.benign_call() |> Map.merge(U8Gates.tainted_arg_lineage())
+
+        mis_stamped =
+          U8Gates.benign_call() |> Map.merge(U8Gates.mis_stamped_lineage())
+
+        clean = U8Gates.benign_call()
+
+        with :ok <- expect_escalate(gate, direct, :tainted_auto_proceeded),
+             :ok <-
+               expect_escalate(gate, mis_stamped, :mis_stamped_auto_proceeded) do
+          case gate.evaluate(gate.new(), clean) do
+            {:proceed, _st} -> :ok
+            other -> {:violation, {:clean_lineage_escalated, other}}
+          end
+        end
+      end)
+    end
+
+    # --- helpers -------------------------------------------------------------
+
+    defp expect_escalate(gate, call, violation_tag) do
+      case gate.evaluate(gate.new(), call) do
+        {:escalate, _req, _st} -> :ok
+        {:proceed, _st} -> {:violation, violation_tag}
+        other -> {:violation, {:unexpected, violation_tag, other}}
+      end
+    end
+
+    # A reproducible decision schedule: 8 escalating calls across 3 tools,
+    # approved at rotating scopes, with fixed denies at i ∈ {4, 8}. The seed
+    # rotates tool/scope assignment; failures report the seed (meta-inv m2).
+    defp drive_decision_sequence(gate, seed) do
+      steps =
+        for i <- 1..8 do
+          %{
+            tool: Enum.at([:fs_write, :shell, :net_send], rem(i + seed, 3)),
+            decision: if(rem(i, 4) == 0, do: :denied, else: :approved),
+            scope: Enum.at([:once, :session, :root], rem(i + seed, 3))
+          }
+        end
+
+      Enum.reduce(steps, {gate.new(), [], []}, fn step, {st, evs, probes} ->
+        call =
+          U8Gates.escalating_call(%{
+            tool: step.tool,
+            effect_class: :irreversible_external
+          })
+
+        case gate.evaluate(st, call) do
+          {:escalate, req, st1} ->
+            d = decision(req.payload.request_ref, step.decision, step.scope)
+
+            case gate.apply_decision(st1, d, human()) do
+              {:ok, st2} -> {st2, evs ++ [{d, human()}], probes ++ [call]}
+              {:error, _} -> {st1, evs, probes ++ [call]}
+            end
+
+          {:proceed, st1} ->
+            {st1, evs, probes ++ [call]}
+
+          {:reject, _reason, st1} ->
+            {st1, evs, probes ++ [call]}
+        end
+      end)
+    end
+
+    defp authorize_tag(gate, state, probe) do
+      case gate.authorize(state, probe, fn -> :ran end) do
+        {tag, _, _} -> tag
+      end
+    end
+
+    defp decision(ref, decision, scope),
+      do: %{request_ref: ref, decision: decision, scope: scope, refs: []}
+
+    defp human, do: %{kind: :human, id: "u-1"}
+
+    defp checkpoint_record,
+      do: %{kind: "checkpoint", family: :loop, type: :checkpoint, tip_offset: 1}
+
+    defp meta_decided_record,
+      do: %{kind: "event", family: :meta, type: :approval_decided, payload: %{}}
+
+    # A contour must never crash the suite: a :not_implemented raise (the
+    # production skeleton) or any error is itself a violation of the contract.
+    def safe(fun) do
+      fun.()
+    rescue
+      e -> {:violation, {:raised, Exception.message(e)}}
+    catch
+      kind, reason -> {:violation, {:caught, kind, reason}}
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -142,13 +142,27 @@ defmodule Raxol.Agent.Red.U8Gates do
     end
   end
 
-  @doc "request_ref encodes tool + call_id so a journaled decision alone rebuilds the grant key."
-  def request_ref(call), do: "req:#{call.tool}:#{call.call_id}"
+  @doc "The ONE canonical tool representation (string) — live-store == parse_ref == rebuild."
+  def tool_key(tool) when is_atom(tool), do: Atom.to_string(tool)
+  def tool_key(tool) when is_binary(tool), do: tool
 
-  @doc "Parse a reference request_ref back into {tool, call_id}."
+  @doc """
+  request_ref encodes tool + call_id so a journaled decision alone rebuilds the
+  grant key. INJECTIVE + delimiter-safe: the (normalized string) tool is
+  length-prefixed, so a ":" in either tool or call_id can't mis-split the ref.
+  """
+  def request_ref(call), do: ref_encode(tool_key(call.tool), call.call_id)
+
+  @doc "Encode {tool, call_id} into a delimiter-safe, injective request_ref."
+  def ref_encode(tool, cid) when is_binary(tool) and is_binary(cid),
+    do: "req:" <> Integer.to_string(byte_size(tool)) <> ":" <> tool <> cid
+
+  @doc "Parse a reference request_ref back into {tool, call_id} (tool is the canonical string)."
   def parse_ref("req:" <> rest) do
-    [tool, cid] = String.split(rest, ":", parts: 2)
-    {String.to_existing_atom(tool), cid}
+    [len_str, tail] = String.split(rest, ":", parts: 2)
+    len = String.to_integer(len_str)
+    <<tool::binary-size(^len), cid::binary>> = tail
+    {tool, cid}
   end
 
   @doc "The approval_requested neutral event a gate returns on escalation (family :loop — frozen F3)."
@@ -194,7 +208,7 @@ defmodule Raxol.Agent.Red.U8Gates do
       taint_fun.(call) ->
         escalate(state, call)
 
-      MapSet.member?(state.session, tool) ->
+      MapSet.member?(state.session, tool_key(tool)) ->
         {:proceed, state}
 
       escalate_p(call) ->
@@ -210,7 +224,7 @@ defmodule Raxol.Agent.Red.U8Gates do
     req = approval_request(ref, call)
 
     pending =
-      Map.put(state.pending, ref, %{call_id: call.call_id, tool: call.tool})
+      Map.put(state.pending, ref, %{call_id: call.call_id, tool: tool_key(call.tool)})
 
     {:escalate, req, %{state | pending: pending}}
   end
@@ -236,7 +250,7 @@ defmodule Raxol.Agent.Red.U8Gates do
     do: %{
       state
       | denied: MapSet.delete(state.denied, cid),
-        session: MapSet.put(state.session, tool)
+        session: MapSet.put(state.session, tool_key(tool))
     }
 
   def grant(state, :denied, _scope, cid, _tool),
@@ -816,6 +830,58 @@ defmodule Raxol.Agent.Red.U8Gates do
           end
         end
       end)
+    end
+
+    # C11 (Fix 1 regression) — request_ref is INJECTIVE + string-canonical:
+    # a STRING-named tool and a tool/call_id containing ":" both survive the
+    # request_ref → parse_ref round-trip, and the fold-rebuilt enforcement state
+    # authorizes the same call identically to the live state. The pre-fix gate
+    # (atom-stringified tool + `String.to_existing_atom` + `split(":", parts: 2)`)
+    # crashes or diverges on exactly these inputs.
+    def ref_roundtrips_string_and_colon(gate) do
+      safe(fn ->
+        cases = [
+          # ":" in BOTH the tool name and the call_id — the naive split mis-parses.
+          %{tool: "weird:tool", call_id: "c:1:x"},
+          # a plain STRING tool — the naive rebuild does String.to_existing_atom.
+          %{tool: "string_only_tool", call_id: "c-plain"}
+        ]
+
+        Enum.reduce_while(cases, :ok, fn overrides, _acc ->
+          case session_grant_rebuild_equals_live(gate, overrides) do
+            :ok -> {:cont, :ok}
+            violation -> {:halt, violation}
+          end
+        end)
+      end)
+    end
+
+    # Escalate a call, approve at :session scope, then assert live and the
+    # decision-folded rebuild admit the SAME call identically — exercising the
+    # tool round-trip (session grants are tool-keyed) across the ref encoding.
+    defp session_grant_rebuild_equals_live(gate, overrides) do
+      call = U8Gates.escalating_call(overrides)
+
+      with {:escalate, req, s1} <- gate.evaluate(gate.new(), call),
+           ref = req.payload.request_ref,
+           d = decision(ref, :approved, :session),
+           {:ok, s2} <- gate.apply_decision(s1, d, human()) do
+        live_tag = authorize_tag(gate, s2, call)
+        rebuilt_tag = authorize_tag(gate, gate.rebuild([{d, human()}]), call)
+
+        cond do
+          live_tag != :proceeded ->
+            {:violation, {:session_grant_did_not_admit, overrides, live_tag}}
+
+          rebuilt_tag != live_tag ->
+            {:violation, {:rebuild_diverged_for_ref, ref, live_tag, rebuilt_tag}}
+
+          true ->
+            :ok
+        end
+      else
+        bad -> {:violation, {:ref_roundtrip_flow_broke, overrides, bad}}
+      end
     end
 
     # --- helpers -------------------------------------------------------------

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -115,10 +115,15 @@ defmodule Raxol.Agent.Red.U8Gates do
   exactly false.
   """
   def escalate_p(call) do
+    # Map.get, never dot access (matches production): a call MISSING a
+    # structural field fails CLOSED to escalation, never raises a KeyError.
+    effect_class = Map.get(call, :effect_class, :__missing__)
+    egress = Map.get(call, :egress, :__missing__)
+
     cond do
-      call.effect_class == :irreversible_external -> true
-      call.egress == true -> true
-      known_effect_class?(call.effect_class) and call.egress == false -> false
+      effect_class == :irreversible_external -> true
+      egress == true -> true
+      known_effect_class?(effect_class) and egress == false -> false
       true -> true
     end
   end
@@ -175,26 +180,57 @@ defmodule Raxol.Agent.Red.U8Gates do
   def tool_key(tool) when is_binary(tool), do: tool
 
   @doc """
-  request_ref encodes tool + call_id so a journaled decision alone rebuilds the
-  grant key. INJECTIVE + delimiter-safe: the (normalized string) tool is
-  length-prefixed, so a ":" in either tool or call_id can't mis-split the ref.
+  request_ref — the ONE request identity (pending key, once-grant key, deny
+  key) — encodes tool + call_id + a digest of the argument lineage, so a
+  journaled decision alone rebuilds the grant key. INJECTIVE + delimiter-safe:
+  tool and call_id are both length-prefixed, so a ":" in either can't mis-split
+  the ref; the digest binds a grant to the request's vetted lineage.
   """
-  def request_ref(call), do: ref_encode(tool_key(call.tool), call.call_id)
+  def request_ref(call),
+    do: ref_encode(tool_key(call.tool), call.call_id, lineage_digest(call))
 
-  @doc "Encode {tool, call_id} into a delimiter-safe, injective request_ref."
-  def ref_encode(tool, cid) when is_binary(tool) and is_binary(cid),
-    do: "req:" <> Integer.to_string(byte_size(tool)) <> ":" <> tool <> cid
-
-  @doc "Parse a reference request_ref back into {tool, call_id} (tool is the canonical string)."
-  def parse_ref("req:" <> rest) do
-    [len_str, tail] = String.split(rest, ":", parts: 2)
-    len = String.to_integer(len_str)
-    <<tool::binary-size(^len), cid::binary>> = tail
-    {tool, cid}
+  @doc "Digest of the call's argument-lineage identity (in-session binder)."
+  def lineage_digest(call) do
+    {Map.get(call, :arg_refs, []), Map.get(call, :lineage, %{})}
+    |> :erlang.phash2(4_294_967_296)
+    |> Integer.to_string()
   end
+
+  @doc "Encode {tool, call_id, digest} into a delimiter-safe, injective request_ref."
+  def ref_encode(tool, cid, digest)
+      when is_binary(tool) and is_binary(cid) and is_binary(digest) do
+    "req:" <>
+      Integer.to_string(byte_size(tool)) <>
+      ":" <> tool <> Integer.to_string(byte_size(cid)) <> ":" <> cid <> digest
+  end
+
+  @doc """
+  Fail-closed parse of a request_ref back into {:ok, {tool, call_id}} (tool is
+  the canonical string); :error — never a raise — on any ref that did not
+  originate from `ref_encode/3` (matches production).
+  """
+  def parse_ref("req:" <> rest) do
+    with [tool_len_str, tail] <- String.split(rest, ":", parts: 2),
+         {tool_len, ""} when tool_len >= 0 <- Integer.parse(tool_len_str),
+         <<tool::binary-size(^tool_len), tail::binary>> <- tail,
+         [cid_len_str, tail] <- String.split(tail, ":", parts: 2),
+         {cid_len, ""} when cid_len >= 0 <- Integer.parse(cid_len_str),
+         <<cid::binary-size(^cid_len), _digest::binary>> <- tail do
+      {:ok, {tool, cid}}
+    else
+      _ -> :error
+    end
+  end
+
+  def parse_ref(_), do: :error
 
   @doc "The approval_requested neutral event a gate returns on escalation (family :loop — frozen F3)."
   def approval_request(ref, call) do
+    # Map.get: a call escalating BECAUSE a structural field is missing must
+    # still produce a well-formed request (matches production).
+    effect_class = Map.get(call, :effect_class)
+    egress = Map.get(call, :egress)
+
     %{
       family: :loop,
       type: :approval_requested,
@@ -202,9 +238,9 @@ defmodule Raxol.Agent.Red.U8Gates do
         request_ref: ref,
         call_id: call.call_id,
         action: call.tool,
-        effect_class: call.effect_class,
-        egress: call.egress,
-        blast_radius: %{effect_class: call.effect_class, egress: call.egress}
+        effect_class: effect_class,
+        egress: egress,
+        blast_radius: %{effect_class: effect_class, egress: egress}
       }
     }
   end
@@ -223,23 +259,23 @@ defmodule Raxol.Agent.Red.U8Gates do
     6. otherwise → auto-proceed (YOLO-applicable over trusted lineage).
   """
   def evaluate_with(state, call, taint_fun) do
-    cid = call.call_id
-    tool = call.tool
-    # `:once` keyed by FULL request identity (tool + call_id) — a grant unlocks
-    # exactly that request; a DIFFERENT request falls through to the taint fold.
-    once_key = request_ref(call)
+    # ONE request identity at every site (matches production): once grants AND
+    # durable denies are keyed by the full request_ref (tool + call_id +
+    # lineage digest), never a bare call_id — a grant unlocks exactly that
+    # request; a DIFFERENT request falls through to the taint fold.
+    ref = request_ref(call)
 
     cond do
-      MapSet.member?(state.once, once_key) ->
-        {:proceed, %{state | once: MapSet.delete(state.once, once_key)}}
+      MapSet.member?(state.once, ref) ->
+        {:proceed, %{state | once: MapSet.delete(state.once, ref)}}
 
-      MapSet.member?(state.denied, cid) ->
+      MapSet.member?(state.denied, ref) ->
         {:reject, :denied, state}
 
       taint_fun.(call) ->
         escalate(state, call)
 
-      MapSet.member?(state.session, tool_key(tool)) ->
+      MapSet.member?(state.session, tool_key(call.tool)) ->
         {:proceed, state}
 
       escalate_p(call) ->
@@ -269,27 +305,49 @@ defmodule Raxol.Agent.Red.U8Gates do
     end
   end
 
-  @doc "Fold one decision into the enforcement projection (grant/deny at scope)."
-  def grant(state, :approved, :once, cid, tool),
+  @doc """
+  Fold one decision into the enforcement projection (grant/deny at scope). The
+  ref (the ONE request identity) keys both once grants and durable denies; each
+  polarity clears the other (matches production).
+  """
+  def grant(state, :approved, :once, ref, _tool),
     do: %{
       state
-      | denied: MapSet.delete(state.denied, cid),
-        once: MapSet.put(state.once, ref_encode(tool_key(tool), cid))
+      | denied: MapSet.delete(state.denied, ref),
+        once: MapSet.put(state.once, ref)
     }
 
-  def grant(state, :approved, scope, cid, tool) when scope in [:session, :root],
+  def grant(state, :approved, scope, ref, tool) when scope in [:session, :root],
     do: %{
       state
-      | denied: MapSet.delete(state.denied, cid),
+      | denied: MapSet.delete(state.denied, ref),
         session: MapSet.put(state.session, tool_key(tool))
     }
 
-  def grant(state, :denied, _scope, cid, tool),
+  def grant(state, :denied, _scope, ref, _tool),
     do: %{
       state
-      | denied: MapSet.put(state.denied, cid),
-        once: MapSet.delete(state.once, ref_encode(tool_key(tool), cid))
+      | denied: MapSet.put(state.denied, ref),
+        once: MapSet.delete(state.once, ref)
     }
+
+  @doc "Actor authentication (matches production): only kind: :human decisions are enacted."
+  def authenticate_actor(%{kind: :human}), do: :ok
+  def authenticate_actor(actor), do: {:error, {:unauthorized_actor, actor_kind(actor)}}
+
+  defp actor_kind(%{kind: kind}), do: kind
+  defp actor_kind(_), do: nil
+
+  @doc "Decision-domain validation (matches production): fail-closed on unknown values."
+  def validate_decision(%{decision: d} = decision) when d in [:approved, :denied] do
+    case Map.get(decision, :scope, :once) do
+      scope when scope in [:once, :session, :root] -> :ok
+      other -> {:error, {:unknown_scope, other}}
+    end
+  end
+
+  def validate_decision(decision),
+    do: {:error, {:unknown_decision, Map.get(decision, :decision)}}
 
   # --- call builders ----------------------------------------------------------
 
@@ -383,34 +441,60 @@ defmodule Raxol.Agent.Red.U8Gates do
       do: U8Gates.authorize_via(__MODULE__, state, call, run_fn)
 
     @impl true
-    def apply_decision(state, %{request_ref: ref} = decision, _actor) do
-      case Map.fetch(state.pending, ref) do
-        :error ->
-          # forged / dangling decision: no live request names this ref
-          {:error, :no_such_request}
+    def apply_decision(state, %{request_ref: ref} = decision, actor) do
+      # The approver is authenticated by the gate (fail-closed): only a
+      # kind: :human envelope actor's decision is enacted. Unknown decision/
+      # scope values are errors, never crashes.
+      with :ok <- U8Gates.authenticate_actor(actor),
+           :ok <- U8Gates.validate_decision(decision),
+           {:ok, %{tool: tool}} <- fetch_pending(state, ref) do
+        state = %{state | pending: Map.delete(state.pending, ref)}
+        scope = Map.get(decision, :scope, :once)
+        {:ok, U8Gates.grant(state, decision.decision, scope, ref, tool)}
+      end
+    end
 
-        {:ok, %{call_id: cid, tool: tool}} ->
-          state = %{state | pending: Map.delete(state.pending, ref)}
-          scope = Map.get(decision, :scope, :once)
-          {:ok, U8Gates.grant(state, decision.decision, scope, cid, tool)}
+    def apply_decision(_state, decision, _actor),
+      do: {:error, {:malformed_decision, decision}}
+
+    defp fetch_pending(state, ref) do
+      case Map.fetch(state.pending, ref) do
+        # forged / dangling decision: no live request names this ref
+        :error -> {:error, :no_such_request}
+        {:ok, entry} -> {:ok, entry}
       end
     end
 
     @impl true
     def rebuild(events) do
-      # The journal is the authority: decisions were request-validated when
-      # first observed, so the fold re-derives the enforcement projection from
-      # the decisions alone (request_ref encodes the grant key). A `:once`-grant
-      # consumption marker (%{consumed_ref}) reproduces post-consumption state.
+      # The journal is the authority: the fold re-derives the enforcement
+      # projection from the decisions alone (request_ref encodes the grant
+      # key). It re-applies the SAME actor authentication as apply_decision (a
+      # non-human decision was never enacted live, so replay enacts nothing),
+      # and degrades fail-closed (no-op, never crash) on out-of-domain input.
+      # A `:once`-grant consumption marker (%{consumed_ref}) reproduces
+      # post-consumption state; removal is restrictive, so no actor gate.
       Enum.reduce(events, new(), fn
         {%{consumed_ref: ref}, _actor}, state ->
           %{state | once: MapSet.delete(state.once, ref)}
 
-        {decision, _actor}, state ->
-          {tool, cid} = U8Gates.parse_ref(decision.request_ref)
-          scope = Map.get(decision, :scope, :once)
-          U8Gates.grant(state, decision.decision, scope, cid, tool)
+        {decision, actor}, state when is_map(decision) ->
+          fold_decision(state, decision, actor)
+
+        _malformed, state ->
+          state
       end)
+    end
+
+    defp fold_decision(state, decision, actor) do
+      with :ok <- U8Gates.authenticate_actor(actor),
+           :ok <- U8Gates.validate_decision(decision),
+           ref when is_binary(ref) <- Map.get(decision, :request_ref, :error),
+           {:ok, {tool, _cid}} <- U8Gates.parse_ref(ref) do
+        U8Gates.grant(state, decision.decision, Map.get(decision, :scope, :once), ref, tool)
+      else
+        _ -> state
+      end
     end
   end
 
@@ -457,7 +541,7 @@ defmodule Raxol.Agent.Red.U8Gates do
         :error ->
           {:error, :no_such_request}
 
-        {:ok, %{call_id: cid, tool: tool}} ->
+        {:ok, %{tool: tool}} ->
           # BUG: drops the decision polarity — a deny grants like an approve.
           state = %{state | pending: Map.delete(state.pending, ref)}
 
@@ -466,7 +550,7 @@ defmodule Raxol.Agent.Red.U8Gates do
              state,
              :approved,
              Map.get(decision, :scope, :once),
-             cid,
+             ref,
              tool
            )}
       end
@@ -1059,6 +1143,253 @@ defmodule Raxol.Agent.Red.U8Gates do
       else
         bad -> {:violation, {:ref_roundtrip_flow_broke, overrides, bad}}
       end
+    end
+
+    # C16 (Drew HIGH-1 regression) — the approver is AUTHENTICATED: an
+    # approval_decided whose envelope actor is not kind: :human (agent, system,
+    # nil, kindless) does NOT unlock the escalated call — neither live
+    # (apply_decision) nor on rebuild (a forged agent-authored decision folded
+    # from the journal) — and the guarded side effect never runs. A :human
+    # approval on the same still-pending request still works. The pre-fix gate
+    # discarded the actor entirely, so an agent self-approved its own write.
+    def non_human_approver_never_grants(gate) do
+      safe(fn ->
+        {:ok, exec} = Counter.start()
+        run = fn -> Counter.bump(exec) end
+        call = U8Gates.escalating_call()
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call) do
+          d = decision(req.payload.request_ref, :approved, :session)
+
+          bad_actors = [
+            %{kind: :agent, id: "agent-1"},
+            %{kind: :system, id: "sys-1"},
+            nil,
+            %{id: "kindless"}
+          ]
+
+          live_violation =
+            Enum.find_value(bad_actors, fn actor ->
+              state =
+                case gate.apply_decision(s1, d, actor) do
+                  {:ok, st} -> st
+                  {:error, _} -> s1
+                end
+
+              case gate.authorize(state, call, run) do
+                {:proceeded, _, _} ->
+                  {:violation, {:non_human_approver_granted_live, actor}}
+
+                _ ->
+                  nil
+              end
+            end)
+
+          rebuild_violation =
+            Enum.find_value(bad_actors, fn actor ->
+              case gate.authorize(gate.rebuild([{d, actor}]), call, run) do
+                {:proceeded, _, _} ->
+                  {:violation, {:non_human_approver_granted_rebuild, actor}}
+
+                _ ->
+                  nil
+              end
+            end)
+
+          cond do
+            live_violation != nil ->
+              live_violation
+
+            rebuild_violation != nil ->
+              rebuild_violation
+
+            Counter.value(exec) != 0 ->
+              {:violation, {:side_effect_ran_unapproved, Counter.value(exec)}}
+
+            true ->
+              # the human decision still works on the untouched pending request
+              case gate.apply_decision(s1, d, human()) do
+                {:ok, s2} ->
+                  case gate.authorize(s2, call, run) do
+                    {:proceeded, _, _} -> :ok
+                    bad -> {:violation, {:human_approval_stopped_working, bad}}
+                  end
+
+                bad ->
+                  {:violation, {:human_approval_rejected, bad}}
+              end
+          end
+        else
+          bad -> {:violation, {:approver_auth_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C17 (Drew HIGH-2 regression) — deny and grant use ONE key (the full
+    # request identity), so a deny is request-scoped: after denying
+    # (tool_a, cid), the SAME request stays durably rejected, but a DIFFERENT
+    # tool sharing the bare call_id gets its own approval cycle (escalates) —
+    # it is never blanket-rejected by another request's deny. The pre-fix gate
+    # keyed denies by bare call_id (asymmetric with the ref-keyed once grants):
+    # this leg over-blocked, and the mirrored keying admitted deny bypass.
+    def deny_is_request_scoped(gate) do
+      safe(fn ->
+        cid = "shared-deny-cid"
+        call_a = U8Gates.escalating_call(%{tool: :deny_tool_a, call_id: cid})
+        call_b = U8Gates.escalating_call(%{tool: :deny_tool_b, call_id: cid})
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call_a),
+             {:ok, s2} <-
+               gate.apply_decision(
+                 s1,
+                 decision(req.payload.request_ref, :denied, :once),
+                 human()
+               ) do
+          cond do
+            not match?({:reject, :denied, _}, gate.evaluate(s2, call_a)) ->
+              {:violation, {:deny_did_not_stick, gate.evaluate(s2, call_a)}}
+
+            not match?({:escalate, _, _}, gate.evaluate(s2, call_b)) ->
+              {:violation, {:deny_over_blocked_other_tool, gate.evaluate(s2, call_b)}}
+
+            true ->
+              :ok
+          end
+        else
+          bad -> {:violation, {:deny_scope_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C18 (Drew MEDIUM regression) — the decision folds degrade fail-closed on
+    # out-of-domain journal input, never crash (replay-DoS class): an unknown
+    # decision value, an out-of-domain scope, an unparseable/foreign
+    # request_ref, and a malformed record all fold as NO-GRANT in rebuild/1
+    # (the session still reconstructs; a valid human grant in the same journal
+    # still applies), and apply_decision returns {:error, _} for out-of-domain
+    # values. The pre-fix folds raised FunctionClauseError/MatchError.
+    def corrupt_journal_folds_fail_closed(gate) do
+      safe(fn ->
+        call = U8Gates.escalating_call(%{tool: :fold_tool, call_id: "c-fold"})
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call) do
+          ref = req.payload.request_ref
+          valid = decision(ref, :approved, :session)
+
+          corrupt = [
+            {%{request_ref: ref, decision: :corrupt, refs: []}, human()},
+            {%{request_ref: ref, decision: :approved, scope: :global, refs: []}, human()},
+            {%{request_ref: "not-a-ref", decision: :approved, scope: :session, refs: []},
+             human()},
+            {%{request_ref: "req:999:overflow", decision: :approved, scope: :session, refs: []},
+             human()},
+            {:not_even_a_decision, human()},
+            :not_even_a_pair
+          ]
+
+          corrupt_only = gate.rebuild(corrupt)
+          with_valid = gate.rebuild(corrupt ++ [{valid, human()}])
+
+          cond do
+            authorize_tag(gate, corrupt_only, call) == :proceeded ->
+              {:violation, :corrupt_journal_granted}
+
+            authorize_tag(gate, with_valid, call) != :proceeded ->
+              {:violation,
+               {:valid_grant_lost_among_corruption, authorize_tag(gate, with_valid, call)}}
+
+            not match?(
+              {:error, _},
+              gate.apply_decision(
+                s1,
+                %{request_ref: ref, decision: :corrupt, refs: []},
+                human()
+              )
+            ) ->
+              {:violation, :unknown_decision_enacted_live}
+
+            not match?(
+              {:error, _},
+              gate.apply_decision(
+                s1,
+                %{request_ref: ref, decision: :approved, scope: :global, refs: []},
+                human()
+              )
+            ) ->
+              {:violation, :unknown_scope_enacted_live}
+
+            true ->
+              :ok
+          end
+        else
+          bad -> {:violation, {:corrupt_fold_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C19 (Drew LOW regression) — the §5.2 predicate is defensive on the
+    # authorization path: a call map MISSING effect_class or egress fails
+    # CLOSED to escalation (both in escalate?/1 and through evaluate/2), never
+    # raises a KeyError. The pre-fix predicate used dot access and crashed.
+    def predicate_missing_fields_fail_closed(gate) do
+      safe(fn ->
+        no_egress = Map.delete(U8Gates.benign_call(), :egress)
+        no_class = Map.delete(U8Gates.benign_call(), :effect_class)
+
+        cond do
+          not gate.escalate?(no_egress) ->
+            {:violation, :missing_egress_proceeded}
+
+          not gate.escalate?(no_class) ->
+            {:violation, :missing_class_proceeded}
+
+          not match?({:escalate, _, _}, gate.evaluate(gate.new(), no_egress)) ->
+            {:violation,
+             {:evaluate_choked_on_missing_egress, gate.evaluate(gate.new(), no_egress)}}
+
+          not match?({:escalate, _, _}, gate.evaluate(gate.new(), no_class)) ->
+            {:violation, {:evaluate_choked_on_missing_class, gate.evaluate(gate.new(), no_class)}}
+
+          true ->
+            :ok
+        end
+      end)
+    end
+
+    # C20 (Drew LOW regression) — a standing `:once` grant is bound to the
+    # request's VETTED lineage, not just (tool, call_id): re-issuing the same
+    # ids with newly-TAINTED lineage misses the grant (the ref's lineage digest
+    # differs), falls through to the decision-time taint fold, and escalates —
+    # the side effect never runs on the stale grant. The pre-fix ref keyed only
+    # tool + call_id, so the standing grant admitted the re-tainted call.
+    def once_grant_bound_to_lineage(gate) do
+      safe(fn ->
+        {:ok, exec} = Counter.start()
+        run = fn -> Counter.bump(exec) end
+        call = U8Gates.escalating_call(%{tool: :lineage_tool, call_id: "c-lin"})
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call),
+             {:ok, s2} <-
+               gate.apply_decision(
+                 s1,
+                 decision(req.payload.request_ref, :approved, :once),
+                 human()
+               ) do
+          retainted = Map.merge(call, U8Gates.tainted_arg_lineage())
+
+          case gate.authorize(s2, retainted, run) do
+            {:escalated, _, _} ->
+              if Counter.value(exec) == 0,
+                do: :ok,
+                else: {:violation, {:side_effect_ran, Counter.value(exec)}}
+
+            bad ->
+              {:violation, {:stale_grant_admitted_retainted_call, bad}}
+          end
+        else
+          bad -> {:violation, {:lineage_binding_flow_broke, bad}}
+        end
+      end)
     end
 
     # --- helpers -------------------------------------------------------------

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -372,11 +372,16 @@ defmodule Raxol.Agent.Red.U8Gates do
     def rebuild(events) do
       # The journal is the authority: decisions were request-validated when
       # first observed, so the fold re-derives the enforcement projection from
-      # the decisions alone (request_ref encodes the grant key).
-      Enum.reduce(events, new(), fn {decision, _actor}, state ->
-        {tool, cid} = U8Gates.parse_ref(decision.request_ref)
-        scope = Map.get(decision, :scope, :once)
-        U8Gates.grant(state, decision.decision, scope, cid, tool)
+      # the decisions alone (request_ref encodes the grant key). A `:once`-grant
+      # consumption marker (%{consumed_ref}) reproduces post-consumption state.
+      Enum.reduce(events, new(), fn
+        {%{consumed_ref: ref}, _actor}, state ->
+          %{state | once: MapSet.delete(state.once, ref)}
+
+        {decision, _actor}, state ->
+          {tool, cid} = U8Gates.parse_ref(decision.request_ref)
+          scope = Map.get(decision, :scope, :once)
+          U8Gates.grant(state, decision.decision, scope, cid, tool)
       end)
     end
   end
@@ -875,6 +880,50 @@ defmodule Raxol.Agent.Red.U8Gates do
           end
         else
           bad -> {:violation, {:once_scope_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C13 (Fix 3 regression) — a CONSUMED `:once` grant is reconstructed by the
+    # fold as consumed: after consuming a once-grant and rebuilding from the
+    # journal (the decision + the consumption marker), the same call is NOT
+    # re-admitted (rebuild == post-consumption live). The pre-fix rebuild folded
+    # only approval_decided, so it resurrected the spent grant on resume.
+    def once_consumption_survives_rebuild(gate) do
+      safe(fn ->
+        {:ok, exec} = Counter.start()
+        run = fn -> Counter.bump(exec) end
+        call = U8Gates.escalating_call()
+
+        with {:escalate, req, s1} <- gate.evaluate(gate.new(), call),
+             ref = req.payload.request_ref,
+             d = decision(ref, :approved, :once),
+             {:ok, s2} <- gate.apply_decision(s1, d, human()),
+             {:proceeded, _, s3} <- gate.authorize(s2, call, run) do
+          # Live state after the one-shot grant is spent: a re-issue escalates.
+          live_tag = authorize_tag(gate, s3, call)
+
+          # The journal the runtime records for this flow: the decision, then the
+          # consumption marker naming the spent grant's ref.
+          journal = [{d, human()}, {%{consumed_ref: ref}, human()}]
+          rebuilt_tag = authorize_tag(gate, gate.rebuild(journal), call)
+
+          cond do
+            Counter.value(exec) != 1 ->
+              {:violation, {:side_effect_count, Counter.value(exec)}}
+
+            live_tag == :proceeded ->
+              {:violation, {:once_not_consumed_live, live_tag}}
+
+            rebuilt_tag != live_tag ->
+              {:violation,
+               {:consumption_not_reconstructed, live_tag, rebuilt_tag}}
+
+            true ->
+              :ok
+          end
+        else
+          bad -> {:violation, {:once_consumption_flow_broke, bad}}
         end
       end)
     end

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -133,8 +133,10 @@ defmodule Raxol.Agent.Red.U8Gates do
 
   @doc """
   The reference taint FOLD (HIGH-1): tainted iff any record reachable from
-  `arg_refs` through `lineage` refs is stamped `:tainted`; an unresolvable ref
-  folds as tainted (fail-closed). Cycle-safe.
+  `arg_refs` through `lineage` refs is stamped `:tainted`. Fails CLOSED (matches
+  production): an unresolvable ref, an unrecognized trust stamp (a future lattice
+  point / garbage), or a malformed (:refs-less / trust-less) entry all fold as
+  tainted. Only an HONEST `:trusted` node has its ref chain followed. Cycle-safe.
   """
   def fold_tainted?(call) do
     lineage = Map.get(call, :lineage, %{})
@@ -148,15 +150,22 @@ defmodule Raxol.Agent.Red.U8Gates do
       tainted_reach?(rest, lineage, seen)
     else
       case Map.get(lineage, id) do
-        # unknown ref → fail-closed (U11 §2.1: unknown trust reads as tainted)
-        nil ->
-          true
-
+        # a taint source: absorbing (refs not followed)
         %{trust: :tainted} ->
           true
 
-        %{refs: refs} ->
+        # an HONEST :trusted node: fold its ref chain (a mis-stamped :trusted
+        # over a tainted chain still folds tainted)
+        %{trust: :trusted, refs: refs} ->
           tainted_reach?(refs ++ rest, lineage, MapSet.put(seen, id))
+
+        # Fail CLOSED (matches production): an unknown ref (nil), an unrecognized
+        # trust stamp (a future lattice point / garbage), or a malformed
+        # (:refs-less / trust-less) entry all read as tainted — U11 §2.1
+        # unknown-trust rule. Never follow the refs of a stamp we don't
+        # recognize, and never crash on a malformed entry.
+        _ ->
+          true
       end
     end
   end
@@ -899,6 +908,34 @@ defmodule Raxol.Agent.Red.U8Gates do
           end
         else
           bad -> {:violation, {:once_scope_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C15 (Fix 5 regression) — the taint fold fails CLOSED on inputs it does not
+    # recognize, matching production: an UNKNOWN-trust leaf (a no-refs leaf whose
+    # trust is an unrecognized value) escalates, and a MALFORMED (:refs-less /
+    # trust-less) entry escalates rather than crashing. Pins the ReferenceGate
+    # spec against a regression toward the old fail-OPEN / CaseClauseError fold.
+    def taint_fold_fails_closed(gate) do
+      safe(fn ->
+        unknown_trust =
+          U8Gates.benign_call(%{
+            arg_refs: [1],
+            lineage: %{1 => %{trust: :unknown_future_value, refs: []}}
+          })
+
+        malformed =
+          U8Gates.benign_call(%{
+            arg_refs: [1],
+            lineage: %{1 => %{note: "no trust, no refs"}}
+          })
+
+        with :ok <-
+               expect_escalate(gate, unknown_trust, :unknown_trust_leaf_proceeded),
+             :ok <-
+               expect_escalate(gate, malformed, :malformed_entry_proceeded) do
+          :ok
         end
       end)
     end

--- a/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u8_gates.ex
@@ -108,9 +108,28 @@ defmodule Raxol.Agent.Red.U8Gates do
       denied: MapSet.new()
     }
 
-  @doc "The pure §5.2 predicate: escalate iff irreversible_external OR egress."
-  def escalate_p(call),
-    do: call.effect_class == :irreversible_external or call.egress == true
+  @doc """
+  The pure §5.2 predicate: escalate iff irreversible_external OR egress. Fails
+  CLOSED (matches production): an unknown effect_class or a non-boolean egress
+  escalates — auto-proceed only for a recognized benign class with egress
+  exactly false.
+  """
+  def escalate_p(call) do
+    cond do
+      call.effect_class == :irreversible_external -> true
+      call.egress == true -> true
+      known_effect_class?(call.effect_class) and call.egress == false -> false
+      true -> true
+    end
+  end
+
+  @known_effect_classes [
+    :reversible_local,
+    :bounded_sandboxable,
+    :irreversible_external
+  ]
+
+  defp known_effect_class?(class), do: class in @known_effect_classes
 
   @doc """
   The reference taint FOLD (HIGH-1): tainted iff any record reachable from
@@ -880,6 +899,38 @@ defmodule Raxol.Agent.Red.U8Gates do
           end
         else
           bad -> {:violation, {:once_scope_flow_broke, bad}}
+        end
+      end)
+    end
+
+    # C14 (Fix 4 regression) — the §5.2 predicate fails CLOSED on inputs it does
+    # not recognize: an UNKNOWN effect_class escalates, and a NON-boolean egress
+    # escalates (the pre-fix `class == :irreversible_external or egress == true`
+    # returned false — a silent proceed — for both).
+    def escalate_predicate_fails_closed(gate) do
+      safe(fn ->
+        unknown_class =
+          U8Gates.escalating_call(%{
+            effect_class: :quantum_teleport,
+            egress: false
+          })
+
+        non_boolean_egress =
+          U8Gates.escalating_call(%{
+            effect_class: :reversible_local,
+            egress: :maybe
+          })
+
+        cond do
+          not gate.escalate?(unknown_class) ->
+            {:violation, {:unknown_class_proceeded, unknown_class.effect_class}}
+
+          not gate.escalate?(non_boolean_egress) ->
+            {:violation,
+             {:non_boolean_egress_proceeded, non_boolean_egress.egress}}
+
+          true ->
+            :ok
         end
       end)
     end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -168,4 +168,32 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
       assert Fingerprint.params_hash(built_a) == Fingerprint.params_hash(built_b)
     end
   end
+
+  # ===========================================================================
+  # Finding 6 (🟡) — what_produced precedence walk
+  # ===========================================================================
+
+  describe "what_produced follows the precedence law (§2.1)" do
+    test "an item_completed offset resolves to its OWN fingerprint (highest precedence)" do
+      %{records: records, item_offset: item_off, z: z} =
+        Gen.fingerprint_precedence(0)
+
+      assert Meta.what_produced(records, item_off) == z,
+             "the item_completed fingerprint wins 'what produced this content'"
+    end
+
+    test "a turn_started offset resolves to the head default, NOT its 'what-was-asked' override" do
+      %{records: records, x: x, y: y} = Gen.fingerprint_precedence(0)
+
+      # offset 2 is the turn_started carrying override Y ("what was asked").
+      produced = Meta.what_produced(records, 2)
+
+      assert produced == x,
+             "a turn_started must resolve to the head default (the effective " <>
+               "producing fp), never the override"
+
+      refute produced == y,
+             "the turn_started override is 'what was asked', not 'what produced'"
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -13,6 +13,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
   @moduletag :capture_log
 
   alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Fingerprint
   alias Raxol.Agent.Meta
   alias Raxol.Agent.Red.MetaJournalGen, as: Gen
 
@@ -139,6 +140,32 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
       # under the old String.to_atom path — a VM-crashing DoS).
       assert after_count - before < 100,
              "decode leaked #{after_count - before} atoms from unknown journal tokens"
+    end
+  end
+
+  # ===========================================================================
+  # Finding 5 (🟡) — canonical_json recurses the key-sort into nested objects
+  # ===========================================================================
+
+  describe "canonical_json is deterministic through nested objects (I2)" do
+    test "nested object keys are sorted at EVERY level, not just the top" do
+      params = %{z_top: 1, a_top: %{y: 1, b: 2, m: %{q: 1, a: 2}}}
+
+      # Sorted at the top, at a_top, AND at the doubly-nested m — the property
+      # the old top-level-only sort (nested via Jason term order) did not give.
+      assert Fingerprint.canonical_json(params) ==
+               ~s({"a_top":{"b":2,"m":{"a":2,"q":1},"y":1},"z_top":1})
+    end
+
+    test "a nested object hashes identically regardless of how it was built" do
+      built_a = %{model: "m", opts: Enum.into([b: 2, a: 1, deep: %{y: 2, x: 1}], %{})}
+
+      built_b = %{}
+      built_b = Map.put(built_b, :opts, Map.new([{:deep, Map.new(x: 1, y: 2)}, {:a, 1}, {:b, 2}]))
+      built_b = Map.put(built_b, :model, "m")
+
+      assert Fingerprint.canonical_json(built_a) == Fingerprint.canonical_json(built_b)
+      assert Fingerprint.params_hash(built_a) == Fingerprint.params_hash(built_b)
     end
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -24,9 +24,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
   describe "taint fails CLOSED on unknown trust (§2.1 pt.1)" do
     test "(a) a record with provenance.trust \"poisoned\" decodes to :tainted, never :trusted" do
       poisoned =
-        Gen.rec(1, :meta, :extract, Gen.meta_payload(:extract, []),
-          trust: "poisoned"
-        )
+        Gen.rec(1, :meta, :extract, Gen.meta_payload(:extract, []), trust: "poisoned")
 
       assert {:ok, %Event{provenance: %{trust: :tainted}}} = Meta.decode(poisoned),
              "a present-but-unrecognized trust token must fail closed to :tainted"
@@ -42,9 +40,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
         )
 
       dependent =
-        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]),
-          trust: "trusted"
-        )
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]), trust: "trusted")
 
       derived = Meta.derive_taint([entry, dependent])
 
@@ -65,9 +61,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
              "absent provenance must default to the frozen grandfather value"
 
       dependent =
-        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]),
-          trust: "trusted"
-        )
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]), trust: "trusted")
 
       # A meta event whose only ref is a grandfathered (absent-provenance) leaf
       # stays trusted — the grandfather path is NOT the same as fail-closed.

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -196,4 +196,34 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
              "the turn_started override is 'what was asked', not 'what produced'"
     end
   end
+
+  # ===========================================================================
+  # Finding 7 (🟡) — validate enforces promote ⇒ :global
+  # ===========================================================================
+
+  describe "validate enforces promote ⇒ :global (§2.1)" do
+    test "a session-scoped promote is rejected at validate" do
+      event = %{
+        family: :meta,
+        type: :promote,
+        payload: Gen.meta_payload(:promote, [1]),
+        scope: :session
+      }
+
+      assert Meta.validate(event) == {:error, {:scope_violation, :promote}},
+             "promote is the only commit type — a session-scoped promote is a " <>
+               "mis-scoped commit and must be rejected"
+    end
+
+    test "a global-scoped promote with refs still passes (regression guard)" do
+      event = %{
+        family: :meta,
+        type: :promote,
+        payload: Gen.meta_payload(:promote, [1]),
+        scope: :global
+      }
+
+      assert Meta.validate(event) == :ok
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -7,8 +7,12 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
 
   These run in regular CI alongside the frozen U11 red suite + controls; they
   pin the security-critical seams the YOLO-safe soundness theorem depends on.
+
+  `async: false` — the atom-table DoS regression reads the GLOBAL
+  `:erlang.system_info(:atom_count)`, so it must not race other async tests
+  creating atoms concurrently (that would inflate the delta).
   """
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   @moduletag :capture_log
 
@@ -66,6 +70,62 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
       # A meta event whose only ref is a grandfathered (absent-provenance) leaf
       # stays trusted — the grandfather path is NOT the same as fail-closed.
       assert Meta.derive_taint([bare, dependent])[2] == :trusted
+    end
+
+    test "(d) a PRESENT-but-trustless provenance fails closed (the last laundering arm)" do
+      # The generator always emits a "trust" key, so these shapes are only
+      # reachable by overriding provenance directly — the real laundering arm.
+
+      # (i) PRESENT map provenance carrying a source but NO trust key.
+      leaf_trustless =
+        Gen.rec(1, :loop, :tool_result, %{name: "x", result: "y", refs: []})
+        |> Map.put("provenance", %{"source" => "probe_c7"})
+
+      # (ii) PRESENT non-map provenance (wrong shape).
+      leaf_nonmap =
+        Gen.rec(2, :loop, :tool_result, %{name: "x", result: "y", refs: []})
+        |> Map.put("provenance", "garbage")
+
+      dep_a =
+        Gen.rec(3, :meta, :extract, Gen.meta_payload(:extract, [1]), trust: "trusted")
+
+      dep_b =
+        Gen.rec(4, :meta, :extract, Gen.meta_payload(:extract, [2]), trust: "trusted")
+
+      derived = Meta.derive_taint([leaf_trustless, leaf_nonmap, dep_a, dep_b])
+
+      # Taint-fold surface: a laundering leaf now taints its dependents.
+      assert derived[3] == :tainted,
+             "a present-but-trustless provenance must ENTER taint, not launder it"
+
+      assert derived[4] == :tainted,
+             "a present non-map provenance must fail closed into taint"
+
+      # Consumer surface (U8/U12 read this): source PRESERVED, trust fails closed.
+      assert {:ok, %Event{provenance: %{source: :probe_c7, trust: :tainted}}} =
+               Meta.decode(leaf_trustless),
+             "decode must preserve the carried source and default trust to :tainted"
+
+      assert {:ok, %Event{provenance: %{source: :primary, trust: :tainted}}} =
+               Meta.decode(leaf_nonmap),
+             "a present non-map provenance must decode to :tainted on the consumer surface"
+
+      # Anti-tautology guard: a WHOLLY-ABSENT provenance still grandfathers.
+      absent = %{
+        "id" => 5,
+        "family" => "loop",
+        "type" => "tool_result",
+        "payload" => %{"refs" => []}
+      }
+
+      dep_c =
+        Gen.rec(6, :meta, :extract, Gen.meta_payload(:extract, [5]), trust: "trusted")
+
+      assert {:ok, %Event{provenance: %{source: :primary, trust: :trusted}}} =
+               Meta.decode(absent)
+
+      assert Meta.derive_taint([absent, dep_c])[6] == :trusted,
+             "absent provenance must remain the only trusted grandfather path"
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -96,4 +96,49 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
              "absent branch_id must default to \"main\""
     end
   end
+
+  # ===========================================================================
+  # Finding 3 (🟡→red) — reader-tolerant decode never exhausts the atom table
+  # ===========================================================================
+
+  describe "decode preserves unknown tokens raw, never materializing atoms (§0.2)" do
+    test "decoding many distinct unknown type/source strings creates no atoms" do
+      before = :erlang.system_info(:atom_count)
+
+      records =
+        for i <- 1..2000 do
+          # A guaranteed-fresh token never compiled as an atom anywhere.
+          tok = "u11_unknown_#{System.unique_integer([:positive])}_#{i}"
+
+          %{
+            "id" => i,
+            "family" => "meta",
+            "type" => tok,
+            "payload" => %{"refs" => []},
+            "provenance" => %{"source" => tok <> "_src", "trust" => "trusted"}
+          }
+        end
+
+      decoded =
+        Enum.map(records, fn r ->
+          {:ok, ev} = Meta.decode(r)
+          ev
+        end)
+
+      after_count = :erlang.system_info(:atom_count)
+
+      # Unknown tokens are preserved RAW as binaries (contract §0.2), never
+      # turned into fresh atoms — so type + source stay binary...
+      assert Enum.all?(decoded, fn ev -> is_binary(ev.type) end),
+             "an unknown type must be preserved as a raw binary"
+
+      assert Enum.all?(decoded, fn ev -> is_binary(ev.provenance.source) end),
+             "an unknown source must be preserved as a raw binary"
+
+      # ...and the atom table did NOT grow (2000 unknowns would add ~4000 atoms
+      # under the old String.to_atom path — a VM-crashing DoS).
+      assert after_count - before < 100,
+             "decode leaked #{after_count - before} atoms from unknown journal tokens"
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -73,4 +73,27 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
       assert Meta.derive_taint([bare, dependent])[2] == :trusted
     end
   end
+
+  # ===========================================================================
+  # Finding 4 (🔴) — branch_id round-trips off disk (read side)
+  # ===========================================================================
+
+  describe "branch_id read-side round-trip (§1.1)" do
+    test "a record written with a non-default branch_id decodes back with it" do
+      rec =
+        Gen.rec(1, :loop, :item_completed, %{item_type: "message", refs: []})
+        |> Map.put("branch_id", "feature-x")
+
+      assert {:ok, %Event{branch_id: "feature-x"}} = Meta.decode(rec),
+             "a non-default branch_id on disk must round-trip onto the Event"
+    end
+
+    test "a record without branch_id decodes to the default \"main\" (grandfather)" do
+      rec = Gen.rec(1, :loop, :item_completed, %{item_type: "message", refs: []})
+      refute Map.has_key?(rec, "branch_id")
+
+      assert {:ok, %Event{branch_id: "main"}} = Meta.decode(rec),
+             "absent branch_id must default to \"main\""
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -1,0 +1,76 @@
+defmodule Raxol.Agent.Red.U11HardeningTest do
+  @moduledoc """
+  Regression suite for the adversarial-review findings on the U11 SUBSTRATE
+  (`Raxol.Agent.Meta` / `Raxol.Agent.Fingerprint`). Each describe block proves
+  the FIXED arm of one finding — the fail-closed (🔴) arms are mandatory:
+  they must reject / taint / preserve, never fail open.
+
+  These run in regular CI alongside the frozen U11 red suite + controls; they
+  pin the security-critical seams the YOLO-safe soundness theorem depends on.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Meta
+  alias Raxol.Agent.Red.MetaJournalGen, as: Gen
+
+  # ===========================================================================
+  # Finding 2 (🔴) — taint fails CLOSED on unknown/garbage trust
+  # ===========================================================================
+
+  describe "taint fails CLOSED on unknown trust (§2.1 pt.1)" do
+    test "(a) a record with provenance.trust \"poisoned\" decodes to :tainted, never :trusted" do
+      poisoned =
+        Gen.rec(1, :meta, :extract, Gen.meta_payload(:extract, []),
+          trust: "poisoned"
+        )
+
+      assert {:ok, %Event{provenance: %{trust: :tainted}}} = Meta.decode(poisoned),
+             "a present-but-unrecognized trust token must fail closed to :tainted"
+    end
+
+    test "(b) a tool_result leaf with unknown trust taints its dependents" do
+      # The entry point stores an unrecognized trust token; the meta event that
+      # refs it stores :trusted but MUST derive :tainted (leaves anchor the fold
+      # via stored_trust, so a laundered entry point can no longer read trusted).
+      entry =
+        Gen.rec(1, :loop, :tool_result, %{name: "fetch", result: "x", refs: []},
+          trust: "garbage-token"
+        )
+
+      dependent =
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]),
+          trust: "trusted"
+        )
+
+      derived = Meta.derive_taint([entry, dependent])
+
+      assert derived[2] == :tainted,
+             "an unknown-trust entry point must taint everything that derives from it"
+    end
+
+    test "(c) absent provenance still reads :trusted (grandfather rule preserved)" do
+      bare = %{
+        "id" => 1,
+        "family" => "loop",
+        "type" => "tool_result",
+        "payload" => %{"refs" => []}
+      }
+
+      assert {:ok, %Event{provenance: %{source: :primary, trust: :trusted}}} =
+               Meta.decode(bare),
+             "absent provenance must default to the frozen grandfather value"
+
+      dependent =
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]),
+          trust: "trusted"
+        )
+
+      # A meta event whose only ref is a grandfathered (absent-provenance) leaf
+      # stays trusted — the grandfather path is NOT the same as fail-closed.
+      assert Meta.derive_taint([bare, dependent])[2] == :trusted
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_meta_controls_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_meta_controls_test.exs
@@ -1,0 +1,414 @@
+defmodule Raxol.Agent.Red.U11MetaControlsTest do
+  @moduledoc """
+  U11-R negative controls + corpus tests — these run in **regular CI** (no
+  `:harness_red` tag) alongside the excluded red suite in
+  `u11_meta_family_red_test.exs`.
+
+  ## Negative controls (meta-invariant m4 — dead injectors)
+
+  Every negative contour of `harness-freeze-contracts.md` §2.3 names a *dead
+  injector*: the exact broken implementation that would make its red
+  green-on-broken. Each control here runs that injector (a broken oracle
+  variant in `Raxol.Agent.Red.MetaOracle`) against the SAME generated journals
+  the red suite uses and asserts the breakage is **detectable** — the broken
+  answer must disagree with the correct oracle exactly where the red asserts.
+  A control failing means the red has lost its teeth.
+
+  Fired-counters (meta-invariant m1): every injector keeps a fire count; the
+  final assertion fails if any armed injector never fired. Schedules are
+  seed-reproducible (m2): every generator takes the seed, and every failure
+  message dumps it.
+
+  ## Corpus tests (P-U11.2 class — not reds)
+
+  The grandfather clause is a pure-decode corpus check: it must be green TODAY
+  against the enabler (frozen struct defaults), and stay green forever.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  alias Raxol.Agent.Contract
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Meta.Registry
+  alias Raxol.Agent.Red.MetaJournalGen, as: Gen
+  alias Raxol.Agent.Red.MetaOracle, as: Oracle
+
+  # ===========================================================================
+  # Dead-injector controls (N-U11.1 … N-U11.10) with fired-counters
+  # ===========================================================================
+
+  # Each injector: {name, fn seed -> :caught | {:missed, info} end}. An injector
+  # FIRES by running its broken variant; it is CAUGHT when the broken answer
+  # disagrees with the correct oracle where the red suite asserts.
+  defp injectors do
+    [
+      {:n_u11_1_pass_through_emit_seam,
+       fn seed ->
+         event = %{family: :meta, type: :totally_bogus, payload: %{refs: []}}
+         correct = Oracle.validate_correct(event)
+         broken = Oracle.validate_pass_through(event)
+
+         if correct == {:error, {:unknown_meta_type, :totally_bogus}} and
+              broken == :ok,
+            do: :caught,
+            else: {:missed, %{seed: seed, correct: correct, broken: broken}}
+       end},
+      {:n_u11_2_emptied_required_keys,
+       fn seed ->
+         payload = Gen.meta_payload(:gate_decision, [1]) |> Map.delete(:seed)
+         event = %{family: :meta, type: :gate_decision, payload: payload}
+         correct = Oracle.validate_correct(event)
+         broken = Oracle.validate_empty_required(event)
+
+         case {correct, broken} do
+           {{:error, {:invalid_meta_payload, :gate_decision, missing}}, :ok} ->
+             if :seed in missing,
+               do: :caught,
+               else: {:missed, %{seed: seed, missing: missing}}
+
+           other ->
+             {:missed, %{seed: seed, got: other}}
+         end
+       end},
+      {:n_u11_3_hardcode_trusted,
+       fn seed ->
+         %{records: records, tainted_offsets: tainted} =
+           Gen.tainted_chain(seed, depth: 4)
+
+         correct = Oracle.derive_taint_correct(records)
+         broken = Oracle.derive_taint_hardcode_trusted(records)
+
+         # The red names the offending {meta_id, tainted_ref_id} pair — here the
+         # detectability check: the broken fold disagrees on every tainted meta.
+         disagreements =
+           Enum.filter(tainted, fn off -> broken[off] != correct[off] end)
+
+         if disagreements == tainted and
+              Enum.all?(tainted, &(correct[&1] == :tainted)),
+            do: :caught,
+            else:
+              {:missed,
+               %{seed: seed, disagreements: disagreements, tainted: tainted}}
+       end},
+      {:n_u11_4_scope_check_deleted,
+       fn seed ->
+         event = %{
+           family: :meta,
+           type: :extract,
+           payload: Gen.meta_payload(:extract, [1]),
+           scope: :global
+         }
+
+         correct = Oracle.validate_correct(event)
+         broken = Oracle.validate_no_scope_check(event)
+
+         if correct == {:error, {:scope_violation, :extract}} and broken == :ok,
+           do: :caught,
+           else: {:missed, %{seed: seed, correct: correct, broken: broken}}
+       end},
+      {:n_u11_5_launder_branch,
+       fn seed ->
+         # The generated chain routes taint through a :promote link — the launder
+         # injector upgrades exactly that link, which the no-laundering red catches.
+         %{records: records} = Gen.tainted_chain(seed, depth: 4)
+         correct = Oracle.derive_taint_correct(records)
+         broken = Oracle.derive_taint_launder(records)
+
+         promote_offsets =
+           for r <- records,
+               Oracle.family(r) == :meta,
+               Oracle.type(r) == :promote,
+               do: Oracle.offset(r)
+
+         laundered =
+           Enum.filter(promote_offsets, fn off ->
+             correct[off] == :tainted and broken[off] == :trusted
+           end)
+
+         if promote_offsets != [] and laundered == promote_offsets,
+           do: :caught,
+           else:
+             {:missed,
+              %{seed: seed, promotes: promote_offsets, laundered: laundered}}
+       end},
+      {:n_u11_6_strict_reader_seam,
+       fn seed ->
+         unknown =
+           Gen.rec(1, :meta, :from_the_future_v9, %{refs: []},
+             source: "probe_x"
+           )
+
+         correct = Oracle.decode_correct(unknown)
+         broken = Oracle.decode_strict(unknown)
+
+         case {correct, broken} do
+           {{:ok, _}, {:error, {:unknown_meta_type, :from_the_future_v9}}} ->
+             :caught
+
+           other ->
+             {:missed, %{seed: seed, got: other}}
+         end
+       end},
+      {:n_u11_7_unfiltered_fold,
+       fn seed ->
+         %{records: records, stripped: stripped} = Gen.interleaved(seed)
+         correct = Oracle.loop_projection_correct(records)
+         also_correct = Oracle.loop_projection_correct(stripped)
+         broken = Oracle.loop_projection_unfiltered(records)
+
+         # Fold independence holds for the correct fold and BREAKS for the
+         # unfiltered one (the interleaved journal always contains ≥1 meta).
+         if correct == also_correct and broken != correct,
+           do: :caught,
+           else: {:missed, %{seed: seed, correct: correct, broken: broken}}
+       end},
+      {:n_u11_8_actor_stamping,
+       fn seed ->
+         %{records: records, expected_actors: expected} =
+           Gen.actor_generations(seed)
+
+         # Reader half: inferring :agent from absence disagrees with the
+         # absent-=-system fold rule.
+         broken_reader = Oracle.fold_actors_infer(records)
+         reader_caught? = broken_reader != expected
+
+         # Producer half: module-local stamping makes two records in ONE write
+         # generation disagree — recomputing from the generation context
+         # (the independent oracle) detects the divergence.
+         [first | rest] = records
+         local_stamp = %{"kind" => "human", "id" => "module-local-invention"}
+         mutated = [Map.put(first, "actor", local_stamp) | rest]
+         producer_caught? = Oracle.fold_actors_correct(mutated) != expected
+
+         if reader_caught? and producer_caught?,
+           do: :caught,
+           else:
+             {:missed,
+              %{seed: seed, reader: reader_caught?, producer: producer_caught?}}
+       end},
+      {:n_u11_9_head_wins_precedence,
+       fn seed ->
+         %{records: records, item_offset: off, x: x, z: z} =
+           Gen.fingerprint_precedence(seed)
+
+         correct = Oracle.what_produced_correct(records, off)
+         broken = Oracle.what_produced_head(records, off)
+
+         if correct == z and broken == x and broken != correct,
+           do: :caught,
+           else: {:missed, %{seed: seed, correct: correct, broken: broken}}
+       end},
+      {:n_u11_10_singular_refs,
+       fn seed ->
+         %{event: event, parents: parents} =
+           Gen.speculation_plural(seed, parents: 3)
+
+         correct = Oracle.validate_correct(event)
+         broken = Oracle.validate_singular_refs(event)
+
+         if length(parents) >= 2 and correct == :ok and
+              match?({:error, _}, broken),
+            do: :caught,
+            else: {:missed, %{seed: seed, correct: correct, broken: broken}}
+       end}
+    ]
+  end
+
+  test "every §2.3 dead injector fires and is caught (m1 fired-counters, m2 seed dump)" do
+    seed = Gen.fresh_seed()
+
+    {fired, missed} =
+      Enum.reduce(injectors(), {%{}, []}, fn {name, run}, {fired, missed} ->
+        fired = Map.update(fired, name, 1, &(&1 + 1))
+
+        case run.(seed) do
+          :caught -> {fired, missed}
+          {:missed, info} -> {fired, [{name, info} | missed]}
+        end
+      end)
+
+    assert missed == [],
+           "dead injector(s) NOT caught — the red suite has lost its teeth: " <>
+             "#{inspect(missed, pretty: true)}\nseed=#{seed}"
+
+    dead = for {name, _} <- injectors(), Map.get(fired, name, 0) == 0, do: name
+
+    assert dead == [],
+           "dead injector(s): armed but never fired: #{inspect(dead)}\n" <>
+             "fired counts: #{inspect(fired)}\nseed=#{seed}"
+
+    # All ten §2.3 contours are armed — a control silently dropped from the
+    # table is itself a dead injector.
+    assert map_size(fired) == 10,
+           "expected 10 armed injectors, got #{map_size(fired)}. seed=#{seed}"
+  end
+
+  # ===========================================================================
+  # Generator non-vacuity (meta-invariant m5 — required patterns)
+  # ===========================================================================
+
+  describe "generator non-vacuity (m5)" do
+    test "tainted chains are ≥3 deep, with a trusted sibling chain" do
+      seed = Gen.fresh_seed()
+
+      %{tainted_offsets: tainted, trusted_offsets: trusted, depth: depth} =
+        Gen.tainted_chain(seed)
+
+      assert depth >= 3, "seed=#{seed}"
+      assert length(tainted) >= 2, "chain must have ≥2 meta links. seed=#{seed}"
+      assert trusted != [], "not-all-tainted guard missing. seed=#{seed}"
+    end
+
+    test "interleaved journals always contain both families" do
+      seed = Gen.fresh_seed()
+
+      for s <- seed..(seed + 20) do
+        %{records: records} = Gen.interleaved(s)
+        families = records |> Enum.map(& &1["family"]) |> MapSet.new()
+
+        assert MapSet.equal?(families, MapSet.new(["loop", "meta"])),
+               "seed=#{s}"
+      end
+    end
+
+    test "speculation generator refuses < 2 parents" do
+      seed = Gen.fresh_seed()
+      %{parents: parents} = Gen.speculation_plural(seed, parents: 1)
+
+      assert length(parents) >= 2,
+             "plural-refs red would be vacuous. seed=#{seed}"
+    end
+
+    test "actor generations include an absent-actor (system-by-rule) generation" do
+      seed = Gen.fresh_seed()
+
+      %{records: records, expected_actors: expected} =
+        Gen.actor_generations(seed)
+
+      assert Enum.any?(records, &is_nil(&1["actor"])), "seed=#{seed}"
+
+      assert Enum.any?(expected, fn {_, a} -> a == %{kind: :system} end),
+             "seed=#{seed}"
+    end
+
+    test "fingerprint journals carry three DISTINCT fingerprints (head ≠ turn ≠ item)" do
+      seed = Gen.fresh_seed()
+      %{x: x, y: y, z: z} = Gen.fingerprint_precedence(seed)
+      assert x != y and y != z and x != z, "seed=#{seed}"
+    end
+  end
+
+  # ===========================================================================
+  # Registry freeze — the enabler's type table matches §2.1 exactly
+  # ===========================================================================
+
+  describe "registry freeze (§2.1 meta type table as data)" do
+    test "all twelve v1 types are registered with their frozen required keys" do
+      frozen = %{
+        gate_decision: [:gate, :score, :threshold, :choice, :seed, :refs],
+        extract: [:class, :op, :item, :refs],
+        residual: [:description, :refs],
+        calibrate: [:gate, :observed_score, :quantile, :new_threshold, :refs],
+        verdict: [:family, :drift_score, :advice, :refs],
+        research: [:conclusion, :refs],
+        promote: [:item, :justification, :refs],
+        probe_run: [:probe, :run_id, :status, :charge, :refs],
+        attach: [:from_offset, :history_policy, :surface, :refs],
+        speculation: [:phase, :branch_ref, :outcome, :refs],
+        approval_decided: [:request_ref, :decision, :refs],
+        policy_amended: [:scope, :rule_id, :before, :after, :source, :refs]
+      }
+
+      assert MapSet.new(Registry.type_names()) == MapSet.new(Map.keys(frozen)),
+             "the registry may only GROW — a missing v1 type is a freeze violation"
+
+      for {type, keys} <- frozen do
+        assert Enum.sort(Registry.required_keys(type)) == Enum.sort(keys),
+               "#{type} required-key set drifted from the freeze"
+
+        assert :refs in Registry.required_keys(type),
+               "refs is the uniform annotation key on EVERY meta type"
+      end
+    end
+
+    test "promote is the ONLY :global type" do
+      globals =
+        for t <- Registry.type_names(), Registry.scope(t) == :global, do: t
+
+      assert globals == [:promote]
+    end
+
+    test "the fingerprint exclusion list is exhaustive and seed is INCLUDED" do
+      assert Enum.sort(Raxol.Agent.Fingerprint.excluded_keys()) ==
+               Enum.sort([
+                 :request_id,
+                 :idempotency_key,
+                 :trace_id,
+                 :timestamp,
+                 :ts
+               ])
+
+      refute :seed in Raxol.Agent.Fingerprint.excluded_keys(),
+             "seed is a sampling parameter — replay identity needs it"
+    end
+  end
+
+  # ===========================================================================
+  # Grandfather corpus (P-U11.2 class — pure decode, green today and forever)
+  # ===========================================================================
+
+  describe "grandfather corpus (P-U11.2 — corpus test, not a red)" do
+    test "the grown Event struct defaults ARE the frozen grandfather values" do
+      e = %Event{}
+      assert e.scope == :session
+      assert e.provenance == %{source: :primary, trust: :trusted}
+      assert e.actor == nil
+    end
+
+    test "a v0 event (no scope/provenance/actor keys) builds to the frozen defaults" do
+      # struct/2 over a v0 field set — exactly what a pre-U11 decoder produces.
+      v0_fields = %{
+        v: 0,
+        id: 7,
+        session_id: "s",
+        turn_id: "t",
+        ts: 123,
+        family: :loop,
+        type: :item_completed,
+        tier: :durable,
+        payload: %{item_type: :message, content: "x"}
+      }
+
+      e = struct(Event, v0_fields)
+      assert e.scope == :session
+      assert e.provenance == %{source: :primary, trust: :trusted}
+      assert e.actor == nil
+    end
+
+    test "encode_line carries the grown envelope fields without breaking v0 JSON shape" do
+      line = Contract.encode_line(%Event{type: :turn_started, session_id: "s"})
+
+      decoded =
+        line
+        |> IO.iodata_to_binary()
+        |> String.trim_trailing("\n")
+        |> Jason.decode!()
+
+      # v0 keys all still present (the contract only grows)...
+      for key <- ~w(v id session_id turn_id ts family type tier payload) do
+        assert Map.has_key?(decoded, key), "encode_line lost v0 key #{key}"
+      end
+
+      # ...and the U11 growth is on the wire with the frozen defaults.
+      assert decoded["scope"] == "session"
+
+      assert decoded["provenance"] == %{
+               "source" => "primary",
+               "trust" => "trusted"
+             }
+
+      assert decoded["actor"] == nil
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
@@ -163,9 +163,7 @@ defmodule Raxol.Agent.Red.U11MetaFamilyRedTest do
            seed: seed
          } do
       unknown =
-        Gen.rec(1, :meta, :from_the_future_v9, %{refs: [], note: "later"},
-          source: "probe_x"
-        )
+        Gen.rec(1, :meta, :from_the_future_v9, %{refs: [], note: "later"}, source: "probe_x")
 
       {[readback], _session} = seed_journal!(base, [unknown])
 

--- a/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
@@ -1,0 +1,462 @@
+defmodule Raxol.Agent.Red.U11MetaFamilyRedTest do
+  @moduledoc """
+  U11-R — permanent **failing-first** red suite for the meta event family +
+  provenance/taint contract (FI-5), authored BEFORE `Raxol.Agent.Meta` is
+  implemented. See `docs/proposals/in-flight/harness-freeze-contracts.md` §2 and
+  docs PR #569.
+
+  Every test here pins one frozen contour of §2 against the REAL seam
+  (`Raxol.Agent.Meta` / `Raxol.Agent.Fingerprint`), which returns
+  `:not_implemented` until U11-I lands — so the suite is RED by construction and
+  goes green only when the real algebra is implemented. Each assertion asserts a
+  POSITIVE concrete shape (`== {:error, …}`, `{:ok, %Event{}}`, `== oracle`,
+  `is_binary/1`) so `:not_implemented` can never satisfy it vacuously.
+
+  The independent oracle (`Raxol.Agent.Red.MetaOracle`, meta-invariant m6) supplies
+  every "expected" value; the negative CONTROLS proving each red has teeth live
+  in `u11_meta_controls_test.exs` and run in CI. This module is tagged
+  `:harness_red` and is excluded from every regular run (test_helper).
+
+  Contour map (freeze §2.2/§2.3):
+    producer-strict seam ....... N-U11.1, N-U11.2, N-U11.4, N-U11.10
+    reader-tolerant seam ....... N-U11.6, P-JS6-class tolerance
+    taint algebra .............. P-U11.3, N-U11.3, N-U11.5, OQ-U11.3
+    scope discipline ........... P-U11.4
+    fold independence .......... P-U11.5, N-U11.7
+    actor producer seam ........ P-U11.6, N-U11.8
+    fingerprint precedence ..... P-U11.7, N-U11.9
+    speculation plural refs .... P-U11.8, N-U11.10
+    codec round-trip ........... P-U11.1
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :harness_red
+  @moduletag :capture_log
+
+  alias Raxol.Agent.Contract.Event
+  alias Raxol.Agent.Fingerprint
+  alias Raxol.Agent.Journal.FileStore
+  alias Raxol.Agent.Meta
+  alias Raxol.Agent.Red.MetaJournalGen, as: Gen
+  alias Raxol.Agent.Red.MetaOracle, as: Oracle
+
+  setup do
+    base =
+      Path.join(
+        System.tmp_dir!(),
+        "red_u11_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf(base) end)
+    {:ok, base: base, seed: Gen.fresh_seed()}
+  end
+
+  defp dump(seed), do: "seed=#{seed}"
+
+  # Seed a REAL journal (single Writer, tolerant Reader) from generated records,
+  # letting the Writer stamp offsets, and read it back. Exercises the production
+  # storage path, not a mock. Returns `{readback_records, session_id}`.
+  defp seed_journal!(base, records) do
+    session = "red-#{System.unique_integer([:positive])}"
+    {:ok, j} = FileStore.open(session, base_dir: base)
+
+    for r <- records do
+      appendable = Map.drop(r, ["id", "schema_version"])
+      {:ok, _off} = FileStore.append(j, appendable)
+    end
+
+    {:ok, readback} = FileStore.read(j)
+    :ok = FileStore.close(j)
+    {readback, session}
+  end
+
+  # ===========================================================================
+  # Producer-strict seam (§2.1 decode/validation seam; N-U11.1/2/4/10)
+  # ===========================================================================
+
+  describe "producer-strict seam — validate/1" do
+    test "N-U11.1 — an unregistered meta type is a loud typed reject", %{
+      seed: seed
+    } do
+      event = %{family: :meta, type: :totally_bogus, payload: %{refs: []}}
+
+      assert Meta.validate(event) ==
+               {:error, {:unknown_meta_type, :totally_bogus}},
+             "unregistered meta type must reject at the emit seam. " <>
+               dump(seed)
+    end
+
+    test "N-U11.2 — a missing required payload key is a loud typed reject", %{
+      seed: seed
+    } do
+      # gate_decision requires :seed among others.
+      payload = Gen.meta_payload(:gate_decision, [1]) |> Map.delete(:seed)
+      event = %{family: :meta, type: :gate_decision, payload: payload}
+
+      assert {:error, {:invalid_meta_payload, :gate_decision, missing}} =
+               Meta.validate(event),
+             "missing required key must reject. " <> dump(seed)
+
+      assert :seed in missing
+    end
+
+    test "N-U11.2 — refs is required on EVERY meta type", %{seed: seed} do
+      payload = Gen.meta_payload(:extract, [1]) |> Map.delete(:refs)
+      event = %{family: :meta, type: :extract, payload: payload}
+
+      assert {:error, {:invalid_meta_payload, :extract, missing}} =
+               Meta.validate(event),
+             "refs is the uniform required annotation key. " <> dump(seed)
+
+      assert :refs in missing
+    end
+
+    test "N-U11.4 — promote with refs: [] is provenance-mandatory reject", %{
+      seed: seed
+    } do
+      payload = %{item: %{k: "v"}, justification: "j", refs: []}
+      event = %{family: :meta, type: :promote, payload: payload, scope: :global}
+
+      assert Meta.validate(event) == {:error, :provenance_required},
+             "promote requires refs != []. " <> dump(seed)
+    end
+
+    test "N-U11.4 — scope :global on a non-promote type is a scope violation",
+         %{seed: seed} do
+      event = %{
+        family: :meta,
+        type: :extract,
+        payload: Gen.meta_payload(:extract, [1]),
+        scope: :global
+      }
+
+      assert Meta.validate(event) == {:error, {:scope_violation, :extract}},
+             ":global is legal only on promote. " <> dump(seed)
+    end
+
+    test "N-U11.10 — speculation :begin ACCEPTS ≥2 in-session parent refs", %{
+      seed: seed
+    } do
+      %{event: event, parents: parents} =
+        Gen.speculation_plural(seed, parents: 3)
+
+      assert length(parents) >= 2
+
+      assert Meta.validate(event) == :ok,
+             "plural parents at speculation begin must be legal (not len==1). " <>
+               dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Reader-tolerant seam (§2.1; N-U11.6)
+  # ===========================================================================
+
+  describe "reader-tolerant seam — decode/1 + typed-fold skipping" do
+    test "N-U11.6 — an unknown meta type from a future journal decodes {:ok,_}, preserved",
+         %{
+           base: base,
+           seed: seed
+         } do
+      unknown =
+        Gen.rec(1, :meta, :from_the_future_v9, %{refs: [], note: "later"},
+          source: "probe_x"
+        )
+
+      {[readback], _session} = seed_journal!(base, [unknown])
+
+      # The tolerant Reader itself never damages on an unknown type (precondition).
+      assert readback["type"] == "from_the_future_v9"
+
+      # The decode seam preserves it rather than erroring (the frozen tolerance).
+      assert {:ok, %Event{type: :from_the_future_v9}} = Meta.decode(readback),
+             "unknown meta type must be preserved, never errored, at the reader seam. " <>
+               dump(seed)
+    end
+
+    test "an unknown meta type is SKIPPED by a typed loop fold (not perturbing it)",
+         %{seed: seed} do
+      %{records: records, stripped: stripped} = Gen.interleaved(seed)
+      future = Gen.rec(99, :meta, :unknown_meta_kind, %{refs: []})
+      with_future = records ++ [future]
+
+      expected = Oracle.loop_projection_correct(stripped)
+
+      assert Meta.loop_projection(with_future) == expected,
+             "unknown meta types must be skipped by typed folds. " <> dump(seed)
+    end
+
+    test "grandfather — a v0 record with no scope/provenance/actor decodes to frozen defaults",
+         %{
+           seed: seed
+         } do
+      v0 = %{
+        "id" => 1,
+        "schema_version" => "1.0.0",
+        "kind" => "event",
+        "v" => 0,
+        "session_id" => "s",
+        "turn_id" => nil,
+        "ts" => 1,
+        "family" => "loop",
+        "type" => "item_completed",
+        "tier" => "durable",
+        "payload" => %{"item_type" => "message", "content" => "x"}
+      }
+
+      assert {:ok,
+              %Event{
+                scope: :session,
+                provenance: %{source: :primary, trust: :trusted},
+                actor: nil
+              }} =
+               Meta.decode(v0),
+             "a v0 record must decode to the grandfather defaults. " <>
+               dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Taint algebra — P-U11.3, N-U11.3/5, OQ-U11.3
+  # ===========================================================================
+
+  describe "taint algebra (FI-5)" do
+    test "P-U11.3 — taint monotonicity over a chain ≥3 deep equals the algebra's answer",
+         %{
+           seed: seed
+         } do
+      %{records: records, tainted_offsets: tainted, depth: depth} =
+        Gen.tainted_chain(seed, depth: 4)
+
+      assert depth >= 3 and length(tainted) >= 2,
+             "generator must produce a chain ≥3 deep. " <> dump(seed)
+
+      expected = Oracle.derive_taint_correct(records)
+
+      assert Meta.derive_taint(records) == expected,
+             "every meta event's derived trust must equal the taint algebra. " <>
+               dump(seed)
+
+      # And concretely: the whole tainted chain is tainted (absorption held).
+      for off <- tainted do
+        assert expected[off] == :tainted
+        assert Meta.derive_taint(records)[off] == :tainted, dump(seed)
+      end
+    end
+
+    test "no laundering — derive_taint never upgrades a tainted ref to :trusted",
+         %{seed: seed} do
+      %{records: records} = Gen.tainted_chain(seed, depth: 3)
+      derived = Meta.derive_taint(records)
+
+      # Every meta whose refs reach a tainted record stays tainted.
+      for r <- records, Oracle.family(r) == :meta do
+        oracle = Oracle.derive_taint_correct(records)[Oracle.offset(r)]
+
+        assert Map.get(derived, Oracle.offset(r)) == oracle,
+               "no :tainted→:trusted laundering path exists in v1. " <>
+                 dump(seed)
+      end
+    end
+
+    test "OQ-U11.3 — a hand-crafted taint violation surfaces a marker, replay stays {:ok,_}",
+         %{
+           base: base,
+           seed: seed
+         } do
+      %{records: records, violated_offset: off} = Gen.violated_journal(seed)
+      {readback, session} = seed_journal!(base, records)
+
+      # NEVER damaged, NEVER hard-rejected — replay tolerance of the violated
+      # journal itself is intact (re-open the SAME session and re-read).
+      {:ok, j} = FileStore.open(session, base_dir: base)
+      assert {:ok, reread} = FileStore.read(j)
+      assert length(reread) == length(records)
+      :ok = FileStore.close(j)
+
+      # The violation surfaces ONLY as an observable fold marker.
+      assert [%{offset: ^off, stored: :trusted, derived: :tainted}] =
+               Meta.taint_violations(readback),
+             "a taint violation is an alarm + :taint_violation marker, never damage. " <>
+               dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Scope discipline — P-U11.4
+  # ===========================================================================
+
+  describe "scope discipline (P-U11.4)" do
+    test "a valid journal passes check_scope (:global only on promote, promote refs != [])",
+         %{
+           seed: seed
+         } do
+      records = for %{record: r} <- Gen.one_per_type(seed), do: r
+
+      assert Meta.check_scope(records) == :ok,
+             ":global appears only on promote and every promote has refs != []. " <>
+               dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Fold independence — P-U11.5
+  # ===========================================================================
+
+  describe "two-populations fold independence (P-U11.5)" do
+    test "a loop-only projection over an interleaved journal equals the fold over the stripped one",
+         %{seed: seed} do
+      %{records: interleaved, stripped: stripped} = Gen.interleaved(seed)
+
+      assert Enum.any?(interleaved, &(&1["family"] == "meta")),
+             "generator must interleave meta. " <> dump(seed)
+
+      expected = Oracle.loop_projection_correct(stripped)
+
+      assert Meta.loop_projection(interleaved) == expected,
+             "meta events must never perturb the loop-only fold. " <> dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Actor producer seam — P-U11.6
+  # ===========================================================================
+
+  describe "actor producer-seam consistency (P-U11.6)" do
+    test "every event's actor equals its write-generation actor; absent folds to system",
+         %{
+           seed: seed
+         } do
+      %{records: records, expected_actors: expected} =
+        Gen.actor_generations(seed)
+
+      assert Enum.any?(expected, fn {_, a} -> a == %{kind: :system} end),
+             "generator must include an absent-actor generation. " <> dump(seed)
+
+      assert Meta.fold_actors(records) == expected,
+             "actor is producer-seam stamped; absent = system by rule. " <>
+               dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Fingerprint precedence — P-U11.7 + canonical_json (P-U11.1)
+  # ===========================================================================
+
+  describe "fingerprint precedence + canonical_json (P-U11.7)" do
+    test "what_produced returns the item_completed fingerprint Z, not head X or override Y",
+         %{
+           seed: seed
+         } do
+      %{records: records, item_offset: off, x: x, y: y, z: z} =
+        Gen.fingerprint_precedence(seed)
+
+      assert x != y and y != z and x != z,
+             "generator must make X≠Y≠Z. " <> dump(seed)
+
+      assert Meta.what_produced(records, off) == z,
+             "the item_completed fingerprint wins 'what produced this content'. " <>
+               dump(seed)
+    end
+
+    test "canonical_json is a byte-stable, key-order-independent serialization with seed INCLUDED",
+         %{seed: seed} do
+      params = %{
+        model: "m",
+        temperature: 0.7,
+        seed: 11,
+        top_p: 1.0,
+        request_id: "REQ-ephemeral"
+      }
+
+      shuffled = %{
+        top_p: 1.0,
+        seed: 11,
+        temperature: 0.7,
+        request_id: "OTHER-ephemeral",
+        model: "m"
+      }
+
+      canon = Fingerprint.canonical_json(params)
+
+      assert is_binary(canon),
+             "canonical_json must produce a binary. " <> dump(seed)
+
+      assert canon == Fingerprint.canonical_json(shuffled),
+             "key order + ephemeral keys must not matter. " <> dump(seed)
+
+      assert canon == Oracle.canonical_json_correct(params),
+             "must match the normative serializer. " <> dump(seed)
+
+      # seed is part of replay identity — changing it MUST change the hash input.
+      with_other_seed = %{params | seed: 999}
+      assert is_binary(Fingerprint.canonical_json(with_other_seed))
+
+      refute canon == Fingerprint.canonical_json(with_other_seed),
+             "seed is INCLUDED in the hash. " <> dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Speculation plural refs round-trip — P-U11.8
+  # ===========================================================================
+
+  describe "speculation refs are plural-capable (P-U11.8)" do
+    test "a speculation{:begin} with ≥2 in-session parents round-trips without a singular assumption",
+         %{seed: seed} do
+      %{record: record, parents: parents} =
+        Gen.speculation_plural(seed, parents: 3)
+
+      assert length(parents) >= 2
+
+      assert {:ok, %Event{} = ev} = Meta.decode(record),
+             "speculation record must decode. " <> dump(seed)
+
+      assert ev.payload["refs"] == parents or ev.payload[:refs] == parents,
+             "≥2 parents must survive decode unchanged. " <> dump(seed)
+
+      # And re-encode is byte-stable (no truncation to one parent).
+      assert is_binary(Meta.encode(ev)), dump(seed)
+    end
+  end
+
+  # ===========================================================================
+  # Codec round-trip — P-U11.1
+  # ===========================================================================
+
+  describe "codec round-trip (P-U11.1)" do
+    test "every registry meta type round-trips encode |> decode byte-stable (post-sanitize)",
+         %{
+           seed: seed
+         } do
+      for %{type: type, record: record} <- Gen.one_per_type(seed) do
+        {:ok, event} =
+          case Meta.decode(record) do
+            {:ok, ev} ->
+              {:ok, ev}
+
+            other ->
+              flunk(
+                "decode(#{type}) returned #{inspect(other)} — expected {:ok, _}. " <>
+                  dump(seed)
+              )
+          end
+
+        encoded = Meta.encode(event)
+
+        assert is_binary(encoded),
+               "encode(#{type}) must be a binary. " <> dump(seed)
+
+        assert {:ok, event2} = Meta.decode(decode_json!(encoded)),
+               "re-decode of #{type} must succeed. " <> dump(seed)
+
+        assert Meta.encode(event2) == encoded,
+               "#{type} must be byte-stable across a second round-trip. " <>
+                 dump(seed)
+      end
+    end
+  end
+
+  defp decode_json!(binary) when is_binary(binary), do: Jason.decode!(binary)
+end

--- a/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
@@ -14,8 +14,12 @@ defmodule Raxol.Agent.Red.U11MetaFamilyRedTest do
 
   The independent oracle (`Raxol.Agent.Red.MetaOracle`, meta-invariant m6) supplies
   every "expected" value; the negative CONTROLS proving each red has teeth live
-  in `u11_meta_controls_test.exs` and run in CI. This module is tagged
-  `:harness_red` and is excluded from every regular run (test_helper).
+  in `u11_meta_controls_test.exs` and run in CI.
+
+  U11-I has landed (`Raxol.Agent.Meta` / `Raxol.Agent.Fingerprint`), so this
+  suite now runs GREEN in every regular run — the `:harness_red` exclusion was
+  lifted the day the implementation made every contour pass. The negative
+  controls stay in CI to guarantee the reds keep their teeth.
 
   Contour map (freeze §2.2/§2.3):
     producer-strict seam ....... N-U11.1, N-U11.2, N-U11.4, N-U11.10
@@ -30,7 +34,6 @@ defmodule Raxol.Agent.Red.U11MetaFamilyRedTest do
   """
   use ExUnit.Case, async: true
 
-  @moduletag :harness_red
   @moduletag :capture_log
 
   alias Raxol.Agent.Contract.Event

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -70,6 +70,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
     test "C10 — taint is a FOLD over refs: a :trusted-STAMPED arg over a tainted chain escalates (HIGH-1, FI-5)" do
       assert :ok = Contours.taint_escalates(BlastRadiusGate)
     end
+
+    test "C11 — request_ref is injective + string-canonical: a STRING tool and a ':'-bearing tool/call_id round-trip and rebuild == live (Fix 1)" do
+      assert :ok = Contours.ref_roundtrips_string_and_colon(BlastRadiusGate)
+    end
   end
 
   describe "U8-R predicate contours (@action_surface — F2 Raxol.Action draft not landed)" do
@@ -155,6 +159,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
     test "C10 taint fold over refs (mis-stamped chain escalates; clean chain proceeds)" do
       assert :ok = Contours.taint_escalates(ReferenceGate)
+    end
+
+    test "C11 request_ref injective + string-canonical (string tool, ':'-bearing tool/call_id round-trip)" do
+      assert :ok = Contours.ref_roundtrips_string_and_colon(ReferenceGate)
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -90,6 +90,26 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
     test "C15 — the taint fold fails closed: an unknown-trust leaf and a malformed lineage entry both escalate (Fix 5)" do
       assert :ok = Contours.taint_fold_fails_closed(BlastRadiusGate)
     end
+
+    test "C16 — the approver is authenticated: a non-:human actor's approval_decided never grants, live or on rebuild; a :human's still does (adversarial-review HIGH-1)" do
+      assert :ok = Contours.non_human_approver_never_grants(BlastRadiusGate)
+    end
+
+    test "C17 — deny and grant share ONE request identity: a deny is request-scoped, never blanket-blocking another tool on a shared call_id (adversarial-review HIGH-2)" do
+      assert :ok = Contours.deny_is_request_scoped(BlastRadiusGate)
+    end
+
+    test "C18 — the decision folds degrade fail-closed on corrupt/out-of-domain journal input: no crash, no grant, valid grants survive (adversarial-review MED)" do
+      assert :ok = Contours.corrupt_journal_folds_fail_closed(BlastRadiusGate)
+    end
+
+    test "C19 — the §5.2 predicate fails closed on a call MISSING effect_class/egress instead of raising (adversarial-review LOW)" do
+      assert :ok = Contours.predicate_missing_fields_fail_closed(BlastRadiusGate)
+    end
+
+    test "C20 — a :once grant is bound to the vetted lineage: the same (tool, call_id) re-issued with tainted lineage re-escalates (adversarial-review LOW)" do
+      assert :ok = Contours.once_grant_bound_to_lineage(BlastRadiusGate)
+    end
   end
 
   describe "U8-R predicate contours (§5.2 — runs green in CI)" do
@@ -193,6 +213,26 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
     test "C15 taint fold fails closed on unknown-trust leaf / malformed entry (spec matches production)" do
       assert :ok = Contours.taint_fold_fails_closed(ReferenceGate)
+    end
+
+    test "C16 non-:human approver never grants (live + rebuild); :human still does" do
+      assert :ok = Contours.non_human_approver_never_grants(ReferenceGate)
+    end
+
+    test "C17 deny is request-scoped (one identity with grants), never over-blocks a shared call_id" do
+      assert :ok = Contours.deny_is_request_scoped(ReferenceGate)
+    end
+
+    test "C18 corrupt journal input folds fail-closed (no crash, no grant, valid grants survive)" do
+      assert :ok = Contours.corrupt_journal_folds_fail_closed(ReferenceGate)
+    end
+
+    test "C19 predicate fails closed on missing effect_class/egress (no KeyError on the authorization path)" do
+      assert :ok = Contours.predicate_missing_fields_fail_closed(ReferenceGate)
+    end
+
+    test "C20 once grant bound to vetted lineage (re-tainted re-issue re-escalates)" do
+      assert :ok = Contours.once_grant_bound_to_lineage(ReferenceGate)
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -74,6 +74,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
     test "C11 — request_ref is injective + string-canonical: a STRING tool and a ':'-bearing tool/call_id round-trip and rebuild == live (Fix 1)" do
       assert :ok = Contours.ref_roundtrips_string_and_colon(BlastRadiusGate)
     end
+
+    test "C12 — a :once grant unlocks exactly that request: (tool_a, cid) does not admit (tool_b, cid), and a tainted (tool_b, cid) still escalates (Fix 2)" do
+      assert :ok = Contours.once_grant_is_request_scoped(BlastRadiusGate)
+    end
   end
 
   describe "U8-R predicate contours (@action_surface — F2 Raxol.Action draft not landed)" do
@@ -163,6 +167,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
     test "C11 request_ref injective + string-canonical (string tool, ':'-bearing tool/call_id round-trip)" do
       assert :ok = Contours.ref_roundtrips_string_and_colon(ReferenceGate)
+    end
+
+    test "C12 once grant is request-scoped (tool+call_id), never admits another tool, never bypasses the taint fold" do
+      assert :ok = Contours.once_grant_is_request_scoped(ReferenceGate)
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -1,0 +1,322 @@
+# U8-R — permanent failing-first red suite for BlastRadiusGate + approvals
+# (AD-6b / AD-14), authored against the ratified freeze contracts
+# (docs/proposals/in-flight/harness-freeze-contracts.md §1.1 / §2.1 / §5.2 and
+# harness-yolo-safe-research.md §2/§5/§7) BEFORE any implementation exists.
+#
+# Two modules, one file, by design:
+#
+#   * `U8BlastRadiusRedTest` (@moduletag :harness_red, excluded in
+#     test_helper.exs) — the RED contours, run against the production skeleton
+#     `Raxol.Agent.Authorization.BlastRadiusGate`. They fail today
+#     (:not_implemented) and turn green IN PLACE when U8 lands: flip the
+#     exclusion off, change no assertion.
+#   * `U8BlastRadiusControlsTest` (untagged — runs in CI every push) — proves
+#     the contours have teeth: the correct ReferenceGate passes every contour
+#     (discrimination / non-vacuity), and every dead injector fails its contour
+#     with the exact violation signature (negative controls, meta-inv m4), with
+#     fired-counters over all injector sites (meta-inv m1) and seed-reported
+#     schedules (meta-inv m2).
+
+defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  @moduletag :harness_red
+  @moduletag :capture_log
+
+  # Fixed, reproducible fold-rebuild schedules (meta-inv m2); keep in sync with
+  # the controls module below.
+  @seeds [11, 23, 37, 58, 71]
+
+  alias Raxol.Agent.Authorization.BlastRadiusGate
+  alias Raxol.Agent.Red.U8Gates.Contours
+
+  describe "U8-R positive contours (RED until U8 lands)" do
+    test "C1 — locked by default: a write tool without approval is a typed reject and the side effect never runs" do
+      assert :ok = Contours.locked_by_default(BlastRadiusGate)
+    end
+
+    test "C2 — escalation emits approval_requested as family :loop (frozen F3) and it is the tip when trailing" do
+      assert :ok =
+               Contours.escalation_emits_tip_eligible_request(BlastRadiusGate)
+    end
+
+    test "C3 — approval_decided :approved with refs to the request unlocks exactly that request (scope :once)" do
+      assert :ok = Contours.approve_once_unlocks(BlastRadiusGate)
+    end
+
+    test "C4 — deny is durable: a post-deny retry without a NEW approval cycle never succeeds" do
+      assert :ok = Contours.deny_is_durable(BlastRadiusGate)
+    end
+
+    test "C5 — :session scope persists across calls within the session" do
+      assert :ok = Contours.session_scope_persists(BlastRadiusGate)
+    end
+
+    test "C6 — fold-rebuild: approval state folded from approval_decided events equals live state (replay law)" do
+      for seed <- @seeds do
+        assert :ok = Contours.fold_rebuild_equals_live(BlastRadiusGate, seed),
+               "rebuild diverged from live enforcement under seed #{seed}"
+      end
+    end
+
+    test "C7 — a forged/dangling approval_decided (refs match no live request) is rejected" do
+      assert :ok = Contours.forged_decision_rejected(BlastRadiusGate)
+    end
+
+    test "C10 — taint is a FOLD over refs: a :trusted-STAMPED arg over a tainted chain escalates (HIGH-1, FI-5)" do
+      assert :ok = Contours.taint_escalates(BlastRadiusGate)
+    end
+  end
+
+  describe "U8-R predicate contours (@action_surface — F2 Raxol.Action draft not landed)" do
+    @describetag :action_surface
+
+    test "C8 — escalate iff effect_class == :irreversible_external OR egress == true (§5.2 normative)" do
+      assert :ok = Contours.escalate_predicate(BlastRadiusGate)
+    end
+
+    test "C9 — :reversible_local + no egress + trusted auto-proceeds; a self-reported destructiveHint never gates" do
+      assert :ok = Contours.predicate_ignores_destructive_hint(BlastRadiusGate)
+    end
+  end
+end
+
+defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  @seeds [11, 23, 37, 58, 71]
+
+  alias Raxol.Agent.Red.U8Gates.Contours
+  alias Raxol.Agent.Red.U8Gates.Fired
+  alias Raxol.Agent.Red.U8Gates.ReferenceGate
+
+  alias Raxol.Agent.Red.U8Gates.{
+    AcceptsForgedDecision,
+    EmitsMetaFamily,
+    ExecutesWhilePending,
+    ForgetsDeny,
+    IgnoresTaint,
+    InMemoryOnly,
+    ReadsDestructiveHint,
+    ReadsStampedTrust
+  }
+
+  # ===========================================================================
+  # Discrimination — the correct ReferenceGate passes every contour, proving
+  # the contours are satisfiable (not vacuous) exactly as written.
+  # ===========================================================================
+
+  describe "discrimination — ReferenceGate satisfies every contour" do
+    test "C1 locked by default" do
+      assert :ok = Contours.locked_by_default(ReferenceGate)
+    end
+
+    test "C2 escalation emits tip-eligible approval_requested" do
+      assert :ok = Contours.escalation_emits_tip_eligible_request(ReferenceGate)
+    end
+
+    test "C3 approve :once unlocks exactly that request" do
+      assert :ok = Contours.approve_once_unlocks(ReferenceGate)
+    end
+
+    test "C4 deny is durable" do
+      assert :ok = Contours.deny_is_durable(ReferenceGate)
+    end
+
+    test "C5 session scope persists" do
+      assert :ok = Contours.session_scope_persists(ReferenceGate)
+    end
+
+    test "C6 fold-rebuild equals live (all seeds)" do
+      for seed <- @seeds do
+        assert :ok = Contours.fold_rebuild_equals_live(ReferenceGate, seed),
+               "reference rebuild diverged under seed #{seed}"
+      end
+    end
+
+    test "C7 forged decision rejected" do
+      assert :ok = Contours.forged_decision_rejected(ReferenceGate)
+    end
+
+    test "C8 §5.2 escalate predicate table" do
+      assert :ok = Contours.escalate_predicate(ReferenceGate)
+    end
+
+    test "C9 predicate ignores self-reported destructive_hint" do
+      assert :ok = Contours.predicate_ignores_destructive_hint(ReferenceGate)
+    end
+
+    test "C10 taint fold over refs (mis-stamped chain escalates; clean chain proceeds)" do
+      assert :ok = Contours.taint_escalates(ReferenceGate)
+    end
+  end
+
+  # ===========================================================================
+  # Negative controls — each dead injector fails its contour with the exact
+  # violation signature (branch probes, meta-inv m3 — never just "not :ok").
+  # ===========================================================================
+
+  # {site, injector, contour id, signature-predicate function name}
+  @injector_table [
+    {:executes_while_pending, ExecutesWhilePending, :c1,
+     :sig_executed_while_locked},
+    {:emits_meta_family, EmitsMetaFamily, :c2, :sig_not_loop_family},
+    {:forgets_deny, ForgetsDeny, :c4, :sig_proceeded_after_deny},
+    {:accepts_forged_decision, AcceptsForgedDecision, :c7,
+     :sig_forged_accepted},
+    {:in_memory_only, InMemoryOnly, :c6, :sig_rebuild_diverged},
+    {:reads_destructive_hint_c8, ReadsDestructiveHint, :c8,
+     :sig_predicate_wrong},
+    {:reads_destructive_hint_c9, ReadsDestructiveHint, :c9,
+     :sig_trusted_self_report},
+    {:ignores_taint, IgnoresTaint, :c10, :sig_tainted_auto_proceeded},
+    {:reads_stamped_trust, ReadsStampedTrust, :c10, :sig_mis_stamped_proceeded}
+  ]
+
+  def sig_executed_while_locked({:violation, {:executed_while_locked, n}})
+      when n > 0, do: true
+
+  def sig_executed_while_locked(_), do: false
+
+  def sig_not_loop_family({:violation, {:not_loop_family, :meta}}), do: true
+  def sig_not_loop_family(_), do: false
+
+  def sig_proceeded_after_deny({:violation, {:proceeded_after_deny, _}}),
+    do: true
+
+  def sig_proceeded_after_deny(_), do: false
+
+  def sig_forged_accepted({:violation, :forged_decision_accepted}), do: true
+  def sig_forged_accepted(_), do: false
+
+  def sig_rebuild_diverged({:violation, {:rebuild_diverged, _seed, [_ | _]}}),
+    do: true
+
+  def sig_rebuild_diverged(_), do: false
+
+  def sig_predicate_wrong({:violation, {:predicate_wrong, _, _, _}}), do: true
+  def sig_predicate_wrong(_), do: false
+
+  def sig_trusted_self_report({:violation, {:trusted_self_report, _}}), do: true
+  def sig_trusted_self_report(_), do: false
+
+  # IgnoresTaint fails at the FIRST taint leg (direct tainted arg auto-proceeds).
+  def sig_tainted_auto_proceeded({:violation, :tainted_auto_proceeded}),
+    do: true
+
+  def sig_tainted_auto_proceeded(_), do: false
+
+  # ReadsStampedTrust PASSES the direct leg (the stamp there is honest) and
+  # fails only the fold-only leg — the discrimination between field-read and
+  # fold is exactly this signature difference.
+  def sig_mis_stamped_proceeded({:violation, :mis_stamped_auto_proceeded}),
+    do: true
+
+  def sig_mis_stamped_proceeded(_), do: false
+
+  defp run_contour(:c1, gate), do: Contours.locked_by_default(gate)
+
+  defp run_contour(:c2, gate),
+    do: Contours.escalation_emits_tip_eligible_request(gate)
+
+  defp run_contour(:c4, gate), do: Contours.deny_is_durable(gate)
+
+  defp run_contour(:c6, gate),
+    do: Contours.fold_rebuild_equals_live(gate, hd(@seeds))
+
+  defp run_contour(:c7, gate), do: Contours.forged_decision_rejected(gate)
+  defp run_contour(:c8, gate), do: Contours.escalate_predicate(gate)
+
+  defp run_contour(:c9, gate),
+    do: Contours.predicate_ignores_destructive_hint(gate)
+
+  defp run_contour(:c10, gate), do: Contours.taint_escalates(gate)
+
+  describe "negative controls — every dead injector fails its contour with its signature" do
+    test "(a) a gate that executes while the approval is pending fails C1" do
+      result = run_contour(:c1, ExecutesWhilePending)
+
+      assert sig_executed_while_locked(result),
+             "expected executed-while-locked, got: #{inspect(result)}"
+    end
+
+    test "(F3) a gate emitting approval_requested as family :meta fails C2 (never tip-eligible)" do
+      result = run_contour(:c2, EmitsMetaFamily)
+
+      assert sig_not_loop_family(result),
+             "expected not-loop-family, got: #{inspect(result)}"
+    end
+
+    test "(b) an engine that forgets deny (retry succeeds) fails C4" do
+      result = run_contour(:c4, ForgetsDeny)
+
+      assert sig_proceeded_after_deny(result),
+             "expected proceeded-after-deny, got: #{inspect(result)}"
+    end
+
+    test "(c) a gate accepting an approval_decided without a matching live request fails C7" do
+      result = run_contour(:c7, AcceptsForgedDecision)
+
+      assert sig_forged_accepted(result),
+             "expected forged-accepted, got: #{inspect(result)}"
+    end
+
+    test "(d) in-memory-only approval state (not rebuildable by fold) fails C6 on every seed" do
+      for seed <- @seeds do
+        result = Contours.fold_rebuild_equals_live(InMemoryOnly, seed)
+
+        assert sig_rebuild_diverged(result),
+               "expected rebuild-diverged under seed #{seed}, got: #{inspect(result)}"
+      end
+    end
+
+    test "(e) a gate reading self-reported destructiveHint instead of effect_class fails C8 and C9" do
+      c8 = run_contour(:c8, ReadsDestructiveHint)
+      c9 = run_contour(:c9, ReadsDestructiveHint)
+
+      assert sig_predicate_wrong(c8),
+             "expected predicate-wrong, got: #{inspect(c8)}"
+
+      assert sig_trusted_self_report(c9),
+             "expected trusted-self-report, got: #{inspect(c9)}"
+    end
+
+    test "(FI-5) a gate ignoring lineage taint entirely fails C10 at the direct-taint leg" do
+      result = run_contour(:c10, IgnoresTaint)
+
+      assert sig_tainted_auto_proceeded(result),
+             "expected tainted-auto-proceeded, got: #{inspect(result)}"
+    end
+
+    test "(HIGH-1) a field-reading gate passes the honest stamp but lets the mis-stamped tainted chain through" do
+      result = run_contour(:c10, ReadsStampedTrust)
+
+      assert sig_mis_stamped_proceeded(result),
+             "expected mis-stamped-auto-proceeded (the fold-only leg), got: #{inspect(result)}"
+    end
+  end
+
+  # ===========================================================================
+  # Fired-counters (meta-inv m1): run the whole injector table in one pass;
+  # every site must fire its signature. A dead injector = green lies.
+  # ===========================================================================
+
+  test "m1 — every dead-injector site fires (no dead injectors)" do
+    {:ok, fired} = Fired.start()
+
+    for {site, injector, contour, sig} <- @injector_table do
+      result = run_contour(contour, injector)
+      if apply(__MODULE__, sig, [result]), do: Fired.fire(fired, site)
+    end
+
+    all = MapSet.new(Enum.map(@injector_table, fn {site, _, _, _} -> site end))
+    missing = MapSet.difference(all, Fired.fired(fired))
+
+    assert MapSet.size(missing) == 0,
+           "dead injector site(s) never fired their signature: #{inspect(MapSet.to_list(missing))}"
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -21,7 +21,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
   @moduledoc false
   use ExUnit.Case, async: true
 
-  @moduletag :harness_red
+  # U8-R has GRADUATED: U8 implemented `Raxol.Agent.Authorization.BlastRadiusGate`
+  # (BlastRadiusGate + approvals + decision-time taint fold, AD-6b/AD-14), so the
+  # positive contours now run untagged in CI. The `:action_surface` describe block
+  # below stays tagged until the F2 `Raxol.Action` draft lands.
   @moduletag :capture_log
 
   # Fixed, reproducible fold-rebuild schedules (meta-inv m2); keep in sync with
@@ -162,17 +165,13 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
   # {site, injector, contour id, signature-predicate function name}
   @injector_table [
-    {:executes_while_pending, ExecutesWhilePending, :c1,
-     :sig_executed_while_locked},
+    {:executes_while_pending, ExecutesWhilePending, :c1, :sig_executed_while_locked},
     {:emits_meta_family, EmitsMetaFamily, :c2, :sig_not_loop_family},
     {:forgets_deny, ForgetsDeny, :c4, :sig_proceeded_after_deny},
-    {:accepts_forged_decision, AcceptsForgedDecision, :c7,
-     :sig_forged_accepted},
+    {:accepts_forged_decision, AcceptsForgedDecision, :c7, :sig_forged_accepted},
     {:in_memory_only, InMemoryOnly, :c6, :sig_rebuild_diverged},
-    {:reads_destructive_hint_c8, ReadsDestructiveHint, :c8,
-     :sig_predicate_wrong},
-    {:reads_destructive_hint_c9, ReadsDestructiveHint, :c9,
-     :sig_trusted_self_report},
+    {:reads_destructive_hint_c8, ReadsDestructiveHint, :c8, :sig_predicate_wrong},
+    {:reads_destructive_hint_c9, ReadsDestructiveHint, :c9, :sig_trusted_self_report},
     {:ignores_taint, IgnoresTaint, :c10, :sig_tainted_auto_proceeded},
     {:reads_stamped_trust, ReadsStampedTrust, :c10, :sig_mis_stamped_proceeded}
   ]

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -86,6 +86,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
     test "C14 — the §5.2 predicate fails closed: an unknown effect_class and a non-boolean egress both escalate (Fix 4)" do
       assert :ok = Contours.escalate_predicate_fails_closed(BlastRadiusGate)
     end
+
+    test "C15 — the taint fold fails closed: an unknown-trust leaf and a malformed lineage entry both escalate (Fix 5)" do
+      assert :ok = Contours.taint_fold_fails_closed(BlastRadiusGate)
+    end
   end
 
   describe "U8-R predicate contours (@action_surface — F2 Raxol.Action draft not landed)" do
@@ -187,6 +191,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
     test "C14 §5.2 predicate fails closed on unknown effect_class / non-boolean egress" do
       assert :ok = Contours.escalate_predicate_fails_closed(ReferenceGate)
+    end
+
+    test "C15 taint fold fails closed on unknown-trust leaf / malformed entry (spec matches production)" do
+      assert :ok = Contours.taint_fold_fails_closed(ReferenceGate)
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -5,11 +5,10 @@
 #
 # Two modules, one file, by design:
 #
-#   * `U8BlastRadiusRedTest` (@moduletag :harness_red, excluded in
-#     test_helper.exs) — the RED contours, run against the production skeleton
-#     `Raxol.Agent.Authorization.BlastRadiusGate`. They fail today
-#     (:not_implemented) and turn green IN PLACE when U8 lands: flip the
-#     exclusion off, change no assertion.
+#   * `U8BlastRadiusRedTest` (GRADUATED — carries only `@moduletag :capture_log`,
+#     runs untagged in CI) — the contours, run against the now-implemented
+#     `Raxol.Agent.Authorization.BlastRadiusGate`. They were authored RED and
+#     turned green IN PLACE when U8 landed; no assertion changed.
 #   * `U8BlastRadiusControlsTest` (untagged — runs in CI every push) — proves
 #     the contours have teeth: the correct ReferenceGate passes every contour
 #     (discrimination / non-vacuity), and every dead injector fails its contour
@@ -22,9 +21,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
   use ExUnit.Case, async: true
 
   # U8-R has GRADUATED: U8 implemented `Raxol.Agent.Authorization.BlastRadiusGate`
-  # (BlastRadiusGate + approvals + decision-time taint fold, AD-6b/AD-14), so the
-  # positive contours now run untagged in CI. The `:action_surface` describe block
-  # below stays tagged until the F2 `Raxol.Action` draft lands.
+  # (BlastRadiusGate + approvals + decision-time taint fold, AD-6b/AD-14), so all
+  # contours — including the §5.2 predicate table (C8/C9) — now run untagged and
+  # GREEN in CI. The predicate reads a structural `effect_class` field supplied
+  # directly by the call map, so it needs no F2 `Raxol.Action` draft to exercise.
   @moduletag :capture_log
 
   # Fixed, reproducible fold-rebuild schedules (meta-inv m2); keep in sync with
@@ -92,9 +92,7 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
     end
   end
 
-  describe "U8-R predicate contours (@action_surface — F2 Raxol.Action draft not landed)" do
-    @describetag :action_surface
-
+  describe "U8-R predicate contours (§5.2 — runs green in CI)" do
     test "C8 — escalate iff effect_class == :irreversible_external OR egress == true (§5.2 normative)" do
       assert :ok = Contours.escalate_predicate(BlastRadiusGate)
     end

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -82,6 +82,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
     test "C13 — a consumed :once grant is reconstructed as consumed: rebuild does not resurrect a spent grant (Fix 3)" do
       assert :ok = Contours.once_consumption_survives_rebuild(BlastRadiusGate)
     end
+
+    test "C14 — the §5.2 predicate fails closed: an unknown effect_class and a non-boolean egress both escalate (Fix 4)" do
+      assert :ok = Contours.escalate_predicate_fails_closed(BlastRadiusGate)
+    end
   end
 
   describe "U8-R predicate contours (@action_surface — F2 Raxol.Action draft not landed)" do
@@ -179,6 +183,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
     test "C13 consumed once grant reconstructed as consumed (rebuild == post-consumption live)" do
       assert :ok = Contours.once_consumption_survives_rebuild(ReferenceGate)
+    end
+
+    test "C14 §5.2 predicate fails closed on unknown effect_class / non-boolean egress" do
+      assert :ok = Contours.escalate_predicate_fails_closed(ReferenceGate)
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -78,6 +78,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusRedTest do
     test "C12 — a :once grant unlocks exactly that request: (tool_a, cid) does not admit (tool_b, cid), and a tainted (tool_b, cid) still escalates (Fix 2)" do
       assert :ok = Contours.once_grant_is_request_scoped(BlastRadiusGate)
     end
+
+    test "C13 — a consumed :once grant is reconstructed as consumed: rebuild does not resurrect a spent grant (Fix 3)" do
+      assert :ok = Contours.once_consumption_survives_rebuild(BlastRadiusGate)
+    end
   end
 
   describe "U8-R predicate contours (@action_surface — F2 Raxol.Action draft not landed)" do
@@ -171,6 +175,10 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
     test "C12 once grant is request-scoped (tool+call_id), never admits another tool, never bypasses the taint fold" do
       assert :ok = Contours.once_grant_is_request_scoped(ReferenceGate)
+    end
+
+    test "C13 consumed once grant reconstructed as consumed (rebuild == post-consumption live)" do
+      assert :ok = Contours.once_consumption_survives_rebuild(ReferenceGate)
     end
   end
 

--- a/packages/raxol_agent/test/test_helper.exs
+++ b/packages/raxol_agent/test/test_helper.exs
@@ -17,7 +17,25 @@ end
 # (not test/support/, which elixirc_paths compiles) — load it explicitly.
 Code.require_file("invariants/support/fault_journal.ex", __DIR__)
 
+# Red-suite support (reference gates, dead injectors, shared contours) lives
+# under test/raxol/agent/red/support/ — load it explicitly, same mechanic.
+Code.require_file("raxol/agent/red/support/u8_gates.ex", __DIR__)
+
 # :pending_unit — Tier 2 invariant skeletons, visible in the suite but inert
 # until their units (U4–U9) land. :mutation — negative-control checklists
-# (meta-invariant m4), run on demand, never in regular CI.
-ExUnit.start(exclude: [:slow, :integration, :docker, :pending_unit, :mutation])
+# (meta-invariant m4), run on demand, never in regular CI. :harness_red —
+# permanent failing-first red suites (test/raxol/agent/red/) authored BEFORE
+# their units against the freeze contracts; excluded until each unit lands,
+# then its reds flip green in place. Their negative controls are untagged and
+# run every CI push. :action_surface — reds depending on the not-yet-landed F2
+# Raxol.Action draft (already under :harness_red; the tag is a marker).
+ExUnit.start(
+  exclude: [
+    :slow,
+    :integration,
+    :docker,
+    :pending_unit,
+    :mutation,
+    :harness_red
+  ]
+)

--- a/packages/raxol_agent/test/test_helper.exs
+++ b/packages/raxol_agent/test/test_helper.exs
@@ -49,8 +49,10 @@ end
 # `Raxol.Agent.Fingerprint`, so it now runs untagged in CI; the tag is kept in
 # the exclude list for the next failing-first red. The negative CONTROLS for the
 # same contours are NOT tagged :harness_red — they run in CI to prove each red
-# has teeth (meta-invariant m4). :action_surface — reds depending on the
-# not-yet-landed F2 Raxol.Action draft (already under :harness_red; a marker).
+# has teeth (meta-invariant m4). (The former `:action_surface` marker on U8-R's
+# §5.2 predicate block was retired: that predicate reads a structural
+# `effect_class` supplied by the call map, needs no F2 `Raxol.Action` draft to
+# exercise, and runs green — so the block is untagged, not deferred.)
 ExUnit.start(
   exclude: [
     :slow,

--- a/packages/raxol_agent/test/test_helper.exs
+++ b/packages/raxol_agent/test/test_helper.exs
@@ -38,11 +38,13 @@ end
 # (meta-invariant m4), run on demand, never in regular CI.
 #
 # :harness_red — permanent failing-first red suites authored BEFORE their
-# implementation lands (here: U11-R meta family + provenance/taint). Excluded
-# from every regular run so CI stays GREEN while the contract is pinned; the
-# suite goes green as its unit (U11-I) implements `Raxol.Agent.Meta`. The
-# negative CONTROLS for the same contours are NOT tagged :harness_red — they run
-# in CI to prove each red has teeth (meta-invariant m4).
+# implementation lands. Excluded from every regular run so CI stays GREEN while
+# the contract is pinned; a suite loses the tag (and joins CI green) the day its
+# unit implements it. U11-R (meta family + provenance/taint) has graduated —
+# U11-I implemented `Raxol.Agent.Meta` / `Raxol.Agent.Fingerprint`, so the suite
+# now runs untagged in CI; the tag is kept in the exclude list for the next
+# failing-first red. The negative CONTROLS for the same contours are NOT tagged
+# :harness_red — they run in CI to prove each red has teeth (meta-invariant m4).
 ExUnit.start(
   exclude: [
     :slow,

--- a/packages/raxol_agent/test/test_helper.exs
+++ b/packages/raxol_agent/test/test_helper.exs
@@ -17,7 +17,39 @@ end
 # (not test/support/, which elixirc_paths compiles) — load it explicitly.
 Code.require_file("invariants/support/fault_journal.ex", __DIR__)
 
+# The U11-R red suite's oracle + generators live under test/raxol/agent/red/
+# support (also outside elixirc_paths) — load them explicitly. Guard against a
+# concurrent red PR having already required them.
+for f <- [
+      "raxol/agent/red/support/meta_oracle.ex",
+      "raxol/agent/red/support/meta_journal_gen.ex"
+    ] do
+  mod =
+    case f do
+      "raxol/agent/red/support/meta_oracle.ex" -> Raxol.Agent.Red.MetaOracle
+      _ -> Raxol.Agent.Red.MetaJournalGen
+    end
+
+  unless Code.ensure_loaded?(mod), do: Code.require_file(f, __DIR__)
+end
+
 # :pending_unit — Tier 2 invariant skeletons, visible in the suite but inert
 # until their units (U4–U9) land. :mutation — negative-control checklists
 # (meta-invariant m4), run on demand, never in regular CI.
-ExUnit.start(exclude: [:slow, :integration, :docker, :pending_unit, :mutation])
+#
+# :harness_red — permanent failing-first red suites authored BEFORE their
+# implementation lands (here: U11-R meta family + provenance/taint). Excluded
+# from every regular run so CI stays GREEN while the contract is pinned; the
+# suite goes green as its unit (U11-I) implements `Raxol.Agent.Meta`. The
+# negative CONTROLS for the same contours are NOT tagged :harness_red — they run
+# in CI to prove each red has teeth (meta-invariant m4).
+ExUnit.start(
+  exclude: [
+    :slow,
+    :integration,
+    :docker,
+    :pending_unit,
+    :mutation,
+    :harness_red
+  ]
+)


### PR DESCRIPTION
## Status: complete unit

Red suite (the spec, below) **+ implementation + adversarial review rounds** — reds now run **green in CI** (`:harness_red` tag dropped). Original red-suite description preserved below as the authored spec.

---

Part of the red-first fan-out authored against docs PR #569.

## What U8 is

Write/destructive tools are **LOCKED by default**. Unlocking requires an approval flow: the BlastRadiusGate evaluates each call (`effect_class` + `egress` + taint), escalating calls emit `approval_requested` (**family `:loop`** — frozen F3, so a resumed conversation lands on the pending approval via the tip predicate), a decision arrives as an `approval_decided` meta event (`%{request_ref, decision, refs}`, actor from the **envelope only**), and only then does the call proceed. Deny is durable (ReviewDecision semantics, AD-14): after a deny, the same request is never retried into success without a NEW approval cycle. Scopes `:once`/`:session`/`:root` mirror `Authorization.Policy`.

This PR is the **permanent failing-first red suite** for that unit, authored BEFORE implementation against the ratified freeze (`harness-freeze-contracts.md` §1.1/§2.1/§5.2, `harness-yolo-safe-research.md` §2/§5/§7). Enabler commit adds the `Raxol.Agent.Authorization.BlastRadiusGate` behaviour skeleton (`:not_implemented`); red commit adds the suite. When U8 lands, the reds flip green **in place** — no assertion changes.

## Contours

| # | Contour |
|---|---|
| C1 | Locked by default: write tool without approval → typed reject; stub counter proves no execution |
| C2 | `approval_requested` emitted `family :loop` + `request_ref`; independent `conversational?`/tip oracle selects it as tip over a trailing checkpoint + meta record (Dormammu-lite, FI-12) |
| C3 | `approval_decided :approved` with refs to the request unlocks exactly that request (scope `:once`) |
| C4 | Deny is durable: post-deny bare retry never succeeds |
| C5 | `:session` scope persists across calls within the session |
| C6 | Fold-rebuild: approval state folded over `approval_decided` events authorizes probes identically to live state (§2.1 replay/resume law) — behavioral equality, 5 fixed seeds |
| C7 | Forged/dangling `approval_decided` (refs match no live request) rejected |
| C8 | `@tag :action_surface` — §5.2 predicate: escalate iff `:irreversible_external` OR `egress` |
| C9 | `@tag :action_surface` — `:reversible_local` + no egress + trusted auto-proceeds; self-reported `destructiveHint` never gates (N-Y5) |
| C10 | **Taint is a FOLD over refs (HIGH-1)**: a `:trusted`-STAMPED arg whose ref chain reaches a tainted record escalates; direct taint escalates despite a benign class (FI-5); clean chain auto-proceeds |

## Dead injectors (negative controls — run in CI)

Each fails its contour with an exact violation signature (m3 branch probes), with a fired-counter pass over all sites (m1) and seed-reported schedules (m2):

- **(a)** `ExecutesWhilePending` — runs the side effect while the approval is pending → fails C1
- **(b)** `ForgetsDeny` — a denied decision grants like an approve → fails C4
- **(c)** `AcceptsForgedDecision` — enacts a decision with no matching live request → fails C7
- **(d)** `InMemoryOnly` — approval state not rebuildable by fold → fails C6 on every seed
- **(e)** `ReadsDestructiveHint` — gates on the self-reported hint instead of `effect_class` → fails C8 + C9
- `ReadsStampedTrust` (**HIGH-1**) — reads the stamped trust field of the direct arg: passes the honest direct-taint leg, fails ONLY the fold-only mis-stamped leg of C10 (the signature difference is the field-read/fold discrimination)
- `IgnoresTaint` — no taint check at all → fails C10 at the direct-taint leg
- `EmitsMetaFamily` — emits `approval_requested` as `family :meta` → fails C2 (F3 is a frozen decision)

`ReferenceGate` (test support) is the executable spec: discrimination tests prove every contour is satisfiable exactly as written.

## Mergeability discipline

- `@moduletag :harness_red` on the RED module; `:harness_red` added to `test_helper.exs` exclusions — CI stays GREEN
- Negative controls + discrimination live in an untagged companion module in the same file — they run every push
- `@tag :action_surface` marks C8/C9 (depend on the not-yet-landed F2 `Raxol.Action` draft)
- Verified: `MIX_ENV=test mix compile --warnings-as-errors` clean; package suite 1039 passed / 0 failed (reds excluded); with `--include harness_red` exactly the 10 reds fail on `:not_implemented`

🤖 Generated with [Claude Code](https://claude.com/claude-code)