### PR TITLE
test: fix the macOS CI flake class (CaptureServer starvation + brittle deadlines)

### DIFF
--- a/packages/raxol_terminal/lib/raxol/terminal/input/character_processor.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/input/character_processor.ex
@@ -145,14 +145,16 @@ defmodule Raxol.Terminal.Input.CharacterProcessor do
         {write_col, write_row, next_cursor_col, next_cursor_row, next_last_col_exceeded}
       )
 
-    log_cursor_positions(
-      current_cursor_col,
-      current_cursor_row,
-      adjusted_write_col,
-      adjusted_write_row,
-      adjusted_next_cursor_col,
-      adjusted_next_cursor_row
-    )
+    # No per-character debug log here (removed): this function runs once
+    # per PRINTABLE CHARACTER, and a `Log.debug` in that loop eagerly
+    # interpolates its message on every call regardless of level, then
+    # (under the test env's `level: :debug` + global `capture_log`)
+    # funnels every character of every emulator replay through ExUnit's
+    # single CaptureServer -- serializing the whole async suite and
+    # pushing replay-oracle tests from seconds into minutes. A
+    # per-character cursor trace is reconstructible from the input bytes
+    # whenever it is actually needed; it earns neither the production
+    # interpolation cost nor the test-suite serialization.
 
     {adjusted_write_col, adjusted_write_row, adjusted_next_cursor_col, adjusted_next_cursor_row,
      adjusted_next_last_col_exceeded}
@@ -181,19 +183,6 @@ defmodule Raxol.Terminal.Input.CharacterProcessor do
   defp log_cursor_debug(cursor_type, cursor) do
     Raxol.Core.Runtime.Log.debug(
       "[calculate_positions] Getting position from #{cursor_type}: #{inspect(cursor)}"
-    )
-  end
-
-  defp log_cursor_positions(
-         current_col,
-         current_row,
-         write_col,
-         write_row,
-         next_col,
-         next_row
-       ) do
-    Raxol.Core.Runtime.Log.debug(
-      "Cursor positions - Current: {#{current_row}, #{current_col}}, Write: {#{write_row}, #{write_col}}, Next: {#{next_row}, #{next_col}}"
     )
   end
 

--- a/test/harness/stream_cadence_test.exs
+++ b/test/harness/stream_cadence_test.exs
@@ -1,5 +1,8 @@
 defmodule Raxol.Harness.StreamCadenceTest do
-  use ExUnit.Case, async: true
+  # CPU-contention flake class (see harness CI-honesty rules): coalescing
+  # windows + receive deadlines starve under loaded shared runners when
+  # sibling suites compete for cores. Serial keeps the timing world honest.
+  use ExUnit.Case, async: false
 
   alias Raxol.Harness.StreamCadence
 
@@ -22,7 +25,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
 
       StreamCadence.ingest(server, "a")
 
-      assert_receive {:render_batch, ["a"]}, 50
+      assert_receive {:render_batch, ["a"]}, 2_000
     end
   end
 
@@ -59,7 +62,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
       server = start(flush_interval_ms: 30)
 
       StreamCadence.ingest(server, "a")
-      assert_receive {:render_batch, ["a"]}, 50
+      assert_receive {:render_batch, ["a"]}, 2_000
 
       StreamCadence.ingest(server, "b")
       StreamCadence.ingest(server, "c")
@@ -67,7 +70,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
 
       refute_receive {:render_batch, _}, 10
 
-      assert_receive {:render_batch, ["b", "c", "d"]}, 50
+      assert_receive {:render_batch, ["b", "c", "d"]}, 2_000
     end
   end
 
@@ -86,7 +89,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
 
       Agent.update(input_pending, fn _ -> false end)
 
-      assert_receive {:render_batch, ["x"]}, 50
+      assert_receive {:render_batch, ["x"]}, 2_000
     end
   end
 
@@ -98,7 +101,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
 
       # The default 16-yield budget exhausts after ~16 x 1ms retries and
       # the decision falls through to the cadence rules -> flush.
-      assert_receive {:render_batch, ["x"]}, 100
+      assert_receive {:render_batch, ["x"]}, 2_000
     end
 
     test ":max_consecutive_yields config seam shortens the hold" do
@@ -106,7 +109,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
 
       StreamCadence.ingest(server, "x")
 
-      assert_receive {:render_batch, ["x"]}, 50
+      assert_receive {:render_batch, ["x"]}, 2_000
     end
   end
 
@@ -129,14 +132,14 @@ defmodule Raxol.Harness.StreamCadenceTest do
       server = start(flush_interval_ms: 60_000, max_pending: 5)
 
       StreamCadence.ingest(server, "seed")
-      assert_receive {:render_batch, ["seed"]}, 50
+      assert_receive {:render_batch, ["seed"]}, 2_000
 
       for i <- 1..10, do: StreamCadence.ingest(server, "d#{i}")
 
       # d6..d10 push the queue past the watermark; d1..d5 are shed.
       dropped_total =
         Enum.reduce(1..5, 0, fn _, acc ->
-          assert_receive {:overflow, %{dropped: n}, %{max_pending: 5}}, 100
+          assert_receive {:overflow, %{dropped: n}, %{max_pending: 5}}, 2_000
           acc + n
         end)
 
@@ -154,25 +157,25 @@ defmodule Raxol.Harness.StreamCadenceTest do
       server = start(flush_interval_ms: 60_000, max_pending: 2)
 
       StreamCadence.ingest(server, "seed")
-      assert_receive {:render_batch, ["seed"]}, 50
+      assert_receive {:render_batch, ["seed"]}, 2_000
 
       for i <- 1..3, do: StreamCadence.ingest(server, "d#{i}")
 
       StreamCadence.flush_now(server)
-      assert_receive {:render_batch, [{:cadence_dropped, 1}, "d2", "d3"]}, 100
+      assert_receive {:render_batch, [{:cadence_dropped, 1}, "d2", "d3"]}, 2_000
 
       StreamCadence.ingest(server, "z")
       StreamCadence.flush_now(server)
 
       # No marker: the counter reset at the previous flush.
-      assert_receive {:render_batch, ["z"]}, 100
+      assert_receive {:render_batch, ["z"]}, 2_000
     end
 
     test "marker prepends without displacing a delta: batch may be max_drain + 1" do
       server = start(flush_interval_ms: 60_000, max_pending: 32)
 
       StreamCadence.ingest(server, "seed")
-      assert_receive {:render_batch, ["seed"]}, 50
+      assert_receive {:render_batch, ["seed"]}, 2_000
 
       deltas = for i <- 1..33, do: "d#{i}"
       Enum.each(deltas, &StreamCadence.ingest(server, &1))
@@ -182,7 +185,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
       # counted against the drain bound, so no delta is displaced.
       StreamCadence.flush_now(server)
 
-      assert_receive {:render_batch, batch}, 100
+      assert_receive {:render_batch, batch}, 2_000
       assert length(batch) == 33
       assert hd(batch) == {:cadence_dropped, 1}
       assert tl(batch) == Enum.drop(deltas, 1)
@@ -196,7 +199,7 @@ defmodule Raxol.Harness.StreamCadenceTest do
       server = start(flush_interval_ms: 60_000)
 
       StreamCadence.ingest(server, "first")
-      assert_receive {:render_batch, ["first"]}, 50
+      assert_receive {:render_batch, ["first"]}, 2_000
 
       deltas = for i <- 1..40, do: "e#{i}"
       Enum.each(deltas, &StreamCadence.ingest(server, &1))
@@ -205,8 +208,8 @@ defmodule Raxol.Harness.StreamCadenceTest do
 
       StreamCadence.flush_now(server)
 
-      assert_receive {:render_batch, batch1}, 50
-      assert_receive {:render_batch, batch2}, 50
+      assert_receive {:render_batch, batch1}, 2_000
+      assert_receive {:render_batch, batch2}, 2_000
       refute_receive {:render_batch, _}, 20
 
       assert length(batch1) == 32
@@ -220,14 +223,14 @@ defmodule Raxol.Harness.StreamCadenceTest do
       server = start([])
 
       StreamCadence.ingest(server, "a")
-      assert_receive {:render_batch, ["a"]}, 50
+      assert_receive {:render_batch, ["a"]}, 2_000
 
       send(server, :flush_due)
 
       assert Process.alive?(server)
 
       StreamCadence.ingest(server, "b")
-      assert_receive {:render_batch, ["b"]}, 50
+      assert_receive {:render_batch, ["b"]}, 2_000
     end
   end
 end

--- a/test/raxol/ui/components/harness/markdown_body_test.exs
+++ b/test/raxol/ui/components/harness/markdown_body_test.exs
@@ -460,7 +460,7 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyTest do
   # rescan-per-strip + mark_content-per-char design. ---
 
   describe "N-MDFUZZ-05 — large opener runs stay bounded (single-pass O(n))" do
-    @perf_bound_us 2_000_000
+    @perf_bound_us 30_000_000
 
     test "20k unclosed brackets render well under the never-hang bound" do
       doc = String.duplicate("[", 20_000)


### PR DESCRIPTION
Both #628 and #631 failed \`Test macos-latest\` on the same suites. Diagnosis and fix:

**Root cause:** \`CharacterProcessor.calculate_positions\` logged per-character at debug level. Under test config (\`level: :debug\` + global \`capture_log\`) every emulator-replay byte serialized through ExUnit's single CaptureServer, starving sibling suites on loaded runners. Removing it cut local harness wall time 397s → ~105s. The failing suites were victims of the contention, not flaky by themselves.

**Hardening (CI-honesty rules — deadlines pin arrival + order, never latency):**
- \`stream_cadence_test\`: \`async: false\` + receive deadlines 50/100ms → 2s.
- \`markdown_body\` N-MDFUZZ-05: never-hang bound 2s → 30s (order-of-magnitude falsifier — the pre-fix Θ(n³) case costs minutes; the bound keeps teeth without runner-load flakes).

Gates: compile --warnings-as-errors clean, both suites 89/89 green, format clean, no lock drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)