### PR TITLE
Harness UI: stable-prefix streaming markdown (O(N^2) -> O(N))

### DIFF
--- a/lib/raxol/ui/components/harness/markdown_body.ex
+++ b/lib/raxol/ui/components/harness/markdown_body.ex
@@ -19,20 +19,31 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody.Checkpoint do
     whenever non-empty).
   - `width` -- the width the frozen elements were rendered at; a change
     invalidates the checkpoint (frozen elements are width-dependent).
+  - `open_fence` -- `nil` when the frozen prefix ends balanced (no fence
+    open), or `{opener_line, drop_count}` when it ends INSIDE a still-open
+    fence eligible for content freezing: `opener_line` is the sanitized
+    opener line verbatim (no trailing newline), and `drop_count` is the
+    number of leading elements (`fenced_code_elements/2`'s blank plus an
+    optional language label) that a fresh re-parse of just `opener_line`
+    would produce before its first content element -- structurally
+    coupled to `MarkdownRenderer.fenced_code_elements/2`'s element shape;
+    the stable-prefix property tests guard this coupling.
   """
 
   defstruct frozen_byte_offset: 0,
             frozen_elements: [],
             raw_prefix: "",
             sanitized_prefix: "",
-            width: nil
+            width: nil,
+            open_fence: nil
 
   @type t :: %__MODULE__{
           frozen_byte_offset: non_neg_integer(),
           frozen_elements: [map()],
           raw_prefix: binary(),
           sanitized_prefix: binary(),
-          width: pos_integer() | nil
+          width: pos_integer() | nil,
+          open_fence: {String.t(), pos_integer()} | nil
         }
 end
 
@@ -130,7 +141,13 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
   element-for-element, at every prefix. The full re-parse remains the
   correctness oracle; the checkpoint only changes how much work gets
   redone, never what the result is. `new_checkpoint/0` builds the initial
-  (empty) checkpoint; `nil` is also accepted as fresh.
+  (empty) checkpoint; `nil` is also accepted as fresh. Per delta, PARSE
+  work is O(live tail); assembling the returned view is Theta(total
+  elements) regardless -- a flat `:children` list equal to the full
+  parse must be materialized, and `frozen ++ tail` recopies the frozen
+  spine -- and each freeze recopies the frozen-elements list once. The
+  optimization removes the quadratic PARSE term; the element-list terms
+  are inherent to the view contract and dwarfed by parsing in practice.
 
   ### The checkpoint rule
 
@@ -142,9 +159,16 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
     matching-marker fence machine AND provisional-close's trimmed-prefix
     fence machine must be closed. A fence parser is forward-only: once a
     matching-marker line closes it, no later byte can reopen it, so a
-    closed fence's extent is permanently fixed -- but an OPEN fence's
-    extent is not yet known, so nothing inside or at its still-open
-    boundary may freeze.
+    closed fence's extent is permanently fixed. An open fence's committed
+    CONTENT lines are themselves immutable (each maps to exactly one code
+    element, appended in order; only the block's trailing blank line
+    moves), so they freeze too -- provided the fence was opened by a
+    raw-prefix marker line with an empty inline scan stack (both fence
+    machines in sync, no live inline frame whose erasure could cross the
+    fence) and at least one content line has been committed (a
+    zero-content fence block has no stable element prefix). An indented
+    opener or closer desynchronizes the two machines and blocks all
+    freezing until they re-sync.
   - **table** -- the line immediately before the boundary must contain no
     `"|"`. A committed `"|"`-line can still become a table HEADER once
     the next line arrives (the header+separator lookahead is 2 lines),
@@ -168,6 +192,26 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
     preserves both `"\\r"` and `"\\n"`, so a CRLF split lands like any
     other chunk boundary.
 
+  ### Scope of the immutability proof
+
+  The proof above is relative to the BUILTIN line-local grammar
+  (`MarkdownRenderer.render_with_builtin/2`) -- the oracle deliberately
+  has no setext headings, link-reference definitions, lazy continuation,
+  or list tightness; each line parses independently, and the only
+  multi-line constructs are fences and tables. Against a full CommonMark
+  parser the boundary rule would be UNSOUND (a later `===` line, a
+  reference definition, or lazy continuation can rewrite earlier
+  output). That is exactly why `render_streaming_incremental/3` delegates
+  to the full render whenever `EarmarkParser` is loadable (dev pulls it
+  via ex_doc; downstream consumers often load earmark): the frozen
+  elements come from the builtin parser, but the full render prefers
+  Earmark there, so the two could disagree. In such environments the
+  optimization is intentionally inert -- behavior is exactly the
+  pre-optimization full re-parse. Forcing the builtin renderer everywhere
+  would instead make streaming and sealed renders disagree in
+  Earmark-loaded environments (a visible reformat at seal time), which is
+  worse than a missing optimization.
+
   ### Cap interaction
 
   The 256KB cap (`@render_byte_cap`) applies to the TOTAL sanitized text
@@ -187,13 +231,20 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
   checkpoint and a full parse -- the output is always oracle-correct,
   never corrupted by a misused checkpoint.
 
-  ### Garbage degradation
+  ### Residual degradations
 
-  A genuinely-invalid byte permanently blocks the checkpoint from
-  advancing past it (the UTF-8 rule above), so a message containing
-  arbitrary garbage degrades to the pre-optimization behavior: a full
-  re-parse of the accumulated text on every delta, still capped at
-  `@render_byte_cap` bytes like any other streaming render.
+  Two shapes still degrade to the pre-optimization full re-parse (still
+  capped at `@render_byte_cap` bytes like any other streaming render):
+
+  - **garbage bytes** -- a genuinely-invalid byte permanently blocks the
+    checkpoint from advancing past it (the UTF-8 rule above), so a
+    message containing arbitrary garbage degrades to a full re-parse of
+    the accumulated text on every delta.
+  - **newline-free content** -- a single ever-growing line has no
+    committed line boundary, and mid-line freezing is semantically
+    impossible (the line's own wrapping/emphasis-pairing/table detection
+    changes as it grows), so it also degrades to the capped full
+    re-parse.
 
   ### Follow-up seam
 
@@ -353,64 +404,244 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
       closed_total = cp.sanitized_prefix <> sanitized_tail
       {fallback_view(closed_total), new_checkpoint()}
     else
-      closed_tail = do_provisional_close(sanitized_tail)
+      render_incremental_tail(cp, text, raw_tail, sanitized_tail, width)
+    end
+  end
 
-      if byte_size(cp.sanitized_prefix) + byte_size(closed_tail) >
-           @render_byte_cap do
-        {fallback_view(cp.sanitized_prefix <> closed_tail), new_checkpoint()}
-      else
-        tail_elements = MarkdownRenderer.render_with_builtin(closed_tail, width)
+  defp render_incremental_tail(
+         %Checkpoint{open_fence: nil} = cp,
+         text,
+         raw_tail,
+         sanitized_tail,
+         width
+       ) do
+    closed_tail = do_provisional_close(sanitized_tail)
 
-        view = %{
-          type: :column,
-          children: cp.frozen_elements ++ tail_elements,
-          style: %{},
-          gap: 0
-        }
+    if byte_size(cp.sanitized_prefix) + byte_size(closed_tail) >
+         @render_byte_cap do
+      {fallback_view(cp.sanitized_prefix <> closed_tail), new_checkpoint()}
+    else
+      tail_elements = MarkdownRenderer.render_with_builtin(closed_tail, width)
 
-        new_cp = advance_checkpoint(cp, text, raw_tail, sanitized_tail, width)
-        {view, new_cp}
-      end
+      view = %{
+        type: :column,
+        children: cp.frozen_elements ++ tail_elements,
+        style: %{},
+        gap: 0
+      }
+
+      new_cp = advance_checkpoint(cp, text, raw_tail, sanitized_tail, width)
+      {view, new_cp}
+    end
+  end
+
+  defp render_incremental_tail(
+         %Checkpoint{open_fence: {opener, drop}} = cp,
+         text,
+         raw_tail,
+         sanitized_tail,
+         width
+       ) do
+    synthetic = opener <> "\n" <> sanitized_tail
+    closed_syn = do_provisional_close(synthetic)
+
+    # Safe: `do_provisional_close/1` never edits the opener line itself
+    # (`strip_ambiguous_fence_opener/1` only ever touches the LAST line,
+    # and a fence-tagged line is otherwise copied byte-for-byte; the
+    # fence closer, if appended, lands at the very END) -- so the first
+    # `byte_size(opener) + 1` bytes of `closed_syn` are byte-identical to
+    # `synthetic`'s own prefix, and slicing them off recovers exactly the
+    # closed FORM of the live tail, keeping cap accounting byte-exact
+    # against the oracle (which closes the same tail from the same
+    # opener, just via the full accumulated prefix instead of this
+    # reconstruction).
+    closed_tail_equiv =
+      binary_part(
+        closed_syn,
+        byte_size(opener) + 1,
+        byte_size(closed_syn) - byte_size(opener) - 1
+      )
+
+    if byte_size(cp.sanitized_prefix) + byte_size(closed_tail_equiv) >
+         @render_byte_cap do
+      {fallback_view(cp.sanitized_prefix <> closed_tail_equiv),
+       new_checkpoint()}
+    else
+      tail_elements =
+        closed_syn
+        |> MarkdownRenderer.render_with_builtin(width)
+        |> Enum.drop(drop)
+        |> drop_zero_content_phantom(opener, sanitized_tail)
+
+      view = %{
+        type: :column,
+        children: cp.frozen_elements ++ tail_elements,
+        style: %{},
+        gap: 0
+      }
+
+      new_cp = advance_checkpoint(cp, text, raw_tail, sanitized_tail, width)
+      {view, new_cp}
     end
   end
 
   defp advance_checkpoint(cp, text, raw_tail, sanitized_tail, width) do
     lines = String.split(sanitized_tail, "\n")
     complete_line_count = length(lines) - 1
+    initial_state = initial_scan_state(cp.open_fence)
 
-    case find_safe_boundary(lines, complete_line_count, raw_tail) do
+    case find_safe_boundary(lines, complete_line_count, raw_tail, initial_state) do
       nil ->
         cp
 
-      {raw_delta, san_delta} ->
+      {raw_delta, san_delta, mode} ->
         segment_sanitized = binary_part(sanitized_tail, 0, san_delta)
         seg_parse_text = binary_part(segment_sanitized, 0, san_delta - 1)
 
+        {prefix_text, drop_count} =
+          case cp.open_fence do
+            nil -> {"", 0}
+            {opener, drop} -> {opener <> "\n", drop}
+          end
+
+        full_seg_text = prefix_text <> seg_parse_text
+
         seg_elements =
-          MarkdownRenderer.render_with_builtin(seg_parse_text, width)
+          full_seg_text
+          |> MarkdownRenderer.render_with_builtin(width)
+          |> Enum.drop(drop_count)
+          |> drop_zero_content_phantom_segment(cp.open_fence, segment_sanitized)
+          |> drop_open_fence_trailing_blank(mode)
+
+        new_open_fence =
+          case mode do
+            {:fence, opener} -> {opener, fence_drop_count(opener, width)}
+            :normal -> nil
+          end
 
         %Checkpoint{
           frozen_byte_offset: cp.frozen_byte_offset + raw_delta,
           frozen_elements: cp.frozen_elements ++ seg_elements,
           raw_prefix: binary_part(text, 0, cp.frozen_byte_offset + raw_delta),
           sanitized_prefix: cp.sanitized_prefix <> segment_sanitized,
-          width: width
+          width: width,
+          open_fence: new_open_fence
         }
     end
   end
 
+  defp initial_scan_state(nil), do: {false, false, [], nil}
+
+  defp initial_scan_state({opener, _drop}) do
+    marker = raw_fence_marker_of(opener)
+    {marker, marker, [], opener}
+  end
+
+  # The trailing blank line of an OPEN fence's `fenced_code_elements/2`
+  # output moves as content grows, so it must never freeze -- drop it
+  # from a segment that ENTERS the next call still inside the (same or a
+  # newly-opened) fence. A segment that closes the fence (`:normal`)
+  # keeps every element: a closed fence's trailing blank is permanently
+  # fixed, exactly like any other closed construct.
+  defp drop_open_fence_trailing_blank(seg_elements, {:fence, _opener}),
+    do: Enum.drop(seg_elements, -1)
+
+  defp drop_open_fence_trailing_blank(seg_elements, :normal), do: seg_elements
+
+  # ZERO-CONTENT PHANTOM guard for the checkpoint-advance path. When this
+  # segment enters an ALREADY-open fence (`cp.open_fence != nil`) and its
+  # own newly-committed lines close that fence on their very FIRST line
+  # (zero real content lines of its own -- the rest of the block's
+  # content already lives in `cp.frozen_elements`, invisible to this
+  # local re-parse of just `opener <> segment`), `fenced_code_elements/2`
+  # still fabricates one spurious `"  "` element from `"" |> String.split
+  # ("\n")`. Drop it. A segment whose first line is itself a real (even
+  # blank) content line before any close is unaffected -- `fenced_
+  # code_elements/2`'s single `"  "` for a genuine blank content line
+  # must NOT be dropped.
+  defp drop_zero_content_phantom_segment(seg_elements, nil, _segment_sanitized),
+    do: seg_elements
+
+  defp drop_zero_content_phantom_segment(
+         seg_elements,
+         {opener, _drop},
+         segment_sanitized
+       ) do
+    marker = raw_fence_marker_of(opener)
+    body_lines = String.split(segment_sanitized, "\n")
+
+    if fence_zero_own_content?(marker, body_lines) do
+      Enum.drop(seg_elements, 1)
+    else
+      seg_elements
+    end
+  end
+
+  # Same guard as `drop_zero_content_phantom_segment/3`, for the VIEW
+  # path (`render_incremental_tail/5`'s fence branch): `sanitized_tail`
+  # here is the live (not-yet-frozen) tail, and its first line -- even a
+  # still-partial one with no trailing `"\n"` yet -- is what determines
+  # whether `do_provisional_close/1`'s fence scan treats this fence as
+  # closing: that scan matches a closer via `fence_marker_of/1` on
+  # WHATEVER line sits there, complete or not (it has no notion of
+  # "committed" the way `find_safe_boundary/4` does), so an in-progress
+  # `` ``` `` typed as the very first new line closes the reconstruction
+  # exactly as it would close a genuinely-final one.
+  defp drop_zero_content_phantom(tail_elements, opener, sanitized_tail) do
+    marker = raw_fence_marker_of(opener)
+    body_lines = String.split(sanitized_tail, "\n")
+
+    if fence_zero_own_content?(marker, body_lines) do
+      Enum.drop(tail_elements, 1)
+    else
+      tail_elements
+    end
+  end
+
+  # `true` iff `body_lines` (a fence's OWN newly-reconstructed content
+  # lines, split by "\n", EXCLUDING the opener) closes the fence at its
+  # very FIRST line -- contributing zero real content lines of its own
+  # before the close. `take_until_fence/3` (the renderer's fence content
+  # scanner) recognizes a closer via a RAW `String.starts_with?/2` check
+  # against the exact opening marker, so this mirrors that exactly;
+  # `do_provisional_close/1`'s own fence scan uses the equivalent
+  # trimmed-prefix check (`fence_marker_of/1`), which agrees with the raw
+  # check whenever the marker itself is raw-prefix (guaranteed here,
+  # since `open_fence` is only ever set for a raw-prefix-eligible
+  # opener -- see the checkpoint rule's fence bullet).
+  defp fence_zero_own_content?(_marker, []), do: false
+
+  defp fence_zero_own_content?(marker, [first | _]),
+    do: String.starts_with?(first, marker)
+
+  # Probes the element shape of a fresh, standalone parse of just
+  # `opener_line` (no trailing newline) to derive how many LEADING
+  # elements (`fenced_code_elements/2`'s blank, plus an optional language
+  # label) precede its first content element. Parsing `opener_line`
+  # alone yields `[blank, label?, <one phantom content element from the
+  # zero-content parse>, blank]` -- length minus 2 is exactly the leading
+  # count. Structurally coupled to `fenced_code_elements/2`'s element
+  # shape; the stable-prefix equivalence property tests guard this
+  # coupling against drift.
+  defp fence_drop_count(opener_line, width) do
+    length(MarkdownRenderer.render_with_builtin(opener_line, width)) - 2
+  end
+
   # Finds the LAST safe boundary among `sanitized_tail`'s complete lines
   # (the first `complete_line_count` entries of `lines` -- the final,
-  # still-partial line is never a candidate). Threads four pieces of
-  # state left-to-right, all starting clean per the invariant that the
-  # frozen prefix always ends balanced: the renderer's raw-prefix fence
-  # machine, provisional-close's trimmed-prefix fence machine, and the
-  # inline scan stack (updated only on lines the trimmed machine tags
-  # `:prose`). Returns `{raw_delta, san_delta}` for the winning candidate
-  # or `nil` if none survive.
-  defp find_safe_boundary(_lines, 0, _raw_tail), do: nil
+  # still-partial line is never a candidate). Threads scan state
+  # left-to-right, seeded from `initial_state` (derived from the
+  # checkpoint's `open_fence`, so a fence already open in the frozen
+  # prefix carries forward rather than restarting clean): the renderer's
+  # raw-prefix fence machine, provisional-close's trimmed-prefix fence
+  # machine, the inline scan stack (updated only on lines the trimmed
+  # machine tags `:prose`), and the still-open fence's ELIGIBLE opener
+  # line (or `nil`). Returns `{raw_delta, san_delta, mode}` for the
+  # winning candidate -- `mode` is `:normal` or `{:fence, opener_line}`
+  # -- or `nil` if none survive.
+  defp find_safe_boundary(_lines, 0, _raw_tail, _initial_state), do: nil
 
-  defp find_safe_boundary(lines, complete_line_count, raw_tail) do
+  defp find_safe_boundary(lines, complete_line_count, raw_tail, initial_state) do
     {valid_prefix, _rest} = longest_valid_utf8_prefix(raw_tail)
     max_raw_delta = byte_size(valid_prefix)
 
@@ -427,16 +658,22 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
       lines
       |> Enum.take(complete_line_count)
       |> Enum.zip(raw_newline_positions)
-      |> Enum.reduce({{false, false, []}, nil, 0}, fn {line, raw_pos},
-                                                      {state, best, san_offset} ->
-        {new_state, safe?} = step_scan_state(state, line)
+      |> Enum.reduce({initial_state, nil, 0}, fn {line, raw_pos},
+                                                 {state, best, san_offset} ->
+        {new_state, candidate} = step_scan_state(state, line)
         san_offset = san_offset + byte_size(line) + 1
         raw_delta = raw_pos + 1
 
         best =
-          if safe? and raw_delta <= max_raw_delta,
-            do: {raw_delta, san_offset},
-            else: best
+          case candidate do
+            nil ->
+              best
+
+            mode ->
+              if raw_delta <= max_raw_delta,
+                do: {raw_delta, san_offset, mode},
+                else: best
+          end
 
         {new_state, best, san_offset}
       end)
@@ -444,7 +681,24 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
     best
   end
 
-  defp step_scan_state({m1, m2, stack}, line) do
+  # One line's contribution to the four-part scan state `{m1, m2, stack,
+  # eligible}`: `m1` is provisional-close's TRIMMED-prefix fence machine
+  # (via `fence_marker_of/1`, same as `fence_scan/1`), `m2` is the
+  # renderer's RAW-prefix machine (via `raw_fence_marker_of/1`, same as
+  # `parse_blocks`/`take_until_fence`), `stack` is the inline
+  # scan stack, and `eligible` is the still-open fence's opener line (or
+  # `nil`) -- set only when a fence opens IN SYNC (raw-prefix, both
+  # machines agreeing, empty inline stack going in), carried forward
+  # unchanged while the SAME fence stays open, and cleared the instant
+  # either machine closes.
+  #
+  # Returns `{new_state, candidate}` where `candidate` is `nil` (no safe
+  # boundary at this line), `:normal` (both fence machines closed, no
+  # live inline state, no pipe -- the existing boundary rule), or
+  # `{:fence, opener}` (this line is a committed CONTENT line of a still-
+  # open, eligible fence -- safe to freeze because every such line maps
+  # to exactly one immutable code element, appended in order).
+  defp step_scan_state({m1, m2, stack, eligible}, line) do
     {new_m1, tag1} = fence_step(m1, fence_marker_of(line))
     {new_m2, _tag2} = fence_step(m2, raw_fence_marker_of(line))
 
@@ -455,11 +709,38 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
         stack
       end
 
-    safe? =
-      new_m1 == false and new_m2 == false and new_stack == [] and
-        not String.contains?(line, "|")
+    new_eligible =
+      cond do
+        new_m1 == false ->
+          nil
 
-    {{new_m1, new_m2, new_stack}, safe?}
+        m1 == false ->
+          if m2 == false and new_m2 == new_m1 and
+               raw_fence_marker_of(line) == new_m1 and stack == [] do
+            line
+          else
+            nil
+          end
+
+        true ->
+          eligible
+      end
+
+    candidate =
+      cond do
+        new_m1 == false and new_m2 == false and new_stack == [] and
+            not String.contains?(line, "|") ->
+          :normal
+
+        m1 != false and new_eligible != nil and new_m1 == m1 and
+            new_stack == [] ->
+          {:fence, new_eligible}
+
+        true ->
+          nil
+      end
+
+    {{new_m1, new_m2, new_stack, new_eligible}, candidate}
   end
 
   # The renderer's own fence detector (`parse_blocks`/`take_until_fence`)

--- a/lib/raxol/ui/components/harness/markdown_body.ex
+++ b/lib/raxol/ui/components/harness/markdown_body.ex
@@ -1,3 +1,41 @@
+defmodule Raxol.UI.Components.Harness.MarkdownBody.Checkpoint do
+  @moduledoc """
+  Carries the frozen (already-parsed) prefix across successive calls to
+  `Raxol.UI.Components.Harness.MarkdownBody.render_streaming_incremental/3`.
+
+  All fields are private implementation state -- callers should treat this
+  as an opaque token: create one via `MarkdownBody.new_checkpoint/0`, thread
+  it through successive `render_streaming_incremental/3` calls, and never
+  construct or inspect the fields directly.
+
+  - `frozen_byte_offset` -- raw byte offset into the caller's accumulated
+    text, always sitting just past a committed `"\\n"` (never inside a
+    line still being typed).
+  - `frozen_elements` -- the already-rendered elements for the frozen
+    prefix; a genuine prefix of every subsequent view's `:children`.
+  - `raw_prefix` -- the exact raw bytes frozen so far, used to detect a
+    non-extending (stale/misused) `text` argument on the next call.
+  - `sanitized_prefix` -- `to_text/1` of `raw_prefix` (ends with `"\\n"`
+    whenever non-empty).
+  - `width` -- the width the frozen elements were rendered at; a change
+    invalidates the checkpoint (frozen elements are width-dependent).
+  """
+
+  defstruct frozen_byte_offset: 0,
+            frozen_elements: [],
+            raw_prefix: "",
+            sanitized_prefix: "",
+            width: nil
+
+  @type t :: %__MODULE__{
+          frozen_byte_offset: non_neg_integer(),
+          frozen_elements: [map()],
+          raw_prefix: binary(),
+          sanitized_prefix: binary(),
+          width: pos_integer() | nil
+        }
+end
+
 defmodule Raxol.UI.Components.Harness.MarkdownBody do
   @moduledoc """
   Renders a message/reasoning block's Markdown content for the harness
@@ -82,17 +120,91 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
   escape handling would need to thread an "escaped" flag through the
   scan; left as a documented gap rather than expanded scope here.
 
-  ## Follow-up seam: stable-prefix optimization
+  ## Stable-prefix streaming (incremental render)
 
-  Today every streaming delta re-parses the FULL accumulated text (byte-
-  capped at 256KB -- see `@render_byte_cap` below). A follow-up unit
-  could instead cache the parse of the longest durable prefix (the text
-  up to the last committed line boundary, which never changes as more
-  deltas arrive) and re-parse only the live tail on each delta.
-  Documented here as a known optimization opportunity, not implemented --
-  this module's current correctness does not depend on it.
+  `render_streaming_incremental/3` is the O(live tail) alternative to
+  re-parsing the FULL accumulated text on every delta: it accepts the
+  full accumulated text, a `width`, and a `Checkpoint` carried from the
+  previous call, and returns `{view, checkpoint}` where `view` is EXACTLY
+  what `render(text, %{mode: :streaming, width: width})` would return --
+  element-for-element, at every prefix. The full re-parse remains the
+  correctness oracle; the checkpoint only changes how much work gets
+  redone, never what the result is. `new_checkpoint/0` builds the initial
+  (empty) checkpoint; `nil` is also accepted as fresh.
+
+  ### The checkpoint rule
+
+  A candidate boundary sits just past a committed `"\\n"` (the still-
+  growing last line is never frozen). A boundary is safe only when ALL of
+  these hold, each protecting a specific construct's immutability:
+
+  - **fence** -- both the renderer's raw-prefix ```` ``` ````/`~~~`
+    matching-marker fence machine AND provisional-close's trimmed-prefix
+    fence machine must be closed. A fence parser is forward-only: once a
+    matching-marker line closes it, no later byte can reopen it, so a
+    closed fence's extent is permanently fixed -- but an OPEN fence's
+    extent is not yet known, so nothing inside or at its still-open
+    boundary may freeze.
+  - **table** -- the line immediately before the boundary must contain no
+    `"|"`. A committed `"|"`-line can still become a table HEADER once
+    the next line arrives (the header+separator lookahead is 2 lines),
+    and a still-absorbing table re-derives column widths over ALL rows,
+    so a later row can rewrite an earlier row's rendered text. Excluding
+    every pipe-containing line from being the boundary's last line rules
+    out both hazards at once.
+  - **inline** -- the provisional-close scan stack must be empty. An
+    unclosed `` **`` / `*` / `` ` `` / `[` on a committed line receives
+    erasures/closers from LATER lines (`resolve_inline_close/1` looks at
+    the tail of the whole prose run), so a boundary with live inline
+    state is not stable.
+  - **single-line constructs** (headings, hr, blockquote, list items,
+    plain paragraphs) are immutable the moment their `"\\n"` arrives --
+    this grammar nests only via fences and tables, both covered above.
+  - **UTF-8** -- the frozen raw segment must be valid UTF-8 on its own
+    (bounded by the longest valid UTF-8 prefix of the live tail). Whole-
+    buffer Latin-1 recovery (`recover_utf8/1`) is not tail-composable, so
+    a boundary past a genuinely-invalid byte would freeze the wrong
+    (recovered) bytes. `"\\r"` needs no special handling: sanitize
+    preserves both `"\\r"` and `"\\n"`, so a CRLF split lands like any
+    other chunk boundary.
+
+  ### Cap interaction
+
+  The 256KB cap (`@render_byte_cap`) applies to the TOTAL sanitized text
+  (frozen prefix + live tail), matching the full re-parse's own cap
+  check. Above it, the view is the same plain-text fallback the full
+  re-parse would produce, and the checkpoint RESETS to fresh -- the next
+  call re-derives everything from scratch rather than growing an
+  unbounded frozen-elements list past the cap.
+
+  ### Misuse guard
+
+  `text` must be an append-only extension of the previous call's `text`
+  at the same `width`; `render_streaming_incremental/3` verifies this by
+  byte-comparing the accumulated text's prefix against the checkpoint's
+  own frozen raw bytes. A width change or a non-extending `text` (stale
+  checkpoint reused against unrelated content) resets to a fresh
+  checkpoint and a full parse -- the output is always oracle-correct,
+  never corrupted by a misused checkpoint.
+
+  ### Garbage degradation
+
+  A genuinely-invalid byte permanently blocks the checkpoint from
+  advancing past it (the UTF-8 rule above), so a message containing
+  arbitrary garbage degrades to the pre-optimization behavior: a full
+  re-parse of the accumulated text on every delta, still capped at
+  `@render_byte_cap` bytes like any other streaming render.
+
+  ### Follow-up seam
+
+  `render/2` and `render_streaming/2` are unchanged -- nothing here
+  alters sealed or full-streaming rendering. Wiring a caller (e.g.
+  `BodyProvider`) to actually carry a `Checkpoint` across deltas, instead
+  of calling `render_streaming/2` fresh each time, is the follow-up seam
+  this module leaves open.
   """
 
+  alias __MODULE__.Checkpoint
   alias Raxol.UI.Components.MarkdownRenderer
   alias Raxol.View.Components
 
@@ -158,6 +270,209 @@ defmodule Raxol.UI.Components.Harness.MarkdownBody do
   @spec render_streaming(term(), pos_integer()) :: map()
   def render_streaming(markdown_text, width) do
     markdown_text |> to_text() |> provisional_close() |> render_via(width)
+  end
+
+  @doc """
+  A fresh, empty `Checkpoint` -- the starting point for a new streamed
+  message. Also see the `nil` shorthand accepted by
+  `render_streaming_incremental/3`.
+  """
+  @spec new_checkpoint() :: Checkpoint.t()
+  def new_checkpoint, do: %Checkpoint{}
+
+  @doc """
+  Incremental streaming render: `text` is the FULL accumulated text
+  (append-only across deltas -- never just the newest chunk), `width` is
+  the render width, and `checkpoint` is the `Checkpoint` returned by the
+  previous call (or `nil`/`new_checkpoint/0` for the first call).
+
+  Returns `{view, checkpoint}`. `view` is always exactly what
+  `render(text, %{mode: :streaming, width: width})` would return; the
+  checkpoint only changes how much of `text` gets re-parsed, never the
+  result. Never raises. See the moduledoc's "Stable-prefix streaming"
+  section for the full checkpoint rule.
+  """
+  @spec render_streaming_incremental(
+          term(),
+          pos_integer(),
+          Checkpoint.t() | nil
+        ) ::
+          {map(), Checkpoint.t()}
+  def render_streaming_incremental(text, width, checkpoint) do
+    do_render_streaming_incremental(text, width, checkpoint)
+  rescue
+    _ -> {render(text, %{mode: :streaming, width: width}), new_checkpoint()}
+  end
+
+  defp do_render_streaming_incremental(text, width, _checkpoint)
+       when not is_binary(text) do
+    {render(text, %{mode: :streaming, width: width}), new_checkpoint()}
+  end
+
+  defp do_render_streaming_incremental(text, width, checkpoint) do
+    if Code.ensure_loaded?(EarmarkParser) do
+      {render(text, %{mode: :streaming, width: width}), new_checkpoint()}
+    else
+      cp = validate_checkpoint(checkpoint, width, text)
+      incremental_render(text, width, cp)
+    end
+  end
+
+  defp validate_checkpoint(nil, _width, _text), do: new_checkpoint()
+
+  defp validate_checkpoint(%Checkpoint{} = cp, width, text) do
+    cond do
+      cp.width != width ->
+        new_checkpoint()
+
+      byte_size(text) < cp.frozen_byte_offset ->
+        new_checkpoint()
+
+      binary_part(text, 0, cp.frozen_byte_offset) != cp.raw_prefix ->
+        new_checkpoint()
+
+      true ->
+        cp
+    end
+  end
+
+  defp validate_checkpoint(_other, _width, _text), do: new_checkpoint()
+
+  defp incremental_render(text, width, cp) do
+    raw_tail =
+      binary_part(
+        text,
+        cp.frozen_byte_offset,
+        byte_size(text) - cp.frozen_byte_offset
+      )
+
+    sanitized_tail = to_text(raw_tail)
+    s_total_size = byte_size(cp.sanitized_prefix) + byte_size(sanitized_tail)
+
+    if s_total_size > @render_byte_cap do
+      closed_total = cp.sanitized_prefix <> sanitized_tail
+      {fallback_view(closed_total), new_checkpoint()}
+    else
+      closed_tail = do_provisional_close(sanitized_tail)
+
+      if byte_size(cp.sanitized_prefix) + byte_size(closed_tail) >
+           @render_byte_cap do
+        {fallback_view(cp.sanitized_prefix <> closed_tail), new_checkpoint()}
+      else
+        tail_elements = MarkdownRenderer.render_with_builtin(closed_tail, width)
+
+        view = %{
+          type: :column,
+          children: cp.frozen_elements ++ tail_elements,
+          style: %{},
+          gap: 0
+        }
+
+        new_cp = advance_checkpoint(cp, text, raw_tail, sanitized_tail, width)
+        {view, new_cp}
+      end
+    end
+  end
+
+  defp advance_checkpoint(cp, text, raw_tail, sanitized_tail, width) do
+    lines = String.split(sanitized_tail, "\n")
+    complete_line_count = length(lines) - 1
+
+    case find_safe_boundary(lines, complete_line_count, raw_tail) do
+      nil ->
+        cp
+
+      {raw_delta, san_delta} ->
+        segment_sanitized = binary_part(sanitized_tail, 0, san_delta)
+        seg_parse_text = binary_part(segment_sanitized, 0, san_delta - 1)
+
+        seg_elements =
+          MarkdownRenderer.render_with_builtin(seg_parse_text, width)
+
+        %Checkpoint{
+          frozen_byte_offset: cp.frozen_byte_offset + raw_delta,
+          frozen_elements: cp.frozen_elements ++ seg_elements,
+          raw_prefix: binary_part(text, 0, cp.frozen_byte_offset + raw_delta),
+          sanitized_prefix: cp.sanitized_prefix <> segment_sanitized,
+          width: width
+        }
+    end
+  end
+
+  # Finds the LAST safe boundary among `sanitized_tail`'s complete lines
+  # (the first `complete_line_count` entries of `lines` -- the final,
+  # still-partial line is never a candidate). Threads four pieces of
+  # state left-to-right, all starting clean per the invariant that the
+  # frozen prefix always ends balanced: the renderer's raw-prefix fence
+  # machine, provisional-close's trimmed-prefix fence machine, and the
+  # inline scan stack (updated only on lines the trimmed machine tags
+  # `:prose`). Returns `{raw_delta, san_delta}` for the winning candidate
+  # or `nil` if none survive.
+  defp find_safe_boundary(_lines, 0, _raw_tail), do: nil
+
+  defp find_safe_boundary(lines, complete_line_count, raw_tail) do
+    {valid_prefix, _rest} = longest_valid_utf8_prefix(raw_tail)
+    max_raw_delta = byte_size(valid_prefix)
+
+    raw_newline_positions =
+      raw_tail
+      |> :binary.matches("\n")
+      |> Enum.map(fn {pos, _len} -> pos end)
+
+    # Zip pairs the i-th complete sanitized line with the i-th raw "\n"
+    # position -- a 1:1 correspondence (sanitize never touches "\n", and
+    # UTF-8 recovery neither drops nor invents a 0x0A byte), and O(1) per
+    # line where an indexed lookup would be O(i).
+    {_final_state, best, _san_offset} =
+      lines
+      |> Enum.take(complete_line_count)
+      |> Enum.zip(raw_newline_positions)
+      |> Enum.reduce({{false, false, []}, nil, 0}, fn {line, raw_pos},
+                                                      {state, best, san_offset} ->
+        {new_state, safe?} = step_scan_state(state, line)
+        san_offset = san_offset + byte_size(line) + 1
+        raw_delta = raw_pos + 1
+
+        best =
+          if safe? and raw_delta <= max_raw_delta,
+            do: {raw_delta, san_offset},
+            else: best
+
+        {new_state, best, san_offset}
+      end)
+
+    best
+  end
+
+  defp step_scan_state({m1, m2, stack}, line) do
+    {new_m1, tag1} = fence_step(m1, fence_marker_of(line))
+    {new_m2, _tag2} = fence_step(m2, raw_fence_marker_of(line))
+
+    new_stack =
+      if tag1 == :prose do
+        scan_markers(String.graphemes(line), 0, stack)
+      else
+        stack
+      end
+
+    safe? =
+      new_m1 == false and new_m2 == false and new_stack == [] and
+        not String.contains?(line, "|")
+
+    {{new_m1, new_m2, new_stack}, safe?}
+  end
+
+  # The renderer's own fence detector (`parse_blocks`/`take_until_fence`)
+  # matches the RAW line, no leading-whitespace trim -- unlike
+  # `fence_marker_of/1` (provisional-close's trimmed version). Kept
+  # separate because the two parsers can (and, per the directed hazard
+  # tests, do) disagree on indented fence markers.
+  defp raw_fence_marker_of(line) do
+    cond do
+      String.starts_with?(line, "```") -> "```"
+      String.starts_with?(line, "~~~") -> "~~~"
+      true -> nil
+    end
   end
 
   # Above this byte size, rendering skips the parse entirely and falls

--- a/test/raxol/ui/components/harness/markdown_body_stable_prefix_test.exs
+++ b/test/raxol/ui/components/harness/markdown_body_stable_prefix_test.exs
@@ -258,8 +258,8 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  describe "boundary hazard: open fence — no boundary inside an unterminated fence" do
-    test "the checkpoint holds at the fence opener until the matching closer arrives" do
+  describe "boundary hazard: open fence — committed content lines freeze; the still-open frame does not" do
+    test "a still-open fence freezes each committed content line, and closing resumes normal freezing" do
       opener = "```\n"
       chunks = [opener, "code | with pipe\n", "**not bold**\n", "```\n", "\n"]
 
@@ -268,17 +268,26 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
       offsets =
         Enum.map(steps, fn {_acc, _view, cp} -> cp.frozen_byte_offset end)
 
-      # while the fence is open (steps 1..3) nothing freezes...
-      assert Enum.take(offsets, 3) == [0, 0, 0],
-             "checkpoint advanced inside an open fence: #{inspect(offsets)}"
+      # after the opener alone there is no committed CONTENT line yet --
+      # nothing to freeze (the zero-content fence block has no stable
+      # element prefix).
+      assert hd(offsets) == 0,
+             "froze at a fence opener with no content: #{inspect(offsets)}"
 
-      # ...and once the matching closer has arrived, the closed fence
-      # block becomes freezable.
-      assert List.last(offsets) > 0,
-             "checkpoint never advanced after the fence closed: #{inspect(offsets)}"
+      # each committed content line inside the still-open fence freezes
+      # (pipes and markers inside fence content are inert -- both parse
+      # stages treat them as literal code).
+      assert Enum.at(offsets, 1) > 0,
+             "a committed fence-content line did not freeze: #{inspect(offsets)}"
+
+      assert Enum.at(offsets, 2) > Enum.at(offsets, 1)
+
+      # and the matching closer transitions back to normal freezing.
+      assert Enum.at(offsets, 3) > Enum.at(offsets, 2),
+             "checkpoint did not advance past the fence closer: #{inspect(offsets)}"
     end
 
-    test "a mismatched ~~~ line inside a ``` fence does not create a boundary" do
+    test "a mismatched ~~~ line inside a ``` fence is fence CONTENT and freezes as such" do
       chunks = ["```\n", "~~~\n", "still code\n", "```\n", "\nafter\n"]
 
       {_acc, _cp, steps} = assert_stream_equivalence(chunks)
@@ -286,7 +295,123 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
       offsets =
         Enum.map(steps, fn {_acc, _view, cp} -> cp.frozen_byte_offset end)
 
-      assert Enum.take(offsets, 3) == [0, 0, 0]
+      # the interior ~~~ line is a committed content line of the open
+      # ``` fence -- freezable, never a (mismatched) closer.
+      assert Enum.at(offsets, 1) > 0
+      assert Enum.at(offsets, 2) > Enum.at(offsets, 1)
+    end
+  end
+
+  # --- adversarial review round, HIGH: a still-open fence (the most
+  # common large streamed payload -- an LLM typing out a code block)
+  # must not defeat the optimization. A closed fence's already-committed
+  # content lines are immutable (the parser is forward-only and each
+  # content line maps to exactly one code element), so they freeze even
+  # while the fence frame itself is still open. ---
+
+  # Total bytes actually re-parsed across a stream: per step, the live
+  # tail is byte_size(acc) - previous frozen_byte_offset. Deterministic
+  # and runner-independent (same metric as the perf pin below).
+  defp parse_work(steps) do
+    offsets_before =
+      [0 | Enum.map(steps, fn {_acc, _view, cp} -> cp.frozen_byte_offset end)]
+
+    steps
+    |> Enum.zip(offsets_before)
+    |> Enum.map(fn {{acc, _view, _cp}, offset} -> byte_size(acc) - offset end)
+    |> Enum.sum()
+  end
+
+  describe "review round, HIGH — streaming code blocks keep parse work linear" do
+    test "a 200-line streaming ```elixir block: equivalence at every step, work bounded by the live tail" do
+      opener = "```elixir\n"
+
+      content =
+        for i <- 1..200, do: "line #{i} of code with *stars* and | pipes |\n"
+
+      chunks = [opener | content]
+      doc = Enum.join(chunks)
+
+      {_acc, cp, steps} = assert_stream_equivalence(chunks)
+
+      # the checkpoint tracks the stream INSIDE the still-open fence --
+      # within one line of the end, not pinned at the opener.
+      assert cp.frozen_byte_offset >= byte_size(doc) - 60,
+             "checkpoint pinned inside an open fence: frozen " <>
+               "#{cp.frozen_byte_offset} of #{byte_size(doc)} bytes"
+
+      # pre-fix this sums prefix sizes (~100x the doc); with fence-
+      # interior freezing the re-parsed tail stays one line, so the sum
+      # is ~1-2x. 4x is the same order-of-magnitude separator the perf
+      # pin uses.
+      work = parse_work(steps)
+
+      assert work < 4 * byte_size(doc),
+             "cumulative re-parsed tail bytes #{work} exceed 4x the doc " <>
+               "size (#{byte_size(doc)}) -- open fences defeat the checkpoint"
+    end
+
+    test "a streaming ~~~ fence freezes its committed content lines too" do
+      chunks = ["~~~\n", "alpha\n", "beta\n", "gamma\n"]
+
+      {_acc, cp, steps} = assert_stream_equivalence(chunks)
+
+      offsets =
+        Enum.map(steps, fn {_acc, _view, cp} -> cp.frozen_byte_offset end)
+
+      assert Enum.at(offsets, 1) > 0
+      assert cp.frozen_byte_offset > 0
+    end
+
+    test "an opener with live inline state before it is ineligible (provisional close may still edit across it)" do
+      # "**bold" leaves an open bold frame on the stack; the fence
+      # content is inert but the PROSE around the fence is one inline
+      # stream -- erasures/closers for that bold can land after the
+      # fence, so nothing (including fence content) may freeze.
+      chunks = ["**bold\n", "```\n", "code one\n", "code two\n"]
+
+      {_acc, cp, _steps} = assert_stream_equivalence(chunks)
+
+      assert cp.frozen_byte_offset == 0,
+             "froze past an opener with a live inline frame"
+    end
+
+    test "an indented opener (renderer/provisional fence machines diverge) is ineligible" do
+      # "  ```" opens provisional-close's trimmed fence machine but NOT
+      # the renderer's raw-prefix one -- the two stages disagree on what
+      # is fence content, so no boundary of either kind is safe.
+      chunks = ["  ```\n", "*text\n", "words\n"]
+
+      {_acc, cp, _steps} = assert_stream_equivalence(chunks)
+
+      assert cp.frozen_byte_offset == 0,
+             "froze while the two fence machines disagreed"
+    end
+
+    test "newline-free content never freezes (documented residual: no committed line boundary exists)" do
+      # A single ever-growing line has no committed "\n" to freeze at,
+      # and mid-line freezing is semantically impossible (the line's own
+      # parse -- wrapping, emphasis pairing, table detection -- changes
+      # as it grows). This degrades to the pre-optimization full
+      # re-parse, bounded by the 256KB cap. Asserted here so the
+      # moduledoc's residual-degradation claim maps to a named test.
+      chunks = for _ <- 1..10, do: String.duplicate("word ", 10)
+
+      {_acc, cp, steps} = assert_stream_equivalence(chunks)
+
+      assert cp.frozen_byte_offset == 0
+
+      # the honest ceiling, pinned with the same work metric as the perf
+      # suite: with no boundary to freeze at, every delta re-parses the
+      # full accumulated text, so work equals the sum of ALL prefix
+      # sizes -- exactly the pre-optimization shape (never worse), with
+      # the 256KB render cap as the absolute bound.
+      naive_work =
+        steps
+        |> Enum.map(fn {acc, _view, _cp} -> byte_size(acc) end)
+        |> Enum.sum()
+
+      assert parse_work(steps) == naive_work
     end
   end
 

--- a/test/raxol/ui/components/harness/markdown_body_stable_prefix_test.exs
+++ b/test/raxol/ui/components/harness/markdown_body_stable_prefix_test.exs
@@ -1,0 +1,550 @@
+defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
+  @moduledoc """
+  Stable-prefix (incremental) streaming render of `MarkdownBody`.
+
+  The contract under test: `MarkdownBody.render_streaming_incremental/3`
+  takes the FULL accumulated text (append-only across deltas), a
+  checkpoint carried from the previous call, and a width, and returns
+  `{view, checkpoint}` where `view` is EXACTLY what the existing full
+  re-parse (`MarkdownBody.render(text, %{mode: :streaming, width: w})`)
+  would return -- element-for-element, at EVERY prefix. The full render
+  is the correctness oracle; the checkpoint is purely an optimization
+  that re-parses only the live tail after the last safe frozen boundary.
+
+  Safe-boundary rule under test (the per-construct immutability proof,
+  documented in `MarkdownBody`'s moduledoc):
+
+  - only just past a committed `\\n` (the last, still-growing line is
+    never frozen);
+  - both fence state machines balanced -- the renderer's raw-prefix
+    ```` ``` ````/`~~~` matching-marker machine AND provisional-close's
+    trimmed-prefix machine (a fence, once CLOSED by a matching-marker
+    line, can never be reopened by later bytes: the parser is
+    forward-only, so its consumed extent is fixed);
+  - the inline provisional-close scan stack is EMPTY (an unclosed
+    `**`/`*`/`` ` ``/`[` on a committed line receives erasures/closers
+    ACROSS later lines, so a boundary with live inline state is not
+    stable);
+  - the line immediately before the boundary contains no `|` (a
+    `|`-containing line can still BECOME a table header when the next
+    line arrives, and a still-absorbing table re-computes column widths
+    over ALL rows -- later rows rewrite earlier rows' rendered text);
+  - the raw frozen segment is valid UTF-8 (whole-buffer Latin-1 recovery
+    after a genuinely-invalid byte is not tail-composable).
+
+  Single-line constructs (headings, hr, blockquote, list items,
+  paragraphs) are immutable the moment their `\\n` arrives -- this
+  grammar has no multi-line nesting besides fences and tables.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Harness.Fixture
+  alias Raxol.UI.Components.Harness.MarkdownBody
+
+  @fixture_path "test/fixtures/harness/sessions/markdown-stream.jsonl"
+  @width 80
+
+  # The correctness oracle: the existing, trusted full re-parse.
+  defp oracle(text, width \\ @width) do
+    MarkdownBody.render(text, %{mode: :streaming, width: width})
+  end
+
+  # Folds `chunks` through the incremental API, asserting oracle
+  # equality at every accumulated prefix. Returns {final_text, final_cp,
+  # per_step} where per_step is a list of {acc, view, cp} in order.
+  defp assert_stream_equivalence(chunks, width \\ @width) do
+    {steps, {final_acc, final_cp}} =
+      Enum.map_reduce(chunks, {"", MarkdownBody.new_checkpoint()}, fn chunk,
+                                                                      {acc, cp} ->
+        acc = acc <> chunk
+
+        {view, cp} = MarkdownBody.render_streaming_incremental(acc, width, cp)
+
+        assert view == oracle(acc, width),
+               "incremental view diverged from the full re-parse oracle\n" <>
+                 "prefix: #{inspect(acc)}\n" <>
+                 "incremental: #{inspect(view)}\n" <>
+                 "oracle: #{inspect(oracle(acc, width))}"
+
+        {{acc, view, cp}, {acc, cp}}
+      end)
+
+    {final_acc, final_cp, steps}
+  end
+
+  defp golden_deltas_and_final do
+    {:ok, session} = Fixture.load(@fixture_path)
+
+    chunks =
+      session
+      |> Fixture.Session.by_type(:item_delta)
+      |> Enum.map(& &1.body.payload["chunk"])
+
+    [completed] = Fixture.Session.by_type(session, :item_completed)
+    final = completed.body.payload["content"]
+
+    {chunks, final}
+  end
+
+  # --- SP-EQ: the equivalence spec (the load-bearing oracle property) ---
+
+  describe "SP-EQ — incremental render equals full re-parse at every prefix" do
+    # Fragments deliberately include unclosed inline constructs, stray
+    # pipes, fence markers, and multibyte text -- the exact hazards the
+    # checkpoint rule must refuse to freeze across.
+    defp inline_fragment_gen do
+      member_of([
+        "plain words here",
+        "**bold**",
+        "*ital*",
+        "`code`",
+        "[t](http://x)",
+        "**unclosed",
+        "*dangling",
+        "`open",
+        "[half",
+        "a | b | c",
+        "text with | pipe",
+        "日本語 😀 café",
+        "__under__",
+        "_u_",
+        "***",
+        "~~~"
+      ])
+    end
+
+    defp line_gen do
+      inline_fragment_gen()
+      |> list_of(min_length: 1, max_length: 3)
+      |> map(&Enum.join(&1, " "))
+    end
+
+    defp block_gen do
+      one_of([
+        map(line_gen(), &(&1 <> "\n")),
+        constant("\n"),
+        map(line_gen(), &("# " <> &1 <> "\n")),
+        map(line_gen(), &("- " <> &1 <> "\n")),
+        map(line_gen(), &("> " <> &1 <> "\n")),
+        constant("---\n"),
+        map(line_gen(), &("```elixir\n" <> &1 <> "\n```\n")),
+        # unclosed fence (never yields a safe boundary after it opens)
+        map(line_gen(), &("```\n" <> &1)),
+        constant("| h1 | h2 |\n|---|---|\n| a | b |\n"),
+        # header + partial separator: the premature-frame streaming shape
+        constant("| h1 | h2 |\n|---|\n")
+      ])
+    end
+
+    defp doc_gen do
+      block_gen()
+      |> list_of(min_length: 1, max_length: 6)
+      |> map(&Enum.join(&1, ""))
+    end
+
+    # Splits `doc` into chunks by a list of byte sizes -- byte-granular,
+    # so cuts land mid-grapheme, mid-marker, and mid-CRLF by design.
+    defp split_by_sizes(doc, sizes) do
+      {chunks, rest} =
+        Enum.reduce_while(sizes, {[], doc}, fn size, {chunks, rest} ->
+          case rest do
+            "" ->
+              {:halt, {chunks, ""}}
+
+            _ ->
+              take = min(size, byte_size(rest))
+              chunk = binary_part(rest, 0, take)
+              rest = binary_part(rest, take, byte_size(rest) - take)
+              {:cont, {[chunk | chunks], rest}}
+          end
+        end)
+
+      chunks = if rest == "", do: chunks, else: [rest | chunks]
+      Enum.reverse(chunks)
+    end
+
+    property "arbitrary markdown streamed in arbitrary byte chunkings matches the oracle at every prefix" do
+      check all(
+              doc <- doc_gen(),
+              sizes <- list_of(integer(1..9), max_length: 80),
+              max_runs: 50
+            ) do
+        chunks = split_by_sizes(doc, sizes)
+        assert_stream_equivalence(chunks)
+      end
+    end
+
+    property "garbage binary chunks match the oracle at every prefix and never raise" do
+      check all(
+              chunks <- list_of(binary(max_length: 40), max_length: 6),
+              max_runs: 100
+            ) do
+        assert_stream_equivalence(chunks)
+      end
+    end
+
+    test "the golden fixture's 17 real delta chunks match the oracle at every boundary" do
+      {chunks, _final} = golden_deltas_and_final()
+      assert length(chunks) == 17
+      assert_stream_equivalence(chunks)
+    end
+
+    test "character-granular streaming of the golden doc matches the oracle at every prefix" do
+      {_chunks, final} = golden_deltas_and_final()
+      chunks = final |> String.graphemes()
+      assert_stream_equivalence(chunks)
+    end
+  end
+
+  # --- SP-IMM: the frozen prefix is genuinely immutable ---
+
+  describe "SP-IMM — frozen elements never change once frozen" do
+    test "each returned view begins with exactly the checkpoint's frozen elements" do
+      {chunks, _final} = golden_deltas_and_final()
+
+      {_acc, _cp, steps} = assert_stream_equivalence(chunks)
+
+      for {{_acc, view, cp}, next} <-
+            Enum.zip(steps, tl(steps) ++ [nil]) do
+        frozen = cp.frozen_elements
+
+        # the checkpoint returned WITH a view is always a prefix of it...
+        assert Enum.take(view.children, length(frozen)) == frozen,
+               "checkpoint's frozen elements are not a prefix of its own view"
+
+        # ...and of every LATER view (no flash/rewrite of frozen output).
+        case next do
+          nil ->
+            :ok
+
+          {_next_acc, next_view, _next_cp} ->
+            assert Enum.take(next_view.children, length(frozen)) == frozen,
+                   "a later delta rewrote already-frozen elements"
+        end
+      end
+    end
+  end
+
+  # --- SP-HAZ: directed hazard cases (each names a clause of the boundary rule) ---
+
+  describe "SP-HAZ — table lookahead: a committed '|' line must not freeze before its next line arrives" do
+    test "a line that later becomes a table header is never frozen prematurely" do
+      # After chunk 1, "| a | b |" is a committed plain-prose line; chunk
+      # 2 retroactively makes it a TABLE HEADER. Freezing it after chunk
+      # 1 would pin the prose parse. The no-pipe boundary clause forbids
+      # that; equivalence holds at both steps.
+      chunks = ["| a | b |\n", "|---|\n", "| 1 | 2 |\n", "\n", "after\n"]
+      assert_stream_equivalence(chunks)
+    end
+
+    test "a later table row widening a column never rewrites frozen output" do
+      # Column widths are computed over ALL rows -- the wide row in chunk
+      # 3 re-renders the header/earlier rows. No part of the table may
+      # freeze until the terminating pipe-free line has arrived.
+      chunks = [
+        "| a | b |\n|---|---|\n",
+        "| x | y |\n",
+        "| much-wider-cell-content | z |\n",
+        "\n",
+        "done\n"
+      ]
+
+      {_acc, cp, _steps} = assert_stream_equivalence(chunks)
+      # after the pipe-free blank + "done" line the table is closed and
+      # freezable -- the checkpoint must have advanced past it.
+      assert cp.frozen_byte_offset > 0
+    end
+  end
+
+  describe "SP-HAZ — open fence: no boundary inside an unterminated fence" do
+    test "the checkpoint holds at the fence opener until the matching closer arrives" do
+      opener = "```\n"
+      chunks = [opener, "code | with pipe\n", "**not bold**\n", "```\n", "\n"]
+
+      {_acc, _cp, steps} = assert_stream_equivalence(chunks)
+
+      offsets =
+        Enum.map(steps, fn {_acc, _view, cp} -> cp.frozen_byte_offset end)
+
+      # while the fence is open (steps 1..3) nothing freezes...
+      assert Enum.take(offsets, 3) == [0, 0, 0],
+             "checkpoint advanced inside an open fence: #{inspect(offsets)}"
+
+      # ...and once the matching closer has arrived, the closed fence
+      # block becomes freezable.
+      assert List.last(offsets) > 0,
+             "checkpoint never advanced after the fence closed: #{inspect(offsets)}"
+    end
+
+    test "a mismatched ~~~ line inside a ``` fence does not create a boundary" do
+      chunks = ["```\n", "~~~\n", "still code\n", "```\n", "\nafter\n"]
+
+      {_acc, _cp, steps} = assert_stream_equivalence(chunks)
+
+      offsets =
+        Enum.map(steps, fn {_acc, _view, cp} -> cp.frozen_byte_offset end)
+
+      assert Enum.take(offsets, 3) == [0, 0, 0]
+    end
+  end
+
+  describe "SP-HAZ — live inline state: an unclosed emphasis spanning lines blocks the boundary" do
+    test "a committed line with an unclosed ** does not freeze until the construct resolves" do
+      chunks = ["start **bold\n", "still bold** done\n", "\n", "next\n"]
+
+      {_acc, _cp, steps} = assert_stream_equivalence(chunks)
+
+      offsets =
+        Enum.map(steps, fn {_acc, _view, cp} -> cp.frozen_byte_offset end)
+
+      # after chunk 1 the line is committed but the inline scan stack
+      # still holds the open bold frame -- no boundary.
+      assert hd(offsets) == 0,
+             "froze a boundary with live inline state: #{inspect(offsets)}"
+
+      # once the bold closes (chunk 2's line), the stack empties and the
+      # boundary is allowed.
+      assert Enum.at(offsets, 1) > 0
+    end
+  end
+
+  describe "SP-HAZ — UTF-8 and CRLF chunk splits" do
+    test "byte-by-byte streaming across multibyte graphemes matches the oracle at every byte" do
+      doc = "café 日本語 😀 done\n\n**bold** more\n"
+
+      chunks =
+        for i <- 0..(byte_size(doc) - 1), do: binary_part(doc, i, 1)
+
+      assert_stream_equivalence(chunks)
+    end
+
+    test "a chunk split between CR and LF matches the oracle at every step" do
+      chunks = ["alpha\r", "\nbeta\r\n\r", "\ngamma **b** end\r", "\n"]
+      assert_stream_equivalence(chunks)
+    end
+
+    test "a genuinely-invalid byte in a committed line degrades to the oracle without freezing past it" do
+      # 0xFF can never begin a UTF-8 codepoint: whole-buffer recovery
+      # Latin-1-converts everything after it, which is not
+      # tail-composable -- so no boundary at or beyond the invalid byte.
+      chunks = ["good line\n\n", <<"bad ", 0xFF, " line\n">>, "tail **b**\n"]
+      assert_stream_equivalence(chunks)
+    end
+  end
+
+  # --- SP-API: checkpoint lifecycle contract ---
+
+  describe "SP-API — checkpoint lifecycle" do
+    test "new_checkpoint/0 starts at offset zero with no frozen elements" do
+      cp = MarkdownBody.new_checkpoint()
+      assert cp.frozen_byte_offset == 0
+      assert cp.frozen_elements == []
+    end
+
+    test "nil is accepted as a fresh checkpoint" do
+      {view, cp} =
+        MarkdownBody.render_streaming_incremental("hi **there**\n", @width, nil)
+
+      assert view == oracle("hi **there**\n")
+      assert cp.frozen_byte_offset >= 0
+    end
+
+    test "a stale checkpoint from DIFFERENT text (non-extension) resets instead of corrupting output" do
+      {_view, cp} =
+        MarkdownBody.render_streaming_incremental(
+          "first doc line\n\nsecond paragraph\n\n",
+          @width,
+          MarkdownBody.new_checkpoint()
+        )
+
+      assert cp.frozen_byte_offset > 0
+
+      # attacker/misuse case: same checkpoint, unrelated text. The guard
+      # must detect the non-extension and fall back to a full parse.
+      other = "completely different content **x**\n"
+
+      {view, new_cp} =
+        MarkdownBody.render_streaming_incremental(other, @width, cp)
+
+      assert view == oracle(other)
+      assert new_cp.frozen_byte_offset <= byte_size(other)
+    end
+
+    test "a width change invalidates the checkpoint (frozen elements are width-dependent)" do
+      text =
+        "a paragraph that is long enough to wrap differently at forty columns **bold**\n\nnext\n"
+
+      {_view, cp} =
+        MarkdownBody.render_streaming_incremental(text, 80, nil)
+
+      {view_40, _cp} =
+        MarkdownBody.render_streaming_incremental(text, 40, cp)
+
+      assert view_40 == oracle(text, 40)
+    end
+
+    test "non-binary input matches the oracle and never raises" do
+      {view, _cp} =
+        MarkdownBody.render_streaming_incremental(%{not: "text"}, @width, nil)
+
+      assert view == oracle(%{not: "text"})
+    end
+  end
+
+  # --- SP-CAP: the 256KB ceiling applies to the TOTAL accumulated text ---
+
+  describe "SP-CAP — the byte cap applies to the total, and resets the checkpoint" do
+    @cap_bytes 256 * 1024
+
+    test "above the cap the view is the oracle-identical plain-text fallback and the checkpoint resets" do
+      small = "intro paragraph\n\n"
+      huge = String.duplicate("word ", 60_000)
+      total = small <> huge
+      assert byte_size(total) > @cap_bytes
+
+      {_view, cp} =
+        MarkdownBody.render_streaming_incremental(small, @width, nil)
+
+      {view, cp_after} =
+        MarkdownBody.render_streaming_incremental(total, @width, cp)
+
+      assert view == oracle(total)
+      # fallback shape: exactly one plain text node (matches the
+      # existing above-cap contract in markdown_body_test.exs).
+      assert %{type: :column, children: [%{type: :text}]} = view
+      assert cp_after.frozen_byte_offset == 0
+      assert cp_after.frozen_elements == []
+    end
+
+    test "below the cap the parse path runs (fallback does NOT fire)" do
+      text = "**bold** and *italic*\n"
+
+      {view, _cp} =
+        MarkdownBody.render_streaming_incremental(text, @width, nil)
+
+      assert view == oracle(text)
+      refute match?(%{children: [%{type: :text, content: ^text}]}, view)
+    end
+  end
+
+  # --- SP-PERF: the O(N^2) -> O(N) pin ---
+
+  # Order-of-magnitude convention (same as N-MDFUZZ-05 in
+  # markdown_body_test.exs): generous absolute bounds that a
+  # wrong-complexity implementation blows past by 10x+, never tight
+  # wall-clock asserts -- CI runners are slow.
+
+  describe "SP-PERF — incremental parse work is bounded by the live tail, not the total" do
+    defp perf_doc do
+      Enum.map_join(1..1_000, "", fn i ->
+        "paragraph #{i} with **bold** text and `code` spans.\n\n"
+      end)
+    end
+
+    defp line_deltas(doc) do
+      lines = String.split(doc, "\n")
+      {body, [last]} = Enum.split(lines, -1)
+      deltas = Enum.map(body, &(&1 <> "\n"))
+      if last == "", do: deltas, else: deltas ++ [last]
+    end
+
+    test "streaming 2000 lines keeps the checkpoint within a hop of the end (the frozen prefix tracks the stream)" do
+      doc = perf_doc()
+      deltas = line_deltas(doc)
+      assert length(deltas) == 2_000
+
+      {_acc, cp} =
+        Enum.reduce(deltas, {"", MarkdownBody.new_checkpoint()}, fn delta,
+                                                                    {acc, cp} ->
+          acc = acc <> delta
+
+          {_view, cp} =
+            MarkdownBody.render_streaming_incremental(acc, @width, cp)
+
+          {acc, cp}
+        end)
+
+      # every blank line is a safe boundary here, so the frozen offset
+      # must sit within one paragraph (< 100 bytes) of the total --
+      # THIS is the structural fact that makes total work O(N): the
+      # re-parsed tail stays O(1) paragraphs regardless of history.
+      assert cp.frozen_byte_offset >= byte_size(doc) - 100,
+             "checkpoint failed to track the stream: frozen " <>
+               "#{cp.frozen_byte_offset} of #{byte_size(doc)} bytes"
+
+      # and the final incremental view still equals the oracle.
+      {view, _cp} =
+        MarkdownBody.render_streaming_incremental(
+          doc,
+          @width,
+          cp
+        )
+
+      assert view == oracle(doc)
+    end
+
+    test "cumulative incremental work over 2000 line-deltas stays well under the never-hang bound" do
+      # Pre-fix, every delta re-parses the FULL accumulated text: 2000
+      # deltas x O(N) parse = O(N^2) total, which blows this bound by an
+      # order of magnitude. Incremental work per delta is O(live tail)
+      # (one paragraph), so the total stays comfortably inside it.
+      doc = perf_doc()
+      deltas = line_deltas(doc)
+
+      {elapsed_us, _} =
+        :timer.tc(fn ->
+          Enum.reduce(deltas, {"", MarkdownBody.new_checkpoint()}, fn delta,
+                                                                      {acc, cp} ->
+            acc = acc <> delta
+
+            {_view, cp} =
+              MarkdownBody.render_streaming_incremental(acc, @width, cp)
+
+            {acc, cp}
+          end)
+        end)
+
+      assert elapsed_us < 2_000_000,
+             "2000 incremental deltas took #{elapsed_us}us (bound 2000000)"
+    end
+
+    # Timing comparisons belong out of the default suite (:slow is
+    # excluded by the repo's default run). This is the before/after
+    # order-of-magnitude receipt, not a CI gate.
+    @tag :slow
+    test "incremental streaming beats per-delta full re-parse by an order of magnitude" do
+      doc = perf_doc()
+      deltas = line_deltas(doc)
+
+      prefixes =
+        deltas
+        |> Enum.scan("", &(&2 <> &1))
+        # every 10th prefix keeps the full-reparse arm tractable while
+        # preserving the O(N^2)-vs-O(N) shape.
+        |> Enum.take_every(10)
+
+      {full_us, _} =
+        :timer.tc(fn ->
+          Enum.each(prefixes, &oracle/1)
+        end)
+
+      {incr_us, _} =
+        :timer.tc(fn ->
+          Enum.reduce(prefixes, MarkdownBody.new_checkpoint(), fn prefix, cp ->
+            {_view, cp} =
+              MarkdownBody.render_streaming_incremental(prefix, @width, cp)
+
+            cp
+          end)
+        end)
+
+      # generous 2x margin on an expected >=10x gap -- comparative, so
+      # runner speed cancels out.
+      assert incr_us * 2 < full_us,
+             "incremental (#{incr_us}us) not clearly faster than " <>
+               "full re-parse (#{full_us}us)"
+    end
+  end
+end

--- a/test/raxol/ui/components/harness/markdown_body_stable_prefix_test.exs
+++ b/test/raxol/ui/components/harness/markdown_body_stable_prefix_test.exs
@@ -88,9 +88,9 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     {chunks, final}
   end
 
-  # --- SP-EQ: the equivalence spec (the load-bearing oracle property) ---
+  # --- the equivalence spec (the load-bearing oracle property) ---
 
-  describe "SP-EQ — incremental render equals full re-parse at every prefix" do
+  describe "equivalence oracle — incremental render equals full re-parse at every prefix" do
     # Fragments deliberately include unclosed inline constructs, stray
     # pipes, fence markers, and multibyte text -- the exact hazards the
     # checkpoint rule must refuse to freeze across.
@@ -198,9 +198,9 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  # --- SP-IMM: the frozen prefix is genuinely immutable ---
+  # --- the frozen prefix is genuinely immutable ---
 
-  describe "SP-IMM — frozen elements never change once frozen" do
+  describe "frozen-prefix immutability — frozen elements never change once frozen" do
     test "each returned view begins with exactly the checkpoint's frozen elements" do
       {chunks, _final} = golden_deltas_and_final()
 
@@ -227,9 +227,9 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  # --- SP-HAZ: directed hazard cases (each names a clause of the boundary rule) ---
+  # --- directed hazard cases (each names a clause of the boundary rule) ---
 
-  describe "SP-HAZ — table lookahead: a committed '|' line must not freeze before its next line arrives" do
+  describe "boundary hazard: table lookahead — a committed pipe line must not freeze before its next line arrives" do
     test "a line that later becomes a table header is never frozen prematurely" do
       # After chunk 1, "| a | b |" is a committed plain-prose line; chunk
       # 2 retroactively makes it a TABLE HEADER. Freezing it after chunk
@@ -258,7 +258,7 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  describe "SP-HAZ — open fence: no boundary inside an unterminated fence" do
+  describe "boundary hazard: open fence — no boundary inside an unterminated fence" do
     test "the checkpoint holds at the fence opener until the matching closer arrives" do
       opener = "```\n"
       chunks = [opener, "code | with pipe\n", "**not bold**\n", "```\n", "\n"]
@@ -290,7 +290,7 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  describe "SP-HAZ — live inline state: an unclosed emphasis spanning lines blocks the boundary" do
+  describe "boundary hazard: live inline state — an unclosed emphasis spanning lines blocks the boundary" do
     test "a committed line with an unclosed ** does not freeze until the construct resolves" do
       chunks = ["start **bold\n", "still bold** done\n", "\n", "next\n"]
 
@@ -310,7 +310,7 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  describe "SP-HAZ — UTF-8 and CRLF chunk splits" do
+  describe "boundary hazard: UTF-8 and CRLF chunk splits" do
     test "byte-by-byte streaming across multibyte graphemes matches the oracle at every byte" do
       doc = "café 日本語 😀 done\n\n**bold** more\n"
 
@@ -334,9 +334,9 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  # --- SP-API: checkpoint lifecycle contract ---
+  # --- checkpoint lifecycle contract ---
 
-  describe "SP-API — checkpoint lifecycle" do
+  describe "checkpoint lifecycle" do
     test "new_checkpoint/0 starts at offset zero with no frozen elements" do
       cp = MarkdownBody.new_checkpoint()
       assert cp.frozen_byte_offset == 0
@@ -393,9 +393,9 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  # --- SP-CAP: the 256KB ceiling applies to the TOTAL accumulated text ---
+  # --- the 256KB ceiling applies to the TOTAL accumulated text ---
 
-  describe "SP-CAP — the byte cap applies to the total, and resets the checkpoint" do
+  describe "byte cap — applies to the total accumulated text, and resets the checkpoint" do
     @cap_bytes 256 * 1024
 
     test "above the cap the view is the oracle-identical plain-text fallback and the checkpoint resets" do
@@ -429,14 +429,14 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
     end
   end
 
-  # --- SP-PERF: the O(N^2) -> O(N) pin ---
+  # --- the O(N^2) -> O(N) pin ---
 
   # Order-of-magnitude convention (same as N-MDFUZZ-05 in
   # markdown_body_test.exs): generous absolute bounds that a
   # wrong-complexity implementation blows past by 10x+, never tight
   # wall-clock asserts -- CI runners are slow.
 
-  describe "SP-PERF — incremental parse work is bounded by the live tail, not the total" do
+  describe "streaming performance — incremental parse work is bounded by the live tail, not the total" do
     defp perf_doc do
       Enum.map_join(1..1_000, "", fn i ->
         "paragraph #{i} with **bold** text and `code` spans.\n\n"
@@ -485,29 +485,44 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyStablePrefixTest do
       assert view == oracle(doc)
     end
 
-    test "cumulative incremental work over 2000 line-deltas stays well under the never-hang bound" do
-      # Pre-fix, every delta re-parses the FULL accumulated text: 2000
-      # deltas x O(N) parse = O(N^2) total, which blows this bound by an
-      # order of magnitude. Incremental work per delta is O(live tail)
-      # (one paragraph), so the total stays comfortably inside it.
+    test "cumulative parse WORK over 2000 line-deltas is linear in the doc, not quadratic" do
+      # A work metric, not wall-clock: per delta, the bytes actually
+      # re-parsed are exactly `byte_size(acc) - frozen_byte_offset` (the
+      # live tail past the checkpoint). This is deterministic and
+      # runner-independent -- a shared CI box under load cannot flake it
+      # -- and it pins the O(N) claim tighter than time does.
+      #
+      # Pre-fix (no checkpoint, offset pinned at 0), the sum is
+      # sum(prefix sizes) ~= 1000x the doc size for this stream. With a
+      # tracking checkpoint the tail stays one paragraph (~2 lines), so
+      # the sum lands around 2x the doc size. 4x is a generous
+      # order-of-magnitude separator (~250x headroom against the
+      # quadratic shape).
       doc = perf_doc()
       deltas = line_deltas(doc)
 
-      {elapsed_us, _} =
-        :timer.tc(fn ->
-          Enum.reduce(deltas, {"", MarkdownBody.new_checkpoint()}, fn delta,
-                                                                      {acc, cp} ->
-            acc = acc <> delta
+      {total_tail_bytes, {_acc, final_cp}} =
+        Enum.reduce(deltas, {0, {"", MarkdownBody.new_checkpoint()}}, fn delta,
+                                                                         {work,
+                                                                          {acc,
+                                                                           cp}} ->
+          acc = acc <> delta
+          tail_bytes = byte_size(acc) - cp.frozen_byte_offset
 
-            {_view, cp} =
-              MarkdownBody.render_streaming_incremental(acc, @width, cp)
+          {_view, cp} =
+            MarkdownBody.render_streaming_incremental(acc, @width, cp)
 
-            {acc, cp}
-          end)
+          {work + tail_bytes, {acc, cp}}
         end)
 
-      assert elapsed_us < 2_000_000,
-             "2000 incremental deltas took #{elapsed_us}us (bound 2000000)"
+      assert total_tail_bytes < 4 * byte_size(doc),
+             "cumulative re-parsed tail bytes #{total_tail_bytes} exceed " <>
+               "4x the doc size (#{byte_size(doc)}) -- the checkpoint is " <>
+               "not bounding per-delta work"
+
+      # the checkpoint only ever moves forward -- offsets are monotone by
+      # construction, and the final one covers (nearly) the whole doc.
+      assert final_cp.frozen_byte_offset >= byte_size(doc) - 100
     end
 
     # Timing comparisons belong out of the default suite (:slow is


### PR DESCRIPTION
Live message bodies re-parsed the FULL accumulated content on every streaming delta — O(N^2) over a turn (measured: a 1000-paragraph document costs ~17.6s of cumulative parse work streamed per-delta). This adds the stable-prefix optimization the module documented as its follow-up seam: freeze what can never change, re-parse only the tail.

## The per-construct immutability proof (the design's core, each clause bound to a named test)

- **Fenced code**: the builtin parser is forward-only — a closed fence's extent is permanently fixed. An OPEN fence blocks the boundary; both fence machines (the renderer's untrimmed one and provisional-close's trimmed one) must agree closed, since they legitimately disagree on indented fences.
- **Tables are NOT immutable at row boundaries** — column widths derive from ALL rows (a later row rewrites earlier rows' rendered text), and a committed pipe-line can retroactively become a header via lookahead. Conservative kill: the line before a boundary must be pipe-free.
- **Inline emphasis/code/links**: the inline scanner joins prose across lines, so a boundary additionally requires an empty inline scan stack — a hazard specific to this module's provisional-close model, not present in the reference design this ports.
- Headings/hr/blockquote/lists/paragraphs: single-line in this grammar, immutable at their newline.
- UTF-8/CRLF: the frozen raw segment must be valid UTF-8; newline positions correspond 1:1 raw-to-sanitized, so tail-only sanitize survives CRLF and mid-grapheme chunk splits with no special cases.

## API + safety

`render_streaming_incremental(text, width, checkpoint) -> {view, checkpoint}` with an opaque checkpoint. Misuse (non-extension text, width change) RESETS the checkpoint — can degrade performance, never correctness. The 256KB cap applies to the total, replicated at both oracle sites; above it the view is the oracle-identical fallback. Never raises.

## The equivalence oracle (load-bearing, mutation-tested)

A property streams arbitrary generated markdown (unclosed constructs, stray pipes, CJK/emoji) in arbitrary BYTE-granular chunkings and asserts the incremental view deep-equals the full re-parse at EVERY prefix. Proven non-vacuous by two deliberate mutations: an off-by-one in the boundary advance and a dropped pipe clause each produced named divergence failures; both reverted, tree re-verified.

## Measured

1000-paragraph doc, 2000 deltas: full re-parse 1758ms over 200 sampled prefixes vs incremental 38ms (46.5x); all 2000 deltas in 96ms total. Committed perf tests use the order-of-magnitude convention (comparative timing `:slow`-tagged).

## Verification

New suite 23/23 (red-first: 0/5 before implementation); markdown suites 151/151; full suite 6115/6121 with the single reproducible failure (MetricsCollector timing) reproducing with the change stashed — pre-existing. Warnings + format clean. Scope fence held: MarkdownBody + tests only. BodyProvider wire-in documented as the next seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)