### PR TITLE
Harness UI: seal-pipeline hardening (write-confirmed sealing, frame order, synchronized output)

### DIFF
--- a/lib/raxol/harness/seal_frontier.ex
+++ b/lib/raxol/harness/seal_frontier.ex
@@ -27,10 +27,13 @@ defmodule Raxol.Harness.SealFrontier do
       scrollback this frame;
     * the footer/tail composition -- which blocks still render in the
       pinned live region (the trailing "pending" preview);
-    * (future, documented seam, not yet built) the resize path's
-      `will_commit` gate and post-commit viewport sizing -- the frame-order
-      unit that must decide sizing at the width a possibly-just-committed
-      block was laid out at.
+    * the synchronized-output bracket decision -- `Raxol.Harness.Surface`'s
+      `seal_frame/3` reads the SAME `will_commit` projection, per-frame, to
+      decide whether this frame's seal + footer repaint needs wrapping in
+      a DEC 2026 bracket (see that module's moduledoc). The post-commit
+      viewport-sizing seam remains future work: this substrate's footer
+      row count is geometry-fixed (never a function of post-seal state),
+      so there is no viewport-sizing decision left to make here.
 
   Consumers never inline their own walk over entries. The consumer table
   today:
@@ -39,11 +42,10 @@ defmodule Raxol.Harness.SealFrontier do
       walk, via `commit_walk/5`.
     * `Raxol.Harness.Surface`'s footer pending-preview (`pending_block/1`,
       via `frontier_scan/1`, itself `scan_frontier/3`) -- read-only.
-
-  Documented seams (not yet built, but must call `scan_frontier/3` before
-  the commit pass in the frame and mirror its stop condition exactly when
-  they land): the resize-path `will_commit` gate, and post-commit viewport
-  sizing.
+    * `Raxol.Harness.Surface`'s synchronized-output bracket gate
+      (`seal_frame/3`, also via `frontier_scan/1`) -- read-only, consulted
+      BEFORE the commit pass to decide whether to open a bracket around
+      it.
 
   ## The entry contract
 
@@ -170,11 +172,13 @@ defmodule Raxol.Harness.SealFrontier do
   it, so the very next pass retries that same entry rather than silently
   skipping past a block that was marked but never actually printed (which
   would make it vanish forever, since a print-once surface cannot re-emit
-  a committed entry). This emit-then-mark contract is the seam a future
-  two-phase seal (a write-confirming substrate) will build on; today's
-  Surface emit (`InlineAuthority.seal/2`) has no error path, so the
-  `{:error, :write_failed, _}` branch is exercised only by this module's
-  own corpus until such a substrate lands.
+  a committed entry). This emit-then-mark contract is the seam a
+  write-confirming substrate builds on -- and that substrate now exists:
+  `Raxol.Harness.Surface.seal_block/2` emits through
+  `InlineAuthority.try_seal/2` (write -> confirm -> mark), and the
+  `{:error, :write_failed, _}` branch is exercised both by this module's
+  own corpus and end-to-end through a real failing device in
+  `test/harness/surface_seal_pipeline_test.exs`.
 
   ## The cursor
 

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -809,6 +809,7 @@ defmodule Raxol.Harness.Surface do
   end
 
   defp do_advance(model, now) do
+    model = heal_sync(model)
     revealed = min(model.revealed + 1, length(model.events))
     events_so_far = Enum.take(model.events, revealed)
 
@@ -831,25 +832,44 @@ defmodule Raxol.Harness.Surface do
   end
 
   # A frame that seals at least one block AND repaints the footer
-  # presents atomically: seal + status + footer run inside one DEC 2026
-  # synchronized-update bracket (InlineAuthority.with_sync/3, gated on
-  # the capability record). The bracket condition is the pre-seal scan's
-  # will_commit -- it exactly predicts "this frame seals >= 1 block"
-  # except when the first emit fails, in which case an empty bracket is
-  # emitted (harmless: a sync frame with no visible change; the
-  # balanced-bracket case in test/harness/surface_seal_pipeline_test.exs
-  # covers the failure path). Frames that seal nothing (early reveals,
-  # tick, handle_input) never open a bracket. :flat has no footer and no
-  # cursor vocabulary -- never bracketed.
+  # presents atomically: seal + status + footer run between
+  # InlineAuthority.sync_open/1 and sync_close/1 -- one DEC 2026
+  # synchronized-update bracket, gated on the capability record. The
+  # bracket condition is the pre-seal scan's will_commit -- it exactly
+  # predicts "this frame seals >= 1 block" except when the first emit
+  # fails, in which case an empty bracket is emitted (harmless: a sync
+  # frame with no visible change; the balanced-bracket case in
+  # test/harness/surface_seal_pipeline_test.exs covers the failure path).
+  # Frames that seal nothing (early reveals, tick, handle_input) never
+  # open a bracket -- but every frame entry point calls heal_sync/1
+  # first, so a close the device refused in an EARLIER frame (the
+  # dangling-open wedge) is re-attempted at the first opportunity of any
+  # kind. :flat has no footer and no cursor vocabulary -- never
+  # bracketed.
+  #
+  # If run_seal_frame/3 raises mid-bracket (a logic bug -- device
+  # failures are tuples, not raises, on this path), the rescue below
+  # makes one best-effort close attempt before re-raising, so a crashing
+  # frame does not also leave the terminal synchronized. The authority
+  # state update is lost with the crash either way; the byte is what
+  # matters to the terminal.
   defp seal_frame(%{mode: :flat} = model, events_so_far, now) do
     run_seal_frame(model, events_so_far, now)
   end
 
   defp seal_frame(model, events_so_far, now) do
     if frontier_scan(model).will_commit do
-      InlineAuthority.with_sync(model.authority, model, fn m ->
-        run_seal_frame(m, events_so_far, now)
-      end)
+      opened = update_authority(model, &InlineAuthority.sync_open/1)
+
+      try do
+        opened
+        |> run_seal_frame(events_so_far, now)
+        |> update_authority(&InlineAuthority.sync_close/1)
+      rescue
+        e ->
+          _ = InlineAuthority.sync_close(opened.authority)
+          reraise e, __STACKTRACE__
+      end
     else
       run_seal_frame(model, events_so_far, now)
     end
@@ -862,6 +882,20 @@ defmodule Raxol.Harness.Surface do
     |> paint_footer()
   end
 
+  # Re-attempts a sync close the device refused in an earlier frame (see
+  # InlineAuthority.sync_close/1's latch contract) -- a byte-free no-op
+  # when nothing is owed, so every frame entry point (do_advance, tick,
+  # handle_input, resize) calls it unconditionally: a dangling ?2026h
+  # heals at the FIRST frame after the device accepts a byte again,
+  # never later.
+  defp heal_sync(%{mode: :flat} = model), do: model
+
+  defp heal_sync(model),
+    do: update_authority(model, &InlineAuthority.sync_close/1)
+
+  defp update_authority(model, fun),
+    do: %{model | authority: fun.(model.authority)}
+
   @doc """
   Advances the elapsed-since-last-event ticker (the status strip's
   `Stage` slot) without revealing a new fixture event -- elapsed ticks
@@ -872,6 +906,7 @@ defmodule Raxol.Harness.Surface do
   @spec tick(t(), integer()) :: t()
   def tick(model, now) when is_integer(now) do
     model
+    |> heal_sync()
     |> put_in([:status, :now], now)
     |> paint_footer()
   end
@@ -999,12 +1034,14 @@ defmodule Raxol.Harness.Surface do
     # The ONE mutating frontier walk (SealFrontier's moduledoc): emit
     # each newly-committable block via seal_block/2, which advances
     # painted_count -- the committed marker frontier_entries/1 reads.
-    # The emit is write-confirming (`InlineAuthority.try_seal/2`): write ->
-    # confirm -> mark. A failed device write halts the walk with
+    # The emit is write-checked (`InlineAuthority.try_seal/2`): write ->
+    # confirm -> mark, where "confirmed" means the device's io server
+    # ACCEPTED the write (see try_seal/2's doc for what that does and
+    # does not promise). A refused write halts the walk with
     # painted_count (the cursor) strictly before the failed entry, and the
     # next advance retries the same block, so a block can never be marked
-    # painted without its bytes confirmed on the device (retry-not-vanish;
-    # covered by test/harness/surface_seal_pipeline_test.exs).
+    # painted for bytes the device refused (retry-not-vanish; covered by
+    # test/harness/surface_seal_pipeline_test.exs).
     result =
       SealFrontier.commit_walk(
         entries,
@@ -1193,6 +1230,7 @@ defmodule Raxol.Harness.Surface do
   """
   @spec handle_input(t(), term()) :: t()
   def handle_input(model, raw_event) do
+    model = heal_sync(model)
     norm = InputEvent.normalize(raw_event)
 
     # Every keystroke is presence evidence for the unread divider's
@@ -2173,7 +2211,7 @@ defmodule Raxol.Harness.Surface do
     do: adopt_resize(model, width, rows)
 
   def resize(model, width, rows) do
-    model = adopt_resize(model, width, rows)
+    model = model |> heal_sync() |> adopt_resize(width, rows)
     lines = footer_lines(model)
     authority = InlineAuthority.keyframe(model.authority, lines)
     %{model | authority: authority, stub_notice: nil}

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -840,6 +840,12 @@ defmodule Raxol.Harness.Surface do
   # fails, in which case an empty bracket is emitted (harmless: a sync
   # frame with no visible change; the balanced-bracket case in
   # test/harness/surface_seal_pipeline_test.exs covers the failure path).
+  # A PERSISTENTLY refusing (alive) device therefore emits one empty
+  # open/close pair per retry frame -- a few bytes of decoration per
+  # frame, deliberately not special-cased: the same frames emit
+  # [:raxol, :harness, :seal, :write_failed] telemetry per refused
+  # write, so the condition is observable from the first frame and the
+  # operator/driver owns the decision to stop advancing.
   # Frames that seal nothing (early reveals, tick, handle_input) never
   # open a bracket -- but every frame entry point calls heal_sync/1
   # first, so a close the device refused in an EARLIER frame (the
@@ -1053,7 +1059,26 @@ defmodule Raxol.Harness.Surface do
             |> Enum.at(index)
             |> apply_fold_override(index, acc.fold_overrides)
 
-          seal_block(acc, block)
+          case seal_block(acc, block) do
+            {:ok, _acc} = ok ->
+              ok
+
+            {:error, :write_failed, _acc} = error ->
+              # The retry loop for a refusing-but-alive device is
+              # unbounded BY DESIGN (a bound would strand the block when
+              # the device recovers) -- this emit is what keeps it from
+              # being unbounded AND invisible: one event per refused
+              # write, from the first frame, so a driver/operator can see
+              # a persistent refusal and decide. A DEAD device never
+              # reaches here (try_seal fail-fasts on a corpse).
+              :telemetry.execute(
+                [:raxol, :harness, :seal, :write_failed],
+                %{},
+                %{index: index, kind: block.kind}
+              )
+
+              error
+          end
         end,
         cursor: model.painted_count
       )

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -751,20 +751,64 @@ defmodule Raxol.Harness.Surface do
   Returns `{model, :ok}` while events remain, `{model, :done}` once every
   fixture event has been revealed AND the final pending block (if any) has
   been flushed to paint.
-  """
-  @spec advance(t(), integer() | nil) :: {t(), :ok | :done}
-  def advance(model, now \\ nil)
 
-  def advance(
-        %{revealed: revealed, events: events, painted_count: painted} = model,
-        _now
-      )
-      when revealed >= length(events) and
-             painted >= length(model.projection.blocks) do
+  ## Options
+
+    * `:resize` -- `{width, rows}`, the atomic combined-frame form for
+      drivers that batch a geometry change with the same advance. When
+      given, the resize is ADOPTED (dims + DECSTBM re-set, via the same
+      `adopt_resize/3` path `resize/2` itself uses, minus that function's
+      own immediate keyframe) BEFORE anything else in this call --
+      specifically, before any block seals this frame. `resize/2` remains
+      the standalone entry point; calling `resize/2` then `advance/2` is
+      equally correct. The `:resize` option exists only for drivers that
+      would otherwise have to sequence two separate calls for what is, to
+      the terminal, one frame.
+
+  ## FRAME-ORDER LAW
+
+  A resize arriving in the SAME frame as an advance MUST be adopted
+  before any seal in that advance: a block sealed at a stale width hard-
+  wraps over-wide rows, and that wrap is permanent corruption once the
+  row scrolls into native scrollback (this process can never rewrite it).
+  This is why the `:resize` option is threaded through
+  `adopt_frame_resize/2` first, unconditionally, ahead of `do_advance/2`.
+
+  The footer row COUNT in this substrate is geometry-fixed (a function of
+  `rows`/`footer_rows` only, never of post-seal state) -- so the
+  reference design's "size the footer to the post-seal state" step is
+  satisfied by construction, with nothing further to do here. The footer
+  REPAINT itself still runs AFTER the seal (see `seal_frame/3`): the
+  trailing `paint_footer/1` self-promotes to a full keyframe via
+  `InlineAuthority`'s own `needs_keyframe` latch (set by `adopt_resize/3`
+  whenever geometry or width changed), so the footer always ends up
+  correct at the newly-adopted geometry without this module needing a
+  second, explicit keyframe call here.
+  """
+  @spec advance(t(), integer() | nil, keyword()) :: {t(), :ok | :done}
+  def advance(model, now \\ nil, opts \\ [])
+
+  def advance(model, now, opts) do
+    model
+    |> adopt_frame_resize(Keyword.get(opts, :resize))
+    |> do_advance(now)
+  end
+
+  defp adopt_frame_resize(model, nil), do: model
+
+  defp adopt_frame_resize(model, {width, rows}),
+    do: adopt_resize(model, width, rows)
+
+  defp do_advance(
+         %{revealed: revealed, events: events, painted_count: painted} = model,
+         _now
+       )
+       when revealed >= length(events) and
+              painted >= length(model.projection.blocks) do
     {model, :done}
   end
 
-  def advance(model, now) do
+  defp do_advance(model, now) do
     revealed = min(model.revealed + 1, length(model.events))
     events_so_far = Enum.take(model.events, revealed)
 
@@ -773,16 +817,49 @@ defmodule Raxol.Harness.Surface do
 
     model =
       %{model | revealed: revealed, projection: projection}
+      # Pure model-state reconciliation (no bytes) -- runs before the
+      # seal frame so the divider bookkeeping is settled ahead of any
+      # paint, and stays OUTSIDE the sync bracket seal_frame may open.
       |> reconcile_unread()
-      |> paint_pending_blocks()
-      |> update_status(events_so_far, now)
-      |> paint_footer()
+      |> seal_frame(events_so_far, now)
 
     finished? =
       model.revealed >= length(model.events) and
         model.painted_count >= length(model.projection.blocks)
 
     {model, if(finished?, do: :done, else: :ok)}
+  end
+
+  # A frame that seals at least one block AND repaints the footer
+  # presents atomically: seal + status + footer run inside one DEC 2026
+  # synchronized-update bracket (InlineAuthority.with_sync/3, gated on
+  # the capability record). The bracket condition is the pre-seal scan's
+  # will_commit -- it exactly predicts "this frame seals >= 1 block"
+  # except when the first emit fails, in which case an empty bracket is
+  # emitted (harmless: a sync frame with no visible change; the
+  # balanced-bracket case in test/harness/surface_seal_pipeline_test.exs
+  # covers the failure path). Frames that seal nothing (early reveals,
+  # tick, handle_input) never open a bracket. :flat has no footer and no
+  # cursor vocabulary -- never bracketed.
+  defp seal_frame(%{mode: :flat} = model, events_so_far, now) do
+    run_seal_frame(model, events_so_far, now)
+  end
+
+  defp seal_frame(model, events_so_far, now) do
+    if frontier_scan(model).will_commit do
+      InlineAuthority.with_sync(model.authority, model, fn m ->
+        run_seal_frame(m, events_so_far, now)
+      end)
+    else
+      run_seal_frame(model, events_so_far, now)
+    end
+  end
+
+  defp run_seal_frame(model, events_so_far, now) do
+    model
+    |> paint_pending_blocks()
+    |> update_status(events_so_far, now)
+    |> paint_footer()
   end
 
   @doc """
@@ -874,6 +951,12 @@ defmodule Raxol.Harness.Surface do
   (`turn_completed`); with today's entry mapping (no running entries,
   window hold unconditional) the scan result is independent of turn
   state, so the one-step-stale status at seal time is harmless.
+
+  A third consumer: `seal_frame/3`'s per-frame synchronized-output
+  bracket decision reads `will_commit` from this same scan to predict
+  "this frame seals >= 1 block" BEFORE the commit pass actually runs --
+  same entries, same classifier, so it can never disagree with what
+  `paint_pending_blocks/1` (via `commit_walk/5`) actually does.
   """
   @spec frontier_scan(t()) :: SealFrontier.scan()
   def frontier_scan(model) do
@@ -916,9 +999,12 @@ defmodule Raxol.Harness.Surface do
     # The ONE mutating frontier walk (SealFrontier's moduledoc): emit
     # each newly-committable block via seal_block/2, which advances
     # painted_count -- the committed marker frontier_entries/1 reads.
-    # The emit is infallible today (InlineAuthority.seal/2 has no error
-    # path), so the walk's write-failure branch stays corpus-only until
-    # a write-confirming substrate lands (the two-phase seal follow-up).
+    # The emit is write-confirming (`InlineAuthority.try_seal/2`): write ->
+    # confirm -> mark. A failed device write halts the walk with
+    # painted_count (the cursor) strictly before the failed entry, and the
+    # next advance retries the same block, so a block can never be marked
+    # painted without its bytes confirmed on the device (retry-not-vanish;
+    # covered by test/harness/surface_seal_pipeline_test.exs).
     result =
       SealFrontier.commit_walk(
         entries,
@@ -930,7 +1016,7 @@ defmodule Raxol.Harness.Surface do
             |> Enum.at(index)
             |> apply_fold_override(index, acc.fold_overrides)
 
-          {:ok, seal_block(acc, block)}
+          seal_block(acc, block)
         end,
         cursor: model.painted_count
       )
@@ -989,14 +1075,19 @@ defmodule Raxol.Harness.Surface do
     end
   end
 
+  # :flat -- the degradation tier's append is a plain stdout/pipe write with
+  # no positioning to confirm; a failed pipe write raising out of the frame
+  # is the honest flat behavior, so the flat emit stays infallible-shaped.
   defp seal_block(%{mode: :flat} = model, block) do
     lines = render_block_lines(block, model, :plain)
     iodata = Enum.map(lines, &(&1 <> "\n"))
     authority = FlatAuthority.seal(model.authority, iodata)
-    %{model | authority: authority, painted_count: model.painted_count + 1}
+
+    {:ok,
+     %{model | authority: authority, painted_count: model.painted_count + 1}}
   end
 
-  # No per-line `\e[K` here: `InlineAuthority.seal/2` sanitizes CONTENT
+  # No per-line `\e[K` here: `InlineAuthority.try_seal/2` sanitizes CONTENT
   # through `ContentGuard.sanitize_line/1` (its allowlist keeps SGR only),
   # so an EL embedded in content never survived -- the guard stripped the
   # ESC and left a literal `[K` painted at the start of every sealed
@@ -1007,8 +1098,15 @@ defmodule Raxol.Harness.Surface do
   defp seal_block(model, block) do
     lines = render_block_lines(block, model, :styled)
     iodata = Enum.map(lines, &[&1, "\r\n"])
-    authority = InlineAuthority.seal(model.authority, iodata)
-    %{model | authority: authority, painted_count: model.painted_count + 1}
+
+    case InlineAuthority.try_seal(model.authority, iodata) do
+      {:ok, authority} ->
+        {:ok,
+         %{model | authority: authority, painted_count: model.painted_count + 1}}
+
+      {:error, :write_failed, authority} ->
+        {:error, :write_failed, %{model | authority: authority}}
+    end
   end
 
   # Called from seal_block/2 -- the print-once paint -- so the grade
@@ -2071,7 +2169,23 @@ defmodule Raxol.Harness.Surface do
   keyframe below repaints it at the new position.
   """
   @spec resize(t(), pos_integer(), pos_integer()) :: t()
-  def resize(%{mode: :flat} = model, width, rows) do
+  def resize(%{mode: :flat} = model, width, rows),
+    do: adopt_resize(model, width, rows)
+
+  def resize(model, width, rows) do
+    model = adopt_resize(model, width, rows)
+    lines = footer_lines(model)
+    authority = InlineAuthority.keyframe(model.authority, lines)
+    %{model | authority: authority, stub_notice: nil}
+  end
+
+  # Shared by `resize/2` and `advance/3`'s `:resize` option -- see
+  # `advance/3`'s FRAME-ORDER LAW doc for why the two paths must never
+  # drift: both need dims + DECSTBM re-set applied identically, and
+  # `resize/2` alone additionally keyframes the footer immediately (which
+  # `advance/3`'s combined frame instead lets its own trailing
+  # `paint_footer/1` self-promote to, via `needs_keyframe`).
+  defp adopt_resize(%{mode: :flat} = model, width, rows) do
     %{
       model
       | authority: FlatAuthority.resize(model.authority, width, rows),
@@ -2080,7 +2194,7 @@ defmodule Raxol.Harness.Surface do
     }
   end
 
-  def resize(model, width, rows) do
+  defp adopt_resize(model, width, rows) do
     model =
       if force_close_overlay?(model, rows) do
         close_overlay(model)
@@ -2089,10 +2203,7 @@ defmodule Raxol.Harness.Surface do
       end
 
     model = %{model | width: width, rows: rows}
-    authority = InlineAuthority.resize(model.authority, width, rows)
-    lines = footer_lines(%{model | authority: authority})
-    authority = InlineAuthority.keyframe(authority, lines)
-    %{model | authority: authority, stub_notice: nil}
+    %{model | authority: InlineAuthority.resize(model.authority, width, rows)}
   end
 
   defp force_close_overlay?(%{overlay: nil}, _new_rows), do: false

--- a/lib/raxol/ui/rendering/paint_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority.ex
@@ -109,6 +109,20 @@ defmodule Raxol.UI.Rendering.PaintAuthority do
     def cursor_position(row) when is_integer(row) and row >= 1 do
       "\e[#{row};1H"
     end
+
+    @doc """
+    DEC 2026 synchronized-update begin: `CSI ? 2026 h`. Paired with
+    `sync_end/0` by `InlineAuthority.sync_open/1`/`sync_close/1`; defined
+    here (not inline at the emit site) so the mode number and set/reset
+    finals live in the shared wire vocabulary, pinned by a raw-byte test
+    rather than duplicated per call site.
+    """
+    @spec sync_begin() :: binary()
+    def sync_begin, do: "\e[?2026h"
+
+    @doc "DEC 2026 synchronized-update end: `CSI ? 2026 l`. See `sync_begin/0`."
+    @spec sync_end() :: binary()
+    def sync_end, do: "\e[?2026l"
   end
 
   defmodule IOAuthority do

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -465,27 +465,40 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   scratch rather than resuming from a cursor that may have been left
   mid-write.
 
-  ## Only device-origin failures are converted to `:write_failed`
+  ## Only RETRYABLE device failures are converted to `:write_failed`
 
-  The rescue below is scoped by `device_io_error?/2`: an exception
-  qualifies only when it is one of the two device classes AND was raised
-  by the `:io` layer itself (the stack head names the raiser):
+  The rescue below is scoped twice, by `retryable_device_error?/2`:
 
-    * `ArgumentError` raised by `:io.put_chars` -- the io server replied
-      `{:error, reason}` (e.g. `{:error, :enospc}`).
-    * `ErlangError` raised by `:io.put_chars` -- the device process is
-      dead (canonically `%ErlangError{original: :terminated}` from a
-      closed `StringIO`/port).
+    * It must be a device failure at all (`device_io_error?/2` -- one of
+      the two device classes AND raised by the `:io` layer itself, the
+      stack head naming the raiser). Anything else RE-RAISES: an
+      `ArgumentError`/`ErlangError` raised by non-device code inside the
+      seal path is a logic bug, and reclassifying it as `:write_failed`
+      would turn it into an unbounded silent retry loop (the same entry
+      re-attempted every frame, forever, with the real error never
+      surfaced).
+    * It must be plausibly TRANSIENT. The `{:error, reason}` io reply
+      (`ArgumentError` from `:io.put_chars`, e.g. `enospc`) is: the
+      device is alive and answering, and may accept the retry. A DEAD
+      device (`%ErlangError{original: :terminated}` -- the io-server
+      process is gone) is NOT: a pid never comes back, so retrying is
+      retrying a corpse, forever and silently. That case RE-RAISES too --
+      the loud crash is the honest outcome for a device that can never
+      heal (and is exactly what the pre-two-phase `seal/2` did).
 
-  Anything else RE-RAISES: an `ArgumentError`/`ErlangError` raised by
-  non-device code inside the seal path is a logic bug, and reclassifying
-  it as `:write_failed` would turn it into an unbounded silent retry loop
-  (the same entry re-attempted every frame, forever, with the real error
-  never surfaced). The validation raise above happens BEFORE the rescued
-  block even starts -- a missing `\\r\\n` is a bug in the calling code,
-  not a device failure. Likewise, `with_cursor/3`'s own nested-bracket
+  The validation raise above happens BEFORE the rescued block even
+  starts -- a missing `\\r\\n` is a bug in the calling code, not a
+  device failure. Likewise, `with_cursor/3`'s own nested-bracket
   `RuntimeError` is deliberately NOT rescued -- a caller bug, not
   something a device retry can fix.
+
+  A refusing-but-alive device CAN loop indefinitely (each frame retries,
+  each retry may be refused again). That loop is deliberate -- a bound
+  would strand the block if the device recovers on attempt N+1 -- but it
+  is not silent: the harness consumer emits
+  `[:raxol, :harness, :seal, :write_failed]` telemetry per refused write
+  (see `Raxol.Harness.Surface`), so a persistent refusal is observable
+  from the first frame.
 
   ## Partial-write honesty (and the scroll-boundary residual)
 
@@ -521,11 +534,21 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
      with_cursor(t, :history, fn inner -> append_sealed(inner, sanitized) end)}
   rescue
     e in [ArgumentError, ErlangError] ->
-      if device_io_error?(e, __STACKTRACE__) do
+      if retryable_device_error?(e, __STACKTRACE__) do
         {:error, :write_failed, t}
       else
         reraise e, __STACKTRACE__
       end
+  end
+
+  # The retryability split on top of device_io_error?/2 (see try_seal/2's
+  # doc): a device failure is only worth a retry when the device is ALIVE
+  # and answering ({:error, reason} reply). A dead device -- the io-server
+  # pid is gone; %ErlangError{original: :terminated} -- can never heal, so
+  # it re-raises (fail-fast) instead of becoming an infinite corpse-retry.
+  defp retryable_device_error?(exception, stacktrace) do
+    device_io_error?(exception, stacktrace) and
+      not match?(%ErlangError{original: :terminated}, exception)
   end
 
   @doc """
@@ -547,6 +570,14 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   The same exception class raised by NON-device code returns false, so
   callers re-raise it loudly instead of misclassifying a logic bug as a
   retryable write failure.
+
+  Note this answers "is it a device io error", NOT "is it worth
+  retrying" -- those are different questions. A dead device
+  (`%ErlangError{original: :terminated}`) IS a device io error by this
+  predicate, but the rescue sites here treat it as fail-fast, never
+  retryable: the io-server pid is gone and can never come back, so a
+  retry loop against it would spin silently forever (the round-2 review
+  finding). See `try_seal/2`'s "Only RETRYABLE device failures" section.
   """
   @spec device_io_error?(Exception.t(), Exception.stacktrace()) :: boolean()
   def device_io_error?(exception, stacktrace)
@@ -583,10 +614,12 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   ## A failed open degrades gracefully
 
-  If the opening write itself fails (device error, per
-  `device_io_error?/2` -- anything else re-raises), the latch is left as
-  it was and the frame simply runs unbracketed: this is a
-  PRESENTATION-only feature and must never take down the frame it wraps.
+  If the opening write itself is REFUSED (the alive-but-refusing device
+  class -- a dead device re-raises, same fail-fast rationale as
+  `try_seal/2`'s corpse rule; anything non-device re-raises too), the
+  latch is left as it was and the frame simply runs unbracketed: this is
+  a PRESENTATION-only feature and must never take down the frame it
+  wraps.
   """
   @spec sync_open(t()) :: t()
   def sync_open(%__MODULE__{sync_output?: false} = t), do: t
@@ -618,6 +651,13 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   therefore "until the next frame with a writable device" -- never
   "forever" -- and, since a refused SEAL write guarantees a retry frame,
   the common failure topology heals immediately.
+
+  The wedge-then-QUIT topology (a close stranded on the session's final
+  frame, no later frame to heal on) is covered one layer down: the
+  inline driver's canonical teardown AND editor-suspend byte sequences
+  (`Raxol.Terminal.InlineDriver.Sequences`, step 1) emit an
+  unconditional `?2026l` backstop -- harmless when nothing is owed, DEC
+  private modes being set/reset.
   """
   @spec sync_close(t()) :: t()
   def sync_close(%__MODULE__{sync_close_pending?: false} = t), do: t
@@ -629,16 +669,20 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     end
   end
 
-  # Best-effort single byte-sequence write for the sync bracket: device
-  # failures (per device_io_error?/2 -- the :io-raised classes only)
-  # report :error; anything else re-raises. A lost sync byte never
-  # crashes the frame it was only decorating.
+  # Best-effort single byte-sequence write for the sync bracket:
+  # RETRYABLE device failures (retryable_device_error?/2 -- the
+  # alive-but-refusing {:error, reason} reply class) report :error, so a
+  # lost sync byte never crashes the frame it was only decorating and the
+  # latch re-attempts later. A DEAD device re-raises, same fail-fast
+  # rationale as confirmed_seal/2: everything after this write hits the
+  # same corpse, and retrying it forever would be the silent-loop
+  # regression round 2 flagged. Non-device raises re-raise (logic bug).
   defp sync_write(device, bytes) do
     IO.write(device, bytes)
     :ok
   rescue
     e in [ArgumentError, ErlangError] ->
-      if device_io_error?(e, __STACKTRACE__) do
+      if retryable_device_error?(e, __STACKTRACE__) do
         :error
       else
         reraise e, __STACKTRACE__

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -257,6 +257,18 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   content is fully re-rendered at its new (smaller) position.
 
   Neither direction ever emits `\e[2J`/`\e[3J`.
+
+  ## Synchronized output (DEC private mode 2026)
+
+  `with_sync/3` is the DEC 2026 synchronized-update bracket
+  (`CSI ? 2026 h` ... `CSI ? 2026 l`): a Surface frame that seals one or
+  more blocks wraps the seal writes and the trailing footer repaint in
+  this bracket so a multi-block seal presents to the terminal atomically
+  (no partial-frame flicker between the sealed history and the repainted
+  footer). It is gated on this authority's `sync_output?` field (measured
+  once, at `new/5`, from the capability record) -- capability-unknown
+  means don't emit, never a guess. See `with_sync/3`'s own doc for the
+  balanced-bracket and failed-open-degrades guarantees.
   """
 
   @behaviour Raxol.UI.Rendering.PaintAuthority
@@ -274,7 +286,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     :next_row,
     in_cursor_bracket: false,
     footer_lines: [],
-    needs_keyframe: false
+    needs_keyframe: false,
+    sync_output?: false
   ]
 
   @type t :: %__MODULE__{
@@ -284,7 +297,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
           next_row: pos_integer(),
           in_cursor_bracket: boolean(),
           footer_lines: [binary()],
-          needs_keyframe: boolean()
+          needs_keyframe: boolean(),
+          sync_output?: boolean()
         }
 
   @doc """
@@ -322,7 +336,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       region: ScrollRegionManager.start(device, rows, footer_rows),
       width: width,
       reflow_capable?: reflow_capable?(caps),
-      next_row: 1
+      next_row: 1,
+      sync_output?: match?(%{sync_output: true}, caps)
     }
   end
 
@@ -385,6 +400,17 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   """
   @spec seal(t(), iodata()) :: t()
   def seal(%__MODULE__{} = t, iodata) do
+    sanitized = validate_seal_iodata!(iodata)
+    with_cursor(t, :history, fn inner -> append_sealed(inner, sanitized) end)
+  end
+
+  # Shared by `seal/2` and `try_seal/2`: enforce the `\r\n`-terminated
+  # caller contract (raises `ArgumentError` -- a caller-contract bug, never
+  # masked as a device failure) and run the content through
+  # `ContentGuard.sanitize_line/1` (see the moduledoc's `ContentGuard`
+  # section). This runs OUTSIDE `try_seal/2`'s rescued scope -- see that
+  # function's doc for why the two error classes must stay distinct.
+  defp validate_seal_iodata!(iodata) do
     binary = IO.iodata_to_binary(iodata)
 
     unless String.ends_with?(binary, "\r\n") do
@@ -394,9 +420,130 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
               inspect(binary)
     end
 
-    sanitized = ContentGuard.sanitize_line(binary)
+    ContentGuard.sanitize_line(binary)
+  end
 
-    with_cursor(t, :history, fn inner -> append_sealed(inner, sanitized) end)
+  @doc """
+  The write-confirming seal: validates and sanitizes `iodata` (via
+  `validate_seal_iodata!/1`, the same discipline `seal/2` uses -- a
+  missing `\\r\\n` terminator is a CALLER-CONTRACT bug and still raises
+  `ArgumentError`, unmasked), then attempts the write and reports whether
+  the device actually confirmed it.
+
+  ## Write -> confirm -> mark
+
+  This is the substrate half of the print-once safety property
+  documented in `Raxol.Harness.SealFrontier.commit_walk/5`: a caller
+  (`Raxol.Harness.Surface.seal_block/2`) marks a block committed only
+  AFTER `try_seal/2` returns `{:ok, _}` -- never before. On `{:error,
+  :write_failed, t}`, the ORIGINAL `t` (the one passed in, `next_row` not
+  advanced) is returned, so a retry re-positions and re-writes from
+  scratch rather than resuming from a cursor that may have been left
+  mid-write.
+
+  ## The two rescued error classes
+
+  Only DEVICE failures are converted to `{:error, :write_failed, t}`:
+
+    * `ArgumentError` -- the io server replied `{:error, reason}` to the
+      underlying `:io.put_chars` request (e.g. `{:error, :enospc}`);
+      `IO.write/2` surfaces this as a raised `ArgumentError`.
+    * `ErlangError` -- the device process is dead (e.g. `%ErlangError{
+      original: :terminated}` from a closed `StringIO`/port).
+
+  The validation raise above happens BEFORE the rescued block even starts
+  -- a missing `\\r\\n` is a bug in the calling code, not a device
+  failure, and must never be silently downgraded to a retryable
+  `:write_failed` (a caller retrying a permanently-malformed call would
+  loop forever). Likewise, `with_cursor/3`'s own nested-bracket
+  `RuntimeError` is deliberately NOT rescued here -- that too is a caller
+  bug (two overlapping brackets), not something a device retry can fix.
+
+  ## Partial-write honesty
+
+  A retry may overwrite a partially-flushed row in place (the device may
+  have accepted some bytes before failing mid-write, on some transports).
+  This is safe: an unconfirmed row was never counted in `seal`'s high-
+  water accounting (`next_row` is only advanced on `{:ok, _}`) nor marked
+  committed by `commit_walk/5`, so a retry writing over it again produces
+  the same rows the confirmed write would have -- no seal-once violation.
+  """
+  @spec try_seal(t(), iodata()) :: {:ok, t()} | {:error, :write_failed, t()}
+  def try_seal(%__MODULE__{} = t, iodata) do
+    sanitized = validate_seal_iodata!(iodata)
+    confirmed_seal(t, sanitized)
+  end
+
+  defp confirmed_seal(t, sanitized) do
+    {:ok,
+     with_cursor(t, :history, fn inner -> append_sealed(inner, sanitized) end)}
+  rescue
+    _e in [ArgumentError, ErlangError] -> {:error, :write_failed, t}
+  end
+
+  @doc """
+  The DEC 2026 synchronized-update bracket (see the moduledoc's
+  "Synchronized output" section): wraps `fun.(acc)` in `CSI ? 2026 h`
+  ... `CSI ? 2026 l` when this authority measured the capability true at
+  construction (`sync_output?`), otherwise runs `fun.(acc)` unbracketed.
+
+  ## Capability-gated, capability-unknown-means-don't-emit
+
+  `sync_output?` is measured once, at `new/5`, from the capability
+  record passed in (`nil`/unknown -> `false`). This function does not
+  re-check the capability itself -- it trusts the field. A `nil`/unknown
+  capability is the documented policy: never emit a presentation-only
+  control sequence on a guess.
+
+  ## Balanced by construction
+
+  The close (`CSI ? 2026 l`) is emitted if AND ONLY IF the open
+  succeeded, via the `after` block below -- even when `fun` raises or
+  returns while a nested seal failed. A caller that sees the open fail
+  degrades to running `fun` completely unbracketed (see below); there is
+  never a dangling open with no matching close, and never a close with no
+  matching open.
+
+  ## A failed open degrades gracefully
+
+  If the opening write itself fails (device error), `fun.(acc)` still
+  runs, just without the bracket -- this is a PRESENTATION-only feature
+  (it only affects how atomically the terminal shows already-correct
+  bytes); it must never be allowed to take down the frame it wraps.
+
+  ## Best-effort byte writes
+
+  `sync_write/2` rescues the same two device-error classes as
+  `try_seal/2` (`ArgumentError` from an `{:error, reason}` io-server
+  reply, `ErlangError` from a dead device) and reports `:error` rather
+  than raising, so a lost sync byte never crashes the frame it was only
+  decorating.
+  """
+  @spec with_sync(t(), acc, (acc -> acc)) :: acc when acc: term()
+  def with_sync(%__MODULE__{sync_output?: false}, acc, fun)
+      when is_function(fun, 1),
+      do: fun.(acc)
+
+  def with_sync(%__MODULE__{region: region}, acc, fun)
+      when is_function(fun, 1) do
+    case sync_write(region.device, "\e[?2026h") do
+      :ok ->
+        try do
+          fun.(acc)
+        after
+          sync_write(region.device, "\e[?2026l")
+        end
+
+      :error ->
+        fun.(acc)
+    end
+  end
+
+  defp sync_write(device, bytes) do
+    IO.write(device, bytes)
+    :ok
+  rescue
+    _e in [ArgumentError, ErlangError] -> :error
   end
 
   @impl true

--- a/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
+++ b/lib/raxol/ui/rendering/paint_authority/inline_authority.ex
@@ -260,15 +260,23 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
 
   ## Synchronized output (DEC private mode 2026)
 
-  `with_sync/3` is the DEC 2026 synchronized-update bracket
-  (`CSI ? 2026 h` ... `CSI ? 2026 l`): a Surface frame that seals one or
-  more blocks wraps the seal writes and the trailing footer repaint in
-  this bracket so a multi-block seal presents to the terminal atomically
-  (no partial-frame flicker between the sealed history and the repainted
-  footer). It is gated on this authority's `sync_output?` field (measured
-  once, at `new/5`, from the capability record) -- capability-unknown
-  means don't emit, never a guess. See `with_sync/3`'s own doc for the
-  balanced-bracket and failed-open-degrades guarantees.
+  `sync_open/1` / `sync_close/1` are the DEC 2026 synchronized-update
+  bracket (`Dialect.sync_begin/0` ... `Dialect.sync_end/0`): a Surface
+  frame that seals one or more blocks wraps the seal writes and the
+  trailing footer repaint in this bracket so a multi-block seal presents
+  to the terminal atomically (no partial-frame flicker between the
+  sealed history and the repainted footer). Gated on this authority's
+  `sync_output?` field (measured once, at `new/5`, from the capability
+  record, strict struct match) -- capability-unknown means don't emit,
+  never a guess.
+
+  The pair is latch-backed (`sync_close_pending?`): a close the device
+  refuses is remembered as OWED and re-attempted on every subsequent
+  frame until a write lands, so a landed `?2026h` can never dangle
+  forever with the terminal wedged in synchronized mode -- the failure
+  window is "until the next frame with a writable device", not
+  "until the process exits". See `sync_open/1`/`sync_close/1` for the
+  full contract.
   """
 
   @behaviour Raxol.UI.Rendering.PaintAuthority
@@ -287,7 +295,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     in_cursor_bracket: false,
     footer_lines: [],
     needs_keyframe: false,
-    sync_output?: false
+    sync_output?: false,
+    sync_close_pending?: false
   ]
 
   @type t :: %__MODULE__{
@@ -298,7 +307,8 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
           in_cursor_bracket: boolean(),
           footer_lines: [binary()],
           needs_keyframe: boolean(),
-          sync_output?: boolean()
+          sync_output?: boolean(),
+          sync_close_pending?: boolean()
         }
 
   @doc """
@@ -337,7 +347,10 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
       width: width,
       reflow_capable?: reflow_capable?(caps),
       next_row: 1,
-      sync_output?: match?(%{sync_output: true}, caps)
+      # Strict struct match, mirroring `reflow_capable?/1`'s own idiom: a
+      # stray plain map carrying a `sync_output: true` key must never
+      # enable emission -- only the probe-built capability record may.
+      sync_output?: match?(%Capabilities{sync_output: true}, caps)
     }
   end
 
@@ -424,11 +437,22 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   end
 
   @doc """
-  The write-confirming seal: validates and sanitizes `iodata` (via
+  The write-checked seal: validates and sanitizes `iodata` (via
   `validate_seal_iodata!/1`, the same discipline `seal/2` uses -- a
   missing `\\r\\n` terminator is a CALLER-CONTRACT bug and still raises
   `ArgumentError`, unmasked), then attempts the write and reports whether
-  the device actually confirmed it.
+  the io server ACCEPTED it.
+
+  ## What "accepted" means (and does not)
+
+  `{:ok, _}` means the device's io server replied `:ok` to the write
+  request -- accepted-into-the-io-server. For a `StringIO`/test device
+  that IS end-to-end delivery; for a buffered pipe or `:stdio` it means
+  the bytes were handed off, not that they were rendered on a screen.
+  Proving end-to-end delivery would need a DSR round-trip this module
+  does not do. "Accepted" is still the load-bearing property for
+  print-once accounting: a block is only ever marked committed for bytes
+  the device did not refuse.
 
   ## Write -> confirm -> mark
 
@@ -441,32 +465,50 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
   scratch rather than resuming from a cursor that may have been left
   mid-write.
 
-  ## The two rescued error classes
+  ## Only device-origin failures are converted to `:write_failed`
 
-  Only DEVICE failures are converted to `{:error, :write_failed, t}`:
+  The rescue below is scoped by `device_io_error?/2`: an exception
+  qualifies only when it is one of the two device classes AND was raised
+  by the `:io` layer itself (the stack head names the raiser):
 
-    * `ArgumentError` -- the io server replied `{:error, reason}` to the
-      underlying `:io.put_chars` request (e.g. `{:error, :enospc}`);
-      `IO.write/2` surfaces this as a raised `ArgumentError`.
-    * `ErlangError` -- the device process is dead (e.g. `%ErlangError{
-      original: :terminated}` from a closed `StringIO`/port).
+    * `ArgumentError` raised by `:io.put_chars` -- the io server replied
+      `{:error, reason}` (e.g. `{:error, :enospc}`).
+    * `ErlangError` raised by `:io.put_chars` -- the device process is
+      dead (canonically `%ErlangError{original: :terminated}` from a
+      closed `StringIO`/port).
 
-  The validation raise above happens BEFORE the rescued block even starts
-  -- a missing `\\r\\n` is a bug in the calling code, not a device
-  failure, and must never be silently downgraded to a retryable
-  `:write_failed` (a caller retrying a permanently-malformed call would
-  loop forever). Likewise, `with_cursor/3`'s own nested-bracket
-  `RuntimeError` is deliberately NOT rescued here -- that too is a caller
-  bug (two overlapping brackets), not something a device retry can fix.
+  Anything else RE-RAISES: an `ArgumentError`/`ErlangError` raised by
+  non-device code inside the seal path is a logic bug, and reclassifying
+  it as `:write_failed` would turn it into an unbounded silent retry loop
+  (the same entry re-attempted every frame, forever, with the real error
+  never surfaced). The validation raise above happens BEFORE the rescued
+  block even starts -- a missing `\\r\\n` is a bug in the calling code,
+  not a device failure. Likewise, `with_cursor/3`'s own nested-bracket
+  `RuntimeError` is deliberately NOT rescued -- a caller bug, not
+  something a device retry can fix.
 
-  ## Partial-write honesty
+  ## Partial-write honesty (and the scroll-boundary residual)
 
-  A retry may overwrite a partially-flushed row in place (the device may
-  have accepted some bytes before failing mid-write, on some transports).
-  This is safe: an unconfirmed row was never counted in `seal`'s high-
-  water accounting (`next_row` is only advanced on `{:ok, _}`) nor marked
-  committed by `commit_walk/5`, so a retry writing over it again produces
-  the same rows the confirmed write would have -- no seal-once violation.
+  On an io-server transport whose requests are accepted or refused as a
+  unit (a `StringIO`, the BEAM's own tty io server -- everything this
+  module is driven by today), a refused write leaves the screen
+  untouched and a retry simply re-positions and re-writes: the retry
+  produces the same rows the accepted write would have, and `next_row`/
+  the committed set never advanced, so print-once accounting holds.
+
+  A raw-fd/pty transport that can PARTIALLY flush before erroring is
+  weaker, and one case is a real residual: if `target_row` is at or near
+  `history_bottom`, partially-flushed `\\r\\n`s scroll the DECSTBM region
+  and evict partially-written rows into native scrollback -- which this
+  process can never rewrite. The retry then re-emits the whole block
+  BELOW those evicted fragments: the fragments are permanent
+  (duplicated/garbled) scrollback content. This module cannot detect or
+  repair that without a transactional device; it is named here so the
+  limit is a documented property, not an implied guarantee. (A
+  line-at-a-time write-and-check emit would bound the damage to one row
+  and is the natural follow-up if a partial-write transport ever drives
+  this path; not implemented -- nothing in the current harness stack
+  writes through one.)
   """
   @spec try_seal(t(), iodata()) :: {:ok, t()} | {:error, :write_failed, t()}
   def try_seal(%__MODULE__{} = t, iodata) do
@@ -478,72 +520,129 @@ defmodule Raxol.UI.Rendering.PaintAuthority.InlineAuthority do
     {:ok,
      with_cursor(t, :history, fn inner -> append_sealed(inner, sanitized) end)}
   rescue
-    _e in [ArgumentError, ErlangError] -> {:error, :write_failed, t}
+    e in [ArgumentError, ErlangError] ->
+      if device_io_error?(e, __STACKTRACE__) do
+        {:error, :write_failed, t}
+      else
+        reraise e, __STACKTRACE__
+      end
   end
 
   @doc """
-  The DEC 2026 synchronized-update bracket (see the moduledoc's
-  "Synchronized output" section): wraps `fun.(acc)` in `CSI ? 2026 h`
-  ... `CSI ? 2026 l` when this authority measured the capability true at
-  construction (`sync_output?`), otherwise runs `fun.(acc)` unbracketed.
+  Whether an exception is a DEVICE failure raised by the `:io` layer --
+  the discriminator scoping `try_seal/2`'s (and the sync bracket's)
+  rescue to the device seam and nothing else.
+
+  True only when BOTH hold:
+
+    * the exception is one of the two classes the io layer raises for a
+      failed write: `ArgumentError` (the io server replied
+      `{:error, reason}`) or `ErlangError` (dead device, canonically
+      `original: :terminated`), and
+    * the stack head names the `:io` module as the raiser -- i.e. the
+      raise came out of `:io.put_chars/2` (or a sibling io call), not
+      from this module's own logic, `:binary`, `String`, or anything
+      else that happens to raise the same exception class.
+
+  The same exception class raised by NON-device code returns false, so
+  callers re-raise it loudly instead of misclassifying a logic bug as a
+  retryable write failure.
+  """
+  @spec device_io_error?(Exception.t(), Exception.stacktrace()) :: boolean()
+  def device_io_error?(exception, stacktrace)
+
+  def device_io_error?(%struct{}, [{:io, _fun, _args, _info} | _rest])
+      when struct in [ArgumentError, ErlangError],
+      do: true
+
+  def device_io_error?(_exception, _stacktrace), do: false
+
+  @doc """
+  Opens a DEC 2026 synchronized-update bracket (`Dialect.sync_begin/0`,
+  `CSI ? 2026 h`) -- the first half of the pair `sync_close/1` completes.
+  See the moduledoc's "Synchronized output" section for the frame shape.
 
   ## Capability-gated, capability-unknown-means-don't-emit
 
   `sync_output?` is measured once, at `new/5`, from the capability
-  record passed in (`nil`/unknown -> `false`). This function does not
-  re-check the capability itself -- it trusts the field. A `nil`/unknown
-  capability is the documented policy: never emit a presentation-only
-  control sequence on a guess.
+  record passed in (`nil`/unknown -> `false`); without it this function
+  is a byte-free no-op. Never emit a presentation-only control sequence
+  on a guess.
 
-  ## Balanced by construction
+  ## The `sync_close_pending?` latch
 
-  The close (`CSI ? 2026 l`) is emitted if AND ONLY IF the open
-  succeeded, via the `after` block below -- even when `fun` raises or
-  returns while a nested seal failed. A caller that sees the open fail
-  degrades to running `fun` completely unbracketed (see below); there is
-  never a dangling open with no matching close, and never a close with no
-  matching open.
+  A successful open sets `sync_close_pending?: true` -- "a close byte is
+  owed to the terminal." The latch is cleared only by a close write the
+  device ACCEPTS (`sync_close/1`), which is what makes the pair's
+  balance claim byte-accurate rather than attempt-accurate: an open that
+  landed is remembered until its close lands, however many attempts that
+  takes. Opening while a close is still owed (a prior frame's close was
+  refused) is harmless -- DEC private modes are set/reset, not counted,
+  so a second `?2026h` on an already-synchronized terminal changes
+  nothing, and the still-set latch keeps the close owed.
 
   ## A failed open degrades gracefully
 
-  If the opening write itself fails (device error), `fun.(acc)` still
-  runs, just without the bracket -- this is a PRESENTATION-only feature
-  (it only affects how atomically the terminal shows already-correct
-  bytes); it must never be allowed to take down the frame it wraps.
-
-  ## Best-effort byte writes
-
-  `sync_write/2` rescues the same two device-error classes as
-  `try_seal/2` (`ArgumentError` from an `{:error, reason}` io-server
-  reply, `ErlangError` from a dead device) and reports `:error` rather
-  than raising, so a lost sync byte never crashes the frame it was only
-  decorating.
+  If the opening write itself fails (device error, per
+  `device_io_error?/2` -- anything else re-raises), the latch is left as
+  it was and the frame simply runs unbracketed: this is a
+  PRESENTATION-only feature and must never take down the frame it wraps.
   """
-  @spec with_sync(t(), acc, (acc -> acc)) :: acc when acc: term()
-  def with_sync(%__MODULE__{sync_output?: false}, acc, fun)
-      when is_function(fun, 1),
-      do: fun.(acc)
+  @spec sync_open(t()) :: t()
+  def sync_open(%__MODULE__{sync_output?: false} = t), do: t
 
-  def with_sync(%__MODULE__{region: region}, acc, fun)
-      when is_function(fun, 1) do
-    case sync_write(region.device, "\e[?2026h") do
-      :ok ->
-        try do
-          fun.(acc)
-        after
-          sync_write(region.device, "\e[?2026l")
-        end
-
-      :error ->
-        fun.(acc)
+  def sync_open(%__MODULE__{region: region} = t) do
+    case sync_write(region.device, Dialect.sync_begin()) do
+      :ok -> %{t | sync_close_pending?: true}
+      :error -> t
     end
   end
 
+  @doc """
+  Closes (or re-attempts closing) the DEC 2026 synchronized-update
+  bracket: when `sync_close_pending?` is set, writes
+  `Dialect.sync_end/0` (`CSI ? 2026 l`) and clears the latch iff the
+  device accepted the byte. A byte-free no-op when no close is owed --
+  safe to call on every frame.
+
+  ## Why the latch instead of "close in an after-block"
+
+  An attempted close is not a delivered close: if the device accepts the
+  OPEN and then refuses the close write (transient `enospc`, a device
+  dying mid-frame), the terminal is left frozen in synchronized mode --
+  and a fire-and-forget close attempt would leave it that way until the
+  process exits. The latch makes the owed close durable state:
+  `Raxol.Harness.Surface` calls this at the top of EVERY frame
+  (advance/tick/input/resize), so a dangling open heals at the first
+  frame after the device accepts a byte again. The residual window is
+  therefore "until the next frame with a writable device" -- never
+  "forever" -- and, since a refused SEAL write guarantees a retry frame,
+  the common failure topology heals immediately.
+  """
+  @spec sync_close(t()) :: t()
+  def sync_close(%__MODULE__{sync_close_pending?: false} = t), do: t
+
+  def sync_close(%__MODULE__{region: region} = t) do
+    case sync_write(region.device, Dialect.sync_end()) do
+      :ok -> %{t | sync_close_pending?: false}
+      :error -> t
+    end
+  end
+
+  # Best-effort single byte-sequence write for the sync bracket: device
+  # failures (per device_io_error?/2 -- the :io-raised classes only)
+  # report :error; anything else re-raises. A lost sync byte never
+  # crashes the frame it was only decorating.
   defp sync_write(device, bytes) do
     IO.write(device, bytes)
     :ok
   rescue
-    _e in [ArgumentError, ErlangError] -> :error
+    e in [ArgumentError, ErlangError] ->
+      if device_io_error?(e, __STACKTRACE__) do
+        :error
+      else
+        reraise e, __STACKTRACE__
+      end
   end
 
   @impl true

--- a/packages/raxol_terminal/lib/raxol/terminal/inline_driver/sequences.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/inline_driver/sequences.ex
@@ -39,7 +39,17 @@ defmodule Raxol.Terminal.InlineDriver.Sequences do
   # crashed session may have left it on, which would otherwise clamp the
   # step-4 absolute cursor move (`move_bottom/1`) inside whatever margins
   # were active instead of the real bottom row.
-  @modes_off "\e[?2004l\e[?1004l\e[?1003l\e[?1006l\e[?1000l\e[?6l"
+  #
+  # DEC 2026 (synchronized update) end is the teardown backstop for the
+  # harness's sync bracket (`InlineAuthority.sync_open/1`/`sync_close/1`):
+  # a close the device refused on the session's FINAL frame has no later
+  # frame to heal on, and a terminal left in synchronized mode is frozen.
+  # DEC private modes are set/reset, so an unconditional `?2026l` is
+  # harmless when nothing is owed and un-wedges the terminal when a close
+  # was stranded -- same defensive shape as the mouse/DECOM resets above.
+  # Also covers the editor-suspend path (`suspend_bytes/1` shares step 1):
+  # an editor must never inherit a synchronized-frozen screen.
+  @modes_off "\e[?2026l\e[?2004l\e[?1004l\e[?1003l\e[?1006l\e[?1000l\e[?6l"
   @release_region "\e[r"
   @autowrap_cursor "\e[?7h\e[?25h"
 

--- a/packages/raxol_terminal/test/raxol/terminal/inline_driver_sequences_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/inline_driver_sequences_test.exs
@@ -48,6 +48,26 @@ defmodule Raxol.Terminal.InlineDriverSequencesTest do
       assert bytes =~ "\e[?1000l"
     end
 
+    test "ends synchronized-update mode (DEC 2026) as a teardown backstop, inside step 1" do
+      # A sync close the device refused on the FINAL frame has no later
+      # frame to heal on (the harness heal seam is per-frame) -- process
+      # exit is the last chance. DEC private modes are set/reset, so an
+      # unconditional ?2026l is harmless when nothing is owed and un-wedges
+      # the terminal when a close was stranded. Belongs to step 1
+      # (modes off), same defensive rationale as the mouse/DECOM resets.
+      bytes = Sequences.teardown_bytes(24)
+
+      assert bytes =~ "\e[?2026l"
+
+      {sync_at, _} = :binary.match(bytes, "\e[?2026l")
+      {region_at, _} = :binary.match(bytes, Sequences.release_region())
+      assert sync_at < region_at
+    end
+
+    test "suspend_bytes/1 carries the same synchronized-update backstop (the editor must not inherit a frozen screen)" do
+      assert Sequences.suspend_bytes(24) =~ "\e[?2026l"
+    end
+
     test "re-enables autowrap and shows the cursor" do
       bytes = Sequences.teardown_bytes(24)
 

--- a/test/harness/golden_snapshot_test.exs
+++ b/test/harness/golden_snapshot_test.exs
@@ -47,6 +47,13 @@ defmodule Raxol.Harness.Surface.GoldenSnapshotTest do
   # (something emitted a sequence outside this vocabulary, e.g. OSC 52
   # clipboard exfiltration) or a deliberate vocabulary extension that must
   # be reviewed and added here consciously.
+  #
+  # DEC 2026 synchronized-update brackets (`CSI ? 2026 h`/`l`, finals
+  # `h`/`l`) are capability-gated (`Capabilities.sync_output`), and every
+  # golden here renders with `capabilities: nil` -- so they never appear
+  # in this vocabulary at all, deliberately: the capability-absent case is
+  # pinned by `test/harness/surface_seal_pipeline_test.exs`
+  # ("capability absent (nil) emits no brackets anywhere in a full run").
   @allowed_csi_finals ~w(H K m r)
   @allowed_esc_chars ~w(7 8)
 

--- a/test/harness/seal_frontier_test.exs
+++ b/test/harness/seal_frontier_test.exs
@@ -481,16 +481,18 @@ defmodule Raxol.Harness.SealFrontierTest do
     end
   end
 
-  # -- net-new case #2: resize-during-commit (NOTED, not implemented) --------
+  # -- net-new case #2: resize-during-commit (IMPLEMENTED) -------------------
   #
-  # The frame-order unit (a follow-up, not this module) must prove the
-  # adopt-size-BEFORE-commit ordering: a block finalizing on a shrink
-  # frame must be laid out at the freshly adopted width, never the stale
-  # one -- a stale-width commit hard-wraps over-wide rows and permanently
-  # garbles the print-once copy in native scrollback. That case needs the
-  # paint pipeline (width adoption + the seal write), which this pure
-  # classifier deliberately has no access to. It is recorded here so the
-  # frame-order unit starts from a named, red-first test obligation:
+  # The frame-order unit proved the adopt-size-BEFORE-commit ordering: a
+  # block finalizing on a shrink frame is laid out at the freshly adopted
+  # width, never the stale one -- a stale-width commit hard-wraps
+  # over-wide rows and permanently garbles the print-once copy in native
+  # scrollback. That case needed the paint pipeline (width adoption + the
+  # seal write), which this pure classifier deliberately has no access
+  # to, so it does NOT live here as a new test -- it lives in
+  # `test/harness/surface_seal_pipeline_test.exs` (describe "2. frame-order
+  # law"), driven end-to-end through `Raxol.Harness.Surface.advance/3`'s
+  # `:resize` option:
   #
   #   test "a block finalizing on a shrink frame commits at the adopted
   #         width, not the stale one"

--- a/test/harness/surface_seal_pipeline_test.exs
+++ b/test/harness/surface_seal_pipeline_test.exs
@@ -87,7 +87,11 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
     def start(opts) do
       {:ok, sink} = StringIO.open("")
       fail_when = Keyword.fetch!(opts, :fail_when)
-      pid = spawn_link(fn -> loop(sink, fail_when, false) end)
+      # :once (default) recovers after the first failure -- the transient
+      # topology. :always keeps refusing every matching write -- the
+      # non-transient topology round-2's observability finding targets.
+      mode = Keyword.get(opts, :mode, :once)
+      pid = spawn_link(fn -> loop(sink, fail_when, mode, false) end)
       {pid, sink}
     end
 
@@ -96,23 +100,23 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       out
     end
 
-    defp loop(sink, fail_when, failed?) do
+    defp loop(sink, fail_when, mode, failed?) do
       receive do
         {:io_request, from, ref, {:put_chars, _enc, chars}} ->
           bytes = IO.iodata_to_binary(chars)
 
-          if not failed? and fail_when.(bytes) do
+          if (mode == :always or not failed?) and fail_when.(bytes) do
             send(from, {:io_reply, ref, {:error, :enospc}})
-            loop(sink, fail_when, true)
+            loop(sink, fail_when, mode, true)
           else
             IO.write(sink, bytes)
             send(from, {:io_reply, ref, :ok})
-            loop(sink, fail_when, failed?)
+            loop(sink, fail_when, mode, failed?)
           end
 
         {:io_request, from, ref, _other} ->
           send(from, {:io_reply, ref, {:error, :request}})
-          loop(sink, fail_when, failed?)
+          loop(sink, fail_when, mode, failed?)
       end
     end
   end
@@ -292,18 +296,21 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       assert occurrences(FailingDevice.confirmed_bytes(sink), @marker) == 1
     end
 
-    test "try_seal/2 returns the authority untouched on a dead device (ErlangError class)" do
+    test "try_seal/2 fail-fasts on a dead device -- a corpse is never retried" do
+      # Round-2 review: a dead device (%ErlangError{original: :terminated})
+      # is PERMANENT by construction -- the io-server pid is gone and the
+      # same pid can never come back -- so classifying it retryable turned
+      # the pre-PR loud crash into a silent infinite retry loop. try_seal/2
+      # must re-raise it (fail-fast, restoring the loud failure), reserving
+      # {:error, :write_failed, _} for the ALIVE-but-refusing device class
+      # (the {:error, reason} io reply), which is plausibly transient.
       {:ok, dead} = StringIO.open("")
-      # Drain the construction bytes, then kill the device.
       authority = InlineAuthority.new(dead, 40, 10, 3)
       StringIO.close(dead)
 
-      assert {:error, :write_failed, returned} =
-               InlineAuthority.try_seal(authority, "line\r\n")
-
-      assert returned == authority,
-             "a failed seal must return the ORIGINAL authority " <>
-               "(next_row not advanced) so the retry re-positions from scratch"
+      assert_raise ErlangError, fn ->
+        InlineAuthority.try_seal(authority, "line\r\n")
+      end
     end
 
     test "try_seal/2 returns the authority untouched on an {:error, _} device reply (ArgumentError class)" do
@@ -712,6 +719,70 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       {open_at, _} = :binary.match(healed, @sync_open)
       {close_at, _} = :binary.match(healed, @sync_close)
       assert close_at > open_at
+    end
+  end
+
+  # =======================================================================
+  # 5. Review round 2: non-transient failure observability
+  # =======================================================================
+
+  describe "5. review round 2: refused-write telemetry" do
+    test "every refused seal write emits [:raxol, :harness, :seal, :write_failed] -- a persistent refusal is observable, not silent" do
+      # Round-2 review: an ALIVE device that permanently refuses the seal
+      # write drives advance/2 to return {model, :ok} forever -- an
+      # unbounded retry with, previously, no external signal at all. The
+      # retry itself is the designed behavior for a refusing-but-alive
+      # device (it may recover; a bound would strand the block when it
+      # does) -- what was missing is OBSERVABILITY. This pins the
+      # telemetry emit: one event per refused write, carrying the block
+      # index and kind, so a driver/operator can see the loop and decide.
+      handler_id = "seal-write-failed-#{inspect(make_ref())}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol, :harness, :seal, :write_failed],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:write_failed, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {device, sink} =
+        FailingDevice.start(
+          fail_when: seal_write_with(@marker),
+          mode: :always
+        )
+
+      content = "preview line one\npreview line two\n" <> @marker
+      model = new_model(message_events(content), device: device)
+      model = advance_to_pending_flush(model)
+
+      # Three failing frames: each returns :ok (retry pending), never
+      # marks, never raises -- and each emits exactly one event.
+      model =
+        Enum.reduce(1..3, model, fn n, m ->
+          {m, :ok} = Surface.advance(m)
+          assert m.painted_count == 0
+
+          assert_received {:write_failed, _measurements, metadata},
+                          "refused write ##{n} must emit telemetry"
+
+          assert metadata.index == 0
+          assert metadata.kind == :message
+          refute_received {:write_failed, _, _}
+          m
+        end)
+
+      assert occurrences(FailingDevice.confirmed_bytes(sink), @marker) == 0
+
+      # The loop stays honest end-to-end: the device is alive, so a
+      # recovery is still possible -- this test only pins that the loop
+      # is VISIBLE while it lasts.
+      assert {_model, :ok} = Surface.advance(model)
+      assert_received {:write_failed, _, _}
     end
   end
 end

--- a/test/harness/surface_seal_pipeline_test.exs
+++ b/test/harness/surface_seal_pipeline_test.exs
@@ -1,0 +1,573 @@
+defmodule Raxol.Harness.SurfaceSealPipelineTest do
+  @moduledoc """
+  The seal-pipeline hardening suite: three coupled correctness properties
+  of the `Raxol.Harness.Surface` seal path, each mapped to a documented
+  guarantee.
+
+  1. **Two-phase seal (write -> confirm -> mark).** The seal walk marks a
+     block committed only AFTER the device write confirmed. A failed
+     write halts the walk with the cursor strictly before the failed
+     entry; the next `advance/2` retries -- the block never silently
+     vanishes (print-once means a marked-but-unprinted block could never
+     be emitted again). `InlineAuthority.try_seal/2` is the
+     write-confirming substrate; `Raxol.Harness.SealFrontier.commit_walk/5`'s
+     `{:error, :write_failed, state}` branch (previously corpus-only) is
+     driven here through the REAL device seam.
+
+  2. **Frame-order law (adopt resize dims FIRST, then seal, then repaint
+     the footer).** A resize arriving in the same frame as an advance
+     must be adopted before any seal in that advance -- a block sealed at
+     a stale width hard-wraps over-wide rows and permanently garbles the
+     print-once copy in native scrollback. This is the named red-first
+     obligation recorded at the bottom of
+     `test/harness/seal_frontier_test.exs`. (In this substrate the footer
+     row count is geometry-fixed -- never a function of post-seal state --
+     so "size the footer to the post-seal state" is satisfied by
+     construction; the load-bearing halves are adopt-before-seal and
+     footer-repaint-after-seal.)
+
+  3. **Synchronized output (DEC private mode 2026).** A frame that seals
+     at least one block AND repaints the footer is wrapped in
+     `\\e[?2026h` ... `\\e[?2026l` so multi-block seals present
+     atomically -- gated on the terminal capability record
+     (`Capabilities.sync_output`); capability absent/unknown emits
+     nothing. Brackets stay balanced even when a seal write fails
+     mid-frame, and the O1 byte oracle models the bracket tokens rather
+     than halting unverifiable.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.Surface
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Capabilities
+  alias Raxol.Test.CrossTerminal.SequenceScanner
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+  alias Raxol.UI.TextMeasure
+
+  @width 100
+  @rows 20
+  @footer_rows 6
+
+  @sync_open "\e[?2026h"
+  @sync_close "\e[?2026l"
+
+  # A content marker that appears in exactly one place: the sealed block's
+  # body. The failing device keys on it, and the retry-not-vanish
+  # assertions count its occurrences in the confirmed byte stream.
+  @marker "RETRY-ME"
+
+  # ---------------------------------------------------------------------
+  # A device that fails exactly one targeted write, then recovers.
+  #
+  # Implements the Erlang I/O protocol. Replies `{:error, :enospc}` to the
+  # FIRST `put_chars` request whose bytes contain `marker` AND a `\r\n`
+  # (only SEAL writes are `\r\n`-terminated -- the footer's pending
+  # preview carries the same content but is CUP-positioned, never
+  # newline-carrying, so the failure targets exactly the seal write). With
+  # `fail_first: true` it instead fails the very first request of any
+  # kind. Every other request delegates to an inner StringIO sink -- so
+  # the sink holds exactly the bytes the device CONFIRMED, which is what a
+  # real terminal would have received. `IO.write/2` surfaces the error
+  # reply as a raised `ArgumentError` (and a dead device as `ErlangError`)
+  # -- the two error classes `InlineAuthority.try_seal/2` must catch.
+  # ---------------------------------------------------------------------
+  defmodule FailingDevice do
+    def start(opts) do
+      {:ok, sink} = StringIO.open("")
+      marker = Keyword.get(opts, :marker)
+      fail_first? = Keyword.get(opts, :fail_first, false)
+      pid = spawn_link(fn -> loop(sink, marker, fail_first?, false) end)
+      {pid, sink}
+    end
+
+    def confirmed_bytes(sink) do
+      {_in, out} = StringIO.contents(sink)
+      out
+    end
+
+    defp loop(sink, marker, fail_first?, failed?) do
+      receive do
+        {:io_request, from, ref, {:put_chars, _enc, chars}} ->
+          bytes = IO.iodata_to_binary(chars)
+
+          fail_now? =
+            not failed? and
+              (fail_first? or
+                 (marker != nil and String.contains?(bytes, marker) and
+                    String.contains?(bytes, "\r\n")))
+
+          if fail_now? do
+            send(from, {:io_reply, ref, {:error, :enospc}})
+            loop(sink, marker, fail_first?, true)
+          else
+            IO.write(sink, bytes)
+            send(from, {:io_reply, ref, :ok})
+            loop(sink, marker, fail_first?, failed?)
+          end
+
+        {:io_request, from, ref, _other} ->
+          send(from, {:io_reply, ref, {:error, :request}})
+          loop(sink, marker, fail_first?, failed?)
+      end
+    end
+  end
+
+  # -- shared helpers -----------------------------------------------------
+
+  # One turn, one completed message block carrying `content`.
+  defp message_events(content) do
+    [
+      %{
+        id: 1,
+        family: :loop,
+        type: :turn_started,
+        tier: :durable,
+        payload: %{prompt: "go"}
+      },
+      %{
+        id: 2,
+        family: :loop,
+        type: :item_started,
+        tier: :durable,
+        payload: %{item_id: "i1", item_type: "message"}
+      },
+      %{
+        id: 3,
+        family: :loop,
+        type: :item_completed,
+        tier: :durable,
+        payload: %{item_id: "i1", item_type: "message", content: content}
+      },
+      %{
+        id: 4,
+        family: :loop,
+        type: :turn_completed,
+        tier: :durable,
+        payload: %{final: true}
+      }
+    ]
+  end
+
+  defp new_model(events, opts) do
+    device =
+      Keyword.get_lazy(opts, :device, fn ->
+        {:ok, dev} = StringIO.open("")
+        dev
+      end)
+
+    Surface.new(
+      events,
+      Keyword.merge(
+        [
+          device: device,
+          width: @width,
+          rows: @rows,
+          footer_rows: @footer_rows,
+          mode: :inline_log,
+          capabilities: nil
+        ],
+        opts
+      )
+    )
+  end
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  # Advances until exactly one step BEFORE the flush: all but the last
+  # event revealed, the single block still pending (held by the foldable
+  # window, which releases only when the reveal finishes). The NEXT
+  # advance reveals the final event AND seals -- the sealing frame.
+  defp advance_to_pending_flush(model) do
+    Enum.reduce(1..(length(model.events) - 1), model, fn _n, m ->
+      {m, :ok} = Surface.advance(m)
+      m
+    end)
+  end
+
+  # The bytes a single step emitted: run `fun`, return {result, new_bytes}.
+  defp frame_bytes(read_fun, fun) do
+    before_bytes = read_fun.()
+    result = fun.()
+    after_bytes = read_fun.()
+
+    {result,
+     binary_part(
+       after_bytes,
+       byte_size(before_bytes),
+       byte_size(after_bytes) - byte_size(before_bytes)
+     )}
+  end
+
+  defp occurrences(haystack, needle) do
+    haystack |> :binary.matches(needle) |> length()
+  end
+
+  # Max VISIBLE line width in a byte stream: folds the token stream,
+  # accumulating text-run display widths into the current line; a newline
+  # or any cursor reposition (CUP) starts a new line, escape tokens
+  # contribute zero width. This is what "laid out at the adopted width"
+  # means at the byte level.
+  defp max_visible_line_width(bytes) do
+    bytes
+    |> SequenceScanner.scan()
+    |> Enum.reduce({0, 0}, fn
+      {:csi, _params, "H"}, {cur, max_w} ->
+        {0, max(max_w, cur)}
+
+      {:text, text}, {cur, max_w} ->
+        [first | rest] = String.split(text, ["\r\n", "\n"])
+
+        case rest do
+          [] ->
+            {cur + TextMeasure.display_width(first), max_w}
+
+          _ ->
+            widths = [cur + TextMeasure.display_width(first)] ++
+                Enum.map(rest, &TextMeasure.display_width/1)
+
+            {List.last(widths), Enum.max([max_w | widths])}
+        end
+
+      _token, acc ->
+        acc
+    end)
+    |> then(fn {cur, max_w} -> max(cur, max_w) end)
+  end
+
+  # =======================================================================
+  # 1. Two-phase seal: write -> confirm -> mark
+  # =======================================================================
+
+  describe "1. two-phase seal (write -> confirm -> mark)" do
+    test "a failed device write leaves the block unsealed and the next advance retries it (retry-not-vanish)" do
+      {device, sink} = FailingDevice.start(marker: @marker)
+
+      # The marker sits on the block's THIRD body line: the footer's
+      # pending-preview (a legitimately repaintable surface, NOT sealed
+      # history) shows only the first two body lines, so the marker's
+      # ONLY route to the device is the seal write itself -- which is
+      # exactly what the confirmed-bytes occurrence counts below measure.
+      content =
+        "preview line one\npreview line two\n" <>
+          @marker <> " " <> String.duplicate("payload ", 6)
+
+      model = new_model(message_events(content), device: device)
+
+      # Reveal everything; the block is still pending (foldable window).
+      model = advance_to_pending_flush(model)
+      assert model.painted_count == 0
+
+      # The flushing frame: the device rejects the seal's content write.
+      # The walk must halt WITHOUT marking -- painted_count unchanged, the
+      # frame survives (no raise out of advance), and no marker bytes were
+      # confirmed by the device.
+      {model, :ok} = Surface.advance(model)
+
+      assert model.painted_count == 0,
+             "a failed write must never mark the block committed " <>
+               "(mark-before-write would make it vanish from print-once history)"
+
+      assert occurrences(FailingDevice.confirmed_bytes(sink), @marker) == 0
+
+      # The very next advance retries the SAME entry and succeeds: the
+      # block seals exactly once -- retried, never vanished, never doubled.
+      {model, :done} = Surface.advance(model)
+
+      assert model.painted_count == 1
+      assert occurrences(FailingDevice.confirmed_bytes(sink), @marker) == 1
+    end
+
+    test "try_seal/2 returns the authority untouched on a dead device (ErlangError class)" do
+      {:ok, dead} = StringIO.open("")
+      # Drain the construction bytes, then kill the device.
+      authority = InlineAuthority.new(dead, 40, 10, 3)
+      StringIO.close(dead)
+
+      assert {:error, :write_failed, returned} =
+               InlineAuthority.try_seal(authority, "line\r\n")
+
+      assert returned == authority,
+             "a failed seal must return the ORIGINAL authority " <>
+               "(next_row not advanced) so the retry re-positions from scratch"
+    end
+
+    test "try_seal/2 returns the authority untouched on an {:error, _} device reply (ArgumentError class)" do
+      # Construction bytes (the DECSTBM set) carry no marker, so they
+      # succeed; the seal content write is the first marker-bearing
+      # request and gets the {:error, :enospc} reply.
+      {device, sink} = FailingDevice.start(marker: "line")
+      authority = InlineAuthority.new(device, 40, 10, 3)
+
+      assert {:error, :write_failed, returned} =
+               InlineAuthority.try_seal(authority, "line\r\n")
+
+      assert returned.next_row == authority.next_row
+      assert occurrences(FailingDevice.confirmed_bytes(sink), "line") == 0
+    end
+
+    test "try_seal/2 still raises on the caller-contract violation (missing \\r\\n) -- never masked as :write_failed" do
+      {:ok, device} = StringIO.open("")
+      authority = InlineAuthority.new(device, 40, 10, 3)
+
+      assert_raise ArgumentError, ~r/\\r\\n-terminated/, fn ->
+        InlineAuthority.try_seal(authority, "no terminator")
+      end
+    end
+
+    test "post-seal fill protection: a fold override on an already-painted block is rejected and stores nothing" do
+      # No placeholder-fill path against sealed content exists in this
+      # codebase (grepped; the SessionRecap pattern has no analogue) -- so
+      # this test PINS the API contract: the only mutation channel aimed
+      # at a painted block (a fold override) must be rejected, storing
+      # nothing, and sealed history bytes must stay byte-identical.
+      {:ok, device} = StringIO.open("")
+      model = new_model(message_events("sealed body"), device: device)
+
+      model =
+        Enum.reduce_while(1..10, model, fn _n, m ->
+          case Surface.advance(m) do
+            {m, :done} -> {:halt, m}
+            {m, :ok} -> {:cont, m}
+          end
+        end)
+
+      assert model.painted_count == 1
+      history_before = raw(device)
+
+      toggled =
+        model
+        |> Surface.focus_transcript()
+        |> Surface.handle_input(Raxol.Core.Events.Event.key("j"))
+        |> Surface.handle_input(Raxol.Core.Events.Event.key("z"))
+
+      assert toggled.fold_overrides == %{},
+             "a fold override for a painted block index must never be stored"
+
+      # Footer notice may repaint; sealed history rows must not. Every new
+      # byte after the toggle must stay inside the footer region.
+      new_bytes =
+        binary_part(
+          raw(device),
+          byte_size(history_before),
+          byte_size(raw(device)) - byte_size(history_before)
+        )
+
+      region_top = @rows - @footer_rows
+
+      for row <- SealOracle.cup_rows(new_bytes) do
+        assert row > region_top or row == 1,
+               "post-toggle byte addressed history row #{row} -- " <>
+                 "sealed content must be untouchable after paint"
+      end
+    end
+  end
+
+  # =======================================================================
+  # 2. Frame-order law: adopt resize dims FIRST, then seal, then footer
+  # =======================================================================
+
+  describe "2. frame-order law (resize-during-commit)" do
+    test "a block finalizing on a shrink frame commits at the adopted width, not the stale one" do
+      # The named obligation from test/harness/seal_frontier_test.exs:
+      # stale-width bytes in the print-once stream are permanent
+      # corruption -- native scrollback cannot be rewritten.
+      {:ok, device} = StringIO.open("")
+      long_line = String.duplicate("wide-content ", 7) <> "END"
+      assert TextMeasure.display_width(long_line) > 60
+
+      model =
+        new_model(message_events(long_line), device: device, width: @width)
+
+      model = advance_to_pending_flush(model)
+      assert model.painted_count == 0
+
+      new_width = 60
+
+      {{model, :done}, flush_bytes} =
+        frame_bytes(fn -> raw(device) end, fn ->
+          Surface.advance(model, nil, resize: {new_width, @rows})
+        end)
+
+      assert model.width == new_width
+      assert model.painted_count == 1
+
+      assert max_visible_line_width(flush_bytes) <= new_width,
+             "a block sealing on a shrink frame must be laid out at the " <>
+               "NEW width (#{new_width}); found a wider line -- stale-width " <>
+               "bytes in the print-once stream are permanent corruption"
+    end
+
+    test "in a combined frame the region re-set precedes the seal, and the footer repaint follows it" do
+      {:ok, device} = StringIO.open("")
+      model = new_model(message_events(@marker), device: device)
+      model = advance_to_pending_flush(model)
+
+      new_rows = 14
+
+      {{model, :done}, flush_bytes} =
+        frame_bytes(fn -> raw(device) end, fn ->
+          Surface.advance(model, nil, resize: {@width, new_rows})
+        end)
+
+      assert model.rows == new_rows
+
+      # Adopt-first, mechanically: the DECSTBM re-set for the NEW split is
+      # the frame's only region set, and it appears BEFORE the sealed
+      # content bytes.
+      assert SealOracle.region_sets(flush_bytes) ==
+               [{1, new_rows - @footer_rows}]
+
+      {region_at, _} = :binary.match(flush_bytes, "\e[1;#{new_rows - @footer_rows}r")
+      {seal_at, _} = :binary.match(flush_bytes, @marker)
+
+      assert region_at < seal_at,
+             "resize dims must be adopted (region re-set) before the seal writes"
+
+      # Footer-repaint-after-seal: at least one footer-region CUP appears
+      # after the sealed content (the keyframe at the new geometry).
+      footer_top = new_rows - @footer_rows + 1
+      tail = binary_part(flush_bytes, seal_at, byte_size(flush_bytes) - seal_at)
+
+      footer_rows_addressed =
+        tail
+        |> SealOracle.cup_rows()
+        |> Enum.filter(&(&1 >= footer_top))
+
+      assert footer_rows_addressed != [],
+             "the footer must be repainted after the seal, at the new geometry"
+    end
+  end
+
+  # =======================================================================
+  # 3. Synchronized output (DEC private mode 2026)
+  # =======================================================================
+
+  describe "3. synchronized output (DEC 2026)" do
+    defp sync_caps, do: %Capabilities{sync_output: true}
+
+    test "a sealing frame is wrapped in ?2026 brackets when the capability reports support" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        new_model(message_events("hello"),
+          device: device,
+          capabilities: sync_caps()
+        )
+
+      model = advance_to_pending_flush(model)
+
+      {{_model, :done}, flush_bytes} =
+        frame_bytes(fn -> raw(device) end, fn -> Surface.advance(model) end)
+
+      assert String.starts_with?(flush_bytes, @sync_open),
+             "the sealing frame's FIRST bytes must open the sync bracket"
+
+      assert String.ends_with?(flush_bytes, @sync_close),
+             "the sealing frame's LAST bytes must close the sync bracket " <>
+               "(after the footer repaint)"
+
+      assert occurrences(flush_bytes, @sync_open) == 1
+      assert occurrences(flush_bytes, @sync_close) == 1
+    end
+
+    test "a non-sealing frame emits no sync brackets" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        new_model(message_events("hello"),
+          device: device,
+          capabilities: sync_caps()
+        )
+
+      # The first advance reveals turn_started -- no block, no seal.
+      {{_model, :ok}, bytes} =
+        frame_bytes(fn -> raw(device) end, fn -> Surface.advance(model) end)
+
+      refute bytes =~ "2026"
+    end
+
+    test "capability absent (nil) emits no brackets anywhere in a full run" do
+      {:ok, device} = StringIO.open("")
+      model = new_model(message_events("hello"), device: device)
+
+      Enum.reduce_while(1..10, model, fn _n, m ->
+        case Surface.advance(m) do
+          {m, :done} -> {:halt, m}
+          {m, :ok} -> {:cont, m}
+        end
+      end)
+
+      refute raw(device) =~ "2026",
+             "capability unknown -> don't emit (inline mode included)"
+    end
+
+    test "flat mode never emits brackets even with the capability present" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        new_model(message_events("hello"),
+          device: device,
+          mode: :flat,
+          capabilities: sync_caps()
+        )
+
+      Enum.reduce_while(1..10, model, fn _n, m ->
+        case Surface.advance(m) do
+          {m, :done} -> {:halt, m}
+          {m, :ok} -> {:cont, m}
+        end
+      end)
+
+      refute raw(device) =~ "2026"
+    end
+
+    test "a seal failure inside the bracket still emits the closing bracket (balanced)" do
+      {device, sink} = FailingDevice.start(marker: @marker)
+
+      model =
+        new_model(message_events(@marker <> " body"),
+          device: device,
+          capabilities: sync_caps()
+        )
+
+      model = advance_to_pending_flush(model)
+
+      # Failing frame, then the retry frame.
+      {model, :ok} = Surface.advance(model)
+      {_model, :done} = Surface.advance(model)
+
+      confirmed = FailingDevice.confirmed_bytes(sink)
+
+      assert occurrences(confirmed, @sync_open) ==
+               occurrences(confirmed, @sync_close),
+             "sync brackets must stay balanced across a mid-frame seal failure"
+
+      assert occurrences(confirmed, @sync_close) >= 1
+    end
+
+    test "the O1 row walk models a sync-bracketed seal stream instead of halting unverifiable" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        new_model(message_events("hello"),
+          device: device,
+          capabilities: sync_caps()
+        )
+
+      model = advance_to_pending_flush(model)
+
+      {{_model, :done}, flush_bytes} =
+        frame_bytes(fn -> raw(device) end, fn -> Surface.advance(model) end)
+
+      assert {:ok, _rows} = SealOracle.row_walk(flush_bytes),
+             "?2026 h/l must be in the oracle's ignorable vocabulary"
+
+      assert SequenceScanner.capability({:csi, "?2026", "h"}) ==
+               :synchronized_output
+    end
+  end
+end

--- a/test/harness/surface_seal_pipeline_test.exs
+++ b/test/harness/surface_seal_pipeline_test.exs
@@ -30,10 +30,19 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
      at least one block AND repaints the footer is wrapped in
      `\\e[?2026h` ... `\\e[?2026l` so multi-block seals present
      atomically -- gated on the terminal capability record
-     (`Capabilities.sync_output`); capability absent/unknown emits
-     nothing. Brackets stay balanced even when a seal write fails
-     mid-frame, and the O1 byte oracle models the bracket tokens rather
-     than halting unverifiable.
+     (`Capabilities.sync_output`, strict struct match); capability
+     absent/unknown emits nothing. Brackets stay balanced even when a
+     seal write fails mid-frame; a CLOSE write the device refuses is
+     latched as owed and re-attempted at the next frame of any kind (the
+     dangling-open wedge heals -- describe 4). The O1 byte oracle models
+     the bracket tokens rather than halting unverifiable.
+
+  Describe block 4 covers the adversarial-review hardening pass on the
+  above: device-error classification by origin
+  (`InlineAuthority.device_io_error?/2` -- a logic bug raising the same
+  exception class must stay loud, never become a silent retry loop), the
+  `Dialect`-owned sync wire vocabulary, the strict capability-record
+  match, and the dangling-close heal.
   """
 
   use ExUnit.Case, async: true
@@ -61,23 +70,24 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
   # A device that fails exactly one targeted write, then recovers.
   #
   # Implements the Erlang I/O protocol. Replies `{:error, :enospc}` to the
-  # FIRST `put_chars` request whose bytes contain `marker` AND a `\r\n`
-  # (only SEAL writes are `\r\n`-terminated -- the footer's pending
-  # preview carries the same content but is CUP-positioned, never
-  # newline-carrying, so the failure targets exactly the seal write). With
-  # `fail_first: true` it instead fails the very first request of any
-  # kind. Every other request delegates to an inner StringIO sink -- so
-  # the sink holds exactly the bytes the device CONFIRMED, which is what a
-  # real terminal would have received. `IO.write/2` surfaces the error
-  # reply as a raised `ArgumentError` (and a dead device as `ErlangError`)
-  # -- the two error classes `InlineAuthority.try_seal/2` must catch.
+  # FIRST `put_chars` request whose bytes satisfy the `fail_when`
+  # predicate, and delegates every other request to an inner StringIO sink
+  # -- so the sink holds exactly the bytes the device ACCEPTED, which is
+  # what a real terminal would have received. `IO.write/2` surfaces the
+  # error reply as a raised `ArgumentError` (and a dead device as
+  # `ErlangError`) -- the two device-error classes the authority's seam
+  # must classify (see `InlineAuthority.device_io_error?/2`).
+  #
+  # `seal_write_with/1` builds the predicate the retry tests use: only
+  # SEAL writes are `\r\n`-terminated (the footer's pending preview
+  # carries the same content but is CUP-positioned, never
+  # newline-carrying), so marker + `\r\n` targets exactly the seal write.
   # ---------------------------------------------------------------------
   defmodule FailingDevice do
     def start(opts) do
       {:ok, sink} = StringIO.open("")
-      marker = Keyword.get(opts, :marker)
-      fail_first? = Keyword.get(opts, :fail_first, false)
-      pid = spawn_link(fn -> loop(sink, marker, fail_first?, false) end)
+      fail_when = Keyword.fetch!(opts, :fail_when)
+      pid = spawn_link(fn -> loop(sink, fail_when, false) end)
       {pid, sink}
     end
 
@@ -86,30 +96,30 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       out
     end
 
-    defp loop(sink, marker, fail_first?, failed?) do
+    defp loop(sink, fail_when, failed?) do
       receive do
         {:io_request, from, ref, {:put_chars, _enc, chars}} ->
           bytes = IO.iodata_to_binary(chars)
 
-          fail_now? =
-            not failed? and
-              (fail_first? or
-                 (marker != nil and String.contains?(bytes, marker) and
-                    String.contains?(bytes, "\r\n")))
-
-          if fail_now? do
+          if not failed? and fail_when.(bytes) do
             send(from, {:io_reply, ref, {:error, :enospc}})
-            loop(sink, marker, fail_first?, true)
+            loop(sink, fail_when, true)
           else
             IO.write(sink, bytes)
             send(from, {:io_reply, ref, :ok})
-            loop(sink, marker, fail_first?, failed?)
+            loop(sink, fail_when, failed?)
           end
 
         {:io_request, from, ref, _other} ->
           send(from, {:io_reply, ref, {:error, :request}})
-          loop(sink, marker, fail_first?, failed?)
+          loop(sink, fail_when, failed?)
       end
+    end
+  end
+
+  defp seal_write_with(marker) do
+    fn bytes ->
+      String.contains?(bytes, marker) and String.contains?(bytes, "\r\n")
     end
   end
 
@@ -226,7 +236,8 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
             {cur + TextMeasure.display_width(first), max_w}
 
           _ ->
-            widths = [cur + TextMeasure.display_width(first)] ++
+            widths =
+              [cur + TextMeasure.display_width(first)] ++
                 Enum.map(rest, &TextMeasure.display_width/1)
 
             {List.last(widths), Enum.max([max_w | widths])}
@@ -244,7 +255,7 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
 
   describe "1. two-phase seal (write -> confirm -> mark)" do
     test "a failed device write leaves the block unsealed and the next advance retries it (retry-not-vanish)" do
-      {device, sink} = FailingDevice.start(marker: @marker)
+      {device, sink} = FailingDevice.start(fail_when: seal_write_with(@marker))
 
       # The marker sits on the block's THIRD body line: the footer's
       # pending-preview (a legitimately repaintable surface, NOT sealed
@@ -299,7 +310,7 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       # Construction bytes (the DECSTBM set) carry no marker, so they
       # succeed; the seal content write is the first marker-bearing
       # request and gets the {:error, :enospc} reply.
-      {device, sink} = FailingDevice.start(marker: "line")
+      {device, sink} = FailingDevice.start(fail_when: seal_write_with("line"))
       authority = InlineAuthority.new(device, 40, 10, 3)
 
       assert {:error, :write_failed, returned} =
@@ -421,7 +432,9 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       assert SealOracle.region_sets(flush_bytes) ==
                [{1, new_rows - @footer_rows}]
 
-      {region_at, _} = :binary.match(flush_bytes, "\e[1;#{new_rows - @footer_rows}r")
+      {region_at, _} =
+        :binary.match(flush_bytes, "\e[1;#{new_rows - @footer_rows}r")
+
       {seal_at, _} = :binary.match(flush_bytes, @marker)
 
       assert region_at < seal_at,
@@ -526,7 +539,7 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
     end
 
     test "a seal failure inside the bracket still emits the closing bracket (balanced)" do
-      {device, sink} = FailingDevice.start(marker: @marker)
+      {device, sink} = FailingDevice.start(fail_when: seal_write_with(@marker))
 
       model =
         new_model(message_events(@marker <> " body"),
@@ -568,6 +581,137 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
 
       assert SequenceScanner.capability({:csi, "?2026", "h"}) ==
                :synchronized_output
+    end
+  end
+
+  # =======================================================================
+  # 4. Adversarial-review hardening (PR review round 1)
+  # =======================================================================
+
+  describe "4. review hardening: device-error classification" do
+    test "device_io_error?/2 recognizes the two device classes and rejects local raises" do
+      # Class 1: an io server replying {:error, reason} -- IO.write raises
+      # ArgumentError FROM :io.put_chars (the stack head names the origin).
+      {device, _sink} = FailingDevice.start(fail_when: fn _bytes -> true end)
+
+      {reply_error, reply_stack} =
+        try do
+          IO.write(device, "x")
+          flunk("expected the failing device to raise")
+        rescue
+          e -> {e, __STACKTRACE__}
+        end
+
+      assert %ArgumentError{} = reply_error
+      assert InlineAuthority.device_io_error?(reply_error, reply_stack)
+
+      # Class 2: a dead device -- ErlangError{original: :terminated},
+      # same :io origin.
+      {:ok, dead} = StringIO.open("")
+      StringIO.close(dead)
+
+      {dead_error, dead_stack} =
+        try do
+          IO.write(dead, "x")
+          flunk("expected the dead device to raise")
+        rescue
+          e -> {e, __STACKTRACE__}
+        end
+
+      assert %ErlangError{original: :terminated} = dead_error
+      assert InlineAuthority.device_io_error?(dead_error, dead_stack)
+
+      # A logic bug raising the SAME exception class from NON-device code
+      # must NOT classify as a device error -- it must stay loud (the
+      # over-broad-rescue finding: masking it would turn a code bug into
+      # an unbounded silent retry loop).
+      {local_error, local_stack} =
+        try do
+          raise ArgumentError, "logic bug, not a device"
+        rescue
+          e -> {e, __STACKTRACE__}
+        end
+
+      refute InlineAuthority.device_io_error?(local_error, local_stack)
+    end
+
+    test "the Dialect owns the sync-bracket wire vocabulary (raw-byte oracle)" do
+      # The raw bytes here are DELIBERATELY duplicated rather than read
+      # from the constant under test: this is the drift guard -- a typo in
+      # the Dialect (2026 vs 2027, h vs l) fails here instead of
+      # propagating silently into every emit site.
+      alias Raxol.UI.Rendering.PaintAuthority.Dialect
+
+      assert Dialect.sync_begin() == "\e[?2026h"
+      assert Dialect.sync_end() == "\e[?2026l"
+    end
+
+    test "a plain map masquerading as a capability record does not enable sync emission" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        new_model(message_events("hello"),
+          device: device,
+          capabilities: %{sync_output: true}
+        )
+
+      model = advance_to_pending_flush(model)
+
+      {_result, flush_bytes} =
+        frame_bytes(fn -> raw(device) end, fn -> Surface.advance(model) end)
+
+      refute flush_bytes =~ "2026",
+             "only a %Capabilities{} record may enable sync emission -- " <>
+               "a stray map with the right key must not"
+    end
+  end
+
+  describe "4. review hardening: dangling sync bracket heals" do
+    test "a close-write failure does not wedge the terminal: the owed close is re-attempted on the next frame" do
+      # The device accepts the OPEN but faults exactly on the CLOSE write
+      # -- the wedge case: ?2026h landed on the wire with no matching
+      # ?2026l, terminal frozen in synchronized mode. The authority must
+      # remember the owed close and re-attempt it on the next frame of any
+      # kind (here: a plain tick), healing as soon as the device accepts a
+      # byte again.
+      {device, sink} =
+        FailingDevice.start(
+          fail_when: fn bytes -> String.contains?(bytes, "\e[?2026l") end
+        )
+
+      model =
+        new_model(message_events("hello"),
+          device: device,
+          capabilities: %Capabilities{sync_output: true}
+        )
+
+      model = advance_to_pending_flush(model)
+      {model, :done} = Surface.advance(model)
+
+      confirmed = FailingDevice.confirmed_bytes(sink)
+
+      assert occurrences(confirmed, @sync_open) == 1
+
+      assert occurrences(confirmed, @sync_close) == 0,
+             "precondition: the close write was rejected by the device"
+
+      # The next frame -- a plain ticker frame, no seal -- must emit the
+      # owed close.
+      _model = Surface.tick(model, 1)
+
+      healed = FailingDevice.confirmed_bytes(sink)
+
+      assert occurrences(healed, @sync_close) == 1,
+             "the owed close must be re-attempted on the next frame -- " <>
+               "a dangling ?2026h wedges the terminal in synchronized mode"
+
+      assert occurrences(healed, @sync_open) ==
+               occurrences(healed, @sync_close)
+
+      # And the close landed AFTER the open (ordering sanity).
+      {open_at, _} = :binary.match(healed, @sync_open)
+      {close_at, _} = :binary.match(healed, @sync_close)
+      assert close_at > open_at
     end
   end
 end


### PR DESCRIPTION
Three coupled correctness items on the seal pipeline, hardening it before live agent traffic. Builds on the merged shared frontier classifier.

## 1. Two-phase seal (write -> confirm -> mark)

Empirically probed the BEAM's device-failure classes first: an io server replying `{:error, reason}` surfaces from `IO.write/2` as ArgumentError; a dead device as ErlangError `:terminated`. `InlineAuthority.try_seal/2` rescues exactly those two, returning `{:error, :write_failed, t}` with `next_row` untouched so a retry re-positions from scratch. The newline caller-contract validation runs OUTSIDE the rescued scope — a malformed call still raises rather than becoming infinitely retryable. `Surface.seal_block/2` returns the frontier walk's emit contract directly: a failed write halts the walk with the cursor before the failed entry; the next advance retries; a block is never marked sealed unless its bytes were accepted. Partial-write honesty documented: a retry may overwrite an unconfirmed row in place — safe because unconfirmed rows never enter high-water accounting.

Fill protection: no placeholder-fill pattern against sealed content exists in the codebase (grep-verified); the only mutation channel (fold overrides on painted blocks) is pinned by test to store nothing and never emit history bytes.

## 2. Frame-order law (adopt-resize-first)

`Surface.advance/3` gains a `:resize {w, h}` option — the atomic combined frame. Resize adoption is extracted into one function SHARED by the standalone resize path and the advance path so they cannot drift; a block sealing on a shrink frame is laid out at the NEW width (the named red-first obligation from the frontier suite, now implemented — stale-width bytes in a print-once stream are permanent corruption). Honest note: the reference design's "size viewport to post-commit height" step has no decision in this substrate (footer row count is geometry-fixed), documented as satisfied by construction; the load-bearing halves are adopt-before-seal and footer-repaint-after-seal.

## 3. Synchronized output (DEC 2026)

`InlineAuthority.with_sync/3`: the authority gates (capability measured once at construction; nil/unknown -> never emit) and owns the bytes. Balanced by construction — the close is emitted iff the open succeeded, through mid-frame seal failures; a failed open degrades to an unbracketed frame (presentation must never take down the frame). The bracket condition is the pre-seal `scan_frontier` `will_commit` — a third consumer of the shared classifier (consumer table updated). SequenceScanner already tokenizes `?2026`; the oracle needed no changes — pinned by tests, and the golden vocabulary allowlist stays deliberately unchanged (goldens render with capabilities nil; comment cites the pinning test).

## Verification

Red-first: 8 of 13 new tests captured failing pre-implementation (retry-not-vanish, try_seal/advance-3 undefined, both sync-bracket assertions); the other 5 are deliberate pins. One test-design flaw caught during implementation review and fixed in the TEST: the footer pending-preview legitimately carries block content, so the leak-detection marker had to sit below the preview window. New suite 13/13; harness+property+cross-terminal sweep 930 passed (212 properties), 0 failures. Warnings + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)