### PR TITLE
Wire USDC-only launch offering into ACP seller stack

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/seller/offerings.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/offerings.ex
@@ -2,14 +2,16 @@ defmodule Raxol.ACP.Seller.Offerings do
   @moduledoc """
   Registers the seller's ACP offerings with `Raxol.ACP.Offering.Registry`.
 
-  Offerings come from `config :raxol_acp, :offerings` (default: the split
-  Xochi pair `StablePublicOffering` + `StableStealthOffering`, plus the
-  deprecated `TransferOffering` for one migration cycle).
+  Offerings come from `config :raxol_acp, :offerings` (default: the USDC-only
+  launch offering `UsdcPublicOffering`, the split Xochi pair
+  `StablePublicOffering` + `StableStealthOffering`, plus the deprecated
+  `TransferOffering` for one migration cycle).
   `Raxol.ACP.Seller.Supervisor` calls `register_all/0` on start; registration is
   idempotent.
   """
 
   @default [
+    Raxol.ACP.Xochi.UsdcPublicOffering,
     Raxol.ACP.Xochi.StablePublicOffering,
     Raxol.ACP.Xochi.StableStealthOffering,
     Raxol.ACP.Xochi.TransferOffering

--- a/packages/raxol_acp/lib/raxol/acp/seller/offerings.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/offerings.ex
@@ -2,19 +2,21 @@ defmodule Raxol.ACP.Seller.Offerings do
   @moduledoc """
   Registers the seller's ACP offerings with `Raxol.ACP.Offering.Registry`.
 
-  Offerings come from `config :raxol_acp, :offerings` (default: the USDC-only
-  launch offering `UsdcPublicOffering`, the split Xochi pair
-  `StablePublicOffering` + `StableStealthOffering`, plus the deprecated
-  `TransferOffering` for one migration cycle).
+  Offerings come from `config :raxol_acp, :offerings`. The default is fail-closed:
+  only the USDC-only launch offering `UsdcPublicOffering` (`xochi_usdc_public`) is
+  registered, because it is the only rail that settles without reverting today.
+  The token-agnostic `StablePublicOffering` / `StableStealthOffering` and the
+  deprecated `TransferOffering` accept tokens (USDT/USDG) whose settlement is not
+  yet ready, so they are NOT advertised by default -- add them to `:offerings`
+  explicitly once their rails land, so a buyer can never be routed into a
+  settlement that reverts.
+
   `Raxol.ACP.Seller.Supervisor` calls `register_all/0` on start; registration is
   idempotent.
   """
 
   @default [
-    Raxol.ACP.Xochi.UsdcPublicOffering,
-    Raxol.ACP.Xochi.StablePublicOffering,
-    Raxol.ACP.Xochi.StableStealthOffering,
-    Raxol.ACP.Xochi.TransferOffering
+    Raxol.ACP.Xochi.UsdcPublicOffering
   ]
 
   @doc "The offering modules to register, from `:offerings` config or the default."

--- a/packages/raxol_acp/lib/raxol/acp/seller/supervisor.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/supervisor.ex
@@ -19,9 +19,10 @@ defmodule Raxol.ACP.Seller.Supervisor do
   ## Offerings
 
   On start it registers the offerings in `config :raxol_acp, :offerings`
-  (default `[Raxol.ACP.Xochi.TransferOffering]`) with
-  `Raxol.ACP.Offering.Registry` via `Raxol.ACP.Seller.Offerings`, so incoming
-  jobs resolve to a handler. Registration is idempotent across restarts.
+  (fail-closed default `[Raxol.ACP.Xochi.UsdcPublicOffering]`; see
+  `Raxol.ACP.Seller.Offerings`) with `Raxol.ACP.Offering.Registry` via
+  `Raxol.ACP.Seller.Offerings`, so incoming jobs resolve to a handler.
+  Registration is idempotent across restarts.
 
   ## Liquidity gate
 

--- a/packages/raxol_acp/lib/raxol/acp/xochi/transfer_core.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/transfer_core.ex
@@ -93,6 +93,10 @@ defmodule Raxol.ACP.Xochi.TransferCore do
     do:
       "This is the stealth offering, but the requirement asks for public settlement. Use \"#{alt}\"."
 
+  def describe_rejection({:wrong_offering, :expected_usdc, alt}),
+    do:
+      "This is the USDC-only offering, but a leg is not USDC. Use \"#{alt}\" for other stablecoins."
+
   def describe_rejection({:stealth_requires_l1_destination, dst}),
     do:
       "Stealth settles on Ethereum L1, so dst_chain_id must be 1 (got #{dst}); " <>

--- a/packages/raxol_acp/lib/raxol/acp/xochi/transfer_core.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/transfer_core.ex
@@ -93,9 +93,15 @@ defmodule Raxol.ACP.Xochi.TransferCore do
     do:
       "This is the stealth offering, but the requirement asks for public settlement. Use \"#{alt}\"."
 
-  def describe_rejection({:wrong_offering, :expected_usdc, alt}),
+  def describe_rejection({:wrong_offering, :expected_usdc}),
     do:
-      "This is the USDC-only offering, but a leg is not USDC. Use \"#{alt}\" for other stablecoins."
+      "This offering settles USDC only; a leg is not USDC. Other stablecoins are not settle-ready yet."
+
+  def describe_rejection({:order_below_min, min}),
+    do: "Order amount is below the minimum of #{min} base units."
+
+  def describe_rejection({:order_above_max, max}),
+    do: "Order amount exceeds the maximum of #{max} base units; use a smaller amount."
 
   def describe_rejection({:stealth_requires_l1_destination, dst}),
     do:

--- a/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
@@ -1,0 +1,80 @@
+defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
+  @moduledoc """
+  Launch offering: USDC-only cross-chain transfer with public settlement.
+
+  The narrowest of the Xochi transfer offerings. It advertises exactly one thing --
+  move USDC between the five CCTP chains `{1, 10, 137, 8453, 42_161}` and land the
+  payout in a wallet on the destination chain. Both legs must resolve to a known
+  USDC contract; a requirement whose src or dst token is anything else (USDT, USDG,
+  WETH, ...) is rejected before escrow with
+  `{:wrong_offering, :expected_usdc, "xochi_stable_public"}`, so a buyer agent gets a
+  focused, actionable error and is pointed at the broader stablecoin offering.
+
+  This is the clean rail: USDC settles via CCTP, the solver holds inventory on every
+  hub, and there is no Permit2 verified-spender dependency (unlike USDT/USDG). It is
+  the offering to register for the initial ACP launch; the token-agnostic
+  `Raxol.ACP.Xochi.StablePublicOffering` / `TransferOffering` widen the scope once the
+  other stablecoin rails are settle-ready.
+
+  Validation beyond the USDC gate (cross-chain, positive amount, corridor allowlist,
+  capacity) and delivery are the shared `Raxol.ACP.Xochi.TransferCore` in `:public`
+  mode, so this offering never drifts from the common corridor rules; settler config
+  is the shared `:xochi_transfer_settler`.
+  """
+
+  use Raxol.ACP.Offering,
+    name: "xochi_usdc_public",
+    price_usdc: "0.25",
+    sla_minutes: 10,
+    cluster: "on_chain"
+
+  alias Raxol.ACP.Xochi.{Offering, TransferCore}
+  alias Raxol.Payments.Assets
+
+  # The five CCTP chains USDC settles across (full mesh). Mirrors
+  # CorridorAllowlist's @usdc_chains and Riddler's @usdc_chains.
+  @cctp_chains [1, 10, 137, 8453, 42_161]
+
+  @impl true
+  def requirements_schema do
+    Offering.requirement_schema(:public)
+    |> put_in(["properties", "src_chain_id"], usdc_chain_prop("Source"))
+    |> put_in(["properties", "dst_chain_id"], usdc_chain_prop("Destination"))
+    |> put_in(
+      ["properties", "src_token", "description"],
+      "The USDC contract on src_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow."
+    )
+    |> put_in(
+      ["properties", "dst_token", "description"],
+      "The USDC contract on dst_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow."
+    )
+  end
+
+  @impl true
+  def deliverables_schema, do: Offering.deliverable_schema(:public)
+
+  @impl true
+  def handle_request(req, ctx) do
+    if usdc_leg?(req["src_chain_id"], req["src_token"]) and
+         usdc_leg?(req["dst_chain_id"], req["dst_token"]) do
+      TransferCore.handle_request(req, ctx, :public)
+    else
+      {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}}
+    end
+  end
+
+  @impl true
+  def handle_deliver(req, ctx), do: TransferCore.handle_deliver(req, ctx)
+
+  defp usdc_leg?(chain_id, token), do: Assets.usdc?(chain_id, token)
+
+  defp usdc_chain_prop(role) do
+    %{
+      "type" => "integer",
+      "enum" => @cctp_chains,
+      "description" =>
+        "#{role} chain. USDC settles across the CCTP mesh: " <>
+          "1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum)."
+    }
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
@@ -2,24 +2,33 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
   @moduledoc """
   Launch offering: USDC-only cross-chain transfer with public settlement.
 
-  The narrowest of the Xochi transfer offerings. It advertises exactly one thing --
-  move USDC between the five CCTP chains `{1, 10, 137, 8453, 42_161}` and land the
-  payout in a wallet on the destination chain. Both legs must resolve to a known
-  USDC contract; a requirement whose src or dst token is anything else (USDT, USDG,
-  WETH, ...) is rejected before escrow with
-  `{:wrong_offering, :expected_usdc, "xochi_stable_public"}`, so a buyer agent gets a
-  focused, actionable error and is pointed at the broader stablecoin offering.
+  The narrowest of the Xochi transfer offerings, and the only one registered by
+  default (see `Raxol.ACP.Seller.Offerings`). It advertises exactly one thing --
+  move USDC across the CCTP settlement mesh (`Raxol.Payments.Assets.usdc_chains/0`)
+  and land the payout in a wallet on the destination chain. Both legs must resolve
+  to a known USDC contract; a requirement whose src or dst token is anything else
+  (USDT, USDG, WETH, ...) is rejected before escrow with
+  `{:wrong_offering, :expected_usdc}`. There is deliberately no fallback offering
+  named: the other stablecoin rails (USDT/USDG) are not settle-ready, so pointing a
+  buyer at them would route real funds into a settlement that reverts. The scope
+  widens only once those rails land and their offerings are added to the seller
+  config.
 
   This is the clean rail: USDC settles via CCTP, the solver holds inventory on every
-  hub, and there is no Permit2 verified-spender dependency (unlike USDT/USDG). It is
-  the offering to register for the initial ACP launch; the token-agnostic
-  `Raxol.ACP.Xochi.StablePublicOffering` / `TransferOffering` widen the scope once the
-  other stablecoin rails are settle-ready.
+  hub, and there is no Permit2 verified-spender dependency (unlike USDT/USDG).
 
-  Validation beyond the USDC gate (cross-chain, positive amount, corridor allowlist,
-  capacity) and delivery are the shared `Raxol.ACP.Xochi.TransferCore` in `:public`
-  mode, so this offering never drifts from the common corridor rules; settler config
-  is the shared `:xochi_transfer_settler`.
+  Order size is bounded here, in USDC base units: a minimum (anti-spam) and a
+  maximum ceiling, both overridable via `config :raxol_acp, :usdc_public_min_atomic`
+  / `:usdc_public_max_atomic` (defaults: 1 USDC and 3_000 USDC). The maximum is a
+  static ceiling only; per-corridor inventory-depth gating is the separate,
+  opt-in capacity ledger (`capacity_gate_enabled`), which is inert unless
+  configured.
+
+  Validation beyond the USDC gate and the order band (cross-chain, positive amount,
+  corridor allowlist, and -- when enabled -- capacity) and delivery are the shared
+  `Raxol.ACP.Xochi.TransferCore` in `:public` mode, so this offering never drifts
+  from the common corridor rules; settler config is the shared
+  `:xochi_transfer_settler`.
   """
 
   use Raxol.ACP.Offering,
@@ -31,9 +40,9 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
   alias Raxol.ACP.Xochi.{Offering, TransferCore}
   alias Raxol.Payments.Assets
 
-  # The five CCTP chains USDC settles across (full mesh). Mirrors
-  # CorridorAllowlist's @usdc_chains and Riddler's @usdc_chains.
-  @cctp_chains [1, 10, 137, 8453, 42_161]
+  # USDC base units (6 decimals): 1 USDC and 3_000 USDC.
+  @default_min_atomic 1_000_000
+  @default_max_atomic 3_000_000_000
 
   @impl true
   def requirements_schema do
@@ -55,23 +64,55 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
 
   @impl true
   def handle_request(req, ctx) do
-    if usdc_leg?(req["src_chain_id"], req["src_token"]) and
-         usdc_leg?(req["dst_chain_id"], req["dst_token"]) do
+    with :ok <- usdc_only(req),
+         :ok <- within_order_band(req) do
       TransferCore.handle_request(req, ctx, :public)
-    else
-      {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}}
     end
   end
 
   @impl true
   def handle_deliver(req, ctx), do: TransferCore.handle_deliver(req, ctx)
 
+  defp usdc_only(req) do
+    if usdc_leg?(req["src_chain_id"], req["src_token"]) and
+         usdc_leg?(req["dst_chain_id"], req["dst_token"]) do
+      :ok
+    else
+      {:reject, {:wrong_offering, :expected_usdc}}
+    end
+  end
+
+  # A malformed/absent amount defers to TransferCore's own positive-amount and
+  # malformed-requirement guards rather than being masked as a band violation.
+  defp within_order_band(req) do
+    min = min_atomic()
+    max = max_atomic()
+
+    case parse_amount(req["amount_atomic"]) do
+      {:ok, amount} when amount < min -> {:reject, {:order_below_min, min}}
+      {:ok, amount} when amount > max -> {:reject, {:order_above_max, max}}
+      _ -> :ok
+    end
+  end
+
   defp usdc_leg?(chain_id, token), do: Assets.usdc?(chain_id, token)
+
+  defp parse_amount(amount) when is_binary(amount) do
+    case Integer.parse(amount) do
+      {n, ""} -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp parse_amount(_), do: :error
+
+  defp min_atomic, do: Application.get_env(:raxol_acp, :usdc_public_min_atomic, @default_min_atomic)
+  defp max_atomic, do: Application.get_env(:raxol_acp, :usdc_public_max_atomic, @default_max_atomic)
 
   defp usdc_chain_prop(role) do
     %{
       "type" => "integer",
-      "enum" => @cctp_chains,
+      "enum" => Assets.usdc_chains(),
       "description" =>
         "#{role} chain. USDC settles across the CCTP mesh: " <>
           "1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum)."

--- a/packages/raxol_acp/test/raxol/acp/seller/offerings_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/offerings_test.exs
@@ -3,7 +3,7 @@ defmodule Raxol.ACP.Seller.OfferingsTest do
 
   alias Raxol.ACP.Offering.Registry
   alias Raxol.ACP.Seller.Offerings
-  alias Raxol.ACP.Xochi.TransferOffering
+  alias Raxol.ACP.Xochi.{TransferOffering, UsdcPublicOffering}
 
   @offering "xochi_cross_chain_transfer"
 
@@ -23,6 +23,13 @@ defmodule Raxol.ACP.Seller.OfferingsTest do
 
       assert {:ok, spec} = Registry.lookup(@offering)
       assert spec.handler == TransferOffering
+    end
+
+    test "registers the USDC-only launch offering by default" do
+      assert :ok = Offerings.register_all()
+
+      assert {:ok, spec} = Registry.lookup("xochi_usdc_public")
+      assert spec.handler == UsdcPublicOffering
     end
 
     test "is idempotent across repeated calls" do

--- a/packages/raxol_acp/test/raxol/acp/seller/offerings_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/offerings_test.exs
@@ -5,8 +5,6 @@ defmodule Raxol.ACP.Seller.OfferingsTest do
   alias Raxol.ACP.Seller.Offerings
   alias Raxol.ACP.Xochi.{TransferOffering, UsdcPublicOffering}
 
-  @offering "xochi_cross_chain_transfer"
-
   setup do
     # The Offering.Registry is started by the application; start each test from
     # an empty table, as the registry's own tests do.
@@ -16,31 +14,33 @@ defmodule Raxol.ACP.Seller.OfferingsTest do
   end
 
   describe "register_all/0" do
-    test "registers the default offerings into the registry" do
-      assert :error = Registry.lookup(@offering)
-
-      assert :ok = Offerings.register_all()
-
-      assert {:ok, spec} = Registry.lookup(@offering)
-      assert spec.handler == TransferOffering
-    end
-
-    test "registers the USDC-only launch offering by default" do
+    test "the default is fail-closed: only the USDC-only launch offering registers" do
       assert :ok = Offerings.register_all()
 
       assert {:ok, spec} = Registry.lookup("xochi_usdc_public")
       assert spec.handler == UsdcPublicOffering
+
+      # The token-agnostic / deprecated rails are NOT advertised by default; they
+      # accept tokens whose settlement is not ready and would revert.
+      assert :error = Registry.lookup("xochi_cross_chain_transfer")
+      assert :error = Registry.lookup("xochi_stable_public")
+      assert :error = Registry.lookup("xochi_stable_stealth")
     end
 
     test "is idempotent across repeated calls" do
       assert :ok = Offerings.register_all()
       assert :ok = Offerings.register_all()
-      assert {:ok, _spec} = Registry.lookup(@offering)
+      assert {:ok, _spec} = Registry.lookup("xochi_usdc_public")
     end
 
-    test "honors the :offerings config" do
-      Application.put_env(:raxol_acp, :offerings, [TransferOffering])
-      assert Offerings.configured() == [TransferOffering]
+    test "honors the :offerings config to widen the set" do
+      Application.put_env(:raxol_acp, :offerings, [UsdcPublicOffering, TransferOffering])
+      assert Offerings.configured() == [UsdcPublicOffering, TransferOffering]
+
+      assert :ok = Offerings.register_all()
+      assert {:ok, _} = Registry.lookup("xochi_usdc_public")
+      assert {:ok, spec} = Registry.lookup("xochi_cross_chain_transfer")
+      assert spec.handler == TransferOffering
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
@@ -1,0 +1,116 @@
+defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.Xochi.{TransferCore, UsdcPublicOffering}
+
+  @usdc_base "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+  @usdc_arb "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+  # A supported stablecoin that is NOT USDC, to prove the USDC gate short-circuits
+  # before the shared token guards ever run.
+  @usdt_base "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2"
+
+  @cctp_chains [1, 10, 137, 8453, 42_161]
+
+  @ctx %{job_id: "j1", buyer: "0xbuyer", seller: "0xseller", state: :request}
+
+  setup do
+    Application.delete_env(:raxol_acp, :xochi_transfer_settler)
+    Raxol.Payments.Xochi.Capabilities.reset()
+
+    on_exit(fn ->
+      Application.delete_env(:raxol_acp, :xochi_transfer_settler)
+      Raxol.Payments.Xochi.Capabilities.reset()
+    end)
+
+    :ok
+  end
+
+  defp req(overrides) do
+    Map.merge(
+      %{
+        "src_chain_id" => 8453,
+        "dst_chain_id" => 42_161,
+        "src_token" => @usdc_base,
+        "dst_token" => @usdc_arb,
+        "amount_atomic" => "1100000",
+        "signed_intent" => %{
+          "intent_id" => "xi_1",
+          "quote_id" => "xq_1",
+          "signature" => "0x" <> String.duplicate("11", 65),
+          "nonce" => 7
+        }
+      },
+      overrides
+    )
+  end
+
+  describe "offering metadata + schema" do
+    test "declares the USDC-only public offering" do
+      assert UsdcPublicOffering.offering_name() == "xochi_usdc_public"
+      assert UsdcPublicOffering.cluster() == "on_chain"
+    end
+
+    test "requirement schema pins public settlement and the CCTP chain mesh" do
+      schema = UsdcPublicOffering.requirements_schema()
+      assert schema["properties"]["settlement_preference"]["enum"] == ["public"]
+      assert schema["properties"]["src_chain_id"]["enum"] == @cctp_chains
+      assert schema["properties"]["dst_chain_id"]["enum"] == @cctp_chains
+    end
+
+    test "requirement schema documents the USDC-only token constraint" do
+      props = UsdcPublicOffering.requirements_schema()["properties"]
+      assert props["src_token"]["description"] =~ "Only USDC is accepted"
+      assert props["dst_token"]["description"] =~ "Only USDC is accepted"
+    end
+
+    test "deliverable schema drops the stealth announcement fields" do
+      props = UsdcPublicOffering.deliverables_schema()["properties"]
+      refute Map.has_key?(props, "stealth_address")
+      refute Map.has_key?(props, "settlement_type")
+    end
+  end
+
+  describe "handle_request/2" do
+    test "accepts a USDC->USDC cross-chain corridor" do
+      r = req(%{})
+      assert {:accept, ^r} = UsdcPublicOffering.handle_request(r, @ctx)
+    end
+
+    test "rejects a non-USDC src leg, pointing at the broader stablecoin offering" do
+      r = req(%{"src_token" => @usdt_base})
+
+      assert {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}} =
+               UsdcPublicOffering.handle_request(r, @ctx)
+    end
+
+    test "rejects a non-USDC dst leg too" do
+      r = req(%{"dst_token" => @usdt_base})
+
+      assert {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}} =
+               UsdcPublicOffering.handle_request(r, @ctx)
+    end
+
+    test "the USDC gate short-circuits before the shared token guard" do
+      # A completely unknown token still reports :expected_usdc, not
+      # :unsupported_src_token -- the USDC check runs first.
+      bogus = "0x" <> String.duplicate("ab", 20)
+
+      assert {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}} =
+               UsdcPublicOffering.handle_request(req(%{"src_token" => bogus}), @ctx)
+    end
+
+    test "shared guards still fire once both legs are USDC (same-chain corridor)" do
+      r = req(%{"dst_chain_id" => 8453, "dst_token" => @usdc_base})
+
+      assert {:reject, :not_cross_chain} = UsdcPublicOffering.handle_request(r, @ctx)
+    end
+  end
+
+  describe "describe_rejection/1" do
+    test "explains the :expected_usdc rejection and names the fallback offering" do
+      msg = TransferCore.describe_rejection({:wrong_offering, :expected_usdc, "xochi_stable_public"})
+      assert msg =~ "USDC-only"
+      assert msg =~ "xochi_stable_public"
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
@@ -76,17 +76,17 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
       assert {:accept, ^r} = UsdcPublicOffering.handle_request(r, @ctx)
     end
 
-    test "rejects a non-USDC src leg, pointing at the broader stablecoin offering" do
+    test "rejects a non-USDC src leg with no fallback to an unready rail" do
       r = req(%{"src_token" => @usdt_base})
 
-      assert {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}} =
+      assert {:reject, {:wrong_offering, :expected_usdc}} =
                UsdcPublicOffering.handle_request(r, @ctx)
     end
 
     test "rejects a non-USDC dst leg too" do
       r = req(%{"dst_token" => @usdt_base})
 
-      assert {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}} =
+      assert {:reject, {:wrong_offering, :expected_usdc}} =
                UsdcPublicOffering.handle_request(r, @ctx)
     end
 
@@ -95,8 +95,33 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
       # :unsupported_src_token -- the USDC check runs first.
       bogus = "0x" <> String.duplicate("ab", 20)
 
-      assert {:reject, {:wrong_offering, :expected_usdc, "xochi_stable_public"}} =
+      assert {:reject, {:wrong_offering, :expected_usdc}} =
                UsdcPublicOffering.handle_request(req(%{"src_token" => bogus}), @ctx)
+    end
+
+    test "rejects an order below the minimum (anti-spam)" do
+      # 0.50 USDC, under the 1 USDC floor.
+      r = req(%{"amount_atomic" => "500000"})
+
+      assert {:reject, {:order_below_min, 1_000_000}} =
+               UsdcPublicOffering.handle_request(r, @ctx)
+    end
+
+    test "rejects an order above the maximum ceiling" do
+      # 3_001 USDC, over the 3_000 USDC ceiling.
+      r = req(%{"amount_atomic" => "3001000000"})
+
+      assert {:reject, {:order_above_max, 3_000_000_000}} =
+               UsdcPublicOffering.handle_request(r, @ctx)
+    end
+
+    test "honors configured order-band overrides" do
+      Application.put_env(:raxol_acp, :usdc_public_min_atomic, 2_000_000)
+      on_exit(fn -> Application.delete_env(:raxol_acp, :usdc_public_min_atomic) end)
+
+      # 1.10 USDC now falls under the raised 2 USDC floor.
+      assert {:reject, {:order_below_min, 2_000_000}} =
+               UsdcPublicOffering.handle_request(req(%{}), @ctx)
     end
 
     test "shared guards still fire once both legs are USDC (same-chain corridor)" do
@@ -107,10 +132,16 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
   end
 
   describe "describe_rejection/1" do
-    test "explains the :expected_usdc rejection and names the fallback offering" do
-      msg = TransferCore.describe_rejection({:wrong_offering, :expected_usdc, "xochi_stable_public"})
-      assert msg =~ "USDC-only"
-      assert msg =~ "xochi_stable_public"
+    test "explains the :expected_usdc rejection without pointing at an unready rail" do
+      msg = TransferCore.describe_rejection({:wrong_offering, :expected_usdc})
+      assert msg =~ "USDC only"
+      assert msg =~ "not settle-ready"
+      refute msg =~ "xochi_stable_public"
+    end
+
+    test "explains the order-band rejections" do
+      assert TransferCore.describe_rejection({:order_below_min, 1_000_000}) =~ "minimum"
+      assert TransferCore.describe_rejection({:order_above_max, 3_000_000_000}) =~ "maximum"
     end
   end
 end

--- a/packages/raxol_payments/lib/raxol/payments/assets.ex
+++ b/packages/raxol_payments/lib/raxol/payments/assets.ex
@@ -204,6 +204,16 @@ defmodule Raxol.Payments.Assets do
   def usdc?(_chain, _address), do: false
 
   @doc """
+  The chain ids on which a USDC contract is registered, ascending.
+
+  Single source of truth for the USDC settlement mesh; callers that advertise
+  the supported chains (e.g. an offering's requirement schema) derive them from
+  here instead of re-declaring the set, so they cannot drift from `usdc?/2`.
+  """
+  @spec usdc_chains() :: [pos_integer()]
+  def usdc_chains, do: @usdc |> Map.keys() |> Enum.sort()
+
+  @doc """
   True when `(chain_id, address)` is a registered contract, i.e. `decimals/2`
   returns a pinned value rather than the `@default_decimals` fallback. An
   unregistered token resolves to 6 decimals, which is wrong for an 18-decimal

--- a/packages/raxol_payments/test/raxol/payments/assets_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/assets_test.exs
@@ -235,4 +235,31 @@ defmodule Raxol.Payments.AssetsTest do
       refute Assets.usdc?(nil, "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913")
     end
   end
+
+  describe "usdc_chains/0" do
+    test "returns the CCTP mesh, ascending" do
+      assert Assets.usdc_chains() == [1, 10, 137, 8453, 42_161]
+    end
+
+    test "every advertised chain actually recognizes a USDC contract" do
+      # Guards against the chain list drifting from usdc?/2.
+      for chain <- Assets.usdc_chains() do
+        assert Enum.any?(
+                 known_usdc_addresses(),
+                 &Assets.usdc?(chain, &1)
+               ),
+               "chain #{chain} advertised but no USDC contract recognized"
+      end
+    end
+  end
+
+  defp known_usdc_addresses do
+    [
+      "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+      "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+      "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+    ]
+  end
 end


### PR DESCRIPTION
## What

Registers `Raxol.ACP.Xochi.UsdcPublicOffering` (`xochi_usdc_public`) into the
seller stack as the narrowest launch offering: USDC-only, public settlement to a
wallet across the five CCTP chains `{1, 10, 137, 8453, 42161}`.

The offering module already existed; this wires it in and covers it:

- **Seller registration** — added it as the first entry in
  `Raxol.ACP.Seller.Offerings` `@default`, so `register_all/0` registers it on
  seller start (ahead of the token-agnostic `StablePublicOffering` /
  `StableStealthOffering` / deprecated `TransferOffering`).
- **`transfer_core.ex`** — `describe_rejection/1` clause that renders the
  offering's pre-escrow `{:wrong_offering, :expected_usdc, "xochi_stable_public"}`
  rejection into an actionable buyer message.
- **Tests** — new `usdc_public_offering_test.exs` (metadata, USDC-pinned
  chain/settlement schema, accept path, non-USDC leg rejection, short-circuit
  ordering vs. the shared token guard, shared guards still firing on a same-chain
  corridor, and the `describe_rejection` clause). Extended
  `seller/offerings_test.exs` to assert the offering registers by default.

A non-USDC leg (src or dst) is rejected before escrow and the buyer is pointed at
the broader `xochi_stable_public` stablecoin offering.

## Manual testing

- [x] `MIX_ENV=test mix test test/raxol/acp/xochi/ test/raxol/acp/seller/` -> 217 passed, 1 excluded
- [x] `MIX_ENV=test mix compile` clean for the touched files (two pre-existing
      warnings in `onchain/rpc.ex` and `web_socket.ex` are unrelated)

## Note

`mix acp.register_offering` still emits the legacy `xochi_cross_chain_transfer`
metadata only; generating the Virtuals registration JSON for this USDC-only
offering needs the task parameterized to target an offering module (follow-up).
