### PR TITLE
test(acp): revert placebo await_initialized barrier (structural no-op)

### DIFF
--- a/packages/raxol_agent_client_protocol/test/capabilities_test.exs
+++ b/packages/raxol_agent_client_protocol/test/capabilities_test.exs
@@ -394,7 +394,19 @@ defmodule Raxol.AgentClientProtocol.CapabilitiesTest do
       }
 
       assert {:ok, _} = Connection.request(ctx.client_conn, "initialize", init_req, 5_000)
-      assert :ok = await_initialized(ctx.client_conn)
+
+      # No barrier needed here: `phase: :initialized` is committed inside the
+      # SAME GenServer reduction that replies to this `request/4` call (see
+      # `handle_inbound_response/2` -> `maybe_client_initialized/3` in
+      # connection.ex) — the reply is sent before the state update, but both
+      # happen with no yield point in between, so OTP's single-process
+      # mailbox serialization guarantees any later message reaching this
+      # connection (including the terminal/create below) observes the
+      # post-commit phase. A polling wait here would be a no-op: the state it
+      # waits for is already true by the time the wait could run. If this
+      # test flakes again under load, the cause is NOT capability-ordering —
+      # diagnose fresh (candidate: request timeout or process-start latency
+      # under CPU starvation), don't paper over it with a wait.
 
       # Decode-INVALID params (missing sessionId/command). If the gate ran
       # AFTER decode we would see -32602; -32601 proves the gate ran first.
@@ -414,7 +426,10 @@ defmodule Raxol.AgentClientProtocol.CapabilitiesTest do
       }
 
       assert {:ok, _} = Connection.request(ctx.client_conn, "initialize", init_req, 5_000)
-      assert :ok = await_initialized(ctx.client_conn)
+
+      # No barrier needed — see the comment in the sibling test above:
+      # `phase: :initialized` is already committed by the time this call
+      # returns (single-process mailbox serialization in Connection).
 
       assert {:ok, %{terminal_id: "term-ok"}} =
                Connection.request(
@@ -431,24 +446,6 @@ defmodule Raxol.AgentClientProtocol.CapabilitiesTest do
       |> Enum.find_value(fn
         {Raxol.AgentClientProtocol.Connection, pid, _type, _mods} -> pid
         _other -> nil
-      end)
-    end
-
-    # Block until the client connection has PROCESSED its initialize response
-    # and committed `caps` (phase :initialized). In production terminal/create
-    # can only reach the client AFTER this (ordered transport: the agent sends
-    # the initialize response before any terminal/create). This test drives the
-    # two through SEPARATE connections, so without this barrier the client's
-    # response-processing can lag the agent-forwarded terminal/create under a
-    # loaded suite, gating on stale (uninitialized) caps -- a test-only race.
-    defp await_initialized(conn) do
-      Enum.reduce_while(1..1000, :timeout, fn _, _ ->
-        if :sys.get_state(conn).phase == :initialized do
-          {:halt, :ok}
-        else
-          Process.sleep(2)
-          {:cont, :timeout}
-        end
       end)
     end
   end


### PR DESCRIPTION
## Summary

An earlier commit added an `await_initialized/1` helper (+ two call sites) to `packages/raxol_agent_client_protocol/test/capabilities_test.exs`, in the "Paired integration: agent terminal/create against a no-terminal client" tests. It claimed to fix a "~3% under 32x parallel load" flake by waiting for the client connection to reach `phase: :initialized` before driving `terminal/create`.

This is a **causal impossibility**, not a fix:

- `Connection.request/4`'s `{:ok, _}` return is produced by `deliver_outcome/2` (`GenServer.reply/2`), called at `connection.ex` line ~1085.
- The commit of `phase: :initialized` happens in `maybe_client_initialized/3`, called immediately after, at lines ~1087-1088 — inside the **same GenServer reduction**, same `handle_inbound_response/2` callback.
- There is no yield point between the reply and the state commit. OTP's single-process mailbox serialization guarantees that any later message reaching that connection (including the routed `terminal/create`) is processed only after the current reduction returns — i.e. only after the state is already committed.
- `await_initialized` therefore polls a condition that is guaranteed true on its very first check. It is a structural no-op: it "fixes" nothing, it just adds latency and a green label.

Verified by reverting the barrier and running `capabilities_test.exs` 80x at 16-way parallelism: 0 failures.

So either the originally-reported flake never existed as described, or it's a *different*, still-latent failure (candidate: request timeout, or process-start latency under CPU starvation) that is now hidden behind a green test. This PR reverts the placebo and leaves an honest comment in its place so a future flake here gets diagnosed fresh instead of re-papered.

## Changes

- Remove `await_initialized/1` and its two call sites in `test/capabilities_test.exs`.
- Replace with a comment explaining the causal-impossibility reasoning and explicitly stating that a future flake in this test is NOT a capability-ordering issue.
- No other `await_initialized` references existed in the package (verified via grep).

## Test plan

- [x] `MIX_ENV=test mix compile --warnings-as-errors` — clean.
- [x] `MIX_ENV=test mix test` — 795 passed (16 properties, 779 tests), 0 failures.