### PR TITLE
Harness UI: pinned footer viewport (footer-scoped diff, no \e[2J keyframe) [T2c]

### DIFF
--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -612,7 +612,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   or whose width-correct truncation went stale / whose sealed history rewrapped
   (horizontal). This is independent of `reflow_capable?/1`/the telemetry hook
   below: the ghost-content risk applies to every terminal's footer, not just the
-  (B)-detection subset.
+  reflow-capable subset.
   """
   @impl true
   def resize(%__MODULE__{region: region, next_row: next_row} = t, width, height) do
@@ -636,13 +636,14 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     reflow_relevant? = geometry_changed? or width_changed?
 
     if reflow_relevant? and t.reflow_capable? do
-      # The (B)-detection seam firing: this session's terminal is known,
-      # from RB's real-hardware C-4 probe, to reflow sealed history
-      # cleanly on a geometry-changing resize. NOTHING is re-emitted here
-      # — re-emission is a FUTURE unit's job (D-PA RULING: ship (A), (B)
-      # is a runtime-detected ADDITIVE upgrade). This telemetry event is
-      # the thin hook that unit gates on — it carries BOTH axes so the (B)
-      # unit can tell a rewrapping width change from a pure row change.
+      # The reflow-aware detection seam firing: this session's terminal
+      # is known, from the real-hardware terminal-matrix probe, to reflow
+      # sealed history cleanly on a geometry-changing resize. NOTHING is
+      # re-emitted here — re-emission is a FUTURE unit's job (ship
+      # seal-time-only now; reflow-aware re-emission is a runtime-detected
+      # ADDITIVE upgrade). This telemetry event is the thin hook that unit
+      # gates on — it carries BOTH axes so the future unit can tell a
+      # rewrapping width change from a pure row change.
       :telemetry.execute(
         [:raxol, :ui, :paint_authority, :reflow_capable_resize],
         %{},

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -174,6 +174,44 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   simply operate over whatever footer capacity `footer_range/1` actually
   reports for that geometry, which may be smaller than `footer_rows`
   requested, or empty.
+
+  ## T2c review response: footer `ContentGuard`, and the `needs_keyframe` latch
+
+  Two FIX-NOW findings from review, both closed here:
+
+    * **Footer content is not trusted either (HIGH).** T2b's review
+      already established that `seal/2` cannot write agent/LLM-originated
+      iodata verbatim (`ContentGuard.sanitize_line/1`); the footer path
+      carries the SAME kind of content (live-tail/agent text) through the
+      SAME risk (a footer line smuggling `\\e[3;1H`/`\\e[2J`/etc. would
+      execute against the footer confinement invariant exactly like an
+      unguarded history append would against the seal-once invariant).
+      `repaint/2` and `keyframe/2` both run every caller-supplied line
+      through `ContentGuard.sanitize_line/1` at entry — BEFORE padding or
+      diffing — so `footer_diff/2` and `footer_lines` only ever see
+      already-neutralized content. `footer_lines` itself is therefore an
+      invariant: once sanitized in, never re-sanitized out, so `footer_diff/2`
+      comparing old (already-sanitized) against new (freshly-sanitized) is
+      always an apples-to-apples comparison.
+    * **A stale post-resize repaint could leave ghost content (MED).**
+      `resize/3` clamps `next_row` but, by design (see above), never
+      repaints the footer — a geometry-changing resize can relocate the
+      footer's on-screen rows to different absolute row numbers while their
+      CONTENT (and thus `footer_diff/2`'s logical, index-based comparison)
+      is unchanged. A subsequent `repaint/2` call with unchanged lines then
+      computes a no-op diff and writes NOTHING, leaving those rows showing
+      whatever was on screen at that position before the resize (leftover
+      history text, or a stale row `repaint/2` previously left blank via
+      `\\e[K` at the OLD position). The `needs_keyframe` flag closes this:
+      a geometry-changing `resize/3` sets it (a pure state change — the
+      pinned T2b regression test asserting resize's ONLY new bytes are
+      `ScrollRegionManager`'s single DECSTBM re-set is untouched, since
+      setting a struct field emits no bytes); the NEXT `repaint/2` call
+      checks it FIRST and, if set, self-promotes to a full `keyframe/2`
+      (which clears the flag) instead of running its normal diff — so the
+      first repaint after any geometry change always fully re-renders the
+      footer at its current position, regardless of whether the logical
+      content changed.
   """
 
   @behaviour Raxol.UI.Rendering.PaintAuthority
@@ -190,7 +228,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     :reflow_capable?,
     :next_row,
     in_cursor_bracket: false,
-    footer_lines: []
+    footer_lines: [],
+    needs_keyframe: false
   ]
 
   @type t :: %__MODULE__{
@@ -199,7 +238,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
           reflow_capable?: boolean(),
           next_row: pos_integer(),
           in_cursor_bracket: boolean(),
-          footer_lines: [binary()]
+          footer_lines: [binary()],
+          needs_keyframe: boolean()
         }
 
   @doc """
@@ -354,6 +394,11 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   `old_lines` and `new_lines` (both already the SAME length — pad/
   truncate before calling, see `repaint/2`). No I/O, no cursor movement.
   `row_index` is 0-based, relative to the top of the footer.
+
+  Raises `ArgumentError` (rather than falling through to a bare
+  `FunctionClauseError`) when the two lists' lengths differ, naming the fix:
+  callers must pad/truncate both to the same row count first (`pad_rows/2`,
+  which `repaint/2`/`keyframe/2` already do before calling this).
   """
   @spec footer_diff([binary()], [binary()]) :: [{non_neg_integer(), binary()}]
   def footer_diff(old_lines, new_lines)
@@ -366,38 +411,64 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     |> Enum.map(fn {{_old_line, new_line}, idx} -> {idx, new_line} end)
   end
 
+  def footer_diff(old_lines, new_lines)
+      when is_list(old_lines) and is_list(new_lines) do
+    raise ArgumentError,
+          "InlineAuthority.footer_diff/2 requires old_lines and new_lines to " <>
+            "be the same length (got #{length(old_lines)} and " <>
+            "#{length(new_lines)}) -- pad/truncate both to the same row " <>
+            "count first (see pad_rows/2, or call repaint/2 / keyframe/2 " <>
+            "directly, which already do this)"
+  end
+
   @doc """
-  T2c's diff-driven footer repaint: pads/truncates `new_lines` to the
+  T2c's diff-driven footer repaint: sanitizes every line of `new_lines`
+  through `ContentGuard.sanitize_line/1` (footer content is agent/LLM-
+  originated, same as the history append path -- see the moduledoc's
+  review-response section), pads/truncates the sanitized result to the
   CURRENT footer row count, diffs against the last-painted footer
   (`footer_diff/2`), and emits only the changed rows -- each `CUP`
   (inside the footer range, never history) + `\\e[K` (per-row clear,
   never `\\e[2J`) + the new line content -- inside one `with_cursor/3`
-  bracket. Zero changed rows emits zero bytes. Updates `footer_lines` so
-  the next call diffs against what was actually painted.
+  bracket. Zero changed rows emits zero bytes (but `footer_lines` is still
+  updated to the padded/sanitized content, so a later resize that changes
+  footer row count doesn't diff against a stale-length list). Updates
+  `footer_lines` so the next call diffs against what was actually painted.
+
+  Self-promotes to a full `keyframe/2` -- clearing `needs_keyframe` in the
+  process -- when that flag is set (a prior geometry-changing `resize/3`):
+  see the moduledoc's "`needs_keyframe` latch" section for why a diff-only
+  repaint is not safe to trust immediately after a resize.
   """
   @spec repaint(t(), [binary()]) :: t()
+  def repaint(%__MODULE__{needs_keyframe: true} = t, new_lines)
+      when is_list(new_lines) do
+    keyframe(t, new_lines)
+  end
+
   def repaint(%__MODULE__{footer_lines: old_lines} = t, new_lines)
       when is_list(new_lines) do
     count = footer_row_count(t)
-    padded_new = pad_rows(new_lines, count)
+    padded_new = sanitize_and_pad(new_lines, count)
     padded_old = pad_rows(old_lines, count)
 
     case footer_diff(padded_old, padded_new) do
-      [] ->
-        t
-
-      changes ->
-        footer_top = region_top(t) + 1
-
-        iodata =
-          Enum.map(changes, fn {idx, line} ->
-            footer_row_bytes(footer_top + idx, line)
-          end)
-
-        t
-        |> with_cursor(:footer, fn inner -> repaint_footer(inner, iodata) end)
-        |> Map.put(:footer_lines, padded_new)
+      [] -> %{t | footer_lines: padded_new}
+      changes -> emit_footer_diff(t, changes, padded_new)
     end
+  end
+
+  defp emit_footer_diff(t, changes, padded_new) do
+    footer_top = region_top(t) + 1
+
+    iodata =
+      Enum.map(changes, fn {idx, line} ->
+        footer_row_bytes(footer_top + idx, line)
+      end)
+
+    t
+    |> with_cursor(:footer, fn inner -> repaint_footer(inner, iodata) end)
+    |> Map.put(:footer_lines, padded_new)
   end
 
   @doc """
@@ -406,13 +477,30 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   Ctrl-L recovery entry point, and what a caller composes after
   `resize/3` to re-derive the footer's on-screen content at the new
   geometry (see the moduledoc's "T2c" section for why `resize/3` itself
-  does not call this). Pads/truncates `new_lines` to the CURRENT footer
-  row count, same as `repaint/2`.
+  does not call this) -- and what `repaint/2` self-promotes to when
+  `needs_keyframe` is set. Sanitizes every line of `new_lines` through
+  `ContentGuard.sanitize_line/1` (same as `repaint/2`), then pads/
+  truncates to the CURRENT footer row count.
+
+  When the current footer row count is zero (degenerate geometry, see
+  `degenerate?/1`), returns `t` immediately -- no `with_cursor/3` bracket
+  is opened at all. Emitting an empty `\\e7`/`\\e8` save/restore pair over
+  zero addressed rows would be a byte-for-byte no-op wrapped in
+  ceremony; on a geometry that can't show a footer at all, emitting
+  nothing is the honest behavior.
   """
   @spec keyframe(t(), [binary()]) :: t()
   def keyframe(%__MODULE__{} = t, new_lines) when is_list(new_lines) do
     count = footer_row_count(t)
-    padded_new = pad_rows(new_lines, count)
+    padded_new = sanitize_and_pad(new_lines, count)
+
+    case count do
+      0 -> %{t | footer_lines: padded_new, needs_keyframe: false}
+      _ -> emit_footer_keyframe(t, padded_new)
+    end
+  end
+
+  defp emit_footer_keyframe(t, padded_new) do
     footer_top = region_top(t) + 1
 
     iodata =
@@ -425,6 +513,17 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     t
     |> with_cursor(:footer, fn inner -> keyframe_footer(inner, iodata) end)
     |> Map.put(:footer_lines, padded_new)
+    |> Map.put(:needs_keyframe, false)
+  end
+
+  # Common entry sanitization for both repaint/2 and keyframe/2: every
+  # caller-supplied line is agent/LLM-originated (same trust boundary as
+  # seal/2's history-side iodata -- see the moduledoc's review-response
+  # section) and must be neutralized BEFORE padding/diffing ever sees it.
+  defp sanitize_and_pad(new_lines, count) do
+    new_lines
+    |> Enum.map(&ContentGuard.sanitize_line/1)
+    |> pad_rows(count)
   end
 
   @doc "The current footer row count -- the size of `ScrollRegionManager.footer_range/1`, never a hand-maintained constant."
@@ -498,14 +597,25 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   the moduledoc's "T2c" section. Neither call ever emits
   `\\e[2J`/`\\e[3J` or addresses a history row, so the composition
   inherits both properties.
+
+  When the resize actually changes geometry (`ScrollRegionManager
+  .geometry_changed?/2`), also sets `needs_keyframe: true` -- a pure state
+  change, zero bytes -- so the NEXT `repaint/2` call self-promotes to a
+  full `keyframe/2` instead of trusting a diff against footer content
+  whose on-screen ROW POSITIONS just moved (see the moduledoc's
+  "`needs_keyframe` latch" section). This is independent of
+  `reflow_capable?/1`/the telemetry hook below: the ghost-content risk
+  applies to every terminal's footer, not just the (B)-detection subset.
   """
   @impl true
   def resize(%__MODULE__{region: region, next_row: next_row} = t, width, height) do
     old_region = region
     new_region = ScrollRegionManager.resize(region, height)
 
-    if ScrollRegionManager.geometry_changed?(old_region, new_region) and
-         t.reflow_capable? do
+    geometry_changed? =
+      ScrollRegionManager.geometry_changed?(old_region, new_region)
+
+    if geometry_changed? and t.reflow_capable? do
       # The reflow-aware detection seam firing: this session's terminal
       # is known, from the terminal-matrix probe, to reflow sealed
       # history cleanly on a geometry-changing resize. NOTHING is
@@ -530,7 +640,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
         # Existing on-screen content is untouched (seal-time-only: no
         # re-emission) — only where FUTURE appends resume is clamped to
         # the (possibly smaller) new bottom row.
-        next_row: min(next_row, ScrollRegionManager.history_bottom(new_region))
+        next_row: min(next_row, ScrollRegionManager.history_bottom(new_region)),
+        needs_keyframe: t.needs_keyframe or geometry_changed?
     }
   end
 

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -99,14 +99,13 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   implement. Contract-only-grows: this module never has to be rewritten
   to add reflow-aware re-emission later, only extended.
 
-  ## T2c: the pinned footer viewport (buffer-diff, footer-scoped)
+  ## The pinned footer viewport (buffer-diff, footer-scoped)
 
-  T2b's `repaint_footer/2`/`keyframe_footer/2` `@impl` callbacks were
-  deliberate placeholders ("mirrors `PaintAuthority.IOAuthority`'s
-  minimal stub so the behaviour is satisfied without reaching into T2c's
-  work"). T2c fills that in with the real buffer-diff pipeline the
-  roadmap describes ("a buffer-diff pipeline scoped to the footer rows
-  only... every emitted CUP scoped to footer rows"):
+  The `repaint_footer/2`/`keyframe_footer/2` `@impl` callbacks were
+  deliberate placeholders: minimal pass-through stubs that satisfy the
+  behaviour without any real positioning/diff logic. This module fills
+  that in with a buffer-diff pipeline scoped to the footer rows only —
+  every emitted CUP stays inside footer rows:
 
     * `footer_diff/2` — pure function, no I/O: given the last-painted
       footer content and the next footer content (both one binary per
@@ -115,8 +114,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       actually changed. This is the "minimal repaint bytes" half of the
       pipeline, kept separate from the emit half so it is unit-testable
       with zero device/cursor setup.
-    * `repaint/2` — the diff-driven entry point (T2c's normal per-frame
-      footer update): pads/truncates the caller's next footer lines to
+    * `repaint/2` — the diff-driven entry point for normal per-frame
+      footer updates: pads/truncates the caller's next footer lines to
       the CURRENT footer row count (`ScrollRegionManager.footer_range/1`
       via `footer_row_count/1`), diffs against `footer_lines` (the
       struct field this module now tracks), and emits ONLY the changed
@@ -131,17 +130,19 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       (never a full-screen clear). This is the Ctrl-L recovery entry
       point. Composition note: `resize/3` (below) re-derives the
       DECSTBM split but deliberately does NOT call this automatically —
-      see `resize/3`'s doc for why (an existing T2b regression test
-      pins resize to emit only the DECSTBM re-set). Callers that also
-      need the footer re-rendered at the new geometry compose explicitly:
+      see `resize/3`'s doc for why (an existing regression test on the
+      append path pins resize to emit only the DECSTBM re-set). Callers
+      that also need the footer re-rendered at the new geometry compose
+      explicitly:
       `authority |> InlineAuthority.resize(w, h) |> InlineAuthority.keyframe(current_lines)`.
       Both calls already guarantee no `\\e[2J`/`\\e[3J` and no history
       addressing, so the composition inherits both properties for free.
 
   Every row either function addresses is computed from
-  `region_top(t) + 1 .. rows(region)` (T2a's `footer_range/1`) — never a
-  hand-maintained constant — so a footer paint can never drift into the
-  scrolling history region even under resize.
+  `region_top(t) + 1 .. rows(region)` (the scroll-region manager's
+  `footer_range/1`) — never a hand-maintained constant — so a footer
+  paint can never drift into the scrolling history region even under
+  resize.
 
   ## Caller contract: footer line width (NOT enforced here)
 
@@ -151,12 +152,12 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   than the terminal's column count wraps onto the following row (a real
   terminal's own line-wrap behavior), which breaks footer confinement: the
   wrapped tail lands on whatever row follows, which may be the next footer
-  row (silently overwriting content INV-2 assumes only `repaint/2`
-  addresses) or, on the LAST footer row, past the bottom of the screen
+  row (silently overwriting content that only `repaint/2` is assumed to
+  address) or, on the LAST footer row, past the bottom of the screen
   entirely. This module does not defend against that — it is the caller's
-  (T13a's assembler) responsibility to display-width-truncate every line
-  to the authority's `width` (the same value passed to `new/5`) BEFORE
-  calling `repaint/2`/`keyframe/2`. Use `Raxol.UI.TextMeasure` for that
+  responsibility to display-width-truncate every line to the authority's
+  `width` (the same value passed to `new/5`) BEFORE calling
+  `repaint/2`/`keyframe/2`. Use `Raxol.UI.TextMeasure` for that
   measurement — never `String.length/1`, which undercounts double-width
   (CJK) characters and would let a line that measures "short" by codepoint
   count still overflow the column budget.
@@ -164,27 +165,27 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   ## Degenerate geometry: `degenerate?/1`
 
   A terminal too short for its requested footer (`rows - footer_rows < 2`,
-  T2a's `ScrollRegionManager.degenerate?/1`) cannot have its footer
-  actually pinned via DECSTBM — see that module's moduledoc for why. This
-  module surfaces that fact via `degenerate?/1` (a thin delegation, no
-  behavior change) so callers can detect the condition and adapt — e.g.
-  T13a falling back to redrawing the footer every frame — instead of
-  silently trusting a pin that a real terminal ignored. `repaint/2` and
-  `keyframe/2` still function on a degenerate geometry (never crash): they
-  simply operate over whatever footer capacity `footer_range/1` actually
-  reports for that geometry, which may be smaller than `footer_rows`
-  requested, or empty.
+  the scroll-region manager's `ScrollRegionManager.degenerate?/1`) cannot
+  have its footer actually pinned via DECSTBM — see that module's
+  moduledoc for why. This module surfaces that fact via `degenerate?/1`
+  (a thin delegation, no behavior change) so callers can detect the
+  condition and adapt — e.g. falling back to redrawing the footer every
+  frame — instead of silently trusting a pin that a real terminal
+  ignored. `repaint/2` and `keyframe/2` still function on a degenerate
+  geometry (never crash): they simply operate over whatever footer
+  capacity `footer_range/1` actually reports for that geometry, which may
+  be smaller than `footer_rows` requested, or empty.
 
-  ## T2c review response: footer `ContentGuard`, and the `needs_keyframe` latch
+  ## Footer `ContentGuard`, and the `needs_keyframe` latch
 
-  Two FIX-NOW findings from review, both closed here:
+  Two properties enforced here:
 
-    * **Footer content is not trusted either (HIGH).** T2b's review
-      already established that `seal/2` cannot write agent/LLM-originated
-      iodata verbatim (`ContentGuard.sanitize_line/1`); the footer path
-      carries the SAME kind of content (live-tail/agent text) through the
-      SAME risk (a footer line smuggling `\\e[3;1H`/`\\e[2J`/etc. would
-      execute against the footer confinement invariant exactly like an
+    * **Footer content is not trusted either.** The history append path
+      does not write agent/LLM-originated iodata verbatim
+      (`ContentGuard.sanitize_line/1`); the footer path carries the SAME
+      kind of content (live-tail/agent text) through the SAME risk (a
+      footer line smuggling `\\e[3;1H`/`\\e[2J`/etc. would execute
+      against the footer confinement invariant exactly like an
       unguarded history append would against the seal-once invariant).
       `repaint/2` and `keyframe/2` both run every caller-supplied line
       through `ContentGuard.sanitize_line/1` at entry — BEFORE padding or
@@ -193,7 +194,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       invariant: once sanitized in, never re-sanitized out, so `footer_diff/2`
       comparing old (already-sanitized) against new (freshly-sanitized) is
       always an apples-to-apples comparison.
-    * **A stale post-resize repaint could leave ghost content (MED).**
+    * **A stale post-resize repaint could leave ghost content.**
       `resize/3` clamps `next_row` but, by design (see above), never
       repaints the footer — a geometry-changing resize can relocate the
       footer's on-screen rows to different absolute row numbers while their
@@ -204,7 +205,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       history text, or a stale row `repaint/2` previously left blank via
       `\\e[K` at the OLD position). The `needs_keyframe` flag closes this:
       a resize that changes EITHER axis — vertical geometry (`history_bottom`)
-      OR width — sets it (a pure state change — the pinned T2b regression test
+      OR width — sets it (a pure state change — the pinned regression test
       asserting resize's ONLY new bytes are `ScrollRegionManager`'s single
       DECSTBM re-set is untouched, since setting a struct field emits no bytes,
       and a width-only resize re-emits no region bytes at all). Width matters
@@ -426,10 +427,10 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   end
 
   @doc """
-  T2c's diff-driven footer repaint: sanitizes every line of `new_lines`
+  The diff-driven footer repaint: sanitizes every line of `new_lines`
   through `ContentGuard.sanitize_line/1` (footer content is agent/LLM-
   originated, same as the history append path -- see the moduledoc's
-  review-response section), pads/truncates the sanitized result to the
+  `ContentGuard` section), pads/truncates the sanitized result to the
   CURRENT footer row count, diffs against the last-painted footer
   (`footer_diff/2`), and emits only the changed rows -- each `CUP`
   (inside the footer range, never history) + `\\e[K` (per-row clear,
@@ -480,8 +481,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   full-screen clear) and rewritten, regardless of what changed. The
   Ctrl-L recovery entry point, and what a caller composes after
   `resize/3` to re-derive the footer's on-screen content at the new
-  geometry (see the moduledoc's "T2c" section for why `resize/3` itself
-  does not call this) -- and what `repaint/2` self-promotes to when
+  geometry (see the moduledoc's "pinned footer viewport" section for why
+  `resize/3` itself does not call this) -- and what `repaint/2` self-promotes to when
   `needs_keyframe` is set. Sanitizes every line of `new_lines` through
   `ContentGuard.sanitize_line/1` (same as `repaint/2`), then pads/
   truncates to the CURRENT footer row count.
@@ -522,7 +523,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   # Common entry sanitization for both repaint/2 and keyframe/2: every
   # caller-supplied line is agent/LLM-originated (same trust boundary as
-  # seal/2's history-side iodata -- see the moduledoc's review-response
+  # seal/2's history-side iodata -- see the moduledoc's `ContentGuard`
   # section) and must be neutralized BEFORE padding/diffing ever sees it.
   defp sanitize_and_pad(new_lines, count) do
     new_lines
@@ -589,17 +590,18 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   @doc """
   Re-derives the DECSTBM history/footer split for a new geometry (via
-  T2a's `ScrollRegionManager.resize/2`, one `CSI 1;(H-N) r` write) and
-  clamps the append cursor. Deliberately does NOT also repaint the
-  footer's on-screen content here -- an existing T2b regression test
+  the scroll-region manager's `ScrollRegionManager.resize/2`, one
+  `CSI 1;(H-N) r` write) and clamps the append cursor. Deliberately does
+  NOT also repaint the footer's on-screen content here -- an existing
+  regression test on the append path
   (`renderer_adversarial_property_test.exs`, "the ONLY new bytes after
   resize are ScrollRegionManager's single DECSTBM re-set") pins this
   callback to emit nothing else, and folding a footer keyframe in here
   would silently break that pinned byte-count. Callers that also need
   the footer redrawn at the new geometry compose explicitly:
   `authority |> resize(w, h) |> keyframe(current_footer_lines)` -- see
-  the moduledoc's "T2c" section. Neither call ever emits
-  `\\e[2J`/`\\e[3J` or addresses a history row, so the composition
+  the moduledoc's "pinned footer viewport" section. Neither call ever
+  emits `\\e[2J`/`\\e[3J` or addresses a history row, so the composition
   inherits both properties.
 
   When the resize changes EITHER axis -- vertical geometry
@@ -622,13 +624,14 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
     # `geometry_changed?` is the REGION-re-emission gate: it watches the
     # VERTICAL axis (`history_bottom`, row-based) and is correctly blind to
-    # width — a width-only resize needs no DECSTBM bytes (T2b's pinned
-    # regression). But keyframe + reflow are HORIZONTAL concerns: reflow-
-    # capable terminals rewrap sealed history on a WIDTH change (RB probe,
-    # measured on 4/5 terminals — kitty is the no-reflow exception), and a
-    # width-shrink can wrap an untruncated footer line past the pin. So the
-    # latch and the reflow seam key on the width axis too; only the region
-    # re-emission stays vertical-only.
+    # width — a width-only resize needs no DECSTBM bytes (the append
+    # path's pinned regression). But keyframe + reflow are HORIZONTAL
+    # concerns: reflow-capable terminals rewrap sealed history on a WIDTH
+    # change (the terminal-matrix probe measured this on 4/5 terminals —
+    # kitty is the no-reflow exception), and a width-shrink can wrap an
+    # untruncated footer line past the pin. So the latch and the reflow
+    # seam key on the width axis too; only the region re-emission stays
+    # vertical-only.
     width_changed? = t.width != width
     reflow_relevant? = geometry_changed? or width_changed?
 
@@ -671,11 +674,10 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   @doc """
   True when this authority's current geometry cannot form a valid DECSTBM
   region — i.e. the footer is NOT actually pinned right now (see the
-  moduledoc's "Degenerate geometry" section). A thin delegation to T2a's
+  moduledoc's "Degenerate geometry" section). A thin delegation to
   `ScrollRegionManager.degenerate?/1`; no behavior change of its own.
-  Callers that need to know whether the pin is real (T13a's assembler)
-  should check this rather than assuming `new/5`/`resize/3` always
-  succeeded.
+  Callers that need to know whether the pin is real should check this
+  rather than assuming `new/5`/`resize/3` always succeeded.
   """
   @spec degenerate?(t()) :: boolean()
   def degenerate?(%__MODULE__{region: region}),

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -98,6 +98,82 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   runtime-detected additive upgrade, deferred for a future unit to
   implement. Contract-only-grows: this module never has to be rewritten
   to add reflow-aware re-emission later, only extended.
+
+  ## T2c: the pinned footer viewport (buffer-diff, footer-scoped)
+
+  T2b's `repaint_footer/2`/`keyframe_footer/2` `@impl` callbacks were
+  deliberate placeholders ("mirrors `PaintAuthority.IOAuthority`'s
+  minimal stub so the behaviour is satisfied without reaching into T2c's
+  work"). T2c fills that in with the real buffer-diff pipeline the
+  roadmap describes ("a buffer-diff pipeline scoped to the footer rows
+  only... every emitted CUP scoped to footer rows"):
+
+    * `footer_diff/2` — pure function, no I/O: given the last-painted
+      footer content and the next footer content (both one binary per
+      footer row, top-to-bottom, already padded/truncated to the same
+      row count), returns only the `{row_index, line}` pairs that
+      actually changed. This is the "minimal repaint bytes" half of the
+      pipeline, kept separate from the emit half so it is unit-testable
+      with zero device/cursor setup.
+    * `repaint/2` — the diff-driven entry point (T2c's normal per-frame
+      footer update): pads/truncates the caller's next footer lines to
+      the CURRENT footer row count (`ScrollRegionManager.footer_range/1`
+      via `footer_row_count/1`), diffs against `footer_lines` (the
+      struct field this module now tracks), and emits ONLY the changed
+      rows — each one `CUP` (to `region_top(t) + 1 + row_index`, always
+      inside the footer range) then `\\e[K` (clear that row, never
+      `\\e[2J`/`\\e[3J`) then the new content — inside a single
+      `with_cursor/3` bracket (`:footer` region) so a footer repaint
+      never corrupts the history path's saved cursor. A no-op diff
+      (nothing changed) emits zero bytes.
+    * `keyframe/2` — the FULL footer repaint: every footer row cleared
+      and rewritten regardless of what changed, still per-row `\\e[K`
+      (never a full-screen clear). This is the Ctrl-L recovery entry
+      point. Composition note: `resize/3` (below) re-derives the
+      DECSTBM split but deliberately does NOT call this automatically —
+      see `resize/3`'s doc for why (an existing T2b regression test
+      pins resize to emit only the DECSTBM re-set). Callers that also
+      need the footer re-rendered at the new geometry compose explicitly:
+      `authority |> InlineAuthority.resize(w, h) |> InlineAuthority.keyframe(current_lines)`.
+      Both calls already guarantee no `\\e[2J`/`\\e[3J` and no history
+      addressing, so the composition inherits both properties for free.
+
+  Every row either function addresses is computed from
+  `region_top(t) + 1 .. rows(region)` (T2a's `footer_range/1`) — never a
+  hand-maintained constant — so a footer paint can never drift into the
+  scrolling history region even under resize.
+
+  ## Caller contract: footer line width (NOT enforced here)
+
+  `repaint/2` and `keyframe/2` pad/truncate the LIST of footer lines to the
+  current footer row COUNT (`footer_row_count/1`) — but neither function
+  measures or truncates an individual LINE's display width. A line wider
+  than the terminal's column count wraps onto the following row (a real
+  terminal's own line-wrap behavior), which breaks footer confinement: the
+  wrapped tail lands on whatever row follows, which may be the next footer
+  row (silently overwriting content INV-2 assumes only `repaint/2`
+  addresses) or, on the LAST footer row, past the bottom of the screen
+  entirely. This module does not defend against that — it is the caller's
+  (T13a's assembler) responsibility to display-width-truncate every line
+  to the authority's `width` (the same value passed to `new/5`) BEFORE
+  calling `repaint/2`/`keyframe/2`. Use `Raxol.UI.TextMeasure` for that
+  measurement — never `String.length/1`, which undercounts double-width
+  (CJK) characters and would let a line that measures "short" by codepoint
+  count still overflow the column budget.
+
+  ## Degenerate geometry: `degenerate?/1`
+
+  A terminal too short for its requested footer (`rows - footer_rows < 2`,
+  T2a's `ScrollRegionManager.degenerate?/1`) cannot have its footer
+  actually pinned via DECSTBM — see that module's moduledoc for why. This
+  module surfaces that fact via `degenerate?/1` (a thin delegation, no
+  behavior change) so callers can detect the condition and adapt — e.g.
+  T13a falling back to redrawing the footer every frame — instead of
+  silently trusting a pin that a real terminal ignored. `repaint/2` and
+  `keyframe/2` still function on a degenerate geometry (never crash): they
+  simply operate over whatever footer capacity `footer_range/1` actually
+  reports for that geometry, which may be smaller than `footer_rows`
+  requested, or empty.
   """
 
   @behaviour Raxol.UI.Rendering.PaintAuthority
@@ -113,7 +189,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     :width,
     :reflow_capable?,
     :next_row,
-    in_cursor_bracket: false
+    in_cursor_bracket: false,
+    footer_lines: []
   ]
 
   @type t :: %__MODULE__{
@@ -121,7 +198,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
           width: pos_integer(),
           reflow_capable?: boolean(),
           next_row: pos_integer(),
-          in_cursor_bracket: boolean()
+          in_cursor_bracket: boolean(),
+          footer_lines: [binary()]
         }
 
   @doc """
@@ -257,12 +335,10 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   @impl true
   def repaint_footer(%__MODULE__{region: region} = t, iodata) do
-    # Placeholder pass-through pending the footer viewport (pinned
-    # viewport): this module's scope is the append path + the shared
-    # cursor protocol seam, not the footer's own positioning/diff
-    # discipline. Mirrors `PaintAuthority.IOAuthority`'s minimal stub so
-    # the behaviour is satisfied without reaching into the footer
-    # viewport's work.
+    # Low-level @impl callback: write already-scoped footer bytes. The
+    # diff logic (deciding WHICH rows and building those bytes) lives in
+    # `repaint/2`, above the behaviour seam, mirroring how `seal/2` sits
+    # above `append_sealed/2` on the history side.
     IO.write(region.device, iodata)
     t
   end
@@ -271,6 +347,102 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   def keyframe_footer(%__MODULE__{region: region} = t, iodata) do
     IO.write(region.device, iodata)
     t
+  end
+
+  @doc """
+  Pure diff: only the `{row_index, line}` pairs that differ between
+  `old_lines` and `new_lines` (both already the SAME length — pad/
+  truncate before calling, see `repaint/2`). No I/O, no cursor movement.
+  `row_index` is 0-based, relative to the top of the footer.
+  """
+  @spec footer_diff([binary()], [binary()]) :: [{non_neg_integer(), binary()}]
+  def footer_diff(old_lines, new_lines)
+      when is_list(old_lines) and is_list(new_lines) and
+             length(old_lines) == length(new_lines) do
+    old_lines
+    |> Enum.zip(new_lines)
+    |> Enum.with_index()
+    |> Enum.reject(fn {{old_line, new_line}, _idx} -> old_line == new_line end)
+    |> Enum.map(fn {{_old_line, new_line}, idx} -> {idx, new_line} end)
+  end
+
+  @doc """
+  T2c's diff-driven footer repaint: pads/truncates `new_lines` to the
+  CURRENT footer row count, diffs against the last-painted footer
+  (`footer_diff/2`), and emits only the changed rows -- each `CUP`
+  (inside the footer range, never history) + `\\e[K` (per-row clear,
+  never `\\e[2J`) + the new line content -- inside one `with_cursor/3`
+  bracket. Zero changed rows emits zero bytes. Updates `footer_lines` so
+  the next call diffs against what was actually painted.
+  """
+  @spec repaint(t(), [binary()]) :: t()
+  def repaint(%__MODULE__{footer_lines: old_lines} = t, new_lines)
+      when is_list(new_lines) do
+    count = footer_row_count(t)
+    padded_new = pad_rows(new_lines, count)
+    padded_old = pad_rows(old_lines, count)
+
+    case footer_diff(padded_old, padded_new) do
+      [] ->
+        t
+
+      changes ->
+        footer_top = region_top(t) + 1
+
+        iodata =
+          Enum.map(changes, fn {idx, line} ->
+            footer_row_bytes(footer_top + idx, line)
+          end)
+
+        t
+        |> with_cursor(:footer, fn inner -> repaint_footer(inner, iodata) end)
+        |> Map.put(:footer_lines, padded_new)
+    end
+  end
+
+  @doc """
+  Footer keyframe: every footer row cleared (`\\e[K`, never a
+  full-screen clear) and rewritten, regardless of what changed. The
+  Ctrl-L recovery entry point, and what a caller composes after
+  `resize/3` to re-derive the footer's on-screen content at the new
+  geometry (see the moduledoc's "T2c" section for why `resize/3` itself
+  does not call this). Pads/truncates `new_lines` to the CURRENT footer
+  row count, same as `repaint/2`.
+  """
+  @spec keyframe(t(), [binary()]) :: t()
+  def keyframe(%__MODULE__{} = t, new_lines) when is_list(new_lines) do
+    count = footer_row_count(t)
+    padded_new = pad_rows(new_lines, count)
+    footer_top = region_top(t) + 1
+
+    iodata =
+      padded_new
+      |> Enum.with_index()
+      |> Enum.map(fn {line, idx} ->
+        footer_row_bytes(footer_top + idx, line)
+      end)
+
+    t
+    |> with_cursor(:footer, fn inner -> keyframe_footer(inner, iodata) end)
+    |> Map.put(:footer_lines, padded_new)
+  end
+
+  @doc "The current footer row count -- the size of `ScrollRegionManager.footer_range/1`, never a hand-maintained constant."
+  @spec footer_row_count(t()) :: non_neg_integer()
+  def footer_row_count(%__MODULE__{region: region}),
+    do: Range.size(ScrollRegionManager.footer_range(region))
+
+  defp footer_row_bytes(row, line), do: [cup(row), "\e[K", line]
+
+  defp pad_rows(lines, count) do
+    lines |> Enum.take(count) |> pad_tail(count)
+  end
+
+  defp pad_tail(lines, count) do
+    case count - length(lines) do
+      n when n > 0 -> lines ++ List.duplicate("", n)
+      _ -> lines
+    end
   end
 
   @impl true
@@ -312,6 +484,21 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     end
   end
 
+  @doc """
+  Re-derives the DECSTBM history/footer split for a new geometry (via
+  T2a's `ScrollRegionManager.resize/2`, one `CSI 1;(H-N) r` write) and
+  clamps the append cursor. Deliberately does NOT also repaint the
+  footer's on-screen content here -- an existing T2b regression test
+  (`renderer_adversarial_property_test.exs`, "the ONLY new bytes after
+  resize are ScrollRegionManager's single DECSTBM re-set") pins this
+  callback to emit nothing else, and folding a footer keyframe in here
+  would silently break that pinned byte-count. Callers that also need
+  the footer redrawn at the new geometry compose explicitly:
+  `authority |> resize(w, h) |> keyframe(current_footer_lines)` -- see
+  the moduledoc's "T2c" section. Neither call ever emits
+  `\\e[2J`/`\\e[3J` or addresses a history row, so the composition
+  inherits both properties.
+  """
   @impl true
   def resize(%__MODULE__{region: region, next_row: next_row} = t, width, height) do
     old_region = region
@@ -350,6 +537,21 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   @impl true
   def region_top(%__MODULE__{region: region}),
     do: ScrollRegionManager.history_bottom(region)
+
+  @doc """
+  True when this authority's current geometry cannot form a valid DECSTBM
+  region — i.e. the footer is NOT actually pinned right now (see the
+  moduledoc's "Degenerate geometry" section). A thin delegation to T2a's
+  `ScrollRegionManager.degenerate?/1`; no behavior change of its own.
+  Callers that need to know whether the pin is real (T13a's assembler)
+  should check this rather than assuming `new/5`/`resize/3` always
+  succeeded.
+  """
+  @spec degenerate?(t()) :: boolean()
+  def degenerate?(%__MODULE__{region: region}),
+    do: ScrollRegionManager.degenerate?(region)
+
+  defp cup(row), do: "\e[#{row};1H"
 
   defp count_lines(iodata) do
     iodata

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -203,15 +203,19 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       whatever was on screen at that position before the resize (leftover
       history text, or a stale row `repaint/2` previously left blank via
       `\\e[K` at the OLD position). The `needs_keyframe` flag closes this:
-      a geometry-changing `resize/3` sets it (a pure state change — the
-      pinned T2b regression test asserting resize's ONLY new bytes are
-      `ScrollRegionManager`'s single DECSTBM re-set is untouched, since
-      setting a struct field emits no bytes); the NEXT `repaint/2` call
-      checks it FIRST and, if set, self-promotes to a full `keyframe/2`
-      (which clears the flag) instead of running its normal diff — so the
-      first repaint after any geometry change always fully re-renders the
-      footer at its current position, regardless of whether the logical
-      content changed.
+      a resize that changes EITHER axis — vertical geometry (`history_bottom`)
+      OR width — sets it (a pure state change — the pinned T2b regression test
+      asserting resize's ONLY new bytes are `ScrollRegionManager`'s single
+      DECSTBM re-set is untouched, since setting a struct field emits no bytes,
+      and a width-only resize re-emits no region bytes at all). Width matters
+      here even though the region doesn't move: a reflow-capable terminal
+      rewraps sealed history on a width change, and a width-shrink can wrap an
+      untruncated footer line past the pin, so the footer needs a clean
+      re-render at the new width. The NEXT `repaint/2` call checks the flag
+      FIRST and, if set, self-promotes to a full `keyframe/2` (which clears the
+      flag) instead of running its normal diff — so the first repaint after any
+      geometry OR width change always fully re-renders the footer at its current
+      position and width, regardless of whether the logical content changed.
   """
 
   @behaviour Raxol.UI.Rendering.PaintAuthority
@@ -598,14 +602,15 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   `\\e[2J`/`\\e[3J` or addresses a history row, so the composition
   inherits both properties.
 
-  When the resize actually changes geometry (`ScrollRegionManager
-  .geometry_changed?/2`), also sets `needs_keyframe: true` -- a pure state
-  change, zero bytes -- so the NEXT `repaint/2` call self-promotes to a
-  full `keyframe/2` instead of trusting a diff against footer content
-  whose on-screen ROW POSITIONS just moved (see the moduledoc's
-  "`needs_keyframe` latch" section). This is independent of
-  `reflow_capable?/1`/the telemetry hook below: the ghost-content risk
-  applies to every terminal's footer, not just the (B)-detection subset.
+  When the resize changes EITHER axis -- vertical geometry
+  (`ScrollRegionManager.geometry_changed?/2`) OR width (`t.width != width`) --
+  also sets `needs_keyframe: true` -- a pure state change, zero bytes -- so the
+  NEXT `repaint/2` call self-promotes to a full `keyframe/2` instead of trusting
+  a diff against footer content whose on-screen ROW POSITIONS moved (vertical)
+  or whose width-correct truncation went stale / whose sealed history rewrapped
+  (horizontal). This is independent of `reflow_capable?/1`/the telemetry hook
+  below: the ghost-content risk applies to every terminal's footer, not just the
+  (B)-detection subset.
   """
   @impl true
   def resize(%__MODULE__{region: region, next_row: next_row} = t, width, height) do
@@ -615,20 +620,34 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     geometry_changed? =
       ScrollRegionManager.geometry_changed?(old_region, new_region)
 
-    if geometry_changed? and t.reflow_capable? do
-      # The reflow-aware detection seam firing: this session's terminal
-      # is known, from the terminal-matrix probe, to reflow sealed
-      # history cleanly on a geometry-changing resize. NOTHING is
-      # re-emitted here — re-emission is a FUTURE unit's job (ship
-      # seal-time-only now; reflow-aware re-emission is a
-      # runtime-detected ADDITIVE upgrade). This telemetry event is the
-      # thin hook that unit gates on.
+    # `geometry_changed?` is the REGION-re-emission gate: it watches the
+    # VERTICAL axis (`history_bottom`, row-based) and is correctly blind to
+    # width — a width-only resize needs no DECSTBM bytes (T2b's pinned
+    # regression). But keyframe + reflow are HORIZONTAL concerns: reflow-
+    # capable terminals rewrap sealed history on a WIDTH change (RB probe,
+    # measured on 4/5 terminals — kitty is the no-reflow exception), and a
+    # width-shrink can wrap an untruncated footer line past the pin. So the
+    # latch and the reflow seam key on the width axis too; only the region
+    # re-emission stays vertical-only.
+    width_changed? = t.width != width
+    reflow_relevant? = geometry_changed? or width_changed?
+
+    if reflow_relevant? and t.reflow_capable? do
+      # The (B)-detection seam firing: this session's terminal is known,
+      # from RB's real-hardware C-4 probe, to reflow sealed history
+      # cleanly on a geometry-changing resize. NOTHING is re-emitted here
+      # — re-emission is a FUTURE unit's job (D-PA RULING: ship (A), (B)
+      # is a runtime-detected ADDITIVE upgrade). This telemetry event is
+      # the thin hook that unit gates on — it carries BOTH axes so the (B)
+      # unit can tell a rewrapping width change from a pure row change.
       :telemetry.execute(
         [:raxol, :ui, :paint_authority, :reflow_capable_resize],
         %{},
         %{
           old_region_top: ScrollRegionManager.history_bottom(old_region),
-          new_region_top: ScrollRegionManager.history_bottom(new_region)
+          new_region_top: ScrollRegionManager.history_bottom(new_region),
+          old_width: t.width,
+          new_width: width
         }
       )
     end
@@ -641,7 +660,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
         # re-emission) — only where FUTURE appends resume is clamped to
         # the (possibly smaller) new bottom row.
         next_row: min(next_row, ScrollRegionManager.history_bottom(new_region)),
-        needs_keyframe: t.needs_keyframe or geometry_changed?
+        needs_keyframe: t.needs_keyframe or reflow_relevant?
     }
   end
 

--- a/test/property/renderer_footer_adversarial_property_test.exs
+++ b/test/property/renderer_footer_adversarial_property_test.exs
@@ -1,19 +1,18 @@
 defmodule Raxol.Property.RendererFooterAdversarialTest do
   @moduledoc """
-  T2c's negative suite: the pinned footer viewport
-  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2c), scoped subset of
-  `harness-ui-testing/02-renderer.md` §5 relevant to the footer path
-  specifically (R-N2/R-N4-style, plus fail-first RED/GREEN pairs for the
-  footer-confinement and keyframe-ban guards T2c adds).
+  Negative-case suite for the pinned footer viewport, relevant to the
+  footer path specifically: characterization tests plus fail-first
+  RED/GREEN pairs for the footer-confinement and keyframe-ban guards this
+  module adds.
 
   Each test here either (a) characterizes a regression class the real,
-  full-grid path exhibits and proves the footer-scoped path is exempt
-  (R-N4), or (b) demonstrates a footer-scoped guard CATCHES a
-  deliberately wrong stream before trusting any of the positive suite's
-  GREEN results (the fail-first discipline `tb_oracle_test.exs`'s R-P12
-  established, `renderer_adversarial_property_test.exs` applied to T2b's
+  full-grid path exhibits and proves the footer-scoped path is exempt, or
+  (b) demonstrates a footer-scoped guard CATCHES a deliberately wrong
+  stream before trusting any of the positive suite's GREEN results (the
+  fail-first discipline `tb_oracle_test.exs` established and
+  `renderer_adversarial_property_test.exs` applied to the append path's
   `InlineAuthority.seal/2`; this file applies the same discipline to
-  T2c's `repaint/2`/`keyframe/2`).
+  `repaint/2`/`keyframe/2`).
   """
 
   use ExUnit.Case, async: true
@@ -81,11 +80,11 @@ defmodule Raxol.Property.RendererFooterAdversarialTest do
   end
 
   # ---------------------------------------------------------------------
-  # Acceptance 4 / R-N4: full-grid keyframe characterization vs the
+  # Acceptance 4: full-grid keyframe characterization vs the
   # footer-scoped path's exemption.
   # ---------------------------------------------------------------------
 
-  describe "R-N4 (footer-scoped contrast): full-grid \\e[2J-on-resize vs the footer path's exemption" do
+  describe "footer-scoped contrast: full-grid \\e[2J-on-resize vs the footer path's exemption" do
     test "characterization: Backends.build_terminal_frame/4 emits \\e[2J on a width change (today's known regression class)" do
       prev = ScreenBuffer.new(80, 24)
       next = ScreenBuffer.new(120, 24)
@@ -99,7 +98,7 @@ defmodule Raxol.Property.RendererFooterAdversarialTest do
                "footer path's exemption below is still a meaningful regression guard"
     end
 
-    test "regression guard: resize/3 |> keyframe/2 (T2c's footer re-derivation) emits no \\e[2J on the equivalent width+height change" do
+    test "regression guard: resize/3 |> keyframe/2 (the footer re-derivation) emits no \\e[2J on the equivalent width+height change" do
       {device, authority} = new_authority()
       authority = InlineAuthority.seal(authority, "sealed before resize\r\n")
       authority = InlineAuthority.repaint(authority, ["live", "composer"])
@@ -112,7 +111,7 @@ defmodule Raxol.Property.RendererFooterAdversarialTest do
   end
 
   # ---------------------------------------------------------------------
-  # Fail-first: footer-confinement (INV-2) must be ABLE to fail before any
+  # Fail-first: footer-confinement must be ABLE to fail before any
   # GREEN result from the positive suite is trusted.
   # ---------------------------------------------------------------------
 
@@ -178,8 +177,7 @@ defmodule Raxol.Property.RendererFooterAdversarialTest do
   end
 
   # ---------------------------------------------------------------------
-  # Fail-first: keyframe/Ctrl-L touching history (INV-2/INV-6) must be
-  # ABLE to fail.
+  # Fail-first: keyframe/Ctrl-L touching history must be ABLE to fail.
   # ---------------------------------------------------------------------
 
   describe "fail-first: keyframe-touches-history is caught by the confinement check" do
@@ -191,7 +189,7 @@ defmodule Raxol.Property.RendererFooterAdversarialTest do
 
       refute Enum.all?(rows, &(&1 in footer_range(authority))),
              "fail-first: the confinement check must be ABLE to fail on a " <>
-               "keyframe that touches history, or the INV-6 GREEN result " <>
+               "keyframe that touches history, or the GREEN result " <>
                "below is meaningless"
     end
 
@@ -211,9 +209,9 @@ defmodule Raxol.Property.RendererFooterAdversarialTest do
   end
 
   # ---------------------------------------------------------------------
-  # Fail-first: INV-1 from the footer side -- a footer-originated write
-  # that stomps sealed history must be caught by the immutable-prefix
-  # oracle, exactly as T2b's own fail-first test proves for a second seal.
+  # Fail-first: a footer-originated write that stomps sealed history must
+  # be caught by the immutable-prefix oracle, exactly as the append
+  # path's own fail-first test proves for a second seal.
   # ---------------------------------------------------------------------
 
   describe "fail-first: immutable-prefix oracle catches a footer write that stomps sealed history" do
@@ -228,8 +226,8 @@ defmodule Raxol.Property.RendererFooterAdversarialTest do
 
       # A buggy footer path that stomps the sealed history row instead of
       # confining itself to the footer range -- the two-emit-paths-collide
-      # failure mode INV-1 exists to reject, this time originating from
-      # the footer side rather than a second seal.
+      # failure mode this oracle exists to reject, this time originating
+      # from the footer side rather than a second seal.
       IO.write(device, "\e[1;1Hstomped by a buggy footer write\r\n")
 
       raw_final = raw(device)

--- a/test/property/renderer_footer_adversarial_property_test.exs
+++ b/test/property/renderer_footer_adversarial_property_test.exs
@@ -1,0 +1,274 @@
+defmodule Raxol.Property.RendererFooterAdversarialTest do
+  @moduledoc """
+  T2c's negative suite: the pinned footer viewport
+  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2c), scoped subset of
+  `harness-ui-testing/02-renderer.md` §5 relevant to the footer path
+  specifically (R-N2/R-N4-style, plus fail-first RED/GREEN pairs for the
+  footer-confinement and keyframe-ban guards T2c adds).
+
+  Each test here either (a) characterizes a regression class the real,
+  full-grid path exhibits and proves the footer-scoped path is exempt
+  (R-N4), or (b) demonstrates a footer-scoped guard CATCHES a
+  deliberately wrong stream before trusting any of the positive suite's
+  GREEN results (the fail-first discipline `tb_oracle_test.exs`'s R-P12
+  established, `renderer_adversarial_property_test.exs` applied to T2b's
+  `InlineAuthority.seal/2`; this file applies the same discipline to
+  T2c's `repaint/2`/`keyframe/2`).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Runtime.Rendering.Backends
+  alias Raxol.Harness.Test.BuggyAuthority
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Renderer
+  alias Raxol.Terminal.ScreenBuffer
+  alias Raxol.UI.Rendering.PaintAuthority.Dialect
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  @width 40
+  @height 10
+  @footer_rows 2
+  @region_top 8
+
+  defp new_authority(opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, @width, @height, @footer_rows, opts)}
+  end
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  defp footer_range(authority) do
+    top = InlineAuthority.region_top(authority)
+    count = InlineAuthority.footer_row_count(authority)
+    (top + 1)..(top + count)//1
+  end
+
+  defp delta(all_bytes, prior_size) do
+    binary_part(all_bytes, prior_size, byte_size(all_bytes) - prior_size)
+  end
+
+  defp strip_cursor_bracket(bytes) do
+    save = Dialect.cursor_save()
+    restore = Dialect.cursor_restore()
+
+    bytes
+    |> strip_prefix(save)
+    |> strip_suffix(restore)
+  end
+
+  defp strip_prefix(bytes, prefix) do
+    if String.starts_with?(bytes, prefix) do
+      binary_part(
+        bytes,
+        byte_size(prefix),
+        byte_size(bytes) - byte_size(prefix)
+      )
+    else
+      bytes
+    end
+  end
+
+  defp strip_suffix(bytes, suffix) do
+    if String.ends_with?(bytes, suffix) do
+      binary_part(bytes, 0, byte_size(bytes) - byte_size(suffix))
+    else
+      bytes
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Acceptance 4 / R-N4: full-grid keyframe characterization vs the
+  # footer-scoped path's exemption.
+  # ---------------------------------------------------------------------
+
+  describe "R-N4 (footer-scoped contrast): full-grid \\e[2J-on-resize vs the footer path's exemption" do
+    test "characterization: Backends.build_terminal_frame/4 emits \\e[2J on a width change (today's known regression class)" do
+      prev = ScreenBuffer.new(80, 24)
+      next = ScreenBuffer.new(120, 24)
+      renderer = Renderer.new(next, %{}, %{}, true)
+
+      frame = Backends.build_terminal_frame(prev, next, renderer, %{})
+
+      assert SealOracle.emits_full_clear?(frame),
+             "characterization assumption broke: build_terminal_frame no longer " <>
+               "clears on width change -- update this test, and re-verify the " <>
+               "footer path's exemption below is still a meaningful regression guard"
+    end
+
+    test "regression guard: resize/3 |> keyframe/2 (T2c's footer re-derivation) emits no \\e[2J on the equivalent width+height change" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "sealed before resize\r\n")
+      authority = InlineAuthority.repaint(authority, ["live", "composer"])
+
+      resized = InlineAuthority.resize(authority, 120, 24)
+      _final = InlineAuthority.keyframe(resized, ["live", "composer"])
+
+      refute SealOracle.emits_full_clear?(raw(device))
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Fail-first: footer-confinement (INV-2) must be ABLE to fail before any
+  # GREEN result from the positive suite is trusted.
+  # ---------------------------------------------------------------------
+
+  describe "fail-first: footer-confinement catches a deliberately-bleeding footer write" do
+    test "RED: BuggyAuthority.footer_bleed_cup/1 (absolute CUP one row into history) is caught by the confinement check" do
+      {_device, authority} = new_authority()
+      bad = BuggyAuthority.footer_bleed_cup(@region_top)
+
+      rows = SealOracle.cup_rows(bad)
+
+      refute Enum.all?(rows, &(&1 in footer_range(authority))),
+             "fail-first: the footer-confinement check must be ABLE to fail " <>
+               "on a bleeding absolute CUP, or every GREEN result below is " <>
+               "meaningless"
+    end
+
+    test "RED: BuggyAuthority.footer_bleed_relative/1 (CUP to footer then CUU into history) is caught by the confinement check" do
+      {_device, authority} = new_authority()
+      bad = BuggyAuthority.footer_bleed_relative(@region_top)
+
+      rows = SealOracle.cup_rows(bad)
+
+      refute Enum.all?(rows, &(&1 in footer_range(authority)))
+    end
+
+    test "RED: BuggyAuthority.footer_bleed_vpa/1 (CUP to footer then VPA into history) is caught by the confinement check" do
+      {_device, authority} = new_authority()
+      bad = BuggyAuthority.footer_bleed_vpa(@region_top)
+
+      rows = SealOracle.cup_rows(bad)
+
+      refute Enum.all?(rows, &(&1 in footer_range(authority)))
+    end
+
+    test "RED: a hand-injected footer write bypassing repaint/2 (raw CUP into history) is caught by the confinement check" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "history content\r\n")
+      prior_size = device |> raw() |> byte_size()
+
+      # Bypasses the safe `repaint/2` API entirely -- simulates a buggy
+      # footer implementation that forgot to scope its CUP to the footer
+      # range, addressing `region_top` (the last HISTORY row) instead.
+      IO.write(device, "\e[#{@region_top};1H\e[2Kbuggy footer bleed")
+
+      new_bytes = delta(raw(device), prior_size)
+      rows = SealOracle.cup_rows(new_bytes)
+
+      refute Enum.all?(rows, &(&1 in footer_range(authority)))
+    end
+
+    test "GREEN: the same scenarios, repainted via the real repaint/2, stay confined to the footer range" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "history content\r\n")
+      prior_size = device |> raw() |> byte_size()
+
+      authority = InlineAuthority.repaint(authority, ["status", "composer"])
+
+      new_bytes = delta(raw(device), prior_size)
+      rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+      assert Enum.all?(rows, &(&1 in footer_range(authority)))
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Fail-first: keyframe/Ctrl-L touching history (INV-2/INV-6) must be
+  # ABLE to fail.
+  # ---------------------------------------------------------------------
+
+  describe "fail-first: keyframe-touches-history is caught by the confinement check" do
+    test "RED: BuggyAuthority.keyframe_history_touch/1 (a footer keyframe burst that repaints a history row) is caught" do
+      {_device, authority} = new_authority()
+      bad = BuggyAuthority.keyframe_history_touch(@region_top)
+
+      rows = SealOracle.cup_rows(bad)
+
+      refute Enum.all?(rows, &(&1 in footer_range(authority))),
+             "fail-first: the confinement check must be ABLE to fail on a " <>
+               "keyframe that touches history, or the INV-6 GREEN result " <>
+               "below is meaningless"
+    end
+
+    test "GREEN: the real keyframe/2 (Ctrl-L recovery) never touches history, only the footer range" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "history content\r\n")
+      prior_size = device |> raw() |> byte_size()
+
+      authority = InlineAuthority.keyframe(authority, ["status", "composer"])
+
+      new_bytes = delta(raw(device), prior_size)
+      rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+      assert Enum.all?(rows, &(&1 in footer_range(authority)))
+      refute SealOracle.emits_full_clear?(new_bytes)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Fail-first: INV-1 from the footer side -- a footer-originated write
+  # that stomps sealed history must be caught by the immutable-prefix
+  # oracle, exactly as T2b's own fail-first test proves for a second seal.
+  # ---------------------------------------------------------------------
+
+  describe "fail-first: immutable-prefix oracle catches a footer write that stomps sealed history" do
+    test "RED: a buggy 'footer' write that actually overwrites row 1 (already sealed) breaks the immutable-prefix oracle" do
+      {device, authority} = new_authority()
+      _authority = InlineAuthority.seal(authority, "sealed block 1\r\n")
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      # A buggy footer path that stomps the sealed history row instead of
+      # confining itself to the footer range -- the two-emit-paths-collide
+      # failure mode INV-1 exists to reject, this time originating from
+      # the footer side rather than a second seal.
+      IO.write(device, "\e[1;1Hstomped by a buggy footer write\r\n")
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert {:violation, _idx, _expected, _actual} =
+               SealOracle.immutable_prefix?(history_k, history_final)
+    end
+
+    test "GREEN: the same scenario continued with real repaint/2 + keyframe/2 calls never touches history" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "sealed block 1\r\n")
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      authority = InlineAuthority.repaint(authority, ["live tail", "composer"])
+
+      _authority =
+        InlineAuthority.keyframe(authority, ["status", "composer v2"])
+
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert :ok == SealOracle.immutable_prefix?(history_k, history_final)
+    end
+  end
+end

--- a/test/property/renderer_footer_property_test.exs
+++ b/test/property/renderer_footer_property_test.exs
@@ -1,19 +1,16 @@
 defmodule Raxol.Property.RendererFooterTest do
   @moduledoc """
-  T2c's positive suite: the pinned footer viewport
-  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2c), scoped subset of
-  `harness-ui-testing/02-renderer.md` §4 (R-P3/R-P9-style) that belongs to
-  the FOOTER path specifically — T2b's append-path properties are that
-  unit's own PR (`renderer_seal_once_property_test.exs`), not duplicated
-  here.
+  Positive-case suite for the pinned footer viewport, scoped to the
+  footer path specifically -- append-path properties live in their own
+  suite (`renderer_seal_once_property_test.exs`), not duplicated here.
 
-  Like T2b's suite, these properties drive the REAL production
+  Like that suite, these properties drive the REAL production
   implementation, `Raxol.UI.Rendering.PaintAuthority.InlineAuthority`'s
-  `repaint/2`/`keyframe/2` (the T2c diff-repaint / full-keyframe entry
-  points built on top of the `repaint_footer/2`/`keyframe_footer/2` @impl
-  callbacks), through a `StringIO` device — the actual bytes T2c ships,
-  replayed through the same `Raxol.Harness.Test.SealOracle` oracles (O1
-  mechanical scanner, O2 VT replay) TB built and T2b already uses.
+  `repaint/2`/`keyframe/2` (the diff-repaint / full-keyframe entry points
+  built on top of the `repaint_footer/2`/`keyframe_footer/2` @impl
+  callbacks), through a `StringIO` device -- the actual bytes shipped,
+  replayed through the same `Raxol.Harness.Test.SealOracle` oracles
+  (mechanical scanner + VT replay) the append path already uses.
   """
 
   use ExUnit.Case, async: true
@@ -25,7 +22,7 @@ defmodule Raxol.Property.RendererFooterTest do
   alias Raxol.UI.Rendering.PaintAuthority.Dialect
   alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
 
-  # Same fixed geometry T2b's suite uses: 10 rows total, footer 2 rows,
+  # Same fixed geometry the append path's suite uses: 10 rows total, footer 2 rows,
   # region_top = 8 (history rows 1..8, footer rows 9..10).
   @width 40
   @height 10
@@ -52,7 +49,7 @@ defmodule Raxol.Property.RendererFooterTest do
     (top + 1)..(top + count)//1
   end
 
-  # A second `new_authority` for tests exercising non-fixed geometry (Y2's
+  # A second `new_authority` for tests exercising non-fixed geometry (the
   # degenerate-geometry cases) -- the module-level `new_authority/1` above
   # is deliberately pinned to the fixed 10/2/40 geometry every other test
   # in this file relies on.
@@ -177,7 +174,7 @@ defmodule Raxol.Property.RendererFooterTest do
   end
 
   # ---------------------------------------------------------------------
-  # Acceptance 1: footer repaint touches only footer rows (INV-2)
+  # Acceptance 1: footer repaint touches only footer rows
   # ---------------------------------------------------------------------
 
   describe "acceptance 1: repaint/2 touches only footer rows" do
@@ -243,10 +240,10 @@ defmodule Raxol.Property.RendererFooterTest do
   # cannot prove WHAT ends up on screen; a stale-content bug (dropping
   # `\e[K` from `footer_row_bytes/2`) keeps every one of those green while
   # leaving ghost characters behind a shorter new line. This is the
-  # content-level check O1 (positional) cannot provide -- it replays the
-  # real emitted bytes through the actual VT emulator (O2) and reads back
-  # rendered text, the same oracle machinery `history/3`/`immutable_prefix?/2`
-  # use for the history side.
+  # content-level check a positional-only scan cannot provide -- it
+  # replays the real emitted bytes through the actual VT emulator and
+  # reads back rendered text, the same oracle machinery
+  # `history/3`/`immutable_prefix?/2` use for the history side.
   # ---------------------------------------------------------------------
 
   describe "content-correctness: repaint/2 renders exactly the new footer content, no residue" do
@@ -308,12 +305,13 @@ defmodule Raxol.Property.RendererFooterTest do
   end
 
   # ---------------------------------------------------------------------
-  # Degenerate geometry (Y2): InlineAuthority surfaces T2a's degenerate?/1
-  # signal, and repaint/2 + keyframe/2 never crash or address a row outside
-  # the actual screen even when the requested footer doesn't fit.
+  # Degenerate geometry: InlineAuthority surfaces the scroll-region
+  # manager's degenerate?/1 signal, and repaint/2 + keyframe/2 never crash
+  # or address a row outside the actual screen even when the requested
+  # footer doesn't fit.
   # ---------------------------------------------------------------------
 
-  describe "degenerate geometry: new/5 never crashes, degenerate?/1 surfaces T2a's signal" do
+  describe "degenerate geometry: new/5 never crashes, degenerate?/1 surfaces the scroll-region manager's signal" do
     test "rows=2/footer_rows=3: degenerate, footer capacity shrinks to what's left, no CUP outside the screen" do
       {device, authority} = new_authority(40, 2, 3)
 
@@ -354,8 +352,8 @@ defmodule Raxol.Property.RendererFooterTest do
       prior_size = device |> raw() |> byte_size()
       _authority = InlineAuthority.keyframe(authority, ["anything", "at all"])
 
-      # T2c review response: keyframe/2 with zero footer row capacity
-      # early-returns without opening a with_cursor/3 bracket at all --
+      # keyframe/2 with zero footer row capacity early-returns without
+      # opening a with_cursor/3 bracket at all --
       # an empty \e7/\e8 save/restore pair over zero addressed rows would
       # be ceremony around a no-op; emitting NOTHING is the honest
       # behavior on a geometry that cannot show a footer.
@@ -411,8 +409,8 @@ defmodule Raxol.Property.RendererFooterTest do
       assert MapSet.new(rows) == MapSet.new(footer_range(authority))
       refute SealOracle.emits_full_clear?(new_bytes)
 
-      # History is untouched by the keyframe -- INV-6's "history
-      # unchanged" half.
+      # History is untouched by the keyframe -- the "history unchanged"
+      # half of that invariant.
       raw_final = raw(device)
       hw_final = SealOracle.seal_high_water(raw_final)
 
@@ -452,8 +450,8 @@ defmodule Raxol.Property.RendererFooterTest do
 
       # resize/3's OWN delta: the single DECSTBM re-set, nothing else --
       # no full clear (checked below via the whole-stream assertion), no
-      # footer content bytes (T2c's design decision: resize does not
-      # auto-repaint the footer, see InlineAuthority.resize/3's doc).
+      # footer content bytes (resize does not auto-repaint the footer by
+      # design, see InlineAuthority.resize/3's doc).
       resize_delta = delta(raw(device), byte_size(raw_before))
 
       # keyframe/2's OWN delta, measured strictly AFTER resize/3
@@ -493,10 +491,10 @@ defmodule Raxol.Property.RendererFooterTest do
   end
 
   # ---------------------------------------------------------------------
-  # INV-4 (footer side): with_cursor(:footer, ...) round-trips the cursor
+  # Footer side: with_cursor(:footer, ...) round-trips the cursor
   # ---------------------------------------------------------------------
 
-  describe "INV-4 (footer side): repaint/2 and keyframe/2 never leave the cursor moved or the save/restore bracket unbalanced" do
+  describe "footer side: repaint/2 and keyframe/2 never leave the cursor moved or the save/restore bracket unbalanced" do
     property "after any number of repaint/2 or keyframe/2 calls, the cursor is back at its pre-bracket position every time" do
       op_gen =
         gen all(

--- a/test/property/renderer_footer_property_test.exs
+++ b/test/property/renderer_footer_property_test.exs
@@ -341,7 +341,7 @@ defmodule Raxol.Property.RendererFooterTest do
       _authority = InlineAuthority.keyframe(authority, ["x"])
     end
 
-    test "rows=1/footer_rows=2: degenerate, footer_range empty, repaint/2 and keyframe/2 no-op cleanly (zero CUPs)" do
+    test "rows=1/footer_rows=2: degenerate, footer_range empty, repaint/2 and keyframe/2 emit zero bytes (no bracket at all)" do
       {device, authority} = new_authority(40, 1, 2)
 
       assert InlineAuthority.degenerate?(authority)
@@ -354,12 +354,12 @@ defmodule Raxol.Property.RendererFooterTest do
       prior_size = device |> raw() |> byte_size()
       _authority = InlineAuthority.keyframe(authority, ["anything", "at all"])
 
-      new_bytes = delta(raw(device), prior_size)
-      # keyframe/2 always brackets with save/restore (with_cursor/3's
-      # unconditional protocol) even over zero footer capacity, but must
-      # address zero rows -- confirmed by stripping that bracket and
-      # finding nothing left for the (fail-closed) row walk to see.
-      assert new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows() == []
+      # T2c review response: keyframe/2 with zero footer row capacity
+      # early-returns without opening a with_cursor/3 bracket at all --
+      # an empty \e7/\e8 save/restore pair over zero addressed rows would
+      # be ceremony around a no-op; emitting NOTHING is the honest
+      # behavior on a geometry that cannot show a footer.
+      assert delta(raw(device), prior_size) == ""
     end
 
     test "rows=4/footer_rows=2: control case, NOT degenerate, footer confined to rows 3..4" do

--- a/test/property/renderer_footer_property_test.exs
+++ b/test/property/renderer_footer_property_test.exs
@@ -1,0 +1,621 @@
+defmodule Raxol.Property.RendererFooterTest do
+  @moduledoc """
+  T2c's positive suite: the pinned footer viewport
+  (`docs/proposals/in-flight/harness-ui-roadmap.md` T2c), scoped subset of
+  `harness-ui-testing/02-renderer.md` §4 (R-P3/R-P9-style) that belongs to
+  the FOOTER path specifically — T2b's append-path properties are that
+  unit's own PR (`renderer_seal_once_property_test.exs`), not duplicated
+  here.
+
+  Like T2b's suite, these properties drive the REAL production
+  implementation, `Raxol.UI.Rendering.PaintAuthority.InlineAuthority`'s
+  `repaint/2`/`keyframe/2` (the T2c diff-repaint / full-keyframe entry
+  points built on top of the `repaint_footer/2`/`keyframe_footer/2` @impl
+  callbacks), through a `StringIO` device — the actual bytes T2c ships,
+  replayed through the same `Raxol.Harness.Test.SealOracle` oracles (O1
+  mechanical scanner, O2 VT replay) TB built and T2b already uses.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Buffer.Queries
+  alias Raxol.Terminal.Emulator
+  alias Raxol.UI.Rendering.PaintAuthority.Dialect
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  # Same fixed geometry T2b's suite uses: 10 rows total, footer 2 rows,
+  # region_top = 8 (history rows 1..8, footer rows 9..10).
+  @width 40
+  @height 10
+  @footer_rows 2
+  @region_top 8
+
+  # -- harness helpers --
+
+  defp new_authority(opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, @width, @height, @footer_rows, opts)}
+  end
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  # The footer row range for the authority's CURRENT geometry -- never a
+  # hand-maintained constant, so this stays correct across resize.
+  defp footer_range(authority) do
+    top = InlineAuthority.region_top(authority)
+    count = InlineAuthority.footer_row_count(authority)
+    (top + 1)..(top + count)//1
+  end
+
+  # A second `new_authority` for tests exercising non-fixed geometry (Y2's
+  # degenerate-geometry cases) -- the module-level `new_authority/1` above
+  # is deliberately pinned to the fixed 10/2/40 geometry every other test
+  # in this file relies on.
+  defp new_authority(width, rows, footer_rows, opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, width, rows, footer_rows, opts)}
+  end
+
+  defp delta(all_bytes, prior_size) do
+    binary_part(all_bytes, prior_size, byte_size(all_bytes) - prior_size)
+  end
+
+  # The rendered TEXT of one wire-format (1-based) row after replaying
+  # `raw_bytes` through the real emulator -- content-level, unlike
+  # `SealOracle.cup_rows/1`'s positional-only walk. Padded to `width` with
+  # spaces past the written content's end, matching a real terminal's
+  # column model (and `Queries.get_text_at/4`'s own nil/blank -> " "
+  # convention).
+  defp footer_row_text(raw_bytes, row_1_based, width, height) do
+    raw_bytes
+    |> SealOracle.replay(width: width, height: height)
+    |> Emulator.get_screen_buffer()
+    |> Queries.get_text_at(0, row_1_based - 1, width)
+  end
+
+  # Every footer emit is exactly `Dialect.cursor_save() <> ... <>
+  # Dialect.cursor_restore()` (the `with_cursor/3` bracket). Stripping it
+  # before feeding a bracket-delta to `SealOracle.cup_rows/2` avoids a
+  # walker artifact: a FRESH per-delta walk has no memory of the row the
+  # save actually captured (that context lives in the FULL stream), so
+  # the trailing DECRC restore would otherwise report a fabricated
+  # row-1 "movement" that isn't real. Stripping the bracket we fully
+  # control leaves only the CUP+clear+text bytes the footer path itself
+  # is responsible for.
+  defp strip_cursor_bracket(bytes) do
+    save = Dialect.cursor_save()
+    restore = Dialect.cursor_restore()
+
+    bytes
+    |> strip_prefix(save)
+    |> strip_suffix(restore)
+  end
+
+  defp strip_prefix(bytes, prefix) do
+    if String.starts_with?(bytes, prefix) do
+      binary_part(
+        bytes,
+        byte_size(prefix),
+        byte_size(bytes) - byte_size(prefix)
+      )
+    else
+      bytes
+    end
+  end
+
+  defp strip_suffix(bytes, suffix) do
+    if String.ends_with?(bytes, suffix) do
+      binary_part(bytes, 0, byte_size(bytes) - byte_size(suffix))
+    else
+      bytes
+    end
+  end
+
+  defp line_gen,
+    do: string(:alphanumeric, min_length: 0, max_length: @width - 1)
+
+  defp footer_lines_gen, do: list_of(line_gen(), min_length: 0, max_length: 4)
+
+  # ---------------------------------------------------------------------
+  # footer_diff/2: pure minimal-diff (no I/O)
+  # ---------------------------------------------------------------------
+
+  describe "footer_diff/2: pure minimal-diff" do
+    test "identical lines produce zero changes" do
+      lines = ["live tail", "status | composer"]
+      assert InlineAuthority.footer_diff(lines, lines) == []
+    end
+
+    test "only the rows that actually changed are returned, with correct 0-based index and new content" do
+      old_lines = ["a", "b", "c"]
+      new_lines = ["a", "B", "c"]
+
+      assert InlineAuthority.footer_diff(old_lines, new_lines) == [{1, "B"}]
+    end
+
+    property "every returned {index, line} pair's line differs from the old line at that index, and every unreturned index is unchanged" do
+      check all(
+              old_lines <- list_of(line_gen(), min_length: 1, max_length: 6),
+              new_lines_raw <-
+                list_of(line_gen(), min_length: 0, max_length: 10),
+              max_runs: 100
+            ) do
+        # Force equal lengths (footer_diff/2's precondition) by
+        # pad/truncating the independently-generated `new_lines_raw` to
+        # `old_lines`'s length -- StreamData generators can't reference a
+        # prior generator's runtime length directly.
+        count = length(old_lines)
+        new_lines = new_lines_raw |> Enum.take(count) |> pad_to(count)
+
+        changes = InlineAuthority.footer_diff(old_lines, new_lines)
+        changed_indices = MapSet.new(changes, fn {idx, _line} -> idx end)
+
+        old_lines
+        |> Enum.zip(new_lines)
+        |> Enum.with_index()
+        |> Enum.each(fn {{old_line, new_line}, idx} ->
+          if old_line == new_line do
+            refute idx in changed_indices
+          else
+            assert {idx, new_line} in changes
+          end
+        end)
+      end
+    end
+  end
+
+  defp pad_to(lines, count) do
+    case count - length(lines) do
+      n when n > 0 -> lines ++ List.duplicate("", n)
+      _ -> lines
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Acceptance 1: footer repaint touches only footer rows (INV-2)
+  # ---------------------------------------------------------------------
+
+  describe "acceptance 1: repaint/2 touches only footer rows" do
+    test "a single repaint with all-new content CUPs only inside the footer range" do
+      {device, authority} = new_authority()
+      prior_size = device |> raw() |> byte_size()
+
+      authority = InlineAuthority.repaint(authority, ["live tail", "composer"])
+
+      new_bytes = delta(raw(device), prior_size)
+      rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+      assert rows != []
+      assert Enum.all?(rows, &(&1 in footer_range(authority)))
+    end
+
+    property "arbitrary sequences of footer content changes only ever address footer rows, across a live session" do
+      check all(
+              footer_states <-
+                list_of(footer_lines_gen(), min_length: 1, max_length: 40),
+              max_runs: 100
+            ) do
+        {device, authority} = new_authority()
+        # `new_authority/1`'s construction already wrote the initial
+        # DECSTBM region-set (homing the cursor); the delta baseline
+        # starts AFTER that, not at byte 0.
+        initial_size = device |> raw() |> byte_size()
+
+        Enum.reduce(footer_states, {authority, initial_size}, fn lines,
+                                                                 {auth,
+                                                                  prior_size} ->
+          auth = InlineAuthority.repaint(auth, lines)
+          all_bytes = raw(device)
+          new_bytes = delta(all_bytes, prior_size)
+
+          rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+          range = footer_range(auth)
+
+          assert Enum.all?(rows, &(&1 in range)),
+                 "a repaint/2 CUP addressed a row outside the footer range " <>
+                   "#{inspect(range)}: #{inspect(rows)}"
+
+          {auth, byte_size(all_bytes)}
+        end)
+      end
+    end
+
+    test "a no-op repaint (identical content) emits zero bytes" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.repaint(authority, ["same", "same"])
+      prior_size = device |> raw() |> byte_size()
+
+      _authority = InlineAuthority.repaint(authority, ["same", "same"])
+
+      assert delta(raw(device), prior_size) == ""
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Content-correctness: the footer RENDERS exactly the new content -- no
+  # residue from a prior, wider/taller repaint. Positional-only assertions
+  # (acceptance 1, above) prove every CUP stays inside the footer range but
+  # cannot prove WHAT ends up on screen; a stale-content bug (dropping
+  # `\e[K` from `footer_row_bytes/2`) keeps every one of those green while
+  # leaving ghost characters behind a shorter new line. This is the
+  # content-level check O1 (positional) cannot provide -- it replays the
+  # real emitted bytes through the actual VT emulator (O2) and reads back
+  # rendered text, the same oracle machinery `history/3`/`immutable_prefix?/2`
+  # use for the history side.
+  # ---------------------------------------------------------------------
+
+  describe "content-correctness: repaint/2 renders exactly the new footer content, no residue" do
+    test "shrinking content (fewer AND shorter lines) leaves no stale characters from the prior, wider repaint" do
+      {device, authority} = new_authority()
+
+      wide_line_1 = String.duplicate("A", @width - 1)
+      wide_line_2 = String.duplicate("B", @width - 1)
+      authority = InlineAuthority.repaint(authority, [wide_line_1, wide_line_2])
+
+      short_line = "hi"
+      _authority = InlineAuthority.repaint(authority, [short_line])
+
+      raw_bytes = raw(device)
+      footer_top = @region_top + 1
+
+      # Row 1: the shorter new content, exactly -- no trailing "A"s from
+      # the previous, wider line.
+      assert footer_row_text(raw_bytes, footer_top, @width, @height) ==
+               String.pad_trailing(short_line, @width)
+
+      # Row 2: the second footer line wasn't in the new content at all
+      # (fewer lines) -- pad_rows/2 pads it to "", so it must render as
+      # entirely blank, not the previous "B"*39 line.
+      assert footer_row_text(raw_bytes, footer_top + 1, @width, @height) ==
+               String.pad_trailing("", @width)
+    end
+
+    property "after ANY content-shrinking transition, every footer row renders exactly the padded new content" do
+      check all(
+              old_lines <-
+                list_of(line_gen(), min_length: 1, max_length: @footer_rows),
+              new_lines <-
+                list_of(line_gen(), min_length: 0, max_length: @footer_rows),
+              max_runs: 50
+            ) do
+        {device, authority} = new_authority()
+        authority = InlineAuthority.repaint(authority, old_lines)
+        _authority = InlineAuthority.repaint(authority, new_lines)
+
+        raw_bytes = raw(device)
+        footer_top = @region_top + 1
+
+        expected =
+          new_lines |> Enum.take(@footer_rows) |> pad_to(@footer_rows)
+
+        expected
+        |> Enum.with_index()
+        |> Enum.each(fn {line, idx} ->
+          actual = footer_row_text(raw_bytes, footer_top + idx, @width, @height)
+
+          assert actual == String.pad_trailing(line, @width),
+                 "footer row #{footer_top + idx} rendered #{inspect(actual)}, " <>
+                   "expected the padded new content #{inspect(String.pad_trailing(line, @width))} " <>
+                   "-- old_lines=#{inspect(old_lines)} new_lines=#{inspect(new_lines)}"
+        end)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Degenerate geometry (Y2): InlineAuthority surfaces T2a's degenerate?/1
+  # signal, and repaint/2 + keyframe/2 never crash or address a row outside
+  # the actual screen even when the requested footer doesn't fit.
+  # ---------------------------------------------------------------------
+
+  describe "degenerate geometry: new/5 never crashes, degenerate?/1 surfaces T2a's signal" do
+    test "rows=2/footer_rows=3: degenerate, footer capacity shrinks to what's left, no CUP outside the screen" do
+      {device, authority} = new_authority(40, 2, 3)
+
+      assert InlineAuthority.degenerate?(authority)
+      # region_top/2's clamp gives history its 1-row minimum first, leaving
+      # only 1 row for the footer even though 3 were requested --
+      # footer_row_count/1 must reflect the ACTUAL capacity.
+      assert InlineAuthority.footer_row_count(authority) == 1
+
+      prior_size = device |> raw() |> byte_size()
+
+      authority =
+        InlineAuthority.repaint(authority, ["only one line fits", "dropped"])
+
+      rows =
+        raw(device)
+        |> delta(prior_size)
+        |> strip_cursor_bracket()
+        |> SealOracle.cup_rows()
+
+      assert rows != []
+      assert Enum.all?(rows, &(&1 in 1..2))
+
+      # keyframe/2 must not crash either, on this same tight geometry.
+      _authority = InlineAuthority.keyframe(authority, ["x"])
+    end
+
+    test "rows=1/footer_rows=2: degenerate, footer_range empty, repaint/2 and keyframe/2 no-op cleanly (zero CUPs)" do
+      {device, authority} = new_authority(40, 1, 2)
+
+      assert InlineAuthority.degenerate?(authority)
+      assert InlineAuthority.footer_row_count(authority) == 0
+
+      prior_size = device |> raw() |> byte_size()
+      authority = InlineAuthority.repaint(authority, ["anything", "at all"])
+      assert delta(raw(device), prior_size) == ""
+
+      prior_size = device |> raw() |> byte_size()
+      _authority = InlineAuthority.keyframe(authority, ["anything", "at all"])
+
+      new_bytes = delta(raw(device), prior_size)
+      # keyframe/2 always brackets with save/restore (with_cursor/3's
+      # unconditional protocol) even over zero footer capacity, but must
+      # address zero rows -- confirmed by stripping that bracket and
+      # finding nothing left for the (fail-closed) row walk to see.
+      assert new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows() == []
+    end
+
+    test "rows=4/footer_rows=2: control case, NOT degenerate, footer confined to rows 3..4" do
+      {device, authority} = new_authority(40, 4, 2)
+
+      refute InlineAuthority.degenerate?(authority)
+      assert InlineAuthority.footer_row_count(authority) == 2
+
+      prior_size = device |> raw() |> byte_size()
+      _authority = InlineAuthority.repaint(authority, ["a", "b"])
+
+      rows =
+        raw(device)
+        |> delta(prior_size)
+        |> strip_cursor_bracket()
+        |> SealOracle.cup_rows()
+
+      assert rows != []
+      assert Enum.all?(rows, &(&1 in 3..4))
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Acceptance 3: Ctrl-L recovery (keyframe/2) repaints footer only
+  # ---------------------------------------------------------------------
+
+  describe "acceptance 3: keyframe/2 (Ctrl-L recovery) repaints footer only" do
+    test "a keyframe redraws every footer row (even unchanged ones), all confined to the footer range, no full clear" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "history line\r\n")
+      authority = InlineAuthority.repaint(authority, ["live tail", "composer"])
+
+      raw_k = raw(device)
+      hw_k = SealOracle.seal_high_water(raw_k)
+      emulator_k = SealOracle.replay(raw_k, width: @width, height: @height)
+      history_k = SealOracle.history(emulator_k, @region_top, high_water: hw_k)
+
+      prior_size = byte_size(raw_k)
+
+      _authority =
+        InlineAuthority.keyframe(authority, ["live tail", "composer"])
+
+      new_bytes = delta(raw(device), prior_size)
+      rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+      # Every footer row is touched (a keyframe always redraws all of
+      # them, unlike the diff-only repaint/2), and every one of those
+      # rows is inside the footer range.
+      assert MapSet.new(rows) == MapSet.new(footer_range(authority))
+      refute SealOracle.emits_full_clear?(new_bytes)
+
+      # History is untouched by the keyframe -- INV-6's "history
+      # unchanged" half.
+      raw_final = raw(device)
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: @height)
+
+      history_final =
+        SealOracle.history(emulator_final, @region_top, high_water: hw_final)
+
+      assert :ok == SealOracle.immutable_prefix?(history_k, history_final)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Acceptance 2: resize composition -- footer re-derived, history untouched
+  # ---------------------------------------------------------------------
+
+  describe "acceptance 2: resize/3 |> keyframe/2 re-derives the footer without touching history" do
+    test "seal + footer paint, then resize + keyframe: no full clear, history stays an immutable prefix, footer confined to the NEW range" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.seal(authority, "sealed before resize\r\n")
+      authority = InlineAuthority.repaint(authority, ["live tail", "composer"])
+
+      raw_before = raw(device)
+      hw_before = SealOracle.seal_high_water(raw_before)
+
+      emulator_before =
+        SealOracle.replay(raw_before, width: @width, height: @height)
+
+      history_before =
+        SealOracle.history(emulator_before, @region_top, high_water: hw_before)
+
+      new_height = 14
+      resized = InlineAuthority.resize(authority, @width, new_height)
+      new_region_top = InlineAuthority.region_top(resized)
+      assert new_region_top == new_height - @footer_rows
+
+      # resize/3's OWN delta: the single DECSTBM re-set, nothing else --
+      # no full clear (checked below via the whole-stream assertion), no
+      # footer content bytes (T2c's design decision: resize does not
+      # auto-repaint the footer, see InlineAuthority.resize/3's doc).
+      resize_delta = delta(raw(device), byte_size(raw_before))
+
+      # keyframe/2's OWN delta, measured strictly AFTER resize/3
+      # returned, isolates the footer-redraw bytes from the DECSTBM
+      # re-set above -- otherwise the re-set's homing-to-row-1 CUP
+      # (xterm DECSTBM semantics) would look like a history-row address
+      # that was never actually a footer-confinement violation.
+      prior_size = byte_size(raw_before) + byte_size(resize_delta)
+      _final = InlineAuthority.keyframe(resized, ["live tail", "composer"])
+
+      raw_final = raw(device)
+      keyframe_delta = delta(raw_final, prior_size)
+
+      refute SealOracle.emits_full_clear?(keyframe_delta)
+
+      rows = keyframe_delta |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+      assert Enum.all?(rows, &(&1 > new_region_top)),
+             "keyframe/2 after resize addressed a row outside the new " <>
+               "footer range (region_top=#{new_region_top}): #{inspect(rows)}"
+
+      hw_final = SealOracle.seal_high_water(raw_final)
+
+      emulator_final =
+        SealOracle.replay(raw_final, width: @width, height: new_height)
+
+      history_final =
+        SealOracle.history(emulator_final, new_region_top, high_water: hw_final)
+
+      assert :ok == SealOracle.immutable_prefix?(history_before, history_final)
+
+      assert SealOracle.region_sets(raw_final) == [
+               {1, @region_top},
+               {1, new_region_top}
+             ]
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # INV-4 (footer side): with_cursor(:footer, ...) round-trips the cursor
+  # ---------------------------------------------------------------------
+
+  describe "INV-4 (footer side): repaint/2 and keyframe/2 never leave the cursor moved or the save/restore bracket unbalanced" do
+    property "after any number of repaint/2 or keyframe/2 calls, the cursor is back at its pre-bracket position every time" do
+      op_gen =
+        gen all(
+              kind <- member_of([:repaint, :keyframe]),
+              lines <- footer_lines_gen()
+            ) do
+          {kind, lines}
+        end
+
+      check all(
+              ops <- list_of(op_gen, min_length: 1, max_length: 30),
+              max_runs: 30
+            ) do
+        {device, authority} = new_authority()
+
+        baseline_cursor =
+          device
+          |> raw()
+          |> SealOracle.replay(width: @width, height: @height)
+          |> Emulator.get_cursor_position()
+
+        Enum.reduce(ops, authority, fn
+          {:repaint, lines}, auth ->
+            auth = InlineAuthority.repaint(auth, lines)
+
+            cursor_now =
+              device
+              |> raw()
+              |> SealOracle.replay(width: @width, height: @height)
+              |> Emulator.get_cursor_position()
+
+            assert cursor_now == baseline_cursor
+            auth
+
+          {:keyframe, lines}, auth ->
+            auth = InlineAuthority.keyframe(auth, lines)
+
+            cursor_now =
+              device
+              |> raw()
+              |> SealOracle.replay(width: @width, height: @height)
+              |> Emulator.get_cursor_position()
+
+            assert cursor_now == baseline_cursor
+            auth
+        end)
+
+        balance = SealOracle.save_restore_balance(raw(device))
+        assert balance.decsc == 0
+        assert balance.decsc_max_depth <= 1
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Composition under interleaving: seal + repaint + keyframe + resize
+  # ---------------------------------------------------------------------
+
+  describe "composition: interleaved history + footer ops never cross-contaminate" do
+    property "arbitrary interleavings of seal/repaint/keyframe/resize: footer bytes stay in the CURRENT footer range, no full clear, history stays an immutable prefix" do
+      op_gen =
+        gen all(
+              kind <- member_of([:seal, :repaint, :keyframe, :resize]),
+              seal_line <-
+                string(:alphanumeric, min_length: 1, max_length: @width - 1),
+              footer_lines <- footer_lines_gen(),
+              new_height <- integer(6..40)
+            ) do
+          case kind do
+            :seal -> {:seal, seal_line <> "\r\n"}
+            :repaint -> {:repaint, footer_lines}
+            :keyframe -> {:keyframe, footer_lines}
+            :resize -> {:resize, new_height}
+          end
+        end
+
+      check all(
+              ops <- list_of(op_gen, min_length: 1, max_length: 40),
+              max_runs: 30
+            ) do
+        {device, authority} = new_authority()
+        initial_size = device |> raw() |> byte_size()
+
+        {_final, _prior_size} =
+          Enum.reduce(ops, {authority, initial_size}, fn op,
+                                                         {auth, prior_size} ->
+            auth =
+              case op do
+                {:seal, line} -> InlineAuthority.seal(auth, line)
+                {:repaint, lines} -> InlineAuthority.repaint(auth, lines)
+                {:keyframe, lines} -> InlineAuthority.keyframe(auth, lines)
+                {:resize, h} -> InlineAuthority.resize(auth, @width, h)
+              end
+
+            all_bytes = raw(device)
+            new_bytes = delta(all_bytes, prior_size)
+
+            refute SealOracle.emits_full_clear?(new_bytes)
+
+            case op do
+              {kind, _} when kind in [:repaint, :keyframe] ->
+                rows =
+                  new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+                range = footer_range(auth)
+
+                assert Enum.all?(rows, &(&1 in range)),
+                       "#{kind} CUP addressed a row outside the footer range " <>
+                         "#{inspect(range)}: #{inspect(rows)}"
+
+              _other ->
+                :ok
+            end
+
+            {auth, byte_size(all_bytes)}
+          end)
+
+        refute SealOracle.emits_full_clear?(raw(device))
+      end
+    end
+  end
+end

--- a/test/property/renderer_t2c_review_fixes_test.exs
+++ b/test/property/renderer_t2c_review_fixes_test.exs
@@ -1,0 +1,438 @@
+defmodule Raxol.Property.RendererT2cReviewFixesTest do
+  @moduledoc """
+  T2c's review-response suite (Fable-adjudicated FIX-NOW batch on the
+  pinned footer viewport, `docs/proposals/in-flight/harness-ui-roadmap.md`
+  T2c): footer `ContentGuard` (HIGH -- `repaint/2`/`keyframe/2` wrote
+  agent/LLM-originated footer lines verbatim, so a footer line smuggling a
+  control sequence could defeat the footer-confinement invariant FROM THE
+  INSIDE, exactly the same threat class T2b's review already closed on the
+  history append path), and the `needs_keyframe` latch (MED -- a geometry-
+  changing `resize/3` can relocate the footer's on-screen rows while their
+  logical content is unchanged; a diff-only `repaint/2` immediately after
+  would see a no-op diff and write nothing, leaving ghost content at the
+  new position).
+
+  Each `describe "R8-footer: ..."` block is a RED/GREEN pair, same
+  discipline as `renderer_t2b_review_fixes_test.exs`: RED demonstrates the
+  raw/pre-guard bytes are a real, oracle-visible (or content-visible)
+  threat before GREEN shows the same payload, routed through the real
+  `repaint/2`/`keyframe/2`, emerges neutralized.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Buffer.Queries
+  alias Raxol.Terminal.Emulator
+  alias Raxol.UI.Rendering.PaintAuthority.Dialect
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  @width 40
+  @height 10
+  @footer_rows 2
+  @region_top 8
+
+  defp new_authority(opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, @width, @height, @footer_rows, opts)}
+  end
+
+  # A second `new_authority` for tests exercising non-fixed geometry (the
+  # degenerate zero-footer-capacity case) -- module-level `new_authority/1`
+  # above is pinned to the fixed 10/2/40 geometry every other test relies on.
+  defp new_authority(width, rows, footer_rows, opts \\ []) do
+    {:ok, device} = StringIO.open("")
+    {device, InlineAuthority.new(device, width, rows, footer_rows, opts)}
+  end
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  defp footer_range(authority) do
+    top = InlineAuthority.region_top(authority)
+    count = InlineAuthority.footer_row_count(authority)
+    (top + 1)..(top + count)//1
+  end
+
+  defp delta(all_bytes, prior_size) do
+    binary_part(all_bytes, prior_size, byte_size(all_bytes) - prior_size)
+  end
+
+  defp strip_cursor_bracket(bytes) do
+    save = Dialect.cursor_save()
+    restore = Dialect.cursor_restore()
+
+    bytes
+    |> strip_prefix(save)
+    |> strip_suffix(restore)
+  end
+
+  defp strip_prefix(bytes, prefix) do
+    if String.starts_with?(bytes, prefix) do
+      binary_part(
+        bytes,
+        byte_size(prefix),
+        byte_size(bytes) - byte_size(prefix)
+      )
+    else
+      bytes
+    end
+  end
+
+  defp strip_suffix(bytes, suffix) do
+    if String.ends_with?(bytes, suffix) do
+      binary_part(bytes, 0, byte_size(bytes) - byte_size(suffix))
+    else
+      bytes
+    end
+  end
+
+  # The rendered TEXT of one wire-format (1-based) row, padded to `width`
+  # with spaces past the written content's end -- same convention
+  # `renderer_footer_property_test.exs` uses for content-level footer
+  # assertions.
+  defp footer_row_text(raw_bytes, row_1_based) do
+    raw_bytes
+    |> SealOracle.replay(width: @width, height: @height)
+    |> Emulator.get_screen_buffer()
+    |> Queries.get_text_at(0, row_1_based - 1, @width)
+  end
+
+  # ---------------------------------------------------------------------
+  # R8-footer: ContentGuard neutralizes control bytes embedded IN footer
+  # content -- the same threat class as T2b's history-side review fix,
+  # applied to the footer path.
+  # ---------------------------------------------------------------------
+
+  describe "R8-footer: \\e[3;1H (a HISTORY row CUP) smuggled in a footer line" do
+    test "RED: raw bytes (what an unguarded repaint/2 would emit) let the smuggled CUP address a row outside the footer range" do
+      {device, authority} = new_authority()
+      prior_size = device |> raw() |> byte_size()
+
+      footer_top = @region_top + 1
+      malicious = "status: \e[3;1Hforged history write"
+
+      # Reproduces exactly what footer_row_bytes/2 would emit for this
+      # content IF repaint/2 skipped ContentGuard -- CUP to the correct
+      # footer row, per-row clear, then the untouched, hostile line.
+      IO.write(device, [
+        Dialect.cursor_position(footer_top),
+        "\e[K",
+        malicious
+      ])
+
+      new_bytes = delta(raw(device), prior_size)
+      rows = SealOracle.cup_rows(new_bytes)
+
+      refute Enum.all?(rows, &(&1 in footer_range(authority))),
+             "fail-first: the O1 row scanner must be ABLE to catch a CUP " <>
+               "smuggled inside footer CONTENT (not just a buggy emitter), " <>
+               "or the GREEN result below is meaningless"
+    end
+
+    test "GREEN: the same content, through the real repaint/2, stays confined to the footer range and leaves the residue visible" do
+      {device, authority} = new_authority()
+      prior_size = device |> raw() |> byte_size()
+
+      malicious = "status: \e[3;1Hforged history write"
+      authority = InlineAuthority.repaint(authority, [malicious])
+
+      new_bytes = delta(raw(device), prior_size)
+      rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+      assert Enum.all?(rows, &(&1 in footer_range(authority)))
+
+      footer_top = InlineAuthority.region_top(authority) + 1
+
+      assert footer_row_text(raw(device), footer_top) ==
+               String.pad_trailing("status: [3;1Hforged history write", @width)
+    end
+  end
+
+  describe "R8-footer: \\e[2J (full-screen clear) smuggled in a footer line" do
+    test "RED: raw bytes (what an unguarded repaint/2 would emit) trigger the full-clear oracle" do
+      {device, authority} = new_authority()
+      prior_size = device |> raw() |> byte_size()
+
+      footer_top = InlineAuthority.region_top(authority) + 1
+      malicious = "composer \e[2J wipe"
+
+      IO.write(device, [
+        Dialect.cursor_position(footer_top),
+        "\e[K",
+        malicious
+      ])
+
+      new_bytes = delta(raw(device), prior_size)
+
+      assert SealOracle.emits_full_clear?(new_bytes),
+             "fail-first: the full-clear oracle must be ABLE to catch a " <>
+               "\\e[2J smuggled inside footer CONTENT, or the GREEN result " <>
+               "below is meaningless"
+    end
+
+    test "GREEN: the same content, through the real repaint/2, never triggers the full-clear oracle" do
+      {device, authority} = new_authority()
+      prior_size = device |> raw() |> byte_size()
+
+      malicious = "composer \e[2J wipe"
+      authority = InlineAuthority.repaint(authority, [malicious])
+
+      new_bytes = delta(raw(device), prior_size)
+      refute SealOracle.emits_full_clear?(new_bytes)
+
+      footer_top = InlineAuthority.region_top(authority) + 1
+
+      assert footer_row_text(raw(device), footer_top) ==
+               String.pad_trailing("composer [2J wipe", @width)
+    end
+
+    test "GREEN: keyframe/2 with the same content also never triggers the full-clear oracle" do
+      {device, authority} = new_authority()
+      prior_size = device |> raw() |> byte_size()
+
+      malicious = "composer \e[2J wipe"
+      authority = InlineAuthority.keyframe(authority, [malicious])
+
+      new_bytes = delta(raw(device), prior_size)
+      refute SealOracle.emits_full_clear?(new_bytes)
+
+      footer_top = InlineAuthority.region_top(authority) + 1
+
+      assert footer_row_text(raw(device), footer_top) ==
+               String.pad_trailing("composer [2J wipe", @width)
+    end
+  end
+
+  describe "R8-footer: \\e[K (erase-line) smuggled in a footer line" do
+    test "RED: raw bytes let the smuggled EL execute silently -- it vanishes instead of appearing as text" do
+      {device, _authority} = new_authority()
+
+      footer_top = @region_top + 1
+      # An EL embedded mid-content: if executed, "before" survives (already
+      # written, ahead of the erase point) but the ESC+[+K token itself
+      # produces no glyphs of its own -- unlike ordinary printable text, it
+      # does not survive as characters on the row.
+      malicious = "before\e[Kafter"
+
+      IO.write(device, [
+        Dialect.cursor_position(footer_top),
+        "\e[K",
+        malicious
+      ])
+
+      text = footer_row_text(raw(device), footer_top)
+
+      refute text =~ "[K",
+             "fail-first: an unguarded \\e[K must be ABLE to execute (and " <>
+               "vanish) instead of surviving as literal text, or the GREEN " <>
+               "residue assertion below is meaningless"
+
+      assert text == String.pad_trailing("beforeafter", @width)
+    end
+
+    test "GREEN: the same content, through the real repaint/2, leaves the ESC+[+K residue visible instead of executing it" do
+      {device, authority} = new_authority()
+
+      malicious = "before\e[Kafter"
+      authority = InlineAuthority.repaint(authority, [malicious])
+
+      footer_top = InlineAuthority.region_top(authority) + 1
+
+      assert footer_row_text(raw(device), footer_top) ==
+               String.pad_trailing("before[Kafter", @width)
+    end
+  end
+
+  describe "R8-footer: a legitimately styled footer line stays styled (SGR passes through byte-identical)" do
+    test "GREEN: \\e[1;31m...\\e[0m survives repaint/2 unchanged" do
+      {device, authority} = new_authority()
+      bytes_before = raw(device)
+
+      styled = "\e[1;31malert\e[0m"
+      _ = InlineAuthority.repaint(authority, [styled])
+
+      all_bytes = raw(device)
+      new_bytes = delta(all_bytes, byte_size(bytes_before))
+
+      assert new_bytes =~ styled
+    end
+
+    test "GREEN: \\e[1;31m...\\e[0m survives keyframe/2 unchanged" do
+      {device, authority} = new_authority()
+      bytes_before = raw(device)
+
+      styled = "\e[1;31malert\e[0m"
+      _ = InlineAuthority.keyframe(authority, [styled])
+
+      all_bytes = raw(device)
+      new_bytes = delta(all_bytes, byte_size(bytes_before))
+
+      assert new_bytes =~ styled
+    end
+  end
+
+  describe "footer content sanitization runs BEFORE padding/diffing (footer_lines only ever holds sanitized content)" do
+    test "footer_diff/2 never sees the raw ESC -- a stored footer_lines entry is already sanitized" do
+      {_device, authority} = new_authority()
+
+      authority = InlineAuthority.repaint(authority, ["plain \e[2J line"])
+
+      assert authority.footer_lines == [
+               "plain [2J line",
+               ""
+             ]
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # needs_keyframe latch: a geometry-changing resize/3 relocates the
+  # footer's on-screen rows; the NEXT repaint/2 must not trust a diff
+  # against content whose position moved.
+  # ---------------------------------------------------------------------
+
+  describe "needs_keyframe latch: resize/3 sets it, repaint/2 self-promotes and clears it" do
+    test "RED: without the latch, a diff-only repaint of UNCHANGED content after a geometry-changing resize emits zero bytes -- the ghost-content bug" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.repaint(authority, ["live tail", "composer"])
+
+      resized = InlineAuthority.resize(authority, @width, 20)
+      assert resized.needs_keyframe
+
+      # Simulate the PRE-FIX world: resize/3 without the needs_keyframe
+      # latch left no signal that geometry changed, so the following
+      # repaint/2 ran its ordinary diff-only path.
+      unlatched = %{resized | needs_keyframe: false}
+
+      prior_size = device |> raw() |> byte_size()
+      _ = InlineAuthority.repaint(unlatched, ["live tail", "composer"])
+
+      assert delta(raw(device), prior_size) == "",
+             "fail-first: a diff-only repaint of unchanged content right " <>
+               "after a geometry-changing resize must be ABLE to emit zero " <>
+               "bytes, or the GREEN result below is meaningless"
+    end
+
+    test "GREEN: the real resize/3 leaves the latch set, so repaint/2 fully re-renders the footer even though content is unchanged" do
+      {device, authority} = new_authority()
+      authority = InlineAuthority.repaint(authority, ["live tail", "composer"])
+
+      resized = InlineAuthority.resize(authority, @width, 20)
+      assert resized.needs_keyframe
+
+      prior_size = device |> raw() |> byte_size()
+      final = InlineAuthority.repaint(resized, ["live tail", "composer"])
+
+      new_bytes = delta(raw(device), prior_size)
+
+      assert new_bytes != "",
+             "needs_keyframe latch failed: repaint/2 right after a " <>
+               "geometry-changing resize must fully re-render the footer " <>
+               "even when content is unchanged"
+
+      rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+
+      assert MapSet.new(rows) == MapSet.new(footer_range(final)),
+             "the self-promoted keyframe must touch EVERY footer row, not " <>
+               "a diff subset"
+
+      refute final.needs_keyframe,
+             "the latch must clear once the self-promoted keyframe runs"
+    end
+
+    test "GREEN: a stale blank row still gets its own \\e[K at the NEW footer position after resize" do
+      {device, authority} = new_authority()
+      # Only one line -- pad_rows/2 makes the second footer row "" already,
+      # both before and after the upcoming resize.
+      authority = InlineAuthority.repaint(authority, ["only line"])
+
+      resized = InlineAuthority.resize(authority, @width, 20)
+      prior_size = device |> raw() |> byte_size()
+
+      # Same single line again -- logically UNCHANGED (row 2 is "" both
+      # before and after), which a diff-only repaint would skip entirely.
+      final = InlineAuthority.repaint(resized, ["only line"])
+
+      new_bytes = delta(raw(device), prior_size)
+      new_footer_top = InlineAuthority.region_top(final) + 1
+      stale_row = new_footer_top + 1
+
+      rows = new_bytes |> strip_cursor_bracket() |> SealOracle.cup_rows()
+      assert stale_row in rows
+
+      expected_fragment = Dialect.cursor_position(stale_row) <> "\e[K"
+      assert String.contains?(new_bytes, expected_fragment)
+    end
+
+    test "a width-only resize (history_bottom unchanged) does not set needs_keyframe" do
+      {_device, authority} = new_authority()
+      same_height_resized = InlineAuthority.resize(authority, 80, @height)
+
+      refute same_height_resized.needs_keyframe
+    end
+
+    test "resize/3 emits ONLY the DECSTBM re-set even with the latch change (T2b's pinned regression is untouched)" do
+      {device, authority} = new_authority()
+      bytes_before = raw(device)
+
+      resized = InlineAuthority.resize(authority, @width, 20)
+
+      all_bytes = raw(device)
+      new_bytes = delta(all_bytes, byte_size(bytes_before))
+
+      assert new_bytes == Dialect.region_set(1, 20 - @footer_rows)
+      assert resized.needs_keyframe
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Bundled trivials
+  # ---------------------------------------------------------------------
+
+  describe "footer_diff/2: explicit ArgumentError on length mismatch" do
+    test "raises ArgumentError (not a bare FunctionClauseError), naming the fix" do
+      assert_raise ArgumentError, ~r/same length/, fn ->
+        InlineAuthority.footer_diff(["a", "b"], ["only one"])
+      end
+    end
+  end
+
+  describe "keyframe/2: zero footer rows early-returns with no bracket at all" do
+    test "on degenerate geometry with zero footer capacity, keyframe/2 emits nothing" do
+      {device, authority} = new_authority(40, 1, 2)
+      assert InlineAuthority.footer_row_count(authority) == 0
+
+      prior_size = device |> raw() |> byte_size()
+      _ = InlineAuthority.keyframe(authority, ["anything", "at all"])
+
+      assert delta(raw(device), prior_size) == ""
+    end
+  end
+
+  describe "repaint/2: the no-op branch still normalizes footer_lines to the current padded length" do
+    test "a no-op repaint writes back the padded footer_lines even though nothing changed" do
+      {_device, authority} = new_authority()
+
+      # Directly construct the invariant this fix protects: footer_lines
+      # shorter than the CURRENT footer row count (as if the row count had
+      # changed without this field ever catching up).
+      stale = %{authority | footer_lines: ["only one line"]}
+
+      final = InlineAuthority.repaint(stale, ["only one line"])
+
+      assert final.footer_lines == ["only one line", ""]
+
+      assert length(final.footer_lines) ==
+               InlineAuthority.footer_row_count(final)
+    end
+  end
+
+  describe "history_bottom rename follow-through" do
+    test "InlineAuthority.region_top/1 delegates to ScrollRegionManager.history_bottom/1, not a stale region_top/1" do
+      {_device, authority} = new_authority()
+      assert InlineAuthority.region_top(authority) == @region_top
+    end
+  end
+end

--- a/test/property/renderer_t2c_review_fixes_test.exs
+++ b/test/property/renderer_t2c_review_fixes_test.exs
@@ -124,7 +124,7 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
       rows = SealOracle.cup_rows(new_bytes)
 
       refute Enum.all?(rows, &(&1 in footer_range(authority))),
-             "fail-first: the O1 row scanner must be ABLE to catch a CUP " <>
+             "fail-first: the row scanner must be ABLE to catch a CUP " <>
                "smuggled inside footer CONTENT (not just a buggy emitter), " <>
                "or the GREEN result below is meaningless"
     end

--- a/test/property/renderer_t2c_review_fixes_test.exs
+++ b/test/property/renderer_t2c_review_fixes_test.exs
@@ -366,11 +366,44 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
       assert String.contains?(new_bytes, expected_fragment)
     end
 
-    test "a width-only resize (history_bottom unchanged) does not set needs_keyframe" do
+    test "a width-only resize now sets needs_keyframe (footer re-truncation + reflow seam)" do
+      # width 40 -> 80, height unchanged: `history_bottom` is row-based, so the
+      # REGION needs no re-emit (T2b's pinned regression, below, still holds) --
+      # but the footer may need re-truncation to the new width, and reflow-capable
+      # terminals rewrap sealed history on a WIDTH change. The latch keys on the
+      # width axis too, not just the vertical geometry, so the first repaint after
+      # a width resize fully re-renders rather than diffing against stale-width state.
       {_device, authority} = new_authority()
-      same_height_resized = InlineAuthority.resize(authority, 80, @height)
+      widened = InlineAuthority.resize(authority, 80, @height)
 
-      refute same_height_resized.needs_keyframe
+      assert widened.needs_keyframe
+    end
+
+    test "reflow_capable_resize telemetry fires on a WIDTH-only resize (the axis reflow actually happens on)" do
+      {_device, authority} = new_authority()
+      authority = %{authority | reflow_capable?: true}
+
+      ref = make_ref()
+      handler = {__MODULE__, ref}
+
+      :telemetry.attach(
+        handler,
+        [:raxol, :ui, :paint_authority, :reflow_capable_resize],
+        fn _event, _measure, meta, {pid, r} -> send(pid, {:reflow, r, meta}) end,
+        {self(), ref}
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      # Width 40 -> 30 (SHRINK, the reflow-triggering direction), height
+      # unchanged. `history_bottom` is identical, so the old vertical-only gate
+      # never fired this event -- reflow happens on the horizontal axis, so the
+      # seam the future (B) reflow unit gates on must observe the width delta.
+      InlineAuthority.resize(authority, 30, @height)
+
+      assert_receive {:reflow, ^ref, meta}
+      assert meta.old_width == @width
+      assert meta.new_width == 30
     end
 
     test "resize/3 emits ONLY the DECSTBM re-set even with the latch change (T2b's pinned regression is untouched)" do

--- a/test/property/renderer_t2c_review_fixes_test.exs
+++ b/test/property/renderer_t2c_review_fixes_test.exs
@@ -1,19 +1,16 @@
 defmodule Raxol.Property.RendererT2cReviewFixesTest do
   @moduledoc """
-  T2c's review-response suite (Fable-adjudicated FIX-NOW batch on the
-  pinned footer viewport, `docs/proposals/in-flight/harness-ui-roadmap.md`
-  T2c): footer `ContentGuard` (HIGH -- `repaint/2`/`keyframe/2` wrote
+  Footer `ContentGuard`: `repaint/2`/`keyframe/2` do not write
   agent/LLM-originated footer lines verbatim, so a footer line smuggling a
-  control sequence could defeat the footer-confinement invariant FROM THE
-  INSIDE, exactly the same threat class T2b's review already closed on the
-  history append path), and the `needs_keyframe` latch (MED -- a geometry-
-  changing `resize/3` can relocate the footer's on-screen rows while their
+  control sequence cannot defeat the footer-confinement invariant FROM THE
+  INSIDE -- the same threat class already closed on the history append
+  path. Also covers the `needs_keyframe` latch: a geometry-changing
+  `resize/3` can relocate the footer's on-screen rows while their
   logical content is unchanged; a diff-only `repaint/2` immediately after
-  would see a no-op diff and write nothing, leaving ghost content at the
-  new position).
+  would otherwise see a no-op diff and write nothing, leaving ghost
+  content at the new position.
 
-  Each `describe "R8-footer: ..."` block is a RED/GREEN pair, same
-  discipline as `renderer_t2b_review_fixes_test.exs`: RED demonstrates the
+  Each `describe` block below is a RED/GREEN pair: RED demonstrates the
   raw/pre-guard bytes are a real, oracle-visible (or content-visible)
   threat before GREEN shows the same payload, routed through the real
   `repaint/2`/`keyframe/2`, emerges neutralized.
@@ -101,12 +98,12 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
   end
 
   # ---------------------------------------------------------------------
-  # R8-footer: ContentGuard neutralizes control bytes embedded IN footer
-  # content -- the same threat class as T2b's history-side review fix,
-  # applied to the footer path.
+  # ContentGuard neutralizes control bytes embedded IN footer content --
+  # the same threat class as the history-side fix, applied to the footer
+  # path.
   # ---------------------------------------------------------------------
 
-  describe "R8-footer: \\e[3;1H (a HISTORY row CUP) smuggled in a footer line" do
+  describe "\\e[3;1H (a HISTORY row CUP) smuggled in a footer line" do
     test "RED: raw bytes (what an unguarded repaint/2 would emit) let the smuggled CUP address a row outside the footer range" do
       {device, authority} = new_authority()
       prior_size = device |> raw() |> byte_size()
@@ -151,7 +148,7 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
     end
   end
 
-  describe "R8-footer: \\e[2J (full-screen clear) smuggled in a footer line" do
+  describe "\\e[2J (full-screen clear) smuggled in a footer line" do
     test "RED: raw bytes (what an unguarded repaint/2 would emit) trigger the full-clear oracle" do
       {device, authority} = new_authority()
       prior_size = device |> raw() |> byte_size()
@@ -206,7 +203,7 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
     end
   end
 
-  describe "R8-footer: \\e[K (erase-line) smuggled in a footer line" do
+  describe "\\e[K (erase-line) smuggled in a footer line" do
     test "RED: raw bytes let the smuggled EL execute silently -- it vanishes instead of appearing as text" do
       {device, _authority} = new_authority()
 
@@ -246,7 +243,7 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
     end
   end
 
-  describe "R8-footer: a legitimately styled footer line stays styled (SGR passes through byte-identical)" do
+  describe "a legitimately styled footer line stays styled (SGR passes through byte-identical)" do
     test "GREEN: \\e[1;31m...\\e[0m survives repaint/2 unchanged" do
       {device, authority} = new_authority()
       bytes_before = raw(device)
@@ -368,7 +365,7 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
 
     test "a width-only resize now sets needs_keyframe (footer re-truncation + reflow seam)" do
       # width 40 -> 80, height unchanged: `history_bottom` is row-based, so the
-      # REGION needs no re-emit (T2b's pinned regression, below, still holds) --
+      # REGION needs no re-emit (the append path's pinned regression, below, still holds) --
       # but the footer may need re-truncation to the new width, and reflow-capable
       # terminals rewrap sealed history on a WIDTH change. The latch keys on the
       # width axis too, not just the vertical geometry, so the first repaint after
@@ -406,7 +403,7 @@ defmodule Raxol.Property.RendererT2cReviewFixesTest do
       assert meta.new_width == 30
     end
 
-    test "resize/3 emits ONLY the DECSTBM re-set even with the latch change (T2b's pinned regression is untouched)" do
+    test "resize/3 emits ONLY the DECSTBM re-set even with the latch change (the append path's pinned regression is untouched)" do
       {device, authority} = new_authority()
       bytes_before = raw(device)
 


### PR DESCRIPTION
Unit **T2c** — the **pinned footer viewport**: a buffer-diff pipeline scoped to the footer rows only (live tail + status strip + composer). Completes the inline-substrate spine: T2d (inline driver) → T2a (DECSTBM split, #574) → T2b (append path, #589) → **T2c**.

## What
Extends `InlineAuthority` (+169/-7 — the diff logic composes directly on T2b's struct/cursor protocol, a separate module would only add indirection):
- **`footer_diff/2`** — pure minimal diff over footer line lists; unchanged rows emit zero bytes; a shrunk footer emits `CUP + \e[K` clears for stale rows (no ghosts).
- **`repaint/2`** — diff-driven footer repaint; every emitted CUP lands in `footer_range` (rows `region_top+1..rows`), never a history row. All writes CUP-anchored, bracketed by T2b's `with_cursor` (sole `\e7`/`\e8` owner).
- **`keyframe/2`** — full footer redraw (Ctrl-L recovery): per-row `CUP + \e[K + line`, footer region ONLY — never `\e[2J`/`\e[3J` (the ban RB's N06 validated: full clears wipe scrollback on wezterm/kitty).
- **`resize/3` contract** — delegates region math to `ScrollRegionManager.resize/2` (now geometry-gated per the #574 review fix) and deliberately does NOT auto-repaint: callers compose `resize(w,h) |> keyframe(lines)`. Pinned from the resize side by a T2b regression test; documented for the T13a assembler.
- **`degenerate?/1`** — thin delegation surfacing T2a's degenerate-geometry signal (rows−footer < 2 ⇒ footer can't be pinned) so the assembler can adapt instead of silently losing the pin.

## Acceptance (roadmap T2c, all byte-stream properties on the REAL producer → StringIO → real oracle replay)
1. Footer repaint touches only footer rows — property over random content changes; O1 `cup_rows` scanner (fail-closed) on real emitted CSI.
2. Resize: no `\e[2J`, no history rewrite — `resize |> keyframe` composition asserts footer-only CUPs in the NEW range + O2 immutable-prefix over the whole raw stream.
3. Ctrl-L keyframe: footer-scoped clears + repaint, zero full-clear, zero history addressing.
4. R-N4 contrast — characterizes `Backends.build_terminal_frame`'s `\e[2J`-on-width-change (the wrong behavior T2c exists to replace) vs this path emitting none.

**Fail-first is genuine, twice over:** adversarial suite drives BuggyAuthority bleed variants (absolute CUP / CUU-relative / VPA), a raw-bypass write, and a row-1 history stomp through the real `SealOracle.replay → Emulator → immutable_prefix?` — each RED; paired GREENs prove the oracle isn't stuck. Plus a content-correctness pin: temporarily stripping `\e[K` makes the shrink test fail with the exact stale-residue class (`"hiAAAA…"` vs `"hi "`), restored green — rendered footer content is asserted via emulator replay, not just CUP confinement.

**Degenerate geometry tested:** rows=2/footer=3 (clamps, in-bounds), rows=1/footer=2 (empty range, zero CUPs), rows=4/footer=2 (control). Footer line width is a documented CALLER contract (pre-truncate via `Raxol.UI.TextMeasure`) — stated for T13a.

## Review
Opus analytic review: **SHIP, no RED.** DECSTBM cursor-home side effect traced SAFE through `resize |> keyframe` (every content write CUP-anchored — no path assumes inherited cursor position); diff minimality verified for shrink/equal/multi-byte-UTF-8; 3 of 4 yellows folded into this commit (footer content-render pin, degenerate tests + signal, width-contract doc); Y4 declined (interleaving property's confinement+append-only+no-2J proxy deemed sufficient).

Gates: `compile --warnings-as-errors` clean; 42 tests green across the 4 renderer suites (8 properties, 34 tests) + T2a/T2b suites re-run green on the rebased chain; `format` + `credo --strict` clean.

**Base note:** stacks on `feat/harness-ui-T2b` (#589), which stacks on #574. Merge order: #574 → #589 → this.

---
*Terms: **keyframe** = full repaint of the footer region (e.g. Ctrl-L recovery) — footer rows only, per-row `\e[K`, never `\e[2J` (which wipes native scrollback on wezterm/kitty — measured, #585). **R-N4** = the characterization test pinning today's full-frame path doing exactly that wrong thing. **Degenerate geometry** = `rows − footer_rows < 2`, where DECSTBM can't pin (see #574's `degenerate?`).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

