### PR TITLE
Harness UI: transcript search (fuzzy body search over the block corpus)

### DIFF
--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -510,17 +510,22 @@ defmodule Raxol.Harness.Surface do
   back to, so `:edit_draft` there seals one honest history line saying
   so instead of pretending.
 
-  ## The pickers (command palette, jump, session)
+  ## The pickers (command palette, jump, session, search)
 
-  Three more `OverlayPicker` consumers ride the same footer-overlay
+  Four more `OverlayPicker` consumers ride the same footer-overlay
   substrate as the picker described above. Ctrl+P (`Keymap`'s
   `:open_palette`, an `:always` chord) opens the command palette from
   anywhere, including mid-compose -- a chord is never typed text, the same
-  reasoning as Ctrl+E. `g` (`:open_jump_picker`) and `s`
-  (`:open_session_picker`) are plain printable letters gated
-  `:not_composing`, the same class as `z`/`j`/`k`: they only resolve in
-  transcript-browse mode, never stealing a letter out of the composer's
-  typed text.
+  reasoning as Ctrl+E. `g` (`:open_jump_picker`), `s`
+  (`:open_session_picker`), and `/` (`:open_search_picker`) are plain
+  printable letters gated `:not_composing`, the same class as `z`/`j`/`k`:
+  they only resolve in transcript-browse mode, never stealing a letter
+  out of the composer's typed text. `open_search_picker/1`'s entries are
+  labeled from `Block.search_text/1` -- a content-derived search corpus
+  (kind, summary, AND body text), not just the summary header
+  `open_jump_picker/1`'s labels use -- clamped per block (see that
+  function's own doc) before `Raxol.Harness.Surface.ViewText.lines/3`
+  ever truncates a rendered row to its display-width budget.
 
   The palette's entries are `Keymap.palette_binds/0` (the labeled subset
   of the bind table) plus two commands that exist only at THIS assembly
@@ -529,7 +534,7 @@ defmodule Raxol.Harness.Surface do
   already exposes as direct API). Picking any palette entry dispatches
   through the exact same `dispatch_command/2` path a keypress takes --
   there is no second, parallel execution mechanism for a palette-picked
-  command. All three pickers (palette, jump, session) opt into
+  command. All four pickers (palette, jump, session, search) opt into
   `Raxol.UI.Harness.OverlayPicker.fuzzy_filter/3` as their `filter_fn`
   (the `Raxol.UI.ListScorer` adapter), not the default substring filter --
   a fuzzy-ranked query is what a "type a few letters, find the entry"
@@ -622,9 +627,17 @@ defmodule Raxol.Harness.Surface do
 
   @default_footer_rows 6
   @default_sessions_dir Path.join(["test", "fixtures", "harness", "sessions"])
-  # Cap on session-picker entries -- see `open_session_picker/1`'s
-  # "Listing cap" doc section (bounded work on the input path).
+  # Cap on session-picker ENTRIES (the entry-count axis) -- see
+  # `open_session_picker/1`'s "Listing cap" doc section.
   @session_picker_cap 100
+  # Cap on the per-label GRAPHEME COUNT of each block's search corpus (the
+  # per-label length axis -- a DIFFERENT axis from `@session_picker_cap`'s
+  # entry count). This is the canonical per-label bound for the search
+  # picker: it is enforced at the source inside `Block.search_text/2`
+  # (which never scans past it), so it also bounds `ListScorer`'s own
+  # `@max_score_graphemes` (a 400-grapheme label is already under the
+  # scorer's 1024 cap). See `open_search_picker/1`'s doc section.
+  @search_label_cap 400
   @stub_interrupt_notice "» interrupt requested (stub — no agent lane in fixture mode)"
 
   @type mode :: :inline_log | :tmux_conservative | :flat
@@ -1613,6 +1626,9 @@ defmodule Raxol.Harness.Surface do
     model |> open_panel(kind) |> handle_open_result(model)
   end
 
+  defp dispatch_command(model, %{type: :open_search_picker}),
+    do: open_search_picker(model)
+
   defp dispatch_command(model, %{type: :focus_transcript}),
     do: focus_transcript(model)
 
@@ -2203,7 +2219,7 @@ defmodule Raxol.Harness.Surface do
     end
   end
 
-  # -- pickers (command palette, jump, session) ----------------------------
+  # -- pickers (command palette, jump, session, search) ---------------------
   # See the moduledoc's "The pickers" section.
 
   @doc """
@@ -2295,6 +2311,101 @@ defmodule Raxol.Harness.Surface do
       on_pick: fn model, item -> %{model | focused_index: item.index} end
     )
     |> handle_open_result(model)
+  end
+
+  @doc """
+  Opens the transcript search picker (`/`, transcript-browse only): one
+  entry per projected block, labeled from `Block.search_text/1` (the
+  full content-derived search corpus, not just `Block.summary/1`'s
+  header line) -- the overlay's fuzzy filter over these labels IS the
+  search: it reaches into block BODIES, not just headers. Picking an
+  entry sets `focused_index`, exactly like `open_jump_picker/1`. An
+  empty block list is an honest no-op notice rather than an empty
+  overlay.
+
+  ## The label clamp (bounded WORK on the input path)
+
+  `Raxol.UI.Harness.OverlayPicker`'s fuzzy ranker runs synchronously,
+  per keystroke, over every label's `label_fn` output -- this Surface is
+  a synchronous pure state machine (fixture mode has no other thread to
+  move the work to), and a block body is unbounded, untrusted content
+  (a fixture's tool-call output, an LLM's streamed response). So each
+  block's search corpus is clamped to #{@search_label_cap} graphemes
+  via `Block.search_text/2`, which applies the clamp AT THE SOURCE --
+  every body field is bounded to the cap BEFORE it is concatenated,
+  joined, or newline-flattened, and `String.slice/3` walks at most that
+  many graphemes and stops. So `open_search_picker/1` does O(cap) work
+  per block, not O(body-size): the clamp bounds the WORK, not merely the
+  label output. (An earlier revision clamped only the flattened result,
+  which bounded the output while the concat + flatten still scanned the
+  whole untrusted body -- fixed by pushing the clamp into
+  `Block.search_text/2`.) This is the per-label GRAPHEME-length axis;
+  the entry-COUNT axis is left uncapped here, matching the accepted
+  `open_jump_picker/1` precedent (see "No entry cap" below). The named,
+  honest consequence: body content past the cap is not searchable.
+
+  ## No entry cap (unlike `open_session_picker/1`)
+
+  `open_search_picker/1` builds one item per block with no ceiling,
+  unlike `open_session_picker/1`'s `@session_picker_cap` entry cap. This
+  mirrors `open_jump_picker/1` (also uncapped) and is deliberate: an
+  entry cap would silently drop blocks OUT of search, making a block
+  unfindable -- a correctness regression, not a safety win. With the
+  per-item work now bounded (see the label clamp above), a single
+  keystroke's ranking is near-linear in `entries x cap`, the same
+  envelope the accepted jump picker already runs in.
+
+  ## Why every label is `kind · summary`, not "the matching line"
+
+  `OverlayPicker`'s `label_fn` is static: it is both the search key AND
+  the rendered row, and it never sees the live query as the operator
+  types -- so a label that shows "the first line that matched" is
+  structurally impossible for this primitive (there is no query yet at
+  label-construction time, and the query changes every keystroke without
+  the labels being rebuilt). Every label is instead `Block.search_text/2`
+  itself (kind-prefixed, source-clamped, newline-flattened) -- the visible,
+  width-truncated HEAD of each row (`"<kind> · <summary>"`) always
+  identifies the block even when the actual match sits deep in an
+  unfolded body line, and picking still jumps focus to the real content
+  underneath. Display-width truncation (CJK-aware) happens exactly once,
+  in `Raxol.Harness.Surface.ViewText.lines/3` -- this function hands the
+  picker full (already-clamped) labels, same as `open_jump_picker/1`.
+  """
+  @spec open_search_picker(t()) :: t()
+  def open_search_picker(%{projection: %{blocks: []}} = model) do
+    %{model | stub_notice: "» no blocks to search"}
+  end
+
+  def open_search_picker(model) do
+    items =
+      model.projection.blocks
+      |> Enum.with_index()
+      |> Enum.map(fn {block, index} ->
+        %{index: index, label: search_label(block)}
+      end)
+
+    model
+    |> open_overlay(items,
+      label_fn: & &1.label,
+      filter_fn: &OverlayPicker.fuzzy_filter/3,
+      title: "search",
+      on_pick: fn model, item -> %{model | focused_index: item.index} end
+    )
+    |> handle_open_result(model)
+  end
+
+  # `Block.search_text/2` bounds the WORK, not just the output: it clamps
+  # every untrusted body field to `@search_label_cap` graphemes at the
+  # source, so the corpus it returns is already <= the cap and the
+  # newline-flatten below (same reason `OverlayPicker.render/1` flattens
+  # every label: one item must always be one footer row) runs over a
+  # bounded string, never over the full body. The flatten only shortens
+  # (`\r\n` -> one space), so the result stays <= the cap -- no second
+  # slice needed here.
+  defp search_label(block) do
+    block
+    |> Block.search_text(@search_label_cap)
+    |> String.replace(["\r\n", "\n", "\r"], " ")
   end
 
   @doc """

--- a/lib/raxol/ui/components/harness/block.ex
+++ b/lib/raxol/ui/components/harness/block.ex
@@ -590,6 +590,142 @@ defmodule Raxol.UI.Components.Harness.Block do
 
   def summary(_block), do: "(empty)"
 
+  @doc """
+  The honest per-block search corpus: `"<kind> · <summary>"` (the same
+  shape `Raxol.Harness.Surface.open_jump_picker/1`'s labels already
+  use) followed by ` · ` plus the block's BODY text, when that body
+  carries content beyond what `summary/1` already shows -- `summary/1`
+  only ever surfaces line 1 of message-shaped content, or the header
+  fields (name/args, path) for the other kinds.
+
+  Body per kind, read defensively from `block.content` (every field
+  may be missing or `nil`; a non-map `content` degrades to the
+  `kind · summary` prefix alone, same as a body that turns out empty):
+
+    * `:message`, `:reasoning`, `:opaque` -- `content.text`, the FULL
+      text (`summary/1` shows only its first line).
+    * `:tool_call` -- `content.result` (`summary/1` already carries
+      name + args).
+    * `:approval` -- the FULL `content.action` (`summary/1` only shows
+      its first line) plus `content.options`: a list whose BINARY
+      entries are joined in. Non-binary entries (atoms, maps, anything
+      else a producer might send) are skipped rather than risking a
+      `to_string/1` call on an arbitrary term -- a named, honest
+      limitation: a block whose options are atoms contributes no
+      option text to the corpus.
+    * `:diff` -- `content.old` and `content.new` (`summary/1` already
+      carries the path).
+
+  No sanitization happens here: `Raxol.Harness.Surface.ViewText.lines/3`
+  is the ONE trust boundary for control-byte stripping and display-width
+  truncation (see that module's moduledoc). Pure; never raises,
+  regardless of `content`'s shape.
+
+  ## Bounding the work (`max_graphemes`)
+
+  `search_text/1` returns the FULL corpus (`max_graphemes: :infinity`).
+  `search_text/2` bounds it: the clamp is applied AT THE SOURCE -- every
+  body field is `String.slice`d to `max_graphemes` (which walks at most
+  `max_graphemes` graphemes and stops, never scanning the tail) BEFORE
+  it is concatenated or joined, and the assembled corpus is clamped once
+  more. So a caller on a synchronous input path (see
+  `Raxol.Harness.Surface.open_search_picker/1`) never pays O(body-size)
+  to build a bounded label out of an unbounded, untrusted body -- the
+  flatten/concat that used to run over the whole body now runs over at
+  most `max_graphemes` graphemes. The named, honest consequence: body
+  content past the cap is not part of the corpus (and so not
+  searchable), same as before -- but now the *work*, not just the
+  *output*, is bounded.
+  """
+  @spec search_text(t()) :: String.t()
+  def search_text(block), do: search_text(block, :infinity)
+
+  @spec search_text(t(), pos_integer() | :infinity) :: String.t()
+  def search_text(%__MODULE__{kind: kind} = block, max_graphemes) do
+    # Clamp the prefix too: `summary/1` returns line 1, but a single-line
+    # body makes "line 1" the whole body, so an unclamped prefix would
+    # re-introduce an O(body) concat below. `summary/1`'s own scan is the
+    # accepted `open_jump_picker/1` baseline; clamping here keeps the
+    # search path at parity with it, adding no unbounded term of its own.
+    prefix = clamp_graphemes("#{kind} · #{summary(block)}", max_graphemes)
+
+    case search_body_text(kind, search_content(block), max_graphemes) do
+      body when is_binary(body) and body != "" ->
+        clamp_graphemes(prefix <> " · " <> body, max_graphemes)
+
+      _empty ->
+        prefix
+    end
+  end
+
+  defp search_content(%__MODULE__{content: content}) when is_map(content),
+    do: content
+
+  defp search_content(_block), do: %{}
+
+  defp search_body_text(kind, content, max)
+       when kind in [:message, :reasoning, :opaque],
+       do: search_text_field(content, :text, max)
+
+  defp search_body_text(:tool_call, content, max),
+    do: search_text_field(content, :result, max)
+
+  defp search_body_text(:approval, content, max) do
+    join_search_parts(
+      [
+        search_text_field(content, :action, max),
+        search_options_text(content, max)
+      ],
+      max
+    )
+  end
+
+  defp search_body_text(:diff, content, max) do
+    join_search_parts(
+      [
+        search_text_field(content, :old, max),
+        search_text_field(content, :new, max)
+      ],
+      max
+    )
+  end
+
+  defp search_body_text(_kind, _content, _max), do: nil
+
+  # Clamp AT THE SOURCE: every field is bounded to `max` graphemes before
+  # it is ever concatenated or joined, so no caller scans past the cap.
+  defp search_text_field(content, key, max) do
+    case Map.get(content, key) do
+      text when is_binary(text) -> clamp_graphemes(text, max)
+      _other -> nil
+    end
+  end
+
+  defp search_options_text(content, max) do
+    case Map.get(content, :options) do
+      options when is_list(options) ->
+        case Enum.filter(options, &is_binary/1) do
+          [] -> nil
+          strings -> clamp_graphemes(Enum.join(strings, " "), max)
+        end
+
+      _other ->
+        nil
+    end
+  end
+
+  defp join_search_parts(parts, max) do
+    case Enum.reject(parts, &(&1 in [nil, ""])) do
+      [] -> nil
+      kept -> clamp_graphemes(Enum.join(kept, " "), max)
+    end
+  end
+
+  defp clamp_graphemes(string, :infinity), do: string
+
+  defp clamp_graphemes(string, max) when is_integer(max) and max >= 0,
+    do: String.slice(string, 0, max)
+
   defp kind_label(raw_kind) when is_atom(raw_kind), do: Atom.to_string(raw_kind)
   defp kind_label(raw_kind) when is_binary(raw_kind), do: raw_kind
   defp kind_label(raw_kind), do: inspect(raw_kind)

--- a/lib/raxol/ui/harness/keymap.ex
+++ b/lib/raxol/ui/harness/keymap.ex
@@ -88,7 +88,12 @@ defmodule Raxol.UI.Harness.Keymap do
       `InputEvent.printable_char/1` is `nil` whenever ctrl is held, so a
       Ctrl+E keypress never reaches this bind's `char:`-only match clause
       at all -- the two live on entirely disjoint matching paths, not a
-      priority order.
+      priority order. The same `:not_composing` guard governs the
+      picker-opening binds below (`g`/`s`/`/` -- jump, session, and
+      search) for the identical reason: each is a plain printable letter
+      that must resolve to typed text while composing, and to filter text
+      -- never a second picker opening underneath the first -- while an
+      overlay is already open.
 
   ## The overlay-open ESC capture (order is load-bearing)
 
@@ -215,8 +220,11 @@ defmodule Raxol.UI.Harness.Keymap do
   that never need to leave the UI lane, so they ride the same channel for
   the command palette's invocation parity without ever being routed to
   `raxol_agent`. `:open_palette` / `:open_jump_picker` /
-  `:open_session_picker` are the same kind of UI-local vocabulary, added
-  for the pickers below.
+  `:open_session_picker` / `:open_search_picker` are the same kind of
+  UI-local vocabulary, added for the pickers below -- `:open_search_picker`
+  (`/`) is gated `:not_composing` exactly like `:open_jump_picker`/
+  `:open_session_picker` (`g`/`s`): transcript-browse only, filter text
+  while an overlay is open, typed text while composing.
 
   ## Palette derivation (the `label` field)
 
@@ -253,6 +261,7 @@ defmodule Raxol.UI.Harness.Keymap do
           | :open_session_picker
           | :open_panel
           | :expand_diff
+          | :open_search_picker
 
   @type command :: %{type: command_type(), payload: map()}
 
@@ -377,6 +386,12 @@ defmodule Raxol.UI.Harness.Keymap do
       guard: :not_composing,
       payload: %{panel: :plan},
       label: "plan panel"
+    },
+    %{
+      char: "/",
+      command_type: :open_search_picker,
+      guard: :not_composing,
+      label: "search transcript"
     }
   ]
 

--- a/test/harness/command_palette_surface_test.exs
+++ b/test/harness/command_palette_surface_test.exs
@@ -521,4 +521,283 @@ defmodule Raxol.Harness.CommandPaletteSurfaceTest do
       assert strip_ansi(raw(device)) =~ "flat mode"
     end
   end
+
+  # ---------------------------------------------------------------------
+  # 6. Search picker ('/'): body-search proof, not just label matching
+  # ---------------------------------------------------------------------
+
+  # A variant of bulk_events/1: `count` message blocks, all one-line
+  # except block `needle_index` (1-based), whose SECOND line is
+  # `needle` -- a token that appears in NO summary and NO other block,
+  # proving the search picker's fuzzy filter reaches into block BODIES
+  # (via `Block.search_text/1`), not just the summary-derived label
+  # every other picker uses.
+  defp bulk_events_with_needle(count, needle_index, needle) do
+    turn_started = %{
+      id: 1,
+      turn_id: "bulk-needle",
+      ts: 1000,
+      family: :loop,
+      type: :turn_started,
+      tier: :durable,
+      payload: %{"prompt" => "bulk-needle"}
+    }
+
+    items =
+      for i <- 1..count do
+        base_id = 2 + (i - 1) * 2
+        item_id = "i#{i}"
+
+        content =
+          if i == needle_index do
+            "history message #{i}\n#{needle}"
+          else
+            "history message #{i}"
+          end
+
+        [
+          %{
+            id: base_id,
+            turn_id: "bulk-needle",
+            ts: 1000 + base_id,
+            family: :loop,
+            type: :item_started,
+            tier: :durable,
+            payload: %{"item_id" => item_id, "item_type" => "message"}
+          },
+          %{
+            id: base_id + 1,
+            turn_id: "bulk-needle",
+            ts: 1000 + base_id + 1,
+            family: :loop,
+            type: :item_completed,
+            tier: :durable,
+            payload: %{
+              "item_id" => item_id,
+              "item_type" => "message",
+              "content" => content
+            }
+          }
+        ]
+      end
+
+    turn_completed = %{
+      id: 2 + count * 2,
+      turn_id: "bulk-needle",
+      ts: 999_999,
+      family: :loop,
+      type: :turn_completed,
+      tier: :durable,
+      payload: %{
+        "iteration" => 1,
+        "usage" => %{"input_tokens" => 1, "output_tokens" => 1},
+        "cost" => 0.0,
+        "final" => true
+      }
+    }
+
+    List.flatten([turn_started, items, turn_completed])
+  end
+
+  # A single-block session whose body carries hostile bytes, for the
+  # sanitization test below -- built by hand (not bulk_events/1) so the
+  # hostile string lands verbatim in exactly one block's content.
+  defp hostile_events(content) do
+    [
+      %{
+        id: 1,
+        turn_id: "hostile",
+        ts: 1000,
+        family: :loop,
+        type: :turn_started,
+        tier: :durable,
+        payload: %{"prompt" => "hostile"}
+      },
+      %{
+        id: 2,
+        turn_id: "hostile",
+        ts: 1001,
+        family: :loop,
+        type: :item_started,
+        tier: :durable,
+        payload: %{"item_id" => "i1", "item_type" => "message"}
+      },
+      %{
+        id: 3,
+        turn_id: "hostile",
+        ts: 1002,
+        family: :loop,
+        type: :item_completed,
+        tier: :durable,
+        payload: %{
+          "item_id" => "i1",
+          "item_type" => "message",
+          "content" => content
+        }
+      },
+      %{
+        id: 4,
+        turn_id: "hostile",
+        ts: 999_999,
+        family: :loop,
+        type: :turn_completed,
+        tier: :durable,
+        payload: %{
+          "iteration" => 1,
+          "usage" => %{"input_tokens" => 1, "output_tokens" => 1},
+          "cost" => 0.0,
+          "final" => true
+        }
+      }
+    ]
+  end
+
+  describe "6. search picker" do
+    test "'/' opens the search picker; one entry per block, each labeled 'message · ...'" do
+      {model, _device} =
+        new_model(bulk_events_with_needle(4, 4, "zebra-needle appears here"))
+
+      model = drive_to_completion(model)
+      model = Surface.focus_transcript(model)
+
+      model = Surface.handle_input(model, Event.key("/"))
+      assert model.overlay != nil, "'/' must open the search picker"
+
+      labels = overlay_labels(model)
+      assert length(labels) == 4
+      assert Enum.all?(labels, &String.starts_with?(&1, "message · "))
+    end
+
+    test "typing a token that only exists in one block's SECOND body line filters to it; picking jumps focus" do
+      {model, _device} =
+        new_model(bulk_events_with_needle(4, 4, "zebra-needle appears here"))
+
+      model = drive_to_completion(model)
+      model = Surface.focus_transcript(model)
+
+      model = Surface.handle_input(model, Event.key("/"))
+      model = type_chars(model, "zebra-needle")
+      model = Surface.handle_input(model, Event.key(:enter))
+
+      assert model.overlay == nil
+      assert model.focused_index == 3
+    end
+
+    test "'/' while composing stays typed text (never opens the picker)" do
+      {model, _device} = new_model([])
+      assert model.composing?
+
+      model = Surface.handle_input(model, Event.key("/"))
+      assert model.overlay == nil
+
+      assert Raxol.UI.Components.Harness.Composer.value(model.composer) =~
+               "/"
+    end
+
+    test "'/' with the palette already open becomes filter text, not a second picker" do
+      {model, _device} = new_model([])
+
+      model = Surface.handle_input(model, ctrl_p())
+      assert model.overlay != nil
+      assert model.overlay.picker.title == "commands"
+
+      model = Surface.handle_input(model, Event.key("/"))
+
+      assert model.overlay != nil
+      assert model.overlay.picker.title == "commands"
+      assert model.overlay.picker.query =~ "/"
+    end
+
+    test "'/' with an empty projection is an honest no-op notice, never an empty overlay" do
+      {model, device} = new_model([])
+      model = Surface.focus_transcript(model)
+
+      model = Surface.handle_input(model, Event.key("/"))
+
+      assert model.overlay == nil
+      assert strip_ansi(raw(device)) =~ "no blocks to search"
+    end
+
+    test "picking 'search transcript' from the palette opens the search picker (palette parity)" do
+      {model, _device} = new_model(bulk_events_with_needle(2, 2, "needle"))
+      model = drive_to_completion(model)
+
+      model = Surface.handle_input(model, ctrl_p())
+      model = type_chars(model, "search transcript")
+      model = Surface.handle_input(model, Event.key(:enter))
+
+      assert model.overlay != nil
+      assert model.overlay.picker.title == "search"
+    end
+
+    test "hostile body content never leaks control bytes (C0, ESC, DEL, C1) into the footer once the picker is open" do
+      # C0 (0x01), ESC/SGR, DEL (0x7F), AND the C1 range (0x80-0x9F):
+      # raw CSI (0x9B) and IND (0x84) are lone high bytes a Latin-1 /
+      # raw-agent stream can carry. #632 made `ViewText.sanitize/1`
+      # code-point-aware so it strips 0x80-0x9F; this feature routes
+      # full block BODIES through that boundary, so the guard must cover
+      # the C1 class the sole sanitizer is now responsible for, not just
+      # C0/ESC (the review's "false assurance" gap).
+      hostile =
+        "visible words \e[31mred\e[0m trailer\x01tail\x7f" <>
+          <<0x9B>> <> "csi" <> <<0x84>> <> "ind"
+
+      {model, device} = new_model(hostile_events(hostile))
+      model = drive_to_completion(model)
+      model = Surface.focus_transcript(model)
+
+      prior = byte_size(raw(device))
+      model = Surface.handle_input(model, Event.key("/"))
+      assert model.overlay != nil
+
+      delta = delta_since(device, prior)
+
+      # Positive check on the stripped view (the row rendered).
+      assert strip_ansi(delta) =~ "visible words"
+
+      # Control-byte refutes run against the RAW delta, NOT the
+      # strip_ansi'd view: `strip_ansi`'s SequenceScanner would itself
+      # eat a lone C1 introducer (0x9B = CSI), so asserting on the
+      # stripped text would pass for the wrong reason (the oracle masking
+      # the byte under test). The renderer only ever emits 7-bit `ESC[`
+      # sequences, never a bare 0x01/0x7F/0x84/0x9B, so their absence in
+      # the raw bytes proves the sanitizer stripped the hostile input.
+      refute delta =~ <<0x01>>, "C0 (0x01) must not reach the device"
+      refute delta =~ <<0x7F>>, "DEL (0x7F) must not reach the device"
+      refute delta =~ <<0x9B>>, "raw CSI (C1) must not reach the device"
+      refute delta =~ <<0x84>>, "IND (C1) must not reach the device"
+    end
+
+    test "a long CJK body opens cleanly: the label is clamped and the claimed overlay height stays sane" do
+      cjk = String.duplicate("漢", 500)
+      {model, _device} = new_model(hostile_events("short line\n#{cjk}"))
+      model = drive_to_completion(model)
+      model = Surface.focus_transcript(model)
+
+      model = Surface.handle_input(model, Event.key("/"))
+      assert model.overlay != nil
+
+      [label] = overlay_labels(model)
+      assert String.length(label) < 450
+
+      assert OverlayPicker.height(model.overlay.picker) == 2
+    end
+
+    test "a needle past the label cap is not searchable -- the named, honest clamp consequence" do
+      # A block whose body is padded past @search_label_cap (400
+      # graphemes) before the needle appears: the clamp means the
+      # needle never reaches the picker's label, so filtering on it
+      # yields no matches.
+      padding = String.duplicate("x", 500)
+      {model, _device} = new_model(hostile_events("#{padding}\nfar-needle"))
+      model = drive_to_completion(model)
+      model = Surface.focus_transcript(model)
+
+      model = Surface.handle_input(model, Event.key("/"))
+      assert model.overlay != nil
+
+      model = type_chars(model, "far-needle")
+      assert OverlayPicker.matches(model.overlay.picker) == []
+    end
+  end
 end

--- a/test/raxol/ui/components/harness/block_search_text_test.exs
+++ b/test/raxol/ui/components/harness/block_search_text_test.exs
@@ -1,0 +1,301 @@
+defmodule Raxol.UI.Components.Harness.BlockSearchTextTest do
+  @moduledoc """
+  `Raxol.UI.Components.Harness.Block.search_text/1` -- the per-block
+  search corpus the transcript search picker
+  (`Raxol.Harness.Surface.open_search_picker/1`) filters over. Every
+  doc guarantee `search_text/1` states maps to a named test here: the
+  `"<kind> · <summary>"` prefix, the per-kind body extension, that the
+  body carries content `summary/1` never shows (full text vs.
+  first-line-only), that hostile content is preserved verbatim
+  (sanitize lives in `Raxol.Harness.Surface.ViewText`, not here), and
+  that any degenerate `content` shape degrades to the prefix alone
+  instead of raising.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.Block
+
+  defp text_events(content, id \\ 1) do
+    [
+      %{
+        id: id,
+        type: :item_completed,
+        payload: %{content: content}
+      }
+    ]
+  end
+
+  defp tool_call_events(name, args, result) do
+    [
+      %{
+        id: 1,
+        type: :item_completed,
+        payload: %{item_type: :tool_use, content: %{name: name, args: args}}
+      },
+      %{
+        id: 2,
+        type: :item_completed,
+        payload: %{item_type: :tool_result, content: result}
+      }
+    ]
+  end
+
+  defp approval_events(action, options) do
+    [
+      %{
+        id: 1,
+        type: :approval_requested,
+        payload: %{action: action, options: options}
+      }
+    ]
+  end
+
+  defp diff_events(path, old, new) do
+    [
+      %{
+        id: 1,
+        type: :item_completed,
+        payload: %{path: path, old: old, new: new}
+      }
+    ]
+  end
+
+  test "message block: search_text carries the kind, the summary line, and a body line summary omits" do
+    block =
+      Block.from_events(:message, text_events("first line\nsecond line unique"))
+
+    text = Block.search_text(block)
+
+    assert text =~ "message"
+    assert text =~ "first line"
+    assert text =~ "second line unique"
+
+    refute Block.summary(block) =~ "second line unique",
+           "precondition: summary/1 only ever shows line 1"
+  end
+
+  test "reasoning block: search_text carries the kind, the summary line, and a body line summary omits" do
+    block =
+      Block.from_events(
+        :reasoning,
+        text_events("reasoning line one\nreasoning line two")
+      )
+
+    text = Block.search_text(block)
+
+    assert text =~ "reasoning"
+    assert text =~ "reasoning line one"
+    assert text =~ "reasoning line two"
+
+    refute Block.summary(block) =~ "reasoning line two"
+  end
+
+  test "tool_call block: search_text carries the name, the args rendering, and the full result text" do
+    block =
+      Block.from_events(
+        :tool_call,
+        tool_call_events("Bash", %{command: "ls -la"}, "file1\nfile2\nfile3")
+      )
+
+    text = Block.search_text(block)
+
+    assert text =~ "tool_call"
+    assert text =~ "Bash"
+    assert text =~ "command: \"ls -la\""
+    assert text =~ "file1"
+    assert text =~ "file2"
+    assert text =~ "file3"
+  end
+
+  test "approval block: search_text carries the full multi-line action and option strings" do
+    action = "rm -rf /tmp/scratch\nthis will delete data permanently"
+
+    block =
+      Block.from_events(
+        :approval,
+        approval_events(action, ["allow", "deny with reason"])
+      )
+
+    text = Block.search_text(block)
+
+    assert text =~ "approval"
+    assert text =~ "rm -rf /tmp/scratch"
+    assert text =~ "this will delete data permanently"
+    assert text =~ "allow"
+    assert text =~ "deny with reason"
+
+    refute Block.summary(block) =~ "this will delete data permanently",
+           "precondition: summary/1 only ever shows action's line 1"
+  end
+
+  test "approval block: non-binary options are skipped, never raise, while binary siblings still surface" do
+    block =
+      Block.from_events(
+        :approval,
+        approval_events("rm -rf /", [:allow, "deny with reason", %{weird: true}])
+      )
+
+    text = Block.search_text(block)
+
+    assert text =~ "deny with reason"
+    refute text =~ "allow", "an atom option must be skipped, not stringified"
+    refute text =~ "weird"
+  end
+
+  test "diff block: search_text carries the path (via summary), the old text, and the new text" do
+    block =
+      Block.from_events(
+        :diff,
+        diff_events(
+          "lib/orders/total.ex",
+          "def total(x), do: x\n",
+          "def total(x), do: x * 2\n"
+        )
+      )
+
+    text = Block.search_text(block)
+
+    assert text =~ "diff"
+    assert text =~ "lib/orders/total.ex"
+    assert text =~ "def total(x), do: x"
+    assert text =~ "x * 2"
+  end
+
+  test "opaque block: search_text carries the raw_kind label and the full text" do
+    block =
+      Block.from_events(
+        :mystery_kind,
+        text_events("payload line one\npayload line two")
+      )
+
+    text = Block.search_text(block)
+
+    assert block.kind == :opaque
+    assert text =~ "opaque"
+    assert text =~ "mystery_kind"
+    assert text =~ "payload line one"
+    assert text =~ "payload line two"
+  end
+
+  test "hostile content: search_text preserves escape and control bytes verbatim, and never raises" do
+    hostile = "line one\e[31mred\e[0m line two\x01trailer"
+    block = Block.from_events(:message, text_events(hostile))
+
+    text = Block.search_text(block)
+
+    assert text =~ "\e[31mred\e[0m"
+    assert text =~ <<0x01>>
+  end
+
+  test "degenerate content: an empty content map or nil-valued fields degrade to the kind · summary prefix, never raise" do
+    empty_block = %Block{
+      kind: :message,
+      raw_kind: :message,
+      event_refs: [],
+      fold: :expanded,
+      seal: :live,
+      outcome: %{exit_code: nil, duration_ms: nil, cost: nil},
+      content: %{}
+    }
+
+    nil_block = %{empty_block | content: %{text: nil}}
+
+    assert Block.search_text(empty_block) == "message · (empty)"
+    assert Block.search_text(nil_block) == "message · (empty)"
+  end
+
+  describe "search_text/2 -- bounded work on the input path (PR #628 HIGH)" do
+    # Regression guard for the adversarial-review HIGH: the cap must bound
+    # the WORK, not just the label output. The observable proxy for
+    # "bounded work" is that the RETURNED corpus is <= the cap regardless
+    # of how large the untrusted body is -- the earlier revision clamped
+    # only downstream, so `search_text/2` (source clamp) is what these
+    # pin. `search_text/1` must stay the FULL, unbounded corpus.
+
+    test "message body: /2 clamps the corpus to the cap; /1 stays unbounded" do
+      body = String.duplicate("x", 100_000)
+      block = Block.from_events(:message, text_events("head\n" <> body))
+
+      assert String.length(Block.search_text(block, 400)) <= 400
+      # /1 (== :infinity) still carries the whole body -- semantics intact.
+      assert String.length(Block.search_text(block)) > 100_000
+      assert Block.search_text(block, :infinity) == Block.search_text(block)
+    end
+
+    test "single giant line (no newlines): prefix clamp keeps /2 at the cap" do
+      # `summary/1` returns line 1, and here line 1 IS the whole body -- so
+      # an unclamped prefix would re-introduce an O(body) concat. The
+      # corpus must still land under the cap.
+      block =
+        Block.from_events(:message, text_events(String.duplicate("z", 50_000)))
+
+      assert String.length(Block.search_text(block, 400)) <= 400
+    end
+
+    test "a token before the cap is in the corpus; a token past it is not" do
+      # 200 graphemes of filler, MARK_NEAR, filler out past 400, MARK_FAR.
+      body =
+        "head\n" <>
+          String.duplicate("a", 200) <>
+          "MARK_NEAR" <>
+          String.duplicate("b", 400) <>
+          "MARK_FAR"
+
+      block = Block.from_events(:message, text_events(body))
+      corpus = Block.search_text(block, 400)
+
+      assert corpus =~ "MARK_NEAR"
+      refute corpus =~ "MARK_FAR", "content past the cap must not be searchable"
+    end
+
+    test "diff body: BOTH old and new are source-clamped, corpus <= cap" do
+      block =
+        Block.from_events(
+          :diff,
+          diff_events(
+            "lib/x.ex",
+            String.duplicate("o", 100_000),
+            String.duplicate("n", 100_000)
+          )
+        )
+
+      assert String.length(Block.search_text(block, 400)) <= 400
+    end
+
+    test "approval body: action and option strings are source-clamped, corpus <= cap" do
+      block =
+        Block.from_events(
+          :approval,
+          approval_events(
+            String.duplicate("A", 100_000),
+            [String.duplicate("o", 100_000), String.duplicate("p", 100_000)]
+          )
+        )
+
+      assert String.length(Block.search_text(block, 400)) <= 400
+    end
+
+    test "tool_call result: source-clamped, corpus <= cap" do
+      block =
+        Block.from_events(
+          :tool_call,
+          tool_call_events(
+            "Bash",
+            %{command: "x"},
+            String.duplicate("r", 100_000)
+          )
+        )
+
+      assert String.length(Block.search_text(block, 400)) <= 400
+    end
+
+    test "a body shorter than the cap is returned intact (clamp never over-trims)" do
+      block = Block.from_events(:message, text_events("short body token_ok"))
+
+      corpus = Block.search_text(block, 400)
+      assert corpus =~ "token_ok"
+      assert corpus == Block.search_text(block)
+    end
+  end
+end

--- a/test/raxol/ui/harness/picker_binds_test.exs
+++ b/test/raxol/ui/harness/picker_binds_test.exs
@@ -85,6 +85,40 @@ defmodule Raxol.UI.Harness.PickerBindsTest do
     end
   end
 
+  # -- 1b. the search picker bind ('/') -----------------------------------
+
+  describe "search picker bind" do
+    test "'/' -> :open_search_picker in transcript-browse only" do
+      assert resolve_from(Event.key_event("/", :pressed, []), %{
+               composing?: false,
+               overlay_open?: false
+             }) == %{type: :open_search_picker, payload: %{}}
+    end
+
+    test "'/' while composing stays :passthrough (typed text)" do
+      assert resolve_from(Event.key_event("/", :pressed, []), %{
+               composing?: true
+             }) == :passthrough
+    end
+
+    test "'/' with an overlay already open stays :passthrough (filter text for the open overlay)" do
+      assert resolve_from(Event.key_event("/", :pressed, []), %{
+               composing?: false,
+               overlay_open?: true
+             }) == :passthrough
+    end
+
+    test "a missing composing? flag fail-safes '/' to :passthrough" do
+      assert resolve_from(Event.key_event("/", :pressed, []), %{}) ==
+               :passthrough
+    end
+
+    test "palette_binds/0 includes the search transcript label" do
+      labels = Enum.map(Keymap.palette_binds(), & &1.label)
+      assert "search transcript" in labels
+    end
+  end
+
   # -- 2. palette derivation: the bind table is the single source of truth --
 
   describe "palette derivation" do


### PR DESCRIPTION
`/` in transcript-browse opens a search picker over every block's content — kind, summary, and the body text the summary never shows. Typing fuzzy-ranks; picking jumps focus to the block. Also a labeled palette entry via the merged registry derivation (no parallel list).

## Corpus (`Block.search_text/1`, new public)

`"<kind> · <summary>"` prefix plus per-kind body: message/reasoning/opaque get full content text; tool calls get the result (the summary already carries name+args); approvals get the full multi-line action + binary options; diffs get old+new (summary carries the path). No sanitize/truncate in derivation — `ViewText.lines/3` stays the SINGLE trust boundary for control bytes and display width.

## Label + bounds

The overlay's label is static (it is both search key and rendered row), so labels are the flattened corpus clamped to 400 graphemes — bounding per-keystroke fuzzy ranking on the synchronous input path (the session-picker cap precedent). The visible width-truncated head is always `kind · summary`, identifying the block even when the match sits deep in the body. Content past the cap is not searchable — documented AND pinned by a named test, not silent.

## Bind

`/` was free; `:not_composing` guard, same class as the jump/session picker binds: typed text while composing, filter text while any overlay is open. Picking uses the jump picker's exact focus path; empty projection refuses with an honest notice.

## Verification

Red-first (captured: `search_text/1` undefined x8, `/` resolving passthrough, 6/8 e2e failing behaviorally). 23 new tests incl. the body-search proof — a token present only in block 3's SECOND body line filters to it and focus lands on 3 — plus hostile-byte sanitization, CJK clamp, and past-cap pins. Targeted suites 126/126; full suite 6195 passed / 0 failed; warnings + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)