### PR TITLE
feat(core): centralized boundary-confinement seam [thread-2]

### DIFF
--- a/packages/raxol_core/lib/raxol/core/boundary/path.ex
+++ b/packages/raxol_core/lib/raxol/core/boundary/path.ex
@@ -1,0 +1,151 @@
+defmodule Raxol.Core.Boundary.Path do
+  @moduledoc """
+  Path-traversal confinement: resolve an untrusted `requested` reference under
+  a trusted `root` and prove the result stays inside that root, rejecting every
+  escape *before* any syscall touches the target.
+
+  This is the centralized seed of the "same gap, four patches" boundary
+  (PR #569 thread 2). It is one of **two** boundary confinements — the other is
+  `Raxol.Core.Boundary.TermText` (terminal-injection). They share a threat
+  narrative but nothing else, so they are two functions, not one.
+
+  Seeded from the proven `Raxol.AgentClientProtocol.Client.FsSandbox.resolve/2`
+  (leaf-symlink *and* symlinked-ancestor resolution, cycle-guarded, rejecting
+  before any target syscall) plus PA-6's ref-shape gate. The Agent Client Protocol package keeps
+  its own tested copy as a documented intentional duplicate; both bind to the
+  same shared conformance vectors (`test/support/boundary_vectors/`) so drift is
+  a red test, not a silent fork.
+
+  ## Rule order
+
+  `confine/3` enforces these in order. Everything below the ref gate happens
+  before any syscall on the *target* (the only I/O is `:file.read_link` during
+  symlink resolution, which reads links, never opens/creates the target):
+
+  1. **Ref-shape gate** — when `ref_format:` is given, the RAW `requested`
+     string must match the regex, else `{:error, :malformed_ref}`. Refs are
+     validated as opaque tokens before they are ever treated as paths. Skipped
+     when the option is absent.
+  2. **Lexical confinement** — `root = Path.expand(root)`;
+     `lexical = Path.expand(Path.join(root, requested))`. Unless `lexical`
+     equals `root` or starts with `root <> "/"`, `{:error, :path_traversal}`.
+     (An absolute `requested` is jailed under `root` by `Path.join`, not
+     honored.)
+  3. **Symlink resolution** — a hand-rolled realpath of BOTH `root` and
+     `lexical`: follows a leaf symlink, recurses into the parent so a symlinked
+     ancestor directory is caught too, resolves POSIX relative link targets
+     against the link's own directory, and works for a not-yet-existing write
+     leaf by resolving the deepest existing ancestor. Depth-capped at 40;
+     a cycle yields `{:error, :too_many_symlinks}`.
+  4. **Post-resolution re-check** — the real path must still be within the real
+     root, else `{:error, :symlink_escape}`.
+
+  Total function: never raises on bad input (a non-binary `root`/`requested`
+  yields `{:error, :invalid_input}`).
+  """
+
+  @max_symlink_depth 40
+
+  @typedoc "Rejection reason returned by `confine/3`."
+  @type reason ::
+          :malformed_ref
+          | :path_traversal
+          | :too_many_symlinks
+          | :symlink_escape
+          | :invalid_input
+
+  @doc """
+  Confine `requested` under `root`.
+
+  Returns `{:ok, real_absolute_path}` when the fully symlink-resolved target
+  provably stays inside the resolved root, or `{:error, reason}` (see the
+  moduledoc rule order for the exact reason per rejection).
+
+  ## Options
+
+    * `:ref_format` — a `Regex.t()` the RAW `requested` string must match before
+      any resolution (e.g. PA-6's
+      `~r/^(blobs|snapshots)\\/[0-9a-f]{64}(\\.json)?$/`). Absent = no gate.
+  """
+  @spec confine(String.t(), String.t(), keyword()) :: {:ok, String.t()} | {:error, reason()}
+  def confine(root, requested, opts \\ [])
+
+  def confine(root, requested, opts)
+      when is_binary(root) and is_binary(requested) and is_list(opts) do
+    with :ok <- ref_gate(requested, Keyword.get(opts, :ref_format)),
+         expanded_root = Path.expand(root),
+         lexical = Path.expand(Path.join(expanded_root, requested)),
+         :ok <- lexical_gate(expanded_root, lexical),
+         {:ok, root_real} <- real_path(expanded_root),
+         {:ok, real} <- real_path(lexical),
+         :ok <- escape_gate(root_real, real) do
+      {:ok, real}
+    end
+  end
+
+  def confine(_root, _requested, _opts), do: {:error, :invalid_input}
+
+  # --- Rule 1: ref-shape gate ------------------------------------------------
+
+  defp ref_gate(_requested, nil), do: :ok
+
+  defp ref_gate(requested, %Regex{} = re) do
+    if Regex.match?(re, requested), do: :ok, else: {:error, :malformed_ref}
+  end
+
+  # A ref_format that is present but not a Regex is a misconfiguration; fail
+  # closed rather than silently skipping the gate or raising.
+  defp ref_gate(_requested, _other), do: {:error, :malformed_ref}
+
+  # --- Rule 2: lexical confinement -------------------------------------------
+
+  defp lexical_gate(root, lexical) do
+    if within?(root, lexical), do: :ok, else: {:error, :path_traversal}
+  end
+
+  # --- Rule 4: post-resolution re-check --------------------------------------
+
+  defp escape_gate(root_real, real) do
+    if within?(root_real, real), do: :ok, else: {:error, :symlink_escape}
+  end
+
+  defp within?(root, path), do: path == root or String.starts_with?(path, root <> "/")
+
+  # --- Rule 3: hand-rolled realpath ------------------------------------------
+  #
+  # If `path` itself is a symlink, follow it (a relative target resolves against
+  # the symlink's OWN directory, per POSIX); otherwise recurse into the parent
+  # so a symlinked ANCESTOR is caught, then rejoin the basename. Both existing
+  # paths (read case) and not-yet-existing ones (write case: leaf absent, every
+  # ancestor present) resolve correctly. Depth-guarded against symlink cycles.
+  defp real_path(path), do: real_path(path, 0)
+
+  defp real_path(_path, depth) when depth > @max_symlink_depth,
+    do: {:error, :too_many_symlinks}
+
+  defp real_path(path, depth) do
+    case :file.read_link(path) do
+      {:ok, target} ->
+        target = to_string(target)
+
+        resolved =
+          if Path.type(target) == :absolute,
+            do: target,
+            else: Path.join(Path.dirname(path), target)
+
+        real_path(Path.expand(resolved), depth + 1)
+
+      {:error, _not_a_symlink_or_missing} ->
+        case Path.dirname(path) do
+          ^path ->
+            {:ok, path}
+
+          parent ->
+            case real_path(parent, depth + 1) do
+              {:ok, real_parent} -> {:ok, Path.join(real_parent, Path.basename(path))}
+              error -> error
+            end
+        end
+    end
+  end
+end

--- a/packages/raxol_core/lib/raxol/core/boundary/path.ex
+++ b/packages/raxol_core/lib/raxol/core/boundary/path.ex
@@ -113,39 +113,47 @@ defmodule Raxol.Core.Boundary.Path do
 
   # --- Rule 3: hand-rolled realpath ------------------------------------------
   #
-  # If `path` itself is a symlink, follow it (a relative target resolves against
-  # the symlink's OWN directory, per POSIX); otherwise recurse into the parent
-  # so a symlinked ANCESTOR is caught, then rejoin the basename. Both existing
-  # paths (read case) and not-yet-existing ones (write case: leaf absent, every
-  # ancestor present) resolve correctly. Depth-guarded against symlink cycles.
-  defp real_path(path), do: real_path(path, 0)
+  # Resolve `path` to its real location by walking components left-to-right from
+  # the filesystem root, carrying a fully-resolved real `base`. A symlink is
+  # followed against `base` -- its REAL parent -- so a relative target (including
+  # `..`) resolves against where the link actually lives, not its lexical
+  # spelling. That is what lets a symlinked ANCESTOR change the effective `..`
+  # count: resolving the target against the lexical parent instead would let a
+  # link under a symlinked ancestor escape the root while still looking interior.
+  # `.`/`..` adjust `base` directly; a component that is not a symlink -- or does
+  # not exist (the write-leaf case) -- is accepted literally so the deepest
+  # existing ancestor still resolves. Only symlink hops count toward the depth
+  # cap, so deep-but-symlink-free nesting is never mistaken for a cycle.
+  defp real_path(path) do
+    [root | rest] = Path.split(Path.expand(path))
+    walk_real(root, rest, 0)
+  end
 
-  defp real_path(_path, depth) when depth > @max_symlink_depth,
+  defp walk_real(_base, _components, depth) when depth > @max_symlink_depth,
     do: {:error, :too_many_symlinks}
 
-  defp real_path(path, depth) do
-    case :file.read_link(path) do
+  defp walk_real(base, [], _depth), do: {:ok, base}
+
+  defp walk_real(base, ["." | rest], depth), do: walk_real(base, rest, depth)
+
+  defp walk_real(base, [".." | rest], depth),
+    do: walk_real(Path.dirname(base), rest, depth)
+
+  defp walk_real(base, [comp | rest], depth) do
+    candidate = Path.join(base, comp)
+
+    case :file.read_link(candidate) do
       {:ok, target} ->
-        target = to_string(target)
-
-        resolved =
-          if Path.type(target) == :absolute,
-            do: target,
-            else: Path.join(Path.dirname(path), target)
-
-        real_path(Path.expand(resolved), depth + 1)
+        # A symlink resolves against its REAL parent (`base`): an absolute target
+        # restarts from the filesystem root, a relative one (possibly with `..`)
+        # is spliced ahead of the remaining components and resolved against base.
+        case Path.split(to_string(target)) do
+          ["/" | target_rest] -> walk_real("/", target_rest ++ rest, depth + 1)
+          target_rest -> walk_real(base, target_rest ++ rest, depth + 1)
+        end
 
       {:error, _not_a_symlink_or_missing} ->
-        case Path.dirname(path) do
-          ^path ->
-            {:ok, path}
-
-          parent ->
-            case real_path(parent, depth + 1) do
-              {:ok, real_parent} -> {:ok, Path.join(real_parent, Path.basename(path))}
-              error -> error
-            end
-        end
+        walk_real(candidate, rest, depth)
     end
   end
 end

--- a/packages/raxol_core/lib/raxol/core/boundary/term_text.ex
+++ b/packages/raxol_core/lib/raxol/core/boundary/term_text.ex
@@ -1,0 +1,123 @@
+defmodule Raxol.Core.Boundary.TermText do
+  @moduledoc """
+  Terminal-injection confinement: neutralize ESC/ANSI/control bytes in
+  untrusted text *before* it reaches the terminal renderer.
+
+  One of the two centralized boundary confinements (PR #569 thread 2); the
+  other is `Raxol.Core.Boundary.Path` (path-traversal). This one has byte-stream
+  semantics — a total function over binaries, no filesystem, never errors, never
+  passes a dangerous byte through. It enforces the repo rule "never embed raw
+  ANSI codes in strings passed to `text()`" *at the untrusted boundary* instead
+  of trusting upstream.
+
+  ## What `sanitize/2` strips
+
+  In a single left-to-right pass:
+
+    * **ESC (`0x1B`) and every sequence it introduces** — CSI (`ESC [` … final
+      `0x40..0x7E`), OSC (`ESC ]` … `BEL`/`ST`; kills title-set and OSC-8
+      hyperlink smuggling), DCS/APC/PM/SOS (`ESC P`/`ESC _`/`ESC ^`/`ESC X` …
+      `ST`), two-byte `ESC <c>` forms, and a truncated trailing `ESC`.
+    * **C0 controls (`0x00..0x1F`)** except the `:allow` list (default `[?\\n]`).
+    * **DEL (`0x7F`)** and **raw C1 controls (`0x80..0x9F`)**.
+    * **Invalid UTF-8 bytes** → replaced with `U+FFFD` (never emit a broken
+      sequence downstream). Raw C1 bytes are stripped (not replaced); other
+      invalid bytes become `U+FFFD`.
+
+  Valid printable text (including CJK, emoji, and other multi-byte UTF-8) passes
+  through unchanged. The function never raises and its output contains no `ESC`
+  and no disallowed control byte for ANY input binary.
+  """
+
+  @typedoc "A C0/allowed control byte value, e.g. `?\\t` or `?\\n`."
+  @type control_byte :: 0..31
+
+  @default_allow [?\n]
+
+  @doc """
+  Sanitize `binary` for safe delivery to a terminal renderer.
+
+  Total: always returns a `String.t()`, never raises.
+
+  ## Options
+
+    * `:allow` — a list of C0 control byte values (`0..31`) to pass through.
+      Defaults to `[?\\n]`. `ESC` (`0x1B`) is never allowed regardless of this
+      list.
+  """
+  @spec sanitize(binary(), keyword()) :: String.t()
+  def sanitize(binary, opts \\ [])
+
+  def sanitize(binary, opts) when is_binary(binary) and is_list(opts) do
+    allow = Keyword.get(opts, :allow, @default_allow)
+    binary |> scan(allow, []) |> Enum.reverse() |> List.to_string()
+  end
+
+  def sanitize(_binary, _opts), do: ""
+
+  # --- byte-stream scanner ---------------------------------------------------
+
+  defp scan(<<>>, _allow, acc), do: acc
+
+  # ESC and everything it introduces are removed as a unit.
+  defp scan(<<0x1B, rest::binary>>, allow, acc) do
+    scan(strip_escape(rest), allow, acc)
+  end
+
+  # A valid UTF-8 codepoint. ESC is handled above, so control checks here cover
+  # the remaining C0/DEL/C1 codepoints; everything else is kept.
+  defp scan(<<cp::utf8, rest::binary>>, allow, acc) do
+    cond do
+      cp == 0x7F -> scan(rest, allow, acc)
+      cp < 0x20 and cp in allow -> scan(rest, allow, [cp | acc])
+      cp < 0x20 -> scan(rest, allow, acc)
+      cp >= 0x80 and cp <= 0x9F -> scan(rest, allow, acc)
+      true -> scan(rest, allow, [cp | acc])
+    end
+  end
+
+  # A raw C1 byte (invalid as a standalone UTF-8 byte) is stripped, not
+  # replaced — matches the "strip raw C1" rule over the generic invalid rule.
+  defp scan(<<b, rest::binary>>, allow, acc) when b >= 0x80 and b <= 0x9F do
+    scan(rest, allow, acc)
+  end
+
+  # Any other invalid UTF-8 byte becomes the replacement character.
+  defp scan(<<_bad, rest::binary>>, allow, acc) do
+    scan(rest, allow, [0xFFFD | acc])
+  end
+
+  # --- escape-sequence consumers (ESC already consumed) ----------------------
+
+  # Truncated trailing ESC: nothing follows.
+  defp strip_escape(<<>>), do: <<>>
+
+  # ESC ESC: leave the second ESC for the outer scanner to re-handle, so no ESC
+  # can ever leak through a double-escape.
+  defp strip_escape(<<0x1B, _::binary>> = rest), do: rest
+
+  # CSI: ESC [ … final byte.
+  defp strip_escape(<<?[, rest::binary>>), do: skip_csi(rest)
+
+  # OSC: ESC ] … BEL/ST.
+  defp strip_escape(<<?], rest::binary>>), do: skip_string(rest)
+
+  # DCS / SOS / PM / APC: ESC P/X/^/_ … ST.
+  defp strip_escape(<<c, rest::binary>>) when c in [?P, ?X, ?^, ?_], do: skip_string(rest)
+
+  # Two-byte ESC <c> form: drop the single following byte.
+  defp strip_escape(<<_c, rest::binary>>), do: rest
+
+  # CSI body: parameter/intermediate bytes 0x20..0x3F, then one final 0x40..0x7E.
+  defp skip_csi(<<>>), do: <<>>
+  defp skip_csi(<<b, rest::binary>>) when b >= 0x40 and b <= 0x7E, do: rest
+  defp skip_csi(<<b, rest::binary>>) when b >= 0x20 and b <= 0x3F, do: skip_csi(rest)
+  # Any other byte terminates a malformed CSI (and is consumed with it).
+  defp skip_csi(<<_b, rest::binary>>), do: rest
+
+  # String terminator scan (OSC/DCS/APC/PM/SOS): consume until BEL or ST.
+  defp skip_string(<<>>), do: <<>>
+  defp skip_string(<<0x07, rest::binary>>), do: rest
+  defp skip_string(<<0x1B, 0x5C, rest::binary>>), do: rest
+  defp skip_string(<<_b, rest::binary>>), do: skip_string(rest)
+end

--- a/packages/raxol_core/test/raxol/core/boundary/path_test.exs
+++ b/packages/raxol_core/test/raxol/core/boundary/path_test.exs
@@ -1,0 +1,221 @@
+defmodule Raxol.Core.Boundary.PathTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Boundary.Path, as: Confine
+  alias Raxol.Core.Boundary.Vectors
+
+  @sha_format ~r/^(blobs|snapshots)\/[0-9a-f]{64}(\.json)?$/
+
+  setup do
+    base =
+      Path.join(System.tmp_dir!(), "raxol_boundary_path_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(base)
+    on_exit(fn -> File.rm_rf!(base) end)
+    {:ok, base: base}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Shared conformance vectors (the drift guard). Same JSON the Agent Client Protocol FsSandbox
+  # copies verbatim.
+  # ---------------------------------------------------------------------------
+
+  describe "shared reject vectors" do
+    for vector <- Vectors.load("path_reject_vectors.json") do
+      @vector vector
+      test "rejects #{vector["name"]} with :#{vector["expect"]}", %{base: base} do
+        vroot = Path.join(base, "vec_#{@vector["name"]}")
+        File.mkdir_p!(vroot)
+        Vectors.materialize(vroot, @vector["setup"])
+        root = Vectors.root_path(vroot, @vector)
+        expected = String.to_existing_atom(@vector["expect"])
+
+        assert Confine.confine(root, @vector["requested"], Vectors.opts(@vector)) ==
+                 {:error, expected}
+      end
+    end
+  end
+
+  describe "shared accept vectors" do
+    for vector <- Vectors.load("path_accept_vectors.json") do
+      @vector vector
+      test "accepts #{vector["name"]}", %{base: base} do
+        vroot = Path.join(base, "vec_#{@vector["name"]}")
+        File.mkdir_p!(vroot)
+        Vectors.materialize(vroot, @vector["setup"])
+        root = Vectors.root_path(vroot, @vector)
+
+        assert {:ok, real} = Confine.confine(root, @vector["requested"], Vectors.opts(@vector))
+        real_root = resolve_real(root)
+        assert real == real_root or String.starts_with?(real, real_root <> "/")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Filesystem behavior assertions (site-level, richer than the vector runner).
+  # ---------------------------------------------------------------------------
+
+  describe "confine/3 real filesystem" do
+    test "confined read resolves to a path under root", %{base: base} do
+      File.mkdir_p!(Path.join(base, "sub"))
+      File.write!(Path.join(base, "sub/a.txt"), "hi")
+
+      assert {:ok, real} = Confine.confine(base, "sub/a.txt")
+      assert File.read!(real) == "hi"
+      assert String.starts_with?(real, resolve_real(base) <> "/")
+    end
+
+    test "not-yet-existing write leaf under root is accepted and writable", %{base: base} do
+      assert {:ok, real} = Confine.confine(base, "new/leaf.txt")
+      refute File.exists?(real)
+      File.mkdir_p!(Path.dirname(real))
+      assert File.write!(real, "created") == :ok
+      assert File.read!(real) == "created"
+      assert String.starts_with?(real, resolve_real(base) <> "/")
+    end
+
+    test "../ escape is rejected and the outside target is neither read nor created", %{
+      base: base
+    } do
+      outside = Path.join(base, "outside")
+      File.mkdir_p!(outside)
+      secret = Path.join(outside, "secret.txt")
+      File.write!(secret, "SECRET")
+
+      root = Path.join(base, "root")
+      File.mkdir_p!(root)
+
+      assert Confine.confine(root, "../outside/secret.txt") == {:error, :path_traversal}
+      # untouched: still exactly what we wrote, and no new file appeared under root
+      assert File.read!(secret) == "SECRET"
+      assert File.ls!(root) == []
+    end
+
+    test "leaf symlink escaping root is rejected (:symlink_escape)", %{base: base} do
+      outside = Path.join(base, "outside")
+      File.mkdir_p!(outside)
+      File.write!(Path.join(outside, "secret.txt"), "SECRET")
+
+      root = Path.join(base, "root")
+      File.mkdir_p!(root)
+      :ok = File.ln_s!("../outside/secret.txt", Path.join(root, "link"))
+
+      assert Confine.confine(root, "link") == {:error, :symlink_escape}
+    end
+
+    test "symlinked ancestor directory escaping root is rejected (:symlink_escape)", %{base: base} do
+      outside = Path.join(base, "outside")
+      File.mkdir_p!(outside)
+      File.write!(Path.join(outside, "secret.txt"), "SECRET")
+
+      root = Path.join(base, "root")
+      File.mkdir_p!(root)
+      :ok = File.ln_s!("../outside", Path.join(root, "esc"))
+
+      assert Confine.confine(root, "esc/secret.txt") == {:error, :symlink_escape}
+    end
+
+    test "symlink pointing inside root is accepted", %{base: base} do
+      root = Path.join(base, "root")
+      File.mkdir_p!(Path.join(root, "data"))
+      File.write!(Path.join(root, "data/x.txt"), "inside")
+      :ok = File.ln_s!("data", Path.join(root, "link"))
+
+      assert {:ok, real} = Confine.confine(root, "link/x.txt")
+      assert File.read!(real) == "inside"
+    end
+
+    test "symlink cycle is rejected (:too_many_symlinks)", %{base: base} do
+      root = Path.join(base, "root")
+      File.mkdir_p!(root)
+      :ok = File.ln_s!("b", Path.join(root, "a"))
+      :ok = File.ln_s!("a", Path.join(root, "b"))
+
+      assert Confine.confine(root, "a") == {:error, :too_many_symlinks}
+    end
+  end
+
+  describe "confine/3 ref-shape gate" do
+    test "accepts a well-formed sha ref", %{base: base} do
+      req = "blobs/" <> String.duplicate("a", 64)
+      assert {:ok, _} = Confine.confine(base, req, ref_format: @sha_format)
+    end
+
+    test "accepts a well-formed snapshot .json ref", %{base: base} do
+      req = "snapshots/" <> String.duplicate("0", 64) <> ".json"
+      assert {:ok, _} = Confine.confine(base, req, ref_format: @sha_format)
+    end
+
+    test "rejects a malformed ref before resolution (:malformed_ref)", %{base: base} do
+      assert Confine.confine(base, "blobs/../../etc/passwd", ref_format: @sha_format) ==
+               {:error, :malformed_ref}
+
+      assert Confine.confine(base, "blobs/" <> String.duplicate("A", 64), ref_format: @sha_format) ==
+               {:error, :malformed_ref}
+
+      assert Confine.confine(base, "blobs/abc123", ref_format: @sha_format) ==
+               {:error, :malformed_ref}
+    end
+
+    test "ref gate fires before the lexical gate", %{base: base} do
+      # a traversal that would also be :path_traversal is reported as
+      # :malformed_ref because the ref gate runs first
+      assert Confine.confine(base, "../../etc/passwd", ref_format: @sha_format) ==
+               {:error, :malformed_ref}
+    end
+  end
+
+  describe "confine/3 totality" do
+    test "non-binary inputs never raise" do
+      assert Confine.confine(nil, "x") == {:error, :invalid_input}
+      assert Confine.confine("/root", nil) == {:error, :invalid_input}
+      assert Confine.confine(123, 456) == {:error, :invalid_input}
+    end
+
+    test "a non-Regex ref_format fails closed (:malformed_ref)", %{base: base} do
+      assert Confine.confine(base, "blobs/x", ref_format: "not-a-regex") ==
+               {:error, :malformed_ref}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Property: confine/3 never returns {:ok, p} with p outside the resolved root.
+  # ---------------------------------------------------------------------------
+
+  describe "property: accepted paths never escape root" do
+    test "random requested refs (with .. segments and absolute paths) never escape", %{
+      base: base
+    } do
+      root = Path.join(base, "proot")
+      File.mkdir_p!(Path.join(root, "sub"))
+      File.write!(Path.join(root, "sub/f.txt"), "x")
+      real_root = resolve_real(root)
+
+      segments = ["a", "b", "sub", "..", "...", "f.txt", "etc", "", ".", "x"]
+
+      for _ <- 1..500 do
+        n = :rand.uniform(6)
+        parts = for _ <- 1..n, do: Enum.random(segments)
+        prefix = if :rand.uniform(2) == 1, do: "/", else: ""
+        requested = prefix <> Enum.join(parts, "/")
+
+        case Confine.confine(root, requested) do
+          {:ok, real} ->
+            assert real == real_root or String.starts_with?(real, real_root <> "/"),
+                   "escape: #{inspect(requested)} -> #{inspect(real)} not under #{inspect(real_root)}"
+
+          {:error, reason} ->
+            assert reason in [:path_traversal, :symlink_escape, :too_many_symlinks]
+        end
+      end
+    end
+  end
+
+  # Resolve a path the same way confine/3 does, for assertion comparisons
+  # (handles macOS /tmp -> /private/tmp symlink normalization).
+  defp resolve_real(path) do
+    {:ok, real} = Confine.confine(path, ".")
+    real
+  end
+end

--- a/packages/raxol_core/test/raxol/core/boundary/path_test.exs
+++ b/packages/raxol_core/test/raxol/core/boundary/path_test.exs
@@ -134,6 +134,36 @@ defmodule Raxol.Core.Boundary.PathTest do
 
       assert Confine.confine(root, "a") == {:error, :too_many_symlinks}
     end
+
+    test "relative leaf symlink under a depth-inflating ancestor cannot under-apply .. (:symlink_escape)",
+         %{base: base} do
+      # A symlink's relative target must resolve against its REAL parent, not its
+      # lexical parent. `loop -> .` inflates lexical depth (root/loop/loop == root),
+      # so resolving `esc -> ../secret.txt` against the LEXICAL parent (root/loop)
+      # lands on root/secret.txt (interior) while the OS resolves it to
+      # base/secret.txt (outside root). Asserts the escape directly -- no
+      # confine-derived oracle -- so it fails if the escape is ever accepted.
+      File.write!(Path.join(base, "secret.txt"), "SECRET")
+
+      root = Path.join(base, "root")
+      File.mkdir_p!(root)
+      :ok = File.ln_s!(".", Path.join(root, "loop"))
+      :ok = File.ln_s!("../secret.txt", Path.join(root, "esc"))
+
+      assert Confine.confine(root, "loop/loop/esc") == {:error, :symlink_escape}
+    end
+
+    test "deep symlink-free nesting is not mistaken for a symlink cycle", %{base: base} do
+      # The depth cap counts symlink hops, not directory nesting: a tree far
+      # deeper than @max_symlink_depth (40) with zero symlinks must still resolve.
+      deep = Enum.map_join(1..80, "/", &"d#{&1}")
+      File.mkdir_p!(Path.join(base, deep))
+      File.write!(Path.join([base, deep, "leaf.txt"]), "deep")
+
+      assert {:ok, real} = Confine.confine(base, deep <> "/leaf.txt")
+      assert File.read!(real) == "deep"
+      assert String.starts_with?(real, resolve_real(base) <> "/")
+    end
   end
 
   describe "confine/3 ref-shape gate" do

--- a/packages/raxol_core/test/raxol/core/boundary/term_text_test.exs
+++ b/packages/raxol_core/test/raxol/core/boundary/term_text_test.exs
@@ -1,0 +1,160 @@
+defmodule Raxol.Core.Boundary.TermTextTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Boundary.TermText
+  alias Raxol.Core.Boundary.Vectors
+
+  # C0 (minus allow) + DEL + ESC that must never survive with the default allow.
+  @default_forbidden Enum.to_list(0x00..0x08) ++
+                       [0x0B] ++ Enum.to_list(0x0E..0x1F) ++ [0x7F]
+
+  # ---------------------------------------------------------------------------
+  # Shared conformance vectors.
+  # ---------------------------------------------------------------------------
+
+  describe "shared vectors" do
+    for vector <- Vectors.load("term_text_vectors.json") do
+      @vector vector
+      test "#{vector["name"]}: #{vector["note"]}" do
+        input = Base.decode16!(@vector["input_hex"], case: :lower)
+        expected = Base.decode16!(@vector["expect_hex"], case: :lower)
+        opts = if @vector["allow"], do: [allow: @vector["allow"]], else: []
+
+        output = TermText.sanitize(input, opts)
+        assert output == expected
+        refute String.contains?(output, "\e")
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Sequence-class coverage.
+  # ---------------------------------------------------------------------------
+
+  describe "escape sequence classes" do
+    test "CSI (SGR, cursor, private) stripped" do
+      assert TermText.sanitize("\e[31mred\e[0m") == "red"
+      assert TermText.sanitize("\e[2J\e[Hclean") == "clean"
+      assert TermText.sanitize("\e[?1049halt") == "alt"
+      assert TermText.sanitize("\e[201~paste") == "paste"
+    end
+
+    test "OSC (BEL- and ST-terminated) stripped" do
+      assert TermText.sanitize("\e]0;title\aX") == "X"
+      assert TermText.sanitize("\e]0;title\e\\X") == "X"
+      assert TermText.sanitize("\e]8;;http://evil\e\\text\e]8;;\e\\") == "text"
+    end
+
+    test "DCS / APC / PM / SOS stripped" do
+      assert TermText.sanitize("\eP1q data\e\\A") == "A"
+      assert TermText.sanitize("\e_apc\e\\B") == "B"
+      assert TermText.sanitize("\e^pm\e\\C") == "C"
+      assert TermText.sanitize("\eXsos\e\\D") == "D"
+    end
+
+    test "two-byte ESC forms stripped" do
+      assert TermText.sanitize("\ecRIS") == "RIS"
+      assert TermText.sanitize("\e=keypad") == "keypad"
+    end
+
+    test "truncated trailing ESC stripped" do
+      assert TermText.sanitize("tail\e") == "tail"
+      assert TermText.sanitize("open\e[") == "open"
+      assert TermText.sanitize("osc\e]0;unterminated") == "osc"
+    end
+
+    test "double ESC never leaks an ESC" do
+      out = TermText.sanitize("\e\e[31mx")
+      refute String.contains?(out, "\e")
+      assert out == "x"
+    end
+  end
+
+  describe "control bytes" do
+    test "C0 controls stripped except default allow (LF)" do
+      assert TermText.sanitize("a\tb\rc\nd") == "abc\nd"
+      assert TermText.sanitize("a\0b") == "ab"
+    end
+
+    test "allow-list is respected" do
+      assert TermText.sanitize("a\tb\nc", allow: [?\t, ?\n]) == "a\tb\nc"
+      assert TermText.sanitize("a\tb", allow: [?\t]) == "a\tb"
+    end
+
+    test "DEL and raw C1 stripped" do
+      assert TermText.sanitize("a\x7Fb") == "ab"
+      assert TermText.sanitize(<<?a, 0x85, ?b>>) == "ab"
+      assert TermText.sanitize(<<?a, 0xC2, 0x85, ?b>>) == "ab"
+    end
+  end
+
+  describe "utf-8 handling" do
+    test "invalid bytes become U+FFFD" do
+      assert TermText.sanitize(<<?a, 0xFF, ?b>>) == "a�b"
+      assert TermText.sanitize(<<0xC3, 0x28>>) == "�("
+    end
+
+    test "benign / multi-byte text passes through unchanged" do
+      assert TermText.sanitize("Hello, world!") == "Hello, world!"
+      assert TermText.sanitize("日本語 ✅🚀") == "日本語 ✅🚀"
+    end
+
+    test "empty input" do
+      assert TermText.sanitize("") == ""
+    end
+
+    test "non-binary input never raises" do
+      assert TermText.sanitize(nil) == ""
+      assert TermText.sanitize(123) == ""
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Properties: no ESC, no disallowed control byte, idempotence — for ANY input.
+  # ---------------------------------------------------------------------------
+
+  describe "property: output is always safe" do
+    test "no ESC and no disallowed control byte survive (default allow)" do
+      for _ <- 1..1000 do
+        input = :crypto.strong_rand_bytes(:rand.uniform(64))
+        out = TermText.sanitize(input)
+        bytes = :binary.bin_to_list(out)
+
+        refute 0x1B in bytes, "ESC leaked from #{inspect(input)}"
+
+        for forbidden <- @default_forbidden do
+          refute forbidden in bytes,
+                 "forbidden byte #{forbidden} leaked from #{inspect(input)}"
+        end
+      end
+    end
+
+    test "C1 control codepoints never survive" do
+      # Byte-level 0x80..0x9F is legal inside valid UTF-8 continuation bytes, so
+      # this checks decoded CODEPOINTS: no C1 control codepoint may remain.
+      for _ <- 1..500 do
+        input = :crypto.strong_rand_bytes(:rand.uniform(48))
+        out = TermText.sanitize(input)
+
+        for cp <- String.to_charlist(out) do
+          refute cp >= 0x80 and cp <= 0x9F, "C1 codepoint #{cp} leaked from #{inspect(input)}"
+        end
+      end
+    end
+
+    test "idempotent" do
+      for _ <- 1..500 do
+        input = :crypto.strong_rand_bytes(:rand.uniform(64))
+        once = TermText.sanitize(input)
+        assert TermText.sanitize(once) == once
+      end
+    end
+
+    test "output is always valid UTF-8" do
+      for _ <- 1..500 do
+        input = :crypto.strong_rand_bytes(:rand.uniform(64))
+        assert String.valid?(TermText.sanitize(input))
+      end
+    end
+  end
+end

--- a/packages/raxol_core/test/support/boundary_vectors.ex
+++ b/packages/raxol_core/test/support/boundary_vectors.ex
@@ -1,0 +1,62 @@
+defmodule Raxol.Core.Boundary.Vectors do
+  @moduledoc """
+  Loader + fixture materializer for the shared boundary conformance vectors in
+  `test/support/boundary_vectors/*.json`.
+
+  These vectors are the single source of truth for the must-reject / must-accept
+  boundary tables. `Raxol.Core.Boundary.Path` (here) and the Agent Client Protocol package's
+  `FsSandbox` both drive the SAME `path_*_vectors.json` — a divergence is a red
+  test, not a silent fork. See `test/support/boundary_vectors/README.md`.
+  """
+
+  @dir Path.join(__DIR__, "boundary_vectors")
+
+  @doc "Load and decode a vectors JSON file; returns the `\"vectors\"` list."
+  @spec load(String.t()) :: [map()]
+  def load(filename) do
+    @dir
+    |> Path.join(filename)
+    |> File.read!()
+    |> JSON.decode!()
+    |> Map.fetch!("vectors")
+  end
+
+  @doc """
+  Materialize a vector's `setup` list under `base` (a fresh tmp dir). Each entry
+  is one of `%{"dir" => p}`, `%{"file" => p, "content" => c}`, or
+  `%{"symlink" => p, "target" => t}` — all paths relative to `base`. Dirs and
+  files are created first, symlinks last (a symlink target need not exist).
+  """
+  @spec materialize(String.t(), [map()]) :: :ok
+  def materialize(base, setup) when is_binary(base) and is_list(setup) do
+    {symlinks, rest} = Enum.split_with(setup, &Map.has_key?(&1, "symlink"))
+
+    Enum.each(rest, fn
+      %{"dir" => rel} ->
+        File.mkdir_p!(Path.join(base, rel))
+
+      %{"file" => rel} = entry ->
+        abs = Path.join(base, rel)
+        File.mkdir_p!(Path.dirname(abs))
+        File.write!(abs, Map.get(entry, "content", ""))
+    end)
+
+    Enum.each(symlinks, fn %{"symlink" => rel, "target" => target} ->
+      abs = Path.join(base, rel)
+      File.mkdir_p!(Path.dirname(abs))
+      :ok = File.ln_s!(target, abs)
+    end)
+
+    :ok
+  end
+
+  @doc "The absolute root path for a vector: `base/<root>` (`\".\"` = base itself)."
+  @spec root_path(String.t(), map()) :: String.t()
+  def root_path(base, %{"root" => "."}), do: base
+  def root_path(base, %{"root" => root}), do: Path.join(base, root)
+
+  @doc "Build the `confine/3` opts keyword list for a vector (compiles `ref_format`)."
+  @spec opts(map()) :: keyword()
+  def opts(%{"ref_format" => src}) when is_binary(src), do: [ref_format: Regex.compile!(src)]
+  def opts(_vector), do: []
+end

--- a/packages/raxol_core/test/support/boundary_vectors/README.md
+++ b/packages/raxol_core/test/support/boundary_vectors/README.md
@@ -1,0 +1,66 @@
+# Shared boundary conformance vectors
+
+Single source of truth for the two centralized boundary confinements
+(PR #569 thread 2, "same gap, four patches"). These are **data-only** JSON
+files, deliberately free of any Elixir/host coupling so they can be copied
+byte-for-byte into another package's test tree.
+
+| File | Drives | Consumers |
+| ---- | ------ | --------- |
+| `path_reject_vectors.json` | `Raxol.Core.Boundary.Path.confine/3` must REJECT | raxol_core **and** the Agent Client Protocol package's `FsSandbox` |
+| `path_accept_vectors.json` | `Raxol.Core.Boundary.Path.confine/3` must ACCEPT | raxol_core **and** the Agent Client Protocol package's `FsSandbox` |
+| `term_text_vectors.json` | `Raxol.Core.Boundary.TermText.sanitize/2` | raxol_core only (UI/terminal lane) |
+
+## The drift guard
+
+Under the ratified dependency decision (proposal option **b**), the Agent Client Protocol package
+`raxol_agent_client_protocol` keeps its own tested `FsSandbox` copy — it must
+stay zero-raxol-dep, so it cannot consume `raxol_core`. To prevent the two
+implementations silently forking, **both bind to these same path vectors**:
+
+- raxol_core runs them in `test/raxol/core/boundary/path_test.exs`.
+- The Agent Client Protocol package (follow-up, in the Agent Client Protocol package repo) MUST **copy
+  `path_reject_vectors.json` and `path_accept_vectors.json` verbatim** into its
+  own test tree and assert its `FsSandbox.resolve/2` agrees:
+  - map `FsSandbox`'s `Error` `data.reason` onto the vector's `expect` atom
+    (`path_traversal` / `symlink_escape` / `too_many_symlinks`);
+  - **skip** any vector carrying `ref_format` — the PA-6 ref-shape gate is a
+    `Path.confine/3`-only feature `FsSandbox` does not implement.
+
+A divergence between the two implementations then shows up as a red test in one
+of the packages, never as an unnoticed security fork. Change a path vector and
+you must update both copies (and the `FsSandbox` moduledoc's duplicate-marker
+line), or neither.
+
+## Schema
+
+### `path_*_vectors.json`
+
+```jsonc
+{
+  "root": "root",              // dir under the tmp base used as confinement root ("." = base)
+  "requested": "../etc/x",     // untrusted ref passed to confine/3
+  "ref_format": "^...$",       // OPTIONAL regex source for the ref-shape gate
+  "setup": [                   // FS fixture materialized under the tmp base (paths relative to base)
+    { "dir": "root" },
+    { "file": "outside/secret.txt", "content": "..." },
+    { "symlink": "root/link", "target": "../outside" }
+  ],
+  "expect": "ok"               // "ok" (accept file) or a rejection reason atom (reject file)
+}
+```
+
+Additionally, for every **reject** vector the surrounding site test must prove
+the outside target was neither read nor created.
+
+### `term_text_vectors.json`
+
+```jsonc
+{
+  "input_hex": "1b5b33316d...",  // lowercase hex of the input binary
+  "allow": [9, 10],              // OPTIONAL C0 byte values passed as opts `allow:`
+  "expect_hex": "68656c6c6f"     // lowercase hex of the intended output binary
+}
+```
+
+Control bytes are hex-encoded so the fixtures stay valid, portable JSON.

--- a/packages/raxol_core/test/support/boundary_vectors/path_accept_vectors.json
+++ b/packages/raxol_core/test/support/boundary_vectors/path_accept_vectors.json
@@ -1,0 +1,75 @@
+{
+  "description": "Shared MUST-ACCEPT conformance vectors for path-traversal confinement (Raxol.Core.Boundary.Path.confine/3). Data-only: the runner materializes `setup` under a fresh tmp base, sets root = tmp_base/<root>, and asserts confine(root, requested, opts) == {:ok, _}. The Agent Client Protocol package copies this file verbatim and asserts its FsSandbox.resolve/2 agrees (skipping vectors that carry `ref_format`, a Path.confine-only gate FsSandbox does not implement). Paths in `root`, `requested`, and every `setup` entry are relative to the tmp base. Change this file and its sibling reject file in lockstep across both packages, or neither.",
+  "vectors": [
+    {
+      "name": "confined_file_read",
+      "root": "root",
+      "requested": "sub/a.txt",
+      "setup": [
+        { "dir": "root" },
+        { "dir": "root/sub" },
+        { "file": "root/sub/a.txt", "content": "hello" }
+      ],
+      "expect": "ok"
+    },
+    {
+      "name": "root_itself",
+      "root": "root",
+      "requested": ".",
+      "setup": [{ "dir": "root" }],
+      "expect": "ok"
+    },
+    {
+      "name": "not_yet_existing_write_leaf",
+      "root": "root",
+      "requested": "newfile.txt",
+      "setup": [{ "dir": "root" }],
+      "expect": "ok"
+    },
+    {
+      "name": "nested_not_yet_existing_leaf",
+      "root": "root",
+      "requested": "exists/new.txt",
+      "setup": [
+        { "dir": "root" },
+        { "dir": "root/exists" }
+      ],
+      "expect": "ok"
+    },
+    {
+      "name": "absolute_requested_jailed_under_root",
+      "root": "root",
+      "requested": "/etc/passwd",
+      "setup": [{ "dir": "root" }],
+      "expect": "ok"
+    },
+    {
+      "name": "symlink_inside_root_ok",
+      "root": "root",
+      "requested": "link/x.txt",
+      "setup": [
+        { "dir": "root" },
+        { "dir": "root/data" },
+        { "file": "root/data/x.txt", "content": "ok" },
+        { "symlink": "root/link", "target": "data" }
+      ],
+      "expect": "ok"
+    },
+    {
+      "name": "valid_sha_blob_ref",
+      "root": "root",
+      "requested": "blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
+      "setup": [{ "dir": "root" }],
+      "expect": "ok"
+    },
+    {
+      "name": "valid_sha_snapshot_json_ref",
+      "root": "root",
+      "requested": "snapshots/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.json",
+      "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
+      "setup": [{ "dir": "root" }],
+      "expect": "ok"
+    }
+  ]
+}

--- a/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
+++ b/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
@@ -1,0 +1,86 @@
+{
+  "description": "Shared MUST-REJECT conformance vectors for path-traversal confinement (Raxol.Core.Boundary.Path.confine/3). Data-only: the runner materializes `setup` under a fresh tmp base, sets root = tmp_base/<root>, and asserts confine(root, requested, opts) == {:error, <expect>}. `expect` is the exact rejection reason atom (as a string). The Agent Client Protocol package copies this file verbatim and asserts its FsSandbox.resolve/2 rejects the same inputs (mapping :path_traversal/:symlink_escape/:too_many_symlinks onto its Error `reason` data; skipping vectors that carry `ref_format`, a Path.confine-only gate FsSandbox does not implement). Additionally, for every reject vector the surrounding site test MUST prove the outside target was neither read nor created. Change this file and its sibling accept file in lockstep across both packages, or neither.",
+  "vectors": [
+    {
+      "name": "parent_traversal",
+      "root": "root",
+      "requested": "../../etc/passwd",
+      "setup": [{ "dir": "root" }],
+      "expect": "path_traversal"
+    },
+    {
+      "name": "interior_traversal_escapes",
+      "root": "root",
+      "requested": "a/../../x",
+      "setup": [{ "dir": "root" }],
+      "expect": "path_traversal"
+    },
+    {
+      "name": "malformed_ref_traversal",
+      "root": "root",
+      "requested": "blobs/../../etc/x",
+      "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
+      "setup": [{ "dir": "root" }],
+      "expect": "malformed_ref"
+    },
+    {
+      "name": "malformed_ref_sneaky_prefix",
+      "root": "root",
+      "requested": "snapshots/../blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
+      "setup": [{ "dir": "root" }],
+      "expect": "malformed_ref"
+    },
+    {
+      "name": "malformed_ref_uppercase_hex",
+      "root": "root",
+      "requested": "blobs/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
+      "setup": [{ "dir": "root" }],
+      "expect": "malformed_ref"
+    },
+    {
+      "name": "malformed_ref_wrong_length_hex",
+      "root": "root",
+      "requested": "blobs/abc123",
+      "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
+      "setup": [{ "dir": "root" }],
+      "expect": "malformed_ref"
+    },
+    {
+      "name": "leaf_symlink_escape",
+      "root": "root",
+      "requested": "link",
+      "setup": [
+        { "dir": "root" },
+        { "dir": "outside" },
+        { "file": "outside/secret.txt", "content": "TOP SECRET" },
+        { "symlink": "root/link", "target": "../outside/secret.txt" }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "symlinked_ancestor_dir_escape",
+      "root": "root",
+      "requested": "esc/secret.txt",
+      "setup": [
+        { "dir": "root" },
+        { "dir": "outside" },
+        { "file": "outside/secret.txt", "content": "TOP SECRET" },
+        { "symlink": "root/esc", "target": "../outside" }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "symlink_cycle",
+      "root": "root",
+      "requested": "a",
+      "setup": [
+        { "dir": "root" },
+        { "symlink": "root/a", "target": "b" },
+        { "symlink": "root/b", "target": "a" }
+      ],
+      "expect": "too_many_symlinks"
+    }
+  ]
+}

--- a/packages/raxol_core/test/support/boundary_vectors/term_text_vectors.json
+++ b/packages/raxol_core/test/support/boundary_vectors/term_text_vectors.json
@@ -1,0 +1,165 @@
+{
+  "description": "Shared conformance vectors for terminal-injection confinement (Raxol.Core.Boundary.TermText.sanitize/2). Data-only: `input_hex` and `expect_hex` are lowercase hex of the input and intended output binaries; `allow` (optional) is a list of C0 byte values passed as opts `allow:`. The runner asserts sanitize(input, opts) == expected for every vector, plus the invariants that the output contains no 0x1B and no disallowed control byte. Home is the UI/terminal lane only; the Agent Client Protocol package does not use this function.",
+  "vectors": [
+    {
+      "expect_hex": "",
+      "input_hex": "",
+      "name": "empty",
+      "note": "empty passes through"
+    },
+    {
+      "expect_hex": "48656c6c6f2c20776f726c642120313233",
+      "input_hex": "48656c6c6f2c20776f726c642120313233",
+      "name": "benign_passthrough",
+      "note": "plain ASCII unchanged"
+    },
+    {
+      "expect_hex": "e697a5e69cace8aa9e",
+      "input_hex": "e697a5e69cace8aa9e",
+      "name": "cjk_passthrough",
+      "note": "multi-byte UTF-8 unchanged"
+    },
+    {
+      "expect_hex": "e29c85f09f9a80",
+      "input_hex": "e29c85f09f9a80",
+      "name": "emoji_passthrough",
+      "note": "emoji unchanged"
+    },
+    {
+      "expect_hex": "610a62",
+      "input_hex": "610a62",
+      "name": "newline_kept_default",
+      "note": "default allow keeps LF"
+    },
+    {
+      "expect_hex": "68656c6c6f",
+      "input_hex": "1b5b33316d68656c6c6f1b5b306d",
+      "name": "csi_color_stripped",
+      "note": "SGR color codes removed"
+    },
+    {
+      "expect_hex": "4f4b",
+      "input_hex": "1b5d303b6576696c074f4b",
+      "name": "osc_title_bel_stripped",
+      "note": "OSC title-set (BEL-terminated) removed"
+    },
+    {
+      "expect_hex": "6c696e6b",
+      "input_hex": "1b5d383b3b687474703a2f2f6576696c1b5c6c696e6b1b5d383b3b1b5c",
+      "name": "osc8_hyperlink_stripped",
+      "note": "OSC-8 hyperlink smuggling removed, text kept"
+    },
+    {
+      "expect_hex": "58",
+      "input_hex": "1b50313b3271736978656c646174611b5c58",
+      "name": "dcs_stripped",
+      "note": "DCS (ST-terminated) removed"
+    },
+    {
+      "expect_hex": "59",
+      "input_hex": "1b5f7061796c6f61641b5c59",
+      "name": "apc_stripped",
+      "note": "APC (ST-terminated) removed"
+    },
+    {
+      "expect_hex": "5a",
+      "input_hex": "1b5e6d73671b5c5a",
+      "name": "pm_stripped",
+      "note": "PM (ST-terminated) removed"
+    },
+    {
+      "expect_hex": "57",
+      "input_hex": "1b5873747566661b5c57",
+      "name": "sos_stripped",
+      "note": "SOS (ST-terminated) removed"
+    },
+    {
+      "expect_hex": "5265736574",
+      "input_hex": "1b635265736574",
+      "name": "two_byte_esc_ris_stripped",
+      "note": "two-byte ESC c (RIS) removed"
+    },
+    {
+      "expect_hex": "74657874",
+      "input_hex": "746578741b",
+      "name": "truncated_trailing_esc",
+      "note": "bare ESC at end of input removed"
+    },
+    {
+      "expect_hex": "64617461",
+      "input_hex": "1b5b3230317e64617461",
+      "name": "bracketed_paste_terminator",
+      "note": "bracketed-paste end sequence removed"
+    },
+    {
+      "expect_hex": "58",
+      "input_hex": "1b5b3f313034396858",
+      "name": "alt_screen_stripped",
+      "note": "alt-screen enable (private CSI) removed"
+    },
+    {
+      "expect_hex": "20636c65616e",
+      "input_hex": "1b5b324a1b5b4820636c65616e",
+      "name": "cursor_move_stripped",
+      "note": "clear + cursor-home removed"
+    },
+    {
+      "expect_hex": "6162",
+      "input_hex": "610962",
+      "name": "tab_stripped_default",
+      "note": "TAB not in default allow -> stripped"
+    },
+    {
+      "expect_hex": "6162",
+      "input_hex": "610d62",
+      "name": "cr_stripped_default",
+      "note": "CR not in default allow -> stripped"
+    },
+    {
+      "allow": [
+        9,
+        10
+      ],
+      "expect_hex": "6109620a63",
+      "input_hex": "6109620a63",
+      "name": "allow_tab_and_newline",
+      "note": "explicit allow keeps TAB and LF"
+    },
+    {
+      "expect_hex": "6162",
+      "input_hex": "617f62",
+      "name": "del_stripped",
+      "note": "DEL (0x7F) removed"
+    },
+    {
+      "expect_hex": "6162",
+      "input_hex": "610062",
+      "name": "nul_stripped",
+      "note": "NUL (0x00) removed"
+    },
+    {
+      "expect_hex": "6162",
+      "input_hex": "618562",
+      "name": "raw_c1_stripped",
+      "note": "raw C1 byte (0x85 NEL) stripped, not replaced"
+    },
+    {
+      "expect_hex": "6162",
+      "input_hex": "61c28562",
+      "name": "encoded_c1_stripped",
+      "note": "UTF-8-encoded C1 (U+0085) stripped"
+    },
+    {
+      "expect_hex": "61efbfbd62",
+      "input_hex": "61ff62",
+      "name": "invalid_utf8_replaced",
+      "note": "invalid byte 0xFF -> U+FFFD"
+    },
+    {
+      "expect_hex": "61efbfbd62",
+      "input_hex": "61a062",
+      "name": "lone_continuation_replaced",
+      "note": "lone continuation 0xA0 -> U+FFFD (above C1 range)"
+    }
+  ]
+}


### PR DESCRIPTION
## What this is

The **decide-once seam** for PR #569 thread 2 ("same gap, four patches", per V's "centralize it" ruling, 2026-07-17). The same class of bug — *untrusted external bytes crossing a boundary without confinement* — was patched (or unpatched) independently at four sites. This lands the centralized contract in `raxol_core`; consumers migrate as follow-ups.

Design source: `docs/proposals/in-flight/confinement-seam-proposal.md` (option **b**). These are **two** confinements sharing a threat narrative but no types/algorithm/failure-modes, so two functions in one boundary namespace, not one.

## The two functions

```elixir
Raxol.Core.Boundary.Path.confine(root :: String.t(), requested :: String.t(), opts :: keyword())
  :: {:ok, real_path :: String.t()} | {:error, atom()}
# opts: ref_format: Regex.t()

Raxol.Core.Boundary.TermText.sanitize(binary(), opts :: keyword()) :: String.t()
# opts: allow: [0..31]  (default [?\n])
```

- **`Path.confine/3`** — path-traversal confinement, ported from the Agent Client Protocol package's proven `FsSandbox`. Rules, all *before any target syscall*: (1) optional ref-shape gate on the RAW ref → `:malformed_ref`; (2) lexical `Path.expand`-under-root prefix check → `:path_traversal`; (3) hand-rolled realpath of BOTH root and target following symlinks — leaf symlink AND symlinked-ancestor-dir, POSIX relative targets, not-yet-existing write leaf, depth-cap 40 → `:too_many_symlinks`; (4) post-resolution re-check → `:symlink_escape`. Total; never raises (`:invalid_input` on bad types).
- **`TermText.sanitize/2`** — terminal-injection confinement. Total function: strips ESC + all introduced sequences (CSI/OSC/DCS/APC/PM/SOS, two-byte forms, truncated trailing ESC), C0 controls except an allow-list, DEL, raw C1; invalid UTF-8 → U+FFFD. Enforces the repo "never embed raw ANSI in `text()`" rule *at the untrusted boundary*.

## The shared-vector drift guard

`raxol_core` cannot be consumed by the deliberately zero-raxol-dep Agent Client Protocol package (option **c** rejected: breaks its standalone-MIT story). So instead of sharing *code*, the two implementations share a **data-only conformance fixture** — `packages/raxol_core/test/support/boundary_vectors/`:

| File | Vectors | Drives |
| ---- | ------- | ------ |
| `path_reject_vectors.json` | 9 | `Path.confine/3` must-reject |
| `path_accept_vectors.json` | 8 | `Path.confine/3` must-accept |
| `term_text_vectors.json` | 26 | `TermText.sanitize/2` |

A raxol_core runner drives the functions over these vectors. The Agent Client Protocol package (follow-up, in the Agent Client Protocol repo) **copies `path_*_vectors.json` verbatim** and asserts its `FsSandbox` agrees (skipping `ref_format` vectors, a `confine/3`-only gate). A divergence is then a red test, not a silent security fork. Documented in the fixture `README.md`.

## Migration table (from the proposal)

| # | Site | Adopts | Lane / owner | Status |
| - | ---- | ------ | ------------ | ------ |
| 1 | #607 fenced-code info-string render | `TermText.sanitize/2` at render-prep | **UI lane — Drew** | follow-up (cross-lane, needs Drew's sign-off) |
| 2 | #569 / PA-6 CAS `$blob`/`snapshot_ref` deref | `Path.confine/3` + `ref_format:` at deref time | harness — ours | follow-up (PA-6/#586 harness-side) |
| 3 | #586 `:erl_tar.extract` per member | `Path.confine/3` per member vs extraction root | harness — ours | follow-up |
| 4 | Agent Client Protocol `fs_sandbox` | **no code change** — canonical seed, binds to shared vectors + duplicate-marker moduledoc | Agent Client Protocol pkg — ours | follow-up (binds to the shared vectors) |

**Note:** this is the decide-once seam only. Consumers migrate as follow-ups — #607 by the UI-lane agent, PA-6/#586 harness-side, and the Agent Client Protocol `fs_sandbox` binding to the shared vectors.

## Validation

- `MIX_ENV=test mix compile --warnings-as-errors` clean.
- 74 boundary tests pass (vector-driven + FS assertions + properties: accepted paths never escape root; sanitize output has no ESC/no disallowed control byte/valid UTF-8/idempotent for any input).
- Full raxol_core suite stays green: **869 passed**.
- No new deps (raxol_core stays telemetry-only; test JSON via built-in `JSON`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Rc719iBNk3hPRNKGrUPgN
