### PR TITLE
ci: stop nightly matrix from duplicating property suite

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,7 +116,16 @@ jobs:
 
       - name: Run full test suite
         run: |
-          mix test --exclude slow --exclude integration --exclude docker --exclude skip_on_ci
+          # --exclude property: the emulator-replay-heavy property tests
+          # (renderer seal-once keystones) are CPU/allocation-bound. Run
+          # inline inside the full ~6k-test process on slow matrix legs
+          # (older Elixir, macOS), scheduler/GC pressure pushes them past
+          # the 60s/180s bounds -- a runner-load artifact, not a hang (the
+          # newer/faster legs pass the same tests). They already run
+          # isolated at --timeout 300000 in the extended-scenarios job, so
+          # excluding them here removes the duplicate run without losing
+          # coverage.
+          mix test --exclude slow --exclude integration --exclude docker --exclude skip_on_ci --exclude property
         env:
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres
@@ -173,7 +182,11 @@ jobs:
 
       - name: Run property-based tests (extended)
         run: |
-          mix test --only property --timeout 300000 || true
+          # No `|| true`: this isolated 300s run is the nightly's property
+          # gate (the matrix job excludes property). It passes reliably in
+          # its own process, so a failure here is a genuine regression that
+          # must fail the build, not be swallowed.
+          mix test --only property --timeout 300000
 
       - name: Generate extended test report
         run: |


### PR DESCRIPTION
## What

Stops the nightly `Test Matrix` job from redundantly running the property
suite inline, which was timing out on the slow matrix legs.

## Root cause

The nightly `test-matrix` "Run full test suite" step ran
`mix test --exclude slow --exclude integration --exclude docker --exclude skip_on_ci`
-- **without** `--exclude property` -- so the emulator-replay-heavy
`renderer_seal_once_property_test.exs` keystones (`:77`, `:119`, `:257`) ran
inline inside the full ~6k-test process at the default 60s (180s for the
keystone). Under the scheduler/GC pressure of that loaded BEAM, on the slower
matrix legs, they consistently blew the bound:

- **Deterministic, not flaky:** the same three tests time out on Elixir
  1.17.3 / 1.18.3 and macOS legs across multiple nights, while **1.19 / 1.20
  on ubuntu pass the identical tests**.
- **Green in isolation:** the `extended-scenarios` job already runs the same
  property tests in their own process at `--timeout 300000` and passes every
  night. Terminal-emulator replay is allocation-heavy; isolated, it is fast.

So this was a runner-load artifact of duplicating the property suite inline,
not a code regression.

## The fix

- `test-matrix` full-suite run now adds `--exclude property` (mirrors
  `ci-unified.yml`'s unit job, which excludes property and delegates to a
  dedicated property job). Coverage is fully preserved by the isolated
  `extended-scenarios` property run.
- Dropped the `|| true` from that isolated property run so it is now the real
  nightly property gate -- a genuine property regression fails the build
  instead of being swallowed. It passes reliably at 300s, so this adds teeth
  without introducing flake.

## Manual testing

- [x] Workflow YAML parses cleanly.
- [x] Diff scoped to `.github/workflows/nightly.yml` only.
- [ ] Confirm on the next scheduled nightly (or `workflow_dispatch`) that
      `Test Matrix` is green across all legs and `Extended Test Scenarios`
      still passes as the property gate.
