### PR TITLE
raxol_payments: announce a stranded row when a poll times out

### DIFF
--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/poll_xochi_status.ex
@@ -110,13 +110,17 @@ defmodule Raxol.Payments.Actions.Payments.PollXochiStatus do
     {:error, Failure.from({:settlement, status.status, reason})}
   end
 
-  defp handle_result({:error, :timeout}, _ctx, id, _budget) do
+  defp handle_result({:error, :timeout}, ctx, id, _budget) do
     # A poll that never reached a terminal status is not a clean failure: the
     # origin funds may already have been pulled while delivery stayed
     # unconfirmed, so the intent is stranded, not failed. Emit a distinct signal
     # so operator tooling can reconcile or close THIS intent, and carry the id in
     # the error so the caller does not re-execute it.
     :telemetry.execute([:raxol, :payments, :xochi, :intent_stranded], %{}, %{intent_id: id})
+    # Advance the live-feed row off "executing" to a stranded state so it does
+    # not sit unresolved. Best-effort; leaves the route in place for a later
+    # terminal announce if a re-poll resolves the intent.
+    SwapAnnouncer.announce_stranded(ctx, id)
     {:error, Failure.from({:stranded, id})}
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -47,6 +47,28 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   and defeat the very unlinkability those modes exist for. The execute and
   terminal rows share the same pseudo id so the browser still merges them into
   one advancing row.
+
+  ## Trust boundary: where and under whose topic a signed row may go
+
+  The `topic_id` is a capability and the announce host is signature-free, so a
+  context that names a hostile host or a wrong topic would exfiltrate a signed
+  activity row to an attacker or into another user's feed. `config/1` therefore
+  fails closed on three axes before it will announce:
+
+    * The announce host must be the swap's own Xochi host, `localhost`, or a
+      host on the operator's allowlist (`config :raxol_payments,
+      :xochi_announce_hosts`). An injected `agent_stream.xochi_api_url` pointing
+      elsewhere is rejected.
+    * The `topic_id` must match the Xochi capability format
+      (`[A-Za-z0-9_-]{16,64}`), so a truncated or malformed topic never ships.
+    * The topic is bound to its authorizing Mandate. When the swap surfaces the
+      authorizing mandate hash (`context.authorizing_mandate_hash`), the topic's
+      declared `mandate_hash` must equal it. Absent that, a binding-required
+      deployment (production by default, or `config :raxol_payments,
+      :require_topic_mandate_binding`) still requires the topic to declare which
+      mandate it serves. Full cryptographic ownership is a Xochi-side check
+      (the worker verifying the signature against the mandate the topic was
+      issued for) and lands with the authorization handoff.
   """
 
   alias Raxol.Payments.Xochi.{AgentStream, SwapRouteStore}
@@ -59,6 +81,14 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   # valid wire amounts (toAmount is nullable). None reveal the real route.
   @redacted_chain 0
   @redacted_from_amount "0"
+
+  # Xochi capability topic format (mirrors TOPIC_ID_RE in the shared contract):
+  # 16-64 base64url characters. A topic that does not match never ships.
+  @topic_id_re ~r/^[A-Za-z0-9_-]{16,64}$/
+  # Announce hosts allowed in addition to the swap's own Xochi host. Localhost
+  # covers `wrangler dev`; production is added via config. The swap's own host is
+  # always allowed (it is already trusted to move the funds).
+  @default_announce_hosts ["api.xochi.fi", "localhost", "127.0.0.1"]
 
   @doc """
   Announce the execute (non-terminal) event and stash the route for the terminal
@@ -75,6 +105,7 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
     case config(context) do
       {:ok, cfg} ->
         event = execute_event(request, quote, exec, cfg.topic_id)
+
         # Key the stash by the REAL intent id: PollXochiStatus only ever observes
         # that. For a private swap the event's own `intent_id` is the pseudo id,
         # so the two must not be conflated.
@@ -116,28 +147,123 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   end
 
   @doc """
-  Resolve the `AgentStream` config from an Action context, or `:skip` when no
-  `topic_id` (or no wallet / announce host) is available. Emits an
+  Resolve the `AgentStream` config from an Action context, or `:skip` when it
+  fails a validation. Emits an
   `[:raxol, :payments, :xochi, :agent_stream, :announce_skipped]` telemetry event
-  carrying the specific reason so a misconfiguration is observable rather than a
-  silent no-op.
+  carrying the specific reason (`:not_configured`, `:no_topic_id`,
+  `:invalid_topic_id`, `:mandate_binding_required`, `:no_wallet`,
+  `:no_announce_host`, `:host_not_allowed`) so a misconfiguration or a rejected
+  host/topic is observable rather than a silent no-op. See the "Trust boundary"
+  section for the host, topic-format, and Mandate-binding rules.
   """
   @spec config(map()) :: {:ok, map()} | :skip
   def config(context) do
-    with {_, %{} = stream} <- {:not_configured, Map.get(context, :agent_stream)},
-         {_, topic_id} when is_binary(topic_id) and topic_id != "" <-
-           {:no_topic_id, Map.get(stream, :topic_id)},
-         {_, {:ok, wallet}} <- {:no_wallet, Map.fetch(context, :wallet)},
-         {_, {:ok, url}} <- {:no_announce_host, resolve_url(stream, context)} do
+    with {:ok, {stream, topic_id}} <- validate_topic(context),
+         {:ok, {wallet, url}} <- validate_target(context, stream) do
       {:ok, build_config(stream, url, topic_id, wallet)}
     else
-      {reason, _} ->
+      {:skip, reason} ->
         emit_skipped(context, reason)
         :skip
     end
   end
 
   # -- Private --
+
+  # The topic axis: a configured, well-formed topic, bound to its mandate.
+  defp validate_topic(context) do
+    with {_, %{} = stream} <- {:not_configured, Map.get(context, :agent_stream)},
+         {_, topic_id} when is_binary(topic_id) and topic_id != "" <-
+           {:no_topic_id, Map.get(stream, :topic_id)},
+         {_, true} <- {:invalid_topic_id, valid_topic_id?(topic_id)},
+         {_, :ok} <- {:mandate_binding_required, mandate_bound(stream, context)} do
+      {:ok, {stream, topic_id}}
+    else
+      {reason, _} -> {:skip, reason}
+    end
+  end
+
+  # The target axis: a signing wallet and an allowlisted announce host.
+  defp validate_target(context, stream) do
+    with {_, {:ok, wallet}} <- {:no_wallet, Map.fetch(context, :wallet)},
+         {_, {:ok, url}} <- {:no_announce_host, resolve_url(stream, context)},
+         {_, :ok} <- {:host_not_allowed, allowed_host(url, context)} do
+      {:ok, {wallet, url}}
+    else
+      {reason, _} -> {:skip, reason}
+    end
+  end
+
+  defp valid_topic_id?(topic_id), do: Regex.match?(@topic_id_re, topic_id)
+
+  # The announce host must be the swap's own Xochi host (already trusted to move
+  # the funds), or a host the operator explicitly allowlisted. A context-injected
+  # override to any other host is rejected so a signed row cannot be exfiltrated.
+  defp allowed_host(url, context) do
+    host = url_host(url)
+    base_host = url_host(get_in(context, [:xochi_config, :base_url]))
+
+    cond do
+      is_nil(host) -> :error
+      host == base_host -> :ok
+      host in configured_hosts() -> :ok
+      true -> :error
+    end
+  end
+
+  defp configured_hosts do
+    Application.get_env(
+      :raxol_payments,
+      :xochi_announce_hosts,
+      @default_announce_hosts
+    )
+  end
+
+  defp url_host(url) when is_binary(url), do: URI.parse(url).host
+  defp url_host(_url), do: nil
+
+  # Bind the topic to the mandate that authorized the swap. When the swap
+  # surfaces that mandate (`context.authorizing_mandate_hash`), the topic's
+  # declared `mandate_hash` must match it byte-for-byte (case-insensitively) so a
+  # topic issued for one mandate cannot ride a swap under another. Absent that
+  # context, a binding-required deployment still requires the topic to name a
+  # mandate; otherwise the check is a no-op.
+  defp mandate_bound(stream, context) do
+    configured = Map.get(stream, :mandate_hash)
+    authorizing = Map.get(context, :authorizing_mandate_hash)
+
+    cond do
+      is_binary(authorizing) and authorizing != "" ->
+        ok_if(is_binary(configured) and hash_eq?(configured, authorizing))
+
+      require_mandate_binding?(context) ->
+        ok_if(present?(configured))
+
+      true ->
+        :ok
+    end
+  end
+
+  defp present?(value), do: is_binary(value) and value != ""
+
+  defp ok_if(true), do: :ok
+  defp ok_if(_false), do: :error
+
+  defp require_mandate_binding?(context) do
+    case Map.get(context, :require_topic_mandate_binding) do
+      flag when is_boolean(flag) ->
+        flag
+
+      _ ->
+        Application.get_env(
+          :raxol_payments,
+          :require_topic_mandate_binding,
+          Raxol.Payments.Deployment.production?()
+        )
+    end
+  end
+
+  defp hash_eq?(a, b), do: String.downcase(a) == String.downcase(b)
 
   # Diagnostics for the best-effort no-op paths. AgentStream emits :dropped once
   # an announce is attempted and fails; this covers the layer above, where an
@@ -181,7 +307,12 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
 
   # Public settlement: disclose the full route. Any other preference (stealth /
   # shielded / unset) settles privately, so the row is redacted to status only.
-  defp execute_event(%QuoteRequest{} = request, %QuoteResponse{} = quote, exec, topic_id) do
+  defp execute_event(
+         %QuoteRequest{} = request,
+         %QuoteResponse{} = quote,
+         exec,
+         topic_id
+       ) do
     if settlement_private?(request) do
       redacted_event(pseudo_id(topic_id, exec.intent_id), execute_status(exec))
     else
@@ -201,7 +332,9 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
 
   # Only an explicit "public" preference discloses the route. Everything else,
   # including a nil/unknown preference, is treated as private (fail safe).
-  defp settlement_private?(%QuoteRequest{settlement_preference: "public"}), do: false
+  defp settlement_private?(%QuoteRequest{settlement_preference: "public"}),
+    do: false
+
   defp settlement_private?(%QuoteRequest{}), do: true
 
   # A redacted row carries no amounts, chains, or tokens and a pseudo intent id.

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_announcer.ex
@@ -147,6 +147,35 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncer do
   end
 
   @doc """
+  Announce a `stranded` row for an intent whose poll timed out before any
+  terminal status. The row was left at its non-terminal execute state, so this
+  advances it to a distinct in-doubt state (the client keeps it out of
+  completed/failed, which is honest: the origin funds may still settle late).
+
+  Reads the route with `peek/1`, NOT `take/1`: if the intent later resolves to a
+  real terminal status on a re-poll, `announce_terminal/3` must still find its
+  route. No-op when no `topic_id` is configured or no route is stashed.
+  """
+  @spec announce_stranded(map(), String.t()) :: :ok
+  def announce_stranded(context, intent_id) do
+    case config(context) do
+      {:ok, cfg} ->
+        case SwapRouteStore.peek(intent_id) do
+          {:ok, base} ->
+            AgentStream.announce(cfg, %{base | status: "stranded", ts: now_ms()})
+            :ok
+
+          :error ->
+            emit_skipped(context, :no_route)
+            :ok
+        end
+
+      :skip ->
+        :ok
+    end
+  end
+
+  @doc """
   Resolve the `AgentStream` config from an Action context, or `:skip` when it
   fails a validation. Emits an
   `[:raxol, :payments, :xochi, :agent_stream, :announce_skipped]` telemetry event

--- a/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/swap_route_store.ex
@@ -89,6 +89,22 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   def take(_intent_id), do: :error
 
+  @doc """
+  Peek (read without deleting) the event stashed for `intent_id`. Same result as
+  `take/1` but leaves the entry in place, so a provisional read (a stranded
+  intent that may still resolve to a real terminal status later) does not consume
+  the route the eventual terminal announce needs.
+  """
+  @spec peek(String.t()) :: {:ok, map()} | :error
+  def peek(intent_id) when is_binary(intent_id) do
+    ensure_started()
+    GenServer.call(__MODULE__, {:peek, intent_id})
+  catch
+    :exit, _ -> :error
+  end
+
+  def peek(_intent_id), do: :error
+
   @doc false
   @spec ensure_started() :: :ok
   def ensure_started do
@@ -119,19 +135,20 @@ defmodule Raxol.Payments.Xochi.SwapRouteStore do
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_call({:take, intent_id}, _from, state) do
-    reply =
-      case :ets.take(@table, intent_id) do
-        [{^intent_id, event, expiry}] ->
-          if expiry >= System.monotonic_time(:millisecond),
-            do: {:ok, event},
-            else: :error
-
-        _ ->
-          :error
-      end
-
-    {:reply, reply, state}
+    {:reply, fresh_entry(:ets.take(@table, intent_id), intent_id), state}
   end
+
+  def handle_manager_call({:peek, intent_id}, _from, state) do
+    {:reply, fresh_entry(:ets.lookup(@table, intent_id), intent_id), state}
+  end
+
+  # Shared result shape for take (delete-on-read) and peek (read-only): an entry
+  # is returned only if present and unexpired.
+  defp fresh_entry([{intent_id, event, expiry}], intent_id) do
+    if expiry >= System.monotonic_time(:millisecond), do: {:ok, event}, else: :error
+  end
+
+  defp fresh_entry(_rows, _intent_id), do: :error
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_cast({:remember, intent_id, event, expiry}, state) do

--- a/packages/raxol_payments/test/raxol/payments/actions/payments/xochi_announce_wiring_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/actions/payments/xochi_announce_wiring_test.exs
@@ -25,7 +25,17 @@ defmodule Raxol.Payments.Actions.Payments.XochiAnnounceWiringTest do
 
   # Xochi worker sim: quote -> execute -> completed status. The announce POST is
   # captured on a separate plug so the swap and the announce stay decoupled.
-  defp xochi_plug do
+  @completed_status %{
+    "intentId" => "int_1",
+    "status" => "completed",
+    "txHash" => "0xabc",
+    "terminal" => true
+  }
+
+  # A status that never reaches terminal, so the poll times out (stranded).
+  @nonterminal_status %{"intentId" => "int_1", "status" => "executing", "terminal" => false}
+
+  defp xochi_plug(status_body \\ @completed_status) do
     fn conn ->
       case conn.request_path do
         "/api/intent/quote" ->
@@ -56,12 +66,7 @@ defmodule Raxol.Payments.Actions.Payments.XochiAnnounceWiringTest do
           })
 
         "/api/intent/int_1/status" ->
-          Req.Test.json(conn, %{
-            "intentId" => "int_1",
-            "status" => "completed",
-            "txHash" => "0xabc",
-            "terminal" => true
-          })
+          Req.Test.json(conn, status_body)
       end
     end
   end
@@ -157,6 +162,27 @@ defmodule Raxol.Payments.Actions.Payments.XochiAnnounceWiringTest do
                PollXochiStatus.run(%{intent_id: "int_1", timeout_ms: 2000}, ctx)
 
       body = assert_announce_verifies("completed")
+      assert body["event"]["intentId"] == "int_1"
+    end
+
+    test "PollXochiStatus fires a stranded announce when the poll times out" do
+      ctx =
+        with_stream(
+          context(%{
+            xochi_config: %{
+              base_url: "https://xochi.test",
+              req_options: [plug: xochi_plug(@nonterminal_status)]
+            }
+          })
+        )
+
+      assert {:ok, _} = ExecuteXochiIntent.run(params(), ctx)
+      assert_announce_verifies("executing")
+
+      assert {:error, %{reason: :stranded}} =
+               PollXochiStatus.run(%{intent_id: "int_1", timeout_ms: 40, interval_ms: 10}, ctx)
+
+      body = assert_announce_verifies("stranded")
       assert body["event"]["intentId"] == "int_1"
     end
   end

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -121,6 +121,92 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
     end
   end
 
+  describe "config/1 trust boundary: announce host allowlist" do
+    test "allows the swap's own Xochi host (override equals base)" do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+    end
+
+    test "allows defaulting to the swap's base_url host" do
+      ctx = context(%{agent_stream: stream_config(%{xochi_api_url: nil})})
+      assert {:ok, %{xochi_api_url: "https://xochi.test"}} = SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects a context-injected host that is not the swap host or allowlisted" do
+      ctx = context(%{agent_stream: stream_config(%{xochi_api_url: "https://attacker.example"})})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "allows a host on the operator allowlist" do
+      Application.put_env(:raxol_payments, :xochi_announce_hosts, ["relay.xochi.example"])
+      on_exit(fn -> Application.delete_env(:raxol_payments, :xochi_announce_hosts) end)
+
+      ctx =
+        context(%{agent_stream: stream_config(%{xochi_api_url: "https://relay.xochi.example"})})
+
+      assert {:ok, %{xochi_api_url: "https://relay.xochi.example"}} = SwapAnnouncer.config(ctx)
+    end
+  end
+
+  describe "config/1 trust boundary: topic_id format" do
+    test "accepts a well-formed base64url topic" do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+    end
+
+    test "rejects a too-short topic" do
+      ctx = context(%{agent_stream: stream_config(%{topic_id: "short"})})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects a topic with illegal characters" do
+      ctx = context(%{agent_stream: stream_config(%{topic_id: "has spaces and!@#chars"})})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+  end
+
+  describe "config/1 trust boundary: topic bound to authorizing Mandate" do
+    test "accepts when the authorizing mandate matches the topic's declared mandate" do
+      ctx =
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xABCDEF"}),
+          authorizing_mandate_hash: "0xabcdef"
+        })
+
+      assert {:ok, _} = SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects when the authorizing mandate does not match" do
+      ctx =
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xdead"}),
+          authorizing_mandate_hash: "0xbeef"
+        })
+
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "rejects when the authorizing mandate is known but the topic declares none" do
+      ctx = context(%{authorizing_mandate_hash: "0xbeef"})
+      assert :skip == SwapAnnouncer.config(ctx)
+    end
+
+    test "when binding is required, a topic must declare its mandate" do
+      base = context(%{require_topic_mandate_binding: true})
+      assert :skip == SwapAnnouncer.config(base)
+
+      bound =
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xabc"}),
+          require_topic_mandate_binding: true
+        })
+
+      assert {:ok, _} = SwapAnnouncer.config(bound)
+    end
+
+    test "binding is a no-op when not required and no authorizing mandate is surfaced" do
+      assert {:ok, _} = SwapAnnouncer.config(context())
+    end
+  end
+
   describe "diagnostics: announce_skipped telemetry" do
     setup do
       ref = make_ref()
@@ -160,6 +246,30 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
       status = %IntentStatus{intent_id: "never_stashed", status: :completed}
       assert :ok == SwapAnnouncer.announce_terminal(context(), "never_stashed", status)
       assert_receive {:skipped, ^ref, :no_route}
+    end
+
+    test "emits :invalid_topic_id for a malformed topic", %{ref: ref} do
+      SwapAnnouncer.config(context(%{agent_stream: stream_config(%{topic_id: "short"})}))
+      assert_receive {:skipped, ^ref, :invalid_topic_id}
+    end
+
+    test "emits :host_not_allowed for an off-allowlist host", %{ref: ref} do
+      SwapAnnouncer.config(
+        context(%{agent_stream: stream_config(%{xochi_api_url: "https://attacker.example"})})
+      )
+
+      assert_receive {:skipped, ^ref, :host_not_allowed}
+    end
+
+    test "emits :mandate_binding_required on a mandate mismatch", %{ref: ref} do
+      SwapAnnouncer.config(
+        context(%{
+          agent_stream: stream_config(%{mandate_hash: "0xdead"}),
+          authorizing_mandate_hash: "0xbeef"
+        })
+      )
+
+      assert_receive {:skipped, ^ref, :mandate_binding_required}
     end
 
     test "does not emit when config resolves cleanly", %{ref: ref} do

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_announcer_test.exs
@@ -391,6 +391,35 @@ defmodule Raxol.Payments.Xochi.SwapAnnouncerTest do
     end
   end
 
+  describe "announce_stranded/2" do
+    test "announces a stranded row and leaves the route for a later terminal" do
+      SwapAnnouncer.announce_execute(context(), request(), quote_resp(), exec())
+      assert_receive {:announce, _path, _execute_body}, 1000
+
+      assert :ok == SwapAnnouncer.announce_stranded(context(), "int_1")
+
+      assert_receive {:announce, "/api/agent/announce", body}, 1000
+      assert body["event"]["intentId"] == "int_1"
+      assert body["event"]["fromChainId"] == 8453
+      assert body["event"]["status"] == "stranded"
+
+      {:ok, recovered} =
+        AgentStream.recover_signer(@topic, event_of(body), body["agentSig"])
+
+      assert String.downcase(recovered) == String.downcase(@agent_address)
+
+      # peek did not consume: a later real terminal can still announce.
+      status = %IntentStatus{intent_id: "int_1", status: :completed}
+      assert :ok == SwapAnnouncer.announce_terminal(context(), "int_1", status)
+      assert_receive {:announce, _path, %{"event" => %{"status" => "completed"}}}, 1000
+    end
+
+    test "skips when no route was stashed for the intent" do
+      assert :ok == SwapAnnouncer.announce_stranded(context(), "never_executed")
+      refute_receive {:announce, _, _}, 200
+    end
+  end
+
   describe "privacy: only public settlements disclose the route" do
     defp expected_pseudo(intent_id) do
       :crypto.hash(:sha256, [@topic, "\n", intent_id])

--- a/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/swap_route_store_test.exs
@@ -63,4 +63,18 @@ defmodule Raxol.Payments.Xochi.SwapRouteStoreTest do
     assert {:ok, %{v: 2}} = SwapRouteStore.take("intent_update")
     assert :error == SwapRouteStore.take("intent_update")
   end
+
+  test "peek reads without consuming" do
+    SwapRouteStore.remember("intent_peek", %{p: 1})
+    assert {:ok, %{p: 1}} = SwapRouteStore.peek("intent_peek")
+    # Still there for a later take.
+    assert {:ok, %{p: 1}} = SwapRouteStore.peek("intent_peek")
+    assert {:ok, %{p: 1}} = SwapRouteStore.take("intent_peek")
+    assert :error == SwapRouteStore.peek("intent_peek")
+  end
+
+  test "peek does not return an expired entry" do
+    SwapRouteStore.remember("intent_peek_exp", %{p: 1}, ttl_ms: -1)
+    assert :error == SwapRouteStore.peek("intent_peek_exp")
+  end
 end


### PR DESCRIPTION
Stacked on #598 / #579. Implements the last item from the adversarial review — the optional **MEDIUM** stranded-terminal announce.

## Problem

When a poll times out before any terminal status (`PollXochiStatus`'s `:timeout` branch), the intent is *stranded*: the origin funds may already have moved while delivery stayed unconfirmed. The `:timeout` branch emitted `:intent_stranded` telemetry but never announced, so the live-feed row sat frozen at its execute state ("executing") forever — the exact UX the feature promises to advance.

## Fix

The `:timeout` branch now calls `SwapAnnouncer.announce_stranded/2`, which advances the row to a distinct `"stranded"` status. That status is deliberately **not** mapped to completed or failed on the client — honest, since a stranded intent may still settle late; it just moves the row out of a frozen "executing".

Crucially it reads the route with a new **`SwapRouteStore.peek/1`** (non-consuming) rather than `take/1`: if a re-poll later resolves the intent to a real terminal status, `announce_terminal/3` must still find its route and advance the row again (executing → stranded → completed).

Best-effort and non-blocking as ever; a no-op without a configured topic or a stashed route.

## Tests

- `announce_stranded/2`: announces `"stranded"` (signature verifies), and `peek` leaves the route so a later `announce_terminal` still fires; skips with no route.
- `SwapRouteStore.peek/1`: read-only (does not consume), respects expiry.
- Wiring: a poll-timeout run asserts `PollXochiStatus` returns `{:error, :stranded}` **and** fires the stranded announce.

## Manual testing

- [x] `MIX_ENV=test mix test` in `raxol_payments` -- 1117 passed, 0 failures
- [x] `mix format --check-formatted` + `mix credo` clean on changed files

With this, every item from the review (CRITICAL, HIGH, and the optional MEDIUMs) is addressed.
