### PR TITLE
fix(terminal): empty OSC payload no longer crashes the ANSI state machine

### DIFF
--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/state_machine.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/state_machine.ex
@@ -514,8 +514,16 @@ defmodule Raxol.Terminal.ANSI.StateMachine do
   end
 
   defp emit_osc_sequence(state) do
-    params = String.split(state.payload_buffer, ";", trim: true)
-    [cmd | rest] = params
+    # `trim: true` on an empty (or all-`;`) payload yields `[]` — an OSC
+    # terminated with no content (e.g. `ESC ] ST`, reachable via a
+    # SUB-cancelled DCS followed by `ESC ]`). Emit it with an empty
+    # command rather than crashing: totality over arbitrary input is the
+    # parser's contract (see the DCS/OSC property suites).
+    {cmd, rest} =
+      case String.split(state.payload_buffer, ";", trim: true) do
+        [] -> {"", []}
+        [cmd | rest] -> {cmd, rest}
+      end
 
     {:emit, %{state | state: :ground},
      %{

--- a/test/property/dcs_parsing_property_test.exs
+++ b/test/property/dcs_parsing_property_test.exs
@@ -32,6 +32,23 @@ defmodule Raxol.Property.DcsParsingTest do
   # the state machine with random unicode inside a DCS string, e.g.
   # `"\eP��...\e\\"`.
   describe "DCS totality" do
+    # Regression: found by this property's random seed on CI. SUB (0x1A)
+    # inside the DCS string cancels it; ESC ] then opens an OSC; the
+    # trailing ST terminates that OSC with an EMPTY payload — and
+    # `emit_osc_sequence/1` crashed with a MatchError trying to split a
+    # command out of the empty payload buffer.
+    test "an empty OSC (via SUB-cancelled DCS) does not raise" do
+      input = <<0x1B, ?P>> <> <<26, 27, 93>> <> <<0x1B, ?\\>>
+
+      StateMachine.process(StateMachine.new(), input)
+      |> assert_sane_result()
+    end
+
+    test "a bare empty OSC terminated by ST does not raise" do
+      StateMachine.process(StateMachine.new(), <<0x1B, ?], 0x1B, ?\\>>)
+      |> assert_sane_result()
+    end
+
     property "never raises on DCS strings wrapping arbitrary bytes" do
       check all(
               payload <- binary(max_length: 64),


### PR DESCRIPTION
#608's Property Tests job flaked on `DcsParsingTest`'s totality property — and it turned out to be a real latent parser crash, reproduced on clean master (not #608's diff; the property rolls a fresh random seed per CI run, so this can hit ANY PR until fixed).

**The path:** SUB (0x1A) inside a DCS string cancels it -> `ESC ]` opens an OSC -> trailing ST terminates that OSC with an EMPTY payload -> `emit_osc_sequence/1` does `[cmd | rest] = String.split(payload, ";", trim: true)` and MatchErrors on `[]`.

**Fix:** emit the empty OSC with an empty command — totality over arbitrary input is the parser's contract (the property suites exist precisely to enforce it).

Red-first: two regression tests (the exact CI seed input `<<26, 27, 93>>` wrapped in DCS, and a bare `ESC ] ST`) failed with the MatchError before the fix. After: DCS/OSC property suites 8/8, raxol_terminal ANSI suite 456 green.

Once this merges, re-running #608's failed jobs should clear it (its other failure is the ListScorer 16ms flake fixed in #611).

🤖 Generated with [Claude Code](https://claude.com/claude-code)