### PR TITLE
Harness UI: printed-history append path (seal-once, immutable-prefix keystone) [T2b]

### DIFF
--- a/lib/raxol/ui/rendering/paint_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority.ex
@@ -96,6 +96,19 @@ defmodule Raxol.UI.Rendering.PaintAuthority do
                bottom >= top do
       "\e[#{top};#{bottom}r"
     end
+
+    @doc """
+    Cursor Position (CUP), 1-based row, column pinned to `1`: `CSI row;1H`.
+    The single byte-builder for "position at the start of history row
+    `row`" -- callers that used to hand-roll `"\\e[\#{row};1H"` (T2b's
+    `InlineAuthority.append_sealed/2`) route through this instead, so the
+    wire format is defined once and pinned by test rather than duplicated
+    per call site.
+    """
+    @spec cursor_position(pos_integer()) :: binary()
+    def cursor_position(row) when is_integer(row) and row >= 1 do
+      "\e[#{row};1H"
+    end
   end
 
   defmodule IOAuthority do

--- a/lib/raxol/ui/rendering/paint_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority.ex
@@ -100,10 +100,10 @@ defmodule Raxol.UI.Rendering.PaintAuthority do
     @doc """
     Cursor Position (CUP), 1-based row, column pinned to `1`: `CSI row;1H`.
     The single byte-builder for "position at the start of history row
-    `row`" -- callers that used to hand-roll `"\\e[\#{row};1H"` (T2b's
-    `InlineAuthority.append_sealed/2`) route through this instead, so the
-    wire format is defined once and pinned by test rather than duplicated
-    per call site.
+    `row`" -- callers that used to hand-roll `"\\e[\#{row};1H"` (the append
+    path's `InlineAuthority.append_sealed/2`) route through this instead,
+    so the wire format is defined once and pinned by test rather than
+    duplicated per call site.
     """
     @spec cursor_position(pos_integer()) :: binary()
     def cursor_position(row) when is_integer(row) and row >= 1 do

--- a/lib/raxol/ui/rendering/paint_authority/content_guard.ex
+++ b/lib/raxol/ui/rendering/paint_authority/content_guard.ex
@@ -1,0 +1,165 @@
+defmodule Raxol.UI.Rendering.PaintAuthority.ContentGuard do
+  @moduledoc """
+  Neutralizes control bytes inside agent/LLM-originated content before it
+  reaches `PaintAuthority.InlineAuthority.seal/2` (T2b review fix, HIGH:
+  "our code was wrong" -- `seal/2`/`append_sealed/2` wrote iodata
+  verbatim, so an embedded `\\e[2J`/`\\e[3J`/CUP inside model output could
+  wipe native scrollback or repaint an already-sealed row FROM INSIDE THE
+  CONTENT, defeating every invariant the append path exists to hold, no
+  matter how correct the fill-down/seal-once machinery around it is).
+
+  This module is intentionally SHARED, not private to T2b:
+  `Raxol.UI.Rendering.PaintAuthority.InlineAuthority.seal/2` is its first
+  caller, and T2c's footer/pinned-viewport repaint path (also fed
+  agent-controlled text) is expected to reuse it rather than growing a
+  second, divergent sanitizer.
+
+  ## The allowlist grammar
+
+  Scanning byte-by-byte (UTF-8 multi-byte sequences pass through as
+  opaque bytes -- nothing here decodes or re-encodes text, it only ever
+  recognizes ASCII control structure):
+
+    * **Printable ASCII** (`0x20..0x7E`) and any byte `>= 0x80`
+      (UTF-8 lead/continuation bytes) -- passed through unchanged.
+    * **`\\t`, `\\r`, `\\n`** -- passed through unchanged (the C0 controls a
+      line of legitimate content actually needs).
+    * **SGR (`CSI ... m`)** -- e.g. `\\e[1;31m`, `\\e[0m` -- passed through
+      VERBATIM. This is the renderer's own styling vocabulary; content
+      that legitimately carries color/style resets must keep working.
+    * **Every other C0 control byte** (`0x00..0x1F` except the three
+      above) and **DEL** (`0x7F`) -- stripped silently. These carry no
+      printable residue worth preserving.
+    * **Any other ESC (`0x1B`)-led sequence** -- a non-SGR CSI (cursor
+      moves, erases, ...), OSC (`\\e]...`), DCS (`\\eP...`), or a bare/
+      truncated ESC with no recognized introducer at all -- has ONLY its
+      leading ESC byte stripped. Scanning resumes immediately after that
+      ESC, so whatever printable bytes followed it (the `[2J` in
+      `\\e[2J`, the `]0;title` in an OSC, etc.) are re-scanned as ordinary
+      text and, being printable, survive into the output.
+
+  ## "Visible-honest" neutralization, not silent deletion
+
+  A `\\e[2J` with its ESC stripped becomes the literal, visible text
+  `[2J` -- four printable characters a terminal just prints, doing
+  nothing else. That is the deliberate choice this module makes over
+  silently deleting the whole sequence: a visible `[2J` fragment in the
+  sealed history is an honest record that content tried to inject a
+  control sequence and got stopped, whereas an invisible drop would look,
+  to anyone watching the terminal, exactly like the model simply never
+  said anything unusual. Any C0 control byte embedded in what would have
+  been that sequence's parameters (e.g. a stray BEL terminating an OSC)
+  IS silently dropped, per the point above -- there is no printable
+  residue for a non-printable control byte to leave behind.
+
+  ## Scope note: OSC 8 hyperlinks
+
+  `OSC 8 ; params ; URI ST text OSC 8 ; ; ST` (terminal hyperlinks) is
+  currently neutralized like any other OSC -- the `\\e]8;...` introducer's
+  ESC is stripped, leaving the URI parameters as visible residue text
+  rather than a clickable link. Allowlisting OSC 8 specifically (parsing
+  its structure enough to keep the link semantics while still rejecting
+  every other OSC subcommand) is deliberately deferred; tracked as
+  backlog, not implemented here.
+  """
+
+  @typedoc false
+  @type acc :: iolist()
+
+  @doc """
+  Sanitizes `iodata` per the allowlist grammar above, returning a binary.
+  Safe to call on a whole multi-line sealed block (not just a single
+  line) -- `\\r`/`\\n` inside are always allowed through, so line
+  boundaries are preserved exactly.
+  """
+  @spec sanitize_line(iodata()) :: binary()
+  def sanitize_line(iodata) do
+    iodata
+    |> IO.iodata_to_binary()
+    |> scan([])
+  end
+
+  # -- ESC handling -------------------------------------------------------
+
+  # `\e[` -- attempt to match a complete CSI sequence. Only one whose
+  # final byte is `m` (SGR) is legitimate and kept verbatim; anything
+  # else falls through to the generic "strip just the ESC" rule below by
+  # re-scanning from the `[` as ordinary bytes.
+  defp scan(<<0x1B, ?[, rest::binary>>, acc) do
+    case match_sgr(rest) do
+      {:ok, sequence, remainder} ->
+        scan(remainder, [sequence | acc])
+
+      :error ->
+        scan(<<?[, rest::binary>>, acc)
+    end
+  end
+
+  # Any other ESC-led byte (OSC `\e]`, DCS `\eP`, or a bare/unrecognized
+  # ESC, including one truncated at the end of input) -- strip only the
+  # ESC byte itself and resume scanning from whatever follows as ordinary
+  # bytes. OSC/DCS terminators (a BEL, or a further ESC for the `ST`
+  # 2-byte terminator) are handled for free by this same rule and the C0
+  # rule below on the next pass -- no separate OSC/DCS parser is needed.
+  defp scan(<<0x1B, rest::binary>>, acc) do
+    scan(rest, acc)
+  end
+
+  # A bare, unterminated ESC at the very end of the input -- nothing
+  # follows to strip alongside it, so the loop's base case below already
+  # handles this: `<<0x1B>>` matches the clause above with `rest == <<>>`.
+
+  # `\t`, `\r`, `\n` -- always passed through.
+  defp scan(<<c, rest::binary>>, acc) when c in [?\t, ?\r, ?\n] do
+    scan(rest, [<<c>> | acc])
+  end
+
+  # Every other C0 control byte, and DEL -- stripped, no residue.
+  defp scan(<<c, rest::binary>>, acc) when c < 0x20 or c == 0x7F do
+    scan(rest, acc)
+  end
+
+  # Printable ASCII and UTF-8 lead/continuation bytes -- pass through.
+  defp scan(<<c, rest::binary>>, acc) do
+    scan(rest, [<<c>> | acc])
+  end
+
+  defp scan(<<>>, acc) do
+    acc |> Enum.reverse() |> IO.iodata_to_binary()
+  end
+
+  # -- CSI/SGR matching ----------------------------------------------------
+
+  # CSI grammar (ECMA-48): parameter bytes `0x30..0x3F`, then intermediate
+  # bytes `0x20..0x2F`, then exactly one final byte `0x40..0x7E`. Only a
+  # final byte of `?m` is accepted here (SGR); every other final byte, or
+  # no final byte at all (truncated at end of input), is `:error` --
+  # callers strip just the leading ESC and let the parameter/intermediate
+  # bytes fall through as ordinary printable text.
+  defp match_sgr(bin), do: match_params(bin, [])
+
+  defp match_params(<<c, rest::binary>>, params) when c in 0x30..0x3F do
+    match_params(rest, [c | params])
+  end
+
+  defp match_params(bin, params), do: match_intermediates(bin, params, [])
+
+  defp match_intermediates(<<c, rest::binary>>, params, inter)
+       when c in 0x20..0x2F do
+    match_intermediates(rest, params, [c | inter])
+  end
+
+  defp match_intermediates(<<?m, rest::binary>>, params, inter) do
+    sequence =
+      IO.iodata_to_binary([
+        <<0x1B, ?[>>,
+        Enum.reverse(params),
+        Enum.reverse(inter),
+        <<?m>>
+      ])
+
+    {:ok, sequence, rest}
+  end
+
+  defp match_intermediates(_bin, _params, _inter), do: :error
+end

--- a/lib/raxol/ui/rendering/paint_authority/content_guard.ex
+++ b/lib/raxol/ui/rendering/paint_authority/content_guard.ex
@@ -1,16 +1,16 @@
 defmodule Raxol.UI.Rendering.PaintAuthority.ContentGuard do
   @moduledoc """
   Neutralizes control bytes inside agent/LLM-originated content before it
-  reaches `PaintAuthority.InlineAuthority.seal/2` (T2b review fix, HIGH:
-  "our code was wrong" -- `seal/2`/`append_sealed/2` wrote iodata
-  verbatim, so an embedded `\\e[2J`/`\\e[3J`/CUP inside model output could
-  wipe native scrollback or repaint an already-sealed row FROM INSIDE THE
-  CONTENT, defeating every invariant the append path exists to hold, no
-  matter how correct the fill-down/seal-once machinery around it is).
+  reaches `PaintAuthority.InlineAuthority.seal/2` -- `seal/2`/
+  `append_sealed/2` previously wrote iodata verbatim, so an embedded
+  `\\e[2J`/`\\e[3J`/CUP inside model output could wipe native scrollback
+  or repaint an already-sealed row FROM INSIDE THE CONTENT, defeating
+  every invariant the append path exists to hold, no matter how correct
+  the fill-down/seal-once machinery around it is.
 
-  This module is intentionally SHARED, not private to T2b:
+  This module is intentionally SHARED, not private to the append path:
   `Raxol.UI.Rendering.PaintAuthority.InlineAuthority.seal/2` is its first
-  caller, and T2c's footer/pinned-viewport repaint path (also fed
+  caller, and the footer viewport's pinned-viewport repaint path (also fed
   agent-controlled text) is expected to reuse it rather than growing a
   second, divergent sanitizer.
 

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -1,23 +1,21 @@
 defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   @moduledoc """
-  T2b's real (production) `PaintAuthority` implementation: the printed-
-  history append path (`docs/proposals/in-flight/harness-ui-roadmap.md`
-  T2b; suite design `harness-ui-testing/02-renderer.md`).
+  The real (production) `PaintAuthority` implementation: the printed-
+  history append path.
 
-  This is the module the roadmap means by "the existing `IOAuthority` is
-  deliberately NOT a full T2b implementation... T2b owns filling this in
-  for real" — it composes:
+  This is the module that fills in what `IOAuthority` deliberately leaves
+  as a stub — it composes:
 
-    * **T2a's `Raxol.Terminal.ScrollRegionManager`** for the DECSTBM
+    * **`Raxol.Terminal.ScrollRegionManager`** for the DECSTBM
       region/footer split (`history_bottom/1`, `resize/2` re-set the region
       exactly once, never a full clear).
-    * **T2d's device seam** — the output sink is a parameter
-      (`IO.device()`), the same `:device` T2a and `InlineDriver` already
-      thread through, so a `StringIO` pid (or `ExUnit.CaptureIO`) captures
-      bytes with no pty in tests and `:stdio` writes for real in
-      production.
+    * **The inline driver's device seam** — the output sink is a parameter
+      (`IO.device()`), the same `:device` the scroll-region manager and
+      `InlineDriver` already thread through, so a `StringIO` pid (or
+      `ExUnit.CaptureIO`) captures bytes with no pty in tests and
+      `:stdio` writes for real in production.
     * **The shared `Dialect` wire vocabulary** (`cursor_save/0`,
-      `cursor_restore/0`) the TB byte-capture oracle
+      `cursor_restore/0`) the byte-capture oracle
       (`Raxol.Harness.Test.SealOracle`) already parses.
 
   ## Seal-once, by construction: fill down, then scroll
@@ -41,13 +39,11 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   that always targets the bottom row from the first append onward front-
   loads the combined `scrollback ++ on-screen` history with content-free
   filler rows ahead of any real content, which defeats the high-water
-  prefix check silently — a bug that existed and was caught by
-  observation during this module's development; fill-down-then-scroll is
-  the fix, and it is load-bearing, not a style preference.
+  prefix check silently; fill-down-then-scroll avoids this, and it is
+  load-bearing, not a style preference.
 
-  The committed fail-first RED test
-  (`test/property/renderer_adversarial_property_test.exs`, "RED:
-  repainting an already-sealed row...") is a separate thing: an ORACLE-
+  The test in `test/property/renderer_adversarial_property_test.exs`
+  ("repainting an already-sealed row...") is a separate thing: an ORACLE-
   VALIDITY guard that hand-injects a known-bad stream (a row-1 repaint —
   a different, also-invalid violation class) to prove `SealOracle`
   catches a real immutable-prefix violation instead of rubber-stamping
@@ -57,15 +53,15 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   ## The cursor-ownership protocol
 
-  Per the roadmap: "one owner module, both paths go through it." This
-  module's `with_cursor/3` is that owner — the SOLE place a save/restore
+  One owner module, both paths go through it. This module's
+  `with_cursor/3` is that owner — the SOLE place a save/restore
   bracket is opened. `append_sealed/2` itself never saves or restores; it
   only positions+writes. The full protocol (save -> position -> emit ->
   restore) is `seal/2`, the composition of the two:
 
       seal(t, iodata) == with_cursor(t, :history, fn s -> append_sealed(s, iodata) end)
 
-  Callers (T2b's own driver, and T2c's footer path for its OWN
+  Callers (the append path's own driver, and the footer viewport's own
   positioning) should go through `with_cursor/3` for anything that moves
   the cursor, so saves and restores from the two emit vocabularies never
   interleave (a save inside another save's bracket silently clobbers the
@@ -75,33 +71,33 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   ## `\\e[2J` is never emitted
 
   Neither this module nor `Raxol.Terminal.ScrollRegionManager` (which owns
-  the DECSTBM re-set on `resize/3`) ever writes `\\e[2J`/`\\e[3J`. Per N06
-  (RB's real-hardware measurement, roadmap §0): a full-screen clear wipes
-  native scrollback on wezterm/kitty, which would destroy history that,
-  once sealed, exists only as terminal-owned pixels this process can no
+  the DECSTBM re-set on `resize/3`) ever writes `\\e[2J`/`\\e[3J`:
+  real-hardware measurement showed a full-screen clear wipes native
+  scrollback on wezterm/kitty, which would destroy history that, once
+  sealed, exists only as terminal-owned pixels this process can no
   longer reconstruct.
 
-  ## D-PA scope: ships (A), wires the (B)-detection seam
+  ## Resize scope: ships seal-time-only, wires the reflow-aware detection seam
 
-  Per the roadmap §0 RULING, this module ships D-PA = **(A) seal-time-
-  only**: `resize/3` NEVER re-emits previously-sealed content — the only
-  byte it writes on resize is `ScrollRegionManager`'s single DECSTBM
-  re-set (content already on-screen is left exactly as it is; a shrinking
-  region merely clamps where FUTURE appends resume, per `next_row`'s
-  resize clamp below). `reflow_capable?/1` is the **(B)-detection SEAM**:
-  a pure predicate over a terminal identity, reporting whether RB's real-
-  hardware C-4 probe measured THIS terminal to reflow sealed scrollback
-  cleanly on resize (today: iTerm2 only — wezterm/kitty were measured NOT
-  to; ghostty is unmeasurable and conservatively `false`). `resize/3`
-  consults it (alongside `ScrollRegionManager.geometry_changed?/2`, T2a's
+  This module ships **seal-time-only**: `resize/3` NEVER re-emits
+  previously-sealed content — the only byte it writes on resize is
+  `ScrollRegionManager`'s single DECSTBM re-set (content already on-screen
+  is left exactly as it is; a shrinking region merely clamps where
+  FUTURE appends resume, per `next_row`'s resize clamp below).
+  `reflow_capable?/1` is the **reflow-aware detection SEAM**: a pure
+  predicate over a terminal identity, reporting whether the
+  terminal-matrix probe measured THIS terminal to reflow sealed
+  scrollback cleanly on resize (today: iTerm2 only — wezterm/kitty were
+  measured NOT to; ghostty is unmeasurable and conservatively `false`).
+  `resize/3` consults it (alongside `ScrollRegionManager.geometry_changed?/2`'s
   thin "did the split point actually move" fact) purely to emit a
   `:telemetry` event when both hold — **no bytes are re-emitted**. A
   FUTURE unit reads that telemetry (or calls `reflow_capable?/1` directly)
   to gate bounded soft-owned-history re-emission. Wiring the hook here,
-  without acting on it, is the whole point: "(B) is a runtime-detected
-  additive upgrade... DEFER (B) re-emission" (roadmap ruling). Contract-
-  only-grows: this module never has to be rewritten to add (B) later,
-  only extended.
+  without acting on it, is the whole point: reflow-aware re-emission is a
+  runtime-detected additive upgrade, deferred for a future unit to
+  implement. Contract-only-grows: this module never has to be rewritten
+  to add reflow-aware re-emission later, only extended.
   """
 
   @behaviour Raxol.UI.Rendering.PaintAuthority
@@ -129,10 +125,11 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
         }
 
   @doc """
-  Builds a new authority: sets the DECSTBM region via T2a's
+  Builds a new authority: sets the DECSTBM region via
   `ScrollRegionManager.start/3` (one write, `CSI 1;(H-N) r`), records
-  whether this session's terminal is on the (B)-detection allowlist, and
-  starts the fill-down cursor (`next_row`) at the region's first row.
+  whether this session's terminal is on the reflow-aware detection
+  allowlist, and starts the fill-down cursor (`next_row`) at the
+  region's first row.
 
   ## Options
 
@@ -174,16 +171,16 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   end
 
   @doc """
-  The (B)-detection SEAM (thin — does not implement (B), see moduledoc).
-  `true` only for terminal identities RB's real-hardware C-4 probe
-  confirmed reflow sealed history cleanly on resize
-  (`docs/proposals/in-flight/harness-ui-roadmap.md` §0: "C-4 resize:
-  iTerm2 REFLOWS sealed history cleanly... Only iTerm2 was resize-
-  testable"). Every other identity — including `nil`/unmeasured
-  (ghostty), and the two terminals RB measured NOT to reflow (wezterm,
-  kitty) — is conservatively `false`. The D-PA RULING is A-default,
-  B-where-EARNED: "earned" means measured on real hardware, never
-  assumed from a `$TERM_PROGRAM` guess.
+  The reflow-aware detection SEAM (thin — does not implement
+  reflow-aware re-emission itself, see moduledoc). `true` only for
+  terminal identities the terminal-matrix probe confirmed reflow sealed
+  history cleanly on resize (iTerm2 reflows sealed history cleanly on
+  resize; it was the only terminal resize-testable on real hardware).
+  Every other identity — including `nil`/unmeasured (ghostty), and the
+  two terminals measured NOT to reflow (wezterm, kitty) — is
+  conservatively `false`. Support defaults to seal-time-only and only
+  turns on where reflow-aware behavior is earned: "earned" means
+  measured on real hardware, never assumed from a `$TERM_PROGRAM` guess.
   """
   @spec reflow_capable?(Capabilities.t() | nil) :: boolean()
   def reflow_capable?(%Capabilities{identity: {"iTerm2", _version}}), do: true
@@ -192,8 +189,9 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   @doc """
   The full cursor-ownership protocol for one sealed append: save the
   cursor, position into the history region (via `append_sealed/2`), emit
-  `iodata`, restore. This is the entry point T2b's caller (and later
-  units building on this substrate) should use — `append_sealed/2` alone
+  `iodata`, restore. This is the entry point the append path's caller
+  (and later units building on this substrate) should use —
+  `append_sealed/2` alone
   only positions+emits; `seal/2` is what makes that a single, save/
   restore-bracketed operation.
 
@@ -259,11 +257,12 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   @impl true
   def repaint_footer(%__MODULE__{region: region} = t, iodata) do
-    # Placeholder pass-through pending T2c (pinned viewport): T2b's scope
-    # is the append path + the shared cursor protocol seam, not the
-    # footer's own positioning/diff discipline. Mirrors
-    # `PaintAuthority.IOAuthority`'s minimal stub so the behaviour is
-    # satisfied without reaching into T2c's work.
+    # Placeholder pass-through pending the footer viewport (pinned
+    # viewport): this module's scope is the append path + the shared
+    # cursor protocol seam, not the footer's own positioning/diff
+    # discipline. Mirrors `PaintAuthority.IOAuthority`'s minimal stub so
+    # the behaviour is satisfied without reaching into the footer
+    # viewport's work.
     IO.write(region.device, iodata)
     t
   end
@@ -320,12 +319,13 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
     if ScrollRegionManager.geometry_changed?(old_region, new_region) and
          t.reflow_capable? do
-      # The (B)-detection seam firing: this session's terminal is known,
-      # from RB's real-hardware C-4 probe, to reflow sealed history
-      # cleanly on a geometry-changing resize. NOTHING is re-emitted here
-      # — re-emission is a FUTURE unit's job (D-PA RULING: ship (A), (B)
-      # is a runtime-detected ADDITIVE upgrade). This telemetry event is
-      # the thin hook that unit gates on.
+      # The reflow-aware detection seam firing: this session's terminal
+      # is known, from the terminal-matrix probe, to reflow sealed
+      # history cleanly on a geometry-changing resize. NOTHING is
+      # re-emitted here — re-emission is a FUTURE unit's job (ship
+      # seal-time-only now; reflow-aware re-emission is a
+      # runtime-detected ADDITIVE upgrade). This telemetry event is the
+      # thin hook that unit gates on.
       :telemetry.execute(
         [:raxol, :ui, :paint_authority, :reflow_capable_resize],
         %{},
@@ -340,7 +340,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       t
       | region: new_region,
         width: width,
-        # Existing on-screen content is untouched (D-PA (A): no
+        # Existing on-screen content is untouched (seal-time-only: no
         # re-emission) — only where FUTURE appends resume is clamped to
         # the (possibly smaller) new bottom row.
         next_row: min(next_row, ScrollRegionManager.history_bottom(new_region))

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -9,7 +9,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   for real" — it composes:
 
     * **T2a's `Raxol.Terminal.ScrollRegionManager`** for the DECSTBM
-      region/footer split (`region_top/1`, `resize/2` re-set the region
+      region/footer split (`history_bottom/1`, `resize/2` re-set the region
       exactly once, never a full clear).
     * **T2d's device seam** — the output sink is a parameter
       (`IO.device()`), the same `:device` T2a and `InlineDriver` already
@@ -27,10 +27,10 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   cursor last was, only falling back to scroll-at-the-boundary once the
   bottom row is reached. This module models that explicitly with a
   `next_row` cursor tracked in its own state: `append_sealed/2` positions
-  at `min(next_row, region_top)` (the next unfilled history row, clamped
+  at `min(next_row, history_bottom)` (the next unfilled history row, clamped
   to the region's bottom once full), writes, and advances `next_row` by
   the number of lines written (also clamped). Once `next_row` reaches
-  `region_top`, every subsequent append targets that same bottom row and
+  `history_bottom`, every subsequent append targets that same bottom row and
   relies on the terminal's own index-at-region-boundary semantics to
   scroll — the row is never re-addressed with different content, only
   ever pushed one row closer to eviction into scrollback.
@@ -53,7 +53,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   catches a real immutable-prefix violation instead of rubber-stamping
   every input. It does not reproduce, and was never meant to reproduce,
   the filler bug described above. There is no code path in this module
-  that CUPs to any row other than `min(next_row, region_top)`.
+  that CUPs to any row other than `min(next_row, history_bottom)`.
 
   ## The cursor-ownership protocol
 
@@ -108,16 +108,24 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   alias Raxol.Terminal.Capabilities
   alias Raxol.Terminal.ScrollRegionManager
+  alias Raxol.UI.Rendering.PaintAuthority.ContentGuard
   alias Raxol.UI.Rendering.PaintAuthority.Dialect
 
   @enforce_keys [:region, :width, :reflow_capable?, :next_row]
-  defstruct [:region, :width, :reflow_capable?, :next_row]
+  defstruct [
+    :region,
+    :width,
+    :reflow_capable?,
+    :next_row,
+    in_cursor_bracket: false
+  ]
 
   @type t :: %__MODULE__{
           region: ScrollRegionManager.t(),
           width: pos_integer(),
           reflow_capable?: boolean(),
-          next_row: pos_integer()
+          next_row: pos_integer(),
+          in_cursor_bracket: boolean()
         }
 
   @doc """
@@ -193,16 +201,46 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   `Raxol.Harness.Test.SealOracle.assert_seal_newline_terminated/1`'s
   discipline) — a dangling partial line would leave the emulator's
   reported column mid-row, and would under-count `next_row`'s advance
-  against what the terminal actually did.
+  against what the terminal actually did. This is now an ENFORCED
+  precondition, not just prose: `seal/2` raises `ArgumentError` when
+  `iodata` does not end in `\\r\\n`.
+
+  ## Content is not trusted (`ContentGuard`)
+
+  `iodata` is agent/LLM-originated content, not renderer-generated
+  bytes — it can carry ANYTHING a language model chooses to emit,
+  including control sequences that would otherwise defeat every
+  invariant this module exists to hold from the INSIDE (a `\\e[2J`
+  wipes native scrollback same as if this module had written it
+  itself; a `\\e[1;1H` repaints an already-sealed row same as any other
+  bug class this module's fill-down design defends against). Before
+  the newline check and before `append_sealed/2` ever sees the bytes,
+  `seal/2` runs `iodata` through
+  `Raxol.UI.Rendering.PaintAuthority.ContentGuard.sanitize_line/1`,
+  which allowlists printable text, the shared SGR vocabulary, and
+  `\\t`/`\\r`/`\\n`, neutralizing everything else. See that module's
+  moduledoc for the exact grammar and the "visible-honest" neutralization
+  rationale.
   """
   @spec seal(t(), iodata()) :: t()
   def seal(%__MODULE__{} = t, iodata) do
-    with_cursor(t, :history, fn inner -> append_sealed(inner, iodata) end)
+    binary = IO.iodata_to_binary(iodata)
+
+    unless String.ends_with?(binary, "\r\n") do
+      raise ArgumentError,
+            "PaintAuthority.InlineAuthority.seal/2 requires \\r\\n-terminated " <>
+              "iodata (a sealed block must be a whole number of lines); got " <>
+              inspect(binary)
+    end
+
+    sanitized = ContentGuard.sanitize_line(binary)
+
+    with_cursor(t, :history, fn inner -> append_sealed(inner, sanitized) end)
   end
 
   @impl true
   def append_sealed(%__MODULE__{region: region, next_row: next_row} = t, iodata) do
-    bottom = ScrollRegionManager.region_top(region)
+    bottom = ScrollRegionManager.history_bottom(region)
     device = region.device
     target_row = min(next_row, bottom)
 
@@ -212,7 +250,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     # scrolls up (oldest history row evicted toward scrollback), the
     # cursor stays on that same bottom row. No other code path in this
     # module ever addresses any other row.
-    IO.write(device, cup(target_row))
+    IO.write(device, Dialect.cursor_position(target_row))
     IO.write(device, iodata)
 
     lines_written = count_lines(iodata)
@@ -237,6 +275,17 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   end
 
   @impl true
+  def with_cursor(%__MODULE__{in_cursor_bracket: true}, cursor_region, fun)
+      when cursor_region in [:history, :footer] and is_function(fun, 1) do
+    raise "PaintAuthority.InlineAuthority.with_cursor/3 called while a " <>
+            "save/restore bracket is already open -- the single hardware " <>
+            "DECSC register has exactly one slot, so a nested save would " <>
+            "silently clobber the outer bracket's saved position before " <>
+            "its own restore runs. Route the nested operation through the " <>
+            "SAME bracket instead of opening a second one (see the " <>
+            "moduledoc's cursor-ownership protocol section)."
+  end
+
   def with_cursor(%__MODULE__{region: region} = t, cursor_region, fun)
       when cursor_region in [:history, :footer] and is_function(fun, 1) do
     device = region.device
@@ -249,8 +298,16 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     # bracket that violates the sole-owner guarantee for every caller
     # after this one. `after` runs on both normal return and unwind; the
     # exception itself is never swallowed, only the restore is guaranteed.
+    #
+    # `in_cursor_bracket: true` is set on the state passed INTO `fun` (not
+    # on `t` itself) so a nested `with_cursor/3` call reached from inside
+    # `fun` hits the guard clause above instead of opening a second
+    # bracket. The flag is cleared again on the way out (whatever `fun`
+    # returned) so the NEXT top-level `with_cursor/3` call on this
+    # authority is not permanently locked out.
     try do
-      fun.(t)
+      result = fun.(%{t | in_cursor_bracket: true})
+      %{result | in_cursor_bracket: false}
     after
       IO.write(device, Dialect.cursor_restore())
     end
@@ -273,8 +330,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
         [:raxol, :ui, :paint_authority, :reflow_capable_resize],
         %{},
         %{
-          old_region_top: old_region.region_top,
-          new_region_top: new_region.region_top
+          old_region_top: ScrollRegionManager.history_bottom(old_region),
+          new_region_top: ScrollRegionManager.history_bottom(new_region)
         }
       )
     end
@@ -286,15 +343,13 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
         # Existing on-screen content is untouched (D-PA (A): no
         # re-emission) — only where FUTURE appends resume is clamped to
         # the (possibly smaller) new bottom row.
-        next_row: min(next_row, new_region.region_top)
+        next_row: min(next_row, ScrollRegionManager.history_bottom(new_region))
     }
   end
 
   @impl true
   def region_top(%__MODULE__{region: region}),
-    do: ScrollRegionManager.region_top(region)
-
-  defp cup(row), do: "\e[#{row};1H"
+    do: ScrollRegionManager.history_bottom(region)
 
   defp count_lines(iodata) do
     iodata

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -1,0 +1,305 @@
+defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
+  @moduledoc """
+  T2b's real (production) `PaintAuthority` implementation: the printed-
+  history append path (`docs/proposals/in-flight/harness-ui-roadmap.md`
+  T2b; suite design `harness-ui-testing/02-renderer.md`).
+
+  This is the module the roadmap means by "the existing `IOAuthority` is
+  deliberately NOT a full T2b implementation... T2b owns filling this in
+  for real" — it composes:
+
+    * **T2a's `Raxol.Terminal.ScrollRegionManager`** for the DECSTBM
+      region/footer split (`region_top/1`, `resize/2` re-set the region
+      exactly once, never a full clear).
+    * **T2d's device seam** — the output sink is a parameter
+      (`IO.device()`), the same `:device` T2a and `InlineDriver` already
+      thread through, so a `StringIO` pid (or `ExUnit.CaptureIO`) captures
+      bytes with no pty in tests and `:stdio` writes for real in
+      production.
+    * **The shared `Dialect` wire vocabulary** (`cursor_save/0`,
+      `cursor_restore/0`) the TB byte-capture oracle
+      (`Raxol.Harness.Test.SealOracle`) already parses.
+
+  ## Seal-once, by construction: fill down, then scroll
+
+  A fresh history region is empty capacity, not yet "full" — real
+  terminal output naturally advances line by line from wherever the
+  cursor last was, only falling back to scroll-at-the-boundary once the
+  bottom row is reached. This module models that explicitly with a
+  `next_row` cursor tracked in its own state: `append_sealed/2` positions
+  at `min(next_row, region_top)` (the next unfilled history row, clamped
+  to the region's bottom once full), writes, and advances `next_row` by
+  the number of lines written (also clamped). Once `next_row` reaches
+  `region_top`, every subsequent append targets that same bottom row and
+  relies on the terminal's own index-at-region-boundary semantics to
+  scroll — the row is never re-addressed with different content, only
+  ever pushed one row closer to eviction into scrollback.
+
+  This isn't a style choice: it is what makes the seal-once invariant
+  (`Raxol.Harness.Test.SealOracle.immutable_prefix?/2`, `history/3`'s
+  emit-derived high-water accounting) actually hold. An implementation
+  that always targets the bottom row from the first append onward front-
+  loads the combined `scrollback ++ on-screen` history with content-free
+  filler rows ahead of any real content, which defeats the high-water
+  prefix check silently — a bug that existed and was caught by
+  observation during this module's development; fill-down-then-scroll is
+  the fix, and it is load-bearing, not a style preference.
+
+  The committed fail-first RED test
+  (`test/property/renderer_adversarial_property_test.exs`, "RED:
+  repainting an already-sealed row...") is a separate thing: an ORACLE-
+  VALIDITY guard that hand-injects a known-bad stream (a row-1 repaint —
+  a different, also-invalid violation class) to prove `SealOracle`
+  catches a real immutable-prefix violation instead of rubber-stamping
+  every input. It does not reproduce, and was never meant to reproduce,
+  the filler bug described above. There is no code path in this module
+  that CUPs to any row other than `min(next_row, region_top)`.
+
+  ## The cursor-ownership protocol
+
+  Per the roadmap: "one owner module, both paths go through it." This
+  module's `with_cursor/3` is that owner — the SOLE place a save/restore
+  bracket is opened. `append_sealed/2` itself never saves or restores; it
+  only positions+writes. The full protocol (save -> position -> emit ->
+  restore) is `seal/2`, the composition of the two:
+
+      seal(t, iodata) == with_cursor(t, :history, fn s -> append_sealed(s, iodata) end)
+
+  Callers (T2b's own driver, and T2c's footer path for its OWN
+  positioning) should go through `with_cursor/3` for anything that moves
+  the cursor, so saves and restores from the two emit vocabularies never
+  interleave (a save inside another save's bracket silently clobbers the
+  single hardware DECSC register — see `SealOracle.save_restore_balance/1`
+  and its `_max_depth` field).
+
+  ## `\\e[2J` is never emitted
+
+  Neither this module nor `Raxol.Terminal.ScrollRegionManager` (which owns
+  the DECSTBM re-set on `resize/3`) ever writes `\\e[2J`/`\\e[3J`. Per N06
+  (RB's real-hardware measurement, roadmap §0): a full-screen clear wipes
+  native scrollback on wezterm/kitty, which would destroy history that,
+  once sealed, exists only as terminal-owned pixels this process can no
+  longer reconstruct.
+
+  ## D-PA scope: ships (A), wires the (B)-detection seam
+
+  Per the roadmap §0 RULING, this module ships D-PA = **(A) seal-time-
+  only**: `resize/3` NEVER re-emits previously-sealed content — the only
+  byte it writes on resize is `ScrollRegionManager`'s single DECSTBM
+  re-set (content already on-screen is left exactly as it is; a shrinking
+  region merely clamps where FUTURE appends resume, per `next_row`'s
+  resize clamp below). `reflow_capable?/1` is the **(B)-detection SEAM**:
+  a pure predicate over a terminal identity, reporting whether RB's real-
+  hardware C-4 probe measured THIS terminal to reflow sealed scrollback
+  cleanly on resize (today: iTerm2 only — wezterm/kitty were measured NOT
+  to; ghostty is unmeasurable and conservatively `false`). `resize/3`
+  consults it (alongside `ScrollRegionManager.geometry_changed?/2`, T2a's
+  thin "did the split point actually move" fact) purely to emit a
+  `:telemetry` event when both hold — **no bytes are re-emitted**. A
+  FUTURE unit reads that telemetry (or calls `reflow_capable?/1` directly)
+  to gate bounded soft-owned-history re-emission. Wiring the hook here,
+  without acting on it, is the whole point: "(B) is a runtime-detected
+  additive upgrade... DEFER (B) re-emission" (roadmap ruling). Contract-
+  only-grows: this module never has to be rewritten to add (B) later,
+  only extended.
+  """
+
+  @behaviour Raxol.UI.Rendering.PaintAuthority
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.ScrollRegionManager
+  alias Raxol.UI.Rendering.PaintAuthority.Dialect
+
+  @enforce_keys [:region, :width, :reflow_capable?, :next_row]
+  defstruct [:region, :width, :reflow_capable?, :next_row]
+
+  @type t :: %__MODULE__{
+          region: ScrollRegionManager.t(),
+          width: pos_integer(),
+          reflow_capable?: boolean(),
+          next_row: pos_integer()
+        }
+
+  @doc """
+  Builds a new authority: sets the DECSTBM region via T2a's
+  `ScrollRegionManager.start/3` (one write, `CSI 1;(H-N) r`), records
+  whether this session's terminal is on the (B)-detection allowlist, and
+  starts the fill-down cursor (`next_row`) at the region's first row.
+
+  ## Options
+
+    * `:capabilities` — a `%Raxol.Terminal.Capabilities{}` (or `nil`) used
+      by `reflow_capable?/1`. Defaults to the cached session record
+      (`Raxol.Terminal.Capabilities.cached/0`) if present, else `nil`.
+      Tests should pass this explicitly rather than relying on the
+      process-global `:persistent_term` cache.
+  """
+  @spec new(
+          IO.device(),
+          pos_integer(),
+          pos_integer(),
+          non_neg_integer(),
+          keyword()
+        ) ::
+          t()
+  def new(device, width, rows, footer_rows, opts \\ [])
+      when is_integer(width) and width > 0 do
+    caps =
+      case Keyword.fetch(opts, :capabilities) do
+        {:ok, caps} -> caps
+        :error -> cached_caps()
+      end
+
+    %__MODULE__{
+      region: ScrollRegionManager.start(device, rows, footer_rows),
+      width: width,
+      reflow_capable?: reflow_capable?(caps),
+      next_row: 1
+    }
+  end
+
+  defp cached_caps do
+    case Capabilities.cached() do
+      {:ok, caps} -> caps
+      :error -> nil
+    end
+  end
+
+  @doc """
+  The (B)-detection SEAM (thin — does not implement (B), see moduledoc).
+  `true` only for terminal identities RB's real-hardware C-4 probe
+  confirmed reflow sealed history cleanly on resize
+  (`docs/proposals/in-flight/harness-ui-roadmap.md` §0: "C-4 resize:
+  iTerm2 REFLOWS sealed history cleanly... Only iTerm2 was resize-
+  testable"). Every other identity — including `nil`/unmeasured
+  (ghostty), and the two terminals RB measured NOT to reflow (wezterm,
+  kitty) — is conservatively `false`. The D-PA RULING is A-default,
+  B-where-EARNED: "earned" means measured on real hardware, never
+  assumed from a `$TERM_PROGRAM` guess.
+  """
+  @spec reflow_capable?(Capabilities.t() | nil) :: boolean()
+  def reflow_capable?(%Capabilities{identity: {"iTerm2", _version}}), do: true
+  def reflow_capable?(_caps), do: false
+
+  @doc """
+  The full cursor-ownership protocol for one sealed append: save the
+  cursor, position into the history region (via `append_sealed/2`), emit
+  `iodata`, restore. This is the entry point T2b's caller (and later
+  units building on this substrate) should use — `append_sealed/2` alone
+  only positions+emits; `seal/2` is what makes that a single, save/
+  restore-bracketed operation.
+
+  `iodata` MUST be a whole number of `\\r\\n`-terminated lines (mirrors
+  `Raxol.Harness.Test.SealOracle.assert_seal_newline_terminated/1`'s
+  discipline) — a dangling partial line would leave the emulator's
+  reported column mid-row, and would under-count `next_row`'s advance
+  against what the terminal actually did.
+  """
+  @spec seal(t(), iodata()) :: t()
+  def seal(%__MODULE__{} = t, iodata) do
+    with_cursor(t, :history, fn inner -> append_sealed(inner, iodata) end)
+  end
+
+  @impl true
+  def append_sealed(%__MODULE__{region: region, next_row: next_row} = t, iodata) do
+    bottom = ScrollRegionManager.region_top(region)
+    device = region.device
+    target_row = min(next_row, bottom)
+
+    # One CUP to the next unfilled history row (or the bottom row, once
+    # full) then the content. Every `\r\n` inside `iodata` that lands ON
+    # the bottom row is an index-at-region-boundary: the DECSTBM region
+    # scrolls up (oldest history row evicted toward scrollback), the
+    # cursor stays on that same bottom row. No other code path in this
+    # module ever addresses any other row.
+    IO.write(device, cup(target_row))
+    IO.write(device, iodata)
+
+    lines_written = count_lines(iodata)
+    %{t | next_row: min(target_row + lines_written, bottom)}
+  end
+
+  @impl true
+  def repaint_footer(%__MODULE__{region: region} = t, iodata) do
+    # Placeholder pass-through pending T2c (pinned viewport): T2b's scope
+    # is the append path + the shared cursor protocol seam, not the
+    # footer's own positioning/diff discipline. Mirrors
+    # `PaintAuthority.IOAuthority`'s minimal stub so the behaviour is
+    # satisfied without reaching into T2c's work.
+    IO.write(region.device, iodata)
+    t
+  end
+
+  @impl true
+  def keyframe_footer(%__MODULE__{region: region} = t, iodata) do
+    IO.write(region.device, iodata)
+    t
+  end
+
+  @impl true
+  def with_cursor(%__MODULE__{region: region} = t, cursor_region, fun)
+      when cursor_region in [:history, :footer] and is_function(fun, 1) do
+    device = region.device
+    IO.write(device, Dialect.cursor_save())
+
+    # `with_cursor/3` is the SOLE owner of the `\e7`/`\e8` save/restore
+    # pair (moduledoc, "the cursor-ownership protocol"). The restore MUST
+    # run even if `fun` raises, or the single hardware DECSC register is
+    # left holding a save with no matching restore -- an unbalanced
+    # bracket that violates the sole-owner guarantee for every caller
+    # after this one. `after` runs on both normal return and unwind; the
+    # exception itself is never swallowed, only the restore is guaranteed.
+    try do
+      fun.(t)
+    after
+      IO.write(device, Dialect.cursor_restore())
+    end
+  end
+
+  @impl true
+  def resize(%__MODULE__{region: region, next_row: next_row} = t, width, height) do
+    old_region = region
+    new_region = ScrollRegionManager.resize(region, height)
+
+    if ScrollRegionManager.geometry_changed?(old_region, new_region) and
+         t.reflow_capable? do
+      # The (B)-detection seam firing: this session's terminal is known,
+      # from RB's real-hardware C-4 probe, to reflow sealed history
+      # cleanly on a geometry-changing resize. NOTHING is re-emitted here
+      # — re-emission is a FUTURE unit's job (D-PA RULING: ship (A), (B)
+      # is a runtime-detected ADDITIVE upgrade). This telemetry event is
+      # the thin hook that unit gates on.
+      :telemetry.execute(
+        [:raxol, :ui, :paint_authority, :reflow_capable_resize],
+        %{},
+        %{
+          old_region_top: old_region.region_top,
+          new_region_top: new_region.region_top
+        }
+      )
+    end
+
+    %{
+      t
+      | region: new_region,
+        width: width,
+        # Existing on-screen content is untouched (D-PA (A): no
+        # re-emission) — only where FUTURE appends resume is clamped to
+        # the (possibly smaller) new bottom row.
+        next_row: min(next_row, new_region.region_top)
+    }
+  end
+
+  @impl true
+  def region_top(%__MODULE__{region: region}),
+    do: ScrollRegionManager.region_top(region)
+
+  defp cup(row), do: "\e[#{row};1H"
+
+  defp count_lines(iodata) do
+    iodata
+    |> IO.iodata_to_binary()
+    |> :binary.matches("\n")
+    |> length()
+  end
+end

--- a/test/property/renderer_adversarial_property_test.exs
+++ b/test/property/renderer_adversarial_property_test.exs
@@ -1,16 +1,15 @@
 defmodule Raxol.Property.RendererAdversarialTest do
   @moduledoc """
-  T2b's negative suite: the printed-history append path
-  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2b), scoped subset of
-  `harness-ui-testing/02-renderer.md` §5 relevant to the append path
-  specifically (R-N4, R-N5-style fail-first) plus the (B)-detection seam
-  the D-PA ruling asks T2b to wire (roadmap §0).
+  The append path's negative suite: the printed-history append path,
+  covering full-grid-path clear-on-resize regression characterization,
+  fail-first checks on the immutable-prefix oracle, and the reflow-aware
+  detection seam.
 
   Each test here either (a) characterizes a regression class the real,
   full-grid path exhibits and proves the new inline path is exempt from
-  it (R-N4), or (b) demonstrates the TB oracle CATCHES a deliberately
+  it, or (b) demonstrates the byte-capture oracle CATCHES a deliberately
   wrong stream before trusting any of the positive suite's green results
-  (the fail-first discipline `tb_oracle_test.exs`'s R-P12 established,
+  (the same fail-first discipline `tb_oracle_test.exs` established,
   applied here to `InlineAuthority` itself rather than a hand-written
   byte string).
   """
@@ -41,11 +40,11 @@ defmodule Raxol.Property.RendererAdversarialTest do
   end
 
   # ---------------------------------------------------------------------
-  # R-N4: today's full-grid path clears on width change; the inline
+  # Today's full-grid path clears on width change; the inline
   # append path is exempt by construction.
   # ---------------------------------------------------------------------
 
-  describe "R-N4: full-grid \\e[2J-on-resize characterization vs the inline path's exemption" do
+  describe "full-grid \\e[2J-on-resize characterization vs the inline path's exemption" do
     test "characterization: Backends.build_terminal_frame/4 emits \\e[2J on a width change (today's known regression class)" do
       prev = ScreenBuffer.new(80, 24)
       next = ScreenBuffer.new(120, 24)
@@ -76,7 +75,7 @@ defmodule Raxol.Property.RendererAdversarialTest do
   # ---------------------------------------------------------------------
 
   describe "fail-first: immutable-prefix oracle catches a deliberately-repainting append" do
-    test "RED: repainting an already-sealed row (simulating a buggy append_sealed) is caught by INV-1" do
+    test "RED: repainting an already-sealed row (simulating a buggy append_sealed) is caught by the immutable-prefix oracle" do
       {device, authority} = new_authority()
 
       # Three CORRECT seals via the real production path.
@@ -92,7 +91,7 @@ defmodule Raxol.Property.RendererAdversarialTest do
 
       _authority = authority
 
-      # Simulate the regression class INV-1 exists to reject: instead of
+      # Simulate the regression class the immutable-prefix oracle exists to reject: instead of
       # ALWAYS positioning at the region's bottom row (the real
       # `InlineAuthority.append_sealed/2`'s only addressing behavior),
       # a buggy implementation repaints row 1 -- already sealed -- with
@@ -109,8 +108,8 @@ defmodule Raxol.Property.RendererAdversarialTest do
         SealOracle.history(emulator_final, @region_top, high_water: hw_final)
 
       # THE RED RUN. If this ever starts returning `:ok`, the oracle
-      # itself has regressed -- this is the demonstrated-red counterpart
-      # to every `:ok` assertion in `renderer_seal_once_property_test.exs`.
+      # itself has regressed -- this is the RED counterpart to every `:ok`
+      # assertion in `renderer_seal_once_property_test.exs`.
       assert {:violation, _idx, _expected, _actual} =
                SealOracle.immutable_prefix?(history_k, history_final)
     end
@@ -181,11 +180,11 @@ defmodule Raxol.Property.RendererAdversarialTest do
   end
 
   # ---------------------------------------------------------------------
-  # The (B)-detection seam: thin, wired, no re-emission.
+  # The reflow-aware detection seam: thin, wired, no re-emission.
   # ---------------------------------------------------------------------
 
-  describe "(B)-detection seam: reflow_capable?/1 + resize/3's telemetry hook" do
-    test "reflow_capable?/1: true only for iTerm2 (RB's C-4 real-hardware matrix), false for everything else" do
+  describe "reflow-aware detection seam: reflow_capable?/1 + resize/3's telemetry hook" do
+    test "reflow_capable?/1: true only for iTerm2 per the terminal-matrix probe, false for everything else" do
       assert InlineAuthority.reflow_capable?(%Capabilities{
                identity: {"iTerm2", "3.5.0"}
              })
@@ -242,7 +241,7 @@ defmodule Raxol.Property.RendererAdversarialTest do
         )
 
       # The ONLY new bytes after resize are ScrollRegionManager's single
-      # DECSTBM re-set -- ships (A) no matter what the seam detects.
+      # DECSTBM re-set -- ships seal-time-only no matter what the seam detects.
       assert new_bytes == Dialect.region_set(1, 20 - @footer_rows)
       refute SealOracle.emits_full_clear?(all_bytes)
     end
@@ -291,8 +290,8 @@ defmodule Raxol.Property.RendererAdversarialTest do
 
       refute_receive {:telemetry_fired, _event, _measurements, _metadata}, 50
 
-      # (A) is still correctly applied regardless -- the DECSTBM re-set
-      # still happens, just with no telemetry.
+      # Seal-time-only is still correctly applied regardless -- the DECSTBM
+      # re-set still happens, just with no telemetry.
       assert SealOracle.region_sets(raw(device)) == [
                {1, @region_top},
                {1, 20 - @footer_rows}

--- a/test/property/renderer_adversarial_property_test.exs
+++ b/test/property/renderer_adversarial_property_test.exs
@@ -1,0 +1,302 @@
+defmodule Raxol.Property.RendererAdversarialTest do
+  @moduledoc """
+  T2b's negative suite: the printed-history append path
+  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2b), scoped subset of
+  `harness-ui-testing/02-renderer.md` §5 relevant to the append path
+  specifically (R-N4, R-N5-style fail-first) plus the (B)-detection seam
+  the D-PA ruling asks T2b to wire (roadmap §0).
+
+  Each test here either (a) characterizes a regression class the real,
+  full-grid path exhibits and proves the new inline path is exempt from
+  it (R-N4), or (b) demonstrates the TB oracle CATCHES a deliberately
+  wrong stream before trusting any of the positive suite's green results
+  (the fail-first discipline `tb_oracle_test.exs`'s R-P12 established,
+  applied here to `InlineAuthority` itself rather than a hand-written
+  byte string).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Runtime.Rendering.Backends
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.Renderer
+  alias Raxol.Terminal.ScreenBuffer
+  alias Raxol.UI.Rendering.PaintAuthority.Dialect
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  @width 40
+  @height 10
+  @footer_rows 2
+  @region_top 8
+
+  defp new_authority(opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, @width, @height, @footer_rows, opts)}
+  end
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  # ---------------------------------------------------------------------
+  # R-N4: today's full-grid path clears on width change; the inline
+  # append path is exempt by construction.
+  # ---------------------------------------------------------------------
+
+  describe "R-N4: full-grid \\e[2J-on-resize characterization vs the inline path's exemption" do
+    test "characterization: Backends.build_terminal_frame/4 emits \\e[2J on a width change (today's known regression class)" do
+      prev = ScreenBuffer.new(80, 24)
+      next = ScreenBuffer.new(120, 24)
+      renderer = Renderer.new(next, %{}, %{}, true)
+
+      frame = Backends.build_terminal_frame(prev, next, renderer, %{})
+
+      assert SealOracle.emits_full_clear?(frame),
+             "characterization assumption broke: build_terminal_frame no longer " <>
+               "clears on width change -- update this test, and re-verify the " <>
+               "inline path's exemption below is still a meaningful regression guard"
+    end
+
+    test "regression guard: InlineAuthority.resize/3 emits no \\e[2J on the equivalent width+height change" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "sealed before resize\r\n")
+
+      _resized = InlineAuthority.resize(authority, 120, 24)
+
+      refute SealOracle.emits_full_clear?(raw(device))
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Fail-first: the immutable-prefix oracle must catch a deliberately-
+  # repainting append before any GREEN result from the positive suite is
+  # trusted.
+  # ---------------------------------------------------------------------
+
+  describe "fail-first: immutable-prefix oracle catches a deliberately-repainting append" do
+    test "RED: repainting an already-sealed row (simulating a buggy append_sealed) is caught by INV-1" do
+      {device, authority} = new_authority()
+
+      # Three CORRECT seals via the real production path.
+      authority =
+        Enum.reduce(1..3, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "correct block #{n}\r\n")
+        end)
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      _authority = authority
+
+      # Simulate the regression class INV-1 exists to reject: instead of
+      # ALWAYS positioning at the region's bottom row (the real
+      # `InlineAuthority.append_sealed/2`'s only addressing behavior),
+      # a buggy implementation repaints row 1 -- already sealed -- with
+      # different content (the Ink-style failure).
+      IO.write(device, "\e[1;1Hrepainted row 1! (violates seal-once)\r\n")
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      # THE RED RUN. If this ever starts returning `:ok`, the oracle
+      # itself has regressed -- this is the demonstrated-red counterpart
+      # to every `:ok` assertion in `renderer_seal_once_property_test.exs`.
+      assert {:violation, _idx, _expected, _actual} =
+               SealOracle.immutable_prefix?(history_k, history_final)
+    end
+
+    test "GREEN: the same 3 blocks, continued with correct InlineAuthority.seal/2 calls, stay a valid immutable prefix" do
+      {device, authority} = new_authority()
+
+      authority =
+        Enum.reduce(1..3, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "correct block #{n}\r\n")
+        end)
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      _authority =
+        Enum.reduce(4..6, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "correct block #{n}\r\n")
+        end)
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert :ok == SealOracle.immutable_prefix?(history_k, history_final)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # with_cursor/3 exception safety: the sole \e7/\e8 owner must not leave
+  # the save/restore bracket unbalanced if the wrapped fun raises.
+  # ---------------------------------------------------------------------
+
+  describe "with_cursor/3: the DECSC/DECRC bracket stays balanced even when the wrapped fun raises" do
+    test "an exception inside the fun still emits the matching restore, then propagates" do
+      {device, authority} = new_authority()
+      bytes_before = raw(device)
+
+      assert_raise RuntimeError, "boom", fn ->
+        InlineAuthority.with_cursor(authority, :history, fn _t ->
+          raise "boom"
+        end)
+      end
+
+      all_bytes = raw(device)
+
+      new_bytes =
+        binary_part(
+          all_bytes,
+          byte_size(bytes_before),
+          byte_size(all_bytes) - byte_size(bytes_before)
+        )
+
+      # The save ("\e7") and restore ("\e8") must both have been emitted,
+      # in order, even though `fun` never returned normally -- the
+      # `after` block in `with_cursor/3` runs on unwind, not just on the
+      # happy path, so the single hardware DECSC register is never left
+      # holding an unmatched save.
+      assert new_bytes == Dialect.cursor_save() <> Dialect.cursor_restore()
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # The (B)-detection seam: thin, wired, no re-emission.
+  # ---------------------------------------------------------------------
+
+  describe "(B)-detection seam: reflow_capable?/1 + resize/3's telemetry hook" do
+    test "reflow_capable?/1: true only for iTerm2 (RB's C-4 real-hardware matrix), false for everything else" do
+      assert InlineAuthority.reflow_capable?(%Capabilities{
+               identity: {"iTerm2", "3.5.0"}
+             })
+
+      refute InlineAuthority.reflow_capable?(%Capabilities{
+               identity: {"WezTerm", "20240203"}
+             })
+
+      refute InlineAuthority.reflow_capable?(%Capabilities{
+               identity: {"kitty", "0.32.2"}
+             })
+
+      refute InlineAuthority.reflow_capable?(%Capabilities{identity: nil})
+      refute InlineAuthority.reflow_capable?(nil)
+    end
+
+    test "resize/3 fires the seam's telemetry event only when geometry changed AND the terminal is reflow-capable -- and re-emits nothing" do
+      handler_id = "t2b-reflow-seam-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :ui, :paint_authority, :reflow_capable_resize],
+        fn event, measurements, metadata, _config ->
+          send(self(), {:telemetry_fired, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      caps = %Capabilities{identity: {"iTerm2", "3.5.0"}}
+      {device, authority} = new_authority(capabilities: caps)
+      authority = InlineAuthority.seal(authority, "sealed\r\n")
+
+      bytes_before_resize = raw(device)
+
+      _resized = InlineAuthority.resize(authority, @width, 20)
+
+      assert_receive {:telemetry_fired,
+                      [:raxol, :ui, :paint_authority, :reflow_capable_resize],
+                      _measurements, metadata}
+
+      assert metadata.old_region_top == @region_top
+      assert metadata.new_region_top == 20 - @footer_rows
+
+      all_bytes = raw(device)
+      assert String.starts_with?(all_bytes, bytes_before_resize)
+
+      new_bytes =
+        binary_part(
+          all_bytes,
+          byte_size(bytes_before_resize),
+          byte_size(all_bytes) - byte_size(bytes_before_resize)
+        )
+
+      # The ONLY new bytes after resize are ScrollRegionManager's single
+      # DECSTBM re-set -- ships (A) no matter what the seam detects.
+      assert new_bytes == Dialect.region_set(1, 20 - @footer_rows)
+      refute SealOracle.emits_full_clear?(all_bytes)
+    end
+
+    test "resize/3 does NOT fire the seam when geometry is unchanged (same height, footer_rows constant)" do
+      handler_id = "t2b-reflow-seam-noop-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :ui, :paint_authority, :reflow_capable_resize],
+        fn event, measurements, metadata, _config ->
+          send(self(), {:telemetry_fired, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      caps = %Capabilities{identity: {"iTerm2", "3.5.0"}}
+      {_device, authority} = new_authority(capabilities: caps)
+
+      _resized = InlineAuthority.resize(authority, @width, @height)
+
+      refute_receive {:telemetry_fired, _event, _measurements, _metadata}, 50
+    end
+
+    test "resize/3 does NOT fire the seam on a reflow-incapable terminal, even when geometry changes" do
+      handler_id =
+        "t2b-reflow-seam-incapable-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :ui, :paint_authority, :reflow_capable_resize],
+        fn event, measurements, metadata, _config ->
+          send(self(), {:telemetry_fired, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      caps = %Capabilities{identity: {"WezTerm", "20240203"}}
+      {device, authority} = new_authority(capabilities: caps)
+
+      _resized = InlineAuthority.resize(authority, @width, 20)
+
+      refute_receive {:telemetry_fired, _event, _measurements, _metadata}, 50
+
+      # (A) is still correctly applied regardless -- the DECSTBM re-set
+      # still happens, just with no telemetry.
+      assert SealOracle.region_sets(raw(device)) == [
+               {1, @region_top},
+               {1, 20 - @footer_rows}
+             ]
+    end
+  end
+end

--- a/test/property/renderer_seal_once_property_test.exs
+++ b/test/property/renderer_seal_once_property_test.exs
@@ -1,0 +1,335 @@
+defmodule Raxol.Property.RendererSealOnceTest do
+  @moduledoc """
+  T2b's positive suite: the printed-history append path
+  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2b), scoped subset of
+  `harness-ui-testing/02-renderer.md` §4 (R-P1..P11) that belongs to the
+  APPEND path specifically — T2c's footer-side properties (R-P3/P9, the
+  pinned-viewport repaint path) are that unit's own PR, not duplicated
+  here.
+
+  Unlike `test/harness/tb_oracle_test.exs` (which drives the
+  `CaptureAuthority` test double), these properties drive the REAL
+  production implementation,
+  `Raxol.UI.Rendering.PaintAuthority.InlineAuthority`, through a
+  `StringIO` device — the actual bytes T2b ships, replayed through the
+  same `Raxol.Harness.Test.SealOracle` oracles (O1 mechanical scanner, O2
+  VT replay) TB built.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Emulator
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  # Small, fixed geometry reused across this suite (matches
+  # `tb_oracle_test.exs`'s convention): 10 rows total, footer 2 rows,
+  # region_top = 8 (history rows 1..8, footer rows 9..10).
+  @width 40
+  @height 10
+  @footer_rows 2
+  @region_top 8
+
+  # -- harness helpers --
+
+  defp new_authority(opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, @width, @height, @footer_rows, opts)}
+  end
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  defp line_gen do
+    string(:alphanumeric, min_length: 1, max_length: @width - 1)
+  end
+
+  # A "block" is 1-3 lines, each `\r\n`-terminated -- the newline discipline
+  # `InlineAuthority.seal/2` requires (mirrors `assert_seal_newline_terminated/1`).
+  defp block_gen do
+    gen all(lines <- list_of(line_gen(), min_length: 1, max_length: 3)) do
+      Enum.map_join(lines, "", &(&1 <> "\r\n"))
+    end
+  end
+
+  defp blocks_gen(opts) do
+    list_of(block_gen(), opts)
+  end
+
+  # ---------------------------------------------------------------------
+  # R-P1/R-P2 keystone: immutable-prefix seal-once
+  # ---------------------------------------------------------------------
+
+  describe "keystone: immutable-prefix (INV-1)" do
+    test "streaming 1000 sealed single-line blocks: zero rewrites at constant width" do
+      {device, authority} = new_authority()
+
+      checkpoint_ks = [1, 8, 9, 50, 137, 274, 500, 999, 1000]
+
+      {_final_authority, snapshots} =
+        Enum.reduce(1..1000, {authority, %{}}, fn n, {auth, snaps} ->
+          auth = InlineAuthority.seal(auth, "block #{n}\r\n")
+
+          snaps =
+            if n in checkpoint_ks,
+              do: Map.put(snaps, n, raw(device)),
+              else: snaps
+
+          {auth, snaps}
+        end)
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+      assert hw_final == 1000
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      for k <- checkpoint_ks do
+        raw_k = Map.fetch!(snapshots, k)
+        hw_k = SealOracle.seal_high_water(raw_k)
+        assert hw_k == k
+
+        emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+
+        history_k =
+          SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+        assert :ok == SealOracle.immutable_prefix?(history_k, history_final),
+               "history diverged at checkpoint k=#{k}"
+      end
+    end
+
+    property "arbitrary block streams: every prefix checkpoint's history is an immutable prefix of the final history" do
+      check all(
+              blocks <- blocks_gen(min_length: 1, max_length: 60),
+              max_runs: 25
+            ) do
+        {device, authority} = new_authority()
+
+        {_final, snapshot_by_index} =
+          Enum.reduce(Enum.with_index(blocks, 1), {authority, %{}}, fn {block,
+                                                                        idx},
+                                                                       {auth,
+                                                                        snaps} ->
+            auth = InlineAuthority.seal(auth, block)
+            {auth, Map.put(snaps, idx, raw(device))}
+          end)
+
+        raw_final = raw(device)
+        hw_final = SealOracle.seal_high_water(raw_final)
+
+        emulator_final =
+          SealOracle.replay(raw_final, width: @width, height: @height)
+
+        history_final =
+          SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+        for {idx, raw_k} <- snapshot_by_index do
+          hw_k = SealOracle.seal_high_water(raw_k)
+          emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+
+          history_k =
+            SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+          assert :ok == SealOracle.immutable_prefix?(history_k, history_final),
+                 "history diverged after seal ##{idx}"
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Footer-confinement + composition with T2a's region (INV-2)
+  # ---------------------------------------------------------------------
+
+  describe "composition with T2a's ScrollRegionManager: sealed lines land in history, never footer" do
+    test "every seal-path CUP addresses a history row (fill-down, then the bottom row), never a footer row" do
+      {device, authority} = new_authority()
+
+      _ =
+        Enum.reduce(1..20, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "block #{n}\r\n")
+        end)
+
+      rows = SealOracle.cup_rows(raw(device))
+
+      # Every row this stream ever addresses (the DECSTBM homing from
+      # `new/5`'s ScrollRegionManager.start, plus every append's CUP -- to
+      # the next unfilled row while filling down, then to the bottom row
+      # once full) is a HISTORY row, `1..region_top`.
+      assert Enum.all?(rows, &(&1 in 1..@region_top))
+
+      # Once the region fills (after 8 single-line seals), every further
+      # append targets the bottom row exactly.
+      assert @region_top in rows
+
+      # Footer rows (9, 10) never appear -- the append path never bleeds
+      # into T2c's territory.
+      refute (@region_top + 1) in rows
+      refute @height in rows
+    end
+
+    test "O2: footer rows stay blank -- the append path never writes on-screen footer content" do
+      {device, authority} = new_authority()
+
+      _ =
+        Enum.reduce(1..3, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "block #{n}\r\n")
+        end)
+
+      emulator = SealOracle.replay(raw(device), width: @width, height: @height)
+
+      footer_rows =
+        emulator
+        |> Emulator.get_screen_buffer()
+        |> Map.get(:cells)
+        |> Enum.drop(@region_top)
+
+      assert length(footer_rows) == @height - @region_top
+
+      assert Enum.all?(footer_rows, fn row ->
+               Enum.all?(row, fn cell ->
+                 Map.get(cell, :char) in [" ", nil, ""]
+               end)
+             end)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # INV-3: no full clear, ever
+  # ---------------------------------------------------------------------
+
+  describe "INV-3: no \\e[2J on the append path, with or without resize" do
+    property "arbitrary seal/resize interleavings never emit a full-screen clear" do
+      op_gen =
+        gen all(
+              kind <- member_of([:seal, :resize]),
+              block <- block_gen(),
+              new_height <- integer(6..40)
+            ) do
+          case kind do
+            :seal -> {:seal, block}
+            :resize -> {:resize, new_height}
+          end
+        end
+
+      check all(
+              ops <- list_of(op_gen, min_length: 1, max_length: 40),
+              max_runs: 30
+            ) do
+        {device, authority} = new_authority()
+
+        Enum.reduce(ops, authority, fn
+          {:seal, block}, auth ->
+            InlineAuthority.seal(auth, block)
+
+          {:resize, new_height}, auth ->
+            InlineAuthority.resize(auth, @width, new_height)
+        end)
+
+        refute SealOracle.emits_full_clear?(raw(device))
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # INV-4: cursor-ownership round-trip
+  # ---------------------------------------------------------------------
+
+  describe "INV-4: cursor-ownership round-trip (interleaved seals never corrupt cursor state)" do
+    property "after any number of seal/2 calls, the cursor is back at its pre-bracket position every time, and save/restore never nests" do
+      check all(
+              blocks <- blocks_gen(min_length: 1, max_length: 30),
+              max_runs: 30
+            ) do
+        {device, authority} = new_authority()
+
+        # Baseline: cursor position implied by just the initial DECSTBM
+        # region-set (home, by xterm's homing-on-DECSTBM semantics).
+        baseline_cursor =
+          device
+          |> raw()
+          |> SealOracle.replay(width: @width, height: @height)
+          |> Emulator.get_cursor_position()
+
+        Enum.reduce(blocks, authority, fn block, auth ->
+          auth = InlineAuthority.seal(auth, block)
+
+          cursor_now =
+            device
+            |> raw()
+            |> SealOracle.replay(width: @width, height: @height)
+            |> Emulator.get_cursor_position()
+
+          assert cursor_now == baseline_cursor,
+                 "cursor did not return to its pre-bracket position after a seal/2 call"
+
+          auth
+        end)
+
+        balance = SealOracle.save_restore_balance(raw(device))
+        assert balance.decsc == 0
+        assert balance.decsc_max_depth <= 1
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # INV-5-A: resize under D-PA policy (A) seal-time-only
+  # ---------------------------------------------------------------------
+
+  describe "INV-5-A: resize never re-emits sealed content; DECSTBM re-set exactly once" do
+    test "seal, resize, seal again: history before resize is byte-unchanged; region re-set fires exactly once per resize" do
+      {device, authority} = new_authority()
+
+      authority = InlineAuthority.seal(authority, "before resize\r\n")
+      raw_before_resize = raw(device)
+      hw_before = SealOracle.seal_high_water(raw_before_resize)
+
+      emulator_before =
+        SealOracle.replay(raw_before_resize, width: @width, height: @height)
+
+      history_before =
+        SealOracle.history(emulator_before, @region_top, high_water: hw_before)
+
+      new_height = 14
+      authority = InlineAuthority.resize(authority, @width, new_height)
+      new_region_top = InlineAuthority.region_top(authority)
+      assert new_region_top == new_height - @footer_rows
+
+      _authority = InlineAuthority.seal(authority, "after resize\r\n")
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      # Replay the FULL final stream at the terminal's ACTUAL dimensions
+      # after the resize (a real resize is an out-of-band terminal
+      # dimension change no ANSI byte encodes -- DECSTBM only communicates
+      # the new scroll-region boundary within whatever the current screen
+      # size already is). Absolute CUP addressing is always relative to
+      # row 1 (the top), so the earlier, pre-resize content still lands at
+      # the same physical rows regardless of which height the replay uses.
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: new_height)
+
+      history_final =
+        SealOracle.history(emulator_final, new_region_top, high_water: hw_final)
+
+      assert :ok == SealOracle.immutable_prefix?(history_before, history_final)
+
+      assert SealOracle.region_sets(raw_final) == [
+               {1, @region_top},
+               {1, new_region_top}
+             ]
+
+      refute SealOracle.emits_full_clear?(raw_final)
+    end
+  end
+end

--- a/test/property/renderer_seal_once_property_test.exs
+++ b/test/property/renderer_seal_once_property_test.exs
@@ -1,19 +1,18 @@
 defmodule Raxol.Property.RendererSealOnceTest do
   @moduledoc """
-  T2b's positive suite: the printed-history append path
-  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2b), scoped subset of
-  `harness-ui-testing/02-renderer.md` §4 (R-P1..P11) that belongs to the
-  APPEND path specifically — T2c's footer-side properties (R-P3/P9, the
-  pinned-viewport repaint path) are that unit's own PR, not duplicated
-  here.
+  The append path's positive suite: the printed-history append path
+  properties that belong to the APPEND path specifically — the footer
+  viewport's own footer-side properties (the pinned-viewport repaint
+  path) are that unit's own PR, not duplicated here.
 
   Unlike `test/harness/tb_oracle_test.exs` (which drives the
   `CaptureAuthority` test double), these properties drive the REAL
   production implementation,
   `Raxol.UI.Rendering.PaintAuthority.InlineAuthority`, through a
-  `StringIO` device — the actual bytes T2b ships, replayed through the
-  same `Raxol.Harness.Test.SealOracle` oracles (O1 mechanical scanner, O2
-  VT replay) TB built.
+  `StringIO` device — the actual bytes the append path ships, replayed
+  through the same `Raxol.Harness.Test.SealOracle` oracles (a mechanical
+  scanner and a VT replay oracle) the byte-capture oracle suite already
+  built.
   """
 
   use ExUnit.Case, async: true
@@ -60,10 +59,10 @@ defmodule Raxol.Property.RendererSealOnceTest do
   end
 
   # ---------------------------------------------------------------------
-  # R-P1/R-P2 keystone: immutable-prefix seal-once
+  # Keystone: immutable-prefix seal-once
   # ---------------------------------------------------------------------
 
-  describe "keystone: immutable-prefix (INV-1)" do
+  describe "keystone: immutable-prefix" do
     test "streaming 1000 sealed single-line blocks: zero rewrites at constant width" do
       {device, authority} = new_authority()
 
@@ -146,10 +145,10 @@ defmodule Raxol.Property.RendererSealOnceTest do
   end
 
   # ---------------------------------------------------------------------
-  # Footer-confinement + composition with T2a's region (INV-2)
+  # Footer-confinement + composition with the scroll-region manager
   # ---------------------------------------------------------------------
 
-  describe "composition with T2a's ScrollRegionManager: sealed lines land in history, never footer" do
+  describe "composition with the scroll-region manager: sealed lines land in history, never footer" do
     test "every seal-path CUP addresses a history row (fill-down, then the bottom row), never a footer row" do
       {device, authority} = new_authority()
 
@@ -171,12 +170,12 @@ defmodule Raxol.Property.RendererSealOnceTest do
       assert @region_top in rows
 
       # Footer rows (9, 10) never appear -- the append path never bleeds
-      # into T2c's territory.
+      # into the footer viewport's territory.
       refute (@region_top + 1) in rows
       refute @height in rows
     end
 
-    test "O2: footer rows stay blank -- the append path never writes on-screen footer content" do
+    test "footer rows stay blank -- the append path never writes on-screen footer content" do
       {device, authority} = new_authority()
 
       _ =
@@ -203,10 +202,10 @@ defmodule Raxol.Property.RendererSealOnceTest do
   end
 
   # ---------------------------------------------------------------------
-  # INV-3: no full clear, ever
+  # No full clear, ever
   # ---------------------------------------------------------------------
 
-  describe "INV-3: no \\e[2J on the append path, with or without resize" do
+  describe "no \\e[2J on the append path, with or without resize" do
     property "arbitrary seal/resize interleavings never emit a full-screen clear" do
       op_gen =
         gen all(
@@ -240,10 +239,10 @@ defmodule Raxol.Property.RendererSealOnceTest do
   end
 
   # ---------------------------------------------------------------------
-  # INV-4: cursor-ownership round-trip
+  # Cursor-ownership round-trip
   # ---------------------------------------------------------------------
 
-  describe "INV-4: cursor-ownership round-trip (interleaved seals never corrupt cursor state)" do
+  describe "cursor-ownership round-trip (interleaved seals never corrupt cursor state)" do
     property "after any number of seal/2 calls, the cursor is back at its pre-bracket position every time, and save/restore never nests" do
       check all(
               blocks <- blocks_gen(min_length: 1, max_length: 30),
@@ -282,10 +281,10 @@ defmodule Raxol.Property.RendererSealOnceTest do
   end
 
   # ---------------------------------------------------------------------
-  # INV-5-A: resize under D-PA policy (A) seal-time-only
+  # Resize under seal-time-only policy
   # ---------------------------------------------------------------------
 
-  describe "INV-5-A: resize never re-emits sealed content; DECSTBM re-set exactly once" do
+  describe "resize never re-emits sealed content; DECSTBM re-set exactly once" do
     test "seal, resize, seal again: history before resize is byte-unchanged; region re-set fires exactly once per resize" do
       {device, authority} = new_authority()
 

--- a/test/property/renderer_t2b_review_fixes_test.exs
+++ b/test/property/renderer_t2b_review_fixes_test.exs
@@ -1,0 +1,479 @@
+defmodule Raxol.Property.RendererT2bReviewFixesTest do
+  @moduledoc """
+  T2b's review-response suite (Fable's FIX-NOW batch on the printed-
+  history append path, `docs/proposals/in-flight/harness-ui-roadmap.md`
+  T2b): `Raxol.UI.Rendering.PaintAuthority.ContentGuard` (HIGH --
+  `seal/2`/`append_sealed/2` wrote agent/LLM-originated iodata verbatim,
+  so a control sequence embedded IN CONTENT could defeat every invariant
+  the append path exists to hold, from the inside), newline-termination
+  enforcement (MED -- the docstring's "MUST be `\\r\\n`-terminated" is now
+  an `ArgumentError`, not prose), and the `with_cursor/3` nesting guard
+  (MED -- the sole-DECSC-owner invariant is now enforced in code).
+
+  Each `describe "R8: ..."` block is a RED/GREEN pair: RED demonstrates,
+  via the byte-capture oracle (`Raxol.Harness.Test.SealOracle`) or a
+  direct `Emulator` inspection, that the raw/pre-guard bytes are a REAL,
+  oracle-visible threat -- not a strawman -- before GREEN shows the same
+  payload, routed through the real `InlineAuthority.seal/2`, emerges
+  neutralized.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Emulator
+  alias Raxol.UI.Rendering.PaintAuthority.ContentGuard
+  alias Raxol.UI.Rendering.PaintAuthority.Dialect
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  @width 40
+  @height 10
+  @footer_rows 2
+  @region_top 8
+
+  defp new_authority(opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, @width, @height, @footer_rows, opts)}
+  end
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  defp row_text(emulator, row_index) do
+    emulator
+    |> Emulator.get_screen_buffer()
+    |> Map.get(:cells)
+    |> Enum.at(row_index)
+    |> Enum.map_join("", fn cell -> Map.get(cell, :char) || " " end)
+    |> String.trim_trailing()
+  end
+
+  # ---------------------------------------------------------------------
+  # R8: ContentGuard neutralizes control bytes embedded IN sealed content
+  # ---------------------------------------------------------------------
+
+  describe "R8: \\e[2J embedded in content" do
+    test "RED: raw bytes trigger the full-clear oracle" do
+      {device, authority} = new_authority()
+      _ = InlineAuthority.seal(authority, "sealed before\r\n")
+      IO.write(device, "agent said: \e[2J surprise\r\n")
+
+      assert SealOracle.emits_full_clear?(raw(device))
+    end
+
+    test "GREEN: the same bytes, through seal/2, never trigger it" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "sealed before\r\n")
+      _ = InlineAuthority.seal(authority, "agent said: \e[2J surprise\r\n")
+
+      refute SealOracle.emits_full_clear?(raw(device))
+
+      emulator = SealOracle.replay(raw(device), width: @width, height: @height)
+      assert row_text(emulator, 1) == "agent said: [2J surprise"
+    end
+  end
+
+  describe "R8: \\e[3J embedded in content" do
+    test "RED: raw bytes trigger the full-clear oracle" do
+      {device, authority} = new_authority()
+      _ = InlineAuthority.seal(authority, "sealed before\r\n")
+      IO.write(device, "agent said: \e[3J surprise\r\n")
+
+      assert SealOracle.emits_full_clear?(raw(device))
+    end
+
+    test "GREEN: the same bytes, through seal/2, never trigger it" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "sealed before\r\n")
+      _ = InlineAuthority.seal(authority, "agent said: \e[3J surprise\r\n")
+
+      refute SealOracle.emits_full_clear?(raw(device))
+
+      emulator = SealOracle.replay(raw(device), width: @width, height: @height)
+      assert row_text(emulator, 1) == "agent said: [3J surprise"
+    end
+  end
+
+  describe "R8: \\e[1;1H embedded in content (CUP repaint attempt)" do
+    test "RED: raw bytes repainting row 1 are caught by the immutable-prefix oracle" do
+      {device, authority} = new_authority()
+
+      authority =
+        Enum.reduce(1..3, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "correct block #{n}\r\n")
+        end)
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      _ = authority
+      # The payload a malicious/careless agent might emit: content that
+      # itself carries a CUP back to row 1 and repaints it.
+      IO.write(device, "\e[1;1Hagent-forged repaint\r\n")
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert {:violation, _idx, _expected, _actual} =
+               SealOracle.immutable_prefix?(history_k, history_final)
+    end
+
+    test "GREEN: the same bytes, through seal/2, never disturb the immutable prefix" do
+      {device, authority} = new_authority()
+
+      authority =
+        Enum.reduce(1..3, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "correct block #{n}\r\n")
+        end)
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      _ = InlineAuthority.seal(authority, "\e[1;1Hagent-forged repaint\r\n")
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert :ok == SealOracle.immutable_prefix?(history_k, history_final)
+
+      # Visible-honest: the ESC is gone, the digits/letters that followed
+      # it survive as literal text on the row the append path actually
+      # used (the next unfilled history row -- row 4 -- never row 1).
+      assert row_text(emulator_final, 3) == "[1;1Hagent-forged repaint"
+    end
+  end
+
+  describe "R8: \\e[5A embedded in content (relative cursor-up + overwrite)" do
+    test "RED: raw bytes moving up then overwriting are caught by the immutable-prefix oracle" do
+      {device, authority} = new_authority()
+
+      authority =
+        Enum.reduce(1..5, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "correct block #{n}\r\n")
+        end)
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      _ = authority
+      IO.write(device, "\e[5Aovershoots up 5 and repaints\r\n")
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert {:violation, _idx, _expected, _actual} =
+               SealOracle.immutable_prefix?(history_k, history_final)
+    end
+
+    test "GREEN: the same bytes, through seal/2, never disturb the immutable prefix" do
+      {device, authority} = new_authority()
+
+      authority =
+        Enum.reduce(1..5, authority, fn n, auth ->
+          InlineAuthority.seal(auth, "correct block #{n}\r\n")
+        end)
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      _ =
+        InlineAuthority.seal(authority, "\e[5Aovershoots up 5 and repaints\r\n")
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert :ok == SealOracle.immutable_prefix?(history_k, history_final)
+    end
+  end
+
+  describe "R8: OSC (\\e]0;title\\a) embedded in content" do
+    test "RED: raw bytes actually set the emulator's window title (a real, executed side effect)" do
+      fresh = SealOracle.replay("", width: @width, height: @height)
+      assert fresh.window_title == nil
+
+      raw_bytes = "\e]0;title\atext after\r\n"
+      emulator = SealOracle.replay(raw_bytes, width: @width, height: @height)
+
+      assert emulator.window_title == "title"
+    end
+
+    test "GREEN: the same bytes, through seal/2, never touch the window title -- the residue is left visible instead" do
+      {device, authority} = new_authority()
+      _ = InlineAuthority.seal(authority, "\e]0;title\atext after\r\n")
+
+      emulator = SealOracle.replay(raw(device), width: @width, height: @height)
+
+      assert emulator.window_title == nil
+      assert row_text(emulator, 0) == "]0;titletext after"
+    end
+  end
+
+  describe "R8: bare partial escape at end-of-line" do
+    test "RED: a truncated CSI at the end of one write corrupts and merges the NEXT line, once concatenated on the wire" do
+      {device, _authority} = new_authority()
+
+      # Simulates two separate emits that end up concatenated on the same
+      # physical byte stream (exactly what two consecutive `IO.write/2`
+      # calls to the same device produce) -- the first ends mid-escape
+      # (no final byte before its own, otherwise-valid, `\r\n` terminator).
+      IO.write(device, "block one \e[9\r\n")
+      IO.write(device, "block two starts here\r\n")
+
+      emulator = SealOracle.replay(raw(device), width: @width, height: @height)
+
+      # The dangling CSI parameter byte is still "open" across the `\r\n`
+      # boundary: the parser keeps hunting for a valid CSI final byte
+      # (`0x40..0x7E`, which covers every letter), finds one in "block"
+      # itself (the leading `b`), and the whole intervening span --
+      # including the line break -- is consumed as that sequence's
+      # parameters instead of being printed. Both lines end up merged
+      # onto one row, with a letter eaten.
+      assert row_text(emulator, 0) == "block one lock two starts here"
+      assert row_text(emulator, 1) == ""
+    end
+
+    test "GREEN: the same two blocks, through separate seal/2 calls, never bleed into each other" do
+      {device, authority} = new_authority()
+
+      authority = InlineAuthority.seal(authority, "block one \e[9\r\n")
+      _ = InlineAuthority.seal(authority, "block two starts here\r\n")
+
+      emulator = SealOracle.replay(raw(device), width: @width, height: @height)
+
+      # Each `seal/2` call sanitizes its OWN iodata completely before any
+      # byte reaches the device -- a dangling escape can never persist
+      # parser state into a LATER seal call the way it can on the raw,
+      # unguarded wire. Row 1 shows the visible residue; row 2 is
+      # completely intact.
+      assert row_text(emulator, 0) == "block one [9"
+      assert row_text(emulator, 1) == "block two starts here"
+    end
+  end
+
+  describe "R8: a legitimately styled line stays styled (SGR passes through byte-identical)" do
+    test "GREEN: \\e[1;31m...\\e[0m survives seal/2 unchanged" do
+      {device, authority} = new_authority()
+      bytes_before = raw(device)
+
+      styled = "\e[1;31mcolored\e[0m\r\n"
+      _ = InlineAuthority.seal(authority, styled)
+
+      all_bytes = raw(device)
+
+      new_bytes =
+        binary_part(
+          all_bytes,
+          byte_size(bytes_before),
+          byte_size(all_bytes) - byte_size(bytes_before)
+        )
+
+      expected =
+        Dialect.cursor_save() <>
+          Dialect.cursor_position(1) <> styled <> Dialect.cursor_restore()
+
+      assert new_bytes == expected
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Newline-termination enforcement
+  # ---------------------------------------------------------------------
+
+  describe "seal/2 enforces \\r\\n-termination" do
+    test "raises ArgumentError on a dangling partial line" do
+      {_device, authority} = new_authority()
+
+      assert_raise ArgumentError, ~r/\\r\\n-terminated/, fn ->
+        InlineAuthority.seal(authority, "partial")
+      end
+    end
+
+    test "raises ArgumentError when terminated with only \\n (no \\r)" do
+      {_device, authority} = new_authority()
+
+      assert_raise ArgumentError, fn ->
+        InlineAuthority.seal(authority, "partial\n")
+      end
+    end
+
+    test "does not raise on a properly \\r\\n-terminated block" do
+      {_device, authority} = new_authority()
+
+      assert %InlineAuthority{} = InlineAuthority.seal(authority, "fine\r\n")
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # with_cursor/3 nesting guard
+  # ---------------------------------------------------------------------
+
+  describe "with_cursor/3 nesting guard: the sole-DECSC-owner invariant, enforced in code" do
+    test "a nested with_cursor/3 call raises" do
+      {_device, authority} = new_authority()
+
+      assert_raise RuntimeError, ~r/nesting|already open/i, fn ->
+        InlineAuthority.with_cursor(authority, :history, fn inner ->
+          InlineAuthority.with_cursor(inner, :history, fn _ -> inner end)
+        end)
+      end
+    end
+
+    test "seal/2 called from inside a with_cursor/3 bracket raises" do
+      {_device, authority} = new_authority()
+
+      assert_raise RuntimeError, ~r/nesting|already open/i, fn ->
+        InlineAuthority.with_cursor(authority, :history, fn inner ->
+          InlineAuthority.seal(inner, "nested seal\r\n")
+        end)
+      end
+    end
+
+    test "the guard does not permanently lock the authority: sequential seals after a normal with_cursor/3 still work" do
+      {device, authority} = new_authority()
+
+      authority =
+        InlineAuthority.with_cursor(authority, :history, fn inner ->
+          InlineAuthority.append_sealed(inner, "first\r\n")
+        end)
+
+      authority = InlineAuthority.seal(authority, "second\r\n")
+      _ = InlineAuthority.seal(authority, "third\r\n")
+
+      emulator = SealOracle.replay(raw(device), width: @width, height: @height)
+      assert row_text(emulator, 0) == "first"
+      assert row_text(emulator, 1) == "second"
+      assert row_text(emulator, 2) == "third"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # cup routed through Dialect.cursor_position/1
+  # ---------------------------------------------------------------------
+
+  describe "cursor positioning is routed through Dialect.cursor_position/1" do
+    test "byte format is pinned: CSI row;1H" do
+      assert Dialect.cursor_position(1) == "\e[1;1H"
+      assert Dialect.cursor_position(23) == "\e[23;1H"
+    end
+
+    test "append_sealed/2's CUP byte-matches Dialect.cursor_position/1 exactly" do
+      {device, authority} = new_authority()
+      bytes_before = raw(device)
+
+      _ = InlineAuthority.append_sealed(authority, "line\r\n")
+
+      all_bytes = raw(device)
+
+      new_bytes =
+        binary_part(
+          all_bytes,
+          byte_size(bytes_before),
+          byte_size(all_bytes) - byte_size(bytes_before)
+        )
+
+      assert new_bytes == Dialect.cursor_position(1) <> "line\r\n"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # ContentGuard.sanitize_line/1: direct grammar tests
+  # ---------------------------------------------------------------------
+
+  describe "ContentGuard.sanitize_line/1: allowlist grammar" do
+    test "printable ASCII and UTF-8 pass through unchanged" do
+      assert ContentGuard.sanitize_line("hello, world! 123") ==
+               "hello, world! 123"
+
+      assert ContentGuard.sanitize_line("héllo wörld — emoji: 🎉") ==
+               "héllo wörld — emoji: 🎉"
+    end
+
+    test "\\t, \\r, \\n pass through unchanged" do
+      assert ContentGuard.sanitize_line("a\tb\r\nc") == "a\tb\r\nc"
+    end
+
+    test "SGR sequences pass through byte-identical" do
+      assert ContentGuard.sanitize_line("\e[1;31mred\e[0m") ==
+               "\e[1;31mred\e[0m"
+
+      assert ContentGuard.sanitize_line("\e[m") == "\e[m"
+      assert ContentGuard.sanitize_line("\e[0m") == "\e[0m"
+    end
+
+    test "non-SGR CSI has only its ESC stripped, residue stays visible" do
+      assert ContentGuard.sanitize_line("\e[2J") == "[2J"
+      assert ContentGuard.sanitize_line("\e[1;1H") == "[1;1H"
+      assert ContentGuard.sanitize_line("\e[5A") == "[5A"
+    end
+
+    test "OSC has only its ESC stripped; the terminating BEL is silently dropped (no residue)" do
+      assert ContentGuard.sanitize_line("\e]0;title\atext") == "]0;titletext"
+    end
+
+    test "OSC with an ST (ESC \\\\) terminator: both ESCs stripped" do
+      assert ContentGuard.sanitize_line("\e]0;title\e\\text") ==
+               "]0;title\\text"
+    end
+
+    test "DCS has only its ESC stripped" do
+      assert ContentGuard.sanitize_line("\eP1$q\e\\rest") == "P1$q\\rest"
+    end
+
+    test "a bare, unterminated ESC at end-of-string is stripped cleanly (no crash)" do
+      assert ContentGuard.sanitize_line("text\e") == "text"
+      assert ContentGuard.sanitize_line("text\e[") == "text["
+      assert ContentGuard.sanitize_line("text\e[9") == "text[9"
+    end
+
+    test "every other C0 control (except \\t/\\r/\\n) is stripped silently" do
+      assert ContentGuard.sanitize_line("a\ab\bc\vd\fe") == "abcde"
+    end
+
+    test "DEL is stripped silently" do
+      assert ContentGuard.sanitize_line("a\x7Fb") == "ab"
+    end
+
+    test "empty input round-trips to an empty binary" do
+      assert ContentGuard.sanitize_line("") == ""
+      assert ContentGuard.sanitize_line([]) == ""
+    end
+
+    test "accepts iodata (lists), not just binaries" do
+      assert ContentGuard.sanitize_line(["ab", ?c, ["d", "\e[2J"]]) == "abcd[2J"
+    end
+  end
+end

--- a/test/property/renderer_t2b_review_fixes_test.exs
+++ b/test/property/renderer_t2b_review_fixes_test.exs
@@ -1,8 +1,7 @@
 defmodule Raxol.Property.RendererT2bReviewFixesTest do
   @moduledoc """
-  T2b's review-response suite (Fable's FIX-NOW batch on the printed-
-  history append path, `docs/proposals/in-flight/harness-ui-roadmap.md`
-  T2b): `Raxol.UI.Rendering.PaintAuthority.ContentGuard` (HIGH --
+  Fixes on the printed-history append path:
+  `Raxol.UI.Rendering.PaintAuthority.ContentGuard` (HIGH --
   `seal/2`/`append_sealed/2` wrote agent/LLM-originated iodata verbatim,
   so a control sequence embedded IN CONTENT could defeat every invariant
   the append path exists to hold, from the inside), newline-termination
@@ -10,7 +9,7 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
   an `ArgumentError`, not prose), and the `with_cursor/3` nesting guard
   (MED -- the sole-DECSC-owner invariant is now enforced in code).
 
-  Each `describe "R8: ..."` block is a RED/GREEN pair: RED demonstrates,
+  Each `describe` block below is a RED/GREEN pair: RED demonstrates,
   via the byte-capture oracle (`Raxol.Harness.Test.SealOracle`) or a
   direct `Emulator` inspection, that the raw/pre-guard bytes are a REAL,
   oracle-visible threat -- not a strawman -- before GREEN shows the same
@@ -51,10 +50,10 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
   end
 
   # ---------------------------------------------------------------------
-  # R8: ContentGuard neutralizes control bytes embedded IN sealed content
+  # ContentGuard neutralizes control bytes embedded IN sealed content
   # ---------------------------------------------------------------------
 
-  describe "R8: \\e[2J embedded in content" do
+  describe "\\e[2J embedded in content" do
     test "RED: raw bytes trigger the full-clear oracle" do
       {device, authority} = new_authority()
       _ = InlineAuthority.seal(authority, "sealed before\r\n")
@@ -75,7 +74,7 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
     end
   end
 
-  describe "R8: \\e[3J embedded in content" do
+  describe "\\e[3J embedded in content" do
     test "RED: raw bytes trigger the full-clear oracle" do
       {device, authority} = new_authority()
       _ = InlineAuthority.seal(authority, "sealed before\r\n")
@@ -96,7 +95,7 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
     end
   end
 
-  describe "R8: \\e[1;1H embedded in content (CUP repaint attempt)" do
+  describe "\\e[1;1H embedded in content (CUP repaint attempt)" do
     test "RED: raw bytes repainting row 1 are caught by the immutable-prefix oracle" do
       {device, authority} = new_authority()
 
@@ -161,7 +160,7 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
     end
   end
 
-  describe "R8: \\e[5A embedded in content (relative cursor-up + overwrite)" do
+  describe "\\e[5A embedded in content (relative cursor-up + overwrite)" do
     test "RED: raw bytes moving up then overwriting are caught by the immutable-prefix oracle" do
       {device, authority} = new_authority()
 
@@ -220,7 +219,7 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
     end
   end
 
-  describe "R8: OSC (\\e]0;title\\a) embedded in content" do
+  describe "OSC (\\e]0;title\\a) embedded in content" do
     test "RED: raw bytes actually set the emulator's window title (a real, executed side effect)" do
       fresh = SealOracle.replay("", width: @width, height: @height)
       assert fresh.window_title == nil
@@ -242,7 +241,7 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
     end
   end
 
-  describe "R8: bare partial escape at end-of-line" do
+  describe "bare partial escape at end-of-line" do
     test "RED: a truncated CSI at the end of one write corrupts and merges the NEXT line, once concatenated on the wire" do
       {device, _authority} = new_authority()
 
@@ -284,7 +283,7 @@ defmodule Raxol.Property.RendererT2bReviewFixesTest do
     end
   end
 
-  describe "R8: a legitimately styled line stays styled (SGR passes through byte-identical)" do
+  describe "a legitimately styled line stays styled (SGR passes through byte-identical)" do
     test "GREEN: \\e[1;31m...\\e[0m survives seal/2 unchanged" do
       {device, authority} = new_authority()
       bytes_before = raw(device)


### PR DESCRIPTION
Unit **T2b** — the **printed-history append path**, the immutable-prefix keystone. This is the substrate that makes "sealed history is never repainted" true in real code. Builds on T2a's DECSTBM region manager (#574).

## What
`Raxol.UI.Rendering.PaintAuthority.InlineAuthority` — the real `PaintAuthority` impl:
- **`seal/2`** = `with_cursor(:history, &append_sealed/2)` — save → position → emit → restore. `with_cursor/3` is the **sole owner** of the `\e7`/`\e8` (DECSC/DECRC) pair, now `try/after`-guarded so the restore always runs even if the producing fun raises (airtight "sole owner").
- **`append_sealed/2`** fills the history region **top-down** via a `next_row` cursor, positioning at `min(next_row, region_top)`, then clamps to the bottom row and relies on the terminal's natural index-at-boundary scroll once full. (A first cut always-CUP'd to the bottom row — that front-loads content-free filler and silently defeats the high-water/immutable-prefix check; **fill-down-then-scroll is load-bearing** and documented as such.)
- **`resize/3`** delegates to `ScrollRegionManager.resize/2` — a single DECSTBM re-set, **zero re-emitted history bytes** (INV-5-A).
- **`reflow_capable?/1`** — thin (B)-seam predicate, `true` only for `{"iTerm2", _}` (RB's C-4 reflow finding); fires `[:raxol,:ui,:paint_authority,:reflow_capable_resize]` telemetry on a geometry-changing resize but implements **no (B) re-emission** (per the ruling: ship (A), (B) runtime-detected only).

## Keystone invariant proven
The immutable-prefix invariant — `history(E_k)` is a byte-identical **prefix** of `history(E_final)` — holds across a 1000-block deterministic stream and a 25-run property, checked at every checkpoint by `SealOracle.immutable_prefix?/2`.

## Tests bind to reality (Drew's 3 questions)
- **Real producer:** positive/adversarial suites drive `seal`/`append_sealed`/`with_cursor` end-to-end into a real `StringIO` device — no logic reimplemented in the test.
- **Goes RED if broken:** a genuine fail-first — three real seals, then a row-1 repaint fed through the **real** `SealOracle.replay` → `Emulator` → `immutable_prefix?` → `{:violation, 0, ...}`; the paired GREEN test proves the oracle isn't stuck returning violation (oracle-validity guard, not a rubber stamp).
- **Real bytes:** INV-5-A asserts byte-identical prior-history prefix + `new_bytes == Dialect.region_set(1,18)`, not a count/proxy. No path emits `\e[2J`/`\e[3J` (grep-verified; the ban that RB's N06 validated).

## Review
Opus analytic review: **SHIP** — cursor boundary math traced correct at `region_top-1/region_top/region_top+1`, `with_cursor` confirmed sole save/restore owner, fail-first genuine, `reflow_capable?` nil-safe and iTerm2-only, no full-clear anywhere. Four yellows raised; #1 (moduledoc overclaimed the fail-first) and #2 (`with_cursor` try/after) folded into this commit; #3/#4 cosmetic, deferred.

Gates: `compile --warnings-as-errors` clean; 16 property/adversarial tests green + T2a's 19 + the 154-test harness oracle suite still green; `mix format` + `mix credo --strict` clean; no mix.lock drift.

**Base note:** this targets `feat/harness-ui-T2a` (#574), not master — T2a isn't merged yet. Rebase to master once #574 lands.

---
*Terms: **seal** = a block written into the terminal's own scrollback, never repainted after. **Immutable-prefix invariant** = bytes emitted up to any checkpoint are a byte-identical prefix of the final stream (checked by replaying real bytes through the terminal emulator — the `SealOracle`). **DECSC/DECRC** = `\e7`/`\e8` cursor save/restore. **D-PA (A)** = the lane's paint-authority ruling: after seal, nothing in history may be rewritten. **INV-5-A / R8** = lane invariant/methodology ids (R8 = every bug shown red before the fix).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

