### PR TITLE
raxol_payments: harden agent-stream (route store, malleability, diagnostics)

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
@@ -330,19 +330,30 @@ defmodule Raxol.Payments.Xochi.AgentStream do
     ExKeccak.hash_256(prefixed)
   end
 
+  # secp256k1 group order halved. A canonical (low-s) signature has
+  # 1 <= s <= n/2. Because (r, n - s) recovers the same key, accepting a high-s
+  # signature would let a third party malleate a posted announce into a second
+  # signature over the same event that still verifies, so the relay fans out a
+  # duplicate row. Reject high-s; our own signer (libsecp256k1) already emits
+  # low-s, and the client's viem check is over the canonical form.
+  @secp256k1_half_n 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0
+
+  # EIP-191/personal_sign is canonical: v is 27 or 28 (never the raw 0/1 recovery
+  # id here) and s is low. Enforce both so a malformed or malleated signature is
+  # rejected rather than recovered. ExSecp256k1.recover wants a 0/1 recovery id.
   defp decode_signature(hex) do
     case Base.decode16(hex, case: :mixed) do
-      {:ok, <<r::binary-size(32), s::binary-size(32), v::8>>} ->
-        {:ok, {r, s, normalize_recovery_id(v)}}
+      {:ok, <<r::binary-size(32), s::binary-size(32), v::8>>} when v in [27, 28] ->
+        if low_s?(s),
+          do: {:ok, {r, s, v - 27}},
+          else: {:error, :malleable_signature}
 
       _ ->
         {:error, :invalid_signature}
     end
   end
 
-  # EIP-191/personal_sign uses v in {27, 28}; ExSecp256k1 wants a 0/1 recovery id.
-  defp normalize_recovery_id(v) when v >= 27, do: v - 27
-  defp normalize_recovery_id(v), do: v
+  defp low_s?(<<s::unsigned-big-256>>), do: s >= 1 and s <= @secp256k1_half_n
 
   # address = last 20 bytes of keccak256(uncompressed pubkey without the 0x04 tag).
   defp address_from_pubkey(<<_prefix::8, xy::binary-size(64)>>) do

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -94,33 +94,69 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   """
   @spec announce_terminal(map(), String.t(), IntentStatus.t()) :: :ok
   def announce_terminal(context, intent_id, %IntentStatus{} = status) do
-    with {:ok, cfg} <- config(context),
-         {:ok, base} <- SwapRouteStore.take(intent_id) do
-      AgentStream.announce(cfg, terminal_event(base, status))
-      :ok
-    else
-      _ -> :ok
+    case config(context) do
+      {:ok, cfg} ->
+        case SwapRouteStore.take(intent_id) do
+          {:ok, base} ->
+            AgentStream.announce(cfg, terminal_event(base, status))
+            :ok
+
+          # No stash for this intent: the execute never announced (unconfigured
+          # then), or the route already expired. Emitting a blank-route terminal
+          # would clobber the row, so skip and record why.
+          :error ->
+            emit_skipped(context, :no_route)
+            :ok
+        end
+
+      # config/1 already emitted the specific skip reason.
+      :skip ->
+        :ok
     end
   end
 
   @doc """
   Resolve the `AgentStream` config from an Action context, or `:skip` when no
-  `topic_id` (or no wallet / announce host) is available.
+  `topic_id` (or no wallet / announce host) is available. Emits an
+  `[:raxol, :payments, :xochi, :agent_stream, :announce_skipped]` telemetry event
+  carrying the specific reason so a misconfiguration is observable rather than a
+  silent no-op.
   """
   @spec config(map()) :: {:ok, map()} | :skip
   def config(context) do
-    with %{} = stream <- Map.get(context, :agent_stream),
-         topic_id when is_binary(topic_id) and topic_id != "" <-
-           Map.get(stream, :topic_id),
-         {:ok, wallet} <- Map.fetch(context, :wallet),
-         {:ok, url} <- resolve_url(stream, context) do
+    with {_, %{} = stream} <- {:not_configured, Map.get(context, :agent_stream)},
+         {_, topic_id} when is_binary(topic_id) and topic_id != "" <-
+           {:no_topic_id, Map.get(stream, :topic_id)},
+         {_, {:ok, wallet}} <- {:no_wallet, Map.fetch(context, :wallet)},
+         {_, {:ok, url}} <- {:no_announce_host, resolve_url(stream, context)} do
       {:ok, build_config(stream, url, topic_id, wallet)}
     else
-      _ -> :skip
+      {reason, _} ->
+        emit_skipped(context, reason)
+        :skip
     end
   end
 
   # -- Private --
+
+  # Diagnostics for the best-effort no-op paths. AgentStream emits :dropped once
+  # an announce is attempted and fails; this covers the layer above, where an
+  # announce is never attempted at all (misconfigured topic/wallet/host, or a
+  # missing/expired route). mandate_hash and the delegator wallet never appear.
+  defp emit_skipped(context, reason) do
+    :telemetry.execute(
+      [:raxol, :payments, :xochi, :agent_stream, :announce_skipped],
+      %{count: 1},
+      %{reason: reason, topic_id: topic_id_hint(context)}
+    )
+  end
+
+  defp topic_id_hint(context) do
+    case Map.get(context, :agent_stream) do
+      %{topic_id: topic_id} -> topic_id
+      _ -> nil
+    end
+  end
 
   defp build_config(stream, url, topic_id, wallet) do
     %{xochi_api_url: url, topic_id: topic_id, wallet: wallet}

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -32,12 +32,33 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   `:wallet` (the agent's own wallet). The delegator/human wallet never appears.
 
   The route (chains, tokens, amounts) is captured at execute and stashed in
-  `Raxol.Payments.Xochi.SwapRouteStore` keyed by intent id, so the later terminal
-  announce can rebuild the full event from only the `intent_id` it observes.
+  `Raxol.Payments.Xochi.SwapRouteStore` keyed by the real intent id, so the later
+  terminal announce can rebuild the event from only the `intent_id` it observes.
+
+  ## Privacy: only public settlements disclose the route
+
+  Safe by default: only a `settlement_preference` of `"public"` announces the
+  full route (chains, tokens, amounts, real intent id). A `"stealth"` or
+  `"shielded"` settlement (and any unset/unknown preference) announces a
+  redacted row instead: the status and timestamp only, under a topic-salted
+  pseudo intent id, with no amounts, chains, or tokens. Announcing the exact
+  delivered amount or the real intent id of a private swap would let an observer
+  join the feed row against the on-chain stealth announcement or shielded note
+  and defeat the very unlinkability those modes exist for. The execute and
+  terminal rows share the same pseudo id so the browser still merges them into
+  one advancing row.
   """
 
   alias Raxol.Payments.Xochi.{AgentStream, SwapRouteStore}
   alias Raxol.Payments.Xochi.Schemas.{IntentStatus, QuoteRequest, QuoteResponse}
+
+  # Placeholder token for a redacted row. The wire schema requires a non-empty
+  # string (fromToken/toToken min length 1), so a private swap cannot send "".
+  @redacted_token "redacted"
+  # Chain ids and amount for a redacted row. 0 is a valid wire int; "0"/nil are
+  # valid wire amounts (toAmount is nullable). None reveal the real route.
+  @redacted_chain 0
+  @redacted_from_amount "0"
 
   @doc """
   Announce the execute (non-terminal) event and stash the route for the terminal
@@ -53,8 +74,11 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
       ) do
     case config(context) do
       {:ok, cfg} ->
-        event = execute_event(request, quote, exec)
-        SwapRouteStore.remember(event.intent_id, event)
+        event = execute_event(request, quote, exec, cfg.topic_id)
+        # Key the stash by the REAL intent id: PollXochiStatus only ever observes
+        # that. For a private swap the event's own `intent_id` is the pseudo id,
+        # so the two must not be conflated.
+        SwapRouteStore.remember(exec.intent_id, event)
         AgentStream.announce(cfg, event)
         :ok
 
@@ -119,18 +143,55 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
     end
   end
 
-  defp execute_event(%QuoteRequest{} = request, %QuoteResponse{} = quote, exec) do
+  # Public settlement: disclose the full route. Any other preference (stealth /
+  # shielded / unset) settles privately, so the row is redacted to status only.
+  defp execute_event(%QuoteRequest{} = request, %QuoteResponse{} = quote, exec, topic_id) do
+    if settlement_private?(request) do
+      redacted_event(pseudo_id(topic_id, exec.intent_id), execute_status(exec))
+    else
+      %{
+        intent_id: exec.intent_id,
+        from_chain_id: request.from_chain_id,
+        to_chain_id: request.to_chain_id,
+        from_token: request.from_token,
+        to_token: request.to_token,
+        from_amount: request.from_amount,
+        to_amount: quote.to_amount,
+        status: execute_status(exec),
+        ts: now_ms()
+      }
+    end
+  end
+
+  # Only an explicit "public" preference discloses the route. Everything else,
+  # including a nil/unknown preference, is treated as private (fail safe).
+  defp settlement_private?(%QuoteRequest{settlement_preference: "public"}), do: false
+  defp settlement_private?(%QuoteRequest{}), do: true
+
+  # A redacted row carries no amounts, chains, or tokens and a pseudo intent id.
+  # Fields are set to the least-revealing values the wire schema still accepts.
+  defp redacted_event(pseudo_intent_id, status) do
     %{
-      intent_id: exec.intent_id,
-      from_chain_id: request.from_chain_id,
-      to_chain_id: request.to_chain_id,
-      from_token: request.from_token,
-      to_token: request.to_token,
-      from_amount: request.from_amount,
-      to_amount: quote.to_amount,
-      status: execute_status(exec),
+      intent_id: pseudo_intent_id,
+      from_chain_id: @redacted_chain,
+      to_chain_id: @redacted_chain,
+      from_token: @redacted_token,
+      to_token: @redacted_token,
+      from_amount: @redacted_from_amount,
+      to_amount: nil,
+      status: status,
       ts: now_ms()
     }
+  end
+
+  # A stable, topic-salted pseudonym for the real intent id: the same real id
+  # under the same topic always yields the same pseudo id (so the execute and
+  # terminal rows merge in the browser), but without the topic secret it cannot
+  # be tied back to the real intent id or to on-chain settlement state.
+  defp pseudo_id(topic_id, intent_id) do
+    :crypto.hash(:sha256, [topic_id, "\n", to_string(intent_id)])
+    |> binary_part(0, 16)
+    |> Base.encode16(case: :lower)
   end
 
   # Rebuild the terminal event from the stashed route, overriding only the status

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
@@ -1,86 +1,90 @@
 defmodule Raxol.Payments.Xochi.SwapRouteStore do
   @moduledoc """
-  Short-lived, best-effort stash of a swap's route event, keyed by intent id.
+  Short-lived, best-effort stash of a swap's announce event, keyed by intent id.
 
   The Xochi swap Actions are two separate calls: `ExecuteXochiIntent` has the
   full route (chains, tokens, amounts) at execute time, while `PollXochiStatus`
   observes the terminal status later with only the `intent_id` in hand. The
-  browser's live feed merges agent-activity rows by `intentId`, so the terminal
-  announce must still carry the full route or it would blank the row.
+  browser's live feed merges agent-activity rows by their (possibly pseudonymous)
+  id, so the terminal announce must carry the same event body or it would blank
+  the row.
 
   This store bridges that gap without threading route data through the poll
-  Action's context: `ExecuteXochiIntent` remembers the route event here at
-  execute, and `PollXochiStatus` takes it back at terminal status to build the
-  full terminal event.
+  Action's context: `ExecuteXochiIntent` remembers the event here at execute
+  (keyed by the real `intent_id`, which is all the poll observes), and
+  `PollXochiStatus` takes it back at terminal status to rebuild the event.
 
   ## Best-effort by design
 
-  Everything here is a no-op on failure -- the announce is telemetry, never part
-  of the swap. If the store is not running (nothing started it), `remember/3`
-  and `take/1` degrade to a silent no-op / miss, and the terminal announce is
-  simply skipped. It self-starts on the first `remember/3` so callers never have
-  to wire it into a supervision tree, though an operator may supervise it via
-  `child_spec/1`.
+  Every entry point is a no-op on failure: the announce is telemetry, never part
+  of the swap. If the store is not running, `remember/3` and `take/1` degrade to
+  a silent no-op or miss and the terminal announce is skipped. It self-starts on
+  first use so callers never have to wire it into a supervision tree, though an
+  operator may supervise it via `child_spec/1`.
 
-  ## Storage
+  ## Storage and access
 
-  A single owner GenServer holds a named `:public` ETS table; `remember/3` and
-  `take/1` read and write it directly (no process round-trip on the hot path).
-  Entries carry a monotonic expiry and are pruned on a periodic timer; a hard
-  size cap bounds growth when terminal statuses are never polled. Keyed by
-  `intent_id`; `take/1` deletes on read so a settled intent's route does not
-  linger.
+  A single owner GenServer holds a `:private` ETS table: only the owner reads or
+  writes it, so no other in-VM process (a co-resident agent, a loaded plugin) can
+  read a public swap's route or poison an entry to make `announce_terminal/3`
+  sign attacker-chosen values under the agent wallet. `remember/3` casts (so a
+  stash never adds latency to the swap path) and `take/1` calls (it needs the
+  reply, and deletes on read so a settled intent's route does not linger).
+  Entries carry a monotonic expiry, are pruned on a periodic timer, and are
+  bounded by a size cap that evicts the oldest entry when full.
   """
 
   use Raxol.Core.Behaviours.BaseManager
 
   @table :raxol_xochi_swap_routes
-  @default_ttl_ms 900_000
+  # Retention: a stranded or slow settlement can take many minutes to reach a
+  # terminal status, and the stash must outlive that gap for the terminal
+  # announce to find its route. One hour comfortably covers realistic
+  # strand-resolution windows without holding events indefinitely.
+  @default_ttl_ms 3_600_000
+  # Size cap: bounds memory if terminal statuses are never polled. Each event is
+  # a small map (~a few hundred bytes), so 10k entries is a couple of MB. When
+  # full, the oldest entry is evicted (never the whole table).
   @max_entries 10_000
+  # Prune cadence: sweep expired entries once a minute. Far finer than the TTL,
+  # so expired routes never linger long past their window.
   @prune_interval_ms 60_000
 
   # -- Public API --
 
   @doc """
-  Remember a swap's route `event` under `intent_id` for a later terminal
-  announce. Best-effort: starts the owner on first use and never raises into the
-  caller. `opts[:ttl_ms]` overrides the default retention (15 minutes).
+  Remember a swap's announce `event` under `intent_id` for a later terminal
+  announce. Best-effort and non-blocking: starts the owner on first use, casts
+  the write, and never raises into the caller. `opts[:ttl_ms]` overrides the
+  default retention (one hour).
   """
   @spec remember(String.t(), map(), keyword()) :: :ok
   def remember(intent_id, event, opts \\ [])
 
   def remember(intent_id, event, opts)
       when is_binary(intent_id) and is_map(event) do
-    ensure_started()
     ttl = Keyword.get(opts, :ttl_ms, @default_ttl_ms)
     expiry = System.monotonic_time(:millisecond) + ttl
-
-    :ets.insert(@table, {intent_id, event, expiry})
+    ensure_started()
+    GenServer.cast(__MODULE__, {:remember, intent_id, event, expiry})
     :ok
-  rescue
-    ArgumentError -> :ok
+  catch
+    :exit, _ -> :ok
   end
 
   def remember(_intent_id, _event, _opts), do: :ok
 
   @doc """
-  Take (read and delete) the route event stashed for `intent_id`. Returns
+  Take (read and delete) the event stashed for `intent_id`. Returns
   `{:ok, event}` when a live entry exists, or `:error` when there is none, it has
   expired, or the store is not running.
   """
   @spec take(String.t()) :: {:ok, map()} | :error
   def take(intent_id) when is_binary(intent_id) do
-    case :ets.take(@table, intent_id) do
-      [{^intent_id, event, expiry}] ->
-        if expiry >= System.monotonic_time(:millisecond),
-          do: {:ok, event},
-          else: :error
-
-      _ ->
-        :error
-    end
-  rescue
-    ArgumentError -> :error
+    ensure_started()
+    GenServer.call(__MODULE__, {:take, intent_id})
+  catch
+    :exit, _ -> :error
   end
 
   def take(_intent_id), do: :error
@@ -108,17 +112,32 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   @impl Raxol.Core.Behaviours.BaseManager
   def init_manager(_opts) do
-    table =
-      :ets.new(@table, [
-        :named_table,
-        :public,
-        :set,
-        read_concurrency: true,
-        write_concurrency: true
-      ])
-
+    table = :ets.new(@table, [:named_table, :private, :set])
     schedule_prune()
     {:ok, %{table: table}}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call({:take, intent_id}, _from, state) do
+    reply =
+      case :ets.take(@table, intent_id) do
+        [{^intent_id, event, expiry}] ->
+          if expiry >= System.monotonic_time(:millisecond),
+            do: {:ok, event},
+            else: :error
+
+        _ ->
+          :error
+      end
+
+    {:reply, reply, state}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_cast({:remember, intent_id, event, expiry}, state) do
+    evict_oldest_if_full(intent_id)
+    :ets.insert(@table, {intent_id, event, expiry})
+    {:noreply, state}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -130,22 +149,40 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   def handle_manager_info(_msg, state), do: {:noreply, state}
 
-  # -- Private --
+  # -- Private (owner process only) --
 
   defp schedule_prune,
     do: Process.send_after(self(), :prune, @prune_interval_ms)
 
-  # Drop expired entries, then, if still over the cap, clear the whole table
-  # rather than track insertion order: this is a best-effort cache, and an
-  # over-cap table means terminals are not being polled, so losing stale routes
-  # is harmless.
+  # Drop every expired entry. Runs on the owner, so a plain match spec is safe.
   defp prune_expired do
     now = System.monotonic_time(:millisecond)
     :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:<, :"$1", now}], [true]}])
+  end
 
-    if :ets.info(@table, :size) > @max_entries,
-      do: :ets.delete_all_objects(@table)
-  rescue
-    ArgumentError -> :ok
+  # Bound the table by evicting the single oldest entry (smallest expiry, which
+  # is the earliest insert since the TTL is uniform) when at capacity, rather
+  # than wiping every in-flight route. Reinserting the same `intent_id` is an
+  # update, not growth, so it never triggers eviction.
+  defp evict_oldest_if_full(intent_id) do
+    if :ets.member(@table, intent_id) or :ets.info(@table, :size) < @max_entries do
+      :ok
+    else
+      case oldest_key() do
+        nil -> :ok
+        key -> :ets.delete(@table, key)
+      end
+    end
+  end
+
+  defp oldest_key do
+    :ets.foldl(
+      fn {key, _event, expiry}, {_mk, min_exp} = acc ->
+        if expiry < min_exp, do: {key, expiry}, else: acc
+      end,
+      {nil, nil},
+      @table
+    )
+    |> elem(0)
   end
 end

--- a/packages/raxol_payments/test/raxol/payments/xochi/agent_stream_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/agent_stream_test.exs
@@ -96,6 +96,22 @@ defmodule Raxol.Payments.Xochi.AgentStreamTest do
     test "the test wallet derives the expected agent address" do
       assert String.downcase(AgentWallet.address()) == String.downcase(@agent_address)
     end
+
+    test "recover_signer rejects a malleated (high-s) signature" do
+      {:ok, "0x" <> hex} = AgentStream.sign_event(AgentWallet, @topic_id, event())
+      <<r::binary-size(32), s::unsigned-big-256, v::8>> = Base.decode16!(hex, case: :lower)
+
+      # The other valid root (r, n - s) with the flipped parity recovers the same
+      # key. viem may accept it; our low-s guard must not, or the relay fans out a
+      # duplicate row.
+      n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+      malleated =
+        "0x" <> Base.encode16(<<r::binary, n - s::unsigned-big-256, 55 - v::8>>, case: :lower)
+
+      assert {:error, :invalid_signature} ==
+               AgentStream.recover_signer(@topic_id, event(), malleated)
+    end
   end
 
   describe "build_body/2" do

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -121,6 +121,53 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
     end
   end
 
+  describe "diagnostics: announce_skipped telemetry" do
+    setup do
+      ref = make_ref()
+      test_pid = self()
+
+      handler = fn _event, _measure, meta, _cfg ->
+        send(test_pid, {:skipped, ref, meta.reason})
+      end
+
+      :telemetry.attach(
+        "skip-#{inspect(ref)}",
+        [:raxol, :payments, :xochi, :agent_stream, :announce_skipped],
+        handler,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("skip-#{inspect(ref)}") end)
+      %{ref: ref}
+    end
+
+    test "emits :not_configured when no agent_stream is set", %{ref: ref} do
+      SwapAnnouncer.config(%{wallet: AgentWallet})
+      assert_receive {:skipped, ^ref, :not_configured}
+    end
+
+    test "emits :no_topic_id when the topic is blank", %{ref: ref} do
+      SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: ""})}))
+      assert_receive {:skipped, ^ref, :no_topic_id}
+    end
+
+    test "emits :no_wallet when the wallet is absent", %{ref: ref} do
+      SwapAnnouncer.config(%{agent_stream: stream_config()})
+      assert_receive {:skipped, ^ref, :no_wallet}
+    end
+
+    test "emits :no_route when the terminal poll finds no stashed route", %{ref: ref} do
+      status = %IntentStatus{intent_id: "never_stashed", status: :completed}
+      assert :ok == SwapAnnouncer.announce_terminal(context(), "never_stashed", status)
+      assert_receive {:skipped, ^ref, :no_route}
+    end
+
+    test "does not emit when config resolves cleanly", %{ref: ref} do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+      refute_receive {:skipped, ^ref, _}, 100
+    end
+  end
+
   describe "announce_execute/4" do
     test "posts a signed, verifiable execute event and stashes the route" do
       assert :ok ==

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -54,7 +54,7 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
     )
   end
 
-  defp request do
+  defp request(preference \\ "public") do
     %QuoteRequest{
       wallet: AgentWallet.address(),
       from_chain_id: 8453,
@@ -62,7 +62,7 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       from_token: @usdc,
       to_token: @usdc,
       from_amount: "500000",
-      settlement_preference: "public"
+      settlement_preference: preference
     }
   end
 
@@ -231,6 +231,100 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       SwapAnnouncer.announce_execute(context(), request(), quote_resp(), exec())
       assert {:ok, _} = SwapRouteStore.take("int_1")
       assert :error == SwapRouteStore.take("int_1")
+    end
+  end
+
+  describe "privacy: only public settlements disclose the route" do
+    defp expected_pseudo(intent_id) do
+      :crypto.hash(:sha256, [@topic, "\n", intent_id])
+      |> binary_part(0, 16)
+      |> Base.encode16(case: :lower)
+    end
+
+    defp assert_redacted(body) do
+      e = body["event"]
+      assert e["fromChainId"] == 0
+      assert e["toChainId"] == 0
+      assert e["fromToken"] == "redacted"
+      assert e["toToken"] == "redacted"
+      assert e["fromAmount"] == "0"
+      assert is_nil(e["toAmount"])
+      # No real amounts/tokens/chains leaked, and the intent id is a pseudonym.
+      refute e["intentId"] == "int_1"
+      refute e["fromAmount"] == "500000"
+    end
+
+    test "a stealth execute announces a redacted row, not the route" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request("stealth"),
+                 quote_resp(),
+                 exec()
+               )
+
+      assert_receive {:announce, "/api/agent/announce", body}, 1000
+      assert_redacted(body)
+      assert body["event"]["status"] == "executing"
+      assert body["event"]["intentId"] == expected_pseudo("int_1")
+
+      # The redacted row is still a valid, verifiable signed announce.
+      {:ok, recovered} =
+        AgentStream.recover_signer(@topic, event_of(body), body["agentSig"])
+
+      assert String.downcase(recovered) == String.downcase(@agent_address)
+    end
+
+    test "an unset settlement preference is treated as private (fail safe)" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request(nil),
+                 quote_resp(),
+                 exec()
+               )
+
+      assert_receive {:announce, _path, body}, 1000
+      assert_redacted(body)
+    end
+
+    test "a shielded terminal row stays redacted and shares the execute pseudo id" do
+      SwapAnnouncer.announce_execute(
+        context(),
+        request("shielded"),
+        quote_resp(),
+        exec()
+      )
+
+      assert_receive {:announce, _path, execute_body}, 1000
+      pseudo = execute_body["event"]["intentId"]
+      assert pseudo == expected_pseudo("int_1")
+
+      status = %IntentStatus{intent_id: "int_1", status: :completed, tx_hash: "0xabc"}
+      assert :ok == SwapAnnouncer.announce_terminal(context(), "int_1", status)
+
+      assert_receive {:announce, _path, terminal_body}, 1000
+      assert_redacted(terminal_body)
+      assert terminal_body["event"]["status"] == "completed"
+      # Same pseudo id so the browser merges the two rows, without exposing the
+      # real intent id at any point.
+      assert terminal_body["event"]["intentId"] == pseudo
+    end
+
+    test "a public execute still discloses the full route" do
+      assert :ok ==
+               SwapAnnouncer.announce_execute(
+                 context(),
+                 request("public"),
+                 quote_resp(),
+                 exec()
+               )
+
+      assert_receive {:announce, _path, body}, 1000
+      assert body["event"]["intentId"] == "int_1"
+      assert body["event"]["fromChainId"] == 8453
+      assert body["event"]["fromAmount"] == "500000"
+      assert body["event"]["toAmount"] == "499000"
     end
   end
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
@@ -36,4 +36,31 @@ defmodule Raxol.Payments.Xochi.SwapRouteStoreTest do
     SwapRouteStore.remember("intent_ttl", %{x: 1}, ttl_ms: -1)
     assert :error == SwapRouteStore.take("intent_ttl")
   end
+
+  test "two executes in one spawned agent process settle cleanly" do
+    # Pins the singleton-registration fix: the original crash only reproduced
+    # from a spawned process running two swaps back to back (whereis -> nil ->
+    # re-start_link -> :ets.new on the existing named table raises in init and
+    # the linked crash killed the caller after funds moved). This must stay a
+    # no-op-safe stash.
+    parent = self()
+
+    spawn(fn ->
+      SwapRouteStore.remember("spawn_1", %{leg: 1})
+      SwapRouteStore.remember("spawn_2", %{leg: 2})
+      send(parent, :done)
+    end)
+
+    assert_receive :done, 1000
+    assert {:ok, %{leg: 1}} = SwapRouteStore.take("spawn_1")
+    assert {:ok, %{leg: 2}} = SwapRouteStore.take("spawn_2")
+    assert Process.alive?(Process.whereis(SwapRouteStore))
+  end
+
+  test "reinserting the same intent id updates rather than duplicates" do
+    SwapRouteStore.remember("intent_update", %{v: 1})
+    SwapRouteStore.remember("intent_update", %{v: 2})
+    assert {:ok, %{v: 2}} = SwapRouteStore.take("intent_update")
+    assert :error == SwapRouteStore.take("intent_update")
+  end
 end


### PR DESCRIPTION
Stacked on #579 (`feat/wire-agent-stream-announce-578`). Addresses the adversarial-review findings that fall outside the stealth/shielded redaction (which is the `redact stealth/shielded swap announces` commit this stacks on). See the review disposition in the #579 thread.

## Route-store hardening (HIGH + MEDIUM)

- **`:private` ETS + GenServer-mediated access.** `SwapRouteStore` no longer exposes a `:public` table with direct writes. The owner GenServer holds a `:private` table; `remember/3` casts, `take/1` calls. Closes the in-VM poison vector (a co-resident agent / loaded plugin could `:ets.insert` a forged route for a known intent id and make `announce_terminal` sign attacker-chosen amounts under the agent wallet) and the read vector (a public swap's route).
- **Oldest-first eviction** replaces the indiscriminate `:ets.delete_all_objects` over-cap wipe, so a fleet whose executes briefly outpace polls no longer loses every in-flight route.
- **TTL 15m -> 1h** to cover realistic strand-resolution windows; the retention / cap / prune constants now carry justifying comments.
- **Singleton registration regression test**: two `remember`s from a spawned process settle cleanly (the shape the original crash needed and the suite structurally couldn't hit).

## Signature malleability (MEDIUM)

`recover_signer` rejects high-s (`s > n/2`) and any `v` outside `{27, 28}`. A malleated `(r, n-s, flipped-v)` twin over the same event no longer verifies into a duplicate row. Our libsecp256k1 signer emits low-s, so the pinned parity vectors still verify.

## Diagnostics (MEDIUM)

`config/1` and the terminal no-route path emit `[:raxol, :payments, :xochi, :agent_stream, :announce_skipped]` with a specific reason (`:not_configured` / `:no_topic_id` / `:no_wallet` / `:no_announce_host` / `:no_route`), so a misconfigured topic/wallet/host or an expired route is observable instead of a silent no-op.

## Not in this PR (flagged in the #579 thread)

- HIGH: announce-host allowlist + Mandate-bound `topic_id` (the remaining blocker).
- Optional: announcing a terminal `stranded` row from the poll `:timeout` branch.

## Manual testing

- [x] `MIX_ENV=test mix test` in `raxol_payments` -- 1097 passed, 0 failures
- [x] New tests: malleated-sig rejection, `announce_skipped` per-reason, spawned-process regression, reinsert-updates, private-table lifecycle
- [x] `mix format --check-formatted` + `mix credo` clean on changed files
