### PR TITLE
Fix payments live-gate demo examples

### DIFF
--- a/packages/raxol_payments/examples/crosschain_stealth_payment.exs
+++ b/packages/raxol_payments/examples/crosschain_stealth_payment.exs
@@ -58,9 +58,7 @@ defmodule CrosschainStealthPayment do
     IO.puts("\n== crosschain stealth payment ==")
     IO.puts("wallet:   #{wallet.address()}")
 
-    IO.puts(
-      "route:    Base(#{@base}) -> Arbitrum(#{@arbitrum})  settlement=stealth\n"
-    )
+    IO.puts("route:    Base(#{@base}) -> Arbitrum(#{@arbitrum})  settlement=stealth\n")
 
     meta = recipient_meta_address()
 
@@ -102,9 +100,7 @@ defmodule CrosschainStealthPayment do
 
     totals = Ledger.get_totals(ledger, :stealth_demo, policy())
 
-    IO.puts(
-      "\nledger:   session=#{totals.session}  lifetime=#{totals.lifetime} USDC"
-    )
+    IO.puts("\nledger:   session=#{totals.session}  lifetime=#{totals.lifetime} USDC")
 
     IO.puts("\n4. spend gate blocks an over-limit intent:")
 
@@ -121,9 +117,7 @@ defmodule CrosschainStealthPayment do
            context
          ) do
       {:error, failure} ->
-        IO.puts(
-          "   denied [#{failure.reason}]: #{failure.message} (no signature released)"
-        )
+        IO.puts("   denied [#{failure.reason}]: #{failure.message} (no signature released)")
 
       {:ok, _} ->
         IO.puts("   ERROR: over-limit intent was not blocked")
@@ -135,10 +129,11 @@ defmodule CrosschainStealthPayment do
     :ok
   end
 
-  # The Tron rail: public-only, deposit-address based. A stealth request to a
-  # Tron destination is downgraded to public with a surfaced warning, and the
-  # deposit is funded by the injected broadcaster (the InMemory one here; the
-  # assembled build wires Raxol.ACP.Relay.OnchainBroadcaster).
+  # The Tron rail: public-only, deposit-address based. Tron has no stealth
+  # settlement, so a stealth request to a Tron destination FAILS CLOSED -- no
+  # silent privacy downgrade; the operator must re-request public explicitly.
+  # The public deposit is then funded by the injected broadcaster (the InMemory
+  # one here; the assembled build wires Raxol.ACP.Relay.OnchainBroadcaster).
   defp tron_leg(context) do
     IO.puts("\n== tron leg: relay rail (public-only) ==")
     IO.puts("route:    Base(#{@base}) -> Tron(#{@tron})  USDC -> USDT\n")
@@ -152,20 +147,32 @@ defmodule CrosschainStealthPayment do
       })
       |> Map.put(:broadcaster, Broadcaster.InMemory)
 
+    base_params = %{
+      amount: "0.25",
+      from_chain_id: @base,
+      to_chain_id: @tron,
+      from_token: @usdc,
+      to_token: @usdt_trc20,
+      to_address: @tron_recipient
+    }
+
+    IO.puts("5. stealth->Tron is refused (fail-closed; no silent privacy downgrade)")
+
+    case ExecuteRelayTransfer.call(Map.put(base_params, :settlement, "stealth"), relay_context) do
+      {:error, failure} ->
+        IO.puts("   refused [#{failure.reason}]: #{failure.message}")
+
+      {:ok, _} ->
+        IO.puts("   ERROR: stealth->Tron should have been refused")
+        System.halt(1)
+    end
+
     transfer =
       step(
-        "5. stealth->Tron downgrades to public; broadcaster funds the deposit",
+        "6. re-request public: broadcaster funds the deposit",
         fn ->
           ExecuteRelayTransfer.call(
-            %{
-              amount: "0.25",
-              from_chain_id: @base,
-              to_chain_id: @tron,
-              from_token: @usdc,
-              to_token: @usdt_trc20,
-              to_address: @tron_recipient,
-              settlement: "stealth"
-            },
+            Map.put(base_params, :settlement, "public"),
             relay_context
           )
         end
@@ -175,11 +182,9 @@ defmodule CrosschainStealthPayment do
       IO.puts("   warn [#{w.code}]: #{w.message}")
     end)
 
-    IO.puts(
-      "   funding: #{transfer.funding}   deposit_tx: #{transfer.deposit_tx_hash}"
-    )
+    IO.puts("   funding: #{transfer.funding}   deposit_tx: #{transfer.deposit_tx_hash}")
 
-    step("6. poll the Tron transfer to settlement", fn ->
+    step("7. poll the Tron transfer to settlement", fn ->
       PollRelayStatus.call(%{transfer_id: transfer.transfer_id}, relay_context)
     end)
   end

--- a/packages/raxol_payments/examples/run_live_relay_gate.sh
+++ b/packages/raxol_payments/examples/run_live_relay_gate.sh
@@ -36,7 +36,11 @@ OP_TOKEN_REF="${OP_TOKEN_REF:-op://Employee/Riddler Tron Relay API Token/passwor
 RELAY_LIVE_FROM_TOKEN="${RELAY_LIVE_FROM_TOKEN:-0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913}"
 RELAY_LIVE_TO_TOKEN="${RELAY_LIVE_TO_TOKEN:-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t}"
 RELAY_LIVE_TO_ADDRESS="${RELAY_LIVE_TO_ADDRESS:-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t}"
-RELAY_LIVE_AMOUNT="${RELAY_LIVE_AMOUNT:-100000}"
+# Human-decimal amount (default 0.10). The relay /relay/quote probe wants atomic
+# units, so it is converted below; the raxol_acp test reads this human value and
+# converts per-token via Assets.to_atomic. Keeping one human value here avoids the
+# atomic-vs-human split that otherwise oversizes the funded run at the spend gate.
+RELAY_LIVE_AMOUNT="${RELAY_LIVE_AMOUNT:-0.10}"
 
 if [[ -z "${RELAY_LIVE_FROM_ADDRESS:-}" ]]; then
   printf 'error: set RELAY_LIVE_FROM_ADDRESS to the EVM source (Base) address\n' >&2
@@ -53,8 +57,10 @@ if [[ -z "${RELAY_LIVE_TOKEN:-}" ]]; then
 fi
 
 printf 'preflight: validating relay quote endpoint (read-only, no funds move)...\n' >&2
+# The relay quote API wants atomic units; the default USDC/USDT origin is 6dp.
+relay_atomic="$(awk -v a="$RELAY_LIVE_AMOUNT" 'BEGIN { printf "%d", a * 1000000 }')"
 quote_body="$(printf '{"transfer_id":"probe","from_chain_id":8453,"to_chain_id":728126428,"from_token":"%s","to_token":"%s","from_amount":"%s","from_address":"%s","to_address":"%s","slippage_bps":50}' \
-  "$RELAY_LIVE_FROM_TOKEN" "$RELAY_LIVE_TO_TOKEN" "$RELAY_LIVE_AMOUNT" "$RELAY_LIVE_FROM_ADDRESS" "$RELAY_LIVE_TO_ADDRESS")"
+  "$RELAY_LIVE_FROM_TOKEN" "$RELAY_LIVE_TO_TOKEN" "$relay_atomic" "$RELAY_LIVE_FROM_ADDRESS" "$RELAY_LIVE_TO_ADDRESS")"
 
 code="$(curl -sS -m 20 -o /dev/null -w '%{http_code}' \
   -X POST "$RELAY_LIVE_URL/relay/quote" \

--- a/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_relay_transfer.ex
+++ b/packages/raxol_payments/lib/raxol/payments/actions/payments/execute_relay_transfer.ex
@@ -56,7 +56,7 @@ defmodule Raxol.Payments.Actions.Payments.ExecuteRelayTransfer do
     name: "payment_execute_relay_transfer",
     sensitive: true,
     description:
-      "Initiate a Tron cross-chain transfer through Riddler Relay: quote, authorize the spend, and start execution. Returns the deposit address to fund and the transfer id to poll. Tron is public-only; a stealth request is downgraded with a warning.",
+      "Initiate a Tron cross-chain transfer through Riddler Relay: quote, authorize the spend, and start execution. Returns the deposit address to fund and the transfer id to poll. Tron is public-only; a stealth request fails closed (no silent downgrade) and must be re-requested as public.",
     schema: [
       input: [
         amount: [


### PR DESCRIPTION
Makes the raxol_payments live-gate examples demo-capable.

## Fixes
- **`crosschain_stealth_payment.exs`** — the Tron leg halted because the code
  was hardened to fail closed on stealth->Tron (no silent privacy downgrade) but
  the example still expected a downgrade. Reworked the leg to show
  *stealth->Tron refused (fail-closed) -> explicit public re-request -> settled*.
  Runs green end-to-end.
- **`execute_relay_transfer.ex`** — the Action description still said "downgraded
  with a warning"; corrected to "fails closed (no silent downgrade), re-request
  as public" to match the code and moduledoc.
- **`run_live_relay_gate.sh`** — `RELAY_LIVE_AMOUNT` was atomic (`100000`) in the
  script but read as a human decimal by the raxol_acp test, so the funded run
  oversized 10^6x and failed closed at the spend gate (no settlement). Made it a
  single human value (`0.10`) and convert to atomic for the read-only preflight.

## Verification
- `crosschain_stealth_payment.exs` runs green end-to-end (offline sim, no funds).
- Full `raxol_payments` suite: 1117 passed, 0 failures.
- Live gates DRY_RUN (read-only, no funds) against production: Xochi Base->Arbitrum
  `can_solve=true`, Xochi->Robinhood (4663 USDG) `can_solve=true`, relay
  Base->Tron endpoint reachable.

## Manual testing
- [x] `MIX_ENV=test mix run examples/crosschain_stealth_payment.exs`
- [x] `MIX_ENV=test mix test` (raxol_payments)
- [x] `DRY_RUN=1 ./examples/run_live_xochi_gate.sh` / `run_live_robinhood_gate.sh` / `run_live_relay_gate.sh`
