### PR TITLE
test(core): converge boundary reject vectors on relative-symlink-under-symlinked-ancestor

### DIFF
--- a/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
+++ b/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
@@ -5,14 +5,22 @@
       "name": "parent_traversal",
       "root": "root",
       "requested": "../../etc/passwd",
-      "setup": [{ "dir": "root" }],
+      "setup": [
+        {
+          "dir": "root"
+        }
+      ],
       "expect": "path_traversal"
     },
     {
       "name": "interior_traversal_escapes",
       "root": "root",
       "requested": "a/../../x",
-      "setup": [{ "dir": "root" }],
+      "setup": [
+        {
+          "dir": "root"
+        }
+      ],
       "expect": "path_traversal"
     },
     {
@@ -20,7 +28,11 @@
       "root": "root",
       "requested": "blobs/../../etc/x",
       "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
-      "setup": [{ "dir": "root" }],
+      "setup": [
+        {
+          "dir": "root"
+        }
+      ],
       "expect": "malformed_ref"
     },
     {
@@ -28,7 +40,11 @@
       "root": "root",
       "requested": "snapshots/../blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
-      "setup": [{ "dir": "root" }],
+      "setup": [
+        {
+          "dir": "root"
+        }
+      ],
       "expect": "malformed_ref"
     },
     {
@@ -36,7 +52,11 @@
       "root": "root",
       "requested": "blobs/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
-      "setup": [{ "dir": "root" }],
+      "setup": [
+        {
+          "dir": "root"
+        }
+      ],
       "expect": "malformed_ref"
     },
     {
@@ -44,7 +64,11 @@
       "root": "root",
       "requested": "blobs/abc123",
       "ref_format": "^(blobs|snapshots)/[0-9a-f]{64}(\\.json)?$",
-      "setup": [{ "dir": "root" }],
+      "setup": [
+        {
+          "dir": "root"
+        }
+      ],
       "expect": "malformed_ref"
     },
     {
@@ -52,10 +76,20 @@
       "root": "root",
       "requested": "link",
       "setup": [
-        { "dir": "root" },
-        { "dir": "outside" },
-        { "file": "outside/secret.txt", "content": "TOP SECRET" },
-        { "symlink": "root/link", "target": "../outside/secret.txt" }
+        {
+          "dir": "root"
+        },
+        {
+          "dir": "outside"
+        },
+        {
+          "file": "outside/secret.txt",
+          "content": "TOP SECRET"
+        },
+        {
+          "symlink": "root/link",
+          "target": "../outside/secret.txt"
+        }
       ],
       "expect": "symlink_escape"
     },
@@ -64,10 +98,20 @@
       "root": "root",
       "requested": "esc/secret.txt",
       "setup": [
-        { "dir": "root" },
-        { "dir": "outside" },
-        { "file": "outside/secret.txt", "content": "TOP SECRET" },
-        { "symlink": "root/esc", "target": "../outside" }
+        {
+          "dir": "root"
+        },
+        {
+          "dir": "outside"
+        },
+        {
+          "file": "outside/secret.txt",
+          "content": "TOP SECRET"
+        },
+        {
+          "symlink": "root/esc",
+          "target": "../outside"
+        }
       ],
       "expect": "symlink_escape"
     },
@@ -76,11 +120,42 @@
       "root": "root",
       "requested": "a",
       "setup": [
-        { "dir": "root" },
-        { "symlink": "root/a", "target": "b" },
-        { "symlink": "root/b", "target": "a" }
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/a",
+          "target": "b"
+        },
+        {
+          "symlink": "root/b",
+          "target": "a"
+        }
       ],
       "expect": "too_many_symlinks"
+    },
+    {
+      "name": "relative_symlink_under_symlinked_ancestor_escape",
+      "root": "root",
+      "requested": "loop/loop/esc",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "file": "secret.txt",
+          "content": "TOP SECRET"
+        },
+        {
+          "symlink": "root/loop",
+          "target": "."
+        },
+        {
+          "symlink": "root/esc",
+          "target": "../secret.txt"
+        }
+      ],
+      "expect": "symlink_escape"
     }
   ]
 }


### PR DESCRIPTION
Follow-up from the ACP #624 / #633 review (DROOdotFOO requested convergence).

The FsSandbox symlink-escape HIGH on #624 slipped past its own drift guard because the shared boundary reject vectors had **no case** for the class the bug lived in: a *relative* symlink target (`root/esc → "../secret.txt"`) reached through a self-referential symlinked ancestor (`root/loop → "."`), requested as `loop/loop/esc`. `FsSandbox` had silently kept the pre-`walk_real` lexical-parent resolver and nothing failed.

Core's `Raxol.Core.Boundary.Path` already resolves this correctly (`walk_real`, from #613) — this PR just adds the vector so the Core reject set stays converged with the package copy that #624 now also gates on. Pure drift-guard hardening on already-correct code.

- Vector: `relative_symlink_under_symlinked_ancestor_escape` → `:symlink_escape`.
- `packages/raxol_core` boundary suite green (77 passed) with the vector.
- Matching vector already added to `raxol_agent_client_protocol`'s copy on #624.