### PR TITLE
Harness UI: full-screen diff expansion (footer-region maximization)

### DIFF
--- a/lib/raxol/harness/diff_expansion.ex
+++ b/lib/raxol/harness/diff_expansion.ex
@@ -1,0 +1,395 @@
+defmodule Raxol.Harness.DiffExpansion do
+  @moduledoc """
+  Pure scrollable window over a full-screen diff render: the state behind
+  the harness surface's "expand the focused diff block" feature.
+
+  This module owns none of the terminal bytes -- it renders a `:diff`
+  content map into a plain list of sanitized, width-truncated, styled
+  lines exactly once, then exposes a clamped scroll offset and a
+  header-plus-slice render over that list. `Raxol.Harness.Surface` is the
+  only caller that turns this into terminal bytes (via `InlineAuthority`);
+  this module never touches an `IO.device()`, a process, or ANSI beyond
+  the SGR it wraps its own lines in.
+
+  ## Rendering: one line per `LineDiff` op, not the Component view tree
+
+  This renders DIRECTLY from `Raxol.UI.Components.Harness.LineDiff.diff/2`
+  -- one styled line per `{:equal | :delete | :insert, line}` op --
+  rather than through `DiffViewer.render/2` piped into
+  `Raxol.Harness.Surface.ViewText.lines/3` (the seam every other harness
+  Component's rendered body uses, and this module's own first
+  implementation used too). That pipeline was tried and rejected, for a
+  concrete, measured reason: `DiffViewer.render/2` composes each visual
+  row from SEVERAL side-by-side leaf nodes (a gutter bar, a line number,
+  a content span, alignment padding) meant to be laid out horizontally by
+  the normal `Preparer -> LayoutEngine -> UIRenderer` pipeline.
+  `ViewText.lines/3` has no notion that those nodes share one physical
+  row -- it flattens every leaf into its OWN line, the same as it does
+  for the genuinely one-text-child-per-line bodies every other harness
+  Component renders (`MessageBlock`, `ReasoningBlock`, `ToolCallBlock`).
+  Measured against a real 20-line diff at 40 columns, that pipeline
+  produced ~170 flattened lines for what should have been ~21 rows --
+  breaking the row math `scroll/2`'s clamp and the surface's
+  `view_rows` claim both depend on. Worse, `ViewText.style_line/2` has no
+  `:background` handling at all (it only ever wraps `:bold`/`:dim`/`:fg`),
+  so even where the flatten produced a usable line, the diff's own
+  add/del row washes -- the merged visual language's whole point -- were
+  silently dropped. Rendering one line directly per op, styled here, is
+  what actually satisfies both "one row per diff line" and "the diff's
+  own styling is preserved."
+
+  ## What this module actually is
+
+  A plain map (`t()`), not a process or a Component:
+
+    * `content` -- the `:diff` content map this expansion was built from
+      (`%{path, old, new, language}`), kept so `resize_view/3` can
+      re-render at a new geometry without the caller re-supplying it.
+      `:language` is accepted (part of the shared `:diff` content schema)
+      and currently unused here -- see "Scope" below.
+    * `lines` -- the full render: one already-sanitized, width-truncated,
+      styled binary per `LineDiff.diff/2` op, in document order. There is
+      no folding of long unchanged runs -- a full-screen review surface
+      exists precisely to show everything (`DiffViewer`'s own folding is
+      a property of ITS renderer, never reached here).
+    * `total` -- `length(lines)`, which is exactly `length(LineDiff.diff(old, new))`.
+    * `offset` -- the first `lines` index visible in the current window,
+      clamped by `scroll/2` to `0..max(0, total - view_rows)`.
+    * `view_rows` / `width` -- the current viewport geometry.
+
+  ## Per-row rendering (sanitize, then truncate, then pad, then style)
+
+  Each op's raw line content goes through, IN ORDER:
+
+    1. **Sanitize** -- `Raxol.Harness.Surface.ViewText.sanitize_line/1`,
+       the SAME trust-boundary byte-strip every harness Component's
+       content passes through (ESC/C0 stripped except `\\t`, `\\t`
+       excepted, multi-byte UTF-8 safe). This is content from an
+       untrusted source (an agent-produced diff) -- sanitizing FIRST
+       means styling (step 4) only ever wraps already-safe bytes.
+    2. **Truncate** -- `ViewText.truncate/2` to `width - 2` display
+       columns (2 reserved for the 1-column gutter glyph plus 1 column
+       of gutter chrome), CJK-safe (`Raxol.UI.TextMeasure`, never
+       `String.length`), ellipsis-truncated when it would overflow.
+    3. **Pad** (changed rows only) -- an `:insert`/`:delete` row's
+       content is right-padded with spaces to fill the full `width - 2`
+       budget, so the row's background wash paints the WHOLE row, not
+       just the columns under the text. `:equal` rows are never padded
+       (no wash to spread, and padding them would waste width truncating
+       real content earlier for no visual benefit).
+    4. **Style** -- `:insert` rows get the `▌` gutter bar plus the
+       merged palette's `add_base`/`add_row_bg` (`DiffViewer.diff_palette/0`
+       -- the single source of these hexes, shared with the grid
+       renderer, never a forked copy); `:delete` rows get `del_base`/
+       `del_row_bg`. Both wrap the WHOLE composed row (gutter + gap +
+       content) in one 24-bit SGR run (`\\e[38;2;r;g;b;48;2;r;g;bm`,
+       fg then bg) and a single `\\e[0m` reset at the end -- one run, not
+       a mid-row reset, since `\\e[0m` clears background too and a
+       second reset partway through the row would cut the wash off
+       early. `:equal` rows get a plain space gutter and carry no SGR at
+       all -- unstyled content, exactly like every other unchanged
+       line in this codebase's diff conventions.
+
+  ## Scope: this is the row-level tier of the diff visual language
+
+  `DiffViewer`'s moduledoc describes several composed tiers: a row wash,
+  a brighter intra-line word-diff emphasis tier on top of it, a gutter
+  tint, and syntax-highlighted tokens. This line renderer carries only
+  the ROW tier -- gutter bar plus full-row wash, read from the exact same
+  `DiffViewer.diff_palette/0` hexes. Word-level emphasis (which parts of
+  a changed line actually differ) and syntax highlighting are
+  `DiffViewer`'s own GRID-rendered tiers (built from several styled
+  spans per row, the very composition this module deliberately does not
+  reach for -- see "Rendering" above) and are out of scope for a
+  single-binary-per-row line renderer. `language` in the content map is
+  accepted, unused.
+
+  ## The header
+
+  `render_lines/1` is one header line (the file path under review, the
+  scroll position, and the dismiss/scroll hints) followed by exactly the
+  visible slice of `lines`. The path is there because full-screen review
+  hides the transcript block that named it -- "which file am I
+  reviewing" is supervision context the expanded view must carry itself.
+  The path is the ELASTIC element: sanitized (producer data) and
+  truncated to whatever display-width budget the fixed position/hint
+  suffix leaves, so a pathological path can never truncate away the
+  scroll position or the dismiss hint. The composed header is then run
+  through `Raxol.Harness.Surface.ViewText.lines/3` itself -- the same
+  width-truncation budget every content line already obeys, so a narrow
+  terminal truncates the header exactly like it would any other row,
+  never overflowing it.
+
+  ## Why this maximizes the footer instead of visiting the alternate screen
+
+  The obvious "full-screen" mechanism would be a bracketed alt-screen
+  visit (`\e[?1049h` ... `\e[?1049l`) around the expanded diff, exactly
+  like a suspended external editor. That was considered and rejected, for
+  reasons worth naming honestly rather than assuming away:
+
+    * The inline driver profile's headline invariant is LC-P-NOALT: no
+      `\e[?1049h` byte anywhere on this rendering path (see
+      `Raxol.Terminal.InlineDriver` and its `Sequences` moduledoc). Even
+      the editor-suspend bracket -- the one place this codebase DOES hand
+      the terminal to another process -- deliberately releases the
+      DECSTBM region instead of visiting the alternate screen. An
+      alt-screen diff expansion would be a different terminal contract
+      than every other surface this harness renders through, not a
+      variant of the same one.
+    * No alt-screen capability detection exists anywhere in this
+      codebase, and `\e[?1049h` support is not reliably probeable from
+      inside a running session -- there is no honest fallback path for a
+      terminal that silently ignores or mishandles the sequence.
+    * The seal oracle's mechanical byte-walk (the strongest verification
+      tool this lane has for "history was never touched") classifies
+      `?1049`/`?47` mode switches as unverifiable control tokens -- an
+      alt-screen bracket would blind exactly the tool that has to prove
+      the sealed-history invariant holds, at the one moment (a
+      full-viewport takeover) where that proof matters most.
+    * An honest alt-screen visit needs editor-suspend-grade compensation
+      machinery: a crash mid-visit stranding the terminal in the alt
+      buffer is a real failure mode that has to be planned for. Growing
+      the footer instead means a crash mid-expansion just leaves a bigger
+      pinned footer -- the existing resize/teardown paths already recover
+      that, with no new compensation code.
+
+  The mechanism this module renders FOR is instead footer-region
+  maximization: `Raxol.Harness.Surface.expand_focused_diff/1` grows the
+  DECSTBM footer (via the same `InlineAuthority.set_footer_rows/2` the
+  overlay picker already uses) to the largest claim that still leaves
+  history its 2-row minimum, and this module supplies the scrollable
+  content that fills it.
+
+  Honest cost of that choice, stated plainly: "full-screen" is
+  approximate (history never shrinks below 2 rows, so a sliver of
+  scrollback stays visible above the expansion), growing over occupied
+  history rows scrolls them into the terminal's native scrollback earlier
+  than ordinary streaming would have (the content is unchanged -- the
+  seal oracle's scrollback-plus-on-screen-history concatenation is
+  invariant under that earlier scroll -- but it happens sooner), and
+  dismissing the expansion does not restore whatever scroll position the
+  operator had before expanding.
+  """
+
+  alias Raxol.Harness.Surface.ViewText
+  alias Raxol.UI.Components.Harness.BodyProvider
+  alias Raxol.UI.Components.Harness.DiffViewer
+  alias Raxol.UI.Components.Harness.LineDiff
+  alias Raxol.UI.TextMeasure
+
+  @type t :: %{
+          content: map(),
+          lines: [String.t()],
+          total: non_neg_integer(),
+          offset: non_neg_integer(),
+          view_rows: pos_integer(),
+          width: pos_integer()
+        }
+
+  # Reserved for the gutter glyph plus one column of gutter chrome (the
+  # gap before content) -- see the moduledoc's "Per-row rendering".
+  @gutter_width 2
+
+  @doc """
+  Builds a new expansion from a `:diff` content map (`%{path, old, new,
+  language}`).
+
+  ## Options
+
+    * `:width` (required) -- display-width budget, `>= 1`.
+    * `:view_rows` (required) -- visible content rows (excluding the
+      header), `>= 1`.
+
+  Refuses with `{:error, :degenerate_view}` when either geometry value is
+  missing or `< 1` -- checked BEFORE content validation, since a
+  degenerate viewport can never render anything regardless of content.
+  Refuses with `{:error, {:invalid_content, reason}}` when `content` is
+  missing a required `:diff` key (`Raxol.UI.Components.Harness.BodyProvider.validate/2`,
+  the same schema check `BlockBody` uses for every other kind).
+  """
+  @spec new(map(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(content, opts) do
+    width = Keyword.get(opts, :width)
+    view_rows = Keyword.get(opts, :view_rows)
+
+    case validate_geometry(width, view_rows) do
+      :ok -> build(content, width, view_rows)
+      error -> error
+    end
+  end
+
+  defp validate_geometry(width, view_rows)
+       when is_integer(width) and width >= 1 and is_integer(view_rows) and
+              view_rows >= 1,
+       do: :ok
+
+  defp validate_geometry(_width, _view_rows), do: {:error, :degenerate_view}
+
+  defp build(content, width, view_rows) do
+    case BodyProvider.validate(:diff, content) do
+      :ok ->
+        lines = render_diff_lines(content, width)
+
+        {:ok,
+         %{
+           content: content,
+           lines: lines,
+           total: length(lines),
+           offset: 0,
+           view_rows: view_rows,
+           width: width
+         }}
+
+      {:error, reason} ->
+        {:error, {:invalid_content, reason}}
+    end
+  end
+
+  # One rendered line per `LineDiff` op -- never folded, never split
+  # across multiple lines (see the moduledoc's "Rendering" section for
+  # why the DiffViewer/ViewText view-tree pipeline is deliberately NOT
+  # used here).
+  defp render_diff_lines(content, width) do
+    old = Map.fetch!(content, :old)
+    new = Map.fetch!(content, :new)
+    palette = DiffViewer.diff_palette()
+
+    old
+    |> LineDiff.diff(new)
+    |> Enum.map(&render_row(&1, width, palette))
+  end
+
+  defp render_row({kind, raw_line}, width, palette) do
+    content_width = max(width - @gutter_width, 0)
+
+    plain =
+      raw_line
+      |> ViewText.sanitize_line()
+      |> ViewText.truncate(content_width)
+
+    build_row(kind, plain, content_width, palette)
+  end
+
+  # `:equal` rows: plain gutter space + content, no padding (nothing to
+  # wash), no SGR at all.
+  defp build_row(:equal, plain, _content_width, _palette) do
+    " " <> " " <> plain
+  end
+
+  # `:insert`/`:delete`: gutter bar + content padded to fill the FULL
+  # content budget (the wash must span the whole row, not stop under the
+  # text -- see the moduledoc), then wrapped in one fg+bg SGR run.
+  defp build_row(:insert, plain, content_width, palette) do
+    style_row(pad(plain, content_width), palette.add_base, palette.add_row_bg)
+  end
+
+  defp build_row(:delete, plain, content_width, palette) do
+    style_row(pad(plain, content_width), palette.del_base, palette.del_row_bg)
+  end
+
+  defp pad(text, width) do
+    deficit = width - TextMeasure.display_width(text)
+    if deficit > 0, do: text <> String.duplicate(" ", deficit), else: text
+  end
+
+  # ONE combined SGR run around the whole row (gutter + gap + content),
+  # ONE trailing reset -- never a reset partway through, which would
+  # clear the background wash early (`\e[0m` resets fg AND bg).
+  defp style_row(padded_content, fg_hex, bg_hex) do
+    "\e[" <>
+      sgr_rgb(38, fg_hex) <>
+      ";" <>
+      sgr_rgb(48, bg_hex) <> "m" <> "▌" <> " " <> padded_content <> "\e[0m"
+  end
+
+  defp sgr_rgb(mode, "#" <> hex) do
+    <<r::binary-size(2), g::binary-size(2), b::binary-size(2)>> = hex
+
+    "#{mode};2;#{String.to_integer(r, 16)};#{String.to_integer(g, 16)};#{String.to_integer(b, 16)}"
+  end
+
+  @doc """
+  Scrolls by `delta` rows (negative scrolls up), clamped to
+  `0..max(0, total - view_rows)`.
+  """
+  @spec scroll(t(), integer()) :: t()
+  def scroll(t, delta) do
+    %{t | offset: clamp_offset(t.offset + delta, t.total, t.view_rows)}
+  end
+
+  defp clamp_offset(offset, total, view_rows) do
+    offset
+    |> max(0)
+    |> min(max(total - view_rows, 0))
+  end
+
+  @doc """
+  Renders the current window: one header line (the file path under
+  review + scroll position + dismiss hint) followed by exactly
+  `Enum.slice(t.lines, t.offset, t.view_rows)`.
+
+  The path is in the header because full-screen review HIDES the
+  transcript block that named it -- "which file am I reviewing" is
+  supervision context the expanded view must carry itself. The path is
+  the ELASTIC element: it is sanitized (producer data -- the same trust
+  boundary every content line goes through) and truncated to whatever
+  display-width budget the fixed position/hint suffix leaves, so a
+  pathological path can never truncate away the scroll position or the
+  dismiss hint.
+  """
+  @spec render_lines(t()) :: [String.t()]
+  def render_lines(t) do
+    [header_line(t) | Enum.slice(t.lines, t.offset, t.view_rows)]
+  end
+
+  defp header_line(t) do
+    first = t.offset + 1
+    last = min(t.offset + t.view_rows, t.total)
+
+    suffix = " · #{first}–#{last}/#{t.total} · j/k · esc"
+    prefix = "» "
+
+    path_budget =
+      t.width - TextMeasure.display_width(prefix <> suffix)
+
+    path =
+      t.content
+      |> Map.get(:path, "")
+      |> ViewText.sanitize_line()
+      |> ViewText.truncate(path_budget)
+
+    text = prefix <> path <> suffix
+
+    case ViewText.lines(%{type: :text, content: text}, t.width, :styled) do
+      [line | _rest] -> line
+      [] -> ""
+    end
+  end
+
+  @doc """
+  Re-renders the SAME `content` at a new `width`/`view_rows` (a resize),
+  clamping the current offset to the new geometry's window. Refuses
+  exactly like `new/2` when the requested geometry is degenerate,
+  leaving `t` untouched.
+  """
+  @spec resize_view(t(), pos_integer(), pos_integer()) ::
+          {:ok, t()} | {:error, :degenerate_view}
+  def resize_view(t, width, view_rows)
+      when is_integer(width) and width >= 1 and is_integer(view_rows) and
+             view_rows >= 1 do
+    lines = render_diff_lines(t.content, width)
+    total = length(lines)
+
+    {:ok,
+     %{
+       t
+       | lines: lines,
+         total: total,
+         offset: clamp_offset(t.offset, total, view_rows),
+         view_rows: view_rows,
+         width: width
+     }}
+  end
+
+  def resize_view(_t, _width, _view_rows), do: {:error, :degenerate_view}
+end

--- a/lib/raxol/harness/diff_expansion.ex
+++ b/lib/raxol/harness/diff_expansion.ex
@@ -196,12 +196,20 @@ defmodule Raxol.Harness.DiffExpansion do
 
   ## Options
 
-    * `:width` (required) -- display-width budget, `>= 1`.
+    * `:width` (required) -- display-width budget. Floored at
+      `@gutter_width + 1` (3): every rendered body row prepends a fixed
+      `@gutter_width`-column gutter (`"▌" <> " "`, or two spaces for an
+      `:equal` row), so a narrower budget can never fit even a
+      zero-content row -- the gutter alone would overflow the column
+      count and wrap onto the next row (which `InlineAuthority.repaint/2`
+      does NOT re-truncate). Below the floor there is also no content
+      column left to show, so a sub-floor width is degenerate twice over.
     * `:view_rows` (required) -- visible content rows (excluding the
       header), `>= 1`.
 
-  Refuses with `{:error, :degenerate_view}` when either geometry value is
-  missing or `< 1` -- checked BEFORE content validation, since a
+  Refuses with `{:error, :degenerate_view}` when `view_rows` is missing
+  or `< 1`, or when `width` is missing or below the gutter floor
+  (`< @gutter_width + 1`) -- checked BEFORE content validation, since a
   degenerate viewport can never render anything regardless of content.
   Refuses with `{:error, {:invalid_content, reason}}` when `content` is
   missing a required `:diff` key (`Raxol.UI.Components.Harness.BodyProvider.validate/2`,
@@ -219,8 +227,8 @@ defmodule Raxol.Harness.DiffExpansion do
   end
 
   defp validate_geometry(width, view_rows)
-       when is_integer(width) and width >= 1 and is_integer(view_rows) and
-              view_rows >= 1,
+       when is_integer(width) and width >= @gutter_width + 1 and
+              is_integer(view_rows) and view_rows >= 1,
        do: :ok
 
   defp validate_geometry(_width, _view_rows), do: {:error, :degenerate_view}
@@ -375,8 +383,8 @@ defmodule Raxol.Harness.DiffExpansion do
   @spec resize_view(t(), pos_integer(), pos_integer()) ::
           {:ok, t()} | {:error, :degenerate_view}
   def resize_view(t, width, view_rows)
-      when is_integer(width) and width >= 1 and is_integer(view_rows) and
-             view_rows >= 1 do
+      when is_integer(width) and width >= @gutter_width + 1 and
+             is_integer(view_rows) and view_rows >= 1 do
     lines = render_diff_lines(t.content, width)
     total = length(lines)
 

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -217,6 +217,72 @@ defmodule Raxol.Harness.Surface do
   long as the overlay is open, and `close_overlay/1` restores the
   authority back to exactly that base value on dismiss or commit.
 
+  ## Full-screen diff expansion (footer maximization)
+
+  `expand_focused_diff/1` hosts a `Raxol.Harness.DiffExpansion` scrollable
+  window over the focused block's diff, by the same GROW-the-footer
+  mechanism as the overlay picker above (`InlineAuthority.set_footer_rows/2`)
+  -- never a centered modal over history, never the alternate screen. The
+  difference from the overlay is the CLAIM shape: an overlay claims a
+  small, fixed height (`OverlayPicker.height/1`); an expansion claims the
+  LARGEST non-degenerate footer the current geometry can host
+  (`max_overlay_rows/2`, the exact same helper, one source of truth --
+  history still keeps its 2-row minimum). See `DiffExpansion`'s own
+  moduledoc for the full mechanism ruling -- why this grows the footer
+  instead of visiting the alternate screen (LC-P-NOALT, the seal oracle's
+  unverifiable-vocabulary concern, the missing alt-screen compensation
+  machinery) -- this section only covers the assembly-layer half of that
+  decision.
+
+  The `e` key (`Raxol.UI.Harness.Keymap`'s `:expand_diff`, a
+  `:not_composing` bind, same guard class as fold/jump) expands the
+  currently focused block when it is a `:diff` block. It rides the exact
+  guard fold/jump already use -- suppressed while composing (plain typed
+  text) and while an overlay OR expansion is already open (`context`'s
+  `overlay_open?` flag is `model.overlay != nil or model.expansion != nil`
+  -- see `handle_input/2`'s moduledoc) -- so `e` can never fire a second,
+  nested expansion or steal a keystroke from an open overlay's filter
+  query.
+
+  ESC closes the expansion, not the running turn, for the identical
+  reason ESC closes an open overlay: `Keymap`'s `:overlay` guard captures
+  it as `:overlay_dismiss` whenever `context.overlay_open?` is true, which
+  it is for an open expansion too. `dispatch_command/2`'s expansion clause
+  for `:overlay_dismiss` precedes the overlay clause (load-bearing order,
+  same class of ordering the overlay's own ESC-priority note documents),
+  so an open expansion's ESC always closes the EXPANSION -- the two can
+  never both be open at once (each refuses while the other is), so this
+  is not actually an ambiguous case, just an explicit one. `q` is a second
+  dismiss key, routed the same way through `route_passthrough/3`'s
+  expansion clause (alongside `j`/`k`/arrow-key scrolling) -- `Enter`,
+  other printable characters, and any other special key are inert while
+  expanded, matching the overlay's own "only the keys the picker actually
+  understands are wired" discipline. Dismissing restores the footer to
+  `model.footer_rows` via `set_footer_rows/2`, which latches
+  `needs_keyframe` -- the trailing `paint_footer/1` self-promotes to a
+  full keyframe, the same byte-identical restore discipline
+  `close_overlay/1` already relies on.
+
+  Honest refusals (see `expand_focused_diff/1`'s doc for the full,
+  ordered list): no footer to grow (`:flat` mode), no block focused, the
+  focused block is not a `:diff` block, the geometry cannot host even the
+  2-row minimum, or the focused block's content fails
+  `BodyProvider`'s `:diff` schema. Every refusal is zero bytes and an
+  unchanged model; the `e` keybind path (`apply_expand/1`) additionally
+  surfaces each one as an honest, visibly-labeled one-frame footer notice
+  through the existing `stub_notice` channel (precondition #6's stub
+  mechanism), never a silent no-op.
+
+  `resize/2` mirrors the overlay's force-close discipline for a geometry
+  that can no longer host the expansion at all, but because the
+  expansion's claim is "the maximum available," not a fixed height, a
+  resize that STILL fits does not merely survive unchanged the way an
+  open overlay does -- the claim is RE-DERIVED at the new geometry every
+  time, the footer re-grown or re-shrunk to match, and
+  `DiffExpansion.resize_view/3` re-renders the same diff content at the
+  new width/window, clamping the scroll offset. See `resize/2`'s own doc
+  for the exact sequencing.
+
   ## Precondition #6 -- command bifurcation (fixture mode = honest UI stubs)
 
   `:interrupt`/`:steer` are the two commands that cross to the agent lane
@@ -517,6 +583,7 @@ defmodule Raxol.Harness.Surface do
   shipped for callers to reuse.
   """
 
+  alias Raxol.Harness.DiffExpansion
   alias Raxol.Harness.Fixture
   alias Raxol.Harness.Fixture.Session
   alias Raxol.Harness.PanelProjection
@@ -563,6 +630,7 @@ defmodule Raxol.Harness.Surface do
           status: map(),
           stub_notice: String.t() | [String.t()] | nil,
           overlay: overlay() | nil,
+          expansion: DiffExpansion.t() | nil,
           editor_session: module() | (String.t(), keyword() -> term()) | nil,
           editor_opts: keyword(),
           unread: UnreadDivider.t(),
@@ -692,6 +760,7 @@ defmodule Raxol.Harness.Surface do
       status: %{},
       stub_notice: nil,
       overlay: nil,
+      expansion: nil,
       editor_session: Keyword.get(opts, :editor_session),
       editor_opts: Keyword.get(opts, :editor_opts, []),
       unread: UnreadDivider.new(),
@@ -1313,12 +1382,22 @@ defmodule Raxol.Harness.Surface do
   Normalizes `raw_event` (`InputEvent.normalize/1`) and resolves it via
   `Keymap.resolve/2` BEFORE the Composer ever sees it -- see the
   moduledoc's precondition #2. A `:passthrough` result reaches
-  `Composer.handle_event/3` only while `composing?` AND no overlay is
-  open; while an overlay picker is open (`model.overlay != nil`), a
-  `:passthrough` result instead reaches
+  `Composer.handle_event/3` only while `composing?` AND no overlay/
+  expansion is open; while an overlay picker is open (`model.overlay !=
+  nil`), a `:passthrough` result instead reaches
   `Raxol.UI.Harness.OverlayPicker.handle_key/2` with the SAME normalized
   event this function already computed (never re-normalized) -- see "The
-  overlay picker" section above. Always repaints the footer afterward.
+  overlay picker" section above. While a diff expansion is open
+  (`model.expansion != nil`), a `:passthrough` result is instead consulted
+  for scroll/dismiss keys directly by this module -- see "Full-screen
+  diff expansion" below. `overlay_open?` in the `Keymap` context carries
+  BOTH transient-footer-view flags (`model.overlay != nil or
+  model.expansion != nil`): an open expansion suppresses the same
+  `:not_composing` binds (and captures ESC as `:overlay_dismiss`) an open
+  overlay would, for the identical reason -- the footer is showing
+  something other than the transcript/composer, and typed letters must
+  reach THAT, never fire commands at state hidden behind it. Always
+  repaints the footer afterward.
   """
   @spec handle_input(t(), term()) :: t()
   def handle_input(model, raw_event) do
@@ -1353,7 +1432,11 @@ defmodule Raxol.Harness.Surface do
       composing?: model.composing?,
       streaming?: not Map.get(model.status, :turn_completed, false),
       focused_block_id: model.focused_index,
-      overlay_open?: model.overlay != nil
+      # BOTH transient footer views ride this flag (see the moduledoc's
+      # "Full-screen diff expansion" section): an open expansion
+      # suppresses the same `:not_composing` binds (and captures ESC as
+      # `:overlay_dismiss`) an open overlay picker would.
+      overlay_open?: model.overlay != nil or model.expansion != nil
     }
   end
 
@@ -1392,6 +1475,29 @@ defmodule Raxol.Harness.Surface do
     end
   end
 
+  # While a diff expansion is open, EVERY :passthrough event is consulted
+  # for the expansion's own small key vocabulary (scroll/dismiss) instead
+  # of reaching the Composer -- mutually exclusive with the overlay clause
+  # above (`expand_focused_diff/1` refuses while an overlay is open, and
+  # `open_overlay/3` refuses while an expansion is open), so relative
+  # clause order between the two is incidental.
+  defp route_passthrough(%{expansion: expansion} = model, norm, _raw_event)
+       when expansion != nil do
+    cond do
+      InputEvent.printable_char(norm) == "j" or InputEvent.key(norm) == :down ->
+        %{model | expansion: DiffExpansion.scroll(expansion, 1)}
+
+      InputEvent.printable_char(norm) == "k" or InputEvent.key(norm) == :up ->
+        %{model | expansion: DiffExpansion.scroll(expansion, -1)}
+
+      InputEvent.printable_char(norm) == "q" ->
+        close_expansion(model)
+
+      true ->
+        model
+    end
+  end
+
   defp route_passthrough(model, _norm, raw_event),
     do: maybe_forward_to_composer(model, raw_event)
 
@@ -1413,11 +1519,22 @@ defmodule Raxol.Harness.Surface do
 
   defp apply_composer_command(_command, model), do: model
 
+  # Must precede the plain :overlay_dismiss clause below: while an
+  # expansion is open, ESC (resolved by Keymap's :overlay guard, which
+  # reads the SAME overlay_open? context flag an open overlay sets --
+  # see handle_input/2's moduledoc) closes the EXPANSION, not a
+  # (necessarily absent, since the two refuse each other) overlay.
+  defp dispatch_command(%{expansion: expansion} = model, %{
+         type: :overlay_dismiss
+       })
+       when expansion != nil,
+       do: close_expansion(model)
+
   defp dispatch_command(model, %{type: :overlay_dismiss}),
     do: close_overlay(model)
 
-  # The command's own payload is the honored fold target -- NOT a second
-  # read of `model.focused_index` here. Both producers (a live keypress
+  # The command's own payload is the honored target -- NOT a second read
+  # of `model.focused_index` here. Both producers (a live keypress
   # resolved by `Keymap.resolve/2` in `handle_input/2`, and a palette
   # pick via `Keymap.command_for/2` in `palette_command/2`) thread
   # `context.focused_block_id` into `payload.block_id` from the SAME
@@ -1425,7 +1542,11 @@ defmodule Raxol.Harness.Surface do
   # exactly one producer chain (context -> payload -> here). A second
   # model read at dispatch time was the adversarial review's named
   # decoupling hazard (2026-07-17, MEDIUM): a value the tests pinned but
-  # nothing consumed.
+  # nothing consumed. `:expand_diff` carries the identical payload shape
+  # and honors it the same way.
+  defp dispatch_command(model, %{type: :expand_diff, payload: payload}),
+    do: apply_expand(model, Map.get(payload, :block_id))
+
   defp dispatch_command(model, %{type: :fold_toggle, payload: payload}) do
     apply_fold_toggle(model, Map.get(payload, :block_id))
   end
@@ -1448,6 +1569,18 @@ defmodule Raxol.Harness.Surface do
        when overlay != nil,
        do: picker_refusal(model, :overlay_already_open)
 
+  # An open diff expansion blocks the palette the same way an open
+  # overlay does (Ctrl+P is `:always`, so the keymap guard never
+  # suppresses it): the footer is expansion-shaped, and the two transient
+  # footer views never coexist -- `open_overlay/3` would refuse with
+  # `:expansion_open` anyway; refusing HERE gives the same honest notice
+  # channel the overlay-already-open case uses.
+  defp dispatch_command(%{expansion: expansion} = model, %{
+         type: :open_palette
+       })
+       when expansion != nil,
+       do: picker_refusal(model, :expansion_open)
+
   defp dispatch_command(model, %{type: :open_palette}),
     do: open_command_palette(model)
 
@@ -1469,6 +1602,22 @@ defmodule Raxol.Harness.Surface do
 
   defp dispatch_command(model, %{type: :focus_composer}),
     do: focus_composer(model)
+
+  # Same freeze rationale as the overlay clauses below, for an open diff
+  # expansion: the composer/transcript state behind a full-screen diff is
+  # hidden, so queuing a steer built from it would be dishonest UI. These
+  # two clauses MUST precede the general `:steer`/`:edit_draft` clauses
+  # (function-clause order load-bearing, same as the overlay pair) --
+  # relative order between the expansion and overlay freeze clauses is
+  # incidental, since the two refuse each other and can never both be
+  # open at once.
+  defp dispatch_command(%{expansion: expansion} = model, %{type: :steer})
+       when expansion != nil,
+       do: model
+
+  defp dispatch_command(%{expansion: expansion} = model, %{type: :edit_draft})
+       when expansion != nil,
+       do: model
 
   # An open overlay freezes the composer buffer mid-pick (see the
   # moduledoc's command-bifurcation note) -- queuing a steer built from
@@ -1835,6 +1984,9 @@ defmodule Raxol.Harness.Surface do
 
   ## Errors
 
+    * `{:error, :expansion_open}` -- a diff expansion (see
+      `expand_focused_diff/1`) is already claiming the footer; the two
+      transient footer views never coexist.
     * `{:error, :overlay_already_open}` -- `model.overlay` is already set.
     * `{:error, :no_footer}` -- `model.mode == :flat` (nothing to grow).
     * `{:error, :insufficient_footer_capacity}` -- the current geometry
@@ -1845,8 +1997,15 @@ defmodule Raxol.Harness.Surface do
   @spec open_overlay(t(), [term()], keyword()) ::
           {:ok, t()}
           | {:error,
-             :overlay_already_open | :no_footer | :insufficient_footer_capacity}
+             :expansion_open
+             | :overlay_already_open
+             | :no_footer
+             | :insufficient_footer_capacity}
   def open_overlay(model, items, opts \\ [])
+
+  def open_overlay(%{expansion: expansion}, _items, _opts)
+      when expansion != nil,
+      do: {:error, :expansion_open}
 
   def open_overlay(%{overlay: overlay}, _items, _opts) when overlay != nil,
     do: {:error, :overlay_already_open}
@@ -2264,8 +2423,177 @@ defmodule Raxol.Harness.Surface do
     %{model | stub_notice: "» a picker is already open"}
   end
 
+  # A diff expansion claims the footer the same way an open picker does
+  # (the two transient footer views never coexist) -- same honest-notice
+  # channel, named for what is actually in the way.
+  defp picker_refusal(model, :expansion_open) do
+    %{model | stub_notice: "» a diff expansion is open — dismiss it first"}
+  end
+
   defp picker_refusal(model, :no_footer) do
     seal_flat_notice(model, "» pickers require the footer (flat mode)")
+  end
+
+  # -- diff expansion (see the moduledoc's "Full-screen diff expansion" section) --
+
+  @doc """
+  Expands the currently focused block full-screen, when it is a `:diff`
+  block, by growing the DECSTBM footer to the largest non-degenerate
+  claim (history keeps its 2-row minimum -- `max_overlay_rows/2`, the
+  SAME helper `open_overlay/3` uses, one source of truth) and hosting a
+  `Raxol.Harness.DiffExpansion` scrollable window inside it. See the
+  moduledoc's "Full-screen diff expansion (footer maximization)" section
+  for the mechanism ruling.
+
+  Refuses, in order (each refusal: zero bytes written, model untouched):
+
+    * `{:error, :expansion_already_open}` -- `model.expansion` is already
+      set.
+    * `{:error, :overlay_open}` -- an overlay picker is open (the two
+      transient footer views never coexist).
+    * `{:error, :no_footer}` -- `model.mode == :flat` (nothing to grow).
+    * `{:error, :no_focus}` -- `model.focused_index` is `nil`.
+    * `{:error, :not_a_diff}` -- the focused block does not exist, or its
+      `kind` is not `:diff`.
+    * `{:error, :insufficient_footer_capacity}` -- the current geometry
+      cannot keep history's 2-row minimum AND host at least a 2-row
+      expansion (one status row and one expansion header row, per the
+      moduledoc's arithmetic).
+    * `{:error, {:invalid_content, reason}}` -- the focused block's
+      content map fails `Raxol.UI.Components.Harness.BodyProvider`'s
+      `:diff` schema (`DiffExpansion.new/2`'s own validation, consulted
+      BEFORE any row is claimed -- a content error never grows the
+      footer).
+  """
+  @spec expand_focused_diff(t()) ::
+          {:ok, t()}
+          | {:error,
+             :expansion_already_open
+             | :overlay_open
+             | :no_footer
+             | :no_focus
+             | :not_a_diff
+             | :insufficient_footer_capacity
+             | {:invalid_content, String.t()}}
+  def expand_focused_diff(model),
+    do: expand_block_at(model, model.focused_index)
+
+  # The parameterized ladder both producers share: the public
+  # `expand_focused_diff/1` reads `model.focused_index`; the
+  # `:expand_diff` command dispatch threads `payload.block_id` instead
+  # (the one-producer-chain rule -- see `dispatch_command/2`'s
+  # payload-honoring comment). Both values originate from the same
+  # `keymap_context/1` construction, so the ladders can never disagree;
+  # parameterizing keeps that a structural fact instead of a coincidence.
+  defp expand_block_at(%{expansion: expansion}, _index) when expansion != nil,
+    do: {:error, :expansion_already_open}
+
+  defp expand_block_at(%{overlay: overlay}, _index) when overlay != nil,
+    do: {:error, :overlay_open}
+
+  defp expand_block_at(%{mode: :flat}, _index), do: {:error, :no_footer}
+
+  defp expand_block_at(_model, nil), do: {:error, :no_focus}
+
+  defp expand_block_at(model, index) do
+    case Enum.at(model.projection.blocks, index) do
+      %{kind: :diff} = block -> do_expand(model, block)
+      _not_a_diff_or_missing -> {:error, :not_a_diff}
+    end
+  end
+
+  defp do_expand(model, block) do
+    claim = max_overlay_rows(model.rows, model.footer_rows)
+
+    if claim < 2 or degenerate?(model) do
+      {:error, :insufficient_footer_capacity}
+    else
+      build_expansion(model, block, claim)
+    end
+  end
+
+  # `DiffExpansion.new/2` (pure, no IO) runs BEFORE `set_footer_rows/2`
+  # ever touches the authority -- a content-validation error propagates
+  # with zero bytes written, exactly like every other refusal above.
+  defp build_expansion(model, block, claim) do
+    view_rows = model.footer_rows + claim - 2
+
+    case DiffExpansion.new(block.content,
+           width: model.width,
+           view_rows: view_rows
+         ) do
+      {:ok, expansion} ->
+        case InlineAuthority.set_footer_rows(
+               model.authority,
+               model.footer_rows + claim
+             ) do
+          {:ok, authority} ->
+            model = %{model | authority: authority, expansion: expansion}
+            {:ok, paint_footer(model)}
+
+          # Unreachable given the capacity check above (belt and braces,
+          # same reasoning as `do_open_overlay/4`'s own defensive branch).
+          {:error, :degenerate} ->
+            {:error, :insufficient_footer_capacity}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Closes the currently-open diff expansion (a no-op when none is open),
+  restoring the footer viewport to `model.footer_rows` (the base value)
+  and repainting. `InlineAuthority.set_footer_rows/2` latches
+  `needs_keyframe` on a shrink, so the trailing `paint_footer/1` call
+  self-promotes to a full keyframe -- the byte-identical restore
+  discipline the moduledoc documents (mirrors `close_overlay/1`
+  verbatim).
+  """
+  @spec close_expansion(t()) :: t()
+  def close_expansion(%{expansion: nil} = model), do: model
+
+  def close_expansion(model) do
+    authority =
+      case InlineAuthority.set_footer_rows(model.authority, model.footer_rows) do
+        {:ok, authority} -> authority
+        # Cannot happen for any authority this module itself constructed
+        # (the base footer_rows was already valid when the expansion
+        # opened) -- kept the authority unchanged rather than crashing if
+        # it somehow did.
+        {:error, _reason} -> model.authority
+      end
+
+    %{model | authority: authority, expansion: nil}
+    |> paint_footer()
+  end
+
+  # `:expand_diff`'s dispatch target: maps every refusal to an honest,
+  # visibly-labeled one-frame footer notice (the SAME `stub_notice`
+  # mechanism `:interrupt`/`:steer`/the fold-on-sealed-block no-op use --
+  # see the moduledoc's precondition #6), never a silent no-op. `{:ok, _}`
+  # passes the already-painted model straight through.
+  defp apply_expand(model, block_id) do
+    case expand_block_at(model, block_id) do
+      {:ok, model} ->
+        model
+
+      {:error, :no_focus} ->
+        %{model | stub_notice: "» expand: no block focused"}
+
+      {:error, :not_a_diff} ->
+        %{model | stub_notice: "» expand: focused block is not a diff"}
+
+      {:error, :insufficient_footer_capacity} ->
+        %{
+          model
+          | stub_notice: "» expand: terminal too small for a full-screen diff"
+        }
+
+      {:error, reason} ->
+        %{model | stub_notice: "» expand: #{inspect(reason)}"}
+    end
   end
 
   # -- footer paint (precondition #5) --------------------------------------
@@ -2299,6 +2627,21 @@ defmodule Raxol.Harness.Surface do
   end
 
   defp refresh_panel_overlay(model), do: model
+
+  # While a diff expansion is open, it claims the WHOLE footer viewport:
+  # composer, preview, and overlay lines are all suppressed (there is no
+  # overlay to suppress anyway -- the two refuse each other) -- only the
+  # status line, a one-frame notice (if any -- e.g. the honest refusal
+  # notices `apply_expand/1` sets right before an expansion attempt
+  # fails, or a stale notice from just before "e" opened one), and the
+  # expansion's own header-plus-window lines. A separate function head
+  # (rather than a branch inside the clause below) keeps this diff
+  # surgical against the existing footer_lines/1 body.
+  defp footer_lines(%{expansion: expansion} = model) when expansion != nil do
+    status_line = StatusStrip.render(model.status, model.width)
+    notice_lines = notice_line(model.stub_notice, model.width)
+    status_line ++ notice_lines ++ DiffExpansion.render_lines(expansion)
+  end
 
   defp footer_lines(model) do
     status_line = StatusStrip.render(model.status, model.width)
@@ -2452,6 +2795,20 @@ defmodule Raxol.Harness.Surface do
   holds `footer_rows` constant, and the overlay's grown claim IS the
   current `footer_rows` as far as the authority is concerned), and the
   keyframe below repaints it at the new position.
+
+  A diff expansion mirrors the same force-close discipline (same
+  `max_overlay_rows/2` capacity check, at the OLD geometry, before
+  anything else runs), but does NOT simply stay open unchanged when it
+  still fits: because the expansion mechanism is "claim the MAXIMUM
+  non-degenerate footer," not a fixed height like the overlay's, the claim
+  is RE-DERIVED at the new geometry every resize (`max_overlay_rows(rows,
+  model.footer_rows)` again), the footer re-grown to match via
+  `InlineAuthority.set_footer_rows/2`, and `DiffExpansion.resize_view/3`
+  re-renders the SAME content at the new width/window (clamping its
+  scroll offset) -- see the moduledoc's "Full-screen diff expansion"
+  section. A `resize_view/3` failure (degenerate target geometry) falls
+  back to closing the expansion and restoring the base pin, same as the
+  too-small force-close path.
   """
   @spec resize(t(), pos_integer(), pos_integer()) :: t()
   def resize(%{mode: :flat} = model, width, rows),
@@ -2487,8 +2844,27 @@ defmodule Raxol.Harness.Surface do
         model
       end
 
+    model =
+      if force_close_expansion?(model, rows) do
+        close_expansion(model)
+      else
+        model
+      end
+
     model = %{model | width: width, rows: rows}
-    %{model | authority: InlineAuthority.resize(model.authority, width, rows)}
+    authority = InlineAuthority.resize(model.authority, width, rows)
+
+    # A still-open expansion re-derives its maximal claim at the new
+    # geometry HERE, in the shared adopt path, so both consumers get it:
+    # `resize/2`'s trailing keyframe repaints the re-rendered window
+    # immediately, and `advance/3`'s combined frame self-promotes via the
+    # `needs_keyframe` latch (already set by `InlineAuthority.resize/3`
+    # above on any geometry change; `resize_expansion/3`'s own
+    # `set_footer_rows/2` latches again whenever the claim changed).
+    # Re-rendering before the frame's seals/paints is the same
+    # frame-order discipline `advance/3`'s FRAME-ORDER LAW pins for
+    # blocks: nothing may paint expansion content at a stale width.
+    resize_expansion(%{model | authority: authority}, width, rows)
   end
 
   defp force_close_overlay?(%{overlay: nil}, _new_rows), do: false
@@ -2502,6 +2878,48 @@ defmodule Raxol.Harness.Surface do
     # never a re-encoded literal that could drift.
     overlay_mod(overlay).height(overlay.picker) >
       max_overlay_rows(new_rows, footer_rows)
+  end
+
+  # A diff expansion's claim is "the maximum non-degenerate footer", not
+  # a fixed height -- so unlike the overlay, force-close is the ONLY
+  # geometry below which it cannot be hosted at all: `max_overlay_rows/2`
+  # returning `< 2` means even the expansion's own 2-row minimum (one
+  # status row, one expansion header row) no longer fits.
+  defp force_close_expansion?(%{expansion: nil}, _new_rows), do: false
+
+  defp force_close_expansion?(%{footer_rows: footer_rows}, new_rows),
+    do: max_overlay_rows(new_rows, footer_rows) < 2
+
+  # Re-derives the expansion's claim at the NEW geometry and re-renders
+  # its content to match -- see `resize/3`'s moduledoc. A no-op when no
+  # expansion is open (including the case just force-closed above, since
+  # `close_expansion/1` already cleared `model.expansion`).
+  defp resize_expansion(%{expansion: nil} = model, _width, _rows), do: model
+
+  defp resize_expansion(model, width, rows) do
+    claim = max_overlay_rows(rows, model.footer_rows)
+
+    case InlineAuthority.set_footer_rows(
+           model.authority,
+           model.footer_rows + claim
+         ) do
+      {:ok, authority} ->
+        view_rows = model.footer_rows + claim - 2
+
+        case DiffExpansion.resize_view(model.expansion, width, view_rows) do
+          {:ok, expansion} ->
+            %{model | authority: authority, expansion: expansion}
+
+          {:error, _reason} ->
+            close_expansion(%{model | authority: authority})
+        end
+
+      # Unreachable given `force_close_expansion?/2` already gated this
+      # call on a non-degenerate claim (belt and braces, same reasoning
+      # as `build_expansion/3`'s own defensive branch).
+      {:error, :degenerate} ->
+        close_expansion(model)
+    end
   end
 
   # -- accessors ------------------------------------------------------------

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -137,7 +137,23 @@ defmodule Raxol.Harness.Surface do
   module truncates every individual LINE to `width` via `ViewText.lines/3`
   (which uses `TextMeasure`, never `String.length`) before that call --
   the caller contract `InlineAuthority.repaint/2`'s moduledoc documents as
-  NOT enforced by that function itself. On resize, `resize/2` composes
+  NOT enforced by that function itself.
+
+  ### The honest-notice law (priority fit before repaint's truncation)
+
+  `repaint/2`'s own pad/truncate is POSITION-BLIND (a tail-drop) -- and
+  the one-shot stub notice is the LAST footer group, so a composed footer
+  that overflows the row budget would silently eat exactly the honest
+  refusal/degradation report the notice channel exists to carry (an
+  integration finding: the overflow only manifests once sibling footer
+  content stacks up). `footer_lines/1` therefore fits the list itself
+  BEFORE the handoff (`fit_footer_lines/3`): display order preserved,
+  discretionary groups yield first (preview, then divider, then the
+  composer's tail, then an overlay's tail, then status -- each trimmed
+  from its tail so a group's leading row survives a partial trim), and a
+  notice is NEVER the row that silently drops -- at a 1-row budget the
+  notice is the row that wins. Pinned by the "honest-notice law under
+  footer overflow" describe in `diff_expand_surface_test.exs`. On resize, `resize/2` composes
   `InlineAuthority.resize/3 |> InlineAuthority.keyframe/2` explicitly (the
   documented composition -- `resize/3` alone never repaints the footer).
   `degenerate?/1` is checked before assuming a pin: a degenerate geometry
@@ -2638,15 +2654,22 @@ defmodule Raxol.Harness.Surface do
   # (rather than a branch inside the clause below) keeps this diff
   # surgical against the existing footer_lines/1 body.
   defp footer_lines(%{expansion: expansion} = model) when expansion != nil do
-    status_line = StatusStrip.render(model.status, model.width)
-    notice_lines = notice_line(model.stub_notice, model.width)
-    status_line ++ notice_lines ++ DiffExpansion.render_lines(expansion)
+    # Same honest-notice law as the normal clause below: the expansion's
+    # body rows are the discretionary tail (its header stays first-in-
+    # group so position/dismiss hints survive a trim), status yields
+    # next, the notice never.
+    fit_footer_lines(
+      [
+        status: StatusStrip.render(model.status, model.width),
+        notice: notice_line(model.stub_notice, model.width),
+        expansion: DiffExpansion.render_lines(expansion)
+      ],
+      [:expansion, :status],
+      footer_budget(model)
+    )
   end
 
   defp footer_lines(model) do
-    status_line = StatusStrip.render(model.status, model.width)
-    overlay_lines = overlay_lines(model)
-
     # Both the divider and the pending/live-tail preview are suppressed
     # while an overlay is open -- the overlay claims that space (see the
     # moduledoc's precondition #5 update, "The overlay picker" section,
@@ -2661,12 +2684,71 @@ defmodule Raxol.Harness.Surface do
         :styled
       )
 
-    notice_lines = notice_line(model.stub_notice, model.width)
-
-    status_line ++
-      overlay_lines ++
-      divider_lines ++ preview_lines ++ composer_lines ++ notice_lines
+    fit_footer_lines(
+      [
+        status: StatusStrip.render(model.status, model.width),
+        overlay: overlay_lines(model),
+        divider: divider_lines,
+        preview: preview_lines,
+        composer: composer_lines,
+        notice: notice_line(model.stub_notice, model.width)
+      ],
+      [:preview, :divider, :composer, :overlay, :status],
+      footer_budget(model)
+    )
   end
+
+  # -- footer fit: the honest-notice law ------------------------------
+  #
+  # `InlineAuthority.repaint/2` pads/TRUNCATES the handed list to the
+  # footer row count POSITION-BLIND (`pad_rows/2` is an `Enum.take/2` --
+  # the tail is the casualty). With the notice as the last footer group,
+  # any composed footer that overflows the budget would silently eat the
+  # honest refusal/degradation notice first -- the exact fail-safe
+  # inversion the notice channel exists to rule out (a notice IS the
+  # honest report that something was refused or degraded; a dropped one
+  # reads as "nothing happened"). So THIS module owns a priority-aware
+  # fit before repaint ever truncates: display order is preserved,
+  # `drop_order` names the discretionary groups from most to least
+  # droppable (each trimmed from its TAIL, so a group's leading line --
+  # the composer's prompt row, the expansion's position header --
+  # survives a partial trim), and the notice group is deliberately
+  # absent from every drop order: as the last resort (notices alone
+  # exceeding the budget) the final head-take keeps the EARLIEST notice
+  # lines rather than crashing. Pinned by the "honest-notice law under
+  # footer overflow" describe in diff_expand_surface_test.exs.
+  defp fit_footer_lines(groups, drop_order, budget) do
+    total =
+      groups |> Enum.map(fn {_key, lines} -> length(lines) end) |> Enum.sum()
+
+    groups
+    |> shed_overflow(drop_order, total - budget)
+    |> Enum.flat_map(fn {_key, lines} -> lines end)
+    |> Enum.take(budget)
+  end
+
+  defp shed_overflow(groups, _drop_order, overflow) when overflow <= 0,
+    do: groups
+
+  defp shed_overflow(groups, [], _overflow), do: groups
+
+  defp shed_overflow(groups, [key | rest], overflow) do
+    lines = Keyword.fetch!(groups, key)
+    shed = min(length(lines), overflow)
+    kept = Enum.take(lines, length(lines) - shed)
+
+    groups
+    |> List.keyreplace(key, 0, {key, kept})
+    |> shed_overflow(rest, overflow - shed)
+  end
+
+  # The row budget the current pin actually provides -- the authority's
+  # own footer range (grown while an overlay/expansion holds a claim),
+  # never a hand-maintained constant. #620's frame pipeline keeps this
+  # geometry-fixed per frame (never a function of post-seal state), so
+  # reading it here is stable within a paint.
+  defp footer_budget(model),
+    do: InlineAuthority.footer_row_count(model.authority)
 
   defp overlay_lines(%{overlay: nil}), do: []
 

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -2518,9 +2518,29 @@ defmodule Raxol.Harness.Surface do
     end
   end
 
+  # The grown footer's top two rows are chrome the expansion always
+  # reserves: one status row plus one expansion header row (the file
+  # path + scroll position line `DiffExpansion.render_lines/1` prepends).
+  # Everything below them is scrollable content, so the content viewport
+  # is `total_footer - @expansion_chrome_rows`. Named once and derived
+  # through `expansion_view_rows/2` so the `build_expansion/3` open path
+  # and the `resize_expansion/3` re-grow path can never drift apart.
+  # NOTE: distinct from the `claim < 2` gate below (that `2` is a minimum
+  # footer GROWTH, not this chrome subtraction -- see `do_expand/2`) and
+  # from `DiffExpansion`'s own `@gutter_width 2` (a per-row column count).
+  @expansion_chrome_rows 2
+
+  defp expansion_view_rows(footer_rows, claim),
+    do: footer_rows + claim - @expansion_chrome_rows
+
   defp do_expand(model, block) do
     claim = max_overlay_rows(model.rows, model.footer_rows)
 
+    # `claim` is the footer GROWTH beyond the base `model.footer_rows`
+    # that still leaves history its 2-row minimum (what
+    # `max_overlay_rows/2` maximizes). A growth below 2 cannot host the
+    # expansion's own two chrome rows, so refuse with the honest notice
+    # rather than open a viewport with no room for content.
     if claim < 2 or degenerate?(model) do
       {:error, :insufficient_footer_capacity}
     else
@@ -2532,7 +2552,7 @@ defmodule Raxol.Harness.Surface do
   # ever touches the authority -- a content-validation error propagates
   # with zero bytes written, exactly like every other refusal above.
   defp build_expansion(model, block, claim) do
-    view_rows = model.footer_rows + claim - 2
+    view_rows = expansion_view_rows(model.footer_rows, claim)
 
     case DiffExpansion.new(block.content,
            width: model.width,
@@ -2552,6 +2572,14 @@ defmodule Raxol.Harness.Surface do
           {:error, :degenerate} ->
             {:error, :insufficient_footer_capacity}
         end
+
+      # A sub-gutter-floor width (`DiffExpansion` refuses `width <
+      # @gutter_width + 1`, since every body row's fixed gutter would
+      # overflow a narrower budget and wrap past the footer region) is a
+      # terminal-too-small refusal, mapped to the same honest notice the
+      # row-degenerate gate above uses -- never emitted as wrapping bytes.
+      {:error, :degenerate_view} ->
+        {:error, :insufficient_footer_capacity}
 
       {:error, reason} ->
         {:error, reason}
@@ -2962,11 +2990,15 @@ defmodule Raxol.Harness.Surface do
       max_overlay_rows(new_rows, footer_rows)
   end
 
-  # A diff expansion's claim is "the maximum non-degenerate footer", not
-  # a fixed height -- so unlike the overlay, force-close is the ONLY
-  # geometry below which it cannot be hosted at all: `max_overlay_rows/2`
-  # returning `< 2` means even the expansion's own 2-row minimum (one
-  # status row, one expansion header row) no longer fits.
+  # A diff expansion's claim is "the maximum non-degenerate footer
+  # GROWTH", not a fixed height -- so unlike the overlay, force-close is
+  # the ONLY geometry below which it cannot be hosted at all. When
+  # `max_overlay_rows/2` (the maximal growth still leaving history its
+  # 2-row minimum) drops below 2, that growth can no longer host the
+  # expansion's own two chrome rows (`@expansion_chrome_rows`: one status
+  # row, one expansion header row), so the expansion must close. The `2`
+  # here is that minimum growth, NOT the chrome subtraction it happens to
+  # equal -- see `expansion_view_rows/2` and `do_expand/2`.
   defp force_close_expansion?(%{expansion: nil}, _new_rows), do: false
 
   defp force_close_expansion?(%{footer_rows: footer_rows}, new_rows),
@@ -2986,7 +3018,7 @@ defmodule Raxol.Harness.Surface do
            model.footer_rows + claim
          ) do
       {:ok, authority} ->
-        view_rows = model.footer_rows + claim - 2
+        view_rows = expansion_view_rows(model.footer_rows, claim)
 
         case DiffExpansion.resize_view(model.expansion, width, view_rows) do
           {:ok, expansion} ->

--- a/lib/raxol/harness/surface/view_text.ex
+++ b/lib/raxol/harness/surface/view_text.ex
@@ -203,19 +203,32 @@ defmodule Raxol.Harness.Surface.ViewText do
   defp add_lines(acc, content, style) do
     content
     |> String.split("\n")
-    |> Enum.reduce(acc, fn line, acc2 -> [{sanitize(line), style} | acc2] end)
+    |> Enum.reduce(acc, fn line, acc2 ->
+      [{sanitize_line(line), style} | acc2]
+    end)
   end
 
-  # Strips control code points before untrusted content reaches the wire:
-  # C0 (0x00-0x1F, incl. ESC/0x1B) except `\t`, DEL (0x7F), AND the C1 range
-  # (U+0080..U+009F) -- the 8-bit-encoded siblings of the ESC-led CSI/OSC/DCS
-  # sequences (0x9B is CSI, 0x9D is OSC), which a byte-wise `>= 0x20` allowlist
-  # would wrongly pass. Decodes by code point so a C1 encoded as UTF-8
-  # (`0xC2 0x9B`) is caught while legitimate multi-byte text is preserved; a
-  # lone raw high byte (a bare C1 like 0x9B, or a stray continuation byte) is
-  # dropped rather than passed through. `\n` needs no exception -- `add_lines/3`
-  # already consumed every `\n` as the line-split delimiter before this runs.
   @c0_exception ?\t
+
+  @doc """
+  Strips control code points before untrusted content reaches the wire:
+  C0 (0x00-0x1F, incl. ESC/0x1B) except `\\t`, DEL (0x7F), AND the C1 range
+  (U+0080..U+009F) -- the 8-bit-encoded siblings of the ESC-led CSI/OSC/DCS
+  sequences (0x9B is CSI, 0x9D is OSC), which a byte-wise `>= 0x20` allowlist
+  would wrongly pass. Decodes by code point so a C1 encoded as UTF-8
+  (`0xC2 0x9B`) is caught while legitimate multi-byte text is preserved; a
+  lone raw high byte (a bare C1 like 0x9B, or a stray continuation byte) is
+  dropped rather than passed through. `\\n` needs no exception -- `add_lines/3`
+  already consumed every `\\n` as the line-split delimiter before this runs.
+
+  Public: this is the ONE sanitize implementation every caller of untrusted
+  single-line content shares -- `add_lines/3` above, and
+  `Raxol.Harness.DiffExpansion`'s own per-row renderer, which needs this exact
+  trust-boundary sanitize WITHOUT `lines/3`'s view-tree flatten. See the
+  moduledoc's "trust boundary" section.
+  """
+  @spec sanitize_line(String.t()) :: String.t()
+  def sanitize_line(text), do: sanitize(text)
 
   defp sanitize(text), do: sanitize(text, <<>>)
 
@@ -234,9 +247,20 @@ defmodule Raxol.Harness.Surface.ViewText do
 
   # -- width truncation (plain content only, before any styling) ---------
 
-  defp truncate(_text, width) when width <= 0, do: ""
+  @doc """
+  Truncates `text` to `width` display columns (`Raxol.UI.TextMeasure`,
+  never `String.length` -- CJK undercounts), ellipsis-truncating
+  (`…`) when it would overflow, mirroring
+  `Raxol.Harness.StatusStrip`'s own truncation convention. Plain content
+  only -- apply BEFORE any styling, never after (see the moduledoc's "Why
+  truncate BEFORE styling"). Public for the same reason `sanitize_line/1`
+  is: `Raxol.Harness.DiffExpansion`'s per-row renderer reuses this exact
+  truncation instead of duplicating it.
+  """
+  @spec truncate(String.t(), non_neg_integer()) :: String.t()
+  def truncate(_text, width) when width <= 0, do: ""
 
-  defp truncate(text, width) do
+  def truncate(text, width) do
     if TextMeasure.display_width(text) <= width do
       text
     else

--- a/lib/raxol/ui/components/harness/diff_viewer.ex
+++ b/lib/raxol/ui/components/harness/diff_viewer.ex
@@ -323,6 +323,31 @@ defmodule Raxol.UI.Components.Harness.DiffViewer do
   defp del_emphasis_bg, do: @diff_palette.del_emphasis_bg
   defp del_gutter_bg, do: @diff_palette.del_gutter_bg
 
+  @doc """
+  The single source of the merged diff visual language's hex tiers (row
+  wash, intra-line emphasis, gutter tint -- see the comment above
+  `@diff_palette`): `add_base`/`add_row_bg`/`add_emphasis_bg`/`add_gutter_bg`
+  and their `del_*` counterparts, each an `"#RRGGBB"` string. This
+  Component's own grid rendering (`render/2`) always reads it through the
+  private per-tier accessors above; `diff_palette/0` exposes the SAME map
+  publicly so a second renderer of this diff visual language never forks
+  its own copy of these hexes. `Raxol.Harness.DiffExpansion`'s per-row
+  line renderer (the full-screen diff expansion's row-level tier of this
+  same visual language -- gutter bar plus row wash, no word-level
+  emphasis or syntax highlighting) is the first such caller.
+  """
+  @spec diff_palette() :: %{
+          add_base: String.t(),
+          add_row_bg: String.t(),
+          add_emphasis_bg: String.t(),
+          add_gutter_bg: String.t(),
+          del_base: String.t(),
+          del_row_bg: String.t(),
+          del_emphasis_bg: String.t(),
+          del_gutter_bg: String.t()
+        }
+  def diff_palette, do: @diff_palette
+
   # -- Perceptual transforms (H-K solver, Raxol.UI.Theming.Salience) --
   #
   # Ground lightness is the reference near-black; pairing this with the

--- a/lib/raxol/ui/harness/keymap.ex
+++ b/lib/raxol/ui/harness/keymap.ex
@@ -63,20 +63,32 @@ defmodule Raxol.UI.Harness.Keymap do
       `key:`-kind rule below) instead of the printable-char path, which
       is nil under ctrl by design.
     * **Guarded by `not composing?`** -- the block-navigation binds
-      (`fold-toggle`, `jump_next`, `jump_prev`). These use plain printable
-      letters (`z`/`j`/`k`), and a prior flat-keymap prototype's named bug
-      (see `harness-ui-STATE.md`, "the demo's flat keymap steals j/k/s/z
-      from typing") was firing them unconditionally, stealing those letters
-      out of the composer's typed text. Gating them on `composing?` is the
-      fix: they only resolve to a command when focus is NOT the composer
-      (browsing the transcript), and fall through to `:passthrough`
-      (ordinary character insertion) while composing. An OPEN OVERLAY
-      suppresses them the same way (the guard consults `overlay_open?`
-      too): with a picker open, `z`/`j`/`k` are filter text the overlay
-      must receive, never commands fired at the transcript hidden behind
-      it -- and the picker's natural open path is exactly transcript-
-      browse mode (`composing?: false`), where a composing?-only guard
-      would fire them (see the "overlay-open ESC capture" section).
+      (`fold-toggle`, `jump_next`, `jump_prev`, `expand_diff`). These use
+      plain printable letters (`z`/`j`/`k`/`e`), and a prior flat-keymap
+      prototype's named bug (see `harness-ui-STATE.md`, "the demo's flat
+      keymap steals j/k/s/z from typing") was firing them unconditionally,
+      stealing those letters out of the composer's typed text. Gating them
+      on `composing?` is the fix: they only resolve to a command when
+      focus is NOT the composer (browsing the transcript), and fall
+      through to `:passthrough` (ordinary character insertion) while
+      composing. An OPEN OVERLAY suppresses them the same way (the guard
+      consults `overlay_open?` too): with a picker open, `z`/`j`/`k`/`e`
+      are filter text the overlay must receive, never commands fired at
+      the transcript hidden behind it -- and the picker's natural open
+      path is exactly transcript-browse mode (`composing?: false`), where
+      a composing?-only guard would fire them (see the "overlay-open ESC
+      capture" section). `e` (expand the focused diff block full-screen)
+      rides the exact same guard for the exact same reason: it is plain
+      typed text while composing, and `Raxol.Harness.Surface` reports its
+      own footer-region expansion through the SAME `overlay_open?` context
+      flag an open overlay picker already uses (see that module's "Full-
+      screen diff expansion" section) -- so `e` is suppressed while an
+      expansion is already open too, not just while an overlay is. It
+      cannot collide with the Ctrl+E editor-handoff chord below:
+      `InputEvent.printable_char/1` is `nil` whenever ctrl is held, so a
+      Ctrl+E keypress never reaches this bind's `char:`-only match clause
+      at all -- the two live on entirely disjoint matching paths, not a
+      priority order.
 
   ## The overlay-open ESC capture (order is load-bearing)
 
@@ -240,6 +252,7 @@ defmodule Raxol.UI.Harness.Keymap do
           | :open_jump_picker
           | :open_session_picker
           | :open_panel
+          | :expand_diff
 
   @type command :: %{type: command_type(), payload: map()}
 
@@ -305,6 +318,16 @@ defmodule Raxol.UI.Harness.Keymap do
       command_type: :jump_prev,
       guard: :not_composing,
       label: "previous block"
+    },
+    # Expand the focused diff block full-screen (see the moduledoc's
+    # `:not_composing` bullet). Plain "e" cannot collide with the Ctrl+E
+    # chord above: `InputEvent.printable_char/1` is nil whenever ctrl is
+    # held, so a Ctrl+E keypress never reaches this bind's match clause.
+    %{
+      char: "e",
+      command_type: :expand_diff,
+      guard: :not_composing,
+      label: "expand diff full-screen"
     },
     # Ctrl+P: same chord shape as Ctrl+E above -- a ctrl chord is never
     # typed text, so this is `:always` too.
@@ -521,11 +544,12 @@ defmodule Raxol.UI.Harness.Keymap do
   defp guard_passes?(%{guard: :overlay}, context),
     do: Map.get(context, :overlay_open?, false)
 
-  defp build_command(%{command_type: :fold_toggle}, context) do
-    %{
-      type: :fold_toggle,
-      payload: %{block_id: Map.get(context, :focused_block_id)}
-    }
+  # `:expand_diff` reuses `:fold_toggle`'s exact payload shape --
+  # `%{block_id: ...}` -- both name the CURRENTLY FOCUSED block; there is
+  # no reason for a second payload vocabulary here.
+  defp build_command(%{command_type: type}, context)
+       when type in [:fold_toggle, :expand_diff] do
+    %{type: type, payload: %{block_id: Map.get(context, :focused_block_id)}}
   end
 
   defp build_command(%{command_type: type} = bind, _context) do

--- a/test/harness/diff_expand_surface_test.exs
+++ b/test/harness/diff_expand_surface_test.exs
@@ -528,6 +528,64 @@ defmodule Raxol.Harness.DiffExpandSurfaceTest do
       assert strip_ansi(raw(device)) =~ "too small"
     end
 
+    test "sub-gutter width: direct call refuses with zero bytes (never grows an over-wide footer)" do
+      {:ok, device} = StringIO.open("")
+
+      # A 2-column-wide terminal has ample ROWS -- the row-degeneracy gate
+      # (`claim < 2 or degenerate?`) passes -- but every diff body row
+      # prepends a fixed 2-column gutter, so a viewport narrower than the
+      # gutter floor could only render rows wider than the column count
+      # (which `InlineAuthority.repaint/2` does NOT truncate -- it would
+      # wrap past the footer region). The width floor must refuse here the
+      # same honest way the row gate refuses a too-short terminal, and
+      # BEFORE `set_footer_rows/2` writes a single byte. Red-first: before
+      # the floor, `DiffExpansion.new/2` accepted `width: 2`, the footer
+      # grew, and `repaint/2` emitted over-wide rows.
+      model =
+        Surface.new([],
+          device: device,
+          width: 2,
+          rows: @rows,
+          footer_rows: @footer_rows,
+          mode: :inline_log
+        )
+
+      model = with_focused_diff(model)
+      prior = byte_size(raw(device))
+
+      assert {:error, :insufficient_footer_capacity} =
+               Surface.expand_focused_diff(model)
+
+      assert byte_size(raw(device)) == prior,
+             "a width-refused expansion must write zero bytes (no footer grow)"
+    end
+
+    test "sub-gutter width: the keybind refuses to open (notice text itself truncates at width 2)" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        Surface.new([],
+          device: device,
+          width: 2,
+          rows: @rows,
+          footer_rows: @footer_rows,
+          mode: :inline_log
+        )
+
+      model = with_focused_diff(model)
+      model = Surface.handle_input(model, Event.key("e"))
+
+      # The refusal maps through the SAME `:insufficient_footer_capacity`
+      # -> "too small" notice the rows-degenerate keybind test above pins;
+      # at width 2 that notice string is itself width-truncated, so this
+      # variant only asserts the observable invariant: the expansion never
+      # opened (no full-screen diff was rendered at an unrenderable width).
+      assert model.expansion == nil
+
+      refute strip_ansi(raw(device)) =~ "▌",
+             "no diff body row (gutter bar) may render at a sub-gutter width"
+    end
+
     test "flat mode has no footer to grow: refuses" do
       {model, _device} = new_model([], mode: :flat)
       model = with_focused_diff(model)
@@ -611,7 +669,7 @@ defmodule Raxol.Harness.DiffExpandSurfaceTest do
         )
 
       model = Surface.focus_transcript(model)
-      model = Surface.handle_input(model, Event.key("e"))
+      _model = Surface.handle_input(model, Event.key("e"))
 
       assert strip_ansi(raw(device)) =~ "no block focused",
              "at the degenerate 1-row budget the notice is the one row " <>
@@ -754,6 +812,68 @@ defmodule Raxol.Harness.DiffExpandSurfaceTest do
 
       assert model.expansion == nil
       assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+    end
+
+    test "sealed history survives the resize-grow-then-dismiss bracket (no clear, no paint over history)" do
+      # Closes the coverage gap the two resize tests above leave open: they
+      # assert `expansion != nil` / `footer_row_count` / offset clamp, but
+      # nothing about the sealed-history invariant across the DECSTBM
+      # RE-GROW that `resize_expansion/3` drives (a `set_footer_rows/2` grow
+      # -- the substrate-sensitive path).
+      #
+      # This asserts the invariant with BYTE-LEVEL seal-adjacent checks
+      # (region re-set, CUP targets, full-clear), NOT `SealOracle`'s
+      # cell-level `immutable_prefix?`. That is deliberate: the re-grow is
+      # only reachable via a terminal HEIGHT change, and `SealOracle.replay`
+      # walks the byte stream at ONE fixed height -- so a cell-level prefix
+      # comparison across a mid-stream height change compares two
+      # differently-sized canvases and returns an artifact, not a real
+      # violation (the same mismatch that made the adversarial probe
+      # inconclusive). The open+scroll+dismiss immutable-prefix bracket in
+      # describe "3" already pins the cell-level invariant at constant
+      # height for the far larger OPEN grow (footer 4 -> rows-2). Note too
+      # that while expanded the footer is always `rows - 2` (history pinned
+      # at its 2-row minimum), so a taller resize claims the terminal's NEW
+      # bottom rows, never additional history -- the re-grow evicts nothing.
+      {model, device} = new_model(bulk_events(4))
+      model = drive_to_completion(model)
+      model = with_focused_diff(model)
+
+      assert model.authority.next_row > @expanded_region_top
+
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+      assert model.expansion != nil
+
+      prior = byte_size(raw(device))
+
+      # Grow the terminal taller WHILE expanded: `resize_expansion/3`
+      # re-derives the maximal claim and re-grows the DECSTBM footer.
+      model = Surface.resize(model, @width, 14)
+      assert model.expansion != nil
+      assert InlineAuthority.footer_row_count(model.authority) == 14 - 2
+
+      grow_delta = delta_since(device, prior)
+
+      # The re-grow must not blank the screen, and every explicit CUP it
+      # emits must land in the footer region (row > region_top), never in
+      # the 2 pinned history rows above it. region_top stays 2 while
+      # expanded, so history is wire rows 1..2 and the footer is 3..14.
+      refute SealOracle.emits_full_clear?(grow_delta),
+             "a resize re-grow must never clear the screen"
+
+      assert Enum.all?(
+               explicit_cup_rows(grow_delta),
+               &(&1 > @expanded_region_top)
+             ),
+             "the re-grow addressed a history row instead of the footer region"
+
+      # Dismiss: footer shrinks back to the base split at the new height.
+      model = Surface.handle_input(model, Event.key(:escape))
+      assert model.expansion == nil
+      assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+
+      refute SealOracle.emits_full_clear?(raw(device)),
+             "the whole resize-grow + dismiss bracket must never clear the screen"
     end
   end
 end

--- a/test/harness/diff_expand_surface_test.exs
+++ b/test/harness/diff_expand_surface_test.exs
@@ -558,6 +558,125 @@ defmodule Raxol.Harness.DiffExpandSurfaceTest do
   end
 
   # ---------------------------------------------------------------------
+  # 7. The honest-notice law under footer overflow (integration finding)
+  # ---------------------------------------------------------------------
+  #
+  # `InlineAuthority.repaint/2` pads/TRUNCATES the line list to the footer
+  # row count position-blind (`Enum.take/2` -- the tail is the casualty).
+  # With the notice as the LAST footer group, any composed footer that
+  # overflows the row budget silently eats the honest refusal/degradation
+  # notice first: an honest-notice-law violation that only manifests when
+  # sibling footer content (evidence rows, previews, extra slots) pushes
+  # the list past the budget. The fix is a priority-ordered fit inside
+  # `footer_lines/1` itself: discretionary rows (preview, divider,
+  # composer tail) yield; a notice is NEVER the line that silently drops.
+
+  describe "7. honest-notice law under footer overflow" do
+    test "a refusal notice survives a footer too small to hold everything (composer yields, never the notice)" do
+      {:ok, device} = StringIO.open("")
+
+      # footer_rows 2: status + composer already exceed the budget, so a
+      # tail-truncating repaint would eat the notice appended after them.
+      model =
+        Surface.new([],
+          device: device,
+          width: @width,
+          rows: 7,
+          footer_rows: 2,
+          mode: :inline_log
+        )
+
+      model = Surface.focus_transcript(model)
+      assert model.focused_index == nil
+
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion == nil
+
+      assert strip_ansi(raw(device)) =~ "no block focused",
+             "the honest refusal notice must never be the row an " <>
+               "overflowing footer silently drops"
+    end
+
+    test "the notice outranks even the status line at a 1-row budget" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        Surface.new([],
+          device: device,
+          width: @width,
+          rows: 7,
+          footer_rows: 1,
+          mode: :inline_log
+        )
+
+      model = Surface.focus_transcript(model)
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert strip_ansi(raw(device)) =~ "no block focused",
+             "at the degenerate 1-row budget the notice is the one row " <>
+               "that must win"
+    end
+
+    test "a notice survives when a pending preview competes for the same rows (the preview yields)" do
+      {:ok, device} = StringIO.open("")
+
+      # footer_rows 4 with a pending-block preview present: status +
+      # preview (2) + composer already meet/exceed the budget before the
+      # notice is appended.
+      model =
+        Surface.new(bulk_events(2),
+          device: device,
+          width: @width,
+          rows: 10,
+          footer_rows: 4,
+          mode: :inline_log
+        )
+
+      # advance far enough that a completed block sits in the pending
+      # (not-yet-painted) preview slot, but not to completion
+      {model, :ok} = Surface.advance(model)
+      {model, :ok} = Surface.advance(model)
+      {model, :ok} = Surface.advance(model)
+
+      model = Surface.focus_transcript(model)
+      prior = byte_size(raw(device))
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion == nil
+
+      assert strip_ansi(delta_since(device, prior)) =~ "no block focused",
+             "a discretionary preview row must yield before an honest " <>
+               "notice is ever dropped"
+    end
+
+    test "footer_lines never hands repaint more rows than the budget (the clamp is priority-aware, not repaint's position-blind tail-drop)" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        Surface.new([],
+          device: device,
+          width: @width,
+          rows: 7,
+          footer_rows: 2,
+          mode: :inline_log
+        )
+
+      model = Surface.focus_transcript(model)
+      prior = byte_size(raw(device))
+      _model = Surface.handle_input(model, Event.key("e"))
+
+      delta = delta_since(device, prior)
+      assert :ok == full_walk!(delta)
+      rows = explicit_cup_rows(delta)
+      assert rows != []
+
+      assert Enum.all?(rows, &(&1 > 7 - 2)),
+             "an overflowing footer must never paint outside its region: #{inspect(rows)}"
+    end
+  end
+
+  # ---------------------------------------------------------------------
   # 6. Interactions with the rest of the surface
   # ---------------------------------------------------------------------
 

--- a/test/harness/diff_expand_surface_test.exs
+++ b/test/harness/diff_expand_surface_test.exs
@@ -1,0 +1,640 @@
+defmodule Raxol.Harness.DiffExpandSurfaceTest do
+  @moduledoc """
+  Full-screen diff expansion hosted inside the assembled harness surface
+  (`Raxol.Harness.Surface`), byte-checked through the same StringIO +
+  `SealOracle` harness the overlay-picker suite uses.
+
+  The substrate ruling under test (footer-region maximization, mechanism
+  B): expanding a focused diff block GROWS the DECSTBM footer to the
+  largest non-degenerate claim (history keeps its 2-row minimum) and
+  renders a scrollable diff viewport inside it -- never the alternate
+  screen (`\\e[?1049h` -- the inline profile's LC-P-NOALT invariant holds
+  across the whole feature), never a paint over history, never
+  `\\e[2J`/`\\e[3J`. Dismiss shrinks back to the base footer split and the
+  latched keyframe restores the footer byte-identically.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Events.Event
+  alias Raxol.Harness.Surface
+  alias Raxol.Harness.Test.SealOracle
+  alias Raxol.Terminal.Emulator
+  alias Raxol.Test.CrossTerminal.SequenceScanner
+  alias Raxol.UI.Components.Harness.{Block, Composer}
+  alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority
+
+  @width 40
+  @rows 12
+  @footer_rows 4
+  @region_top @rows - @footer_rows
+
+  # Maximization: the largest non-degenerate claim leaves history its
+  # 2-row minimum -- footer grows to rows - 2.
+  @expanded_footer_rows @rows - 2
+  @expanded_region_top @rows - @expanded_footer_rows
+
+  @old_text Enum.map_join(1..20, "\n", &"alpha line #{&1}")
+  @new_text String.replace(
+              @old_text,
+              "alpha line 10",
+              "EXPANDED_MARKER line ten"
+            )
+
+  # -- shared helpers (overlay-suite conventions) -------------------------
+
+  defp raw(device) do
+    {_in, out} = StringIO.contents(device)
+    out
+  end
+
+  defp new_model(events, opts \\ []) do
+    {:ok, device} = StringIO.open("")
+
+    defaults = [
+      device: device,
+      width: @width,
+      rows: @rows,
+      footer_rows: @footer_rows,
+      mode: :inline_log
+    ]
+
+    model = Surface.new(events, Keyword.merge(defaults, opts))
+    {model, device}
+  end
+
+  defp drive_to_completion(model) do
+    case Surface.advance(model) do
+      {model, :done} -> model
+      {model, :ok} -> drive_to_completion(model)
+    end
+  end
+
+  defp delta_since(device, prior_size) do
+    all = raw(device)
+    binary_part(all, prior_size, byte_size(all) - prior_size)
+  end
+
+  defp strip_ansi(bytes) when is_binary(bytes) do
+    bytes
+    |> SequenceScanner.scan()
+    |> Enum.filter(&match?({:text, _}, &1))
+    |> Enum.map_join("", fn {:text, text} -> text end)
+  end
+
+  defp history_at(bytes, region_top) do
+    emulator = SealOracle.replay(bytes, width: @width, height: @rows)
+    SealOracle.history(emulator, region_top)
+  end
+
+  # The footer's on-screen rows (full Cell rows, styles included) -- the
+  # byte-identical-restore comparison surface.
+  defp footer_cells_at(bytes, region_top) do
+    bytes
+    |> SealOracle.replay(width: @width, height: @rows)
+    |> Emulator.get_screen_buffer()
+    |> Map.get(:cells)
+    |> Enum.drop(region_top)
+  end
+
+  defp explicit_cup_rows(bytes) do
+    bytes
+    |> SequenceScanner.scan()
+    |> Enum.filter(&match?({:csi, _params, "H"}, &1))
+    |> Enum.map(fn {:csi, params, "H"} ->
+      case params |> String.split(";") |> List.first() |> Integer.parse() do
+        {n, _rest} -> n
+        :error -> 1
+      end
+    end)
+  end
+
+  defp full_walk!(bytes) do
+    _rows = SealOracle.cup_rows(bytes)
+    :ok
+  end
+
+  defp diff_block(old, new) do
+    %Block{
+      kind: :diff,
+      raw_kind: "diff",
+      event_refs: [],
+      fold: :expanded,
+      seal: :sealed,
+      outcome: %{exit_code: nil, duration_ms: nil, cost: nil},
+      content: %{path: "lib/sample.ex", old: old, new: new, language: nil}
+    }
+  end
+
+  # Injects a diff block into the projection (no producer resolves the
+  # :diff kind yet -- the path is wired but dormant, so tests construct
+  # it directly), focuses it, and enters transcript-browse mode.
+  defp with_focused_diff(model, old \\ @old_text, new \\ @new_text) do
+    blocks = model.projection.blocks ++ [diff_block(old, new)]
+
+    model = %{model | projection: %{model.projection | blocks: blocks}}
+    model = %{model | focused_index: length(blocks) - 1}
+    Surface.focus_transcript(model)
+  end
+
+  defp bulk_events(count) do
+    turn_started = %{
+      id: 1,
+      turn_id: "bulk",
+      ts: 1000,
+      family: :loop,
+      type: :turn_started,
+      tier: :durable,
+      payload: %{"prompt" => "bulk"}
+    }
+
+    items =
+      for i <- 1..count do
+        base_id = 2 + (i - 1) * 2
+        item_id = "i#{i}"
+
+        [
+          %{
+            id: base_id,
+            turn_id: "bulk",
+            ts: 1000 + base_id,
+            family: :loop,
+            type: :item_started,
+            tier: :durable,
+            payload: %{"item_id" => item_id, "item_type" => "message"}
+          },
+          %{
+            id: base_id + 1,
+            turn_id: "bulk",
+            ts: 1000 + base_id + 1,
+            family: :loop,
+            type: :item_completed,
+            tier: :durable,
+            payload: %{
+              "item_id" => item_id,
+              "item_type" => "message",
+              "content" => "history message #{i}"
+            }
+          }
+        ]
+      end
+
+    turn_completed = %{
+      id: 2 + count * 2,
+      turn_id: "bulk",
+      ts: 999_999,
+      family: :loop,
+      type: :turn_completed,
+      tier: :durable,
+      payload: %{
+        "iteration" => 1,
+        "usage" => %{"input_tokens" => 1, "output_tokens" => 1},
+        "cost" => 0.0,
+        "final" => true
+      }
+    }
+
+    List.flatten([turn_started, items, turn_completed])
+  end
+
+  # ---------------------------------------------------------------------
+  # 1. The keybind guard matrix ('e' = expand focused diff)
+  # ---------------------------------------------------------------------
+
+  describe "1. keybind guard matrix" do
+    test "while composing, 'e' is typed text -- never an expansion" do
+      {model, _device} = new_model([])
+      model = with_focused_diff(model)
+      model = Surface.focus_composer(model)
+      assert model.composing?
+
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion == nil
+      assert Composer.value(model.composer) == "e"
+      assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+    end
+
+    test "transcript-browse + focused diff: 'e' expands to the maximized footer" do
+      {model, device} = new_model([])
+      model = with_focused_diff(model)
+      prior = byte_size(raw(device))
+
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion != nil
+
+      assert InlineAuthority.footer_row_count(model.authority) ==
+               @expanded_footer_rows
+
+      delta = delta_since(device, prior)
+      assert SealOracle.region_sets(delta) == [{1, @expanded_region_top}]
+
+      assert :ok == full_walk!(delta)
+      rows = explicit_cup_rows(delta)
+      assert rows != [], "expanding must actually paint the diff view"
+
+      assert Enum.all?(rows, &(&1 > @expanded_region_top)),
+             "expansion paint addressed a history row: #{inspect(rows)}"
+
+      # One rendered line per visual diff row (the pure suite pins the
+      # exact math): the first unscrolled frame shows the header (path +
+      # position) and the top of the diff; the changed row mid-file is
+      # reached by scrolling.
+      plain = strip_ansi(delta)
+      assert plain =~ "lib/sample.ex"
+      assert plain =~ "alpha line 1"
+
+      model =
+        Enum.reduce(1..20, model, fn _i, m ->
+          Surface.handle_input(m, Event.key("j"))
+        end)
+
+      _model = model
+
+      assert strip_ansi(raw(device)) =~ "EXPANDED_MARKER",
+             "the changed row must be reachable by scrolling"
+
+      refute SealOracle.emits_full_clear?(raw(device))
+    end
+
+    test "focused block is not a diff: honest notice, zero grow" do
+      {model, device} = new_model(bulk_events(2))
+      model = drive_to_completion(model)
+      model = Surface.focus_transcript(model)
+      model = Surface.handle_input(model, Event.key("j"))
+      assert model.focused_index == 0
+
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion == nil
+      assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+      assert strip_ansi(raw(device)) =~ "not a diff"
+    end
+
+    test "no block focused: honest notice, zero grow" do
+      {model, device} = new_model([])
+      model = Surface.focus_transcript(model)
+      assert model.focused_index == nil
+
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion == nil
+      assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+      assert strip_ansi(raw(device)) =~ "no block focused"
+    end
+
+    test "with an overlay open, 'e' is filter text -- never an expansion" do
+      {model, _device} = new_model([])
+      model = with_focused_diff(model)
+
+      assert {:ok, model} = Surface.open_overlay(model, ["echo", "foxtrot"])
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion == nil
+      assert model.overlay.picker.query == "e"
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 2. Scrolling inside the expanded view
+  # ---------------------------------------------------------------------
+
+  describe "2. scrolling" do
+    setup do
+      {model, device} = new_model([])
+      model = with_focused_diff(model)
+      model = Surface.handle_input(model, Event.key("e"))
+      assert model.expansion != nil
+      {:ok, model: model, device: device}
+    end
+
+    test "j/down scroll down; k/up scroll up; both clamped", %{model: model} do
+      assert model.expansion.offset == 0
+
+      model = Surface.handle_input(model, Event.key("k"))
+      assert model.expansion.offset == 0, "scroll up from the top clamps"
+
+      model = Surface.handle_input(model, Event.key("j"))
+      assert model.expansion.offset == 1
+
+      model = Surface.handle_input(model, Event.key(:down))
+      assert model.expansion.offset == 2
+
+      model = Surface.handle_input(model, Event.key(:up))
+      assert model.expansion.offset == 1
+
+      model =
+        Enum.reduce(1..500, model, fn _i, m ->
+          Surface.handle_input(m, Event.key("j"))
+        end)
+
+      max_offset = model.expansion.total - model.expansion.view_rows
+      assert model.expansion.offset == max_offset, "scroll down clamps at end"
+    end
+
+    test "scroll repaints stay inside the expanded footer", %{
+      model: model,
+      device: device
+    } do
+      prior = byte_size(raw(device))
+      _model = Surface.handle_input(model, Event.key("j"))
+      delta = delta_since(device, prior)
+
+      assert :ok == full_walk!(delta)
+      rows = explicit_cup_rows(delta)
+      assert rows != []
+
+      assert Enum.all?(rows, &(&1 > @expanded_region_top)),
+             "scroll repaint addressed a history row: #{inspect(rows)}"
+    end
+
+    test "'q' dismisses, same as ESC", %{model: model} do
+      model = Surface.handle_input(model, Event.key("q"))
+      assert model.expansion == nil
+      assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 3. The dismiss bracket: exact restoration
+  # ---------------------------------------------------------------------
+
+  describe "3. dismiss restores the prior harness state exactly" do
+    test "ESC closes the expansion (never interrupt); footer restored byte-identically; focus preserved" do
+      {model, device} = new_model([])
+      model = with_focused_diff(model)
+      focused_before = model.focused_index
+
+      # settle one repaint post-focus so the baseline footer is current
+      model = Surface.handle_input(model, Event.key(:up))
+      footer_before = footer_cells_at(raw(device), @region_top)
+
+      model = Surface.handle_input(model, Event.key("e"))
+      assert model.expansion != nil
+      model = Surface.handle_input(model, Event.key("j"))
+
+      prior = byte_size(raw(device))
+      model = Surface.handle_input(model, Event.key(:escape))
+
+      assert model.expansion == nil
+      delta = delta_since(device, prior)
+
+      refute strip_ansi(delta) =~ "interrupt requested",
+             "ESC on an open expansion must dismiss, never interrupt"
+
+      assert SealOracle.region_sets(delta) == [{1, @region_top}]
+      assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+
+      # byte-identical footer: full Cell rows, styles included
+      footer_after = footer_cells_at(raw(device), @region_top)
+      assert footer_after == footer_before
+
+      # focus position preserved, still transcript-browse
+      assert model.focused_index == focused_before
+      refute model.composing?
+
+      # ESC again, expansion closed: the normal interrupt stub fires
+      _model = Surface.handle_input(model, Event.key(:escape))
+      assert strip_ansi(raw(device)) =~ "interrupt requested"
+    end
+
+    test "sealed history survives the full expand + scroll + dismiss bracket (immutable prefix)" do
+      {model, device} = new_model(bulk_events(4))
+      model = drive_to_completion(model)
+      model = with_focused_diff(model)
+
+      # precondition: sealed content occupies rows the grow will claim
+      assert model.authority.next_row > @expanded_region_top
+
+      history_before = history_at(raw(device), @region_top)
+      assert history_before != []
+
+      model = Surface.handle_input(model, Event.key("e"))
+      assert model.expansion != nil
+
+      history_during = history_at(raw(device), @expanded_region_top)
+
+      assert :ok ==
+               SealOracle.immutable_prefix?(history_before, history_during),
+             "growing the footer must scroll occupied rows up, never overwrite them"
+
+      model = Surface.handle_input(model, Event.key("j"))
+      model = Surface.handle_input(model, Event.key(:escape))
+      assert model.expansion == nil
+
+      history_after = history_at(raw(device), @region_top)
+
+      assert :ok ==
+               SealOracle.immutable_prefix?(history_before, history_after),
+             "history must survive the full expand + dismiss round trip"
+
+      refute SealOracle.emits_full_clear?(raw(device))
+    end
+
+    test "the whole feature never touches the alternate screen (LC-P-NOALT)" do
+      {model, device} = new_model([])
+      model = with_focused_diff(model)
+
+      model = Surface.handle_input(model, Event.key("e"))
+      model = Surface.handle_input(model, Event.key("j"))
+      _model = Surface.handle_input(model, Event.key(:escape))
+
+      bytes = raw(device)
+      refute bytes =~ "\e[?1049", "alt-screen byte on the inline path"
+      refute bytes =~ "\e[?47", "legacy alt-screen byte on the inline path"
+      refute SealOracle.emits_full_clear?(bytes)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 4. Hostile diff content at the surface level
+  # ---------------------------------------------------------------------
+
+  describe "4. hostile diff content" do
+    test "escape sequences in agent-produced diff text never reach the wire" do
+      hostile_new =
+        Enum.join(
+          [
+            "\e[2Jwipe attempt",
+            "\e[?1049halt attempt",
+            "\e]0;osc injection\adone",
+            "plain line"
+          ],
+          "\n"
+        )
+
+      {model, device} = new_model([])
+      model = with_focused_diff(model, "", hostile_new)
+      prior = byte_size(raw(device))
+
+      model = Surface.handle_input(model, Event.key("e"))
+      assert model.expansion != nil
+
+      delta = delta_since(device, prior)
+      refute delta =~ "\e[2J"
+      refute delta =~ "\e[?1049"
+      refute delta =~ "\e]0;"
+
+      # the walk's fail-closed vocabulary sweep still passes: hostile
+      # content introduced no unmodeled control tokens
+      assert :ok == full_walk!(delta)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 5. Degenerate geometry + flat mode: honest refusal
+  # ---------------------------------------------------------------------
+
+  describe "5. refusal" do
+    test "too-short terminal: direct call refuses with zero bytes and an unchanged model" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        Surface.new([],
+          device: device,
+          width: @width,
+          rows: 7,
+          footer_rows: 4,
+          mode: :inline_log
+        )
+
+      model = with_focused_diff(model)
+      prior = byte_size(raw(device))
+
+      assert {:error, :insufficient_footer_capacity} =
+               Surface.expand_focused_diff(model)
+
+      assert byte_size(raw(device)) == prior,
+             "a refused expansion must write zero bytes"
+    end
+
+    test "too-short terminal: the keybind surfaces an honest notice instead" do
+      {:ok, device} = StringIO.open("")
+
+      model =
+        Surface.new([],
+          device: device,
+          width: @width,
+          rows: 7,
+          footer_rows: 4,
+          mode: :inline_log
+        )
+
+      model = with_focused_diff(model)
+      model = Surface.handle_input(model, Event.key("e"))
+
+      assert model.expansion == nil
+      assert strip_ansi(raw(device)) =~ "too small"
+    end
+
+    test "flat mode has no footer to grow: refuses" do
+      {model, _device} = new_model([], mode: :flat)
+      model = with_focused_diff(model)
+      assert {:error, :no_footer} = Surface.expand_focused_diff(model)
+    end
+
+    test "expanding twice refuses; expanding with an overlay open refuses" do
+      {model, _device} = new_model([])
+      model = with_focused_diff(model)
+
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+
+      assert {:error, :expansion_already_open} =
+               Surface.expand_focused_diff(model)
+
+      model = Surface.close_expansion(model)
+      assert {:ok, model} = Surface.open_overlay(model, ["a", "b"])
+      assert {:error, :overlay_open} = Surface.expand_focused_diff(model)
+    end
+
+    test "opening an overlay while expanded refuses" do
+      {model, _device} = new_model([])
+      model = with_focused_diff(model)
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+
+      assert {:error, :expansion_open} = Surface.open_overlay(model, ["a"])
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 6. Interactions with the rest of the surface
+  # ---------------------------------------------------------------------
+
+  describe "6. interactions" do
+    test "Ctrl+E (editor handoff) is a no-op while expanded -- the footer is expansion-shaped" do
+      test_pid = self()
+
+      session = fn _draft, _opts ->
+        send(test_pid, :editor_called)
+        {:error, :should_never_run}
+      end
+
+      {model, _device} = new_model([], editor_session: session)
+      model = with_focused_diff(model)
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+
+      model =
+        Surface.handle_input(model, Event.key_event("e", :pressed, [:ctrl]))
+
+      refute_received :editor_called
+      assert model.expansion != nil
+    end
+
+    test "Tab (:steer) is a no-op while expanded -- the composer is hidden state" do
+      {model, _device} = new_model([])
+      model = with_focused_diff(model)
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+      composer_before = model.composer
+
+      model = Surface.handle_input(model, Event.key(:tab))
+
+      assert model.composer == composer_before
+      assert model.expansion != nil
+    end
+
+    test "j/k scroll the expansion -- transcript focus never moves behind it" do
+      {model, _device} = new_model(bulk_events(2))
+      model = drive_to_completion(model)
+      model = with_focused_diff(model)
+      focused_before = model.focused_index
+
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+      model = Surface.handle_input(model, Event.key("j"))
+      model = Surface.handle_input(model, Event.key("j"))
+
+      assert model.focused_index == focused_before,
+             "the transcript jump cursor must not move behind the expansion"
+
+      assert model.expansion.offset == 2
+    end
+
+    test "resize that still fits re-derives the claim and keeps the expansion open" do
+      {model, _device} = new_model([])
+      model = with_focused_diff(model)
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+
+      # rows 14: max claim leaves the 2-row history minimum
+      model = Surface.resize(model, @width, 14)
+
+      assert model.expansion != nil
+      assert InlineAuthority.footer_row_count(model.authority) == 14 - 2
+
+      max_offset =
+        max(model.expansion.total - model.expansion.view_rows, 0)
+
+      assert model.expansion.offset <= max_offset
+    end
+
+    test "resize below capacity force-closes the expansion and restores the base pin" do
+      {model, _device} = new_model([])
+      model = with_focused_diff(model)
+      assert {:ok, model} = Surface.expand_focused_diff(model)
+
+      model = Surface.resize(model, @width, 7)
+
+      assert model.expansion == nil
+      assert InlineAuthority.footer_row_count(model.authority) == @footer_rows
+    end
+  end
+end

--- a/test/raxol/harness/diff_expansion_test.exs
+++ b/test/raxol/harness/diff_expansion_test.exs
@@ -1,0 +1,318 @@
+defmodule Raxol.Harness.DiffExpansionTest do
+  @moduledoc """
+  Pure-state suite for `Raxol.Harness.DiffExpansion`: the full-screen
+  diff expansion's scrollable window over a pre-rendered, sanitized,
+  width-truncated line list.
+
+  Contract pinned here (each test names the moduledoc guarantee it maps
+  to):
+
+    * `new/2` renders EXACTLY ONE styled line per visual diff row,
+      directly from `LineDiff.diff/2` -- never through the view-tree
+      flatten (`ViewText` splits a multi-node row into one line per leaf
+      and drops backgrounds entirely, which would break both the row
+      math and the diff's visual language).
+    * The FULL diff is present (no unchanged-run folding -- a review
+      surface never hides context).
+    * Added/removed rows carry the merged diff palette's row washes
+      (`DiffViewer.diff_palette/0`) as 24-bit SGR backgrounds spanning
+      the full row width, plus the `▌` gutter bar -- the diff's own
+      visual language at line granularity.
+    * `scroll/2` is clamped line math: offset stays within
+      `0..max(0, total - view_rows)`.
+    * `render_lines/1` is a position header plus the visible slice.
+    * Hostile content (agent-produced diff text) never survives to the
+      rendered lines as control bytes: after stripping the styling
+      layer's own SGR, no ESC/C0 remains (content is sanitized BEFORE
+      styling, through the same seam `ViewText` owns).
+    * CJK truncation is display-width-honest (TextMeasure, never
+      String.length).
+    * Degenerate view geometry refuses (`{:error, ...}`), never renders
+      a broken window.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Harness.DiffExpansion
+  alias Raxol.UI.Components.Harness.{DiffViewer, LineDiff}
+  alias Raxol.UI.TextMeasure
+
+  @width 40
+  @view_rows 5
+
+  defp content(old, new, extra \\ %{}) do
+    Map.merge(
+      %{path: "lib/sample.ex", old: old, new: new, language: nil},
+      extra
+    )
+  end
+
+  defp new!(old, new, opts \\ []) do
+    opts = Keyword.merge([width: @width, view_rows: @view_rows], opts)
+    {:ok, exp} = DiffExpansion.new(content(old, new), opts)
+    exp
+  end
+
+  # Styling is applied AFTER sanitize/truncation by ViewText's :styled
+  # mode -- legitimate SGR (`\e[...m`) is the ONLY escape vocabulary a
+  # rendered line may carry. Stripping it must leave zero ESC/C0 bytes
+  # (tab excepted: ViewText's own documented C0 exception).
+  defp strip_sgr(line), do: String.replace(line, ~r/\e\[[0-9;]*m/, "")
+
+  defp control_free?(line) do
+    line
+    |> strip_sgr()
+    |> String.to_charlist()
+    |> Enum.all?(fn ch -> ch == ?\t or (ch >= 0x20 and ch != 0x7F) end)
+  end
+
+  # "#RRGGBB" -> the 24-bit SGR background fragment ("48;2;r;g;b") --
+  # how the merged palette's hex washes must reach the wire.
+  defp bg_sgr("#" <> hex) do
+    {r, g, b} =
+      {String.slice(hex, 0, 2), String.slice(hex, 2, 2),
+       String.slice(hex, 4, 2)}
+
+    "48;2;#{String.to_integer(r, 16)};#{String.to_integer(g, 16)};#{String.to_integer(b, 16)}"
+  end
+
+  describe "new/2 renders the full diff, one line per visual row" do
+    test "exactly one rendered line per LineDiff op -- the row math the scroll window relies on" do
+      old = Enum.map_join(1..12, "\n", &"line #{&1}")
+      new = String.replace(old, "line 7", "line seven")
+
+      exp = new!(old, new)
+
+      assert exp.total == length(LineDiff.diff(old, new)),
+             "a visual diff row must never split into multiple rendered lines"
+    end
+
+    test "long unchanged runs are NOT folded away -- every content line is present" do
+      # 30 identical lines with one change at the end: 29 equal ops +
+      # 1 delete + 1 insert = 31 rows, all present. A folding renderer
+      # would collapse the run into one "N unchanged lines" row.
+      old = Enum.map_join(1..30, "\n", &"line #{&1}")
+      new = String.replace(old, "line 30", "line thirty")
+
+      exp = new!(old, new)
+
+      assert exp.total == 31
+
+      refute Enum.any?(exp.lines, &(strip_sgr(&1) =~ "unchanged lines")),
+             "full-screen expansion must never fold unchanged runs"
+    end
+
+    test "refuses a content map missing required diff keys" do
+      assert {:error, _reason} =
+               DiffExpansion.new(
+                 %{path: "x.ex", old: "a"},
+                 width: @width,
+                 view_rows: @view_rows
+               )
+    end
+
+    test "refuses degenerate view geometry" do
+      assert {:error, _reason} =
+               DiffExpansion.new(content("a", "b"),
+                 width: @width,
+                 view_rows: 0
+               )
+
+      assert {:error, _reason} =
+               DiffExpansion.new(content("a", "b"),
+                 width: 0,
+                 view_rows: @view_rows
+               )
+    end
+
+    test "starts at offset 0 with the requested window" do
+      exp = new!("a\nb\nc", "a\nB\nc")
+      assert exp.offset == 0
+      assert exp.view_rows == @view_rows
+      assert exp.width == @width
+    end
+  end
+
+  describe "scroll/2 clamped line math" do
+    setup do
+      old = Enum.map_join(1..30, "\n", &"line #{&1}")
+      new = String.replace(old, "line 15", "line fifteen")
+      {:ok, exp: new!(old, new)}
+    end
+
+    test "scrolling down advances the offset by the delta", %{exp: exp} do
+      assert DiffExpansion.scroll(exp, 3).offset == 3
+    end
+
+    test "scrolling up from the top clamps at 0", %{exp: exp} do
+      assert DiffExpansion.scroll(exp, -5).offset == 0
+
+      exp = DiffExpansion.scroll(exp, 2)
+      assert DiffExpansion.scroll(exp, -10).offset == 0
+    end
+
+    test "scrolling past the end clamps at total - view_rows", %{exp: exp} do
+      max_offset = exp.total - exp.view_rows
+      assert max_offset > 0
+
+      assert DiffExpansion.scroll(exp, 10_000).offset == max_offset
+    end
+
+    test "a diff shorter than the window never scrolls" do
+      # "a" -> "b" is exactly two rows (one delete + one insert) under
+      # the one-line-per-op contract -- comfortably inside a 5-row window.
+      exp = new!("a", "b")
+      assert exp.total == 2
+      assert DiffExpansion.scroll(exp, 5).offset == 0
+    end
+  end
+
+  describe "the diff's own visual language (the merged palette)" do
+    test "an added row carries the add wash + gutter bar; a removed row the del wash; equal rows neither" do
+      exp = new!("one\ntwo", "one\ntwo\nthree")
+      # ops: equal, equal, insert
+      [equal_line, _equal2, insert_line] = exp.lines
+
+      add_bg = bg_sgr(DiffViewer.diff_palette().add_row_bg)
+      del_bg = bg_sgr(DiffViewer.diff_palette().del_row_bg)
+
+      assert insert_line =~ add_bg,
+             "an added row must carry the merged palette's add wash"
+
+      assert strip_sgr(insert_line) =~ "▌",
+             "an added row must carry the gutter bar"
+
+      refute equal_line =~ add_bg
+      refute equal_line =~ del_bg
+
+      exp_del = new!("one\ntwo", "one")
+      # ops: equal, delete
+      [_equal, delete_line] = exp_del.lines
+
+      assert delete_line =~ del_bg,
+             "a removed row must carry the merged palette's del wash"
+
+      assert strip_sgr(delete_line) =~ "▌"
+    end
+
+    test "a changed row's wash spans the full width (padded, not just under the text)" do
+      exp = new!("base", "other")
+      # ops: delete "base", insert "other"
+      [delete_line, insert_line] = exp.lines
+
+      for line <- [delete_line, insert_line] do
+        assert TextMeasure.display_width(strip_sgr(line)) == @width,
+               "the row wash must paint the whole row, not stop at the text"
+      end
+    end
+  end
+
+  describe "render_lines/1 windowing" do
+    setup do
+      old = Enum.map_join(1..30, "\n", &"line #{&1}")
+      {:ok, exp: new!(old, old <> "\nline 31")}
+    end
+
+    test "returns one header line plus exactly the visible slice", %{exp: exp} do
+      rendered = DiffExpansion.render_lines(exp)
+      assert length(rendered) == exp.view_rows + 1
+
+      [_header | body] = rendered
+      assert body == Enum.slice(exp.lines, 0, exp.view_rows)
+    end
+
+    test "the window follows the scroll offset", %{exp: exp} do
+      scrolled = DiffExpansion.scroll(exp, 4)
+      [_header | body] = DiffExpansion.render_lines(scrolled)
+      assert body == Enum.slice(exp.lines, 4, exp.view_rows)
+    end
+
+    test "the header carries the scroll position and the dismiss hint", %{
+      exp: exp
+    } do
+      [header | _body] = DiffExpansion.render_lines(exp)
+      plain = strip_sgr(header)
+      assert plain =~ "/#{exp.total}"
+      assert plain =~ "esc"
+    end
+
+    test "the header carries the file path -- full-screen review hides the transcript context that named it",
+         %{exp: exp} do
+      [header | _body] = DiffExpansion.render_lines(exp)
+      assert strip_sgr(header) =~ "lib/sample.ex"
+    end
+
+    test "every rendered line fits the width budget (display width, not bytes)",
+         %{exp: exp} do
+      for line <- DiffExpansion.render_lines(exp) do
+        assert TextMeasure.display_width(strip_sgr(line)) <= exp.width
+      end
+    end
+  end
+
+  describe "CJK-safe truncation" do
+    test "double-width characters never overflow the width budget" do
+      wide_line = String.duplicate("日本語テキスト", 10)
+      exp = new!("", wide_line, width: 21)
+
+      for line <- DiffExpansion.render_lines(exp) do
+        assert TextMeasure.display_width(strip_sgr(line)) <= 21,
+               "CJK line overflowed the width budget: #{inspect(line)}"
+      end
+    end
+  end
+
+  describe "hostile diff content (agent-produced text)" do
+    test "control bytes and escape sequences never survive to rendered lines" do
+      hostile =
+        Enum.join(
+          [
+            "\e[2Jwipe attempt",
+            "\e[?1049halt-screen attempt",
+            "\e]0;title injection\abody",
+            "bell\a and null\x00 and cr\r mixed",
+            "del\x7fbyte"
+          ],
+          "\n"
+        )
+
+      exp = new!("", hostile)
+
+      for line <- exp.lines ++ DiffExpansion.render_lines(exp) do
+        assert control_free?(line),
+               "control bytes leaked into a rendered line: #{inspect(line)}"
+      end
+
+      joined = Enum.join(exp.lines, "")
+      refute joined =~ "\e[2J"
+      refute joined =~ "\e[?1049"
+      refute joined =~ "\e]"
+    end
+  end
+
+  describe "resize_view/3" do
+    test "re-renders at the new geometry and clamps the offset" do
+      old = Enum.map_join(1..30, "\n", &"line #{&1}")
+      exp = new!(old, old <> "\nline 31")
+      exp = DiffExpansion.scroll(exp, 10_000)
+      max_before = exp.offset
+
+      {:ok, resized} = DiffExpansion.resize_view(exp, 30, exp.total + 10)
+      assert resized.width == 30
+      assert resized.offset == 0, "a window taller than the diff clamps to 0"
+
+      {:ok, narrower} = DiffExpansion.resize_view(exp, 30, @view_rows)
+      assert narrower.offset <= max_before
+
+      for line <- DiffExpansion.render_lines(narrower) do
+        assert TextMeasure.display_width(strip_sgr(line)) <= 30
+      end
+    end
+
+    test "refuses degenerate geometry" do
+      exp = new!("a", "b")
+      assert {:error, _} = DiffExpansion.resize_view(exp, @width, 0)
+      assert {:error, _} = DiffExpansion.resize_view(exp, 0, @view_rows)
+    end
+  end
+end

--- a/test/raxol/harness/diff_expansion_test.exs
+++ b/test/raxol/harness/diff_expansion_test.exs
@@ -133,6 +133,40 @@ defmodule Raxol.Harness.DiffExpansionTest do
     end
   end
 
+  describe "gutter width floor (honest refusal, never overflow bytes)" do
+    # Every body row prepends a fixed 2-column gutter (`▌` + gap, or two
+    # spaces for an `:equal` row), so a row is at least 2 display columns
+    # regardless of `width`. `InlineAuthority.repaint/2` does NOT truncate
+    # an over-wide line -- it wraps onto the next row (or past the screen
+    # bottom on the last footer row), overwriting content. The only honest
+    # behavior below the gutter floor is to REFUSE, not to render bytes
+    # wider than the column count. Red-first: before the floor,
+    # `new(width: 1)` returned `{:ok, _}` whose body rows rendered 2
+    # display columns into a 1-column budget.
+    test "refuses width 1 -- the exact case where a 2-col gutter overflows a 1-col budget" do
+      assert {:error, :degenerate_view} =
+               DiffExpansion.new(content("a", "b"), width: 1, view_rows: 4)
+    end
+
+    test "refuses width 2 -- fits the gutter but leaves zero content columns" do
+      assert {:error, :degenerate_view} =
+               DiffExpansion.new(content("a", "b"), width: 2, view_rows: 4)
+    end
+
+    test "admits width 3 (the floor: gutter + one content column) and no line overflows it" do
+      # A changed diff exercises the widest row shape (gutter bar + padded
+      # wash). At the floor width EVERY rendered line -- header included --
+      # must fit the column budget exactly, never wrap.
+      {:ok, exp} =
+        DiffExpansion.new(content("a", "b"), width: 3, view_rows: 4)
+
+      for line <- DiffExpansion.render_lines(exp) do
+        assert TextMeasure.display_width(strip_sgr(line)) <= 3,
+               "a rendered line overflowed the floor width: #{inspect(line)}"
+      end
+    end
+  end
+
   describe "scroll/2 clamped line math" do
     setup do
       old = Enum.map_join(1..30, "\n", &"line #{&1}")
@@ -313,6 +347,18 @@ defmodule Raxol.Harness.DiffExpansionTest do
       exp = new!("a", "b")
       assert {:error, _} = DiffExpansion.resize_view(exp, @width, 0)
       assert {:error, _} = DiffExpansion.resize_view(exp, 0, @view_rows)
+    end
+
+    test "refuses a resize below the gutter width floor, leaving t untouched" do
+      # A resize down to a sub-floor width must refuse exactly like `new/2`
+      # rather than re-render body rows wider than the new column count.
+      exp = new!("a", "b")
+
+      assert {:error, :degenerate_view} =
+               DiffExpansion.resize_view(exp, 1, @view_rows)
+
+      assert {:error, :degenerate_view} =
+               DiffExpansion.resize_view(exp, 2, @view_rows)
     end
   end
 end

--- a/test/raxol/ui/harness/keymap_test.exs
+++ b/test/raxol/ui/harness/keymap_test.exs
@@ -125,10 +125,10 @@ defmodule Raxol.UI.Harness.KeymapTest do
              }) == :passthrough
     end
 
-    test "plain 'e' while NOT composing is also :passthrough ('e' is not a nav bind)" do
+    test "plain 'e' while NOT composing is :expand_diff (the full-screen diff expansion nav bind)" do
       assert resolve_from(Event.key_event("e", :pressed, []), %{
                composing?: false
-             }) == :passthrough
+             }) == %{type: :expand_diff, payload: %{block_id: nil}}
     end
 
     test "Ctrl+Alt+E -> :passthrough (chord binds require an EXACT mods match)" do


### PR DESCRIPTION
Inline diff blocks are right for glancing; a real code review needs the whole terminal. `e` on a focused diff block expands it to a near-full-screen scrollable view; ESC/`q` restores the harness byte-identically.

## Mechanism ruling: footer-region maximization (alt-screen rejected on evidence)

The alternative — a bracketed alt-screen visit — was rejected on four grounds, documented with the ruling in the module:
1. No-alt-screen is the inline profile's named headline invariant; even the editor-suspend bracket deliberately releases the region rather than visiting the alt screen.
2. No capability story: zero alt-screen detection exists, and 1049 support is not reliably probeable.
3. **Verification blindness**: the seal oracle classifies `?1049` as unverifiable — the bracket would blind the lane's strongest oracle exactly where "sealed history untouched" must be proven. Footer maximization is fully verifiable by both oracles.
4. Bracket weight: honesty would demand editor-suspend-grade compensation machinery; a crash mid-expansion instead leaves only a bigger footer that existing resize/teardown recovers.

Honest costs stated: full-screen is approximate (history keeps >= 2 rows); occupied rows scroll into native scrollback earlier (bytes invariant under the oracle's concatenation model); scroll position not restored on dismiss.

## Design

- Expand grows the DECSTBM footer to the largest non-degenerate claim via the merged `set_footer_rows` (reusing the overlay's own capacity helper — one source of truth); dismiss shrinks to base, and the `needs_keyframe` latch makes the restore repaint self-promote — footer restored BYTE-IDENTICALLY (asserted over full cell rows, styles included). Sealed history immutable-prefix-checked across the whole enter/scroll/dismiss bracket.
- Renderer: one styled line per LineDiff op — sanitize (through ViewText's trust-boundary seam) -> CJK-safe truncate -> pad -> a single 24-bit SGR run per changed row with the shared diff palette washes and a gutter marker. (A first-pass renderer via the generic view flattening was caught in review rendering ~8x stacked lines with backgrounds dropped — reworked red-first.)
- Keybind `e` (`:not_composing`): typed text while composing, filter text under overlays, suppressed while expanded; ESC/`q` dismiss (ESC never fires interrupt while expanded); j/k/arrows scroll; steer/edit-draft freeze while expanded (overlay-parity honesty). Header carries the file path as the elastic element so position/esc hints always survive narrow widths.
- Degenerate geometry refuses honestly; resize re-derives the claim or force-closes.

## Verification

Red-first three times over (initial 0/10 + 1/22; renderer correction 5 red; path-in-header 2 red). New suites 42 tests green; adjacent suites 150 green in the combined gate; full suite 6138/6141 (2 rerun-green, 1 pre-existing environmental). Warnings + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)