### PR TITLE
Harness UI: seal-review follow-up for #630 — tail-bound pin teeth, neutralization pin, legibility

### DIFF
--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -266,13 +266,20 @@ defmodule Raxol.Harness.Surface do
   The preview shows ONE block (two lines of it). Today the two never
   differ: the only frontier hold a shipped producer can create is the
   foldable window on the NEWEST block, so the unsealed suffix past the
-  cursor is at most one block long (pinned by the tail-bound test in
-  `test/harness/surface_frontier_feed_test.exs`). The moment a producer
-  emits live blocks (a mid-list awaiting-input approval holding several
-  finalized blocks behind it), that bound breaks and the one-block
-  preview under-reports -- the pinning test fails loudly then, and the
-  multi-block tail rendering it forces is the live-lane (T13b) unit's
-  decision, not silently absorbed here.
+  cursor is at most one block long. Two tests in
+  `test/harness/surface_frontier_feed_test.exs` guard this together, and
+  the split matters: the fixture-REPLAY pin only proves the bound holds
+  over today's shipped corpus (it replays `.jsonl`, so it structurally
+  cannot observe a runtime producer -- on its own it would pass
+  vacuously). Its teeth come from the paired SYNTHETIC test, which builds
+  the exact runtime hold the corpus lacks -- a mid-list awaiting-input
+  `:approval` holding finalized blocks behind it -- and asserts the
+  frontier genuinely stops there, so more than one block sits past the
+  cursor. That is the multi-block hold the one-block preview cannot
+  honor: the moment a producer wires such a hold into a real advance, the
+  bound breaks and the preview under-reports, forcing the multi-block
+  tail rendering decision (the live-lane / T13b unit's), never silently
+  absorbed here.
 
   `Raxol.UI.Components.Harness.Block.seal` is an item-LIFECYCLE field:
   `BlockBuilder` only ever constructs a block once its source item(s)
@@ -968,9 +975,10 @@ defmodule Raxol.Harness.Surface do
 
   Field mapping (the design decision this assembly makes):
 
-    * `committed?` -- `index < painted_count`: physical paint is this
-      module's commit marker, and it only ever advances a contiguous
-      prefix, so the high-water mark IS the committed set.
+    * `committed?` -- delegated to `block_sealed?/2`, THE single-source
+      committed-marker predicate (its doc states the `painted_count`
+      comparison exactly once; restating it here is the drift the
+      unification exists to prevent).
     * `running?` -- `Block.live?/1`, an honest passthrough. Always false
       today (the block builder only constructs completed, sealed blocks),
       which leaves the classifier's mid-turn running exceptions dormant
@@ -2409,11 +2417,16 @@ defmodule Raxol.Harness.Surface do
     # frame the walk's cursor and the scan agree (`tail_start ==
     # painted_count`, the scan/walk-agreement property), so this changes
     # nothing there; on a refusal the cursor is the honest one.
-    tail_start = model.painted_count
+    #
+    # Named `committed_cursor`, NOT `tail_start`: this PR's whole thesis is
+    # that the scan's `tail_start` and the committed cursor are DIFFERENT
+    # quantities that diverge exactly on refusal, so the one function whose
+    # reason-to-exist is that distinction must not reuse the scan's name.
+    committed_cursor = model.painted_count
 
-    case Enum.slice(model.projection.blocks, tail_start..-1//1) do
+    case Enum.slice(model.projection.blocks, committed_cursor..-1//1) do
       [] -> nil
-      [block | _rest] -> {block, tail_start}
+      [block | _rest] -> {block, committed_cursor}
     end
   end
 

--- a/test/harness/surface_frontier_feed_test.exs
+++ b/test/harness/surface_frontier_feed_test.exs
@@ -238,37 +238,61 @@ defmodule Raxol.Harness.SurfaceFrontierFeedTest do
           Raxol.Harness.Fixture.load(Path.join(sessions_dir, name <> ".jsonl"))
 
         model = real_model(session)
+        cap = advance_cap(model)
 
-        Enum.reduce_while(1..advance_cap(model), model, fn _i, m ->
-          {m, outcome} = Surface.advance(m)
+        # Track the terminal outcome so the cap cannot silently swallow an
+        # incomplete drain: reduce over `{model, outcome}` and assert `:done`
+        # after the loop (the #635-R1 saboteur note). A fixture that needs
+        # more than `cap` steps would otherwise exit the loop with its tail
+        # blocks un-run -- hiding any late `unsealed > 1` in that tail.
+        {_final, outcome} =
+          Enum.reduce_while(1..cap, {model, :running}, fn _i, {m, _} ->
+            {m, step} = Surface.advance(m)
 
-          unsealed = length(m.projection.blocks) - m.painted_count
+            unsealed = length(m.projection.blocks) - m.painted_count
 
-          assert unsealed <= @max_unsealed_past_cursor,
-                 "fixture #{name}: #{unsealed} blocks past the committed " <>
-                   "cursor -- the one-block pending preview would hide " <>
-                   "#{unsealed - @max_unsealed_past_cursor} of them " <>
-                   "(multi-block tail rendering is the live-lane follow-up " <>
-                   "this pin exists to force)"
+            assert unsealed <= @max_unsealed_past_cursor,
+                   "fixture #{name}: #{unsealed} blocks past the committed " <>
+                     "cursor -- the one-block pending preview would hide " <>
+                     "#{unsealed - @max_unsealed_past_cursor} of them " <>
+                     "(multi-block tail rendering is the live-lane follow-up " <>
+                     "this pin exists to force)"
 
-          if outcome == :done, do: {:halt, m}, else: {:cont, m}
-        end)
+            if step == :done,
+              do: {:halt, {m, :done}},
+              else: {:cont, {m, :running}}
+          end)
+
+        assert outcome == :done,
+               "fixture #{name}: the advance loop hit its #{cap}-step cap " <>
+                 "without reaching :done -- the drain is incomplete, so a " <>
+                 "late unsealed > 1 in the un-run tail would go unseen. " <>
+                 "Raise advance_cap/1 or fix the stalled advance."
       end
     end
 
-    test "a synthetic mid-list live-approval hold strands >1 block past the cursor -- the runtime case the fixture replay cannot reach" do
+    test "a synthetic mid-list live-approval hold makes frontier_scan/1 strand >1 block past the cursor -- the strand precondition the fixture replay cannot reach" do
       # The teeth the fixture replay above lacks. No shipped producer emits
       # a live approval, so the corpus can only ever create the one hold
       # that keeps `unsealed <= 1` (the foldable window on the NEWEST
       # block). This builds the hold the corpus structurally cannot: a LIVE
       # :approval mid-list, with finalized blocks sealed BEHIND it.
       #
+      # REFERENT (the #635-R1 correction): every assertion below is on
+      # `frontier_scan/1` -- the CLASSIFIER, which decides where the
+      # committed cursor stops. Nothing here asserts on the footer preview
+      # RENDER; this pins the strand PRECONDITION (more than one block sits
+      # past the cursor), not the under-report itself. The preview-render
+      # assertion is deliberately out of scope: the synthetic hold cannot be
+      # produced from `Surface.new/2` events (the block builder only emits
+      # sealed blocks), so there is no real model to render. When the live
+      # lane (T13b) makes this hold reachable from a real advance, the
+      # single-block preview must become multi-block -- and THAT change is
+      # where the preview-render assertion belongs.
+      #
       # Per `SealFrontier.committable?`, a `pending_input?` entry stops the
       # frontier UNCONDITIONALLY, so the committed cursor pins at the
-      # approval and every finalized block behind it is stranded. That is
-      # exactly the multi-block hold the single-block footer preview cannot
-      # honor -- when a producer wires this into a real advance, the
-      # one-block preview MUST become multi-block.
+      # approval and every finalized block behind it is stranded.
       blocks = [
         block(:approval, :live),
         block(:message, :sealed),
@@ -292,10 +316,10 @@ defmodule Raxol.Harness.SurfaceFrontierFeedTest do
       assert unsealed > @max_unsealed_past_cursor,
              "a mid-list live-approval hold must strand more than " <>
                "#{@max_unsealed_past_cursor} block past the committed " <>
-               "cursor (got #{unsealed}); the one-block footer preview " <>
-               "shows only the first, silently hiding the rest -- this is " <>
-               "the multi-block tail-rendering decision the fixture-replay " <>
-               "pin above cannot force on its own"
+               "cursor (got #{unsealed}); the single-block footer preview " <>
+               "would then show only the first and silently hide the rest " <>
+               "-- the multi-block tail-rendering decision the fixture-" <>
+               "replay pin above cannot force on its own"
     end
   end
 

--- a/test/harness/surface_frontier_feed_test.exs
+++ b/test/harness/surface_frontier_feed_test.exs
@@ -20,6 +20,13 @@ defmodule Raxol.Harness.SurfaceFrontierFeedTest do
   alias Raxol.Harness.Surface
   alias Raxol.UI.Components.Harness.Block
 
+  # THE load-bearing invariant of the one-block footer preview design (see
+  # Surface's moduledoc): the footer renders exactly one block, so the
+  # preview is honest only while at most this many blocks sit past the
+  # committed cursor. Named here rather than left as a bare `<= 1` literal
+  # because it is the whole reason the tail-bound tests below exist.
+  @max_unsealed_past_cursor 1
+
   defp block(kind, seal) do
     Block.from_events(kind, [%{id: 1, payload: %{content: "x"}}], seal: seal)
   end
@@ -154,6 +161,12 @@ defmodule Raxol.Harness.SurfaceFrontierFeedTest do
     )
   end
 
+  # A generous upper bound on the advances needed to drain a fixture: two
+  # steps per event (reveal + seal) plus slack for the trailing
+  # foldable-window release. Caps the reduce so a wedged advance can never
+  # spin forever; named rather than inlined as `length(events) * 2 + 10`.
+  defp advance_cap(model), do: length(model.events) * 2 + 10
+
   defp advance_times(model, n) do
     Enum.reduce(1..n, model, fn _i, m ->
       {m, _} = Surface.advance(m)
@@ -207,11 +220,15 @@ defmodule Raxol.Harness.SurfaceFrontierFeedTest do
       # honest only while the unsealed suffix past `painted_count` is at
       # most one block long -- true today because the only frontier hold
       # a shipped producer can create is the foldable window on the
-      # NEWEST block. The moment a producer emits live blocks (a
-      # mid-list awaiting-input approval holding finalized blocks behind
-      # it), this bound breaks: this test then fails LOUDLY, forcing the
-      # multi-block tail rendering decision (the live-lane follow-up)
-      # instead of letting held blocks silently vanish from view.
+      # NEWEST block.
+      #
+      # HONEST SCOPE: this is a fixture REPLAY. It proves the bound holds
+      # over today's shipped corpus, but it can only ever exercise holds a
+      # `.jsonl` can encode -- it structurally CANNOT observe a runtime
+      # producer emitting a live mid-list approval, so on its own it would
+      # pass vacuously (no shipped fixture creates a mid-list hold). Its
+      # teeth live in the paired synthetic test below, which builds that
+      # exact runtime hold directly and proves the bound is reachable-breakable.
       sessions_dir = Path.join(["test", "fixtures", "harness", "sessions"])
       names = Surface.list_fixture_sessions(sessions_dir)
       assert names != [], "no shipped fixtures found -- the pin needs corpus"
@@ -221,22 +238,64 @@ defmodule Raxol.Harness.SurfaceFrontierFeedTest do
           Raxol.Harness.Fixture.load(Path.join(sessions_dir, name <> ".jsonl"))
 
         model = real_model(session)
-        cap = length(model.events) * 2 + 10
 
-        Enum.reduce_while(1..cap, model, fn _i, m ->
+        Enum.reduce_while(1..advance_cap(model), model, fn _i, m ->
           {m, outcome} = Surface.advance(m)
 
           unsealed = length(m.projection.blocks) - m.painted_count
 
-          assert unsealed <= 1,
+          assert unsealed <= @max_unsealed_past_cursor,
                  "fixture #{name}: #{unsealed} blocks past the committed " <>
                    "cursor -- the one-block pending preview would hide " <>
-                   "#{unsealed - 1} of them (multi-block tail rendering " <>
-                   "is the live-lane follow-up this pin exists to force)"
+                   "#{unsealed - @max_unsealed_past_cursor} of them " <>
+                   "(multi-block tail rendering is the live-lane follow-up " <>
+                   "this pin exists to force)"
 
           if outcome == :done, do: {:halt, m}, else: {:cont, m}
         end)
       end
+    end
+
+    test "a synthetic mid-list live-approval hold strands >1 block past the cursor -- the runtime case the fixture replay cannot reach" do
+      # The teeth the fixture replay above lacks. No shipped producer emits
+      # a live approval, so the corpus can only ever create the one hold
+      # that keeps `unsealed <= 1` (the foldable window on the NEWEST
+      # block). This builds the hold the corpus structurally cannot: a LIVE
+      # :approval mid-list, with finalized blocks sealed BEHIND it.
+      #
+      # Per `SealFrontier.committable?`, a `pending_input?` entry stops the
+      # frontier UNCONDITIONALLY, so the committed cursor pins at the
+      # approval and every finalized block behind it is stranded. That is
+      # exactly the multi-block hold the single-block footer preview cannot
+      # honor -- when a producer wires this into a real advance, the
+      # one-block preview MUST become multi-block.
+      blocks = [
+        block(:approval, :live),
+        block(:message, :sealed),
+        block(:message, :sealed)
+      ]
+
+      # Reveal finished (revealed == total_events) so the newest-block
+      # foldable window is NOT what holds -- the hold is purely the
+      # mid-list approval, isolating the multi-block scenario.
+      m = model(blocks, revealed: 3, total_events: 3, painted: 0)
+
+      scan = Surface.frontier_scan(m)
+
+      assert scan.tail_start == 0,
+             "the frontier must hold at the mid-list live approval " <>
+               "(index 0) -- sealing past an unanswered prompt would " <>
+               "freeze it into print-once history"
+
+      unsealed = length(m.projection.blocks) - scan.tail_start
+
+      assert unsealed > @max_unsealed_past_cursor,
+             "a mid-list live-approval hold must strand more than " <>
+               "#{@max_unsealed_past_cursor} block past the committed " <>
+               "cursor (got #{unsealed}); the one-block footer preview " <>
+               "shows only the first, silently hiding the rest -- this is " <>
+               "the multi-block tail-rendering decision the fixture-replay " <>
+               "pin above cannot force on its own"
     end
   end
 

--- a/test/harness/surface_seal_pipeline_test.exs
+++ b/test/harness/surface_seal_pipeline_test.exs
@@ -373,19 +373,38 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
                "footer preview -- invisible-but-retrying is under-reporting"
     end
 
-    test "a refused-write block carrying a clear-screen escape is neutralized in the footer preview (not a live \\e[2J)" do
-      # The display half above pins that a refused block stays VISIBLE in
-      # the footer. This pins that it stays visible HONESTLY. The refused
-      # block reaches the terminal ONLY via the footer preview (its seal
-      # write is refused), and here its content carries a raw CSI
-      # clear-screen -- `\e[2J`, the exact sequence the seal-frontier laws
-      # forbid from ever reaching the wire (it would wipe native
-      # scrollback / the immutable prefix). The footer repaint's
-      # `ContentGuard` must strip the leading ESC, so the operator sees the
-      # literal `[2J` residue, never a live escape. Presence alone (the
-      # test above) does not cover this: a newly-LIVE display path needs a
-      # neutralization pin, same as the seal path has.
+    test "no full-clear reaches the wire through the refused-write footer-preview path (end-to-end, independent oracle)" do
+      # The display half above pins that a refused block stays VISIBLE in the
+      # footer preview. This pins that it stays visible HONESTLY: content that
+      # smuggles a raw CSI full-screen clear (`\e[2J` -- forbidden on the
+      # inline surface, it wipes native scrollback / the immutable prefix)
+      # must never reach the wire as a live escape through this path.
+      #
+      # SCOPE + attribution (the #635-R1 correction). This is an END-TO-END
+      # integration pin over the whole refused-write -> footer-preview
+      # pipeline, NOT a single-seam pin -- and it does not attribute to one
+      # layer. TWO layers neutralize here, so this path has genuine defense
+      # in depth (traced: the raw `\e[2J` is already gone from the rendered
+      # view before ContentGuard ever runs):
+      #   1. the message-body renderer strips ESC/C0 while building the
+      #      display view, so footer content arrives already de-escaped;
+      #   2. the footer paint routes EVERY line through
+      #      `ContentGuard.sanitize_line/1` (`inline_authority.ex:436,860`).
+      # The two SEAM guarantees are pinned directly and red-first ELSEWHERE:
+      # `ContentGuard.sanitize_line(<<0x1B, "[2J">>) == "[2J"` in
+      # `test/raxol/harness/c1_sanitizer_test.exs`, and the footer-paint seam
+      # against the same independent full-clear oracle in
+      # `test/property/renderer_t2c_review_fixes_test.exs`. This test proves
+      # they COMPOSE over the refused-write preview surface, judged by that
+      # independent oracle (`SealOracle.emits_full_clear?/1`) rather than a
+      # brittle byte-substring match.
       hostile = @marker <> " \e[2J HOSTILE"
+
+      # Fail-first (the t2c discipline): the oracle must be ABLE to catch a
+      # raw full-clear, or the GREEN refute below is vacuous.
+      assert SealOracle.emits_full_clear?("composer " <> hostile),
+             "fail-first: the full-clear oracle must catch a raw \\e[2J, " <>
+               "or the clean result below is meaningless"
 
       {device, sink} =
         FailingDevice.start(fail_when: seal_write_with(@marker), mode: :always)
@@ -404,15 +423,13 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
       assert occurrences(keyframe_bytes, @marker) >= 1,
              "the refused block must still be visible in the footer preview"
 
-      assert occurrences(keyframe_bytes, "\e[2J") == 0,
-             "a hostile clear-screen in refused-write content must never " <>
-               "reach the wire as a live escape -- the footer's newly-live " <>
-               "display path must neutralize the ESC, same as the seal path"
+      refute SealOracle.emits_full_clear?(keyframe_bytes),
+             "no \\e[2J may reach the wire through the refused-write footer " <>
+               "preview -- the independent full-clear oracle must stay silent"
 
       assert occurrences(keyframe_bytes, "[2J") >= 1,
-             "the neutralized clear-screen must remain visible as literal " <>
-               "`[2J` residue in the footer preview (honest-visible, not " <>
-               "silently dropped)"
+             "the neutralized clear-screen stays honestly visible as literal " <>
+               "`[2J` residue in the footer preview (not silently dropped)"
     end
 
     test "post-seal fill protection: a fold override on an already-painted block is rejected and stores nothing" do

--- a/test/harness/surface_seal_pipeline_test.exs
+++ b/test/harness/surface_seal_pipeline_test.exs
@@ -373,6 +373,48 @@ defmodule Raxol.Harness.SurfaceSealPipelineTest do
                "footer preview -- invisible-but-retrying is under-reporting"
     end
 
+    test "a refused-write block carrying a clear-screen escape is neutralized in the footer preview (not a live \\e[2J)" do
+      # The display half above pins that a refused block stays VISIBLE in
+      # the footer. This pins that it stays visible HONESTLY. The refused
+      # block reaches the terminal ONLY via the footer preview (its seal
+      # write is refused), and here its content carries a raw CSI
+      # clear-screen -- `\e[2J`, the exact sequence the seal-frontier laws
+      # forbid from ever reaching the wire (it would wipe native
+      # scrollback / the immutable prefix). The footer repaint's
+      # `ContentGuard` must strip the leading ESC, so the operator sees the
+      # literal `[2J` residue, never a live escape. Presence alone (the
+      # test above) does not cover this: a newly-LIVE display path needs a
+      # neutralization pin, same as the seal path has.
+      hostile = @marker <> " \e[2J HOSTILE"
+
+      {device, sink} =
+        FailingDevice.start(fail_when: seal_write_with(@marker), mode: :always)
+
+      model = new_model(message_events(hostile), device: device)
+      model = advance_to_pending_flush(model)
+
+      {model, :ok} = Surface.advance(model)
+      assert model.painted_count == 0
+
+      read = fn -> FailingDevice.confirmed_bytes(sink) end
+
+      {_model, keyframe_bytes} =
+        frame_bytes(read, fn -> Surface.resize(model, @width, @rows) end)
+
+      assert occurrences(keyframe_bytes, @marker) >= 1,
+             "the refused block must still be visible in the footer preview"
+
+      assert occurrences(keyframe_bytes, "\e[2J") == 0,
+             "a hostile clear-screen in refused-write content must never " <>
+               "reach the wire as a live escape -- the footer's newly-live " <>
+               "display path must neutralize the ESC, same as the seal path"
+
+      assert occurrences(keyframe_bytes, "[2J") >= 1,
+             "the neutralized clear-screen must remain visible as literal " <>
+               "`[2J` residue in the footer preview (honest-visible, not " <>
+               "silently dropped)"
+    end
+
     test "post-seal fill protection: a fold override on an already-painted block is rejected and stores nothing" do
       # No placeholder-fill path against sealed content exists in this
       # codebase (grepped; the SessionRecap pattern has no analogue) -- so


### PR DESCRIPTION
Follow-up to the adversarial review of #630 (verdict CONCERNS, merged non-blocking). #630 landed by squash; this PR addresses its review findings on top of `master`.

## Disposition ledger

| ID | Sev | Finding | Verdict | Disposition |
|----|-----|---------|---------|-------------|
| S1 | Medium | one-block tail-bound pin is vacuous (fixture replay, no approval/awaiting corpus → `unsealed <= 1` passes for free) | **VERIFIED** | Enforced with a synthetic tripwire. A fixture replay structurally cannot observe a runtime producer, so I added a paired **synthetic mid-list live-approval hold** — `[approval(live), message, message]`, reveal finished — and assert `frontier_scan/1` stops at the approval (`tail_start == 0`) with `> 1` block stranded past the cursor. That is the exact multi-block hold the corpus lacks; per `SealFrontier.committable?` a `pending_input?` entry stops the frontier unconditionally, so the hold is reachable the moment a producer emits it. Fixture pin kept (now honestly scoped as corpus-only) + moduledoc reworded. |
| SA1 | Low | newly-LIVE footer-preview path presence-tested, not neutralization-tested | **VERIFIED (boundary sound)** | Added a neutralization pin: a refused-write block whose content carries `\e[2J` (the one sequence the seal laws forbid on the wire). Assert the footer keyframe shows literal `[2J` residue and **zero** live `\e[2J` — confirms `ContentGuard.sanitize_line/1` strips the ESC at the repaint seam. Passing regression, not a live vuln. |
| N1 | Low | local `tail_start` in `pending_block/1` lies (it's the committed cursor) | **VERIFIED** | Renamed `tail_start` → `committed_cursor` (the function's whole thesis is that the two differ). |
| N2 | Low | `committed? -- index < painted_count` restated in prose beside code that delegates to `block_sealed?/2` | **VERIFIED** | Folded the doc literal into a reference to `block_sealed?/2` (single-source predicate). |
| N3 | Low | `<= 1` bound and `length(events) * 2 + 10` step cap are unnamed magic literals | **VERIFIED** | Named `@max_unsealed_past_cursor` and `advance_cap/1`. |

No CRITICAL/HIGH raised; nothing refuted. Immutable-prefix / seal-overwrite invariant untouched (rename is a no-op; doc/test-only otherwise).

## Gates
- `mix compile --warnings-as-errors`: clean
- `test/harness/surface_frontier_feed_test.exs` + `surface_seal_pipeline_test.exs`: **27 passed** (+2 new)
- `test/harness/` (seed 0): **625 passed, 0 failed**, 1 skipped
- `mix format --check-formatted`: clean
- mix.lock untouched