### PR TITLE
Generate xochi_usdc_public ACP registration JSON

### DIFF
--- a/packages/raxol_acp/lib/mix/tasks/acp.register_offering.ex
+++ b/packages/raxol_acp/lib/mix/tasks/acp.register_offering.ex
@@ -15,13 +15,17 @@ defmodule Mix.Tasks.Acp.RegisterOffering do
 
   ## Usage
 
-      mix acp.register_offering                            # mainnet, stdout
+      mix acp.register_offering                            # usdc_public, mainnet, stdout
       mix acp.register_offering --network sepolia
+      mix acp.register_offering --offering stealth
       mix acp.register_offering --out offering.json
       mix acp.register_offering --pretty                   # indented JSON
 
   ## Options
 
+  - `--offering` -- which offering to emit: `usdc_public` (default, the launch
+    offering `xochi_usdc_public`), `public`, `stealth`, or `legacy` (the
+    deprecated token-agnostic `xochi_cross_chain_transfer`).
   - `--network` -- `mainnet` (default) or `sepolia`. Picks the contract
     addresses + ACP server URL embedded in the output.
   - `--out PATH` -- write to a file instead of stdout.
@@ -43,14 +47,15 @@ defmodule Mix.Tasks.Acp.RegisterOffering do
   def run(args) do
     {opts, _, _} =
       OptionParser.parse(args,
-        strict: [network: :string, out: :string, pretty: :boolean]
+        strict: [network: :string, offering: :string, out: :string, pretty: :boolean]
       )
 
     network = opts |> Keyword.get(:network, "mainnet") |> String.to_atom()
+    offering = opts |> Keyword.get(:offering, "usdc_public") |> String.to_atom()
     pretty? = Keyword.get(opts, :pretty, false)
     out = Keyword.get(opts, :out)
 
-    payload = build_payload(network)
+    payload = build_payload(network, offering)
     json = if pretty?, do: Jason.encode!(payload, pretty: true), else: Jason.encode!(payload)
 
     case out do
@@ -64,8 +69,8 @@ defmodule Mix.Tasks.Acp.RegisterOffering do
   end
 
   @doc false
-  def build_payload(network) do
-    meta = Offering.offering_metadata()
+  def build_payload(network, offering \\ :usdc_public) do
+    meta = offering_metadata(offering)
 
     chain_config =
       case network do
@@ -98,4 +103,15 @@ defmodule Mix.Tasks.Acp.RegisterOffering do
       }
     }
   end
+
+  defp offering_metadata(:legacy), do: Offering.offering_metadata()
+
+  defp offering_metadata(mode) when mode in [:usdc_public, :public, :stealth],
+    do: Offering.offering_metadata(mode)
+
+  defp offering_metadata(other),
+    do:
+      Mix.raise(
+        "unknown --offering #{inspect(other)}; expected usdc_public, public, stealth, or legacy"
+      )
 end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -292,7 +292,7 @@ defmodule Raxol.ACP.Xochi.Offering do
   ERC-5564 `stealth_meta_address`. Built from `requirement_schema/0` so the two
   variants never drift from the shared corridor/intent fields.
   """
-  @spec requirement_schema(:public | :stealth) :: map()
+  @spec requirement_schema(:public | :usdc_public | :stealth) :: map()
   def requirement_schema(:public) do
     put_in(requirement_schema(), ["properties", "settlement_preference"], %{
       "type" => "string",
@@ -300,6 +300,23 @@ defmodule Raxol.ACP.Xochi.Offering do
       "default" => "public",
       "description" => "Public settlement: the payout lands in a wallet on the destination chain."
     })
+  end
+
+  # USDC-only public settlement: `:public` plus both legs pinned to the CCTP
+  # mesh. The chain enum derives from `Raxol.Payments.Assets.usdc_chains/0` so it
+  # cannot drift from the runtime USDC gate in `UsdcPublicOffering`.
+  def requirement_schema(:usdc_public) do
+    requirement_schema(:public)
+    |> put_in(["properties", "src_chain_id"], usdc_chain_prop("Source"))
+    |> put_in(["properties", "dst_chain_id"], usdc_chain_prop("Destination"))
+    |> put_in(
+      ["properties", "src_token", "description"],
+      "The USDC contract on src_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow."
+    )
+    |> put_in(
+      ["properties", "dst_token", "description"],
+      "The USDC contract on dst_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow."
+    )
   end
 
   def requirement_schema(:stealth) do
@@ -335,16 +352,28 @@ defmodule Raxol.ACP.Xochi.Offering do
     |> update_in(["required"], &(&1 ++ ["stealth_meta_address"]))
   end
 
+  defp usdc_chain_prop(role) do
+    %{
+      "type" => "integer",
+      "enum" => Raxol.Payments.Assets.usdc_chains(),
+      "description" =>
+        "#{role} chain. USDC settles across the CCTP mesh: " <>
+          "1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum)."
+    }
+  end
+
   @doc """
   Deliverable schema narrowed to a settlement mode. `:public` drops the stealth
   announcement fields; `:stealth` promotes them to `required`.
   """
-  @spec deliverable_schema(:public | :stealth) :: map()
+  @spec deliverable_schema(:public | :usdc_public | :stealth) :: map()
   def deliverable_schema(:public) do
     update_in(deliverable_schema(), ["properties"], fn props ->
       Map.drop(props, ["settlement_type", "stealth_address", "ephemeral_pub_key", "view_tag"])
     end)
   end
+
+  def deliverable_schema(:usdc_public), do: deliverable_schema(:public)
 
   def deliverable_schema(:stealth) do
     update_in(deliverable_schema(), ["required"], fn required ->
@@ -352,8 +381,28 @@ defmodule Raxol.ACP.Xochi.Offering do
     end)
   end
 
-  @doc "Marketplace metadata for a mode-specific offering (`:public` | `:stealth`)."
-  @spec offering_metadata(:public | :stealth) :: map()
+  @doc "Marketplace metadata for a mode-specific offering (`:usdc_public` | `:public` | `:stealth`)."
+  @spec offering_metadata(:usdc_public | :public | :stealth) :: map()
+  def offering_metadata(:usdc_public) do
+    %{
+      name: "xochi_usdc_public",
+      display_name: "Xochi USDC Transfer (Public)",
+      description:
+        "USDC-only cross-chain settlement to a wallet on the destination chain, across " <>
+          "the CCTP mesh (Ethereum, Optimism, Polygon, Base, Arbitrum). The buyer signs a " <>
+          "Xochi intent, the storefront relays it and returns the settlement tx hashes; " <>
+          "the buyer escrows only the storefront fee (a plain job, no fund hook). Both " <>
+          "legs must be USDC; other stablecoins are rejected before escrow. Order size is " <>
+          "bounded (min 1 USDC, max 3,000 USDC).",
+      required_funds: true,
+      hook_kind: "none",
+      sla_minutes: 10,
+      requirement_schema: requirement_schema(:usdc_public),
+      deliverable_schema: deliverable_schema(:usdc_public),
+      tags: ["payments", "cross-chain", "stablecoin", "usdc", "xochi", "public"]
+    }
+  end
+
   def offering_metadata(:public) do
     %{
       name: "xochi_stable_public",

--- a/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
@@ -45,22 +45,10 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
   @default_max_atomic 3_000_000_000
 
   @impl true
-  def requirements_schema do
-    Offering.requirement_schema(:public)
-    |> put_in(["properties", "src_chain_id"], usdc_chain_prop("Source"))
-    |> put_in(["properties", "dst_chain_id"], usdc_chain_prop("Destination"))
-    |> put_in(
-      ["properties", "src_token", "description"],
-      "The USDC contract on src_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow."
-    )
-    |> put_in(
-      ["properties", "dst_token", "description"],
-      "The USDC contract on dst_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow."
-    )
-  end
+  def requirements_schema, do: Offering.requirement_schema(:usdc_public)
 
   @impl true
-  def deliverables_schema, do: Offering.deliverable_schema(:public)
+  def deliverables_schema, do: Offering.deliverable_schema(:usdc_public)
 
   @impl true
   def handle_request(req, ctx) do
@@ -106,16 +94,9 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
 
   defp parse_amount(_), do: :error
 
-  defp min_atomic, do: Application.get_env(:raxol_acp, :usdc_public_min_atomic, @default_min_atomic)
-  defp max_atomic, do: Application.get_env(:raxol_acp, :usdc_public_max_atomic, @default_max_atomic)
+  defp min_atomic,
+    do: Application.get_env(:raxol_acp, :usdc_public_min_atomic, @default_min_atomic)
 
-  defp usdc_chain_prop(role) do
-    %{
-      "type" => "integer",
-      "enum" => Assets.usdc_chains(),
-      "description" =>
-        "#{role} chain. USDC settles across the CCTP mesh: " <>
-          "1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum)."
-    }
-  end
+  defp max_atomic,
+    do: Application.get_env(:raxol_acp, :usdc_public_max_atomic, @default_max_atomic)
 end

--- a/packages/raxol_acp/priv/offering.usdc_public.mainnet.json
+++ b/packages/raxol_acp/priv/offering.usdc_public.mainnet.json
@@ -1,0 +1,173 @@
+{
+  "deliverableSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "amount_atomic": {
+        "description": "The transfer amount settled, in token base units (matches the requirement's amount_atomic; committed so the deliverable hash pins what was moved).",
+        "pattern": "^[0-9]+$",
+        "type": "string"
+      },
+      "intent_id": {
+        "description": "Xochi intent identifier returned by POST /xochi/quote.",
+        "type": "string"
+      },
+      "receiving_tx_hash": {
+        "description": "The destination-arrival transaction hash for a two-leg settlement. Absent (null) for an instant single-tx fill.",
+        "pattern": "^0x[0-9a-fA-F]{64}$",
+        "type": "string"
+      },
+      "settlement_tx_hash": {
+        "description": "The authoritative settlement transaction hash. For an instant fill this is the destination delivery; for a two-leg bridge it is the origin leg (with the destination arrival in receiving_tx_hash).",
+        "pattern": "^0x[0-9a-fA-F]{64}$",
+        "type": "string"
+      },
+      "status": {
+        "description": "Settlement lifecycle state; a delivered job is always completed.",
+        "enum": [
+          "completed"
+        ],
+        "type": "string"
+      }
+    },
+    "required": [
+      "intent_id",
+      "settlement_tx_hash",
+      "status"
+    ],
+    "type": "object"
+  },
+  "description": "USDC-only cross-chain settlement to a wallet on the destination chain, across the CCTP mesh (Ethereum, Optimism, Polygon, Base, Arbitrum). The buyer signs a Xochi intent, the storefront relays it and returns the settlement tx hashes; the buyer escrows only the storefront fee (a plain job, no fund hook). Both legs must be USDC; other stablecoins are rejected before escrow. Order size is bounded (min 1 USDC, max 3,000 USDC).",
+  "displayName": "Xochi USDC Transfer (Public)",
+  "hookKind": "none",
+  "name": "xochi_usdc_public",
+  "network": {
+    "acpCoreAddress": "0x238E541BfefD82238730D00a2208E5497F1832E0",
+    "acpServerUrl": "https://api.acp.virtuals.io",
+    "chainId": 8453,
+    "fundTransferHookAddress": "0x0EaD25150985Bce0B4925c54E4ee1D856381A86B",
+    "name": "Base Mainnet"
+  },
+  "requiredFunds": true,
+  "requirementSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": false,
+    "properties": {
+      "amount_atomic": {
+        "description": "Transfer size in token base units (USDC: 1 USDC = 1_000_000). Used to size the storefront fee (bps of this) and to commit the deliverable amount; the on-chain amount is fixed by the buyer's signed intent.",
+        "pattern": "^[0-9]+$",
+        "type": "string"
+      },
+      "destination": {
+        "description": "Optional: the recipient the buyer signed into their Xochi intent, for the buyer's or evaluator's audit trail. raxol does not use or enforce it; the destination is fixed by the buyer's signature.",
+        "pattern": "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
+        "type": "string"
+      },
+      "dst_chain_id": {
+        "description": "Destination chain. USDC settles across the CCTP mesh: 1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum).",
+        "enum": [
+          1,
+          10,
+          137,
+          8453,
+          42161
+        ],
+        "type": "integer"
+      },
+      "dst_token": {
+        "description": "The USDC contract on dst_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow.",
+        "pattern": "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
+        "type": "string"
+      },
+      "settlement_preference": {
+        "default": "public",
+        "description": "Public settlement: the payout lands in a wallet on the destination chain.",
+        "enum": [
+          "public"
+        ],
+        "type": "string"
+      },
+      "signed_intent": {
+        "additionalProperties": false,
+        "description": "The buyer's pre-signed Xochi intent bundle. The buyer quotes and signs the EIP-712 intent against Xochi directly; the storefront relays it verbatim (Riddler verifies it against its own persisted quote, so the amount and route cannot be forged).",
+        "properties": {
+          "aztec_proof": {
+            "description": "Optional shielded-claim proof.",
+            "type": "string"
+          },
+          "intent_id": {
+            "description": "Xochi intent id the buyer signed.",
+            "type": "string"
+          },
+          "nonce": {
+            "description": "Worker replay-dedup nonce.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pull_signature": {
+            "description": "Optional ERC-3009/Permit2 origin-pull signature (absent for non-pulling methods).",
+            "pattern": "^0x[0-9a-fA-F]+$",
+            "type": "string"
+          },
+          "quote_id": {
+            "description": "Xochi quote id the signature binds to.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "EIP-712 signature over the XochiIntent.",
+            "pattern": "^0x[0-9a-fA-F]+$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "intent_id",
+          "quote_id",
+          "signature",
+          "nonce"
+        ],
+        "type": "object"
+      },
+      "slippage_bps": {
+        "default": 50,
+        "description": "Optional audit hint; the buyer's signed quote fixes slippage.",
+        "maximum": 1000,
+        "minimum": 0,
+        "type": "integer"
+      },
+      "src_chain_id": {
+        "description": "Source chain. USDC settles across the CCTP mesh: 1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum).",
+        "enum": [
+          1,
+          10,
+          137,
+          8453,
+          42161
+        ],
+        "type": "integer"
+      },
+      "src_token": {
+        "description": "The USDC contract on src_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow.",
+        "pattern": "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
+        "type": "string"
+      }
+    },
+    "required": [
+      "src_chain_id",
+      "dst_chain_id",
+      "src_token",
+      "dst_token",
+      "amount_atomic",
+      "signed_intent"
+    ],
+    "type": "object"
+  },
+  "slaMinutes": 10,
+  "tags": [
+    "payments",
+    "cross-chain",
+    "stablecoin",
+    "usdc",
+    "xochi",
+    "public"
+  ]
+}

--- a/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
+++ b/packages/raxol_acp/test/mix/tasks/acp.register_offering_test.exs
@@ -32,14 +32,31 @@ defmodule Mix.Tasks.Acp.RegisterOfferingTest do
       assert payload["network"]["acpServerUrl"] == "https://api-dev.acp.virtuals.io"
     end
 
-    test "embeds the Xochi offering metadata verbatim" do
+    test "defaults to the USDC-only launch offering" do
       payload = RegisterOffering.build_payload(:mainnet)
 
-      assert payload["name"] == "xochi_cross_chain_transfer"
+      assert payload["name"] == "xochi_usdc_public"
       assert payload["hookKind"] == "none"
       assert payload["requiredFunds"] == true
       assert payload["slaMinutes"] == 10
       assert "payments" in payload["tags"]
+      assert "usdc" in payload["tags"]
+
+      # USDC launch offering pins both legs to the CCTP mesh.
+      props = payload["requirementSchema"]["properties"]
+      assert props["src_chain_id"]["enum"] == [1, 10, 137, 8453, 42_161]
+      assert props["dst_chain_id"]["enum"] == [1, 10, 137, 8453, 42_161]
+    end
+
+    test "--offering legacy emits the deprecated token-agnostic offering" do
+      payload = RegisterOffering.build_payload(:mainnet, :legacy)
+      assert payload["name"] == "xochi_cross_chain_transfer"
+    end
+
+    test "unknown --offering raises with a helpful message" do
+      assert_raise Mix.Error, ~r/unknown --offering/, fn ->
+        RegisterOffering.build_payload(:mainnet, :bogus)
+      end
     end
 
     test "requirement schema is JSON-Schema 2020-12 with the corridor + signed-intent fields" do
@@ -76,7 +93,7 @@ defmodule Mix.Tasks.Acp.RegisterOfferingTest do
       json = Jason.encode!(payload)
 
       assert {:ok, decoded} = Jason.decode(json)
-      assert decoded["name"] == "xochi_cross_chain_transfer"
+      assert decoded["name"] == "xochi_usdc_public"
     end
 
     test "unknown network raises with a helpful message" do


### PR DESCRIPTION
## What

Teaches `mix acp.register_offering` to emit the Virtuals registration JSON for the
USDC-only launch offering (`xochi_usdc_public`), and checks in the generated file.

Previously the task was hardcoded to the legacy `xochi_cross_chain_transfer`
metadata, so it could not produce the launch offering's document.

- **`--offering` flag** (default `usdc_public`): selects `usdc_public` | `public` |
  `stealth` | `legacy`. `build_payload/2` maps it to the matching
  `Xochi.Offering.offering_metadata/*` variant.
- **`Xochi.Offering` gains the `:usdc_public` variant** of `requirement_schema/1`,
  `deliverable_schema/1`, and `offering_metadata/1`. The USDC chain-enum + token
  descriptions now live here (single source), and `UsdcPublicOffering` delegates to
  it instead of re-deriving the schema -- so the on-wire offering and the generated
  registration JSON can never drift.
- **Generated artifact**: `priv/offering.usdc_public.mainnet.json` (Base mainnet:
  ACP Core `0x238E...832E0`, fund-transfer hook `0x0EaD...1A86B`, server
  `api.acp.virtuals.io`). Regenerate with:

      mix acp.register_offering --pretty --out offering.json          # mainnet
      mix acp.register_offering --network sepolia --pretty            # dev

The JSON pins both legs to the CCTP mesh `[1,10,137,8453,42161]`,
`settlement_preference: ["public"]`, USDC-only token descriptions, and bounds
`status` to `completed`.

## Manual testing

- [x] `MIX_ENV=test mix test` (raxol_acp) -> 636 passed, 31 excluded
- [x] `mix acp.register_offering --pretty` produces `name: xochi_usdc_public` with
      the CCTP chain enums and Base mainnet network block
- [x] `--offering legacy` still emits `xochi_cross_chain_transfer`; unknown
      `--offering` raises a helpful error

## Operator workflow

Paste `priv/offering.usdc_public.mainnet.json` into the Virtuals dashboard
(Offerings -> New offering) after registering the agent at `app.virtuals.io/acp/new`.
