### PR TITLE
Harness UI: full logical seal — refused-write display gap (LIVE), sealed? boundary unification (LIVE), tail-bound pin

### DIFF
--- a/lib/raxol/harness/seal_frontier.ex
+++ b/lib/raxol/harness/seal_frontier.ex
@@ -40,12 +40,28 @@ defmodule Raxol.Harness.SealFrontier do
 
     * `Raxol.Harness.Surface.paint_pending_blocks/1` -- the one mutating
       walk, via `commit_walk/5`.
-    * `Raxol.Harness.Surface`'s footer pending-preview (`pending_block/1`,
-      via `frontier_scan/1`, itself `scan_frontier/3`) -- read-only.
+    * `Raxol.Harness.Surface`'s footer pending-preview (`pending_block/1`)
+      -- reads the WALK's committed cursor (`painted_count`), not the
+      scan: the scan is the pre-commit projection and consumes
+      committable entries, so it would hide a block whose seal write was
+      just refused. Cursor and scan agree on every successful frame (the
+      scan/walk-agreement property below); on a refusal the cursor is
+      the display-honest one.
     * `Raxol.Harness.Surface`'s synchronized-output bracket gate
-      (`seal_frame/3`, also via `frontier_scan/1`) -- read-only, consulted
-      BEFORE the commit pass to decide whether to open a bracket around
-      it.
+      (`seal_frame/3`, via `frontier_scan/1`, itself `scan_frontier/3`)
+      -- read-only, consulted BEFORE the commit pass to decide whether
+      to open a bracket around it.
+    * The keyframe/reflow gate is NOT a consumer, by construction: the
+      reference design's resize path must pick its behavior on
+      `will_commit` because its viewport height is a function of the
+      post-commit tail, but this substrate's resize path
+      (`Raxol.Harness.Surface.resize/2` / the `advance/3` `:resize`
+      option) never seals and never sizes anything off frontier state --
+      the footer row count is geometry-fixed, and a combined
+      resize+advance frame adopts geometry FIRST (the frame-order law),
+      then lets the ordinary seal frame run. A future change that makes
+      the resize path seal, or the footer height a function of tail
+      content, MUST route its decision through this classifier.
 
   ## The entry contract
 
@@ -155,8 +171,12 @@ defmodule Raxol.Harness.SealFrontier do
   first index a commit pass would NOT consume -- i.e. where the live tail
   begins after this frame's (hypothetical or already-run) commit. This
   function never mutates anything; it exists so a consumer can ask "where
-  would the frontier land" without actually committing (the footer preview
-  needs exactly this, and the resize seam will too).
+  would the frontier land" without actually committing (the sync-bracket
+  gate and the seal pass's detach target need exactly this, and the
+  resize seam will too). Display surfaces that must show what is NOT yet
+  physically committed key on the walk's cursor instead -- the scan
+  consumes committable entries, so it overshoots the committed set
+  whenever an emit fails (see the consumer table above).
 
   ## `commit_walk/5` -- the one mutating walk
 

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -254,11 +254,25 @@ defmodule Raxol.Harness.Surface do
   The "which blocks may seal" decision itself now lives in
   `Raxol.Harness.SealFrontier` (a shared classifier, not restated per
   consumer). `frontier_entries/1` expresses the foldable window described
-  below as the frontier's `pending_input?` hold on the newest block, and
-  both the seal pass (`paint_pending_blocks/1`) and the footer's pending
-  preview (`pending_block/1`) consult `frontier_scan/1` -- the same
-  entries, the same classifier -- so they can never disagree on where the
-  frontier stops.
+  below as the frontier's `pending_input?` hold on the newest block; the
+  seal pass (`paint_pending_blocks/1`) walks it via `commit_walk/5`, and
+  the footer's pending preview (`pending_block/1`) shows the first block
+  past the walk's own committed cursor (`painted_count`) -- the
+  post-commit truth, which equals the pre-commit scan's `tail_start` on
+  every successful frame and stays honest (block still visible) when a
+  seal write is refused. One classifier decides where the frontier
+  stops; the cursor records where it actually got to.
+
+  The preview shows ONE block (two lines of it). Today the two never
+  differ: the only frontier hold a shipped producer can create is the
+  foldable window on the NEWEST block, so the unsealed suffix past the
+  cursor is at most one block long (pinned by the tail-bound test in
+  `test/harness/surface_frontier_feed_test.exs`). The moment a producer
+  emits live blocks (a mid-list awaiting-input approval holding several
+  finalized blocks behind it), that bound breaks and the one-block
+  preview under-reports -- the pinning test fails loudly then, and the
+  multi-block tail rendering it forces is the live-lane (T13b) unit's
+  decision, not silently absorbed here.
 
   `Raxol.UI.Components.Harness.Block.seal` is an item-LIFECYCLE field:
   `BlockBuilder` only ever constructs a block once its source item(s)
@@ -799,16 +813,14 @@ defmodule Raxol.Harness.Surface do
   defp adopt_frame_resize(model, {width, rows}),
     do: adopt_resize(model, width, rows)
 
-  defp do_advance(
-         %{revealed: revealed, events: events, painted_count: painted} = model,
-         _now
-       )
-       when revealed >= length(events) and
-              painted >= length(model.projection.blocks) do
-    {model, :done}
+  # Done-ness is stated exactly once, in `done?/1` -- this entry check
+  # and the post-frame check below both consult it, so "everything
+  # revealed and everything sealed" can never mean two different things.
+  defp do_advance(model, now) do
+    if done?(model), do: {model, :done}, else: run_advance(model, now)
   end
 
-  defp do_advance(model, now) do
+  defp run_advance(model, now) do
     model = heal_sync(model)
     revealed = min(model.revealed + 1, length(model.events))
     events_so_far = Enum.take(model.events, revealed)
@@ -824,11 +836,7 @@ defmodule Raxol.Harness.Surface do
       |> reconcile_unread()
       |> seal_frame(events_so_far, now)
 
-    finished? =
-      model.revealed >= length(model.events) and
-        model.painted_count >= length(model.projection.blocks)
-
-    {model, if(finished?, do: :done, else: :ok)}
+    {model, if(done?(model), do: :done, else: :ok)}
   end
 
   # A frame that seals at least one block AND repaints the footer
@@ -967,7 +975,7 @@ defmodule Raxol.Harness.Surface do
     |> Enum.map(fn {block, index} ->
       %{
         kind: block.kind,
-        committed?: index < model.painted_count,
+        committed?: block_sealed?(model, index),
         running?: Block.live?(block),
         pending_input?:
           awaiting_input?(block) or
@@ -975,6 +983,24 @@ defmodule Raxol.Harness.Surface do
       }
     end)
   end
+
+  # THE committed-marker mapping, stated exactly once: block `index` is
+  # sealed (physically painted into print-once history) iff it sits below
+  # the `painted_count` high-water mark -- the mark only ever advances a
+  # contiguous prefix, so the comparison IS the committed set. Both the
+  # frontier feed above (`committed?`) and the fold fill-guard
+  # (`apply_fold_toggle/2` -- the one mutation channel aimed at a block)
+  # consult this one predicate, so the "what counts as sealed" boundary
+  # can never drift between the classifier's view and the guard's
+  # (boundary-agreement pinned in
+  # test/harness/surface_frontier_feed_test.exs).
+  # No `index >= 0` guard on purpose: a degenerate negative index (no
+  # producer can build one -- `move_focus/2` clamps at 0 -- but the
+  # payload is data) classifies as "sealed" and lands on the honest
+  # refusal notice, never a crash mid-input-frame. Fail-closed: the
+  # restrictive answer for a nonsense index is "not foldable."
+  defp block_sealed?(model, index) when is_integer(index),
+    do: index < model.painted_count
 
   # A live approval block is, per `Block`'s own contract, a question still
   # waiting on the user -- the genuine awaiting-input feed for the
@@ -984,20 +1010,27 @@ defmodule Raxol.Harness.Surface do
     do: Block.live?(block) and block.kind == :approval
 
   @doc """
-  The shared frontier consultation every consumer in this module goes
-  through: `SealFrontier.scan_frontier/3` over `frontier_entries/1`.
-  `tail_start` is both the seal pass's paint target and the first block
-  the footer's pending preview may show -- one number, so the two can
-  never disagree. `turn_running?` is derived from the status snapshot
-  (`turn_completed`); with today's entry mapping (no running entries,
-  window hold unconditional) the scan result is independent of turn
-  state, so the one-step-stale status at seal time is harmless.
+  The shared PRE-commit frontier consultation: `SealFrontier.scan_frontier/3`
+  over `frontier_entries/1`. Two consumers read it, both BEFORE the
+  commit pass runs: `paint_pending_blocks/1`'s detach target
+  (`tail_start` -- every block at or past "about to seal" gets its
+  content detached), and `seal_frame/3`'s per-frame synchronized-output
+  bracket decision (`will_commit` predicts "this frame seals >= 1
+  block" -- same entries, same classifier, so it can never disagree
+  with what the walk actually attempts). `turn_running?` is derived
+  from the status snapshot (`turn_completed`); with today's entry
+  mapping (no running entries, window hold unconditional) the scan
+  result is independent of turn state, so the one-step-stale status at
+  seal time is harmless.
 
-  A third consumer: `seal_frame/3`'s per-frame synchronized-output
-  bracket decision reads `will_commit` from this same scan to predict
-  "this frame seals >= 1 block" BEFORE the commit pass actually runs --
-  same entries, same classifier, so it can never disagree with what
-  `paint_pending_blocks/1` (via `commit_walk/5`) actually does.
+  The footer's pending preview (`pending_block/1`) deliberately does
+  NOT read this scan: it keys on the committed cursor
+  (`painted_count`) instead, because the scan consumes committable
+  entries and would therefore hide a block whose seal write was just
+  REFUSED (see `pending_block/1`'s comment for the full rationale).
+  The two agree on every successful frame (the scan/walk-agreement
+  property); they diverge exactly when a write fails, and the cursor
+  is the display-honest side of that divergence.
   """
   @spec frontier_scan(t()) :: SealFrontier.scan()
   def frontier_scan(model) do
@@ -1590,8 +1623,19 @@ defmodule Raxol.Harness.Surface do
     %{model | stub_notice: "» no block focused — jump to a block first (g)"}
   end
 
-  defp apply_fold_toggle(model, index)
-       when is_integer(index) and index < model.painted_count do
+  # The sealed?/unsealed? split below goes through `block_sealed?/2` --
+  # the SAME predicate that feeds the frontier classifier's `committed?`
+  # flag (see `frontier_entries/1`) -- so the fill-guard's boundary and
+  # the classifier's can never disagree by construction.
+  defp apply_fold_toggle(model, index) when is_integer(index) do
+    if block_sealed?(model, index) do
+      sealed_fold_refusal(model, index)
+    else
+      store_fold_override(model, index)
+    end
+  end
+
+  defp sealed_fold_refusal(model, index) do
     # Already physically painted -- seal-time-only: sealed history is
     # never repainted, so a fold toggle on it is a documented no-op,
     # exactly like `Block.fold_allowed?/2`'s post-seal gate (enforced
@@ -1609,7 +1653,7 @@ defmodule Raxol.Harness.Surface do
     %{model | stub_notice: "» block #{index} sealed — fold unavailable"}
   end
 
-  defp apply_fold_toggle(model, index) do
+  defp store_fold_override(model, index) do
     case Enum.at(model.projection.blocks, index) do
       nil ->
         model
@@ -2183,11 +2227,21 @@ defmodule Raxol.Harness.Surface do
   end
 
   defp pending_block(model) do
-    # Post-seal, `tail_start == painted_count` always -- the committed
-    # prefix skips to the high-water mark and the walk already consumed
-    # everything committable -- so this is the same block as before, now
-    # DERIVED from the shared classifier instead of restated.
-    tail_start = frontier_scan(model).tail_start
+    # Keyed on the committed CURSOR (`painted_count` -- `commit_walk/5`'s
+    # own post-walk cursor), NOT on `frontier_scan/1`'s `tail_start`. The
+    # scan is the PRE-commit projection ("what would remain after an
+    # ideal commit this frame"): it consumes committable entries, so
+    # after a REFUSED seal write (`{:error, :write_failed, _}` -- the
+    # walk halts, `painted_count` stays strictly before the failed
+    # entry) the two diverge, and the scan-keyed preview would skip the
+    # very block that is not yet in history -- invisible on both
+    # surfaces at once, exactly the under-reporting the display half of
+    # retry-not-vanish forbids (pinned in
+    # test/harness/surface_seal_pipeline_test.exs). On every successful
+    # frame the walk's cursor and the scan agree (`tail_start ==
+    # painted_count`, the scan/walk-agreement property), so this changes
+    # nothing there; on a refusal the cursor is the honest one.
+    tail_start = model.painted_count
 
     case Enum.slice(model.projection.blocks, tail_start..-1//1) do
       [] -> nil

--- a/test/harness/surface_frontier_feed_test.exs
+++ b/test/harness/surface_frontier_feed_test.exs
@@ -92,6 +92,154 @@ defmodule Raxol.Harness.SurfaceFrontierFeedTest do
     end
   end
 
+  # -- real-model helpers (Surface.new over a replayed session) ------------
+
+  defp two_block_events do
+    [
+      %{
+        id: 1,
+        family: :loop,
+        type: :turn_started,
+        tier: :durable,
+        payload: %{prompt: "go"}
+      },
+      %{
+        id: 2,
+        family: :loop,
+        type: :item_started,
+        tier: :durable,
+        payload: %{item_id: "i1", item_type: "message"}
+      },
+      %{
+        id: 3,
+        family: :loop,
+        type: :item_completed,
+        tier: :durable,
+        payload: %{item_id: "i1", item_type: "message", content: "first"}
+      },
+      %{
+        id: 4,
+        family: :loop,
+        type: :item_started,
+        tier: :durable,
+        payload: %{item_id: "i2", item_type: "message"}
+      },
+      %{
+        id: 5,
+        family: :loop,
+        type: :item_completed,
+        tier: :durable,
+        payload: %{item_id: "i2", item_type: "message", content: "second"}
+      },
+      %{
+        id: 6,
+        family: :loop,
+        type: :turn_completed,
+        tier: :durable,
+        payload: %{final: true}
+      }
+    ]
+  end
+
+  defp real_model(events) do
+    {:ok, device} = StringIO.open("")
+
+    Surface.new(events,
+      device: device,
+      width: 80,
+      rows: 24,
+      footer_rows: 6,
+      mode: :inline_log,
+      capabilities: nil
+    )
+  end
+
+  defp advance_times(model, n) do
+    Enum.reduce(1..n, model, fn _i, m ->
+      {m, _} = Surface.advance(m)
+      m
+    end)
+  end
+
+  describe "the sealed? boundary (fill-guard vs classifier feed agreement)" do
+    test "the fold fill-guard refuses exactly the indices the frontier feed marks committed?" do
+      # 5 of 6 events revealed: both blocks exist, block 0 sealed, block 1
+      # held by the foldable window -- painted_count sits exactly on the
+      # boundary this test pins.
+      model = two_block_events() |> real_model() |> advance_times(5)
+      assert model.painted_count == 1
+
+      committed_flags =
+        model |> Surface.frontier_entries() |> Enum.map(& &1.committed?)
+
+      assert committed_flags == [true, false]
+
+      # Drive the ONLY mutation channel aimed at a block (the fold
+      # toggle) at each index, through the public input path. The
+      # refusal boundary must be the SAME boundary the classifier feed
+      # reports -- both sides now read one predicate, and this test is
+      # the tripwire if that ever un-unifies.
+      browsing = Surface.focus_transcript(model)
+
+      on_sealed =
+        browsing
+        |> Surface.handle_input(Raxol.Core.Events.Event.key("j"))
+        |> Surface.handle_input(Raxol.Core.Events.Event.key("z"))
+
+      assert on_sealed.fold_overrides == %{},
+             "index 0 is committed? in the frontier feed -- the fill-guard " <>
+               "must refuse it identically"
+
+      on_pending =
+        on_sealed
+        |> Surface.handle_input(Raxol.Core.Events.Event.key("j"))
+        |> Surface.handle_input(Raxol.Core.Events.Event.key("z"))
+
+      assert Map.has_key?(on_pending.fold_overrides, 1),
+             "index 1 is NOT committed? in the frontier feed -- the " <>
+               "fill-guard must accept the fold identically"
+    end
+  end
+
+  describe "the one-block tail bound (what keeps the single-block preview honest)" do
+    test "after every advance over every shipped fixture, at most ONE block sits past the committed cursor" do
+      # The footer's pending preview renders exactly one block. That is
+      # honest only while the unsealed suffix past `painted_count` is at
+      # most one block long -- true today because the only frontier hold
+      # a shipped producer can create is the foldable window on the
+      # NEWEST block. The moment a producer emits live blocks (a
+      # mid-list awaiting-input approval holding finalized blocks behind
+      # it), this bound breaks: this test then fails LOUDLY, forcing the
+      # multi-block tail rendering decision (the live-lane follow-up)
+      # instead of letting held blocks silently vanish from view.
+      sessions_dir = Path.join(["test", "fixtures", "harness", "sessions"])
+      names = Surface.list_fixture_sessions(sessions_dir)
+      assert names != [], "no shipped fixtures found -- the pin needs corpus"
+
+      for name <- names do
+        {:ok, session} =
+          Raxol.Harness.Fixture.load(Path.join(sessions_dir, name <> ".jsonl"))
+
+        model = real_model(session)
+        cap = length(model.events) * 2 + 10
+
+        Enum.reduce_while(1..cap, model, fn _i, m ->
+          {m, outcome} = Surface.advance(m)
+
+          unsealed = length(m.projection.blocks) - m.painted_count
+
+          assert unsealed <= 1,
+                 "fixture #{name}: #{unsealed} blocks past the committed " <>
+                   "cursor -- the one-block pending preview would hide " <>
+                   "#{unsealed - 1} of them (multi-block tail rendering " <>
+                   "is the live-lane follow-up this pin exists to force)"
+
+          if outcome == :done, do: {:halt, m}, else: {:cont, m}
+        end)
+      end
+    end
+  end
+
   describe "the foldable-window feed (unchanged)" do
     test "the newest block holds the window while the reveal is unfinished, and releases at reveal end" do
       blocks = [block(:message, :sealed), block(:message, :sealed)]

--- a/test/harness/surface_seal_pipeline_test.exs
+++ b/test/harness/surface_seal_pipeline_test.exs
@@ -336,6 +336,43 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       end
     end
 
+    test "a refused seal write keeps the unsealed block visible in the footer preview (the display half of retry-not-vanish)" do
+      # The state half of retry-not-vanish (the test above) proves the
+      # block stays unsealed for retry. This is the DISPLAY half: while
+      # it waits, the block must still be somewhere the operator can see
+      # -- it is not in history (the device refused those bytes), so the
+      # footer's pending preview is its only honest home. Deriving the
+      # preview from `scan_frontier/3`'s tail_start hides it: the scan is
+      # the PRE-commit projection ("what would remain after an ideal
+      # commit"), which consumes committable entries -- including the one
+      # whose write just failed -- so the failed block lands BEFORE
+      # tail_start and vanishes from both surfaces at once. The preview
+      # must key on the committed cursor (painted_count) instead.
+      {device, sink} =
+        FailingDevice.start(fail_when: seal_write_with(@marker), mode: :always)
+
+      model = new_model(message_events(@marker <> " body"), device: device)
+      model = advance_to_pending_flush(model)
+
+      # The flushing frame: the seal write is refused, the block stays
+      # unsealed (state half, pinned above).
+      {model, :ok} = Surface.advance(model)
+      assert model.painted_count == 0
+
+      # Force a full-footer keyframe (resize/2 keyframes unconditionally;
+      # footer rows are CUP-positioned, never \r\n-carrying, so the
+      # :always device accepts them) and read exactly its bytes: the
+      # unsealed block's content MUST be painted in the footer preview.
+      read = fn -> FailingDevice.confirmed_bytes(sink) end
+
+      {_model, keyframe_bytes} =
+        frame_bytes(read, fn -> Surface.resize(model, @width, @rows) end)
+
+      assert occurrences(keyframe_bytes, @marker) >= 1,
+             "an unsealed (refused-write) block must stay visible in the " <>
+               "footer preview -- invisible-but-retrying is under-reporting"
+    end
+
     test "post-seal fill protection: a fold override on an already-painted block is rejected and stores nothing" do
       # No placeholder-fill path against sealed content exists in this
       # codebase (grepped; the SessionRecap pattern has no analogue) -- so


### PR DESCRIPTION
The full-logical-seal unit of the SHG chain (full-logical-seal → commit-cap → T6). Per the reshaped DAG this unit is "the vehicle that carries G1–G4" — so Phase 0 was a verify-first audit of master (2416b13b8, post-#620) against the SHG spec, and Phase 1 built only the real gaps that audit found.

## Phase 0 — gap analysis (audited against code, not the ledger)

**G1 (shared frontier classifier): LIVE on master, with two structural dispositions.**
`Raxol.Harness.SealFrontier` (`classify/3`, `committable?/3`, `scan_frontier/3`, `commit_walk/5`) is the one classifier. Consumers verified by grep — no module outside `Surface` carries frontier logic:
- **Sealer**: `Surface.paint_pending_blocks/1` via `commit_walk/5` (the one mutating walk). LIVE.
- **Tail renderer** (footer pending preview): consumed the scan — this PR moves it to the walk's committed cursor, see gap 1 below. LIVE.
- **Sync-bracket gate**: `seal_frame/3` reads `will_commit` from the same scan, pre-commit. LIVE (from #620).
- **Footer-sizer**: structurally ABSENT — the footer row count is geometry-fixed, never a function of post-seal state (already declared in the moduledoc).
- **Keyframe/reflow gate**: structurally NOT a consumer — the resize path never seals and never sizes off frontier state; a combined resize+advance frame adopts geometry first (frame-order law), then the ordinary seal frame runs. This disposition was undocumented; the consumer table now records it, with the obligation to route through the classifier if the resize path ever seals or the footer height ever becomes tail-dependent.

Remaining private restatements found inside `Surface` itself: the committed-marker mapping (`index < painted_count`) encoded independently in the frontier feed and the fold fill-guard, and done-ness encoded twice (`do_advance/2` guard vs `done?/1`). Closed in this PR (gap 2).

**G2 (two-phase seal): LIVE on master** (#620): write→confirm→mark via `InlineAuthority.try_seal/2`, walk halts with cursor strictly before a failed entry, dead-device fail-fast, `write_failed` telemetry, retry-not-vanish proven through a real refusing io device. The spec's placeholder-fill guard: no placeholder-fill path exists in this codebase (grepped; pinned in the pipeline suite); the one mutation channel aimed at a block (fold override) refuses on painted blocks, test-pinned. What #620 did NOT cover is the **display half** of retry-not-vanish — gap 1 below, this PR's one behavioral fix.

**G3 (pending-input holds frontier): LIVE on master.** First clause unconditional on turn state; corpus cases 2 and 9 ported; the surface feed derives both instances (live `:approval` — dormant until a producer emits live blocks — and the foldable window), tested at both layers including the idle-turn hold.

**G4 (frame-order law): LIVE on master** (#620): `advance/3` `:resize` adopts dims+DECSTBM before any seal, footer repaint after the seal via the `needs_keyframe` self-promotion; resize-during-commit (the spec's prose-only failure mode) is test-covered at the byte level. "Size footer to post-seal height" is satisfied by construction (geometry-fixed footer).

**Corpus: 16/16 pure cases ported** (`test/harness/seal_frontier_test.exs`, including both release arcs and the mid-list shift/truncate cursor cases) **plus both net-new additions** the spec calls for: the scan≡walk agreement property (and a second property tying both walks to a reference walk of repeated `classify/3` calls), and the resize-during-commit red-first case. Renderer-level cases 17–22 belong to commit-cap (height exactness, capping — the next unit, which also owns wiring `seal_display_mode/1`, still declared NOT YET WIRED) and to G7 (native-color lock).

## What this PR builds (the real gaps)

**1. Refused-write display gap — behavioral fix, red-first.** `pending_block/1` derived the footer preview from `scan_frontier/3`'s `tail_start`. The scan is the PRE-commit projection: it consumes committable entries. #620 made the walk failable, so after a refused seal write the block was in NEITHER surface — not in history (device refused the bytes), not in the preview (scan consumed past it). Invisible-but-retrying is under-reporting (the endgame rule). Fix: the preview keys on the committed cursor (`painted_count`, the walk's own post-commit truth). Cursor and scan agree on every successful frame (the scan/walk-agreement property); they diverge exactly on refusal, and the cursor is the display-honest side. Red test: `:always`-refusing device + forced full-footer keyframe; RED on master (0 marker occurrences), GREEN with the fix.

**2. `sealed?` boundary unification + drift tripwire.** One `block_sealed?/2` predicate now feeds both the classifier's `committed?` flag and the fold fill-guard; a boundary-agreement test drives the fold gate at both sides of the boundary through the public input path. Done-ness likewise unified onto `done?/1`. (Refactor with tripwire enforcement — the red-first obligation doesn't apply to same-behavior unification; stated per the gauntlet's measured-claims rule.)

**3. One-block tail bound pinned.** The preview renders exactly one block — honest only while at most one block sits past the committed cursor, which holds for every shipped producer (the only hold is the foldable window on the newest block). A fixture-replay pin asserts the bound after every advance over every shipped fixture. The moment a producer emits live mid-list blocks (a held approval queuing finalized blocks behind it), the pin fails loudly and forces the multi-block tail rendering decision at the live lane (T13b) instead of held blocks silently vanishing. Named in the moduledoc as a designed limit, not implied.

## LIVE / SEAM ledger

- Gap 1 fix: **LIVE** (call site `pending_block/1`, enforced by `surface_seal_pipeline_test.exs` "display half of retry-not-vanish").
- Gap 2 unification: **LIVE** (both call sites in production paths; boundary test in `surface_frontier_feed_test.exs`).
- Gap 3 pin: **LIVE** test enforcing a producer invariant; the multi-block tail renderer it will one day demand is deliberately NOT built here (live-lane decision).
- Still-declared seams, unchanged by this PR: `seal_display_mode/1` (commit-cap wires it), the `:background_task`/`:message` running relaxations and the live-approval feed (dormant until a producer emits running/live entries — corpus-tested), footer-sizer/keyframe-gate dispositions (structural, now documented).

## Growth inventory

No new collections, queues, accumulators, or logs. `block_sealed?/2` is O(1); `pending_block/1` keeps the same one-slice shape; `do_advance/2`'s `done?/1` check is the same two length walks the deleted guard did. Test-side: the fixture-replay pin is bounded by `2 × events + 10` steps per fixture over the (small, shipped) fixture corpus.

## Test tally

- 3 new tests: refused-write preview visibility (red-first), sealed?-boundary agreement, fixture-replay tail bound.
- Suites: `test/harness/` + `test/property/` + `test/cross_terminal/` — **1022 passed (212 properties, 810 tests), 1 skipped, 17 excluded, 0 failures**.
- `MIX_ENV=test mix compile --warnings-as-errors` clean; `mix format --check-formatted` clean.
- Gauntlet run against the diff; one self-caught finding folded in pre-push (a `>= 0` guard on `block_sealed?/2` would have turned a degenerate negative index from an honest refusal into a crash mid-input-frame — removed, fail-closed refusal kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144dN6HHGipkajE2cJi9mce