### PR TITLE
test: order-of-magnitude bound on the 1M-grapheme scorer guard (CI flake)

### DIFF
--- a/test/raxol/ui/list_scorer_test.exs
+++ b/test/raxol/ui/list_scorer_test.exs
@@ -281,7 +281,12 @@ defmodule Raxol.UI.ListScorerTest do
 
       millis = micros / 1000
 
-      assert millis < 16.0,
+      # Order-of-magnitude blowup guard, matching the sibling test's
+      # convention above: without the clamp, the O(query * key) DP over a
+      # 1M-grapheme label costs seconds — 200ms catches that class while
+      # absorbing shared-CI-runner load (a 16ms wall-clock target flaked
+      # on loaded runners at ~25ms with the clamp working correctly).
+      assert millis < 200.0,
              "expected the 1M-grapheme adversarial label to stay bounded, took #{millis}ms"
 
       assert [%{item: matched, key: key}] = results


### PR DESCRIPTION
The macOS matrix on #610 flaked on `ListScorerTest`'s 1M-grapheme adversarial test: `assert millis < 16.0` wall-clock took 24.9ms on a loaded shared runner — with the grapheme clamp working correctly. Same disease class as the earlier Windows property timeouts: absolute-time asserts on shared CI turn runner load into false correctness failures.

The test's purpose is blowup detection (an unclamped O(query x key) DP over a 1M-grapheme label costs seconds), and the file's own sibling test already documents the right convention: "Regression guard only (order-of-magnitude), not the 16ms target" at 200ms. This applies the same convention to the adversarial case, with a comment recording the flake data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)