### PR TITLE
Harness UI: keybind layer (canonical events → typed commands, composer-safe) [T12]

### DIFF
--- a/lib/raxol/ui/harness/keymap.ex
+++ b/lib/raxol/ui/harness/keymap.ex
@@ -22,7 +22,22 @@ defmodule Raxol.UI.Harness.Keymap do
 
     * **tui-steal rule** (chords replace keys later without restructuring
       the dispatch logic -- a bind's `match` grows a `mods:` requirement,
-      the walking loop does not change).
+      the walking loop does not change). This is not aspirational: a
+      `key:`-kind bind with no declared `mods:` matches only a BARE
+      keypress (no ctrl/alt/meta held) -- Ctrl+Tab, Alt+Tab, and Meta+Tab
+      all fall through to `:passthrough` rather than firing `:steer`,
+      because they are shortcuts wired to something else, not "Tab". An
+      entry that DOES declare `mods:` (a full `InputEvent.mods()` map)
+      requires an EXACT match against the normalized event's `mods`
+      instead of the bare-keypress default -- that is the chord's match
+      spec growing a field, per the promise above, with `resolve/2`'s
+      walking loop untouched. Shift alone is not restricted by the
+      bare-keypress default (mirrors `InputEvent.text?/1`: shift-only is
+      not a shortcut), so Shift+Tab still resolves through the plain
+      `:tab` bind. `char:`-kind binds need no separate mods check --
+      `InputEvent.printable_char/1` already returns `nil` whenever
+      ctrl/alt/meta is held, so a modifier-qualified letter never reaches
+      the char-kind match branch in the first place.
     * **Invocation parity with T15's palette**: the palette can enumerate
       `binds/0` and invoke `command_for/2` on any entry directly (a command
       palette is just another way to select a bind, not a second source of
@@ -49,6 +64,38 @@ defmodule Raxol.UI.Harness.Keymap do
       fix: they only resolve to a command when focus is NOT the composer
       (browsing the transcript), and fall through to `:passthrough`
       (ordinary character insertion) while composing.
+
+  ### Fail-safe default: missing `composing?` means composing
+
+  A caller that omits `composing?` from `context()` entirely (forgets it,
+  or is a code path -- palette invocation, a future non-composer
+  interaction -- that never renders a composer at all) gets the
+  fail-SAFE reading: **treated as composing**, so the guarded binds
+  (`fold-toggle`, `jump_next`, `jump_prev`) resolve to `:passthrough`,
+  never firing. This is deliberately asymmetric with what would be
+  simplest to implement (`Map.get(context, :composing?, false)`, "missing
+  means not composing"), because the two failure directions are not
+  equally bad:
+
+    * **Fail-safe (this module's choice)**: a caller that never sets
+      `composing?` gets dead `j`/`k`/`z` navigation. That is immediately
+      discoverable -- the keys visibly do nothing -- and ESC/Tab are
+      unaffected (`:always` binds never consult `composing?`), so nothing
+      load-bearing is silently broken.
+    * **Fail-open (the rejected alternative)**: a caller that never sets
+      `composing?` gets the guarded binds firing unconditionally --
+      exactly the named prototype bug this module exists to fix (see
+      below), except now triggered by an *absent* flag instead of a
+      flat keymap with no guard at all. Typed `j`/`k`/`z` would silently
+      turn into fold-toggle/jump commands instead of inserting characters,
+      with no crash and no visible error -- the worst kind of bug, because
+      it looks like normal typing until content goes missing.
+
+  Only an explicit `composing?: false` opts a caller INTO guarded-bind
+  resolution. `context()` also normalizes a bare `nil` (e.g. "no block
+  focused" callers that pass `nil` instead of `%{}`) to `%{}` before any
+  guard consults it, so the crash surface is not bind-dependent -- see
+  `resolve/2`'s doc.
 
   `context()` is deliberately small: `composing?` (is the composer
   focused/receiving text), `streaming?` (is a turn currently running), and
@@ -123,7 +170,8 @@ defmodule Raxol.UI.Harness.Keymap do
           required(:command_type) => command_type(),
           optional(:key) => atom(),
           optional(:char) => String.t(),
-          optional(:guard) => guard()
+          optional(:guard) => guard(),
+          optional(:mods) => InputEvent.mods()
         }
 
   # Plain keys only (v1) -- see moduledoc's "tui-steal rule": a future chord
@@ -152,7 +200,7 @@ defmodule Raxol.UI.Harness.Keymap do
   invocation-parity test and available to T15 for the same reason.
   """
   @spec command_types() :: [command_type()]
-  def command_types, do: Enum.map(@binds, & &1.command_type)
+  def command_types, do: @binds |> Enum.map(& &1.command_type) |> Enum.uniq()
 
   @doc """
   Resolve a normalized `InputEvent.t()` (see `Raxol.UI.Harness.InputEvent`
@@ -160,31 +208,64 @@ defmodule Raxol.UI.Harness.Keymap do
   a mode context into a typed command, or `:passthrough` when no bind
   applies (composer-focus guard blocked it, or the key simply isn't bound).
 
+  A bare `nil` context (e.g. "no block focused" callers that pass `nil`
+  instead of `%{}`) normalizes to `%{}` before any guard consults it --
+  every field then falls back to its documented default (see the
+  moduledoc's fail-safe-default section for `composing?`) instead of the
+  guard raising on a non-map.
+
   Pure: no process state, no side effects, never raises on a well-formed
   `InputEvent.t()`.
   """
-  @spec resolve(InputEvent.t(), context()) :: command() | :passthrough
-  def resolve(norm, context \\ %{}) do
+  @spec resolve(InputEvent.t(), context() | nil) :: command() | :passthrough
+  def resolve(norm, context \\ %{})
+
+  def resolve(norm, nil), do: resolve(norm, %{})
+
+  def resolve(norm, context) do
     case Enum.find(@binds, &matches?(&1, norm, context)) do
       nil -> :passthrough
       bind -> build_command(bind, context)
     end
   end
 
-  # -- private --
-
-  defp matches?(%{key: key} = bind, norm, context) do
-    InputEvent.key(norm) == key and guard_passes?(bind, context)
+  @doc false
+  # Exposed (not `defp`) so the modifier-exact-match branch is directly
+  # unit-testable against a fixture bind without adding a chord to the
+  # shipped v1 table -- see keymap_test.exs's "modifier-aware key binds".
+  @spec matches?(bind(), InputEvent.t(), context()) :: boolean()
+  def matches?(%{key: key} = bind, norm, context) do
+    InputEvent.key(norm) == key and mods_match?(bind, norm) and
+      guard_passes?(bind, context)
   end
 
-  defp matches?(%{char: char} = bind, norm, context) do
+  def matches?(%{char: char} = bind, norm, context) do
     InputEvent.printable_char(norm) == char and guard_passes?(bind, context)
+  end
+
+  # -- private --
+
+  # `key:`-kind binds are modifier-aware (see moduledoc's tui-steal rule):
+  # no declared `mods:` means "bare keypress only" -- ctrl/alt/meta held
+  # fails the match (Ctrl+Tab/Alt+Tab/Meta+Tab are shortcuts, not Tab).
+  # Shift is deliberately excluded from that check (mirrors
+  # `InputEvent.text?/1`: shift-only is not a shortcut), so Shift+Tab
+  # still resolves through the plain `:tab` bind. A bind that DOES
+  # declare `mods:` requires an EXACT match against the normalized
+  # event's `mods` map instead.
+  defp mods_match?(%{mods: required_mods}, norm), do: norm.mods == required_mods
+
+  defp mods_match?(_bind, norm) do
+    not (norm.mods.ctrl or norm.mods.alt or norm.mods.meta)
   end
 
   defp guard_passes?(%{guard: :always}, _context), do: true
 
+  # Missing `composing?` defaults to `true` (composing) -- the fail-safe
+  # direction. See moduledoc's "Fail-safe default" section: a caller must
+  # opt IN to guarded-bind resolution with an explicit `composing?: false`.
   defp guard_passes?(%{guard: :not_composing}, context),
-    do: not Map.get(context, :composing?, false)
+    do: not Map.get(context, :composing?, true)
 
   defp build_command(%{command_type: :fold_toggle}, context) do
     %{

--- a/lib/raxol/ui/harness/keymap.ex
+++ b/lib/raxol/ui/harness/keymap.ex
@@ -1,0 +1,199 @@
+defmodule Raxol.UI.Harness.Keymap do
+  @moduledoc """
+  Harness keybind layer: canonical input event + mode context → typed
+  command, or `:passthrough`. T12 in `harness-ui-roadmap.md`.
+
+  ## The seam this closes
+
+  `Raxol.UI.Harness.InputEvent` (T27) already reduces every driver key-event
+  shape to one canonical `t()`. This module is the next layer: it decides
+  what a *normalized* keypress *means* -- interrupt the running turn, queue
+  a steer, toggle a block's fold, move focus between blocks -- without
+  knowing anything about drivers, terminals, or ANSI. `resolve/2` is a pure
+  function: `(InputEvent.t(), context()) -> command() | :passthrough`. It
+  never touches process state, never renders, never calls into a live
+  component.
+
+  ## Why a data table, not a `cond`/`case` ladder
+
+  `binds/0` returns the keymap as a plain list of maps -- match spec +
+  guard name + command type, no closures. `resolve/2` walks it. Two things
+  fall out of that for free:
+
+    * **tui-steal rule** (chords replace keys later without restructuring
+      the dispatch logic -- a bind's `match` grows a `mods:` requirement,
+      the walking loop does not change).
+    * **Invocation parity with T15's palette**: the palette can enumerate
+      `binds/0` and invoke `command_for/2` on any entry directly (a command
+      palette is just another way to select a bind, not a second source of
+      truth for what commands exist). `command_types/0` is the exact union
+      this module can ever emit -- there are no commands hiding outside the
+      table.
+
+  ## The composer-focus guard
+
+  Two classes of bind:
+
+    * **Always live** -- fire regardless of `context.composing?`. Only ESC
+      (`:interrupt`) and the steer-submit key (`:tab`, `:steer`) are in this
+      class, because both are non-printable control keys that can never be
+      part of typed text, and ESC in particular must never be swallowed by
+      whatever currently has focus (AD-1: interrupt is a supervised kill
+      now, not a cooperative flag queued behind typing).
+    * **Guarded by `not composing?`** -- the block-navigation binds
+      (`fold-toggle`, `jump_next`, `jump_prev`). These use plain printable
+      letters (`z`/`j`/`k`), and a prior flat-keymap prototype's named bug
+      (see `harness-ui-STATE.md`, "the demo's flat keymap steals j/k/s/z
+      from typing") was firing them unconditionally, stealing those letters
+      out of the composer's typed text. Gating them on `composing?` is the
+      fix: they only resolve to a command when focus is NOT the composer
+      (browsing the transcript), and fall through to `:passthrough`
+      (ordinary character insertion) while composing.
+
+  `context()` is deliberately small: `composing?` (is the composer
+  focused/receiving text), `streaming?` (is a turn currently running), and
+  `focused_block_id` (which block, if any, a fold/jump command should
+  target). `streaming?` does not gate ESC -- interrupt is unconditional and
+  immediate (roadmap: "ESC during streaming emits interrupt, not
+  buffered"); sending it when nothing is running is a harmless no-op
+  downstream, and NEVER emitting it because of a mode check is the failure
+  mode AD-1 exists to rule out.
+
+  ## Steer-submit: why Tab, not a modified Enter
+
+  Plain Enter (single-line, non-empty buffer) already submits as `:prompt`
+  entirely inside `Raxol.UI.Components.Harness.Composer` (T11) -- that
+  path never reaches this module. Steer needs a *different* key, and it
+  must be one that can fire *while the user is mid-composing* (queuing a
+  steer message is the whole point), so it cannot be a plain printable
+  character (those are text, full stop -- see the guard above). `Tab` is
+  the documented precedent for exactly this shape of decision
+  (`harness-spec-protocol.md` / `harness-spec-frontend.md`: "the corpus's
+  named steer-vs-interrupt primitive (Tab=queue / Enter=now)"); it also has
+  a first-class canonical key atom (`:tab`) verified across the real
+  termbox and ANSI wires by T27, and Composer does not otherwise bind it.
+
+  ## Command shape: reusing U3's channel without a compile-time dependency
+
+  `packages/raxol_agent` owns the live command struct
+  (`Raxol.Agent.Command`, `%Command{type: atom(), payload: map()}`,
+  U3/#543) and the harness protocol's validation seam (`decode/1`). Main
+  `raxol` does not (and per the package dependency graph, must not) depend
+  on `raxol_agent` -- this module ships in the harness-UI lane, which is
+  fixture-driven and requires no agent lane (T13a's own acceptance: "No
+  agent lane required"). Per the documented cross-package convention
+  (`CLAUDE.md`: "Struct patterns across package boundaries use map
+  patterns... instead of struct patterns"), `command()` here is a **plain
+  map** with the *same field names* U3 shipped -- `%{type: atom(), payload:
+  map()}` -- not the struct. This is not a parallel command type: it is the
+  identical wire shape, one `struct(Raxol.Agent.Command, cmd)` away from
+  the real thing at the one boundary (T13b's live wiring) that actually
+  depends on `raxol_agent`.
+
+  `:interrupt` mirrors U3's existing type verbatim (empty payload, same as
+  U3's own `:interrupt` validation). `:steer` mirrors the protocol spec's
+  documented (not yet decoded by U3) `steer` type
+  (`harness-spec-protocol.md` §4: `%{text}`) -- T12 emits an empty payload
+  since it has no access to composer text (a pure keymap, per the roadmap,
+  takes the event + a *small* mode context, not component state); the
+  assembly layer that already has the composer's buffer fills `payload.text`
+  in before dispatch. `:fold_toggle` / `:jump_next` / `:jump_prev` are new
+  vocabulary this unit adds (the task's own named example of "a needed
+  command kind [that] doesn't exist yet") -- transcript-navigation actions
+  that never need to leave the UI lane, so they ride the same channel for
+  T15 invocation-parity without ever being routed to `raxol_agent`.
+  """
+
+  alias Raxol.UI.Harness.InputEvent
+
+  @type context :: %{
+          optional(:composing?) => boolean(),
+          optional(:streaming?) => boolean(),
+          optional(:focused_block_id) => term()
+        }
+
+  @type command_type ::
+          :interrupt | :steer | :fold_toggle | :jump_next | :jump_prev
+
+  @type command :: %{type: command_type(), payload: map()}
+
+  @type guard :: :always | :not_composing
+
+  @type bind :: %{
+          required(:command_type) => command_type(),
+          optional(:key) => atom(),
+          optional(:char) => String.t(),
+          optional(:guard) => guard()
+        }
+
+  # Plain keys only (v1) -- see moduledoc's "tui-steal rule": a future chord
+  # (e.g. requiring :ctrl) is a new field on the matching entry, not a
+  # restructure of `resolve/2`. Order matters only in that the first match
+  # wins; the table is designed so no two entries can ever both match a
+  # single normalized event, so today the order is not load-bearing.
+  @binds [
+    %{key: :escape, command_type: :interrupt, guard: :always},
+    %{key: :tab, command_type: :steer, guard: :always},
+    %{char: "z", command_type: :fold_toggle, guard: :not_composing},
+    %{char: "j", command_type: :jump_next, guard: :not_composing},
+    %{char: "k", command_type: :jump_prev, guard: :not_composing}
+  ]
+
+  @doc """
+  The keymap as data -- one entry per v1 bind. Exposed so T15's command
+  palette can enumerate every invokable command without a second table.
+  """
+  @spec binds() :: [bind()]
+  def binds, do: @binds
+
+  @doc """
+  The exact set of command types this module can ever emit -- the union
+  `binds/0` declares, nothing hidden outside the table. Used by the
+  invocation-parity test and available to T15 for the same reason.
+  """
+  @spec command_types() :: [command_type()]
+  def command_types, do: Enum.map(@binds, & &1.command_type)
+
+  @doc """
+  Resolve a normalized `InputEvent.t()` (see `Raxol.UI.Harness.InputEvent`
+  -- callers normalize first; this module never sees a raw driver event) +
+  a mode context into a typed command, or `:passthrough` when no bind
+  applies (composer-focus guard blocked it, or the key simply isn't bound).
+
+  Pure: no process state, no side effects, never raises on a well-formed
+  `InputEvent.t()`.
+  """
+  @spec resolve(InputEvent.t(), context()) :: command() | :passthrough
+  def resolve(norm, context \\ %{}) do
+    case Enum.find(@binds, &matches?(&1, norm, context)) do
+      nil -> :passthrough
+      bind -> build_command(bind, context)
+    end
+  end
+
+  # -- private --
+
+  defp matches?(%{key: key} = bind, norm, context) do
+    InputEvent.key(norm) == key and guard_passes?(bind, context)
+  end
+
+  defp matches?(%{char: char} = bind, norm, context) do
+    InputEvent.printable_char(norm) == char and guard_passes?(bind, context)
+  end
+
+  defp guard_passes?(%{guard: :always}, _context), do: true
+
+  defp guard_passes?(%{guard: :not_composing}, context),
+    do: not Map.get(context, :composing?, false)
+
+  defp build_command(%{command_type: :fold_toggle}, context) do
+    %{
+      type: :fold_toggle,
+      payload: %{block_id: Map.get(context, :focused_block_id)}
+    }
+  end
+
+  defp build_command(%{command_type: type}, _context) do
+    %{type: type, payload: %{}}
+  end
+end

--- a/test/raxol/ui/harness/keymap_test.exs
+++ b/test/raxol/ui/harness/keymap_test.exs
@@ -161,13 +161,21 @@ defmodule Raxol.UI.Harness.KeymapTest do
              }) == %{type: :fold_toggle, payload: %{block_id: nil}}
     end
 
-    test "composing?: unset defaults to the guarded (non-composing) behavior -- callers must opt in explicitly" do
-      # Absence of :composing? in context must not accidentally suppress a
-      # navigation bind -- Map.get(context, :composing?, false) means
-      # "unset == not composing", the safe default for callers (e.g. tests,
-      # a palette invocation) that never render a composer at all.
+    test "composing?: unset defaults to the fail-safe (composing) behavior -- callers must opt in explicitly to guarded binds" do
+      # Absence of :composing? in context must not accidentally let a
+      # navigation bind fire and steal a keystroke -- Map.get(context,
+      # :composing?, true) means "unset == composing", the fail-safe
+      # default. Only an explicit composing?: false opts a caller INTO
+      # guarded-bind resolution (e.g. a transcript-browsing mode that
+      # deliberately declares it isn't composing).
       assert resolve_from(Event.key_event("j", :pressed, []), %{}) ==
-               %{type: :jump_next, payload: %{}}
+               :passthrough
+    end
+
+    test "composing?: false explicitly opts in to guarded-bind resolution" do
+      assert resolve_from(Event.key_event("j", :pressed, []), %{
+               composing?: false
+             }) == %{type: :jump_next, payload: %{}}
     end
 
     test "ESC and Tab are the explicit exceptions -- they fire even while composing?: true" do
@@ -196,7 +204,10 @@ defmodule Raxol.UI.Harness.KeymapTest do
 
   describe "invocation parity" do
     test "command_types/0 is exactly the union binds/0 can ever emit" do
-      declared = Keymap.command_types() |> Enum.uniq() |> MapSet.new()
+      # command_types/0 documents itself as "the exact set" -- a set, not a
+      # dup-capable list -- so it uniqs internally now; no compensating
+      # Enum.uniq/1 needed here.
+      declared = Keymap.command_types() |> MapSet.new()
 
       emitted =
         Keymap.binds()
@@ -222,15 +233,103 @@ defmodule Raxol.UI.Harness.KeymapTest do
       do: InputEvent.normalize(Event.key_event(char, :pressed, []))
   end
 
-  # -- 5. fail-first RED proof (see commit message / report for the manual
-  # red run against a deliberately-broken guard) --
+  # -- 5. modifier-aware key binds (Drew's review, T12 fix-now #2) --
+
+  describe "modifier-aware key binds" do
+    test "Ctrl+Tab (translator shape) -> :passthrough" do
+      assert resolve_from(translator_event(@tb_tab, 0, 2)) == :passthrough
+    end
+
+    test "Ctrl+Tab (Event.key_event/3 shape) -> :passthrough" do
+      assert resolve_from(Event.key_event(:tab, :pressed, [:ctrl])) ==
+               :passthrough
+    end
+
+    test "Alt+Tab (Event.key_event/3 shape) -> :passthrough" do
+      assert resolve_from(Event.key_event(:tab, :pressed, [:alt])) ==
+               :passthrough
+    end
+
+    test "plain Tab (translator shape, no modifiers) -> :steer" do
+      assert resolve_from(translator_event(@tb_tab, 0)) ==
+               %{type: :steer, payload: %{}}
+    end
+
+    test "plain Tab (Event.key_event/3 shape, no modifiers) -> :steer" do
+      assert resolve_from(Event.key_event(:tab, :pressed, [])) ==
+               %{type: :steer, payload: %{}}
+    end
+
+    test "a declared mods: bind requires an EXACT match, not just 'no modifiers held'" do
+      # Fixture-only bind (never added to the shipped v1 table) that
+      # exercises the chord-growth extension point the moduledoc promises:
+      # a bind that declares `mods:` requires the normalized event's mods
+      # to match it exactly, rather than falling back to the bare-keypress
+      # default `matches?/3` uses for every un-chorded v1 bind.
+      chord = %{
+        key: :tab,
+        command_type: :steer,
+        guard: :always,
+        mods: %{ctrl: true, alt: false, shift: false, meta: false}
+      }
+
+      ctrl_tab =
+        Event.key_event(:tab, :pressed, [:ctrl]) |> InputEvent.normalize()
+
+      plain_tab = Event.key_event(:tab, :pressed, []) |> InputEvent.normalize()
+
+      alt_tab =
+        Event.key_event(:tab, :pressed, [:alt]) |> InputEvent.normalize()
+
+      ctrl_shift_tab =
+        Event.key_event(:tab, :pressed, [:ctrl, :shift])
+        |> InputEvent.normalize()
+
+      assert Keymap.matches?(chord, ctrl_tab, %{})
+      refute Keymap.matches?(chord, plain_tab, %{})
+      refute Keymap.matches?(chord, alt_tab, %{})
+      refute Keymap.matches?(chord, ctrl_shift_tab, %{})
+    end
+  end
+
+  # -- 6. resolve/2 with a nil context ("no block focused" callers) --
+
+  describe "resolve/2 with a nil context" do
+    test "nil normalizes to %{} -- guard: :always binds are unaffected" do
+      assert resolve_from(Event.key_event(:escape, :pressed, []), nil) ==
+               %{type: :interrupt, payload: %{}}
+    end
+
+    test "nil normalizes to %{} -- guard: :not_composing binds no longer raise, and resolve to :passthrough per the fail-safe default" do
+      # Before the fix, guard_passes?/2 called Map.get(nil, :composing?,
+      # _) directly and raised (BadMapError) for any :not_composing-
+      # guarded bind -- a crash surface that depended on which bind
+      # matched, since :always binds never touch context at all. resolve/2
+      # now normalizes nil to %{} up front, so every bind sees a real map.
+      assert resolve_from(Event.key_event("j", :pressed, []), nil) ==
+               :passthrough
+    end
+  end
+
+  # -- 7. fail-first RED proofs (see commit message / report for the manual
+  # red runs against deliberately-reverted code) --
   #
-  # The property test above ("composing?: true always passes through...")
-  # is the fail-first proof: temporarily inlining `true` in place of
-  # `guard_passes?/2`'s `:not_composing` clause (so `z`/`j`/`k` fire
-  # unconditionally, reproducing the named prototype bug) reddens this
-  # exact property immediately (StreamData shrinks to a single-char
-  # counterexample, e.g. "j", within the same run) with no other test
-  # touched. Restoring the guard turns it green again. This is the
-  # regression this suite exists to prevent.
+  # (a) The property test above ("composing?: true always passes
+  # through...") is the fail-first proof for the composer-focus guard
+  # itself: temporarily inlining `true` in place of `guard_passes?/2`'s
+  # `:not_composing` clause (so `z`/`j`/`k` fire unconditionally,
+  # reproducing the named prototype bug) reddens this exact property
+  # immediately (StreamData shrinks to a single-char counterexample, e.g.
+  # "j", within the same run) with no other test touched. Restoring the
+  # guard turns it green again.
+  #
+  # (b) "composing?: unset defaults to the fail-safe (composing)
+  # behavior" above is the fail-first proof for the DEFAULT DIRECTION
+  # fix: reverting `guard_passes?/2`'s `Map.get(context, :composing?,
+  # true)` back to the old `Map.get(context, :composing?, false)` reddens
+  # this exact test (it asserts :passthrough; the old default resolves
+  # to `%{type: :jump_next, payload: %{}}` instead) with no other test in
+  # this module touched -- this is the precise inversion Drew's review
+  # named: a caller that omits `composing?` must get guarded (dead)
+  # navigation, not silently-armed guarded binds.
 end

--- a/test/raxol/ui/harness/keymap_test.exs
+++ b/test/raxol/ui/harness/keymap_test.exs
@@ -1,0 +1,236 @@
+defmodule Raxol.UI.Harness.KeymapTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.Terminal.ANSI.InputParser
+  alias Raxol.Terminal.Driver.EventTranslator
+  alias Raxol.UI.Harness.InputEvent
+  alias Raxol.UI.Harness.Keymap
+
+  # -- real-producer helpers (mirrors input_event_test.exs's approach: drive
+  # the REAL T27 emitters, never hand-build a translator-/parser-shaped map) --
+
+  @tb_escape 27
+  @tb_tab 9
+
+  defp translator_event(key_code, char_code, mod_code \\ 0) do
+    {:ok, event} =
+      EventTranslator.translate(%{
+        type: :key,
+        key: key_code,
+        char: char_code,
+        mod: mod_code
+      })
+
+    event
+  end
+
+  defp parser_event(binary) do
+    [event] = InputParser.parse(binary)
+    event
+  end
+
+  defp resolve_from(raw_event, context \\ %{}) do
+    raw_event |> InputEvent.normalize() |> Keymap.resolve(context)
+  end
+
+  # -- 1. table test: each v1 bind, canonical event -> exactly its typed
+  # command, driven through the real producers for every shape that can
+  # represent it --
+
+  describe "v1 binds -- table over real T27 producers" do
+    test "ESC (translator shape) -> :interrupt" do
+      assert resolve_from(translator_event(@tb_escape, 0)) ==
+               %{type: :interrupt, payload: %{}}
+    end
+
+    test "ESC (ANSI parser shape) -> :interrupt" do
+      assert resolve_from(parser_event(<<27>>)) ==
+               %{type: :interrupt, payload: %{}}
+    end
+
+    test "ESC (Event.key_event/3 shape) -> :interrupt" do
+      assert resolve_from(Event.key_event(:escape, :pressed, [])) ==
+               %{type: :interrupt, payload: %{}}
+    end
+
+    test "Tab (translator shape) -> :steer" do
+      assert resolve_from(translator_event(@tb_tab, 0)) ==
+               %{type: :steer, payload: %{}}
+    end
+
+    test "Tab (ANSI parser shape) -> :steer" do
+      assert resolve_from(parser_event(<<9>>)) == %{type: :steer, payload: %{}}
+    end
+
+    test "Tab (Event.key_event/3 shape) -> :steer" do
+      assert resolve_from(Event.key_event(:tab, :pressed, [])) ==
+               %{type: :steer, payload: %{}}
+    end
+
+    test "'z' (translator shape) -> :fold_toggle, not composing" do
+      assert resolve_from(translator_event(0, ?z), %{composing?: false}) ==
+               %{type: :fold_toggle, payload: %{block_id: nil}}
+    end
+
+    test "'z' (ANSI parser shape) -> :fold_toggle, not composing" do
+      assert resolve_from(parser_event("z"), %{composing?: false}) ==
+               %{type: :fold_toggle, payload: %{block_id: nil}}
+    end
+
+    test "'z' (Event.key_event/3 shape) -> :fold_toggle, carries focused_block_id" do
+      assert resolve_from(Event.key_event("z", :pressed, []), %{
+               composing?: false,
+               focused_block_id: "blk-7"
+             }) == %{type: :fold_toggle, payload: %{block_id: "blk-7"}}
+    end
+
+    test "'j' (translator shape) -> :jump_next, not composing" do
+      assert resolve_from(translator_event(0, ?j), %{composing?: false}) ==
+               %{type: :jump_next, payload: %{}}
+    end
+
+    test "'j' (ANSI parser shape) -> :jump_next, not composing" do
+      assert resolve_from(parser_event("j"), %{composing?: false}) ==
+               %{type: :jump_next, payload: %{}}
+    end
+
+    test "'k' (translator shape) -> :jump_prev, not composing" do
+      assert resolve_from(translator_event(0, ?k), %{composing?: false}) ==
+               %{type: :jump_prev, payload: %{}}
+    end
+
+    test "'k' (ANSI parser shape) -> :jump_prev, not composing" do
+      assert resolve_from(parser_event("k"), %{composing?: false}) ==
+               %{type: :jump_prev, payload: %{}}
+    end
+
+    test "an unbound key normalizes but resolves to :passthrough" do
+      assert resolve_from(Event.key_event("q", :pressed, []), %{
+               composing?: false
+             }) == :passthrough
+    end
+
+    test "an unbound special key resolves to :passthrough" do
+      assert resolve_from(Event.key_event(:up, :pressed, []), %{
+               composing?: false
+             }) == :passthrough
+    end
+  end
+
+  # -- 2. ESC-during-streaming: the roadmap's named acceptance wording --
+
+  describe "ESC during streaming" do
+    test "ESC while streaming?: true still yields :interrupt, immediately, not buffered" do
+      assert resolve_from(Event.key_event(:escape, :pressed, []), %{
+               streaming?: true,
+               composing?: true
+             }) == %{type: :interrupt, payload: %{}}
+    end
+
+    test "ESC while streaming?: false also yields :interrupt (harmless no-op downstream, never dropped)" do
+      assert resolve_from(Event.key_event(:escape, :pressed, []), %{
+               streaming?: false
+             }) == %{type: :interrupt, payload: %{}}
+    end
+  end
+
+  # -- 3. composer-focus guard --
+
+  describe "composer-focus guard" do
+    test "'j'/'k'/'z' pass through while composing (no stolen keys)" do
+      for char <- ["j", "k", "z"] do
+        assert resolve_from(Event.key_event(char, :pressed, []), %{
+                 composing?: true
+               }) == :passthrough
+      end
+    end
+
+    test "'j'/'k'/'z' resolve to their bind while not composing" do
+      assert resolve_from(Event.key_event("j", :pressed, []), %{
+               composing?: false
+             }) == %{type: :jump_next, payload: %{}}
+
+      assert resolve_from(Event.key_event("k", :pressed, []), %{
+               composing?: false
+             }) == %{type: :jump_prev, payload: %{}}
+
+      assert resolve_from(Event.key_event("z", :pressed, []), %{
+               composing?: false
+             }) == %{type: :fold_toggle, payload: %{block_id: nil}}
+    end
+
+    test "composing?: unset defaults to the guarded (non-composing) behavior -- callers must opt in explicitly" do
+      # Absence of :composing? in context must not accidentally suppress a
+      # navigation bind -- Map.get(context, :composing?, false) means
+      # "unset == not composing", the safe default for callers (e.g. tests,
+      # a palette invocation) that never render a composer at all.
+      assert resolve_from(Event.key_event("j", :pressed, []), %{}) ==
+               %{type: :jump_next, payload: %{}}
+    end
+
+    test "ESC and Tab are the explicit exceptions -- they fire even while composing?: true" do
+      assert resolve_from(Event.key_event(:escape, :pressed, []), %{
+               composing?: true
+             }) == %{type: :interrupt, payload: %{}}
+
+      assert resolve_from(Event.key_event(:tab, :pressed, []), %{
+               composing?: true
+             }) == %{type: :steer, payload: %{}}
+    end
+
+    property "composing?: true always passes through printable characters, except the explicit exceptions" do
+      check all(char <- StreamData.string(:alphanumeric, length: 1)) do
+        result =
+          resolve_from(Event.key_event(char, :pressed, []), %{
+            composing?: true
+          })
+
+        assert result == :passthrough
+      end
+    end
+  end
+
+  # -- 4. invocation-parity seam (T15's palette) --
+
+  describe "invocation parity" do
+    test "command_types/0 is exactly the union binds/0 can ever emit" do
+      declared = Keymap.command_types() |> Enum.uniq() |> MapSet.new()
+
+      emitted =
+        Keymap.binds()
+        |> Enum.map(fn bind ->
+          norm = fixture_for(bind)
+          context = %{composing?: false, focused_block_id: "any"}
+
+          case Keymap.resolve(norm, context) do
+            %{type: type} -> type
+            :passthrough -> flunk("bind #{inspect(bind)} did not resolve")
+          end
+        end)
+        |> MapSet.new()
+
+      assert declared == emitted
+      assert MapSet.size(declared) == length(Keymap.binds())
+    end
+
+    defp fixture_for(%{key: key}),
+      do: InputEvent.normalize(Event.key_event(key, :pressed, []))
+
+    defp fixture_for(%{char: char}),
+      do: InputEvent.normalize(Event.key_event(char, :pressed, []))
+  end
+
+  # -- 5. fail-first RED proof (see commit message / report for the manual
+  # red run against a deliberately-broken guard) --
+  #
+  # The property test above ("composing?: true always passes through...")
+  # is the fail-first proof: temporarily inlining `true` in place of
+  # `guard_passes?/2`'s `:not_composing` clause (so `z`/`j`/`k` fire
+  # unconditionally, reproducing the named prototype bug) reddens this
+  # exact property immediately (StreamData shrinks to a single-char
+  # counterexample, e.g. "j", within the same run) with no other test
+  # touched. Restoring the guard turns it green again. This is the
+  # regression this suite exists to prevent.
+end


### PR DESCRIPTION
Unit **T12 — keybind layer**. Pure keymap: T27 canonical input events (+ mode context) → typed commands. The data-table design (`binds/0`) is the invocation-parity seam T15's palette enumerates — no hidden case clauses (asserted by test: the emitted-command union equals the table).

**v1 binds:** ESC → `:interrupt` (`:always` — AD-1: interrupt must never be swallowed by focus) · Tab → `:steer` (`:always`; "Tab=queue / Enter=now" per the protocol spec — Enter stays the composer's) · `z` → `:fold_toggle` · `j`/`k` → `:jump_next`/`:jump_prev` (all three `:not_composing`-guarded — the direct fix for the prototype's "keymap stole j/k/s/z from typing" bug).

**Shape-match is proven, not assumed:** the suite drives the REAL T27 emitters (`EventTranslator.translate/1`, `InputParser.parse/1`, `Event.key_event/3` — the exact driver dispatch path) through the keymap across all three wire shapes. If the driver emitted `:esc` instead of `:escape`, the suite goes red.

**Command shape:** plain `%{type: atom, payload: map}` — field-identical to `%Raxol.Agent.Command{}` (main raxol cannot depend on raxol_agent; map-across-boundary per repo convention; conversion is literally `struct(Command, cmd)` for the agent-bound types).

Red-first: guard mutated to always-pass → composing-guard property red, StreamData shrank to exactly `"j"`; restored green (23/23).

Opus review: **SHIP, no RED.** Four yellows, all T13a/T13b seam preconditions (recorded in the STATE doc as T13a acceptance inputs):
1. T13a MUST dispatch keymap-first for `:always` binds — T11's composer catch-all delegates every unhandled key into MultiLineInput, so component-first wiring would kill both ESC-interrupt and Tab-steer.
2. T13b conversion bifurcation: `:interrupt`/`:steer` cross to the agent lane as `%Command{}`; `:fold_toggle`/`:jump_*` stay UI-local.
3. ESC-always vs ESC-to-close overlays (T14) — resolve in T13a's focus model.
4. `streaming?` context field forward-declared, currently unread.

Gates: compile --warnings-as-errors clean; 23/23 + T27 (66) + T11 composer (46) green together; format + credo --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
