### PR TITLE
Deploy raxol_acp Xochi solver as isolated fly.io app

### DIFF
--- a/docker/Dockerfile.raxol-acp
+++ b/docker/Dockerfile.raxol-acp
@@ -10,8 +10,10 @@
 # Build from the repository root:
 #   docker build -f docker/Dockerfile.raxol-acp -t raxol-acp .
 #
-# Wallet-safe by construction: no private key is baked in or read at runtime; the
-# sidecar only reads balances/receipts over public RPC and never moves funds.
+# No private key is BAKED INTO the image. Wallet-safe only in the default accounting
+# mode, where the sidecar just reads balances/receipts over public RPC and never moves
+# funds. In solver mode (XOCHI_SOLVER_ENABLED=true) the release READS a real signing
+# key -- RAXOL_ACP_AGENT_PRIVATE_KEY -- from the runtime env (a fly secret) and signs tx.
 
 ARG ELIXIR_IMAGE=elixir:1.20.0-otp-29
 ARG RUNNER_IMAGE=debian:bookworm-slim

--- a/fly.acp.toml
+++ b/fly.acp.toml
@@ -33,7 +33,11 @@
 #        (`fly deploy -c fly.acp.toml --ha=false`), then pin + verify:
 #            fly scale count 1 -a raxol-solver
 #            fly machines list -a raxol-solver   # expect exactly one started
-#        Never scale up (would race the wallet). deploy-raxol-solver.sh does this.
+#        Never scale up (would race the wallet). deploy-raxol-solver.sh asserts the
+#        count == 1 after deploy and fails otherwise -- but the toml cannot PREVENT a
+#        later out-of-band `fly scale count 2`. Enforce continuously out-of-band with a
+#        monitored machine-count check (ansible-riddler scripts/raxol-solver-fly.sh
+#        `guard` asserts exactly one started machine; run it on a cron + alert).
 #
 # 2. NO PUBLIC INBOUND. The solver is an OUTBOUND client only: ACP EIP-712 auth
 #    + SSE job stream + Base mainnet tx submission. It serves nothing. Hence NO
@@ -51,6 +55,12 @@
 app = 'raxol-solver'
 primary_region = 'sjc'
 kill_signal = 'SIGTERM'
+# Drain window before SIGKILL. After broadcasting a settlement tx the solver blocks in
+# RPC.await_receipt (up to ~30s); the fly default of 5s would SIGKILL the BEAM mid-await
+# on any deploy/reschedule -- the tx lands on-chain while the ACP job never records
+# completion -> stuck job / stranded funds (the class the axol drain gate prevents).
+# 60s >= receipt-await + margin, so an in-flight settlement finishes before shutdown.
+kill_timeout = '60s'
 
 [build]
   dockerfile = "docker/Dockerfile.raxol-acp"
@@ -62,7 +72,8 @@ kill_signal = 'SIGTERM'
 #   RAXOL_ACP_AGENT_PRIVATE_KEY  -- low-value agent signing EOA (NOT the inventory wallet)
 #   RAXOL_ACP_EVALUATOR          -- the agent's OWN address (trusted-buyer mode)
 #   XOCHI_AUTH_TOKEN             -- Xochi worker bearer token
-#   RAXOL_ACP_RPC_URL            -- private Base RPC; overrides the public default below
+#   RAXOL_ACP_RPC_URL            -- private Base RPC; REQUIRED (NOT defaulted here --
+#                                   runtime.exs fails the boot closed in solver mode if unset)
 [env]
   # Enables the SIGNING solver. config/runtime.exs (:prod) reads this exact var:
   #   config :raxol_acp, xochi_solver_enabled: System.get_env("XOCHI_SOLVER_ENABLED") == "true"
@@ -79,10 +90,11 @@ kill_signal = 'SIGTERM'
   # script. A change requires a redeploy (parsed via String.to_integer at boot).
   XOCHI_FEE_BPS = '8'
 
-  # Base mainnet RPC for auth + on-chain submit. Public default -- rate-limited and
-  # unsuitable for a production signing solver; the deploy script overrides it with a
-  # private endpoint via a RAXOL_ACP_RPC_URL secret (a secret set overrides this value).
-  RAXOL_ACP_RPC_URL = 'https://mainnet.base.org'
+  # RAXOL_ACP_RPC_URL is deliberately NOT defaulted here. A public-RPC default would let
+  # a misstaged secret silently run the signing solver on the rate-limited public Base
+  # endpoint -> 429 storms on nonce fetch + tx submit (the axol RPC-429 crashloop class).
+  # It is a REQUIRED secret (set by scripts/deploy-raxol-solver.sh from op://); solver
+  # mode in config/runtime.exs fails the boot CLOSED if it is unset.
 
 # Modest single VM: this is a lightweight outbound client (one SSE stream + one
 # signer), not a server. Shared CPU is plenty.

--- a/fly.acp.toml
+++ b/fly.acp.toml
@@ -1,0 +1,92 @@
+# fly.acp.toml -- dedicated fly.io app for the raxol_acp ACP settlement SOLVER.
+#
+# See https://fly.io/docs/reference/configuration/
+#
+# DEPLOYING: this is a NON-DEFAULT config filename. The image AND this [env] block
+# land on the machine ONLY via `fly deploy -c fly.acp.toml` -- `fly secrets set`
+# alone does NOT apply [env]. Use scripts/deploy-raxol-solver.sh, which stages the
+# op:// secrets and then runs `fly deploy -c fly.acp.toml --ha=false`.
+#
+# ============================================================================
+# SECURITY / TOPOLOGY RATIONALE -- read before editing.
+# ============================================================================
+# This app ('raxol-solver') is an ISOLATED, single-purpose deployment of the
+# raxol_acp release (docker/Dockerfile.raxol-acp) running in SOLVER mode. It is
+# NOT the public 'raxol' playground app (see fly.toml) -- do not co-locate them.
+#
+# 1. EXACTLY ONE MACHINE, ALWAYS RUNNING.
+#    In solver mode this node holds ONE agent signing EOA and consumes ONE SSE
+#    job stream. A second instance would double-process ACP jobs and race the
+#    wallet nonce (double-spend / stuck nonce). So this app must run a single
+#    machine and must NOT autoscale.
+#      - There is NO [http_service]/[[services]] block below, therefore there is
+#        NO auto_stop_machines / auto_start_machines behavior at all: the one
+#        deployed machine simply runs continuously. That is the always-on
+#        mechanism for a services-less worker.
+#      - `min_machines_running` is INTENTIONALLY ABSENT. Per the fly.io config
+#        reference it is only valid INSIDE [http_service]/[[services]] and only
+#        takes effect when auto_stop_machines is "stop"/"suspend". There is no
+#        top-level or [[vm]]-level min_machines_running; adding one here would
+#        be an ignored/invalid key.
+#      - Machine COUNT is a scale concern, not a fly.toml concern, and is a
+#        REQUIRED deploy step (not a passive default). Deploy single-machine
+#        (`fly deploy -c fly.acp.toml --ha=false`), then pin + verify:
+#            fly scale count 1 -a raxol-solver
+#            fly machines list -a raxol-solver   # expect exactly one started
+#        Never scale up (would race the wallet). deploy-raxol-solver.sh does this.
+#
+# 2. NO PUBLIC INBOUND. The solver is an OUTBOUND client only: ACP EIP-712 auth
+#    + SSE job stream + Base mainnet tx submission. It serves nothing. Hence NO
+#    [http_service] and NO [[services]] port. (Contrast: the playground 'raxol'
+#    app deliberately exposes a public :2222 SSH sandbox -- that MUST NOT appear
+#    here. This node signs real transactions.)
+#
+# 3. NO ERLANG DISTRIBUTION. RELEASE_DISTRIBUTION is left UNSET so
+#    rel/env.sh.eex's default of 'none' holds (keyless single node, no cookie
+#    surface). In solver mode config/runtime.exs FAILS THE BOOT CLOSED if
+#    RELEASE_DISTRIBUTION is anything but 'none' -- the signing node must expose
+#    no cookie-reachable REPL. Do NOT set RELEASE_DISTRIBUTION for this app.
+# ============================================================================
+
+app = 'raxol-solver'
+primary_region = 'sjc'
+kill_signal = 'SIGTERM'
+
+[build]
+  dockerfile = "docker/Dockerfile.raxol-acp"
+  ignorefile = ".dockerignore"
+
+# NON-SECRET env only. Secrets are seeded out-of-band from 1Password op:// refs by
+# scripts/deploy-raxol-solver.sh (`fly secrets import --stage`, applied by the
+# subsequent `fly deploy -c fly.acp.toml`). Required secrets:
+#   RAXOL_ACP_AGENT_PRIVATE_KEY  -- low-value agent signing EOA (NOT the inventory wallet)
+#   RAXOL_ACP_EVALUATOR          -- the agent's OWN address (trusted-buyer mode)
+#   XOCHI_AUTH_TOKEN             -- Xochi worker bearer token
+#   RAXOL_ACP_RPC_URL            -- private Base RPC; overrides the public default below
+[env]
+  # Enables the SIGNING solver. config/runtime.exs (:prod) reads this exact var:
+  #   config :raxol_acp, xochi_solver_enabled: System.get_env("XOCHI_SOLVER_ENABLED") == "true"
+  # which flips SolverApplication.enabled?/0. Any value other than "true" (or unset)
+  # leaves the app in read-only accounting mode: it boots healthy but picks up no jobs.
+  # This [env] lands on the machine only via `fly deploy -c fly.acp.toml`.
+  XOCHI_SOLVER_ENABLED = 'true'
+
+  # Xochi WORKER base URL (the agent-service API), NOT riddler.axol.io/xochi/*.
+  XOCHI_BASE_URL = 'https://api.xochi.fi'
+
+  # Storefront fee in basis points. SolverApplication defaults to 50 (0.5%); the
+  # launch target is 8. Pinned here (non-secret) so the fee is independent of any
+  # script. A change requires a redeploy (parsed via String.to_integer at boot).
+  XOCHI_FEE_BPS = '8'
+
+  # Base mainnet RPC for auth + on-chain submit. Public default -- rate-limited and
+  # unsuitable for a production signing solver; the deploy script overrides it with a
+  # private endpoint via a RAXOL_ACP_RPC_URL secret (a secret set overrides this value).
+  RAXOL_ACP_RPC_URL = 'https://mainnet.base.org'
+
+# Modest single VM: this is a lightweight outbound client (one SSE stream + one
+# signer), not a server. Shared CPU is plenty.
+[[vm]]
+  memory = '512mb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/packages/raxol_acp/config/runtime.exs
+++ b/packages/raxol_acp/config/runtime.exs
@@ -46,4 +46,15 @@ if config_env() == :prod do
     signing node must expose no cookie-reachable REPL.
     """
   end
+
+  # Solver mode signs real transactions; it must run on an explicitly-configured
+  # (private) Base RPC, never silently fall back to the rate-limited public endpoint
+  # (that path 429-storms nonce fetch + tx submit -- the axol RPC-429 crashloop class).
+  # Require RAXOL_ACP_RPC_URL rather than defaulting it; set it as a fly secret.
+  if solver_enabled? and String.trim(System.get_env("RAXOL_ACP_RPC_URL", "")) == "" do
+    raise """
+    raxol_acp solver mode requires RAXOL_ACP_RPC_URL (a private Base RPC). Refusing to \
+    boot on the public-RPC default -- set it as a fly secret (scripts/deploy-raxol-solver.sh).
+    """
+  end
 end

--- a/packages/raxol_acp/config/runtime.exs
+++ b/packages/raxol_acp/config/runtime.exs
@@ -1,6 +1,12 @@
 import Config
 
-# Runtime (boot-time) config for the read-only settlement-accounting sidecar.
+# Runtime (boot-time) config for the raxol_acp release. Two modes share this file:
+#
+#   * accounting sidecar (default) -- read-only ledger/monitor over public RPC; it
+#     holds no signing key and never moves funds.
+#   * solver (XOCHI_SOLVER_ENABLED=true, wired below) -- a SIGNING runtime: it reads
+#     RAXOL_ACP_AGENT_PRIVATE_KEY at boot and signs EIP-712 auth plus on-chain ACP
+#     tx. In this mode the "read-only/keyless" framing below does NOT hold.
 #
 # Prod-gated so `mix`/tests in this package are unaffected. Reads the accounting
 # deployment contract via `Raxol.Payments.Accounting.env_config/0` -- the same
@@ -8,12 +14,12 @@ import Config
 #
 # Deliberately NOT included: the origin-pull solver-pin guard from the root
 # config/runtime.exs. That guard fails a boot closed unless XOCHI_SOLVER_* is set,
-# to protect a node that SIGNS origin pulls. This sidecar is read-only and never
-# signs, so the guard is irrelevant here and would force an unrelated env var.
-#
-# The sidecar runs without Erlang distribution (see rel/env.sh.eex), so it holds no
-# cookie-reachable node and no signing key; the distribution/REPL boot gates in
-# Raxol.Payments.Deployment are therefore not wired here.
+# to protect a node that SIGNS origin pulls -- it is not wired here. The
+# distribution/REPL boot gates in Raxol.Payments.Deployment are likewise not wired.
+# Because those gates are absent, solver mode instead fails the boot CLOSED below if
+# Erlang distribution is on (see the RELEASE_DISTRIBUTION guard): the signing node
+# must expose no cookie-reachable REPL. rel/env.sh.eex defaults distribution to
+# "none"; the guard catches an operator override.
 if config_env() == :prod do
   config :logger, level: :info
 
@@ -21,4 +27,23 @@ if config_env() == :prod do
 
   config :raxol_payments, :accounting, accounting_opts
   config :raxol_acp, accounting_enabled: accounting_enabled
+
+  # Solver mode is gated by Application config, not an env var -- wire the flag from
+  # XOCHI_SOLVER_ENABLED so a fly deploy can toggle the signing solver without a
+  # rebuild. Defaults false (accounting-only) for any other/unset value.
+  solver_enabled? = System.get_env("XOCHI_SOLVER_ENABLED") == "true"
+  config :raxol_acp, xochi_solver_enabled: solver_enabled?
+
+  # Solver mode holds a real signing EOA, and the distribution/REPL security boot
+  # gates are not wired here (see the moduledoc). Nothing else keeps distribution
+  # off, so fail the boot CLOSED if an operator turned it on: a cookie-reachable
+  # REPL onto a wallet-holding node is a remote path to the signing key.
+  # rel/env.sh.eex defaults RELEASE_DISTRIBUTION to "none".
+  if solver_enabled? and System.get_env("RELEASE_DISTRIBUTION", "none") not in ["none", ""] do
+    raise """
+    raxol_acp solver mode forbids Erlang distribution: RELEASE_DISTRIBUTION must be \
+    unset or "none" (got #{inspect(System.get_env("RELEASE_DISTRIBUTION"))}). The \
+    signing node must expose no cookie-reachable REPL.
+    """
+  end
 end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/heartbeat.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/heartbeat.ex
@@ -1,0 +1,58 @@
+defmodule Raxol.ACP.Xochi.Heartbeat do
+  @moduledoc """
+  Periodic liveness signal for the Xochi storefront solver.
+
+  The solver is an outbound SSE client with NO inbound port, so a silently-stalled
+  stream (expired auth, half-open socket) neither crashes nor is reschedulable by a fly
+  health check, and an idle-but-alive node looks identical to a wedged one. This
+  GenServer emits a heartbeat on a fixed interval regardless of job flow:
+
+    * a `Logger.info("xochi solver heartbeat", ...)` line, and
+    * a `[:raxol, :acp, :xochi, :solver, :heartbeat]` telemetry event
+      (measurements: `%{ticks, uptime_ms}`).
+
+  External monitoring should alert when the heartbeat goes stale (no log/metric within a
+  few intervals) and restart the machine. Started last in
+  `Raxol.ACP.Xochi.SolverApplication`'s tree so a heartbeat crash restarts nothing above
+  it under `:rest_for_one`.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @telemetry_event [:raxol, :acp, :xochi, :solver, :heartbeat]
+  @default_interval_ms 30_000
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(opts) do
+    state = %{
+      interval_ms: Keyword.get(opts, :interval_ms, @default_interval_ms),
+      ticks: 0,
+      started_at: System.monotonic_time(:millisecond)
+    }
+
+    {:ok, schedule(state)}
+  end
+
+  @impl true
+  def handle_info(:heartbeat, state) do
+    ticks = state.ticks + 1
+    uptime_ms = System.monotonic_time(:millisecond) - state.started_at
+
+    :telemetry.execute(@telemetry_event, %{ticks: ticks, uptime_ms: uptime_ms}, %{})
+    Logger.info("xochi solver heartbeat", ticks: ticks, uptime_ms: uptime_ms)
+
+    {:noreply, schedule(%{state | ticks: ticks})}
+  end
+
+  defp schedule(state) do
+    Process.send_after(self(), :heartbeat, state.interval_ms)
+    state
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_application.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_application.ex
@@ -4,7 +4,7 @@ defmodule Raxol.ACP.Xochi.SolverApplication do
   against Virtuals, streams jobs, and settles each funded job by relaying the
   buyer's pre-signed Xochi intent.
 
-  Supervises four children (`:rest_for_one`, so an `Auth`/`Agent` crash restarts
+  Supervises five children (`:rest_for_one`, so an `Auth`/`Agent` crash restarts
   everything downstream):
 
     1. `Raxol.ACP.Auth` -- EIP-712 auth against the Virtuals server.
@@ -14,6 +14,8 @@ defmodule Raxol.ACP.Xochi.SolverApplication do
        storefront relay `settle_fn` and submits the deliverable on-chain.
     4. an internal stream starter -- calls `Agent.start_stream/1` last, so the
        solver is subscribed before the first SSE event arrives.
+    5. `Raxol.ACP.Xochi.Heartbeat` -- periodic liveness log + telemetry, last so its
+       crash restarts nothing above it.
 
   The `settle_fn` is a pure relay (`Raxol.ACP.Xochi.Settler.build/1`, `:xochi_config`
   only): it never re-signs, so no signing wallet is wired here. raxol earns the
@@ -45,7 +47,7 @@ defmodule Raxol.ACP.Xochi.SolverApplication do
   use Supervisor
 
   alias Raxol.ACP
-  alias Raxol.ACP.Xochi.{Settler, SolverAgent}
+  alias Raxol.ACP.Xochi.{Heartbeat, Settler, SolverAgent}
 
   # Base mainnet. The storefront authenticates and submits on Base; the transferred
   # funds move across chains inside the buyer's Xochi intent, off the ACP ledger.
@@ -130,7 +132,11 @@ defmodule Raxol.ACP.Xochi.SolverApplication do
         id: :stream_starter,
         start: {Task, :start_link, [fn -> :ok = ACP.Agent.start_stream(agent_name()) end]},
         restart: :transient
-      }
+      },
+      # Liveness heartbeat -- last so a crash here restarts nothing above it under
+      # :rest_for_one. Emits a periodic log + telemetry event so external monitoring can
+      # tell a live-but-idle solver from a wedged one (no inbound port for a fly check).
+      {Heartbeat, name: heartbeat_name()}
     ]
 
     Supervisor.init(children, strategy: :rest_for_one)
@@ -141,6 +147,7 @@ defmodule Raxol.ACP.Xochi.SolverApplication do
   defp auth_name, do: Module.concat(__MODULE__, Auth)
   defp agent_name, do: Module.concat(__MODULE__, Agent)
   defp solver_name, do: Module.concat(__MODULE__, Solver)
+  defp heartbeat_name, do: Module.concat(__MODULE__, Heartbeat)
 
   defp decode_pk!("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
   defp decode_pk!(hex), do: Base.decode16!(hex, case: :mixed)

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_application.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_application.ex
@@ -67,6 +67,14 @@ defmodule Raxol.ACP.Xochi.SolverApplication do
   @impl true
   def init(_opts) do
     chain = ACP.Chain.mainnet()
+
+    # Secret-handling invariant -- KEEP THIS if you reuse the solver pattern. The raw
+    # key exists only as this transient local; `JSONRPC.new/1` immediately wraps it in a
+    # `Raxol.ACP.Secret` before it enters the provider config. That wrapper redacts under
+    # `Inspect`, so the key never renders into an OTP/SASL crash report even though the
+    # provider is passed as a supervised child's start arg (a plain unwrapped key here
+    # WOULD leak on any boot-time child crash -- see Secret's moduledoc). Do not log or
+    # interpolate `private_key`; only `Secret.reveal/1` at a sign call site unwraps it.
     private_key = decode_pk!(System.fetch_env!("RAXOL_ACP_AGENT_PRIVATE_KEY"))
     rpc_url = System.get_env("RAXOL_ACP_RPC_URL", chain.rpc_url)
     server_url = chain.acp_server_url

--- a/packages/raxol_acp/rel/env.sh.eex
+++ b/packages/raxol_acp/rel/env.sh.eex
@@ -9,4 +9,9 @@
 #
 # An operator who genuinely needs a clustered deploy can override RELEASE_DISTRIBUTION
 # (sname|name) and RELEASE_NODE in the container environment.
+#
+# BUT NOT in solver mode: when XOCHI_SOLVER_ENABLED=true this node holds a real signing
+# EOA, and config/runtime.exs fails the boot CLOSED if RELEASE_DISTRIBUTION is anything
+# other than "none" (a cookie-reachable REPL onto a wallet-holding node is a path to the
+# signing key). Leave distribution off for the raxol-solver app.
 export RELEASE_DISTRIBUTION="${RELEASE_DISTRIBUTION:-none}"

--- a/packages/raxol_acp/test/raxol/acp/xochi/heartbeat_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/heartbeat_test.exs
@@ -1,0 +1,37 @@
+defmodule Raxol.ACP.Xochi.HeartbeatTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Xochi.Heartbeat
+
+  @event [:raxol, :acp, :xochi, :solver, :heartbeat]
+
+  test "emits a heartbeat telemetry event with monotonic tick + uptime when driven" do
+    ref = make_ref()
+    handler_id = {__MODULE__, ref}
+
+    :telemetry.attach(
+      handler_id,
+      @event,
+      fn @event, measurements, _meta, test_pid -> send(test_pid, {:heartbeat, measurements}) end,
+      self()
+    )
+
+    # Long interval so the process's own timer never fires during the test; we drive the
+    # tick deterministically by sending :heartbeat ourselves (no sleeps, no flakiness).
+    {:ok, pid} =
+      Heartbeat.start_link(
+        interval_ms: 60_000,
+        name: :"heartbeat_#{System.unique_integer([:positive])}"
+      )
+
+    send(pid, :heartbeat)
+    assert_receive {:heartbeat, %{ticks: 1, uptime_ms: uptime}}
+    assert is_integer(uptime) and uptime >= 0
+
+    send(pid, :heartbeat)
+    assert_receive {:heartbeat, %{ticks: 2}}
+
+    :telemetry.detach(handler_id)
+    GenServer.stop(pid)
+  end
+end

--- a/scripts/deploy-raxol-solver.sh
+++ b/scripts/deploy-raxol-solver.sh
@@ -23,12 +23,18 @@
 # ----------------------------------------------------------------------------------------
 #
 # Usage:
-#   ./scripts/deploy-raxol-solver.sh
+#   ./scripts/deploy-raxol-solver.sh [--yes]   # --yes / ASSUME_YES=1 skips the confirm prompt
 
 set -euo pipefail
-# A failed 'op read' inside a command substitution must abort the whole run rather than
-# silently seeding an empty secret. inherit_errexit propagates set -e into $( ... ).
-shopt -s inherit_errexit
+# NB: `inherit_errexit` is deliberately NOT used -- it needs bash >= 4.4 (macOS ships
+# 3.2), and it would NOT prevent an empty-secret seed anyway: a failed `op read` inside a
+# printf-arg substitution is masked (printf succeeds with an empty string). stage_secrets
+# resolves each secret into a CHECKED assignment instead.
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
 
 # Run from the repo root so `fly deploy -c fly.acp.toml` and the Docker build context resolve.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -80,6 +86,7 @@ require_app_exists() {
 preflight() {
   require_cmd op
   require_cmd fly
+  require_cmd jq
   require_op_signed_in
   require_app_exists
 }
@@ -90,13 +97,27 @@ preflight() {
 # resolved plaintext never lands in another process's command line; --stage defers the
 # rollout to the single `fly deploy` below. (XOCHI_BASE_URL / XOCHI_FEE_BPS / the enable
 # flag are NON-secret and live in fly.acp.toml [env].)
+#
+# Each op read is a discrete, CHECKED assignment before the printf -- not inlined as
+# `printf "KEY=$(op read ...)"`. A failed op read inside a printf-arg substitution is
+# masked (printf still succeeds with an empty string), so the inline form would silently
+# stage a BLANK secret (e.g. an empty private key). Assign-then-check catches both a
+# failed read and an empty value.
 stage_secrets() {
-  printf 'Staging %d secrets into fly app %q (out of argv)...\n' 4 "${APP}"
+  local pk evaluator auth rpc
+  pk="$(op read "${OP_AGENT_PRIVATE_KEY}")"    || die "op read failed for ${OP_AGENT_PRIVATE_KEY}"
+  evaluator="$(op read "${OP_AGENT_ADDRESS}")" || die "op read failed for ${OP_AGENT_ADDRESS}"
+  auth="$(op read "${OP_XOCHI_AUTH_TOKEN}")"   || die "op read failed for ${OP_XOCHI_AUTH_TOKEN}"
+  rpc="$(op read "${OP_BASE_RPC_URL}")"        || die "op read failed for ${OP_BASE_RPC_URL}"
+  [[ -n "${pk}" && -n "${evaluator}" && -n "${auth}" && -n "${rpc}" ]] \
+    || die "a resolved secret is empty; refusing to stage a blank secret"
+
+  printf 'Staging 4 secrets into fly app %q (out of argv)...\n' "${APP}"
   printf '%s\n' \
-    "RAXOL_ACP_AGENT_PRIVATE_KEY=$(op read "${OP_AGENT_PRIVATE_KEY}")" \
-    "RAXOL_ACP_EVALUATOR=$(op read "${OP_AGENT_ADDRESS}")" \
-    "XOCHI_AUTH_TOKEN=$(op read "${OP_XOCHI_AUTH_TOKEN}")" \
-    "RAXOL_ACP_RPC_URL=$(op read "${OP_BASE_RPC_URL}")" \
+    "RAXOL_ACP_AGENT_PRIVATE_KEY=${pk}" \
+    "RAXOL_ACP_EVALUATOR=${evaluator}" \
+    "XOCHI_AUTH_TOKEN=${auth}" \
+    "RAXOL_ACP_RPC_URL=${rpc}" \
     | fly secrets import --stage -a "${APP}"
 }
 
@@ -109,15 +130,38 @@ deploy_single_machine() {
 }
 
 # Enforce the single-machine invariant (one shared signing EOA + one SSE stream: a second
-# machine would race the wallet nonce). Then show the machine list for verification.
+# machine would race the wallet nonce). Scale to 1, then ASSERT exactly one started
+# machine and fail loudly otherwise -- never just print the list for a human to eyeball.
 enforce_single_machine() {
   fly scale count 1 -a "${APP}" --yes
-  printf 'Deployed machines (expect exactly one started):\n'
-  fly machines list -a "${APP}"
+  local started
+  started="$(fly machines list -a "${APP}" --json | jq '[.[] | select(.state == "started")] | length')" \
+    || die "could not list machines for ${APP}"
+  if [[ "${started}" != "1" ]]; then
+    fly machines list -a "${APP}" >&2
+    die "expected exactly 1 started machine, found ${started} -- a 2nd solver races the wallet nonce; scale back to 1"
+  fi
+  printf 'Verified: exactly one started machine.\n'
+}
+
+# Guard a live production deploy behind an interactive confirmation, unless --yes or
+# ASSUME_YES=1. This deploys a real signing solver; it must not happen by accident.
+confirm() {
+  [[ "${ASSUME_YES}" == "1" ]] && return 0
+  printf 'Deploy the PRODUCTION signing solver %q? [y/N] ' "${APP}"
+  local reply
+  read -r reply || die "aborted (no confirmation)"
+  [[ "${reply}" == "y" || "${reply}" == "Y" ]] || die "aborted by operator"
 }
 
 main() {
+  ASSUME_YES=0
+  local arg
+  for arg in "$@"; do
+    [[ "${arg}" == "--yes" || "${arg}" == "-y" ]] && ASSUME_YES=1
+  done
   preflight
+  confirm
   stage_secrets
   deploy_single_machine
   enforce_single_machine

--- a/scripts/deploy-raxol-solver.sh
+++ b/scripts/deploy-raxol-solver.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# deploy-raxol-solver.sh -- seed the raxol_acp Xochi solver's runtime secrets into a
+# DEDICATED, isolated fly.io app ('raxol-solver') and ship a single rolling deploy.
+#
+# CANONICAL SAFE PATTERN (mirrors ansible vars/vault_axol.yml op:// refs): nothing secret
+# lives at rest. Every value is a 1Password reference resolved at deploy time via 'op read'
+# and piped straight into 'fly secrets import' on STDIN. Secrets are NEVER written to disk,
+# echoed, assigned to a variable, or passed as a command-line argument (so they never appear
+# in flyctl's argv / `ps` / shell history). Before running you MUST:
+#   1. 'op signin' (the 1Password CLI must be authenticated),
+#   2. create the fly app once ('fly apps create raxol-solver'), and
+#   3. replace the PLACEHOLDER op:// paths below with your real vault/item/field names.
+#
+# This app is intentionally SEPARATE from the public 'raxol' playground app (the anonymous
+# SSH sandbox on :2222). Keeping the solver isolated is the whole point -- do not co-locate.
+#
+# ----------------------------------------------------------------------------------------
+# CRITICAL: RAXOL_ACP_AGENT_PRIVATE_KEY MUST be a LOW-VALUE OPERATIONAL / gas wallet.
+# It signs ACP auth + on-chain submit/complete for job settlement. It must NEVER be the
+# high-value Riddler relayer / inventory wallet. Pointing this at the inventory key would
+# collapse the blast-radius isolation this dedicated app exists to provide.
+# ----------------------------------------------------------------------------------------
+#
+# Usage:
+#   ./scripts/deploy-raxol-solver.sh
+
+set -euo pipefail
+# A failed 'op read' inside a command substitution must abort the whole run rather than
+# silently seeding an empty secret. inherit_errexit propagates set -e into $( ... ).
+shopt -s inherit_errexit
+
+# Run from the repo root so `fly deploy -c fly.acp.toml` and the Docker build context resolve.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# --- Configuration -----------------------------------------------------------------------
+
+# Target fly.io app + its config file. Dedicated + isolated -- NOT the public 'raxol' app.
+readonly APP="raxol-solver"
+readonly FLY_CONFIG="fly.acp.toml"
+
+# PLACEHOLDER op:// references -- REPLACE with your real vault/item/field names.
+# (../raxol is a PUBLIC repo: never commit real vault names, addresses, or tokens here.)
+#
+# Trusted-buyer mode: the evaluator is the agent's OWN address, so both the private key and
+# the evaluator address are read from the SAME low-value agent wallet item.
+readonly OP_AGENT_PRIVATE_KEY="op://Vault/Raxol ACP Agent Wallet/private-key"
+readonly OP_AGENT_ADDRESS="op://Vault/Raxol ACP Agent Wallet/address"
+readonly OP_XOCHI_AUTH_TOKEN="op://Vault/Xochi Worker Token/credential"
+readonly OP_BASE_RPC_URL="op://Vault/Base RPC/url"
+
+# --- Preflight ---------------------------------------------------------------------------
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    printf 'error: required command %q not found on PATH\n' "${cmd}" >&2
+    exit 1
+  fi
+}
+
+require_op_signed_in() {
+  # 'op whoami' exits non-zero when no account is signed in.
+  if ! op whoami >/dev/null 2>&1; then
+    printf 'error: 1Password CLI is not signed in. Run: op signin\n' >&2
+    exit 1
+  fi
+}
+
+require_app_exists() {
+  if ! fly status -a "${APP}" >/dev/null 2>&1; then
+    printf 'error: fly app %q does not exist. Create it once with: fly apps create %q\n' \
+      "${APP}" "${APP}" >&2
+    exit 1
+  fi
+}
+
+preflight() {
+  require_cmd op
+  require_cmd fly
+  require_op_signed_in
+  require_app_exists
+}
+
+# --- Deploy ------------------------------------------------------------------------------
+
+# Stage all solver secrets from 1Password, out of argv. printf is a bash builtin, so the
+# resolved plaintext never lands in another process's command line; --stage defers the
+# rollout to the single `fly deploy` below. (XOCHI_BASE_URL / XOCHI_FEE_BPS / the enable
+# flag are NON-secret and live in fly.acp.toml [env].)
+stage_secrets() {
+  printf 'Staging %d secrets into fly app %q (out of argv)...\n' 4 "${APP}"
+  printf '%s\n' \
+    "RAXOL_ACP_AGENT_PRIVATE_KEY=$(op read "${OP_AGENT_PRIVATE_KEY}")" \
+    "RAXOL_ACP_EVALUATOR=$(op read "${OP_AGENT_ADDRESS}")" \
+    "XOCHI_AUTH_TOKEN=$(op read "${OP_XOCHI_AUTH_TOKEN}")" \
+    "RAXOL_ACP_RPC_URL=$(op read "${OP_BASE_RPC_URL}")" \
+    | fly secrets import --stage -a "${APP}"
+}
+
+# Ship the image + fly.acp.toml [env] (incl. XOCHI_SOLVER_ENABLED) and apply the staged
+# secrets, as a single-machine deploy. `fly secrets set` alone would NOT apply [env] from a
+# non-default config filename, and would leave the solver flag unset (boots healthy-but-inert).
+deploy_single_machine() {
+  printf 'Deploying %q from %q (single machine)...\n' "${APP}" "${FLY_CONFIG}"
+  fly deploy -c "${FLY_CONFIG}" -a "${APP}" --ha=false
+}
+
+# Enforce the single-machine invariant (one shared signing EOA + one SSE stream: a second
+# machine would race the wallet nonce). Then show the machine list for verification.
+enforce_single_machine() {
+  fly scale count 1 -a "${APP}" --yes
+  printf 'Deployed machines (expect exactly one started):\n'
+  fly machines list -a "${APP}"
+}
+
+main() {
+  preflight
+  stage_secrets
+  deploy_single_machine
+  enforce_single_machine
+  printf 'Done. raxol-solver deployed with staged secrets + fly.acp.toml [env].\n'
+}
+
+main "$@"


### PR DESCRIPTION
## What

Deploys the `raxol_acp` Xochi storefront solver (`xochi_stable_public`) as a **dedicated, isolated fly.io app** (`raxol-solver`), separate from the public `raxol` playground app (which runs an anonymous SSH sandbox on :2222). In solver mode the release reads a real signing EOA at boot, so this is a signing runtime, not the read-only accounting sidecar the release was originally written as.

## Why

The solver agent was never actually deployed — the live `raxol` app is the playground and does not start `SolverApplication`. Worse, `:xochi_solver_enabled` was **compile-time only**: setting a fly env var did nothing, so a naive deploy would boot healthy but pick up zero jobs.

## Changes

- **`packages/raxol_acp/config/runtime.exs`**
  - Wire `:xochi_solver_enabled` from `XOCHI_SOLVER_ENABLED` (fly can now toggle the signing solver without a rebuild).
  - **Fail boot CLOSED** if `RELEASE_DISTRIBUTION != none` in solver mode — a signing node must expose no cookie-reachable REPL (the distribution/REPL boot gates aren't wired in this release).
  - Correct the stale "read-only / keyless / never signs" moduledoc for solver mode.
- **`packages/raxol_acp/rel/env.sh.eex`, `docker/Dockerfile.raxol-acp`** — correct the "wallet-safe / read-only" comments: no key is baked into the image, but solver mode reads `RAXOL_ACP_AGENT_PRIVATE_KEY` from the runtime env (a fly secret).
- **`fly.acp.toml`** (new) — dedicated `raxol-solver` app: single always-on machine (one signing EOA + one SSE stream → a 2nd instance races the wallet nonce), **no `[http_service]` / `[[services]]`** (outbound-only client, zero public surface), `XOCHI_FEE_BPS='8'` pinned in `[env]`.
- **`scripts/deploy-raxol-solver.sh`** (new) — seed secrets from 1Password `op://` refs via `fly secrets import --stage` on **stdin** (no argv/`ps` leak), then `fly deploy -c fly.acp.toml --ha=false` + `fly scale count 1`. Placeholder `op://` paths only (public repo).

## Adversarial review

Built and reviewed via a multi-agent workflow (env-contract truth → parallel draft → security / boot-correctness / public-repo-safety verify → synthesis). 0 blockers; all warnings folded in (argv leak, distribution enforcement, config-file-must-deploy, single-machine, `$`-figure/staging-host redaction).

## Secret handling (verified — no fix needed)

An adversarial review pass flagged a possible signing-key leak via OTP/SASL crash logs. On source read this is **already mitigated**: `Raxol.ACP.ProviderAdapter.JSONRPC` wraps the key in `Raxol.ACP.Secret` on construction, whose `Inspect` impl renders `#Raxol.ACP.Secret<redacted>` (test-pinned in `secret_test.exs`), and it's only unwrapped via `Secret.reveal/1` at the `ExSecp256k1.sign` call sites — never a log/interpolation. `XOCHI_AUTH_TOKEN` is captured inside the `settle_fn` closure. So the key never renders into a crash report even though the provider is a supervised child's start arg.

This PR adds a pointer comment at the solver boot site (`solver_application.ex`) documenting that invariant, so a future author reusing the solver pattern keeps the key wrapped rather than reinheriting the trap.

## Hardening (adversarial review, verdict CONCERNS)

A three-persona adversarial review surfaced two HIGH findings mirroring known axol production incidents, plus mediums — all addressed here:

- **HIGH — stranded funds on shutdown**: no `kill_timeout` meant fly's 5s default could SIGKILL the BEAM mid-`RPC.await_receipt` (~30s), landing a tx while the ACP job never completes. Fixed: `kill_timeout = '60s'`.
- **HIGH — single-machine not enforced**: the toml can't stop an out-of-band `fly scale count 2`. `deploy-raxol-solver.sh` now **asserts** exactly one started machine (fails, not eyeballs), and the toml points at the ansible-riddler `guard` cron for continuous enforcement.
- **MED — silent public-RPC fallback → 429 crashloop**: dropped the public `RAXOL_ACP_RPC_URL` default from `[env]`; `runtime.exs` now **fails boot closed** if it's unset in solver mode.
- **MED — deploy foot-gun**: added a confirmation gate (`--yes`/`ASSUME_YES=1` to skip).
- **Bonus (missed by the review)**: the `printf "$(op read)"` pattern could silently stage a **blank secret** on a failed read — now checked per-secret assignments; also dropped `inherit_errexit` (bash 3.2 incompatible).
- **Liveness signal**: new `Raxol.ACP.Xochi.Heartbeat` GenServer emits a periodic log + `[:raxol,:acp,:xochi,:solver,:heartbeat]` telemetry, so external monitoring can distinguish a live-but-idle solver from a wedged SSE stream (the app has no inbound port for a fly health check). Wired last in the tree; deterministic test.

## Manual testing

- [ ] `shellcheck scripts/deploy-raxol-solver.sh` — passes
- [ ] `mix format --check-formatted packages/raxol_acp/config/runtime.exs` — passes
- [ ] `mix compile` (raxol_acp) with `XOCHI_SOLVER_ENABLED` set/unset — flag flips `SolverApplication.enabled?/0`
- [ ] Deploy against ACP **dev** first; drive one job; confirm `[:raxol, :acp, :xochi, :solver, :event]` telemetry (`:job_created` → `:settling` → `:submitted` → `:job_completed`)
- [ ] `fly ssh console -a raxol-solver -C 'printenv XOCHI_SOLVER_ENABLED XOCHI_BASE_URL'` after deploy
- [ ] Confirm exactly one started machine: `fly machines list -a raxol-solver`
- [ ] Agent EOA is a low-value operational key (NOT the inventory wallet) and registered on the ACP marketplace
