### PR TITLE
Harness UI: degradation ladder (mode select + flat authority) [T3]

### DIFF
--- a/lib/raxol/ui/rendering/paint_authority/flat_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/flat_authority.ex
@@ -1,0 +1,122 @@
+defmodule Raxol.UI.Rendering.PaintAuthority.FlatAuthority do
+  @moduledoc """
+  T3's `:flat` tier: the append-only, zero-region, zero-cursor-jump
+  `PaintAuthority` implementation
+  (`docs/proposals/in-flight/harness-ui-roadmap.md`, unit T3 —
+  "degradation ladder"). Picked by
+  `Raxol.UI.Rendering.PaintAuthority.ModeSelect.select/3` for `TERM=dumb`,
+  non-tty, CI-without-tty, and degenerate-geometry sessions — the
+  screen-reader answer, the CI/pipe answer, the block-hater answer (AD-U2).
+
+  ## The SGR/escape decision: zero escape bytes, full stop
+
+  Unlike `InlineAuthority` (which never emits a full clear but DOES emit
+  DECSTBM/CUP/cursor-save bytes) this module never writes ANY byte in the
+  `0x1B` (ESC) family — not just cursor movement, but also SGR styling.
+  This is a deliberate v1 simplification, not an oversight:
+
+    * A conditionally-styled flat mode (SGR when the destination happens
+      to be a real tty, plain when it's a genuine pipe) would need its
+      own tty-detection seam threaded into the AUTHORITY itself, when
+      `ModeSelect` already computed that exact fact once, at startup, to
+      pick `:flat` in the first place. Re-deriving it a second time inside
+      the authority (or plumbing the `:tty?` flag through as authority
+      state) is more machinery than a v1 flat writer needs.
+    * Zero escape bytes is also the easiest claim to make PROVABLY true:
+      the mechanical acceptance check ("flat output contains no
+      cursor-move/CUP/scroll sequences") reduces to "every scanned token
+      is `{:text, _}`" with no exceptions to special-case for allowed SGR
+      runs.
+    * This is additive, not a rewrite, to upgrade later: a future unit
+      that wants styled flat output for a genuine tty destination can
+      thread `ModeSelect`'s already-computed `:tty?` fact into `new/3` as
+      an opt-in flag and add SGR emission ONLY on that path, without
+      touching the append-only/no-region/no-cursor contract this module
+      ships today.
+
+  ## Line-terminator convention: plain `\\n`
+
+  `InlineAuthority.seal/2` requires `\\r\\n`-terminated content because a
+  real terminal in raw mode needs the explicit carriage return (output
+  translation is off). `:flat`'s destination is a pipe, a log file, a
+  screen reader, or a CI capture buffer — none of which need or want the
+  extra `\\r`. Callers building content for `FlatAuthority` should
+  terminate each line with plain `\\n`. This module does not enforce or
+  rewrite terminators itself (it writes `iodata` verbatim, exactly like
+  `PaintAuthority.IOAuthority`'s minimal-stub convention) — the `\\r\\n`
+  vs. `\\n` choice lives entirely in what the CALLER passes in, so a
+  caller that already has `\\r\\n`-terminated content (e.g. replaying the
+  same fixture through both tiers for a parity check) gets it written
+  through unchanged rather than silently rewritten.
+
+  ## What every callback does
+
+    * `append_sealed/2` — writes `iodata` verbatim. No CUP, ever.
+    * `repaint_footer/2` / `keyframe_footer/2` — NO-OP (return state
+      unchanged, write nothing). Flat has no footer to repaint or
+      keyframe; a caller that calls these on a flat authority gets
+      silence, not stray bytes.
+    * `with_cursor/3` — runs `fun` directly against the state. No save,
+      no restore: there is no cursor position worth protecting when
+      nothing ever moves it.
+    * `resize/3` — updates the tracked `width`/`height` but writes zero
+      bytes. There is no region to re-pin.
+    * `region_top/1` — returns `height`: with no footer carved out, the
+      entire screen is (conceptually) history/content.
+  """
+
+  @behaviour Raxol.UI.Rendering.PaintAuthority
+
+  @enforce_keys [:device, :width, :height]
+  defstruct [:device, :width, :height]
+
+  @type t :: %__MODULE__{
+          device: IO.device(),
+          width: pos_integer(),
+          height: pos_integer()
+        }
+
+  @doc "Builds a new flat authority state. No device writes happen at construction."
+  @spec new(IO.device(), pos_integer(), pos_integer()) :: t()
+  def new(device, width, height)
+      when is_integer(width) and width > 0 and is_integer(height) and
+             height > 0 do
+    %__MODULE__{device: device, width: width, height: height}
+  end
+
+  @doc """
+  Sugar mirroring `InlineAuthority.seal/2`'s call shape so a caller can
+  swap authorities without changing its call site: `seal/2` is exactly
+  `append_sealed/2` here (no cursor bracket to wrap it in).
+  """
+  @spec seal(t(), iodata()) :: t()
+  def seal(%__MODULE__{} = t, iodata), do: append_sealed(t, iodata)
+
+  @impl true
+  def append_sealed(%__MODULE__{device: device} = t, iodata) do
+    IO.write(device, iodata)
+    t
+  end
+
+  @impl true
+  def repaint_footer(%__MODULE__{} = t, _iodata), do: t
+
+  @impl true
+  def keyframe_footer(%__MODULE__{} = t, _iodata), do: t
+
+  @impl true
+  def with_cursor(%__MODULE__{} = t, region, fun)
+      when region in [:history, :footer] and is_function(fun, 1) do
+    fun.(t)
+  end
+
+  @impl true
+  def resize(%__MODULE__{} = t, width, height)
+      when is_integer(width) and width > 0 and is_integer(height) and
+             height > 0 do
+    %{t | width: width, height: height}
+  end
+
+  @impl true
+  def region_top(%__MODULE__{height: height}), do: height
+end

--- a/lib/raxol/ui/rendering/paint_authority/flat_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/flat_authority.ex
@@ -1,12 +1,10 @@
 defmodule Raxol.UI.Rendering.PaintAuthority.FlatAuthority do
   @moduledoc """
-  T3's `:flat` tier: the append-only, zero-region, zero-cursor-jump
-  `PaintAuthority` implementation
-  (`docs/proposals/in-flight/harness-ui-roadmap.md`, unit T3 —
-  "degradation ladder"). Picked by
+  The degradation ladder's `:flat` tier: the append-only, zero-region,
+  zero-cursor-jump `PaintAuthority` implementation. Picked by
   `Raxol.UI.Rendering.PaintAuthority.ModeSelect.select/3` for `TERM=dumb`,
   non-tty, CI-without-tty, and degenerate-geometry sessions — the
-  screen-reader answer, the CI/pipe answer, the block-hater answer (AD-U2).
+  screen-reader answer, the CI/pipe answer, the block-hater answer.
 
   ## The SGR/escape decision: zero escape bytes, enforced IN THIS MODULE
 

--- a/lib/raxol/ui/rendering/paint_authority/flat_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/flat_authority.ex
@@ -8,12 +8,20 @@ defmodule Raxol.UI.Rendering.PaintAuthority.FlatAuthority do
   non-tty, CI-without-tty, and degenerate-geometry sessions — the
   screen-reader answer, the CI/pipe answer, the block-hater answer (AD-U2).
 
-  ## The SGR/escape decision: zero escape bytes, full stop
+  ## The SGR/escape decision: zero escape bytes, enforced IN THIS MODULE
 
   Unlike `InlineAuthority` (which never emits a full clear but DOES emit
   DECSTBM/CUP/cursor-save bytes) this module never writes ANY byte in the
-  `0x1B` (ESC) family — not just cursor movement, but also SGR styling.
-  This is a deliberate v1 simplification, not an oversight:
+  C0 control range (`0x00`-`0x1F`, which includes `0x1B`/ESC) except
+  `\\t`, `\\r`, `\\n` — not just cursor movement, but also SGR styling and
+  bare control bytes like BEL. This is a deliberate v1 simplification, not
+  an oversight, AND it is a property `append_sealed/2` enforces itself by
+  scrubbing those bytes out of the iodata before it ever reaches the
+  device — it is not a contract callers have to uphold on their own.
+  Content flowing into this authority can originate from an LLM response,
+  a tool's stdout, or any other untrusted source; a caller forgetting to
+  sanitize it must not be able to smuggle a screen clear or a color
+  change through the flat tier.
 
     * A conditionally-styled flat mode (SGR when the destination happens
       to be a real tty, plain when it's a genuine pipe) would need its
@@ -26,7 +34,17 @@ defmodule Raxol.UI.Rendering.PaintAuthority.FlatAuthority do
       the mechanical acceptance check ("flat output contains no
       cursor-move/CUP/scroll sequences") reduces to "every scanned token
       is `{:text, _}`" with no exceptions to special-case for allowed SGR
-      runs.
+      runs — and now that the scrub happens inside the module, that
+      property holds regardless of what a caller passes in, not just for
+      well-behaved callers.
+    * Scrubbing the ESC lead byte and leaving the rest of a hostile
+      sequence's bytes untouched (e.g. `\\e[31m` becomes the visible
+      fragment `[31m`) is an intentional, HONEST failure mode: a reader
+      sees garbled-looking text and knows something was stripped. The
+      alternative — swallowing the whole sequence body, or worse, leaving
+      it byte-for-byte intact — risks an invisible injection that changes
+      what a downstream pipe or screen reader does without any visible
+      trace. A visible fragment is strictly safer than a silent one.
     * This is additive, not a rewrite, to upgrade later: a future unit
       that wants styled flat output for a genuine tty destination can
       thread `ModeSelect`'s already-computed `:tty?` fact into `new/3` as
@@ -42,16 +60,19 @@ defmodule Raxol.UI.Rendering.PaintAuthority.FlatAuthority do
   screen reader, or a CI capture buffer — none of which need or want the
   extra `\\r`. Callers building content for `FlatAuthority` should
   terminate each line with plain `\\n`. This module does not enforce or
-  rewrite terminators itself (it writes `iodata` verbatim, exactly like
-  `PaintAuthority.IOAuthority`'s minimal-stub convention) — the `\\r\\n`
-  vs. `\\n` choice lives entirely in what the CALLER passes in, so a
-  caller that already has `\\r\\n`-terminated content (e.g. replaying the
-  same fixture through both tiers for a parity check) gets it written
-  through unchanged rather than silently rewritten.
+  rewrite terminators itself — `\\t`, `\\r`, and `\\n` are all exempt from
+  the C0 scrub described above, so both conventions pass through
+  unchanged (exactly like `PaintAuthority.IOAuthority`'s minimal-stub
+  convention for everything outside that scrub) — the `\\r\\n` vs. `\\n`
+  choice lives entirely in what the CALLER passes in, so a caller that
+  already has `\\r\\n`-terminated content (e.g. replaying the same
+  fixture through both tiers for a parity check) gets it written through
+  unchanged rather than silently rewritten.
 
   ## What every callback does
 
-    * `append_sealed/2` — writes `iodata` verbatim. No CUP, ever.
+    * `append_sealed/2` — scrubs C0 control bytes (except `\\t`/`\\r`/`\\n`)
+      out of `iodata`, then writes what remains. No CUP, ever.
     * `repaint_footer/2` / `keyframe_footer/2` — NO-OP (return state
       unchanged, write nothing). Flat has no footer to repaint or
       keyframe; a caller that calls these on a flat authority gets
@@ -94,8 +115,22 @@ defmodule Raxol.UI.Rendering.PaintAuthority.FlatAuthority do
 
   @impl true
   def append_sealed(%__MODULE__{device: device} = t, iodata) do
-    IO.write(device, iodata)
+    IO.write(device, scrub(iodata))
     t
+  end
+
+  # Module-enforced escape scrub (see moduledoc): strips every C0 control
+  # byte (0x00-0x1F, which includes ESC/0x1B) except `\t`/`\r`/`\n`.
+  # Byte-wise stripping is safe for UTF-8 content: multi-byte sequence
+  # lead bytes (0xC2-0xF4) and continuation bytes (0x80-0xBF) are both
+  # outside the C0 range, so no valid UTF-8 codepoint is ever split.
+  @c0_exceptions [?\t, ?\r, ?\n]
+
+  defp scrub(iodata) do
+    for <<byte <- IO.iodata_to_binary(iodata)>>,
+        byte >= 0x20 or byte in @c0_exceptions,
+        into: <<>>,
+        do: <<byte>>
   end
 
   @impl true

--- a/lib/raxol/ui/rendering/paint_authority/mode_select.ex
+++ b/lib/raxol/ui/rendering/paint_authority/mode_select.ex
@@ -33,23 +33,43 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
       zero regions, zero cursor jumps. The screen-reader answer, the
       CI/pipe answer, the block-hater answer (AD-U2).
 
-  ## Rule order (first match wins)
+  ## Rule order
 
-  1. **Explicit env override** (`RAXOL_HARNESS_MODE=flat|tmux|inline`)
-     wins over every other signal, including a degenerate terminal or a
-     detected multiplexer -- an operator who typed the override gets
-     exactly what they asked for.
-  2. **Headless** (`TERM=dumb`, not a tty, or `CI` truthy AND not a tty)
-     -> `:flat`. This has to run before the tmux check: a CI runner
-     piping output through `TERM=dumb` (or no tty at all) is not a place
-     any cursor-positioning tier belongs, tmux-flavored or not.
-  3. **Degenerate geometry** (`ScrollRegionManager.degenerate?/2`: the
-     terminal is too short to hold a footer plus a 1-row history region)
-     -> `:flat`.
-  4. **tmux/screen multiplexer detected** -> `:tmux_conservative`.
-  5. Otherwise -> `:inline_log`.
+  Mode-pick happens in two passes: first a CANDIDATE mode is resolved
+  (from an explicit override or from auto-detection), then a
+  degenerate-geometry FLOOR is applied to whatever that candidate is.
+  The floor runs LAST, after the candidate is chosen, not as one more
+  item in the override/auto-detect priority list -- see "Why the
+  degenerate floor applies after override resolution" below for why that
+  distinction is load-bearing.
 
-  ### Why degenerate geometry is checked before tmux (rules 3 vs. 4)
+  ### Pass 1: resolve a candidate mode
+
+  1. **Explicit env override** (`RAXOL_HARNESS_MODE=flat|tmux|inline`,
+     case- and whitespace-insensitive) is the candidate, when recognized.
+     An unrecognized non-empty value does NOT win -- it falls through to
+     auto-detection below, and is surfaced separately via
+     `select_with_reason/3`'s `:override_unrecognized` reason so a caller
+     can warn instead of silently guessing what the operator meant.
+  2. Otherwise, auto-detect:
+     a. **Headless** (`TERM=dumb`, not a tty, or `CI` truthy AND not a
+        tty) -> `:flat`. This has to run before the tmux check: a CI
+        runner piping output through `TERM=dumb` (or no tty at all) is
+        not a place any cursor-positioning tier belongs, tmux-flavored
+        or not.
+     b. **tmux/screen multiplexer detected** -> `:tmux_conservative`.
+     c. Otherwise -> `:inline_log`.
+
+  ### Pass 2: the degenerate-geometry floor
+
+  **Degenerate geometry** (`ScrollRegionManager.degenerate?/2`: the
+  terminal is too short to hold a footer plus a 1-row history region)
+  clamps ANY non-`:flat` candidate down to `:flat`, regardless of whether
+  that candidate came from an override or from auto-detection. A
+  candidate that is already `:flat` (override or auto-detected) is left
+  alone -- the floor is a one-way clamp, never a way to escape `:flat`.
+
+  ### Why the degenerate floor applies after override resolution
 
   This ordering is load-bearing, not cosmetic: a degenerate geometry
   (too few rows to hold a footer plus a 1-row history region, e.g.
@@ -59,20 +79,30 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
   row 1 BEFORE the terminal has scrolled -- each new block overwrites the
   previous one instead of accumulating (traced on real bytes: `\e[1;1HL1...`
   then `\e[1;1HM1...`, with `L1` clobbered, never reaching scrollback).
-  This happens whether or not the session is also inside tmux: tmux's
-  clamped capability profile changes which escape sequences
-  `InlineAuthority` is willing to assume are honored, but it does nothing
-  to fix a `region_top` that is pinned at 1 by the geometry itself. So a
-  session that is BOTH degenerate AND tmux-detected still gets the
-  clobbering append path if routed to `:tmux_conservative` -- there is no
-  additional safety purchased by keeping the tmux-specific clamping, only
-  a broken transcript. `:flat` sidesteps the whole failure mode: it never
-  positions a cursor, so there is no pinned row to clobber, and every
-  sealed line survives in order. That is strictly safer than any
-  cursor-positioning tier at degenerate geometry, which is why degenerate
-  geometry outranks tmux detection in the rule order. A tmux session with
-  ADEQUATE geometry has no such pinning problem and keeps its
-  `:tmux_conservative` tier as before.
+
+  That clobber has nothing to do with WHY `InlineAuthority` was picked --
+  it fires identically whether the route there was auto-detected tmux
+  (this unit's original regression: a tmux-detected session at degenerate
+  geometry must not fall through to `:tmux_conservative`, since that tier
+  still reaches the same clobbering `InlineAuthority` append path) or an
+  operator-supplied `RAXOL_HARNESS_MODE=inline`/`=tmux` override picked
+  the same authority explicitly. An override that special-cased itself to
+  skip the floor would reproduce the EXACT byte-traced clobber above,
+  just reached via an exported env var instead of auto-detection --
+  there is no additional safety purchased by letting an override outrank
+  the floor, only a broken transcript once the geometry turns out to be
+  degenerate at runtime (which the operator setting the override at
+  shell-startup time cannot always know in advance). `:flat` sidesteps
+  the whole failure mode: it never positions a cursor, so there is no
+  pinned row to clobber, and every sealed line survives in order. That is
+  strictly safer than any cursor-positioning tier at degenerate geometry,
+  for a candidate reached by ANY path, which is why the floor applies
+  uniformly AFTER candidate resolution rather than being folded into the
+  override-vs-auto-detect priority order. A `:flat` override is always
+  honored -- it is already the floor's own target, so clamping is a
+  no-op -- and a session with ADEQUATE geometry has no pinning problem and
+  keeps whatever candidate it resolved to (override or auto-detected) as
+  before.
   """
 
   alias Raxol.Terminal.Capabilities
@@ -80,6 +110,29 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
 
   @typedoc "Which `PaintAuthority` tier a session should render through."
   @type mode :: :inline_log | :tmux_conservative | :flat
+
+  @typedoc """
+  Why `select_with_reason/3` picked the mode it returned:
+
+    * `:override` — a recognized `RAXOL_HARNESS_MODE` value was honored
+      as-is (or was already `:flat`, so the degenerate floor was a no-op).
+    * `:override_unrecognized` — `RAXOL_HARNESS_MODE` was set to a
+      non-empty value that isn't `flat`/`tmux`/`inline` (after
+      trim+downcase); the mode fell through to auto-detection.
+    * `:headless` — auto-detected via `TERM=dumb` / non-tty / CI-without-tty.
+    * `:tmux` — auto-detected via a `TMUX`/`screen`-prefixed `TERM` env var
+      or a `Capabilities.multiplexer` of `:tmux`/`:screen`.
+    * `:default` — auto-detection fell through to the `:inline_log` default.
+    * `:degenerate_clamp` — the degenerate-geometry floor overrode
+      whatever candidate the above resolved to (see moduledoc).
+  """
+  @type reason ::
+          :override
+          | :override_unrecognized
+          | :headless
+          | :tmux
+          | :default
+          | :degenerate_clamp
 
   @typedoc """
   Pre-gathered environment facts. String keys mirror OS env var names
@@ -103,40 +156,104 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
       check is then skipped (treated as non-degenerate), matching every
       other rule's fail-open-to-`:inline_log` default.
     * `:footer_rows` — the footer row count the caller intends to pin
-      (`N` in the roadmap's `H - N` split). Defaults to `0`.
+      (`N` in the roadmap's `H - N` split). Defaults to `0`. A negative
+      or non-integer value is also treated as fail-open-to-non-degenerate
+      rather than raised — `ScrollRegionManager.degenerate?/2` itself
+      guards `footer_rows >= 0`, so this module has to guard the same
+      thing before delegating, or a caller-supplied `footer_rows: -1`
+      would crash mode-pick instead of degrading gracefully.
 
   Never consults `System.get_env/1`, `:persistent_term`, or any device —
-  purely a function of its three arguments.
+  purely a function of its three arguments. Delegates to
+  `select_with_reason/3` and discards the reason; use that function
+  directly when the reason is needed (e.g. a startup notice explaining
+  WHY a session ended up in `:flat`).
   """
   @spec select(Capabilities.t() | nil, env(), keyword()) :: mode()
   def select(caps, env, opts \\ []) when is_map(env) and is_list(opts) do
+    {mode, _reason} = select_with_reason(caps, env, opts)
+    mode
+  end
+
+  @doc """
+  Same mode-pick as `select/3`, plus the `reason()` the pick came from
+  (see the `t:reason/0` typedoc). This is the seam T13a's assembler uses
+  to print a startup notice ("routing through :flat because geometry is
+  too small for a footer" and similar).
+  """
+  @spec select_with_reason(Capabilities.t() | nil, env(), keyword()) ::
+          {mode(), reason()}
+  def select_with_reason(caps, env, opts \\ [])
+      when is_map(env) and is_list(opts) do
+    caps
+    |> resolve_candidate(env)
+    |> apply_degenerate_floor(opts)
+  end
+
+  # ---- pass 1: resolve the candidate mode (override, else auto-detect) ----
+
+  defp resolve_candidate(caps, env) do
     case override(env) do
-      nil -> select_without_override(caps, env, opts)
-      mode -> mode
+      {:ok, mode} -> {mode, :override}
+      :unrecognized -> {auto_detect_mode(caps, env), :override_unrecognized}
+      :none -> auto_detect(caps, env)
     end
   end
 
-  defp select_without_override(caps, env, opts) do
+  defp auto_detect_mode(caps, env) do
+    {mode, _reason} = auto_detect(caps, env)
+    mode
+  end
+
+  defp auto_detect(caps, env) do
     cond do
-      headless?(env) -> :flat
-      degenerate_geometry?(opts) -> :flat
-      tmux?(caps, env) -> :tmux_conservative
-      true -> :inline_log
+      headless?(env) -> {:flat, :headless}
+      tmux?(caps, env) -> {:tmux_conservative, :tmux}
+      true -> {:inline_log, :default}
     end
   end
 
-  # ---- rule 1: explicit override ----
+  # ---- pass 2: degenerate-geometry floor (see moduledoc) ----
+
+  defp apply_degenerate_floor({:flat, reason}, _opts), do: {:flat, reason}
+
+  defp apply_degenerate_floor({mode, reason}, opts) do
+    if degenerate_geometry?(opts) do
+      {:flat, :degenerate_clamp}
+    else
+      {mode, reason}
+    end
+  end
+
+  # ---- explicit override: recognized value, unrecognized, or absent ----
+  # Values are trimmed and downcased before matching, so `Flat`/` flat `
+  # both match `flat`.
 
   defp override(env) do
     case Map.get(env, "RAXOL_HARNESS_MODE") do
-      "flat" -> :flat
-      "tmux" -> :tmux_conservative
-      "inline" -> :inline_log
-      _other -> nil
+      nil ->
+        :none
+
+      "" ->
+        :none
+
+      raw ->
+        override_normalized(
+          raw
+          |> to_string()
+          |> String.trim()
+          |> String.downcase()
+        )
     end
   end
 
-  # ---- rule 2: headless (TERM=dumb / non-tty / CI-without-tty) ----
+  defp override_normalized(""), do: :none
+  defp override_normalized("flat"), do: {:ok, :flat}
+  defp override_normalized("tmux"), do: {:ok, :tmux_conservative}
+  defp override_normalized("inline"), do: {:ok, :inline_log}
+  defp override_normalized(_other), do: :unrecognized
+
+  # ---- headless (TERM=dumb / non-tty / CI-without-tty) ----
 
   defp headless?(env) do
     dumb_term?(env) or non_tty?(env) or ci_without_tty?(env)
@@ -154,7 +271,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
   defp truthy?("0"), do: false
   defp truthy?(_other), do: true
 
-  # ---- rule 4: tmux/screen multiplexer ----
+  # ---- tmux/screen multiplexer ----
 
   defp tmux?(caps, env), do: tmux_env?(env) or multiplexer_detected?(caps)
 
@@ -180,16 +297,20 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
 
   defp multiplexer_detected?(_caps), do: false
 
-  # ---- rule 3: degenerate geometry ----
-
+  # ---- degenerate geometry (the pass-2 floor) ----
+  #
+  # Fails open to `false` (non-degenerate) whenever `:rows`/`:footer_rows`
+  # aren't the shape `ScrollRegionManager.degenerate?/2` itself requires
+  # (`rows` a positive integer, `footer_rows` a non-negative integer) --
+  # matching every other rule's fail-open default rather than raising a
+  # `FunctionClauseError` on a caller-supplied `footer_rows: -1`.
   defp degenerate_geometry?(opts) do
-    case Keyword.get(opts, :rows) do
-      rows when is_integer(rows) and rows > 0 ->
-        footer_rows = Keyword.get(opts, :footer_rows, 0)
-        ScrollRegionManager.degenerate?(rows, footer_rows)
-
-      _other ->
-        false
+    with rows when is_integer(rows) and rows > 0 <- Keyword.get(opts, :rows),
+         footer_rows when is_integer(footer_rows) and footer_rows >= 0 <-
+           Keyword.get(opts, :footer_rows, 0) do
+      ScrollRegionManager.degenerate?(rows, footer_rows)
+    else
+      _other -> false
     end
   end
 end

--- a/lib/raxol/ui/rendering/paint_authority/mode_select.ex
+++ b/lib/raxol/ui/rendering/paint_authority/mode_select.ex
@@ -1,28 +1,27 @@
 defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
   @moduledoc """
-  T3's startup mode-pick decision: caps + env -> which `PaintAuthority`
-  profile a session renders through
-  (`docs/proposals/in-flight/harness-ui-roadmap.md`, unit T3 —
-  "degradation ladder").
+  The degradation ladder's startup mode-pick decision: caps + env ->
+  which `PaintAuthority` profile a session renders through.
 
   This is a PURE function. It never calls `System.get_env/1` or does any
-  I/O itself -- callers (T13a's assembler, or a `mix run` entry point) are
-  responsible for gathering the env map and passing it in, exactly the
-  same discipline `Raxol.Terminal.Capabilities.Classifier.classify/3`
-  already uses for its own env seed (`04-capability.md`: "env sniffing is
-  only ever a free first-pass seed"). Keeping the decision pure is what
-  makes the full mode-pick matrix table-testable without a pty or a real
-  tmux session.
+  I/O itself -- callers (the assembled harness's assembler, or a `mix run`
+  entry point) are responsible for gathering the env map and passing it
+  in, exactly the same discipline
+  `Raxol.Terminal.Capabilities.Classifier.classify/3` already uses for its
+  own env seed (env sniffing is only ever a free first-pass seed). Keeping
+  the decision pure is what makes the full mode-pick matrix table-testable
+  without a pty or a real tmux session.
 
   ## The three tiers
 
-    * `:inline_log` — the default: `InlineAuthority` (T2b/T2c), full
-      DECSTBM-pinned footer + scrolling history.
-    * `:tmux_conservative` — NOT a separate authority module. Per the
-      roadmap: "tmux tier per T0: no OSC marks assumed consumed, clamped
-      caps, possibly transient-region algorithm." T1's capability ladder
-      already clamps `%Capabilities{}` for a detected multiplexer before
-      it ever reaches `InlineAuthority.new/5` (`reflow_capable?/1` is
+    * `:inline_log` — the default: `InlineAuthority` (the append path +
+      the footer viewport), full DECSTBM-pinned footer + scrolling
+      history.
+    * `:tmux_conservative` — NOT a separate authority module. The tmux
+      tier assumes no OSC marks are consumed, clamps caps, and possibly
+      uses a transient-region algorithm; the capability ladder already
+      clamps `%Capabilities{}` for a detected multiplexer before it ever
+      reaches `InlineAuthority.new/5` (`reflow_capable?/1` is
       conservatively `false` for anything that isn't measured, and tmux is
       never on that allowlist); `ModeSelect` only picks the TIER NAME so a
       caller knows to route through that same `InlineAuthority` with the
@@ -31,7 +30,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
       not add one.
     * `:flat` — `FlatAuthority` (this unit, sibling module): append-only,
       zero regions, zero cursor jumps. The screen-reader answer, the
-      CI/pipe answer, the block-hater answer (AD-U2).
+      CI/pipe answer, the block-hater answer.
 
   ## Rule order
 
@@ -156,7 +155,7 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
       check is then skipped (treated as non-degenerate), matching every
       other rule's fail-open-to-`:inline_log` default.
     * `:footer_rows` — the footer row count the caller intends to pin
-      (`N` in the roadmap's `H - N` split). Defaults to `0`. A negative
+      (`N` in the `H - N` split). Defaults to `0`. A negative
       or non-integer value is also treated as fail-open-to-non-degenerate
       rather than raised — `ScrollRegionManager.degenerate?/2` itself
       guards `footer_rows >= 0`, so this module has to guard the same
@@ -177,9 +176,9 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
 
   @doc """
   Same mode-pick as `select/3`, plus the `reason()` the pick came from
-  (see the `t:reason/0` typedoc). This is the seam T13a's assembler uses
-  to print a startup notice ("routing through :flat because geometry is
-  too small for a footer" and similar).
+  (see the `t:reason/0` typedoc). This is the seam the assembled harness's
+  assembler uses to print a startup notice ("routing through :flat
+  because geometry is too small for a footer" and similar).
   """
   @spec select_with_reason(Capabilities.t() | nil, env(), keyword()) ::
           {mode(), reason()}

--- a/lib/raxol/ui/rendering/paint_authority/mode_select.ex
+++ b/lib/raxol/ui/rendering/paint_authority/mode_select.ex
@@ -1,0 +1,195 @@
+defmodule Raxol.UI.Rendering.PaintAuthority.ModeSelect do
+  @moduledoc """
+  T3's startup mode-pick decision: caps + env -> which `PaintAuthority`
+  profile a session renders through
+  (`docs/proposals/in-flight/harness-ui-roadmap.md`, unit T3 —
+  "degradation ladder").
+
+  This is a PURE function. It never calls `System.get_env/1` or does any
+  I/O itself -- callers (T13a's assembler, or a `mix run` entry point) are
+  responsible for gathering the env map and passing it in, exactly the
+  same discipline `Raxol.Terminal.Capabilities.Classifier.classify/3`
+  already uses for its own env seed (`04-capability.md`: "env sniffing is
+  only ever a free first-pass seed"). Keeping the decision pure is what
+  makes the full mode-pick matrix table-testable without a pty or a real
+  tmux session.
+
+  ## The three tiers
+
+    * `:inline_log` — the default: `InlineAuthority` (T2b/T2c), full
+      DECSTBM-pinned footer + scrolling history.
+    * `:tmux_conservative` — NOT a separate authority module. Per the
+      roadmap: "tmux tier per T0: no OSC marks assumed consumed, clamped
+      caps, possibly transient-region algorithm." T1's capability ladder
+      already clamps `%Capabilities{}` for a detected multiplexer before
+      it ever reaches `InlineAuthority.new/5` (`reflow_capable?/1` is
+      conservatively `false` for anything that isn't measured, and tmux is
+      never on that allowlist); `ModeSelect` only picks the TIER NAME so a
+      caller knows to route through that same `InlineAuthority` with the
+      already-clamped capability record it fetched from `Capabilities`.
+      There is no `TmuxConservativeAuthority` module and this unit does
+      not add one.
+    * `:flat` — `FlatAuthority` (this unit, sibling module): append-only,
+      zero regions, zero cursor jumps. The screen-reader answer, the
+      CI/pipe answer, the block-hater answer (AD-U2).
+
+  ## Rule order (first match wins)
+
+  1. **Explicit env override** (`RAXOL_HARNESS_MODE=flat|tmux|inline`)
+     wins over every other signal, including a degenerate terminal or a
+     detected multiplexer -- an operator who typed the override gets
+     exactly what they asked for.
+  2. **Headless** (`TERM=dumb`, not a tty, or `CI` truthy AND not a tty)
+     -> `:flat`. This has to run before the tmux check: a CI runner
+     piping output through `TERM=dumb` (or no tty at all) is not a place
+     any cursor-positioning tier belongs, tmux-flavored or not.
+  3. **Degenerate geometry** (`ScrollRegionManager.degenerate?/2`: the
+     terminal is too short to hold a footer plus a 1-row history region)
+     -> `:flat`.
+  4. **tmux/screen multiplexer detected** -> `:tmux_conservative`.
+  5. Otherwise -> `:inline_log`.
+
+  ### Why degenerate geometry is checked before tmux (rules 3 vs. 4)
+
+  This ordering is load-bearing, not cosmetic: a degenerate geometry
+  (too few rows to hold a footer plus a 1-row history region, e.g.
+  `rows: 2, footer_rows: 2`) means `ScrollRegionManager` cannot carve out
+  a real history region, so `region_top` pins at row 1. Every subsequent
+  `InlineAuthority` seal then issues its append CUP to that same pinned
+  row 1 BEFORE the terminal has scrolled -- each new block overwrites the
+  previous one instead of accumulating (traced on real bytes: `\e[1;1HL1...`
+  then `\e[1;1HM1...`, with `L1` clobbered, never reaching scrollback).
+  This happens whether or not the session is also inside tmux: tmux's
+  clamped capability profile changes which escape sequences
+  `InlineAuthority` is willing to assume are honored, but it does nothing
+  to fix a `region_top` that is pinned at 1 by the geometry itself. So a
+  session that is BOTH degenerate AND tmux-detected still gets the
+  clobbering append path if routed to `:tmux_conservative` -- there is no
+  additional safety purchased by keeping the tmux-specific clamping, only
+  a broken transcript. `:flat` sidesteps the whole failure mode: it never
+  positions a cursor, so there is no pinned row to clobber, and every
+  sealed line survives in order. That is strictly safer than any
+  cursor-positioning tier at degenerate geometry, which is why degenerate
+  geometry outranks tmux detection in the rule order. A tmux session with
+  ADEQUATE geometry has no such pinning problem and keeps its
+  `:tmux_conservative` tier as before.
+  """
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Terminal.ScrollRegionManager
+
+  @typedoc "Which `PaintAuthority` tier a session should render through."
+  @type mode :: :inline_log | :tmux_conservative | :flat
+
+  @typedoc """
+  Pre-gathered environment facts. String keys mirror OS env var names
+  (`System.get_env/0`'s shape) verbatim so callers can pass that map
+  through with no translation. `:tty?` is the one non-OS-env key: real
+  tty detection is an I/O call, not a pure fact, so it is the caller's
+  job to determine it (e.g. via `:io.columns/0`/`:file.isatty` or a
+  driver-level flag) and thread the answer in here.
+  """
+  @type env :: %{
+          optional(String.t()) => String.t() | nil,
+          optional(:tty?) => boolean()
+        }
+
+  @doc """
+  Picks the render mode. `opts` carries geometry for the degenerate-
+  terminal check:
+
+    * `:rows` — total terminal rows (integer). Omit when geometry is
+      unknown (e.g. before the first resize event) — the degenerate
+      check is then skipped (treated as non-degenerate), matching every
+      other rule's fail-open-to-`:inline_log` default.
+    * `:footer_rows` — the footer row count the caller intends to pin
+      (`N` in the roadmap's `H - N` split). Defaults to `0`.
+
+  Never consults `System.get_env/1`, `:persistent_term`, or any device —
+  purely a function of its three arguments.
+  """
+  @spec select(Capabilities.t() | nil, env(), keyword()) :: mode()
+  def select(caps, env, opts \\ []) when is_map(env) and is_list(opts) do
+    case override(env) do
+      nil -> select_without_override(caps, env, opts)
+      mode -> mode
+    end
+  end
+
+  defp select_without_override(caps, env, opts) do
+    cond do
+      headless?(env) -> :flat
+      degenerate_geometry?(opts) -> :flat
+      tmux?(caps, env) -> :tmux_conservative
+      true -> :inline_log
+    end
+  end
+
+  # ---- rule 1: explicit override ----
+
+  defp override(env) do
+    case Map.get(env, "RAXOL_HARNESS_MODE") do
+      "flat" -> :flat
+      "tmux" -> :tmux_conservative
+      "inline" -> :inline_log
+      _other -> nil
+    end
+  end
+
+  # ---- rule 2: headless (TERM=dumb / non-tty / CI-without-tty) ----
+
+  defp headless?(env) do
+    dumb_term?(env) or non_tty?(env) or ci_without_tty?(env)
+  end
+
+  defp dumb_term?(env), do: Map.get(env, "TERM") == "dumb"
+
+  defp non_tty?(env), do: Map.get(env, :tty?, true) == false
+
+  defp ci_without_tty?(env), do: truthy?(Map.get(env, "CI")) and non_tty?(env)
+
+  defp truthy?(nil), do: false
+  defp truthy?(""), do: false
+  defp truthy?("false"), do: false
+  defp truthy?("0"), do: false
+  defp truthy?(_other), do: true
+
+  # ---- rule 4: tmux/screen multiplexer ----
+
+  defp tmux?(caps, env), do: tmux_env?(env) or multiplexer_detected?(caps)
+
+  defp tmux_env?(env) do
+    present?(env, "TMUX") or term_prefix?(env, "screen") or
+      term_prefix?(env, "tmux")
+  end
+
+  defp term_prefix?(env, prefix) do
+    env |> Map.get("TERM", "") |> to_string() |> String.starts_with?(prefix)
+  end
+
+  defp present?(env, key) do
+    case Map.get(env, key) do
+      nil -> false
+      "" -> false
+      _other -> true
+    end
+  end
+
+  defp multiplexer_detected?(%Capabilities{multiplexer: multiplexer}),
+    do: multiplexer in [:tmux, :screen]
+
+  defp multiplexer_detected?(_caps), do: false
+
+  # ---- rule 3: degenerate geometry ----
+
+  defp degenerate_geometry?(opts) do
+    case Keyword.get(opts, :rows) do
+      rows when is_integer(rows) and rows > 0 ->
+        footer_rows = Keyword.get(opts, :footer_rows, 0)
+        ScrollRegionManager.degenerate?(rows, footer_rows)
+
+      _other ->
+        false
+    end
+  end
+end

--- a/test/harness/t3_degradation_ladder_test.exs
+++ b/test/harness/t3_degradation_ladder_test.exs
@@ -1,0 +1,398 @@
+defmodule Raxol.Harness.T3DegradationLadderTest do
+  @moduledoc """
+  Acceptance suite for roadmap unit T3 (degradation ladder):
+  `docs/proposals/in-flight/harness-ui-roadmap.md` — "Mode pick at
+  startup: caps + env override -> `:inline_log` | `:tmux_conservative` |
+  `:flat`... same fixture renders correct linear transcript with
+  `TERM=dumb`; flat output contains no cursor-move/CUP/scroll sequences
+  (mechanical assert); tmux env picks the conservative tier."
+
+  Four groups, mirroring the unit's brief:
+
+    1. Mode-pick matrix — table + property coverage of
+       `ModeSelect.select/3` over caps x env x geometry combinations.
+    2. THE mechanical flat assert — a representative fixture driven
+       through `FlatAuthority` contains zero escape-sequence tokens.
+    3. R8 demonstrated-red — a deliberately-wrong flat writer (one CUP)
+       is caught by the same mechanical assert; the real `FlatAuthority`
+       passes the identical fixture cleanly.
+    4. Same-fixture parity — `InlineAuthority` and `FlatAuthority`, driven
+       with the same fixture, agree on LINE CONTENT (styling/positioning
+       aside).
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Test.CrossTerminal.SequenceScanner
+
+  alias Raxol.UI.Rendering.PaintAuthority.{
+    FlatAuthority,
+    InlineAuthority,
+    ModeSelect
+  }
+
+  # ---------------------------------------------------------------------
+  # A deliberately-wrong flat writer (R8 fixture): same shape as
+  # `Raxol.Harness.Test.BuggyAuthority` but scoped to this unit, since
+  # BuggyAuthority's existing streams are all T2b/T2c (footer/history)
+  # shaped, not "a flat writer that shouldn't move the cursor at all."
+  # ---------------------------------------------------------------------
+  defmodule BuggyFlatAuthority do
+    @moduledoc """
+    Emits one CUP (`\\e[1;1H`) before every append -- exactly the shape a
+    broken "let's just reposition to be safe" patch to `FlatAuthority`
+    might introduce. Proves the mechanical zero-escape assert
+    (`flat_is_pure_text?/1` below) actually catches an escape sequence
+    instead of rubber-stamping every input.
+    """
+    @behaviour Raxol.UI.Rendering.PaintAuthority
+
+    @enforce_keys [:device]
+    defstruct [:device]
+
+    @type t :: %__MODULE__{device: IO.device()}
+
+    @impl true
+    def append_sealed(%__MODULE__{device: device} = t, iodata) do
+      IO.write(device, "\e[1;1H")
+      IO.write(device, iodata)
+      t
+    end
+
+    @impl true
+    def repaint_footer(t, _iodata), do: t
+    @impl true
+    def keyframe_footer(t, _iodata), do: t
+    @impl true
+    def with_cursor(t, _region, fun), do: fun.(t)
+    @impl true
+    def resize(t, _width, _height), do: t
+    @impl true
+    def region_top(_t), do: 1
+  end
+
+  # -- shared harness helpers ------------------------------------------
+
+  @width 40
+  @height 10
+  @footer_rows 2
+
+  # A representative session: a mix of plain lines, a multi-line "tool
+  # call" block, and unicode content -- close enough to the shape T7's
+  # journal-fold projection will eventually hand this unit (a list of
+  # sealed blocks, each a list of plain text lines with NO terminator
+  # baked in yet) without depending on T7's JSONL fixtures, which are
+  # journal-envelope shaped, not render-byte shaped (T13a's job to bridge
+  # the two, not this unit's).
+  @fixture_blocks [
+    ["assistant: analyzing the request..."],
+    ["tool_call: ls -la", "  total 24", "  drwxr-xr-x  5 raxol staff  160 ."],
+    ["assistant: found 3 files, café résumé naïve — done."]
+  ]
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  # Every scanned token is `{:text, _}` -- the mechanical "zero escape
+  # bytes anywhere" assert `FlatAuthority`'s moduledoc commits to. Reuses
+  # the project's existing ANSI tokenizer (CLAUDE.md: reuse
+  # `raxol_terminal`'s parser as the test oracle, never hand-roll one)
+  # rather than a bespoke `\e[` regex.
+  defp flat_is_pure_text?(raw) when is_binary(raw) do
+    raw
+    |> SequenceScanner.scan()
+    |> Enum.all?(&match?({:text, _text}, &1))
+  end
+
+  # ---------------------------------------------------------------------
+  # 1. Mode-pick matrix
+  # ---------------------------------------------------------------------
+
+  describe "ModeSelect.select/3: mode-pick matrix" do
+    test "table: caps x env x geometry combinations pick the documented mode" do
+      tmux_caps = %Capabilities{multiplexer: :tmux}
+      no_caps = nil
+
+      table = [
+        # {description, caps, env, opts, expected}
+        {"plain xterm, no signals -> inline_log", no_caps,
+         %{"TERM" => "xterm-256color"}, [], :inline_log},
+        {"TERM=dumb -> flat", no_caps, %{"TERM" => "dumb"}, [], :flat},
+        {"non-tty (tty?: false) -> flat", no_caps,
+         %{"TERM" => "xterm-256color", :tty? => false}, [], :flat},
+        {"CI=true WITHOUT tty -> flat", no_caps,
+         %{"CI" => "true", :tty? => false}, [], :flat},
+        {"CI=true WITH tty -> inline_log (CI alone is not enough)", no_caps,
+         %{"CI" => "true", :tty? => true, "TERM" => "xterm-256color"}, [],
+         :inline_log},
+        {"TMUX var set -> tmux_conservative", no_caps,
+         %{
+           "TMUX" => "/tmp/tmux-1000/default,1234,0",
+           "TERM" => "tmux-256color"
+         }, [], :tmux_conservative},
+        {"TERM starts with screen, no TMUX var -> tmux_conservative", no_caps,
+         %{"TERM" => "screen-256color"}, [], :tmux_conservative},
+        {"caps.multiplexer == :tmux, no env hints -> tmux_conservative",
+         tmux_caps, %{"TERM" => "xterm-256color"}, [], :tmux_conservative},
+        {"degenerate geometry, no other signals -> flat", no_caps,
+         %{"TERM" => "xterm-256color"}, [rows: 2, footer_rows: 2], :flat},
+        {"adequate geometry -> inline_log", no_caps,
+         %{"TERM" => "xterm-256color"}, [rows: 40, footer_rows: 2],
+         :inline_log},
+        {"geometry unknown (:rows omitted) -> treated as non-degenerate",
+         no_caps, %{"TERM" => "xterm-256color"}, [footer_rows: 2], :inline_log},
+        {"tmux AND degenerate geometry -> flat (degenerate geometry outranks tmux: InlineAuthority's append path clobbers row 1 pre-scroll when region_top pins at 1)",
+         no_caps,
+         %{
+           "TMUX" => "/tmp/tmux-1000/default,1234,0",
+           "TERM" => "tmux-256color"
+         }, [rows: 2, footer_rows: 2], :flat},
+        {"override=flat wins over an otherwise-plain terminal", no_caps,
+         %{"RAXOL_HARNESS_MODE" => "flat", "TERM" => "xterm-256color"}, [],
+         :flat},
+        {"override=tmux wins over TERM=dumb", no_caps,
+         %{"RAXOL_HARNESS_MODE" => "tmux", "TERM" => "dumb"}, [],
+         :tmux_conservative},
+        {"override=inline wins over TERM=dumb AND degenerate geometry", no_caps,
+         %{"RAXOL_HARNESS_MODE" => "inline", "TERM" => "dumb"},
+         [rows: 2, footer_rows: 2], :inline_log},
+        {"override=inline wins over a detected tmux session", tmux_caps,
+         %{"RAXOL_HARNESS_MODE" => "inline", "TMUX" => "x"}, [], :inline_log}
+      ]
+
+      for {description, caps, env, opts, expected} <- table do
+        assert ModeSelect.select(caps, env, opts) == expected, description
+      end
+    end
+
+    test "regression: tmux + degenerate geometry (rows=2, footer_rows=2) -> :flat, not :tmux_conservative" do
+      # Traced on real bytes: at region_top=1 (the only value
+      # ScrollRegionManager can pin when rows=2/footer_rows=2 leaves no
+      # room for a history region), InlineAuthority's append path CUPs to
+      # row 1 on every seal BEFORE the terminal scrolls -- each new block
+      # overwrites the previous one instead of accumulating (`\e[1;1HL1...`
+      # then `\e[1;1HM1...`, `L1` clobbered, never reaching scrollback).
+      # Routing this corner to `:tmux_conservative` still reaches that
+      # same InlineAuthority append path, so the clobber happens whether
+      # or not tmux is detected. Pinned explicitly here (independent of
+      # the table above) so this corner can never silently regress back
+      # to `:tmux_conservative` without a targeted, named test failing.
+      env_var_tmux = %{
+        "TMUX" => "/tmp/tmux-1000/default,1234,0",
+        "TERM" => "tmux-256color"
+      }
+
+      caps_multiplexer_tmux = %Capabilities{multiplexer: :tmux}
+
+      assert ModeSelect.select(nil, env_var_tmux, rows: 2, footer_rows: 2) ==
+               :flat
+
+      assert ModeSelect.select(
+               caps_multiplexer_tmux,
+               %{"TERM" => "xterm-256color"},
+               rows: 2,
+               footer_rows: 2
+             ) == :flat
+    end
+
+    property "explicit override always wins, regardless of any other signal" do
+      check all(
+              term <-
+                member_of(["dumb", "xterm-256color", "screen", "tmux-256color"]),
+              tmux_var <- member_of([nil, "", "/tmp/tmux-1000/default,1234,0"]),
+              ci <- member_of([nil, "true", "false"]),
+              tty? <- boolean(),
+              multiplexer <- member_of([:none, :tmux, :screen]),
+              rows <- one_of([constant(nil), integer(1..3)]),
+              override_mode <- member_of(["flat", "tmux", "inline"]),
+              max_runs: 50
+            ) do
+        env =
+          %{
+            "TERM" => term,
+            "CI" => ci,
+            :tty? => tty?,
+            "RAXOL_HARNESS_MODE" => override_mode
+          }
+          |> maybe_put_tmux(tmux_var)
+
+        caps = %Capabilities{multiplexer: multiplexer}
+        opts = if rows, do: [rows: rows, footer_rows: 2], else: []
+
+        expected =
+          case override_mode do
+            "flat" -> :flat
+            "tmux" -> :tmux_conservative
+            "inline" -> :inline_log
+          end
+
+        assert ModeSelect.select(caps, env, opts) == expected
+      end
+    end
+
+    property "with no override: headless always wins flat regardless of tmux/geometry signals" do
+      check all(
+              tmux_var <- member_of([nil, "/tmp/tmux-1000/default,1234,0"]),
+              multiplexer <- member_of([:none, :tmux, :screen]),
+              rows <- integer(1..40),
+              max_runs: 30
+            ) do
+        env = %{"TERM" => "dumb"} |> maybe_put_tmux(tmux_var)
+        caps = %Capabilities{multiplexer: multiplexer}
+        opts = [rows: rows, footer_rows: 2]
+
+        assert ModeSelect.select(caps, env, opts) == :flat
+      end
+    end
+
+    defp maybe_put_tmux(env, nil), do: env
+    defp maybe_put_tmux(env, ""), do: env
+    defp maybe_put_tmux(env, value), do: Map.put(env, "TMUX", value)
+  end
+
+  # ---------------------------------------------------------------------
+  # 2. THE mechanical flat assert
+  # ---------------------------------------------------------------------
+
+  describe "FlatAuthority: the mechanical zero-escape assert" do
+    test "TERM=dumb fixture, driven through FlatAuthority, contains zero cursor-move/CUP/scroll/escape sequences" do
+      {:ok, device} = StringIO.open("")
+      authority = FlatAuthority.new(device, @width, @height)
+
+      _final =
+        Enum.reduce(@fixture_blocks, authority, fn lines, auth ->
+          FlatAuthority.seal(auth, flat_block(lines))
+        end)
+
+      output = raw(device)
+
+      assert flat_is_pure_text?(output),
+             "flat output must contain zero escape-sequence tokens, got: #{inspect(SequenceScanner.scan(output))}"
+
+      # Linear-transcript correctness: the lines appear, in order, exactly
+      # as sealed (append-only, no reordering, no loss).
+      assert output ==
+               Enum.map_join(@fixture_blocks, "", &flat_block/1)
+    end
+
+    test "resize and footer/keyframe calls on FlatAuthority write zero bytes" do
+      {:ok, device} = StringIO.open("")
+      authority = FlatAuthority.new(device, @width, @height)
+
+      authority =
+        authority
+        |> FlatAuthority.seal("assistant: hello\n")
+        |> FlatAuthority.repaint_footer("should not appear")
+        |> FlatAuthority.keyframe_footer("should not appear either")
+        |> FlatAuthority.resize(80, 24)
+
+      assert FlatAuthority.region_top(authority) == 24
+      assert raw(device) == "assistant: hello\n"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 3. R8 demonstrated-red
+  # ---------------------------------------------------------------------
+
+  describe "R8 demonstrated-red: the mechanical assert catches a real violation" do
+    test "a flat writer that emits one CUP fails the assert; the real FlatAuthority passes the identical fixture" do
+      {:ok, bad_device} = StringIO.open("")
+      bad = %BuggyFlatAuthority{device: bad_device}
+
+      Enum.each(@fixture_blocks, fn lines ->
+        BuggyFlatAuthority.append_sealed(bad, flat_block(lines))
+      end)
+
+      bad_output = raw(bad_device)
+
+      refute flat_is_pure_text?(bad_output),
+             "RED proof failed: the buggy authority's CUP must be caught by the mechanical assert"
+
+      assert Enum.any?(
+               SequenceScanner.scan(bad_output),
+               &match?({:csi, _params, "H"}, &1)
+             ),
+             "the buggy stream should contain the injected CUP token"
+
+      {:ok, good_device} = StringIO.open("")
+      good = FlatAuthority.new(good_device, @width, @height)
+
+      Enum.reduce(@fixture_blocks, good, fn lines, auth ->
+        FlatAuthority.seal(auth, flat_block(lines))
+      end)
+
+      good_output = raw(good_device)
+
+      assert flat_is_pure_text?(good_output),
+             "GREEN proof failed: the real FlatAuthority must never emit an escape sequence on the same fixture"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 4. Same-fixture parity: InlineAuthority vs FlatAuthority
+  # ---------------------------------------------------------------------
+
+  describe "same-fixture parity: InlineAuthority and FlatAuthority agree on line content" do
+    test "the same transcript, different substrate: identical LINE CONTENT sequence" do
+      {:ok, inline_device} = StringIO.open("")
+
+      inline_authority =
+        InlineAuthority.new(inline_device, @width, @height, @footer_rows,
+          capabilities: nil
+        )
+
+      _final_inline =
+        Enum.reduce(@fixture_blocks, inline_authority, fn lines, auth ->
+          InlineAuthority.seal(auth, inline_block(lines))
+        end)
+
+      {:ok, flat_device} = StringIO.open("")
+      flat_authority = FlatAuthority.new(flat_device, @width, @height)
+
+      _final_flat =
+        Enum.reduce(@fixture_blocks, flat_authority, fn lines, auth ->
+          FlatAuthority.seal(auth, flat_block(lines))
+        end)
+
+      inline_lines = lines_from_raw(raw(inline_device))
+      flat_lines = lines_from_raw(raw(flat_device))
+
+      expected_lines = Enum.flat_map(@fixture_blocks, & &1)
+
+      assert inline_lines == expected_lines
+      assert flat_lines == expected_lines
+      assert inline_lines == flat_lines
+    end
+  end
+
+  # -- fixture-shaping helpers (test-local, not production contract) ---
+
+  # InlineAuthority's real production contract: iodata already
+  # `\r\n`-terminated per line (mirrors `renderer_seal_once_property_test.exs`'s
+  # `block_gen/0` convention).
+  defp inline_block(lines), do: Enum.map_join(lines, "", &(&1 <> "\r\n"))
+
+  # FlatAuthority's documented convention: plain `\n`-terminated per line.
+  defp flat_block(lines), do: Enum.map_join(lines, "", &(&1 <> "\n"))
+
+  # Recovers the pure content-line sequence from a raw byte stream,
+  # regardless of which authority produced it: scans out every escape
+  # token (CUP, cursor save/restore, DECSTBM, ...) via the same tokenizer
+  # `flat_is_pure_text?/1` uses, keeps only `{:text, _}` runs, then splits
+  # on line terminators (normalizing `\r\n` to `\n` first so both
+  # authorities' conventions compare equal).
+  defp lines_from_raw(raw) do
+    raw
+    |> SequenceScanner.scan()
+    |> Enum.filter(&match?({:text, _text}, &1))
+    |> Enum.map_join("", fn {:text, text} -> text end)
+    |> String.replace("\r\n", "\n")
+    |> String.split("\n")
+    |> Enum.drop(-1)
+  end
+end

--- a/test/harness/t3_degradation_ladder_test.exs
+++ b/test/harness/t3_degradation_ladder_test.exs
@@ -1,21 +1,20 @@
 defmodule Raxol.Harness.T3DegradationLadderTest do
   @moduledoc """
-  Acceptance suite for roadmap unit T3 (degradation ladder):
-  `docs/proposals/in-flight/harness-ui-roadmap.md` — "Mode pick at
-  startup: caps + env override -> `:inline_log` | `:tmux_conservative` |
-  `:flat`... same fixture renders correct linear transcript with
-  `TERM=dumb`; flat output contains no cursor-move/CUP/scroll sequences
-  (mechanical assert); tmux env picks the conservative tier."
+  Acceptance suite for the degradation ladder: mode pick at startup (caps
+  + env override -> `:inline_log` | `:tmux_conservative` | `:flat`); the
+  same fixture renders a correct linear transcript with `TERM=dumb`; flat
+  output contains no cursor-move/CUP/scroll sequences (mechanical
+  assert); tmux env picks the conservative tier.
 
-  Four groups, mirroring the unit's brief:
+  Four groups:
 
     1. Mode-pick matrix — table + property coverage of
        `ModeSelect.select/3` over caps x env x geometry combinations.
     2. THE mechanical flat assert — a representative fixture driven
        through `FlatAuthority` contains zero escape-sequence tokens.
-    3. R8 demonstrated-red — a deliberately-wrong flat writer (one CUP)
-       is caught by the same mechanical assert; the real `FlatAuthority`
-       passes the identical fixture cleanly.
+    3. A deliberately-wrong flat writer (one CUP) is caught by the same
+       mechanical assert; the real `FlatAuthority` passes the identical
+       fixture cleanly.
     4. Same-fixture parity — `InlineAuthority` and `FlatAuthority`, driven
        with the same fixture, agree on LINE CONTENT (styling/positioning
        aside).
@@ -34,10 +33,10 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
   }
 
   # ---------------------------------------------------------------------
-  # A deliberately-wrong flat writer (R8 fixture): same shape as
+  # A deliberately-wrong flat writer: same shape as
   # `Raxol.Harness.Test.BuggyAuthority` but scoped to this unit, since
-  # BuggyAuthority's existing streams are all T2b/T2c (footer/history)
-  # shaped, not "a flat writer that shouldn't move the cursor at all."
+  # BuggyAuthority's existing streams are all footer/history shaped, not
+  # "a flat writer that shouldn't move the cursor at all."
   # ---------------------------------------------------------------------
   defmodule BuggyFlatAuthority do
     @moduledoc """
@@ -80,12 +79,13 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
   @footer_rows 2
 
   # A representative session: a mix of plain lines, a multi-line "tool
-  # call" block, and unicode content -- close enough to the shape T7's
-  # journal-fold projection will eventually hand this unit (a list of
-  # sealed blocks, each a list of plain text lines with NO terminator
-  # baked in yet) without depending on T7's JSONL fixtures, which are
-  # journal-envelope shaped, not render-byte shaped (T13a's job to bridge
-  # the two, not this unit's).
+  # call" block, and unicode content -- close enough to the shape the
+  # block builder's journal-fold projection will eventually hand this
+  # unit (a list of sealed blocks, each a list of plain text lines with
+  # NO terminator baked in yet) without depending on the block builder's
+  # JSONL fixtures, which are journal-envelope shaped, not render-byte
+  # shaped (bridging the two is the assembled harness's job, not this
+  # unit's).
   @fixture_blocks [
     ["assistant: analyzing the request..."],
     ["tool_call: ls -la", "  total 24", "  drwxr-xr-x  5 raxol staff  160 ."],
@@ -160,7 +160,7 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
         {"override=tmux wins over TERM=dumb (no geometry given -> no floor to apply)",
          no_caps, %{"RAXOL_HARNESS_MODE" => "tmux", "TERM" => "dumb"}, [],
          :tmux_conservative},
-        {"override=inline at degenerate geometry is floored to :flat (HIGH review fix; see describe block below for the red-first proof)",
+        {"override=inline at degenerate geometry is floored to :flat",
          no_caps, %{"RAXOL_HARNESS_MODE" => "inline", "TERM" => "dumb"},
          [rows: 2, footer_rows: 2], :flat},
         {"override=tmux at degenerate geometry is floored to :flat too",
@@ -208,13 +208,13 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
     end
 
     property "explicit override wins over every other signal, UNLESS the degenerate floor clamps it to :flat" do
-      # HIGH review fix: `rows <- integer(1..3)` with `footer_rows: 2`
-      # fixed is ALWAYS degenerate (region_top = max(rows - 2, 1) = 1 <
-      # 2 for every value in that range), so whenever geometry is given
-      # at all in this property, the floor clamps any non-:flat override
-      # down to :flat. Pre-fix, this property asserted the override won
+      # `rows <- integer(1..3)` with `footer_rows: 2` fixed is ALWAYS
+      # degenerate (region_top = max(rows - 2, 1) = 1 < 2 for every value
+      # in that range), so whenever geometry is given at all in this
+      # property, the floor clamps any non-:flat override down to :flat.
+      # Before this was fixed, this property asserted the override won
       # unconditionally even at that geometry -- exactly the clobber bug
-      # this batch fixes (see ModeSelect's moduledoc).
+      # fixed here (see ModeSelect's moduledoc).
       check all(
               term <-
                 member_of(["dumb", "xterm-256color", "screen", "tmux-256color"]),
@@ -277,12 +277,12 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
   end
 
   # ---------------------------------------------------------------------
-  # 1b. Override-outranks-degenerate floor: RED-FIRST proof (HIGH review fix)
+  # 1b. Override-outranks-degenerate floor
   # ---------------------------------------------------------------------
 
-  describe "ModeSelect.select_with_reason/3: override-outranks-degenerate floor (HIGH review fix)" do
+  describe "ModeSelect.select_with_reason/3: override-outranks-degenerate floor" do
     test "override=inline at degenerate geometry clamps to :flat, not :inline_log" do
-      # RED-FIRST: before this fix, `select/3` returned the override mode
+      # Before this was fixed, `select/3` returned the override mode
       # unconditionally (`override(env)` short-circuited before the
       # degenerate check ever ran), so this exact combination -- an
       # exported `RAXOL_HARNESS_MODE=inline` later run in a 2-row split --
@@ -396,7 +396,7 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
     end
   end
 
-  describe "FlatAuthority: append_sealed/2 scrubs hostile escape bytes (HIGH review fix)" do
+  describe "FlatAuthority: append_sealed/2 scrubs hostile escape bytes" do
     test "content carrying a CSI clear, an SGR color change, and a bare BEL is scrubbed to plain text" do
       {:ok, device} = StringIO.open("")
       authority = FlatAuthority.new(device, @width, @height)
@@ -438,10 +438,10 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
   end
 
   # ---------------------------------------------------------------------
-  # 3. R8 demonstrated-red
+  # 3. The mechanical assert catches a real violation
   # ---------------------------------------------------------------------
 
-  describe "R8 demonstrated-red: the mechanical assert catches a real violation" do
+  describe "the mechanical assert catches a real violation" do
     test "a flat writer that emits one CUP fails the assert; the real FlatAuthority passes the identical fixture" do
       {:ok, bad_device} = StringIO.open("")
       bad = %BuggyFlatAuthority{device: bad_device}
@@ -453,7 +453,7 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
       bad_output = raw(bad_device)
 
       refute flat_is_pure_text?(bad_output),
-             "RED proof failed: the buggy authority's CUP must be caught by the mechanical assert"
+             "the buggy authority's CUP must be caught by the mechanical assert"
 
       assert Enum.any?(
                SequenceScanner.scan(bad_output),
@@ -471,7 +471,7 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
       good_output = raw(good_device)
 
       assert flat_is_pure_text?(good_output),
-             "GREEN proof failed: the real FlatAuthority must never emit an escape sequence on the same fixture"
+             "the real FlatAuthority must never emit an escape sequence on the same fixture"
     end
   end
 

--- a/test/harness/t3_degradation_ladder_test.exs
+++ b/test/harness/t3_degradation_ladder_test.exs
@@ -145,7 +145,10 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
          :inline_log},
         {"geometry unknown (:rows omitted) -> treated as non-degenerate",
          no_caps, %{"TERM" => "xterm-256color"}, [footer_rows: 2], :inline_log},
-        {"tmux AND degenerate geometry -> flat (degenerate geometry outranks tmux: InlineAuthority's append path clobbers row 1 pre-scroll when region_top pins at 1)",
+        {"footer_rows: -1 (invalid) is guarded, fails open to non-degenerate rather than raising",
+         no_caps, %{"TERM" => "xterm-256color"}, [rows: 2, footer_rows: -1],
+         :inline_log},
+        {"tmux AND degenerate geometry -> flat (see moduledoc: 'Why the degenerate floor applies after override resolution')",
          no_caps,
          %{
            "TMUX" => "/tmp/tmux-1000/default,1234,0",
@@ -154,14 +157,26 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
         {"override=flat wins over an otherwise-plain terminal", no_caps,
          %{"RAXOL_HARNESS_MODE" => "flat", "TERM" => "xterm-256color"}, [],
          :flat},
-        {"override=tmux wins over TERM=dumb", no_caps,
-         %{"RAXOL_HARNESS_MODE" => "tmux", "TERM" => "dumb"}, [],
+        {"override=tmux wins over TERM=dumb (no geometry given -> no floor to apply)",
+         no_caps, %{"RAXOL_HARNESS_MODE" => "tmux", "TERM" => "dumb"}, [],
          :tmux_conservative},
-        {"override=inline wins over TERM=dumb AND degenerate geometry", no_caps,
-         %{"RAXOL_HARNESS_MODE" => "inline", "TERM" => "dumb"},
-         [rows: 2, footer_rows: 2], :inline_log},
-        {"override=inline wins over a detected tmux session", tmux_caps,
-         %{"RAXOL_HARNESS_MODE" => "inline", "TMUX" => "x"}, [], :inline_log}
+        {"override=inline at degenerate geometry is floored to :flat (HIGH review fix; see describe block below for the red-first proof)",
+         no_caps, %{"RAXOL_HARNESS_MODE" => "inline", "TERM" => "dumb"},
+         [rows: 2, footer_rows: 2], :flat},
+        {"override=tmux at degenerate geometry is floored to :flat too",
+         no_caps, %{"RAXOL_HARNESS_MODE" => "tmux", "TERM" => "xterm-256color"},
+         [rows: 2, footer_rows: 2], :flat},
+        {"override=flat at degenerate geometry is honored (already :flat, floor is a no-op)",
+         no_caps, %{"RAXOL_HARNESS_MODE" => "flat", "TERM" => "xterm-256color"},
+         [rows: 2, footer_rows: 2], :flat},
+        {"override=inline wins over a detected tmux session (no geometry given -> no floor to apply)",
+         tmux_caps, %{"RAXOL_HARNESS_MODE" => "inline", "TMUX" => "x"}, [],
+         :inline_log},
+        {"unrecognized override value falls through to auto-detect", no_caps,
+         %{"RAXOL_HARNESS_MODE" => "bogus", "TERM" => "xterm-256color"}, [],
+         :inline_log},
+        {"override value is trimmed and downcased", no_caps,
+         %{"RAXOL_HARNESS_MODE" => " Flat "}, [], :flat}
       ]
 
       for {description, caps, env, opts, expected} <- table do
@@ -170,17 +185,10 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
     end
 
     test "regression: tmux + degenerate geometry (rows=2, footer_rows=2) -> :flat, not :tmux_conservative" do
-      # Traced on real bytes: at region_top=1 (the only value
-      # ScrollRegionManager can pin when rows=2/footer_rows=2 leaves no
-      # room for a history region), InlineAuthority's append path CUPs to
-      # row 1 on every seal BEFORE the terminal scrolls -- each new block
-      # overwrites the previous one instead of accumulating (`\e[1;1HL1...`
-      # then `\e[1;1HM1...`, `L1` clobbered, never reaching scrollback).
-      # Routing this corner to `:tmux_conservative` still reaches that
-      # same InlineAuthority append path, so the clobber happens whether
-      # or not tmux is detected. Pinned explicitly here (independent of
-      # the table above) so this corner can never silently regress back
-      # to `:tmux_conservative` without a targeted, named test failing.
+      # See ModeSelect's moduledoc ("Why the degenerate floor applies
+      # after override resolution") for the byte-traced clobber this
+      # pins against. Kept as a named test, independent of the table
+      # above, so this corner can never silently regress.
       env_var_tmux = %{
         "TMUX" => "/tmp/tmux-1000/default,1234,0",
         "TERM" => "tmux-256color"
@@ -199,7 +207,14 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
              ) == :flat
     end
 
-    property "explicit override always wins, regardless of any other signal" do
+    property "explicit override wins over every other signal, UNLESS the degenerate floor clamps it to :flat" do
+      # HIGH review fix: `rows <- integer(1..3)` with `footer_rows: 2`
+      # fixed is ALWAYS degenerate (region_top = max(rows - 2, 1) = 1 <
+      # 2 for every value in that range), so whenever geometry is given
+      # at all in this property, the floor clamps any non-:flat override
+      # down to :flat. Pre-fix, this property asserted the override won
+      # unconditionally even at that geometry -- exactly the clobber bug
+      # this batch fixes (see ModeSelect's moduledoc).
       check all(
               term <-
                 member_of(["dumb", "xterm-256color", "screen", "tmux-256color"]),
@@ -223,12 +238,19 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
         caps = %Capabilities{multiplexer: multiplexer}
         opts = if rows, do: [rows: rows, footer_rows: 2], else: []
 
-        expected =
+        override_expected =
           case override_mode do
             "flat" -> :flat
             "tmux" -> :tmux_conservative
             "inline" -> :inline_log
           end
+
+        # `rows` present in this property is always degenerate (see the
+        # comment above) -- the floor only ever pushes TOWARD :flat.
+        expected =
+          if rows && override_expected != :flat,
+            do: :flat,
+            else: override_expected
 
         assert ModeSelect.select(caps, env, opts) == expected
       end
@@ -252,6 +274,85 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
     defp maybe_put_tmux(env, nil), do: env
     defp maybe_put_tmux(env, ""), do: env
     defp maybe_put_tmux(env, value), do: Map.put(env, "TMUX", value)
+  end
+
+  # ---------------------------------------------------------------------
+  # 1b. Override-outranks-degenerate floor: RED-FIRST proof (HIGH review fix)
+  # ---------------------------------------------------------------------
+
+  describe "ModeSelect.select_with_reason/3: override-outranks-degenerate floor (HIGH review fix)" do
+    test "override=inline at degenerate geometry clamps to :flat, not :inline_log" do
+      # RED-FIRST: before this fix, `select/3` returned the override mode
+      # unconditionally (`override(env)` short-circuited before the
+      # degenerate check ever ran), so this exact combination -- an
+      # exported `RAXOL_HARNESS_MODE=inline` later run in a 2-row split --
+      # returned `:inline_log` and reproduced the same byte-traced
+      # row-1 clobber as the auto-detected tmux+degenerate regression
+      # above. See ModeSelect's moduledoc for the full rationale.
+      env = %{"RAXOL_HARNESS_MODE" => "inline", "TERM" => "xterm-256color"}
+
+      assert ModeSelect.select(nil, env, rows: 2, footer_rows: 2) == :flat
+
+      assert ModeSelect.select_with_reason(nil, env, rows: 2, footer_rows: 2) ==
+               {:flat, :degenerate_clamp}
+    end
+
+    test "override=tmux at degenerate geometry also clamps to :flat" do
+      env = %{"RAXOL_HARNESS_MODE" => "tmux", "TERM" => "xterm-256color"}
+
+      assert ModeSelect.select_with_reason(nil, env, rows: 2, footer_rows: 2) ==
+               {:flat, :degenerate_clamp}
+    end
+
+    test "override=flat at degenerate geometry is honored as-is (already :flat, floor is a no-op)" do
+      env = %{"RAXOL_HARNESS_MODE" => "flat", "TERM" => "xterm-256color"}
+
+      assert ModeSelect.select_with_reason(nil, env, rows: 2, footer_rows: 2) ==
+               {:flat, :override}
+    end
+
+    test "override at ADEQUATE geometry is unaffected by the floor" do
+      env = %{"RAXOL_HARNESS_MODE" => "inline", "TERM" => "xterm-256color"}
+
+      assert ModeSelect.select_with_reason(nil, env, rows: 40, footer_rows: 2) ==
+               {:inline_log, :override}
+    end
+
+    test "auto-detected reasons: :headless, :tmux, :default" do
+      assert ModeSelect.select_with_reason(nil, %{"TERM" => "dumb"}, []) ==
+               {:flat, :headless}
+
+      assert ModeSelect.select_with_reason(
+               nil,
+               %{"TMUX" => "x", "TERM" => "tmux-256color"},
+               []
+             ) == {:tmux_conservative, :tmux}
+
+      assert ModeSelect.select_with_reason(
+               nil,
+               %{"TERM" => "xterm-256color"},
+               []
+             ) ==
+               {:inline_log, :default}
+    end
+
+    test "unrecognized override value falls through to auto-detect and surfaces :override_unrecognized" do
+      env = %{"RAXOL_HARNESS_MODE" => "bogus", "TERM" => "xterm-256color"}
+
+      assert ModeSelect.select_with_reason(nil, env, []) ==
+               {:inline_log, :override_unrecognized}
+    end
+
+    test "override value is trimmed and downcased before matching" do
+      assert ModeSelect.select(nil, %{"RAXOL_HARNESS_MODE" => "Flat"}, []) ==
+               :flat
+
+      assert ModeSelect.select(nil, %{"RAXOL_HARNESS_MODE" => " flat "}, []) ==
+               :flat
+
+      assert ModeSelect.select(nil, %{"RAXOL_HARNESS_MODE" => "TMUX"}, []) ==
+               :tmux_conservative
+    end
   end
 
   # ---------------------------------------------------------------------
@@ -292,6 +393,47 @@ defmodule Raxol.Harness.T3DegradationLadderTest do
 
       assert FlatAuthority.region_top(authority) == 24
       assert raw(device) == "assistant: hello\n"
+    end
+  end
+
+  describe "FlatAuthority: append_sealed/2 scrubs hostile escape bytes (HIGH review fix)" do
+    test "content carrying a CSI clear, an SGR color change, and a bare BEL is scrubbed to plain text" do
+      {:ok, device} = StringIO.open("")
+      authority = FlatAuthority.new(device, @width, @height)
+
+      hostile = "before\e[2Jafter\e[31mred\adone\n"
+
+      _final = FlatAuthority.seal(authority, hostile)
+
+      output = raw(device)
+
+      assert flat_is_pure_text?(output),
+             "scrubbed output must contain zero escape-sequence tokens, got: #{inspect(SequenceScanner.scan(output))}"
+
+      # Module-enforced, not caller-trusted (see moduledoc): the ESC lead
+      # byte and the bare BEL are stripped, but the rest of each sequence's
+      # bytes survive as a visible, garbled-looking fragment ("[2J",
+      # "[31m") rather than being silently swallowed whole -- an HONEST
+      # detectable failure, not an invisible injection.
+      assert output == "before[2Jafter[31mreddone\n"
+    end
+
+    test "\\t, \\r, and \\n survive the scrub unchanged" do
+      {:ok, device} = StringIO.open("")
+      authority = FlatAuthority.new(device, @width, @height)
+
+      _final = FlatAuthority.seal(authority, "a\tb\r\nc\n")
+
+      assert raw(device) == "a\tb\r\nc\n"
+    end
+
+    test "multi-byte UTF-8 content is untouched by the byte-wise scrub" do
+      {:ok, device} = StringIO.open("")
+      authority = FlatAuthority.new(device, @width, @height)
+
+      _final = FlatAuthority.seal(authority, "café résumé naïve\n")
+
+      assert raw(device) == "café résumé naïve\n"
     end
   end
 


### PR DESCRIPTION
Unit **T3 — degradation ladder**: the startup mode pick + the `:flat` substrate. Answers AD-U2 (block-haters), CI/pipes, and screen readers with one honest rule: when the fancy substrate can't keep its promises, drop to the tier that can.

## What
- **`ModeSelect.select/3`** — pure `(caps, env, opts) → :inline_log | :tmux_conservative | :flat`. First match wins: `RAXOL_HARNESS_MODE` override → headless (`TERM=dumb` / non-tty / CI-without-tty) → **degenerate geometry → :flat** → tmux/screen → `:inline_log`. No `System.get_env` inside — env is an argument.
- **`FlatAuthority`** — third `PaintAuthority` impl: append-only, **zero escape bytes of any kind** (not just movement — documented v1 decision; SGR-when-tty is a later opt-in flag, additive). Footer/keyframe no-ops, resize writes nothing.
- **`:tmux_conservative` is not a new module** — it's `InlineAuthority` under T1's already-clamped caps; T3 only names the tier.

## The review catch (why degenerate outranks tmux)
The first cut checked tmux before degenerate geometry, with a "the byte layer degrades gracefully" rationale. Opus review **byte-traced it and proved data loss**: at degenerate geometry `region_top` pins at 1, so every seal CUPs to row 1 and **overwrites the prior block before it can scroll into scrollback** (`\e[1;1HL1…\e[1;1HM1…` — L1 destroyed). Flat prints the same transcript linearly, loses nothing, and can't violate any tmux constraint (zero escapes). Order swapped; the corner is regression-pinned through both tmux signal paths (`TMUX` env and `caps.multiplexer`); the rationale now documents the trace instead of contradicting it.

## Tests bind to reality
- The mechanical flat assert is **fail-closed, not vacuous**: the scanner routes every `0x1B` to a non-text token (an unknown/unterminated escape can never be classified as text), so "every token is text" ≡ "no ESC byte anywhere". R8 red-first: a buggy flat writer emitting one CUP fails the same scanner on the same fixture; the real `FlatAuthority` passes.
- Same-fixture parity: real `InlineAuthority` and real `FlatAuthority` both driven; line-content sequences equal (order-sensitive) — "same transcript, different substrate".
- Mode-pick matrix: property + table over caps × env × geometry, incl. garbage override ignored (falls through, no crash), `CI=true`+tty stays inline.

Opus review: RED on the ordering (fixed as above, red-first shown), everything else clean — scanner fail-closure, purity, PaintAuthority conformance, zero-escape all verified. Side-find logged to backlog: the shared `SequenceScanner` hangs on a lone trailing `\e` at EOF (hangs, not false-passes — fail-closure holds).

Gates: `compile --warnings-as-errors` clean; 15/15 T3+renderer green, 183/183 full harness+property; format + credo --strict clean.

**Base note:** stacks on `feat/harness-ui-T2b` (#589) — needs `InlineAuthority` + `degenerate?/2`. Merge after #589.

---
*Terms: **AD-U2** = the cohort-research finding that a segment of operators reject block chrome entirely — flat mode is their first-class answer, not a fallback. **degenerate geometry** = terminal too short to pin a footer (#574). **R8** = demonstrated-red methodology rule.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

