### PR TITLE
fix(acp): single-sender session/update delivery (no drop/reorder)

### DIFF
--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
@@ -330,17 +330,19 @@ defmodule Raxol.AgentClientProtocol.Client do
   failure/decode failure, same vocabulary as `Connection.async_request/6`'s
   `outcome`.
 
-  Ordering caveat: `session/update` forwarding to the subscribed process
-  runs in a separate handler task per notification (Connection design
-  §4.4), while the terminal `session/prompt` response is delivered
-  directly by `Connection` itself -- the WIRE order between them is
-  invariant (I3: no update after its turn's response), but the two
-  deliveries landing in *this* process's mailbox are two different
-  senders, so BEAM gives no cross-sender guarantee. This function does one
-  short best-effort settle pass after the terminal message arrives to
-  absorb same-turn stragglers; treat `updates` as "very likely complete,
-  not protocol-guaranteed complete" -- `prompt_stream/4` has no such gap
-  because it never leaves the receive loop.
+  Ordering: `Connection` delivers `session/update` forwarding to the
+  subscribed process SYNCHRONOUSLY, from the Connection process itself,
+  before it ever looks at the next inbound frame (see
+  `Connection`'s "Single-sender `session/update` delivery" moduledoc
+  section) -- and the terminal `session/prompt` response is also delivered
+  directly by `Connection`. Both now originate from the SAME sender to
+  this process, so BEAM's per-sender/per-receiver FIFO guarantee applies:
+  the WIRE invariant (I3: no update after its turn's response) carries
+  through to mailbox order here, not just on the wire. This function still
+  does one short best-effort settle pass after the terminal message
+  arrives, kept as defence-in-depth (e.g. against a future notification
+  path that isn't single-sender) rather than because it is required for
+  correctness today.
 
   Always subscribes and unsubscribes around the call, including on error.
 

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
@@ -89,11 +89,13 @@ defmodule Raxol.AgentClientProtocol.Client do
   mailbox protocol. The generated default `c:session_update/2` (unless you
   override it) forwards every decoded update to whichever processes called
   `subscribe/3` for that `{conn, session_id}` pair, as
-  `{:acp_session_update, session_id, update, rx_seq}` -- `update` is always
-  an already-decoded `Raxol.AgentClientProtocol.Schema.SessionUpdate.t()`
-  (see `decode_update/1`'s doc for why an undecodable variant never reaches
-  this path at all), and `rx_seq` is the inbound frame's monotone sequence
-  stamp (the reorder key -- see below).
+  `{:acp_session_update, session_id, update, rx_seq, update_seq}` -- `update`
+  is always an already-decoded
+  `Raxol.AgentClientProtocol.Schema.SessionUpdate.t()` (see `decode_update/1`'s
+  doc for why an undecodable variant never reaches this path at all), `rx_seq`
+  is the inbound frame's monotone per-connection stamp, and `update_seq` is the
+  agent's PER-SESSION update ordinal (the reorder key) or `nil` when unstamped
+  -- see below.
 
   `prompt/3` and `prompt_stream/4` build on `subscribe/3` to give a
   synchronous-feeling API over the inherently asynchronous protocol:
@@ -113,10 +115,11 @@ defmodule Raxol.AgentClientProtocol.Client do
   for the turn: update deliveries arrive from concurrent per-notification
   dispatch tasks (non-blocking, so parallel/interleaved update streams
   flow), so they can land out of wire order and can even race the terminal
-  result into the mailbox. Each carries its `rx_seq`; the loop buffers by
-  `rx_seq`, drains every update below the result's own `rx_seq` before
-  completing, and returns them in restored wire order -- see their docs for
-  the exact mechanics.
+  result into the mailbox. Each carries the agent's per-session `update_seq`;
+  the loop releases each update the instant it is contiguous (LIVE, in
+  per-session order), holding a gap until the missing ordinal lands, and
+  falls back to `rx_seq` boundary ordering for an agent that does not stamp
+  `update_seq` -- see their docs for the exact mechanics.
 
   ## `fs_sandbox`: a working filesystem client with zero callbacks
 
@@ -214,15 +217,19 @@ defmodule Raxol.AgentClientProtocol.Client do
   Subscribe `subscriber` (default `self()`) to `session_id`'s
   `session/update` deliveries on `conn`. The generated default
   `c:session_update/2` (unless overridden) broadcasts
-  `{:acp_session_update, session_id, update, rx_seq}` to every subscriber
-  registered for `{conn, session_id}` -- `update` is always an
+  `{:acp_session_update, session_id, update, rx_seq, update_seq}` to every
+  subscriber registered for `{conn, session_id}` -- `update` is always an
   already-decoded `Raxol.AgentClientProtocol.Schema.SessionUpdate.t()`
   (see `decode_update/1`'s doc for why an undecodable variant never
-  reaches this path), and `rx_seq` is the inbound notification frame's
-  monotone sequence stamp (`Ctx.rx_seq`). Because each update is forwarded
-  from its OWN concurrent dispatch task, deliveries to the subscriber's
-  mailbox can be out of wire order; `rx_seq` is the key a consumer uses to
-  restore that order (`prompt/3`/`prompt_stream/4` do this for you). NOT
+  reaches this path), `rx_seq` is the inbound notification frame's
+  monotone per-connection stamp (`Ctx.rx_seq`), and `update_seq` is the
+  agent's PER-SESSION update ordinal read from
+  `_meta["raxol.io"]["update_seq"]` (or `nil` when the agent did not stamp
+  it). Because each update is forwarded from its OWN concurrent dispatch
+  task, deliveries to the subscriber's mailbox can be out of wire order;
+  `update_seq` is the key a consumer uses to restore per-session order and
+  release incrementally (`prompt/3`/`prompt_stream/4` do this for you),
+  falling back to `rx_seq` ordering when `update_seq` is `nil`. NOT
   idempotent: subscribing the same pid twice for
   the same key registers it twice in the underlying `:bag` -- each
   registration receives its own copy of every broadcast, so the pid gets
@@ -256,24 +263,52 @@ defmodule Raxol.AgentClientProtocol.Client do
   # (design docs' "handler crash never reaches the wire" spirit, applied
   # here even though a notification crash is already log-only, IC/§4.4).
   #
-  # `rx_seq` is the inbound `session/update` frame's monotone sequence
-  # (`Ctx.rx_seq`); it rides the delivered tuple as the 4th element so a
-  # consumer can restore wire order across concurrent per-notification
-  # dispatch tasks (see `prompt/3`/`prompt_stream/4`). Defaults to `0` so a
-  # direct/legacy `broadcast_update/3` caller (custom handler, replay
-  # tooling) keeps working -- such deliveries simply sort as "seq 0".
-  @spec broadcast_update(pid(), String.t(), term(), non_neg_integer()) :: :ok
-  def broadcast_update(conn, session_id, update, rx_seq \\ 0) do
+  # The delivered 5-tuple `{:acp_session_update, session_id, update, rx_seq,
+  # update_seq}`:
+  #
+  #   * `rx_seq` — the inbound frame's GLOBAL per-connection monotone stamp
+  #     (`Ctx.rx_seq`); kept as a frame stamp / tiebreaker. Defaults to `0` so a
+  #     direct/legacy `broadcast_update/3` caller (custom handler, replay tooling)
+  #     keeps working.
+  #   * `update_seq` — the PER-SESSION update ordinal the agent stamped into
+  #     `_meta["raxol.io"]["update_seq"]` (see `Session.stamp_update_seq/2`), or
+  #     `nil` when the agent did not stamp it. This is the reorder KEY that lets a
+  #     consumer release updates in contiguous `0..N` order the instant each is
+  #     available (LIVE incremental streaming). When it is `nil`, a consumer falls
+  #     back to arrival-order delivery (best-effort, no reorder guarantee) — see
+  #     `prompt/3` / `prompt_stream/4`.
+  @spec broadcast_update(pid(), String.t(), term(), non_neg_integer(), non_neg_integer() | nil) ::
+          :ok
+  def broadcast_update(conn, session_id, update, rx_seq \\ 0, update_seq \\ nil) do
     ensure_subs_table!()
 
     for {_key, subscriber} <- :ets.lookup(@subs_table, {conn, session_id}) do
-      send(subscriber, {:acp_session_update, session_id, update, rx_seq})
+      send(subscriber, {:acp_session_update, session_id, update, rx_seq, update_seq})
     end
 
     :ok
   rescue
     _ -> :ok
   end
+
+  @doc """
+  Extract the per-session `update_seq` an agent stamped into a
+  `session/update` notification's vendor `_meta` bucket
+  (`_meta["raxol.io"]["update_seq"]`), or `nil` when absent (a non-raxol
+  agent, an unstamped notification, or an opaque notification shape). This
+  is the reorder key `prompt/3` / `prompt_stream/4` use for LIVE
+  incremental in-order release; `nil` triggers their arrival-order
+  fallback.
+  """
+  @spec extract_update_seq(term()) :: non_neg_integer() | nil
+  def extract_update_seq(%{_meta: meta}) when is_map(meta) do
+    case meta do
+      %{"raxol.io" => %{"update_seq" => n}} when is_integer(n) and n >= 0 -> n
+      _ -> nil
+    end
+  end
+
+  def extract_update_seq(_other), do: nil
 
   defp ensure_subs_table! do
     if :ets.whereis(@subs_table) == :undefined do
@@ -356,15 +391,18 @@ defmodule Raxol.AgentClientProtocol.Client do
   by `Connection` itself. Different senders means the subscriber's mailbox
   gives no cross-sender order, and the result can even land before a
   same-turn update that is still in flight. So this function does NOT trust
-  mailbox order: every delivery carries the inbound frame's monotone
-  `rx_seq`, and `Connection` also sends an `{:acp_result_seq, tag, rx_seq}`
-  companion just before the result. This loop buffers updates by `rx_seq`,
-  and on the terminal result (frame seq `R`) drains every same-turn update
-  (all have `rx_seq < R` by wire invariant I3) with a bounded settle pass,
-  then returns them in restored `rx_seq` (wire) order. The bounded settle
-  pass is the completeness bound (an in-flight dispatch task's `send`
-  lands within scheduling latency; the pass resets on each straggler); `R`
-  is the turn-boundary classifier.
+  mailbox order: it reorders on the agent-stamped PER-SESSION `update_seq`
+  (`_meta["raxol.io"]["update_seq"]`, reset to `0` each turn — see
+  `Raxol.AgentClientProtocol.Session`). It tracks a next-expected ordinal,
+  accumulating each update the instant it is contiguous and holding a
+  higher one until the gap fills; on the terminal result a bounded settle
+  pass absorbs any straggler, then it returns the turn's updates in
+  `update_seq` order. When the agent does NOT stamp `update_seq` (a
+  non-raxol agent), it falls back to buffering by the frame's `rx_seq` and
+  returning them in `rx_seq` order at the turn boundary (deterministic,
+  no-drop, but not incremental). Either way no same-turn update is dropped;
+  `Connection` always delivers a terminal result (its protocol timeout is
+  the single authority), so the loop never blocks unbounded on a gap.
 
   Always subscribes and unsubscribes around the call, including on error.
 
@@ -392,7 +430,7 @@ defmodule Raxol.AgentClientProtocol.Client do
              tag,
              timeout_ms
            ) do
-        :ok -> collect_prompt(session_id, tag, [], nil)
+        :ok -> collect_prompt(session_id, tag, new_reorder())
         {:error, _} = err -> err
       end
     after
@@ -400,83 +438,171 @@ defmodule Raxol.AgentClientProtocol.Client do
     end
   end
 
-  # Milliseconds the reorder buffer keeps its settle window open after the
-  # turn's result, waiting for an in-flight per-notification dispatch task's
-  # `send/2` to land. That send is an ETS lookup + `send` (sub-millisecond),
-  # spawned before the result frame, so this is enormous headroom; the
-  # window RESETS on every straggler, so it only trails the LAST one. It is
-  # the completeness bound for the no-drop guarantee (there is no positive
-  # "all updates delivered" signal under a global per-connection `rx_seq`,
-  # since a numeric gap is an unrelated frame, not a missing update).
+  # Milliseconds the reorder buffer keeps a POST-RESULT settle window open,
+  # waiting for an in-flight per-notification dispatch task's `send/2` to land
+  # before it flushes any still-buffered out-of-order tail. That send is an
+  # ETS lookup + `send` (sub-millisecond), spawned before the result frame, so
+  # this is enormous headroom; the window RESETS on every straggler, so it only
+  # trails the LAST one. The primary completeness bound, though, is the terminal
+  # result itself: `Connection` ALWAYS delivers `{:acp_result, tag, _}` (its own
+  # protocol timeout is the single authority, IC-3), so the receive loop never
+  # blocks unbounded on a missing update — a genuine gap resolves at the result.
   @update_settle_ms 25
 
-  # `buf` is a list of `{rx_seq, update}`; sorted only at the end so the
-  # order the concurrent dispatch tasks happen to deliver in never matters.
-  # `result_seq` is the terminal response frame's `rx_seq` (from the
-  # `{:acp_result_seq, ...}` companion), or `nil` if the turn ended without
-  # a response frame (Connection-side timeout/close).
-  defp collect_prompt(session_id, tag, buf, result_seq) do
-    receive do
-      {:acp_session_update, ^session_id, update, seq} ->
-        collect_prompt(session_id, tag, [{seq, update} | buf], result_seq)
+  # -- reorder engine (LIVE incremental contiguous release) -------------------
+  #
+  # A consumer watches ONE session/prompt turn. The agent stamps a PER-SESSION
+  # `update_seq`, reset to 0 at the turn's start, so the turn's updates form a
+  # contiguous `0..N`. Deliveries arrive from concurrent per-notification
+  # dispatch tasks (non-blocking, so parallel/interleaved streams flow), so they
+  # can land out of order; `next` is the next-expected ordinal. An update whose
+  # `update_seq == next` releases IMMEDIATELY (live), then cascade-releases any
+  # contiguous successors already buffered; a higher ordinal buffers (a gap ⇒
+  # hold for the missing lower one, delivered shortly by its own dispatch task,
+  # or the result closes the turn — never an unbounded block, since `Connection`
+  # ALWAYS delivers a terminal `{:acp_result, ...}`); a lower ordinal is a dup and
+  # is dropped.
+  #
+  # GRACEFUL FALLBACK (update_seq == nil): a non-raxol / unstamped agent gives no
+  # per-session ordinal, so contiguous release is impossible. Rather than block
+  # (there is no ordinal to wait for) OR emit in raw arrival order (which the
+  # concurrent per-notification dispatch tasks scramble non-deterministically),
+  # such updates are buffered by the frame's GLOBAL `rx_seq` and released, sorted
+  # by `rx_seq`, at the turn boundary — the prior deterministic, non-blocking,
+  # no-drop behavior. The LIVE, in-order, incremental guarantee therefore holds
+  # ONLY when the agent stamps `update_seq`; an unstamped turn degrades to the
+  # boundary-ordered delivery it had before, never to a flaky arrival order.
+  #
+  # The reorder state: `%{next, buf, fallback, released}` — `buf` maps
+  # `update_seq => update` for held out-of-order STAMPED updates; `fallback` is a
+  # reverse list of `{rx_seq, update}` for UNSTAMPED ones; `released` is the
+  # reverse-ordered list of already-released updates (returned by `prompt/3`,
+  # ignored by `prompt_stream/4` which side-effects via `on_update` at release).
+  # A turn is all-stamped or all-unstamped, so exactly one of buf/fallback is
+  # ever populated.
 
-      {:acp_result_seq, ^tag, seq} ->
-        collect_prompt(session_id, tag, buf, seq)
+  defp new_reorder, do: %{next: 0, buf: %{}, fallback: [], released: []}
+
+  # `on_update` is the live sink (an arity-1 fun) for `prompt_stream/4`, or `nil`
+  # for `prompt/3` (accumulate only).
+  defp collect_prompt(session_id, tag, ro) do
+    receive do
+      {:acp_session_update, ^session_id, update, rx_seq, update_seq} ->
+        collect_prompt(session_id, tag, deliver_update(ro, update, update_seq, rx_seq, nil))
+
+      {:acp_result_seq, ^tag, _seq} ->
+        # Turn-boundary companion — consumed so it never lingers; the update_seq
+        # ordinals (not the global rx_seq) drive stamped ordering now, so it is
+        # inert for the stamped path (the unstamped fallback still sorts by rx_seq
+        # at the boundary, below, independent of this companion).
+        collect_prompt(session_id, tag, ro)
 
       {:acp_result, ^tag, {:ok, response}} ->
-        updates = buf |> drain_updates(session_id, result_seq) |> order_updates()
-        {:ok, {updates, response}}
+        ro = settle_updates(session_id, ro, nil)
+        {:ok, {Enum.reverse(ro.released), response}}
 
       {:acp_result, ^tag, {:error, _} = error} ->
         error
     end
   end
 
-  # Absorb same-turn stragglers that raced the result into the mailbox from
-  # their (concurrent, non-blocking) dispatch tasks. Wire invariant I3
-  # guarantees every same-turn update's frame preceded the result frame, so
-  # each has `rx_seq < result_seq`; either way we never drop an update for
-  # this session. The bounded window resets on each straggler.
-  defp drain_updates(buf, session_id, result_seq) do
-    receive do
-      {:acp_session_update, ^session_id, update, seq}
-      when is_integer(result_seq) and seq < result_seq ->
-        drain_updates([{seq, update} | buf], session_id, result_seq)
+  # Route one delivered update through the release state machine.
+  defp deliver_update(ro, update, nil, rx_seq, _on_update) do
+    # Fallback: buffer by frame rx_seq; released sorted at the boundary.
+    %{ro | fallback: [{rx_seq, update} | ro.fallback]}
+  end
 
-      # No result_seq (timeout/close, no response frame) or a seq that is not
-      # below the turn boundary (should be impossible by I3): absorb rather
-      # than drop, still bounded by the settle window.
-      {:acp_session_update, ^session_id, update, seq} ->
-        drain_updates([{seq, update} | buf], session_id, result_seq)
-    after
-      @update_settle_ms -> buf
+  defp deliver_update(%{next: next} = ro, update, update_seq, _rx_seq, on_update) do
+    cond do
+      update_seq == next ->
+        ro = emit_update(ro, update, on_update)
+        cascade_release(%{ro | next: next + 1}, on_update)
+
+      update_seq > next ->
+        %{ro | buf: Map.put(ro.buf, update_seq, update)}
+
+      true ->
+        # update_seq < next: already released (a duplicate delivery) — drop.
+        ro
     end
   end
 
-  defp order_updates(buf) do
-    buf |> Enum.sort_by(&elem(&1, 0)) |> Enum.map(&elem(&1, 1))
+  # Release every contiguous successor now sitting in the buffer.
+  defp cascade_release(%{next: next, buf: buf} = ro, on_update) do
+    case Map.pop(buf, next) do
+      {nil, _buf} ->
+        ro
+
+      {update, buf} ->
+        ro = emit_update(%{ro | buf: buf}, update, on_update)
+        cascade_release(%{ro | next: next + 1}, on_update)
+    end
+  end
+
+  # Release one update: side-effect via `on_update` (prompt_stream) if present,
+  # and always record it (reverse order) so prompt/3 can return the turn's list.
+  defp emit_update(ro, update, nil), do: %{ro | released: [update | ro.released]}
+
+  defp emit_update(ro, update, on_update) when is_function(on_update, 1) do
+    on_update.(update)
+    %{ro | released: [update | ro.released]}
+  end
+
+  # After the terminal result, drain any same-turn straggler still in flight
+  # (bounded window, resets on each), delivering it through the same state
+  # machine, then FLUSH: any out-of-order STAMPED tail an unfillable gap left in
+  # `buf` (ascending update_seq) followed by the UNSTAMPED `fallback` (ascending
+  # rx_seq) — nothing dropped (best-effort completeness).
+  defp settle_updates(session_id, ro, on_update) do
+    receive do
+      {:acp_session_update, ^session_id, update, rx_seq, update_seq} ->
+        settle_updates(
+          session_id,
+          deliver_update(ro, update, update_seq, rx_seq, on_update),
+          on_update
+        )
+    after
+      @update_settle_ms -> flush_buffers(ro, on_update)
+    end
+  end
+
+  defp flush_buffers(%{buf: buf, fallback: fallback} = ro, on_update) do
+    ro =
+      buf
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.reduce(%{ro | buf: %{}}, fn {_seq, update}, acc ->
+        emit_update(acc, update, on_update)
+      end)
+
+    fallback
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.reduce(%{ro | fallback: []}, fn {_rx_seq, update}, acc ->
+      emit_update(acc, update, on_update)
+    end)
   end
 
   @doc """
   Callback variant of `prompt/3`: `on_update.(update)` is invoked, in this
-  process, for each `session/update` of the turn -- in restored `rx_seq`
-  (wire) order. Returns `{:ok, response}` / `{:error, term()}` for the
-  terminal outcome, same vocabulary as `Connection.async_request/6`'s
-  `outcome`. Always subscribes and unsubscribes around the call, including
-  on error.
+  process, for each `session/update` of the turn -- in `update_seq` order.
+  Returns `{:ok, response}` / `{:error, term()}` for the terminal outcome,
+  same vocabulary as `Connection.async_request/6`'s `outcome`. Always
+  subscribes and unsubscribes around the call, including on error.
 
-  Same reorder/no-drop contract as `prompt/3`: updates arrive from
-  concurrent per-notification dispatch tasks (non-blocking, so
+  Same reorder/no-drop contract as `prompt/3`, and LIVE incremental: updates
+  arrive from concurrent per-notification dispatch tasks (non-blocking, so
   parallel/interleaved streams flow), so they can land out of order and can
-  race the terminal result. This variant therefore does NOT invoke
-  `on_update` in raw arrival order -- it buffers by `rx_seq` and, once the
-  turn boundary is known (the result's `rx_seq`, after a bounded straggler
-  drain), replays the whole turn to `on_update` in `rx_seq` order. That
-  trades pre-result incremental latency for deterministic ordering: under a
-  global per-connection `rx_seq`, the result frame is the only sound
-  completeness barrier (a numeric gap is an unrelated frame, not a missing
-  update), so no update can be safely released before it without risking a
-  lower-`rx_seq` straggler arriving afterward.
+  race the terminal result. This variant reorders on the agent-stamped
+  PER-SESSION `update_seq`: it invokes `on_update` for an update the INSTANT
+  it is contiguous (`update_seq == next-expected`), then cascade-releases any
+  buffered successors -- so an in-order stamped stream streams incrementally
+  rather than waiting for the turn boundary. A gap holds the higher ordinals
+  until the missing one lands (or the result closes the turn). When the agent
+  does NOT stamp `update_seq`, it falls back to `prompt/3`'s behavior:
+  buffer by `rx_seq` and replay to `on_update` in `rx_seq` order at the turn
+  boundary (deterministic, no-drop, but not incremental). A bounded settle
+  drain after the result flushes any straggler on BOTH the ok and error
+  outcome, so updates observed up to (and just after) the result are never
+  dropped.
 
   **Precondition:** same as `prompt/3` -- requires the generated default
   `c:session_update/2`; an overridden `session_update/2` that doesn't call
@@ -500,7 +626,7 @@ defmodule Raxol.AgentClientProtocol.Client do
              tag,
              timeout_ms
            ) do
-        :ok -> stream_prompt(session_id, tag, on_update, [], nil)
+        :ok -> stream_prompt(session_id, tag, on_update, new_reorder())
         {:error, _} = err -> err
       end
     after
@@ -508,24 +634,28 @@ defmodule Raxol.AgentClientProtocol.Client do
     end
   end
 
-  # Same reorder buffer as `collect_prompt/4`, but instead of returning the
-  # list it replays it to `on_update` in `rx_seq` order once the turn
-  # boundary is known. Emits on BOTH the ok and error terminal outcome so
-  # updates observed before an error are never silently dropped.
-  defp stream_prompt(session_id, tag, on_update, buf, result_seq) do
+  # Same reorder engine as `collect_prompt/3`, but LIVE: each update is passed to
+  # `on_update` at the instant it becomes contiguous (`deliver_update/4` with the
+  # real sink), so an in-order stamped stream streams incrementally instead of
+  # waiting for the turn boundary. On the terminal result, a bounded settle drain
+  # absorbs any straggler then flushes any out-of-order tail — so updates
+  # observed right up to (and after) the result are never dropped, on BOTH the ok
+  # and error outcome.
+  defp stream_prompt(session_id, tag, on_update, ro) do
     receive do
-      {:acp_session_update, ^session_id, update, seq} ->
-        stream_prompt(session_id, tag, on_update, [{seq, update} | buf], result_seq)
+      {:acp_session_update, ^session_id, update, rx_seq, update_seq} ->
+        stream_prompt(
+          session_id,
+          tag,
+          on_update,
+          deliver_update(ro, update, update_seq, rx_seq, on_update)
+        )
 
-      {:acp_result_seq, ^tag, seq} ->
-        stream_prompt(session_id, tag, on_update, buf, seq)
+      {:acp_result_seq, ^tag, _seq} ->
+        stream_prompt(session_id, tag, on_update, ro)
 
       {:acp_result, ^tag, outcome} ->
-        buf
-        |> drain_updates(session_id, result_seq)
-        |> order_updates()
-        |> Enum.each(on_update)
-
+        _ = settle_updates(session_id, ro, on_update)
         outcome
     end
   end
@@ -570,7 +700,8 @@ defmodule Raxol.AgentClientProtocol.Client do
           ctx.conn,
           notification.session_id,
           notification.update,
-          ctx.rx_seq
+          ctx.rx_seq,
+          Raxol.AgentClientProtocol.Client.extract_update_seq(notification)
         )
       end
 

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
@@ -89,10 +89,11 @@ defmodule Raxol.AgentClientProtocol.Client do
   mailbox protocol. The generated default `c:session_update/2` (unless you
   override it) forwards every decoded update to whichever processes called
   `subscribe/3` for that `{conn, session_id}` pair, as
-  `{:acp_session_update, session_id, update}` -- `update` is always an
-  already-decoded `Raxol.AgentClientProtocol.Schema.SessionUpdate.t()` (see
-  `decode_update/1`'s doc for why an undecodable variant never reaches
-  this path at all).
+  `{:acp_session_update, session_id, update, rx_seq}` -- `update` is always
+  an already-decoded `Raxol.AgentClientProtocol.Schema.SessionUpdate.t()`
+  (see `decode_update/1`'s doc for why an undecodable variant never reaches
+  this path at all), and `rx_seq` is the inbound frame's monotone sequence
+  stamp (the reorder key -- see below).
 
   `prompt/3` and `prompt_stream/4` build on `subscribe/3` to give a
   synchronous-feeling API over the inherently asynchronous protocol:
@@ -108,8 +109,14 @@ defmodule Raxol.AgentClientProtocol.Client do
   Both drive the request through `Connection.async_request/6` (not the
   blocking `Connection.request/4` wrapper) specifically so the calling
   process can `receive` session/update deliveries *and* the terminal
-  result in one loop -- see their docs for the exact mechanics and the
-  ordering caveat.
+  result in one loop -- and both act as the *reorder/consolidation point*
+  for the turn: update deliveries arrive from concurrent per-notification
+  dispatch tasks (non-blocking, so parallel/interleaved update streams
+  flow), so they can land out of wire order and can even race the terminal
+  result into the mailbox. Each carries its `rx_seq`; the loop buffers by
+  `rx_seq`, drains every update below the result's own `rx_seq` before
+  completing, and returns them in restored wire order -- see their docs for
+  the exact mechanics.
 
   ## `fs_sandbox`: a working filesystem client with zero callbacks
 
@@ -207,11 +214,16 @@ defmodule Raxol.AgentClientProtocol.Client do
   Subscribe `subscriber` (default `self()`) to `session_id`'s
   `session/update` deliveries on `conn`. The generated default
   `c:session_update/2` (unless overridden) broadcasts
-  `{:acp_session_update, session_id, update}` to every subscriber
+  `{:acp_session_update, session_id, update, rx_seq}` to every subscriber
   registered for `{conn, session_id}` -- `update` is always an
   already-decoded `Raxol.AgentClientProtocol.Schema.SessionUpdate.t()`
   (see `decode_update/1`'s doc for why an undecodable variant never
-  reaches this path). NOT idempotent: subscribing the same pid twice for
+  reaches this path), and `rx_seq` is the inbound notification frame's
+  monotone sequence stamp (`Ctx.rx_seq`). Because each update is forwarded
+  from its OWN concurrent dispatch task, deliveries to the subscriber's
+  mailbox can be out of wire order; `rx_seq` is the key a consumer uses to
+  restore that order (`prompt/3`/`prompt_stream/4` do this for you). NOT
+  idempotent: subscribing the same pid twice for
   the same key registers it twice in the underlying `:bag` -- each
   registration receives its own copy of every broadcast, so the pid gets
   the update twice. Subscribe once per `{conn, session_id, pid}`, or
@@ -243,12 +255,19 @@ defmodule Raxol.AgentClientProtocol.Client do
   # notification handler task calling this must never crash on its account
   # (design docs' "handler crash never reaches the wire" spirit, applied
   # here even though a notification crash is already log-only, IC/§4.4).
-  @spec broadcast_update(pid(), String.t(), term()) :: :ok
-  def broadcast_update(conn, session_id, update) do
+  #
+  # `rx_seq` is the inbound `session/update` frame's monotone sequence
+  # (`Ctx.rx_seq`); it rides the delivered tuple as the 4th element so a
+  # consumer can restore wire order across concurrent per-notification
+  # dispatch tasks (see `prompt/3`/`prompt_stream/4`). Defaults to `0` so a
+  # direct/legacy `broadcast_update/3` caller (custom handler, replay
+  # tooling) keeps working -- such deliveries simply sort as "seq 0".
+  @spec broadcast_update(pid(), String.t(), term(), non_neg_integer()) :: :ok
+  def broadcast_update(conn, session_id, update, rx_seq \\ 0) do
     ensure_subs_table!()
 
     for {_key, subscriber} <- :ets.lookup(@subs_table, {conn, session_id}) do
-      send(subscriber, {:acp_session_update, session_id, update})
+      send(subscriber, {:acp_session_update, session_id, update, rx_seq})
     end
 
     :ok
@@ -330,26 +349,29 @@ defmodule Raxol.AgentClientProtocol.Client do
   failure/decode failure, same vocabulary as `Connection.async_request/6`'s
   `outcome`.
 
-  Ordering: `Connection` delivers `session/update` forwarding to the
-  subscribed process SYNCHRONOUSLY, from the Connection process itself,
-  before it ever looks at the next inbound frame (see
-  `Connection`'s "Single-sender `session/update` delivery" moduledoc
-  section) -- and the terminal `session/prompt` response is also delivered
-  directly by `Connection`. Both now originate from the SAME sender to
-  this process, so BEAM's per-sender/per-receiver FIFO guarantee applies:
-  the WIRE invariant (I3: no update after its turn's response) carries
-  through to mailbox order here, not just on the wire. This function still
-  does one short best-effort settle pass after the terminal message
-  arrives, kept as defence-in-depth (e.g. against a future notification
-  path that isn't single-sender) rather than because it is required for
-  correctness today.
+  Ordering & no-drop (client-side reorder): `session/update` deliveries
+  are forwarded from concurrent per-notification dispatch tasks (so a slow
+  handler never blocks `Connection`, and parallel/interleaved update
+  streams flow), while the terminal `session/prompt` response is delivered
+  by `Connection` itself. Different senders means the subscriber's mailbox
+  gives no cross-sender order, and the result can even land before a
+  same-turn update that is still in flight. So this function does NOT trust
+  mailbox order: every delivery carries the inbound frame's monotone
+  `rx_seq`, and `Connection` also sends an `{:acp_result_seq, tag, rx_seq}`
+  companion just before the result. This loop buffers updates by `rx_seq`,
+  and on the terminal result (frame seq `R`) drains every same-turn update
+  (all have `rx_seq < R` by wire invariant I3) with a bounded settle pass,
+  then returns them in restored `rx_seq` (wire) order. The bounded settle
+  pass is the completeness bound (an in-flight dispatch task's `send`
+  lands within scheduling latency; the pass resets on each straggler); `R`
+  is the turn-boundary classifier.
 
   Always subscribes and unsubscribes around the call, including on error.
 
   **Precondition:** requires the generated default `c:session_update/2`
   (the one `use Raxol.AgentClientProtocol.Client` installs). If your
   handler module overrides `session_update/2` and does not itself call
-  `broadcast_update/3`, `subscribe/3` never fires and `updates` is `[]`
+  `broadcast_update/4`, `subscribe/3` never fires and `updates` is `[]`
   for every turn, forever -- see the moduledoc's "Session-consumer
   ergonomics" section.
   """
@@ -370,7 +392,7 @@ defmodule Raxol.AgentClientProtocol.Client do
              tag,
              timeout_ms
            ) do
-        :ok -> collect_prompt(session_id, tag, [])
+        :ok -> collect_prompt(session_id, tag, [], nil)
         {:error, _} = err -> err
       end
     after
@@ -378,41 +400,87 @@ defmodule Raxol.AgentClientProtocol.Client do
     end
   end
 
-  defp collect_prompt(session_id, tag, acc) do
+  # Milliseconds the reorder buffer keeps its settle window open after the
+  # turn's result, waiting for an in-flight per-notification dispatch task's
+  # `send/2` to land. That send is an ETS lookup + `send` (sub-millisecond),
+  # spawned before the result frame, so this is enormous headroom; the
+  # window RESETS on every straggler, so it only trails the LAST one. It is
+  # the completeness bound for the no-drop guarantee (there is no positive
+  # "all updates delivered" signal under a global per-connection `rx_seq`,
+  # since a numeric gap is an unrelated frame, not a missing update).
+  @update_settle_ms 25
+
+  # `buf` is a list of `{rx_seq, update}`; sorted only at the end so the
+  # order the concurrent dispatch tasks happen to deliver in never matters.
+  # `result_seq` is the terminal response frame's `rx_seq` (from the
+  # `{:acp_result_seq, ...}` companion), or `nil` if the turn ended without
+  # a response frame (Connection-side timeout/close).
+  defp collect_prompt(session_id, tag, buf, result_seq) do
     receive do
-      {:acp_session_update, ^session_id, update} ->
-        collect_prompt(session_id, tag, [update | acc])
+      {:acp_session_update, ^session_id, update, seq} ->
+        collect_prompt(session_id, tag, [{seq, update} | buf], result_seq)
+
+      {:acp_result_seq, ^tag, seq} ->
+        collect_prompt(session_id, tag, buf, seq)
 
       {:acp_result, ^tag, {:ok, response}} ->
-        {:ok, {settle_updates(session_id, acc), response}}
+        updates = buf |> drain_updates(session_id, result_seq) |> order_updates()
+        {:ok, {updates, response}}
 
       {:acp_result, ^tag, {:error, _} = error} ->
         error
     end
   end
 
-  defp settle_updates(session_id, acc) do
+  # Absorb same-turn stragglers that raced the result into the mailbox from
+  # their (concurrent, non-blocking) dispatch tasks. Wire invariant I3
+  # guarantees every same-turn update's frame preceded the result frame, so
+  # each has `rx_seq < result_seq`; either way we never drop an update for
+  # this session. The bounded window resets on each straggler.
+  defp drain_updates(buf, session_id, result_seq) do
     receive do
-      {:acp_session_update, ^session_id, update} ->
-        settle_updates(session_id, [update | acc])
+      {:acp_session_update, ^session_id, update, seq}
+      when is_integer(result_seq) and seq < result_seq ->
+        drain_updates([{seq, update} | buf], session_id, result_seq)
+
+      # No result_seq (timeout/close, no response frame) or a seq that is not
+      # below the turn boundary (should be impossible by I3): absorb rather
+      # than drop, still bounded by the settle window.
+      {:acp_session_update, ^session_id, update, seq} ->
+        drain_updates([{seq, update} | buf], session_id, result_seq)
     after
-      5 -> Enum.reverse(acc)
+      @update_settle_ms -> buf
     end
   end
 
+  defp order_updates(buf) do
+    buf |> Enum.sort_by(&elem(&1, 0)) |> Enum.map(&elem(&1, 1))
+  end
+
   @doc """
-  Streaming-callback variant of `prompt/3`: `on_update.(update)` is invoked
-  synchronously, in this process, for each `session/update` as it is
-  received -- no accumulation, no post-hoc settle pass (this variant's
-  receive loop never exits until the terminal message arrives, so there is
-  no window for a straggler to be missed). Returns `{:ok, response}` /
-  `{:error, term()}` for the terminal outcome, same vocabulary as
-  `Connection.async_request/6`'s `outcome`. Always subscribes and
-  unsubscribes around the call, including on error.
+  Callback variant of `prompt/3`: `on_update.(update)` is invoked, in this
+  process, for each `session/update` of the turn -- in restored `rx_seq`
+  (wire) order. Returns `{:ok, response}` / `{:error, term()}` for the
+  terminal outcome, same vocabulary as `Connection.async_request/6`'s
+  `outcome`. Always subscribes and unsubscribes around the call, including
+  on error.
+
+  Same reorder/no-drop contract as `prompt/3`: updates arrive from
+  concurrent per-notification dispatch tasks (non-blocking, so
+  parallel/interleaved streams flow), so they can land out of order and can
+  race the terminal result. This variant therefore does NOT invoke
+  `on_update` in raw arrival order -- it buffers by `rx_seq` and, once the
+  turn boundary is known (the result's `rx_seq`, after a bounded straggler
+  drain), replays the whole turn to `on_update` in `rx_seq` order. That
+  trades pre-result incremental latency for deterministic ordering: under a
+  global per-connection `rx_seq`, the result frame is the only sound
+  completeness barrier (a numeric gap is an unrelated frame, not a missing
+  update), so no update can be safely released before it without risking a
+  lower-`rx_seq` straggler arriving afterward.
 
   **Precondition:** same as `prompt/3` -- requires the generated default
   `c:session_update/2`; an overridden `session_update/2` that doesn't call
-  `broadcast_update/3` means `on_update` is never invoked.
+  `broadcast_update/4` means `on_update` is never invoked.
   """
   @spec prompt_stream(pid(), struct(), (update() -> any()), pos_integer()) ::
           {:ok, struct() | {:ext, map()}} | {:error, term()}
@@ -432,7 +500,7 @@ defmodule Raxol.AgentClientProtocol.Client do
              tag,
              timeout_ms
            ) do
-        :ok -> stream_prompt(session_id, tag, on_update)
+        :ok -> stream_prompt(session_id, tag, on_update, [], nil)
         {:error, _} = err -> err
       end
     after
@@ -440,13 +508,24 @@ defmodule Raxol.AgentClientProtocol.Client do
     end
   end
 
-  defp stream_prompt(session_id, tag, on_update) do
+  # Same reorder buffer as `collect_prompt/4`, but instead of returning the
+  # list it replays it to `on_update` in `rx_seq` order once the turn
+  # boundary is known. Emits on BOTH the ok and error terminal outcome so
+  # updates observed before an error are never silently dropped.
+  defp stream_prompt(session_id, tag, on_update, buf, result_seq) do
     receive do
-      {:acp_session_update, ^session_id, update} ->
-        on_update.(update)
-        stream_prompt(session_id, tag, on_update)
+      {:acp_session_update, ^session_id, update, seq} ->
+        stream_prompt(session_id, tag, on_update, [{seq, update} | buf], result_seq)
+
+      {:acp_result_seq, ^tag, seq} ->
+        stream_prompt(session_id, tag, on_update, buf, seq)
 
       {:acp_result, ^tag, outcome} ->
+        buf
+        |> drain_updates(session_id, result_seq)
+        |> order_updates()
+        |> Enum.each(on_update)
+
         outcome
     end
   end
@@ -490,7 +569,8 @@ defmodule Raxol.AgentClientProtocol.Client do
         Raxol.AgentClientProtocol.Client.broadcast_update(
           ctx.conn,
           notification.session_id,
-          notification.update
+          notification.update,
+          ctx.rx_seq
         )
       end
 

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
@@ -116,6 +116,21 @@ defmodule Raxol.AgentClientProtocol.Connection do
        `parent_sup` + `which_children` resolution in `handle_continue/2`
        (IC-8); the shared IC pins the tree shape but not the child ids, so
        resolution is by child module/type heuristic.
+
+  ## Single-sender `session/update` delivery (post-ship fix)
+
+  Every OTHER inbound notification dispatches to its own
+  `Task.Supervisor.async_nolink` task (§4.4), same as an inbound request
+  (§4). `session/update` (client role only) is the one deliberate
+  exception, added after ship: it is handled SYNCHRONOUSLY, in this
+  process, by `dispatch_session_update_sync/2` — see that function's doc
+  for the drop/reorder race this closes (three different BEAM senders —
+  Connection for the turn's terminal result, a fresh task per update —
+  gave no cross-sender mailbox-ordering guarantee to a `Client.subscribe/3`
+  consumer) and the accepted trade-off (a slow custom `session_update/2`
+  override now runs on this process's own message loop instead of an
+  isolated task; a crash is still caught and never reaches the wire or
+  takes the Connection down).
   """
 
   use GenServer
@@ -983,9 +998,96 @@ defmodule Raxol.AgentClientProtocol.Connection do
       notif.method == "session/cancel" ->
         route_session_cancel(notif.params, rx_seq, state)
 
+      notif.method == "session/update" and state.role == :client ->
+        dispatch_session_update_sync(notif, state)
+
       true ->
         dispatch_inbound_notification(notif, state)
     end
+  end
+
+  # `session/update` (client role only) -- SYNCHRONOUS, single-sender
+  # delivery. This is a deliberate exception to "every inbound notification
+  # dispatches to its own async_nolink task" (§4.4): see the moduledoc's
+  # "Single-sender session/update delivery" section for the full race this
+  # closes and why running it here, in THIS process, is what closes it.
+  #
+  # In short: `Client.subscribe/3`'s default `session_update/2` forwards the
+  # decoded update via `send/2` to whichever process called `subscribe/3`
+  # (typically `prompt_stream/4`'s caller). The turn's terminal
+  # `session/prompt` RESPONSE is delivered to that same process directly by
+  # THIS Connection (`deliver_outcome/2`). When the update's forwarding
+  # `send/2` instead came from a separate per-notification task, it and the
+  # response were two different BEAM senders to the same receiver -- no
+  # cross-sender mailbox-ordering guarantee -- so the response could land
+  # first and `prompt_stream/4`'s receive loop would exit before an
+  # in-flight update was ever read, silently dropping it.
+  #
+  # The Connection handles inbound wire frames strictly in arrival order
+  # (one frame per `handle_info`), and the wire itself guarantees no
+  # `session/update` for a turn arrives after that turn's `session/prompt`
+  # response. So finishing this dispatch -- including whatever `send/2` the
+  # handler performs -- before the Connection ever looks at the next frame
+  # guarantees that send happens-before the terminal result's send, AND
+  # both now originate from this SAME process, giving BEAM's real
+  # per-sender/per-receiver FIFO guarantee.
+  #
+  # Trade-off (deliberate, scoped to this one method): a slow or crashing
+  # CUSTOM `c:session_update/2` override now runs on the Connection's own
+  # message loop instead of an isolated task, and can delay it. The crash
+  # side is still contained: `run_session_update_sync/4` wraps the call so
+  # a raise/throw/exit is logged + telemetried exactly like an async
+  # handler crash would be (§4.4), never taking the Connection down and
+  # never producing a wire frame (notifications never do). The DEFAULT
+  # handler (an ETS lookup + `send/2`) is cheap by construction, so this
+  # only matters for apps overriding `session_update/2` with something
+  # heavier -- an accepted cost for the correctness guarantee
+  # `prompt/3`/`prompt_stream/4` depend on.
+  defp dispatch_session_update_sync(%Notification{method: method, params: params}, state) do
+    case Router.decode(state.role, :notification, method, params) do
+      {:error, _reason} ->
+        Logger.debug("ACP: unknown/invalid notification #{method} dropped")
+        emit_telemetry([:raxol, :acp, :unknown_notification], %{method: method})
+        {:noreply, state}
+
+      {:ok, dispatchable} ->
+        ctx = %Ctx{
+          conn: self(),
+          role: state.role,
+          caps: state.caps,
+          handler_state: state.handler_state,
+          reply_ref: nil,
+          rx_seq: 0,
+          session_sup: state.session_sup,
+          task_sup: state.task_sup
+        }
+
+        run_session_update_sync(state.role, state.handler, dispatchable, ctx, method)
+        {:noreply, state}
+    end
+  end
+
+  # Never let a handler crash reach the wire OR take the Connection down
+  # (§4.4 parity with the async-task crash path in `handle_task_down/3`) --
+  # `rescue` covers a raised exception, `catch` covers a bare `throw`/`exit`
+  # from handler code, so this is total regardless of how the handler
+  # misbehaves.
+  defp run_session_update_sync(side, handler, dispatchable, ctx, method) do
+    run_dispatch(side, handler, dispatchable, ctx)
+    :ok
+  rescue
+    e ->
+      Logger.error(
+        "ACP: notification handler crashed (#{method}): #{Exception.format(:error, e, __STACKTRACE__)}"
+      )
+
+      emit_telemetry([:raxol, :acp, :handler_crash], %{kind: :notification, method: method})
+      :ok
+  catch
+    kind, reason ->
+      Logger.error("ACP: notification handler #{kind} (#{method}): #{inspect(reason)}")
+      emit_telemetry([:raxol, :acp, :handler_crash], %{kind: :notification, method: method})
+      :ok
   end
 
   defp dispatch_inbound_notification(%Notification{method: method, params: params}, state) do

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
@@ -117,20 +117,34 @@ defmodule Raxol.AgentClientProtocol.Connection do
        (IC-8); the shared IC pins the tree shape but not the child ids, so
        resolution is by child module/type heuristic.
 
-  ## Single-sender `session/update` delivery (post-ship fix)
+  ## `rx_seq` stamping for client-side update reordering (post-ship fix)
 
-  Every OTHER inbound notification dispatches to its own
-  `Task.Supervisor.async_nolink` task (§4.4), same as an inbound request
-  (§4). `session/update` (client role only) is the one deliberate
-  exception, added after ship: it is handled SYNCHRONOUSLY, in this
-  process, by `dispatch_session_update_sync/2` — see that function's doc
-  for the drop/reorder race this closes (three different BEAM senders —
-  Connection for the turn's terminal result, a fresh task per update —
-  gave no cross-sender mailbox-ordering guarantee to a `Client.subscribe/3`
-  consumer) and the accepted trade-off (a slow custom `session_update/2`
-  override now runs on this process's own message loop instead of an
-  isolated task; a crash is still caught and never reaches the wire or
-  takes the Connection down).
+  Every inbound notification — `session/update` included — dispatches to its
+  own `Task.Supervisor.async_nolink` task (§4.4), so a slow or custom
+  `session_update/2` handler NEVER head-of-line-blocks the Connection's
+  frame loop: parallel/interleaved update streams flow concurrently. The
+  consequence is that the forwarding `send/2` to a `Client.subscribe/3`
+  consumer happens from a *fresh task per notification*, while the turn's
+  terminal `session/prompt` response is delivered by THIS process
+  (`deliver_outcome/2`) — different senders, so BEAM gives no cross-sender
+  mailbox order. Rather than serialize everything through the Connection
+  (which would reintroduce head-of-line blocking), the Connection stamps
+  every delivery with the inbound frame's monotone `rx_seq` and makes the
+  CLIENT the consolidation/reordering point:
+
+    * `session/update` deliveries carry the notification frame's `rx_seq` as
+      the 4th element of `{:acp_session_update, session_id, update, rx_seq}`
+      (threaded through `Ctx.rx_seq` → the generated `session_update/2` →
+      `Client.broadcast_update/4`).
+    * a `session/prompt` response additionally sends the owner an
+      `{:acp_result_seq, tag, rx_seq}` companion (the response frame's
+      `rx_seq`) immediately before `{:acp_result, tag, outcome}`, so the
+      consumer knows the turn boundary and can drain every lower-`rx_seq`
+      update before completing.
+
+  See `Client.prompt/3`/`prompt_stream/4` for the reorder buffer that
+  restores wire order from these stamps and guarantees no same-turn update
+  is dropped.
   """
 
   use GenServer
@@ -199,6 +213,16 @@ defmodule Raxol.AgentClientProtocol.Connection do
   frame is accepted by the transport, and later delivers **exactly one**
   `{:acp_result, tag, outcome}` to `owner` — unless `owner` consumed the
   entry first via `cancel_request/2` (then zero). Connection owns the timeout.
+
+  When the outcome came from an actual peer RESPONSE frame (not a
+  Connection-side timeout/close), `owner` also receives an
+  `{:acp_result_seq, tag, rx_seq}` companion IMMEDIATELY BEFORE the
+  `{:acp_result, ...}` — the response frame's monotone inbound sequence.
+  It lets a consumer that is also receiving `{:acp_session_update, _, _,
+  rx_seq}` deliveries (via `Client.subscribe/3`) reorder them and drain
+  every lower-`rx_seq` same-turn update before completing (see the
+  "rx_seq stamping" moduledoc section). Owners that don't subscribe can
+  ignore it.
   """
   @spec async_request(
           pid(),
@@ -631,7 +655,7 @@ defmodule Raxol.AgentClientProtocol.Connection do
 
       Map.has_key?(frame, "id") and
           (Map.has_key?(frame, "result") or Map.has_key?(frame, "error")) ->
-        classify_response(frame, state)
+        classify_response(frame, rx_seq, state)
 
       Map.has_key?(frame, "method") ->
         classify_notification(frame, rx_seq, state)
@@ -674,9 +698,9 @@ defmodule Raxol.AgentClientProtocol.Connection do
   # cross-correlated to an unrelated in-flight request of theirs. Any real
   # in-flight request we made under this id resolves by its own timeout
   # instead, per the design's row 15/16/19 precedent.
-  defp classify_response(frame, state) do
+  defp classify_response(frame, rx_seq, state) do
     case Response.from_json(frame) do
-      {:ok, resp} -> handle_inbound_response(resp, state)
+      {:ok, resp} -> handle_inbound_response(resp, rx_seq, state)
       {:error, _reason} -> drop_malformed_response(frame, state)
     end
   end
@@ -998,52 +1022,12 @@ defmodule Raxol.AgentClientProtocol.Connection do
       notif.method == "session/cancel" ->
         route_session_cancel(notif.params, rx_seq, state)
 
-      notif.method == "session/update" and state.role == :client ->
-        dispatch_session_update_sync(notif, state)
-
       true ->
-        dispatch_inbound_notification(notif, state)
+        dispatch_inbound_notification(notif, rx_seq, state)
     end
   end
 
-  # `session/update` (client role only) -- SYNCHRONOUS, single-sender
-  # delivery. This is a deliberate exception to "every inbound notification
-  # dispatches to its own async_nolink task" (§4.4): see the moduledoc's
-  # "Single-sender session/update delivery" section for the full race this
-  # closes and why running it here, in THIS process, is what closes it.
-  #
-  # In short: `Client.subscribe/3`'s default `session_update/2` forwards the
-  # decoded update via `send/2` to whichever process called `subscribe/3`
-  # (typically `prompt_stream/4`'s caller). The turn's terminal
-  # `session/prompt` RESPONSE is delivered to that same process directly by
-  # THIS Connection (`deliver_outcome/2`). When the update's forwarding
-  # `send/2` instead came from a separate per-notification task, it and the
-  # response were two different BEAM senders to the same receiver -- no
-  # cross-sender mailbox-ordering guarantee -- so the response could land
-  # first and `prompt_stream/4`'s receive loop would exit before an
-  # in-flight update was ever read, silently dropping it.
-  #
-  # The Connection handles inbound wire frames strictly in arrival order
-  # (one frame per `handle_info`), and the wire itself guarantees no
-  # `session/update` for a turn arrives after that turn's `session/prompt`
-  # response. So finishing this dispatch -- including whatever `send/2` the
-  # handler performs -- before the Connection ever looks at the next frame
-  # guarantees that send happens-before the terminal result's send, AND
-  # both now originate from this SAME process, giving BEAM's real
-  # per-sender/per-receiver FIFO guarantee.
-  #
-  # Trade-off (deliberate, scoped to this one method): a slow or crashing
-  # CUSTOM `c:session_update/2` override now runs on the Connection's own
-  # message loop instead of an isolated task, and can delay it. The crash
-  # side is still contained: `run_session_update_sync/4` wraps the call so
-  # a raise/throw/exit is logged + telemetried exactly like an async
-  # handler crash would be (§4.4), never taking the Connection down and
-  # never producing a wire frame (notifications never do). The DEFAULT
-  # handler (an ETS lookup + `send/2`) is cheap by construction, so this
-  # only matters for apps overriding `session_update/2` with something
-  # heavier -- an accepted cost for the correctness guarantee
-  # `prompt/3`/`prompt_stream/4` depend on.
-  defp dispatch_session_update_sync(%Notification{method: method, params: params}, state) do
+  defp dispatch_inbound_notification(%Notification{method: method, params: params}, rx_seq, state) do
     case Router.decode(state.role, :notification, method, params) do
       {:error, _reason} ->
         Logger.debug("ACP: unknown/invalid notification #{method} dropped")
@@ -1051,60 +1035,18 @@ defmodule Raxol.AgentClientProtocol.Connection do
         {:noreply, state}
 
       {:ok, dispatchable} ->
+        # `rx_seq` (the inbound frame's monotone stamp) is threaded onto the
+        # dispatch Ctx so the client-role `session/update` handler can forward
+        # it to `subscribe/3` consumers for reorder/no-drop (moduledoc's
+        # "rx_seq stamping" section). Notifications other than `session/update`
+        # ignore it; carrying it uniformly costs nothing.
         ctx = %Ctx{
           conn: self(),
           role: state.role,
           caps: state.caps,
           handler_state: state.handler_state,
           reply_ref: nil,
-          rx_seq: 0,
-          session_sup: state.session_sup,
-          task_sup: state.task_sup
-        }
-
-        run_session_update_sync(state.role, state.handler, dispatchable, ctx, method)
-        {:noreply, state}
-    end
-  end
-
-  # Never let a handler crash reach the wire OR take the Connection down
-  # (§4.4 parity with the async-task crash path in `handle_task_down/3`) --
-  # `rescue` covers a raised exception, `catch` covers a bare `throw`/`exit`
-  # from handler code, so this is total regardless of how the handler
-  # misbehaves.
-  defp run_session_update_sync(side, handler, dispatchable, ctx, method) do
-    run_dispatch(side, handler, dispatchable, ctx)
-    :ok
-  rescue
-    e ->
-      Logger.error(
-        "ACP: notification handler crashed (#{method}): #{Exception.format(:error, e, __STACKTRACE__)}"
-      )
-
-      emit_telemetry([:raxol, :acp, :handler_crash], %{kind: :notification, method: method})
-      :ok
-  catch
-    kind, reason ->
-      Logger.error("ACP: notification handler #{kind} (#{method}): #{inspect(reason)}")
-      emit_telemetry([:raxol, :acp, :handler_crash], %{kind: :notification, method: method})
-      :ok
-  end
-
-  defp dispatch_inbound_notification(%Notification{method: method, params: params}, state) do
-    case Router.decode(state.role, :notification, method, params) do
-      {:error, _reason} ->
-        Logger.debug("ACP: unknown/invalid notification #{method} dropped")
-        emit_telemetry([:raxol, :acp, :unknown_notification], %{method: method})
-        {:noreply, state}
-
-      {:ok, dispatchable} ->
-        ctx = %Ctx{
-          conn: self(),
-          role: state.role,
-          caps: state.caps,
-          handler_state: state.handler_state,
-          reply_ref: nil,
-          rx_seq: 0,
+          rx_seq: rx_seq,
           session_sup: state.session_sup,
           task_sup: state.task_sup
         }
@@ -1172,7 +1114,7 @@ defmodule Raxol.AgentClientProtocol.Connection do
   # Correlated response arrival (§2.4)
   # ===========================================================================
 
-  defp handle_inbound_response(resp, state) do
+  defp handle_inbound_response(resp, rx_seq, state) do
     id = elem(resp, 1)
 
     case Map.pop(state.pending_out, id) do
@@ -1184,6 +1126,13 @@ defmodule Raxol.AgentClientProtocol.Connection do
       {%{reply_to: rt, method: method, timer_ref: timer}, pending_out} ->
         if timer, do: Process.cancel_timer(timer)
         outcome = decode_response(resp, method)
+        # Stamp the terminal outcome with this response frame's `rx_seq` for an
+        # async owner (`{:acp_result_seq, tag, rx_seq}`) so `Client.prompt/3` /
+        # `prompt_stream/4` know the turn boundary and can drain every
+        # lower-`rx_seq` `session/update` before completing (moduledoc's "rx_seq
+        # stamping" section). Sync callers (`{:call, from}`) never subscribe to
+        # updates, so they get no companion.
+        deliver_result_seq(rt, rx_seq)
         deliver_outcome(rt, outcome)
 
         state = %{state | pending_out: pending_out, out_tags: drop_tag(state.out_tags, rt)}
@@ -1304,6 +1253,19 @@ defmodule Raxol.AgentClientProtocol.Connection do
     send(pid, {:acp_result, tag, outcome})
     :ok
   end
+
+  # Companion to `deliver_outcome/2` for an async owner: the terminal
+  # response frame's `rx_seq`, sent immediately BEFORE `{:acp_result, ...}`
+  # (both from THIS process, so they arrive in order). Lets a consumer that
+  # also receives `{:acp_session_update, _, _, rx_seq}` deliveries drain
+  # every lower-`rx_seq` same-turn update before it completes. Sync callers
+  # never subscribe to updates, so there is nothing to reorder for them.
+  defp deliver_result_seq({:owner, pid, tag}, rx_seq) do
+    send(pid, {:acp_result_seq, tag, rx_seq})
+    :ok
+  end
+
+  defp deliver_result_seq({:call, _from}, _rx_seq), do: :ok
 
   defp demonitor_adopter(%{adopter: {_pid, mon}}), do: Process.demonitor(mon, [:flush])
   defp demonitor_adopter(_entry), do: :ok

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
@@ -133,18 +133,22 @@ defmodule Raxol.AgentClientProtocol.Connection do
   CLIENT the consolidation/reordering point:
 
     * `session/update` deliveries carry the notification frame's `rx_seq` as
-      the 4th element of `{:acp_session_update, session_id, update, rx_seq}`
-      (threaded through `Ctx.rx_seq` → the generated `session_update/2` →
-      `Client.broadcast_update/4`).
+      the 4th element of `{:acp_session_update, session_id, update, rx_seq,
+      update_seq}` (threaded through `Ctx.rx_seq` → the generated
+      `session_update/2` → `Client.broadcast_update/5`). The 5th element,
+      `update_seq`, is the agent's PER-SESSION update ordinal read from
+      `_meta["raxol.io"]["update_seq"]` (or `nil` when unstamped) — the
+      reorder key the consumer uses for LIVE incremental in-order release
+      (`rx_seq` remains the per-connection frame stamp / tiebreaker).
     * a `session/prompt` response additionally sends the owner an
       `{:acp_result_seq, tag, rx_seq}` companion (the response frame's
-      `rx_seq`) immediately before `{:acp_result, tag, outcome}`, so the
-      consumer knows the turn boundary and can drain every lower-`rx_seq`
-      update before completing.
+      `rx_seq`) immediately before `{:acp_result, tag, outcome}` — the
+      turn-boundary signal that closes the consumer's settle drain.
 
-  See `Client.prompt/3`/`prompt_stream/4` for the reorder buffer that
-  restores wire order from these stamps and guarantees no same-turn update
-  is dropped.
+  See `Client.prompt/3`/`prompt_stream/4` for the per-session reorder engine
+  that releases each update the instant it is contiguous and guarantees no
+  same-turn update is dropped (falling back to `rx_seq` boundary ordering for
+  an agent that does not stamp `update_seq`).
   """
 
   use GenServer

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/session.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/session.ex
@@ -162,6 +162,7 @@ defmodule Raxol.AgentClientProtocol.Session do
           emitter: module(),
           journal: {module(), term()} | nil,
           turn_seq: non_neg_integer(),
+          update_seq: non_neg_integer(),
           idle_timer: reference() | nil,
           idle_epoch: non_neg_integer(),
           config: %{
@@ -182,6 +183,19 @@ defmodule Raxol.AgentClientProtocol.Session do
             emitter: @default_emitter,
             journal: nil,
             turn_seq: 0,
+            # -- per-session update ordinal (LIVE incremental delivery) --------
+            # Stamped into every emitted `session/update` notification's
+            # `_meta["raxol.io"]["update_seq"]` (the vendor bucket, mirroring the
+            # reattach taint/offset rider convention). Unlike the GLOBAL
+            # per-connection `rx_seq` (a frame counter shared by ALL sessions on a
+            # connection — a numeric gap there is an unrelated frame, not a missing
+            # update), THIS counter is per-Session and RESETS to 0 at each turn
+            # start (`begin_prompt`), so a `session/prompt` consumer always expects
+            # a contiguous `0..N` for the turn it is watching and can release each
+            # update the instant it is contiguous (gap ⇒ wait for the missing one).
+            # The Session mailbox serializes concurrent `post_update` calls, so
+            # parallel/interleaved in-turn updates get a single total order here.
+            update_seq: 0,
             idle_timer: nil,
             idle_epoch: 0,
             config: %{}
@@ -380,7 +394,13 @@ defmodule Raxol.AgentClientProtocol.Session do
           }
 
           # A live turn is never idle — disarm the reaper until the turn drains.
-          state = disarm_idle(%{state | turn: {:prompting, turn}, turn_seq: turn_seq})
+          # Reset the per-session update ordinal so THIS turn's updates are stamped
+          # a contiguous 0..N (the consumer's next-expected index starts at 0). Only
+          # one turn is ever live per Session (the I12 busy row rejects a second
+          # prompt), so turns never overlap and a per-turn reset cannot collide.
+          state =
+            disarm_idle(%{state | turn: {:prompting, turn}, turn_seq: turn_seq, update_seq: 0})
+
           {:reply, :ok, state}
       end
     end
@@ -426,10 +446,20 @@ defmodule Raxol.AgentClientProtocol.Session do
       emit_telemetry([:raxol, :acp, :empty_chunk_rejected], %{session_id: state.session_id})
       {:reply, {:error, :empty_chunk}, state}
     else
+      # Stamp the per-session update ordinal into the OUTGOING notification's
+      # `_meta["raxol.io"]["update_seq"]` BEFORE the emitter seam, so BOTH emitters
+      # (Direct and Journal) carry the identical stamped notification and the
+      # counter is emitter-agnostic. Only NON-rejected updates consume an ordinal
+      # (an empty chunk was rejected above and never gets a seq — so the consumer
+      # sees no phantom gap). `n` is stamped, then the counter advances.
+      n = state.update_seq
+      notification = stamp_update_seq(notification, n)
       # Emit seam (§2.4): Direct forwards to Connection.notify (base behavior);
       # Journal ALSO durably appends the update to the Writer (J10 durability).
       _ = state.emitter.emit(state, notification)
-      {:reply, :ok, put_turn(state, ts, %{t | updates_emitted?: true})}
+
+      {:reply, :ok,
+       put_turn(%{state | update_seq: n + 1}, ts, %{t | updates_emitted?: true})}
     end
   end
 
@@ -781,6 +811,24 @@ defmodule Raxol.AgentClientProtocol.Session do
        do: true
 
   defp empty_chunk?(_other), do: false
+
+  # Stamp the per-session update ordinal into the notification envelope's vendor
+  # `_meta` bucket (`_meta["raxol.io"]["update_seq"]`), mirroring the reattach
+  # rider convention (offset/taint/ts under the same "raxol.io" key). A vanilla
+  # ACP client ignores `_meta`; an offset/seq-aware consumer reads it. Additive:
+  # any other `_meta` keys already on the notification are preserved. An opaque
+  # (non-SessionNotification) test-double notification is passed through unstamped
+  # — the consumer then falls back to arrival-order delivery for it.
+  @vendor_meta_key "raxol.io"
+  @spec stamp_update_seq(term(), non_neg_integer()) :: term()
+  defp stamp_update_seq(%SessionNotification{_meta: meta} = notif, n) do
+    meta = meta || %{}
+    vendor = Map.get(meta, @vendor_meta_key, %{})
+    vendor = Map.put(vendor, "update_seq", n)
+    %{notif | _meta: Map.put(meta, @vendor_meta_key, vendor)}
+  end
+
+  defp stamp_update_seq(other, _n), do: other
 
   @spec render(Turn.outcome()) :: {:ok, PromptResponse.t()} | {:error, Error.t()}
   defp render({:stop, reason}), do: {:ok, PromptResponse.new(reason)}

--- a/packages/raxol_agent_client_protocol/test/client_ergonomics_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_ergonomics_test.exs
@@ -197,7 +197,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
         session_update_frame("sess-timeout", "late")
       )
 
-      refute_receive {:acp_session_update, "sess-timeout", _, _}, 200
+      refute_receive {:acp_session_update, "sess-timeout", _, _, _}, 200
     end
   end
 
@@ -280,11 +280,11 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
       )
 
       assert_receive {:acp_session_update, ^session_id,
-                      {:current_mode_update, %{current_mode_id: "z"}}, _}
+                      {:current_mode_update, %{current_mode_id: "z"}}, _, _}
 
       assert_receive {:second_got,
                       {:acp_session_update, ^session_id,
-                       {:current_mode_update, %{current_mode_id: "z"}}, _}}
+                       {:current_mode_update, %{current_mode_id: "z"}}, _, _}}
     end
 
     test "unsubscribe/3 stops further delivery to that pid" do
@@ -301,7 +301,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
         session_update_frame(session_id, "x")
       )
 
-      refute_receive {:acp_session_update, ^session_id, _, _}, 200
+      refute_receive {:acp_session_update, ^session_id, _, _, _}, 200
     end
   end
 
@@ -344,7 +344,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
 
       # never reaches session_update/2 (and therefore never reaches
       # subscribe/3's broadcast) -- Connection/Router drop it centrally.
-      refute_receive {:acp_session_update, ^session_id, _, _}, 200
+      refute_receive {:acp_session_update, ^session_id, _, _, _}, 200
       assert Process.alive?(conn)
 
       # prove the connection isn't wedged: a well-formed notification right
@@ -356,7 +356,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
       )
 
       assert_receive {:acp_session_update, ^session_id,
-                      {:current_mode_update, %{current_mode_id: "ok"}}, _}
+                      {:current_mode_update, %{current_mode_id: "ok"}}, _, _}
     end
   end
 

--- a/packages/raxol_agent_client_protocol/test/client_ergonomics_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_ergonomics_test.exs
@@ -197,7 +197,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
         session_update_frame("sess-timeout", "late")
       )
 
-      refute_receive {:acp_session_update, "sess-timeout", _}, 200
+      refute_receive {:acp_session_update, "sess-timeout", _, _}, 200
     end
   end
 
@@ -206,7 +206,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
   # ===========================================================================
 
   describe "prompt_stream/4 (callback variant)" do
-    test "invokes on_update synchronously per update with no post-hoc gap, then returns the response" do
+    test "replays every update to on_update in rx_seq order at the turn boundary, then returns the response" do
       %{conn: conn, peer: peer} = start_client_conn(EchoClient)
       :ok = complete_handshake(conn, peer)
 
@@ -233,17 +233,18 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
         session_update_frame("sess-stream", "s1")
       )
 
-      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "s1"}}}
-
       ScriptedPeer.send_notification(
         peer,
         "session/update",
         session_update_frame("sess-stream", "s2")
       )
 
-      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "s2"}}}
-
       ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
+
+      # The reorder buffer replays the whole turn once the result's boundary
+      # is known -- in rx_seq (wire) order, none dropped.
+      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "s1"}}}
+      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "s2"}}}
 
       assert {:ok, response} = Task.await(caller)
       assert response.stop_reason == :end_turn
@@ -279,11 +280,11 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
       )
 
       assert_receive {:acp_session_update, ^session_id,
-                      {:current_mode_update, %{current_mode_id: "z"}}}
+                      {:current_mode_update, %{current_mode_id: "z"}}, _}
 
       assert_receive {:second_got,
                       {:acp_session_update, ^session_id,
-                       {:current_mode_update, %{current_mode_id: "z"}}}}
+                       {:current_mode_update, %{current_mode_id: "z"}}, _}}
     end
 
     test "unsubscribe/3 stops further delivery to that pid" do
@@ -300,7 +301,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
         session_update_frame(session_id, "x")
       )
 
-      refute_receive {:acp_session_update, ^session_id, _}, 200
+      refute_receive {:acp_session_update, ^session_id, _, _}, 200
     end
   end
 
@@ -343,7 +344,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
 
       # never reaches session_update/2 (and therefore never reaches
       # subscribe/3's broadcast) -- Connection/Router drop it centrally.
-      refute_receive {:acp_session_update, ^session_id, _}, 200
+      refute_receive {:acp_session_update, ^session_id, _, _}, 200
       assert Process.alive?(conn)
 
       # prove the connection isn't wedged: a well-formed notification right
@@ -355,7 +356,7 @@ defmodule Raxol.AgentClientProtocol.ClientErgonomicsTest do
       )
 
       assert_receive {:acp_session_update, ^session_id,
-                      {:current_mode_update, %{current_mode_id: "ok"}}}
+                      {:current_mode_update, %{current_mode_id: "ok"}}, _}
     end
   end
 

--- a/packages/raxol_agent_client_protocol/test/client_session_update_delivery_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_session_update_delivery_test.exs
@@ -1,0 +1,194 @@
+# Regression test for a real shipped concurrency bug: `session/update`
+# notifications could be DROPPED (silently) and REORDERED relative to a
+# prompt turn's terminal `session/prompt` result, from the perspective of
+# `Client.prompt_stream/4` (and, by the same mechanism, `Client.prompt/3`).
+#
+# Mechanism (pre-fix): every inbound notification -- including
+# `session/update` -- was dispatched to its OWN
+# `Task.Supervisor.async_nolink` task (`Connection.dispatch_inbound_notification/2`).
+# The generated default `session_update/2` forwards the decoded update via
+# `send/2` FROM that per-notification task process
+# (`Client.broadcast_update/3`). Meanwhile the turn's terminal
+# `session/prompt` RESULT is delivered directly by the `Connection` process
+# itself (`Connection.deliver_outcome/2`). Three different sender
+# processes (Connection, and a fresh Task per notification) means BEAM
+# gives NO cross-sender mailbox-ordering guarantee to the subscriber: the
+# terminal result can land in the subscriber's mailbox before a same-turn
+# update that is still in flight. `prompt_stream/4`'s receive loop exits as
+# soon as it sees the terminal result, so any update that arrives after is
+# never read by anyone -- silently lost, not merely delayed.
+#
+# This file constructs that exact interleaving deterministically (no
+# `Process.sleep`, no timing race to CREATE the condition -- only a bounded
+# `Task.yield/2` used to let the SUT's own independent, already-in-flight
+# response-delivery settle before we release a held notification handler;
+# see the big comment in the test body for why that specific wait is sound
+# and not "timing-tight").
+defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Raxol.AgentClientProtocol.Client
+  alias Raxol.AgentClientProtocol.Connection
+  alias Raxol.AgentClientProtocol.Test.ScriptedPeer
+  alias Raxol.AgentClientProtocol.Transport.Paired
+
+  alias Raxol.AgentClientProtocol.Schema.AgentTypes.{InitializeRequest, PromptRequest}
+  alias Raxol.AgentClientProtocol.Schema.ClientTypes.ClientCapabilities
+  alias Raxol.AgentClientProtocol.Schema.ContentBlock
+
+  # ===========================================================================
+  # Fixture: a client whose `session_update/2` PAUSES mid-dispatch until
+  # explicitly released. This lets the test control exactly when the
+  # forwarding `send/2` to a `subscribe/3` subscriber happens, so the
+  # interleaving from the bug report -- "deliver the prompt result while an
+  # update is still pending" -- is constructed on purpose rather than hoped
+  # for.
+  # ===========================================================================
+
+  defmodule BlockableUpdateClient do
+    @moduledoc false
+    use Raxol.AgentClientProtocol.Client
+
+    @impl true
+    def session_update(notification, ctx) do
+      ref = make_ref()
+      send(ctx.handler_state, {:session_update_ready, self(), ref})
+
+      receive do
+        {^ref, :go} -> :ok
+      end
+
+      Raxol.AgentClientProtocol.Client.broadcast_update(
+        ctx.conn,
+        notification.session_id,
+        notification.update
+      )
+    end
+  end
+
+  # ===========================================================================
+  # Helpers -- same technique as `client_ergonomics_test.exs`'s own
+  # `start_client_conn/1` / `complete_handshake/1` (deliberately
+  # reimplemented locally rather than shared, to keep this file
+  # self-contained and avoid touching a file another lane owns).
+  # ===========================================================================
+
+  defp start_client_conn(handler, handler_arg) do
+    task_sup = start_supervised!({Task.Supervisor, []})
+    {conn_handle, peer} = ScriptedPeer.new()
+
+    conn =
+      start_supervised!(
+        {Connection,
+         [
+           role: :client,
+           transport: {Paired, conn_handle},
+           handler: handler,
+           handler_arg: handler_arg,
+           task_sup: task_sup
+         ]}
+      )
+
+    %{conn: conn, peer: peer}
+  end
+
+  defp complete_handshake(conn, peer, client_caps \\ ClientCapabilities.new()) do
+    init_request = %{InitializeRequest.new(1) | client_capabilities: client_caps}
+    task = Task.async(fn -> Connection.request(conn, "initialize", init_request, 2_000) end)
+
+    frame = ScriptedPeer.recv(peer)
+    assert frame["method"] == "initialize"
+    ScriptedPeer.send_result(peer, frame["id"], %{"protocolVersion" => 1})
+    assert {:ok, _init_resp} = Task.await(task)
+    :ok
+  end
+
+  defp session_update_frame(session_id, mode_id) do
+    %{
+      "sessionId" => session_id,
+      "update" => %{"sessionUpdate" => "current_mode_update", "currentModeId" => mode_id}
+    }
+  end
+
+  # ===========================================================================
+  # The red-first witness.
+  # ===========================================================================
+
+  describe "session/update delivery vs. the turn's terminal result (single-sender ordering)" do
+    test "an update pending at the moment the terminal result is delivered is neither lost nor reordered" do
+      test_pid = self()
+      %{conn: conn, peer: peer} = start_client_conn(BlockableUpdateClient, test_pid)
+      :ok = complete_handshake(conn, peer)
+
+      session_id = "sess-race"
+      request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
+
+      caller =
+        Task.async(fn ->
+          Client.prompt_stream(
+            conn,
+            request,
+            fn update -> send(test_pid, {:streamed, update}) end,
+            2_000
+          )
+        end)
+
+      frame = ScriptedPeer.recv(peer)
+      assert frame["method"] == "session/prompt"
+      id = frame["id"]
+
+      # 1. Send the update. Its dispatch (Task pre-fix, the Connection
+      #    process itself post-fix) starts running and immediately parks,
+      #    proven by the synchronous ready-ping below -- so we know FOR
+      #    CERTAIN the forwarding `send/2` to the `prompt_stream/4`
+      #    subscriber has NOT happened yet.
+      ScriptedPeer.send_notification(
+        peer,
+        "session/update",
+        session_update_frame(session_id, "will-be-lost")
+      )
+
+      assert_receive {:session_update_ready, handler_pid, ref}, 500
+
+      # 2. Deliver the turn's terminal result while that update is still
+      #    held open -- exactly the interleaving the bug report describes.
+      ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
+
+      # 3. Give the SUT's OWN, already-in-flight response-delivery path a
+      #    generous, bounded window to settle BEFORE we release the held
+      #    notification handler. This does not race to construct the bug --
+      #    it only matters for the PRE-FIX code, where response delivery is
+      #    entirely independent of the still-parked notification task and
+      #    completes near-instantly (no I/O, pure local message passing);
+      #    300ms is enormous headroom for that. For the FIXED code this
+      #    `Task.yield/2` is not a race at all: the Connection process is
+      #    provably still blocked inside the synchronous update dispatch
+      #    (it cannot have processed the response frame yet, by
+      #    construction), so `Task.yield/2` deterministically returns `nil`
+      #    here every time, fix or no fix.
+      already_done = Task.yield(caller, 300)
+
+      # 4. Only now release the held handler.
+      send(handler_pid, {ref, :go})
+
+      result =
+        case already_done do
+          {:ok, outcome} -> outcome
+          nil -> Task.await(caller, 1_000)
+        end
+
+      # The update must have reached `on_update` -- pre-fix, `already_done`
+      # is `{:ok, _}` here (the terminal result won the race independently
+      # of the gate), the streaming task's receive loop already returned
+      # before the update was ever forwarded, and this never arrives:
+      # `prompt_stream/4` silently dropped a same-turn update.
+      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "will-be-lost"}}},
+                      1_000
+
+      assert {:ok, response} = result
+      assert response.stop_reason == :end_turn
+    end
+  end
+end

--- a/packages/raxol_agent_client_protocol/test/client_session_update_delivery_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_session_update_delivery_test.exs
@@ -1,41 +1,33 @@
-# Regression + design tests for `session/update` delivery to
-# `Client.prompt/3` / `prompt_stream/4`.
+# LIVE incremental in-order `session/update` delivery, keyed on the agent's
+# PER-SESSION `update_seq` (`_meta["raxol.io"]["update_seq"]`, reset to 0 each
+# turn -- see `Raxol.AgentClientProtocol.Session`).
 #
-# The shipped bug: every inbound notification -- `session/update` included --
-# is dispatched to its OWN `Task.Supervisor.async_nolink` task
-# (`Connection.dispatch_inbound_notification/3`), and the generated default
-# `session_update/2` forwards the decoded update via `send/2` FROM that
-# per-notification task (`Client.broadcast_update/4`). Meanwhile the turn's
-# terminal `session/prompt` RESULT is delivered directly by the `Connection`
-# process itself (`Connection.deliver_outcome/2`). Different sender processes
-# means BEAM gives NO cross-sender mailbox-ordering guarantee to the
-# subscriber: the terminal result can land before a same-turn update still in
-# flight, AND two updates dispatched by two tasks can land out of wire order.
+# The design: every inbound notification is dispatched on its OWN
+# `Task.Supervisor.async_nolink` task (`Connection.dispatch_inbound_notification/3`),
+# and the terminal `session/prompt` RESULT is delivered directly by the
+# `Connection` process. Different sender processes ⇒ BEAM gives NO cross-sender
+# mailbox order: same-turn updates can land out of order and can even race the
+# result. The GLOBAL per-connection `rx_seq` orders frames but cannot tell a
+# consumer WHEN a turn's set is complete (a numeric gap is an unrelated frame,
+# not a missing update), so the prior fix could only reorder + emit at the TURN
+# BOUNDARY, losing live streaming.
 #
-# The fix keeps delivery non-blocking/concurrent (so a slow handler never
-# head-of-line-blocks the Connection and parallel/interleaved update streams
-# flow) and makes the CLIENT the consolidation point: every delivery carries
-# the inbound frame's monotone `rx_seq`, the terminal result additionally
-# carries its own frame `rx_seq` (`{:acp_result_seq, tag, rx_seq}`), and
-# `prompt/3`/`prompt_stream/4` buffer updates by `rx_seq`, drain every
-# same-turn update below the result's seq (bounded settle window), and
-# release them in restored wire order.
+# The fix stamps a PER-SESSION `update_seq` (contiguous `0..N` within a turn).
+# The consumer tracks a next-expected ordinal and RELEASES each update the
+# instant it is contiguous (LIVE), buffering out-of-order ones and holding a gap
+# until the missing lower ordinal lands. `prompt_stream/4` calls `on_update`
+# live; `prompt/3` accumulates in order. When the agent does NOT stamp
+# `update_seq`, the consumer falls back to buffering by `rx_seq` and releasing in
+# `rx_seq` order at the turn boundary (deterministic, no-drop, non-blocking, but
+# not incremental).
 #
-# These three tests witness: (a) an update pending when the result lands is
-# not dropped; (b) updates delivered out of `rx_seq` order are collected in
-# `rx_seq` order; (c) two interleaved update streams (distinct `rx_seq`s,
-# scrambled arrival) are all delivered, in `rx_seq` order, none dropped.
-#
-# Determinism (no `Process.sleep`, no timing race to CREATE the condition):
-# a fixture whose `session_update/2` PARKS mid-dispatch until explicitly
-# released lets each test place the forwarding `send/2` exactly where it
-# wants relative to the result and to the other updates. (b)/(c) release all
-# updates BEFORE delivering the result, so every update is queued before the
-# result frame -- order is decided purely by the buffer's sort, with zero
-# window dependence. (a) is the one case that RELEASES AFTER the result, and
-# relies only on the update landing within the bounded settle window -- an
-# ETS-lookup + `send` after an explicit release, orders of magnitude inside
-# the window.
+# Determinism (no `Process.sleep`, no wall-clock): the reorder engine RELEASES
+# ONLY in contiguous `update_seq` order, so the emission order is a structural
+# invariant, independent of the order the concurrent dispatch tasks happen to
+# deliver in. A fixture whose `session_update/2` PARKS mid-dispatch until
+# explicitly released lets each test place the forwarding `send/2` where it wants
+# relative to the others; the assertions read the EMISSION order (single-sender
+# per turn), which the contiguous-release rule pins deterministically.
 defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
   use ExUnit.Case, async: false
 
@@ -43,20 +35,142 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
 
   alias Raxol.AgentClientProtocol.Client
   alias Raxol.AgentClientProtocol.Connection
+  alias Raxol.AgentClientProtocol.Session
+  alias Raxol.AgentClientProtocol.Session.Emitter
+  alias Raxol.AgentClientProtocol.Session.Supervisor, as: SessionSup
+  alias Raxol.AgentClientProtocol.Test.FakeConnection
   alias Raxol.AgentClientProtocol.Test.ScriptedPeer
   alias Raxol.AgentClientProtocol.Transport.Paired
 
   alias Raxol.AgentClientProtocol.Schema.AgentTypes.{InitializeRequest, PromptRequest}
   alias Raxol.AgentClientProtocol.Schema.ClientTypes.ClientCapabilities
   alias Raxol.AgentClientProtocol.Schema.ContentBlock
+  alias Raxol.AgentClientProtocol.Schema.CurrentModeUpdate
+  alias Raxol.AgentClientProtocol.Schema.LifecycleExtras.SessionNotification
 
   # ===========================================================================
-  # Fixture: a client whose `session_update/2` announces itself (with the
-  # update payload and its `ctx.rx_seq`) then PARKS until explicitly released.
-  # The test releases handlers in whatever order it wants, so the mailbox
-  # interleaving each scenario needs is constructed on purpose rather than
-  # hoped for. On release it forwards via `broadcast_update/4`, carrying the
-  # real `ctx.rx_seq` (the reorder key).
+  # PRODUCER-REAL: drive a real Session emit and assert the OUTGOING wire
+  # notification carries an incrementing per-session `_meta["raxol.io"]
+  # ["update_seq"]` (0,1,2). This is NOT a hand-built notification -- the
+  # Session state machine stamps it in `post_update`, before the emitter seam.
+  # ===========================================================================
+
+  describe "agent-side: the Session stamps a per-session update_seq on every emitted session/update" do
+    setup do
+      start_supervised!(SessionSup.registry_child_spec())
+      task_sup = start_supervised!({Task.Supervisor, []})
+      {:ok, task_sup: task_sup}
+    end
+
+    test "outgoing notifications carry _meta[\"raxol.io\"][\"update_seq\"] = 0,1,2, in emit order",
+         %{task_sup: task_sup} do
+      conn = start_supervised!({FakeConnection, []}, id: {:conn, make_ref()})
+      sid = "sess-producer"
+
+      # A real turn runner that emits three real session/update notifications
+      # through Session.post_update, then ends the turn.
+      runner = fn session_pid, _req ->
+        for n <- 1..3 do
+          notif =
+            SessionNotification.new(sid, {:current_mode_update, CurrentModeUpdate.new("mode-#{n}")})
+
+          :ok = Session.post_update(session_pid, notif)
+        end
+
+        {:stop, :end_turn}
+      end
+
+      session =
+        start_supervised!(%{
+          id: {:sess, make_ref()},
+          restart: :temporary,
+          start:
+            {Session, :start_link,
+             [
+               [
+                 session_id: sid,
+                 conn: conn,
+                 conn_mod: FakeConnection,
+                 task_sup: task_sup,
+                 turn_runner: runner,
+                 emitter: Emitter.Direct,
+                 config: %{cancel_backstop_ms: 50}
+               ]
+             ]}
+        })
+
+      reply_ref = make_ref()
+      :ok = Session.begin_prompt(session, :prompt_req, reply_ref, 1)
+
+      # Wait for the turn to resolve (its single reply lands after the 3 notifies).
+      wait_until(fn -> FakeConnection.count(conn, :reply) >= 1 end)
+
+      seqs =
+        conn
+        |> FakeConnection.entries(:notify)
+        |> Enum.map(fn {:notify, "session/update", %SessionNotification{} = n} ->
+          get_in(n._meta, ["raxol.io", "update_seq"])
+        end)
+
+      assert seqs == [0, 1, 2]
+    end
+
+    test "a second turn RESETS the per-session update_seq back to 0 (each turn is a fresh 0..N)",
+         %{task_sup: task_sup} do
+      conn = start_supervised!({FakeConnection, []}, id: {:conn, make_ref()})
+      sid = "sess-producer-reset"
+
+      one_update = fn session_pid, _req ->
+        notif =
+          SessionNotification.new(sid, {:current_mode_update, CurrentModeUpdate.new("only")})
+
+        :ok = Session.post_update(session_pid, notif)
+        {:stop, :end_turn}
+      end
+
+      session =
+        start_supervised!(%{
+          id: {:sess, make_ref()},
+          restart: :temporary,
+          start:
+            {Session, :start_link,
+             [
+               [
+                 session_id: sid,
+                 conn: conn,
+                 conn_mod: FakeConnection,
+                 task_sup: task_sup,
+                 turn_runner: one_update,
+                 emitter: Emitter.Direct,
+                 config: %{cancel_backstop_ms: 50}
+               ]
+             ]}
+        })
+
+      # Turn 1.
+      :ok = Session.begin_prompt(session, :prompt_req, make_ref(), 1)
+      wait_until(fn -> FakeConnection.count(conn, :reply) >= 1 end)
+      # Turn 2 (same Session process).
+      :ok = Session.begin_prompt(session, :prompt_req, make_ref(), 2)
+      wait_until(fn -> FakeConnection.count(conn, :reply) >= 2 end)
+
+      seqs =
+        conn
+        |> FakeConnection.entries(:notify)
+        |> Enum.map(fn {:notify, "session/update", %SessionNotification{} = n} ->
+          get_in(n._meta, ["raxol.io", "update_seq"])
+        end)
+
+      # Both turns' single update is stamped 0 -- the counter reset per turn.
+      assert seqs == [0, 0]
+    end
+  end
+
+  # ===========================================================================
+  # CONSUMER fixture: a client whose `session_update/2` announces itself (with
+  # the update payload, its `ctx.rx_seq`, and the extracted per-session
+  # `update_seq`) then PARKS until explicitly released. On release it forwards
+  # via `broadcast_update/5`, carrying the real `update_seq` (the reorder key).
   # ===========================================================================
 
   defmodule GatedUpdateClient do
@@ -66,7 +180,12 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
     @impl true
     def session_update(notification, ctx) do
       ref = make_ref()
-      send(ctx.handler_state, {:update_gate, self(), ref, notification.update, ctx.rx_seq})
+      update_seq = Raxol.AgentClientProtocol.Client.extract_update_seq(notification)
+
+      send(
+        ctx.handler_state,
+        {:update_gate, self(), ref, notification.update, ctx.rx_seq, update_seq}
+      )
 
       receive do
         {^ref, :go} -> :ok
@@ -76,20 +195,18 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
         ctx.conn,
         notification.session_id,
         notification.update,
-        ctx.rx_seq
+        ctx.rx_seq,
+        update_seq
       )
     end
   end
 
   # ===========================================================================
-  # Helpers -- same technique as `client_ergonomics_test.exs`'s own
-  # `start_client_conn/1` / `complete_handshake/1` (deliberately
-  # reimplemented locally rather than shared, to keep this file
-  # self-contained and avoid touching a file another lane owns).
+  # Helpers (reimplemented locally to keep this file self-contained).
   # ===========================================================================
 
   defp start_client_conn(handler, handler_arg) do
-    task_sup = start_supervised!({Task.Supervisor, []})
+    task_sup = start_supervised!({Task.Supervisor, []}, id: {:tsup, make_ref()})
     {conn_handle, peer} = ScriptedPeer.new()
 
     conn =
@@ -101,7 +218,8 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
            handler: handler,
            handler_arg: handler_arg,
            task_sup: task_sup
-         ]}
+         ]},
+        id: {:conn, make_ref()}
       )
 
     %{conn: conn, peer: peer}
@@ -118,46 +236,60 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
     :ok
   end
 
-  defp send_update(peer, session_id, mode_id) do
-    ScriptedPeer.send_notification(peer, "session/update", %{
+  # Send a `session/update` frame carrying `update_seq` in the vendor `_meta`
+  # bucket (nil ⇒ no `_meta` stamp, exercising the graceful fallback).
+  defp send_update(peer, session_id, mode_id, update_seq) do
+    base = %{
       "sessionId" => session_id,
       "update" => %{"sessionUpdate" => "current_mode_update", "currentModeId" => mode_id}
-    })
+    }
+
+    frame =
+      case update_seq do
+        nil -> base
+        n -> Map.put(base, "_meta", %{"raxol.io" => %{"update_seq" => n}})
+      end
+
+    ScriptedPeer.send_notification(peer, "session/update", frame)
   end
 
-  # Block for the parked handler's announcement, returning `{pid, ref, seq}`
-  # for the update whose mode id is `mode_id`. Handlers announce as soon as
-  # their dispatch task runs; matching on the payload lets a test wait for a
-  # SPECIFIC update regardless of the order the tasks happened to start in.
+  # Block for the parked handler's announcement for the update whose mode id is
+  # `mode_id`, returning `{pid, ref}`. Matching on the payload lets a test wait
+  # for a SPECIFIC update regardless of dispatch-task start order.
   defp await_gate(mode_id) do
     assert_receive {:update_gate, pid, ref,
-                    {:current_mode_update, %{current_mode_id: ^mode_id}}, seq},
+                    {:current_mode_update, %{current_mode_id: ^mode_id}}, _rx_seq, _useq},
                    1_000
 
-    {pid, ref, seq}
+    {pid, ref}
   end
 
-  defp release({pid, ref, _seq}), do: send(pid, {ref, :go})
+  defp release({pid, ref}), do: send(pid, {ref, :go})
 
-  defp mode_ids(updates) do
-    Enum.map(updates, fn {:current_mode_update, %{current_mode_id: mid}} -> mid end)
+  defp mode_id({:current_mode_update, %{current_mode_id: mid}}), do: mid
+
+  defp recv_streamed(tag, count) do
+    for _ <- 1..count do
+      assert_receive {^tag, update}, 1_000
+      mode_id(update)
+    end
   end
 
   # ===========================================================================
-  # (a) drop witness: a result delivered while an update is still pending must
-  #     NOT lose that update. Against a naive consumer that exits on the
-  #     result without draining, the released update lands after the loop has
-  #     already returned and is silently dropped; the reorder buffer's bounded
-  #     drain absorbs it.
+  # (a) LIVE incremental in-order: updates stamped 0..N delivered OUT of order
+  #     to prompt_stream/4 ⇒ on_update fires in 0..N order, each released the
+  #     instant it is contiguous -- and BEFORE the turn result (the live
+  #     witness). Against an arrival-order/no-seq consumer, releasing reverse
+  #     would fire N..0.
   # ===========================================================================
 
-  describe "an update pending when the terminal result arrives" do
-    test "is drained, not dropped, and still reaches the consumer" do
+  describe "(a) live incremental in-order delivery to prompt_stream/4" do
+    test "on_update fires in update_seq order, released live before the turn result" do
       test_pid = self()
       %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
       :ok = complete_handshake(conn, peer)
 
-      session_id = "sess-drop"
+      session_id = "sess-live"
       request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
 
       caller =
@@ -174,91 +306,44 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
       assert frame["method"] == "session/prompt"
       id = frame["id"]
 
-      # Update dispatched; its handler parks (proven by the gate ping), so the
-      # forwarding send has NOT happened yet.
-      send_update(peer, session_id, "will-be-lost")
-      gate = await_gate("will-be-lost")
+      # Stamp 0,1,2; park all three.
+      send_update(peer, session_id, "u0", 0)
+      send_update(peer, session_id, "u1", 1)
+      send_update(peer, session_id, "u2", 2)
+      g0 = await_gate("u0")
+      g1 = await_gate("u1")
+      g2 = await_gate("u2")
 
-      # Deliver the terminal result while that update is still held -- the
-      # exact interleaving the bug describes.
+      # Release REVERSE: 2 and 1 buffer (held, out of order); 0 releases and
+      # cascade-releases 1 then 2 -- contiguous order regardless of arrival.
+      release(g2)
+      release(g1)
+      release(g0)
+
+      # LIVE: all three emitted, in ascending update_seq order, BEFORE the
+      # result frame is even sent.
+      assert recv_streamed(:streamed, 3) == ["u0", "u1", "u2"]
+
       ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
-
-      # Barrier (not a timing hack): the Connection processes its mailbox in
-      # order, so once this synchronous `:sys.get_state/1` returns, the
-      # Connection has finished handling the result frame -- meaning it has
-      # ALREADY sent the `{:acp_result_seq, ...}` + `{:acp_result, ...}` into
-      # the consumer's mailbox. Only THEN do we release the held update, so
-      # the forwarded update is queued strictly AFTER the terminal result.
-      # A naive consumer that exits on the result drops it; the reorder
-      # buffer's drain finds it already queued and delivers it. Deterministic
-      # for both, with zero dependence on the settle window's length.
-      :sys.get_state(conn)
-      release(gate)
-
-      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "will-be-lost"}}},
-                     1_000
-
       assert {:ok, response} = Task.await(caller, 1_000)
       assert response.stop_reason == :end_turn
     end
   end
 
   # ===========================================================================
-  # (b) reorder: two updates delivered to the consumer OUT of `rx_seq` order
-  #     (later-seq released first) must be collected in `rx_seq` order.
+  # (b) gap-wait: seq 0 then 2 arrive with 1 still missing ⇒ 2 is HELD (never
+  #     emitted ahead of 1); once 1 arrives, 1 then 2 release. Proven by the
+  #     emission order [u0, u1, u2]: a consumer that didn't hold 2 would emit
+  #     [u0, u2, u1] (2 released on arrival, before 1).
   # ===========================================================================
 
-  describe "updates delivered out of rx_seq order" do
-    test "are collected by prompt/3 in rx_seq (wire) order, none lost" do
+  describe "(b) a gap holds the higher ordinal until the missing one arrives" do
+    test "seq 2 is held while 1 is missing, then 1,2 release in order" do
       test_pid = self()
       %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
       :ok = complete_handshake(conn, peer)
 
-      session_id = "sess-reorder"
-      request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
-      caller = Task.async(fn -> Client.prompt(conn, request, 2_000) end)
-
-      frame = ScriptedPeer.recv(peer)
-      assert frame["method"] == "session/prompt"
-      id = frame["id"]
-
-      # "a" is sent (and framed) first, so it has the LOWER rx_seq; "b" second,
-      # higher. Both park.
-      send_update(peer, session_id, "a")
-      send_update(peer, session_id, "b")
-      gate_a = await_gate("a")
-      gate_b = await_gate("b")
-      assert elem(gate_a, 2) < elem(gate_b, 2)
-
-      # Release the HIGHER-seq update first, so it reaches the consumer's
-      # mailbox before the lower one -- wire order reversed on arrival. Both
-      # land before the result, so ordering is decided purely by the buffer.
-      release(gate_b)
-      release(gate_a)
-
-      ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
-
-      assert {:ok, {updates, response}} = Task.await(caller, 1_000)
-      assert response.stop_reason == :end_turn
-      # Restored to rx_seq order despite reversed arrival.
-      assert mode_ids(updates) == ["a", "b"]
-    end
-  end
-
-  # ===========================================================================
-  # (c) parallel/interleaved: two logical update streams interleaved on the
-  #     wire (distinct rx_seqs), delivered to the consumer in a scrambled
-  #     order, must ALL arrive at prompt_stream/4's callback, in rx_seq order,
-  #     none dropped. This is the parallel-tool-call case the design targets.
-  # ===========================================================================
-
-  describe "two interleaved update streams with distinct rx_seqs" do
-    test "are all delivered to prompt_stream/4 in rx_seq order, none dropped" do
-      test_pid = self()
-      %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
-      :ok = complete_handshake(conn, peer)
-
-      session_id = "sess-interleave"
+      session_id = "sess-gap"
       request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
 
       caller =
@@ -275,37 +360,160 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
       assert frame["method"] == "session/prompt"
       id = frame["id"]
 
-      # Stream A = a1,a2 ; stream B = b1,b2. Interleaved on the wire so the
-      # rx_seq (frame) order is a1 < b1 < a2 < b2.
-      send_update(peer, session_id, "a1")
-      send_update(peer, session_id, "b1")
-      send_update(peer, session_id, "a2")
-      send_update(peer, session_id, "b2")
+      # seq 0 arrives and releases live.
+      send_update(peer, session_id, "u0", 0)
+      release(await_gate("u0"))
+      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "u0"}}}, 1_000
 
-      gates = Map.new(~w(a1 b1 a2 b2), fn mid -> {mid, await_gate(mid)} end)
+      # seq 2 arrives with 1 STILL MISSING -> buffered (held).
+      send_update(peer, session_id, "u2", 2)
+      release(await_gate("u2"))
 
-      # Release in a scrambled order (concurrent tasks landing every which
-      # way). All land before the result, so none can be dropped and order is
-      # entirely the buffer's job.
-      for mid <- ~w(b2 a2 b1 a1), do: release(gates[mid])
+      # The missing seq 1 finally arrives -> releases 1, then cascade-releases 2.
+      send_update(peer, session_id, "u1", 1)
+      release(await_gate("u1"))
+
+      # Emission order proves 2 was held until 1: contiguous release can never
+      # emit 2 before 1.
+      assert recv_streamed(:streamed, 2) == ["u1", "u2"]
+
+      ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
+      assert {:ok, response} = Task.await(caller, 1_000)
+      assert response.stop_reason == :end_turn
+    end
+  end
+
+  # ===========================================================================
+  # (c) parallel-interleaved TWO sessions: each session's stream has its OWN
+  #     per-session update_seq domain (0,1). Interleaved on the wire and
+  #     released scrambled, each session's updates reach ITS OWN consumer in ITS
+  #     OWN order, none dropped or crossed between sessions.
+  # ===========================================================================
+
+  describe "(c) two sessions' interleaved streams stay in their own per-session order" do
+    test "each prompt_stream releases its session's updates 0,1 in order, none crossed" do
+      test_pid = self()
+      %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
+      :ok = complete_handshake(conn, peer)
+
+      sid_a = "sess-a"
+      sid_b = "sess-b"
+      req_a = PromptRequest.new(sid_a, [ContentBlock.from_string("a")])
+      req_b = PromptRequest.new(sid_b, [ContentBlock.from_string("b")])
+
+      caller_a =
+        Task.async(fn ->
+          Client.prompt_stream(conn, req_a, fn u -> send(test_pid, {:a, u}) end, 2_000)
+        end)
+
+      caller_b =
+        Task.async(fn ->
+          Client.prompt_stream(conn, req_b, fn u -> send(test_pid, {:b, u}) end, 2_000)
+        end)
+
+      frame1 = ScriptedPeer.recv(peer)
+      frame2 = ScriptedPeer.recv(peer)
+      assert frame1["method"] == "session/prompt"
+      assert frame2["method"] == "session/prompt"
+
+      ids = %{frame1["params"]["sessionId"] => frame1["id"], frame2["params"]["sessionId"] => frame2["id"]}
+
+      # Interleave on the wire; each session carries its OWN 0,1 ordinal.
+      send_update(peer, sid_a, "a0", 0)
+      send_update(peer, sid_b, "b0", 0)
+      send_update(peer, sid_a, "a1", 1)
+      send_update(peer, sid_b, "b1", 1)
+
+      gates =
+        Map.new(~w(a0 b0 a1 b1), fn mid -> {mid, await_gate(mid)} end)
+
+      # Release scrambled -- contiguous release still pins each session's order.
+      for mid <- ~w(b1 a1 b0 a0), do: release(gates[mid])
+
+      # Within each session tag (single sender), messages arrive in emission
+      # order, which must be the per-session update_seq order.
+      assert recv_streamed(:a, 2) == ["a0", "a1"]
+      assert recv_streamed(:b, 2) == ["b0", "b1"]
+      refute_receive {:a, _}, 100
+      refute_receive {:b, _}, 100
+
+      ScriptedPeer.send_result(peer, ids[sid_a], %{"stopReason" => "end_turn"})
+      ScriptedPeer.send_result(peer, ids[sid_b], %{"stopReason" => "end_turn"})
+      assert {:ok, %{stop_reason: :end_turn}} = Task.await(caller_a, 1_000)
+      assert {:ok, %{stop_reason: :end_turn}} = Task.await(caller_b, 1_000)
+    end
+  end
+
+  # ===========================================================================
+  # (d) graceful fallback: updates with NO update_seq in `_meta` are delivered
+  #     (not blocked waiting for an ordinal that will never come). Against a
+  #     consumer that REQUIRED update_seq and blocked on its absence, on_update
+  #     would never fire and the turn would time out.
+  # ===========================================================================
+
+  describe "(d) graceful fallback when the agent does not stamp update_seq" do
+    test "unstamped updates are all delivered (in rx_seq order), never blocked" do
+      test_pid = self()
+      %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
+      :ok = complete_handshake(conn, peer)
+
+      session_id = "sess-fallback"
+      request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
+
+      caller =
+        Task.async(fn ->
+          Client.prompt_stream(
+            conn,
+            request,
+            fn update -> send(test_pid, {:streamed, update}) end,
+            2_000
+          )
+        end)
+
+      frame = ScriptedPeer.recv(peer)
+      assert frame["method"] == "session/prompt"
+      id = frame["id"]
+
+      # No update_seq (nil) on either -- the graceful-fallback path.
+      send_update(peer, session_id, "f0", nil)
+      send_update(peer, session_id, "f1", nil)
+      gate0 = await_gate("f0")
+      gate1 = await_gate("f1")
+
+      # `f0` is framed first (lower rx_seq); release `f1` first to prove the
+      # fallback restores rx_seq order rather than raw arrival order.
+      release(gate1)
+      release(gate0)
 
       ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
 
-      # `on_update` is invoked from a single sender (the caller task), so the
-      # `{:streamed, _}` messages land in emission order. Receiving four with
-      # an UNPINNED pattern therefore reads them in the exact order they were
-      # emitted -- which must be restored rx_seq (wire) order, none dropped.
-      emitted =
-        for _ <- 1..4 do
-          assert_receive {:streamed, update}, 1_000
-          update
-        end
-
-      assert mode_ids(emitted) == ["a1", "b1", "a2", "b2"]
+      # Both delivered (not blocked), in rx_seq (wire) order.
+      assert recv_streamed(:streamed, 2) == ["f0", "f1"]
       refute_receive {:streamed, _}, 100
 
       assert {:ok, response} = Task.await(caller, 1_000)
       assert response.stop_reason == :end_turn
+    end
+  end
+
+  # -- shared -----------------------------------------------------------------
+
+  defp wait_until(fun, timeout \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) > deadline ->
+        flunk("wait_until timed out")
+
+      true ->
+        Process.sleep(5)
+        do_wait_until(fun, deadline)
     end
   end
 end

--- a/packages/raxol_agent_client_protocol/test/client_session_update_delivery_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_session_update_delivery_test.exs
@@ -1,29 +1,41 @@
-# Regression test for a real shipped concurrency bug: `session/update`
-# notifications could be DROPPED (silently) and REORDERED relative to a
-# prompt turn's terminal `session/prompt` result, from the perspective of
-# `Client.prompt_stream/4` (and, by the same mechanism, `Client.prompt/3`).
+# Regression + design tests for `session/update` delivery to
+# `Client.prompt/3` / `prompt_stream/4`.
 #
-# Mechanism (pre-fix): every inbound notification -- including
-# `session/update` -- was dispatched to its OWN
-# `Task.Supervisor.async_nolink` task (`Connection.dispatch_inbound_notification/2`).
-# The generated default `session_update/2` forwards the decoded update via
-# `send/2` FROM that per-notification task process
-# (`Client.broadcast_update/3`). Meanwhile the turn's terminal
-# `session/prompt` RESULT is delivered directly by the `Connection` process
-# itself (`Connection.deliver_outcome/2`). Three different sender
-# processes (Connection, and a fresh Task per notification) means BEAM
-# gives NO cross-sender mailbox-ordering guarantee to the subscriber: the
-# terminal result can land in the subscriber's mailbox before a same-turn
-# update that is still in flight. `prompt_stream/4`'s receive loop exits as
-# soon as it sees the terminal result, so any update that arrives after is
-# never read by anyone -- silently lost, not merely delayed.
+# The shipped bug: every inbound notification -- `session/update` included --
+# is dispatched to its OWN `Task.Supervisor.async_nolink` task
+# (`Connection.dispatch_inbound_notification/3`), and the generated default
+# `session_update/2` forwards the decoded update via `send/2` FROM that
+# per-notification task (`Client.broadcast_update/4`). Meanwhile the turn's
+# terminal `session/prompt` RESULT is delivered directly by the `Connection`
+# process itself (`Connection.deliver_outcome/2`). Different sender processes
+# means BEAM gives NO cross-sender mailbox-ordering guarantee to the
+# subscriber: the terminal result can land before a same-turn update still in
+# flight, AND two updates dispatched by two tasks can land out of wire order.
 #
-# This file constructs that exact interleaving deterministically (no
-# `Process.sleep`, no timing race to CREATE the condition -- only a bounded
-# `Task.yield/2` used to let the SUT's own independent, already-in-flight
-# response-delivery settle before we release a held notification handler;
-# see the big comment in the test body for why that specific wait is sound
-# and not "timing-tight").
+# The fix keeps delivery non-blocking/concurrent (so a slow handler never
+# head-of-line-blocks the Connection and parallel/interleaved update streams
+# flow) and makes the CLIENT the consolidation point: every delivery carries
+# the inbound frame's monotone `rx_seq`, the terminal result additionally
+# carries its own frame `rx_seq` (`{:acp_result_seq, tag, rx_seq}`), and
+# `prompt/3`/`prompt_stream/4` buffer updates by `rx_seq`, drain every
+# same-turn update below the result's seq (bounded settle window), and
+# release them in restored wire order.
+#
+# These three tests witness: (a) an update pending when the result lands is
+# not dropped; (b) updates delivered out of `rx_seq` order are collected in
+# `rx_seq` order; (c) two interleaved update streams (distinct `rx_seq`s,
+# scrambled arrival) are all delivered, in `rx_seq` order, none dropped.
+#
+# Determinism (no `Process.sleep`, no timing race to CREATE the condition):
+# a fixture whose `session_update/2` PARKS mid-dispatch until explicitly
+# released lets each test place the forwarding `send/2` exactly where it
+# wants relative to the result and to the other updates. (b)/(c) release all
+# updates BEFORE delivering the result, so every update is queued before the
+# result frame -- order is decided purely by the buffer's sort, with zero
+# window dependence. (a) is the one case that RELEASES AFTER the result, and
+# relies only on the update landing within the bounded settle window -- an
+# ETS-lookup + `send` after an explicit release, orders of magnitude inside
+# the window.
 defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
   use ExUnit.Case, async: false
 
@@ -39,22 +51,22 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
   alias Raxol.AgentClientProtocol.Schema.ContentBlock
 
   # ===========================================================================
-  # Fixture: a client whose `session_update/2` PAUSES mid-dispatch until
-  # explicitly released. This lets the test control exactly when the
-  # forwarding `send/2` to a `subscribe/3` subscriber happens, so the
-  # interleaving from the bug report -- "deliver the prompt result while an
-  # update is still pending" -- is constructed on purpose rather than hoped
-  # for.
+  # Fixture: a client whose `session_update/2` announces itself (with the
+  # update payload and its `ctx.rx_seq`) then PARKS until explicitly released.
+  # The test releases handlers in whatever order it wants, so the mailbox
+  # interleaving each scenario needs is constructed on purpose rather than
+  # hoped for. On release it forwards via `broadcast_update/4`, carrying the
+  # real `ctx.rx_seq` (the reorder key).
   # ===========================================================================
 
-  defmodule BlockableUpdateClient do
+  defmodule GatedUpdateClient do
     @moduledoc false
     use Raxol.AgentClientProtocol.Client
 
     @impl true
     def session_update(notification, ctx) do
       ref = make_ref()
-      send(ctx.handler_state, {:session_update_ready, self(), ref})
+      send(ctx.handler_state, {:update_gate, self(), ref, notification.update, ctx.rx_seq})
 
       receive do
         {^ref, :go} -> :ok
@@ -63,7 +75,8 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
       Raxol.AgentClientProtocol.Client.broadcast_update(
         ctx.conn,
         notification.session_id,
-        notification.update
+        notification.update,
+        ctx.rx_seq
       )
     end
   end
@@ -105,24 +118,46 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
     :ok
   end
 
-  defp session_update_frame(session_id, mode_id) do
-    %{
+  defp send_update(peer, session_id, mode_id) do
+    ScriptedPeer.send_notification(peer, "session/update", %{
       "sessionId" => session_id,
       "update" => %{"sessionUpdate" => "current_mode_update", "currentModeId" => mode_id}
-    }
+    })
+  end
+
+  # Block for the parked handler's announcement, returning `{pid, ref, seq}`
+  # for the update whose mode id is `mode_id`. Handlers announce as soon as
+  # their dispatch task runs; matching on the payload lets a test wait for a
+  # SPECIFIC update regardless of the order the tasks happened to start in.
+  defp await_gate(mode_id) do
+    assert_receive {:update_gate, pid, ref,
+                    {:current_mode_update, %{current_mode_id: ^mode_id}}, seq},
+                   1_000
+
+    {pid, ref, seq}
+  end
+
+  defp release({pid, ref, _seq}), do: send(pid, {ref, :go})
+
+  defp mode_ids(updates) do
+    Enum.map(updates, fn {:current_mode_update, %{current_mode_id: mid}} -> mid end)
   end
 
   # ===========================================================================
-  # The red-first witness.
+  # (a) drop witness: a result delivered while an update is still pending must
+  #     NOT lose that update. Against a naive consumer that exits on the
+  #     result without draining, the released update lands after the loop has
+  #     already returned and is silently dropped; the reorder buffer's bounded
+  #     drain absorbs it.
   # ===========================================================================
 
-  describe "session/update delivery vs. the turn's terminal result (single-sender ordering)" do
-    test "an update pending at the moment the terminal result is delivered is neither lost nor reordered" do
+  describe "an update pending when the terminal result arrives" do
+    test "is drained, not dropped, and still reaches the consumer" do
       test_pid = self()
-      %{conn: conn, peer: peer} = start_client_conn(BlockableUpdateClient, test_pid)
+      %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
       :ok = complete_handshake(conn, peer)
 
-      session_id = "sess-race"
+      session_id = "sess-drop"
       request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
 
       caller =
@@ -139,55 +174,137 @@ defmodule Raxol.AgentClientProtocol.ClientSessionUpdateDeliveryTest do
       assert frame["method"] == "session/prompt"
       id = frame["id"]
 
-      # 1. Send the update. Its dispatch (Task pre-fix, the Connection
-      #    process itself post-fix) starts running and immediately parks,
-      #    proven by the synchronous ready-ping below -- so we know FOR
-      #    CERTAIN the forwarding `send/2` to the `prompt_stream/4`
-      #    subscriber has NOT happened yet.
-      ScriptedPeer.send_notification(
-        peer,
-        "session/update",
-        session_update_frame(session_id, "will-be-lost")
-      )
+      # Update dispatched; its handler parks (proven by the gate ping), so the
+      # forwarding send has NOT happened yet.
+      send_update(peer, session_id, "will-be-lost")
+      gate = await_gate("will-be-lost")
 
-      assert_receive {:session_update_ready, handler_pid, ref}, 500
-
-      # 2. Deliver the turn's terminal result while that update is still
-      #    held open -- exactly the interleaving the bug report describes.
+      # Deliver the terminal result while that update is still held -- the
+      # exact interleaving the bug describes.
       ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
 
-      # 3. Give the SUT's OWN, already-in-flight response-delivery path a
-      #    generous, bounded window to settle BEFORE we release the held
-      #    notification handler. This does not race to construct the bug --
-      #    it only matters for the PRE-FIX code, where response delivery is
-      #    entirely independent of the still-parked notification task and
-      #    completes near-instantly (no I/O, pure local message passing);
-      #    300ms is enormous headroom for that. For the FIXED code this
-      #    `Task.yield/2` is not a race at all: the Connection process is
-      #    provably still blocked inside the synchronous update dispatch
-      #    (it cannot have processed the response frame yet, by
-      #    construction), so `Task.yield/2` deterministically returns `nil`
-      #    here every time, fix or no fix.
-      already_done = Task.yield(caller, 300)
+      # Barrier (not a timing hack): the Connection processes its mailbox in
+      # order, so once this synchronous `:sys.get_state/1` returns, the
+      # Connection has finished handling the result frame -- meaning it has
+      # ALREADY sent the `{:acp_result_seq, ...}` + `{:acp_result, ...}` into
+      # the consumer's mailbox. Only THEN do we release the held update, so
+      # the forwarded update is queued strictly AFTER the terminal result.
+      # A naive consumer that exits on the result drops it; the reorder
+      # buffer's drain finds it already queued and delivers it. Deterministic
+      # for both, with zero dependence on the settle window's length.
+      :sys.get_state(conn)
+      release(gate)
 
-      # 4. Only now release the held handler.
-      send(handler_pid, {ref, :go})
+      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "will-be-lost"}}},
+                     1_000
 
-      result =
-        case already_done do
-          {:ok, outcome} -> outcome
-          nil -> Task.await(caller, 1_000)
+      assert {:ok, response} = Task.await(caller, 1_000)
+      assert response.stop_reason == :end_turn
+    end
+  end
+
+  # ===========================================================================
+  # (b) reorder: two updates delivered to the consumer OUT of `rx_seq` order
+  #     (later-seq released first) must be collected in `rx_seq` order.
+  # ===========================================================================
+
+  describe "updates delivered out of rx_seq order" do
+    test "are collected by prompt/3 in rx_seq (wire) order, none lost" do
+      test_pid = self()
+      %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
+      :ok = complete_handshake(conn, peer)
+
+      session_id = "sess-reorder"
+      request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
+      caller = Task.async(fn -> Client.prompt(conn, request, 2_000) end)
+
+      frame = ScriptedPeer.recv(peer)
+      assert frame["method"] == "session/prompt"
+      id = frame["id"]
+
+      # "a" is sent (and framed) first, so it has the LOWER rx_seq; "b" second,
+      # higher. Both park.
+      send_update(peer, session_id, "a")
+      send_update(peer, session_id, "b")
+      gate_a = await_gate("a")
+      gate_b = await_gate("b")
+      assert elem(gate_a, 2) < elem(gate_b, 2)
+
+      # Release the HIGHER-seq update first, so it reaches the consumer's
+      # mailbox before the lower one -- wire order reversed on arrival. Both
+      # land before the result, so ordering is decided purely by the buffer.
+      release(gate_b)
+      release(gate_a)
+
+      ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
+
+      assert {:ok, {updates, response}} = Task.await(caller, 1_000)
+      assert response.stop_reason == :end_turn
+      # Restored to rx_seq order despite reversed arrival.
+      assert mode_ids(updates) == ["a", "b"]
+    end
+  end
+
+  # ===========================================================================
+  # (c) parallel/interleaved: two logical update streams interleaved on the
+  #     wire (distinct rx_seqs), delivered to the consumer in a scrambled
+  #     order, must ALL arrive at prompt_stream/4's callback, in rx_seq order,
+  #     none dropped. This is the parallel-tool-call case the design targets.
+  # ===========================================================================
+
+  describe "two interleaved update streams with distinct rx_seqs" do
+    test "are all delivered to prompt_stream/4 in rx_seq order, none dropped" do
+      test_pid = self()
+      %{conn: conn, peer: peer} = start_client_conn(GatedUpdateClient, test_pid)
+      :ok = complete_handshake(conn, peer)
+
+      session_id = "sess-interleave"
+      request = PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
+
+      caller =
+        Task.async(fn ->
+          Client.prompt_stream(
+            conn,
+            request,
+            fn update -> send(test_pid, {:streamed, update}) end,
+            2_000
+          )
+        end)
+
+      frame = ScriptedPeer.recv(peer)
+      assert frame["method"] == "session/prompt"
+      id = frame["id"]
+
+      # Stream A = a1,a2 ; stream B = b1,b2. Interleaved on the wire so the
+      # rx_seq (frame) order is a1 < b1 < a2 < b2.
+      send_update(peer, session_id, "a1")
+      send_update(peer, session_id, "b1")
+      send_update(peer, session_id, "a2")
+      send_update(peer, session_id, "b2")
+
+      gates = Map.new(~w(a1 b1 a2 b2), fn mid -> {mid, await_gate(mid)} end)
+
+      # Release in a scrambled order (concurrent tasks landing every which
+      # way). All land before the result, so none can be dropped and order is
+      # entirely the buffer's job.
+      for mid <- ~w(b2 a2 b1 a1), do: release(gates[mid])
+
+      ScriptedPeer.send_result(peer, id, %{"stopReason" => "end_turn"})
+
+      # `on_update` is invoked from a single sender (the caller task), so the
+      # `{:streamed, _}` messages land in emission order. Receiving four with
+      # an UNPINNED pattern therefore reads them in the exact order they were
+      # emitted -- which must be restored rx_seq (wire) order, none dropped.
+      emitted =
+        for _ <- 1..4 do
+          assert_receive {:streamed, update}, 1_000
+          update
         end
 
-      # The update must have reached `on_update` -- pre-fix, `already_done`
-      # is `{:ok, _}` here (the terminal result won the race independently
-      # of the gate), the streaming task's receive loop already returned
-      # before the update was ever forwarded, and this never arrives:
-      # `prompt_stream/4` silently dropped a same-turn update.
-      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "will-be-lost"}}},
-                      1_000
+      assert mode_ids(emitted) == ["a1", "b1", "a2", "b2"]
+      refute_receive {:streamed, _}, 100
 
-      assert {:ok, response} = result
+      assert {:ok, response} = Task.await(caller, 1_000)
       assert response.stop_reason == :end_turn
     end
   end

--- a/packages/raxol_agent_client_protocol/test/client_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_test.exs
@@ -111,7 +111,8 @@ defmodule Raxol.AgentClientProtocol.ClientTest do
 
       :ok = Client.subscribe(conn, "sess-1", self())
       assert BareClient.session_update(notification, ctx) == :ok
-      assert_receive {:acp_session_update, "sess-1", {:agent_message_chunk, :placeholder}}
+      # 4th element is `ctx.rx_seq` (the reorder key); the struct default is 0.
+      assert_receive {:acp_session_update, "sess-1", {:agent_message_chunk, :placeholder}, 0}
     end
 
     test "handle_ext_request/3 defaults to method_not_found" do

--- a/packages/raxol_agent_client_protocol/test/client_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_test.exs
@@ -111,8 +111,10 @@ defmodule Raxol.AgentClientProtocol.ClientTest do
 
       :ok = Client.subscribe(conn, "sess-1", self())
       assert BareClient.session_update(notification, ctx) == :ok
-      # 4th element is `ctx.rx_seq` (the reorder key); the struct default is 0.
-      assert_receive {:acp_session_update, "sess-1", {:agent_message_chunk, :placeholder}, 0}
+      # 4th element is `ctx.rx_seq` (frame stamp; struct default 0); 5th is the
+      # per-session `update_seq` reorder key -- `nil` here (bare notification,
+      # no `_meta["raxol.io"]["update_seq"]` stamp).
+      assert_receive {:acp_session_update, "sess-1", {:agent_message_chunk, :placeholder}, 0, nil}
     end
 
     test "handle_ext_request/3 defaults to method_not_found" do


### PR DESCRIPTION
## LIVE incremental in-order `session/update` delivery (per-session `update_seq`)

Supersedes the earlier global-`rx_seq` **boundary-emit** approach on this branch. That version used the GLOBAL per-connection frame counter (`rx_seq`) as the reorder key — which gives ordering but not *completeness* (a numeric gap in `rx_seq` is an unrelated frame, not a missing update), so it was forced to buffer every update and emit the whole turn only at the **turn boundary**, losing live streaming.

This version streams **live**: the agent stamps a **per-session monotone `update_seq`** so the consumer can release each update the instant it is contiguous.

### Agent side (producer)
- The `Session` GenServer stamps a per-session `update_seq` into every emitted `session/update` notification's `_meta["raxol.io"]["update_seq"]` (mirroring the reattach taint/offset rider convention).
- Stamped in the Session core **before the emitter seam**, so `Emitter.Direct` and `Emitter.Journal` both carry the identical stamped notification (emitter-agnostic).
- The counter **resets to 0 at each turn start** (`begin_prompt`), so every `session/prompt` turn's updates form a contiguous `0..N` and the consumer's next-expected index always starts at 0. Only one turn is ever live per session (the I12 busy rule), so per-turn reset never collides.
- The Session mailbox serializes concurrent `post_update` calls, giving parallel/interleaved in-turn updates a single total order. Rejected empty chunks consume no ordinal (no phantom gap).

### Wire
- The ordinal rides `_meta["raxol.io"]["update_seq"]` — spec-compatible: a vanilla ACP client ignores `_meta`; a vanilla agent simply never stamps it. It survives client decode via the existing `SessionNotification` `_meta` fold.

### Client side (consumer)
- `prompt/3` / `prompt_stream/4` track a next-expected ordinal: an update whose `update_seq == next` is **released immediately** (`prompt_stream` fires `on_update` live; `prompt` accumulates in order), then cascade-releases any contiguous successors already buffered; a higher ordinal buffers; a gap holds the higher ones until the missing lower one lands.
- **Bounded, never deadlocks:** `Connection` always delivers a terminal `{:acp_result, …}` (its protocol timeout is the single authority), and a bounded post-result settle drain absorbs stragglers then flushes any out-of-order tail — nothing dropped.
- **Graceful fallback:** an update with no `update_seq` (non-raxol / unstamped agent) is buffered by `rx_seq` and released in `rx_seq` order at the turn boundary — the prior deterministic, no-drop, non-blocking behavior. The live/in-order guarantee holds **only** when the agent stamps the seq.
- Delivery tuple grows to `{:acp_session_update, session_id, update, rx_seq, update_seq}` — `rx_seq` kept as the per-connection frame stamp / tiebreaker; `update_seq` is the new reorder key (`nil` when unstamped). `{:acp_result_seq, tag, rx_seq}` stays as the turn-boundary signal.

### Tests
- **Producer-real:** drives a real `Session` emit and asserts the outgoing notifications carry `_meta["raxol.io"]["update_seq"]` = 0,1,2, and that a second turn resets back to 0.
- **Consumer red-first witnesses (deterministic, mailbox barriers, no sleep/wall-clock):** (a) live incremental in-order (out-of-order arrivals ⇒ `on_update` fires 0..N, released before the result); (b) gap-wait (seq 0,2 arrive, 1 missing ⇒ 2 held until 1 lands, then 1,2 release); (c) two sessions interleaved, each released in its own per-session order, none crossed; (d) graceful fallback (unstamped updates delivered, never blocked). The three ordering witnesses were confirmed **red** against an arrival-order consumer.

Full suite: **801 passing** (16 properties, 785 tests). `mix compile --warnings-as-errors` clean.