### PR TITLE
Harness UI: stall/doom-loop detector + status strip alert seam

### DIFF
--- a/lib/raxol/harness/stall_detector.ex
+++ b/lib/raxol/harness/stall_detector.ex
@@ -1,0 +1,446 @@
+defmodule Raxol.Harness.StallDetector do
+  @moduledoc """
+  The stall / doom-loop detector: a pure supervision instrument that
+  tells the human "the agent you're watching has wedged" instead of
+  letting a lying spinner run.
+
+  ## Design laws
+
+  1. **Pure detection policy.** Feed it observations, get a verdict.
+     No processes, no timers, no clocks in here -- the caller owns time
+     and passes timestamps in (`observe/2`) or polls with its own clock
+     (`check/2`). Identical inputs always produce identical outputs.
+
+  2. **Independent budget.** The escalation budget (`escalations_left`)
+     is this detector's own counter for *quality* alarms. It is
+     completely separate from any transport/error retry counting a
+     caller may also keep -- a flaky network and a wedged agent are
+     different failure classes and must never share a budget.
+
+  3. **Never auto-recover.** The detector takes no corrective action on
+     the agent -- no interrupt, no resample, no retry. Its entire public
+     surface is construction and observation; judgment over visible
+     output belongs to the human it reports to.
+
+  4. **Hard graceful terminal.** Each distinct `:stalled`/`:looping`
+     alarm spends one unit of the escalation budget. Once the budget is
+     spent, further alarms are returned with `standing_by: true` -- the
+     verdict still tells the truth (class + current evidence), but is
+     never presented as a fresh escalation again. Deterministic
+     termination, no alert fatigue. A repeat of the *same* alarm never
+     spends budget either (it is flagged `standing_by` as "already
+     reported"). The budget never refills within a detector instance;
+     callers that want per-turn budgets construct a detector per turn.
+
+  5. **Honesty floor.** No verdict without evidence: every non-`:ok`
+     verdict carries the reason, the structured detail, and a
+     human-readable `summary` naming exactly what triggered it. A fresh
+     or insufficient observation window is `:ok` -- never
+     suspect-by-default. False alarms erode trust in the instrument.
+
+  ## Signals
+
+  * **Repetition** -- the same tool called with byte-identical
+    arguments `@default_repetition_threshold` times within the recent
+    call window (`:looping`); the count just below that is `:suspect`.
+  * **Ping-pong** -- two distinct calls alternating A,B,A,B for
+    `@default_ping_pong_threshold` full cycles (`:looping`); one cycle
+    short of that is `:suspect`. Cycle lengths 1 and 2 only, exact
+    argument match -- deliberately simple.
+  * **No-progress elapse** -- a working agent with no new events for
+    longer than a threshold. The thresholds default to the status
+    strip's shipped hung heuristic
+    (`Raxol.Harness.StatusStrip.default_warn_after_ms/0` /
+    `default_hung_after_ms/0`) rather than a parallel set of constants:
+    past warn is `:suspect`, past hung is `:stalled`.
+
+  When a call-pattern signal and a time signal fire simultaneously the
+  most severe wins (`:looping` > `:stalled` > `:suspect`), with the
+  pattern signal breaking ties -- its evidence names the concrete
+  wedge, which is more actionable than a bare elapsed number.
+
+  The detector is always-on by construction: it has no enabled flag.
+  Whether to consult it at all is the caller's decision, made simply by
+  constructing one (or not).
+
+  ## Wiring
+
+  The one shipped consumer is the status strip: pass the latest verdict
+  as the strip's optional `:stall_verdict` state key and a
+  `:stalled`/`:looping` verdict renders as a highest-priority `ALERT:`
+  notice naming the evidence. `observation_from_event/1` maps harness
+  fixture/journal events (the `Raxol.Harness.Fixture.Event` shape) to
+  observations, converting microsecond event timestamps to the
+  millisecond domain the thresholds live in -- the same µs -> ms
+  convention `Raxol.UI.Components.Harness.Block` uses for durations.
+  """
+
+  alias Raxol.Harness.StatusStrip
+
+  defmodule Verdict do
+    @moduledoc """
+    One detector verdict. `class` is the four-state answer; `evidence`
+    is nil exactly when `class` is `:ok` (the honesty floor), otherwise
+    a map always carrying `:reason` and a human-readable `:summary`
+    plus reason-specific detail. `standing_by: true` marks a verdict
+    that is NOT a fresh escalation: either a repeat of an
+    already-reported alarm, or an alarm raised after the escalation
+    budget was spent.
+    """
+
+    defstruct class: :ok, evidence: nil, standing_by: false
+
+    @type class :: :ok | :suspect | :stalled | :looping
+
+    @type evidence :: %{
+            :reason => :repetition | :ping_pong | :no_progress,
+            :summary => String.t(),
+            optional(:tool) => term(),
+            optional(:count) => pos_integer(),
+            optional(:tools) => {term(), term()},
+            optional(:cycles) => pos_integer(),
+            optional(:elapsed_ms) => non_neg_integer()
+          }
+
+    @type t :: %__MODULE__{
+            class: class(),
+            evidence: evidence() | nil,
+            standing_by: boolean()
+          }
+  end
+
+  # Four byte-identical calls: an agent legitimately re-reads a file two
+  # or three times while working on it (read, edit, re-check); a fourth
+  # identical call in the recent window is where legitimate re-checking
+  # ends. Conservative on purpose -- a false loop alarm costs more trust
+  # than a one-call-late true one.
+  @default_repetition_threshold 4
+
+  # Three full A,B cycles (six calls): alternating between two calls
+  # once or twice is a normal investigate-compare shape; a third full
+  # round trip with identical arguments is not.
+  @default_ping_pong_threshold 3
+
+  # Three distinct fresh alarms name the problem; a fourth re-alarm on a
+  # human who has not intervened after three is fatigue, not
+  # information.
+  @default_escalation_budget 3
+
+  @enforce_keys [
+    :repetition_threshold,
+    :ping_pong_threshold,
+    :warn_after_ms,
+    :hung_after_ms,
+    :escalations_left,
+    :max_history
+  ]
+  defstruct [
+    :repetition_threshold,
+    :ping_pong_threshold,
+    :warn_after_ms,
+    :hung_after_ms,
+    :escalations_left,
+    :max_history,
+    calls: [],
+    last_activity_at: nil,
+    last_alarm: nil
+  ]
+
+  @typedoc """
+  Observations are the detector's whole input vocabulary:
+
+  * `{:tool_call, name, arguments, at_ms}` -- the agent invoked a tool.
+  * `{:progress, at_ms}` -- any other observable activity (deltas,
+    results, messages). Progress feeds the no-progress clock but never
+    resets the call window: tool results always interleave tool calls,
+    so a loop must stay visible through them.
+  """
+  @type observation ::
+          {:tool_call, name :: term(), arguments :: term(), at_ms :: integer()}
+          | {:progress, at_ms :: integer()}
+
+  @type t :: %__MODULE__{
+          repetition_threshold: pos_integer(),
+          ping_pong_threshold: pos_integer(),
+          warn_after_ms: pos_integer(),
+          hung_after_ms: pos_integer(),
+          escalations_left: non_neg_integer(),
+          max_history: pos_integer(),
+          calls: [{term(), term()}],
+          last_activity_at: integer() | nil,
+          last_alarm: tuple() | nil
+        }
+
+  @doc """
+  Builds a detector. Options (all with documented defaults above):
+  `:repetition_threshold`, `:ping_pong_threshold`, `:warn_after_ms`,
+  `:hung_after_ms`, `:escalation_budget`.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    repetition_threshold =
+      Keyword.get(opts, :repetition_threshold, @default_repetition_threshold)
+
+    ping_pong_threshold =
+      Keyword.get(opts, :ping_pong_threshold, @default_ping_pong_threshold)
+
+    %__MODULE__{
+      repetition_threshold: repetition_threshold,
+      ping_pong_threshold: ping_pong_threshold,
+      warn_after_ms:
+        Keyword.get(opts, :warn_after_ms, StatusStrip.default_warn_after_ms()),
+      hung_after_ms:
+        Keyword.get(opts, :hung_after_ms, StatusStrip.default_hung_after_ms()),
+      escalations_left:
+        Keyword.get(opts, :escalation_budget, @default_escalation_budget),
+      # Just enough history to decide both call-pattern signals; nothing
+      # in the verdict ever looks further back, so nothing older is kept
+      # (bounded state, observation count can't grow the detector).
+      max_history: max(repetition_threshold, 2 * ping_pong_threshold)
+    }
+  end
+
+  @doc """
+  Feeds one observation, returning `{verdict, detector}`. An
+  observation IS activity, so the no-progress clock resets here; only
+  the call-pattern signals can fire from `observe/2`.
+  """
+  @spec observe(t(), observation()) :: {Verdict.t(), t()}
+  def observe(%__MODULE__{} = detector, {:tool_call, name, arguments, at}) do
+    detector = %{
+      detector
+      | calls:
+          Enum.take([{name, arguments} | detector.calls], detector.max_history),
+        last_activity_at: at
+    }
+
+    resolve(detector, pattern_detection(detector))
+  end
+
+  def observe(%__MODULE__{} = detector, {:progress, at}) do
+    detector = %{detector | last_activity_at: at}
+    resolve(detector, pattern_detection(detector))
+  end
+
+  @doc """
+  Polls the detector against the caller's clock (same millisecond
+  domain the observations used), returning `{verdict, detector}`. This
+  is where the no-progress signal can fire; an active call-pattern
+  alarm also stays visible here (a clock tick must never clear a loop
+  verdict). With no activity ever observed the window is insufficient:
+  `:ok`, per the honesty floor.
+  """
+  @spec check(t(), integer()) :: {Verdict.t(), t()}
+  def check(%__MODULE__{} = detector, now) when is_integer(now) do
+    detection =
+      most_severe(pattern_detection(detector), time_detection(detector, now))
+
+    resolve(detector, detection)
+  end
+
+  @doc """
+  Maps one harness event (a `Raxol.Harness.Fixture.Event` struct or an
+  event-shaped map: atom top-level keys, string payload keys,
+  microsecond `ts`) to an observation, or `nil` when the event is not
+  an observation (meta family, or no usable timestamp). A completed
+  `tool_use` item becomes a `:tool_call`; every other loop-family event
+  is `:progress`.
+  """
+  @spec observation_from_event(map()) :: observation() | nil
+  def observation_from_event(event) when is_map(event) do
+    ts = Map.get(event, :ts)
+    payload = Map.get(event, :payload) || %{}
+
+    cond do
+      Map.get(event, :family) != :loop or not is_integer(ts) ->
+        nil
+
+      Map.get(event, :type) == :item_completed and
+          Map.get(payload, "item_type") == "tool_use" ->
+        {:tool_call, Map.get(payload, "name"), Map.get(payload, "arguments"),
+         us_to_ms(ts)}
+
+      true ->
+        {:progress, us_to_ms(ts)}
+    end
+  end
+
+  # Event timestamps are microseconds (see the fixture schema); the
+  # detector's thresholds live in milliseconds, matching the status
+  # strip. Same conversion Block uses for durations.
+  defp us_to_ms(ts), do: div(ts, 1000)
+
+  # -- detection: call patterns ------------------------------------------
+
+  # Returns nil or {class, signature, evidence}. The signature is the
+  # alarm's stable identity for budget/dedup purposes: it excludes
+  # anything that grows while the SAME wedge continues (counts, cycle
+  # totals, elapsed), so a persisting alarm is one escalation, not many.
+  defp pattern_detection(%__MODULE__{calls: calls} = detector) do
+    run = leading_run(calls)
+    cycles = leading_cycles(calls)
+
+    cond do
+      run >= detector.repetition_threshold ->
+        repetition(:looping, calls, run)
+
+      cycles >= detector.ping_pong_threshold ->
+        ping_pong(:looping, calls, cycles)
+
+      run == detector.repetition_threshold - 1 ->
+        repetition(:suspect, calls, run)
+
+      cycles == detector.ping_pong_threshold - 1 ->
+        ping_pong(:suspect, calls, cycles)
+
+      true ->
+        nil
+    end
+  end
+
+  defp repetition(class, [{name, arguments} | _rest], count) do
+    lead = if class == :looping, do: "possible loop", else: "repeated call"
+
+    {class, {:repetition, class, name, arguments},
+     %{
+       reason: :repetition,
+       tool: name,
+       count: count,
+       summary: "#{lead}: #{name} x#{count} same args"
+     }}
+  end
+
+  defp ping_pong(class, [later, earlier | _rest], cycles) do
+    {earlier_name, _args} = earlier
+    {later_name, _args} = later
+    lead = if class == :looping, do: "possible loop", else: "alternating calls"
+
+    {class, {:ping_pong, class, Enum.sort([earlier, later])},
+     %{
+       reason: :ping_pong,
+       tools: {earlier_name, later_name},
+       cycles: cycles,
+       summary: "#{lead}: #{earlier_name}<->#{later_name} x#{cycles}"
+     }}
+  end
+
+  # Length of the identical prefix of the call window (newest first).
+  defp leading_run([]), do: 0
+
+  defp leading_run([head | rest]) do
+    1 + Enum.count(Enum.take_while(rest, &(&1 == head)))
+  end
+
+  # Full A,B cycles at the head of the window: the longest prefix in
+  # which every entry equals the entry two positions before it, with the
+  # first two entries distinct (pure repetition is the cycle-1 signal,
+  # never counted here). Six alternating entries = three full cycles.
+  defp leading_cycles([first, second | _rest] = calls) when first != second do
+    div(alternating_prefix(calls), 2)
+  end
+
+  defp leading_cycles(_calls), do: 0
+
+  defp alternating_prefix([first, second | rest]) do
+    # Beyond the first two entries, position i must repeat position
+    # i - 2 -- i.e. match the infinite alternation first,second,first,...
+    matched =
+      rest
+      |> Enum.zip(Stream.cycle([first, second]))
+      |> Enum.take_while(fn {entry, expected} -> entry == expected end)
+      |> length()
+
+    2 + matched
+  end
+
+  defp time_detection(%__MODULE__{last_activity_at: nil}, _now), do: nil
+
+  defp time_detection(%__MODULE__{last_activity_at: last} = detector, now) do
+    elapsed = max(now - last, 0)
+
+    cond do
+      elapsed >= detector.hung_after_ms ->
+        {:stalled, {:no_progress, :stalled},
+         %{
+           reason: :no_progress,
+           elapsed_ms: elapsed,
+           summary: "no output for #{format_elapsed(elapsed)}"
+         }}
+
+      elapsed >= detector.warn_after_ms ->
+        {:suspect, {:no_progress, :suspect},
+         %{
+           reason: :no_progress,
+           elapsed_ms: elapsed,
+           summary: "quiet for #{format_elapsed(elapsed)}"
+         }}
+
+      true ->
+        nil
+    end
+  end
+
+  # Same rendering the status strip uses for elapsed values, so the
+  # detector's evidence and the strip's Stage ticker read alike.
+  defp format_elapsed(ms) when ms < 60_000, do: "#{div(ms, 1000)}s"
+
+  defp format_elapsed(ms) do
+    total_s = div(ms, 1000)
+    seconds = rem(total_s, 60)
+    padded = if seconds < 10, do: "0#{seconds}", else: "#{seconds}"
+    "#{div(total_s, 60)}m#{padded}s"
+  end
+
+  # -- severity + budget resolution -----------------------------------------
+
+  @severity %{looping: 3, stalled: 2, suspect: 1}
+
+  # Pattern first: on a severity tie its evidence (the concrete wedge)
+  # beats a bare elapsed number.
+  defp most_severe(nil, time), do: time
+  defp most_severe(pattern, nil), do: pattern
+
+  defp most_severe({p_class, _, _} = pattern, {t_class, _, _} = time) do
+    if @severity[t_class] > @severity[p_class], do: time, else: pattern
+  end
+
+  # No detection: the honest all-clear. Clearing forgets the last alarm,
+  # so the SAME wedge recurring later is a new incident (and, budget
+  # permitting, a fresh escalation) -- flapping is bounded by the budget,
+  # never by suppression.
+  defp resolve(detector, nil) do
+    {%Verdict{}, %{detector | last_alarm: nil}}
+  end
+
+  defp resolve(%__MODULE__{last_alarm: sig} = detector, {class, sig, evidence}) do
+    # The same alarm persisting: already reported, never a fresh
+    # escalation, never a budget spend.
+    {%Verdict{class: class, evidence: evidence, standing_by: true}, detector}
+  end
+
+  defp resolve(detector, {:suspect, signature, evidence}) do
+    # Pre-alarms are free: they are hints the caller may consult, not
+    # escalations (the strip does not even render them).
+    {%Verdict{class: :suspect, evidence: evidence},
+     %{detector | last_alarm: signature}}
+  end
+
+  defp resolve(
+         %__MODULE__{escalations_left: 0} = detector,
+         {class, signature, evidence}
+       ) do
+    # Terminal: reported, standing by. Evidence stays current and
+    # honest; the standing_by flag is what guarantees no re-alarm.
+    {%Verdict{class: class, evidence: evidence, standing_by: true},
+     %{detector | last_alarm: signature}}
+  end
+
+  defp resolve(detector, {class, signature, evidence}) do
+    {%Verdict{class: class, evidence: evidence},
+     %{
+       detector
+       | last_alarm: signature,
+         escalations_left: detector.escalations_left - 1
+     }}
+  end
+end

--- a/lib/raxol/harness/status_strip.ex
+++ b/lib/raxol/harness/status_strip.ex
@@ -68,6 +68,13 @@ defmodule Raxol.Harness.StatusStrip do
   | `Ctx`   | context %      | `context_pct` gated by `turn_completed`|
   | `Cost`  | session cost   | `cost`                                 |
 
+  One conditional notice sits outside the slot system: an optional
+  `:stall_verdict` entry (the stall detector's one integration seam --
+  see `Raxol.Harness.StallDetector` and the private `stall_notice/1`)
+  prepends an `ALERT: <evidence>` segment at the very highest priority
+  when, and only when, the verdict is `:stalled`/`:looping` with a
+  non-empty evidence summary.
+
   Priority order, highest first (kept longest as width shrinks; see
   `field_keys/0` and `render/2`): `needs_input` (safety: an agent
   waiting on approval must never silently disappear from a narrow
@@ -211,6 +218,24 @@ defmodule Raxol.Harness.StatusStrip do
   def glyphs, do: [@missing, @ellipsis]
 
   @doc """
+  The default "slow but plausible" threshold for the Stage elapsed
+  ticker, in milliseconds. Public so the stall detector's no-progress
+  signal formalizes THIS heuristic instead of inventing a parallel
+  constant -- the strip stays the single source of truth for what
+  "quiet too long" means.
+  """
+  @spec default_warn_after_ms() :: pos_integer()
+  def default_warn_after_ms, do: @default_warn_after_ms
+
+  @doc """
+  The default "gone quiet long enough that a human should look"
+  threshold, in milliseconds. See `default_warn_after_ms/0` for why
+  this is public.
+  """
+  @spec default_hung_after_ms() :: pos_integer()
+  def default_hung_after_ms, do: @default_hung_after_ms
+
+  @doc """
   Projects `state` into the status strip's footer lines for a pinned
   region `width` display columns wide. Always returns exactly one line
   (a single-element list) -- the list return type matches the general
@@ -232,7 +257,47 @@ defmodule Raxol.Harness.StatusStrip do
         "#{label}: #{value_fn.(state)}"
       end)
 
+    segments =
+      case stall_notice(state) do
+        nil -> segments
+        notice -> [notice | segments]
+      end
+
     [fit_to_width(segments, safe_width)]
+  end
+
+  # -- stall verdict notice -------------------------------------------------
+
+  # The stall detector's one integration seam (see
+  # `Raxol.Harness.StallDetector`): an optional `:stall_verdict` state
+  # entry -- the detector's verdict struct or any map of the same shape.
+  # Only `:stalled` / `:looping` render; `:suspect` is a pre-alarm the
+  # detector surfaces for callers that want it, deliberately kept off
+  # the strip (the same false-alarm economy behind its honesty floor).
+  #
+  # This is a conditional NOTICE, not a fifth labelled slot: the
+  # always-render-`—` convention exists so missing *data* is visibly
+  # missing, but "no alarm" is the healthy state, and a permanent
+  # `Alert: —` slot would be pure noise. When present it takes highest
+  # priority -- ahead even of `needs_input` -- because a wedged agent is
+  # the one condition this instrument exists to make impossible to miss,
+  # and unlike needs-input it arrives with no other on-screen trace.
+  #
+  # No notice ever renders without evidence text: an alarm the operator
+  # cannot act on is noise (the detector's own law, enforced again here
+  # defensively). Evidence summaries embed tool names straight from
+  # agent events -- the same injection surface as `turn_stage` -- so the
+  # summary passes through the same control-character sweep.
+  defp stall_notice(state) do
+    case Map.get(state, :stall_verdict) do
+      %{class: class, evidence: %{summary: summary}}
+      when class in [:stalled, :looping] and is_binary(summary) and
+             summary != "" ->
+        "ALERT: #{sanitize_stage(summary)}"
+
+      _ ->
+        nil
+    end
   end
 
   # -- per-field slot formatting ----------------------------------------

--- a/test/harness/stall_detector_fixture_test.exs
+++ b/test/harness/stall_detector_fixture_test.exs
@@ -1,0 +1,195 @@
+defmodule Raxol.Harness.StallDetectorFixtureTest do
+  @moduledoc """
+  End-to-end: a recorded looping session, replayed through the real
+  fixture loader, drives the stall detector, whose verdict surfaces on
+  the status strip -- the full observation -> verdict -> notice path a
+  live harness would take.
+
+  The fixture is constructed inline (written to a per-test tmp dir and
+  loaded through `Raxol.Harness.Fixture.load/1`) rather than checked in
+  next to the golden sessions: it exists to exercise the detector seam,
+  not to freeze a projection snapshot, so it carries no `.blocks.json` /
+  `.t7blocks.json` companions and stays out of the golden name lists.
+
+  RED-FIRST: this file was written and run before the detector module
+  or the strip wiring existed; it failed with `UndefinedFunctionError`
+  on `StallDetector.new/0`.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.Fixture
+  alias Raxol.Harness.Fixture.Session
+  alias Raxol.Harness.StallDetector
+  alias Raxol.Harness.StallDetector.Verdict
+  alias Raxol.Harness.StatusStrip
+
+  @moduletag :tmp_dir
+
+  # One turn in which the agent reads the same file four times in a row
+  # (tool_use with byte-identical arguments), each call answered by a
+  # tool_result -- the classic wedged re-read loop. The session ends
+  # mid-loop on the fourth call: no turn_completed, because the agent
+  # never gets there. Schema follows the checked-in golden sessions
+  # (harness-fixture/1, envelope v1, dense monotonic ids, ts in
+  # microseconds).
+  @header ~s({"record":"header","schema":"harness-fixture/1","envelope_v":1,) <>
+            ~s("harness_version":"0.1.0","backend":"anthropic",) <>
+            ~s("model":"claude-sonnet-5","config_hash":"cfg-looping-01",) <>
+            ~s("recorded_at":"2026-07-17T12:00:00Z","name":"looping-tool",) <>
+            ~s("kind":"golden","notes":"agent wedged re-reading mix.exs; ) <>
+            ~s(exercises the stall detector end-to-end"})
+
+  defp envelope(id, ts_us, type, payload) do
+    body = %{
+      id: id,
+      turn_id: "t1",
+      ts: ts_us,
+      family: "loop",
+      type: type,
+      tier: "durable",
+      payload: payload
+    }
+
+    Jason.encode!(%{
+      record: "envelope",
+      v: 1,
+      session_id: "sess-looping-tool",
+      kind: "event",
+      body: body
+    })
+  end
+
+  defp looping_fixture do
+    base_ts = 1_752_581_100_000_000
+
+    tool_use = fn item ->
+      %{
+        "item_id" => item,
+        "item_type" => "tool_use",
+        "name" => "read_file",
+        "arguments" => %{"path" => "mix.exs"},
+        "call_id" => "call-#{item}"
+      }
+    end
+
+    events =
+      [
+        {"turn_started", %{"prompt" => "fix the failing test"}},
+        {"item_started", %{"item_id" => "i1", "item_type" => "tool_use"}},
+        {"item_completed", tool_use.("i1")},
+        {"item_started", %{"item_id" => "i2", "item_type" => "tool_result"}},
+        {"item_completed",
+         %{
+           "item_id" => "i2",
+           "item_type" => "tool_result",
+           "name" => "read_file",
+           "content" => "defmodule ..."
+         }},
+        {"item_started", %{"item_id" => "i3", "item_type" => "tool_use"}},
+        {"item_completed", tool_use.("i3")},
+        {"item_started", %{"item_id" => "i4", "item_type" => "tool_result"}},
+        {"item_completed",
+         %{
+           "item_id" => "i4",
+           "item_type" => "tool_result",
+           "name" => "read_file",
+           "content" => "defmodule ..."
+         }},
+        {"item_started", %{"item_id" => "i5", "item_type" => "tool_use"}},
+        {"item_completed", tool_use.("i5")},
+        {"item_started", %{"item_id" => "i6", "item_type" => "tool_result"}},
+        {"item_completed",
+         %{
+           "item_id" => "i6",
+           "item_type" => "tool_result",
+           "name" => "read_file",
+           "content" => "defmodule ..."
+         }},
+        {"item_started", %{"item_id" => "i7", "item_type" => "tool_use"}},
+        {"item_completed", tool_use.("i7")}
+      ]
+      |> Enum.with_index(1)
+      |> Enum.map(fn {{type, payload}, id} ->
+        envelope(id, base_ts + id * 100_000, type, payload)
+      end)
+
+    Enum.join([@header | events], "\n") <> "\n"
+  end
+
+  test "a looping session replays into a strip-visible loop alert", %{
+    tmp_dir: tmp_dir
+  } do
+    path = Path.join(tmp_dir, "looping-tool.jsonl")
+    File.write!(path, looping_fixture())
+
+    assert {:ok, %Session{} = session} = Fixture.load(path)
+
+    {verdict, detector} =
+      session.envelopes
+      |> Enum.map(& &1.body)
+      |> Enum.map(&StallDetector.observation_from_event/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.reduce({nil, StallDetector.new()}, fn obs, {_verdict, det} ->
+        StallDetector.observe(det, obs)
+      end)
+
+    # The fourth identical read is the fresh escalation: explained, and
+    # a first report (not a budget-exhausted echo).
+    assert %Verdict{class: :looping, standing_by: false, evidence: evidence} =
+             verdict
+
+    assert evidence.reason == :repetition
+    assert evidence.tool == "read_file"
+    assert evidence.count == 4
+    assert detector.escalations_left < StallDetector.new().escalations_left
+
+    # And the strip surfaces it as its highest-priority notice.
+    [line] =
+      StatusStrip.render(
+        %{turn_stage: :tool_call, needs_input: false, stall_verdict: verdict},
+        200
+      )
+
+    assert line =~ "ALERT: possible loop: read_file x4 same args"
+    assert line =~ "Stage: tool_call"
+  end
+
+  test "a healthy session replays to :ok end to end", %{tmp_dir: tmp_dir} do
+    # The honesty floor at the seam level: replaying a normal session
+    # through the same path must never surface an alert.
+    path = Path.join(tmp_dir, "healthy.jsonl")
+
+    events =
+      [
+        envelope(1, 1_752_581_100_100_000, "turn_started", %{"prompt" => "hi"}),
+        envelope(2, 1_752_581_100_200_000, "item_started", %{
+          "item_id" => "i1",
+          "item_type" => "message"
+        }),
+        envelope(3, 1_752_581_100_300_000, "item_completed", %{
+          "item_id" => "i1",
+          "item_type" => "message",
+          "content" => "hello"
+        })
+      ]
+
+    File.write!(path, Enum.join([@header | events], "\n") <> "\n")
+
+    assert {:ok, session} = Fixture.load(path)
+
+    {verdict, _detector} =
+      session.envelopes
+      |> Enum.map(& &1.body)
+      |> Enum.map(&StallDetector.observation_from_event/1)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.reduce({nil, StallDetector.new()}, fn obs, {_verdict, det} ->
+        StallDetector.observe(det, obs)
+      end)
+
+    assert %Verdict{class: :ok, evidence: nil} = verdict
+
+    [line] = StatusStrip.render(%{stall_verdict: verdict}, 200)
+    refute line =~ "ALERT"
+  end
+end

--- a/test/harness/stall_detector_test.exs
+++ b/test/harness/stall_detector_test.exs
@@ -1,0 +1,429 @@
+defmodule Raxol.Harness.StallDetectorTest do
+  @moduledoc """
+  The stall / doom-loop detector: a pure supervision instrument that
+  turns a stream of observations (tool calls, output activity, clock
+  ticks) into an explained verdict, so the human supervising an agent
+  learns "this agent has wedged" instead of watching a lying spinner.
+
+  Each `describe` block below encodes one of the detector's design laws
+  as an executable contract:
+
+    1. PURE DETECTION POLICY -- observations in, verdict out, caller
+       owns time, every non-ok verdict carries its evidence.
+    2. INDEPENDENT BUDGET -- escalation accounting is the detector's
+       own counter, consumed only by fresh alarms.
+    3. NEVER AUTO-RECOVER -- the module exposes observation/verdict
+       functions only; there is no corrective surface at all.
+    4. HARD GRACEFUL TERMINAL -- a spent budget yields a deterministic
+       "reported, standing by" state, never an endless re-alarm.
+    5. HONESTY FLOOR -- a fresh or insufficient observation window is
+       `:ok`; no verdict ever fires without evidence.
+
+  RED-FIRST: this entire file was written and run against a codebase
+  with no `Raxol.Harness.StallDetector` module (every test failed with
+  `UndefinedFunctionError`) before the implementation existed.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.StallDetector
+  alias Raxol.Harness.StallDetector.Verdict
+  alias Raxol.Harness.StatusStrip
+
+  # -- helpers ---------------------------------------------------------
+
+  @args %{"path" => "mix.exs"}
+
+  defp call(name, args \\ @args, at \\ 0), do: {:tool_call, name, args, at}
+
+  # Folds a list of observations, returning the FINAL {verdict, detector}.
+  defp drive(det, observations) do
+    Enum.reduce(observations, {nil, det}, fn obs, {_verdict, d} ->
+      StallDetector.observe(d, obs)
+    end)
+  end
+
+  defp repeat_call(name, n), do: List.duplicate(call(name), n)
+
+  # -- law 1: pure detection policy -------------------------------------
+
+  describe "law 1: pure detection policy" do
+    test "observe/2 is a pure fold: identical inputs, identical outputs" do
+      observations = repeat_call("read_file", 4) ++ [{:progress, 1_000}]
+
+      first = drive(StallDetector.new(), observations)
+      second = drive(StallDetector.new(), observations)
+
+      assert first == second
+    end
+
+    test "check/2 is pure too: same detector + same now, same verdict" do
+      {_verdict, det} = drive(StallDetector.new(), [{:progress, 0}])
+
+      assert StallDetector.check(det, 90_000) ==
+               StallDetector.check(det, 90_000)
+    end
+
+    test "verdicts are structs carrying class, evidence, and standing_by only" do
+      keys =
+        %Verdict{} |> Map.from_struct() |> Map.keys() |> Enum.sort()
+
+      assert keys == [:class, :evidence, :standing_by]
+    end
+
+    test "every non-ok verdict carries evidence with a reason and a summary" do
+      {verdict, _det} = drive(StallDetector.new(), repeat_call("read_file", 4))
+
+      assert %Verdict{class: :looping, evidence: evidence} = verdict
+      assert is_atom(evidence.reason)
+      assert is_binary(evidence.summary)
+      assert evidence.summary != ""
+    end
+  end
+
+  # -- law 5: honesty floor ----------------------------------------------
+
+  describe "law 5: honesty floor (fresh window is :ok, never suspect-by-default)" do
+    test "a fresh detector checked against any clock is :ok with no evidence" do
+      det = StallDetector.new()
+
+      assert {%Verdict{class: :ok, evidence: nil}, _det} =
+               StallDetector.check(det, 999_999_999)
+    end
+
+    test "a couple of identical calls is normal work, not a verdict" do
+      {verdict, _det} = drive(StallDetector.new(), repeat_call("read_file", 2))
+
+      assert %Verdict{class: :ok, evidence: nil} = verdict
+    end
+
+    test ":ok verdicts never carry evidence" do
+      {verdict, _det} = drive(StallDetector.new(), [call("read_file")])
+
+      assert %Verdict{class: :ok, evidence: nil, standing_by: false} = verdict
+    end
+  end
+
+  # -- signal: repetition --------------------------------------------------
+
+  describe "repetition: same tool, identical arguments" do
+    test "four identical calls is a loop verdict naming tool, count, and args" do
+      {verdict, _det} = drive(StallDetector.new(), repeat_call("read_file", 4))
+
+      assert %Verdict{class: :looping, evidence: evidence} = verdict
+      assert evidence.reason == :repetition
+      assert evidence.tool == "read_file"
+      assert evidence.count == 4
+      assert evidence.summary == "possible loop: read_file x4 same args"
+    end
+
+    test "three identical calls (threshold minus one) is :suspect with evidence" do
+      {verdict, _det} = drive(StallDetector.new(), repeat_call("read_file", 3))
+
+      assert %Verdict{class: :suspect, evidence: evidence} = verdict
+      assert evidence.reason == :repetition
+      assert evidence.count == 3
+    end
+
+    test "four calls to the same tool with DIFFERENT args is :ok" do
+      observations =
+        for i <- 1..4, do: call("read_file", %{"path" => "file#{i}.ex"})
+
+      {verdict, _det} = drive(StallDetector.new(), observations)
+
+      assert %Verdict{class: :ok} = verdict
+    end
+
+    test "interleaved progress events do not reset the call window" do
+      observations =
+        Enum.intersperse(repeat_call("read_file", 4), {:progress, 100})
+
+      {verdict, _det} = drive(StallDetector.new(), observations)
+
+      assert %Verdict{class: :looping, evidence: %{reason: :repetition}} =
+               verdict
+    end
+
+    test "a different call clears an active loop verdict back to :ok" do
+      {_verdict, det} = drive(StallDetector.new(), repeat_call("read_file", 4))
+
+      {verdict, _det} = StallDetector.observe(det, call("list_dir", %{}))
+
+      assert %Verdict{class: :ok, evidence: nil} = verdict
+    end
+
+    test "the loop verdict keeps counting past the threshold" do
+      {verdict, _det} = drive(StallDetector.new(), repeat_call("read_file", 6))
+
+      assert %Verdict{class: :looping, evidence: %{count: 6}} = verdict
+    end
+  end
+
+  # -- signal: ping-pong (cycle length 2) -----------------------------------
+
+  describe "ping-pong: two tools alternating" do
+    test "three full A,B cycles is a loop verdict naming both tools" do
+      a = call("read_file")
+      b = call("list_dir", %{})
+
+      {verdict, _det} = drive(StallDetector.new(), [a, b, a, b, a, b])
+
+      assert %Verdict{class: :looping, evidence: evidence} = verdict
+      assert evidence.reason == :ping_pong
+      assert evidence.cycles == 3
+      assert evidence.summary == "possible loop: read_file<->list_dir x3"
+    end
+
+    test "two full cycles (threshold minus one) is :suspect" do
+      a = call("read_file")
+      b = call("list_dir", %{})
+
+      {verdict, _det} = drive(StallDetector.new(), [a, b, a, b])
+
+      assert %Verdict{class: :suspect, evidence: %{reason: :ping_pong}} =
+               verdict
+    end
+
+    test "the same tool with two alternating argument sets is still ping-pong" do
+      a = call("read_file", %{"path" => "a.ex"})
+      b = call("read_file", %{"path" => "b.ex"})
+
+      {verdict, _det} = drive(StallDetector.new(), [a, b, a, b, a, b])
+
+      assert %Verdict{class: :looping, evidence: %{reason: :ping_pong}} =
+               verdict
+    end
+
+    test "a broken alternation is :ok" do
+      a = call("read_file")
+      b = call("list_dir", %{})
+      c = call("grep", %{"q" => "x"})
+
+      {verdict, _det} = drive(StallDetector.new(), [a, b, a, b, a, c])
+
+      assert %Verdict{class: :ok} = verdict
+    end
+
+    test "pure repetition is never misread as ping-pong" do
+      {verdict, _det} = drive(StallDetector.new(), repeat_call("read_file", 3))
+
+      assert %Verdict{evidence: %{reason: :repetition}} = verdict
+    end
+  end
+
+  # -- signal: no-progress elapse -------------------------------------------
+
+  describe "no-progress elapse (the status strip's hung heuristic, formalized)" do
+    test "defaults are the status strip's own thresholds, not a parallel set" do
+      det = StallDetector.new()
+
+      assert det.warn_after_ms == StatusStrip.default_warn_after_ms()
+      assert det.hung_after_ms == StatusStrip.default_hung_after_ms()
+    end
+
+    test "under the warn threshold is :ok" do
+      {_verdict, det} = drive(StallDetector.new(), [{:progress, 0}])
+
+      assert {%Verdict{class: :ok}, _det} =
+               StallDetector.check(det, 14_999)
+    end
+
+    test "past the warn threshold is :suspect with elapsed evidence" do
+      {_verdict, det} = drive(StallDetector.new(), [{:progress, 0}])
+
+      {verdict, _det} = StallDetector.check(det, 15_000)
+
+      assert %Verdict{class: :suspect, evidence: evidence} = verdict
+      assert evidence.reason == :no_progress
+      assert evidence.elapsed_ms == 15_000
+    end
+
+    test "past the hung threshold is :stalled with a human-readable summary" do
+      {_verdict, det} = drive(StallDetector.new(), [{:progress, 0}])
+
+      {verdict, _det} = StallDetector.check(det, 75_000)
+
+      assert %Verdict{class: :stalled, evidence: evidence} = verdict
+      assert evidence.reason == :no_progress
+      assert evidence.elapsed_ms == 75_000
+      assert evidence.summary == "no output for 1m15s"
+    end
+
+    test "any observation resets the elapse window" do
+      {_verdict, det} = drive(StallDetector.new(), [{:progress, 0}])
+      {_verdict, det} = StallDetector.observe(det, {:progress, 59_000})
+
+      assert {%Verdict{class: :ok}, _det} =
+               StallDetector.check(det, 70_000)
+    end
+
+    test "thresholds are overridable at construction" do
+      det = StallDetector.new(warn_after_ms: 1_000, hung_after_ms: 4_000)
+      {_verdict, det} = StallDetector.observe(det, {:progress, 0})
+
+      assert {%Verdict{class: :stalled}, _det} = StallDetector.check(det, 5_000)
+    end
+
+    test "a clock running backwards clamps to zero elapsed, never crashes" do
+      {_verdict, det} = drive(StallDetector.new(), [{:progress, 100_000}])
+
+      assert {%Verdict{class: :ok}, _det} = StallDetector.check(det, 50_000)
+    end
+
+    test "an active loop verdict is not cleared by a mere clock tick" do
+      {_verdict, det} = drive(StallDetector.new(), repeat_call("read_file", 4))
+
+      {verdict, _det} = StallDetector.check(det, 1_000)
+
+      assert %Verdict{class: :looping} = verdict
+    end
+  end
+
+  # -- law 3: never auto-recover ---------------------------------------------
+
+  describe "law 3: the detector only surfaces verdicts, never acts" do
+    test "the module's whole public surface is construction + observation" do
+      exports =
+        StallDetector.__info__(:functions)
+        |> Keyword.keys()
+        |> Enum.reject(&(&1 == :__struct__))
+        |> Enum.sort()
+        |> Enum.uniq()
+
+      assert exports == [:check, :new, :observation_from_event, :observe]
+    end
+  end
+
+  # -- law 2 + law 4: independent budget, hard graceful terminal --------------
+
+  describe "law 2: the escalation budget is the detector's own counter" do
+    test "ordinary observations never touch the budget" do
+      det = StallDetector.new()
+      {_verdict, driven} = drive(det, [call("a", %{}), call("b", %{})])
+
+      assert driven.escalations_left == det.escalations_left
+    end
+
+    test "only a fresh alarm spends budget; a persisting one does not" do
+      {_verdict, det} = drive(StallDetector.new(), repeat_call("read_file", 4))
+      spent_once = det.escalations_left
+
+      # The loop persists: same signature, no additional spend.
+      {verdict, det} = StallDetector.observe(det, call("read_file"))
+
+      assert det.escalations_left == spent_once
+      assert %Verdict{class: :looping, standing_by: true} = verdict
+    end
+
+    test "suspect pre-alarms are free: only :stalled/:looping spend budget" do
+      det = StallDetector.new()
+      {verdict, driven} = drive(det, repeat_call("read_file", 3))
+
+      assert %Verdict{class: :suspect} = verdict
+      assert driven.escalations_left == det.escalations_left
+    end
+  end
+
+  describe "law 4: hard graceful terminal once the budget is spent" do
+    test "a spent budget yields standing_by verdicts with honest evidence" do
+      det = StallDetector.new(escalation_budget: 1)
+
+      # Alarm one: fresh escalation, spends the whole budget.
+      {verdict, det} = drive(det, repeat_call("read_file", 4))
+      assert %Verdict{class: :looping, standing_by: false} = verdict
+      assert det.escalations_left == 0
+
+      # Recover, then wedge on a different tool.
+      {%Verdict{class: :ok}, det} =
+        StallDetector.observe(det, call("compile", %{}))
+
+      {verdict, _det} = drive(det, repeat_call("run_tests", 4))
+
+      # Terminal state: the verdict still tells the truth about WHAT is
+      # wrong (class + current evidence), but is flagged standing_by --
+      # it is never presented as a fresh escalation again.
+      assert %Verdict{class: :looping, standing_by: true, evidence: evidence} =
+               verdict
+
+      assert evidence.tool == "run_tests"
+    end
+
+    test "the terminal state is stable across further observations" do
+      det = StallDetector.new(escalation_budget: 0)
+
+      {verdict, det} = drive(det, repeat_call("read_file", 4))
+      assert %Verdict{standing_by: true} = verdict
+
+      {verdict, _det} = StallDetector.observe(det, call("read_file"))
+      assert %Verdict{class: :looping, standing_by: true} = verdict
+    end
+
+    test "recovery to :ok is always available regardless of budget" do
+      det = StallDetector.new(escalation_budget: 0)
+      {_verdict, det} = drive(det, repeat_call("read_file", 4))
+
+      {verdict, _det} = StallDetector.observe(det, call("list_dir", %{}))
+
+      assert %Verdict{class: :ok, evidence: nil, standing_by: false} = verdict
+    end
+  end
+
+  # -- fixture-event mapping ---------------------------------------------------
+
+  describe "observation_from_event/1: harness fixture events -> observations" do
+    test "a completed tool_use item maps to a tool_call with ms timestamps" do
+      event = %{
+        id: 5,
+        turn_id: "t1",
+        ts: 1_752_581_100_400_000,
+        family: :loop,
+        type: :item_completed,
+        tier: :durable,
+        payload: %{
+          "item_id" => "i2",
+          "item_type" => "tool_use",
+          "name" => "list_dir",
+          "arguments" => %{"path" => "."},
+          "call_id" => "call-1"
+        }
+      }
+
+      assert StallDetector.observation_from_event(event) ==
+               {:tool_call, "list_dir", %{"path" => "."}, 1_752_581_100_400}
+    end
+
+    test "any other loop-family event maps to progress activity" do
+      event = %{
+        id: 7,
+        turn_id: "t1",
+        ts: 1_752_581_100_600_000,
+        family: :loop,
+        type: :item_completed,
+        tier: :durable,
+        payload: %{"item_type" => "tool_result", "content" => "ok"}
+      }
+
+      assert StallDetector.observation_from_event(event) ==
+               {:progress, 1_752_581_100_600}
+    end
+
+    test "meta-family events are not observations" do
+      event = %{
+        id: 1,
+        ts: 1_752_581_100_000_000,
+        family: :meta,
+        type: :config_changed,
+        tier: :durable,
+        payload: %{}
+      }
+
+      assert StallDetector.observation_from_event(event) == nil
+    end
+
+    test "an event without a usable timestamp is not an observation" do
+      event = %{family: :loop, type: :item_delta, ts: nil, payload: %{}}
+
+      assert StallDetector.observation_from_event(event) == nil
+    end
+  end
+end

--- a/test/harness/t10_status_strip_test.exs
+++ b/test/harness/t10_status_strip_test.exs
@@ -265,6 +265,110 @@ defmodule Raxol.Harness.T10StatusStripTest do
     end
   end
 
+  describe "stall verdict notice (the stall detector's one integration seam)" do
+    # RED-FIRST: these tests were written and run before `render/2` knew
+    # the `:stall_verdict` key existed -- every rendering assertion below
+    # failed (the key was silently ignored, no ALERT segment appeared)
+    # until the wiring landed.
+
+    @looping_verdict %{
+      class: :looping,
+      evidence: %{
+        reason: :repetition,
+        tool: "read_file",
+        count: 4,
+        summary: "possible loop: read_file x4 same args"
+      }
+    }
+
+    test "a :looping verdict prepends an ALERT segment naming the evidence" do
+      state = Map.put(@full_state, :stall_verdict, @looping_verdict)
+
+      assert StatusStrip.render(state, 200) == [
+               "ALERT: possible loop: read_file x4 same args | " <>
+                 "Input: clear | Stage: tool_call 4s | Ctx: 42% | Cost: $1.23"
+             ]
+    end
+
+    test "a :stalled verdict renders the same needs-attention notice" do
+      verdict = %{
+        class: :stalled,
+        evidence: %{reason: :no_progress, summary: "no output for 1m15s"}
+      }
+
+      [line] = StatusStrip.render(%{stall_verdict: verdict}, 200)
+
+      assert line =~ "ALERT: no output for 1m15s"
+    end
+
+    test "a :suspect verdict renders NO notice (pre-alarms stay off the strip)" do
+      verdict = %{
+        class: :suspect,
+        evidence: %{
+          reason: :repetition,
+          summary: "repeated call: x x3 same args"
+        }
+      }
+
+      state = Map.put(@full_state, :stall_verdict, verdict)
+
+      assert StatusStrip.render(state, 200) ==
+               StatusStrip.render(@full_state, 200)
+    end
+
+    test "an :ok verdict and an absent key render identically" do
+      ok_verdict = %{class: :ok, evidence: nil}
+      state = Map.put(@full_state, :stall_verdict, ok_verdict)
+
+      assert StatusStrip.render(state, 200) ==
+               StatusStrip.render(@full_state, 200)
+    end
+
+    test "a verdict without evidence renders NO notice (no unexplained alarms)" do
+      # The detector's honesty floor says no verdict without evidence;
+      # the strip enforces the same law defensively -- an alarm the
+      # operator can't act on is noise, not information.
+      state =
+        Map.put(@full_state, :stall_verdict, %{class: :stalled, evidence: nil})
+
+      assert StatusStrip.render(state, 200) ==
+               StatusStrip.render(@full_state, 200)
+    end
+
+    test "the ALERT segment has highest priority under width pressure" do
+      state = Map.put(@full_state, :stall_verdict, @looping_verdict)
+      alert = "ALERT: possible loop: read_file x4 same args"
+
+      [line] =
+        StatusStrip.render(state, Raxol.UI.TextMeasure.display_width(alert))
+
+      assert line == alert
+      refute line =~ "Input:"
+    end
+
+    test "an ESC-laden evidence summary is sanitized like any footer text" do
+      # Evidence summaries embed tool names, which come straight from
+      # agent events -- the same injection surface as `turn_stage`.
+      verdict = %{
+        class: :looping,
+        evidence: %{reason: :repetition, summary: "loop: x\e[2J y\nz"}
+      }
+
+      [line] = StatusStrip.render(%{stall_verdict: verdict}, 200)
+
+      refute line =~ "\e"
+      refute line =~ "\n"
+      assert line =~ "ALERT: loop: x[2J yz"
+    end
+  end
+
+  describe "shared thresholds (single source of truth for the hung heuristic)" do
+    test "the warn/hung defaults are exposed for the stall detector to reuse" do
+      assert StatusStrip.default_warn_after_ms() == 15_000
+      assert StatusStrip.default_hung_after_ms() == 60_000
+    end
+  end
+
   describe "stage sanitization (injection guard: turn_stage reaches a byte-level pinned writer unsanitized)" do
     test "an ESC-laden stage is sanitized -- no ESC byte reaches the output" do
       # RED-FIRST: before `sanitize_stage/1` existed, `stage_value/1`


### PR DESCRIPTION
The honesty instrument for a wedged agent: today a looping agent looks identical to a thinking one — spinner runs, tokens flow. This adds a pure detection policy that classifies the observation stream and a status-strip alert seam that surfaces the verdict with its evidence.

## Detector (`Raxol.Harness.StallDetector`, pure)

- `new/1` -> struct; `observe/2` takes `{:tool_call, name, args, at_ms}` / `{:progress, at_ms}`; `check/2` is the caller's clock tick. No processes, no timers, no wall clock — the caller owns time.
- `%Verdict{class: :ok | :suspect | :stalled | :looping, evidence, standing_by}` — every non-ok verdict carries WHY (reason + human summary); a fresh/insufficient window returns `:ok`, never suspect-by-default.
- Signals: exact-match tool repetition (N=4), ping-pong A/B cycling (3 full cycles), no-progress elapse (reuses the strip's warn 15s / hung 60s constants — single source of truth, pinned equal by test).
- Escalation budget is its own counter, fully separate from any transport/error retry counting; distinct wedge signatures spend 1 each, a persisting wedge is ONE escalation (signatures exclude growing counters). Budget spent -> `standing_by: true` (reported, not re-alarming), evidence stays honest.
- The detector NEVER acts on the agent — no auto-interrupt, no auto-resample. Visible-output judgment belongs to the human.

## Strip wiring (one seam)

Optional `:stall_verdict` input -> highest-priority `ALERT:` segment naming the evidence (e.g. "possible loop: read_file x4 same args"). Conditional notice, not a permanent slot — "no alarm" is healthy state. Outranks needs-input in width priority (a wedged agent has no other on-screen trace). Alert text goes through the strip's existing control-character sanitization.

## Verification (red-first)

RED run captured before implementation: detector files failed on the nonexistent module; strip file 5 failures on the then-ignored `:stall_verdict` key. GREEN: full `test/harness/` suite 269 passed, 0 failures (78 in touched files) — 30 detector unit tests (one describe per design law + per signal), 2 fixture-replay e2e tests (looping session -> alert; healthy session -> no alert) through the real `Fixture.load/1`, 9 new strip tests. `--warnings-as-errors` + `mix format --check-formatted` clean; no mix.lock drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)