### PR TITLE
Harness UI: needs-input starvation guard + 256-color tier separation pin

### DIFF
--- a/lib/raxol/ui/components/harness/block.ex
+++ b/lib/raxol/ui/components/harness/block.ex
@@ -104,6 +104,14 @@ defmodule Raxol.UI.Components.Harness.Block do
   tiers where a minimum legibility must be preserved (see the `Prominence`
   moduledoc's "Two modes").
 
+  A **live `:approval` block auto-engages the needs-input starvation
+  guard** (`Prominence.resolve/3`'s `needs_input: true`): a pending
+  question is never faded below ordinary context content, whatever
+  prominence a demotion sweep hands it. A sealed approval is an answered
+  question and fades free. `context[:needs_input]` (boolean) overrides the
+  derivation in either direction -- flag any awaiting-input component in,
+  or an approval out.
+
   When `context[:markdown]` is enabled, the Markdown body is faded to the
   same resolved colour as the header, so the whole block dims together.
 
@@ -387,7 +395,7 @@ defmodule Raxol.UI.Components.Harness.Block do
     # no fade), then thread it into every text-producing branch --
     # header, content, and outcome all carry the SAME `:fg`, and the
     # per-line content map never re-runs the H-K solver.
-    fg = prominence_fg(context)
+    fg = prominence_fg(block, context)
     header = header_view(block, width, fg)
     outcome_children = outcome_row_view(block.outcome, fg)
 
@@ -434,13 +442,13 @@ defmodule Raxol.UI.Components.Harness.Block do
   defp apply_fg(style, nil), do: style
   defp apply_fg(style, fg), do: Map.put(style, :fg, fg)
 
-  defp prominence_fg(context) do
+  defp prominence_fg(block, context) do
     case Map.get(context, :prominence, 1.0) do
       p when is_number(p) and p >= 1.0 ->
         nil
 
       p when is_number(p) ->
-        Prominence.resolve(@chrome_fg, p, prominence_opts(context))
+        Prominence.resolve(@chrome_fg, p, prominence_opts(block, context))
 
       _other ->
         nil
@@ -452,10 +460,30 @@ defmodule Raxol.UI.Components.Harness.Block do
   # solver's reference ground), and an explicit `ground: nil` would
   # short-circuit that default. `:legibility_floor` is threaded through when
   # present (T9 sets it true for acting tiers; default false = pure fade).
-  defp prominence_opts(context) do
+  # `:needs_input` engages the starvation guard (see `needs_input?/2`).
+  defp prominence_opts(block, context) do
     []
     |> put_opt(:ground, Map.get(context, :ground))
     |> put_opt(:legibility_floor, Map.get(context, :legibility_floor))
+    |> put_opt(:needs_input, needs_input?(block, context))
+  end
+
+  # A LIVE approval block is, by definition, waiting on the user -- it
+  # auto-engages `Prominence`'s needs-input starvation guard so no
+  # demotion sweep can fade the pending question below ordinary context.
+  # Once sealed it is an answered question (history), so the auto-flag
+  # drops. `context[:needs_input]` overrides the derivation either way
+  # (a caller can flag any awaiting-input component in, or an approval
+  # out). Returns `nil` (not `false`) when the guard is off so
+  # `put_opt/3` omits the key entirely.
+  defp needs_input?(block, context) do
+    engaged =
+      case Map.get(context, :needs_input) do
+        value when is_boolean(value) -> value
+        _absent -> block.kind == :approval and block.seal == :live
+      end
+
+    if engaged, do: true, else: nil
   end
 
   defp put_opt(opts, _key, nil), do: opts

--- a/lib/raxol/ui/harness/prominence.ex
+++ b/lib/raxol/ui/harness/prominence.ex
@@ -75,6 +75,19 @@ defmodule Raxol.UI.Harness.Prominence do
   run picks the highest ratio at which every cell is legible and pins it
   here permanently.
 
+  ## The needs-input starvation guard (policy floor)
+
+  Content that is *waiting on the user* (an approval prompt, a composer
+  asking for input) must never be starved of visibility below the ordinary
+  context it interrupts, no matter what prominence value a demotion sweep
+  hands it -- a projection bug must not be able to fade the one thing the
+  user has to see. `needs_input: true` floors the *effective prominence*
+  at `needs_input_floor/0` (`#{0.6}`, the ordinary-context tier of the
+  shipped salience ladder) before the fade runs. The floor raises only:
+  prominences at or above it pass through byte-identical, and
+  `prominence >= 1.0` remains the identity. It composes with (and applies
+  before) the opt-in legibility clamp.
+
   ## Truecolor-only floor; 256-color deferred
 
   The clamp guarantees the floor on the **24-bit hex it emits** -- it is
@@ -85,15 +98,20 @@ defmodule Raxol.UI.Harness.Prominence do
   a redistributed per-ground tier ladder for 256-color (fewer,
   wider-spaced tiers chosen in-palette), not a post-hoc clamp on a
   quantized value -- deferred here because it needs a quantization-pipeline
-  decision this module does not make.
+  decision this module does not make. One minimum IS pinned by regression
+  test: the 1.0/0.6 prominence pair must survive
+  `Raxol.UI.Theming.Colors.find_closest_256_color/1` as distinct palette
+  indices (the coarsest tier separation the ladder needs on a 256-color
+  terminal).
 
   ## Scope
 
   This module resolves a single foreground color; it does not decide
   *which* prominence a block gets nor *whether* the floor is engaged for it
   (that's the caller's policy -- it owns the acting-vs-context call and
-  passes `legibility_floor:` accordingly), nor whether a sealed block may
-  be restyled at all (that's separate fold/authorization territory).
+  passes `legibility_floor:`/`needs_input:` accordingly), nor whether a
+  sealed block may be restyled at all (that's separate fold/authorization
+  territory).
   """
 
   alias Raxol.UI.Theming.Salience
@@ -103,17 +121,32 @@ defmodule Raxol.UI.Harness.Prominence do
   # human-eye ratification pass (see moduledoc).
   @floor_ratio 3.0
 
+  # The ordinary-context prominence tier of the shipped salience ladder
+  # (1.0 / 0.8 / 0.6 / 0.4): the level ordinary context content renders at.
+  # Needs-input content is floored here so it never resolves below the
+  # context it interrupts (see the moduledoc's starvation-guard section).
+  @needs_input_prominence_floor 0.6
+
   @clamp_iterations 24
 
   @type opts :: [
           ground: float(),
           legibility_floor: boolean(),
-          floor_ratio: float()
+          floor_ratio: float(),
+          needs_input: boolean()
         ]
 
   @doc "The placeholder WCAG-style legibility floor ratio (see moduledoc)."
   @spec floor_ratio() :: float()
   def floor_ratio, do: @floor_ratio
+
+  @doc """
+  The prominence floor applied under `needs_input: true` -- the
+  ordinary-context tier of the shipped salience ladder, so content awaiting
+  user input never resolves below ordinary context content.
+  """
+  @spec needs_input_floor() :: float()
+  def needs_input_floor, do: @needs_input_prominence_floor
 
   @doc """
   Resolves `hex` at `prominence` (`0.0..1.0`) against a ground.
@@ -138,6 +171,11 @@ defmodule Raxol.UI.Harness.Prominence do
       (default `false` = pure fade).
     * `:floor_ratio` - override the legibility floor ratio (default
       `#{@floor_ratio}`); only consulted when `legibility_floor: true`.
+    * `:needs_input` - `true` floors the effective prominence at
+      `needs_input_floor/0` (`#{@needs_input_prominence_floor}`) before the
+      fade -- the starvation guard for content awaiting user input (see
+      moduledoc). Default `false`. Raises the effective prominence only;
+      inert at or above the floor.
 
   `prominence >= 1.0` is the identity (byte-identical `hex` back, no ground
   lookup, no clamp, regardless of `:legibility_floor`) -- a neutrality
@@ -152,7 +190,9 @@ defmodule Raxol.UI.Harness.Prominence do
   def resolve(hex, prominence, _opts) when prominence >= 1.0, do: hex
 
   def resolve(hex, prominence, opts) do
-    prominence = clamp_prominence(prominence)
+    prominence =
+      prominence |> clamp_prominence() |> apply_needs_input_floor(opts)
+
     ground = resolve_ground(opts)
     {l, c, h} = Salience.hex_to_oklch(hex)
     apparent = Salience.apparent_lightness(l, c, h)
@@ -225,6 +265,16 @@ defmodule Raxol.UI.Harness.Prominence do
   # instead.
   defp clamp_prominence(prominence) when prominence < 0.0, do: 0.0
   defp clamp_prominence(prominence), do: prominence
+
+  # The needs-input starvation guard (see moduledoc): floors the effective
+  # prominence at the ordinary-context tier, so content awaiting user input
+  # never resolves below the context it interrupts. Raises only -- at or
+  # above the floor it is the identity.
+  defp apply_needs_input_floor(prominence, opts) do
+    if Keyword.get(opts, :needs_input, false),
+      do: max(prominence, @needs_input_prominence_floor),
+      else: prominence
+  end
 
   defp legibility_floor?(opts), do: Keyword.get(opts, :legibility_floor, false)
 

--- a/test/raxol/ui/harness/prominence_property_test.exs
+++ b/test/raxol/ui/harness/prominence_property_test.exs
@@ -221,4 +221,31 @@ defmodule Raxol.UI.Harness.ProminencePropertyTest do
       assert resolved =~ ~r/^#[0-9a-f]{6}$/
     end
   end
+
+  # ---------------------------------------------------------------------
+  # Needs-input starvation guard: a needs-input resolve never lands below
+  # the ordinary-context resolve of the same seed, for ANY handed
+  # prominence (including ones far below the floor), on both grounds.
+  # ---------------------------------------------------------------------
+
+  property "needs-input never resolves below ordinary context, both grounds" do
+    check all(
+            h <- hue_gen(),
+            c <- chroma_gen(),
+            tier <- member_of(Salience.tiers()),
+            ground <- ground_gen(),
+            prominence <- float(min: 0.0, max: 1.0)
+          ) do
+      seed = Salience.solve(tier, c, h, ground: ground)
+
+      guarded =
+        Prominence.resolve(seed, prominence, ground: ground, needs_input: true)
+
+      context_level =
+        Prominence.resolve(seed, Prominence.needs_input_floor(), ground: ground)
+
+      assert apparent_contrast(guarded, ground) >=
+               apparent_contrast(context_level, ground) - @eps_quant
+    end
+  end
 end

--- a/test/raxol/ui/harness/prominence_test.exs
+++ b/test/raxol/ui/harness/prominence_test.exs
@@ -570,4 +570,216 @@ defmodule Raxol.UI.Harness.ProminenceTest do
       assert ratio <= ceiling_ratio + 1.0e-6
     end
   end
+
+  # ---------------------------------------------------------------------
+  # Needs-input starvation guard: content awaiting user input must never
+  # resolve below ordinary context content, regardless of the prominence
+  # value handed to it -- a policy floor in the mapping layer, so a
+  # projection bug (or an aggressive demotion sweep) can never starve an
+  # approval prompt of visibility below the context it interrupts.
+  # ---------------------------------------------------------------------
+
+  describe "needs-input starvation guard (policy floor)" do
+    @needs_input_seeds %{
+      @dark_ground => ["#c1712c", "#abb7c3", "#B4B4B4"],
+      @light_ground => ["#3b444f", "#B4B4B4"]
+    }
+
+    test "the floor constant equals the ordinary-context prominence tier" do
+      assert Prominence.needs_input_floor() == 0.6
+    end
+
+    test "needs_input: true floors the resolve at the ordinary-context prominence, both grounds" do
+      for {ground, seeds} <- @needs_input_seeds,
+          seed <- seeds,
+          prominence <- [0.0, 0.2, 0.4, 0.59] do
+        guarded =
+          Prominence.resolve(seed, prominence,
+            ground: ground,
+            needs_input: true
+          )
+
+        context_level =
+          Prominence.resolve(seed, Prominence.needs_input_floor(),
+            ground: ground
+          )
+
+        assert guarded == context_level,
+               "#{seed} p#{prominence} ground#{ground}: expected the " <>
+                 "floored resolve #{context_level}, got #{guarded}"
+      end
+    end
+
+    test "needs-input never resolves below ordinary context contrast, both grounds" do
+      for {ground, seeds} <- @needs_input_seeds,
+          seed <- seeds,
+          prominence <- [0.0, 0.1, 0.3, 0.5] do
+        ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+
+        guarded =
+          Prominence.resolve(seed, prominence,
+            ground: ground,
+            needs_input: true
+          )
+
+        context_level =
+          Prominence.resolve(seed, Prominence.needs_input_floor(),
+            ground: ground
+          )
+
+        assert Prominence.wcag_ratio(guarded, ground_hex) >=
+                 Prominence.wcag_ratio(context_level, ground_hex) - 1.0e-9
+      end
+    end
+
+    test "above the floor, needs_input is inert (byte-identical to the plain resolve)" do
+      for ground <- [@dark_ground, @light_ground], prominence <- [0.8, 0.9] do
+        assert Prominence.resolve("#c1712c", prominence,
+                 ground: ground,
+                 needs_input: true
+               ) ==
+                 Prominence.resolve("#c1712c", prominence, ground: ground)
+      end
+    end
+
+    test "prominence 1.0 with needs_input stays the byte-identical identity" do
+      assert Prominence.resolve("#c1712c", 1.0,
+               ground: @dark_ground,
+               needs_input: true
+             ) == "#c1712c"
+    end
+
+    test "needs_input composes with the legibility floor (clamp applies after the policy floor)" do
+      # A low-contrast seed at a starved prominence: the policy floor lifts
+      # it to the context tier first, then the opt-in legibility clamp still
+      # guarantees the WCAG floor on the result.
+      seed = Salience.solve(:recede, 0.02, 250, ground: @dark_ground)
+      ground_hex = Salience.oklch_to_hex(@dark_ground, 0.0, 0.0)
+
+      resolved =
+        Prominence.resolve(seed, 0.1,
+          ground: @dark_ground,
+          needs_input: true,
+          legibility_floor: true
+        )
+
+      assert Prominence.wcag_ratio(resolved, ground_hex) >=
+               Prominence.floor_ratio() - 1.0e-6
+    end
+  end
+
+  describe "Block needs-input floor integration" do
+    @approval_events [
+      %{
+        id: 7,
+        payload: %{action: "delete scratch dir", options: ["allow", "deny"]}
+      }
+    ]
+
+    test "a live approval block never paints dimmer than the ordinary-context resolve" do
+      block = Block.from_events(:approval, @approval_events)
+      assert Block.live?(block)
+
+      %{children: [header | _]} =
+        Block.render(block, %{prominence: 0.2, ground: @dark_ground})
+
+      assert header.style.fg ==
+               Prominence.resolve("#B4B4B4", Prominence.needs_input_floor(),
+                 ground: @dark_ground
+               )
+    end
+
+    test "an ordinary message block at the same prominence fades below the approval floor" do
+      message =
+        Block.from_events(:message, [
+          %{type: :item_completed, content: "context chatter"}
+        ])
+
+      %{children: [header | _]} =
+        Block.render(message, %{prominence: 0.2, ground: @dark_ground})
+
+      assert header.style.fg ==
+               Prominence.resolve("#B4B4B4", 0.2, ground: @dark_ground)
+
+      ground_hex = Salience.oklch_to_hex(@dark_ground, 0.0, 0.0)
+
+      floored_fg =
+        Prominence.resolve("#B4B4B4", Prominence.needs_input_floor(),
+          ground: @dark_ground
+        )
+
+      assert Prominence.wcag_ratio(header.style.fg, ground_hex) <
+               Prominence.wcag_ratio(floored_fg, ground_hex)
+    end
+
+    test "context[:needs_input] flags any block into the floor (explicit override)" do
+      message =
+        Block.from_events(:message, [
+          %{type: :item_completed, content: "composer draft"}
+        ])
+
+      %{children: [header | _]} =
+        Block.render(message, %{
+          prominence: 0.2,
+          ground: @dark_ground,
+          needs_input: true
+        })
+
+      assert header.style.fg ==
+               Prominence.resolve("#B4B4B4", Prominence.needs_input_floor(),
+                 ground: @dark_ground
+               )
+    end
+
+    test "a sealed approval block is no longer awaiting input -- it fades free" do
+      # An answered (sealed) approval prompt is history, not a pending
+      # question; the auto-flag applies only while the block is live.
+      block = :approval |> Block.from_events(@approval_events) |> Block.seal()
+
+      %{children: [header | _]} =
+        Block.render(block, %{prominence: 0.2, ground: @dark_ground})
+
+      assert header.style.fg ==
+               Prominence.resolve("#B4B4B4", 0.2, ground: @dark_ground)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 256-color degradation guard: when a resolved color is quantized to the
+  # xterm-256 palette (`Raxol.UI.Theming.Colors.find_closest_256_color/1`,
+  # the shipped degradation path), the 1.0 and 0.6 prominence tiers must
+  # not collapse to the SAME palette index -- the minimum tier separation
+  # the salience ladder needs to survive a 256-color terminal.
+  # ---------------------------------------------------------------------
+
+  describe "256-color quantization tier collapse guard (1.0/0.6 pair)" do
+    test "prominence 1.0 and 0.6 quantize to distinct 256-color indices, both grounds" do
+      for {ground, seeds} <- %{
+            @dark_ground => ["#c1712c", "#abb7c3", "#B4B4B4"],
+            @light_ground => ["#3b444f", "#B4B4B4"]
+          },
+          seed <- seeds do
+        full = Prominence.resolve(seed, 1.0, ground: ground)
+        faded = Prominence.resolve(seed, 0.6, ground: ground)
+
+        full_idx = seed_256_index(full)
+        faded_idx = seed_256_index(faded)
+
+        assert full_idx != faded_idx,
+               "#{seed} on ground #{ground}: 1.0 (#{full}) and 0.6 " <>
+                 "(#{faded}) both quantize to 256-color index #{full_idx}"
+      end
+    end
+
+    defp seed_256_index(hex) do
+      hex
+      |> hex_to_rgb_tuple()
+      |> Raxol.UI.Theming.Colors.find_closest_256_color()
+    end
+
+    defp hex_to_rgb_tuple("#" <> <<r::binary-2, g::binary-2, b::binary-2>>) do
+      {String.to_integer(r, 16), String.to_integer(g, 16),
+       String.to_integer(b, 16)}
+    end
+  end
 end


### PR DESCRIPTION
Two gaps in the merged prominence unit (#560/#568/#594), built red-first. An audit against the salience acceptance list confirmed the merged implementation already covers the rest (byte-exact tier fixtures on both grounds, default-1.0 zero-visual-change keystone, ground-threaded fade with monotone-WCAG-on-light-ground tests, opt-in legibility floor).

## 1. Needs-input starvation guard

A component awaiting user input must never fade below ordinary context content — an approval prompt that fades out is the harness hiding the one thing that needs the human. Red-first (6 unit tests + 1 property demonstrably failing before the change):

- `Prominence.resolve/3` gains `needs_input: true`, flooring effective prominence at `needs_input_floor/0` = 0.6 (the ordinary-context tier of the shipped ladder) before the fade. Raises only; identity preserved at >= 1.0; composes before the legibility clamp.
- `Harness.Block` auto-engages it for a live `:approval` block and drops it once sealed — an answered question fades like anything else. `context[:needs_input]` overrides in both directions.

## 2. 256-color tier separation pin

Master does have a 256-color quantization path (`Colors.find_closest_256_color/1`), contrary to the merged moduledoc's blanket deferral. New regression pin: the 1.0 vs 0.6 resolves quantize to distinct 256-color indices for all salience seeds on both grounds (passed immediately — a pin, not a fix; full 256-color floor survival stays a documented deferral, now noted accurately in the moduledoc).

## Verification
- Prominence suites 76 -> 88 (8 properties, 80 tests); full harness+theming+block sweep 506 passed, 0 failures.
- `MIX_ENV=test mix compile --warnings-as-errors` clean; no mix.lock drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)