### PR TITLE
feat(harness): U21 evidence tri-state wire marker (#619 residual)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/contract.ex
+++ b/packages/raxol_agent/lib/raxol/agent/contract.ex
@@ -27,6 +27,54 @@ defmodule Raxol.Agent.Contract do
   durable journal sink attach behind this same boundary in later steps —
   producers change, the contract does not.
 
+  ## U21 evidence tri-state wire marker (#619 residual)
+
+  On a `turn_completed{final: true}` produced by `gated_done_payload/4`, the
+  payload grows one optional discriminator plus one optional detail —
+  additive, grow-only, mirrors the Q1 `context`-field growth pattern:
+
+    * `evidence: :accepted | :rejected | :absent` — grow-only enum (atom
+      in-memory, JSON string on the wire, same convention as every other
+      enum on this surface).
+      - `:accepted` — stamped alongside `refs` (untouched: still the sole
+        accepted-refs carrier, no rename, no move).
+      - `:absent` — the `{:error, :evidence_required}` gate arm: the turn
+        offered no refs at all.
+      - `:rejected` — the `{:error, reason}` gate arm: refs were offered and
+        the gate refused them.
+    * `evidence_rejected` (present only when `evidence: :rejected`) —
+      `%{"refs" => offered_refs, "reason" => reason_name, "ref" =>
+      offset_or_nil}`, the `Raxol.Agent.DoneGate` verdict tuple flattened
+      EXPLICITLY into these string values — never handed to
+      `sanitize_payload/1` to `inspect/1`-stringify a raw tuple onto the
+      wire. `reason_name` is one of `"missing_ref"`, `"not_evidence"`,
+      `"foreign_turn"`, `"stale_evidence"`, `"mutation_echo"`.
+      `DoneGate`'s `:unturned_done` reject is unreachable on this path
+      (`pump/3` always mints a non-nil `turn_id`) and deliberately has no
+      clause here — it stays out of the wire enum.
+
+  Before this marker, a rejected done and a never-offered done were
+  byte-identical on the wire (`%{usage, final: true}`, no `refs`) — the two
+  gate-telemetry signals distinguished them live, but telemetry is not
+  journaled, so a replayed surface could not tell "offered but refused" from
+  "never offered". `evidence_status/1` decodes the field with the
+  grandfather rule this gap requires: an `evidence` key present is
+  authoritative; a **legacy** record (key absent) with `refs` present
+  grandfathers to `:accepted` (the `refs` carrier never lied); a legacy
+  record with neither key present is genuinely `:unknown` — it must NEVER
+  be guessed as `:absent`, which would launder a historical rejection into
+  a false "never offered" claim.
+
+  Both `[:raxol, :agent, :done_gate, :ungated_done]` and `[:raxol, :agent,
+  :done_gate, :rejected_evidence]` telemetry stay exactly as they were —
+  this marker is the durable/replay view; telemetry remains the live-ops
+  view. `refs` is untouched. The journal `schema_version` default bumps
+  1.0.0 -> 1.1.0 (`Raxol.Agent.Journal.FileStore.Writer`, additive per AD-11
+  upcast-on-read) alongside this payload growth; the pinned `v1.0.0` golden
+  corpus stays literal "1.0.0" and unrewritten (an old journal's records are
+  never rewritten in place, only decoded — covered by the grandfather rule
+  above).
+
   ## Producers
 
   The v0 producer is `pump/3`: it drains a `Raxol.Agent.Stream.run/2` or
@@ -271,7 +319,9 @@ defmodule Raxol.Agent.Contract do
 
     case DoneGate.gate(journal, turn_id, refs) do
       {:ok, _done} ->
-        Map.put(base, :refs, refs)
+        base
+        |> Map.put(:refs, refs)
+        |> Map.put(:evidence, :accepted)
 
       {:error, :evidence_required} ->
         :telemetry.execute(
@@ -280,7 +330,7 @@ defmodule Raxol.Agent.Contract do
           %{turn_id: turn_id}
         )
 
-        base
+        Map.put(base, :evidence, :absent)
 
       {:error, reason} ->
         :telemetry.execute(
@@ -290,6 +340,67 @@ defmodule Raxol.Agent.Contract do
         )
 
         base
+        |> Map.put(:evidence, :rejected)
+        |> Map.put(:evidence_rejected, evidence_rejected_detail(refs, reason))
+    end
+  end
+
+  # Flatten the DoneGate verdict tuple onto the wire EXPLICITLY — this must
+  # never be handed to `sanitize_payload/1` to `inspect/1`-stringify (that
+  # would render `"{:mutation_echo, 3}"` instead of a JSON-shaped detail).
+  # Every `DoneGate.gate/3` rejection reaching this arm (i.e. everything but
+  # `:evidence_required`, matched separately above) is a `{reason, offset}`
+  # pair per `DoneGate.verdict/0`. `:unturned_done` is the one bare-atom
+  # reject and is unreachable here — `pump/3` always mints a non-nil
+  # `turn_id` — so it deliberately has no clause and stays out of the wire
+  # enum; a value there would be a real invariant violation worth crashing
+  # loudly on rather than silently coercing.
+  @spec evidence_rejected_detail([DoneGate.offset()], {atom(), DoneGate.offset()}) ::
+          %{String.t() => term()}
+  defp evidence_rejected_detail(refs, {reason, offset}) when is_atom(reason) do
+    %{"refs" => refs, "reason" => Atom.to_string(reason), "ref" => offset}
+  end
+
+  @doc """
+  Decode a `turn_completed{final: true}` payload's evidence status.
+
+  Tolerant of both atom- and string-keyed payloads and both atom- and
+  string-valued enums (live in-memory events vs. journal-replayed JSON —
+  same convention as `Raxol.Agent.DoneGate`'s accessors).
+
+  Implements the grandfather rule for records written before this marker
+  existed (see moduledoc): an `evidence` key present is authoritative and
+  wins outright. A legacy record (key absent) with `refs` present
+  grandfathers to `:accepted` — the `refs` carrier never lied about
+  acceptance. A legacy record with **neither** key present is genuinely
+  `:unknown`: before this marker, a rejected done and a never-offered done
+  were wire-identical, so there is no way to tell them apart after the
+  fact. This case must NEVER decode as `:absent` — that would launder a
+  historical rejection into a false "never offered" claim.
+  """
+  @spec evidence_status(map()) :: :accepted | :rejected | :absent | :unknown
+  def evidence_status(payload) when is_map(payload) do
+    case fetch_either(payload, :evidence) do
+      {:ok, value} ->
+        normalize_evidence(value)
+
+      :error ->
+        case fetch_either(payload, :refs) do
+          {:ok, _refs} -> :accepted
+          :error -> :unknown
+        end
+    end
+  end
+
+  defp normalize_evidence(value) when value in [:accepted, "accepted"], do: :accepted
+  defp normalize_evidence(value) when value in [:rejected, "rejected"], do: :rejected
+  defp normalize_evidence(value) when value in [:absent, "absent"], do: :absent
+
+  defp fetch_either(map, key) when is_map(map) do
+    cond do
+      Map.has_key?(map, key) -> {:ok, Map.get(map, key)}
+      Map.has_key?(map, Atom.to_string(key)) -> {:ok, Map.get(map, Atom.to_string(key))}
+      true -> :error
     end
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/contract.ex
+++ b/packages/raxol_agent/lib/raxol/agent/contract.ex
@@ -75,6 +75,48 @@ defmodule Raxol.Agent.Contract do
   never rewritten in place, only decoded — covered by the grandfather rule
   above).
 
+  ## Trust boundary (S2, PR #631) — producer-stamped, journal-trusted
+
+  `evidence_status/1` is a **decode**, not a **re-derivation**. It reports the
+  enum the producer stamped; it does NOT re-run `DoneGate.gate/3` over the
+  journal at read time. The soundness of the marker therefore rests on two
+  explicit assumptions, stated here so a reader wiring it to a surface knows
+  exactly what it does and does not defend against:
+
+    1. **Producer honesty is stamped, not asserted.** The marker is written by
+       `gated_done_payload/4` from the *same* `DoneGate.gate/3` verdict that
+       decides the done — producer and decider are one call, they cannot
+       disagree at write time. This producer half is pinned by
+       `Raxol.Agent.ContractTest` ("the done gate is consulted on the real done
+       path", "a mutation's own result echo is rejected", "a zero-tool turn
+       closes ungated") and by `Raxol.Agent.Red.U21RealProducerRegressionTest`,
+       which gates journals produced by the real `pump/3`, not synthetic ones.
+
+    2. **The reader trusts the journal.** A hand-forged or replayed line that
+       stamps `evidence: :accepted` — or a legacy-shaped forged line that omits
+       the marker but carries a `refs` list, which the grandfather arm blesses
+       `:accepted` — will decode as proven-done. This is the **identical**
+       threat model as `refs` themselves and every other durable field: a
+       journal that can be forged can fabricate tool results, refs, and verdicts
+       directly. The marker adds no trust surface the journal did not already
+       assume (append-only, single-writer integrity per harness-spec-backend).
+       It is sound only on a trusted, append-only journal.
+
+  What the decoder *does* defend, after the S1 fix: an `evidence` value it
+  cannot understand — a forged string, a future enum value, a garbage type —
+  fails safe to `:unknown`, never `:accepted` (see `normalize_evidence/1`). A
+  forged non-legacy line thus cannot launder a bogus marker into acceptance.
+
+  **Read-side re-derivation was considered and deliberately rejected.**
+  Re-running `DoneGate.gate/3` at decode time would (a) require the whole
+  journal + turn + refs, coupling a pure single-record decode to journal state
+  it does not carry, and (b) resurrect exactly the display-side re-evaluation of
+  *open* gate predicates (staleness relative to *later* mutations) that the #619
+  round-2 ledger settled must NOT be frozen or recomputed at the display surface.
+  Documenting the append-only trust assumption is the honest, #619-consistent
+  close; a hostile-journal re-check is out of scope for a producer-stamped
+  durable marker.
+
   ## Producers
 
   The v0 producer is `pump/3`: it drains a `Raxol.Agent.Stream.run/2` or
@@ -377,6 +419,18 @@ defmodule Raxol.Agent.Contract do
   were wire-identical, so there is no way to tell them apart after the
   fact. This case must NEVER decode as `:absent` — that would launder a
   historical rejection into a false "never offered" claim.
+
+  Totality (S1): the decoder never crashes. An `evidence` value it does not
+  recognize — a future grow-only enum value, a forged string, a garbage type —
+  degrades to `:unknown` (fail-safe, never `:accepted`); see
+  `normalize_evidence/1`. The decode is quaternary — `:accepted | :rejected |
+  :absent | :unknown` — even though the wire enum a producer stamps is
+  tri-state; `:unknown` is the decode-only bucket for legacy/unrecognized
+  records, so a consumer's `case` over this must handle four outcomes.
+
+  Trust: this reports the stamped enum, it does not re-derive the verdict from
+  the journal — see the "Trust boundary" section in the moduledoc for what that
+  does and does not defend (S2).
   """
   @spec evidence_status(map()) :: :accepted | :rejected | :absent | :unknown
   def evidence_status(payload) when is_map(payload) do
@@ -395,6 +449,19 @@ defmodule Raxol.Agent.Contract do
   defp normalize_evidence(value) when value in [:accepted, "accepted"], do: :accepted
   defp normalize_evidence(value) when value in [:rejected, "rejected"], do: :rejected
   defp normalize_evidence(value) when value in [:absent, "absent"], do: :absent
+
+  # Total fallthrough (S1, PR #631). The `evidence` enum is grow-only (AD-11
+  # upcast-on-read): a reader on 1.1.0 WILL meet a future 1.2.0 journal carrying
+  # a 4th value — exactly the grow-forward case the enum promises — and must
+  # degrade, not `FunctionClauseError` on the replay surface. A corrupt or
+  # forged line (`evidence: "bogus"`, a number, nil) lands here too. Every
+  # unrecognized value fails safe to `:unknown` — never `:accepted` — the same
+  # safe direction the grandfather rule already takes absence: an authoritative
+  # marker that cannot be understood is treated as "cannot vouch", never as
+  # proven-done. This also means a forged non-legacy line whose bogus `evidence`
+  # value sits atop a `refs` list decodes `:unknown` (the key is present, so the
+  # refs-grandfather arm is never consulted), not laundered to `:accepted`.
+  defp normalize_evidence(_), do: :unknown
 
   defp fetch_either(map, key) when is_map(map) do
     cond do

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
@@ -24,7 +24,7 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
   @default_segment_cap 8 * 1024 * 1024
   @default_sync_ceiling_ms 200
   @default_immediate_types ["tool_result", "approval"]
-  @default_schema_version "1.0.0"
+  @default_schema_version "1.1.0"
 
   defstruct [
     :session_id,

--- a/packages/raxol_agent/test/invariants/fixtures/contract_snapshot.json
+++ b/packages/raxol_agent/test/invariants/fixtures/contract_snapshot.json
@@ -1,6 +1,6 @@
 {
   "_comment": "I9 contract snapshot — the checked-in floor the contract may only GROW from. contract_invariants_test.exs re-produces every shape below through the real producers and fails on removal, rename, type-narrowing, tier flip, enum-value removal, or event-type removal. Adding fields/types/enum values is legal and does NOT require touching this file; removing or renaming anything here is a contract break.",
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "contract_version": 0,
   "envelope": {
     "required": [

--- a/packages/raxol_agent/test/invariants/identity_invariants_test.exs
+++ b/packages/raxol_agent/test/invariants/identity_invariants_test.exs
@@ -514,7 +514,7 @@ defmodule Raxol.Agent.Invariants.IdentityInvariantsTest do
       "type" => e.type,
       "tier" => e.tier,
       "payload" => e.payload,
-      "schema_version" => "1.0.0"
+      "schema_version" => "1.1.0"
     }
 
     assert Jason.encode!(reconstructed) == line,

--- a/packages/raxol_agent/test/raxol/agent/contract_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/contract_test.exs
@@ -324,6 +324,47 @@ defmodule Raxol.Agent.ContractTest do
       # historical rejection into a false "never offered" claim.
       refute Contract.evidence_status(%{final: true, usage: %{}}) == :absent
     end
+
+    # S1 (PR #631, Drew's reproduction) — the decoder must be TOTAL. The
+    # `evidence` enum is grow-only (AD-11 upcast-on-read): a reader on 1.1.0
+    # WILL meet a future 1.2.0 journal carrying a 4th value, and a corrupt or
+    # forged line can carry anything. Before the fix `normalize_evidence/1` had
+    # exactly three clauses and raised `FunctionClauseError` on the replay
+    # surface. Every unrecognized value must degrade to `:unknown`, never crash,
+    # never `:accepted`.
+    test "a future/unknown string enum value decodes to :unknown (Drew's exact repro), never crashes" do
+      # Drew's reproduction: a 1.2.0 journal's 4th evidence value replayed as a
+      # JSON string on a 1.1.0 reader.
+      assert Contract.evidence_status(%{"evidence" => "verified_v2"}) == :unknown
+    end
+
+    test "a future/unknown atom enum value decodes to :unknown" do
+      assert Contract.evidence_status(%{evidence: :verified_v2}) == :unknown
+    end
+
+    test "a garbage-typed evidence value decodes to :unknown, never crashes" do
+      for garbage <- [42, nil, true, %{}, [1, 2, 3], {:tuple, :val}, 3.14] do
+        assert Contract.evidence_status(%{evidence: garbage}) == :unknown,
+               "garbage evidence value #{inspect(garbage)} did not decode :unknown"
+
+        assert Contract.evidence_status(%{"evidence" => garbage}) == :unknown,
+               "string-keyed garbage evidence #{inspect(garbage)} did not decode :unknown"
+      end
+    end
+
+    test "an unrecognized authoritative marker never launders to :accepted, even with refs present" do
+      # S2 hardening face: the `evidence` key IS present (not a legacy record),
+      # so the refs-grandfather arm must never be consulted — a forged/unknown
+      # marker value sitting atop a refs list decodes :unknown, NOT :accepted.
+      assert Contract.evidence_status(%{"evidence" => "bogus", "refs" => [3]}) ==
+               :unknown
+
+      refute Contract.evidence_status(%{"evidence" => "bogus", "refs" => [3]}) ==
+               :accepted
+
+      assert Contract.evidence_status(%{evidence: :forged, refs: [1, 2]}) ==
+               :unknown
+    end
   end
 
   describe "encode_line/1" do

--- a/packages/raxol_agent/test/raxol/agent/contract_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/contract_test.exs
@@ -160,6 +160,172 @@ defmodule Raxol.Agent.ContractTest do
     end
   end
 
+  describe "U21 evidence tri-state wire marker (#619 residual)" do
+    # Before the marker: a REJECTED done (evidence offered, gate refused it)
+    # and a NEVER-OFFERED done (:evidence_required — no refs at all) both
+    # close with the exact same payload shape: `%{usage, final: true}`, no
+    # `refs`, no other discriminator. Telemetry distinguishes them live, but
+    # telemetry is not journaled, so a replayed/attached surface (the UI
+    # lane's T19 renderer) cannot tell "rejected" from "absent" after the
+    # fact. These two payloads pin that gap and must stop matching once the
+    # marker lands.
+    test "a rejected done and a never-offered done are indistinguishable without the marker" do
+      session_id = "u21-marker-rejected-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      # Rejected arm: the only postdating tool_result is the mutation's own
+      # echo (:mutation_echo) — evidence was offered and refused.
+      rejected_stream = [
+        {:tool_use, %{name: "fs_write", arguments: %{}, id: "call-1"}},
+        {:tool_result, %{name: "fs_write", result: "wrote"}},
+        {:done, %{content: "done", usage: %{}}}
+      ]
+
+      assert {:ok, _} = Contract.pump(session_id, rejected_stream, prompt: "p")
+      rejected_final = session_id |> drain_events() |> List.last()
+
+      # Absent arm: a zero-tool turn — no evidence ever offered.
+      absent_session_id = "u21-marker-absent-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(absent_session_id)
+
+      {:ok, _} = Contract.pump(absent_session_id, mock_stream("plain answer"), prompt: "hi")
+      absent_final = absent_session_id |> drain_events() |> List.last()
+
+      # Both close `final: true` with no `refs` — the wire-identical shape
+      # this marker exists to break.
+      assert rejected_final.payload.final == true
+      assert absent_final.payload.final == true
+      refute Map.has_key?(rejected_final.payload, :refs)
+      refute Map.has_key?(absent_final.payload, :refs)
+
+      # The marker: once stamped, these must diverge.
+      assert rejected_final.payload[:evidence] == :rejected
+      assert absent_final.payload[:evidence] == :absent
+      assert rejected_final.payload[:evidence] != absent_final.payload[:evidence]
+    end
+
+    test "accepted done carries evidence: :accepted alongside the untouched refs carrier" do
+      session_id = "u21-marker-accepted-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      stream = [
+        {:tool_use, %{name: "fs_write", arguments: %{path: "/x"}, id: "call-1"}},
+        {:tool_result, %{name: "run_tests", result: "tests: 12 passed"}},
+        {:done, %{content: "done", usage: %{output_tokens: 1}}}
+      ]
+
+      assert {:ok, _} = Contract.pump(session_id, stream, prompt: "p")
+      final = session_id |> drain_events() |> List.last()
+
+      assert final.payload.evidence == :accepted
+      assert final.payload.refs == [3]
+      refute Map.has_key?(final.payload, :evidence_rejected)
+    end
+
+    test "rejected done carries evidence_rejected with the DoneGate reason flattened onto the wire, never inspect-stringified" do
+      session_id = "u21-marker-detail-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      stream = [
+        {:tool_use, %{name: "fs_write", arguments: %{}, id: "call-1"}},
+        {:tool_result, %{name: "fs_write", result: "wrote"}},
+        {:done, %{content: "done", usage: %{}}}
+      ]
+
+      assert {:ok, _} = Contract.pump(session_id, stream, prompt: "p")
+      final = session_id |> drain_events() |> List.last()
+
+      assert final.payload.evidence == :rejected
+
+      assert %{"refs" => offered_refs, "reason" => reason, "ref" => offending_ref} =
+               final.payload.evidence_rejected
+
+      assert is_list(offered_refs)
+      assert reason == "mutation_echo"
+      assert is_integer(offending_ref)
+
+      # Never `inspect/1`-stringified (that would look like "{:mutation_echo, 3}").
+      refute reason =~ "{"
+      refute reason =~ ":"
+
+      # Survives a real JSON round-trip (the actual wire path).
+      line = final |> Contract.encode_line() |> IO.iodata_to_binary()
+      assert {:ok, decoded} = Jason.decode(String.trim_trailing(line))
+      assert decoded["payload"]["evidence"] == "rejected"
+
+      assert decoded["payload"]["evidence_rejected"] == %{
+               "refs" => offered_refs,
+               "reason" => "mutation_echo",
+               "ref" => offending_ref
+             }
+    end
+
+    test "absent done (:evidence_required) carries evidence: :absent and no evidence_rejected detail" do
+      session_id = "u21-marker-absent-detail-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      {:ok, _} = Contract.pump(session_id, mock_stream("plain answer"), prompt: "hi")
+      final = session_id |> drain_events() |> List.last()
+
+      assert final.payload.evidence == :absent
+      refute Map.has_key?(final.payload, :evidence_rejected)
+      refute Map.has_key?(final.payload, :refs)
+    end
+
+    test "the DoneGate reject reason is not observable on the wire before the marker (telemetry-only today)" do
+      # This test pins the CURRENT payload shape's ceiling: nothing about
+      # *why* the gate rejected survives onto `final.payload` apart from the
+      # new `evidence_rejected` detail this PR adds. It guards against a
+      # future regression that puts the raw verdict tuple (or an
+      # `inspect/1` rendering of it) directly under an unexpected key.
+      session_id = "u21-marker-reason-shape-#{System.unique_integer([:positive])}"
+      :ok = SessionStreamer.subscribe(session_id)
+
+      stream = [
+        {:tool_use, %{name: "fs_write", arguments: %{}, id: "call-1"}},
+        {:tool_result, %{name: "fs_write", result: "wrote"}},
+        {:done, %{content: "done", usage: %{}}}
+      ]
+
+      assert {:ok, _} = Contract.pump(session_id, stream, prompt: "p")
+      final = session_id |> drain_events() |> List.last()
+
+      allowed_keys = MapSet.new([:usage, :final, :evidence, :evidence_rejected])
+      assert MapSet.new(Map.keys(final.payload)) |> MapSet.subset?(allowed_keys)
+
+      refute Map.has_key?(final.payload, :reason)
+      refute Map.has_key?(final.payload, :ref)
+    end
+  end
+
+  describe "evidence_status/1 (grandfather decode rule)" do
+    test "an authoritative marker key wins outright" do
+      assert Contract.evidence_status(%{evidence: :accepted}) == :accepted
+      assert Contract.evidence_status(%{evidence: :rejected, refs: []}) == :rejected
+      assert Contract.evidence_status(%{evidence: :absent}) == :absent
+
+      # String-keyed / string-valued (as replayed off the journal via
+      # Jason.decode).
+      assert Contract.evidence_status(%{"evidence" => "accepted"}) == :accepted
+      assert Contract.evidence_status(%{"evidence" => "rejected"}) == :rejected
+      assert Contract.evidence_status(%{"evidence" => "absent"}) == :absent
+    end
+
+    test "legacy record (no evidence key) with refs present grandfathers to :accepted" do
+      assert Contract.evidence_status(%{final: true, refs: [3]}) == :accepted
+      assert Contract.evidence_status(%{"final" => true, "refs" => [3]}) == :accepted
+    end
+
+    test "legacy record (no evidence key, no refs) is genuinely unknown — never guessed as :absent" do
+      assert Contract.evidence_status(%{final: true, usage: %{}}) == :unknown
+      assert Contract.evidence_status(%{"final" => true, "usage" => %{}}) == :unknown
+
+      # In particular it must NOT be `:absent`: that would launder a
+      # historical rejection into a false "never offered" claim.
+      refute Contract.evidence_status(%{final: true, usage: %{}}) == :absent
+    end
+  end
+
   describe "encode_line/1" do
     test "produces one decodable JSON line per event" do
       event = %Event{

--- a/packages/raxol_agent/test/raxol/agent/journal_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/journal_test.exs
@@ -202,7 +202,7 @@ defmodule Raxol.Agent.JournalTest do
       assert meta["cwd"] == "/tmp/wd"
       assert meta["title"] == "hello"
       assert is_binary(meta["created_at"])
-      assert meta["schema_version"] == "1.0.0"
+      assert meta["schema_version"] == "1.1.0"
 
       created = meta["created_at"]
       FileStore.append(j, %{"type" => "x"})


### PR DESCRIPTION
## The gap (#619 residual)

`Contract.gated_done_payload/4` (`packages/raxol_agent/lib/raxol/agent/contract.ex`) builds the `turn_completed{final: true}` payload for every closed turn. Before this PR:

- gate **accepts** -> `%{usage, final: true, refs: [...]}`
- gate returns `:evidence_required` (**nothing ever offered**) -> `%{usage, final: true}` + ephemeral telemetry `...:ungated_done`
- gate **rejects** offered evidence (`{:error, reason}`) -> `%{usage, final: true}` + ephemeral telemetry `...:rejected_evidence`

The last two are **byte-identical on the wire and in the journal** — telemetry is not journaled, so a replayed/attached surface cannot distinguish "offered-but-rejected" from "never offered".

## The marker

Additive, grow-only growth on the existing `turn_completed{final: true}` payload:

- `evidence: :accepted | :rejected | :absent` — grow-only enum (atom in-memory, JSON string on the wire, same convention as every other enum on this surface).
- `evidence_rejected` (present only when `evidence: :rejected`) — `%{"refs" => offered_refs, "reason" => reason_name, "ref" => offending_offset}`, the `DoneGate` verdict tuple flattened **explicitly** into these string values — never handed to `sanitize_payload/1` to `inspect/1`-stringify a raw tuple onto the wire. `reason_name ∈ "missing_ref" | "not_evidence" | "foreign_turn" | "stale_evidence" | "mutation_echo"`. `DoneGate`'s `:unturned_done` reject is unreachable on this path (`pump/3` always mints a non-nil `turn_id`) and deliberately has no clause — it stays out of the wire enum.

`refs` and both existing telemetry signals (`[:raxol, :agent, :done_gate, :ungated_done]` / `:rejected_evidence`) are **untouched** — this marker is the durable/replay view, telemetry remains the live-ops view.

## Grandfather rule (back-compat)

Adds `Contract.evidence_status/1`, a decode helper the UI lane's T19 renderer (or anyone reading historical journals) can use instead of reimplementing this:

- `evidence` key present -> authoritative three-state, wins outright.
- key **absent**, `refs` present -> `:accepted` (the `refs` carrier never lied about acceptance).
- key **absent**, `refs` **absent** -> genuinely `:unknown` — **never** defaults to `:absent`. Before this marker, a rejected done and a never-offered done were wire-identical, so a legacy record truly cannot be told apart after the fact; guessing `:absent` would launder a historical rejection into a false "never offered" claim.

## schema_version bump

Journal `schema_version` default bumps `1.0.0 -> 1.1.0` (`Raxol.Agent.Journal.FileStore.Writer`) — a sanctioned additive minor bump per the freeze contract's AD-11 upcast-on-read rule. The pinned `v1.0.0` golden corpus stays literal `"1.0.0"` and unrewritten (old journal records are never rewritten in place, only decoded — covered by the grandfather rule above). Three sites that hardcoded the previous default (`journal_test.exs`, the I2 byte-identity reconstruction in `identity_invariants_test.exs`, and the I9 `contract_snapshot.json` floor descriptor) are updated to track it.

## Tests

RED-FIRST: `contract_test.exs` gained a `describe` block pinning that a rejected done and an absent-evidence done were indistinguishable pre-marker, that the DoneGate reject reason wasn't observable on the wire, and the grandfather decode rule (including the "never guess `:absent`" case) — confirmed failing against pre-marker code, all green against this change.

```
SKIP_TERMBOX2_TESTS=true TMPDIR=/tmp MIX_ENV=test mix test
Result: 1447 passed (13 properties, 1434 tests), 35 excluded
```

## Scope

Additive/grow-only — no freeze re-litigation. `DoneGate` itself is untouched; this is purely the producer stamping what it already knows before dropping it on the floor. UI/T19 is the consuming reviewer of this marker (their renderer should wire "no evidence" / "evidence rejected: <reason>" states to the `evidence` enum / `evidence_status/1`, not to refs-key-absence).

**Do not merge** — review-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)