### PR TITLE
test: fix the editor tmp-dir flake (url-base64 underscore split)

### DIFF
--- a/test/raxol/harness/editor_session_test.exs
+++ b/test/raxol/harness/editor_session_test.exs
@@ -444,11 +444,13 @@ defmodule Raxol.Harness.EditorSessionTest do
     # the per-run dir name carries a strong-random segment, honoring the
     # confidentiality doc's unpredictability claim (round-2 review: the
     # doc said strong_rand_bytes but the name was counter+timestamp) --
-    # 6 random bytes -> 8 url-base64 chars as the final `_`-separated part
-    assert [random_segment | _] =
-             draft_dir |> Path.basename() |> String.split("_") |> Enum.reverse()
+    # 6 random bytes -> exactly 8 trailing url-base64 chars. Asserted on
+    # the last 8 CHARS, not a `_` split: url-base64's alphabet includes
+    # `_`, so splitting on it self-truncated the segment ~12% of runs
+    # (flake found failing two unrelated PRs' CI).
+    random_segment = draft_dir |> Path.basename() |> String.slice(-8, 8)
 
-    assert String.length(random_segment) >= 8
+    assert String.length(random_segment) == 8
     assert random_segment =~ ~r/\A[A-Za-z0-9_-]+\z/
     refute random_segment =~ ~r/\A[0-9]+\z/
 


### PR DESCRIPTION
`editor_session_test.exs:414` extracted the random tmp-dir segment by splitting the name on `_` — but the segment is url-base64, whose alphabet includes `_`, so ~1 run in 8 self-truncated it and failed the length assertion. It just failed the macOS matrix on two unrelated PRs (#615, #618) back to back, and was independently diagnosed by the palette track's full-suite sweep.

The random suffix is always exactly 8 chars (6 bytes, url-base64, no padding): assert on the last 8 characters directly. Deterministic — verified by repeated local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)