### PR TITLE
Harness UI: grade transcript blocks by turn recency into prominence

### DIFF
--- a/lib/raxol/harness/recency_policy.ex
+++ b/lib/raxol/harness/recency_policy.ex
@@ -24,6 +24,20 @@ defmodule Raxol.Harness.RecencyPolicy do
   darker: an ungraded block is never demoted below full prominence by
   this policy's own uncertainty.
 
+  ### Why these values (the ladder's provenance)
+
+  The four tiers are not new: they are the shipped salience ladder
+  already pinned by `Raxol.UI.Harness.Prominence` -- `0.6` is the
+  ordinary-context tier (`Prominence.needs_input_floor/0` floors
+  awaiting-input content exactly there), the `1.0`/`0.6` pair is pinned
+  by regression to survive 256-color quantization as distinct palette
+  indices, and `0.4` is that ladder's own floor. This policy was
+  ratified with an explicit "no new tiers" fence: it maps recency onto
+  the EXISTING ladder, one uniform `0.2` step per turn behind, and any
+  retuning of the tier values themselves belongs to the solver-side
+  ladder (and its pending human-eye ratification pass, see the
+  `Prominence` moduledoc), never to this mapping.
+
   ## Seal-time grading (the substrate law)
 
   Prominence for a block is decided **exactly once, at the moment the
@@ -129,6 +143,13 @@ defmodule Raxol.Harness.RecencyPolicy do
   `turns_behind` is `position(current_turn) - position(block_turn)` in
   that order.
 
+  **Caller contract (load-bearing): `turn_ids` must be in transcript
+  order.** Positional recency is meaningless on a reordered list -- a
+  turn that appears first IS oldest to this function, whatever its id
+  looks like. This is a documented precondition, not something this
+  pure function can validate (turn ids are opaque; there is no
+  order-independent notion of "older" to check against).
+
   Rules (each a documented guarantee, never darker than honest
   uncertainty warrants):
 
@@ -162,7 +183,8 @@ defmodule Raxol.Harness.RecencyPolicy do
   `Raxol.Harness.Projection` was built from.
 
   Derivation (defensive throughout -- a non-map entry in `events` is
-  skipped, never raised on):
+  skipped, never raised on; the whole derivation is a SINGLE pass over
+  `events`, so grading one block costs one walk, never three):
 
     * the block's own turn is the `:turn_id` of the FIRST event in
       `events` whose `:id` is in `block.event_refs` (`nil` if
@@ -175,14 +197,25 @@ defmodule Raxol.Harness.RecencyPolicy do
   Empty `events`, an unresolvable block turn, or a `nil` current turn
   all fall out of the same `grade/2` core as `1.0` -- see that
   function's own rule list.
+
+  **Input contract (load-bearing, guaranteed upstream for the intended
+  feed):** `events` must be journal/ingest-ordered and complete for the
+  blocks being graded. Both hold for `projection.source_events` by
+  construction: `Raxol.Harness.Projection.Recovery.filter_ids/1` drops
+  duplicate/out-of-order ids BEFORE retention (so the retained list is
+  id-monotonic), and `source_events` retains EVERY durable event for
+  the session un-windowed (only `:ephemeral` tier -- `item_delta`
+  traffic, which never enters a block's `event_refs` -- is excluded),
+  so every block built by the projection resolves its turn here. A
+  caller feeding a reordered or windowed list violates the contract;
+  each violation degrades toward `1.0` (never darker), per the same
+  uncertainty rule as everything else in this module.
   """
   @spec grade_block(map(), [map()]) :: prominence()
   def grade_block(%{event_refs: refs}, events) when is_list(events) do
-    safe_events = Enum.filter(events, &is_map/1)
-    order = safe_events |> Enum.map(&Map.get(&1, :turn_id)) |> turn_order()
-    current_turn = current_turn_of(safe_events)
+    {rev_order, current_turn, block_turn} = scan_events(events, refs)
+    order = Enum.reverse(rev_order)
     current_position = position(order, current_turn)
-    block_turn = block_turn_of(refs, safe_events)
 
     grade_one(order, current_position, block_turn, current_turn)
   end
@@ -227,19 +260,46 @@ defmodule Raxol.Harness.RecencyPolicy do
 
   # -- grade_block/2 event-derivation helpers ------------------------------
 
-  defp current_turn_of(events) do
-    events
-    |> Enum.map(&Map.get(&1, :turn_id))
-    |> Enum.reject(&is_nil/1)
-    |> List.last()
+  # One pass over `events` deriving all three of grade_block/2's inputs
+  # at once (the doc's "one walk, never three"): the distinct non-nil
+  # turn order (accumulated REVERSED, with a MapSet for O(1) seen
+  # checks -- the caller reverses back to first-seen order), the current
+  # turn (last non-nil turn_id wins by overwrite), and the block's own
+  # turn (the FIRST event whose id is in `refs`; latched with a
+  # `{:found, turn}` tuple rather than a bare sentinel atom so an
+  # opaque turn id can never collide with "not found yet"). Non-map
+  # entries fall through the guard and are skipped, never raised on.
+  defp scan_events(events, refs) do
+    {_seen, rev_order, current_turn, block_turn} =
+      Enum.reduce(events, {MapSet.new(), [], nil, :none}, fn
+        event, {seen, rev_order, current, found} when is_map(event) ->
+          turn = Map.get(event, :turn_id)
+
+          {seen, rev_order} =
+            if is_nil(turn) or MapSet.member?(seen, turn) do
+              {seen, rev_order}
+            else
+              {MapSet.put(seen, turn), [turn | rev_order]}
+            end
+
+          current = if is_nil(turn), do: current, else: turn
+
+          found =
+            if found == :none and Map.get(event, :id) in refs do
+              {:found, turn}
+            else
+              found
+            end
+
+          {seen, rev_order, current, found}
+
+        _non_map, acc ->
+          acc
+      end)
+
+    {rev_order, current_turn, unwrap_block_turn(block_turn)}
   end
 
-  defp block_turn_of([], _events), do: nil
-
-  defp block_turn_of(refs, events) do
-    case Enum.find(events, fn event -> Map.get(event, :id) in refs end) do
-      nil -> nil
-      event -> Map.get(event, :turn_id)
-    end
-  end
+  defp unwrap_block_turn({:found, turn}), do: turn
+  defp unwrap_block_turn(:none), do: nil
 end

--- a/lib/raxol/harness/recency_policy.ex
+++ b/lib/raxol/harness/recency_policy.ex
@@ -74,6 +74,15 @@ defmodule Raxol.Harness.RecencyPolicy do
   an approval outranks its own ladder tier automatically, with no
   needs-input branch anywhere in this module.
 
+  Scope note: on today's sole wiring point (the fixture-replay
+  surface's seal path) this composition is dormant -- the block builder
+  constructs every block already `:sealed`, and the seal frontier holds
+  a live approval back from painting at all, so a live approval never
+  reaches the graded path there; it lives in the repaintable footer
+  instead. The floor composition is real and tested at the `Prominence`
+  layer, and engages the moment a live-rendering surface grades live
+  blocks.
+
   ## Coverage today (an honest scope note)
 
   The grade is threaded through `Raxol.UI.Components.Harness.BlockBody`'s
@@ -222,6 +231,38 @@ defmodule Raxol.Harness.RecencyPolicy do
 
   def grade_block(_block, _events), do: 1.0
 
+  @doc """
+  Batch form of `grade_block/2`: grades EVERY block in `blocks` against
+  `events` with a SINGLE walk over the event list -- `O(events +
+  total_refs)` for the whole batch, where the per-block form re-derives
+  the (identical) turn order and current turn from the full event list
+  on every call.
+
+  Equivalence law (tested): `grade_blocks(blocks, events)` is exactly
+  `Enum.map(blocks, &grade_block(&1, events))` -- same input contract,
+  same defensive fallbacks, only the cost differs. This is the entry
+  point a bulk paint should use: a full re-render, a reattach rebuild,
+  or any pass that grades a whole projection at once. The incremental
+  seal path (`Raxol.Harness.Surface.render_block_lines/3`) keeps the
+  per-block form because its hold-back-one design seals a bounded
+  number of blocks per advance.
+  """
+  @spec grade_blocks([map()], [map()]) :: [prominence()]
+  def grade_blocks(blocks, events) when is_list(blocks) and is_list(events) do
+    {rev_order, current_turn, turn_by_id} = index_events(events)
+    order = Enum.reverse(rev_order)
+    current_position = position(order, current_turn)
+
+    Enum.map(blocks, fn
+      %{event_refs: refs} ->
+        block_turn = first_ref_turn(refs, turn_by_id)
+        grade_one(order, current_position, block_turn, current_turn)
+
+      _other ->
+        1.0
+    end)
+  end
+
   # -- grade/2 + grade_block/2 shared core --------------------------------
 
   # Never darker than 1.0 when either side of the comparison is
@@ -270,22 +311,18 @@ defmodule Raxol.Harness.RecencyPolicy do
   # opaque turn id can never collide with "not found yet"). Non-map
   # entries fall through the guard and are skipped, never raised on.
   defp scan_events(events, refs) do
+    ref_set = MapSet.new(refs)
+
     {_seen, rev_order, current_turn, block_turn} =
       Enum.reduce(events, {MapSet.new(), [], nil, :none}, fn
         event, {seen, rev_order, current, found} when is_map(event) ->
           turn = Map.get(event, :turn_id)
-
-          {seen, rev_order} =
-            if is_nil(turn) or MapSet.member?(seen, turn) do
-              {seen, rev_order}
-            else
-              {MapSet.put(seen, turn), [turn | rev_order]}
-            end
-
+          {seen, rev_order} = note_turn(seen, rev_order, turn)
           current = if is_nil(turn), do: current, else: turn
 
           found =
-            if found == :none and Map.get(event, :id) in refs do
+            if found == :none and
+                 MapSet.member?(ref_set, Map.get(event, :id)) do
               {:found, turn}
             else
               found
@@ -302,4 +339,60 @@ defmodule Raxol.Harness.RecencyPolicy do
 
   defp unwrap_block_turn({:found, turn}), do: turn
   defp unwrap_block_turn(:none), do: nil
+
+  # First-seen turn-order accumulation, shared by both event walks:
+  # skip nil and already-seen turns, otherwise prepend (the caller
+  # reverses back to first-seen order once, at the end).
+  defp note_turn(seen, rev_order, turn) do
+    if is_nil(turn) or MapSet.member?(seen, turn) do
+      {seen, rev_order}
+    else
+      {MapSet.put(seen, turn), [turn | rev_order]}
+    end
+  end
+
+  # -- grade_blocks/2 batch helpers ----------------------------------------
+
+  # The batch counterpart of scan_events/2: ONE walk over `events`
+  # deriving the turn order, the current turn, AND an id -> {position,
+  # turn} index -- so each block afterwards resolves its own turn in
+  # O(its refs) instead of re-walking the event list. `Map.put_new/3`
+  # keeps the FIRST occurrence per id (filter_ids guarantees unique ids
+  # on the intended feed; first-wins preserves grade_block/2's
+  # first-matching-event semantics on a contract-violating one).
+  defp index_events(events) do
+    {_seen, rev_order, current_turn, turn_by_id, _pos} =
+      Enum.reduce(events, {MapSet.new(), [], nil, %{}, 0}, fn
+        event, {seen, rev_order, current, by_id, pos} when is_map(event) ->
+          turn = Map.get(event, :turn_id)
+          {seen, rev_order} = note_turn(seen, rev_order, turn)
+          current = if is_nil(turn), do: current, else: turn
+          by_id = Map.put_new(by_id, Map.get(event, :id), {pos, turn})
+          {seen, rev_order, current, by_id, pos + 1}
+
+        _non_map, acc ->
+          acc
+      end)
+
+    {rev_order, current_turn, turn_by_id}
+  end
+
+  # The turn of the FIRST event (by event position, not ref position)
+  # whose id appears in `refs` -- exactly grade_block/2's derivation,
+  # answered from the prebuilt index. `nil` when nothing resolves.
+  defp first_ref_turn(refs, turn_by_id) when is_list(refs) do
+    refs
+    |> Enum.flat_map(fn ref ->
+      case Map.fetch(turn_by_id, ref) do
+        {:ok, {pos, turn}} -> [{pos, turn}]
+        :error -> []
+      end
+    end)
+    |> case do
+      [] -> nil
+      found -> found |> Enum.min_by(&elem(&1, 0)) |> elem(1)
+    end
+  end
+
+  defp first_ref_turn(_refs, _turn_by_id), do: nil
 end

--- a/lib/raxol/harness/recency_policy.ex
+++ b/lib/raxol/harness/recency_policy.ex
@@ -1,0 +1,245 @@
+defmodule Raxol.Harness.RecencyPolicy do
+  @moduledoc """
+  Turn recency -> per-block prominence: the policy that decides WHICH
+  `prominence` (`0.0..1.0`) a transcript block gets, based purely on how
+  many turns behind the current one its own turn is. This module is pure
+  turn-identity arithmetic -- no processes, no clocks, no config reads,
+  no rendering. It feeds `context[:prominence]` into
+  `Raxol.UI.Components.Harness.Block.render/2`
+  (`Raxol.UI.Harness.Prominence.resolve/3` underneath), but never calls
+  either.
+
+  ## The ladder
+
+  `turns_behind` steps down a fixed four-tier ladder, floored at
+  `floor/0` (`#{0.4}`):
+
+  ```
+  turns_behind:   0     1     2     3+
+  prominence:    1.0   0.8   0.6   0.4
+  ```
+
+  `nil` or negative `turns_behind` -- an unknown or (defensively)
+  future-relative position -- always resolves to `1.0`, never something
+  darker: an ungraded block is never demoted below full prominence by
+  this policy's own uncertainty.
+
+  ## Seal-time grading (the substrate law)
+
+  Prominence for a block is decided **exactly once, at the moment the
+  block is painted/sealed**, and is never re-graded afterward -- the
+  print-once history substrate this framework paints through cannot
+  repaint scrollback (see `Raxol.Harness.Surface`'s own "seal / seal-once"
+  glossary entry). A block sealed during its own turn seals at `1.0` and
+  does NOT fade when the next turn starts; it is not re-visited once
+  painted.
+
+  The fade ladder is therefore visible wherever MULTIPLE turns are
+  painted in one pass -- a full re-render, a reattach rebuild, the live
+  region -- while incrementally sealed inline history keeps its
+  seal-time grade forever, unchanged by anything that happens
+  afterward. This is the honest, substrate-constrained reading of the
+  ratified "scoped by policy" clause: the policy grades a block once,
+  when it is painted; there is no retroactive re-grading, and no
+  mechanism in this module (or its one caller,
+  `Raxol.Harness.Surface.render_block_lines/3`) ever asks "what would
+  this block's prominence be now?" for an already-sealed block.
+
+  ## Composition with the needs-input floor
+
+  This policy only produces the RECENCY prominence -- it has no opinion
+  on, and never special-cases, content that is awaiting user input.
+  That promotion lives one layer below, in
+  `Raxol.UI.Components.Harness.Block` and
+  `Raxol.UI.Harness.Prominence`: a live `:approval` block auto-passes
+  `needs_input: true` into its render context, and
+  `Prominence.resolve/3` floors the EFFECTIVE prominence at
+  `Prominence.needs_input_floor/0` (`#{0.6}`) before the fade runs. So a
+  pending approval this policy grades at, say, `0.4` (three-plus turns
+  behind) still renders no dimmer than the `0.6` ordinary-context tier --
+  an approval outranks its own ladder tier automatically, with no
+  needs-input branch anywhere in this module.
+
+  ## Coverage today (an honest scope note)
+
+  The grade is threaded through `Raxol.UI.Components.Harness.BlockBody`'s
+  render context for EVERY block, but only `Block.render/2` -- the folded
+  path, and every fallback -- resolves `context[:prominence]` into a fade
+  today. The expanded rich body components mounted via
+  `Raxol.UI.Components.Harness.BodyProvider` do not yet thread the key
+  (a pre-existing gap in those components, not in this policy or its
+  wiring); when they grow that support, the grade is already there in
+  their context, unchanged.
+
+  ## Turn identity is opaque
+
+  `turn_ids`/`turn_id` are opaque terms (atoms in tests, strings on the
+  wire) compared only with `==` -- this module has no notion of a turn's
+  internal shape, ordering by VALUE, or timestamps. "Recency" here means
+  purely POSITION in first-seen order among the turns actually present,
+  never wall-clock or `ts` distance.
+  """
+
+  @typedoc "An opaque turn identifier -- compared only with `==`."
+  @type turn_id :: term()
+
+  @typedoc "A resolved prominence value, `0.0..1.0`."
+  @type prominence :: float()
+
+  # The floor of the fade ladder -- three-or-more turns behind the
+  # current one renders at this level, never darker. Single source of
+  # truth for both `prominence/1`'s own floor clause and any caller that
+  # wants to name the floor directly (mirrors
+  # `Raxol.UI.Harness.Prominence.needs_input_floor/0`'s own pattern).
+  @floor 0.4
+
+  @doc """
+  The floor of the recency fade ladder (`#{@floor}`) -- the prominence a
+  block three-or-more turns behind the current one renders at.
+  """
+  @spec floor() :: prominence()
+  def floor, do: @floor
+
+  @doc """
+  Maps `turns_behind` (a non-negative integer distance from the current
+  turn) onto its ladder prominence: `0 -> 1.0`, `1 -> 0.8`, `2 -> 0.6`,
+  `3` or more `-> #{@floor}` (the floor). `nil` or a negative integer --
+  an unknown or defensively-clamped position -- always resolves to
+  `1.0`: this policy's own uncertainty never reads as "darker."
+  """
+  @spec prominence(integer() | nil) :: prominence()
+  def prominence(nil), do: 1.0
+
+  def prominence(turns_behind)
+      when is_integer(turns_behind) and turns_behind < 0, do: 1.0
+
+  def prominence(0), do: 1.0
+  def prominence(1), do: 0.8
+  def prominence(2), do: 0.6
+  def prominence(turns_behind) when is_integer(turns_behind), do: @floor
+
+  @doc """
+  Grades `turn_ids` (the per-block list of turn identifiers, in
+  transcript order) against `current_turn`, returning a same-length list
+  of ladder prominences.
+
+  Turn ORDER is the distinct non-nil turn ids in `turn_ids`, in
+  first-seen order (never wall-clock, never a separate turn list --
+  exactly the turns actually present in this transcript). A block's
+  `turns_behind` is `position(current_turn) - position(block_turn)` in
+  that order.
+
+  Rules (each a documented guarantee, never darker than honest
+  uncertainty warrants):
+
+    * `current_turn` is `nil` -- no honest way to grade -- every block
+      grades `1.0`.
+    * `current_turn` absent from the order (a brand-new turn with no
+      blocks yet in `turn_ids`) is treated as one position NEWER than
+      the newest listed turn -- every existing block is graded one tier
+      further behind than it would be if that new turn already had an
+      entry.
+    * A block's own turn id `nil` grades that block `1.0` (nothing to
+      grade against).
+    * A block's turn NEWER than `current_turn` (shouldn't happen in a
+      well-formed transcript; handled defensively) clamps `turns_behind`
+      to `0` -> `1.0`, rather than extrapolating a "prominence above
+      1.0" that has no meaning.
+  """
+  @spec grade([turn_id() | nil], turn_id() | nil) :: [prominence()]
+  def grade(turn_ids, current_turn) when is_list(turn_ids) do
+    order = turn_order(turn_ids)
+    current_position = position(order, current_turn)
+
+    Enum.map(turn_ids, &grade_one(order, current_position, &1, current_turn))
+  end
+
+  @doc """
+  Convenience for the render path: grades `block` (matched loosely as
+  `%{event_refs: refs}` so both `Raxol.UI.Components.Harness.Block.t()`
+  and a plain map with that key work) against `events` -- typically
+  `projection.source_events`, the retained durable events a
+  `Raxol.Harness.Projection` was built from.
+
+  Derivation (defensive throughout -- a non-map entry in `events` is
+  skipped, never raised on):
+
+    * the block's own turn is the `:turn_id` of the FIRST event in
+      `events` whose `:id` is in `block.event_refs` (`nil` if
+      `event_refs` is empty or nothing matches);
+    * the current turn is the `:turn_id` of the LAST event in `events`
+      that carries a non-nil `:turn_id` (`nil` if none do);
+    * the turn order is the distinct non-nil `:turn_id`s across
+      `events`, in first-seen order.
+
+  Empty `events`, an unresolvable block turn, or a `nil` current turn
+  all fall out of the same `grade/2` core as `1.0` -- see that
+  function's own rule list.
+  """
+  @spec grade_block(map(), [map()]) :: prominence()
+  def grade_block(%{event_refs: refs}, events) when is_list(events) do
+    safe_events = Enum.filter(events, &is_map/1)
+    order = safe_events |> Enum.map(&Map.get(&1, :turn_id)) |> turn_order()
+    current_turn = current_turn_of(safe_events)
+    current_position = position(order, current_turn)
+    block_turn = block_turn_of(refs, safe_events)
+
+    grade_one(order, current_position, block_turn, current_turn)
+  end
+
+  def grade_block(_block, _events), do: 1.0
+
+  # -- grade/2 + grade_block/2 shared core --------------------------------
+
+  # Never darker than 1.0 when either side of the comparison is
+  # unknown -- both nil-current (no honest grading possible) and
+  # nil-block-turn (nothing to grade this particular block against) are
+  # handled BEFORE any position lookup, so neither ever reaches
+  # `position/2` with a `nil` to search for.
+  defp grade_one(_order, _current_position, _turn_id, nil), do: 1.0
+  defp grade_one(_order, _current_position, nil, _current_turn), do: 1.0
+
+  defp grade_one(order, current_position, turn_id, _current_turn) do
+    turns_behind = current_position - position(order, turn_id)
+    prominence(max(turns_behind, 0))
+  end
+
+  defp turn_order(turn_ids) do
+    turn_ids |> Enum.reject(&is_nil/1) |> Enum.uniq()
+  end
+
+  # Position of `turn_id` in `order` (first-seen index). A `turn_id` NOT
+  # found in `order` -- the "current turn is a brand-new turn with no
+  # blocks yet" case for `current_turn`, or (defensively) an
+  # inconsistent block turn -- is treated as one position NEWER than the
+  # newest listed turn (`length(order)`, one past the last valid index).
+  # Reused identically for both the current turn and a block's own turn:
+  # an unresolvable BLOCK turn hitting this same fallback makes
+  # `turns_behind` non-positive (since `current_position <= length(order)`
+  # always), which `grade_one/4`'s `max(turns_behind, 0)` clamp already
+  # turns into `1.0` -- so one fallback correctly serves both cases.
+  defp position(order, turn_id) do
+    case Enum.find_index(order, &(&1 == turn_id)) do
+      nil -> length(order)
+      index -> index
+    end
+  end
+
+  # -- grade_block/2 event-derivation helpers ------------------------------
+
+  defp current_turn_of(events) do
+    events
+    |> Enum.map(&Map.get(&1, :turn_id))
+    |> Enum.reject(&is_nil/1)
+    |> List.last()
+  end
+
+  defp block_turn_of([], _events), do: nil
+
+  defp block_turn_of(refs, events) do
+    case Enum.find(events, fn event -> Map.get(event, :id) in refs end) do
+      nil -> nil
+      event -> Map.get(event, :turn_id)
+    end
+  end
+end

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -921,7 +921,10 @@ defmodule Raxol.Harness.Surface do
   # Called from seal_block/2 -- the print-once paint -- so the grade
   # computed here IS the seal-time grade (see RecencyPolicy's moduledoc,
   # "Seal-time grading"): painted history is never re-graded because it
-  # is never repainted.
+  # is never repainted. The grade trusts source_events' journal order
+  # and durable completeness -- both guaranteed upstream
+  # (Recovery.filter_ids/1 id-monotonicity; un-windowed durable-only
+  # retention); see RecencyPolicy.grade_block/2's input contract.
   defp render_block_lines(block, model, mode) do
     prominence =
       RecencyPolicy.grade_block(block, model.projection.source_events)

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -408,6 +408,7 @@ defmodule Raxol.Harness.Surface do
 
   alias Raxol.Harness.Fixture.Session
   alias Raxol.Harness.Projection
+  alias Raxol.Harness.RecencyPolicy
   alias Raxol.Harness.SealFrontier
   alias Raxol.Terminal.ScrollRegionManager
   alias Raxol.Harness.StatusStrip
@@ -917,9 +918,16 @@ defmodule Raxol.Harness.Surface do
     %{model | authority: authority, painted_count: model.painted_count + 1}
   end
 
+  # Called from seal_block/2 -- the print-once paint -- so the grade
+  # computed here IS the seal-time grade (see RecencyPolicy's moduledoc,
+  # "Seal-time grading"): painted history is never re-graded because it
+  # is never repainted.
   defp render_block_lines(block, model, mode) do
+    prominence =
+      RecencyPolicy.grade_block(block, model.projection.source_events)
+
     block
-    |> BlockBody.render(%{width: model.width})
+    |> BlockBody.render(%{width: model.width, prominence: prominence})
     |> ViewText.lines(model.width, mode)
   end
 

--- a/test/harness/recency_policy_test.exs
+++ b/test/harness/recency_policy_test.exs
@@ -197,6 +197,160 @@ defmodule Raxol.Harness.RecencyPolicyTest do
   end
 
   # ---------------------------------------------------------------------
+  # D2. grade_blocks/2 -- the batch path: one event walk for a whole
+  #     projection (the bulk-paint / reattach-rebuild consumer)
+  # ---------------------------------------------------------------------
+
+  describe "grade_blocks/2 batch-grades a projection in one event walk" do
+    defp five_turn_projection do
+      events =
+        Enum.flat_map(1..5, fn n ->
+          base = (n - 1) * 3
+
+          [
+            %{
+              id: base + 1,
+              turn_id: "t#{n}",
+              ts: n * 1000,
+              family: :loop,
+              type: :turn_started,
+              tier: :durable,
+              payload: %{}
+            },
+            %{
+              id: base + 2,
+              turn_id: "t#{n}",
+              ts: n * 1000 + 10,
+              family: :loop,
+              type: :item_started,
+              tier: :durable,
+              payload: %{"item_id" => "i#{n}", "item_type" => "message"}
+            },
+            %{
+              id: base + 3,
+              turn_id: "t#{n}",
+              ts: n * 1000 + 20,
+              family: :loop,
+              type: :item_completed,
+              tier: :durable,
+              payload: %{
+                "item_id" => "i#{n}",
+                "item_type" => "message",
+                "content" => "turn #{n} reply"
+              }
+            }
+          ]
+        end)
+
+      Projection.project(events)
+    end
+
+    test "matches per-block grade_block/2 exactly (the equivalence law)" do
+      projection = five_turn_projection()
+
+      batch =
+        RecencyPolicy.grade_blocks(projection.blocks, projection.source_events)
+
+      singles =
+        Enum.map(
+          projection.blocks,
+          &RecencyPolicy.grade_block(&1, projection.source_events)
+        )
+
+      assert batch == singles
+      assert batch == [0.4, 0.4, 0.6, 0.8, 1.0]
+    end
+
+    test "empty blocks and empty events degrade safely" do
+      projection = five_turn_projection()
+
+      assert RecencyPolicy.grade_blocks([], projection.source_events) == []
+
+      assert RecencyPolicy.grade_blocks(projection.blocks, []) ==
+               [1.0, 1.0, 1.0, 1.0, 1.0]
+    end
+
+    test "a block with unresolvable refs grades 1.0 in the batch too" do
+      projection = five_turn_projection()
+
+      orphan =
+        Block.from_events(:message, [
+          %{id: 9_991, type: :item_completed, content: "orphan"}
+        ])
+
+      grades =
+        RecencyPolicy.grade_blocks(
+          projection.blocks ++ [orphan],
+          projection.source_events
+        )
+
+      assert List.last(grades) == 1.0
+      assert Enum.take(grades, 5) == [0.4, 0.4, 0.6, 0.8, 1.0]
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # D3. The anti-inversion invariant, made self-defending: every block a
+  #     projection builds resolves its turn against that projection's own
+  #     source_events. This is the tripwire for the retention decision at
+  #     Raxol.Harness.Projection (source_events = every durable event,
+  #     un-windowed; ephemeral item_delta traffic never enters a block's
+  #     event_refs). The day someone bounds source_events for memory, THIS
+  #     test goes red before old scrollback can silently grade loud.
+  # ---------------------------------------------------------------------
+
+  describe "the anti-inversion invariant (blocks always resolve against source_events)" do
+    @session_fixtures ~w(simple-chat long-folds multi-tool-turn markdown-stream
+                         taint-propagation unicode-heavy adversarial)
+
+    test "every shipped fixture's blocks resolve their event_refs in source_events" do
+      for name <- @session_fixtures do
+        path = "test/fixtures/harness/sessions/#{name}.jsonl"
+        {:ok, session} = Raxol.Harness.Fixture.load(path)
+        projection = Projection.project(session)
+
+        source_ids =
+          projection.source_events
+          |> Enum.map(&Map.get(&1, :id))
+          |> MapSet.new()
+
+        for block <- projection.blocks do
+          resolvable =
+            Enum.any?(block.event_refs, &MapSet.member?(source_ids, &1))
+
+          assert resolvable,
+                 "#{name}: block #{inspect(block.event_refs)} resolves no " <>
+                   "ref in source_events -- the un-windowed durable " <>
+                   "retention invariant broke (see Projection's " <>
+                   "source_events construction); recency grading would " <>
+                   "silently return 1.0 (loud) for this block"
+        end
+      end
+    end
+
+    test "negative control: a windowed source_events degrades old blocks to 1.0 (loud), the documented failure mode" do
+      # This is the exact behavior the invariant above protects against
+      # becoming reachable: grading against a WINDOWED tail of events
+      # (here: only the newest turn retained) resolves an old block's
+      # turn to nothing, and the ratified never-darker rule grades it
+      # 1.0. Correct per the unknown-turn spec; wrong as an attention
+      # signal -- which is why retention must stay un-windowed while
+      # this policy feeds on source_events.
+      projection = five_turn_projection()
+      [oldest_block | _] = projection.blocks
+
+      windowed_tail = Enum.take(projection.source_events, -3)
+
+      assert RecencyPolicy.grade_block(oldest_block, windowed_tail) == 1.0
+
+      assert RecencyPolicy.grade_block(
+               oldest_block,
+               projection.source_events
+             ) == 0.4
+    end
+  end
+
+  # ---------------------------------------------------------------------
   # E. a five-turn fixture renders the documented ladder byte-exact
   # ---------------------------------------------------------------------
 

--- a/test/harness/recency_policy_test.exs
+++ b/test/harness/recency_policy_test.exs
@@ -1,0 +1,467 @@
+defmodule Raxol.Harness.RecencyPolicyTest do
+  @moduledoc """
+  Acceptance tests for `Raxol.Harness.RecencyPolicy` (turn recency ->
+  per-block prominence) and its one wiring point in
+  `Raxol.Harness.Surface.render_block_lines/3`.
+
+  Written RED-FIRST: this file was run against the codebase BEFORE
+  `lib/raxol/harness/recency_policy.ex` existed and before
+  `render_block_lines/3` was wired -- see the task's final report for the
+  captured failing-run evidence. Every test below anchors on a concrete
+  documented guarantee (the ladder, the unknown-turn fallback, the
+  seal-time grading contract, the needs-input composition), never a bare
+  presence assert.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.Projection
+  alias Raxol.Harness.RecencyPolicy
+  alias Raxol.Harness.Surface
+  alias Raxol.Harness.Surface.ViewText
+  alias Raxol.UI.Components.Harness.Block
+  alias Raxol.UI.Harness.Prominence
+
+  # ---------------------------------------------------------------------
+  # A. prominence/1 -- the documented ladder
+  # ---------------------------------------------------------------------
+
+  describe "prominence/1 steps the documented ladder and floors at 0.4" do
+    test "the table: 0/1/2/3/4/10/nil/-1" do
+      table = [
+        {0, 1.0},
+        {1, 0.8},
+        {2, 0.6},
+        {3, 0.4},
+        {4, 0.4},
+        {10, 0.4},
+        {nil, 1.0},
+        {-1, 1.0}
+      ]
+
+      for {turns_behind, expected} <- table do
+        assert RecencyPolicy.prominence(turns_behind) == expected,
+               "turns_behind #{inspect(turns_behind)}: expected #{expected}, " <>
+                 "got #{RecencyPolicy.prominence(turns_behind)}"
+      end
+    end
+
+    test "floor/0 is the single source of the ladder's floor value" do
+      assert RecencyPolicy.floor() == 0.4
+      assert RecencyPolicy.prominence(3) == RecencyPolicy.floor()
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # B. grade/2 -- the pure core, a five-turn transcript
+  # ---------------------------------------------------------------------
+
+  describe "grade/2 grades a five-turn transcript down the ladder from the current turn" do
+    test "five distinct turns, current = newest" do
+      turn_ids = [:t1, :t2, :t3, :t4, :t5]
+      assert RecencyPolicy.grade(turn_ids, :t5) == [0.4, 0.4, 0.6, 0.8, 1.0]
+    end
+
+    test "a repeated turn id grades identically at every occurrence" do
+      assert RecencyPolicy.grade([:t1, :t1, :t2], :t2) == [0.8, 0.8, 1.0]
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # C. grade/2 -- unknown-turn fallback: never darker than 1.0
+  # ---------------------------------------------------------------------
+
+  describe "grade/2 unknown-turn fallback is 1.0, never darker" do
+    test "a nil current turn grades every block 1.0" do
+      assert RecencyPolicy.grade([:t1, :t2, :t3], nil) == [1.0, 1.0, 1.0]
+    end
+
+    test "a nil turn id inside the list grades that block 1.0, others graded normally" do
+      assert RecencyPolicy.grade([:t1, nil, :t2], :t2) == [0.8, 1.0, 1.0]
+    end
+
+    test "a current turn absent from the list grades everything one tier deeper" do
+      assert RecencyPolicy.grade([:t1, :t2], :t3) == [0.6, 0.8]
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # D. grade_block/2 -- deriving turn identity from event_refs + source events
+  # ---------------------------------------------------------------------
+
+  describe "grade_block/2 derives turn identity from event refs and source events" do
+    defp two_turn_events do
+      [
+        %{
+          id: 1,
+          turn_id: "t1",
+          ts: 100,
+          family: :loop,
+          type: :turn_started,
+          tier: :durable,
+          payload: %{}
+        },
+        %{
+          id: 2,
+          turn_id: "t1",
+          ts: 110,
+          family: :loop,
+          type: :item_started,
+          tier: :durable,
+          payload: %{"item_id" => "i1", "item_type" => "message"}
+        },
+        %{
+          id: 3,
+          turn_id: "t1",
+          ts: 120,
+          family: :loop,
+          type: :item_completed,
+          tier: :durable,
+          payload: %{
+            "item_id" => "i1",
+            "item_type" => "message",
+            "content" => "turn 1 reply"
+          }
+        },
+        %{
+          id: 4,
+          turn_id: "t2",
+          ts: 200,
+          family: :loop,
+          type: :turn_started,
+          tier: :durable,
+          payload: %{}
+        },
+        %{
+          id: 5,
+          turn_id: "t2",
+          ts: 210,
+          family: :loop,
+          type: :item_started,
+          tier: :durable,
+          payload: %{"item_id" => "i2", "item_type" => "message"}
+        },
+        %{
+          id: 6,
+          turn_id: "t2",
+          ts: 220,
+          family: :loop,
+          type: :item_completed,
+          tier: :durable,
+          payload: %{
+            "item_id" => "i2",
+            "item_type" => "message",
+            "content" => "turn 2 reply"
+          }
+        }
+      ]
+    end
+
+    test "the older-turn block grades 0.8, the current-turn block grades 1.0" do
+      events = two_turn_events()
+      projection = Projection.project(events)
+      assert [block1, block2] = projection.blocks
+
+      assert RecencyPolicy.grade_block(block1, projection.source_events) == 0.8
+      assert RecencyPolicy.grade_block(block2, projection.source_events) == 1.0
+    end
+
+    test "a block whose event_refs match nothing in events grades 1.0" do
+      events = two_turn_events()
+
+      unmatched_block =
+        Block.from_events(:message, [
+          %{id: 999, type: :item_completed, content: "orphan"}
+        ])
+
+      assert RecencyPolicy.grade_block(unmatched_block, events) == 1.0
+    end
+
+    test "empty events grades 1.0" do
+      block =
+        Block.from_events(:message, [
+          %{id: 1, type: :item_completed, content: "hi"}
+        ])
+
+      assert RecencyPolicy.grade_block(block, []) == 1.0
+    end
+
+    test "a non-map entry inside events does not raise, and is simply skipped" do
+      projection = Projection.project(two_turn_events())
+      assert [block1 | _] = projection.blocks
+
+      polluted_events = two_turn_events() ++ ["not a map", 42, nil]
+
+      assert RecencyPolicy.grade_block(block1, polluted_events) == 0.8
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # E. a five-turn fixture renders the documented ladder byte-exact
+  # ---------------------------------------------------------------------
+
+  describe "a five-turn fixture renders the documented ladder byte-exact" do
+    defp turn_events(n) do
+      base = (n - 1) * 3
+
+      [
+        %{
+          id: base + 1,
+          turn_id: "t#{n}",
+          ts: n * 1000,
+          family: :loop,
+          type: :turn_started,
+          tier: :durable,
+          payload: %{}
+        },
+        %{
+          id: base + 2,
+          turn_id: "t#{n}",
+          ts: n * 1000 + 10,
+          family: :loop,
+          type: :item_started,
+          tier: :durable,
+          payload: %{"item_id" => "i#{n}", "item_type" => "message"}
+        },
+        %{
+          id: base + 3,
+          turn_id: "t#{n}",
+          ts: n * 1000 + 20,
+          family: :loop,
+          type: :item_completed,
+          tier: :durable,
+          payload: %{
+            "item_id" => "i#{n}",
+            "item_type" => "message",
+            "content" => "turn #{n} reply"
+          }
+        }
+      ]
+    end
+
+    test "grades 1..5 down the ladder and the header fg matches Prominence.resolve/3 byte-exact" do
+      events = Enum.flat_map(1..5, &turn_events/1)
+      projection = Projection.project(events)
+      assert length(projection.blocks) == 5
+
+      grades =
+        Enum.map(
+          projection.blocks,
+          &RecencyPolicy.grade_block(&1, projection.source_events)
+        )
+
+      assert grades == [0.4, 0.4, 0.6, 0.8, 1.0]
+
+      for {block, grade} <- Enum.zip(projection.blocks, grades) do
+        %{children: [header | _]} =
+          Block.render(block, %{width: 80, prominence: grade, ground: 0.2})
+
+        if grade >= 1.0 do
+          refute Map.has_key?(header.style, :fg),
+                 "newest (current-turn) block must render neutral (no :fg)"
+        else
+          expected_fg = Prominence.resolve("#B4B4B4", grade, ground: 0.2)
+
+          assert header.style.fg == expected_fg,
+                 "grade #{grade}: expected fg #{expected_fg}, got #{header.style.fg}"
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # F. a live approval outranks its ladder tier via the needs-input floor
+  # ---------------------------------------------------------------------
+
+  describe "a live approval block outranks its ladder tier via the needs-input floor" do
+    test "the approval's header floors at the context tier, brighter than a plain 0.4 grade" do
+      block =
+        Block.from_events(
+          :approval,
+          [
+            %{
+              id: 99,
+              type: :approval_requested,
+              payload: %{action: "rm -rf /tmp/x"}
+            }
+          ],
+          seal: :live
+        )
+
+      assert Block.live?(block)
+
+      %{children: [header | _]} =
+        Block.render(block, %{width: 80, prominence: 0.4, ground: 0.2})
+
+      floored_fg =
+        Prominence.resolve("#B4B4B4", 0.4, needs_input: true, ground: 0.2)
+
+      context_tier_fg = Prominence.resolve("#B4B4B4", 0.6, ground: 0.2)
+      plain_fg = Prominence.resolve("#B4B4B4", 0.4, ground: 0.2)
+
+      assert floored_fg == context_tier_fg
+      assert header.style.fg == floored_fg
+      refute header.style.fg == plain_fg
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # G. the wiring: surface seals blocks at their seal-time grade
+  # ---------------------------------------------------------------------
+
+  describe "surface seals blocks at their seal-time grade" do
+    defp two_turn_wire_events do
+      [
+        %{
+          id: 1,
+          turn_id: "t1",
+          ts: 100,
+          family: :loop,
+          type: :turn_started,
+          tier: :durable,
+          payload: %{}
+        },
+        %{
+          id: 2,
+          turn_id: "t1",
+          ts: 110,
+          family: :loop,
+          type: :item_started,
+          tier: :durable,
+          payload: %{"item_id" => "i1", "item_type" => "message"}
+        },
+        %{
+          id: 3,
+          turn_id: "t1",
+          ts: 120,
+          family: :loop,
+          type: :item_completed,
+          tier: :durable,
+          payload: %{
+            "item_id" => "i1",
+            "item_type" => "message",
+            "content" => "turn 1 reply"
+          }
+        },
+        %{
+          id: 4,
+          turn_id: "t2",
+          ts: 200,
+          family: :loop,
+          type: :turn_started,
+          tier: :durable,
+          payload: %{}
+        },
+        %{
+          id: 5,
+          turn_id: "t2",
+          ts: 210,
+          family: :loop,
+          type: :item_started,
+          tier: :durable,
+          payload: %{"item_id" => "i2", "item_type" => "message"}
+        },
+        %{
+          id: 6,
+          turn_id: "t2",
+          ts: 220,
+          family: :loop,
+          type: :item_completed,
+          tier: :durable,
+          payload: %{
+            "item_id" => "i2",
+            "item_type" => "message",
+            "content" => "turn 2 reply"
+          }
+        }
+      ]
+    end
+
+    defp advance_until_done(model) do
+      case Surface.advance(model) do
+        {advanced, :done} -> advanced
+        {advanced, :ok} -> advance_until_done(advanced)
+      end
+    end
+
+    # "#rrggbb" -> "38;2;R;G;B" (decimal), the 24-bit truecolor SGR
+    # fragment `Raxol.Harness.Surface.ViewText`'s `maybe_fg/2` emits.
+    defp hex_to_sgr_fragment("#" <> hex) do
+      {value, ""} = Integer.parse(hex, 16)
+      r = value |> Bitwise.bsr(16) |> Bitwise.band(0xFF)
+      g = value |> Bitwise.bsr(8) |> Bitwise.band(0xFF)
+      b = Bitwise.band(value, 0xFF)
+      "38;2;#{r};#{g};#{b}"
+    end
+
+    test "turn-1's block seals at its seal-time grade; the newest block stays neutral" do
+      events = two_turn_wire_events()
+      {:ok, device} = StringIO.open("")
+
+      # message defaults to :expanded fold (Block.default_fold/1), which
+      # routes through BlockBody -> BodyProvider -> MessageBlock -- a rich
+      # T5 body component that does not (yet) thread context[:prominence]
+      # at all (out of scope for this unit; only Block.render/2 honors
+      # prominence today). Forcing message blocks :folded routes
+      # BlockBody.render/2 through its `:folded` clause, which delegates
+      # straight to Block.render/2 -- the path this policy actually feeds.
+      _final_model =
+        events
+        |> Surface.new(
+          device: device,
+          width: 80,
+          rows: 24,
+          mode: :inline_log,
+          fold_defaults: %{message: :folded}
+        )
+        |> advance_until_done()
+
+      {_in, out} = StringIO.contents(device)
+
+      # Seal timing (see Surface.frontier_entries/1): turn-1's block
+      # completes on event 3, but paint_pending_blocks/1 holds the newest
+      # completed block back for exactly one more advance/2 call unless
+      # the fixture reveal has finished. Turn-2's own item_completed
+      # (event 6) is simultaneously the event that both completes turn-2's
+      # block AND finishes the reveal (revealed == length(events)) -- so
+      # `reveal_finished?` flips true in the SAME advance/2 step that
+      # produces the second block, and both blocks clear the frontier's
+      # hold-back-one-block gate together, sealing in the same
+      # paint_pending_blocks/1 pass. At that moment
+      # model.projection.source_events already contains both turns'
+      # events; current turn = "t2" (the last event's turn_id), and
+      # turn-1's block is exactly one turn behind -> ladder step 0.8.
+      expected_grade = 0.8
+      expected_hex = Prominence.resolve("#B4B4B4", expected_grade, [])
+      expected_fragment = hex_to_sgr_fragment(expected_hex)
+
+      assert out =~ expected_fragment,
+             "expected the seal-time-graded fragment #{expected_fragment} " <>
+               "(from #{expected_hex}) in sealed output, got:\n#{out}"
+
+      # The last (current-turn) block seals at grade 1.0 -- neutral, no
+      # :fg touched. Reconstruct its own bare (unstyled) header line via
+      # the SAME Block.render + ViewText.lines path seal_block/2 uses, and
+      # confirm it appears in the sealed output immediately followed by
+      # "\r\n" with no "\e[0m" reset in between -- which is only possible
+      # if no SGR wrapping was ever added (a styled line always inserts
+      # "\e[0m" between content and the "\r\n" seal_block/2 appends).
+      final_projection =
+        Projection.project(events, fold_defaults: %{message: :folded})
+
+      last_block = List.last(final_projection.blocks)
+
+      neutral_line =
+        last_block
+        |> Block.render(%{width: 80, prominence: 1.0})
+        |> ViewText.lines(80, :styled)
+        |> hd()
+
+      refute neutral_line =~ "38;2",
+             "the newest block's own reconstructed neutral line must carry no fg"
+
+      assert out =~ neutral_line <> "\r\n",
+             "expected the newest block's bare, unstyled header line in sealed output"
+    end
+  end
+end


### PR DESCRIPTION
The salience wave's payoff: nothing assigned prominence until now — every block rendered at 1.0. This adds the pure recency policy so the transcript reads like attention: current turn loud, older turns stepped down by perceptual tier, approvals never buried.

## Policy (`Raxol.Harness.RecencyPolicy`, pure — no processes, no clocks, no config)

- `prominence(turns_behind)`: 0 -> 1.0, 1 -> 0.8, 2 -> 0.6, 3+ -> 0.4 (floor); nil/negative -> 1.0 — uncertainty never reads darker.
- `grade(turn_ids, current_turn)` pure core (turn order = first-seen distinct ids; defensive fallbacks all resolve toward loud) + `grade_block/2` render-path convenience deriving turn identity from `event_refs`.

## Seal-time grading (the substrate-honest reading of the spec)

Prominence is decided exactly once, when a block is painted/sealed, and never re-graded — print-once history cannot repaint scrollback. A block sealed during its own turn seals at 1.0 and does NOT fade when the next turn starts; the fade ladder is visible wherever multiple turns paint in one pass, while incrementally sealed history keeps its seal-time grade forever. Stated plainly in the moduledoc.

## Wiring

One alias + the body of one private function (`render_block_lines/3` — the single place block render context is built, called from `seal_block/2`, so the grade computed there IS the seal-time grade). 10-line additive diff. Needs-input promotion required zero policy code: Block auto-passes `needs_input: true` for live approvals and the merged prominence floor (0.6) + accent engage — approval outranks the ladder by composition, proven by a named end-to-end test.

## Verification

Red-first: 9 failed / 2 passed before the module and wiring existed (incl. the wiring test failing on the absent seal-time fade fragment in real sealed bytes). 14 policy tests: ladder table, five-turn grade `[0.4, 0.4, 0.6, 0.8, 1.0]`, unknown-turn fallbacks, five-turn fixture rendering the ladder byte-exact against the solver (newest block asserted SGR-free), live-approval-outranks-tier, and a surface seal-time test observing grade 0.8 in real sealed bytes. Harness suites 1134/1134; full suite 6107/6113 (all 6 pre-existing flakes, 5 pass on rerun). Golden snapshots unchanged — no bless needed. Warnings + format clean.

## Documented follow-up

The expanded rich-body components (BodyProvider path) don't yet thread `context[:prominence]` — pre-existing gap, honestly stated in the moduledoc's "Coverage today" section; the grade is already present in their context for when they grow support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)