### PR TITLE
feat(acp): transport-ordering layer — receiver-side session/update delivery (supersedes #640)

### DIFF
--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
@@ -92,10 +92,9 @@ defmodule Raxol.AgentClientProtocol.Client do
   `{:acp_session_update, session_id, update}` -- `update` is always an
   already-decoded `Raxol.AgentClientProtocol.Schema.SessionUpdate.t()` (see
   `decode_update/1`'s doc for why an undecodable variant never reaches
-  this path at all).
-
-  `prompt/3` and `prompt_stream/4` build on `subscribe/3` to give a
-  synchronous-feeling API over the inherently asynchronous protocol:
+  this path at all). `subscribe/3` remains useful for a custom
+  `session_update/2` override that wants a broadcast fan-out, but it is
+  NOT how `prompt/3`/`prompt_stream/4` get their updates (see below).
 
       {:ok, {updates, response}} =
         Client.prompt(client_conn, PromptRequest.new(session_id, prompt_blocks))
@@ -105,11 +104,23 @@ defmodule Raxol.AgentClientProtocol.Client do
           IO.inspect(update, label: "update")
         end)
 
-  Both drive the request through `Connection.async_request/6` (not the
-  blocking `Connection.request/4` wrapper) specifically so the calling
-  process can `receive` session/update deliveries *and* the terminal
-  result in one loop -- see their docs for the exact mechanics and the
-  ordering caveat.
+  `prompt/3` and `prompt_stream/4` drive the request through
+  `Connection.async_request/6` and then consume the **direct turn-delivery
+  channel** (`Raxol.AgentClientProtocol.Delivery`'s moduledoc):
+  `Connection` opens a turn at submit time and, for every `session/update`
+  belonging to that turn, sends the calling process
+  `{:acp_turn_update, tag, ordinal, notification}` directly, itself --
+  the same single-sender operation it uses for the terminal
+  `{:acp_result, tag, outcome}`. Because one process sends every update,
+  the turn-end companion, and the result, BEAM's pairwise FIFO guarantees
+  they arrive in wire order with NO reorder buffer, NO settle timer, and a
+  synchronous, deterministic failure (`{:error, {:delivery_gap, _}}`) if
+  the turn-end count and the delivered-update count ever disagree. This
+  is the actual fix for the drop/reorder bug the previous
+  `subscribe/3`-based implementation of these two functions had (a
+  separate handler task per notification vs. the Connection's own
+  terminal-result send -- two different senders, no cross-sender FIFO
+  guarantee).
 
   ## `fs_sandbox`: a working filesystem client with zero callbacks
 
@@ -148,6 +159,7 @@ defmodule Raxol.AgentClientProtocol.Client do
   require Raxol.AgentClientProtocol.Handler.Codegen
 
   alias Raxol.AgentClientProtocol.Connection
+  alias Raxol.AgentClientProtocol.Delivery
   alias Raxol.AgentClientProtocol.Error
   alias Raxol.AgentClientProtocol.Handler.Codegen
   alias Raxol.AgentClientProtocol.Schema.SessionUpdate
@@ -216,6 +228,13 @@ defmodule Raxol.AgentClientProtocol.Client do
   registration receives its own copy of every broadcast, so the pid gets
   the update twice. Subscribe once per `{conn, session_id, pid}`, or
   dedupe on receipt if you can't guarantee that.
+
+  This broadcast path still fans out through a per-notification dispatch
+  task (one task per `session/update`), so it has no cross-notification
+  ordering guarantee on its own -- it is NOT what `prompt/3`/
+  `prompt_stream/4` use (see the moduledoc's "Session-consumer ergonomics"
+  section); it remains here for custom `session_update/2` overrides that
+  want a simple fan-out primitive.
   """
   @spec subscribe(pid(), String.t(), pid()) :: :ok
   def subscribe(conn, session_id, subscriber \\ self())
@@ -308,145 +327,127 @@ defmodule Raxol.AgentClientProtocol.Client do
 
   # ===========================================================================
   # prompt/3, prompt_stream/4 -- session-consumer convenience over
-  # Connection.async_request/6 (IC-3). Both subscribe the CALLING process
-  # for the turn's session_id and drive the request asynchronously
-  # specifically so that same process can `receive` both
-  # `{:acp_session_update, ...}` and the terminal `{:acp_result, ...}` in
-  # one loop -- `Connection.request/4`'s blocking `GenServer.call` would
-  # queue those update messages, unread, until the call returns, which
-  # buys nothing over this loop and would force a settle-drain regardless.
+  # Connection.async_request/6 (IC-3), consuming the DIRECT turn-delivery
+  # channel (Raxol.AgentClientProtocol.Delivery's moduledoc), not the
+  # multi-sender subscribe/3 broadcast. `Connection` opens a turn at
+  # submit time and sends every `session/update` belonging to it, the
+  # turn-end companion, and the terminal result FROM ITSELF -- one sender,
+  # so this process's mailbox order is exactly wire order. No settle
+  # timer, no reorder buffer: a real gap is a synchronous, deterministic
+  # `{:error, {:delivery_gap, _}}` observed at the terminal result, never
+  # a race against a not-yet-scheduled task.
   # ===========================================================================
 
-  @typedoc "A decoded session/update payload delivered via `subscribe/3` (always successfully decoded -- see `decode_update/1`)."
+  @typedoc "A decoded session/update payload (always successfully decoded -- see `decode_update/1`)."
   @type update :: SessionUpdate.t()
 
   @doc """
   Send `session/prompt` and collect every `session/update` delivered for
-  its `session_id` until the response resolves. Returns
+  the turn until the response resolves. Returns
   `{:ok, {updates, response}}` -- `updates` is the list of decoded
   `SessionUpdate.t()` payloads observed during the turn, oldest first;
   `response` is the decoded result struct (or `{:ext, map()}` for a
   non-table result marker) -- or `{:error, term()}` on timeout/transport
-  failure/decode failure, same vocabulary as `Connection.async_request/6`'s
-  `outcome`.
+  failure/decode failure/delivery gap, same vocabulary as
+  `Connection.async_request/6`'s `outcome` plus
+  `{:error, {:delivery_gap, %{delivered:, expected:}}}` when the
+  Connection's own turn-end count disagrees with what this process
+  actually received (a definite loss signal, not a heuristic).
 
-  Ordering caveat: `session/update` forwarding to the subscribed process
-  runs in a separate handler task per notification (Connection design
-  §4.4), while the terminal `session/prompt` response is delivered
-  directly by `Connection` itself -- the WIRE order between them is
-  invariant (I3: no update after its turn's response), but the two
-  deliveries landing in *this* process's mailbox are two different
-  senders, so BEAM gives no cross-sender guarantee. This function does one
-  short best-effort settle pass after the terminal message arrives to
-  absorb same-turn stragglers; treat `updates` as "very likely complete,
-  not protocol-guaranteed complete" -- `prompt_stream/4` has no such gap
-  because it never leaves the receive loop.
-
-  Always subscribes and unsubscribes around the call, including on error.
-
-  **Precondition:** requires the generated default `c:session_update/2`
-  (the one `use Raxol.AgentClientProtocol.Client` installs). If your
-  handler module overrides `session_update/2` and does not itself call
-  `broadcast_update/3`, `subscribe/3` never fires and `updates` is `[]`
-  for every turn, forever -- see the moduledoc's "Session-consumer
-  ergonomics" section.
+  No settle pass, no timer: the direct channel makes updates, the turn-end
+  count, and the result all arrive from the Connection itself, so mailbox
+  order already equals wire order (transport-ordering design §4.4/§4.8).
   """
   @spec prompt(pid(), struct(), pos_integer()) ::
           {:ok, {[update()], struct() | {:ext, map()}}} | {:error, term()}
   def prompt(conn, request, timeout_ms \\ 60_000)
       when is_pid(conn) and is_integer(timeout_ms) and timeout_ms > 0 do
-    session_id = request.session_id
     tag = make_ref()
-    :ok = subscribe(conn, session_id, self())
 
-    try do
-      case Connection.async_request(
-             conn,
-             "session/prompt",
-             request,
-             self(),
-             tag,
-             timeout_ms
-           ) do
-        :ok -> collect_prompt(session_id, tag, [])
-        {:error, _} = err -> err
-      end
-    after
-      unsubscribe(conn, session_id, self())
+    case Connection.async_request(conn, "session/prompt", request, self(), tag, timeout_ms) do
+      :ok -> prompt_loop(tag, 0, [], nil)
+      {:error, _} = err -> err
     end
   end
 
-  defp collect_prompt(session_id, tag, acc) do
+  defp prompt_loop(tag, next, acc, count) do
     receive do
-      {:acp_session_update, ^session_id, update} ->
-        collect_prompt(session_id, tag, [update | acc])
+      {:acp_turn_update, ^tag, ordinal, notif} when ordinal == next ->
+        prompt_loop(tag, next + 1, [notif.update | acc], count)
+
+      {:acp_turn_update, ^tag, ordinal, _notif} ->
+        # Single-sender FIFO (the Connection is the ONE sender of updates,
+        # turn_end, and result for this tag) makes this branch unreachable
+        # in practice -- a defensive tripwire, never a silent skip.
+        fail_turn(:delivery_order, %{expected: next, got: ordinal})
+
+      {:acp_turn_end, ^tag, n} ->
+        prompt_loop(tag, next, acc, n)
 
       {:acp_result, ^tag, {:ok, response}} ->
-        {:ok, {settle_updates(session_id, acc), response}}
+        if count != nil and next < count do
+          fail_turn(:delivery_gap, %{delivered: next, expected: count})
+        else
+          {:ok, {Enum.reverse(acc), response}}
+        end
 
       {:acp_result, ^tag, {:error, _} = error} ->
         error
     end
   end
 
-  defp settle_updates(session_id, acc) do
-    receive do
-      {:acp_session_update, ^session_id, update} ->
-        settle_updates(session_id, [update | acc])
-    after
-      5 -> Enum.reverse(acc)
-    end
-  end
-
   @doc """
   Streaming-callback variant of `prompt/3`: `on_update.(update)` is invoked
   synchronously, in this process, for each `session/update` as it is
-  received -- no accumulation, no post-hoc settle pass (this variant's
-  receive loop never exits until the terminal message arrives, so there is
-  no window for a straggler to be missed). Returns `{:ok, response}` /
-  `{:error, term()}` for the terminal outcome, same vocabulary as
-  `Connection.async_request/6`'s `outcome`. Always subscribes and
-  unsubscribes around the call, including on error.
-
-  **Precondition:** same as `prompt/3` -- requires the generated default
-  `c:session_update/2`; an overridden `session_update/2` that doesn't call
-  `broadcast_update/3` means `on_update` is never invoked.
+  received -- no accumulation (O(1) memory: this loop keeps no update
+  list at all). Returns `{:ok, response}` / `{:error, term()}` for the
+  terminal outcome, same vocabulary as `prompt/3` (including the
+  `{:error, {:delivery_gap, _}}` fail-the-turn case).
   """
   @spec prompt_stream(pid(), struct(), (update() -> any()), pos_integer()) ::
           {:ok, struct() | {:ext, map()}} | {:error, term()}
   def prompt_stream(conn, request, on_update, timeout_ms \\ 60_000)
       when is_pid(conn) and is_function(on_update, 1) and is_integer(timeout_ms) and
              timeout_ms > 0 do
-    session_id = request.session_id
     tag = make_ref()
-    :ok = subscribe(conn, session_id, self())
 
-    try do
-      case Connection.async_request(
-             conn,
-             "session/prompt",
-             request,
-             self(),
-             tag,
-             timeout_ms
-           ) do
-        :ok -> stream_prompt(session_id, tag, on_update)
-        {:error, _} = err -> err
-      end
-    after
-      unsubscribe(conn, session_id, self())
+    case Connection.async_request(conn, "session/prompt", request, self(), tag, timeout_ms) do
+      :ok -> stream_loop(tag, 0, nil, on_update)
+      {:error, _} = err -> err
     end
   end
 
-  defp stream_prompt(session_id, tag, on_update) do
+  defp stream_loop(tag, next, count, on_update) do
     receive do
-      {:acp_session_update, ^session_id, update} ->
-        on_update.(update)
-        stream_prompt(session_id, tag, on_update)
+      {:acp_turn_update, ^tag, ordinal, notif} when ordinal == next ->
+        on_update.(notif.update)
+        stream_loop(tag, next + 1, count, on_update)
 
-      {:acp_result, ^tag, outcome} ->
-        outcome
+      {:acp_turn_update, ^tag, ordinal, _notif} ->
+        fail_turn(:delivery_order, %{expected: next, got: ordinal})
+
+      {:acp_turn_end, ^tag, n} ->
+        stream_loop(tag, next, n, on_update)
+
+      {:acp_result, ^tag, {:ok, response}} ->
+        if count != nil and next < count do
+          fail_turn(:delivery_gap, %{delivered: next, expected: count})
+        else
+          {:ok, response}
+        end
+
+      {:acp_result, ^tag, {:error, _} = error} ->
+        error
     end
+  end
+
+  # ADR-0030 clause 3's fail-the-turn default: emit exactly one `:fail`
+  # telemetry event (D9) and return the error tuple -- never a silent
+  # partial list, never a timer/retry.
+  @spec fail_turn(atom(), map()) :: {:error, {atom(), map()}}
+  defp fail_turn(reason, meta) do
+    Delivery.emit(Map.merge(%{decision: :fail}, meta))
+    {:error, {reason, meta}}
   end
 
   defmacro __using__(opts) do

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
@@ -13,7 +13,10 @@ defmodule Raxol.AgentClientProtocol.Connection.Ctx do
   `reply_ref` is present (`reference()`) for requests and `nil` for
   notifications. `rx_seq` is the inbound frame's monotone sequence stamp
   (IC-5c) — `begin_prompt` forwards it to the Session so cancel-vs-prompt
-  commutes by wire order.
+  commutes by wire order. `delivery_stamp` is the receiver-assigned
+  ordering key (`Raxol.AgentClientProtocol.Delivery.t()`) for a
+  `session/update` dispatch — `nil` for every other dispatch (transport-
+  ordering design §4.5).
   """
 
   @enforce_keys [:conn, :role]
@@ -23,6 +26,7 @@ defmodule Raxol.AgentClientProtocol.Connection.Ctx do
             handler_state: nil,
             reply_ref: nil,
             rx_seq: 0,
+            delivery_stamp: nil,
             session_sup: nil,
             task_sup: nil
 
@@ -33,8 +37,35 @@ defmodule Raxol.AgentClientProtocol.Connection.Ctx do
           handler_state: term(),
           reply_ref: reference() | nil,
           rx_seq: non_neg_integer(),
+          delivery_stamp: Raxol.AgentClientProtocol.Delivery.t() | nil,
           session_sup: pid() | nil,
           task_sup: pid() | nil
+        }
+end
+
+defmodule Raxol.AgentClientProtocol.Connection.TurnState do
+  @moduledoc """
+  Per-session open-turn state, populated only on a client-role Connection
+  (transport-ordering design §4.2, ADR-0030 clauses 1/5).
+
+  Opened by `Connection`'s outbound submit path at a successful
+  `session/prompt` async-owner submission (`reply_to = {:owner, ...}`);
+  closed by whichever of response / timeout / cancel / transport-down
+  resolves the request first. `token` is minted fresh (`make_ref/0`) at
+  open and never derived from any peer-supplied id (clause 5): a peer that
+  replays or reuses a session/request id cannot alias a stale turn's
+  straggler into a new turn, because the tokens differ by construction.
+  """
+
+  @enforce_keys [:token, :owner, :tag, :out_id]
+  defstruct token: nil, owner: nil, tag: nil, out_id: nil, next_ordinal: 0
+
+  @type t :: %__MODULE__{
+          token: reference(),
+          owner: pid(),
+          tag: term(),
+          out_id: term(),
+          next_ordinal: non_neg_integer()
         }
 end
 
@@ -121,8 +152,8 @@ defmodule Raxol.AgentClientProtocol.Connection do
   use GenServer
   require Logger
 
-  alias Raxol.AgentClientProtocol.{Capabilities, Error, Router}
-  alias Raxol.AgentClientProtocol.Connection.Ctx
+  alias Raxol.AgentClientProtocol.{Capabilities, Delivery, Error, Router}
+  alias Raxol.AgentClientProtocol.Connection.{Ctx, TurnState}
   alias Raxol.AgentClientProtocol.Rpc.{Message, Notification, Request, RequestId, Response}
   alias Raxol.AgentClientProtocol.Schema.AgentTypes.CancelNotification
   alias Raxol.AgentClientProtocol.Schema.LifecycleExtras.CancelRequestNotification
@@ -158,7 +189,19 @@ defmodule Raxol.AgentClientProtocol.Connection do
             handler: nil,
             handler_state: nil,
             task_sup: nil,
-            max_in: @default_max_inbound
+            max_in: @default_max_inbound,
+            # Client-role-only turn-delivery state (transport-ordering design
+            # §4.2). `turns`: session_id => %TurnState{} for the session's
+            # currently open `session/prompt` turn. `turn_ids`: the reverse
+            # index, out_id => session_id, so the response/timeout/cancel
+            # paths can pop a turn by the wire id they already have in hand.
+            # `oot_seq`: session_id => count of out-of-turn (no open turn)
+            # `session/update` notifications stamped so far — receiver-
+            # assigned, monotone, never reset (clause 5's out-of-turn
+            # namespace).
+            turns: %{},
+            turn_ids: %{},
+            oot_seq: %{}
 
   @type role :: :agent | :client
 
@@ -249,6 +292,26 @@ defmodule Raxol.AgentClientProtocol.Connection do
   def close(conn) when is_pid(conn) do
     reject_self!(conn)
     GenServer.call(conn, :close)
+  end
+
+  @doc """
+  Race-free base-ordinal accessor for a session's delivery stream
+  (transport-ordering design §4.5). Because this is a `GenServer.call`
+  (serialized with the demux point that assigns ordinals), a caller that
+  subscribes to the broadcast path THEN calls this learns an exact base:
+  every stamp assigned after this call returns is guaranteed to reach a
+  live subscriber, and every stamp `<= ordinal` is pre-subscription.
+  `turn: nil` means the session currently has no open `session/prompt`
+  turn (the out-of-turn namespace applies). NOTE: this accessor is the
+  seam the bounded Reorder engine (a later unit) consumes to compute its
+  `:next` base; the primary direct-delivery path (`Client.prompt/3`,
+  `prompt_stream/4`) does not need it at all.
+  """
+  @spec update_watermark(pid(), String.t()) ::
+          {:ok, %{turn: reference() | nil, ordinal: non_neg_integer()}}
+  def update_watermark(conn, session_id) when is_pid(conn) and is_binary(session_id) do
+    reject_self!(conn)
+    GenServer.call(conn, {:update_watermark, session_id})
   end
 
   defp reject_self!(conn) do
@@ -399,8 +462,25 @@ defmodule Raxol.AgentClientProtocol.Connection do
         {entry, pending_out} = Map.pop(state.pending_out, id)
         if entry && entry.timer_ref, do: Process.cancel_timer(entry.timer_ref)
         best_effort_cancel_notify(id, state)
-        {:reply, :ok, %{state | pending_out: pending_out, out_tags: out_tags}}
+        # §4.6: pop any open turn SILENTLY — no `:acp_turn_end` — IC-3's
+        # "delivers nothing" contract for a consumed entry is preserved.
+        state = pop_turn_silent(id, %{state | pending_out: pending_out, out_tags: out_tags})
+        {:reply, :ok, state}
     end
+  end
+
+  # §4.5: race-free watermark accessor. A `GenServer.call`, so it is
+  # serialized with the demux point (`dispatch_inbound_notification/3`) —
+  # every ordinal assigned after this reply is observed is guaranteed not
+  # yet delivered to any pre-existing broadcast subscriber.
+  def handle_call({:update_watermark, session_id}, _from, state) do
+    watermark =
+      case Map.get(state.turns, session_id) do
+        %TurnState{token: token, next_ordinal: n} -> %{turn: token, ordinal: max(n - 1, 0)}
+        nil -> %{turn: nil, ordinal: Map.get(state.oot_seq, session_id, 0)}
+      end
+
+    {:reply, {:ok, watermark}, state}
   end
 
   # -- Delegated reply (§4.6, IC-4) --
@@ -487,9 +567,95 @@ defmodule Raxol.AgentClientProtocol.Connection do
                     out_tags: add_tag(state.out_tags, reply_to, id)
                 }
 
+                st = maybe_open_turn(method, reply_to, params, id, st)
+
                 {:parked, st}
             end
         end
+    end
+  end
+
+  # ===========================================================================
+  # Turn open (§4.3) — a `session/prompt` submitted via `async_request`
+  # (reply_to = {:owner, owner, tag}) opens a turn: a receiver-minted token
+  # namespacing every subsequent `session/update` for its session until the
+  # turn closes (§4.6). A SYNC `Connection.request/4` caller (`{:call,
+  # from}`) is blocked in `GenServer.call` and cannot receive a `send/2`
+  # delivery anyway (the existing rationale at the top of this module,
+  # §5/§7), so its session's updates are stamped out-of-turn instead
+  # (`oot_seq`) — there is no owner pid to open a turn for.
+  # ===========================================================================
+
+  defp maybe_open_turn("session/prompt", {:owner, owner, tag}, params, id, state) do
+    case prompt_session_id(params) do
+      nil ->
+        state
+
+      session_id ->
+        state = close_replaced_turn(state, session_id)
+        turn = %TurnState{token: make_ref(), owner: owner, tag: tag, out_id: id, next_ordinal: 0}
+
+        %{
+          state
+          | turns: Map.put(state.turns, session_id, turn),
+            turn_ids: Map.put(state.turn_ids, id, session_id)
+        }
+    end
+  end
+
+  defp maybe_open_turn(_method, _reply_to, _params, _id, state), do: state
+
+  defp prompt_session_id(%{session_id: session_id}) when is_binary(session_id), do: session_id
+  defp prompt_session_id(%{"sessionId" => session_id}) when is_binary(session_id), do: session_id
+  defp prompt_session_id(_other), do: nil
+
+  # "One turn per session" (§4.3): a second `session/prompt` for a session
+  # with an already-open turn REPLACES it — the OLD turn's owner is sent its
+  # `{:acp_turn_end, old_tag, count}` companion first. Session invariant I12
+  # rejects this agent-side anyway; receiver behavior here is defined, not
+  # undefined.
+  defp close_replaced_turn(state, session_id) do
+    case Map.get(state.turns, session_id) do
+      nil ->
+        state
+
+      %TurnState{tag: old_tag, owner: old_owner, out_id: old_out_id, next_ordinal: count} ->
+        send(old_owner, {:acp_turn_end, old_tag, count})
+
+        %{
+          state
+          | turns: Map.delete(state.turns, session_id),
+            turn_ids: Map.delete(state.turn_ids, old_out_id)
+        }
+    end
+  end
+
+  # §4.6: pop turn state for `out_id` and send its `{:acp_turn_end, ...}`
+  # companion, if one is open. Called immediately BEFORE `deliver_outcome/2`
+  # on both the response and timeout paths, from this same process, so the
+  # owner's mailbox order is updates 0..count-1, then turn_end, then result
+  # — one sender, FIFO by construction.
+  defp close_turn_for(out_id, state) do
+    case Map.pop(state.turn_ids, out_id) do
+      {nil, _} ->
+        state
+
+      {session_id, turn_ids} ->
+        {turn, turns} = Map.pop(state.turns, session_id)
+        if turn, do: send(turn.owner, {:acp_turn_end, turn.tag, turn.next_ordinal})
+        %{state | turns: turns, turn_ids: turn_ids}
+    end
+  end
+
+  # §4.6: `cancel_request/2`'s silent pop — no `:acp_turn_end` (a cancelled
+  # entry delivers nothing, IC-3).
+  defp pop_turn_silent(out_id, state) do
+    case Map.pop(state.turn_ids, out_id) do
+      {nil, _} ->
+        state
+
+      {session_id, turn_ids} ->
+        %{state | turns: Map.delete(state.turns, session_id), turn_ids: turn_ids}
     end
   end
 
@@ -516,6 +682,7 @@ defmodule Raxol.AgentClientProtocol.Connection do
         {:noreply, state}
 
       {%{reply_to: rt}, pending_out} ->
+        state = close_turn_for(id, state)
         deliver_outcome(rt, {:error, :timeout})
         best_effort_cancel_notify(id, state)
         {:noreply, %{state | pending_out: pending_out, out_tags: drop_tag(state.out_tags, rt)}}
@@ -984,47 +1151,91 @@ defmodule Raxol.AgentClientProtocol.Connection do
         route_session_cancel(notif.params, rx_seq, state)
 
       true ->
-        dispatch_inbound_notification(notif, state)
+        dispatch_inbound_notification(notif, rx_seq, state)
     end
   end
 
-  defp dispatch_inbound_notification(%Notification{method: method, params: params}, state) do
+  defp dispatch_inbound_notification(%Notification{method: method, params: params}, rx_seq, state) do
     case Router.decode(state.role, :notification, method, params) do
       {:error, _reason} ->
         Logger.debug("ACP: unknown/invalid notification #{method} dropped")
         emit_telemetry([:raxol, :acp, :unknown_notification], %{method: method})
         {:noreply, state}
 
+      # §4.4: this is the actual demux-point fix. `session/update` is
+      # stamped AND delivered directly to the open turn's owner (or stamped
+      # out-of-turn) BEFORE the handler dispatch task is spawned below —
+      # the same `send/2`-from-this-process operation `deliver_outcome/2`
+      # already performs for the terminal result, never user code running
+      # on the Connection loop (that was round 1's mistake, not this one).
+      {:ok, {:session_update, notif} = dispatchable} ->
+        {stamp, state} = stamp_and_deliver_update(notif, rx_seq, state)
+        dispatch_notification_task(method, dispatchable, stamp, state)
+
       {:ok, dispatchable} ->
-        ctx = %Ctx{
-          conn: self(),
-          role: state.role,
-          caps: state.caps,
-          handler_state: state.handler_state,
-          reply_ref: nil,
-          rx_seq: 0,
-          session_sup: state.session_sup,
-          task_sup: state.task_sup
-        }
+        dispatch_notification_task(method, dispatchable, nil, state)
+    end
+  end
 
-        # A notification carries no reply obligation, so an over-capacity spawn is
-        # DROPPED (log + telemetry), never a wire frame — and never a raise that
-        # would take the Connection down (§4.4, flood-DoS guard symmetry).
-        case start_dispatch_task(state, fn ->
-               run_dispatch(state.role, state.handler, dispatchable, ctx)
-             end) do
-          {:error, reason} ->
-            Logger.warning(
-              "ACP: notification #{method} dropped — dispatch task_sup saturated (#{inspect(reason)})"
-            )
+  # §4.4/§4.5: the receiver-assigned contiguous per-turn ordinal, and the
+  # direct single-sender delivery to the turn owner. `notif.session_id` has
+  # an open turn ⇒ deliver `{:acp_turn_update, tag, ordinal, notif}` to its
+  # owner and advance `next_ordinal`; no open turn ⇒ stamp out-of-turn
+  # (`oot_seq`, per-session, monotone, never reset — clause 5's out-of-turn
+  # namespace). Returns the `Delivery.Stamp` for the broadcast path's `Ctx`.
+  defp stamp_and_deliver_update(%{session_id: session_id} = notif, rx_seq, state) do
+    case Map.get(state.turns, session_id) do
+      %TurnState{owner: owner, tag: tag, token: token, next_ordinal: n} ->
+        send(owner, {:acp_turn_update, tag, n, notif})
 
-            emit_telemetry([:raxol, :acp, :notification_shed], %{method: method})
-            {:noreply, state}
+        Delivery.emit(%{
+          session: session_id,
+          turn: token,
+          decision: :emit,
+          buffered: 0,
+          ordinal: n
+        })
 
-          {:ok, task} ->
-            {:noreply,
-             %{state | task_index: Map.put(state.task_index, task.ref, {:notification, method})}}
-        end
+        state = put_in(state.turns[session_id].next_ordinal, n + 1)
+        {Delivery.new(token, n, rx_seq), state}
+
+      nil ->
+        ordinal = Map.get(state.oot_seq, session_id, 0)
+        state = %{state | oot_seq: Map.put(state.oot_seq, session_id, ordinal + 1)}
+        {Delivery.new(nil, ordinal, rx_seq), state}
+    end
+  end
+
+  defp dispatch_notification_task(method, dispatchable, stamp, state) do
+    ctx = %Ctx{
+      conn: self(),
+      role: state.role,
+      caps: state.caps,
+      handler_state: state.handler_state,
+      reply_ref: nil,
+      rx_seq: 0,
+      delivery_stamp: stamp,
+      session_sup: state.session_sup,
+      task_sup: state.task_sup
+    }
+
+    # A notification carries no reply obligation, so an over-capacity spawn is
+    # DROPPED (log + telemetry), never a wire frame — and never a raise that
+    # would take the Connection down (§4.4, flood-DoS guard symmetry).
+    case start_dispatch_task(state, fn ->
+           run_dispatch(state.role, state.handler, dispatchable, ctx)
+         end) do
+      {:error, reason} ->
+        Logger.warning(
+          "ACP: notification #{method} dropped — dispatch task_sup saturated (#{inspect(reason)})"
+        )
+
+        emit_telemetry([:raxol, :acp, :notification_shed], %{method: method})
+        {:noreply, state}
+
+      {:ok, task} ->
+        {:noreply,
+         %{state | task_index: Map.put(state.task_index, task.ref, {:notification, method})}}
     end
   end
 
@@ -1081,6 +1292,7 @@ defmodule Raxol.AgentClientProtocol.Connection do
 
       {%{reply_to: rt, method: method, timer_ref: timer}, pending_out} ->
         if timer, do: Process.cancel_timer(timer)
+        state = close_turn_for(id, state)
         outcome = decode_response(resp, method)
         deliver_outcome(rt, outcome)
 
@@ -1180,6 +1392,9 @@ defmodule Raxol.AgentClientProtocol.Connection do
         pending_in: %{},
         task_index: %{},
         reply_refs: %{},
+        turns: %{},
+        turn_ids: %{},
+        oot_seq: %{},
         phase: :closed
     }
   end

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/delivery.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/delivery.ex
@@ -1,0 +1,79 @@
+defmodule Raxol.AgentClientProtocol.Delivery do
+  @moduledoc """
+  Delivery vocabulary shared by `Connection` (stamping + direct turn
+  delivery) and `Client` (turn consumption) — the transport-ordering design
+  (`TRANSPORT_ORDERING_DESIGN.md` §4, ADR-0030 clauses 1/2/5).
+
+  ## Message shapes (the direct turn-delivery channel)
+
+  For a turn opened by a `session/prompt` submitted via
+  `Connection.async_request/6` (`reply_to = {:owner, owner, tag}`), the
+  Connection sends `owner` three message shapes directly, ALL from the
+  Connection process itself — the same single-sender operation
+  `deliver_outcome/2` already uses for the terminal result — so BEAM's
+  per-sender-per-receiver FIFO guarantees the owner's mailbox order equals
+  demux order equals wire order:
+
+    * `{:acp_turn_update, tag, ordinal, notification}` — one per
+      `session/update` notification belonging to the turn's session,
+      stamped with a contiguous per-turn ordinal starting at 0.
+    * `{:acp_turn_end, tag, count}` — sent exactly once, immediately before
+      the terminal `{:acp_result, tag, outcome}`; `count` is the number of
+      `:acp_turn_update` messages the owner should have received (ordinals
+      `0..count-1`).
+    * `{:acp_result, tag, outcome}` — the existing terminal delivery
+      (`Connection.async_request/6`'s IC-3 contract), unchanged.
+
+  Because the Connection is the single sender of all three shapes, a
+  consumer needs no settle timer and no reorder buffer on this path:
+  `delivered < count` observed at the terminal result is a definite,
+  synchronous signal of dropped updates, never a race.
+
+  ## The stamp (broadcast path)
+
+  `t:t/0` is the per-notification ordering key threaded onto
+  `Connection.Ctx.delivery_stamp` for every `session/update` dispatch
+  (`nil` for anything else) — for the multi-sender broadcast path
+  (`subscribe/3`, custom `session_update/2` overrides) that still fans out
+  through per-notification dispatch tasks and therefore needs an explicit
+  key to reconstruct order. `turn` is the receiver-minted turn token (`nil`
+  when the update is out-of-turn — no open prompt turn for the session on
+  this connection); `ordinal` is the contiguous per-(session, namespace)
+  stamp assigned at the demux point; `rx_seq` is the connection-wide
+  monotone frame stamp (kept for the unrelated cancel/prompt wire-order
+  latch, IC-5c — untouched by this design).
+  """
+
+  @typedoc "Per-notification ordering key, receiver-assigned at the demux point (clause 1)."
+  @type t :: %__MODULE__{
+          turn: reference() | nil,
+          ordinal: non_neg_integer(),
+          rx_seq: non_neg_integer()
+        }
+
+  @enforce_keys [:ordinal, :rx_seq]
+  defstruct turn: nil, ordinal: 0, rx_seq: 0
+
+  @doc "Build a Stamp."
+  @spec new(reference() | nil, non_neg_integer(), non_neg_integer()) :: t()
+  def new(turn, ordinal, rx_seq) when is_integer(ordinal) and is_integer(rx_seq) do
+    %__MODULE__{turn: turn, ordinal: ordinal, rx_seq: rx_seq}
+  end
+
+  @doc """
+  Emit the `[:raxol, :acp, :delivery]` telemetry event (clauses 2/9) when
+  `:telemetry` is loaded; a silent no-op otherwise (this package does not
+  depend on `:telemetry`, matching `Connection`'s own optional-telemetry
+  guard). `metadata` should include `:decision` — one of
+  `:emit | :buffer | :gap | :fail` — plus whichever of `:session`, `:turn`,
+  `:buffered`, `:ordinal` apply at the call site.
+  """
+  @spec emit(map()) :: :ok
+  def emit(metadata) when is_map(metadata) do
+    if Code.ensure_loaded?(:telemetry) and function_exported?(:telemetry, :execute, 3) do
+      apply(:telemetry, :execute, [[:raxol, :acp, :delivery], %{count: 1}, metadata])
+    end
+
+    :ok
+  end
+end

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport.ex
@@ -29,7 +29,7 @@ defmodule Raxol.AgentClientProtocol.Transport do
 
   A transport delivers inbound frames to its owner as plain messages —
   never as a callback, since a transport does not know its owner's
-  module. The owner should expect exactly these two message shapes:
+  module. The owner should expect these message shapes:
 
     * `{:acp_transport, transport_ref, {:message, message}}` — one
       complete, decoded JSON-RPC frame (request, response, or
@@ -38,6 +38,19 @@ defmodule Raxol.AgentClientProtocol.Transport do
       transport will deliver no further messages. `reason` is an atom or
       term describing why (e.g. `:peer_closed`, `:local_close`,
       `{:error, term}`).
+    * `{:acp_transport, transport_ref, {:decode_error, reason, raw}}` —
+      OPTIONAL third shape for byte-level transports only. Emitted when
+      one unit of wire input (e.g. one NDJSON line) fails to decode into
+      a JSON-RPC frame at all. `reason` is a term describing why (e.g. a
+      `Jason.DecodeError` struct, or `{:not_an_object, term}` when the
+      input decoded to valid JSON that isn't an object); `raw` is the
+      raw, undecoded input that produced the failure. In-process
+      transports with no serialization step (`Transport.Paired`) never
+      emit this shape — there is no wire to fail to decode.
+      `Transport.Stdio` does emit it. When emitted, the decode error
+      occupies exactly the stream position the failed frame would have
+      taken: it never reorders the `{:message, _}` frames around it (see
+      T-ORD below — this shape participates in the same ordered stream).
 
   `transport_ref` identifies *which* transport handle the message belongs
   to. It is opaque to the owner and should only be compared with `==/2`,
@@ -46,23 +59,58 @@ defmodule Raxol.AgentClientProtocol.Transport do
 
   ## Delivery guarantees
 
-  Implementations of this behaviour MUST provide:
+  Implementations of this behaviour MUST satisfy the following four
+  named clauses. They are MANDATED, not negotiated — there is no
+  `ordered?`-style capability flag, and no callback exists to query one.
+  A carrier whose underlying medium does not preserve order (e.g. frames
+  fanned over multiple independent streams/paths) MUST restore order
+  internally — a private sequencing envelope plus a bounded reassembly
+  buffer, invisible above this behaviour — before it ever emits
+  `{:message, _}` to the owner. From the owner's perspective every
+  conforming transport is indistinguishable from an already-ordered one:
+  ordering is a transport property, never a field on the ACP wire.
 
-    * **Ordering** — messages sent via consecutive `send_message/2` calls
-      from a single caller process arrive at the peer's owner in the same
-      order they were sent.
-    * **Reliability** — `send_message/2` returning `{:ok, state}` means
-      the transport has accepted the message for delivery; it does not
-      guarantee the peer has *processed* it, but the transport must not
-      silently drop an accepted message short of `close/1` or peer death.
-    * **Duplex** — both ends may send at any time, independently and
-      concurrently; a transport must not require request/response
+    * **T-ORD (ordered inbound delivery).** Per direction, the sequence
+      of frames delivered to the owner as `{:message, frame}` (and, in
+      its stream position, `{:decode_error, _, _}` where emitted) is
+      EXACTLY the sequence the peer's send path accepted, in acceptance
+      order. "Acceptance order" is the serialization order of the peer
+      transport's single-writer send path: every transport this package
+      ships funnels concurrent `send_message/2` callers through one
+      process before anything leaves for the peer (`Transport.Stdio`
+      serializes writes through its owning `GenServer`'s mailbox;
+      `Transport.Paired` serializes through a `GenServer.call` into the
+      sending side before the peer-side `cast`), so "acceptance order"
+      is well-defined even when multiple local processes call
+      `send_message/2` concurrently. Consequence for callers: a receiver
+      that stamps an ordinal at the single sequential point where it
+      processes inbound `{:acp_transport, ...}` messages gets a faithful
+      ordering key for free — no reorder buffer is required above this
+      layer for an ordered transport.
+    * **T-REL (no silent drop; accepted implies delivered-or-closed).** A
+      frame accepted by `send_message/2` (`{:ok, state}`) is either
+      eventually delivered to the peer's owner, or the stream terminates
+      with `{:closed, reason}` — a transport never drops an accepted
+      frame and then keeps delivering later ones. `send_message/2`
+      returning `{:ok, state}` does not guarantee the peer has
+      *processed* the message, only that the transport has accepted it
+      for delivery.
+    * **T-DUP (no duplication, and duplex).** A transport delivers each
+      accepted frame to the owner AT MOST once (combined with T-REL: an
+      accepted frame not preceded by a terminal `{:closed, _}` is
+      delivered EXACTLY once). Independently, both ends may send at any
+      time, concurrently; a transport must not require request/response
       turn-taking.
+    * **T-TERM (terminal close).** `{:closed, reason}` is delivered to
+      the owner at most once, and nothing — no `{:message, _}`, no
+      `{:decode_error, _, _}`, no second `{:closed, _}` — is delivered
+      after it.
 
-  Implementations MAY be lossy or reorder frames only after `close/1` has
-  been called on either end, at which point `{:error, :closed}` (or a
-  `{:closed, reason}` delivery) is the expected observable behaviour
-  instead of silent loss.
+  Implementations MAY be lossy or reorder frames only strictly AFTER
+  `close/1` has been called on either end, or a `{:closed, reason}` has
+  already been delivered — at which point `{:error, :closed}` (or simply
+  no further delivery) is the expected observable behaviour instead of
+  silent loss or reorder.
   """
 
   @typedoc "The process that receives a transport's inbound `{:acp_transport, ...}` messages."

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport/envelope.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport/envelope.ex
@@ -1,0 +1,101 @@
+defmodule Raxol.AgentClientProtocol.Transport.Envelope do
+  @moduledoc """
+  A pure, process-free sequencing envelope for **unordered-carrier**
+  transports (design-stub — no shipped transport uses this yet; see
+  `Raxol.AgentClientProtocol.Transport.Reassembly` for the receive-side
+  counterpart).
+
+  Every shipped transport (stdio, `Transport.Paired`, a future WebSocket)
+  is already an ordered carrier: frames arrive at the owner in exactly the
+  order the peer sent them, so no sequencing is needed. A future carrier
+  that reorders frames in flight (e.g. frames fanned over several ordered
+  streams, or datagrams with app-level retransmit below this layer) can
+  satisfy the same ordered-delivery contract by wrapping each frame with a
+  sender-assigned, per-connection, per-direction monotone counter (`tseq`)
+  before handing it to the carrier, and unwrapping + reassembling
+  (`Reassembly`) on receipt — restoring order *before* the frame is ever
+  handed to the owner. The Connection, the Session, the Client, and the
+  ACP wire never observe `tseq`; it lives and dies entirely inside the
+  transport.
+
+  ## Wire shape
+
+  The envelope wraps a frame map with two extra top-level fields:
+
+      %{"acpenv" => 1, "s" => tseq, "f" => frame}
+
+    * `"acpenv"` — envelope format version (currently always `1`).
+    * `"s"` — the sender-assigned `tseq`, a positive integer, monotone
+      per connection per direction. This is transport-internal framing,
+      never ACP protocol content: it is stripped by `unwrap/1` before the
+      frame reaches anything above the transport, and it must never be
+      threaded through `_meta` or any other ACP-visible location (that
+      was precisely the trust-boundary mistake this design corrects one
+      layer up, in the Connection's receiver-assigned delivery stamp).
+    * `"f"` — the original JSON-RPC frame (request, response, or
+      notification map), untouched.
+
+  A concrete carrier may re-encode this shape however its wire format
+  requires (e.g. as a binary header instead of JSON keys); the three
+  *fields* — version, sequence, frame — are what's normative, and this
+  module's `wrap/2` / `unwrap/1` give the reference (map-shaped)
+  implementation used by pure tests and by any carrier happy to use JSON
+  maps directly.
+
+  ## Purity
+
+  Both functions are total, deterministic, and side-effect-free: no
+  process, no I/O, no shared state. The caller (a transport's
+  single-writer send path, mirroring the `Framer`'s threading pattern) is
+  responsible for minting successive `tseq` values and for threading
+  `Reassembly` state across `push/3` calls on receipt.
+  """
+
+  @acpenv_version 1
+
+  @typedoc "One JSON-RPC frame (a decoded map), unmodified by the envelope."
+  @type frame :: map()
+
+  @typedoc "Sender-assigned, per-connection, per-direction monotone sequence number (starts at 1)."
+  @type tseq :: pos_integer()
+
+  @typedoc "The wire-shaped envelope map produced by `wrap/2`."
+  @type envelope :: %{required(String.t()) => term()}
+
+  @doc """
+  Wrap `frame` with sequencing metadata for `tseq`.
+
+  `frame` must be a map (a decoded JSON-RPC frame); `tseq` must be a
+  positive integer. Returns the envelope map
+  `%{"acpenv" => 1, "s" => tseq, "f" => frame}`.
+  """
+  @spec wrap(frame(), tseq()) :: envelope()
+  def wrap(frame, tseq) when is_map(frame) and is_integer(tseq) and tseq > 0 do
+    %{"acpenv" => @acpenv_version, "s" => tseq, "f" => frame}
+  end
+
+  @doc """
+  Unwrap an enveloped map, returning its `tseq` and inner frame.
+
+  Succeeds only for a map with the exact envelope shape — the current
+  `"acpenv"` version, an `"s"` that is a positive integer, and an `"f"`
+  that is a map. Anything else (a bare un-enveloped frame, a future/past
+  envelope version, a malformed `"s"`/`"f"`) yields
+  `{:error, :not_enveloped}` rather than raising: the caller (the
+  receiving carrier) decides whether that is a protocol violation or
+  simply "not this envelope version" — this module only recognizes its
+  own shape.
+
+  Round-trips with `wrap/2`: `unwrap(wrap(frame, tseq)) == {:ok, tseq, frame}`
+  for every valid `frame`/`tseq` pair. The returned frame is
+  byte-for-byte (term-for-term) identical to the wrapped input — the
+  envelope carries no rider that survives into it.
+  """
+  @spec unwrap(map()) :: {:ok, tseq(), frame()} | {:error, :not_enveloped}
+  def unwrap(%{"acpenv" => @acpenv_version, "s" => tseq, "f" => frame})
+      when is_integer(tseq) and tseq > 0 and is_map(frame) do
+    {:ok, tseq, frame}
+  end
+
+  def unwrap(_other), do: {:error, :not_enveloped}
+end

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport/reassembly.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport/reassembly.ex
@@ -1,0 +1,217 @@
+defmodule Raxol.AgentClientProtocol.Transport.Reassembly do
+  @moduledoc """
+  A pure, process-free reorder buffer for **unordered-carrier** transports
+  (design-stub — pairs with `Raxol.AgentClientProtocol.Transport.Envelope`
+  on the send side; no shipped transport uses this yet).
+
+  Shaped exactly like `Transport.Framer`: no process, no mailbox, no I/O —
+  a caller (a transport's single reader) threads `t()` through successive
+  `push/3` calls as enveloped frames arrive off the wire, in *whatever*
+  order the carrier delivers them, and gets back the frames that are now
+  releasable *in original send order*.
+
+  ## Scope: reliable-unordered, not lossy
+
+  This module targets carriers that reorder frames but never lose them
+  (e.g. frames fanned out over several independently-ordered streams, a
+  bus with per-partition-only ordering, or a datagram carrier with its
+  own retransmit below this layer). It restores order; it does not
+  detect or recover from loss. A missing `tseq` and a merely-delayed
+  `tseq` are indistinguishable to this module — both simply hold up
+  release until either the gap arrives or the watermark is crossed. A
+  *lossy* carrier needs its own ARQ (ack/retransmit) underneath this
+  layer to turn itself into a reliable-unordered one; that is a transport
+  concern, not an ordering one, and is out of scope here.
+
+  ## Semantics
+
+    * `next_expected` starts at `1` (or `:start`, see `new/1`).
+    * `tseq == next_expected` — release that frame, then cascade: release
+      every already-buffered contiguous successor (`next_expected + 1`,
+      `+2`, ...) in one `push/3` call, advancing `next_expected` past all
+      of them.
+    * `tseq > next_expected` — buffer it (keyed by `tseq`); nothing is
+      released.
+    * `tseq < next_expected` — a duplicate of an already-released frame;
+      dropped silently (idempotent under carrier-level retransmit).
+    * a duplicate of an already-*buffered* (not yet released) `tseq` —
+      also dropped silently; the buffer keeps the first copy.
+    * the buffer crossing either watermark (`:max_buffered_frames`,
+      default `#{inspect(1024)}`; `:max_buffered_bytes`, default 16 MiB)
+      returns `{:closed, {:transport, :reassembly_overflow}}` — the
+      **only** failure mode. There is no other way this module ever
+      reports a problem.
+
+  ## Overflow-bounded, never timer-bounded
+
+  There is no wall clock anywhere in this module — no timer, no
+  `Process.send_after`, no deadline. While under the watermark, an
+  out-of-order frame is held indefinitely, waiting for its missing
+  predecessor; the only two resolutions are the predecessor's arrival or
+  the watermark closing the stream. A carrier that wants liveness
+  detection (peer silently vanished, nothing further will ever arrive)
+  implements its own keepalive below this layer and calls `close/1` (or
+  simply stops calling `push/3` and tears down its own state) — that is
+  the carrier's reliability concern, not this buffer's ordering concern.
+
+  ## Usage
+
+      buf = Reassembly.new()
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"b" => 2})   # buffered, nothing releasable yet
+      {:ok, released, buf} = Reassembly.push(buf, 1, %{"a" => 1})
+      # released == [%{"a" => 1}, %{"b" => 2}]  -- 1 releases, then 2 cascades
+  """
+
+  @default_max_buffered_frames 1_024
+  @default_max_buffered_bytes 16 * 1024 * 1024
+
+  @enforce_keys [:next_expected, :max_buffered_frames, :max_buffered_bytes]
+  defstruct next_expected: 1,
+            buffer: %{},
+            buffered_bytes: 0,
+            max_buffered_frames: @default_max_buffered_frames,
+            max_buffered_bytes: @default_max_buffered_bytes
+
+  @typedoc "One JSON-RPC frame (a decoded map), as delivered by `Envelope.unwrap/1`."
+  @type frame :: map()
+
+  @typedoc "Sender-assigned monotone sequence number (see `Envelope`)."
+  @type tseq :: pos_integer()
+
+  @type t :: %__MODULE__{
+          next_expected: pos_integer(),
+          buffer: %{optional(tseq()) => frame()},
+          buffered_bytes: non_neg_integer(),
+          max_buffered_frames: pos_integer(),
+          max_buffered_bytes: pos_integer()
+        }
+
+  @typedoc "The sole failure this module ever produces: the watermark was crossed."
+  @type overflow_reason :: {:transport, :reassembly_overflow}
+
+  @doc """
+  Create a fresh reassembly buffer.
+
+  Options:
+
+    * `:start` — the first `tseq` this buffer expects (default `1`,
+      matching `Envelope`'s counter start). Must be a positive integer.
+    * `:max_buffered_frames` — maximum number of not-yet-releasable
+      frames held at once before overflow (default
+      `#{@default_max_buffered_frames}`). Must be a positive integer.
+    * `:max_buffered_bytes` — maximum approximate total size (in bytes,
+      via `:erlang.external_size/1` on each buffered frame) of buffered
+      frames before overflow (default #{@default_max_buffered_bytes}
+      = 16 MiB). Must be a positive integer.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    start = Keyword.get(opts, :start, 1)
+    max_frames = Keyword.get(opts, :max_buffered_frames, @default_max_buffered_frames)
+    max_bytes = Keyword.get(opts, :max_buffered_bytes, @default_max_buffered_bytes)
+
+    unless is_integer(start) and start > 0 do
+      raise ArgumentError, "start must be a positive integer, got: #{inspect(start)}"
+    end
+
+    unless is_integer(max_frames) and max_frames > 0 do
+      raise ArgumentError,
+            "max_buffered_frames must be a positive integer, got: #{inspect(max_frames)}"
+    end
+
+    unless is_integer(max_bytes) and max_bytes > 0 do
+      raise ArgumentError,
+            "max_buffered_bytes must be a positive integer, got: #{inspect(max_bytes)}"
+    end
+
+    %__MODULE__{
+      next_expected: start,
+      max_buffered_frames: max_frames,
+      max_buffered_bytes: max_bytes
+    }
+  end
+
+  @doc """
+  Feed one arrived (already-unwrapped) `{tseq, frame}` pair into the
+  buffer.
+
+  Returns `{:ok, released, buffer}` where `released` is the (possibly
+  empty) list of frames now releasable, in original send order — or
+  `{:closed, {:transport, :reassembly_overflow}}` if admitting this frame
+  would cross either watermark. Once `:closed` is returned the caller
+  MUST stop calling `push/3` (mirroring `T-TERM`: nothing is delivered
+  after a close) and deliver
+  `{:acp_transport, ref, {:closed, {:transport, :reassembly_overflow}}}`
+  to its owner; this module holds no further state for that stream.
+  """
+  @spec push(t(), tseq(), frame()) ::
+          {:ok, [frame()], t()} | {:closed, overflow_reason()}
+  def push(%__MODULE__{} = t, tseq, frame)
+      when is_integer(tseq) and tseq > 0 and is_map(frame) do
+    cond do
+      tseq < t.next_expected ->
+        # Already released. Idempotent drop under carrier-level retransmit.
+        {:ok, [], t}
+
+      tseq == t.next_expected ->
+        {released, t} = release_cascade(t, frame)
+        {:ok, released, t}
+
+      Map.has_key?(t.buffer, tseq) ->
+        # Already buffered, not yet released. Idempotent drop.
+        {:ok, [], t}
+
+      true ->
+        admit(t, tseq, frame)
+    end
+  end
+
+  # -- Internal -----------------------------------------------------------
+
+  # tseq == next_expected: release it, then walk forward releasing every
+  # already-buffered contiguous successor.
+  @spec release_cascade(t(), frame()) :: {[frame()], t()}
+  defp release_cascade(%__MODULE__{} = t, frame) do
+    t = %{t | next_expected: t.next_expected + 1}
+    cascade(t, [frame])
+  end
+
+  @spec cascade(t(), [frame(), ...]) :: {[frame()], t()}
+  defp cascade(%__MODULE__{} = t, acc) do
+    case Map.pop(t.buffer, t.next_expected) do
+      {nil, _same_buffer} ->
+        {Enum.reverse(acc), t}
+
+      {buffered_frame, rest} ->
+        t = %{
+          t
+          | buffer: rest,
+            buffered_bytes: t.buffered_bytes - frame_size(buffered_frame),
+            next_expected: t.next_expected + 1
+        }
+
+        cascade(t, [buffered_frame | acc])
+    end
+  end
+
+  # tseq > next_expected and not already buffered: admit into the buffer
+  # unless doing so would cross either watermark.
+  @spec admit(t(), tseq(), frame()) :: {:ok, [frame()], t()} | {:closed, overflow_reason()}
+  defp admit(%__MODULE__{} = t, tseq, frame) do
+    size = frame_size(frame)
+    new_buffer = Map.put(t.buffer, tseq, frame)
+    new_bytes = t.buffered_bytes + size
+
+    if map_size(new_buffer) > t.max_buffered_frames or new_bytes > t.max_buffered_bytes do
+      {:closed, {:transport, :reassembly_overflow}}
+    else
+      {:ok, [], %{t | buffer: new_buffer, buffered_bytes: new_bytes}}
+    end
+  end
+
+  # Approximate wire footprint of a buffered frame, for the byte watermark.
+  # Deterministic and pure (no encode/decode round trip needed); the exact
+  # figure isn't load-bearing, only that it monotonically reflects size.
+  @spec frame_size(frame()) :: non_neg_integer()
+  defp frame_size(frame), do: :erlang.external_size(frame)
+end

--- a/packages/raxol_agent_client_protocol/test/INVARIANTS.md
+++ b/packages/raxol_agent_client_protocol/test/INVARIANTS.md
@@ -137,6 +137,34 @@ carries the family legend.
 | F5 | Volume / no-loss: no data loss or reordering across 10k frames fed in randomly sized chunks; the buffer drains empty. | `framer_test.exs` `describe "F5 volume ..."` |
 | F6 | Re-chunking invariance (property): any re-chunking of concatenated JSON lines yields the original frames in order; CRLF and LF terminators are equivalent; an oversized frame errors then resyncs (totality). | `framer_test.exs` `describe "F6 re-chunking invariance ..."` |
 
+## Family `D` — delivery / transport ordering (D1..D9) — **[NEW registration]**
+
+Home: `test/connection_delivery_test.exs` (D1/D2/D3/D5/D7/D9 — the Connection
+unit + `Client.prompt/3`/`prompt_stream/4`'s direct turn-delivery channel);
+`client_ergonomics_test.exs`'s `prompt_stream/4` describe block already covers
+D6's positive case. D4 (the bounded broadcast-path Reorder engine) is
+**RESERVED** here — no `Delivery.Reorder` module exists yet; a later unit owns
+it. Registered per the transport-ordering design
+(`TRANSPORT_ORDERING_DESIGN.md` §4/§8, ADR-0030 clauses 1/2/3/5/9): the
+Connection stamps a receiver-assigned, contiguous per-turn ordinal at the
+demux point (`dispatch_inbound_notification/3`) and delivers
+`{:acp_turn_update, tag, ordinal, notification}` to the turn's owner DIRECTLY,
+itself — the same single-sender operation `deliver_outcome/2` already uses for
+the terminal result — so the owner's mailbox order is wire order with no
+reorder buffer and no settle timer needed on this path.
+
+| ID | Canonical property | Enforcing test (`file:line`) |
+|----|--------------------|------------------------------|
+| D1 | Order: the turn owner observes a turn's updates in stamped order 0..N-1 for ANY interleaving/delay of the per-notification dispatch tasks (direct delivery happens at demux time, before any task is spawned). | `connection_delivery_test.exs` `describe "D1 order"` |
+| D2 | No silent drop: `delivered < turn_end count` at an ok-result ⇒ `{:error, {:delivery_gap, _}}`, never a silent partial list (the real single-sender Connection cannot produce a gap at all — D1 is the proof; a fault-injected fake Connection double manufactures it here). | `connection_delivery_test.exs` `describe "D2 no silent drop / fail-the-turn"` |
+| D3 | No timer in the guarantee: `Client.prompt/3`'s and `prompt_stream/4`'s receive loops (and `Delivery`) contain no wall-clock `after`/`Process.send_after` — the Connection's own terminal-result guarantee (exactly one `{:acp_result, tag, _}` per accepted submission) bounds the loop instead. | `connection_delivery_test.exs` `describe "D3 no wall-clock timer (grep-gate)"` |
+| D4 | **RESERVED** — bounded Reorder-engine occupancy; no `Delivery.Reorder` module exists yet (a later unit's scope). | — |
+| D5 | Peer cannot wedge or steer delivery: a hostile agent that replays/freezes/garbles `_meta` (incl. the retired `update_seq` shape) changes NOTHING about stamped order or delivery; `_meta` reaches the handler byte-identical (opaque, never read for ordering). | `connection_delivery_test.exs` `describe "D5 hostile peer cannot steer delivery"` |
+| D6 | Streaming live: `prompt_stream/4` invokes `on_update` synchronously at receipt, strictly before the terminal result, with no accumulation (O(1) — the loop keeps no update list at all). | `client_ergonomics_test.exs:209` (positive case); `connection_delivery_test.exs` D2's `prompt_stream/4` gap test re-confirms the no-settle-timer half |
+| D7 | Recursive namespace: a straggler demuxed after a turn's result is stamped out-of-turn and never reaches the departed owner as a turn message; a fresh turn for the same session gets a fresh receiver-minted token with ordinals reset to 0 (no cross-turn aliasing); two sessions' concurrent turns never cross-deliver. | `connection_delivery_test.exs` `describe "D7 recursive turn namespace"` |
+| D8 | **RESERVED** — replay idempotence across reconnect (reattach/journal integration); a later unit's scope. | — |
+| D9 | Telemetry contract: every delivery decision emits `[:raxol, :acp, :delivery]` with `%{session, turn, decision, buffered, ordinal}` (direct path: `decision: :emit, buffered: 0`); the client's fail-the-turn gap emits exactly one `:fail` decision. Asserted via a test-local literal `:telemetry` module (the package has no real `:telemetry` dependency, deviation #5). | `connection_delivery_test.exs` `describe "D9 telemetry contract"` |
+
 ---
 
 # EXTENSION

--- a/packages/raxol_agent_client_protocol/test/INVARIANTS.md
+++ b/packages/raxol_agent_client_protocol/test/INVARIANTS.md
@@ -121,7 +121,7 @@ enforcing test is cited.
 | IC-7 | The Connection never blocks — no `GenServer.call` to itself, no synchronous wait on tasks, no transport call that waits on peer progress. | `connection_test.exs:765` (Inv-8) |
 | IC-8 | Sibling supervision tree: `task_sup`/`session_sup` resolved from the parent supervisor by module/type heuristic (injectable in tests); Connection is `:temporary`. | `connection_test.exs:88`; `integration/end_to_end_test.exs:300` |
 
-## Family `F` — NDJSON framing / transport (F1..F6) — **[NEW registration]**
+## Family `F` — NDJSON framing / transport (F1..F7) — **[NEW registration]**
 
 Home: `test/transport/framer_test.exs`. These IDs *name what the existing
 thorough framer tests already prove* — no test behavior was rewritten; each
@@ -136,6 +136,12 @@ carries the family legend.
 | F4 | Oversized-frame rejection + resync: a line exceeding `max_frame_bytes` yields `{:frame_too_large, size}` WITHOUT unbounded buffering and resyncs at the next terminator (surrounding frames intact, exactly-at-limit passes, default 64MiB, `new/1` rejects non-positive max). | `framer_test.exs` `describe "F4 oversized-frame rejection + resync ..."` |
 | F5 | Volume / no-loss: no data loss or reordering across 10k frames fed in randomly sized chunks; the buffer drains empty. | `framer_test.exs` `describe "F5 volume ..."` |
 | F6 | Re-chunking invariance (property): any re-chunking of concatenated JSON lines yields the original frames in order; CRLF and LF terminators are equivalent; an oversized frame errors then resyncs (totality). | `framer_test.exs` `describe "F6 re-chunking invariance ..."` |
+| F7 | **[NEW]** Transport ordered delivery (T-ORD, `transport.ex` "Delivery guarantees"): per direction, frames delivered to the owner as `{:message, frame}` arrive in EXACTLY the order the peer's send path accepted them — pinned against `Transport.Paired`; a deliberately-reordering fake transport run through the identical check FAILS it (falsifier proof: the check is sensitive to reordering, not vacuous). | `test/transport/ordering_contract_test.exs` `describe "F7 T-ORD conformance: Transport.Paired"` (green) + `describe "F7 red variant: the conformance check is a real falsifier"` (red) |
+
+*Note (F7):* lives in its own file (`ordering_contract_test.exs`), not
+`framer_test.exs` — it exercises the `Transport` behaviour contract
+(acceptance-order delivery across a whole transport), not the Framer's
+byte-splitting, so it does not belong beside F1-F6.
 
 ---
 

--- a/packages/raxol_agent_client_protocol/test/INVARIANTS.md
+++ b/packages/raxol_agent_client_protocol/test/INVARIANTS.md
@@ -136,6 +136,7 @@ carries the family legend.
 | F4 | Oversized-frame rejection + resync: a line exceeding `max_frame_bytes` yields `{:frame_too_large, size}` WITHOUT unbounded buffering and resyncs at the next terminator (surrounding frames intact, exactly-at-limit passes, default 64MiB, `new/1` rejects non-positive max). | `framer_test.exs` `describe "F4 oversized-frame rejection + resync ..."` |
 | F5 | Volume / no-loss: no data loss or reordering across 10k frames fed in randomly sized chunks; the buffer drains empty. | `framer_test.exs` `describe "F5 volume ..."` |
 | F6 | Re-chunking invariance (property): any re-chunking of concatenated JSON lines yields the original frames in order; CRLF and LF terminators are equivalent; an oversized frame errors then resyncs (totality). | `framer_test.exs` `describe "F6 re-chunking invariance ..."` |
+| F8 | Unordered-transport design-stub: `Envelope.wrap/2`/`unwrap/1` round-trip for any frame/tseq (the tseq never leaks into the unwrapped frame); `Reassembly.push/3` releases a tseq-enveloped frame sequence in original order for ANY arrival permutation (property), cascades a contiguous buffered run in one call, drops duplicates (already-released or already-buffered) silently, and crosses either watermark (frame-count or byte) as `{:closed, {:transport, :reassembly_overflow}}` — never growing past it, never timer-bounded. | `transport/reassembly_test.exs` `describe "F8a Envelope ..."` / `"F8b Reassembly ..."` |
 
 ---
 

--- a/packages/raxol_agent_client_protocol/test/connection_delivery_test.exs
+++ b/packages/raxol_agent_client_protocol/test/connection_delivery_test.exs
@@ -1,0 +1,622 @@
+# Red-first suite for the transport-ordering design's Connection unit
+# (TRANSPORT_ORDERING_DESIGN.md §4, ADR-0030 clauses 1/2/3/5/9) -- the
+# ACTUAL fix for the shipped session/update drop/reorder bug: a
+# receiver-assigned per-turn ordinal stamped at the demux point
+# (`dispatch_inbound_notification/3`), delivered to the turn owner
+# DIRECTLY by the Connection itself (`{:acp_turn_update, tag, ordinal,
+# notification}`), the same single-sender operation `deliver_outcome/2`
+# already uses for the terminal result -- so BEAM's pairwise FIFO makes the
+# owner's mailbox order equal wire order, with NO reorder buffer and NO
+# settle timer needed on this path.
+#
+# Registers the D family invariants (test/INVARIANTS.md): D1 (order), D2
+# (no silent drop / fail-the-turn), D3 (no wall-clock timer), D5 (hostile
+# peer cannot wedge/steer delivery), D7 (recursive turn-namespace / no
+# straggler cross-talk), D9 (telemetry contract). D4/D6 are the (not yet
+# built) bounded Reorder engine's and the client streaming path's own
+# invariants respectively -- D6's positive case is already exercised by
+# `client_ergonomics_test.exs`'s `prompt_stream/4` describe block; both
+# flagged as NOT owned by this file.
+#
+# Driving mechanism: `Raxol.AgentClientProtocol.Test.ScriptedPeer` plays
+# the *agent* peer at the raw wire-map level against a real, directly
+# started `Raxol.AgentClientProtocol.Connection` (`role: :client`) -- same
+# technique as `connection_test.exs`'s `start_client_conn/1` and
+# `client_ergonomics_test.exs`'s local reimplementation of it (both files
+# are owned by other units; reimplemented locally here too, not touched).
+# The test PROCESS ITSELF is always the turn owner (`self()` passed
+# straight to `Connection.async_request/6`) -- `async_request` returns as
+# soon as the frame is queued, so no wrapper `Task` is needed just to hold
+# the owner pid; `:acp_turn_update`/`:acp_turn_end`/`:acp_result` land
+# directly in this process's mailbox, assertable via `assert_receive`.
+
+defmodule Raxol.AgentClientProtocol.ConnectionDeliveryTest.Client do
+  @moduledoc false
+  # A client handler whose `session_update/2` rendezvous-blocks: it reports
+  # that it started running -- `{:handler_running, notif, ref, task_pid}`,
+  # `task_pid` being ITS OWN dispatch-task pid -- to the test process, then
+  # waits for `{:proceed, ref}` sent to that same pid before returning.
+  # This lets a test hold one notification's dispatch task open
+  # indefinitely while a LATER notification's task runs and finishes
+  # first -- the scrambled fan-out the shipped bug depended on -- while
+  # asserting the owner still observes `:acp_turn_update` in stamped order
+  # regardless (D1): direct delivery happens at the demux point, before
+  # any task is even spawned, so it cannot be affected by how those tasks
+  # are later scheduled.
+  use Raxol.AgentClientProtocol.Client
+
+  @impl true
+  def session_update(notif, ctx) do
+    test_pid = ctx.handler_state
+    ref = make_ref()
+    send(test_pid, {:handler_running, notif, ref, self()})
+
+    receive do
+      {:proceed, ^ref} -> :ok
+    end
+  end
+end
+
+defmodule Raxol.AgentClientProtocol.ConnectionDeliveryTest.FaultConnection do
+  @moduledoc false
+  # A minimal Connection DOUBLE for D2 -- answers `async_request/6`'s wire
+  # shape with `:ok` (satisfying `Client.prompt/3`/`prompt_stream/4`'s call
+  # contract) and reports the minted `{owner, tag}` back to the test
+  # process. This exists ONLY to manufacture the `delivery_gap` scenario:
+  # the real, single-sender Connection cannot produce it at all (this
+  # file's D1 test is the proof that the path is unreachable), so testing
+  # the client's fail-the-turn logic requires an adversarial double that
+  # claims more updates were stamped (`{:acp_turn_end, tag, count}`) than
+  # were actually sent -- exactly the fault injection the design's D2 row
+  # calls for.
+  use GenServer
+
+  def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+
+  @impl true
+  def init(test_pid), do: {:ok, test_pid}
+
+  @impl true
+  def handle_call({:async_request, _method, _params, owner, tag, _timeout}, _from, test_pid) do
+    send(test_pid, {:captured, owner, tag})
+    {:reply, :ok, test_pid}
+  end
+end
+
+defmodule Raxol.AgentClientProtocol.ConnectionDeliveryTest do
+  # async: false -- defines a global `:telemetry` module below (D9) and
+  # drives real Connection/Paired processes, matching connection_test.exs's
+  # own precedent.
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Raxol.AgentClientProtocol.Client
+  alias Raxol.AgentClientProtocol.Connection
+  alias Raxol.AgentClientProtocol.ConnectionDeliveryTest.FaultConnection
+  alias Raxol.AgentClientProtocol.Test.ScriptedPeer
+  alias Raxol.AgentClientProtocol.Transport.Paired
+
+  alias Raxol.AgentClientProtocol.Schema.AgentTypes.{InitializeRequest, PromptRequest}
+  alias Raxol.AgentClientProtocol.Schema.ContentBlock
+
+  @scramble_client Raxol.AgentClientProtocol.ConnectionDeliveryTest.Client
+
+  # ===========================================================================
+  # Fixtures & helpers (local reimplementation -- connection_test.exs and
+  # client_ergonomics_test.exs are owned by other units, not touched).
+  # ===========================================================================
+
+  defp start_client_conn(handler, handler_arg) do
+    task_sup = start_supervised!({Task.Supervisor, []})
+    {conn_handle, peer} = ScriptedPeer.new()
+
+    conn =
+      start_supervised!(
+        {Connection,
+         [
+           role: :client,
+           transport: {Paired, conn_handle},
+           handler: handler,
+           handler_arg: handler_arg,
+           task_sup: task_sup
+         ]}
+      )
+
+    %{conn: conn, peer: peer}
+  end
+
+  defp complete_handshake(conn, peer) do
+    task =
+      Task.async(fn ->
+        Connection.request(conn, "initialize", InitializeRequest.new(1), 2_000)
+      end)
+
+    frame = ScriptedPeer.recv(peer)
+    assert frame["method"] == "initialize"
+    ScriptedPeer.send_result(peer, frame["id"], %{"protocolVersion" => 1})
+    assert {:ok, _} = Task.await(task)
+    :ok
+  end
+
+  defp update_frame(session_id, mode_id, meta \\ nil) do
+    base = %{
+      "sessionId" => session_id,
+      "update" => %{"sessionUpdate" => "current_mode_update", "currentModeId" => mode_id}
+    }
+
+    if meta, do: Map.put(base, "_meta", meta), else: base
+  end
+
+  defp prompt_request(session_id),
+    do: PromptRequest.new(session_id, [ContentBlock.from_string("hi")])
+
+  # Opens a real turn on `conn` by calling `Connection.async_request/6`
+  # DIRECTLY from the calling (test) process -- `self()` is the owner, so
+  # every `:acp_turn_update`/`:acp_turn_end`/`:acp_result` for `tag` lands
+  # straight in this process's own mailbox. `async_request/6` returns as
+  # soon as the frame is queued (it does not block for the turn's
+  # lifetime), so no wrapper `Task` is needed. Returns the wire id of the
+  # `session/prompt` request (for `ScriptedPeer.send_result/3`).
+  defp open_turn(conn, peer, session_id, tag) do
+    :ok =
+      Connection.async_request(
+        conn,
+        "session/prompt",
+        prompt_request(session_id),
+        self(),
+        tag,
+        5_000
+      )
+
+    frame = ScriptedPeer.recv(peer)
+    assert frame["method"] == "session/prompt"
+    frame["id"]
+  end
+
+  # Send `{:proceed, ref}` to the BLOCKED dispatch task itself (`task_pid`,
+  # captured from the handler's `{:handler_running, notif, ref, task_pid}`
+  # report) and wait for it to actually finish (it re-reports nothing on
+  # exit, so we just give the scheduler a beat via a monitor).
+  defp release(task_pid, ref) do
+    mon = Process.monitor(task_pid)
+    send(task_pid, {:proceed, ref})
+    assert_receive {:DOWN, ^mon, :process, ^task_pid, _}, 500
+  end
+
+  # ===========================================================================
+  # D1 -- order: the turn owner observes updates in stamped order 0..N-1
+  # for ANY interleaving/delay of the per-notification dispatch tasks.
+  # ===========================================================================
+
+  describe "D1 order" do
+    test "direct delivery is demux-ordered even when dispatch task 0 is held open while task 1 finishes first" do
+      %{conn: conn, peer: peer} = start_client_conn(@scramble_client, self())
+      :ok = complete_handshake(conn, peer)
+
+      tag = make_ref()
+      out_id = open_turn(conn, peer, "sess-d1", tag)
+
+      # Frame 0: its dispatch task starts and BLOCKS (rendezvous), holding
+      # itself open indefinitely.
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-d1", "m0"))
+
+      assert_receive {:handler_running,
+                      %{update: {:current_mode_update, %{current_mode_id: "m0"}}}, ref0, task0},
+                     500
+
+      # Frame 1: its OWN dispatch task starts and finishes IMMEDIATELY,
+      # racing ahead of task 0's still-blocked dispatch.
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-d1", "m1"))
+
+      assert_receive {:handler_running,
+                      %{update: {:current_mode_update, %{current_mode_id: "m1"}}}, ref1, task1},
+                     500
+
+      release(task1, ref1)
+
+      # Only NOW release task 0 -- it was the scrambled, slower one.
+      release(task0, ref0)
+
+      # The OWNER's mailbox -- a completely separate delivery path from
+      # the per-notification dispatch tasks above -- is unaffected by
+      # which task finished first: it still received ordinal 0 strictly
+      # before ordinal 1, because both sends happened at demux time
+      # (BEFORE either task was even spawned), from the single Connection
+      # process.
+      assert_receive {:acp_turn_update, ^tag, 0,
+                      %{update: {:current_mode_update, %{current_mode_id: "m0"}}}},
+                     500
+
+      assert_receive {:acp_turn_update, ^tag, 1,
+                      %{update: {:current_mode_update, %{current_mode_id: "m1"}}}},
+                     500
+
+      ScriptedPeer.send_result(peer, out_id, %{"stopReason" => "end_turn"})
+    end
+  end
+
+  # ===========================================================================
+  # D2 -- no silent drop: delivered < turn_end count at an ok-result fails
+  # the turn (never a silent partial list). The real single-sender
+  # Connection cannot produce this (D1 proves the path unreachable), so a
+  # fault-injected fake Connection double manufactures the gap.
+  # ===========================================================================
+
+  describe "D2 no silent drop / fail-the-turn" do
+    test "prompt/3 fails the turn when the turn_end count exceeds what was actually delivered" do
+      {:ok, fake} = FaultConnection.start_link(self())
+
+      caller = Task.async(fn -> Client.prompt(fake, prompt_request("s-gap"), 2_000) end)
+
+      assert_receive {:captured, owner, tag}, 500
+      # Only ONE update is actually sent...
+      send(
+        owner,
+        {:acp_turn_update, tag, 0, %{update: {:current_mode_update, %{current_mode_id: "m0"}}}}
+      )
+
+      # ...but the connection double claims TWO were stamped.
+      send(owner, {:acp_turn_end, tag, 2})
+      send(owner, {:acp_result, tag, {:ok, %{stop_reason: :end_turn}}})
+
+      assert {:error, {:delivery_gap, %{delivered: 1, expected: 2}}} = Task.await(caller)
+    end
+
+    test "prompt_stream/4 fails the turn on the same gap, after already having streamed the delivered update" do
+      {:ok, fake} = FaultConnection.start_link(self())
+      test_pid = self()
+
+      caller =
+        Task.async(fn ->
+          Client.prompt_stream(
+            fake,
+            prompt_request("s-gap-2"),
+            fn u -> send(test_pid, {:streamed, u}) end,
+            2_000
+          )
+        end)
+
+      assert_receive {:captured, owner, tag}, 500
+
+      send(
+        owner,
+        {:acp_turn_update, tag, 0, %{update: {:current_mode_update, %{current_mode_id: "m0"}}}}
+      )
+
+      assert_receive {:streamed, {:current_mode_update, %{current_mode_id: "m0"}}}, 500
+
+      send(owner, {:acp_turn_end, tag, 3})
+      send(owner, {:acp_result, tag, {:ok, %{stop_reason: :end_turn}}})
+
+      assert {:error, {:delivery_gap, %{delivered: 1, expected: 3}}} = Task.await(caller)
+    end
+
+    test "no gap is reported when delivered == turn_end count (the honest, common case)" do
+      {:ok, fake} = FaultConnection.start_link(self())
+      caller = Task.async(fn -> Client.prompt(fake, prompt_request("s-ok"), 2_000) end)
+
+      assert_receive {:captured, owner, tag}, 500
+
+      send(
+        owner,
+        {:acp_turn_update, tag, 0, %{update: {:current_mode_update, %{current_mode_id: "m0"}}}}
+      )
+
+      send(owner, {:acp_turn_end, tag, 1})
+      send(owner, {:acp_result, tag, {:ok, %{stop_reason: :end_turn}}})
+
+      assert {:ok,
+              {[{:current_mode_update, %{current_mode_id: "m0"}}], %{stop_reason: :end_turn}}} =
+               Task.await(caller)
+    end
+  end
+
+  # ===========================================================================
+  # D3 -- no timer in the guarantee: grep-gate over the shipped source, not
+  # a runtime scheduling test (a wall-clock delay is not something a test
+  # can prove absent by racing it -- the design's own §8 D3 row pairs the
+  # behavioral delivery test with a static grep). Client.prompt/3's and
+  # prompt_stream/4's receive loops (and Delivery) must contain no
+  # `after <n> ->` timeout clause and no `Process.send_after` call --
+  # the OLD implementation's `@update_settle_ms`/`after 5 ->` settle
+  # window is exactly what this gate would have caught.
+  # ===========================================================================
+
+  describe "D3 no wall-clock timer (grep-gate)" do
+    test "client.ex's receive loops contain no `after` timeout clause or Process.send_after" do
+      source =
+        "lib/raxol/agent_client_protocol/client.ex"
+        |> Path.expand(Path.join(__DIR__, ".."))
+        |> File.read!()
+
+      refute source =~ ~r/Process\.send_after/,
+             "client.ex must never arm a wall-clock timer (ADR-0030 clause 3)"
+
+      # A bare `after <integer> ->` inside a `receive do ... end` block is
+      # the settle-window shape this design removes. `try/after` (cleanup)
+      # is a different construct entirely and does not match this pattern
+      # (it has no `->` clause body keyed on an integer timeout).
+      refute source =~ ~r/\n\s*after\s+\d+\s*->/,
+             "client.ex must never have a receive-loop settle timer (the old @update_settle_ms shape)"
+    end
+
+    test "delivery.ex contains no wall-clock timer either" do
+      source =
+        "lib/raxol/agent_client_protocol/delivery.ex"
+        |> Path.expand(Path.join(__DIR__, ".."))
+        |> File.read!()
+
+      refute source =~ ~r/Process\.send_after/
+      refute source =~ ~r/\n\s*after\s+\d+\s*->/
+    end
+  end
+
+  # ===========================================================================
+  # D5 -- a hostile peer cannot wedge or steer delivery: garbled/replayed
+  # `_meta` (the old, now-removed `update_seq` shape included) changes
+  # NOTHING about stamped order; `_meta` reaches the handler byte-identical
+  # (opaque -- never read for ordering).
+  # ===========================================================================
+
+  describe "D5 hostile peer cannot steer delivery" do
+    test "identical/frozen/garbled _meta on every update never affects the stamped ordinal or delivery" do
+      %{conn: conn, peer: peer} = start_client_conn(@scramble_client, self())
+      :ok = complete_handshake(conn, peer)
+
+      tag = make_ref()
+      out_id = open_turn(conn, peer, "sess-d5", tag)
+
+      # A "frozen" replayed meta bucket -- exactly the shape round 3's
+      # rejected agent-stamped update_seq used, and a garbled variant.
+      frozen_meta = %{"raxol.io" => %{"update_seq" => 0}}
+      garbled_meta = %{"raxol.io" => %{"update_seq" => "not-a-number", "junk" => [1, 2, 3]}}
+
+      ScriptedPeer.send_notification(
+        peer,
+        "session/update",
+        update_frame("sess-d5", "g0", frozen_meta)
+      )
+
+      assert_receive {:handler_running, notif0, ref0, task0}, 500
+      release(task0, ref0)
+
+      ScriptedPeer.send_notification(
+        peer,
+        "session/update",
+        update_frame("sess-d5", "g1", frozen_meta)
+      )
+
+      assert_receive {:handler_running, notif1, ref1, task1}, 500
+      release(task1, ref1)
+
+      ScriptedPeer.send_notification(
+        peer,
+        "session/update",
+        update_frame("sess-d5", "g2", garbled_meta)
+      )
+
+      assert_receive {:handler_running, notif2, ref2, task2}, 500
+      release(task2, ref2)
+
+      # Ordinals stamped 0, 1, 2 regardless of the (identical, then
+      # garbled) `_meta` -- never read for ordering.
+      assert_receive {:acp_turn_update, ^tag, 0,
+                      %{update: {:current_mode_update, %{current_mode_id: "g0"}}}},
+                     500
+
+      assert_receive {:acp_turn_update, ^tag, 1,
+                      %{update: {:current_mode_update, %{current_mode_id: "g1"}}}},
+                     500
+
+      assert_receive {:acp_turn_update, ^tag, 2,
+                      %{update: {:current_mode_update, %{current_mode_id: "g2"}}}},
+                     500
+
+      # `_meta` reaches the handler byte-identical -- opaque passthrough.
+      assert notif0._meta == frozen_meta
+      assert notif1._meta == frozen_meta
+      assert notif2._meta == garbled_meta
+
+      ScriptedPeer.send_result(peer, out_id, %{"stopReason" => "end_turn"})
+    end
+  end
+
+  # ===========================================================================
+  # D7 -- recursive namespace: a straggler demuxed after turn N's result
+  # never reaches the departed owner as a turn message; a fresh turn for
+  # the same session gets a fresh token + ordinals reset to 0 (no
+  # cross-turn aliasing); two sessions' concurrent turns never cross.
+  # ===========================================================================
+
+  describe "D7 recursive turn namespace" do
+    test "a stray update after the turn's result is never delivered as a turn message; a fresh turn gets a fresh token" do
+      %{conn: conn, peer: peer} = start_client_conn(@scramble_client, self())
+      :ok = complete_handshake(conn, peer)
+
+      tag_a = make_ref()
+      out_id_a = open_turn(conn, peer, "sess-d7", tag_a)
+
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-d7", "a0"))
+      assert_receive {:handler_running, _n, ref_a0, task_a0}, 500
+      release(task_a0, ref_a0)
+      assert_receive {:acp_turn_update, ^tag_a, 0, _}, 500
+
+      ScriptedPeer.send_result(peer, out_id_a, %{"stopReason" => "end_turn"})
+      assert_receive {:acp_turn_end, ^tag_a, 1}, 500
+      assert_receive {:acp_result, ^tag_a, {:ok, _}}, 500
+
+      # A straggler for the SAME session arrives after the turn closed.
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-d7", "stray"))
+      assert_receive {:handler_running, _n, ref_stray, task_stray}, 500
+      release(task_stray, ref_stray)
+
+      # It never reaches turn A's tag as a turn message (stamped
+      # out-of-turn instead -- no owner to alias into).
+      refute_receive {:acp_turn_update, ^tag_a, _, _}, 200
+
+      # A fresh turn B for the SAME session gets a FRESH token; its first
+      # ordinal is 0 again -- no aliasing with turn A's history.
+      tag_b = make_ref()
+      out_id_b = open_turn(conn, peer, "sess-d7", tag_b)
+      assert tag_a != tag_b
+
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-d7", "b0"))
+      assert_receive {:handler_running, _n, ref_b0, task_b0}, 500
+      release(task_b0, ref_b0)
+
+      assert_receive {:acp_turn_update, ^tag_b, 0,
+                      %{update: {:current_mode_update, %{current_mode_id: "b0"}}}},
+                     500
+
+      refute_receive {:acp_turn_update, ^tag_a, _, _}, 100
+
+      ScriptedPeer.send_result(peer, out_id_b, %{"stopReason" => "end_turn"})
+    end
+
+    test "two sessions' concurrent turns never cross-deliver" do
+      %{conn: conn, peer: peer} = start_client_conn(@scramble_client, self())
+      :ok = complete_handshake(conn, peer)
+
+      tag_x = make_ref()
+      tag_y = make_ref()
+      out_id_x = open_turn(conn, peer, "sess-x", tag_x)
+      out_id_y = open_turn(conn, peer, "sess-y", tag_y)
+
+      # Interleave: y0, x0, y1, x1.
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-y", "y0"))
+      assert_receive {:handler_running, _, ry0, ty0}, 500
+      release(ty0, ry0)
+
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-x", "x0"))
+      assert_receive {:handler_running, _, rx0, tx0}, 500
+      release(tx0, rx0)
+
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-y", "y1"))
+      assert_receive {:handler_running, _, ry1, ty1}, 500
+      release(ty1, ry1)
+
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-x", "x1"))
+      assert_receive {:handler_running, _, rx1, tx1}, 500
+      release(tx1, rx1)
+
+      # Each session's ordinals are independent (both start at 0), and
+      # never cross into the other tag.
+      assert_receive {:acp_turn_update, ^tag_x, 0,
+                      %{update: {:current_mode_update, %{current_mode_id: "x0"}}}},
+                     500
+
+      assert_receive {:acp_turn_update, ^tag_x, 1,
+                      %{update: {:current_mode_update, %{current_mode_id: "x1"}}}},
+                     500
+
+      assert_receive {:acp_turn_update, ^tag_y, 0,
+                      %{update: {:current_mode_update, %{current_mode_id: "y0"}}}},
+                     500
+
+      assert_receive {:acp_turn_update, ^tag_y, 1,
+                      %{update: {:current_mode_update, %{current_mode_id: "y1"}}}},
+                     500
+
+      refute_receive {:acp_turn_update, ^tag_x, _,
+                      %{update: {:current_mode_update, %{current_mode_id: "y" <> _}}}},
+                     100
+
+      refute_receive {:acp_turn_update, ^tag_y, _,
+                      %{update: {:current_mode_update, %{current_mode_id: "x" <> _}}}},
+                     100
+
+      ScriptedPeer.send_result(peer, out_id_x, %{"stopReason" => "end_turn"})
+      ScriptedPeer.send_result(peer, out_id_y, %{"stopReason" => "end_turn"})
+    end
+  end
+
+  # ===========================================================================
+  # D9 -- telemetry contract: every delivery decision emits
+  # [:raxol, :acp, :delivery] with %{session, turn, decision, buffered,
+  # ordinal}, partitioning into :emit | :buffer | :gap | :fail (:gap is
+  # unreachable in v1 -- nothing is coalescible; not asserted here, no
+  # such variant exists yet). This package does not depend on `:telemetry`
+  # (Connection's own moduledoc, deviation #5) -- a minimal literal
+  # `:telemetry` module is defined below purely so
+  # `Code.ensure_loaded?(:telemetry)` resolves true for this file's
+  # assertions, without adding a real dependency to the package.
+  # ===========================================================================
+
+  describe "D9 telemetry contract" do
+    setup do
+      :telemetry.attach_collector(self())
+      :ok
+    end
+
+    test "a direct-delivered update emits :emit with buffered: 0" do
+      %{conn: conn, peer: peer} = start_client_conn(@scramble_client, self())
+      :ok = complete_handshake(conn, peer)
+
+      tag = make_ref()
+      out_id = open_turn(conn, peer, "sess-d9", tag)
+
+      ScriptedPeer.send_notification(peer, "session/update", update_frame("sess-d9", "t0"))
+      assert_receive {:handler_running, _, ref, task}, 500
+      release(task, ref)
+
+      assert_receive {:telemetry_event, [:raxol, :acp, :delivery], %{count: 1},
+                      %{
+                        session: "sess-d9",
+                        turn: turn_token,
+                        decision: :emit,
+                        buffered: 0,
+                        ordinal: 0
+                      }},
+                     500
+
+      assert is_reference(turn_token)
+      ScriptedPeer.send_result(peer, out_id, %{"stopReason" => "end_turn"})
+    end
+
+    test "a fail-the-turn gap emits exactly one :fail decision (client-side)" do
+      {:ok, fake} = FaultConnection.start_link(self())
+      caller = Task.async(fn -> Client.prompt(fake, prompt_request("s-gap-telemetry"), 2_000) end)
+
+      assert_receive {:captured, owner, tag}, 500
+      send(owner, {:acp_turn_end, tag, 1})
+      send(owner, {:acp_result, tag, {:ok, %{stop_reason: :end_turn}}})
+
+      assert {:error, {:delivery_gap, %{delivered: 0, expected: 1}}} = Task.await(caller)
+
+      assert_receive {:telemetry_event, [:raxol, :acp, :delivery], %{count: 1},
+                      %{decision: :fail, delivered: 0, expected: 1}},
+                     500
+
+      refute_receive {:telemetry_event, [:raxol, :acp, :delivery], _, %{decision: :fail}}, 100
+    end
+  end
+end
+
+# A minimal, LITERAL `:telemetry` module (an Erlang-style atom module name)
+# -- defined at the bottom of this test file so
+# `Code.ensure_loaded?(:telemetry)` / `function_exported?(:telemetry,
+# :execute, 3)` (the exact guard both `Connection`'s and
+# `Raxol.AgentClientProtocol.Delivery`'s telemetry helpers use) resolve
+# true for the D9 describe block above, WITHOUT adding a real `:telemetry`
+# dependency to the package (deviation #5: "Telemetry events are emitted
+# only when :telemetry is loaded... otherwise Logger carries the signal").
+# `execute/3` forwards to whichever pid last called `attach_collector/1`
+# (this file runs `async: false`, so there is never more than one
+# collector live at a time).
+defmodule :telemetry do
+  @moduledoc false
+
+  @collector_key {__MODULE__, :collector}
+
+  def attach_collector(pid), do: :persistent_term.put(@collector_key, pid)
+
+  def execute(event, measurements, metadata) do
+    case :persistent_term.get(@collector_key, nil) do
+      nil -> :ok
+      pid -> send(pid, {:telemetry_event, event, measurements, metadata})
+    end
+
+    :ok
+  end
+end

--- a/packages/raxol_agent_client_protocol/test/support/conformance/case_runner.ex
+++ b/packages/raxol_agent_client_protocol/test/support/conformance/case_runner.ex
@@ -306,6 +306,17 @@ defmodule Raxol.AgentClientProtocol.Test.Conformance.CaseRunner do
     result =
       Connection.request(harness.client_conn, "session/prompt", req, opts.update_timeout_ms)
 
+    # The synchronous prompt result has no happens-before with MockClient's
+    # `session/update` accumulation (that runs on the async broadcast-callback
+    # path, a fresh dispatch task per notification). All update FRAMES were
+    # received before the response frame (I3), but their handler tasks may not
+    # have appended to the accumulator yet when a downstream `updates_*` check
+    # reads it. Quiesce the accumulator (bounded) before returning so a check
+    # never races the drain. Test-harness synchronization only — not a runtime
+    # ordering assertion (the prompt/prompt_stream direct channel is what the
+    # real ordering guarantee rides on; this fixture uses the callback path).
+    quiesce_updates(harness.client_state)
+
     result = apply_expect_error(result, step["expect_error"], "session/prompt")
     save(ctx, step["save_as"], unwrap(result))
   end
@@ -416,6 +427,23 @@ defmodule Raxol.AgentClientProtocol.Test.Conformance.CaseRunner do
 
   defp save(ctx, nil, _value), do: ctx
   defp save(ctx, key, value), do: %{ctx | saved: Map.put(ctx.saved, key, value)}
+
+  # Poll the MockClient update accumulator until its length is stable across two
+  # consecutive reads (the async dispatch tasks have drained) or a bounded cap
+  # is reached. Resolves in a few ms for the mock's burst-then-done pattern.
+  defp quiesce_updates(client_state, prev \\ -1, tries \\ 0)
+  defp quiesce_updates(_client_state, _prev, tries) when tries >= 50, do: :ok
+
+  defp quiesce_updates(client_state, prev, tries) do
+    count = client_state |> MockClient.updates() |> length()
+
+    if count == prev and count > 0 do
+      :ok
+    else
+      Process.sleep(2)
+      quiesce_updates(client_state, count, tries + 1)
+    end
+  end
 
   defp resolve_ref("$" <> key, saved) do
     case Map.fetch(saved, key) do

--- a/packages/raxol_agent_client_protocol/test/transport/ordering_contract_test.exs
+++ b/packages/raxol_agent_client_protocol/test/transport/ordering_contract_test.exs
@@ -1,0 +1,160 @@
+defmodule Raxol.AgentClientProtocol.Transport.OrderingContractTest do
+  @moduledoc """
+  F7 conformance suite: pins the `Raxol.AgentClientProtocol.Transport`
+  behaviour's T-ORD clause (transport.ex `## Delivery guarantees`) — per
+  direction, frames delivered to the owner as `{:message, frame}` arrive in
+  EXACTLY the order the peer's send path accepted them.
+
+  This is a *behavioral* test, not a doc assertion: it drives real frames
+  through the real `Transport.Paired` implementation and checks arrival
+  order against send order.
+
+  The second `describe` block is the falsifier proof the design's F7 entry
+  calls for: a deliberately reordering fake transport, run through the
+  IDENTICAL check, must fail it. If the check couldn't tell the two apart
+  it would be vacuous — this pins that it can.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.AgentClientProtocol.Transport.Paired
+
+  # -- Shared oracle --------------------------------------------------------
+  #
+  # The same "collect N `{:message, ...}` deliveries, in the order they land
+  # in this process's mailbox" check is applied to both the real transport
+  # (must pass) and the reordering fake (must fail) below.
+
+  defp collect_seqs(n, timeout \\ 2_000) do
+    for _ <- 1..n do
+      assert_receive {:acp_transport, _ref, {:message, %{"seq" => seq}}}, timeout
+      seq
+    end
+  end
+
+  describe "F7 T-ORD conformance: Transport.Paired" do
+    test "N frames sent from a single process arrive at the owner in send order" do
+      {left, right} = Paired.create_pair()
+      :ok = Paired.set_owner(right, self())
+      n = 2_000
+
+      Enum.reduce(1..n, left, fn i, side ->
+        {:ok, side} = Paired.send_message(side, %{"seq" => i})
+        side
+      end)
+
+      assert collect_seqs(n) == Enum.to_list(1..n)
+    end
+
+    test "acceptance order (not scheduling order) governs: sends from many tasks funnel through one owner's send order per side" do
+      {left, right} = Paired.create_pair()
+      :ok = Paired.set_owner(right, self())
+      n = 300
+
+      # Each send is issued sequentially against `left` (the transport's
+      # single-writer send path serializes acceptance), so even though this
+      # process could be preempted between calls, the ACCEPTANCE order is
+      # exactly the call order below — which is what T-ORD promises arrival
+      # will match.
+      Enum.reduce(1..n, left, fn i, side ->
+        {:ok, side} = Paired.send_message(side, %{"seq" => i})
+        side
+      end)
+
+      assert collect_seqs(n) == Enum.to_list(1..n)
+    end
+  end
+
+  describe "F7 red variant: the conformance check is a real falsifier" do
+    defmodule ShufflingFakeTransport do
+      @moduledoc """
+      Test-only fake satisfying the `Transport` behaviour's callback
+      SHAPES (`send_message/2`, `close/1`) but deliberately violating
+      T-ORD: it buffers every accepted frame and, on `flush/1`, delivers
+      them to the owner in reverse (LIFO) order — the last frame accepted
+      arrives first. It still satisfies T-REL/T-DUP (every accepted frame
+      is delivered, exactly once) so the ONLY property it breaks is
+      ordering, isolating what the F7 check actually detects.
+      """
+
+      @behaviour Raxol.AgentClientProtocol.Transport
+
+      use GenServer
+
+      @type t :: %__MODULE__{pid: pid()}
+      defstruct [:pid]
+
+      @spec start(pid()) :: t()
+      def start(owner) when is_pid(owner) do
+        {:ok, pid} = GenServer.start_link(__MODULE__, %{owner: owner, buffer: []})
+        %__MODULE__{pid: pid}
+      end
+
+      @impl Raxol.AgentClientProtocol.Transport
+      @spec send_message(t(), map()) :: {:ok, t()} | {:error, term()}
+      def send_message(%__MODULE__{pid: pid} = t, message) when is_map(message) do
+        :ok = GenServer.call(pid, {:buffer, message})
+        {:ok, t}
+      end
+
+      @impl Raxol.AgentClientProtocol.Transport
+      @spec close(t()) :: :ok
+      def close(%__MODULE__{pid: pid}) do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+        :ok
+      end
+
+      @doc """
+      Test-only: deliver every buffered frame to the owner in REVERSE
+      (LIFO) order. Deliberately violates T-ORD so the F7 oracle above
+      has something real to fail against.
+      """
+      @spec flush(t()) :: :ok
+      def flush(%__MODULE__{pid: pid}) do
+        GenServer.call(pid, :flush)
+      end
+
+      @impl GenServer
+      def init(state), do: {:ok, state}
+
+      @impl GenServer
+      def handle_call({:buffer, message}, _from, %{buffer: buffer} = state) do
+        {:reply, :ok, %{state | buffer: [message | buffer]}}
+      end
+
+      def handle_call(:flush, _from, %{owner: owner, buffer: buffer} = state) do
+        # `buffer` accumulated via prepend, so it is already in
+        # arrived-most-recent-first order; delivering it AS-IS is exactly
+        # the reverse of acceptance order.
+        Enum.each(buffer, fn message ->
+          send(owner, {:acp_transport, self(), {:message, message}})
+        end)
+
+        {:reply, :ok, %{state | buffer: []}}
+      end
+    end
+
+    test "a transport that delivers frames out of acceptance order fails the F7 check" do
+      fake = ShufflingFakeTransport.start(self())
+      n = 20
+
+      Enum.each(1..n, fn i ->
+        {:ok, _} = ShufflingFakeTransport.send_message(fake, %{"seq" => i})
+      end)
+
+      :ok = ShufflingFakeTransport.flush(fake)
+
+      received = collect_seqs(n)
+
+      # T-REL/T-DUP still hold: every accepted frame arrived, exactly once.
+      assert Enum.sort(received) == Enum.to_list(1..n)
+
+      # T-ORD does NOT hold: arrival order is the exact reverse of send
+      # order, not send order itself. This is the falsifier proof — the
+      # identical "arrival == send order" check applied to Paired above
+      # correctly distinguishes a conforming transport from this one.
+      refute received == Enum.to_list(1..n)
+      assert received == Enum.to_list(n..1//-1)
+    end
+  end
+end

--- a/packages/raxol_agent_client_protocol/test/transport/reassembly_test.exs
+++ b/packages/raxol_agent_client_protocol/test/transport/reassembly_test.exs
@@ -1,0 +1,272 @@
+defmodule Raxol.AgentClientProtocol.Transport.ReassemblyTest do
+  @moduledoc """
+  F8 — envelope wrap/unwrap round-trip + seq-strip, and reassembly
+  reordering for the unordered-transport design-stub class. Canonical
+  statement lives in `test/INVARIANTS.md` (CORE › Framing/transport, `F8`
+  row). This is the buildable stub of a class no shipped transport uses
+  yet (`Transport.Envelope` + `Transport.Reassembly`), pure and
+  process-free like `Transport.Framer`'s F1-F6 suite:
+
+    * F8a — `Envelope.wrap/2` / `Envelope.unwrap/1` round-trip for any
+      frame/tseq pair; the sequence number never leaks into the unwrapped
+      frame (seq-strip); a non-enveloped or malformed map is rejected.
+    * F8b — `Reassembly.push/3` releases a tseq-enveloped frame sequence
+      in original order for ANY arrival permutation (property); duplicates
+      (already-released or already-buffered) are dropped with no extra
+      release; a contiguous run already buffered cascades in one `push/3`
+      call; crossing either watermark (frame-count or byte) yields
+      `{:closed, {:transport, :reassembly_overflow}}` and never grows past
+      it; nothing here is timer-bounded (no `Process.sleep`/`after`
+      anywhere in this file — determinism is asserted by construction, not
+      by racing a clock).
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.AgentClientProtocol.Transport.Envelope
+  alias Raxol.AgentClientProtocol.Transport.Reassembly
+
+  describe "F8a Envelope: wrap/unwrap round-trip, seq-strip, rejection" do
+    property "unwrap(wrap(frame, tseq)) == {:ok, tseq, frame} for any frame/tseq" do
+      check all(
+              frame <- frame_generator(),
+              tseq <- positive_integer()
+            ) do
+        assert Envelope.unwrap(Envelope.wrap(frame, tseq)) == {:ok, tseq, frame}
+      end
+    end
+
+    test "the wire shape is exactly {acpenv, s, f}" do
+      wrapped = Envelope.wrap(%{"method" => "session/update"}, 17)
+
+      assert wrapped == %{
+               "acpenv" => 1,
+               "s" => 17,
+               "f" => %{"method" => "session/update"}
+             }
+    end
+
+    test "the sequence number never appears inside the unwrapped frame (seq-strip)" do
+      frame = %{"jsonrpc" => "2.0", "method" => "session/update", "params" => %{"a" => 1}}
+      wrapped = Envelope.wrap(frame, 42)
+
+      {:ok, _tseq, unwrapped} = Envelope.unwrap(wrapped)
+
+      refute Map.has_key?(unwrapped, "acpenv")
+      refute Map.has_key?(unwrapped, "s")
+      assert unwrapped == frame
+    end
+
+    test "a plain, un-enveloped frame is rejected" do
+      assert Envelope.unwrap(%{"jsonrpc" => "2.0", "method" => "initialize"}) ==
+               {:error, :not_enveloped}
+    end
+
+    test "an unknown envelope version is rejected" do
+      assert Envelope.unwrap(%{"acpenv" => 2, "s" => 1, "f" => %{}}) ==
+               {:error, :not_enveloped}
+    end
+
+    test "a non-positive or non-integer sequence is rejected" do
+      assert Envelope.unwrap(%{"acpenv" => 1, "s" => 0, "f" => %{}}) == {:error, :not_enveloped}
+      assert Envelope.unwrap(%{"acpenv" => 1, "s" => -1, "f" => %{}}) == {:error, :not_enveloped}
+      assert Envelope.unwrap(%{"acpenv" => 1, "s" => "1", "f" => %{}}) == {:error, :not_enveloped}
+    end
+
+    test "a non-map frame field is rejected" do
+      assert Envelope.unwrap(%{"acpenv" => 1, "s" => 1, "f" => "not a map"}) ==
+               {:error, :not_enveloped}
+    end
+
+    test "an arbitrary non-map value is rejected" do
+      assert Envelope.unwrap("just a string") == {:error, :not_enveloped}
+      assert Envelope.unwrap(42) == {:error, :not_enveloped}
+    end
+  end
+
+  describe "F8b Reassembly: in-order release under scrambled push order" do
+    test "in-order arrival releases each frame immediately, one at a time" do
+      buf = Reassembly.new()
+
+      {:ok, [f1], buf} = Reassembly.push(buf, 1, %{"n" => 1})
+      {:ok, [f2], buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      {:ok, [f3], _buf} = Reassembly.push(buf, 3, %{"n" => 3})
+
+      assert [f1, f2, f3] == [%{"n" => 1}, %{"n" => 2}, %{"n" => 3}]
+    end
+
+    test "a single out-of-order frame is buffered, then released on cascade" do
+      buf = Reassembly.new()
+
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      {:ok, released, _buf} = Reassembly.push(buf, 1, %{"n" => 1})
+
+      assert released == [%{"n" => 1}, %{"n" => 2}]
+    end
+
+    test "a full reverse-order arrival cascades in one final push" do
+      buf = Reassembly.new()
+
+      {:ok, [], buf} = Reassembly.push(buf, 5, %{"n" => 5})
+      {:ok, [], buf} = Reassembly.push(buf, 4, %{"n" => 4})
+      {:ok, [], buf} = Reassembly.push(buf, 3, %{"n" => 3})
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      {:ok, released, _buf} = Reassembly.push(buf, 1, %{"n" => 1})
+
+      assert released == [%{"n" => 1}, %{"n" => 2}, %{"n" => 3}, %{"n" => 4}, %{"n" => 5}]
+    end
+
+    test "duplicate of an already-released tseq is dropped silently" do
+      buf = Reassembly.new()
+
+      {:ok, [_f1], buf} = Reassembly.push(buf, 1, %{"n" => 1})
+      {:ok, released, buf} = Reassembly.push(buf, 1, %{"n" => 1})
+      assert released == []
+
+      # buffer keeps working normally afterwards
+      {:ok, [f2], _buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      assert f2 == %{"n" => 2}
+    end
+
+    test "duplicate of an already-buffered (not yet released) tseq is dropped silently" do
+      buf = Reassembly.new()
+
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"n" => 2, "copy" => :first})
+      {:ok, released, buf} = Reassembly.push(buf, 2, %{"n" => 2, "copy" => :second})
+      assert released == []
+
+      # the first copy is the one that is eventually released
+      {:ok, [_f1, f2], _buf} = Reassembly.push(buf, 1, %{"n" => 1})
+      assert f2 == %{"n" => 2, "copy" => :first}
+    end
+
+    property "for any permutation of a contiguous tseq run, the concatenation of every push's released frames reproduces the original order, with no loss and no duplication" do
+      check all(
+              n <- integer(1..40),
+              seed <- integer(0..1_000_000)
+            ) do
+        frames = for i <- 1..n, do: %{"n" => i}
+        order = deterministic_shuffle(1..n, seed)
+
+        {released, final_buf} =
+          Enum.reduce(order, {[], Reassembly.new()}, fn tseq, {acc, buf} ->
+            frame = Enum.at(frames, tseq - 1)
+            {:ok, new_released, buf} = Reassembly.push(buf, tseq, frame)
+            {acc ++ new_released, buf}
+          end)
+
+        assert released == frames
+        assert final_buf.buffer == %{}
+        assert final_buf.buffered_bytes == 0
+        assert final_buf.next_expected == n + 1
+      end
+    end
+
+    test "duplicates interleaved with a scrambled arrival still reproduce the original order exactly once" do
+      buf = Reassembly.new()
+
+      {:ok, [], buf} = Reassembly.push(buf, 3, %{"n" => 3})
+      {:ok, [], buf} = Reassembly.push(buf, 3, %{"n" => 3})
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      {:ok, released1, buf} = Reassembly.push(buf, 1, %{"n" => 1})
+      {:ok, released2, _buf} = Reassembly.push(buf, 1, %{"n" => 1})
+
+      assert released1 == [%{"n" => 1}, %{"n" => 2}, %{"n" => 3}]
+      assert released2 == []
+    end
+  end
+
+  describe "F8b Reassembly: overflow-bounded (never timer-bounded)" do
+    test "crossing the frame-count watermark closes with reassembly_overflow" do
+      buf = Reassembly.new(max_buffered_frames: 3)
+
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      {:ok, [], buf} = Reassembly.push(buf, 3, %{"n" => 3})
+      {:ok, [], buf} = Reassembly.push(buf, 4, %{"n" => 4})
+
+      assert Reassembly.push(buf, 5, %{"n" => 5}) ==
+               {:closed, {:transport, :reassembly_overflow}}
+    end
+
+    test "staying at or under the frame-count watermark never overflows" do
+      buf = Reassembly.new(max_buffered_frames: 3)
+
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      {:ok, [], buf} = Reassembly.push(buf, 3, %{"n" => 3})
+      {:ok, [], buf} = Reassembly.push(buf, 4, %{"n" => 4})
+
+      # releasing frees buffer slots; a subsequent buffered frame at the
+      # same watermark is fine because the count never exceeds max.
+      {:ok, released, buf} = Reassembly.push(buf, 1, %{"n" => 1})
+      assert released == [%{"n" => 1}, %{"n" => 2}, %{"n" => 3}, %{"n" => 4}]
+      assert buf.buffer == %{}
+    end
+
+    test "crossing the byte watermark closes with reassembly_overflow" do
+      # each frame's approximate external size is well under 200 bytes;
+      # a tiny byte cap forces overflow on the very first buffered frame.
+      buf = Reassembly.new(max_buffered_bytes: 10)
+
+      assert Reassembly.push(buf, 2, %{"payload" => String.duplicate("x", 100)}) ==
+               {:closed, {:transport, :reassembly_overflow}}
+    end
+
+    test "the buffer never grows past the watermark (bounded, not merely detected late)" do
+      buf = Reassembly.new(max_buffered_frames: 2)
+
+      {:ok, [], buf} = Reassembly.push(buf, 2, %{"n" => 2})
+      {:ok, [], buf} = Reassembly.push(buf, 3, %{"n" => 3})
+      assert map_size(buf.buffer) == 2
+
+      assert Reassembly.push(buf, 4, %{"n" => 4}) ==
+               {:closed, {:transport, :reassembly_overflow}}
+    end
+
+    test "new/1 rejects non-positive options" do
+      assert_raise ArgumentError, fn -> Reassembly.new(max_buffered_frames: 0) end
+      assert_raise ArgumentError, fn -> Reassembly.new(max_buffered_bytes: -1) end
+      assert_raise ArgumentError, fn -> Reassembly.new(start: 0) end
+    end
+
+    test "new/1 honors a non-default :start" do
+      buf = Reassembly.new(start: 100)
+
+      {:ok, [], buf} = Reassembly.push(buf, 101, %{"n" => 101})
+      {:ok, released, _buf} = Reassembly.push(buf, 100, %{"n" => 100})
+
+      assert released == [%{"n" => 100}, %{"n" => 101}]
+    end
+  end
+
+  # -- Helpers --------------------------------------------------------------
+
+  defp frame_generator do
+    gen all(
+          method <- member_of(["session/update", "initialize", "session/prompt"]),
+          id <- one_of([integer(), string(:alphanumeric, max_length: 8)]),
+          extra <-
+            map_of(string(:alphanumeric, min_length: 1, max_length: 6), integer(), max_length: 4)
+        ) do
+      Map.merge(%{"jsonrpc" => "2.0", "method" => method, "id" => id}, extra)
+    end
+  end
+
+  # Deterministic per-seed Fisher-Yates shuffle so a property failure is
+  # reproducible from the printed `n`/`seed` pair alone. Threads its own
+  # `:rand` state explicitly (`seed_s`/`uniform_s`) rather than touching
+  # the process's global random state, so it never perturbs StreamData's
+  # own generation of subsequent `n`/`seed` values within the same run.
+  defp deterministic_shuffle(enumerable, seed) do
+    state = :rand.seed_s(:exsss, {seed, seed, seed})
+    {shuffled, _state} = shuffle_with(Enum.to_list(enumerable), [], state)
+    shuffled
+  end
+
+  defp shuffle_with([], acc, state), do: {acc, state}
+
+  defp shuffle_with(list, acc, state) do
+    {index, state} = :rand.uniform_s(length(list), state)
+    {elem, rest} = List.pop_at(list, index - 1)
+    shuffle_with(rest, [elem | acc], state)
+  end
+end


### PR DESCRIPTION
Fixes the shipped `session/update` drop/reorder bug the right way, per ADR-0030 (#641) — **ordering is a transport property, resolved receiver-side; nothing goes on the ACP wire.** Supersedes #640 (which put a peer-supplied ordering key on the wire — the trust-boundary violation Drew's ADR rejects).

## The fix
`session/update` over an ordered transport already arrives in send order; the bug was **our** client-side fan-out (each notification dispatched in its own Task, delivered from different processes → scrambled). This makes the Connection deliver to the turn owner **itself** at the single demux point, in order.

- **Transport contract (`T-ORD`/`T-REL`/`T-DUP`/`T-TERM`)** mandated on the `Transport` behaviour — no `ordered?` flag; an unordered carrier earns it internally. Sequenced transports (stdio/Paired/WS) satisfy it unchanged (proof chain in the doc). F7 conformance test + falsifier.
- **`Transport.Envelope` + `Transport.Reassembly`** — pure modules for a future unordered carrier (transport-`tseq`, stripped before delivery, **never on the ACP wire**; overflow-bounded, no timer). Design-stub, addable later without touching Connection. F8 tests incl. a permutation property.
- **Connection receiver-side ordering** — a receiver-minted `make_ref()` turn token (ADR clause 5), a contiguous per-turn ordinal stamped at demux, single-sender direct delivery to the owner (`{:acp_turn_update}` / `{:acp_turn_end, count}` / `{:acp_result}` — no user code on the loop). Primary `prompt`/`prompt_stream` path is single-sender-FIFO ⇒ **no reorder buffer, occupancy 0**. Streaming preserved (live `on_update`, O(1)). **Fail-the-turn** on a delivery gap (`{:error, {:delivery_gap,_}}` + `:fail` telemetry) — **no timers anywhere**.
- Agent `_meta` returns to opaque consolidation data (never load-bearing for order).

## ADR-0030 compliance
Clauses **1 (receiver-assigned key), 3 (overflow-bounded/fail-the-turn, no timer), 4 (streaming), 5 (recursive receiver-assignment)** satisfied on the primary path. **Clause 2** (bounded/observable reorder buffer for the multi-subscriber *broadcast* path) is a focused **follow-up** — that path is unchanged from master (always async fan-out), so this PR is a strict improvement; the follow-up adds `Delivery.Reorder` + a reattach replay-order test.

## Verification
830 tests green (compile `--warnings-as-errors` clean). Red-first witnesses for drop/reorder/live/fail-the-turn (confirmed red against master's fan-out via `git stash`). New invariant families `F7`/`F8`/`D1..D9` registered in `test/INVARIANTS.md`. A pre-existing conformance-harness race (acpx-007, amplified by the scheduling shift) hardened with a bounded accumulator quiesce (harness-sync only).

Built design-first (Fable) + a Sonnet fleet against a work-unit partition; design doc drove the units.