### PR TITLE
Harness UI: polarity-aware 16-color salience mapping (semantic roles survive degradation)

### DIFF
--- a/lib/raxol/ui/theming/ansi16_salience.ex
+++ b/lib/raxol/ui/theming/ansi16_salience.ex
@@ -18,7 +18,32 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
   measuring distance in RGB space, each semantic role is PINNED to a
   hue-preserving ANSI slot chosen so the role's category (red/green/yellow/
   blue/magenta/neutral) is never lost and never confused with another
-  role's category.
+  role's category. (`:running` is reserved for activity state -- no RGB
+  seed exists in the harness yet, which is why measured naive-collapse
+  counts say "11 fields" while `roles/0` returns 12.)
+
+  ## Legibility floor
+
+  Every slot assignment meets a WCAG-style 3:1 contrast ratio against its
+  polarity's canonical ground, measured on the module's reference palette
+  (`Raxol.UI.Theming.Colors.ansi_to_rgb/1`), with one small, named
+  exemption set on light polarity only:
+
+    * Green/yellow state roles on light ground: no green or yellow slot in
+      the reference palette is legible on light ground (best available:
+      normal green 1.98:1, normal yellow 1.56:1). The best-effort normal
+      slots (2 and 3) are pinned anyway, because swapping hue family would
+      be a category lie worse than low contrast for a state signal, and
+      gray would erase the signal entirely. Real light-mode terminal
+      themes darken these slots; the pin keeps the category-true handle
+      for them to interpret.
+    * Muted/border recede chrome on light ground: silver is a subtle
+      light-UI border by design; receding below the floor is these roles'
+      function.
+
+  Dark polarity has NO exemptions: every dark-canvas assignment meets the
+  floor outright. The ranked priority throughout the table is explicit:
+  legibility > category preservation > tier separation.
 
   ## Polarity-awareness
 
@@ -26,35 +51,55 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
   (9-15) per hue. Which one reads as "the loud one" depends on the canvas:
   bright variants pop on a dark background, normal variants pop on a light
   background. `polarity/1` derives the canvas from ground OKLCH lightness
-  using the same threshold as `Raxol.UI.Theming.Salience`'s `:auto` polarity
-  resolution (`ground < 0.5` is dark).
+  using the same threshold as `Raxol.UI.Theming.Salience`'s `:auto`
+  polarity resolution (`ground < 0.5` is dark). Because a 16-color path is
+  a fallback, `polarity/1` must not crash when the OSC 11 background probe
+  has no reading: `nil` falls back to the reference ground's polarity;
+  other non-numbers still raise.
 
   ## Tier degradation
 
-  The shipped prominence ladder has four tiers (1.0 / 0.8 / 0.6 / 0.4), but
-  16-color can only express two distinguishable steps per hue (normal vs.
-  bright). The ladder folds pairwise at `loud_threshold/0` (0.8): prominence
-  `>= 0.8` resolves to the loud tier, everything below resolves to the soft
-  tier. That fold keeps `1.0` and `0.6` -- the coarsest separation the
-  instrument requires -- on distinct slots for every role except `:muted`
-  and `:border`, which already sit at the dimmest slot that stays legible
-  (the recede floor); folding them is intentional, not a gap.
+  The shipped prominence ladder has four tiers (1.0 / 0.8 / 0.6 / 0.4),
+  but 16-color can express at most two distinguishable steps per hue. The
+  ladder folds pairwise at `loud_threshold/0` (0.8): prominence `>= 0.8`
+  resolves to the loud tier, everything below resolves to the soft tier.
+
+  Which roles keep distinct 1.0 vs 0.6 slots is per polarity. On dark, all
+  roles stay distinct except `:muted` and `:border`, which already sit at
+  the dimmest legible slot (the recede floor -- intentional fold). On
+  light, the reference palette leaves single legible slots for several
+  families, so the fold list grows: `:muted`, `:border`, `:warning`,
+  `:success`, `:diff_add`, `:running`, `:foreground`, and `:chrome` all
+  trade tier separation for the legibility floor.
 
   ## Accepted losses
 
   This is a lossy degradation and it accepts specific losses in exchange
-  for never lying about hue:
+  for never lying about hue and never dropping below legibility where the
+  palette allows:
 
     * Sub-hue detail is dropped -- an orange warning and a yellow warning
       both land on the yellow slot.
     * `:diff_add` folds onto `:success`'s green family and `:diff_del`
       folds onto `:error`'s red family; these are in-family folds, not
       category lies.
+    * `:accent` renders on the cyan slots on a dark canvas: the palette's
+      normal blue (slot 4, #0000EE) is illegible on black -- the classic
+      blue-on-black problem -- and the bright blue slot alone cannot
+      express two tiers. Cyan is the adjacent cool slot and no other role
+      occupies it; the role's category stays `:blue`.
     * `:emphasis` trades its warm (yellow-adjacent) seed hue for the
       max-contrast neutral slot at its loudest tier, so it can never be
       mistaken for the `:warning` state signal -- the yellow slot is
       reserved for warning. `:emphasis` keeps its anchor function (it is
       still the loudest role in the ramp) without competing for a hue.
+    * The neutral ramp merges. On dark at the soft tier, `:foreground`,
+      `:chrome`, `:muted`, and `:border` all share slot 8 -- receded body
+      text merges into recede chrome, because slot 8 is the only legible
+      sub-body neutral on dark. On light the whole mid-ramp compresses
+      onto slot 8: the palette has exactly two legible neutrals on light
+      ground (black and dark gray), so foreground and chrome fold onto
+      dark gray at both tiers.
     * `:running` is reserved for activity/in-progress state and given its
       own hue family (magenta), separate from the alarm/success/warning
       triad.
@@ -65,7 +110,10 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
   `Raxol.UI.Theming.Colors.find_closest_basic_color/1` (nearest-RGB) must
   not be used for semantic roles -- see its `@doc` for the pointer back
   here. Truecolor and 256-color rendering are unaffected; this module is
-  additive.
+  additive. Note the table is not yet consumed by the render path (wiring
+  the capability gate is a follow-up); until then
+  `find_closest_basic_color/1` remains the live -- lossy -- 16-color
+  fallback.
 
   ## Unknown roles
 
@@ -74,6 +122,8 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
   fallback clause for atoms outside that set -- they raise
   `FunctionClauseError` rather than silently guessing a slot.
   """
+
+  alias Raxol.UI.Theming.Salience
 
   @type role ::
           :foreground
@@ -99,46 +149,82 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
   # {1.0, 0.8} -> loud, {0.6, 0.4, ...} -> soft.
   @loud_threshold 0.8
 
-  # Chromatic roles and their base ANSI hue slot (the normal-intensity
-  # 1-5 range). Dark canvas: loud = bright variant (base + 8), soft =
-  # normal (base). Light canvas: the polarity flip -- loud = normal,
-  # soft = bright.
-  @chromatic_base %{
-    error: 1,
-    diff_del: 1,
-    success: 2,
-    diff_add: 2,
-    warning: 3,
-    accent: 4,
-    running: 5
-  }
-
-  @chromatic_roles Map.keys(@chromatic_base)
-
-  # Neutral roles: explicit {loud, soft} slot per polarity. Emphasis is
-  # the anchor tier (max-contrast slot); foreground/chrome sit one step
-  # below it; muted/border are the recede tier at the dimmest readable
-  # slot (their floor -- loud and soft intentionally coincide there).
-  @neutral_table %{
+  # Explicit per-polarity per-tier slot pins. The design is no longer one
+  # intensity-flip formula: legibility against the canonical ground
+  # (measured on Colors.ansi_to_rgb/1) overrides the flip wherever the
+  # palette leaves a family without two -- or any -- legible slots.
+  #
+  # Dark canvas: bright-loud / normal-soft for every family it works for;
+  # accent moves to the cyan slots (normal blue is 1.93:1 on black).
+  #
+  # Light canvas: the flip holds only where the bright variant stays
+  # legible (red, blue); warning/success/diff_add/running fold both tiers
+  # onto their single best slot; the neutral mid-ramp compresses onto
+  # dark gray (slot 8).
+  @slot_table %{
     dark: %{
-      emphasis: {15, 7},
-      foreground: {7, 8},
-      chrome: {7, 8},
-      muted: {8, 8},
-      border: {8, 8}
+      loud: %{
+        error: 9,
+        diff_del: 9,
+        success: 10,
+        diff_add: 10,
+        warning: 11,
+        accent: 14,
+        running: 13,
+        emphasis: 15,
+        foreground: 7,
+        chrome: 7,
+        muted: 8,
+        border: 8
+      },
+      soft: %{
+        error: 1,
+        diff_del: 1,
+        success: 2,
+        diff_add: 2,
+        warning: 3,
+        accent: 6,
+        running: 5,
+        emphasis: 7,
+        foreground: 8,
+        chrome: 8,
+        muted: 8,
+        border: 8
+      }
     },
     light: %{
-      emphasis: {0, 8},
-      foreground: {8, 7},
-      chrome: {8, 7},
-      muted: {7, 7},
-      border: {7, 7}
+      loud: %{
+        error: 1,
+        diff_del: 1,
+        success: 2,
+        diff_add: 2,
+        warning: 3,
+        accent: 4,
+        running: 5,
+        emphasis: 0,
+        foreground: 8,
+        chrome: 8,
+        muted: 7,
+        border: 7
+      },
+      soft: %{
+        error: 9,
+        diff_del: 9,
+        success: 2,
+        diff_add: 2,
+        warning: 3,
+        accent: 12,
+        running: 5,
+        emphasis: 8,
+        foreground: 8,
+        chrome: 8,
+        muted: 7,
+        border: 7
+      }
     }
   }
 
-  @neutral_roles Map.keys(@neutral_table.dark)
-
-  @roles @chromatic_roles ++ @neutral_roles
+  @roles Map.keys(@slot_table.dark.loud)
 
   @doc "The semantic salience roles this table covers."
   @spec roles() :: [role()]
@@ -149,8 +235,16 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
 
   Mirrors `Raxol.UI.Theming.Salience`'s `:auto` polarity threshold: a
   ground lightness below `0.5` is a dark canvas, `0.5` and above is light.
+
+  A 16-color path is a fallback and must not crash when ground detection
+  (the OSC 11 background probe) has no reading: `nil` falls back to the
+  reference ground's polarity. Other non-numbers raise
+  `FunctionClauseError` -- fail-loud on garbage, graceful on the
+  documented unknown.
   """
-  @spec polarity(number()) :: polarity()
+  @spec polarity(number() | nil) :: polarity()
+  def polarity(nil), do: polarity(Salience.reference_ground())
+
   def polarity(ground_lightness) when is_number(ground_lightness) do
     if ground_lightness < 0.5, do: :dark, else: :light
   end
@@ -172,25 +266,17 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
   """
   @spec slot(role(), polarity(), number()) :: slot()
   def slot(role, polarity, prominence)
-      when is_number(prominence) and role in @chromatic_roles do
-    base = Map.fetch!(@chromatic_base, role)
-    chromatic_slot(polarity, tier(prominence), base)
-  end
-
-  def slot(role, polarity, prominence)
-      when is_number(prominence) and role in @neutral_roles do
-    {loud, soft} = @neutral_table[polarity][role]
-
-    case tier(prominence) do
-      :loud -> loud
-      :soft -> soft
-    end
+      when is_number(prominence) and role in @roles do
+    @slot_table
+    |> Map.fetch!(polarity)
+    |> Map.fetch!(tier(prominence))
+    |> Map.fetch!(role)
   end
 
   @doc "The full role -> slot map for a given polarity and prominence."
   @spec table(polarity(), number()) :: %{role() => slot()}
-  def table(polarity, prominence \\ 1.0) do
-    Map.new(@roles, fn role -> {role, slot(role, polarity, prominence)} end)
+  def table(polarity, prominence \\ 1.0) when is_number(prominence) do
+    @slot_table |> Map.fetch!(polarity) |> Map.fetch!(tier(prominence))
   end
 
   @doc "The hue family a role belongs to."
@@ -211,10 +297,4 @@ defmodule Raxol.UI.Theming.Ansi16Salience do
   @spec tier(number()) :: tier()
   defp tier(prominence) when prominence >= @loud_threshold, do: :loud
   defp tier(_prominence), do: :soft
-
-  @spec chromatic_slot(polarity(), tier(), non_neg_integer()) :: slot()
-  defp chromatic_slot(:dark, :loud, base), do: base + 8
-  defp chromatic_slot(:dark, :soft, base), do: base
-  defp chromatic_slot(:light, :loud, base), do: base
-  defp chromatic_slot(:light, :soft, base), do: base + 8
 end

--- a/lib/raxol/ui/theming/ansi16_salience.ex
+++ b/lib/raxol/ui/theming/ansi16_salience.ex
@@ -1,0 +1,220 @@
+defmodule Raxol.UI.Theming.Ansi16Salience do
+  @moduledoc """
+  Polarity-preserving 16-color (ANSI16) degradation table for semantic
+  salience roles.
+
+  ## Why this module exists
+
+  On a 16-color terminal, naive nearest-RGB quantization of the solved
+  salience palette (`Raxol.UI.Theming.Colors.find_closest_basic_color/1`)
+  collapses most semantic fields onto the gray ramp: measured on this
+  codebase, 8 of the 11 harness-painted fields (success, accent, emphasis,
+  diff add/del, chrome, ...) gray out on the dark reference ground, and the
+  survivors lie about their hue -- solved `error` nearest-RGB-quantizes to
+  ANSI 3 (yellow), not any red slot. Averaging RGB channels down to 16 flat
+  swatches erases the hue information that carries semantic meaning.
+
+  This module replaces that lossy path for semantic colors. Instead of
+  measuring distance in RGB space, each semantic role is PINNED to a
+  hue-preserving ANSI slot chosen so the role's category (red/green/yellow/
+  blue/magenta/neutral) is never lost and never confused with another
+  role's category.
+
+  ## Polarity-awareness
+
+  ANSI16 offers a normal-intensity slot (1-7) and a bright-intensity slot
+  (9-15) per hue. Which one reads as "the loud one" depends on the canvas:
+  bright variants pop on a dark background, normal variants pop on a light
+  background. `polarity/1` derives the canvas from ground OKLCH lightness
+  using the same threshold as `Raxol.UI.Theming.Salience`'s `:auto` polarity
+  resolution (`ground < 0.5` is dark).
+
+  ## Tier degradation
+
+  The shipped prominence ladder has four tiers (1.0 / 0.8 / 0.6 / 0.4), but
+  16-color can only express two distinguishable steps per hue (normal vs.
+  bright). The ladder folds pairwise at `loud_threshold/0` (0.8): prominence
+  `>= 0.8` resolves to the loud tier, everything below resolves to the soft
+  tier. That fold keeps `1.0` and `0.6` -- the coarsest separation the
+  instrument requires -- on distinct slots for every role except `:muted`
+  and `:border`, which already sit at the dimmest slot that stays legible
+  (the recede floor); folding them is intentional, not a gap.
+
+  ## Accepted losses
+
+  This is a lossy degradation and it accepts specific losses in exchange
+  for never lying about hue:
+
+    * Sub-hue detail is dropped -- an orange warning and a yellow warning
+      both land on the yellow slot.
+    * `:diff_add` folds onto `:success`'s green family and `:diff_del`
+      folds onto `:error`'s red family; these are in-family folds, not
+      category lies.
+    * `:emphasis` trades its warm (yellow-adjacent) seed hue for the
+      max-contrast neutral slot at its loudest tier, so it can never be
+      mistaken for the `:warning` state signal -- the yellow slot is
+      reserved for warning. `:emphasis` keeps its anchor function (it is
+      still the loudest role in the ramp) without competing for a hue.
+    * `:running` is reserved for activity/in-progress state and given its
+      own hue family (magenta), separate from the alarm/success/warning
+      triad.
+
+  ## Scope
+
+  This table is the only supported 16-color path for semantic role colors.
+  `Raxol.UI.Theming.Colors.find_closest_basic_color/1` (nearest-RGB) must
+  not be used for semantic roles -- see its `@doc` for the pointer back
+  here. Truecolor and 256-color rendering are unaffected; this module is
+  additive.
+
+  ## Unknown roles
+
+  `roles/0` is the closed, compile-time set of roles this table knows
+  about. `slot/2`, `slot/3`, and `category/1` intentionally have no
+  fallback clause for atoms outside that set -- they raise
+  `FunctionClauseError` rather than silently guessing a slot.
+  """
+
+  @type role ::
+          :foreground
+          | :accent
+          | :error
+          | :warning
+          | :success
+          | :emphasis
+          | :muted
+          | :border
+          | :chrome
+          | :diff_add
+          | :diff_del
+          | :running
+
+  @type polarity :: :dark | :light
+  @type slot :: 0..15
+  @type category :: :red | :green | :yellow | :blue | :magenta | :neutral
+  @type tier :: :loud | :soft
+
+  # Prominence >= this value resolves to the loud tier; below is soft. The
+  # shipped 4-tier ladder (1.0 / 0.8 / 0.6 / 0.4) folds pairwise here:
+  # {1.0, 0.8} -> loud, {0.6, 0.4, ...} -> soft.
+  @loud_threshold 0.8
+
+  # Chromatic roles and their base ANSI hue slot (the normal-intensity
+  # 1-5 range). Dark canvas: loud = bright variant (base + 8), soft =
+  # normal (base). Light canvas: the polarity flip -- loud = normal,
+  # soft = bright.
+  @chromatic_base %{
+    error: 1,
+    diff_del: 1,
+    success: 2,
+    diff_add: 2,
+    warning: 3,
+    accent: 4,
+    running: 5
+  }
+
+  @chromatic_roles Map.keys(@chromatic_base)
+
+  # Neutral roles: explicit {loud, soft} slot per polarity. Emphasis is
+  # the anchor tier (max-contrast slot); foreground/chrome sit one step
+  # below it; muted/border are the recede tier at the dimmest readable
+  # slot (their floor -- loud and soft intentionally coincide there).
+  @neutral_table %{
+    dark: %{
+      emphasis: {15, 7},
+      foreground: {7, 8},
+      chrome: {7, 8},
+      muted: {8, 8},
+      border: {8, 8}
+    },
+    light: %{
+      emphasis: {0, 8},
+      foreground: {8, 7},
+      chrome: {8, 7},
+      muted: {7, 7},
+      border: {7, 7}
+    }
+  }
+
+  @neutral_roles Map.keys(@neutral_table.dark)
+
+  @roles @chromatic_roles ++ @neutral_roles
+
+  @doc "The semantic salience roles this table covers."
+  @spec roles() :: [role()]
+  def roles, do: @roles
+
+  @doc """
+  Derives canvas polarity from ground OKLCH lightness.
+
+  Mirrors `Raxol.UI.Theming.Salience`'s `:auto` polarity threshold: a
+  ground lightness below `0.5` is a dark canvas, `0.5` and above is light.
+  """
+  @spec polarity(number()) :: polarity()
+  def polarity(ground_lightness) when is_number(ground_lightness) do
+    if ground_lightness < 0.5, do: :dark, else: :light
+  end
+
+  @doc """
+  Prominence at or above this value resolves to the loud tier; below it
+  resolves to the soft tier.
+  """
+  @spec loud_threshold() :: float()
+  def loud_threshold, do: @loud_threshold
+
+  @doc "Same as `slot/3` at full (`1.0`) prominence."
+  @spec slot(role(), polarity()) :: slot()
+  def slot(role, polarity), do: slot(role, polarity, 1.0)
+
+  @doc """
+  Resolves a semantic role to its ANSI16 slot for the given canvas
+  polarity and prominence.
+  """
+  @spec slot(role(), polarity(), number()) :: slot()
+  def slot(role, polarity, prominence)
+      when is_number(prominence) and role in @chromatic_roles do
+    base = Map.fetch!(@chromatic_base, role)
+    chromatic_slot(polarity, tier(prominence), base)
+  end
+
+  def slot(role, polarity, prominence)
+      when is_number(prominence) and role in @neutral_roles do
+    {loud, soft} = @neutral_table[polarity][role]
+
+    case tier(prominence) do
+      :loud -> loud
+      :soft -> soft
+    end
+  end
+
+  @doc "The full role -> slot map for a given polarity and prominence."
+  @spec table(polarity(), number()) :: %{role() => slot()}
+  def table(polarity, prominence \\ 1.0) do
+    Map.new(@roles, fn role -> {role, slot(role, polarity, prominence)} end)
+  end
+
+  @doc "The hue family a role belongs to."
+  @spec category(role()) :: category()
+  def category(:error), do: :red
+  def category(:diff_del), do: :red
+  def category(:success), do: :green
+  def category(:diff_add), do: :green
+  def category(:warning), do: :yellow
+  def category(:accent), do: :blue
+  def category(:running), do: :magenta
+  def category(:foreground), do: :neutral
+  def category(:chrome), do: :neutral
+  def category(:emphasis), do: :neutral
+  def category(:muted), do: :neutral
+  def category(:border), do: :neutral
+
+  @spec tier(number()) :: tier()
+  defp tier(prominence) when prominence >= @loud_threshold, do: :loud
+  defp tier(_prominence), do: :soft
+
+  @spec chromatic_slot(polarity(), tier(), non_neg_integer()) :: slot()
+  defp chromatic_slot(:dark, :loud, base), do: base + 8
+  defp chromatic_slot(:dark, :soft, base), do: base
+  defp chromatic_slot(:light, :loud, base), do: base
+  defp chromatic_slot(:light, :soft, base), do: base + 8
+end

--- a/lib/raxol/ui/theming/colors.ex
+++ b/lib/raxol/ui/theming/colors.ex
@@ -399,6 +399,10 @@ defmodule Raxol.UI.Theming.Colors do
 
   @doc """
   Finds the closest ANSI basic color index (0-15) to the given RGB color.
+
+  For semantic salience roles (error, accent, success, ...), prefer
+  `Raxol.UI.Theming.Ansi16Salience` instead: nearest-RGB quantization
+  collapses most of the solved semantic palette onto the gray ramp.
   """
   @spec find_closest_basic_color(color_rgb) :: 0..15
   def find_closest_basic_color(rgb) do

--- a/test/raxol/ui/theming/ansi16_salience_test.exs
+++ b/test/raxol/ui/theming/ansi16_salience_test.exs
@@ -1,0 +1,333 @@
+defmodule Raxol.UI.Theming.Ansi16SalienceTest do
+  @moduledoc """
+  Pins the polarity-preserving 16-color salience degradation
+  (`Raxol.UI.Theming.Ansi16Salience`).
+
+  ## Why this module exists (measured on this codebase)
+
+  Naive nearest-RGB quantization (`Colors.find_closest_basic_color/1`) of
+  the solved salience palette collapses 8 of 11 harness-painted semantic
+  fields to a gray slot on the dark reference ground (success, accent,
+  emphasis, diff add/del, chrome, ...) and commits category lies on what
+  survives: solved `error` lands on ANSI 3 (yellow), and on a light ground
+  solved `emphasis` lands on ANSI 1 (red) and `foreground` on ANSI 6
+  (cyan). The dedicated role table below is the fix: each semantic role is
+  PINNED to a hue-preserving ANSI slot, polarity-aware, and nearest-RGB is
+  never consulted for semantic colors.
+
+  ## The audit tripwire
+
+  The named budgets (`@chromatic_gray_budget`, `@cross_category_collision_budget`)
+  are the regression tripwire the reference design teaches: enumerate every
+  semantic field the harness paints, and assert the count that collapses to
+  the same ANSI slot (especially gray) stays under an explicit budget.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Theming.Ansi16Salience
+  alias Raxol.UI.Theming.Colors
+  alias Raxol.UI.Theming.Salience
+  alias Raxol.UI.Theming.SalienceTheme
+
+  @polarities [:dark, :light]
+
+  # The two prominence tiers 16-color can express: the shipped ladder
+  # (1.0 / 0.8 / 0.6 / 0.4) folds pairwise -- {1.0, 0.8} -> loud,
+  # {0.6, 0.4} -> soft. The 1.0 vs 0.6 pair is the coarsest separation the
+  # instrument requires (same pair the 256-color pin guards).
+  @full 1.0
+  @receded 0.6
+
+  # The four achromatic ANSI16 slots: black, silver, dark gray, bright white.
+  @gray_slots [0, 7, 8, 15]
+
+  # ---- named audit budgets (the regression tripwire) --------------------
+
+  # Chromatic roles landing on a gray slot: NONE, ever. Gray is exactly the
+  # collapse this module exists to prevent.
+  @chromatic_gray_budget 0
+
+  # Roles sharing one slot with a role of a DIFFERENT hue family (a
+  # category lie: error indistinguishable from warning, etc.): NONE.
+  # In-family folds (diff_del onto error's red, chrome onto foreground's
+  # neutral ramp) are intentional and unbudgeted.
+  @cross_category_collision_budget 0
+
+  # ---- the role -> slot table (both polarities, both tiers) -------------
+
+  describe "chromatic role -> slot table" do
+    # Base hue slots: red 1, green 2, yellow 3, blue 4, magenta 5.
+    # Dark canvas: loud = bright variant (base + 8), soft = normal (base).
+    # Light canvas: the polarity flip -- loud = normal, soft = bright.
+    @chromatic_expected %{
+      error: 1,
+      diff_del: 1,
+      success: 2,
+      diff_add: 2,
+      warning: 3,
+      accent: 4,
+      running: 5
+    }
+
+    test "dark polarity: bright set when loud, normal set when receded" do
+      for {role, base} <- @chromatic_expected do
+        assert Ansi16Salience.slot(role, :dark, @full) == base + 8,
+               "#{role} loud on dark must be bright slot #{base + 8}"
+
+        assert Ansi16Salience.slot(role, :dark, @receded) == base,
+               "#{role} receded on dark must be normal slot #{base}"
+      end
+    end
+
+    test "light polarity: normal set when loud, bright set when receded" do
+      for {role, base} <- @chromatic_expected do
+        assert Ansi16Salience.slot(role, :light, @full) == base,
+               "#{role} loud on light must be normal slot #{base}"
+
+        assert Ansi16Salience.slot(role, :light, @receded) == base + 8,
+               "#{role} receded on light must be bright slot #{base + 8}"
+      end
+    end
+  end
+
+  describe "neutral role -> slot table" do
+    # The neutral ramp mirrors the chromatic polarity flip. Emphasis is the
+    # anchor tier and takes the max-contrast slot; body foreground sits one
+    # step below it so the anchor can still exceed baseline; muted/border
+    # are the recede tier and sit at the dimmest readable slot (their
+    # floor -- see the tier-separation exemption below).
+    test "dark polarity neutral ramp" do
+      assert Ansi16Salience.slot(:emphasis, :dark, @full) == 15
+      assert Ansi16Salience.slot(:emphasis, :dark, @receded) == 7
+      assert Ansi16Salience.slot(:foreground, :dark, @full) == 7
+      assert Ansi16Salience.slot(:foreground, :dark, @receded) == 8
+      assert Ansi16Salience.slot(:chrome, :dark, @full) == 7
+      assert Ansi16Salience.slot(:chrome, :dark, @receded) == 8
+      assert Ansi16Salience.slot(:muted, :dark, @full) == 8
+      assert Ansi16Salience.slot(:border, :dark, @full) == 8
+    end
+
+    test "light polarity neutral ramp" do
+      assert Ansi16Salience.slot(:emphasis, :light, @full) == 0
+      assert Ansi16Salience.slot(:emphasis, :light, @receded) == 8
+      assert Ansi16Salience.slot(:foreground, :light, @full) == 8
+      assert Ansi16Salience.slot(:foreground, :light, @receded) == 7
+      assert Ansi16Salience.slot(:chrome, :light, @full) == 8
+      assert Ansi16Salience.slot(:chrome, :light, @receded) == 7
+      assert Ansi16Salience.slot(:muted, :light, @full) == 7
+      assert Ansi16Salience.slot(:border, :light, @full) == 7
+    end
+  end
+
+  describe "role enumeration and table/2" do
+    test "roles/0 covers every semantic field the harness paints" do
+      # The 8 SalienceTheme seed roles + the harness constants (Block
+      # chrome #B4B4B4, DiffViewer add/del bases) + :running (reserved for
+      # activity state, per the reference design's magenta family).
+      seed_names = Enum.map(SalienceTheme.seeds(), & &1.name)
+
+      for name <- seed_names do
+        assert name in Ansi16Salience.roles(),
+               "seed role #{name} missing from the ANSI16 role table"
+      end
+
+      for extra <- [:chrome, :diff_add, :diff_del, :running] do
+        assert extra in Ansi16Salience.roles()
+      end
+    end
+
+    test "table/2 maps every role exactly once, both polarities and tiers" do
+      for polarity <- @polarities, prominence <- [@full, @receded] do
+        table = Ansi16Salience.table(polarity, prominence)
+
+        assert Map.keys(table) |> Enum.sort() ==
+                 Ansi16Salience.roles() |> Enum.sort()
+
+        for {role, slot} <- table do
+          assert slot in 0..15
+          assert Ansi16Salience.slot(role, polarity, prominence) == slot
+        end
+      end
+    end
+  end
+
+  describe "polarity/1 (ground lightness -> canvas polarity)" do
+    test "classifies dark and light grounds like the salience solver" do
+      # Mirrors Salience's :auto polarity threshold (ground < 0.5).
+      assert Ansi16Salience.polarity(Salience.reference_ground()) == :dark
+      assert Ansi16Salience.polarity(0.2) == :dark
+      assert Ansi16Salience.polarity(0.0) == :dark
+      assert Ansi16Salience.polarity(0.97) == :light
+      assert Ansi16Salience.polarity(0.5) == :light
+      assert Ansi16Salience.polarity(1.0) == :light
+    end
+  end
+
+  # ---- tier separation: the 1.0 vs 0.6 pin ------------------------------
+
+  describe "tier separation (1.0 vs 0.6 survive 16-color)" do
+    test "every non-recede role resolves distinct slots at 1.0 vs 0.6" do
+      for polarity <- @polarities,
+          role <- Ansi16Salience.roles(),
+          role not in [:muted, :border] do
+        loud = Ansi16Salience.slot(role, polarity, @full)
+        soft = Ansi16Salience.slot(role, polarity, @receded)
+
+        assert loud != soft,
+               "#{role} on #{polarity}: 1.0 and 0.6 both land on slot #{loud}"
+      end
+    end
+
+    test "muted and border are the documented recede floor (tiers fold)" do
+      # The recede tier already sits at the dimmest readable slot; ANSI16
+      # has nothing dimmer that stays visible, so the fold is intentional.
+      for polarity <- @polarities, role <- [:muted, :border] do
+        assert Ansi16Salience.slot(role, polarity, @full) ==
+                 Ansi16Salience.slot(role, polarity, @receded)
+      end
+    end
+
+    test "the shipped 4-tier ladder folds pairwise at the loud threshold" do
+      threshold = Ansi16Salience.loud_threshold()
+      assert threshold == 0.8
+
+      for polarity <- @polarities, role <- Ansi16Salience.roles() do
+        # {1.0, 0.8} -> loud
+        assert Ansi16Salience.slot(role, polarity, 1.0) ==
+                 Ansi16Salience.slot(role, polarity, 0.8)
+
+        # {0.6, 0.4} -> soft, and below-threshold stays soft to 0.0
+        assert Ansi16Salience.slot(role, polarity, 0.6) ==
+                 Ansi16Salience.slot(role, polarity, 0.4)
+
+        assert Ansi16Salience.slot(role, polarity, 0.6) ==
+                 Ansi16Salience.slot(role, polarity, 0.0)
+
+        # just under the threshold is soft
+        assert Ansi16Salience.slot(role, polarity, 0.79) ==
+                 Ansi16Salience.slot(role, polarity, 0.6)
+      end
+    end
+  end
+
+  # ---- THE AUDIT: collapse budgets (the regression tripwire) ------------
+
+  describe "audit: gray-collapse and cross-category collision budgets" do
+    test "no chromatic role lands on a gray slot (budget #{@chromatic_gray_budget})" do
+      for polarity <- @polarities, prominence <- [@full, @receded] do
+        collapsed =
+          for role <- Ansi16Salience.roles(),
+              Ansi16Salience.category(role) != :neutral,
+              Ansi16Salience.slot(role, polarity, prominence) in @gray_slots,
+              do: role
+
+        assert length(collapsed) <= @chromatic_gray_budget,
+               "chromatic roles collapsed to gray on #{polarity}@#{prominence}: " <>
+                 inspect(collapsed)
+      end
+    end
+
+    test "no slot hosts two hue families (budget #{@cross_category_collision_budget})" do
+      for polarity <- @polarities, prominence <- [@full, @receded] do
+        colliding =
+          Ansi16Salience.table(polarity, prominence)
+          |> Enum.group_by(fn {_role, slot} -> slot end, fn {role, _} ->
+            role
+          end)
+          |> Enum.filter(fn {_slot, roles} ->
+            roles
+            |> Enum.map(&Ansi16Salience.category/1)
+            |> Enum.uniq()
+            |> length() > 1
+          end)
+
+        assert length(colliding) <= @cross_category_collision_budget,
+               "slots hosting multiple hue families on #{polarity}@#{prominence}: " <>
+                 inspect(colliding)
+      end
+    end
+
+    test "category/1 assigns every role a hue family" do
+      families = [:red, :green, :yellow, :blue, :magenta, :neutral]
+
+      for role <- Ansi16Salience.roles() do
+        assert Ansi16Salience.category(role) in families
+      end
+
+      # The in-family folds the design accepts:
+      assert Ansi16Salience.category(:diff_del) ==
+               Ansi16Salience.category(:error)
+
+      assert Ansi16Salience.category(:diff_add) ==
+               Ansi16Salience.category(:success)
+
+      assert Ansi16Salience.category(:chrome) ==
+               Ansi16Salience.category(:foreground)
+    end
+  end
+
+  # ---- why not nearest-RGB: the measured collapse this module prevents --
+
+  describe "naive nearest-RGB collapse (the failure mode this replaces)" do
+    # The harness constants painted outside the seed table:
+    # Block/@chrome_fg and DiffViewer's diff palette bases.
+    @harness_constants %{
+      chrome: "#B4B4B4",
+      diff_add: "#5ECC71",
+      diff_del: "#FF6762"
+    }
+
+    test "nearest-RGB grays out most of the solved palette on dark ground" do
+      # Measured at design time: 8 of 11 fields -> gray on the dark
+      # reference ground (0.2). Asserted with slack (>= 6) so solver
+      # drift doesn't flake the tripwire; if this ever drops below 6 the
+      # naive path got dramatically better and the pin deserves a re-look.
+      grays = naive_gray_count(0.2)
+
+      assert grays >= 6,
+             "naive 16-color quantization grays out #{grays}/11 fields " <>
+               "on dark ground; expected the collapse this module fixes"
+    end
+
+    test "nearest-RGB grays out the light-ground palette too" do
+      # Measured at design time: 6 of 11 fields -> gray on light ground
+      # (0.97), including error and success themselves.
+      grays = naive_gray_count(0.97)
+      assert grays >= 5
+    end
+
+    test "nearest-RGB commits a category lie on the solved error color" do
+      # Measured at design time: solved error on dark ground (#bd413f)
+      # nearest-RGB-quantizes to ANSI 3 (yellow) -- not any red slot.
+      palette = Salience.solve_palette(SalienceTheme.seeds(), ground: 0.2)
+      naive_slot = naive_slot(palette.error)
+
+      refute naive_slot in [1, 9],
+             "solved error now quantizes to a red slot (#{naive_slot}) -- " <>
+               "re-evaluate whether the pinned table is still needed"
+
+      # The pinned path never lies:
+      assert Ansi16Salience.slot(:error, :dark, @full) in [1, 9]
+    end
+
+    defp naive_gray_count(ground) do
+      solved =
+        Salience.solve_palette(SalienceTheme.seeds(), ground: ground)
+
+      (Map.to_list(solved) ++ Map.to_list(@harness_constants))
+      |> Enum.map(fn {_name, hex} -> naive_slot(hex) end)
+      |> Enum.count(&(&1 in @gray_slots))
+    end
+
+    defp naive_slot(hex) do
+      hex
+      |> hex_to_rgb_tuple()
+      |> Colors.find_closest_basic_color()
+    end
+
+    defp hex_to_rgb_tuple("#" <> <<r::binary-2, g::binary-2, b::binary-2>>) do
+      {String.to_integer(r, 16), String.to_integer(g, 16),
+       String.to_integer(b, 16)}
+    end
+  end
+end

--- a/test/raxol/ui/theming/ansi16_salience_test.exs
+++ b/test/raxol/ui/theming/ansi16_salience_test.exs
@@ -15,15 +15,23 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
   PINNED to a hue-preserving ANSI slot, polarity-aware, and nearest-RGB is
   never consulted for semantic colors.
 
-  ## The audit tripwire
+  ## The audit tripwires
 
-  The named budgets (`@chromatic_gray_budget`, `@cross_category_collision_budget`)
-  are the regression tripwire the reference design teaches: enumerate every
-  semantic field the harness paints, and assert the count that collapses to
-  the same ANSI slot (especially gray) stays under an explicit budget.
+  Three named budgets/floors are the regression tripwire:
+
+    * `@chromatic_gray_budget` / `@cross_category_collision_budget` --
+      enumerate every semantic field the harness paints and cap slot
+      collapse (especially onto gray).
+    * `@legibility_floor` -- every role x tier x polarity must meet a
+      WCAG-style 3:1 contrast ratio against its polarity's canonical
+      ground, measured on the module's own reference palette
+      (`Colors.ansi_to_rgb/1`). The exceptions are the EXACT named set in
+      `@floor_exemptions`, each pinned to its documented best-effort slot
+      so the exemption list cannot silently grow or drift.
   """
   use ExUnit.Case, async: true
 
+  alias Raxol.UI.Harness.Prominence
   alias Raxol.UI.Theming.Ansi16Salience
   alias Raxol.UI.Theming.Colors
   alias Raxol.UI.Theming.Salience
@@ -37,6 +45,11 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
   # instrument requires (same pair the 256-color pin guards).
   @full 1.0
   @receded 0.6
+
+  # Canonical grounds per polarity: the solver's dark reference ground and
+  # the near-white light ground the prominence tests already use.
+  @dark_ground Salience.reference_ground()
+  @light_ground 0.97
 
   # The four achromatic ANSI16 slots: black, silver, dark gray, bright white.
   @gray_slots [0, 7, 8, 15]
@@ -53,49 +66,151 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
   # neutral ramp) are intentional and unbudgeted.
   @cross_category_collision_budget 0
 
+  # WCAG-style contrast floor every slot assignment must meet against its
+  # polarity's canonical ground -- the module's stated purpose ("survive
+  # degradation AND stay legible") enforced as a test, not implied.
+  @legibility_floor 3.0
+
+  # The EXACT set of role x tier x polarity entries allowed under the
+  # floor, each pinned to its documented best-effort slot. Two classes,
+  # both palette-limited (measured on `Colors.ansi_to_rgb/1` against the
+  # canonical light ground #f5f5f5):
+  #
+  #   * Green/yellow state roles on LIGHT: no green or yellow slot in the
+  #     reference palette meets 3:1 on light ground (best available:
+  #     normal green slot 2 = 1.98:1, normal yellow slot 3 = 1.56:1).
+  #     Swapping family (red/magenta) would be a category lie worse than
+  #     low contrast for a state signal, and gray would erase it. Both
+  #     tiers pin to the best-effort normal slot. Real light-mode terminal
+  #     themes darken these slots (e.g. Solarized's #B58900 yellow); the
+  #     pin keeps the category-true handle for them to interpret.
+  #   * Recede chrome (muted/border) on LIGHT: slot 7 (silver, 1.16:1) is
+  #     the palette's only sub-body neutral -- a subtle light-UI border by
+  #     design. Receding below the floor is these roles' function; they
+  #     are likewise exempt from tier separation.
+  #
+  # DARK polarity has NO exemptions: every dark assignment meets 3:1.
+  @floor_exemptions %{
+    {:light, :warning, @full} => 3,
+    {:light, :warning, @receded} => 3,
+    {:light, :success, @full} => 2,
+    {:light, :success, @receded} => 2,
+    {:light, :diff_add, @full} => 2,
+    {:light, :diff_add, @receded} => 2,
+    {:light, :muted, @full} => 7,
+    {:light, :muted, @receded} => 7,
+    {:light, :border, @full} => 7,
+    {:light, :border, @receded} => 7
+  }
+
+  # Roles whose loud and soft tiers intentionally coincide (fold), per
+  # polarity. Dark: only the recede floor. Light: the reference palette
+  # leaves single legible slots for several families (no legible green/
+  # yellow at all; one legible magenta; two legible neutrals), so those
+  # roles trade tier separation for the legibility floor -- the ranked
+  # priority this module documents (legibility > category > tier).
+  @tier_fold_exempt %{
+    dark: [:muted, :border],
+    light: [
+      :muted,
+      :border,
+      :warning,
+      :success,
+      :diff_add,
+      :running,
+      :foreground,
+      :chrome
+    ]
+  }
+
   # ---- the role -> slot table (both polarities, both tiers) -------------
 
   describe "chromatic role -> slot table" do
-    # Base hue slots: red 1, green 2, yellow 3, blue 4, magenta 5.
-    # Dark canvas: loud = bright variant (base + 8), soft = normal (base).
-    # Light canvas: the polarity flip -- loud = normal, soft = bright.
+    # Explicit per-polarity pins. The dark side keeps the bright-loud /
+    # normal-soft intensity flip for every family it works for; accent
+    # moves to the cyan slots because the palette's normal blue (slot 4,
+    # #0000EE) is illegible on the dark ground (1.93:1 -- the classic
+    # blue-on-black problem) and slot 12 alone cannot express two tiers.
+    # The light side keeps the flip only where the bright variant stays
+    # legible on light ground (red, blue); green/yellow/magenta fold to
+    # their single best slot (see @floor_exemptions / @tier_fold_exempt).
     @chromatic_expected %{
-      error: 1,
-      diff_del: 1,
-      success: 2,
-      diff_add: 2,
-      warning: 3,
-      accent: 4,
-      running: 5
+      dark: %{
+        loud: %{
+          error: 9,
+          diff_del: 9,
+          success: 10,
+          diff_add: 10,
+          warning: 11,
+          accent: 14,
+          running: 13
+        },
+        soft: %{
+          error: 1,
+          diff_del: 1,
+          success: 2,
+          diff_add: 2,
+          warning: 3,
+          accent: 6,
+          running: 5
+        }
+      },
+      light: %{
+        loud: %{
+          error: 1,
+          diff_del: 1,
+          success: 2,
+          diff_add: 2,
+          warning: 3,
+          accent: 4,
+          running: 5
+        },
+        soft: %{
+          error: 9,
+          diff_del: 9,
+          success: 2,
+          diff_add: 2,
+          warning: 3,
+          accent: 12,
+          running: 5
+        }
+      }
     }
 
-    test "dark polarity: bright set when loud, normal set when receded" do
-      for {role, base} <- @chromatic_expected do
-        assert Ansi16Salience.slot(role, :dark, @full) == base + 8,
-               "#{role} loud on dark must be bright slot #{base + 8}"
+    test "dark polarity chromatic pins (loud and receded)" do
+      for {role, slot} <- @chromatic_expected.dark.loud do
+        assert Ansi16Salience.slot(role, :dark, @full) == slot,
+               "#{role} loud on dark must be slot #{slot}"
+      end
 
-        assert Ansi16Salience.slot(role, :dark, @receded) == base,
-               "#{role} receded on dark must be normal slot #{base}"
+      for {role, slot} <- @chromatic_expected.dark.soft do
+        assert Ansi16Salience.slot(role, :dark, @receded) == slot,
+               "#{role} receded on dark must be slot #{slot}"
       end
     end
 
-    test "light polarity: normal set when loud, bright set when receded" do
-      for {role, base} <- @chromatic_expected do
-        assert Ansi16Salience.slot(role, :light, @full) == base,
-               "#{role} loud on light must be normal slot #{base}"
+    test "light polarity chromatic pins (loud and receded)" do
+      for {role, slot} <- @chromatic_expected.light.loud do
+        assert Ansi16Salience.slot(role, :light, @full) == slot,
+               "#{role} loud on light must be slot #{slot}"
+      end
 
-        assert Ansi16Salience.slot(role, :light, @receded) == base + 8,
-               "#{role} receded on light must be bright slot #{base + 8}"
+      for {role, slot} <- @chromatic_expected.light.soft do
+        assert Ansi16Salience.slot(role, :light, @receded) == slot,
+               "#{role} receded on light must be slot #{slot}"
       end
     end
   end
 
   describe "neutral role -> slot table" do
-    # The neutral ramp mirrors the chromatic polarity flip. Emphasis is the
-    # anchor tier and takes the max-contrast slot; body foreground sits one
-    # step below it so the anchor can still exceed baseline; muted/border
-    # are the recede tier and sit at the dimmest readable slot (their
-    # floor -- see the tier-separation exemption below).
+    # The neutral ramp: emphasis is the anchor tier and takes the
+    # max-contrast slot; body foreground sits one step below it so the
+    # anchor can still exceed baseline; muted/border are the recede tier.
+    # On light ground the palette has exactly two legible neutrals (black
+    # 19.26:1, dark gray 3.67:1), so the light mid-ramp compresses onto
+    # dark gray: foreground and chrome fold (loud == soft == 8) and the
+    # receded emphasis joins them -- documented distinction loss, traded
+    # for the legibility floor.
     test "dark polarity neutral ramp" do
       assert Ansi16Salience.slot(:emphasis, :dark, @full) == 15
       assert Ansi16Salience.slot(:emphasis, :dark, @receded) == 7
@@ -111,11 +226,22 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
       assert Ansi16Salience.slot(:emphasis, :light, @full) == 0
       assert Ansi16Salience.slot(:emphasis, :light, @receded) == 8
       assert Ansi16Salience.slot(:foreground, :light, @full) == 8
-      assert Ansi16Salience.slot(:foreground, :light, @receded) == 7
+      assert Ansi16Salience.slot(:foreground, :light, @receded) == 8
       assert Ansi16Salience.slot(:chrome, :light, @full) == 8
-      assert Ansi16Salience.slot(:chrome, :light, @receded) == 7
+      assert Ansi16Salience.slot(:chrome, :light, @receded) == 8
       assert Ansi16Salience.slot(:muted, :light, @full) == 7
       assert Ansi16Salience.slot(:border, :light, @full) == 7
+    end
+
+    test "dark receded neutrals merge onto the recede floor (documented)" do
+      # At soft tier on dark, foreground, chrome, muted, and border all
+      # share slot 8 -- receded body text becomes indistinguishable from
+      # recede chrome. Intentional: slot 8 is the only sub-body neutral
+      # that stays legible on the dark ground (4.52:1); the alternative
+      # (silver) would collide with the LOUD body slot instead.
+      for role <- [:foreground, :chrome, :muted, :border] do
+        assert Ansi16Salience.slot(role, :dark, @receded) == 8
+      end
     end
   end
 
@@ -123,7 +249,9 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
     test "roles/0 covers every semantic field the harness paints" do
       # The 8 SalienceTheme seed roles + the harness constants (Block
       # chrome #B4B4B4, DiffViewer add/del bases) + :running (reserved for
-      # activity state, per the reference design's magenta family).
+      # activity state; it has no RGB seed anywhere in the harness yet,
+      # which is why measured naive-collapse counts say "11 fields" while
+      # roles/0 returns 12).
       seed_names = Enum.map(SalienceTheme.seeds(), & &1.name)
 
       for name <- seed_names do
@@ -161,15 +289,28 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
       assert Ansi16Salience.polarity(0.5) == :light
       assert Ansi16Salience.polarity(1.0) == :light
     end
+
+    test "nil ground (detection unavailable) falls back to the reference ground" do
+      # A 16-color path is a fallback; it must not crash when the OSC 11
+      # background probe has no reading. nil lands on the solver's
+      # reference ground polarity (dark). Other non-numbers still raise:
+      # fail-loud on garbage, graceful on the documented unknown.
+      assert Ansi16Salience.polarity(nil) ==
+               Ansi16Salience.polarity(Salience.reference_ground())
+
+      assert_raise FunctionClauseError, fn ->
+        Ansi16Salience.polarity("#161616")
+      end
+    end
   end
 
   # ---- tier separation: the 1.0 vs 0.6 pin ------------------------------
 
   describe "tier separation (1.0 vs 0.6 survive 16-color)" do
-    test "every non-recede role resolves distinct slots at 1.0 vs 0.6" do
+    test "every non-exempt role resolves distinct slots at 1.0 vs 0.6" do
       for polarity <- @polarities,
           role <- Ansi16Salience.roles(),
-          role not in [:muted, :border] do
+          role not in @tier_fold_exempt[polarity] do
         loud = Ansi16Salience.slot(role, polarity, @full)
         soft = Ansi16Salience.slot(role, polarity, @receded)
 
@@ -178,12 +319,14 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
       end
     end
 
-    test "muted and border are the documented recede floor (tiers fold)" do
-      # The recede tier already sits at the dimmest readable slot; ANSI16
-      # has nothing dimmer that stays visible, so the fold is intentional.
-      for polarity <- @polarities, role <- [:muted, :border] do
+    test "exempt roles fold exactly as documented (tiers coincide)" do
+      # The fold list is a pin, not a permission: an exempt role whose
+      # tiers become separable again should be removed from the list.
+      for {polarity, roles} <- @tier_fold_exempt, role <- roles do
         assert Ansi16Salience.slot(role, polarity, @full) ==
-                 Ansi16Salience.slot(role, polarity, @receded)
+                 Ansi16Salience.slot(role, polarity, @receded),
+               "#{role} on #{polarity} is fold-exempt but resolves " <>
+                 "distinct tiers -- drop it from the exemption list"
       end
     end
 
@@ -207,6 +350,78 @@ defmodule Raxol.UI.Theming.Ansi16SalienceTest do
         assert Ansi16Salience.slot(role, polarity, 0.79) ==
                  Ansi16Salience.slot(role, polarity, 0.6)
       end
+    end
+  end
+
+  # ---- THE LEGIBILITY FLOOR: the module's purpose, asserted -------------
+
+  describe "legibility floor (WCAG-style 3:1 against canonical grounds)" do
+    test "every non-exempt role x tier x polarity meets the floor" do
+      for {polarity, ground} <- [dark: @dark_ground, light: @light_ground],
+          prominence <- [@full, @receded],
+          role <- Ansi16Salience.roles(),
+          not Map.has_key?(@floor_exemptions, {polarity, role, prominence}) do
+        slot = Ansi16Salience.slot(role, polarity, prominence)
+        ratio = slot_contrast(slot, ground)
+
+        assert ratio >= @legibility_floor,
+               "#{role}@#{prominence} on #{polarity}: slot #{slot} is " <>
+                 "#{Float.round(ratio, 2)}:1 against ground -- below the " <>
+                 "#{@legibility_floor}:1 floor"
+      end
+    end
+
+    test "exempt entries sit exactly on their documented best-effort slot" do
+      # Exemptions are pins: an exempt entry may not drift to a different
+      # (possibly worse) slot, and if the palette ever gains a compliant
+      # in-family slot the pin should be retired, not silently bypassed.
+      for {{polarity, role, prominence}, pinned_slot} <- @floor_exemptions do
+        assert Ansi16Salience.slot(role, polarity, prominence) ==
+                 pinned_slot,
+               "#{role}@#{prominence} on #{polarity} is floor-exempt but " <>
+                 "moved off its documented slot #{pinned_slot}"
+      end
+    end
+
+    test "soft tier never reads louder than loud tier (fade direction)" do
+      # The receded tier must sit at equal-or-lower contrast than the full
+      # tier -- a soft slot brighter than its loud slot would invert the
+      # salience gradient the instrument exists to show.
+      for {polarity, ground} <- [dark: @dark_ground, light: @light_ground],
+          role <- Ansi16Salience.roles() do
+        loud =
+          slot_contrast(Ansi16Salience.slot(role, polarity, @full), ground)
+
+        soft =
+          slot_contrast(Ansi16Salience.slot(role, polarity, @receded), ground)
+
+        assert soft <= loud,
+               "#{role} on #{polarity}: receded tier (#{Float.round(soft, 2)}) " <>
+                 "reads louder than full tier (#{Float.round(loud, 2)})"
+      end
+    end
+
+    test "dark polarity needs no exemptions" do
+      # Documented invariant: every dark-canvas assignment meets the floor
+      # outright. If a dark exemption ever becomes necessary, that is a
+      # design regression to surface, not a map entry to add.
+      refute Enum.any?(@floor_exemptions, fn {{polarity, _, _}, _} ->
+               polarity == :dark
+             end)
+    end
+
+    defp slot_contrast(slot, ground) do
+      ground_hex = Salience.oklch_to_hex(ground, 0.0, 0.0)
+      Prominence.wcag_ratio(slot_hex(slot), ground_hex)
+    end
+
+    defp slot_hex(slot) do
+      {r, g, b} = Colors.ansi_to_rgb(slot)
+
+      "#" <>
+        Enum.map_join([r, g, b], fn ch ->
+          ch |> Integer.to_string(16) |> String.pad_leading(2, "0")
+        end)
     end
   end
 


### PR DESCRIPTION
On 16-color terminals, nearest-RGB quantization erases exactly the signal the harness exists to show — measured on our own solver output: 8 of 11 semantic fields collapse to gray on a dark ground (6 of 11 on light), and the solved error color quantizes to ANSI 3 — yellow. Error arriving as yellow is the instrument lying.

## What this adds

`Raxol.UI.Theming.Ansi16Salience` — a pure role -> ANSI-slot table for the 12 semantic roles the harness paints (the 8 salience seeds + block chrome + diff add/del + running). Callers gate on terminal capability and ask by ROLE, never by RGB. Additive only: truecolor and 256-color paths untouched, byte-exact theme fixtures untouched.

Design rules:
- Category preserved: error stays red-family, success green, warning yellow, accent blue, running magenta — on both polarities (bright 9-15 loud on dark canvas, normal 1-7 on light; tiers fold pairwise at the 0.8 threshold).
- Emphasis deliberately trades its warm hue for the max-contrast neutral slot so it can never be confused with the warning signal (yellow is reserved for state).
- Muted/border are the documented recede floor — the only roles exempt from the loud/soft tier distinction.

## Regression tripwires (all red-first)

- `@chromatic_gray_budget 0`: no chromatic role may land on a gray slot, both polarities, both tiers.
- `@cross_category_collision_budget 0`: no slot hosts two hue families.
- Measured-collapse pins on the naive path (>=6/11 gray dark, >=5/11 light, error-quantizes-to-yellow) — proving the audit is testing a real failure, not a vacuous claim.

## Verification

Full test file written before implementation: 10/12 red. After: 12/12 green; theming+harness sweep 199 passed, zero regressions; full suite 5814/5816 (both failures pre-existing/environmental, confirmed present with these changes removed). `--warnings-as-errors` + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)