### PR TITLE
payments: gate agent-stream announce host + topic format

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -22,9 +22,13 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
 
     * `:topic_id` -- the capability handed to the agent out of band at Mandate
       authorization (see the "Capability handoff" section of `AgentStream`).
-      Required; absent, every entry point here is a silent no-op.
+      Required; must match Xochi's topic format (16-64 char base64url). A missing
+      or malformed topic makes every entry point here a silent no-op.
     * `:xochi_api_url` -- announce host. Optional; defaults to
-      `xochi_config.base_url` (the same host the swap ran against).
+      `xochi_config.base_url` (the same host the swap ran against). An explicit
+      value is honored only when its host matches that swap host or the
+      `config :raxol_payments, :agent_stream_hosts` allowlist; otherwise the
+      announce is skipped rather than sent to an unrecognized host.
     * `:mandate_hash` -- telemetry-only, never on the wire. Optional.
     * `:jitter_ms`, `:req_options` -- forwarded to `AgentStream` when present.
 
@@ -59,6 +63,11 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   # valid wire amounts (toAmount is nullable). None reveal the real route.
   @redacted_chain 0
   @redacted_from_amount "0"
+
+  # Capability topic id format, byte-matching Xochi's `TOPIC_ID_RE`
+  # (`agentStream.ts`): 128-bit random, base64url, 16-64 chars. A topic that does
+  # not match is rejected before anything is announced.
+  @topic_id_re ~r/^[A-Za-z0-9_-]{16,64}$/
 
   @doc """
   Announce the execute (non-terminal) event and stash the route for the terminal
@@ -127,6 +136,7 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
     with {_, %{} = stream} <- {:not_configured, Map.get(context, :agent_stream)},
          {_, topic_id} when is_binary(topic_id) and topic_id != "" <-
            {:no_topic_id, Map.get(stream, :topic_id)},
+         {_, true} <- {:bad_topic_id, Regex.match?(@topic_id_re, topic_id)},
          {_, {:ok, wallet}} <- {:no_wallet, Map.fetch(context, :wallet)},
          {_, {:ok, url}} <- {:no_announce_host, resolve_url(stream, context)} do
       {:ok, build_config(stream, url, topic_id, wallet)}
@@ -165,19 +175,37 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
     |> put_optional(:req_options, Map.get(stream, :req_options))
   end
 
-  # An explicit announce host wins; otherwise reuse the swap's Xochi base_url.
+  # Resolve the announce host. An explicit `xochi_api_url` is honored only when
+  # its host matches the swap's own Xochi host or an operator-configured
+  # allowlist; otherwise the swap's `xochi_config.base_url` is used. This stops a
+  # poisoned context from redirecting signed announces (event + agentWallet +
+  # signature) to an attacker-controlled endpoint.
   defp resolve_url(stream, context) do
+    swap_url = get_in(context, [:xochi_config, :base_url])
+
     case Map.get(stream, :xochi_api_url) do
       url when is_binary(url) and url != "" ->
-        {:ok, url}
+        if announce_host_allowed?(url, swap_url), do: {:ok, url}, else: :error
 
       _ ->
-        case get_in(context, [:xochi_config, :base_url]) do
+        case swap_url do
           url when is_binary(url) and url != "" -> {:ok, url}
           _ -> :error
         end
     end
   end
+
+  defp announce_host_allowed?(url, swap_url) do
+    host = uri_host(url)
+    host != nil and (host == uri_host(swap_url) or host in allowed_hosts())
+  end
+
+  defp allowed_hosts do
+    Application.get_env(:raxol_payments, :agent_stream_hosts, [])
+  end
+
+  defp uri_host(url) when is_binary(url), do: URI.parse(url).host
+  defp uri_host(_url), do: nil
 
   # Public settlement: disclose the full route. Any other preference (stealth /
   # shielded / unset) settles privately, so the row is redacted to status only.

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -119,6 +119,35 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       assert :skip ==
                SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: ""})}))
     end
+
+    test "skips a topic_id that fails the Xochi format" do
+      # too short (< 16 chars), and illegal characters, are both rejected.
+      assert :skip ==
+               SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: "short"})}))
+
+      assert :skip ==
+               SwapAnnouncer.config(
+                 context(%{agent_stream: stream_config(%{topic_id: "has spaces and bangs!!"})})
+               )
+    end
+
+    test "skips an announce host that is neither the swap host nor allowlisted" do
+      ctx =
+        context(%{agent_stream: stream_config(%{xochi_api_url: "https://evil.example"})})
+
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "honors an announce host on the configured allowlist" do
+      Application.put_env(:raxol_payments, :agent_stream_hosts, ["relay.xochi.example"])
+      on_exit(fn -> Application.delete_env(:raxol_payments, :agent_stream_hosts) end)
+
+      ctx =
+        context(%{agent_stream: stream_config(%{xochi_api_url: "https://relay.xochi.example"})})
+
+      assert {:ok, %{xochi_api_url: "https://relay.xochi.example"}} =
+               SwapAnnouncer.config(ctx)
+    end
   end
 
   describe "diagnostics: announce_skipped telemetry" do


### PR DESCRIPTION
Follow-up to #596. Closes the one open adversarial-review finding #596 did not cover: the announce host was context-controlled and only HTTPS-gated, so a poisoned Action context could redirect every signed announce (event + `agentWallet` + signature) to an attacker-controlled endpoint. `topic_id` was also accepted unvalidated.

## Changes
- **Announce-host allowlist** (`resolve_url/2`): an explicit `agent_stream.xochi_api_url` is honored only when its host matches the swap's own Xochi host (`xochi_config.base_url`) or a new `config :raxol_payments, :agent_stream_hosts` allowlist. Otherwise it resolves to `:error`, which #596's diagnostics already surface as `announce_skipped` reason `:no_announce_host`. Default posture: same-host only.
- **Topic-id format validation** (`config/1`): `topic_id` must match Xochi's `TOPIC_ID_RE` (`^[A-Za-z0-9_-]{16,64}$`, byte-matched from `agentStream.ts`) before anything is announced; a malformed topic skips with new reason `:bad_topic_id`.
- Moduledoc updated for both fields.

## Tests
4 new `config/1` tests: malformed topic skipped, non-allowlisted host skipped, allowlisted host honored (plus the existing suite). `mix test test/raxol/payments/xochi test/raxol/payments/actions` -> 296 passed, 0 failures.

## Manual testing
- [ ] Configure an agent with `agent_stream.xochi_api_url` pointing at a non-Xochi host; confirm no announce is sent and `announce_skipped{reason: :no_announce_host}` fires.
- [ ] Add that host to `config :raxol_payments, :agent_stream_hosts`; confirm the announce is sent.
- [ ] Configure a malformed `topic_id`; confirm `announce_skipped{reason: :bad_topic_id}`.

## Notes
Not addressed here (needs mandate infrastructure): full cryptographic binding of `topic_id` to the authorizing Mandate. This PR is format validation + host allowlist only.
