### PR TITLE
Strip C1 control codepoints in ViewText + ContentGuard (#616)

### DIFF
--- a/lib/raxol/harness/surface/view_text.ex
+++ b/lib/raxol/harness/surface/view_text.ex
@@ -206,24 +206,31 @@ defmodule Raxol.Harness.Surface.ViewText do
     |> Enum.reduce(acc, fn line, acc2 -> [{sanitize(line), style} | acc2] end)
   end
 
-  # Strips every C0 control byte (0x00-0x1F, which includes ESC/0x1B)
-  # except `\t`, mirroring `FlatAuthority.scrub/1`'s own byte-wise
-  # technique and its safety argument verbatim: multi-byte UTF-8 lead
-  # (0xC2-0xF4) and continuation (0x80-0xBF) bytes are both `>= 0x20`, so
-  # stripping byte-by-byte never splits a valid codepoint. `\n` needs no
-  # exception here -- `add_lines/3` above already consumed every `\n` as
-  # the line-split delimiter before this ever runs, so none survives into
-  # a single line's content for this function to see. DEL (0x7F) is stripped
-  # too -- it is `>= 0x20` but a non-printing control that terminals may act
-  # on, so the `>= 0x20` allowlist alone would wrongly pass it.
+  # Strips control code points before untrusted content reaches the wire:
+  # C0 (0x00-0x1F, incl. ESC/0x1B) except `\t`, DEL (0x7F), AND the C1 range
+  # (U+0080..U+009F) -- the 8-bit-encoded siblings of the ESC-led CSI/OSC/DCS
+  # sequences (0x9B is CSI, 0x9D is OSC), which a byte-wise `>= 0x20` allowlist
+  # would wrongly pass. Decodes by code point so a C1 encoded as UTF-8
+  # (`0xC2 0x9B`) is caught while legitimate multi-byte text is preserved; a
+  # lone raw high byte (a bare C1 like 0x9B, or a stray continuation byte) is
+  # dropped rather than passed through. `\n` needs no exception -- `add_lines/3`
+  # already consumed every `\n` as the line-split delimiter before this runs.
   @c0_exception ?\t
 
-  defp sanitize(text) do
-    for <<byte <- text>>,
-        (byte >= 0x20 and byte != 0x7F) or byte == @c0_exception,
-        into: <<>>,
-        do: <<byte>>
+  defp sanitize(text), do: sanitize(text, <<>>)
+
+  defp sanitize(<<>>, acc), do: acc
+
+  defp sanitize(<<@c0_exception, rest::binary>>, acc),
+    do: sanitize(rest, <<acc::binary, @c0_exception>>)
+
+  defp sanitize(<<cp::utf8, rest::binary>>, acc) do
+    if cp < 0x20 or cp == 0x7F or (cp >= 0x80 and cp <= 0x9F),
+      do: sanitize(rest, acc),
+      else: sanitize(rest, <<acc::binary, cp::utf8>>)
   end
+
+  defp sanitize(<<_byte, rest::binary>>, acc), do: sanitize(rest, acc)
 
   # -- width truncation (plain content only, before any styling) ---------
 

--- a/lib/raxol/ui/rendering/paint_authority/content_guard.ex
+++ b/lib/raxol/ui/rendering/paint_authority/content_guard.ex
@@ -119,9 +119,27 @@ defmodule Raxol.UI.Rendering.PaintAuthority.ContentGuard do
     scan(rest, acc)
   end
 
-  # Printable ASCII and UTF-8 lead/continuation bytes -- pass through.
-  defp scan(<<c, rest::binary>>, acc) do
+  # Printable ASCII passes through as a single byte.
+  defp scan(<<c, rest::binary>>, acc) when c >= 0x20 and c <= 0x7E do
     scan(rest, [<<c>> | acc])
+  end
+
+  # A code point >= 0x80: strip the C1 control range (U+0080..U+009F) -- the
+  # 8-bit-encoded siblings of the ESC-led CSI/OSC/DCS sequences neutralized
+  # above (0x9B is CSI, 0x9D is OSC), which a byte-wise pass-through would let
+  # through raw. Decoding by code point catches a C1 encoded as UTF-8
+  # (`0xC2 0x9B`) while every other high code point (real UTF-8 text) passes
+  # through intact.
+  defp scan(<<cp::utf8, rest::binary>>, acc) when cp >= 0x80 do
+    if cp <= 0x9F,
+      do: scan(rest, acc),
+      else: scan(rest, [<<cp::utf8>> | acc])
+  end
+
+  # A high byte that is not a valid UTF-8 start (a lone raw C1 like 0x9B, or a
+  # stray continuation byte) -- dropped, no residue.
+  defp scan(<<_c, rest::binary>>, acc) do
+    scan(rest, acc)
   end
 
   defp scan(<<>>, acc) do

--- a/test/raxol/harness/c1_sanitizer_test.exs
+++ b/test/raxol/harness/c1_sanitizer_test.exs
@@ -1,0 +1,69 @@
+defmodule Raxol.Harness.C1SanitizerTest do
+  # Regression for the C1 control-byte gap (issue #616): both render-path
+  # sanitizers used a byte-wise `>= 0x20` allowlist that let the 8-bit C1
+  # controls (U+0080..U+009F) through raw -- the siblings of the ESC-led
+  # sequences they otherwise neutralize. On a terminal honoring 8-bit C1,
+  # `0x9B` is CSI and `0x9D` is OSC, so raw C1 in agent-authored content was a
+  # live injection vector at the footer / picker / transcript-search surfaces.
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Rendering.PaintAuthority.ContentGuard
+  alias Raxol.Harness.Surface.ViewText
+
+  defp has_c1?(bin) do
+    bin |> :binary.bin_to_list() |> Enum.any?(&(&1 >= 0x80 and &1 <= 0x9F))
+  end
+
+  describe "ContentGuard.sanitize_line/1 strips C1 controls" do
+    test "raw 8-bit C1 CSI/OSC/IND are removed" do
+      for c1 <- [0x9B, 0x9D, 0x90, 0x84, 0x85] do
+        out = ContentGuard.sanitize_line(<<c1, "2J">>)
+
+        refute has_c1?(out),
+               "raw C1 #{inspect(c1, base: :hex)} survived: #{inspect(out)}"
+      end
+    end
+
+    test "UTF-8-encoded C1 (0xC2 0x9B) is removed" do
+      out = ContentGuard.sanitize_line(<<0xC2, 0x9B, "2J">>)
+      refute has_c1?(out)
+      assert out == "2J"
+    end
+
+    test "SGR is still preserved verbatim" do
+      assert ContentGuard.sanitize_line(<<0x1B, "[1;31mhi", 0x1B, "[0m">>) ==
+               <<0x1B, "[1;31mhi", 0x1B, "[0m">>
+    end
+
+    test "ESC-led CSI is still neutralized to visible residue" do
+      assert ContentGuard.sanitize_line(<<0x1B, "[2J">>) == "[2J"
+    end
+
+    test "legitimate multi-byte UTF-8 text is preserved (incl. a 0x80-range continuation byte)" do
+      # U+00E9 (e-acute) and U+0840 (Mandaic letter, whose 3rd byte is 0x80).
+      text = <<0xC3, 0xA9, 0xE0, 0xA1, 0x80, "abc">>
+      assert ContentGuard.sanitize_line(text) == text
+    end
+  end
+
+  describe "ViewText plain lines strip C1 controls" do
+    defp plain(content) do
+      %{type: :text, content: content, style: %{}}
+      |> ViewText.lines(80, :plain)
+      |> Enum.map_join("", fn
+        {c, _style} -> c
+        c when is_binary(c) -> c
+      end)
+    end
+
+    test "raw and UTF-8 C1 do not reach the wire" do
+      refute has_c1?(plain(<<"before", 0x9B, "2J", "after">>))
+      refute has_c1?(plain(<<"x", 0xC2, 0x9D, "0;title", 0x07>>))
+    end
+
+    test "printable and multi-byte UTF-8 survive" do
+      assert plain("hello world") == "hello world"
+      assert plain(<<0xC3, 0xA9>>) == <<0xC3, 0xA9>>
+    end
+  end
+end


### PR DESCRIPTION
Closes the C1 control-byte gap (#616) in both render-path sanitizers.

## The gap
`ContentGuard.sanitize_line/1` and `ViewText.sanitize/1` used a byte-wise `>= 0x20`
allowlist, so the 8-bit C1 controls (U+0080..U+009F) passed through raw -- the
siblings of the ESC-led CSI/OSC/DCS sequences those functions otherwise neutralize.
On a terminal honoring 8-bit C1, `0x9B` is CSI and `0x9D` is OSC, so raw C1 in
agent-authored content was a live injection vector at the footer / picker /
transcript-search / projection-panel surfaces (surfaced as the top finding on #628
and #629).

## The fix
Both sanitizers now decode by code point and strip the C1 range (U+0080..U+009F)
while preserving legitimate multi-byte UTF-8 (a C1 encoded as `0xC2 0x9B` is caught;
a real char like U+0840 whose continuation byte is `0x80` is kept). A lone raw high
byte that is not a valid UTF-8 start (a bare C1, or a stray continuation byte) is
dropped rather than passed through. `ContentGuard` keeps its SGR-verbatim behavior;
`ViewText` keeps stripping ESC entirely.

## Tests
`test/raxol/harness/c1_sanitizer_test.exs` -- red-then-green: 3 C1 assertions fail
against the old byte-wise code, all pass after (raw C1, UTF-8-encoded C1, ViewText
plain path), plus SGR-preserved / ESC-neutralized / multi-byte-UTF-8-preserved
regressions. Full affected suite (ContentGuard property + golden snapshots + overlay
picker + t13a + editor surface): 154 passed, 0 failures.

## Manual testing
- [x] `mix test test/raxol/harness/c1_sanitizer_test.exs` (7 pass; 3 fail on pre-fix)
- [x] affected ContentGuard/ViewText suites green (154 tests)
