### PR TITLE
Harness UI: shared seal-frontier classifier (one committability decision, every consumer)

### DIFF
--- a/lib/raxol/harness/seal_frontier.ex
+++ b/lib/raxol/harness/seal_frontier.ex
@@ -1,0 +1,433 @@
+defmodule Raxol.Harness.SealFrontier do
+  @moduledoc """
+  The shared classifier for "which blocks may seal (commit) this frame" --
+  the one piece of logic every consumer that needs to answer that question
+  goes through, instead of each restating its own walk.
+
+  ## The committed frontier
+
+  The committed frontier is the leading contiguous run of already-committed
+  entries plus whatever newly-committable entries follow them. Everything
+  past that point -- `tail_start` in `scan/0` and `commit_walk/5`'s return
+  -- stays in the repaintable live region (in our substrate, the
+  `InlineAuthority` footer viewport) until it, in turn, becomes
+  committable. Sealed history is print-once: once a block is written
+  through `InlineAuthority.seal/2`, it is never repainted. Getting the
+  frontier boundary wrong in either direction is user-visible: too eager
+  and a still-mutating block freezes mid-change in permanent scrollback;
+  too conservative and a done block never leaves the footer.
+
+  ## Why one shared classifier
+
+  Three concerns all need to agree on exactly where the frontier stops, or
+  a block's rendered height flips between the live region and native
+  scrollback and the prompt visibly jumps at commit time:
+
+    * the seal pass -- which blocks get physically written into terminal
+      scrollback this frame;
+    * the footer/tail composition -- which blocks still render in the
+      pinned live region (the trailing "pending" preview);
+    * (future, documented seam, not yet built) the resize path's
+      `will_commit` gate and post-commit viewport sizing -- the frame-order
+      unit that must decide sizing at the width a possibly-just-committed
+      block was laid out at.
+
+  Consumers never inline their own walk over entries. The consumer table
+  today:
+
+    * `Raxol.Harness.Surface.paint_pending_blocks/1` -- the one mutating
+      walk, via `commit_walk/5`.
+    * `Raxol.Harness.Surface`'s footer pending-preview (`pending_block/1`,
+      via `frontier_scan/1`, itself `scan_frontier/3`) -- read-only.
+
+  Documented seams (not yet built, but must call `scan_frontier/3` before
+  the commit pass in the frame and mirror its stop condition exactly when
+  they land): the resize-path `will_commit` gate, and post-commit viewport
+  sizing.
+
+  ## The entry contract
+
+  Entries are projection-agnostic plain maps (`t:entry/0`) so this
+  classifier stays decoupled from any one producer's data model. Today
+  `Raxol.Harness.Surface.frontier_entries/1` builds them from projection
+  blocks plus that module's own painted high-water mark. The live tail
+  (still-streaming, not-yet-a-block items) never enters the entry list at
+  all: a still-streaming item has no committable form until it completes
+  into a block, so it is definitionally past the frontier already -- there
+  is nothing for this classifier to say about it.
+
+  ## Decision order and rationale (`committable?/3`)
+
+  The order below is load-bearing -- each step assumes the ones before it
+  already ran:
+
+    1. `pending_input?` true -> not committable, UNCONDITIONALLY, regardless
+       of turn state. An entry awaiting a user answer (e.g. a permission
+       prompt) still has a rendered form that changes when the prompt
+       resolves; committing it now (print-once) would freeze the "waiting"
+       form forever. This check runs BEFORE the idle relaxation below on
+       purpose: idle relaxation exists to forgive a *stale running flag*,
+       never a live pending-input mark, which is exactly why pending input
+       is checked first and unconditionally.
+    2. `not turn_running?` -> committable (the idle relaxation). A producer
+       can leave a `running?` flag set on an entry after the turn has
+       already ended (a finalize event missed at a transition boundary);
+       if idleness didn't override a stale flag, that entry would
+       permanently wedge the frontier for the rest of the session. This
+       relaxation only ever reaches entries that already passed the
+       pending-input check, so it can never release something still
+       awaiting input.
+    3. `not running?` -> committable (the ordinary, no-exceptions case: a
+       finalized entry with nothing outstanding always commits).
+    4. Running, mid-turn: not committable UNLESS one of exactly two
+       exceptions applies:
+         * `kind == :background_task` -- always committable, even as the
+           last entry of a still-running turn. A background-task entry is
+           a lifecycle marker; its `running?` flag drives an animation
+           only, and its *content* never subsequently changes --
+           completion arrives later as a wholly SEPARATE entry. Gating it
+           on the flag would wedge the frontier for the rest of the turn
+           for no reason: nothing about this entry will ever change.
+         * `kind == :message and not is_last?` -- committable. A message
+           with a LATER entry already in the list is provably complete:
+           the producer has moved on, which could only happen once this
+           message stopped changing, regardless of what its own `running?`
+           flag says. Tools get NO such relaxation: a running tool call
+           may still mutate its own result at any time, so it holds the
+           frontier regardless of what comes after it. And the relaxation
+           only applies to a message that is NOT the last entry -- the
+           last entry of a still-running turn always stays live, on the
+           theory that it may still be the one actively streaming.
+
+  Both exceptions are RESERVED/dormant today: `:background_task` is a kind
+  no producer currently emits (there is no background-task lane yet), and
+  today's block builder only ever constructs completed blocks (`running?`
+  always `false`), so the `:message` relaxation never actually fires
+  either. Both are corpus-tested here and load-bearing for the future
+  agent lane, where entries can legitimately carry a stale or genuinely
+  in-progress `running?` flag.
+
+  ## `classify/3`
+
+  `classify(entries, i, turn_running?)` is the public single-step
+  primitive: given the FULL entry list and an absolute index, decide
+  `:commit` / `:skip` / `:stop` for that one index. In order:
+
+    1. Compute `is_last? = i + 1 >= length(entries)` first (needed by the
+       `:message` exception above).
+    2. Out of bounds -> `:stop`.
+    3. Entry already `committed?` -> `:skip`. The per-entry `committed?`
+       flag is authoritative; a caller-held cursor (see below) is only a
+       lower-bound hint, never a source of truth, so a walk that starts
+       before the true frontier must still skip past anything already
+       committed rather than re-emit it.
+    4. Not committable (per `committable?/3`) -> `:stop`. Once one entry in
+       the walk order is not committable, nothing after it can commit this
+       frame either -- the frontier is a contiguous prefix, not a sieve.
+    5. Otherwise -> `:commit`.
+
+  The two multi-entry walks below (`scan_frontier/3`, `commit_walk/5`) are
+  implemented over the suffix list carrying the absolute index along (to
+  avoid `length/1` and `Enum.at/2` costing O(n) per step, which would make
+  a full walk O(n^2)) rather than by literally calling `classify/3` in a
+  loop -- but they are specified to produce results IDENTICAL to repeatedly
+  calling `classify/3`, and that equivalence is covered by the
+  scan/walk-agreement property test.
+
+  ## `scan_frontier/3` -- the read-only projection
+
+  Walks from `opts[:cursor]` (default `0`) applying the `classify/3` step
+  order: `:stop` breaks the walk, `:skip` advances past an already-
+  committed entry, `:commit` records that a commit pass this frame would
+  do work (`will_commit: true`) and advances. Returns `tail_start`, the
+  first index a commit pass would NOT consume -- i.e. where the live tail
+  begins after this frame's (hypothetical or already-run) commit. This
+  function never mutates anything; it exists so a consumer can ask "where
+  would the frontier land" without actually committing (the footer preview
+  needs exactly this, and the resize seam will too).
+
+  ## `commit_walk/5` -- the one mutating walk
+
+  The only place entries actually get marked committed. From
+  `opts[:cursor]` (default `0`): `:stop` breaks, `:skip` advances past an
+  already-committed entry, and `:commit` invokes `emit_fn.(acc, index)`
+  FIRST -- the entry is only marked `committed?: true` (and the count/
+  cursor/acc advanced) on `{:ok, new_acc}`. Emit-before-mark is the
+  print-once safety property: a write -> confirm -> mark order means a
+  block can never be marked committed without having actually been
+  written. On `{:error, :write_failed, new_acc}` the walk HALTS entirely --
+  the entry stays uncommitted, and the returned cursor is strictly BEFORE
+  it, so the very next pass retries that same entry rather than silently
+  skipping past a block that was marked but never actually printed (which
+  would make it vanish forever, since a print-once surface cannot re-emit
+  a committed entry). This emit-then-mark contract is the seam a future
+  two-phase seal (a write-confirming substrate) will build on; today's
+  Surface emit (`InlineAuthority.seal/2`) has no error path, so the
+  `{:error, :write_failed, _}` branch is exercised only by this module's
+  own corpus until such a substrate lands.
+
+  ## The cursor
+
+  A caller-held index into the entry list -- a lower-bound OPTIMIZATION
+  hint only, never authoritative (the per-entry `committed?` flags are
+  the source of truth; see `classify/3` step 3 above). A cursor lets a
+  caller skip re-scanning a long already-committed prefix every frame
+  without needing per-entry flags to do it safely (a stale/too-low cursor
+  is always safe -- it just costs a few extra `:skip` steps -- while a
+  stale/too-HIGH cursor would be a correctness bug were the flags not
+  authoritative underneath it).
+
+  A caller that persists a cursor across list mutations (removal,
+  truncation) must adjust it explicitly, since indices shift:
+
+    * `cursor_after_removal/2` -- decrements the cursor by one when the
+      removed index was strictly below it (an entry above/at the cursor
+      shifting the cursor's own target down by one), otherwise leaves it
+      unchanged. Never goes below zero.
+    * `cursor_after_truncate/2` -- clamps the cursor to the new (shorter)
+      length, so a cursor that pointed past the end of a just-truncated
+      list doesn't strand references to entries that no longer exist.
+
+  ## `seal_display_mode/1`
+
+  The print-once per-kind fidelity policy lives here, in one place,
+  because committed scrollback cannot be re-folded after the fact (it is
+  static terminal text once written): `:reasoning` collapses to its
+  marker (reasoning traces are the least useful thing to keep expanded
+  forever in scrollback), `:tool_call` truncates (tool output can be
+  arbitrarily long; a truncated summary is what belongs in permanent
+  history), and `:diff` stays expanded always (a diff is the key artifact
+  of an edit -- there is no useful truncated form of it). Everything else
+  -- `:message`, `:approval`, `:opaque`, and any unrecognized kind --
+  defaults to `:expanded`: the safe default for a kind this policy has no
+  specific opinion about is to show it in full, not to guess at a
+  collapse/truncate rule that might hide something that mattered.
+  """
+
+  @type entry :: %{
+          optional(:kind) => term(),
+          optional(:committed?) => boolean(),
+          optional(:running?) => boolean(),
+          optional(:pending_input?) => boolean()
+        }
+
+  @type scan :: %{tail_start: non_neg_integer(), will_commit: boolean()}
+  @type step :: :commit | :skip | :stop
+  @type emit_fn :: (acc :: term(), index :: non_neg_integer() ->
+                      {:ok, term()} | {:error, :write_failed, term()})
+
+  # -- committability ---------------------------------------------------------
+
+  @doc """
+  Whether a single entry may commit (seal) right now. See the moduledoc's
+  "Decision order and rationale" section -- the order below is load-bearing.
+  """
+  @spec committable?(entry(), boolean(), boolean()) :: boolean()
+  def committable?(entry, turn_running?, is_last?) do
+    pending_input? = Map.get(entry, :pending_input?, false)
+    running? = Map.get(entry, :running?, false)
+    kind = Map.get(entry, :kind, nil)
+
+    cond do
+      pending_input? -> false
+      not turn_running? -> true
+      not running? -> true
+      kind == :background_task -> true
+      kind == :message and not is_last? -> true
+      true -> false
+    end
+  end
+
+  # -- single-step classification ---------------------------------------------
+
+  @doc """
+  Classifies the entry at absolute index `i` in `entries`: `:commit`,
+  `:skip` (already committed), or `:stop` (out of bounds, or this entry --
+  and therefore everything after it this frame -- is not committable). See
+  the moduledoc's "`classify/3`" section for the full step order.
+  """
+  @spec classify([entry()], non_neg_integer(), boolean()) :: step()
+  def classify(entries, i, turn_running?) do
+    total = length(entries)
+    is_last? = i + 1 >= total
+
+    case Enum.at(entries, i) do
+      nil ->
+        :stop
+
+      entry ->
+        cond do
+          Map.get(entry, :committed?, false) -> :skip
+          not committable?(entry, turn_running?, is_last?) -> :stop
+          true -> :commit
+        end
+    end
+  end
+
+  # -- read-only projection ----------------------------------------------------
+
+  @doc """
+  Read-only projection of where the frontier stands: walks from
+  `opts[:cursor]` (default `0`) and returns `tail_start` (the first index a
+  commit pass would not consume) and `will_commit` (whether that pass would
+  do anything at all). Never mutates `entries`. See the moduledoc.
+  """
+  @spec scan_frontier([entry()], boolean(), keyword()) :: scan()
+  def scan_frontier(entries, turn_running?, opts \\ []) do
+    cursor = Keyword.get(opts, :cursor, 0)
+    total = length(entries)
+
+    {tail_start, will_commit} =
+      scan_walk(entries, total, cursor, turn_running?, false)
+
+    %{tail_start: tail_start, will_commit: will_commit}
+  end
+
+  defp scan_walk(_entries, total, index, _turn_running?, will_commit)
+       when index >= total,
+       do: {index, will_commit}
+
+  defp scan_walk(entries, total, index, turn_running?, will_commit) do
+    is_last? = index + 1 >= total
+    entry = Enum.at(entries, index)
+
+    cond do
+      Map.get(entry, :committed?, false) ->
+        scan_walk(entries, total, index + 1, turn_running?, will_commit)
+
+      not committable?(entry, turn_running?, is_last?) ->
+        {index, will_commit}
+
+      true ->
+        scan_walk(entries, total, index + 1, turn_running?, true)
+    end
+  end
+
+  # -- the one mutating walk ----------------------------------------------------
+
+  @doc """
+  The one mutating walk: from `opts[:cursor]` (default `0`), commits every
+  entry it can via `emit_fn`, marking each `committed?: true` only after a
+  successful emit. See the moduledoc's "`commit_walk/5`" section for the
+  full emit-then-mark and failure-halt contract.
+  """
+  @spec commit_walk([entry()], boolean(), acc, emit_fn(), keyword()) ::
+          %{
+            entries: [entry()],
+            cursor: non_neg_integer(),
+            committed: non_neg_integer(),
+            acc: acc
+          }
+        when acc: term()
+  def commit_walk(entries, turn_running?, acc, emit_fn, opts \\ []) do
+    cursor = Keyword.get(opts, :cursor, 0)
+    total = length(entries)
+
+    commit_step(entries, total, cursor, turn_running?, acc, emit_fn, 0)
+  end
+
+  defp commit_step(
+         entries,
+         total,
+         index,
+         _turn_running?,
+         acc,
+         _emit_fn,
+         committed
+       )
+       when index >= total do
+    %{entries: entries, cursor: index, committed: committed, acc: acc}
+  end
+
+  defp commit_step(
+         entries,
+         total,
+         index,
+         turn_running?,
+         acc,
+         emit_fn,
+         committed
+       ) do
+    is_last? = index + 1 >= total
+    entry = Enum.at(entries, index)
+
+    cond do
+      Map.get(entry, :committed?, false) ->
+        commit_step(
+          entries,
+          total,
+          index + 1,
+          turn_running?,
+          acc,
+          emit_fn,
+          committed
+        )
+
+      not committable?(entry, turn_running?, is_last?) ->
+        %{entries: entries, cursor: index, committed: committed, acc: acc}
+
+      true ->
+        case emit_fn.(acc, index) do
+          {:ok, new_acc} ->
+            updated_entries =
+              List.update_at(entries, index, &Map.put(&1, :committed?, true))
+
+            commit_step(
+              updated_entries,
+              total,
+              index + 1,
+              turn_running?,
+              new_acc,
+              emit_fn,
+              committed + 1
+            )
+
+          {:error, :write_failed, new_acc} ->
+            %{
+              entries: entries,
+              cursor: index,
+              committed: committed,
+              acc: new_acc
+            }
+        end
+    end
+  end
+
+  # -- cursor maintenance -------------------------------------------------------
+
+  @doc """
+  Adjusts a persisted cursor after removing the entry at `removed_index`:
+  decrements by one when the removal happened strictly below the cursor
+  (shifting the cursor's own target down by one), otherwise leaves it
+  unchanged. Never returns below zero.
+  """
+  @spec cursor_after_removal(non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  def cursor_after_removal(cursor, removed_index) when removed_index < cursor,
+    do: max(cursor - 1, 0)
+
+  def cursor_after_removal(cursor, _removed_index), do: cursor
+
+  @doc """
+  Adjusts a persisted cursor after the entry list is truncated to
+  `new_length`: clamps the cursor so it never points past the end of the
+  (now shorter) list.
+  """
+  @spec cursor_after_truncate(non_neg_integer(), non_neg_integer()) ::
+          non_neg_integer()
+  def cursor_after_truncate(cursor, new_length), do: min(cursor, new_length)
+
+  # -- seal display policy ------------------------------------------------------
+
+  @doc """
+  The print-once per-kind fidelity policy: `:reasoning` collapses,
+  `:tool_call` truncates, `:diff` always stays fully expanded, everything
+  else defaults to `:expanded`. See the moduledoc's "`seal_display_mode/1`"
+  section.
+  """
+  @spec seal_display_mode(term()) :: :expanded | :collapsed | :truncated
+  def seal_display_mode(:reasoning), do: :collapsed
+  def seal_display_mode(:tool_call), do: :truncated
+  def seal_display_mode(:diff), do: :expanded
+  def seal_display_mode(_other), do: :expanded
+end

--- a/lib/raxol/harness/seal_frontier.ex
+++ b/lib/raxol/harness/seal_frontier.ex
@@ -62,13 +62,20 @@ defmodule Raxol.Harness.SealFrontier do
   already ran:
 
     1. `pending_input?` true -> not committable, UNCONDITIONALLY, regardless
-       of turn state. An entry awaiting a user answer (e.g. a permission
-       prompt) still has a rendered form that changes when the prompt
-       resolves; committing it now (print-once) would freeze the "waiting"
-       form forever. This check runs BEFORE the idle relaxation below on
-       purpose: idle relaxation exists to forgive a *stale running flag*,
-       never a live pending-input mark, which is exactly why pending input
-       is checked first and unconditionally.
+       of turn state. The invariant behind the flag: the entry's rendered
+       form can still change in response to user interaction, so committing
+       it now (print-once) would freeze a form the user is about to change.
+       The sole producer today (`Raxol.Harness.Surface.frontier_entries/1`)
+       feeds it from BOTH known instances of that invariant: a live
+       `:approval` block still waiting on the user's answer (the
+       permission-prompt case -- per `Raxol.UI.Components.Harness.Block`'s
+       own contract, "a live approval block is, by definition, waiting on
+       the user"; dormant until a producer emits live blocks), and the
+       surface's one-advance foldable window on the newest block (a fold
+       toggle is the pending interaction). This check runs BEFORE the idle
+       relaxation below on purpose: idle relaxation exists to forgive a
+       *stale running flag*, never a live pending-input mark, which is
+       exactly why pending input is checked first and unconditionally.
     2. `not turn_running?` -> committable (the idle relaxation). A producer
        can leave a `running?` flag set on an entry after the turn has
        already ended (a finalize event missed at a transition boundary);
@@ -131,8 +138,11 @@ defmodule Raxol.Harness.SealFrontier do
   avoid `length/1` and `Enum.at/2` costing O(n) per step, which would make
   a full walk O(n^2)) rather than by literally calling `classify/3` in a
   loop -- but they are specified to produce results IDENTICAL to repeatedly
-  calling `classify/3`, and that equivalence is covered by the
-  scan/walk-agreement property test.
+  calling `classify/3`, and that equivalence is covered directly by the
+  classify-agreement property test (a reference walk built from repeated
+  `classify/3` calls, compared against both walks for arbitrary generated
+  states), alongside the scan/walk-agreement property tying the two walks
+  to each other.
 
   ## `scan_frontier/3` -- the read-only projection
 
@@ -190,18 +200,29 @@ defmodule Raxol.Harness.SealFrontier do
 
   ## `seal_display_mode/1`
 
-  The print-once per-kind fidelity policy lives here, in one place,
-  because committed scrollback cannot be re-folded after the fact (it is
-  static terminal text once written): `:reasoning` collapses to its
-  marker (reasoning traces are the least useful thing to keep expanded
-  forever in scrollback), `:tool_call` truncates (tool output can be
-  arbitrarily long; a truncated summary is what belongs in permanent
-  history), and `:diff` stays expanded always (a diff is the key artifact
-  of an edit -- there is no useful truncated form of it). Everything else
-  -- `:message`, `:approval`, `:opaque`, and any unrecognized kind --
+  The print-once per-kind fidelity policy TABLE, declared here so the
+  consumer that eventually applies it reads it from one place instead of
+  restating it. Committed scrollback cannot be re-folded after the fact
+  (it is static terminal text once written), hence per-kind fidelity is
+  a seal-time decision: `:reasoning` collapses to its marker (reasoning
+  traces are the least useful thing to keep expanded forever in
+  scrollback), `:tool_call` truncates (tool output can be arbitrarily
+  long; a truncated summary is what belongs in permanent history), and
+  `:diff` stays expanded always (a diff is the key artifact of an edit --
+  there is no useful truncated form of it). Everything else --
+  `:message`, `:approval`, `:opaque`, and any unrecognized kind --
   defaults to `:expanded`: the safe default for a kind this policy has no
   specific opinion about is to show it in full, not to guess at a
   collapse/truncate rule that might hide something that mattered.
+
+  NOT YET WIRED: no live seal path consults this policy today.
+  `Raxol.Harness.Surface`'s `seal_block/2` seals a block at its current
+  fold state, and the truncated tool-output rendering this table calls
+  for does not exist yet -- both are renderer-level work owned by the
+  commit-cap / frame-order follow-up, which consumes this table rather
+  than inventing its own. Until that lands, sealed tool output is NOT
+  bounded on its way into permanent scrollback; the table is the declared
+  policy (corpus-tested for the values), not an enforced one.
   """
 
   @type entry :: %{
@@ -221,8 +242,19 @@ defmodule Raxol.Harness.SealFrontier do
   @doc """
   Whether a single entry may commit (seal) right now. See the moduledoc's
   "Decision order and rationale" section -- the order below is load-bearing.
+
+  The two boolean arguments are positional and adjacent -- transposing them
+  silently miscomputes the frontier, so the @spec names them and every
+  caller in this codebase passes them via identically-named variables
+  (`turn_running?`, then the is-last flag). Keyword-izing them was
+  considered and declined: this signature is pinned by the ported
+  reference design, and the walks are the only intended callers.
   """
-  @spec committable?(entry(), boolean(), boolean()) :: boolean()
+  @spec committable?(
+          entry :: entry(),
+          turn_running? :: boolean(),
+          is_last? :: boolean()
+        ) :: boolean()
   def committable?(entry, turn_running?, is_last?) do
     pending_input? = Map.get(entry, :pending_input?, false)
     running? = Map.get(entry, :running?, false)
@@ -246,19 +278,23 @@ defmodule Raxol.Harness.SealFrontier do
   and therefore everything after it this frame -- is not committable). See
   the moduledoc's "`classify/3`" section for the full step order.
   """
-  @spec classify([entry()], non_neg_integer(), boolean()) :: step()
+  @spec classify(
+          entries :: [entry()],
+          i :: non_neg_integer(),
+          turn_running? :: boolean()
+        ) :: step()
   def classify(entries, i, turn_running?) do
-    total = length(entries)
-    is_last? = i + 1 >= total
-
-    case Enum.at(entries, i) do
-      nil ->
+    # One O(i) traversal: the head of the dropped suffix is the entry, and
+    # an empty rest IS the is-last check -- no length/1 + Enum.at/2 double
+    # pass over the whole list.
+    case Enum.drop(entries, i) do
+      [] ->
         :stop
 
-      entry ->
+      [entry | rest] ->
         cond do
           Map.get(entry, :committed?, false) -> :skip
-          not committable?(entry, turn_running?, is_last?) -> :stop
+          not committable?(entry, turn_running?, rest == []) -> :stop
           true -> :commit
         end
     end
@@ -272,34 +308,35 @@ defmodule Raxol.Harness.SealFrontier do
   commit pass would not consume) and `will_commit` (whether that pass would
   do anything at all). Never mutates `entries`. See the moduledoc.
   """
-  @spec scan_frontier([entry()], boolean(), keyword()) :: scan()
+  @spec scan_frontier(
+          entries :: [entry()],
+          turn_running? :: boolean(),
+          opts :: keyword()
+        ) :: scan()
   def scan_frontier(entries, turn_running?, opts \\ []) do
     cursor = Keyword.get(opts, :cursor, 0)
-    total = length(entries)
 
-    {tail_start, will_commit} =
-      scan_walk(entries, total, cursor, turn_running?, false)
-
-    %{tail_start: tail_start, will_commit: will_commit}
+    entries
+    |> Enum.drop(cursor)
+    |> scan_walk(cursor, turn_running?, false)
   end
 
-  defp scan_walk(_entries, total, index, _turn_running?, will_commit)
-       when index >= total,
-       do: {index, will_commit}
+  # Suffix walk: pattern-match `[entry | rest]` carrying the absolute
+  # index as a counter -- `rest == []` is the is-last check -- so the
+  # whole scan is O(n), never O(n) `Enum.at/2` per step.
+  defp scan_walk([], index, _turn_running?, will_commit),
+    do: %{tail_start: index, will_commit: will_commit}
 
-  defp scan_walk(entries, total, index, turn_running?, will_commit) do
-    is_last? = index + 1 >= total
-    entry = Enum.at(entries, index)
-
+  defp scan_walk([entry | rest], index, turn_running?, will_commit) do
     cond do
       Map.get(entry, :committed?, false) ->
-        scan_walk(entries, total, index + 1, turn_running?, will_commit)
+        scan_walk(rest, index + 1, turn_running?, will_commit)
 
-      not committable?(entry, turn_running?, is_last?) ->
-        {index, will_commit}
+      not committable?(entry, turn_running?, rest == []) ->
+        %{tail_start: index, will_commit: will_commit}
 
       true ->
-        scan_walk(entries, total, index + 1, turn_running?, true)
+        scan_walk(rest, index + 1, turn_running?, true)
     end
   end
 
@@ -311,7 +348,13 @@ defmodule Raxol.Harness.SealFrontier do
   successful emit. See the moduledoc's "`commit_walk/5`" section for the
   full emit-then-mark and failure-halt contract.
   """
-  @spec commit_walk([entry()], boolean(), acc, emit_fn(), keyword()) ::
+  @spec commit_walk(
+          entries :: [entry()],
+          turn_running? :: boolean(),
+          acc,
+          emit_fn(),
+          opts :: keyword()
+        ) ::
           %{
             entries: [entry()],
             cursor: non_neg_integer(),
@@ -321,76 +364,88 @@ defmodule Raxol.Harness.SealFrontier do
         when acc: term()
   def commit_walk(entries, turn_running?, acc, emit_fn, opts \\ []) do
     cursor = Keyword.get(opts, :cursor, 0)
-    total = length(entries)
+    {prefix, suffix} = Enum.split(entries, cursor)
 
-    commit_step(entries, total, cursor, turn_running?, acc, emit_fn, 0)
+    commit_step(
+      suffix,
+      Enum.reverse(prefix),
+      cursor,
+      turn_running?,
+      acc,
+      emit_fn,
+      0
+    )
+  end
+
+  # Suffix walk, same shape as scan_walk/4: `rev_walked` accumulates the
+  # already-walked entries in reverse (marking a just-emitted entry
+  # committed is an O(1) prepend, never an O(n) List.update_at/3), and the
+  # final entry list is one reverse-onto of the untouched remainder -- the
+  # whole walk is O(n).
+  defp commit_step([], rev_walked, index, _turn_running?, acc, _emit, count) do
+    %{
+      entries: Enum.reverse(rev_walked),
+      cursor: index,
+      committed: count,
+      acc: acc
+    }
   end
 
   defp commit_step(
-         entries,
-         total,
-         index,
-         _turn_running?,
-         acc,
-         _emit_fn,
-         committed
-       )
-       when index >= total do
-    %{entries: entries, cursor: index, committed: committed, acc: acc}
-  end
-
-  defp commit_step(
-         entries,
-         total,
+         [entry | rest],
+         rev_walked,
          index,
          turn_running?,
          acc,
          emit_fn,
-         committed
+         count
        ) do
-    is_last? = index + 1 >= total
-    entry = Enum.at(entries, index)
-
     cond do
       Map.get(entry, :committed?, false) ->
         commit_step(
-          entries,
-          total,
+          rest,
+          [entry | rev_walked],
           index + 1,
           turn_running?,
           acc,
           emit_fn,
-          committed
+          count
         )
 
-      not committable?(entry, turn_running?, is_last?) ->
-        %{entries: entries, cursor: index, committed: committed, acc: acc}
+      not committable?(entry, turn_running?, rest == []) ->
+        halt_walk(rev_walked, [entry | rest], index, count, acc)
 
       true ->
         case emit_fn.(acc, index) do
           {:ok, new_acc} ->
-            updated_entries =
-              List.update_at(entries, index, &Map.put(&1, :committed?, true))
+            sealed = Map.put(entry, :committed?, true)
 
             commit_step(
-              updated_entries,
-              total,
+              rest,
+              [sealed | rev_walked],
               index + 1,
               turn_running?,
               new_acc,
               emit_fn,
-              committed + 1
+              count + 1
             )
 
           {:error, :write_failed, new_acc} ->
-            %{
-              entries: entries,
-              cursor: index,
-              committed: committed,
-              acc: new_acc
-            }
+            halt_walk(rev_walked, [entry | rest], index, count, new_acc)
         end
     end
+  end
+
+  # The walk stopped at `remaining`'s head (a blocker, or a failed emit):
+  # rebuild the full entry list with the stopping entry left untouched and
+  # the cursor strictly before it.
+  defp halt_walk(rev_walked, remaining, index, count, acc) do
+    %{
+      entries: Enum.reverse(rev_walked, remaining),
+      cursor: index,
+      committed: count,
+      acc: acc
+    }
   end
 
   # -- cursor maintenance -------------------------------------------------------

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -215,6 +215,15 @@ defmodule Raxol.Harness.Surface do
 
   ## Fold/jump and the seal-time-only gate -- a translation, not a reuse
 
+  The "which blocks may seal" decision itself now lives in
+  `Raxol.Harness.SealFrontier` (a shared classifier, not restated per
+  consumer). `frontier_entries/1` expresses the foldable window described
+  below as the frontier's `pending_input?` hold on the newest block, and
+  both the seal pass (`paint_pending_blocks/1`) and the footer's pending
+  preview (`pending_block/1`) consult `frontier_scan/1` -- the same
+  entries, the same classifier -- so they can never disagree on where the
+  frontier stops.
+
   `Raxol.UI.Components.Harness.Block.seal` is an item-LIFECYCLE field:
   `BlockBuilder` only ever constructs a block once its source item(s)
   complete, always with `seal: :sealed` (see `BlockBuilder.build_block/2`).
@@ -368,6 +377,7 @@ defmodule Raxol.Harness.Surface do
 
   alias Raxol.Harness.Fixture.Session
   alias Raxol.Harness.Projection
+  alias Raxol.Harness.SealFrontier
   alias Raxol.Terminal.ScrollRegionManager
   alias Raxol.Harness.StatusStrip
   alias Raxol.Harness.Surface.ViewText
@@ -648,15 +658,82 @@ defmodule Raxol.Harness.Surface do
     |> paint_footer()
   end
 
+  @doc """
+  Builds the seal-frontier entry list (`Raxol.Harness.SealFrontier.entry/0`)
+  from the current projection. One entry per completed block, in order;
+  the live tail never enters the list (a still-streaming item has no
+  committable form until it completes into a block, so it is
+  definitionally past the frontier).
+
+  Field mapping (the design decision this assembly makes):
+
+    * `committed?` -- `index < painted_count`: physical paint is this
+      module's commit marker, and it only ever advances a contiguous
+      prefix, so the high-water mark IS the committed set.
+    * `running?` -- `Block.live?/1`, an honest passthrough. Always false
+      today (the block builder only constructs completed, sealed blocks),
+      which leaves the classifier's mid-turn running exceptions dormant
+      until a producer emits still-running entries.
+    * `pending_input?` -- true for the NEWEST block while the fixture
+      reveal is unfinished: this is the one-advance foldable window (see
+      the moduledoc's "Fold/jump and the seal-time-only gate"), expressed
+      in frontier terms. The window block's rendered form may still change
+      on user interaction (a fold toggle), which is exactly the print-once
+      hazard the frontier's pending-input gate exists for -- committing it
+      would freeze a form the user may still flip. The hold is
+      unconditional on turn state (matching the window's own semantics:
+      it releases on reveal completion, not on turn boundaries). When the
+      block builder later grows a completed-but-unsealed phase, this
+      derivation moves down a layer.
+  """
+  @spec frontier_entries(t()) :: [SealFrontier.entry()]
+  def frontier_entries(model) do
+    blocks = model.projection.blocks
+    total = length(blocks)
+    reveal_finished? = model.revealed >= length(model.events)
+
+    blocks
+    |> Enum.with_index()
+    |> Enum.map(fn {block, index} ->
+      %{
+        kind: block.kind,
+        committed?: index < model.painted_count,
+        running?: Block.live?(block),
+        pending_input?: not reveal_finished? and index == total - 1
+      }
+    end)
+  end
+
+  @doc """
+  The shared frontier consultation every consumer in this module goes
+  through: `SealFrontier.scan_frontier/3` over `frontier_entries/1`.
+  `tail_start` is both the seal pass's paint target and the first block
+  the footer's pending preview may show -- one number, so the two can
+  never disagree. `turn_running?` is derived from the status snapshot
+  (`turn_completed`); with today's entry mapping (no running entries,
+  window hold unconditional) the scan result is independent of turn
+  state, so the one-step-stale status at seal time is harmless.
+  """
+  @spec frontier_scan(t()) :: SealFrontier.scan()
+  def frontier_scan(model) do
+    SealFrontier.scan_frontier(frontier_entries(model), turn_running?(model))
+  end
+
+  defp turn_running?(model),
+    do: not Map.get(model.status, :turn_completed, false)
+
   # Leaves the newest completed block un-painted for exactly one more
   # `advance/2` call (see moduledoc, "Fold/jump and the seal-time-only gate") --
   # UNLESS the fixture has finished revealing, in which case every
   # remaining block is flushed (nothing will ever arrive to make the last
-  # block "not newest" otherwise, and it would never get painted).
+  # block "not newest" otherwise, and it would never get painted). The
+  # hold now lives in `frontier_entries/1`'s pending-input mapping;
+  # `SealFrontier`'s shared classifier decides where the frontier stops
+  # from there.
   defp paint_pending_blocks(model) do
-    total = length(model.projection.blocks)
-    finished? = model.revealed >= length(model.events)
-    target = if finished?, do: total, else: max(total - 1, 0)
+    entries = frontier_entries(model)
+    turn_running? = turn_running?(model)
+    scan = SealFrontier.scan_frontier(entries, turn_running?)
 
     # `model.projection` was just rebuilt FRESH by `Projection.project/2`
     # (`advance/2`, the caller) -- EVERY block, including ones already
@@ -673,18 +750,31 @@ defmodule Raxol.Harness.Surface do
     # `advance/2` silently hand back an un-detached reference for every
     # block this module already committed to never holding once sealed
     # (see the moduledoc's "sub-binary pinning footgun" section).
-    model = detach_up_to(model, target)
+    model = detach_up_to(model, scan.tail_start)
 
-    count = max(target - model.painted_count, 0)
+    # The ONE mutating frontier walk (SealFrontier's moduledoc): emit
+    # each newly-committable block via seal_block/2, which advances
+    # painted_count -- the committed marker frontier_entries/1 reads.
+    # The emit is infallible today (InlineAuthority.seal/2 has no error
+    # path), so the walk's write-failure branch stays corpus-only until
+    # a write-confirming substrate lands (the two-phase seal follow-up).
+    result =
+      SealFrontier.commit_walk(
+        entries,
+        turn_running?,
+        model,
+        fn acc, index ->
+          block =
+            acc.projection.blocks
+            |> Enum.at(index)
+            |> apply_fold_override(index, acc.fold_overrides)
 
-    to_paint =
-      model.projection.blocks
-      |> Enum.slice(model.painted_count, count)
-      |> Enum.with_index(model.painted_count)
+          {:ok, seal_block(acc, block)}
+        end,
+        cursor: model.painted_count
+      )
 
-    Enum.reduce(to_paint, model, fn {block, index}, acc ->
-      seal_block(acc, apply_fold_override(block, index, acc.fold_overrides))
-    end)
+    result.acc
   end
 
   # Detaches (see `detach_content/1`) every block at index `< target` and
@@ -1187,9 +1277,15 @@ defmodule Raxol.Harness.Surface do
   end
 
   defp pending_block(model) do
-    case Enum.slice(model.projection.blocks, model.painted_count..-1//1) do
+    # Post-seal, `tail_start == painted_count` always -- the committed
+    # prefix skips to the high-water mark and the walk already consumed
+    # everything committable -- so this is the same block as before, now
+    # DERIVED from the shared classifier instead of restated.
+    tail_start = frontier_scan(model).tail_start
+
+    case Enum.slice(model.projection.blocks, tail_start..-1//1) do
       [] -> nil
-      [block | _rest] -> {block, model.painted_count}
+      [block | _rest] -> {block, tail_start}
     end
   end
 

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -674,17 +674,28 @@ defmodule Raxol.Harness.Surface do
       today (the block builder only constructs completed, sealed blocks),
       which leaves the classifier's mid-turn running exceptions dormant
       until a producer emits still-running entries.
-    * `pending_input?` -- true for the NEWEST block while the fixture
-      reveal is unfinished: this is the one-advance foldable window (see
-      the moduledoc's "Fold/jump and the seal-time-only gate"), expressed
-      in frontier terms. The window block's rendered form may still change
-      on user interaction (a fold toggle), which is exactly the print-once
-      hazard the frontier's pending-input gate exists for -- committing it
-      would freeze a form the user may still flip. The hold is
-      unconditional on turn state (matching the window's own semantics:
-      it releases on reveal completion, not on turn boundaries). When the
-      block builder later grows a completed-but-unsealed phase, this
-      derivation moves down a layer.
+    * `pending_input?` -- the frontier gate's invariant is "the rendered
+      form can still change on user interaction; print-once must not
+      freeze it," and this feed derives BOTH instances of it:
+
+        1. A LIVE `:approval` block (`Block.live?/1` with
+           `kind: :approval`) is, per `Block`'s own contract, a question
+           still waiting on the user -- the genuine awaiting-input
+           lifecycle, held in EVERY turn state and at any position (the
+           gate exists precisely so the idle relaxation can never seal an
+           unanswered prompt past a stale running flag). Dormant today --
+           the block builder only constructs sealed blocks -- but the
+           gate's contract holds the moment a producer emits live
+           approval blocks.
+        2. The NEWEST block while the fixture reveal is unfinished: the
+           one-advance foldable window (see the moduledoc's "Fold/jump
+           and the seal-time-only gate"), expressed in frontier terms --
+           a fold toggle is the pending interaction. The hold is
+           unconditional on turn state (matching the window's own
+           semantics: it releases on reveal completion, not on turn
+           boundaries). When the block builder later grows a
+           completed-but-unsealed phase, this derivation moves down a
+           layer.
   """
   @spec frontier_entries(t()) :: [SealFrontier.entry()]
   def frontier_entries(model) do
@@ -699,10 +710,19 @@ defmodule Raxol.Harness.Surface do
         kind: block.kind,
         committed?: index < model.painted_count,
         running?: Block.live?(block),
-        pending_input?: not reveal_finished? and index == total - 1
+        pending_input?:
+          awaiting_input?(block) or
+            (not reveal_finished? and index == total - 1)
       }
     end)
   end
+
+  # A live approval block is, per `Block`'s own contract, a question still
+  # waiting on the user -- the genuine awaiting-input feed for the
+  # frontier's pending-input gate. A sealed approval is an answered
+  # question and does not feed the gate. See `frontier_entries/1`'s doc.
+  defp awaiting_input?(block),
+    do: Block.live?(block) and block.kind == :approval
 
   @doc """
   The shared frontier consultation every consumer in this module goes

--- a/test/harness/seal_frontier_test.exs
+++ b/test/harness/seal_frontier_test.exs
@@ -324,6 +324,39 @@ defmodule Raxol.Harness.SealFrontierTest do
     end
   end
 
+  describe "classify/3 (the single-step primitive)" do
+    test "step order: committed skips, committable commits, blocker stops, out of bounds stops" do
+      entries = [
+        %{finalized() | committed?: true},
+        finalized(),
+        running(),
+        finalized()
+      ]
+
+      assert SealFrontier.classify(entries, 0, true) == :skip
+      assert SealFrontier.classify(entries, 1, true) == :commit
+      assert SealFrontier.classify(entries, 2, true) == :stop
+      assert SealFrontier.classify(entries, 4, true) == :stop
+      assert SealFrontier.classify([], 0, true) == :stop
+    end
+
+    test "an already-committed entry skips even when it is also pending input" do
+      # The committed check precedes committability: the committed flags
+      # are authoritative, and a committed entry is history whatever its
+      # other marks say.
+      entries = [pending(%{finalized() | committed?: true}), finalized()]
+      assert SealFrontier.classify(entries, 0, false) == :skip
+    end
+
+    test "is_last is computed against the full entry list" do
+      # A running message: held while last, released by a later entry.
+      assert SealFrontier.classify([running(:message)], 0, true) == :stop
+
+      assert SealFrontier.classify([running(:message), running()], 0, true) ==
+               :commit
+    end
+  end
+
   describe "seal display mode policy" do
     test "per-kind print-once fidelity" do
       # Committed scrollback cannot be re-folded (static terminal text),
@@ -396,6 +429,54 @@ defmodule Raxol.Harness.SealFrontierTest do
 
         refute post.will_commit
         assert post.tail_start == result.cursor
+      end
+    end
+
+    property "both walks agree with a reference walk of repeated classify/3 calls" do
+      # classify/3 is the public single-step primitive; the two walks are
+      # implemented as suffix walks for performance and are SPECIFIED to
+      # produce results identical to calling classify/3 in a loop. This
+      # property is that specification, closed over arbitrary states --
+      # without it, classify/3 would be a third, independent copy of the
+      # step order, free to drift from the walks undetected.
+      check all(
+              entries <- StreamData.list_of(entry_gen(), max_length: 12),
+              turn_running? <- StreamData.boolean()
+            ) do
+        {ref_tail, ref_committed} =
+          classify_reference_walk(entries, turn_running?)
+
+        scan = SealFrontier.scan_frontier(entries, turn_running?)
+
+        assert scan == %{
+                 tail_start: ref_tail,
+                 will_commit: ref_committed != []
+               }
+
+        result =
+          SealFrontier.commit_walk(entries, turn_running?, [], fn seen, index ->
+            {:ok, [index | seen]}
+          end)
+
+        assert result.cursor == ref_tail
+        assert Enum.reverse(result.acc) == ref_committed
+      end
+    end
+
+    # The naive reference walk: literally call classify/3 per index from 0,
+    # collecting the indices it says to commit, until it says :stop.
+    defp classify_reference_walk(entries, turn_running?, index \\ 0, acc \\ []) do
+      case SealFrontier.classify(entries, index, turn_running?) do
+        :stop ->
+          {index, Enum.reverse(acc)}
+
+        :skip ->
+          classify_reference_walk(entries, turn_running?, index + 1, acc)
+
+        :commit ->
+          classify_reference_walk(entries, turn_running?, index + 1, [
+            index | acc
+          ])
       end
     end
   end

--- a/test/harness/seal_frontier_test.exs
+++ b/test/harness/seal_frontier_test.exs
@@ -1,0 +1,416 @@
+defmodule Raxol.Harness.SealFrontierTest do
+  @moduledoc """
+  The seal-frontier corpus: pure classifier/state-machine tests ported
+  from the reference pager's commit-pipeline suite, plus this port's two
+  net-new cases (the scan/walk agreement property, and the noted-only
+  resize-during-commit case at the bottom of this file).
+
+  Every test here drives `Raxol.Harness.SealFrontier` directly over
+  plain entry maps -- no renderer, no paint authority, no fixture
+  session. The renderer-level half of the reference suite (height
+  exactness, native-color lock, commit capping) belongs to the later
+  frame-order unit, not this module.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Harness.SealFrontier
+
+  # -- entry builders --------------------------------------------------------
+
+  # The default kind is deliberately one with NO mid-turn relaxation
+  # (mirroring the reference suite's stub blocks, which are "not an
+  # AgentMessage"): a running tool may still update its result, so it
+  # gets the strict running gate.
+  defp finalized(kind \\ :tool_call),
+    do: %{kind: kind, committed?: false, running?: false, pending_input?: false}
+
+  defp running(kind \\ :tool_call), do: %{finalized(kind) | running?: true}
+
+  defp pending(entry), do: %{entry | pending_input?: true}
+
+  defp committed_flags(entries), do: Enum.map(entries, & &1.committed?)
+
+  # Run a commit pass, collecting the emitted indices.
+  # Returns {emitted_indices, updated_entries, cursor}.
+  defp commit_collect(entries, turn_running?, opts \\ []) do
+    result =
+      SealFrontier.commit_walk(
+        entries,
+        turn_running?,
+        [],
+        fn seen, index -> {:ok, [index | seen]} end,
+        opts
+      )
+
+    {Enum.reverse(result.acc), result.entries, result.cursor}
+  end
+
+  # -- the ported corpus -----------------------------------------------------
+
+  describe "frontier walk" do
+    test "commits the leading finalized run and stops at a running entry" do
+      entries = [finalized(), finalized(), running(), finalized()]
+
+      # The entry AFTER the running blocker must NOT commit yet.
+      {emitted, entries, cursor} = commit_collect(entries, true)
+      assert emitted == [0, 1]
+      assert cursor == 2
+      assert committed_flags(entries) == [true, true, false, false]
+
+      # Finalizing the blocker releases it and everything after it.
+      entries = List.update_at(entries, 2, &%{&1 | running?: false})
+
+      {emitted, _entries, cursor} =
+        commit_collect(entries, true, cursor: cursor)
+
+      assert emitted == [2, 3]
+      assert cursor == 4
+    end
+
+    test "pending user input holds the frontier" do
+      # Finalized but awaiting a permission answer: stops the walk even
+      # though it (and the entry after it) are finalized.
+      entries = [finalized(), pending(finalized()), finalized()]
+
+      {emitted, entries, cursor} = commit_collect(entries, true)
+      assert emitted == [0]
+
+      # Resolving the prompt releases the rest of the run.
+      entries = List.update_at(entries, 1, &%{&1 | pending_input?: false})
+
+      {emitted, _entries, _cursor} =
+        commit_collect(entries, true, cursor: cursor)
+
+      assert emitted == [1, 2]
+    end
+
+    test "a running message commits once a later block exists" do
+      # A tracker can leave a message's running flag set until turn end.
+      # While it is the LAST entry it may still be streaming -> stays live.
+      entries = [running(:message)]
+      {emitted, entries, cursor} = commit_collect(entries, true)
+      assert emitted == []
+      assert cursor == 0
+
+      # A later block proves the message is complete (the producer moved
+      # past it) -> it commits mid-turn despite the lingering flag. The
+      # new last/running entry stays live.
+      entries = entries ++ [running(:tool_call)]
+
+      {emitted, entries, _cursor} =
+        commit_collect(entries, true, cursor: cursor)
+
+      assert emitted == [0]
+      assert committed_flags(entries) == [true, false]
+    end
+
+    test "a running tool still holds the frontier even with a later block" do
+      # The message relaxation must NOT extend to tools: a running tool
+      # can still update its result, so committing it (print-once) would
+      # lose the update. It holds regardless of later blocks.
+      entries = [finalized(), running(:tool_call), finalized()]
+
+      {emitted, _entries, cursor} = commit_collect(entries, true)
+      assert emitted == [0]
+      assert cursor == 1
+    end
+
+    test "a background-task start commits while running and does not wedge the frontier" do
+      # A background-task lifecycle entry's running flag drives animation
+      # only -- its content never changes (completion arrives as a
+      # SEPARATE block). Gating it on the flag would wedge the frontier
+      # for the rest of the turn.
+      entries = [finalized(), running(:background_task), running(:tool_call)]
+
+      {emitted, entries, _cursor} = commit_collect(entries, true)
+      assert emitted == [0, 1]
+      assert committed_flags(entries) == [true, true, false]
+    end
+
+    test "a background-task start commits as the last running entry" do
+      # Even as the last entry of a still-running turn: a lifecycle block
+      # never streams more content.
+      entries = [finalized(), running(:background_task)]
+
+      {emitted, _entries, _cursor} = commit_collect(entries, true)
+      assert emitted == [0, 1]
+    end
+
+    test "no double commit after a mid-list shift remove" do
+      entries = [finalized(), finalized(), finalized()]
+      {emitted, entries, cursor} = commit_collect(entries, true)
+      assert emitted == [0, 1, 2]
+      assert cursor == 3
+
+      # Remove an already-committed entry below the cursor (the remaining
+      # indices shift down). The committed flags travel with the shifted
+      # entries, so neither survivor is re-emitted.
+      entries = List.delete_at(entries, 0)
+      cursor = SealFrontier.cursor_after_removal(cursor, 0)
+      entries = entries ++ [finalized()]
+
+      {emitted, entries, _cursor} =
+        commit_collect(entries, true, cursor: cursor)
+
+      assert emitted == [2]
+      assert committed_flags(entries) == [true, true, true]
+    end
+
+    test "mid-list removal below the cursor does not strand uncommitted entries" do
+      # A committed placeholder is removed AFTER new uncommitted entries
+      # were appended past the cursor. Without the cursor decrement the
+      # first appended entry slides below the cursor and is never
+      # committed NOR shown in the live tail (silently missing).
+      entries = [finalized(), finalized()]
+      {emitted, entries, cursor} = commit_collect(entries, false)
+      assert emitted == [0, 1]
+      assert cursor == 2
+
+      entries = entries ++ [finalized(), finalized()]
+      entries = List.delete_at(entries, 1)
+      cursor = SealFrontier.cursor_after_removal(cursor, 1)
+      assert cursor == 1
+
+      {emitted, entries, _cursor} =
+        commit_collect(entries, false, cursor: cursor)
+
+      assert emitted == [1, 2]
+      assert committed_flags(entries) == [true, true, true]
+    end
+
+    test "pending user input holds the frontier even when idle" do
+      # The idle relaxation applies ONLY to stale running flags, never to
+      # a pending-input mark: the pending entry's rendered form still
+      # changes when the prompt resolves, and a committed copy is frozen.
+      entries = [finalized(), pending(finalized())]
+
+      {emitted, entries, cursor} = commit_collect(entries, false)
+      assert emitted == [0], "pending entry must hold the frontier"
+      refute Enum.at(entries, 1).committed?
+
+      entries = List.update_at(entries, 1, &%{&1 | pending_input?: false})
+
+      {emitted, _entries, _cursor} =
+        commit_collect(entries, false, cursor: cursor)
+
+      assert emitted == [1]
+    end
+
+    test "a failed emit leaves the entry uncommitted for retry" do
+      # Print-once invariant: a write failure must NOT mark the entry
+      # committed -- a marked-but-unprinted block can never be emitted
+      # again and would silently vanish. The walk halts with the cursor
+      # strictly before the failed entry; the next pass retries.
+      entries = [finalized(), finalized()]
+
+      result =
+        SealFrontier.commit_walk(entries, false, 0, fn calls, _index ->
+          {:error, :write_failed, calls + 1}
+        end)
+
+      assert result.committed == 0, "nothing committed on failure"
+      assert result.acc == 1, "walk stops at the first failure"
+      assert committed_flags(result.entries) == [false, false]
+      assert result.cursor == 0, "cursor holds strictly before the failure"
+
+      # The retry pass succeeds and commits both.
+      result =
+        SealFrontier.commit_walk(result.entries, false, nil, fn acc, _index ->
+          {:ok, acc}
+        end)
+
+      assert result.committed == 2
+      assert committed_flags(result.entries) == [true, true]
+    end
+
+    test "scan_frontier mirrors the mutating walk in every phase" do
+      entries = [finalized(), finalized(), running(), finalized()]
+
+      # Pre-commit: the pass would commit two entries and stop at the
+      # running one.
+      scan = SealFrontier.scan_frontier(entries, true)
+      assert scan.will_commit
+      assert scan.tail_start == 2
+
+      result =
+        SealFrontier.commit_walk(entries, true, nil, fn acc, _index ->
+          {:ok, acc}
+        end)
+
+      assert result.committed == 2
+      assert result.cursor == scan.tail_start
+
+      # Post-commit: nothing left to commit; the tail starts at the cursor.
+      scan =
+        SealFrontier.scan_frontier(result.entries, true, cursor: result.cursor)
+
+      refute scan.will_commit
+      assert scan.tail_start == 2
+
+      # Idle with nothing pending: everything is committable.
+      scan =
+        SealFrontier.scan_frontier(result.entries, false, cursor: result.cursor)
+
+      assert scan.will_commit
+      assert scan.tail_start == 4
+    end
+
+    test "removing from below the frontier then pushing still commits" do
+      entries = [finalized(), finalized(), finalized()]
+      {emitted, entries, cursor} = commit_collect(entries, true)
+      assert emitted == [0, 1, 2]
+
+      # Rewind: drop everything from index 1. Without the cursor clamp
+      # the cursor would strand at 3 and silently skip the next pushes.
+      entries = Enum.take(entries, 1)
+      cursor = SealFrontier.cursor_after_truncate(cursor, length(entries))
+      assert cursor == 1
+
+      entries = entries ++ [finalized()]
+
+      {emitted, _entries, _cursor} =
+        commit_collect(entries, true, cursor: cursor)
+
+      assert emitted == [1]
+    end
+
+    test "the walk advances the frontier and marks committed exactly once" do
+      entries = [finalized(), finalized(), finalized()]
+
+      {emitted, entries, cursor} = commit_collect(entries, false)
+      assert emitted == [0, 1, 2]
+      assert cursor == 3
+      assert committed_flags(entries) == [true, true, true]
+
+      # A second pass commits nothing: already-committed entries skip.
+      {emitted, _entries, _cursor} =
+        commit_collect(entries, false, cursor: cursor)
+
+      assert emitted == []
+    end
+
+    test "an idle turn commits past a stale running entry" do
+      # Stuck-spinner regression: a producer can leave a running flag set
+      # after the turn ends (a finalize missed at a transition). While
+      # the turn runs that entry correctly holds the frontier; once the
+      # turn is idle the frontier must advance past it.
+      entries = [finalized(), running(), finalized()]
+
+      {emitted, entries, cursor} = commit_collect(entries, true)
+      assert emitted == [0]
+      assert cursor == 1
+
+      {emitted, _entries, cursor} =
+        commit_collect(entries, false, cursor: cursor)
+
+      assert emitted == [1, 2]
+      assert cursor == 3
+    end
+
+    test "clearing the entry list resets the frontier" do
+      entries = [finalized()]
+      {_emitted, _entries, cursor} = commit_collect(entries, true)
+      assert cursor == 1
+
+      cursor = SealFrontier.cursor_after_truncate(cursor, 0)
+      assert cursor == 0
+
+      assert SealFrontier.scan_frontier([], true) == %{
+               tail_start: 0,
+               will_commit: false
+             }
+    end
+  end
+
+  describe "seal display mode policy" do
+    test "per-kind print-once fidelity" do
+      # Committed scrollback cannot be re-folded (static terminal text),
+      # so the per-kind fidelity policy lives in one place: reasoning
+      # collapses to its marker, tool output truncates, diffs (the key
+      # artifact of an edit) and messages stay full.
+      assert SealFrontier.seal_display_mode(:reasoning) == :collapsed
+      assert SealFrontier.seal_display_mode(:tool_call) == :truncated
+      assert SealFrontier.seal_display_mode(:diff) == :expanded
+      assert SealFrontier.seal_display_mode(:message) == :expanded
+      assert SealFrontier.seal_display_mode(:approval) == :expanded
+      assert SealFrontier.seal_display_mode(:opaque) == :expanded
+      assert SealFrontier.seal_display_mode(:never_seen_kind) == :expanded
+    end
+  end
+
+  # -- net-new case #1: the agreement property -------------------------------
+
+  describe "scan/walk agreement (property)" do
+    defp entry_gen do
+      gen all(
+            kind <-
+              StreamData.member_of([
+                :message,
+                :reasoning,
+                :tool_call,
+                :diff,
+                :approval,
+                :background_task,
+                :opaque
+              ]),
+            committed? <- StreamData.boolean(),
+            running? <- StreamData.boolean(),
+            pending_input? <- StreamData.boolean()
+          ) do
+        %{
+          kind: kind,
+          committed?: committed?,
+          running?: running?,
+          pending_input?: pending_input?
+        }
+      end
+    end
+
+    property "scan_frontier agrees with the mutating walk for arbitrary states" do
+      check all(
+              entries <- StreamData.list_of(entry_gen(), max_length: 12),
+              turn_running? <- StreamData.boolean()
+            ) do
+        scan = SealFrontier.scan_frontier(entries, turn_running?)
+
+        result =
+          SealFrontier.commit_walk(entries, turn_running?, 0, fn count,
+                                                                 _index ->
+            {:ok, count + 1}
+          end)
+
+        # The read-only projection and the mutating walk agree on where
+        # the live tail starts and on whether anything commits.
+        assert result.cursor == scan.tail_start
+        assert result.committed == result.acc
+        assert result.committed > 0 == scan.will_commit
+
+        # After the walk, a re-scan converges: nothing further to commit
+        # this frame, and the tail start is exactly the persisted cursor.
+        post =
+          SealFrontier.scan_frontier(result.entries, turn_running?,
+            cursor: result.cursor
+          )
+
+        refute post.will_commit
+        assert post.tail_start == result.cursor
+      end
+    end
+  end
+
+  # -- net-new case #2: resize-during-commit (NOTED, not implemented) --------
+  #
+  # The frame-order unit (a follow-up, not this module) must prove the
+  # adopt-size-BEFORE-commit ordering: a block finalizing on a shrink
+  # frame must be laid out at the freshly adopted width, never the stale
+  # one -- a stale-width commit hard-wraps over-wide rows and permanently
+  # garbles the print-once copy in native scrollback. That case needs the
+  # paint pipeline (width adoption + the seal write), which this pure
+  # classifier deliberately has no access to. It is recorded here so the
+  # frame-order unit starts from a named, red-first test obligation:
+  #
+  #   test "a block finalizing on a shrink frame commits at the adopted
+  #         width, not the stale one"
+end

--- a/test/harness/surface_frontier_feed_test.exs
+++ b/test/harness/surface_frontier_feed_test.exs
@@ -1,0 +1,114 @@
+defmodule Raxol.Harness.SurfaceFrontierFeedTest do
+  @moduledoc """
+  The pending-input feed contract of `Raxol.Harness.Surface.frontier_entries/1`:
+  the seal frontier's pending-input gate documents "an entry whose rendered
+  form can still change on user interaction must never seal," and this suite
+  pins the feed to that meaning for BOTH of its instances -- a genuinely
+  awaiting-input block (a live `:approval`, per `Block`'s own contract "a
+  live approval block is, by definition, waiting on the user") and the
+  surface's one-advance foldable window on the newest block.
+
+  These tests drive `frontier_entries/1` / `frontier_scan/1` over hand-built
+  model maps (both functions are pure over plain maps), because today's
+  block builder only ever constructs sealed blocks -- the live-approval
+  lifecycle is dormant in fixture mode, and the whole point here is that the
+  feed must honor the gate's contract the moment a producer emits it.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.Surface
+  alias Raxol.UI.Components.Harness.Block
+
+  defp block(kind, seal) do
+    Block.from_events(kind, [%{id: 1, payload: %{content: "x"}}], seal: seal)
+  end
+
+  # A minimal model map carrying exactly the fields frontier_entries/1 and
+  # frontier_scan/1 read: projection blocks, the painted high-water mark,
+  # reveal progress, and the status snapshot (turn_running? derivation).
+  defp model(blocks, opts) do
+    revealed = Keyword.get(opts, :revealed, 0)
+    total_events = Keyword.get(opts, :total_events, revealed)
+
+    %{
+      projection: %{blocks: blocks},
+      painted_count: Keyword.get(opts, :painted, 0),
+      revealed: revealed,
+      events: List.duplicate(%{}, total_events),
+      status: Keyword.get(opts, :status, %{})
+    }
+  end
+
+  describe "the genuine awaiting-input feed (live approval blocks)" do
+    test "a live approval block is pending input even when it is NOT the newest entry" do
+      # The reveal-window mapping alone would give this block
+      # pending_input?: false (it is not the newest block), letting it
+      # seal mid-question the moment the frontier reaches it.
+      blocks = [block(:approval, :live), block(:message, :sealed)]
+
+      entries =
+        Surface.frontier_entries(model(blocks, revealed: 1, total_events: 3))
+
+      assert Enum.at(entries, 0).pending_input?,
+             "a live approval block must feed the frontier's pending-input gate " <>
+               "regardless of its position"
+    end
+
+    test "a live approval block stays pending after the reveal finishes, even on an idle turn" do
+      # Reveal finished (window closed) AND turn idle: the idle relaxation
+      # forgives stale running flags, so without a pending-input feed the
+      # live approval would seal into print-once scrollback while still
+      # waiting on the user -- the exact failure the gate exists to prevent.
+      blocks = [block(:message, :sealed), block(:approval, :live)]
+
+      model =
+        model(blocks,
+          revealed: 2,
+          total_events: 2,
+          painted: 1,
+          status: %{turn_completed: true}
+        )
+
+      entries = Surface.frontier_entries(model)
+      assert Enum.at(entries, 1).pending_input?
+
+      scan = Surface.frontier_scan(model)
+
+      assert scan.tail_start == 1,
+             "the frontier must hold at the live approval block in every turn state"
+
+      refute scan.will_commit
+    end
+
+    test "a SEALED approval block is an answered question and does not feed the gate" do
+      blocks = [block(:approval, :sealed), block(:message, :sealed)]
+
+      entries =
+        Surface.frontier_entries(model(blocks, revealed: 2, total_events: 2))
+
+      refute Enum.at(entries, 0).pending_input?
+      refute Enum.at(entries, 1).pending_input?
+    end
+  end
+
+  describe "the foldable-window feed (unchanged)" do
+    test "the newest block holds the window while the reveal is unfinished, and releases at reveal end" do
+      blocks = [block(:message, :sealed), block(:message, :sealed)]
+
+      during =
+        Surface.frontier_entries(model(blocks, revealed: 1, total_events: 3))
+
+      refute Enum.at(during, 0).pending_input?
+
+      assert Enum.at(during, 1).pending_input?,
+             "newest block sits in the foldable window"
+
+      finished =
+        Surface.frontier_entries(model(blocks, revealed: 3, total_events: 3))
+
+      refute Enum.at(finished, 1).pending_input?,
+             "the window releases on reveal completion"
+    end
+  end
+end


### PR DESCRIPTION
The foundation unit for hardening the seal pipeline before live traffic. One pure classifier decides which finished blocks may be sealed into terminal scrollback; every consumer (the seal pass today; the resize gate and viewport sizing when they land) consults it, so they can never disagree about where the frontier stops — the disagreement failure mode is a block's height flipping between the live region and native scrollback, jumping the prompt on every seal.

## The module

`Raxol.Harness.SealFrontier` (pure, 433 lines with full design-note moduledoc):
- `classify/3` -> `:commit | :skip | :stop` with a fixed decision order: pending-input check FIRST and unconditional on turn state (a block awaiting the human must never seal — print-once would freeze the "waiting" form in scrollback), idle relaxation past stale running flags, and two committable-while-running exceptions (a non-last message is provably complete; a background-task lifecycle block's running flag is animation-only).
- `frontier_scan/1` — read-only projection (`tail_start`, `will_commit`) that must mirror the mutating walk exactly; the agreement is pinned by a property test over arbitrary generated states.
- `commit_walk/5` — the ONE mutating walk: emit-then-mark, halting on write failure with the cursor held strictly before the failed entry (a print-once mode can never re-emit a block marked committed that never reached the terminal — it would silently vanish).
- Per-kind display-mode policy frozen at seal (reasoning collapsed, tool calls truncated, diffs expanded).

## The wiring (behavior-identical by construction)

- Projection-agnostic entries: plain maps produced by `Surface.frontier_entries/1`; committed-set = the painted high-water prefix; the live streaming tail never enters the list.
- The surface's one-advance foldable window maps to `pending_input?: true` on the newest block — a fold toggle is exactly the still-mutating-rendered-form hazard the pending gate exists for. The scan lands where the old inline arithmetic did; the existing acceptance suite proves it.
- Cursor is caller-held and a lower-bound hint only; `cursor_after_removal/2` / `cursor_after_truncate/2` cover list mutations.

## Follow-up seams (documented, deliberately not invented)

Resize-path `will_commit` gate + post-commit viewport sizing (the frame-order unit); two-phase write-confirmed sealing building on the `{:error, :write_failed, _}` branch; resize-during-commit recorded as a named red-first obligation in the test file.

## Verification

Red-first: corpus written and failing before the module existed. New suite 17/17 (16 corpus cases + scan/walk agreement property). Full harness+property sweep: 612 passed, 0 failures. `--warnings-as-errors` + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)