### PR TITLE
Harness UI: wire message bodies through the streaming-safe markdown path

### DIFF
--- a/lib/raxol/ui/components/harness/block.ex
+++ b/lib/raxol/ui/components/harness/block.ex
@@ -607,8 +607,11 @@ defmodule Raxol.UI.Components.Harness.Block do
   defp markdown_source(%__MODULE__{content: %{text: text}}),
     do: to_display_text(text)
 
-  defp markdown_mode(%__MODULE__{seal: :sealed}), do: :sealed
-  defp markdown_mode(%__MODULE__{seal: :live}), do: :streaming
+  # The seal->mode mapping lives in exactly one place --
+  # `MarkdownBody.mode_for_seal/1` -- so this call site and
+  # `BodyProvider`'s `:message` props can never drift apart.
+  defp markdown_mode(%__MODULE__{seal: seal}),
+    do: MarkdownBody.mode_for_seal(seal)
 
   # Recursively applies the resolved prominence colour to every text node
   # in a rendered view tree (the MarkdownBody result), so the Markdown

--- a/lib/raxol/ui/components/harness/block_body.ex
+++ b/lib/raxol/ui/components/harness/block_body.ex
@@ -77,7 +77,11 @@ defmodule Raxol.UI.Components.Harness.BlockBody do
   defp mount_body(block, context) do
     BodyProvider.mount(block.kind, block.content,
       context: context,
-      outcome: block.outcome
+      outcome: block.outcome,
+      # threads the block's own seal so a live :message body streams with
+      # provisional close instead of a plain full parse -- see
+      # `BodyProvider.mount/3`'s `:seal` option doc.
+      seal: block.seal
     )
   rescue
     e ->

--- a/lib/raxol/ui/components/harness/body_provider.ex
+++ b/lib/raxol/ui/components/harness/body_provider.ex
@@ -73,6 +73,7 @@ defmodule Raxol.UI.Components.Harness.BodyProvider do
     ApprovalPrompt,
     Block,
     DiffViewer,
+    MarkdownBody,
     MessageBlock,
     ReasoningBlock,
     ToolCallBlock,
@@ -276,7 +277,7 @@ defmodule Raxol.UI.Components.Harness.BodyProvider do
       role: Map.get(body, :role, :assistant),
       content: Map.fetch!(body, :text),
       width: width_from(context),
-      mode: if(seal == :live, do: :streaming, else: :sealed)
+      mode: MarkdownBody.mode_for_seal(seal)
     ]
   end
 

--- a/lib/raxol/ui/components/harness/body_provider.ex
+++ b/lib/raxol/ui/components/harness/body_provider.ex
@@ -59,6 +59,14 @@ defmodule Raxol.UI.Components.Harness.BodyProvider do
   rendering (one-line summary + outcome row) is `Block.render/2`'s own
   proven code path -- `BlockBody` reuses it directly rather than
   reimplementing a second summary renderer here.
+
+  ## `:reasoning` stays plain through this path, by design
+
+  Unlike `:message`, a `:reasoning` body is never threaded through
+  `Harness.MarkdownBody` here -- `ReasoningBlock` renders dim plain text
+  on purpose (reasoning is meant to read as quieter, secondary content).
+  Styled Markdown reasoning is an explicit opt-in that lives entirely in
+  `Block.render/2`'s own `context[:markdown]` path, not in this seam.
   """
 
   alias Raxol.UI.Components.Harness.{
@@ -160,6 +168,14 @@ defmodule Raxol.UI.Components.Harness.BodyProvider do
     * `:context` -- render context passed to every mounted component's
       `render/2` (default `%{}`); `:width` inside it sizes `:message`,
       `:reasoning`, and `:diff` bodies.
+    * `:seal` -- `:live | :sealed` (default `:sealed`), the block's own
+      seal state. Threaded only into the `:message` body, as
+      `MessageBlock`'s render `:mode` (`:live` -> `:streaming`, `:sealed`
+      -> `:sealed`) -- a live message renders with the provisional-close
+      streaming treatment, a sealed one as a plain full parse. Defaulting
+      to `:sealed` means existing direct callers of `mount/3` see zero
+      behavior change; `BlockBody` is the one caller that passes the
+      block's real `seal`. Every other kind accepts and ignores it.
     * `:outcome` -- a `Block.outcome()` map (default `%{}`), consulted
       only for `:tool_call` to derive the mounted status glyph
       (`:pending` with no result yet, `:failed` on a non-zero
@@ -191,12 +207,13 @@ defmodule Raxol.UI.Components.Harness.BodyProvider do
   def mount(kind, body, opts \\ []) do
     context = Keyword.get(opts, :context, %{})
     outcome = Keyword.get(opts, :outcome, %{})
+    seal = Keyword.get(opts, :seal, :sealed)
 
     with {:ok, expected_component} <- component_for(kind),
          component = Keyword.get(opts, :component, expected_component),
          :ok <- ensure_component(kind, component, expected_component),
          :ok <- validate(kind, body) do
-      {:ok, build_view(kind, component, body, outcome, context)}
+      {:ok, build_view(kind, component, body, outcome, context, seal)}
     end
   end
 
@@ -210,23 +227,23 @@ defmodule Raxol.UI.Components.Harness.BodyProvider do
 
   # -- per-kind view construction ---------------------------------------
 
-  defp build_view(:message, component, body, _outcome, context) do
-    mount_one(component, message_props(body, context), context)
+  defp build_view(:message, component, body, _outcome, context, seal) do
+    mount_one(component, message_props(body, context, seal), context)
   end
 
-  defp build_view(:reasoning, component, body, _outcome, context) do
+  defp build_view(:reasoning, component, body, _outcome, context, _seal) do
     mount_one(component, reasoning_props(body, context), context)
   end
 
-  defp build_view(:diff, component, body, _outcome, context) do
+  defp build_view(:diff, component, body, _outcome, context, _seal) do
     mount_one(component, diff_props(body, context), context)
   end
 
-  defp build_view(:approval, component, body, _outcome, context) do
+  defp build_view(:approval, component, body, _outcome, context, _seal) do
     mount_one(component, approval_props(body), context)
   end
 
-  defp build_view(:tool_call, component, body, outcome, context) do
+  defp build_view(:tool_call, component, body, outcome, context, _seal) do
     call_view = mount_one(component, tool_call_props(body, outcome), context)
 
     case Map.get(body, :result) do
@@ -254,11 +271,12 @@ defmodule Raxol.UI.Components.Harness.BodyProvider do
     component.render(state, context)
   end
 
-  defp message_props(body, context) do
+  defp message_props(body, context, seal) do
     [
       role: Map.get(body, :role, :assistant),
       content: Map.fetch!(body, :text),
-      width: width_from(context)
+      width: width_from(context),
+      mode: if(seal == :live, do: :streaming, else: :sealed)
     ]
   end
 

--- a/lib/raxol/ui/components/harness/markdown_body.ex
+++ b/lib/raxol/ui/components/harness/markdown_body.ex
@@ -81,6 +81,16 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
   marker character still toggles/opens its construct normally. Full
   escape handling would need to thread an "escaped" flag through the
   scan; left as a documented gap rather than expanded scope here.
+
+  ## Follow-up seam: stable-prefix optimization
+
+  Today every streaming delta re-parses the FULL accumulated text (byte-
+  capped at 256KB -- see `@render_byte_cap` below). A follow-up unit
+  could instead cache the parse of the longest durable prefix (the text
+  up to the last committed line boundary, which never changes as more
+  deltas arrive) and re-parse only the live tail on each delta.
+  Documented here as a known optimization opportunity, not implemented --
+  this module's current correctness does not depend on it.
   """
 
   alias Raxol.UI.Components.MarkdownRenderer

--- a/lib/raxol/ui/components/harness/markdown_body.ex
+++ b/lib/raxol/ui/components/harness/markdown_body.ex
@@ -98,6 +98,19 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
 
   @type mode :: :sealed | :streaming
 
+  @doc """
+  The single vocabulary bridge from a block's seal state (`:live |
+  :sealed`, see `Raxol.UI.Components.Harness.Block`) to this module's
+  render mode: `:live -> :streaming`, `:sealed -> :sealed`. Every call
+  site that glues block seal to Markdown rendering (`BodyProvider`'s
+  `:message` props, `Block.render/2`'s `context[:markdown]` path) MUST
+  use this rather than re-deriving the mapping -- two names for the same
+  binary state is already one too many.
+  """
+  @spec mode_for_seal(Raxol.UI.Components.Harness.Block.seal_state()) :: mode()
+  def mode_for_seal(:live), do: :streaming
+  def mode_for_seal(:sealed), do: :sealed
+
   # Above this byte size, both the provisional-close scan and the
   # downstream render/parse skip their normal work and fall back to a
   # cheap identity/plain-text path. Pure insurance: the scan is

--- a/lib/raxol/ui/components/harness/message_block.ex
+++ b/lib/raxol/ui/components/harness/message_block.ex
@@ -2,25 +2,35 @@ defmodule Raxol.UI.Components.Harness.MessageBlock do
   @moduledoc """
   Renders a completed transcript message: `item_completed{item_type: :message, content}`.
 
-  `content` is a Markdown string. Rendering the Markdown itself is delegated
-  entirely to `Raxol.UI.Components.MarkdownRenderer` -- this module only adds
-  a dim, accent-colored role prefix (`role: :user | :assistant`) above it so
-  turns are visually distinguishable without shouting.
+  `content` is a Markdown string. Body rendering is delegated entirely to
+  `Raxol.UI.Components.Harness.MarkdownBody`, which adds a streaming-aware
+  provisional close (`mode: :streaming`), control-char/ANSI sanitization,
+  and a never-raise fallback on top of the plain Markdown parse -- this
+  module only adds a dim, accent-colored role prefix
+  (`role: :user | :assistant`) above it so turns are visually
+  distinguishable without shouting. `render/2` is pure content -> view: no
+  state of its own is read or written.
+
+  The stable-prefix optimization (cache the parse of the durable prefix of
+  a streaming message and only re-parse the live tail) is a documented
+  follow-up seam in `MarkdownBody`, not implemented here.
   """
 
-  alias Raxol.UI.Components.MarkdownRenderer
+  alias Raxol.UI.Components.Harness.MarkdownBody
   alias Raxol.UI.StyleHelper
   alias Raxol.View.Components
 
   use Raxol.UI.Components.Base.Component
 
   @type role :: :user | :assistant
+  @type mode :: :sealed | :streaming
 
   @type t :: %{
           id: String.t() | atom(),
           role: role(),
           content: String.t(),
           width: pos_integer(),
+          mode: mode(),
           style: map(),
           theme: map()
         }
@@ -38,6 +48,7 @@ defmodule Raxol.UI.Components.Harness.MessageBlock do
       role: Keyword.get(props, :role, :assistant),
       content: Keyword.get(props, :content, ""),
       width: Keyword.get(props, :width, Raxol.Core.Defaults.terminal_width()),
+      mode: Keyword.get(props, :mode, :sealed),
       style: Keyword.get(props, :style, %{}),
       theme: Keyword.get(props, :theme, %{})
     }
@@ -54,14 +65,14 @@ defmodule Raxol.UI.Components.Harness.MessageBlock do
     base_style =
       StyleHelper.merge_component_styles(state, context, :harness_message_block)
 
-    {:ok, md_state} =
-      MarkdownRenderer.init(%{markdown_text: state.content, width: state.width})
+    body =
+      MarkdownBody.render(state.content, %{width: state.width, mode: state.mode})
 
     %{
       type: :column,
       style: base_style,
       gap: 0,
-      children: [role_header(state), MarkdownRenderer.render(md_state, context)]
+      children: [role_header(state), body]
     }
   end
 

--- a/lib/raxol/ui/components/harness/message_block.ex
+++ b/lib/raxol/ui/components/harness/message_block.ex
@@ -14,6 +14,12 @@ defmodule Raxol.UI.Components.Harness.MessageBlock do
   The stable-prefix optimization (cache the parse of the durable prefix of
   a streaming message and only re-parse the live tail) is a documented
   follow-up seam in `MarkdownBody`, not implemented here.
+
+  Behavioral note: sanitization applies in BOTH modes, so even a `:sealed`
+  render of control-char-bearing content is intentionally NOT
+  byte-identical to the old raw `MarkdownRenderer` parse -- control/ESC
+  bytes are stripped, invalid UTF-8 is recovered. Clean content renders
+  identically.
   """
 
   alias Raxol.UI.Components.Harness.MarkdownBody

--- a/lib/raxol/ui/components/markdown_renderer.ex
+++ b/lib/raxol/ui/components/markdown_renderer.ex
@@ -16,6 +16,15 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
   performed, and none is planned as part of this label. The label plus
   the plain `@code_style` code body is the seam a future highlighter
   would slot into, not something this module implements itself.
+
+  Trust note: a new output surface added to a shared component inherits
+  the component's OWN trust contract, not the calling path's. This
+  module's contract is "callers may pass untrusted text", and it has
+  direct callers with no sanitizer in front (the harness path's
+  `Harness.MarkdownBody` pre-strips control bytes, but e.g. the
+  playground's `DemoHelpers.markdown/2` does not) -- so the label is
+  control/ESC-sanitized and length-clamped here, at the boundary that
+  produces it, regardless of which caller supplied the input.
   """
   use Raxol.UI.Components.Base.Component
 
@@ -312,20 +321,38 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
 
   def code_language_from_attrs(_attrs), do: nil
 
+  # The info string is UNTRUSTED input reaching a NEW output surface (the
+  # label line), so it is made safe here, at this module's own boundary --
+  # not on any particular calling path (see the moduledoc's trust note):
+  # all C0 controls, DEL, and C1 bytes are stripped BEFORE word extraction
+  # (`~r/\s+/` does not treat ESC as whitespace, so `elixir\e[2J` would
+  # otherwise survive as one "word" and smuggle a live escape sequence
+  # into `text()`), and the surviving word is clamped so a pathological
+  # no-whitespace info string can never become an unbounded label line.
+  @info_string_control_chars ~r/[\x00-\x1F\x7F\x{0080}-\x{009F}]/u
+  @max_lang_label_width 32
+
   # The displayed language tag is the first whitespace-separated word of
-  # an info string, an optional Earmark "language-" class prefix stripped
-  # first (a no-op when there is none, e.g. a bare fence info string like
-  # `elixir title=demo`). Absent/blank/whitespace-only input yields `nil`,
-  # not an empty string -- `code_label_elements/1` treats those the same,
-  # but keeping the "no label" case as a single value simplifies callers.
+  # the sanitized info string, an optional Earmark "language-" class
+  # prefix stripped first (a no-op when there is none, e.g. a bare fence
+  # info string like `elixir title=demo`). Absent/blank/sanitized-to-empty
+  # input yields `nil`, not an empty string -- keeping the "no label" case
+  # as a single value simplifies callers.
   defp lang_word(value) do
     value
     |> to_string()
+    |> String.replace(@info_string_control_chars, "")
     |> String.replace_prefix("language-", "")
     |> String.trim()
     |> String.split(~r/\s+/, trim: true)
     |> List.first()
+    |> clamp_lang()
   end
+
+  defp clamp_lang(nil), do: nil
+
+  defp clamp_lang(lang),
+    do: TextLayout.truncate(lang, @max_lang_label_width, :ellipsis)
 
   # --- Shared segment rendering (fits-vs-wrapped) ---
   #
@@ -630,8 +657,10 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
     Enum.concat([[blank], code_label_elements(lang), code_elements, [blank]])
   end
 
+  # `lang` is always `lang_word/1`'s output here: `nil` or a non-empty,
+  # sanitized, clamped word -- there is deliberately no `""` clause, since
+  # `lang_word/1` maps every empty/blank/sanitized-away case to `nil`.
   defp code_label_elements(nil), do: []
-  defp code_label_elements(""), do: []
 
   defp code_label_elements(lang) do
     [Components.text(content: "  " <> lang, style: %{dim: true})]

--- a/lib/raxol/ui/components/markdown_renderer.ex
+++ b/lib/raxol/ui/components/markdown_renderer.ex
@@ -9,6 +9,13 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
   Inline styling does not survive a wrap boundary: a line that overflows
   `width` falls back to plain, unstyled wrapped text, though wrapped
   output never leaks literal Markdown marker characters.
+
+  A fenced code block's info string (the language tag after ```` ``` ````
+  or `~~~`, e.g. `elixir` in ` ```elixir `) renders as a dim label line
+  above the code body. This is display-only -- no syntax highlighting is
+  performed, and none is planned as part of this label. The label plus
+  the plain `@code_style` code body is the seam a future highlighter
+  would slot into, not something this module implements itself.
   """
   use Raxol.UI.Components.Base.Component
 
@@ -171,18 +178,8 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
 
   defp ast_node_to_elements({"pre", _attrs, children, _meta}, _width) do
     code_text = extract_code_text(children)
-    lines = String.split(code_text, "\n")
-
-    code_elements =
-      Enum.map(lines, fn line ->
-        Components.text(content: "  " <> line, style: @code_style)
-      end)
-
-    Enum.concat([
-      [Components.text(content: "")],
-      code_elements,
-      [Components.text(content: "")]
-    ])
+    lang = pre_code_language(children)
+    fenced_code_elements(code_text, lang)
   end
 
   defp ast_node_to_elements({"blockquote", _attrs, children, _meta}, width) do
@@ -292,6 +289,44 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
     end)
   end
 
+  # Earmark wraps a fenced code block's language tag in the inner `code`
+  # node's `class` attr (`language-elixir` per the CommonMark convention,
+  # though a bare `elixir` is accepted too via `code_language_from_attrs/1`).
+  defp pre_code_language(children) when is_list(children) do
+    Enum.find_value(children, fn
+      {"code", attrs, _inner, _meta} -> code_language_from_attrs(attrs)
+      _other -> nil
+    end)
+  end
+
+  defp pre_code_language(_children), do: nil
+
+  @doc false
+  @spec code_language_from_attrs(list()) :: String.t() | nil
+  def code_language_from_attrs(attrs) when is_list(attrs) do
+    case List.keyfind(attrs, "class", 0) do
+      {"class", value} -> lang_word(value)
+      nil -> nil
+    end
+  end
+
+  def code_language_from_attrs(_attrs), do: nil
+
+  # The displayed language tag is the first whitespace-separated word of
+  # an info string, an optional Earmark "language-" class prefix stripped
+  # first (a no-op when there is none, e.g. a bare fence info string like
+  # `elixir title=demo`). Absent/blank/whitespace-only input yields `nil`,
+  # not an empty string -- `code_label_elements/1` treats those the same,
+  # but keeping the "no label" case as a single value simplifies callers.
+  defp lang_word(value) do
+    value
+    |> to_string()
+    |> String.replace_prefix("language-", "")
+    |> String.trim()
+    |> String.split(~r/\s+/, trim: true)
+    |> List.first()
+  end
+
   # --- Shared segment rendering (fits-vs-wrapped) ---
   #
   # `[{text, style}, ...]` segments render as: a plain `text` element when
@@ -381,13 +416,16 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
   # fence marker; a fence only closes on a line using the SAME marker it
   # opened with, so a stray line of the other marker type while the fence
   # is open is fence CONTENT, not a closer (mismatched fences never
-  # prematurely end the block).
-  defp parse_blocks(["```" <> _ | rest], width, acc) do
-    parse_fenced_block("```", rest, width, acc)
+  # prematurely end the block). Whatever follows the marker on the opening
+  # line is the info string -- its first word (if any) becomes the
+  # displayed language label; the rest (e.g. a `title=demo` attribute) is
+  # discarded, same as it always was before labels existed.
+  defp parse_blocks(["```" <> info | rest], width, acc) do
+    parse_fenced_block("```", lang_word(info), rest, width, acc)
   end
 
-  defp parse_blocks(["~~~" <> _ | rest], width, acc) do
-    parse_fenced_block("~~~", rest, width, acc)
+  defp parse_blocks(["~~~" <> info | rest], width, acc) do
+    parse_fenced_block("~~~", lang_word(info), rest, width, acc)
   end
 
   # GFM table: a header row immediately followed by a separator-shaped row
@@ -561,19 +599,42 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
 
   defp slice_group(text, {start, len}), do: String.slice(text, start, len)
 
-  defp parse_fenced_block(marker, rest, width, acc) do
+  defp parse_fenced_block(marker, lang, rest, width, acc) do
     {code_lines, remaining} = take_until_fence(rest, marker, [])
+    code_text = Enum.join(code_lines, "\n")
+    elements = fenced_code_elements(code_text, lang)
 
+    # Same reverse-then-cons convention every other `parse_blocks` clause
+    # uses (`acc` is fully reversed once at the very end, in
+    # `render_with_builtin/2`) -- pushing this block's elements on
+    # pre-reversed keeps them in correct reading order after that final
+    # reversal, exactly like a single `parse_line/2` result would be.
+    parse_blocks(remaining, width, Enum.reverse(elements) ++ acc)
+  end
+
+  # Shared by both the Earmark AST path (`ast_node_to_elements/2` for
+  # `"pre"`) and this builtin path, so the two parsers can't drift on how
+  # the language label sits relative to the surrounding blank lines and
+  # code body: blank, optional dim label, code lines, blank. `lang` is
+  # `nil` (or an empty/absent tag) -> no label line at all, not an empty one.
+  defp fenced_code_elements(code_text, lang) do
     code_elements =
-      Enum.map(code_lines, fn line ->
+      code_text
+      |> String.split("\n")
+      |> Enum.map(fn line ->
         Components.text(content: "  " <> line, style: @code_style)
       end)
 
-    new_acc =
-      [Components.text(content: "") | code_elements] ++
-        [Components.text(content: "") | acc]
+    blank = Components.text(content: "")
 
-    parse_blocks(remaining, width, new_acc)
+    Enum.concat([[blank], code_label_elements(lang), code_elements, [blank]])
+  end
+
+  defp code_label_elements(nil), do: []
+  defp code_label_elements(""), do: []
+
+  defp code_label_elements(lang) do
+    [Components.text(content: "  " <> lang, style: %{dim: true})]
   end
 
   defp take_until_fence([], _marker, acc), do: {Enum.reverse(acc), []}

--- a/test/raxol/ui/components/harness/block_body_test.exs
+++ b/test/raxol/ui/components/harness/block_body_test.exs
@@ -1,7 +1,10 @@
 defmodule Raxol.UI.Components.Harness.BlockBodyTest do
   use ExUnit.Case, async: true
 
+  alias Raxol.Harness.Fixture
   alias Raxol.UI.Components.Harness.{Block, BlockBody}
+
+  @markdown_fixture_path "test/fixtures/harness/sessions/markdown-stream.jsonl"
 
   defp default_context,
     do: %{theme: Raxol.UI.Theming.Theme.default_theme(), width: 80}
@@ -12,6 +15,45 @@ defmodule Raxol.UI.Components.Harness.BlockBodyTest do
     do: Enum.flat_map(children, &flat_texts/1)
 
   defp flat_texts(_node), do: []
+
+  defp flat_leaves(%{type: :text, content: content} = node),
+    do: [{content, node[:style] || %{}}]
+
+  defp flat_leaves(%{children: children}) when is_list(children),
+    do: Enum.flat_map(children, &flat_leaves/1)
+
+  defp flat_leaves(_node), do: []
+
+  defp message_block(text, opts) do
+    Block.from_events(
+      :message,
+      [
+        %{
+          id: 1,
+          type: :item_completed,
+          payload: %{item_type: :message, content: text}
+        }
+      ],
+      Keyword.merge([fold: :expanded], opts)
+    )
+  end
+
+  # Same golden-doc loading convention as markdown_body_test.exs: the
+  # deltas and the final content come live from the fixture file, never
+  # hardcoded.
+  defp golden_deltas_and_final do
+    {:ok, session} = Fixture.load(@markdown_fixture_path)
+
+    chunks =
+      session
+      |> Fixture.Session.by_type(:item_delta)
+      |> Enum.map(& &1.body.payload["chunk"])
+
+    [completed] = Fixture.Session.by_type(session, :item_completed)
+    {chunks, completed.body.payload["content"]}
+  end
+
+  defp delta_prefixes(chunks), do: Enum.scan(chunks, "", &(&2 <> &1))
 
   # -- one realistic events list per kind, reused for both fold states
   # (folded/expanded is a Block construction option, not a different
@@ -335,6 +377,93 @@ defmodule Raxol.UI.Components.Harness.BlockBodyTest do
 
       assert reason =~ "FunctionClauseError",
              "expected the exception module in the recovered reason/metadata"
+    end
+  end
+
+  # A message block reaching this path may still be LIVE: its accumulated
+  # text can end inside an unclosed construct. BlockBody threads
+  # `block.seal` into `BodyProvider.mount/3`, so a live body renders the
+  # provisional-close streaming treatment and a sealed body the plain full
+  # parse -- the transcript never flashes a raw marker mid-stream.
+  describe "live markdown message bodies stream safely end-to-end" do
+    test "a live expanded message with a trailing unclosed construct never leaks markers" do
+      block = message_block("streaming **bold", seal: :live)
+      texts = flat_texts(BlockBody.render(block, default_context()))
+
+      assert Enum.any?(texts, &(&1 =~ "[assistant]")),
+             "the real MessageBlock must mount (not the Block.render fallback)"
+
+      assert Enum.any?(texts, &(&1 =~ "bold"))
+
+      refute Enum.any?(texts, &(&1 =~ "*")),
+             "a live message's unclosed bold marker leaked through BlockBody"
+    end
+
+    test "the same content sealed renders the final full parse -- the marker stays literal" do
+      block = message_block("streaming **bold", seal: :sealed)
+      texts = flat_texts(BlockBody.render(block, default_context()))
+
+      assert Enum.any?(texts, &(&1 =~ "**")),
+             "sealed content is final -- a genuinely-unclosed marker stays literal"
+    end
+
+    test "folding a live markdown block still delegates to Block.render/2 (fold x streaming interaction)" do
+      block = message_block("streaming **bold", seal: :live, fold: :folded)
+
+      assert BlockBody.render(block, default_context()) ==
+               Block.render(block, default_context())
+    end
+  end
+
+  describe "golden fixture: markdown streams through the full BlockBody path" do
+    test "every delta-boundary prefix of a live message renders with no marker leak and no raw ANSI" do
+      {chunks, _final} = golden_deltas_and_final()
+
+      for prefix <- delta_prefixes(chunks) do
+        block = message_block(prefix, seal: :live)
+        texts = flat_texts(BlockBody.render(block, default_context()))
+
+        for text <- texts do
+          refute text =~ "\e",
+                 "raw ESC byte in rendered text at prefix #{inspect(prefix)}"
+
+          refute text =~ "```",
+                 "fence marker leaked at prefix #{inspect(prefix)}: #{inspect(text)}"
+
+          refute text =~ "*",
+                 "'*' leaked at prefix #{inspect(prefix)}: #{inspect(text)}"
+
+          refute text =~ "_",
+                 "'_' leaked at prefix #{inspect(prefix)}: #{inspect(text)}"
+
+          refute text =~ "`",
+                 "'`' leaked at prefix #{inspect(prefix)}: #{inspect(text)}"
+        end
+      end
+    end
+
+    test "the sealed final content renders the styled document -- no raw ANSI bytes in the element tree" do
+      {_chunks, final} = golden_deltas_and_final()
+
+      block = message_block(final, seal: :sealed)
+      rendered = BlockBody.render(block, default_context())
+      texts = flat_texts(rendered)
+      leaves = flat_leaves(rendered)
+
+      assert Enum.any?(texts, &(&1 =~ "Diagnostic Report"))
+
+      assert Enum.any?(leaves, fn {content, style} ->
+               content == "run" and style[:bold] == true
+             end),
+             "the **run** emphasis must render as a bold span"
+
+      assert Enum.any?(leaves, fn {content, style} ->
+               content =~ "defmodule" and style[:fg] == :yellow
+             end),
+             "fenced code lines must render with the code accent"
+
+      refute Enum.any?(texts, &(&1 =~ "\e"))
+      refute Enum.any?(texts, &(&1 =~ "```"))
     end
   end
 end

--- a/test/raxol/ui/components/harness/body_provider_test.exs
+++ b/test/raxol/ui/components/harness/body_provider_test.exs
@@ -349,4 +349,57 @@ defmodule Raxol.UI.Components.Harness.BodyProviderTest do
       refute Enum.any?(texts, &(&1 =~ "No tracked effects."))
     end
   end
+
+  # `mount/3` takes the block's seal state (`:seal` -- `:live | :sealed`,
+  # default `:sealed`) and threads it into the `:message` body as
+  # `MessageBlock`'s render mode: a live message renders with the
+  # provisional-close streaming treatment, a sealed one as a plain full
+  # parse. Default is `:sealed` so existing direct callers see zero change;
+  # `BlockBody` passes the real `block.seal`. Other kinds accept and
+  # ignore the option.
+  describe "seal threading -- :message bodies stream-render while live" do
+    test "seal: :live renders the message body with provisional close (no marker leak)" do
+      {:ok, view} =
+        BodyProvider.mount(:message, %{text: "wip **bold"},
+          context: default_context(),
+          seal: :live
+        )
+
+      texts = flat_texts(view)
+
+      assert Enum.any?(texts, &(&1 =~ "bold"))
+
+      refute Enum.any?(texts, &(&1 =~ "*")),
+             "a live message's unclosed marker leaked through the mount"
+    end
+
+    test "seal: :sealed (and omitted) renders a plain full parse -- the unclosed marker stays literal" do
+      {:ok, sealed_view} =
+        BodyProvider.mount(:message, %{text: "wip **bold"},
+          context: default_context(),
+          seal: :sealed
+        )
+
+      {:ok, default_view} =
+        BodyProvider.mount(:message, %{text: "wip **bold"},
+          context: default_context()
+        )
+
+      assert Enum.any?(flat_texts(sealed_view), &(&1 =~ "**"))
+
+      # ids are per-init unique -- parity is about rendered content, so
+      # compare the text projection, not the raw view maps.
+      assert flat_texts(sealed_view) == flat_texts(default_view)
+    end
+
+    test "seal is accepted and harmless for non-message kinds" do
+      assert {:ok, _view} =
+               BodyProvider.mount(
+                 :tool_call,
+                 %{name: "Bash", args: %{command: "ls"}},
+                 context: default_context(),
+                 seal: :live
+               )
+    end
+  end
 end

--- a/test/raxol/ui/components/harness/markdown_body_test.exs
+++ b/test/raxol/ui/components/harness/markdown_body_test.exs
@@ -71,6 +71,15 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyTest do
 
   defp delta_prefixes(chunks), do: Enum.scan(chunks, "", &(&2 <> &1))
 
+  # --- seal -> mode vocabulary bridge ---
+
+  describe "mode_for_seal/1 -- the single seal->mode vocabulary bridge" do
+    test "maps :live to :streaming and :sealed to :sealed" do
+      assert MarkdownBody.mode_for_seal(:live) == :streaming
+      assert MarkdownBody.mode_for_seal(:sealed) == :sealed
+    end
+  end
+
   # --- render/2 basic dispatch ---
 
   describe "render/2 dispatch" do

--- a/test/raxol/ui/components/harness/message_block_test.exs
+++ b/test/raxol/ui/components/harness/message_block_test.exs
@@ -9,6 +9,21 @@ defmodule Raxol.UI.Components.Harness.MessageBlockTest do
     %{theme: Raxol.UI.Theming.Theme.default_theme()}
   end
 
+  defp flat_texts(%{type: :text, content: content}), do: [content]
+
+  defp flat_texts(%{children: children}) when is_list(children),
+    do: Enum.flat_map(children, &flat_texts/1)
+
+  defp flat_texts(_node), do: []
+
+  defp flat_leaves(%{type: :text, content: content} = node),
+    do: [{content, node[:style] || %{}}]
+
+  defp flat_leaves(%{children: children}) when is_list(children),
+    do: Enum.flat_map(children, &flat_leaves/1)
+
+  defp flat_leaves(_node), do: []
+
   describe "init/1" do
     test "initializes with default values" do
       assert {:ok, state} = MessageBlock.init(id: :m1)
@@ -86,6 +101,85 @@ defmodule Raxol.UI.Components.Harness.MessageBlockTest do
       expected_body = MarkdownRenderer.render(md_state, default_context())
 
       assert body_el == expected_body
+    end
+  end
+
+  # The BodyProvider seam mounts this component for a block that may still
+  # be LIVE (streaming). The body render is delegated to Harness.MarkdownBody
+  # so a live message gets the provisional-close treatment and every message
+  # gets its sanitization -- pure content -> view, no state.
+  describe "streaming mode (BodyProvider seam)" do
+    test "defaults to :sealed mode" do
+      assert {:ok, state} = MessageBlock.init(id: :m_mode_default)
+      assert state.mode == :sealed
+    end
+
+    test "accepts mode: :streaming" do
+      assert {:ok, state} =
+               MessageBlock.init(id: :m_mode_stream, mode: :streaming)
+
+      assert state.mode == :streaming
+    end
+
+    test ":streaming provisionally closes a trailing unclosed construct -- no marker leak" do
+      {:ok, state} =
+        MessageBlock.init(
+          id: :m_stream,
+          content: "checking **disk",
+          mode: :streaming,
+          width: 80
+        )
+
+      rendered = MessageBlock.render(state, default_context())
+      texts = flat_texts(rendered)
+
+      assert Enum.any?(texts, &(&1 =~ "disk"))
+
+      refute Enum.any?(texts, &(&1 =~ "*")),
+             "a live message's unclosed bold marker leaked as literal text"
+
+      assert Enum.any?(flat_leaves(rendered), fn {content, style} ->
+               content =~ "disk" and style[:bold] == true
+             end),
+             "the provisionally-closed span must render styled bold"
+    end
+
+    test ":sealed (default) renders the same unclosed marker literally -- parity with the plain full parse" do
+      {:ok, state} =
+        MessageBlock.init(id: :m_sealed, content: "checking **disk", width: 80)
+
+      rendered = MessageBlock.render(state, default_context())
+
+      assert Enum.any?(flat_texts(rendered), &(&1 =~ "**")),
+             "sealed content is final -- a genuinely-unclosed marker stays literal"
+    end
+  end
+
+  describe "sanitization and total safety (via MarkdownBody)" do
+    test "raw ANSI escape bytes in content never reach the element tree" do
+      {:ok, state} =
+        MessageBlock.init(
+          id: :m_ansi,
+          content: "ok \e[31mred\e[0m done",
+          width: 80
+        )
+
+      rendered = MessageBlock.render(state, default_context())
+      texts = flat_texts(rendered)
+
+      assert Enum.any?(texts, &(&1 =~ "red"))
+
+      refute Enum.any?(texts, &(&1 =~ "\e")),
+             "an embedded ESC byte reached the element tree -- this violates " <>
+               "the no-raw-ANSI-in-text() rule at the View-DSL boundary"
+    end
+
+    test "non-binary content never raises" do
+      {:ok, state} =
+        MessageBlock.init(id: :m_bad, content: %{oops: :shape}, width: 80)
+
+      rendered = MessageBlock.render(state, default_context())
+      assert rendered.type == :column
     end
   end
 

--- a/test/raxol/ui/components/markdown_renderer_test.exs
+++ b/test/raxol/ui/components/markdown_renderer_test.exs
@@ -493,6 +493,57 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
       refute full_text(result) =~ "title"
     end
 
+    # A shared component's new output surface inherits the component's OWN
+    # trust contract, not the calling path's: MarkdownRenderer's contract is
+    # "callers may pass untrusted text", and it has direct callers with no
+    # MarkdownBody pre-sanitization in front (e.g. the playground's
+    # DemoHelpers.markdown/2). So the label must be safe at THIS boundary,
+    # regardless of which path produced the input.
+    test "control/ESC bytes in the info string never reach the label" do
+      md = "```elixir\e[2J\n:ok\n```"
+      result = render_md(md)
+
+      refute full_text(result) =~ "\e",
+             "a raw ESC byte from the fence info string reached text()"
+
+      assert [label] =
+               Enum.filter(children(result), &(&1[:style][:dim] == true))
+
+      assert String.starts_with?(label.content, "  elixir")
+    end
+
+    test "a control-chars-only info string yields no label at all" do
+      md = "```\e\n:ok\n```"
+      result = render_md(md)
+
+      refute full_text(result) =~ "\e"
+
+      refute Enum.any?(children(result), &(&1[:style][:dim] == true)),
+             "a sanitized-to-empty info string must not grow an empty label"
+    end
+
+    test "an oversized info string is clamped to a bounded label line" do
+      lang = String.duplicate("x", 100_000)
+      md = "```#{lang}\n:ok\n```"
+      result = render_md(md)
+
+      assert [label] =
+               Enum.filter(children(result), &(&1[:style][:dim] == true))
+
+      assert Raxol.UI.TextMeasure.display_width(label.content) <= 40,
+             "the label line must stay bounded no matter the info string size"
+    end
+
+    test "code_language_from_attrs/1 sanitizes and clamps too -- Earmark attrs are equally untrusted" do
+      assert MarkdownRenderer.code_language_from_attrs([
+               {"class", "elixir\e[2J"}
+             ]) == "elixir[2J"
+
+      long = String.duplicate("y", 500)
+      clamped = MarkdownRenderer.code_language_from_attrs([{"class", long}])
+      assert String.length(clamped) <= 32
+    end
+
     test "code_language_from_attrs/1 extracts Earmark's class attr, stripping the language- prefix" do
       assert MarkdownRenderer.code_language_from_attrs([{"class", "elixir"}]) ==
                "elixir"

--- a/test/raxol/ui/components/markdown_renderer_test.exs
+++ b/test/raxol/ui/components/markdown_renderer_test.exs
@@ -297,6 +297,22 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
         assert String.starts_with?(line.content, "  ")
       end
     end
+
+    # Regression pin: the builtin fenced path used to push code lines onto
+    # the reversed accumulator in already-correct order, so the final
+    # reversal flipped them -- a multi-line block rendered bottom-to-top.
+    test "renders multi-line code in source order" do
+      md = "```\nfirst\nsecond\nthird\n```"
+      result = render_md(md)
+
+      code_contents =
+        result
+        |> children()
+        |> Enum.filter(&(&1.style[:fg] == :yellow))
+        |> Enum.map(& &1.content)
+
+      assert code_contents == ["  first", "  second", "  third"]
+    end
   end
 
   describe "blockquotes" do
@@ -414,6 +430,79 @@ defmodule Raxol.UI.Components.MarkdownRendererTest do
                {"bold", %{bold: true}},
                {" tail", %{}}
              ]
+    end
+  end
+
+  # A fence's info string ("```elixir") names the code's language. The
+  # renderer displays it as a dim label line above the (monospace, yellow)
+  # code body. Display only -- NO syntax highlighting in this unit; the
+  # label + @code_style block is the documented seam a future highlighter
+  # slots into.
+  describe "fenced code language tags (info string)" do
+    test "renders the language as a dim label line above the code body" do
+      md = "```elixir\nIO.puts(\"hi\")\n```"
+      result = render_md(md)
+
+      assert [label] =
+               Enum.filter(children(result), &(&1[:content] == "  elixir"))
+
+      assert label.style[:dim] == true
+
+      label_idx =
+        Enum.find_index(children(result), &(&1[:content] == "  elixir"))
+
+      code_idx =
+        Enum.find_index(children(result), &((&1[:content] || "") =~ "IO.puts"))
+
+      assert label_idx < code_idx,
+             "the language label must sit above the code body"
+    end
+
+    test "the label is chrome, not code -- dim, never the code accent" do
+      md = "```elixir\nIO.puts(\"hi\")\n```"
+      result = render_md(md)
+
+      [label] = Enum.filter(children(result), &(&1[:content] == "  elixir"))
+
+      refute label.style[:fg] == :yellow,
+             "the label must be visually distinct from the code body"
+    end
+
+    test "an untagged fence renders no label line (and no dim element at all)" do
+      md = "```\nhello\n```"
+      result = render_md(md)
+
+      assert length(children(result)) == 3
+
+      refute Enum.any?(children(result), &(&1[:style][:dim] == true)),
+             "an untagged fence must not grow a label line"
+    end
+
+    test "~~~ fences carry the label too" do
+      md = "~~~python\nx = 1\n~~~"
+      result = render_md(md)
+
+      assert Enum.any?(children(result), &(&1[:content] == "  python"))
+    end
+
+    test "only the first word of the info string becomes the label" do
+      md = "```elixir title=demo\n:ok\n```"
+      result = render_md(md)
+
+      assert Enum.any?(children(result), &(&1[:content] == "  elixir"))
+      refute full_text(result) =~ "title"
+    end
+
+    test "code_language_from_attrs/1 extracts Earmark's class attr, stripping the language- prefix" do
+      assert MarkdownRenderer.code_language_from_attrs([{"class", "elixir"}]) ==
+               "elixir"
+
+      assert MarkdownRenderer.code_language_from_attrs([
+               {"class", "language-rust"}
+             ]) == "rust"
+
+      assert MarkdownRenderer.code_language_from_attrs([]) == nil
+      assert MarkdownRenderer.code_language_from_attrs([{"class", ""}]) == nil
     end
   end
 end


### PR DESCRIPTION
The streaming-safe markdown machinery (provisional-close for live blocks, sanitization, never-raise) landed earlier as #563 — but the BodyProvider-mounted message path ignored all of it: live message blocks did a raw full parse of partial streams (unclosed constructs flashing raw markers) with no sanitization. This wires the mounted path end-to-end and holds scope to the genuine gaps.

## What changed

- `BlockBody` -> `BodyProvider.mount(seal: block.seal)` -> `MessageBlock` -> `MarkdownBody`: live blocks stream through provisional close, so unclosed fences/emphasis never flash raw markers mid-stream; content is control-char/ANSI-sanitized (no ESC bytes reach the element tree); garbage content falls back to plain text, never raises. Defaults are `:sealed` everywhere — existing callers see zero change.
- Fence info-string language now renders as a dim label line above the code body (first word only). Syntax highlighting stays a documented seam.
- Both parser paths (builtin + opportunistic Earmark AST in dev) now share one fence-assembly helper so they cannot drift.
- `:reasoning` bodies stay deliberately plain through this path (documented).

## Latent bug found and fixed

The rework surfaced a builtin-path bug: multi-line fenced code rendered bottom-to-top (reversed-accumulator misuse). Fixed, pinned with a source-order regression test.

## Parser decision

No new dependency: `earmark_parser` exists only transitively via ex_doc (`only: :dev`), so the hand-rolled builtin parser is the de-facto test/prod path already.

## Verification

Red-first: 12 failing tests before implementation (mode/sanitization, seal-threading, end-to-end leak, language labels) + a golden-fixture replay through the full BlockBody path at every delta prefix and at seal. Harness component suite 526 passed, test/harness/ 292, playground (the other MarkdownRenderer consumer) 324 — zero regressions. Warnings-as-errors + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)