### PR TITLE
feat(ui): shared normalized keystroke seam for the harness

### DIFF
--- a/lib/raxol/ui/harness/input_event.ex
+++ b/lib/raxol/ui/harness/input_event.ex
@@ -175,6 +175,10 @@ defmodule Raxol.UI.Harness.InputEvent do
           shift: boolean(),
           meta: boolean()
         }
+  # Single source for the kind vocabulary: the `@type kind` below and the
+  # idempotence fast-path guard both derive from it, so a new kind cannot
+  # silently regress one without the other.
+  @kinds [:char, :key, :paste, :other]
   @type kind :: :char | :key | :paste | :other
   @type key_state :: :pressed | :released | :repeat | nil
 
@@ -214,8 +218,20 @@ defmodule Raxol.UI.Harness.InputEvent do
   `:raw` level deeper than component dispatch can find it.
   """
   @spec normalize(term()) :: t()
-  def normalize(%{kind: kind, mods: %{}} = already_normalized)
-      when kind in [:char, :key, :paste, :other],
+  # The fast-path matches the CANONICAL mods shape (all four boolean keys),
+  # not `mods: %{}` -- an empty-map pattern matches ANY map, which would let
+  # a map that merely carries a `kind` and some `mods` field (e.g. a
+  # `%{kind: :paste, text: "\e[2J...", mods: %{}}`) short-circuit the
+  # normalizer and return verbatim, bypassing paste ANSI/control-byte
+  # sanitization and char content validation. Requiring the full canonical
+  # mods shape means only genuinely-normalized events (the pump's own
+  # sanitized output) take the fast path; anything else -- empty, partial,
+  # or malformed mods -- falls through to real normalization.
+  def normalize(
+        %{kind: kind, mods: %{ctrl: _, alt: _, shift: _, meta: _}} =
+          already_normalized
+      )
+      when kind in @kinds,
       do: already_normalized
 
   def normalize(

--- a/lib/raxol/ui/harness/input_event.ex
+++ b/lib/raxol/ui/harness/input_event.ex
@@ -6,8 +6,8 @@ defmodule Raxol.UI.Harness.InputEvent do
 
   The terminal driver reaches component `handle_event/3` callbacks through
   THREE incompatible key-event shapes depending on which layer produced the
-  event, plus a fourth paste shape. Two harness components (`T11` composer,
-  `T14` picker) independently hit this gap and each grew inline defensive
+  event, plus a fourth paste shape. Two harness components (the composer,
+  the picker) independently hit this gap and each grew inline defensive
   reshaping. `Raxol.UI.Components.Input.TextInput` also copes with it ad
   hoc (`data[:modifiers] || []`). This module is the single normalizer all
   of them should converge on.
@@ -122,13 +122,13 @@ defmodule Raxol.UI.Harness.InputEvent do
       F5-F12/Insert/Delete/PageUp/PageDown are agreement-tested unmodified
       only (their ANSI tilde encoding here has no modifier parameter).
 
-  ## What T11/T14 (and T12/T13a) migrate to
+  ## The shared shortcut/text-input predicate
 
   Composer (`lib/raxol/ui/components/harness/composer.ex`) and picker
-  (`lib/raxol/ui/components/harness/picker.ex`, `feat/harness-ui-T14`)
-  each hand-rolled a `text_input?/1`-style predicate reading
+  (`lib/raxol/ui/components/harness/picker.ex`) both use the pattern below
+  instead of hand-rolling a `text_input?/1`-style predicate that reads
   `data[:modifiers] || []` alongside `data[:ctrl]`/`data[:alt]` booleans.
-  Both retire that inline logic in favor of the pattern below. Note the
+  Note the
   ordering: `shortcut?/1` is checked FIRST, because a shortcut is
   ALSO a `kind: :char` (Ctrl+A) or `kind: :key` (Ctrl+Up) -- routing on
   `text?/1`/`key/1` first would drop char-shortcuts into the no-op branch
@@ -202,8 +202,22 @@ defmodule Raxol.UI.Harness.InputEvent do
   struct OR passed as a bare `data` map) into the canonical form above.
 
   Total: never raises. Anything unrecognized normalizes to `kind: :other`.
+
+  IDEMPOTENT by contract (the SessionPump's PumpContract §4): the live
+  pump normalizes at its boundary, and `HarnessApp.Model.handle_key/2`
+  normalizes again for its own Keymap routing -- so a second pass must
+  return the input UNCHANGED. Without idempotence, re-normalizing an
+  already-normalized map reads `mods` as all-false (extract_mods looks
+  for top-level `:ctrl`/`:alt` fields, which the canonical shape nests
+  under `:mods`) -- silently un-pressing Ctrl on every live chord,
+  breaking the quit protocol -- and buries the original `%Event{}` one
+  `:raw` level deeper than component dispatch can find it.
   """
   @spec normalize(term()) :: t()
+  def normalize(%{kind: kind, mods: %{}} = already_normalized)
+      when kind in [:char, :key, :paste, :other],
+      do: already_normalized
+
   def normalize(
         %Raxol.Core.Events.Event{type: :paste, data: %{text: text}} = raw
       )

--- a/test/raxol/ui/harness/input_event_test.exs
+++ b/test/raxol/ui/harness/input_event_test.exs
@@ -899,4 +899,46 @@ defmodule Raxol.UI.Harness.InputEventTest do
       refute String.contains?(norm.text, "\e")
     end
   end
+
+  describe "normalize/1 -- idempotence (the SessionPump contract)" do
+    # PumpContract §4: the live pump normalizes at its boundary, and
+    # HarnessApp.Model.handle_key/2 normalizes again for its own routing.
+    # A second pass must be a no-op -- before this property held, the
+    # second pass read mods as all-false (un-pressing Ctrl on every live
+    # chord) and buried the original Event one :raw level too deep for
+    # component dispatch.
+
+    test "a normalized char map passes through unchanged" do
+      norm = InputEvent.normalize(Event.key("x"))
+      assert InputEvent.normalize(norm) == norm
+      assert norm.raw != nil
+    end
+
+    test "ctrl chords survive the double pass (the quit-protocol bug)" do
+      norm =
+        InputEvent.normalize(%Event{
+          type: :key,
+          data: %{key: "c", state: :pressed, modifiers: [:ctrl]}
+        })
+
+      twice = InputEvent.normalize(norm)
+      assert twice.mods.ctrl == true
+      assert twice == norm
+    end
+
+    test "a normalized special key keeps its key atom and :raw Event" do
+      event = Event.key_event(:enter, :pressed, [])
+      norm = InputEvent.normalize(event)
+      twice = InputEvent.normalize(norm)
+
+      assert twice.kind == :key
+      assert twice.key == :enter
+      assert twice.raw == event
+    end
+
+    test "the paste shape is idempotent too" do
+      norm = InputEvent.normalize(Event.paste_event("hello", {0, 0}))
+      assert InputEvent.normalize(norm) == norm
+    end
+  end
 end

--- a/test/raxol/ui/harness/input_event_test.exs
+++ b/test/raxol/ui/harness/input_event_test.exs
@@ -940,5 +940,46 @@ defmodule Raxol.UI.Harness.InputEventTest do
       norm = InputEvent.normalize(Event.paste_event("hello", {0, 0}))
       assert InputEvent.normalize(norm) == norm
     end
+
+    # The fast path must recognize only GENUINELY-normalized events (the
+    # canonical four-key mods shape), never any map that merely carries a
+    # `kind` and some `mods` field. `mods: %{}` matches ANY map, so before
+    # this a crafted map short-circuited the normalizer and returned its
+    # unsanitized content verbatim.
+    test "a paste-shaped map with empty mods is NOT trusted verbatim -- it is re-sanitized" do
+      hostile = %{kind: :paste, text: "\e[2J\e]0;pwned\ahi", mods: %{}}
+
+      result = InputEvent.normalize(hostile)
+
+      # Fell through to real paste normalization: ESC/BEL control bytes are
+      # stripped, not passed through to an insertion sink.
+      refute result.text =~ "\e"
+      refute result.text =~ "\a"
+      assert result.text =~ "hi"
+    end
+
+    test "a partial-mods map is re-normalized to the canonical mods shape" do
+      partial = %{kind: :char, char: "a", mods: %{ctrl: true}}
+
+      result = InputEvent.normalize(partial)
+
+      # Not returned unchanged: mods is rebuilt to the full four-key shape
+      # so text?/1 and shortcut?/1 clause heads bind.
+      assert Map.keys(result.mods) |> Enum.sort() == [:alt, :ctrl, :meta, :shift]
+    end
+
+    test "a fully-canonical map (all four mods keys) still passes through unchanged" do
+      norm = %{
+        kind: :char,
+        char: "a",
+        key: nil,
+        text: nil,
+        mods: %{ctrl: false, alt: false, shift: false, meta: false},
+        state: nil,
+        raw: :original
+      }
+
+      assert InputEvent.normalize(norm) == norm
+    end
   end
 end


### PR DESCRIPTION
InputEvent.normalize/1 — one place that turns raw key events into the
harness's printable/control shape. A thin seam the composer, overlays,
and pump contract all consume.

Part of the harness-endgame merge campaign (wave 1).