### PR TITLE
Harness UI: hand the composer draft to $EDITOR with a suspend/resume bracket

### DIFF
--- a/examples/harness_fixture_demo.exs
+++ b/examples/harness_fixture_demo.exs
@@ -20,7 +20,10 @@
 #
 # Keys while running: `z` fold/unfold the focused block, `j`/`k` move
 # focus (once off the composer -- see `Surface.focus_transcript/1`), `Tab`
-# queues a steer stub, `Esc` shows an interrupt stub (no agent lane in
+# queues a steer stub, `Ctrl-E` opens the composer draft in $VISUAL/$EDITOR
+# (the harness suspends its terminal claim while the editor owns the tty,
+# then resumes and reloads the edited draft -- see
+# `Raxol.Harness.EditorSession`), `Esc` shows an interrupt stub (no agent lane in
 # fixture mode -- see `Raxol.Harness.Surface`'s moduledoc, precondition
 # #6), `q` quits cleanly WHEN THE COMPOSER BUFFER IS EMPTY (Ctrl-C does
 # not: raw mode disables SIGINT delivery, per `Raxol.Terminal.InlineDriver`'s
@@ -86,7 +89,11 @@ defmodule Raxol.Examples.HarnessFixtureDemo do
         width: width,
         rows: rows,
         footer_rows: @footer_rows,
-        tty?: tty?
+        tty?: tty?,
+        # Ctrl-E hands the composer draft to $VISUAL/$EDITOR (real tty
+        # runs only -- a piped/CI run has no terminal to hand over, and
+        # Surface renders its honest stub notice instead).
+        editor_session: if(tty?, do: Raxol.Harness.EditorSession)
       )
 
     try do

--- a/lib/raxol/harness/editor_session.ex
+++ b/lib/raxol/harness/editor_session.ex
@@ -1,0 +1,326 @@
+defmodule Raxol.Harness.EditorSession do
+  @moduledoc """
+  The THIN impure runner for the composer's external-editor handoff:
+  drives `Raxol.Harness.EditorSuspend`'s pure state machine and
+  interprets each step against the real device / stty / reader gate /
+  editor process. All sequencing, ordering, and failure-recovery policy
+  lives in the pure machine; this module only performs effects.
+
+  ## The spawn mechanism (why a Port with `:nouse_stdio`)
+
+  The editor must own the REAL tty. `System.cmd/3` can never provide
+  that -- its child's stdio is a pipe pair back to the BEAM. A
+  `Port.open({:spawn, cmd}, [:nouse_stdio, :exit_status])` moves the
+  port's own pipe protocol to fds 3/4, so the child INHERITS the BEAM's
+  fds 0/1/2 -- the terminal itself. This is byte-for-byte the mechanism
+  OTP's own shell uses for its open-in-editor feature (`user_drv`'s
+  Ctrl+O path: `disable_reader` -> `open_port(..., [nouse_stdio])` ->
+  reload on port exit -> `enable_reader`), so the approach is
+  OTP-sanctioned, not novel. `{:spawn, string}` goes through `/bin/sh`,
+  which buys two things: `$EDITOR` values carrying arguments
+  (`"code -w"`) work unmodified, and a missing editor binary surfaces
+  as the shell's exit status 127 -- mapped here to a keep-the-draft
+  `{:editor_not_found, cmd}` outcome instead of a crash. The temp-file
+  path is single-quote shell-escaped before it joins the command line.
+
+  The `:spawn_fun` seam is `(shell_command :: String.t()) ->
+  non_neg_integer() | :crashed` -- synchronous, returning the editor's
+  exit status (`:crashed` when the port died without ever delivering
+  one). The default implementation is the Port described above.
+
+  ## Outcomes
+
+    * `{:ok, %{text: edited, width: w, rows: h}}` -- editor exited 0 and
+      the temp file read back; `text` is the decoded draft
+      (`EditorSuspend.decode_draft/1`).
+    * `{:kept, reason, %{width: w, rows: h}}` -- the terminal was
+      suspended and RESUMED, but the draft is kept unchanged:
+      `:editor_nonzero` | `{:editor_not_found, cmd}` | `:editor_crashed`
+      | `:reload_failed`.
+    * `{:error, {:reader_disable, reason}}` / `{:error, {step, reason}}`
+      -- a step failed before the handoff completed; the machine's
+      compensation ran, so the terminal is back in a recoverable state.
+      In particular a reader-disable failure aborts BEFORE any byte
+      touches the device: never hand the tty to an editor while the
+      BEAM reader still competes for its keystrokes.
+
+  A step that RAISES (rather than returning an error) still runs the
+  machine's `recovery/1` compensation first, then the exception
+  propagates unchanged -- callers that must not crash (the harness UI
+  loop) wrap their call; the terminal is already restored by the time
+  the exception reaches them either way. The temp file is additionally
+  removed in a `try/after`, so no path -- including the raise path --
+  leaks it.
+
+  ## What this module deliberately does NOT do
+
+  It never writes DECSTBM region bytes. The machine's
+  `:reassert_region` step is interpreted as a no-op HERE because region
+  emission is owned by the paint authority
+  (`Raxol.UI.Rendering.PaintAuthority.InlineAuthority.reassert/1` over
+  its `ScrollRegionManager` state -- the single-DECSTBM-owner rule): the
+  caller that owns the authority (`Raxol.Harness.Surface`'s edit-draft
+  dispatch) composes `resize |> reassert` on EVERY return from this
+  function -- ok, kept, or error -- so the pin is guaranteed
+  belt-and-braces regardless of where a failure landed. Geometry is
+  re-queried here (while still cooked, before re-entering raw mode) and
+  returned so that caller re-pins at the terminal's CURRENT size.
+
+  Every injectable seam has a real default: `:stty` (module),
+  `:reader_gate` (module), `:reader` (pid), `:env`, `:tmp_dir`,
+  `:spawn_fun`, `:size_fun`, `:device`. Tests drive the full sequence
+  with fakes and a StringIO device; the real tty is never touched by
+  the suite.
+  """
+
+  alias Raxol.Harness.EditorSuspend
+  alias Raxol.Terminal.InlineDriver.ReaderGate
+  alias Raxol.Terminal.InlineDriver.Sequences
+
+  @type outcome ::
+          {:ok, %{text: String.t(), width: pos_integer(), rows: pos_integer()}}
+          | {:kept, term(), %{width: pos_integer(), rows: pos_integer()}}
+          | {:error, {atom(), term()}}
+
+  @spec run(String.t(), keyword()) :: outcome()
+  def run(draft, opts) when is_binary(draft) and is_list(opts) do
+    rows = Keyword.fetch!(opts, :rows)
+    stty = Keyword.get(opts, :stty, Raxol.Terminal.Driver.Stty)
+
+    {:ok, editor} =
+      opts
+      |> Keyword.get_lazy(:env, fn -> System.get_env() end)
+      |> EditorSuspend.resolve_editor()
+
+    path =
+      opts
+      |> Keyword.get_lazy(:tmp_dir, &System.tmp_dir!/0)
+      |> Path.join(EditorSuspend.tmp_filename(unique()))
+
+    ctx = %{
+      draft: draft,
+      editor: editor,
+      path: path,
+      cmd: nil,
+      device: Keyword.get(opts, :device, :stdio),
+      rows: rows,
+      width: Keyword.get(opts, :width, 80),
+      stty: stty,
+      gate: Keyword.get(opts, :reader_gate, ReaderGate),
+      reader:
+        Keyword.get_lazy(opts, :reader, fn ->
+          Process.whereis(:user_drv_reader)
+        end),
+      spawn_fun: Keyword.get(opts, :spawn_fun, &default_spawn/1),
+      size_fun: Keyword.get(opts, :size_fun, fn -> stty.size() end),
+      exit_status: nil,
+      outcome: nil
+    }
+
+    try do
+      drive(EditorSuspend.new(), ctx)
+    after
+      # Belt-and-braces: the machine's own :cleanup_tmp (happy path) or
+      # compensation (failure path) already removes the file; this
+      # `after` guarantees it even on the raise path. Removing an
+      # already-removed file is a harmless error tuple.
+      _ = File.rm(path)
+    end
+  end
+
+  # -- the machine loop --------------------------------------------------
+
+  defp drive(machine, ctx) do
+    case EditorSuspend.advance(machine, :ok) do
+      {:done, _machine} ->
+        finish(ctx)
+
+      {:effect, step, machine} ->
+        run_step(step, machine, ctx)
+    end
+  end
+
+  # A raise inside a step still runs the machine's compensation (the
+  # `recovery/1` rescue seam) before propagating unchanged -- the
+  # terminal must be recoverable even when the failure is an exception,
+  # not an error return.
+  defp run_step(step, machine, ctx) do
+    interpret(step, ctx)
+  rescue
+    error ->
+      Enum.each(EditorSuspend.recovery(machine), &compensate(&1, ctx))
+      reraise error, __STACKTRACE__
+  catch
+    kind, reason ->
+      Enum.each(EditorSuspend.recovery(machine), &compensate(&1, ctx))
+      :erlang.raise(kind, reason, __STACKTRACE__)
+  else
+    {:ok, ctx} ->
+      drive(machine, ctx)
+
+    {:error, reason} ->
+      {:abort, compensation, _machine} =
+        EditorSuspend.advance(machine, {:error, reason})
+
+      Enum.each(compensation, &compensate(&1, ctx))
+      {:error, {error_tag(step), reason}}
+  end
+
+  defp finish(%{outcome: nil} = ctx),
+    do: {:ok, %{text: ctx.text, width: ctx.width, rows: ctx.rows}}
+
+  defp finish(%{outcome: {:kept, reason}} = ctx),
+    do: {:kept, reason, %{width: ctx.width, rows: ctx.rows}}
+
+  # The one step whose public error tag differs from its machine name:
+  # callers see the RESOURCE that failed (the reader gate), not the
+  # machine-internal step atom.
+  defp error_tag(:disable_reader), do: :reader_disable
+  defp error_tag(step), do: step
+
+  # -- step interpretation ----------------------------------------------
+
+  defp interpret(:write_tmp, ctx) do
+    case File.write(ctx.path, EditorSuspend.encode_draft(ctx.draft)) do
+      :ok -> {:ok, ctx}
+      {:error, posix} -> {:error, posix}
+    end
+  end
+
+  defp interpret(:disable_reader, ctx) do
+    # A disable failure ABORTS the suspend: never hand the tty to an
+    # editor while the BEAM reader still competes for its bytes.
+    case ctx.gate.disable(ctx.reader) do
+      :ok -> {:ok, ctx}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp interpret(:release_screen, ctx) do
+    IO.write(ctx.device, Sequences.suspend_bytes(ctx.rows))
+    {:ok, ctx}
+  end
+
+  defp interpret(:restore_tty, ctx) do
+    # `restore(nil)` falls through to `stty sane` -- the canonical cooked
+    # baseline. The pre-raw snapshot belongs to the InlineDriver (it
+    # restores it at final teardown); this bracket only needs sane modes
+    # for the editor to start from.
+    ctx.stty.restore(nil)
+    {:ok, ctx}
+  end
+
+  defp interpret(:spawn_editor, ctx) do
+    # Pure bookkeeping: assemble the shell command. The synchronous
+    # handoff itself happens at :await_editor -- keeping the two steps
+    # distinct preserves the machine's step vocabulary even though the
+    # default spawn is blocking.
+    {:ok, %{ctx | cmd: ctx.editor <> " " <> shell_quote(ctx.path)}}
+  end
+
+  defp interpret(:await_editor, ctx) do
+    {:ok, %{ctx | exit_status: ctx.spawn_fun.(ctx.cmd)}}
+  end
+
+  defp interpret(:requery_size, ctx) do
+    case ctx.size_fun.() do
+      {:ok, cols, rows} when is_integer(cols) and is_integer(rows) ->
+        {:ok, %{ctx | width: cols, rows: rows}}
+
+      _other ->
+        # No honest answer -- keep the geometry the caller passed in.
+        {:ok, ctx}
+    end
+  end
+
+  defp interpret(:raw_tty, ctx) do
+    ctx.stty.raw!()
+    {:ok, ctx}
+  end
+
+  defp interpret(:enable_reader, ctx) do
+    # An enable failure leaves input degraded but is survivable --
+    # continuing (the caller can notify) beats aborting a resume that is
+    # already half-done.
+    _ = ctx.gate.enable(ctx.reader)
+    {:ok, ctx}
+  end
+
+  defp interpret(:reinit_modes, ctx) do
+    IO.write(ctx.device, Sequences.init_bytes())
+    {:ok, ctx}
+  end
+
+  defp interpret(:reassert_region, ctx) do
+    # Deliberate no-op HERE: region bytes are owned by the paint
+    # authority; the caller composes `resize |> reassert` on every
+    # return (see the moduledoc's "does NOT do" section).
+    {:ok, ctx}
+  end
+
+  defp interpret(:reload_draft, %{exit_status: 0} = ctx) do
+    case File.read(ctx.path) do
+      {:ok, content} ->
+        {:ok, Map.put(ctx, :text, EditorSuspend.decode_draft(content))}
+
+      {:error, _posix} ->
+        {:ok, %{ctx | outcome: {:kept, :reload_failed}}}
+    end
+  end
+
+  defp interpret(:reload_draft, %{exit_status: 127} = ctx),
+    do: {:ok, %{ctx | outcome: {:kept, {:editor_not_found, ctx.editor}}}}
+
+  defp interpret(:reload_draft, %{exit_status: :crashed} = ctx),
+    do: {:ok, %{ctx | outcome: {:kept, :editor_crashed}}}
+
+  defp interpret(:reload_draft, ctx),
+    do: {:ok, %{ctx | outcome: {:kept, :editor_nonzero}}}
+
+  defp interpret(:cleanup_tmp, ctx) do
+    _ = File.rm(ctx.path)
+    {:ok, ctx}
+  end
+
+  # -- compensation interpretation ---------------------------------------
+
+  defp compensate(:raw_tty, ctx), do: ctx.stty.raw!()
+  defp compensate(:enable_reader, ctx), do: ctx.gate.enable(ctx.reader)
+
+  defp compensate(:reinit_modes, ctx),
+    do: IO.write(ctx.device, Sequences.init_bytes())
+
+  # Region bytes stay with the authority owner -- same rationale as the
+  # forward step; the caller reasserts on every return.
+  defp compensate(:reassert_region, _ctx), do: :ok
+  defp compensate(:cleanup_tmp, ctx), do: File.rm(ctx.path)
+
+  # -- the real spawn ----------------------------------------------------
+
+  # Synchronous: opens the port (the editor now owns fds 0/1/2 -- the
+  # tty) and blocks until it delivers an exit status. `:crashed` when
+  # the port dies without one.
+  defp default_spawn(cmd) do
+    port = Port.open({:spawn, cmd}, [:nouse_stdio, :exit_status])
+    ref = Port.monitor(port)
+
+    receive do
+      {^port, {:exit_status, status}} ->
+        Port.demonitor(ref, [:flush])
+        status
+
+      {:DOWN, ^ref, :port, ^port, _reason} ->
+        :crashed
+    end
+  end
+
+  # Single-quote wrapping with the canonical '\'' escape -- the tmp path
+  # is generated (safe characters only), but quote it anyway: `{:spawn,
+  # string}` goes through /bin/sh.
+  defp shell_quote(path),
+    do: "'" <> String.replace(path, "'", "'\\''") <> "'"
+
+  defp unique do
+    "#{:erlang.unique_integer([:positive, :monotonic])}_#{System.os_time(:microsecond)}"
+  end
+end

--- a/lib/raxol/harness/editor_session.ex
+++ b/lib/raxol/harness/editor_session.ex
@@ -30,19 +30,29 @@ defmodule Raxol.Harness.EditorSession do
 
   ## Outcomes
 
-    * `{:ok, %{text: edited, width: w, rows: h}}` -- editor exited 0 and
-      the temp file read back; `text` is the decoded draft
-      (`EditorSuspend.decode_draft/1`).
-    * `{:kept, reason, %{width: w, rows: h}}` -- the terminal was
-      suspended and RESUMED, but the draft is kept unchanged:
-      `:editor_nonzero` | `{:editor_not_found, cmd}` | `:editor_crashed`
-      | `:reload_failed`.
+    * `{:ok, %{text: edited, width: w, rows: h, degraded: [...]}}` --
+      editor exited 0 and the temp file read back; `text` is the
+      decoded draft (`EditorSuspend.decode_draft/1`).
+    * `{:kept, reason, %{width: w, rows: h, degraded: [...]}}` -- the
+      terminal was suspended and RESUMED, but the draft is kept
+      unchanged: `:editor_nonzero` | `{:editor_not_found, cmd}` |
+      `:editor_crashed` | `:editor_timeout` | `:reload_failed`.
     * `{:error, {:reader_disable, reason}}` / `{:error, {step, reason}}`
       -- a step failed before the handoff completed; the machine's
       compensation ran, so the terminal is back in a recoverable state.
       In particular a reader-disable failure aborts BEFORE any byte
       touches the device: never hand the tty to an editor while the
       BEAM reader still competes for its keystrokes.
+
+  `degraded` is the machine's `EditorSuspend.degradations/1` list --
+  `[]` on a clean run. A non-empty list (today: `{:enable_reader,
+  reason}` when the stdin reader failed to re-enable after the editor)
+  means the run COMPLETED but keyboard input may be dead; the failure
+  also emits `[:raxol, :harness, :editor, :reader_enable_failed]`
+  telemetry with `%{reason: reason}` metadata. Callers MUST surface a
+  non-empty `degraded` to the operator (Surface renders a footer
+  warning) -- it is never safe to show the edited draft as if nothing
+  happened while the tty cannot type.
 
   A step that RAISES (rather than returning an error) still runs the
   machine's `recovery/1` compensation first, then the exception
@@ -51,6 +61,37 @@ defmodule Raxol.Harness.EditorSession do
   the exception reaches them either way. The temp file is additionally
   removed in a `try/after`, so no path -- including the raise path --
   leaks it.
+
+  ## Draft confidentiality (the temp file is a secret)
+
+  A composer draft can contain anything the operator types -- API keys,
+  private text. It is therefore never written bare into the shared
+  tmp dir: each run creates a fresh per-run subdirectory chmod'd `0700`
+  (unreadable to other local users regardless of file modes or umask),
+  with an unpredictable `:crypto.strong_rand_bytes`-suffixed name, and
+  the draft file inside it is created by `write_draft_file/2` with
+  `[:exclusive]` (`O_CREAT | O_EXCL` -- creation FAILS on any
+  pre-existing path, and per POSIX the final path component is never
+  followed as a symlink under `O_EXCL`, so a pre-planted symlink cannot
+  redirect the write) and chmod'd `0600`. Cleanup removes the whole
+  per-run directory on every path.
+
+  ## Trust boundary: `$VISUAL`/`$EDITOR` is the operator's own shell config
+
+  The editor command is interpolated into a `/bin/sh` command line
+  UNVALIDATED, by design -- the same contract git, crontab, and OTP's
+  own shell honor (all of them sh-execute `$EDITOR`, precisely so
+  values like `"code -w"` or `emacsclient -a ""` work; a metacharacter
+  allowlist would break real configurations while defending a boundary
+  that does not exist here). It is safe under exactly one assumption:
+  the process environment is the SAME trust domain as the operator's
+  shell -- whoever set `$EDITOR` could already run commands as this
+  user. The draft content itself never reaches the shell (only the
+  quoted generated path does). Embedders that expose the harness across
+  a privilege boundary where the environment is attacker-influenceable
+  (SSH `AcceptEnv`/`ForceCommand` setups, sudo `env_keep`, a service
+  manager injecting env) MUST NOT pass the ambient environment through
+  -- inject a vetted `:env` explicitly instead.
 
   ## What this module deliberately does NOT do
 
@@ -78,8 +119,19 @@ defmodule Raxol.Harness.EditorSession do
   alias Raxol.Terminal.InlineDriver.Sequences
 
   @type outcome ::
-          {:ok, %{text: String.t(), width: pos_integer(), rows: pos_integer()}}
-          | {:kept, term(), %{width: pos_integer(), rows: pos_integer()}}
+          {:ok,
+           %{
+             text: String.t(),
+             width: pos_integer(),
+             rows: pos_integer(),
+             degraded: [{EditorSuspend.step(), term()}]
+           }}
+          | {:kept, term(),
+             %{
+               width: pos_integer(),
+               rows: pos_integer(),
+               degraded: [{EditorSuspend.step(), term()}]
+             }}
           | {:error, {atom(), term()}}
 
   @spec run(String.t(), keyword()) :: outcome()
@@ -92,15 +144,21 @@ defmodule Raxol.Harness.EditorSession do
       |> Keyword.get_lazy(:env, fn -> System.get_env() end)
       |> EditorSuspend.resolve_editor()
 
-    path =
+    # A fresh, unpredictably-named per-run directory (see the moduledoc's
+    # confidentiality section) -- created 0700 by :write_tmp, removed
+    # whole by :cleanup_tmp / the `after` below.
+    dir =
       opts
       |> Keyword.get_lazy(:tmp_dir, &System.tmp_dir!/0)
-      |> Path.join(EditorSuspend.tmp_filename(unique()))
+      |> Path.join("raxol_editor_" <> unique())
+
+    editor_timeout = Keyword.get(opts, :editor_timeout_ms, :infinity)
 
     ctx = %{
       draft: draft,
       editor: editor,
-      path: path,
+      dir: dir,
+      path: Path.join(dir, EditorSuspend.tmp_filename(unique())),
       cmd: nil,
       device: Keyword.get(opts, :device, :stdio),
       rows: rows,
@@ -111,7 +169,10 @@ defmodule Raxol.Harness.EditorSession do
         Keyword.get_lazy(opts, :reader, fn ->
           Process.whereis(:user_drv_reader)
         end),
-      spawn_fun: Keyword.get(opts, :spawn_fun, &default_spawn/1),
+      spawn_fun:
+        Keyword.get(opts, :spawn_fun, fn cmd ->
+          default_spawn(cmd, editor_timeout)
+        end),
       size_fun: Keyword.get(opts, :size_fun, fn -> stty.size() end),
       exit_status: nil,
       outcome: nil
@@ -121,19 +182,35 @@ defmodule Raxol.Harness.EditorSession do
       drive(EditorSuspend.new(), ctx)
     after
       # Belt-and-braces: the machine's own :cleanup_tmp (happy path) or
-      # compensation (failure path) already removes the file; this
+      # compensation (failure path) already removes the directory; this
       # `after` guarantees it even on the raise path. Removing an
-      # already-removed file is a harmless error tuple.
-      _ = File.rm(path)
+      # already-removed directory is a harmless no-op.
+      _ = File.rm_rf(dir)
+    end
+  end
+
+  @doc false
+  # The exclusive-create draft write, exposed for the security suite:
+  # `[:exclusive]` = O_CREAT|O_EXCL, so a pre-existing path (including a
+  # pre-planted symlink -- O_EXCL never follows the final component) is
+  # refused with {:error, :eexist} instead of truncated/redirected. The
+  # file is chmod'd 0600 after the write; its 0700 parent directory is
+  # what actually confines the content window in between.
+  @spec write_draft_file(Path.t(), binary()) :: :ok | {:error, term()}
+  def write_draft_file(path, content) do
+    with {:ok, io} <- :file.open(path, [:write, :exclusive, :binary, :raw]),
+         :ok <- :file.write(io, content),
+         :ok <- :file.close(io) do
+      File.chmod(path, 0o600)
     end
   end
 
   # -- the machine loop --------------------------------------------------
 
-  defp drive(machine, ctx) do
-    case EditorSuspend.advance(machine, :ok) do
-      {:done, _machine} ->
-        finish(ctx)
+  defp drive(machine, ctx, event \\ :ok) do
+    case EditorSuspend.advance(machine, event) do
+      {:done, machine} ->
+        finish(ctx, machine)
 
       {:effect, step, machine} ->
         run_step(step, machine, ctx)
@@ -156,7 +233,13 @@ defmodule Raxol.Harness.EditorSession do
       :erlang.raise(kind, reason, __STACKTRACE__)
   else
     {:ok, ctx} ->
-      drive(machine, ctx)
+      drive(machine, ctx, :ok)
+
+    {:degraded, reason} ->
+      # The step failed but must not abort (today: :enable_reader) --
+      # the machine records it so `finish/2` reports it; interpret/2
+      # already emitted the telemetry.
+      drive(machine, ctx, {:degraded, reason})
 
     {:error, reason} ->
       {:abort, compensation, _machine} =
@@ -166,11 +249,24 @@ defmodule Raxol.Harness.EditorSession do
       {:error, {error_tag(step), reason}}
   end
 
-  defp finish(%{outcome: nil} = ctx),
-    do: {:ok, %{text: ctx.text, width: ctx.width, rows: ctx.rows}}
+  defp finish(%{outcome: nil} = ctx, machine) do
+    {:ok,
+     %{
+       text: ctx.text,
+       width: ctx.width,
+       rows: ctx.rows,
+       degraded: EditorSuspend.degradations(machine)
+     }}
+  end
 
-  defp finish(%{outcome: {:kept, reason}} = ctx),
-    do: {:kept, reason, %{width: ctx.width, rows: ctx.rows}}
+  defp finish(%{outcome: {:kept, reason}} = ctx, machine) do
+    {:kept, reason,
+     %{
+       width: ctx.width,
+       rows: ctx.rows,
+       degraded: EditorSuspend.degradations(machine)
+     }}
+  end
 
   # The one step whose public error tag differs from its machine name:
   # callers see the RESOURCE that failed (the reader gate), not the
@@ -181,9 +277,15 @@ defmodule Raxol.Harness.EditorSession do
   # -- step interpretation ----------------------------------------------
 
   defp interpret(:write_tmp, ctx) do
-    case File.write(ctx.path, EditorSuspend.encode_draft(ctx.draft)) do
-      :ok -> {:ok, ctx}
-      {:error, posix} -> {:error, posix}
+    # 0700 per-run dir FIRST (the confinement), then the exclusive-create
+    # 0600 draft file inside it -- see the moduledoc's confidentiality
+    # section. The mkdir itself is fresh-named (strong-random suffix), so
+    # an existing path here is already suspicious and refused.
+    with :ok <- File.mkdir(ctx.dir),
+         :ok <- File.chmod(ctx.dir, 0o700),
+         :ok <-
+           write_draft_file(ctx.path, EditorSuspend.encode_draft(ctx.draft)) do
+      {:ok, ctx}
     end
   end
 
@@ -239,11 +341,25 @@ defmodule Raxol.Harness.EditorSession do
   end
 
   defp interpret(:enable_reader, ctx) do
-    # An enable failure leaves input degraded but is survivable --
-    # continuing (the caller can notify) beats aborting a resume that is
-    # already half-done.
-    _ = ctx.gate.enable(ctx.reader)
-    {:ok, ctx}
+    # An enable failure leaves input degraded but must not abort a
+    # resume that is already half-done -- and it must NEVER be silent:
+    # the {:degraded, reason} report is recorded by the machine, carried
+    # on the outcome for the caller to surface, and telemetry-emitted
+    # here (review finding: the old `_ = enable(...)` swallow reported
+    # a permanently-deaf tty as a clean {:ok, text}).
+    case ctx.gate.enable(ctx.reader) do
+      :ok ->
+        {:ok, ctx}
+
+      {:error, reason} ->
+        :telemetry.execute(
+          [:raxol, :harness, :editor, :reader_enable_failed],
+          %{},
+          %{reason: reason}
+        )
+
+        {:degraded, reason}
+    end
   end
 
   defp interpret(:reinit_modes, ctx) do
@@ -274,11 +390,14 @@ defmodule Raxol.Harness.EditorSession do
   defp interpret(:reload_draft, %{exit_status: :crashed} = ctx),
     do: {:ok, %{ctx | outcome: {:kept, :editor_crashed}}}
 
+  defp interpret(:reload_draft, %{exit_status: :timeout} = ctx),
+    do: {:ok, %{ctx | outcome: {:kept, :editor_timeout}}}
+
   defp interpret(:reload_draft, ctx),
     do: {:ok, %{ctx | outcome: {:kept, :editor_nonzero}}}
 
   defp interpret(:cleanup_tmp, ctx) do
-    _ = File.rm(ctx.path)
+    _ = File.rm_rf(ctx.dir)
     {:ok, ctx}
   end
 
@@ -293,14 +412,20 @@ defmodule Raxol.Harness.EditorSession do
   # Region bytes stay with the authority owner -- same rationale as the
   # forward step; the caller reasserts on every return.
   defp compensate(:reassert_region, _ctx), do: :ok
-  defp compensate(:cleanup_tmp, ctx), do: File.rm(ctx.path)
+  defp compensate(:cleanup_tmp, ctx), do: File.rm_rf(ctx.dir)
 
   # -- the real spawn ----------------------------------------------------
 
   # Synchronous: opens the port (the editor now owns fds 0/1/2 -- the
   # tty) and blocks until it delivers an exit status. `:crashed` when
-  # the port dies without one.
-  defp default_spawn(cmd) do
+  # the port dies without one; `:timeout` when `:editor_timeout_ms`
+  # elapses first (default `:infinity` -- a human legitimately edits for
+  # an arbitrary time on their own tty and can always quit the editor
+  # themselves; the bound exists for embedders/automation, threaded
+  # through Surface's `:editor_opts`). On timeout the editor process is
+  # best-effort SIGTERMed and the port closed before returning, so the
+  # resume bracket does not race a still-writing editor.
+  defp default_spawn(cmd, timeout) do
     port = Port.open({:spawn, cmd}, [:nouse_stdio, :exit_status])
     ref = Port.monitor(port)
 
@@ -311,7 +436,30 @@ defmodule Raxol.Harness.EditorSession do
 
       {:DOWN, ^ref, :port, ^port, _reason} ->
         :crashed
+    after
+      timeout ->
+        kill_editor(port, ref)
+        :timeout
     end
+  end
+
+  defp kill_editor(port, ref) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} ->
+        _ =
+          System.cmd("kill", ["-TERM", Integer.to_string(os_pid)],
+            stderr_to_stdout: true
+          )
+
+      _no_pid ->
+        :ok
+    end
+
+    Port.demonitor(ref, [:flush])
+
+    if Port.info(port), do: Port.close(port)
+  rescue
+    ArgumentError -> :ok
   end
 
   # Single-quote wrapping with the canonical '\'' escape -- the tmp path

--- a/lib/raxol/harness/editor_session.ex
+++ b/lib/raxol/harness/editor_session.ex
@@ -24,9 +24,19 @@ defmodule Raxol.Harness.EditorSession do
   path is single-quote shell-escaped before it joins the command line.
 
   The `:spawn_fun` seam is `(shell_command :: String.t()) ->
-  non_neg_integer() | :crashed` -- synchronous, returning the editor's
-  exit status (`:crashed` when the port died without ever delivering
-  one). The default implementation is the Port described above.
+  non_neg_integer() | :crashed | :timeout` -- synchronous, returning the
+  editor's exit status (`:crashed` when the port died without ever
+  delivering one; `:timeout` when `:editor_timeout_ms` elapsed first).
+  The default implementation is the Port described above.
+
+  The default `:editor_timeout_ms` is `:infinity` -- an interactive
+  human legitimately edits for arbitrary time on their own tty and can
+  always quit the editor themselves. This deliberately leaves
+  NON-interactive embedders (automation, agents, CI harnesses driving a
+  pty) unprotected against a wedged editor by default: such embedders
+  MUST set a bound (via this option, or `Raxol.Harness.Surface`'s
+  `:editor_opts`), or a never-exiting editor blocks the calling loop
+  forever.
 
   ## Outcomes
 
@@ -458,6 +468,18 @@ defmodule Raxol.Harness.EditorSession do
     Port.demonitor(ref, [:flush])
 
     if Port.info(port), do: Port.close(port)
+
+    # Drain a raced exit_status: the editor may have exited in the window
+    # between the timeout firing and the close above, leaving a stray
+    # `{port, {:exit_status, _}}` in THIS process's mailbox -- which is
+    # the harness dispatcher/TEA-loop process, where an unmatched message
+    # would sit forever (round-2 review). Zero-timeout receive: gone if
+    # present, free if not.
+    receive do
+      {^port, {:exit_status, _late}} -> :ok
+    after
+      0 -> :ok
+    end
   rescue
     ArgumentError -> :ok
   end
@@ -468,7 +490,15 @@ defmodule Raxol.Harness.EditorSession do
   defp shell_quote(path),
     do: "'" <> String.replace(path, "'", "'\\''") <> "'"
 
+  # Counter + timestamp for uniqueness/debuggability, PLUS a
+  # :crypto.strong_rand_bytes segment for unpredictability -- the
+  # confidentiality section's claim, honored in code (round-2 review
+  # caught the doc promising crypto randomness the old counter+timestamp
+  # name did not deliver). 6 bytes -> 8 url-safe base64 chars.
   defp unique do
-    "#{:erlang.unique_integer([:positive, :monotonic])}_#{System.os_time(:microsecond)}"
+    random =
+      6 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+
+    "#{:erlang.unique_integer([:positive, :monotonic])}_#{System.os_time(:microsecond)}_#{random}"
   end
 end

--- a/lib/raxol/harness/editor_suspend.ex
+++ b/lib/raxol/harness/editor_suspend.ex
@@ -1,0 +1,264 @@
+defmodule Raxol.Harness.EditorSuspend do
+  @moduledoc """
+  The PURE side of the composer's external-editor handoff: editor
+  resolution policy, the draft round-trip discipline, the temp-file
+  naming policy, and -- the load-bearing part -- the suspend/resume
+  state machine with per-step compensation.
+
+  No IO, no processes, no tty anywhere in this module. The thin impure
+  runner (`Raxol.Harness.EditorSession`) drives this machine and
+  interprets each emitted step against the real device/stty/reader;
+  keeping the sequencing HERE means the ordering and the
+  failure-recovery table are plain data, exhaustively testable with a
+  ledger fold instead of a mocked terminal.
+
+  ## The step sequence (pinned, order is load-bearing)
+
+  Suspend bracket:
+
+    1. `:write_tmp` -- persist the draft first: the cheapest step, and
+       failing it unwinds nothing.
+    2. `:disable_reader` -- quiesce the BEAM's tty reader
+       (`Raxol.Terminal.InlineDriver.ReaderGate`) BEFORE any terminal
+       bytes: from this point typed keystrokes queue in the kernel for
+       the editor instead of being split between two readers. It is also
+       the most failure-prone step, and failing here still unwinds
+       nothing terminal-visible.
+    3. `:release_screen` -- the canonical suspend bytes
+       (`Raxol.Terminal.InlineDriver.Sequences.suspend_bytes/1`: modes
+       off, `CSI r`, autowrap+cursor, bare park). MUST run while the tty
+       is still raw, else the escapes are line-processed as garbage --
+       the same invariant the teardown order pins.
+    4. `:restore_tty` -- cooked modes, LAST among the terminal
+       operations: the editor needs sane modes to start from (a
+       line-based `$EDITOR` would be unusable raw, and Ctrl-C must work
+       if it wedges before installing its own termios).
+    5. `:spawn_editor` / `:await_editor` -- the synchronous handoff.
+
+  Resume bracket:
+
+    6. `:requery_size` -- while still cooked: the terminal may have been
+       resized while the editor owned it.
+    7. `:raw_tty` -- before the reader is re-enabled, so no cooked-mode
+       echo race on queued typing.
+    8. `:enable_reader` -- the gate reopens; the reader's armed state
+       persisted across the bracket.
+    9. `:reinit_modes` -- `Sequences.init_bytes/0` (bracketed paste +
+       focus reporting back on; the suspend's modes-off turned them off).
+   10. `:reassert_region` -- the UNCONDITIONAL DECSTBM re-pin
+       (`InlineAuthority.reassert/1`; a geometry-gated resize alone would
+       skip the write when nothing changed).
+   11. `:reload_draft` -- read the temp file back (exit-status policy is
+       the runner's concern; this machine only sequences).
+   12. `:cleanup_tmp` -- always last, every path.
+
+  ## Compensation (what is restorable at each failure point)
+
+  Each step's effect on the externally observable resources is a ledger
+  transition over `{tty, reader, screen, modes, tmp}`. `advance/2` with
+  `{:error, reason}` (and `recovery/1`, the runner's rescue seam)
+  derives the compensation from the ledger of COMPLETED steps only --
+  never compensating work that was not done -- emitted in the safe
+  resume order: `:raw_tty`, `:enable_reader`, `:reinit_modes`,
+  `:reassert_region`, `:cleanup_tmp` (each included only when the
+  ledger actually deviates). By construction, completed-steps ++
+  compensation always folds back to the invariant
+  `{raw, enabled, asserted, on, absent}` -- the exhaustive test in
+  `editor_suspend_test.exs` pins exactly that, over every failure point.
+
+  ## Draft round-trip discipline
+
+  `encode_draft/1` is the identity -- the draft is written verbatim.
+  `decode_draft/1` strips exactly ONE trailing line terminator (`\\r\\n`
+  or `\\n`), nothing else: POSIX editors append exactly one trailing
+  newline to a saved file, so stripping one restores the draft
+  byte-for-byte for any draft not itself ending in a newline (composer
+  drafts never do -- Enter submits). Mirrors the OTP shell editor's
+  `string:chomp` choice.
+  """
+
+  @type step ::
+          :write_tmp
+          | :disable_reader
+          | :release_screen
+          | :restore_tty
+          | :spawn_editor
+          | :await_editor
+          | :requery_size
+          | :raw_tty
+          | :enable_reader
+          | :reinit_modes
+          | :reassert_region
+          | :reload_draft
+          | :cleanup_tmp
+
+  @type machine :: %{completed: [step()], pending: step() | nil}
+
+  @steps [
+    :write_tmp,
+    :disable_reader,
+    :release_screen,
+    :restore_tty,
+    :spawn_editor,
+    :await_editor,
+    :requery_size,
+    :raw_tty,
+    :enable_reader,
+    :reinit_modes,
+    :reassert_region,
+    :reload_draft,
+    :cleanup_tmp
+  ]
+
+  # Compensation steps in the safe resume order: tty raw first (no
+  # cooked-echo race), then the reader, then modes/region bytes, tmp
+  # cleanup always last.
+  @recovery_order [
+    :raw_tty,
+    :enable_reader,
+    :reinit_modes,
+    :reassert_region,
+    :cleanup_tmp
+  ]
+
+  @initial_ledger %{
+    tty: :raw,
+    reader: :enabled,
+    screen: :asserted,
+    modes: :on,
+    tmp: :absent
+  }
+
+  # -- policy -----------------------------------------------------------
+
+  @doc """
+  `$VISUAL` || `$EDITOR` || `"vi"` -- first NON-EMPTY wins (an
+  empty-string export is treated as unset, not as an editor named "").
+  Always succeeds: the fallback exists by policy; a missing binary
+  surfaces later as the shell's exit 127, which the runner maps to a
+  keep-the-draft notice rather than a crash.
+  """
+  @spec resolve_editor(%{optional(String.t()) => String.t()}) ::
+          {:ok, String.t()}
+  def resolve_editor(env) when is_map(env) do
+    editor =
+      [Map.get(env, "VISUAL"), Map.get(env, "EDITOR"), "vi"]
+      |> Enum.find(fn value -> is_binary(value) and value != "" end)
+
+    {:ok, editor}
+  end
+
+  @doc "Draft -> file content: the identity (written verbatim)."
+  @spec encode_draft(String.t()) :: String.t()
+  def encode_draft(draft) when is_binary(draft), do: draft
+
+  @doc """
+  File content -> draft: strips exactly one trailing `\\r\\n` or `\\n`
+  (see the moduledoc's round-trip discipline). Everything else is
+  preserved byte-for-byte.
+  """
+  @spec decode_draft(binary()) :: String.t()
+  def decode_draft(content) when is_binary(content) do
+    cond do
+      String.ends_with?(content, "\r\n") ->
+        binary_part(content, 0, byte_size(content) - 2)
+
+      String.ends_with?(content, "\n") ->
+        binary_part(content, 0, byte_size(content) - 1)
+
+      true ->
+        content
+    end
+  end
+
+  @doc "Pure temp-file naming policy; the runner joins it to the tmpdir."
+  @spec tmp_filename(String.t()) :: String.t()
+  def tmp_filename(unique) when is_binary(unique),
+    do: "raxol_draft_#{unique}.md"
+
+  # -- the machine ------------------------------------------------------
+
+  @doc "The canonical ordered step list (see the moduledoc)."
+  @spec steps() :: [step()]
+  def steps, do: @steps
+
+  @doc "A fresh machine: nothing completed, nothing pending."
+  @spec new() :: machine()
+  def new, do: %{completed: [], pending: nil}
+
+  @doc """
+  Report the outcome of the pending step and receive the next effect.
+
+    * `advance(machine, :ok)` -- the pending step (if any) completed;
+      returns `{:effect, next_step, machine}` with the next step now
+      pending, or `{:done, machine}` when the sequence is exhausted.
+    * `advance(machine, {:error, reason})` -- the pending step FAILED
+      (its work was not done); returns `{:abort, compensation, machine}`
+      where `compensation` covers the COMPLETED steps only, in the safe
+      resume order (see the moduledoc).
+  """
+  @spec advance(machine(), :ok | {:error, term()}) ::
+          {:effect, step(), machine()}
+          | {:done, machine()}
+          | {:abort, [step()], machine()}
+  def advance(%{completed: completed, pending: pending}, :ok) do
+    completed = if pending, do: completed ++ [pending], else: completed
+
+    case Enum.at(@steps, length(completed)) do
+      nil -> {:done, %{completed: completed, pending: nil}}
+      step -> {:effect, step, %{completed: completed, pending: step}}
+    end
+  end
+
+  def advance(%{completed: completed} = machine, {:error, _reason}) do
+    {:abort, compensation(completed), %{machine | pending: nil}}
+  end
+
+  @doc """
+  The compensation the abort path would take from this machine's
+  position -- the runner's rescue seam: on an EXCEPTION mid-step (rather
+  than an error return), the runner interprets exactly these steps
+  before surfacing the failure. Identical to what
+  `advance(machine, {:error, _})` would return.
+  """
+  @spec recovery(machine()) :: [step()]
+  def recovery(%{completed: completed}), do: compensation(completed)
+
+  # -- private ----------------------------------------------------------
+
+  # Derive compensation from the ledger of completed work: include each
+  # recovery step (in @recovery_order) only when the resource it repairs
+  # actually deviates from the invariant. Never compensates a step whose
+  # work was not done, by construction.
+  defp compensation(completed) do
+    ledger = Enum.reduce(completed, @initial_ledger, &apply_step(&2, &1))
+
+    Enum.filter(@recovery_order, fn
+      :raw_tty -> ledger.tty != :raw
+      :enable_reader -> ledger.reader != :enabled
+      :reinit_modes -> ledger.modes != :on
+      :reassert_region -> ledger.screen != :asserted
+      :cleanup_tmp -> ledger.tmp != :absent
+    end)
+  end
+
+  # The resource-ledger transition table -- one clause per step (and the
+  # compensation steps reuse the same vocabulary, so a compensated
+  # prefix folds back to the invariant with the same function).
+  defp apply_step(ledger, :write_tmp), do: %{ledger | tmp: :present}
+  defp apply_step(ledger, :disable_reader), do: %{ledger | reader: :disabled}
+
+  defp apply_step(ledger, :release_screen),
+    do: %{ledger | screen: :released, modes: :off}
+
+  defp apply_step(ledger, :restore_tty), do: %{ledger | tty: :cooked}
+  defp apply_step(ledger, :spawn_editor), do: ledger
+  defp apply_step(ledger, :await_editor), do: ledger
+  defp apply_step(ledger, :requery_size), do: ledger
+  defp apply_step(ledger, :raw_tty), do: %{ledger | tty: :raw}
+  defp apply_step(ledger, :enable_reader), do: %{ledger | reader: :enabled}
+  defp apply_step(ledger, :reinit_modes), do: %{ledger | modes: :on}
+  defp apply_step(ledger, :reassert_region), do: %{ledger | screen: :asserted}
+  defp apply_step(ledger, :reload_draft), do: ledger
+  defp apply_step(ledger, :cleanup_tmp), do: %{ledger | tmp: :absent}
+end

--- a/lib/raxol/harness/editor_suspend.ex
+++ b/lib/raxol/harness/editor_suspend.ex
@@ -57,14 +57,42 @@ defmodule Raxol.Harness.EditorSuspend do
   Each step's effect on the externally observable resources is a ledger
   transition over `{tty, reader, screen, modes, tmp}`. `advance/2` with
   `{:error, reason}` (and `recovery/1`, the runner's rescue seam)
-  derives the compensation from the ledger of COMPLETED steps only --
-  never compensating work that was not done -- emitted in the safe
-  resume order: `:raw_tty`, `:enable_reader`, `:reinit_modes`,
+  derives the compensation from the ledger, emitted in the safe resume
+  order: `:raw_tty`, `:enable_reader`, `:reinit_modes`,
   `:reassert_region`, `:cleanup_tmp` (each included only when the
   ledger actually deviates). By construction, completed-steps ++
   compensation always folds back to the invariant
   `{raw, enabled, asserted, on, absent}` -- the exhaustive test in
   `editor_suspend_test.exs` pins exactly that, over every failure point.
+
+  ### Worst-case assumption for suspend-phase failures
+
+  A FAILED suspend-phase step (`:write_tmp`, `:disable_reader`,
+  `:release_screen`, `:restore_tty`) is folded into the ledger AS IF its
+  effects landed: a failed `File.write` may have created the file
+  (ENOSPC after create), a raising `IO.write` may have emitted part of
+  its bytes, a timed-out stty/gate call may have taken effect with the
+  reply lost. Compensating effects that never happened is harmless
+  (every compensation is idempotent toward the invariant -- an enable
+  against a never-disabled reader is ignored and times out, a re-raw of
+  an already-raw tty is a no-op); NOT compensating effects that DID
+  happen strands the terminal. Resume-phase steps get the opposite
+  assumption -- a failed `:raw_tty`/`:reinit_modes` is NOT done, so
+  compensation retries it.
+
+  ### Degradable steps: `:enable_reader`
+
+  `:enable_reader` is the one step whose failure must NOT abort: the
+  resume is already half-done, and finishing it (modes, region, draft
+  reload) with degraded input beats stranding the terminal mid-resume.
+  The runner reports it via `advance(machine, {:degraded, reason})`:
+  the machine continues to the next step but records the degradation --
+  the ledger keeps `reader: :disabled` (a degraded enable is honestly
+  NOT an enable, so a later failure's compensation retries the reader),
+  and `degradations/1` exposes the list so the runner/caller MUST
+  surface it (notice + telemetry) instead of a silent `{:ok, ...}`.
+  A `{:degraded, _}` report on any non-degradable step raises: it is a
+  programmer error, not a policy choice.
 
   ## Draft round-trip discipline
 
@@ -92,7 +120,8 @@ defmodule Raxol.Harness.EditorSuspend do
           | :reload_draft
           | :cleanup_tmp
 
-  @type machine :: %{completed: [step()], pending: step() | nil}
+  @type completion :: {step(), :ok | {:degraded, term()}}
+  @type machine :: %{completed: [completion()], pending: step() | nil}
 
   @steps [
     :write_tmp,
@@ -120,6 +149,20 @@ defmodule Raxol.Harness.EditorSuspend do
     :reassert_region,
     :cleanup_tmp
   ]
+
+  # Suspend-phase steps whose FAILURE is folded into the ledger as if
+  # their effects landed (worst case) -- see the moduledoc's
+  # "Worst-case assumption" section.
+  @assume_done_on_failure [
+    :write_tmp,
+    :disable_reader,
+    :release_screen,
+    :restore_tty
+  ]
+
+  # Steps whose failure may be reported as {:degraded, reason} instead of
+  # {:error, reason} -- see the moduledoc's "Degradable steps" section.
+  @degradable [:enable_reader]
 
   @initial_ledger %{
     tty: :raw,
@@ -192,26 +235,45 @@ defmodule Raxol.Harness.EditorSuspend do
     * `advance(machine, :ok)` -- the pending step (if any) completed;
       returns `{:effect, next_step, machine}` with the next step now
       pending, or `{:done, machine}` when the sequence is exhausted.
-    * `advance(machine, {:error, reason})` -- the pending step FAILED
-      (its work was not done); returns `{:abort, compensation, machine}`
-      where `compensation` covers the COMPLETED steps only, in the safe
-      resume order (see the moduledoc).
+    * `advance(machine, {:degraded, reason})` -- the pending step is a
+      DEGRADABLE step (`:enable_reader`) whose work failed but whose
+      failure must not abort the resume: the machine continues exactly
+      like `:ok` but RECORDS the degradation (`degradations/1`), and the
+      ledger keeps the resource un-repaired so a later failure's
+      compensation retries it. Raises `ArgumentError` on a
+      non-degradable step (programmer error, not policy).
+    * `advance(machine, {:error, reason})` -- the pending step FAILED;
+      returns `{:abort, compensation, machine}` where `compensation`
+      covers the completed steps PLUS, for a suspend-phase pending step,
+      the worst-case assumption that its effects landed (see the
+      moduledoc), in the safe resume order.
   """
-  @spec advance(machine(), :ok | {:error, term()}) ::
+  @spec advance(machine(), :ok | {:degraded, term()} | {:error, term()}) ::
           {:effect, step(), machine()}
           | {:done, machine()}
           | {:abort, [step()], machine()}
   def advance(%{completed: completed, pending: pending}, :ok) do
-    completed = if pending, do: completed ++ [pending], else: completed
-
-    case Enum.at(@steps, length(completed)) do
-      nil -> {:done, %{completed: completed, pending: nil}}
-      step -> {:effect, step, %{completed: completed, pending: step}}
-    end
+    completed = if pending, do: completed ++ [{pending, :ok}], else: completed
+    continue(completed)
   end
 
-  def advance(%{completed: completed} = machine, {:error, _reason}) do
-    {:abort, compensation(completed), %{machine | pending: nil}}
+  def advance(%{completed: completed, pending: pending}, {:degraded, reason})
+      when pending in @degradable do
+    continue(completed ++ [{pending, {:degraded, reason}}])
+  end
+
+  def advance(%{pending: pending}, {:degraded, _reason}) do
+    raise ArgumentError,
+          "step #{inspect(pending)} is not degradable -- only " <>
+            "#{inspect(@degradable)} may report {:degraded, reason}; " <>
+            "a failure here must be {:error, reason} (abort + compensation)"
+  end
+
+  def advance(
+        %{completed: completed, pending: pending} = machine,
+        {:error, _reason}
+      ) do
+    {:abort, compensation(completed, pending), %{machine | pending: nil}}
   end
 
   @doc """
@@ -222,16 +284,45 @@ defmodule Raxol.Harness.EditorSuspend do
   `advance(machine, {:error, _})` would return.
   """
   @spec recovery(machine()) :: [step()]
-  def recovery(%{completed: completed}), do: compensation(completed)
+  def recovery(%{completed: completed, pending: pending}),
+    do: compensation(completed, pending)
+
+  @doc """
+  Every degradation recorded so far, as `{step, reason}` in step order.
+  A non-empty list at `:done` means the run COMPLETED but a resource
+  could not be restored (today: the stdin reader after the editor) --
+  the runner must surface this to the operator, never swallow it.
+  """
+  @spec degradations(machine()) :: [{step(), term()}]
+  def degradations(%{completed: completed}) do
+    for {step, {:degraded, reason}} <- completed, do: {step, reason}
+  end
 
   # -- private ----------------------------------------------------------
 
-  # Derive compensation from the ledger of completed work: include each
-  # recovery step (in @recovery_order) only when the resource it repairs
-  # actually deviates from the invariant. Never compensates a step whose
-  # work was not done, by construction.
-  defp compensation(completed) do
-    ledger = Enum.reduce(completed, @initial_ledger, &apply_step(&2, &1))
+  defp continue(completed) do
+    case Enum.at(@steps, length(completed)) do
+      nil -> {:done, %{completed: completed, pending: nil}}
+      step -> {:effect, step, %{completed: completed, pending: step}}
+    end
+  end
+
+  # Derive compensation from the ledger: fold the completed work (a
+  # degraded completion contributes NO effect -- the resource was not
+  # repaired) plus, for a suspend-phase pending step that failed, the
+  # worst-case assumption that its effects landed. Include each recovery
+  # step (in @recovery_order) only when the resource it repairs actually
+  # deviates from the invariant.
+  defp compensation(completed, pending) do
+    assumed =
+      if pending in @assume_done_on_failure, do: [{pending, :ok}], else: []
+
+    ledger =
+      Enum.reduce(
+        completed ++ assumed,
+        @initial_ledger,
+        &apply_completion(&2, &1)
+      )
 
     Enum.filter(@recovery_order, fn
       :raw_tty -> ledger.tty != :raw
@@ -241,6 +332,12 @@ defmodule Raxol.Harness.EditorSuspend do
       :cleanup_tmp -> ledger.tmp != :absent
     end)
   end
+
+  # A step that completed :ok applies its ledger transition; a DEGRADED
+  # completion applies none -- the resource it was meant to repair is
+  # honestly still broken (see the moduledoc's degradable-steps section).
+  defp apply_completion(ledger, {step, :ok}), do: apply_step(ledger, step)
+  defp apply_completion(ledger, {_step, {:degraded, _reason}}), do: ledger
 
   # The resource-ledger transition table -- one clause per step (and the
   # compensation steps reuse the same vocabulary, so a compensated

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -442,7 +442,7 @@ defmodule Raxol.Harness.Surface do
           rows: pos_integer(),
           footer_rows: pos_integer(),
           status: map(),
-          stub_notice: String.t() | nil,
+          stub_notice: String.t() | [String.t()] | nil,
           overlay: overlay() | nil,
           editor_session: module() | (String.t(), keyword() -> term()) | nil,
           editor_opts: keyword()
@@ -1178,19 +1178,23 @@ defmodule Raxol.Harness.Surface do
   # finding was exactly this warning being swallowed): the operator is
   # about to discover their keyboard is dead, and a silent success frame
   # would read as "everything is fine".
+  #
+  # The warning gets its OWN notice line, never appended to a kept
+  # notice: `ViewText.lines/3` end-truncates each line to the width
+  # budget, so a same-line append made the warning the first casualty of
+  # a long kept notice (e.g. a long `{:editor_not_found, cmd}`) on an
+  # 80-column terminal -- the round-2 review's finding. Per-line, both
+  # messages survive truncation independently.
   defp apply_degraded_notice(model, []), do: model
 
   defp apply_degraded_notice(model, [_ | _]) do
-    # Kept deliberately terse: the footer notice line is truncated to the
-    # terminal width by ViewText, and this warning must survive even when
-    # appended after a kept-notice on an 80-column terminal.
+    warning =
+      "» warning: input reader failed to re-enable — keyboard may be dead"
+
     notice =
       case model.stub_notice do
-        nil ->
-          "» warning: input reader failed to re-enable — keyboard may be dead"
-
-        kept ->
-          kept <> " · input reader failed to re-enable"
+        nil -> warning
+        kept -> [kept, warning]
       end
 
     %{model | stub_notice: notice}
@@ -1481,6 +1485,13 @@ defmodule Raxol.Harness.Surface do
     do: ViewText.lines(OverlayPicker.render(picker), width, :styled)
 
   defp notice_line(nil, _width), do: []
+
+  # A LIST of notices renders one footer line each -- each independently
+  # width-truncated, so a long first notice can never truncate away a
+  # later one (the degraded-resume warning rides this; see
+  # `apply_degraded_notice/2`).
+  defp notice_line(notices, width) when is_list(notices),
+    do: Enum.flat_map(notices, &notice_line(&1, width))
 
   defp notice_line(text, width),
     do: ViewText.lines(%{type: :text, content: text}, width, :styled)

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -444,7 +444,8 @@ defmodule Raxol.Harness.Surface do
           status: map(),
           stub_notice: String.t() | nil,
           overlay: overlay() | nil,
-          editor_session: module() | (String.t(), keyword() -> term()) | nil
+          editor_session: module() | (String.t(), keyword() -> term()) | nil,
+          editor_opts: keyword()
         }
 
   @typedoc """
@@ -488,6 +489,11 @@ defmodule Raxol.Harness.Surface do
       section); `nil` renders an honest stub notice instead. Embedders
       with a real tty pass `Raxol.Harness.EditorSession`; tests inject a
       fun returning canned outcomes.
+    * `:editor_opts` -- extra options merged into every editor-session
+      call (e.g. `editor_timeout_ms: 60_000`, or an explicit vetted
+      `:env` -- see `Raxol.Harness.EditorSession`'s trust-boundary
+      section). Model-owned `device`/`rows`/`width` always win over
+      entries here.
 
   ## Startup mode notice (the degradation ladder's `select_with_reason/3` seam)
 
@@ -555,7 +561,8 @@ defmodule Raxol.Harness.Surface do
       status: %{},
       stub_notice: nil,
       overlay: nil,
-      editor_session: Keyword.get(opts, :editor_session)
+      editor_session: Keyword.get(opts, :editor_session),
+      editor_opts: Keyword.get(opts, :editor_opts, [])
     }
 
     model
@@ -1123,11 +1130,14 @@ defmodule Raxol.Harness.Surface do
   defp run_editor(model) do
     draft = Composer.value(model.composer)
 
-    opts = [
-      device: authority_device(model.authority),
-      rows: model.rows,
-      width: model.width
-    ]
+    # `:editor_opts` is the embedder seam (timeout, vetted env, ...);
+    # model-owned device/geometry always win.
+    opts =
+      Keyword.merge(model.editor_opts,
+        device: authority_device(model.authority),
+        rows: model.rows,
+        width: model.width
+      )
 
     # The session returns with the tty raw again and the reader re-enabled,
     # but WITHOUT the DECSTBM pin (region bytes are owned by this model's
@@ -1142,13 +1152,15 @@ defmodule Raxol.Harness.Surface do
     # redundant, idempotent DECSTBM re-emit is cheaper than reasoning about
     # exactly which failure points left the region released.
     case call_editor_session(model.editor_session, draft, opts) do
-      {:ok, %{text: text, width: width, rows: rows}} ->
+      {:ok, %{text: text, width: width, rows: rows} = result} ->
         model = resume_geometry(model, width, rows)
-        %{model | composer: Composer.set_value(model.composer, text)}
+        model = %{model | composer: Composer.set_value(model.composer, text)}
+        apply_degraded_notice(model, Map.get(result, :degraded, []))
 
-      {:kept, reason, %{width: width, rows: rows}} ->
+      {:kept, reason, %{width: width, rows: rows} = geo} ->
         model = resume_geometry(model, width, rows)
-        %{model | stub_notice: kept_notice(reason)}
+        model = %{model | stub_notice: kept_notice(reason)}
+        apply_degraded_notice(model, Map.get(geo, :degraded, []))
 
       {:error, reason} ->
         model = resume_geometry(model, model.width, model.rows)
@@ -1158,6 +1170,30 @@ defmodule Raxol.Harness.Surface do
           | stub_notice: "» editor suspend aborted: #{inspect(reason)}"
         }
     end
+  end
+
+  # A non-empty degradation list means the session resumed but a
+  # terminal resource could not be restored -- today, the stdin reader
+  # after the editor. This MUST be visible (the review's critical
+  # finding was exactly this warning being swallowed): the operator is
+  # about to discover their keyboard is dead, and a silent success frame
+  # would read as "everything is fine".
+  defp apply_degraded_notice(model, []), do: model
+
+  defp apply_degraded_notice(model, [_ | _]) do
+    # Kept deliberately terse: the footer notice line is truncated to the
+    # terminal width by ViewText, and this warning must survive even when
+    # appended after a kept-notice on an 80-column terminal.
+    notice =
+      case model.stub_notice do
+        nil ->
+          "» warning: input reader failed to re-enable — keyboard may be dead"
+
+        kept ->
+          kept <> " · input reader failed to re-enable"
+      end
+
+    %{model | stub_notice: notice}
   end
 
   # The session's contract propagates exceptions AFTER running its
@@ -1204,6 +1240,8 @@ defmodule Raxol.Harness.Surface do
     do: "» editor not found: #{cmd} — draft kept"
 
   defp kept_notice(:editor_crashed), do: "» editor crashed — draft kept"
+
+  defp kept_notice(:editor_timeout), do: "» editor timed out — draft kept"
 
   defp kept_notice(:reload_failed),
     do: "» could not reload edited draft — draft kept"

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -347,6 +347,37 @@ defmodule Raxol.Harness.Surface do
   hibernate during. Noted here as the next thing to reach for, not
   implemented.
 
+  ## External editor handoff (the `:edit_draft` command, Ctrl+E)
+
+  Long prompts don't belong in a 6-row footer composer. The Ctrl+E chord
+  (`Raxol.UI.Harness.Keymap`'s `:edit_draft`, an `:always` bind) hands
+  the composer draft to `$VISUAL`/`$EDITOR` via the injected
+  `:editor_session` (see `new/2`'s options): the session suspends the
+  terminal claim (the canonical suspend bytes release the DECSTBM
+  region, cooked modes come back, the BEAM stdin reader is gated off),
+  runs the editor synchronously attached to the tty, and resumes (raw
+  mode, reader, init bytes). What the session deliberately does NOT do
+  is re-pin the region -- region bytes are owned by THIS model's
+  authority, so every return branch here composes
+  `InlineAuthority.resize/3 |> InlineAuthority.reassert/1`
+  (`resize/3` alone is geometry-gated: a terminal NOT resized while
+  suspended would get zero region bytes and stay silently un-pinned),
+  and `reassert/1`'s `needs_keyframe` latch turns the next
+  `paint_footer/1` into a full keyframe. On editor exit 0 the edited
+  draft replaces the composer's value (`Composer.set_value/2`); any
+  other outcome keeps the original draft and surfaces a one-frame
+  footer notice through the existing `stub_notice` channel.
+
+  Sealed history above the footer survives the whole bracket untouched
+  by construction -- no code path here or in the session addresses a
+  history row, and the suspend bytes contain no `\\e[2J`/`\\e[3J`. The
+  one documented residual: an editor that does NOT use the alternate
+  screen may scribble over the not-yet-scrolled on-screen portion of
+  history (cosmetic; content already in native scrollback is unreachable
+  to us and to it). `:flat` mode has no footer composer to hand a draft
+  back to, so `:edit_draft` there seals one honest history line saying
+  so instead of pretending.
+
   ## Precondition #7 -- teardown ownership (this module owns NONE)
 
   `new/2` sets the DECSTBM history/footer split via
@@ -412,7 +443,8 @@ defmodule Raxol.Harness.Surface do
           footer_rows: pos_integer(),
           status: map(),
           stub_notice: String.t() | nil,
-          overlay: overlay() | nil
+          overlay: overlay() | nil,
+          editor_session: module() | (String.t(), keyword() -> term()) | nil
         }
 
   @typedoc """
@@ -449,6 +481,13 @@ defmodule Raxol.Harness.Surface do
       entirely (test seam). Bypasses the startup mode notice below too --
       an explicit `:mode` is a test/caller decision, not a pick this
       module made, so there is no `reason()` to explain.
+    * `:editor_session` -- `nil` (default), a module implementing
+      `Raxol.Harness.EditorSession`'s `run(draft, opts)` contract, or a
+      2-arity fun with the same contract. Enables the Ctrl+E external-
+      editor handoff (see the moduledoc's "External editor handoff"
+      section); `nil` renders an honest stub notice instead. Embedders
+      with a real tty pass `Raxol.Harness.EditorSession`; tests inject a
+      fun returning canned outcomes.
 
   ## Startup mode notice (the degradation ladder's `select_with_reason/3` seam)
 
@@ -515,7 +554,8 @@ defmodule Raxol.Harness.Surface do
       footer_rows: footer_rows,
       status: %{},
       stub_notice: nil,
-      overlay: nil
+      overlay: nil,
+      editor_session: Keyword.get(opts, :editor_session)
     }
 
     model
@@ -1025,6 +1065,17 @@ defmodule Raxol.Harness.Surface do
        when overlay != nil,
        do: model
 
+  # Same freeze rationale for the editor handoff: an open overlay hides
+  # the composer buffer mid-pick, and suspending the terminal to edit
+  # that hidden state (while the footer is overlay-shaped and would be
+  # keyframed back at the WRONG row split on resume) would be the same
+  # dishonest UI. Clause order load-bearing, as above.
+  defp dispatch_command(%{overlay: overlay} = model, %{type: :edit_draft})
+       when overlay != nil,
+       do: model
+
+  defp dispatch_command(model, %{type: :edit_draft}), do: run_editor(model)
+
   defp dispatch_command(model, %{type: :steer}) do
     text = Composer.value(model.composer)
 
@@ -1039,6 +1090,125 @@ defmodule Raxol.Harness.Surface do
   end
 
   defp dispatch_command(model, _other), do: model
+
+  # -- external editor handoff (the :edit_draft command) -------------------
+  #
+  # Ordering of the clauses is load-bearing: flat mode first (there is no
+  # footer composer to hand a draft back to, whatever session is wired),
+  # then the no-session stub, then the real handoff.
+
+  # `:flat` has no footer and never renders the composer, so there is no
+  # surface for the edited draft (or a footer notice) to come back to --
+  # seal one honest history line instead, through the same
+  # `FlatAuthority.seal/2` path `apply_mode_notice/2` uses.
+  defp run_editor(%{mode: :flat} = model) do
+    lines =
+      ViewText.lines(
+        %{
+          type: :text,
+          content: "» external editor requires the footer composer (flat mode)"
+        },
+        model.width,
+        :plain
+      )
+
+    iodata = Enum.map(lines, &(&1 <> "\n"))
+    %{model | authority: FlatAuthority.seal(model.authority, iodata)}
+  end
+
+  defp run_editor(%{editor_session: nil} = model) do
+    %{model | stub_notice: "» external editor not wired in this embedding"}
+  end
+
+  defp run_editor(model) do
+    draft = Composer.value(model.composer)
+
+    opts = [
+      device: authority_device(model.authority),
+      rows: model.rows,
+      width: model.width
+    ]
+
+    # The session returns with the tty raw again and the reader re-enabled,
+    # but WITHOUT the DECSTBM pin (region bytes are owned by this model's
+    # authority -- see `Raxol.Harness.EditorSession`'s moduledoc). Every
+    # branch below therefore runs `resume_geometry/3`: `resize/3` absorbs a
+    # mid-suspend terminal resize, `reassert/1` guarantees the pin when
+    # geometry did NOT change (resize alone is geometry-gated and would
+    # write zero region bytes), and its `needs_keyframe` latch makes
+    # `handle_input/2`'s trailing `paint_footer/1` self-promote to a full
+    # keyframe. Belt-and-braces on the `{:error, _}` branch too: the
+    # session's compensation already restored what it could, and one
+    # redundant, idempotent DECSTBM re-emit is cheaper than reasoning about
+    # exactly which failure points left the region released.
+    case call_editor_session(model.editor_session, draft, opts) do
+      {:ok, %{text: text, width: width, rows: rows}} ->
+        model = resume_geometry(model, width, rows)
+        %{model | composer: Composer.set_value(model.composer, text)}
+
+      {:kept, reason, %{width: width, rows: rows}} ->
+        model = resume_geometry(model, width, rows)
+        %{model | stub_notice: kept_notice(reason)}
+
+      {:error, reason} ->
+        model = resume_geometry(model, model.width, model.rows)
+
+        %{
+          model
+          | stub_notice: "» editor suspend aborted: #{inspect(reason)}"
+        }
+    end
+  end
+
+  # The session's contract propagates exceptions AFTER running its
+  # compensation (see `Raxol.Harness.EditorSession`) -- the terminal is
+  # already restored by the time one reaches here, so this UI loop
+  # degrades to the same notice path as any other session error instead
+  # of crashing mid-frame.
+  defp call_editor_session(session, draft, opts) do
+    invoke_editor_session(session, draft, opts)
+  rescue
+    error -> {:error, {:editor_session, Exception.message(error)}}
+  catch
+    kind, reason -> {:error, {:editor_session, {kind, reason}}}
+  end
+
+  defp invoke_editor_session(session, draft, opts) when is_atom(session),
+    do: session.run(draft, opts)
+
+  defp invoke_editor_session(session, draft, opts)
+       when is_function(session, 2),
+       do: session.(draft, opts)
+
+  defp authority_device(%{region: %{device: device}}), do: device
+
+  # Mirrors `resize/2`'s inline-mode shape but composes
+  # `InlineAuthority.resize/3 |> InlineAuthority.reassert/1` -- the
+  # documented resume composition (see `InlineAuthority.reassert/1`'s doc
+  # for why resize alone cannot re-pin an unchanged geometry). No explicit
+  # keyframe call here: `reassert/1` latches `needs_keyframe`, and the
+  # caller's trailing `paint_footer/1` self-promotes to a full keyframe.
+  defp resume_geometry(model, width, rows) do
+    authority =
+      model.authority
+      |> InlineAuthority.resize(width, rows)
+      |> InlineAuthority.reassert()
+
+    %{model | authority: authority, width: width, rows: rows}
+  end
+
+  defp kept_notice(:editor_nonzero),
+    do: "» editor exited nonzero — draft kept"
+
+  defp kept_notice({:editor_not_found, cmd}),
+    do: "» editor not found: #{cmd} — draft kept"
+
+  defp kept_notice(:editor_crashed), do: "» editor crashed — draft kept"
+
+  defp kept_notice(:reload_failed),
+    do: "» could not reload edited draft — draft kept"
+
+  defp kept_notice(other), do: "» editor: #{inspect(other)} — draft kept"
 
   # -- fold / jump (precondition-adjacent: the seal-time-only translation) --
 

--- a/lib/raxol/ui/harness/keymap.ex
+++ b/lib/raxol/ui/harness/keymap.ex
@@ -49,12 +49,18 @@ defmodule Raxol.UI.Harness.Keymap do
 
   Two classes of bind:
 
-    * **Always live** -- fire regardless of `context.composing?`. Only ESC
-      (`:interrupt`) and the steer-submit key (`:tab`, `:steer`) are in this
-      class, because both are non-printable control keys that can never be
-      part of typed text, and ESC in particular must never be swallowed by
-      whatever currently has focus (AD-1: interrupt is a supervised kill
-      now, not a cooperative flag queued behind typing).
+    * **Always live** -- fire regardless of `context.composing?`. ESC
+      (`:interrupt`), the steer-submit key (`:tab`, `:steer`), and the
+      Ctrl+E chord (`:edit_draft` -- hand the composer draft to
+      `$EDITOR`) are in this class, because all three are non-printable
+      control keys/chords that can never be part of typed text, and ESC
+      in particular must never be swallowed by whatever currently has
+      focus (AD-1: interrupt is a supervised kill now, not a cooperative
+      flag queued behind typing). Ctrl+E is the first `char:`-kind chord
+      in the table -- a `char:` bind that declares `mods:` requires an
+      EXACT modifier match against the normalized event (mirroring the
+      `key:`-kind rule below) instead of the printable-char path, which
+      is nil under ctrl by design.
     * **Guarded by `not composing?`** -- the block-navigation binds
       (`fold-toggle`, `jump_next`, `jump_prev`). These use plain printable
       letters (`z`/`j`/`k`), and a prior flat-keymap prototype's named bug
@@ -209,6 +215,7 @@ defmodule Raxol.UI.Harness.Keymap do
   @type command_type ::
           :interrupt
           | :steer
+          | :edit_draft
           | :fold_toggle
           | :jump_next
           | :jump_prev
@@ -240,6 +247,19 @@ defmodule Raxol.UI.Harness.Keymap do
     %{key: :escape, command_type: :overlay_dismiss, guard: :overlay},
     %{key: :escape, command_type: :interrupt, guard: :always},
     %{key: :tab, command_type: :steer, guard: :always},
+    # Ctrl+E: hand the composer draft to $EDITOR. A `char:`-kind bind that
+    # DECLARES `mods:` -- the tui-steal promise cashing in for char-kind
+    # binds (see the moduledoc): the match spec grew a `mods:` field, the
+    # walking loop did not change. A ctrl chord can never be typed text
+    # (`InputEvent.printable_char/1` is nil under ctrl), so this is
+    # `:always`, same class as ESC/Tab; the command acts on the composer's
+    # buffer whether or not the composer has focus.
+    %{
+      char: "e",
+      mods: %{ctrl: true, alt: false, shift: false, meta: false},
+      command_type: :edit_draft,
+      guard: :always
+    },
     %{char: "z", command_type: :fold_toggle, guard: :not_composing},
     %{char: "j", command_type: :jump_next, guard: :not_composing},
     %{char: "k", command_type: :jump_prev, guard: :not_composing}
@@ -314,6 +334,19 @@ defmodule Raxol.UI.Harness.Keymap do
   @spec matches?(bind(), InputEvent.t(), context()) :: boolean()
   def matches?(%{key: key} = bind, norm, context) do
     InputEvent.key(norm) == key and mods_match?(bind, norm) and
+      guard_passes?(bind, context)
+  end
+
+  # A `char:`-kind bind that DECLARES `mods:` is a chord: match on the raw
+  # normalized `char` + an EXACT `mods` map, NOT via
+  # `InputEvent.printable_char/1` -- which is deliberately `nil` whenever
+  # ctrl/alt/meta is held (that nil is exactly why undeclared-mods char
+  # binds below never see chords, and it stays untouched). This clause
+  # must precede the plain char clause: a bind map carrying both `:char`
+  # and `:mods` would otherwise fall into the printable_char path and
+  # never match its own chord.
+  def matches?(%{char: char, mods: required_mods} = bind, norm, context) do
+    match?(%{kind: :char, char: ^char}, norm) and norm.mods == required_mods and
       guard_passes?(bind, context)
   end
 

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -838,6 +838,50 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     end)
   end
 
+  @doc """
+  Re-asserts the DECSTBM history/footer split UNCONDITIONALLY (via
+  `ScrollRegionManager.reassert/1`, one `CSI 1;(H-N) r` write regardless
+  of whether geometry changed) and latches `needs_keyframe: true` -- the
+  resume entry point after an external process owned the terminal (an
+  `$EDITOR` session that released the region via the canonical suspend
+  bytes).
+
+  ## Why `resize/3` alone cannot do this
+
+  `resize/3`'s region re-emission is geometry-gated (see
+  `ScrollRegionManager.resize/2`'s "Geometry-gated resize emission"):
+  when the terminal was NOT resized while suspended, `history_bottom` is
+  unchanged and resize writes ZERO region bytes -- silently leaving the
+  region released even though this struct still believes the footer is
+  pinned. The documented resume composition is therefore
+
+      authority |> resize(new_w, new_h) |> reassert()
+
+  -- `resize/3` handles a mid-suspend geometry change (and may emit its
+  own region bytes for it; the duplicate emit from `reassert/1` in that
+  case is harmless -- identical, idempotent bytes), `reassert/1`
+  guarantees the pin for the unchanged case.
+
+  ## Why the latch instead of an explicit keyframe
+
+  The editor repainted arbitrary screen content while it owned the tty,
+  so the last-painted `footer_lines` no longer describe what is
+  on-screen -- a logical diff against them would be a lie. Setting
+  `needs_keyframe` (a pure state change, zero bytes) makes the NEXT
+  `repaint/2` self-promote to a full `keyframe/2` (the existing
+  post-resize ghost-content mechanism, see the moduledoc), so the first
+  ordinary footer paint after resume fully re-renders every footer row
+  with no new paint code and no second keyframe call site.
+
+  Never emits `\\e[2J`/`\\e[3J`; never addresses a history row. Sealed
+  history above the footer survives the whole suspend/resume bracket
+  untouched by construction.
+  """
+  @spec reassert(t()) :: t()
+  def reassert(%__MODULE__{region: region} = t) do
+    %{t | region: ScrollRegionManager.reassert(region), needs_keyframe: true}
+  end
+
   @impl true
   def region_top(%__MODULE__{region: region}),
     do: ScrollRegionManager.history_bottom(region)

--- a/packages/raxol_terminal/lib/raxol/terminal/inline_driver/reader_gate.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/inline_driver/reader_gate.ex
@@ -1,0 +1,96 @@
+defmodule Raxol.Terminal.InlineDriver.ReaderGate do
+  @moduledoc """
+  Quiesce/resume the BEAM's prim_tty stdin reader, so an external
+  process (an `$EDITOR` handed the tty by the harness composer) is not
+  robbed of keystrokes while it owns the terminal.
+
+  ## The problem this closes
+
+  `Raxol.Terminal.InlineDriver` arms the prim_tty reader process
+  (registered as `:user_drv_reader`) with a standing `{:read, :infinity}`
+  and traces its sends -- that is how raw keystrokes reach the inline
+  input path at all. But the reader holds an outstanding read on the
+  SAME tty an editor would read from: with both readers live, the kernel
+  splits typed bytes between them arbitrarily, and the editor sees only
+  a random subset of what the user types. The reader must be disabled
+  for the duration of the handoff, and re-enabled on resume.
+
+  ## The protocol (OTP's own, not an invention)
+
+  This is byte-for-byte the wire protocol `:prim_tty.disable_reader/1` /
+  `:prim_tty.enable_reader/1` speak to the reader process -- the exact
+  mechanism OTP's own shell uses for its open-in-editor feature (Ctrl+O
+  in `erl`; see `user_drv:open_editor/2` in the kernel application). We
+  cannot call `:prim_tty` directly because its `state()` record lives
+  inside `user_drv`'s gen_statem state, so this module speaks the
+  reader's message protocol against the registered pid instead -- the
+  same coupling `InlineDriver.start_stdin_reader/0` already accepts by
+  sending `{:read, :infinity}` raw.
+
+  The call shape is an alias-monitor request:
+  `ref = monitor(process, reader, alias: :reply_demonitor)`, send
+  `{ref, :disable | :enable}`, await `{ref, reply}`. While disabled the
+  reader blocks in a selective receive waiting ONLY for the enable
+  message (verified against OTP kernel `prim_tty.erl`'s `reader_loop/2`):
+  it consumes no tty bytes, so kernel input queues for the editor. Its
+  armed `{:read, :infinity}` state and the erlang trace flag both
+  persist across the disable/enable bracket (same process, state map
+  retained), so no re-arm is needed on resume.
+
+  ## Failure semantics
+
+    * `nil` reader (headless, piped stdin, `install_reader?: false`) --
+      `:ok`, a documented no-op: there is nothing reading the tty, so
+      there is nothing to gate.
+    * Reply timeout -- `{:error, :timeout}`. A `disable/2` timeout must
+      ABORT the suspend (never hand the tty to an editor while the BEAM
+      reader still competes for its bytes); an `enable/2` timeout leaves
+      input degraded but is survivable (the caller may notify rather
+      than crash).
+    * Reader died -- `{:error, {:reader_down, reason}}`.
+
+  There is one accepted race, the same one OTP accepts: a keystroke
+  arriving in the instant before the disable is processed may already
+  have been consumed by the reader. The window is a single scheduler
+  hop; the byte is delivered to the harness (which is mid-suspend and
+  ignores it) rather than lost to the kernel.
+  """
+
+  @default_timeout_ms 2_000
+
+  @spec disable(pid() | nil, timeout()) :: :ok | {:error, term()}
+  def disable(reader \\ Process.whereis(:user_drv_reader), timeout \\ @default_timeout_ms)
+
+  def disable(nil, _timeout), do: :ok
+
+  def disable(reader, timeout) when is_pid(reader),
+    do: call(reader, :disable, timeout)
+
+  @spec enable(pid() | nil, timeout()) :: :ok | {:error, term()}
+  def enable(reader \\ Process.whereis(:user_drv_reader), timeout \\ @default_timeout_ms)
+
+  def enable(nil, _timeout), do: :ok
+
+  def enable(reader, timeout) when is_pid(reader),
+    do: call(reader, :enable, timeout)
+
+  # The alias-monitor request/reply OTP's prim_tty `call/2` uses: the
+  # alias doubles as the reply address and auto-demonitors on reply
+  # (`:reply_demonitor`), so no stale DOWN can arrive after a success.
+  defp call(reader, msg, timeout) do
+    ref = :erlang.monitor(:process, reader, alias: :reply_demonitor)
+    send(reader, {ref, msg})
+
+    receive do
+      {^ref, _reply} ->
+        :ok
+
+      {:DOWN, ^ref, :process, _pid, reason} ->
+        {:error, {:reader_down, reason}}
+    after
+      timeout ->
+        :erlang.demonitor(ref, [:flush])
+        {:error, :timeout}
+    end
+  end
+end

--- a/packages/raxol_terminal/lib/raxol/terminal/inline_driver/reader_gate.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/inline_driver/reader_gate.ex
@@ -54,9 +54,31 @@ defmodule Raxol.Terminal.InlineDriver.ReaderGate do
   have been consumed by the reader. The window is a single scheduler
   hop; the byte is delivered to the harness (which is mid-suspend and
   ignores it) rather than lost to the kernel.
+
+  ## Version coupling: pinned range and the drift failure mode
+
+  This wire protocol is OTP-private. Tested/verified range: **OTP 26
+  through 29** (the disable/enable branch of `reader_loop/2` is
+  byte-identical across them; prim_tty itself first shipped the reader
+  in OTP 26). Below the floor, `disable/2`/`enable/2` refuse with
+  `{:error, {:unsupported_otp, release}}` rather than sending a message
+  whose receiver semantics were never verified.
+
+  If a FUTURE OTP changes the reader's message shape, the failure mode
+  is fail-closed by construction, not silent corruption: `reader_loop`'s
+  catch-all clause ignores unknown messages, so the gate's call times
+  out (`{:error, :timeout}`, bounded), and the one caller that matters
+  treats a disable failure as ABORT-the-suspend -- the tty is never
+  handed to an editor with the gate in an unknown state. Bumping the
+  pinned range above is a deliberate act: re-read `prim_tty.erl`'s
+  `reader_loop/2` for the new release and extend the ceiling in this
+  doc; the protocol suite (`reader_gate_test.exs`, scripted readers)
+  pins the wire shape this module SPEAKS, and the pty round-trip test
+  exercises it against the REAL reader.
   """
 
   @default_timeout_ms 2_000
+  @min_otp 26
 
   @spec disable(pid() | nil, timeout()) :: :ok | {:error, term()}
   def disable(reader \\ Process.whereis(:user_drv_reader), timeout \\ @default_timeout_ms)
@@ -77,7 +99,19 @@ defmodule Raxol.Terminal.InlineDriver.ReaderGate do
   # The alias-monitor request/reply OTP's prim_tty `call/2` uses: the
   # alias doubles as the reply address and auto-demonitors on reply
   # (`:reply_demonitor`), so no stale DOWN can arrive after a success.
+  # Refuses below the verified OTP floor rather than speaking an
+  # unverified protocol (see the moduledoc's version-coupling section).
   defp call(reader, msg, timeout) do
+    release = otp_release()
+
+    if release < @min_otp do
+      {:error, {:unsupported_otp, release}}
+    else
+      do_call(reader, msg, timeout)
+    end
+  end
+
+  defp do_call(reader, msg, timeout) do
     ref = :erlang.monitor(:process, reader, alias: :reply_demonitor)
     send(reader, {ref, msg})
 
@@ -92,5 +126,13 @@ defmodule Raxol.Terminal.InlineDriver.ReaderGate do
         :erlang.demonitor(ref, [:flush])
         {:error, :timeout}
     end
+  end
+
+  defp otp_release do
+    :otp_release |> :erlang.system_info() |> List.to_integer()
+  rescue
+    # A non-numeric release string (never seen in practice) reads as
+    # "unknown, too old" -- refusing is the safe direction.
+    _ -> 0
   end
 end

--- a/packages/raxol_terminal/lib/raxol/terminal/inline_driver/sequences.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/inline_driver/sequences.ex
@@ -65,12 +65,25 @@ defmodule Raxol.Terminal.InlineDriver.Sequences do
   def autowrap_cursor, do: @autowrap_cursor
 
   @doc """
-  Step 4: absolute-move to `(rows, 1)` then CRLF. Safe to be unclamped
-  because the scroll region is already gone by this point (step 2).
+  The bare absolute park at `(rows, 1)` -- the shared "magic byte"
+  builder both `move_bottom/1` (park + fresh-line CRLF, for the shell
+  handoff) and `suspend_bytes/1` (park only, for the editor handoff)
+  compose from. Safe to be unclamped only AFTER the region release
+  (step 2).
+  """
+  @spec park_bottom(pos_integer()) :: binary()
+  def park_bottom(rows) when is_integer(rows) and rows > 0 do
+    "\e[#{rows};1H"
+  end
+
+  @doc """
+  Step 4: absolute-move to `(rows, 1)` (`park_bottom/1`) then CRLF. Safe
+  to be unclamped because the scroll region is already gone by this
+  point (step 2).
   """
   @spec move_bottom(pos_integer()) :: binary()
   def move_bottom(rows) when is_integer(rows) and rows > 0 do
-    "\e[#{rows};1H\r\n"
+    park_bottom(rows) <> "\r\n"
   end
 
   @doc """
@@ -118,6 +131,6 @@ defmodule Raxol.Terminal.InlineDriver.Sequences do
   """
   @spec suspend_bytes(pos_integer()) :: binary()
   def suspend_bytes(rows) when is_integer(rows) and rows > 0 do
-    modes_off() <> release_region() <> autowrap_cursor() <> "\e[#{rows};1H"
+    modes_off() <> release_region() <> autowrap_cursor() <> park_bottom(rows)
   end
 end

--- a/packages/raxol_terminal/lib/raxol/terminal/inline_driver/sequences.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/inline_driver/sequences.ex
@@ -82,4 +82,42 @@ defmodule Raxol.Terminal.InlineDriver.Sequences do
   def teardown_bytes(rows) when is_integer(rows) and rows > 0 do
     modes_off() <> release_region() <> autowrap_cursor() <> move_bottom(rows)
   end
+
+  @doc """
+  Suspend bytes -- the editor-handoff sibling of `teardown_bytes/1`
+  (an external `$EDITOR` process, not process exit, is about to own the
+  tty). Steps 1-3 of the canonical teardown order, verbatim
+  (`modes_off/0`, `release_region/0`, `autowrap_cursor/0`), plus an
+  absolute cursor park at `(rows, 1)` -- WITHOUT step 4's trailing CRLF.
+
+  ## Why steps 1-3 apply unchanged
+
+  Same reasoning as the teardown order: modes must go off WHILE STILL
+  RAW (else the escapes echo back as if typed), and `CSI r` must precede
+  any absolute cursor move (else the move clamps into the still-active
+  old region, INV-1).
+
+  ## Why this DROPS step 4's trailing CRLF
+
+  `move_bottom/1`'s CRLF exists to hand the SHELL a fresh line after this
+  process exits for good -- the shell prompt that appears next expects to
+  start at column 1 of a blank row. An editor handoff is not that: the
+  region has just been released, so a CRLF here would scroll the FULL
+  (now region-free) screen up by one line, smearing whatever was on the
+  bottom row (a stale footer) into the row above it -- and that row is
+  inside the just-released history area, which cannot be re-addressed
+  once scrolled (the seal-time-only invariant). The bare park (`CSI
+  rows;1 H`, no `\\r\\n`) leaves the cursor at the right row without
+  scrolling anything, which is exactly what the editor needs: it will
+  clear/redraw its own screen (or, for a non-alt-screen editor, simply
+  start typing from wherever the cursor already is) without this driver
+  having pre-scrolled a footer row into unreachable history first.
+
+  Never emits `\\e[2J`/`\\e[3J` -- same substrate law as every other
+  sequence builder in this module.
+  """
+  @spec suspend_bytes(pos_integer()) :: binary()
+  def suspend_bytes(rows) when is_integer(rows) and rows > 0 do
+    modes_off() <> release_region() <> autowrap_cursor() <> "\e[#{rows};1H"
+  end
 end

--- a/packages/raxol_terminal/lib/raxol/terminal/scroll_region_manager.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/scroll_region_manager.ex
@@ -402,4 +402,47 @@ defmodule Raxol.Terminal.ScrollRegionManager do
         degenerate?: degenerate?(rows, new_footer_rows)
     }
   end
+
+  @doc """
+  Re-emits `region_set_bytes(rows, footer_rows)` to `state`'s device
+  UNCONDITIONALLY and returns `state` unchanged (same geometry, same
+  device, same everything) -- the resume-after-suspend counterpart to
+  `resize/2`'s geometry-gated emission.
+
+  ## Why unconditional (contrast `resize/2`)
+
+  `resize/2` skips the write when the new `history_bottom` matches the
+  current one -- correct for an ordinary resize, where the region is
+  never in question (this module keeps it pinned continuously from
+  `start/3` onward, so "geometry unchanged" really does mean "nothing to
+  re-pin"). But a resume after an EXTERNAL process owned the terminal
+  (an `$EDITOR` session that released the region via
+  `Raxol.Terminal.InlineDriver.Sequences.suspend_bytes/1`, the canonical
+  suspend bytes) genuinely un-pins the region without changing geometry
+  at all -- `resize/2`'s gate would (correctly, for ITS purpose) see
+  identical `history_bottom` and skip the write, silently leaving the
+  terminal un-pinned even though this process still believes the footer
+  is pinned. `reassert/1` is the different call site that needs the
+  unconditional form: always re-emit, regardless of whether geometry
+  moved.
+
+  Degenerate geometry (`degenerate?(state)`) re-emits the same
+  full-screen release `region_set_bytes/2` already emits for that case --
+  an honest un-pin, consistent with what `start/3`/`resize/2` would write
+  at that same geometry (see the moduledoc's "Degenerate terminals"
+  section).
+
+  DECSTBM's cursor-homing side effect is acceptable here: every
+  subsequent paint (`InlineAuthority.repaint/2`/`keyframe/2`) CUPs to an
+  absolute row before writing anything, so a homed cursor never becomes
+  visible.
+  """
+  @spec reassert(t()) :: t()
+  def reassert(
+        %__MODULE__{device: device, rows: rows, footer_rows: footer_rows} =
+          state
+      ) do
+    IO.write(device, region_set_bytes(rows, footer_rows))
+    state
+  end
 end

--- a/test/harness/editor_pty_test.exs
+++ b/test/harness/editor_pty_test.exs
@@ -1,0 +1,181 @@
+defmodule Raxol.Harness.EditorPtyTest do
+  @moduledoc """
+  Full editor-handoff round trip under a REAL kernel pty: a harness
+  driver (InlineDriver + Surface + the real EditorSession) runs under
+  `Raxol.Test.PtyHarness`, Ctrl-E is injected as the raw 0x05 byte, a
+  fake `$EDITOR` (a shell script appending a marker to the draft file)
+  takes the tty, and the resumed harness repaints the composer with the
+  edited draft.
+
+  This is the tier reserved for facts a pure byte-capture cannot
+  observe: the reader gate against the real prim_tty reader, `/dev/tty`
+  stty transitions, and a real child process inheriting the pty via
+  `:nouse_stdio`. Tagged `:skip_on_ci` (same rationale as the pty smoke
+  suite: real-pty timing on shared CI runners flakes in the
+  kernel/runner, not in the assertions) -- run locally with
+
+      mix test --include skip_on_ci --include pty test/harness/editor_pty_test.exs
+
+  Skips cleanly when `python3` is absent.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Raxol.Test.PtyHarness
+
+  @moduletag :pty
+  @moduletag :unix_only
+  @moduletag :skip_on_ci
+  @moduletag timeout: 120_000
+
+  setup_all do
+    if PtyHarness.available?() do
+      :ok
+    else
+      {:skip, "python3 not found on PATH"}
+    end
+  end
+
+  # `stty -a` renders modes as bare tokens when set, minus-prefixed when
+  # clear; exact token membership avoids the substring trap.
+  defp stty_tokens(output), do: String.split(output, ~r/[\s;]+/, trim: true)
+
+  defp write_fake_editor!(dir) do
+    path = Path.join(dir, "fake_editor.sh")
+
+    File.write!(path, """
+    #!/bin/sh
+    printf 'EDITED-BY-FAKE' >> "$1"
+    exit 0
+    """)
+
+    File.chmod!(path, 0o755)
+    path
+  end
+
+  # A minimal real-tty driver: InlineDriver raw input -> Surface with the
+  # REAL EditorSession wired. Prints a READY sentinel once armed; quits on
+  # a plain "q".
+  defp write_driver_script!(dir) do
+    path = Path.join(dir, "editor_pty_driver.exs")
+
+    File.write!(path, """
+    alias Raxol.Harness.Surface
+    alias Raxol.UI.Harness.InputEvent
+
+    {:ok, driver} =
+      Raxol.Terminal.InlineDriver.start_link(
+        subscriber: self(),
+        device: :stdio,
+        rows: 24,
+        probe?: false,
+        tty?: true
+      )
+
+    IO.write(:stdio, "HARNESS-READY\\r\\n")
+
+    Surface.startup_push_up(:stdio, 24)
+
+    model =
+      Surface.new([],
+        device: :stdio,
+        width: 80,
+        rows: 24,
+        footer_rows: 6,
+        tty?: true,
+        mode: :inline_log,
+        editor_session: Raxol.Harness.EditorSession
+      )
+
+    loop = fn loop, model ->
+      receive do
+        {:inline_input, event} ->
+          norm = InputEvent.normalize(event)
+
+          if InputEvent.printable_char(norm) == "q" do
+            :ok
+          else
+            loop.(loop, Surface.handle_input(model, event))
+          end
+      after
+        60_000 -> :ok
+      end
+    end
+
+    loop.(loop, model)
+    GenServer.stop(driver, :normal)
+    """)
+
+    path
+  end
+
+  test "Ctrl-E: suspend releases the region, the fake editor edits the draft, resume re-pins and repaints" do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol_editor_pty_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    fake_editor = write_fake_editor!(dir)
+    driver_script = write_driver_script!(dir)
+    repo_root = File.cwd!()
+
+    {:ok, session} =
+      PtyHarness.start(
+        [
+          "sh",
+          "-c",
+          "cd '#{repo_root}' && exec mix run --no-start '#{driver_script}'"
+        ],
+        winsize: {24, 80},
+        env: %{
+          "EDITOR" => fake_editor,
+          "VISUAL" => "",
+          "MIX_ENV" => "test"
+        }
+      )
+
+    on_exit(fn ->
+      PtyHarness.stop(session)
+      File.rm(session.capture_path)
+      File.rm_rf!(dir)
+    end)
+
+    # mix startup under the pty can take a while on first load
+    assert :ok = PtyHarness.await_capture(session, "HARNESS-READY", 60_000)
+
+    # Ctrl-E: the raw 0x05 byte, exactly what a terminal sends
+    assert :ok = PtyHarness.write(session, <<5>>)
+
+    # the edited draft must come back through the resumed footer keyframe
+    assert :ok = PtyHarness.await_capture(session, "EDITED-BY-FAKE", 30_000)
+
+    # quit and drain to EOF (await is the capture-completeness barrier)
+    assert :ok = PtyHarness.write(session, "q")
+    assert {:ok, {:exit, 0}} = PtyHarness.await(session, 30_000)
+
+    {:ok, output} = PtyHarness.read_output(session)
+
+    # suspend released the region...
+    assert output =~ "\e[r"
+    # ...and resume re-pinned it (80x24, 6-row footer -> CSI 1;18r). The
+    # pin appears at startup AND again after resume: at least twice.
+    pin_matches = :binary.matches(output, "\e[1;18r")
+    assert length(pin_matches) >= 2
+
+    # the resume re-pin comes AFTER the suspend release
+    {first_release, _} = :binary.match(output, "\e[r")
+    {last_pin, _} = List.last(pin_matches)
+    assert last_pin > first_release
+
+    # the substrate law held across the whole session
+    refute output =~ "\e[2J"
+    refute output =~ "\e[3J"
+
+    # post-mortem: the driver's teardown restored a cooked line
+    # discipline (icanon as a bare token, not "-icanon")
+    assert {:ok, stty_output} = PtyHarness.post_mortem(session)
+    assert "icanon" in stty_tokens(stty_output)
+  end
+end

--- a/test/harness/editor_surface_test.exs
+++ b/test/harness/editor_surface_test.exs
@@ -1,0 +1,178 @@
+defmodule Raxol.Harness.EditorSurfaceTest do
+  @moduledoc """
+  `Raxol.Harness.Surface` + the `:edit_draft` command: the Ctrl+E chord
+  dispatched through the real keymap-first `handle_input/2` path with a
+  STUB editor session injected. Asserts the model-side contract (draft
+  replaced / kept, notices, geometry update) and the byte-side contract
+  (the re-pin + full footer keyframe on resume). StringIO only.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.Harness.Surface
+  alias Raxol.UI.Components.Harness.Composer
+
+  defp open_device, do: StringIO.open("") |> elem(1)
+
+  defp flush(device), do: StringIO.flush(device)
+
+  defp new_surface(device, opts \\ []) do
+    Surface.new(
+      [],
+      Keyword.merge(
+        [
+          device: device,
+          width: 80,
+          rows: 24,
+          footer_rows: 6,
+          mode: :inline_log
+        ],
+        opts
+      )
+    )
+  end
+
+  defp ctrl_e, do: Event.key_event("e", :pressed, [:ctrl])
+
+  defp with_draft(model, text),
+    do: %{model | composer: Composer.set_value(model.composer, text)}
+
+  test "the session receives the composer's current draft" do
+    device = open_device()
+    parent = self()
+
+    session = fn draft, opts ->
+      send(parent, {:session_called, draft, opts})
+      {:ok, %{text: draft, width: 80, rows: 24}}
+    end
+
+    model =
+      device |> new_surface(editor_session: session) |> with_draft("my draft")
+
+    _model = Surface.handle_input(model, ctrl_e())
+
+    assert_received {:session_called, "my draft", opts}
+    assert opts[:rows] == 24
+    assert opts[:width] == 80
+    # the device threaded to the session is the authority's own
+    assert opts[:device] == device
+  end
+
+  test "{:ok, text} replaces the composer draft and the footer keyframe carries it" do
+    device = open_device()
+
+    session = fn _draft, _opts ->
+      {:ok, %{text: "edited in vim", width: 80, rows: 24}}
+    end
+
+    model =
+      device |> new_surface(editor_session: session) |> with_draft("before")
+
+    _ = flush(device)
+    model = Surface.handle_input(model, ctrl_e())
+
+    assert Composer.value(model.composer) == "edited in vim"
+
+    bytes = flush(device)
+    # the resume re-pin (geometry unchanged -- only reassert emits it)
+    assert bytes =~ "\e[1;18r"
+    # the promoted keyframe re-rendered the composer with the new text
+    assert bytes =~ "edited in vim"
+  end
+
+  test "{:kept, reason, geo} keeps the original draft and shows a one-frame notice" do
+    device = open_device()
+
+    session = fn _draft, _opts ->
+      {:kept, :editor_nonzero, %{width: 80, rows: 24}}
+    end
+
+    model =
+      device |> new_surface(editor_session: session) |> with_draft("original")
+
+    _ = flush(device)
+    model = Surface.handle_input(model, ctrl_e())
+
+    assert Composer.value(model.composer) == "original"
+
+    bytes = flush(device)
+    assert bytes =~ "draft kept"
+    assert bytes =~ "\e[1;18r"
+
+    # one-frame: the notice is consumed by the paint that rendered it
+    assert model.stub_notice == nil
+  end
+
+  test "{:error, reason} shows the abort notice and STILL re-pins (belt-and-braces)" do
+    device = open_device()
+
+    session = fn _draft, _opts -> {:error, {:reader_disable, :timeout}} end
+
+    model = new_surface(device, editor_session: session)
+    _ = flush(device)
+    model = Surface.handle_input(model, ctrl_e())
+
+    bytes = flush(device)
+    assert bytes =~ "editor suspend aborted"
+    assert bytes =~ "\e[1;18r"
+    assert Composer.value(model.composer) == ""
+  end
+
+  test "a raising session degrades to the abort notice -- the UI loop survives" do
+    device = open_device()
+
+    session = fn _draft, _opts -> raise "session exploded" end
+
+    model = new_surface(device, editor_session: session)
+    _ = flush(device)
+    model = Surface.handle_input(model, ctrl_e())
+
+    bytes = flush(device)
+    assert bytes =~ "editor suspend aborted"
+    assert model.stub_notice == nil
+  end
+
+  test "geometry changed while suspended: model + pin track the session's re-queried size" do
+    device = open_device()
+
+    session = fn _draft, _opts ->
+      {:ok, %{text: "t", width: 100, rows: 30}}
+    end
+
+    model = new_surface(device, editor_session: session)
+    _ = flush(device)
+    model = Surface.handle_input(model, ctrl_e())
+
+    assert model.width == 100
+    assert model.rows == 30
+    # the pin is at the NEW split (30 rows - 6 footer)
+    assert flush(device) =~ "\e[1;24r"
+  end
+
+  test "no session wired: honest stub notice, no crash" do
+    device = open_device()
+    model = new_surface(device)
+    _ = flush(device)
+    _model = Surface.handle_input(model, ctrl_e())
+
+    assert flush(device) =~ "external editor not wired"
+  end
+
+  test "flat mode: seals one honest history line (no footer composer to edit into)" do
+    device = open_device()
+
+    model =
+      new_surface(device,
+        mode: :flat,
+        editor_session: fn _draft, _opts -> flunk("must not be called") end
+      )
+
+    _ = flush(device)
+    _model = Surface.handle_input(model, ctrl_e())
+
+    bytes = flush(device)
+    assert bytes =~ "external editor requires the footer composer"
+    assert String.ends_with?(bytes, "\n")
+  end
+end

--- a/test/harness/editor_surface_test.exs
+++ b/test/harness/editor_surface_test.exs
@@ -150,6 +150,84 @@ defmodule Raxol.Harness.EditorSurfaceTest do
     assert flush(device) =~ "\e[1;24r"
   end
 
+  test "a degraded resume (reader did not re-enable) surfaces a visible warning even on success" do
+    device = open_device()
+
+    session = fn _draft, _opts ->
+      {:ok,
+       %{
+         text: "edited",
+         width: 80,
+         rows: 24,
+         degraded: [{:enable_reader, {:reader_down, :noproc}}]
+       }}
+    end
+
+    model = new_surface(device, editor_session: session)
+    _ = flush(device)
+    model = Surface.handle_input(model, ctrl_e())
+
+    # the edit itself still landed...
+    assert Composer.value(model.composer) == "edited"
+    # ...but the input-death warning is visibly rendered, not swallowed
+    assert flush(device) =~ "input reader failed to re-enable"
+  end
+
+  test "a degraded KEPT outcome carries both the kept notice and the degradation warning" do
+    device = open_device()
+
+    session = fn _draft, _opts ->
+      {:kept, :editor_nonzero,
+       %{width: 80, rows: 24, degraded: [{:enable_reader, :timeout}]}}
+    end
+
+    model = new_surface(device, editor_session: session)
+    _ = flush(device)
+    _model = Surface.handle_input(model, ctrl_e())
+
+    bytes = flush(device)
+    assert bytes =~ "draft kept"
+    assert bytes =~ "input reader failed to re-enable"
+  end
+
+  test "{:kept, :editor_timeout, geo} renders a timeout notice" do
+    device = open_device()
+
+    session = fn _draft, _opts ->
+      {:kept, :editor_timeout, %{width: 80, rows: 24}}
+    end
+
+    model = new_surface(device, editor_session: session)
+    _ = flush(device)
+    _model = Surface.handle_input(model, ctrl_e())
+
+    assert flush(device) =~ "editor timed out"
+  end
+
+  test ":editor_opts flow through to the session (embedder seam, e.g. :editor_timeout_ms)" do
+    device = open_device()
+    parent = self()
+
+    session = fn _draft, opts ->
+      send(parent, {:session_opts, opts})
+      {:ok, %{text: "t", width: 80, rows: 24}}
+    end
+
+    model =
+      new_surface(device,
+        editor_session: session,
+        editor_opts: [editor_timeout_ms: 5_000]
+      )
+
+    _model = Surface.handle_input(model, ctrl_e())
+
+    assert_received {:session_opts, opts}
+    assert opts[:editor_timeout_ms] == 5_000
+    # model-owned geometry/device always win over editor_opts
+    assert opts[:rows] == 24
+    assert opts[:device] == device
+  end
+
   test "no session wired: honest stub notice, no crash" do
     device = open_device()
     model = new_surface(device)

--- a/test/harness/editor_surface_test.exs
+++ b/test/harness/editor_surface_test.exs
@@ -190,6 +190,27 @@ defmodule Raxol.Harness.EditorSurfaceTest do
     assert bytes =~ "input reader failed to re-enable"
   end
 
+  test "the degradation warning survives a LONG kept notice at 80 cols (own line, exempt from the kept notice's truncation)" do
+    device = open_device()
+
+    # The round-2 review's exact scenario: a long editor command makes the
+    # kept notice alone ~65 cols; appended on the same line, the warning
+    # was entirely truncated away by ViewText's end-truncation.
+    session = fn _draft, _opts ->
+      {:kept, {:editor_not_found, "code --wait --user-data-dir=/tmp/x"},
+       %{width: 80, rows: 24, degraded: [{:enable_reader, :timeout}]}}
+    end
+
+    model = new_surface(device, editor_session: session)
+    _ = flush(device)
+    _model = Surface.handle_input(model, ctrl_e())
+
+    bytes = flush(device)
+    # BOTH messages fully present -- the warning on its own footer line
+    assert bytes =~ "input reader failed to re-enable"
+    assert bytes =~ "draft kept"
+  end
+
   test "{:kept, :editor_timeout, geo} renders a timeout notice" do
     device = open_device()
 

--- a/test/harness/editor_suspend_substrate_test.exs
+++ b/test/harness/editor_suspend_substrate_test.exs
@@ -52,6 +52,12 @@ defmodule Raxol.Harness.EditorSuspendSubstrateTest do
       refute bytes =~ "\e[2J"
       refute bytes =~ "\e[3J"
     end
+
+    test "the park is a named builder (park_bottom/1), shared with move_bottom/1" do
+      assert Sequences.park_bottom(24) == "\e[24;1H"
+      assert String.ends_with?(Sequences.suspend_bytes(24), Sequences.park_bottom(24))
+      assert Sequences.move_bottom(24) == Sequences.park_bottom(24) <> "\r\n"
+    end
   end
 
   describe "ScrollRegionManager.reassert/1" do

--- a/test/harness/editor_suspend_substrate_test.exs
+++ b/test/harness/editor_suspend_substrate_test.exs
@@ -1,0 +1,163 @@
+defmodule Raxol.Harness.EditorSuspendSubstrateTest do
+  @moduledoc """
+  Byte-level substrate suite for the editor-handoff primitives: the
+  suspend byte vocabulary (`Sequences.suspend_bytes/1`), the
+  unconditional region re-pin (`ScrollRegionManager.reassert/1`), and
+  the authority-level resume composition
+  (`InlineAuthority.resize |> reassert` + the `needs_keyframe`
+  self-promotion). StringIO capture only -- no pty, no termbox, no OS
+  tty.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.InlineDriver.Sequences
+  alias Raxol.Terminal.ScrollRegionManager
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  defp open_device, do: StringIO.open("") |> elem(1)
+
+  defp flush(device), do: StringIO.flush(device)
+
+  describe "Sequences.suspend_bytes/1" do
+    test "exact byte composition: teardown steps 1-3 plus a BARE park (no CRLF)" do
+      assert Sequences.suspend_bytes(24) ==
+               Sequences.modes_off() <>
+                 Sequences.release_region() <>
+                 Sequences.autowrap_cursor() <> "\e[24;1H"
+    end
+
+    test "teardown is suspend plus exactly the fresh-line CRLF (the shell-handoff difference)" do
+      for rows <- [2, 24, 60] do
+        assert Sequences.teardown_bytes(rows) ==
+                 Sequences.suspend_bytes(rows) <> "\r\n"
+      end
+    end
+
+    test "ordering: modes off, then region release, then autowrap, then park" do
+      bytes = Sequences.suspend_bytes(24)
+
+      {modes_idx, _} = :binary.match(bytes, Sequences.modes_off())
+      {release_idx, _} = :binary.match(bytes, "\e[r")
+      {autowrap_idx, _} = :binary.match(bytes, Sequences.autowrap_cursor())
+      {park_idx, _} = :binary.match(bytes, "\e[24;1H")
+
+      assert modes_idx < release_idx
+      assert release_idx < autowrap_idx
+      assert autowrap_idx < park_idx
+    end
+
+    test "never a screen clear (the substrate law)" do
+      bytes = Sequences.suspend_bytes(24)
+      refute bytes =~ "\e[2J"
+      refute bytes =~ "\e[3J"
+    end
+  end
+
+  describe "ScrollRegionManager.reassert/1" do
+    test "re-emits the pin UNCONDITIONALLY on unchanged geometry (contrast resize/2's gate)" do
+      device = open_device()
+      region = ScrollRegionManager.start(device, 24, 6)
+      _ = flush(device)
+
+      # resize to the SAME geometry: zero bytes (the documented gate)
+      region = ScrollRegionManager.resize(region, 24)
+      assert flush(device) == ""
+
+      # reassert: exactly one full DECSTBM re-set, nothing else
+      reasserted = ScrollRegionManager.reassert(region)
+      assert flush(device) == "\e[1;18r"
+
+      # state unchanged -- reassert is bytes-only
+      assert reasserted == region
+    end
+
+    test "degenerate geometry re-emits the honest full-screen release" do
+      device = open_device()
+      region = ScrollRegionManager.start(device, 3, 6)
+      assert flush(device) == "\e[r"
+
+      _ = ScrollRegionManager.reassert(region)
+      assert flush(device) == "\e[r"
+    end
+  end
+
+  describe "InlineAuthority resume composition" do
+    test "reassert/1 re-emits the pin and latches needs_keyframe" do
+      device = open_device()
+      authority = InlineAuthority.new(device, 80, 24, 6, capabilities: nil)
+      _ = flush(device)
+
+      refute authority.needs_keyframe
+
+      authority = InlineAuthority.reassert(authority)
+
+      assert authority.needs_keyframe
+      assert flush(device) == "\e[1;18r"
+    end
+
+    test "the next repaint with UNCHANGED lines self-promotes to a full keyframe" do
+      device = open_device()
+      authority = InlineAuthority.new(device, 80, 24, 6, capabilities: nil)
+      lines = ["status", "composer"]
+
+      authority = InlineAuthority.repaint(authority, lines)
+      _ = flush(device)
+
+      # steady state: an unchanged repaint is a byte-free no-op diff
+      authority = InlineAuthority.repaint(authority, lines)
+      assert flush(device) == ""
+
+      # after reassert, the SAME unchanged repaint must fully re-render:
+      # the editor scribbled the screen, so the logical diff is a lie
+      authority = InlineAuthority.reassert(authority)
+      _ = flush(device)
+
+      authority = InlineAuthority.repaint(authority, lines)
+      bytes = flush(device)
+
+      # every footer row (19..24 for 24 rows / 6 footer) is re-addressed
+      for row <- 19..24 do
+        assert bytes =~ "\e[#{row};1H",
+               "keyframe after reassert must re-address footer row #{row}"
+      end
+
+      # and the latch is consumed
+      refute authority.needs_keyframe
+    end
+
+    test "resize-to-same-geometry |> reassert still emits the pin (the resume composition)" do
+      device = open_device()
+      authority = InlineAuthority.new(device, 80, 24, 6, capabilities: nil)
+      _ = flush(device)
+
+      authority =
+        authority
+        |> InlineAuthority.resize(80, 24)
+        |> InlineAuthority.reassert()
+
+      # resize wrote nothing (geometry-gated); reassert wrote the pin
+      assert flush(device) == "\e[1;18r"
+      assert authority.needs_keyframe
+    end
+
+    test "resize-to-NEW-geometry |> reassert re-pins at the new split" do
+      device = open_device()
+      authority = InlineAuthority.new(device, 80, 24, 6, capabilities: nil)
+      _ = flush(device)
+
+      _authority =
+        authority
+        |> InlineAuthority.resize(100, 30)
+        |> InlineAuthority.reassert()
+
+      bytes = flush(device)
+
+      # resize emits the new split once, reassert re-emits it (harmless,
+      # idempotent duplicate -- the documented cost of the belt-and-braces
+      # composition); no other bytes, and never the OLD split
+      assert bytes == "\e[1;24r\e[1;24r"
+      refute bytes =~ "\e[1;18r"
+    end
+  end
+end

--- a/test/harness/reader_gate_test.exs
+++ b/test/harness/reader_gate_test.exs
@@ -1,0 +1,61 @@
+defmodule Raxol.Terminal.InlineDriver.ReaderGateTest do
+  @moduledoc """
+  Direct protocol suite for `Raxol.Terminal.InlineDriver.ReaderGate`
+  against SCRIPTED reader processes -- no real prim_tty reader, no tty.
+  Covers the alias-call request/reply, the timeout bound (the fail-closed
+  path a future OTP protocol drift degrades to), the dead-reader monitor
+  path, and the nil no-op.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.InlineDriver.ReaderGate
+
+  # A process speaking prim_tty's reader protocol: acks disable, then
+  # blocks in a selective receive for enable (exactly reader_loop/2's
+  # disabled state).
+  defp scripted_reader do
+    spawn(fn ->
+      receive do
+        {disable_ref, :disable} ->
+          send(disable_ref, {disable_ref, :ok})
+
+          receive do
+            {enable_ref, :enable} -> send(enable_ref, {enable_ref, :ok})
+          end
+      end
+    end)
+  end
+
+  test "disable then enable against a protocol-speaking reader" do
+    reader = scripted_reader()
+
+    assert :ok = ReaderGate.disable(reader, 1_000)
+    assert :ok = ReaderGate.enable(reader, 1_000)
+  end
+
+  test "a reader that ignores the message (protocol drift) degrades to a bounded timeout -- fail-closed" do
+    # This IS the documented failure mode when OTP changes the reader wire
+    # protocol: the reader loop's catch-all ignores the unknown message,
+    # the gate times out, and the caller ABORTS the suspend rather than
+    # handing a contested tty to the editor.
+    deaf = spawn(fn -> Process.sleep(:infinity) end)
+
+    assert {:error, :timeout} = ReaderGate.disable(deaf, 50)
+    assert {:error, :timeout} = ReaderGate.enable(deaf, 50)
+  end
+
+  test "a dead reader surfaces as {:reader_down, reason} via the monitor, not a timeout" do
+    dead = spawn(fn -> :ok end)
+    ref = Process.monitor(dead)
+    assert_receive {:DOWN, ^ref, :process, ^dead, _}, 1_000
+
+    assert {:error, {:reader_down, :noproc}} = ReaderGate.disable(dead, 1_000)
+    assert {:error, {:reader_down, :noproc}} = ReaderGate.enable(dead, 1_000)
+  end
+
+  test "nil reader (headless / piped stdin / no prim_tty) is a documented no-op" do
+    assert :ok = ReaderGate.disable(nil, 50)
+    assert :ok = ReaderGate.enable(nil, 50)
+  end
+end

--- a/test/raxol/harness/editor_session_test.exs
+++ b/test/raxol/harness/editor_session_test.exs
@@ -441,6 +441,17 @@ defmodule Raxol.Harness.EditorSessionTest do
     assert Path.dirname(draft_dir) == tmp_dir
     refute draft_dir == tmp_dir
 
+    # the per-run dir name carries a strong-random segment, honoring the
+    # confidentiality doc's unpredictability claim (round-2 review: the
+    # doc said strong_rand_bytes but the name was counter+timestamp) --
+    # 6 random bytes -> 8 url-base64 chars as the final `_`-separated part
+    assert [random_segment | _] =
+             draft_dir |> Path.basename() |> String.split("_") |> Enum.reverse()
+
+    assert String.length(random_segment) >= 8
+    assert random_segment =~ ~r/\A[A-Za-z0-9_-]+\z/
+    refute random_segment =~ ~r/\A[0-9]+\z/
+
     # the whole per-run directory is gone afterward
     assert File.ls!(tmp_dir) == []
   end

--- a/test/raxol/harness/editor_session_test.exs
+++ b/test/raxol/harness/editor_session_test.exs
@@ -1,0 +1,372 @@
+defmodule Raxol.Harness.EditorSessionTest do
+  @moduledoc """
+  Suite for `Raxol.Harness.EditorSession` -- the thin, impure runner that
+  interprets `Raxol.Harness.EditorSuspend`'s machine against real (here:
+  injected) side effects.
+
+  Every seam is injected: a fake stty module recording calls, a fake
+  reader-gate module, a fake `spawn_fun`, a `StringIO` device, a
+  test-owned tmp dir. `run/2` is synchronous and executes in the CALLING
+  process, so the fakes record through the test process's own process
+  dictionary -- no agents, no races (each test still gets its own process,
+  so `async: true` stays safe).
+
+  Interleaving evidence: `StringIO` can't participate in a single shared
+  recorder, so the stty/reader-gate fakes snapshot the device's
+  bytes-so-far at call time -- "suspend bytes were on the device BEFORE
+  stty restore ran" is assertable without a custom IO server.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.EditorSession
+  alias Raxol.Terminal.InlineDriver.Sequences
+
+  @rows 24
+  @width 80
+
+  # -- recording fakes (process-dictionary recorder; see moduledoc) ------
+
+  defp events, do: Process.get(:editor_session_events, [])
+
+  defp device_bytes do
+    case Process.get(:editor_session_device) do
+      nil ->
+        ""
+
+      device ->
+        {_in, out} = StringIO.contents(device)
+        out
+    end
+  end
+
+  # `run/2` executes in the test process, so a fake that `send`s to
+  # `self()` would deposit messages in the test mailbox -- workable, but
+  # the process dictionary is simpler and strictly ordered. These
+  # module-based fakes route through the pdict via the helpers above by
+  # being called IN the test process.
+  defmodule PdictStty do
+    def restore(saved) do
+      pdict_record({:stty_restore, saved, pdict_device_bytes()})
+      :ok
+    end
+
+    def raw! do
+      pdict_record({:stty_raw, pdict_device_bytes()})
+      :ok
+    end
+
+    def size do
+      pdict_record(:size)
+      {:ok, 100, 30}
+    end
+
+    def pdict_record(event) do
+      Process.put(
+        :editor_session_events,
+        Process.get(:editor_session_events, []) ++ [event]
+      )
+    end
+
+    def pdict_device_bytes do
+      case Process.get(:editor_session_device) do
+        nil ->
+          ""
+
+        device ->
+          {_in, out} = StringIO.contents(device)
+          out
+      end
+    end
+  end
+
+  defmodule PdictReaderGate do
+    def disable(reader) do
+      PdictStty.pdict_record(
+        {:disable_reader, reader, PdictStty.pdict_device_bytes()}
+      )
+
+      Process.get(:reader_gate_disable_result, :ok)
+    end
+
+    def enable(reader) do
+      PdictStty.pdict_record(
+        {:enable_reader, reader, PdictStty.pdict_device_bytes()}
+      )
+
+      :ok
+    end
+  end
+
+  # Extracts the single-quoted tmp path from the spawned shell command
+  # (`shell_quote/1` wraps in single quotes; test paths carry none).
+  defp quoted_path(cmd) do
+    [_pre, path | _rest] = String.split(cmd, "'")
+    path
+  end
+
+  defp base_opts(device, tmp_dir, spawn_fun) do
+    Process.put(:editor_session_device, device)
+
+    [
+      device: device,
+      rows: @rows,
+      width: @width,
+      stty: PdictStty,
+      reader_gate: PdictReaderGate,
+      reader: self(),
+      env: %{"EDITOR" => "fake-editor"},
+      tmp_dir: tmp_dir,
+      spawn_fun: spawn_fun
+    ]
+  end
+
+  defp fresh_tmp_dir(context_line) do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol_editor_session_#{context_line}_#{:erlang.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  defp event_names do
+    Enum.map(events(), fn
+      {name, _a} -> name
+      {name, _a, _b} -> name
+      name when is_atom(name) -> name
+    end)
+  end
+
+  # ---------------------------------------------------------------------
+  # happy path
+  # ---------------------------------------------------------------------
+
+  test "happy path: side-effect order, edited text returned, tmp file gone" do
+    tmp_dir = fresh_tmp_dir("happy")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn cmd ->
+      PdictStty.pdict_record({:spawn, cmd})
+      path = quoted_path(cmd)
+      # a POSIX editor: saves the buffer with exactly one trailing newline
+      File.write!(path, "edited draft\n")
+      0
+    end
+
+    result =
+      EditorSession.run(
+        "original draft",
+        base_opts(device, tmp_dir, spawn_fun)
+      )
+
+    assert {:ok, %{text: "edited draft", width: 100, rows: 30}} = result
+
+    # the recorded side-effect order, exactly
+    assert event_names() == [
+             :disable_reader,
+             :stty_restore,
+             :spawn,
+             :size,
+             :stty_raw,
+             :enable_reader
+           ]
+
+    # interleaving evidence via bytes-so-far snapshots:
+    # nothing on the device before the reader was disabled...
+    assert [{:disable_reader, _reader, bytes_at_disable} | _] = events()
+    assert bytes_at_disable == ""
+
+    # ...the suspend bytes were written BEFORE the stty restore ran...
+    {:stty_restore, nil, bytes_at_restore} =
+      Enum.find(events(), &match?({:stty_restore, _, _}, &1))
+
+    assert bytes_at_restore =~ Sequences.suspend_bytes(@rows)
+
+    # ...and init_bytes only landed AFTER the reader was re-enabled.
+    {:enable_reader, _reader, bytes_at_enable} =
+      Enum.find(events(), &match?({:enable_reader, _, _}, &1))
+
+    refute bytes_at_enable =~ Sequences.init_bytes()
+    assert device_bytes() =~ Sequences.init_bytes()
+
+    # tmp file gone
+    assert File.ls!(tmp_dir) == []
+  end
+
+  # ---------------------------------------------------------------------
+  # editor exit statuses
+  # ---------------------------------------------------------------------
+
+  test "editor exits 3 -> {:kept, :editor_nonzero, geo}; resume still ran; tmp gone" do
+    tmp_dir = fresh_tmp_dir("nonzero")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn cmd ->
+      PdictStty.pdict_record({:spawn, cmd})
+      # editor scribbled something before dying -- must NOT come back
+      File.write!(quoted_path(cmd), "half-saved garbage\n")
+      3
+    end
+
+    result =
+      EditorSession.run("keep me", base_opts(device, tmp_dir, spawn_fun))
+
+    assert {:kept, :editor_nonzero, %{width: 100, rows: 30}} = result
+
+    # resume side effects still ran despite the nonzero exit
+    assert :stty_raw in event_names()
+    assert :enable_reader in event_names()
+    assert device_bytes() =~ Sequences.init_bytes()
+
+    assert File.ls!(tmp_dir) == []
+  end
+
+  test "editor exits 127 -> {:kept, {:editor_not_found, cmd}, geo}" do
+    tmp_dir = fresh_tmp_dir("notfound")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn _cmd -> 127 end
+
+    result =
+      EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+
+    assert {:kept, {:editor_not_found, "fake-editor"}, %{width: 100, rows: 30}} =
+             result
+
+    assert File.ls!(tmp_dir) == []
+  end
+
+  test "port crash (:crashed from spawn_fun) -> {:kept, :editor_crashed, geo}" do
+    tmp_dir = fresh_tmp_dir("crashed")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn _cmd -> :crashed end
+
+    result =
+      EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+
+    assert {:kept, :editor_crashed, %{width: 100, rows: 30}} = result
+    assert File.ls!(tmp_dir) == []
+  end
+
+  test "exit 0 but the tmp file was deleted by the editor -> {:kept, :reload_failed, geo}" do
+    tmp_dir = fresh_tmp_dir("reload")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn cmd ->
+      File.rm!(quoted_path(cmd))
+      0
+    end
+
+    result =
+      EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+
+    assert {:kept, :reload_failed, %{width: 100, rows: 30}} = result
+    assert File.ls!(tmp_dir) == []
+  end
+
+  # ---------------------------------------------------------------------
+  # exception mid-run: compensation runs, then the exception propagates
+  # ---------------------------------------------------------------------
+
+  test "spawn_fun raises -> compensation ran (raw + enable recorded), tmp gone, exception propagates" do
+    tmp_dir = fresh_tmp_dir("raise")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn _cmd -> raise "editor spawn exploded" end
+
+    assert_raise RuntimeError, "editor spawn exploded", fn ->
+      EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+    end
+
+    # the machine's recovery compensation was interpreted: raw_tty, then
+    # enable_reader (in that order -- no cooked-echo race), then reinit
+    names = event_names()
+    raw_idx = Enum.find_index(names, &(&1 == :stty_raw))
+    enable_idx = Enum.find_index(names, &(&1 == :enable_reader))
+    assert raw_idx != nil and enable_idx != nil
+    assert raw_idx < enable_idx
+    assert device_bytes() =~ Sequences.init_bytes()
+
+    # tmp gone even on the raise path (the try/after wrap)
+    assert File.ls!(tmp_dir) == []
+  end
+
+  # ---------------------------------------------------------------------
+  # reader-disable failure: abort BEFORE any bytes touch the device
+  # ---------------------------------------------------------------------
+
+  test "reader disable {:error, :timeout} -> {:error, {:reader_disable, :timeout}}, NO device bytes, tmp gone" do
+    tmp_dir = fresh_tmp_dir("gate")
+    {:ok, device} = StringIO.open("")
+
+    Process.put(:reader_gate_disable_result, {:error, :timeout})
+
+    spawn_fun = fn _cmd ->
+      flunk("the editor must never be spawned when the reader gate fails")
+    end
+
+    result =
+      EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+
+    assert result == {:error, {:reader_disable, :timeout}}
+
+    # never hand the tty to an editor while the BEAM reader competes for
+    # its bytes -- and never release the screen either: zero device bytes.
+    assert device_bytes() == ""
+
+    assert File.ls!(tmp_dir) == []
+  end
+
+  # ---------------------------------------------------------------------
+  # suspend-segment byte content
+  # ---------------------------------------------------------------------
+
+  test "suspend bytes: modes off, region release, autowrap, park -- no \\e[2J/\\e[3J, no trailing CRLF after the park" do
+    tmp_dir = fresh_tmp_dir("bytes")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn cmd ->
+      # snapshot the SUSPEND segment: everything written before the
+      # editor ran
+      PdictStty.pdict_record({:suspend_segment, PdictStty.pdict_device_bytes()})
+      File.write!(quoted_path(cmd), "x\n")
+      0
+    end
+
+    {:ok, _} = EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+
+    {:suspend_segment, suspend_segment} =
+      Enum.find(events(), &match?({:suspend_segment, _}, &1))
+
+    park = "\e[#{@rows};1H"
+
+    assert suspend_segment =~ Sequences.modes_off()
+    assert suspend_segment =~ "\e[r"
+    assert suspend_segment =~ "\e[?7h\e[?25h"
+    assert suspend_segment =~ park
+
+    refute suspend_segment =~ "\e[2J"
+    refute suspend_segment =~ "\e[3J"
+
+    # the park is the LAST thing in the suspend segment -- no trailing
+    # CRLF (the teardown-vs-suspend distinction: a CRLF here would scroll
+    # a stale footer row into un-repaintable history)
+    assert String.ends_with?(suspend_segment, park)
+    refute suspend_segment =~ park <> "\r\n"
+
+    # ordering: modes off, then release, then autowrap, then park
+    {modes_idx, _} = :binary.match(suspend_segment, Sequences.modes_off())
+    {release_idx, _} = :binary.match(suspend_segment, "\e[r")
+    {autowrap_idx, _} = :binary.match(suspend_segment, "\e[?7h\e[?25h")
+    {park_idx, _} = :binary.match(suspend_segment, park)
+
+    assert modes_idx < release_idx
+    assert release_idx < autowrap_idx
+    assert autowrap_idx < park_idx
+  end
+end

--- a/test/raxol/harness/editor_session_test.exs
+++ b/test/raxol/harness/editor_session_test.exs
@@ -94,7 +94,7 @@ defmodule Raxol.Harness.EditorSessionTest do
         {:enable_reader, reader, PdictStty.pdict_device_bytes()}
       )
 
-      :ok
+      Process.get(:reader_gate_enable_result, :ok)
     end
   end
 
@@ -320,6 +320,190 @@ defmodule Raxol.Harness.EditorSessionTest do
     assert device_bytes() == ""
 
     assert File.ls!(tmp_dir) == []
+  end
+
+  # ---------------------------------------------------------------------
+  # reader re-enable failure: DEGRADED, never silent (review CRITICAL)
+  # ---------------------------------------------------------------------
+
+  test "enable failure is reported as a degradation on the OK outcome -- never swallowed" do
+    tmp_dir = fresh_tmp_dir("degraded_ok")
+    {:ok, device} = StringIO.open("")
+
+    Process.put(:reader_gate_enable_result, {:error, {:reader_down, :noproc}})
+
+    spawn_fun = fn cmd ->
+      File.write!(quoted_path(cmd), "edited\n")
+      0
+    end
+
+    result =
+      EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+
+    assert {:ok,
+            %{
+              text: "edited",
+              degraded: [{:enable_reader, {:reader_down, :noproc}}]
+            }} = result
+
+    # the resume still completed: modes re-inited despite the dead reader
+    assert device_bytes() =~ Sequences.init_bytes()
+    assert File.ls!(tmp_dir) == []
+  end
+
+  test "enable failure is reported as a degradation on KEPT outcomes too" do
+    tmp_dir = fresh_tmp_dir("degraded_kept")
+    {:ok, device} = StringIO.open("")
+
+    Process.put(:reader_gate_enable_result, {:error, :timeout})
+
+    spawn_fun = fn _cmd -> 3 end
+
+    assert {:kept, :editor_nonzero, %{degraded: [{:enable_reader, :timeout}]}} =
+             EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+  end
+
+  test "a clean run reports an EMPTY degradation list" do
+    tmp_dir = fresh_tmp_dir("degraded_none")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn cmd ->
+      File.write!(quoted_path(cmd), "x\n")
+      0
+    end
+
+    assert {:ok, %{degraded: []}} =
+             EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+  end
+
+  test "enable failure emits the reader_enable_failed telemetry event" do
+    tmp_dir = fresh_tmp_dir("degraded_tel")
+    {:ok, device} = StringIO.open("")
+    parent = self()
+    handler_id = "editor-session-test-#{:erlang.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :harness, :editor, :reader_enable_failed],
+        fn _event, _measurements, metadata, _config ->
+          send(parent, {:telemetry, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    Process.put(:reader_gate_enable_result, {:error, {:reader_down, :killed}})
+
+    spawn_fun = fn cmd ->
+      File.write!(quoted_path(cmd), "x\n")
+      0
+    end
+
+    {:ok, _} = EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
+
+    assert_received {:telemetry, %{reason: {:reader_down, :killed}}}
+  end
+
+  # ---------------------------------------------------------------------
+  # temp-file confidentiality (review security finding)
+  # ---------------------------------------------------------------------
+
+  @tag :unix_only
+  test "the draft lives in a fresh 0700 per-run directory as a 0600 file -- never bare in the shared tmp dir" do
+    tmp_dir = fresh_tmp_dir("perms")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn cmd ->
+      path = quoted_path(cmd)
+      %File.Stat{mode: file_mode} = File.stat!(path)
+      dir = Path.dirname(path)
+      %File.Stat{mode: dir_mode} = File.stat!(dir)
+
+      PdictStty.pdict_record(
+        {:perms, Bitwise.band(file_mode, 0o777), Bitwise.band(dir_mode, 0o777),
+         dir}
+      )
+
+      File.write!(path, "x\n")
+      0
+    end
+
+    {:ok, _} = EditorSession.run("secret draft", base_opts(device, tmp_dir, spawn_fun))
+
+    {:perms, file_perms, dir_perms, draft_dir} =
+      Enum.find(events(), &match?({:perms, _, _, _}, &1))
+
+    assert file_perms == 0o600
+    assert dir_perms == 0o700
+    # a per-run SUBDIRECTORY of the injected tmp dir, not the tmp dir itself
+    assert Path.dirname(draft_dir) == tmp_dir
+    refute draft_dir == tmp_dir
+
+    # the whole per-run directory is gone afterward
+    assert File.ls!(tmp_dir) == []
+  end
+
+  @tag :unix_only
+  test "draft creation is O_EXCL: a pre-existing file (or pre-planted symlink) is refused, never followed" do
+    tmp_dir = fresh_tmp_dir("excl")
+
+    existing = Path.join(tmp_dir, "existing.md")
+    File.write!(existing, "already here")
+    assert {:error, :eexist} = EditorSession.write_draft_file(existing, "draft")
+    # the pre-existing content was NOT truncated or replaced
+    assert File.read!(existing) == "already here"
+
+    target = Path.join(tmp_dir, "attacker_target")
+    File.write!(target, "victim file")
+    link = Path.join(tmp_dir, "planted.md")
+    :ok = :file.make_symlink(target, link)
+
+    assert {:error, :eexist} = EditorSession.write_draft_file(link, "draft")
+    # the symlink's target is untouched
+    assert File.read!(target) == "victim file"
+  end
+
+  # ---------------------------------------------------------------------
+  # editor timeout (review finding: unbounded synchronous wait)
+  # ---------------------------------------------------------------------
+
+  test "a wedged editor is bounded by :editor_timeout_ms -> {:kept, :editor_timeout, geo}" do
+    tmp_dir = fresh_tmp_dir("timeout")
+    {:ok, device} = StringIO.open("")
+
+    # REAL default spawn (no :spawn_fun injected): "sleep 3" plays the
+    # wedged editor; the 300ms bound must kill the wait long before the
+    # 3s exit would deliver a status.
+    opts =
+      base_opts(device, tmp_dir, nil)
+      |> Keyword.delete(:spawn_fun)
+      |> Keyword.merge(
+        env: %{"EDITOR" => "sleep 3 #"},
+        editor_timeout_ms: 300
+      )
+
+    started = System.monotonic_time(:millisecond)
+    result = EditorSession.run("draft", opts)
+    elapsed = System.monotonic_time(:millisecond) - started
+
+    assert {:kept, :editor_timeout, %{}} = result
+    assert elapsed < 2_000
+
+    # the resume bracket still ran
+    assert :stty_raw in event_names()
+    assert File.ls!(tmp_dir) == []
+  end
+
+  test "spawn_fun returning :timeout maps to {:kept, :editor_timeout, geo}" do
+    tmp_dir = fresh_tmp_dir("timeout_map")
+    {:ok, device} = StringIO.open("")
+
+    spawn_fun = fn _cmd -> :timeout end
+
+    assert {:kept, :editor_timeout, %{width: 100, rows: 30}} =
+             EditorSession.run("draft", base_opts(device, tmp_dir, spawn_fun))
   end
 
   # ---------------------------------------------------------------------

--- a/test/raxol/harness/editor_session_test.exs
+++ b/test/raxol/harness/editor_session_test.exs
@@ -469,6 +469,9 @@ defmodule Raxol.Harness.EditorSessionTest do
   # editor timeout (review finding: unbounded synchronous wait)
   # ---------------------------------------------------------------------
 
+  # The fake wedged editor is `sleep 3` spawned via sh — Unix-only tools;
+  # on Windows the spawn fails instantly and the timeout path never runs.
+  @tag :unix_only
   test "a wedged editor is bounded by :editor_timeout_ms -> {:kept, :editor_timeout, geo}" do
     tmp_dir = fresh_tmp_dir("timeout")
     {:ok, device} = StringIO.open("")

--- a/test/raxol/harness/editor_suspend_test.exs
+++ b/test/raxol/harness/editor_suspend_test.exs
@@ -1,0 +1,296 @@
+defmodule Raxol.Harness.EditorSuspendTest do
+  @moduledoc """
+  Pure-function suite for `Raxol.Harness.EditorSuspend`: editor
+  resolution policy, the draft round-trip (encode/decode), the tmp-file
+  naming policy, and -- the load-bearing part -- the suspend/resume state
+  machine with per-step compensation.
+
+  Everything here is data-in/data-out: no processes, no IO, no tty. The
+  impure runner (`Raxol.Harness.EditorSession`) interprets this machine;
+  its own suite (`editor_session_test.exs`) covers the interpretation.
+
+  The compensation invariant is checked exhaustively (every failure
+  point) with a plain ledger fold -- the failure-point set is finite, so
+  a comprehension covers it completely with no property framework.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.EditorSuspend
+
+  # The canonical ordered step list this machine must emit on the happy
+  # path. `:requery_size` sits BEFORE `:raw_tty` because the size query
+  # must run while the tty is still cooked (the runner's own documented
+  # ordering); everything else follows the suspend/resume bracket order.
+  @expected_steps [
+    :write_tmp,
+    :disable_reader,
+    :release_screen,
+    :restore_tty,
+    :spawn_editor,
+    :await_editor,
+    :requery_size,
+    :raw_tty,
+    :enable_reader,
+    :reinit_modes,
+    :reassert_region,
+    :reload_draft,
+    :cleanup_tmp
+  ]
+
+  # ---------------------------------------------------------------------
+  # resolve_editor/1
+  # ---------------------------------------------------------------------
+
+  describe "resolve_editor/1" do
+    test "VISUAL wins over EDITOR" do
+      assert EditorSuspend.resolve_editor(%{
+               "VISUAL" => "code -w",
+               "EDITOR" => "vim"
+             }) == {:ok, "code -w"}
+    end
+
+    test "empty-string VISUAL falls through to EDITOR" do
+      assert EditorSuspend.resolve_editor(%{
+               "VISUAL" => "",
+               "EDITOR" => "vim"
+             }) == {:ok, "vim"}
+    end
+
+    test "missing VISUAL falls through to EDITOR" do
+      assert EditorSuspend.resolve_editor(%{"EDITOR" => "nano"}) ==
+               {:ok, "nano"}
+    end
+
+    test "both empty/missing falls back to vi" do
+      assert EditorSuspend.resolve_editor(%{}) == {:ok, "vi"}
+      assert EditorSuspend.resolve_editor(%{"VISUAL" => "", "EDITOR" => ""}) ==
+               {:ok, "vi"}
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # draft round-trip: encode/decode
+  # ---------------------------------------------------------------------
+
+  describe "draft round-trip" do
+    test "decode(encode(d) <> \"\\n\") == d for representative drafts" do
+      drafts = [
+        "one line",
+        "multi\nline\ndraft",
+        "trailing backslash \\",
+        "unicode 你好世界 🎉 école",
+        ""
+      ]
+
+      for d <- drafts do
+        assert EditorSuspend.decode_draft(EditorSuspend.encode_draft(d) <> "\n") ==
+                 d
+      end
+    end
+
+    test "decode strips exactly ONE trailing newline" do
+      assert EditorSuspend.decode_draft("a\n\n") == "a\n"
+      assert EditorSuspend.decode_draft("a\n") == "a"
+      assert EditorSuspend.decode_draft("a") == "a"
+    end
+
+    test "decode handles a trailing \\r\\n as one terminator" do
+      assert EditorSuspend.decode_draft("a\r\n") == "a"
+      assert EditorSuspend.decode_draft("a\r\n\r\n") == "a\r\n"
+    end
+
+    test "encode is identity" do
+      for d <- ["", "x", "a\nb", "tabs\tand \\ slashes"] do
+        assert EditorSuspend.encode_draft(d) == d
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # tmp_filename/1
+  # ---------------------------------------------------------------------
+
+  describe "tmp_filename/1" do
+    test "pure name policy: raxol_draft_<unique>.md" do
+      assert EditorSuspend.tmp_filename("abc123") == "raxol_draft_abc123.md"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # the state machine: happy-path ordering
+  # ---------------------------------------------------------------------
+
+  # Drives the machine with `:ok` for every effect, collecting the
+  # emitted step sequence until `{:done, _}`.
+  defp drive_happy(machine, acc \\ []) do
+    case EditorSuspend.advance(machine, :ok) do
+      {:done, _machine} -> Enum.reverse(acc)
+      {:effect, step, machine} -> drive_happy(machine, [step | acc])
+    end
+  end
+
+  # Advances the machine `n` times with `:ok` (issuing `n` effects; the
+  # first `n - 1` are completed, the n-th is pending), returning the
+  # machine plus the pending step.
+  defp drive_to_step(n) do
+    Enum.reduce(1..n, {EditorSuspend.new(), nil}, fn _i, {machine, _prev} ->
+      {:effect, step, machine} = EditorSuspend.advance(machine, :ok)
+      {machine, step}
+    end)
+  end
+
+  describe "machine: happy-path effect order (pinned)" do
+    test "emits the full step list in the exact documented order" do
+      assert drive_happy(EditorSuspend.new()) == @expected_steps
+    end
+
+    test "suspend bracket ordering: reader disable BEFORE screen release BEFORE tty restore BEFORE spawn" do
+      steps = drive_happy(EditorSuspend.new())
+      idx = fn step -> Enum.find_index(steps, &(&1 == step)) end
+
+      assert idx.(:disable_reader) < idx.(:release_screen)
+      assert idx.(:release_screen) < idx.(:restore_tty)
+      assert idx.(:restore_tty) < idx.(:spawn_editor)
+    end
+
+    test "resume bracket ordering: raw BEFORE reader enable BEFORE reinit" do
+      steps = drive_happy(EditorSuspend.new())
+      idx = fn step -> Enum.find_index(steps, &(&1 == step)) end
+
+      assert idx.(:raw_tty) < idx.(:enable_reader)
+      assert idx.(:enable_reader) < idx.(:reinit_modes)
+    end
+
+    test "cleanup_tmp is the final step" do
+      assert List.last(drive_happy(EditorSuspend.new())) == :cleanup_tmp
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # the state machine: compensation invariant, every failure point
+  # ---------------------------------------------------------------------
+
+  # A simple resource ledger interpreting each step (and each
+  # compensation step -- same vocabulary, same transitions) as a
+  # transition over the terminal's externally-observable resources. The
+  # invariant: starting from {raw, enabled, asserted, absent}, any
+  # completed prefix followed by its compensation must land back on
+  # exactly that state.
+  @initial_ledger %{
+    tty: :raw,
+    reader: :enabled,
+    screen: :asserted,
+    modes: :on,
+    tmp: :absent
+  }
+
+  defp ledger_apply(ledger, :write_tmp), do: %{ledger | tmp: :present}
+  defp ledger_apply(ledger, :disable_reader), do: %{ledger | reader: :disabled}
+
+  defp ledger_apply(ledger, :release_screen),
+    do: %{ledger | screen: :released, modes: :off}
+
+  defp ledger_apply(ledger, :restore_tty), do: %{ledger | tty: :cooked}
+  defp ledger_apply(ledger, :spawn_editor), do: ledger
+  defp ledger_apply(ledger, :await_editor), do: ledger
+  defp ledger_apply(ledger, :requery_size), do: ledger
+  defp ledger_apply(ledger, :raw_tty), do: %{ledger | tty: :raw}
+  defp ledger_apply(ledger, :enable_reader), do: %{ledger | reader: :enabled}
+  defp ledger_apply(ledger, :reinit_modes), do: %{ledger | modes: :on}
+  defp ledger_apply(ledger, :reassert_region), do: %{ledger | screen: :asserted}
+  defp ledger_apply(ledger, :reload_draft), do: ledger
+  defp ledger_apply(ledger, :cleanup_tmp), do: %{ledger | tmp: :absent}
+
+  describe "machine: recovery property (exhaustive over every failure point)" do
+    test "for EVERY failure point, completed-steps ++ compensation restores the resource-ledger invariant" do
+      total = length(@expected_steps)
+
+      for fail_at <- 1..total do
+        {machine, pending} = drive_to_step(fail_at)
+        assert pending == Enum.at(@expected_steps, fail_at - 1)
+
+        {:abort, compensation, _machine} =
+          EditorSuspend.advance(machine, {:error, :boom})
+
+        completed = Enum.take(@expected_steps, fail_at - 1)
+
+        final =
+          Enum.reduce(completed ++ compensation, @initial_ledger, &ledger_apply(&2, &1))
+
+        assert final == @initial_ledger,
+               "failure at #{inspect(pending)} (step #{fail_at}): " <>
+                 "completed #{inspect(completed)} ++ compensation " <>
+                 "#{inspect(compensation)} leaves ledger #{inspect(final)}, " <>
+                 "not the invariant #{inspect(@initial_ledger)}"
+      end
+    end
+
+    test "compensation never includes a step whose work was not done: failing the very first step compensates nothing" do
+      {machine, :write_tmp} = drive_to_step(1)
+
+      assert {:abort, [], _machine} =
+               EditorSuspend.advance(machine, {:error, :eacces})
+    end
+
+    test "failing disable_reader (first terminal-state step) compensates only the tmp file" do
+      {machine, :disable_reader} = drive_to_step(2)
+
+      assert {:abort, [:cleanup_tmp], _machine} =
+               EditorSuspend.advance(machine, {:error, :timeout})
+    end
+
+    test "spawn_editor failure compensates like a restore_tty-complete failure" do
+      {machine_spawn, :spawn_editor} = drive_to_step(5)
+
+      {:abort, comp_spawn, _} =
+        EditorSuspend.advance(machine_spawn, {:error, :boom})
+
+      assert comp_spawn == [
+               :raw_tty,
+               :enable_reader,
+               :reinit_modes,
+               :reassert_region,
+               :cleanup_tmp
+             ]
+    end
+
+    test "a resume-phase failure (reload_draft) compensates only cleanup -- the terminal is already restored" do
+      reload_index =
+        Enum.find_index(@expected_steps, &(&1 == :reload_draft)) + 1
+
+      {machine, :reload_draft} = drive_to_step(reload_index)
+
+      assert {:abort, [:cleanup_tmp], _machine} =
+               EditorSuspend.advance(machine, {:error, :enoent})
+    end
+
+    test "compensation order is the safe resume order: raw before enable before reinit/reassert, cleanup last" do
+      # Fail at :await_editor -- the deepest all-suspend-steps-completed
+      # point -- and pin the exact ordered compensation.
+      {machine, :await_editor} = drive_to_step(6)
+
+      {:abort, compensation, _machine} =
+        EditorSuspend.advance(machine, {:error, :boom})
+
+      assert compensation == [
+               :raw_tty,
+               :enable_reader,
+               :reinit_modes,
+               :reassert_region,
+               :cleanup_tmp
+             ]
+    end
+
+    test "recovery/1 reports the same compensation the abort path would take (the runner's rescue seam)" do
+      for fail_at <- 1..length(@expected_steps) do
+        {machine, _pending} = drive_to_step(fail_at)
+
+        {:abort, compensation, _} =
+          EditorSuspend.advance(machine, {:error, :boom})
+
+        assert EditorSuspend.recovery(machine) == compensation
+      end
+    end
+  end
+end

--- a/test/raxol/harness/editor_suspend_test.exs
+++ b/test/raxol/harness/editor_suspend_test.exs
@@ -226,17 +226,22 @@ defmodule Raxol.Harness.EditorSuspendTest do
       end
     end
 
-    test "compensation never includes a step whose work was not done: failing the very first step compensates nothing" do
+    test "failing write_tmp assumes a partial file may exist (worst case): compensates [:cleanup_tmp]" do
       {machine, :write_tmp} = drive_to_step(1)
 
-      assert {:abort, [], _machine} =
+      assert {:abort, [:cleanup_tmp], _machine} =
                EditorSuspend.advance(machine, {:error, :eacces})
     end
 
-    test "failing disable_reader (first terminal-state step) compensates only the tmp file" do
+    test "failing disable_reader assumes the disable may have LANDED with the reply lost: compensates the reader too" do
+      # A gate timeout cannot distinguish "never disabled" from "disabled,
+      # reply lost". Worst case is a permanently-deaf tty, so compensation
+      # must include :enable_reader -- against a never-disabled reader the
+      # enable message is ignored by the reader loop's catch-all and the
+      # compensation call just times out harmlessly.
       {machine, :disable_reader} = drive_to_step(2)
 
-      assert {:abort, [:cleanup_tmp], _machine} =
+      assert {:abort, [:enable_reader, :cleanup_tmp], _machine} =
                EditorSuspend.advance(machine, {:error, :timeout})
     end
 
@@ -291,6 +296,115 @@ defmodule Raxol.Harness.EditorSuspendTest do
 
         assert EditorSuspend.recovery(machine) == compensation
       end
+    end
+
+    # Suspend-phase steps must be assumed DONE when they fail: a failed
+    # IO.write may have partially landed its bytes, a failed File.write may
+    # have created the file, a timed-out stty/gate call may have taken
+    # effect with the reply lost. Resume-phase steps get the opposite
+    # assumption (not done), so compensation RETRIES them. This is the
+    # stronger, worst-case form of the invariant above.
+    @assume_done_on_failure [
+      :write_tmp,
+      :disable_reader,
+      :release_screen,
+      :restore_tty
+    ]
+
+    test "WORST CASE: completed ++ (pending, if suspend-phase) ++ compensation still restores the invariant" do
+      for fail_at <- 1..length(@expected_steps) do
+        {machine, pending} = drive_to_step(fail_at)
+
+        {:abort, compensation, _machine} =
+          EditorSuspend.advance(machine, {:error, :boom})
+
+        completed = Enum.take(@expected_steps, fail_at - 1)
+        assumed = if pending in @assume_done_on_failure, do: [pending], else: []
+
+        final =
+          Enum.reduce(
+            completed ++ assumed ++ compensation,
+            @initial_ledger,
+            &ledger_apply(&2, &1)
+          )
+
+        assert final == @initial_ledger,
+               "worst-case failure at #{inspect(pending)} (step #{fail_at}): " <>
+                 "completed #{inspect(completed)} ++ assumed #{inspect(assumed)} ++ " <>
+                 "compensation #{inspect(compensation)} leaves ledger " <>
+                 "#{inspect(final)}, not the invariant"
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # degradable steps: enable_reader can FAIL without aborting the resume
+  # ---------------------------------------------------------------------
+
+  describe "machine: degradable enable_reader" do
+    defp enable_index,
+      do: Enum.find_index(@expected_steps, &(&1 == :enable_reader)) + 1
+
+    test "a degraded enable continues to the next step and is RECORDED, never silently ok" do
+      {machine, :enable_reader} = drive_to_step(enable_index())
+
+      assert {:effect, :reinit_modes, machine} =
+               EditorSuspend.advance(
+                 machine,
+                 {:degraded, {:reader_down, :killed}}
+               )
+
+      assert EditorSuspend.degradations(machine) ==
+               [{:enable_reader, {:reader_down, :killed}}]
+    end
+
+    test "a non-degradable step rejects {:degraded, _} loudly (programmer error, not a policy)" do
+      {machine, :write_tmp} = drive_to_step(1)
+
+      assert_raise ArgumentError, fn ->
+        EditorSuspend.advance(machine, {:degraded, :whatever})
+      end
+    end
+
+    test "the ledger never lies: after a degraded enable, a later failure re-compensates the reader" do
+      {machine, :enable_reader} = drive_to_step(enable_index())
+
+      {:effect, :reinit_modes, machine} =
+        EditorSuspend.advance(machine, {:degraded, :noproc})
+
+      {:abort, compensation, _machine} =
+        EditorSuspend.advance(machine, {:error, :boom})
+
+      assert :enable_reader in compensation
+    end
+
+    test "a run completing WITH a degraded enable still reports the degradation at :done" do
+      {machine, :enable_reader} = drive_to_step(enable_index())
+
+      {:effect, :reinit_modes, machine} =
+        EditorSuspend.advance(machine, {:degraded, :noproc})
+
+      final =
+        Enum.reduce_while(1..20, machine, fn _i, machine ->
+          case EditorSuspend.advance(machine, :ok) do
+            {:effect, _step, machine} -> {:cont, machine}
+            {:done, machine} -> {:halt, machine}
+          end
+        end)
+
+      assert EditorSuspend.degradations(final) == [{:enable_reader, :noproc}]
+    end
+
+    test "a clean happy path reports zero degradations" do
+      final =
+        Enum.reduce_while(1..20, EditorSuspend.new(), fn _i, machine ->
+          case EditorSuspend.advance(machine, :ok) do
+            {:effect, _step, machine} -> {:cont, machine}
+            {:done, machine} -> {:halt, machine}
+          end
+        end)
+
+      assert EditorSuspend.degradations(final) == []
     end
   end
 end

--- a/test/raxol/ui/harness/keymap_test.exs
+++ b/test/raxol/ui/harness/keymap_test.exs
@@ -106,6 +106,37 @@ defmodule Raxol.UI.Harness.KeymapTest do
                %{type: :jump_prev, payload: %{}}
     end
 
+    test "Ctrl+E (ANSI parser shape, raw 0x05 byte) -> :edit_draft, even while composing" do
+      assert resolve_from(parser_event(<<5>>), %{composing?: true}) ==
+               %{type: :edit_draft, payload: %{}}
+    end
+
+    test "Ctrl+E (Event.key_event/3 shape) -> :edit_draft regardless of composing?" do
+      for composing? <- [true, false] do
+        assert resolve_from(Event.key_event("e", :pressed, [:ctrl]), %{
+                 composing?: composing?
+               }) == %{type: :edit_draft, payload: %{}}
+      end
+    end
+
+    test "plain 'e' while composing stays :passthrough (ordinary character insertion)" do
+      assert resolve_from(Event.key_event("e", :pressed, []), %{
+               composing?: true
+             }) == :passthrough
+    end
+
+    test "plain 'e' while NOT composing is also :passthrough ('e' is not a nav bind)" do
+      assert resolve_from(Event.key_event("e", :pressed, []), %{
+               composing?: false
+             }) == :passthrough
+    end
+
+    test "Ctrl+Alt+E -> :passthrough (chord binds require an EXACT mods match)" do
+      assert resolve_from(Event.key_event("e", :pressed, [:ctrl, :alt]), %{
+               composing?: true
+             }) == :passthrough
+    end
+
     test "an unbound key normalizes but resolves to :passthrough" do
       assert resolve_from(Event.key_event("q", :pressed, []), %{
                composing?: false
@@ -240,6 +271,13 @@ defmodule Raxol.UI.Harness.KeymapTest do
 
     defp fixture_for(%{key: key}),
       do: InputEvent.normalize(Event.key_event(key, :pressed, []))
+
+    # A char-kind CHORD bind (declared `mods:`) needs its modifiers in the
+    # fixture event, else the exact-mods match correctly rejects it.
+    defp fixture_for(%{char: char, mods: mods}) do
+      modifiers = for {mod, true} <- mods, do: mod
+      InputEvent.normalize(Event.key_event(char, :pressed, modifiers))
+    end
 
     defp fixture_for(%{char: char}),
       do: InputEvent.normalize(Event.key_event(char, :pressed, []))


### PR DESCRIPTION
Long prompts don't belong in a 6-row footer composer. Ctrl-E hands the draft to `$VISUAL || $EDITOR || vi` in a temp file, suspends the harness's terminal claim while the editor owns the tty, then resumes the substrate and reloads the edited draft.

## The terminal handoff (each step grounded in evidence)

**Suspend:** resolve editor + write temp file (nothing to unwind) -> disable the prim_tty stdin reader via a new `ReaderGate` (BYTE-FOR-BYTE OTP's own shell open-editor mechanism — `user_drv:open_editor/2`'s disable/enable alias protocol against the reader process InlineDriver already traces; disable failure ABORTS, never hand the tty to a competing reader) -> emit suspend bytes while still raw (teardown steps 1-3 verbatim + a BARE cursor park: teardown's CRLF would scroll a stale footer row into un-repaintable history; pinned by `teardown_bytes == suspend_bytes <> "\r\n"`) -> `stty sane` last so the editor starts cooked and Ctrl-C works if it wedges.

**Spawn:** `Port.open({:spawn, cmd}, [:nouse_stdio, :exit_status])` — `:nouse_stdio` moves port pipes to fds 3/4 so the child inherits fds 0/1/2 = the REAL tty (`System.cmd` can never do this). `{:spawn, string}` via sh supports arg-carrying editors ("code -w") and gives exit-127-as-not-found.

**Resume:** re-query size while still cooked (terminal may have been resized under the editor) -> raw before reader re-enable (no echo race) -> reader enable -> init bytes -> `resize |> reassert` at the Surface. `ScrollRegionManager.resize/2` is geometry-gated (zero bytes when unchanged), so resume adds an unconditional `reassert/1`; `InlineAuthority.reassert/1` latches `needs_keyframe` so the next repaint self-promotes to a full keyframe — the editor scribbled the screen; a logical diff would lie. Exit 0 reloads the draft (exactly one trailing newline stripped — POSIX editor discipline); nonzero/127/crash/reload-failure keep the original draft + a one-frame notice. Temp file removed on every path. Sealed history untouched by construction.

## Pure/impure split

`Raxol.Harness.EditorSuspend` (pure): a 13-step state machine whose per-failure-point compensation is DERIVED from a resource ledger `{tty, reader, screen, modes, tmp}` in safe resume order — tested exhaustively over every failure point. `Raxol.Harness.EditorSession`: thin interpreter, every seam injectable; exceptions run compensation then propagate.

## Keybind

Ctrl-E -> `:edit_draft` (`:always` class) — the keymap's first char-kind CHORD, using the documented declared-mods exact-match extension; plain `e` still inserts.

## Verification

Red-first machine tests (0/3 before, 20/20 after). 51 new tests total: 20 machine, 8 session-runner (interleaving snapshots via recording fakes), 9 substrate byte-level, 8 surface dispatch, 5 keymap chord cases, and **1 real-pty round trip (PASSED: real reader gate, scripted fake $EDITOR, release->re-pin ordering verified in captured bytes, cooked post-mortem stty)** under `:pty :unix_only :skip_on_ci`. Main suite 5843/5852 and raxol_terminal 2202/2206 — every non-green reproduced identically on pristine master/with changes stashed. Format + warnings clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)