### PR TITLE
Fix raxol-solver boot + SSE stability (post-#668/#669)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,5 +59,12 @@ docker/
 # CI/CD
 .github/
 
-# Large directories that aren't needed
+# Large directories that aren't needed. These are build-irrelevant artifacts that
+# otherwise bloat the build context (uploaded to the fly builder on every deploy):
+#   priv/plts -- Dialyzer PLT cache (~49MB)
+#   demos     -- asciinema .cast recordings (~23MB)
+#   doc       -- generated ExDoc HTML (~15MB; distinct from the `docs/` rule above)
 priv/static/
+priv/plts/
+demos/
+doc/

--- a/docker/Dockerfile.raxol-acp
+++ b/docker/Dockerfile.raxol-acp
@@ -21,10 +21,14 @@
 # secrets), never the image.
 
 ARG ELIXIR_IMAGE=elixir:1.20.0-otp-29
-ARG NODE_IMAGE=node:22-bookworm-slim
-# The runner is a Node image (same debian bookworm base) so `node` runs the signing
-# sidecar; the BEAM's own ERTS ships in the release.
-ARG RUNNER_IMAGE=node:22-bookworm-slim
+ARG NODE_IMAGE=node:22-trixie-slim
+# The runner is a Node image so `node` runs the signing sidecar; the BEAM's own ERTS
+# ships in the release. It MUST be Debian trixie to match ELIXIR_IMAGE's glibc: the
+# elixir:1.20-otp-29 builder is trixie (glibc 2.41) and compiles beam.smp against
+# GLIBC_2.38+, so a bookworm runner (glibc 2.36) fails at boot with
+# "libm.so.6: version `GLIBC_2.38' not found". Keep builder and runner on the same
+# Debian release.
+ARG RUNNER_IMAGE=node:22-trixie-slim
 
 # --- Signing-sidecar deps: install node_modules in-container (never from the host) ---
 FROM ${NODE_IMAGE} AS sidecar-deps

--- a/docker/Dockerfile.raxol-acp
+++ b/docker/Dockerfile.raxol-acp
@@ -32,6 +32,13 @@ ARG RUNNER_IMAGE=node:22-trixie-slim
 
 # --- Signing-sidecar deps: install node_modules in-container (never from the host) ---
 FROM ${NODE_IMAGE} AS sidecar-deps
+# python3 + toolchain: a transitive optional native module (utf-8-validate via the SDK's
+# websocket dep) has no prebuilt binary on some arches and falls back to node-gyp compile.
+# Installing the toolchain makes `npm ci` succeed on both amd64 and arm64. This stage is
+# discarded -- only node_modules is copied out -- so the tools never reach the final image.
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /sidecar
 COPY packages/raxol_acp/priv/signer_sidecar/package.json \
      packages/raxol_acp/priv/signer_sidecar/package-lock.json ./

--- a/packages/raxol_acp/lib/raxol/acp/agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/agent.ex
@@ -47,7 +47,14 @@ defmodule Raxol.ACP.Agent do
 
   use GenServer
 
+  require Logger
+
   alias Raxol.ACP.{Event, JobApi, JobSession, Transport}
+
+  # Backoff before re-opening the SSE stream after it ends (server close or transport
+  # error). The stream is a long-lived connection that WILL drop in normal operation;
+  # the Agent owns reconnection (see Transport.SSE.stream_loop's contract).
+  @stream_reconnect_ms 2_000
 
   @type t :: %__MODULE__{
           provider: term(),
@@ -191,13 +198,7 @@ defmodule Raxol.ACP.Agent do
   def handle_call(:start_stream, _from, %{started?: true} = state), do: {:reply, :ok, state}
 
   def handle_call(:start_stream, _from, state) do
-    ctx = %{
-      owner: self(),
-      chain_ids: state.supported_chain_ids,
-      wallet_address: state.wallet_address
-    }
-
-    case Transport.connect(state.transport, ctx) do
+    case open_stream(state) do
       :ok -> {:reply, :ok, %{state | started?: true}}
       err -> {:reply, err, state}
     end
@@ -260,6 +261,45 @@ defmodule Raxol.ACP.Agent do
     }
 
     {:noreply, state}
+  end
+
+  # The SSE stream runs as a Task.async owned by this Agent (Transport.SSE.connect).
+  # When it ends -- the server closed the stream or a transport error occurred -- the
+  # Task delivers {ref, result}. Per the transport contract the Agent owns reconnection:
+  # flush the paired :DOWN, then re-open after a short backoff, rather than crash on the
+  # unhandled message. (Reconnect re-fetches the auth token via Transport.connect.)
+  def handle_info({ref, _result}, state) when is_reference(ref) do
+    Process.demonitor(ref, [:flush])
+    Logger.info("ACP SSE stream ended; reconnecting in #{@stream_reconnect_ms}ms")
+    Process.send_after(self(), :reconnect_stream, @stream_reconnect_ms)
+    {:noreply, %{state | started?: false}}
+  end
+
+  # A reconnect is already-open (e.g. start_stream ran in the interim) -- nothing to do.
+  def handle_info(:reconnect_stream, %{started?: true} = state), do: {:noreply, state}
+
+  def handle_info(:reconnect_stream, state) do
+    case open_stream(state) do
+      :ok ->
+        {:noreply, %{state | started?: true}}
+
+      {:error, reason} ->
+        Logger.warning("ACP SSE reconnect failed (#{inspect(reason)}); retrying")
+        Process.send_after(self(), :reconnect_stream, @stream_reconnect_ms)
+        {:noreply, state}
+    end
+  end
+
+  # -- Stream --
+
+  defp open_stream(state) do
+    ctx = %{
+      owner: self(),
+      chain_ids: state.supported_chain_ids,
+      wallet_address: state.wallet_address
+    }
+
+    Transport.connect(state.transport, ctx)
   end
 
   # -- Routing --

--- a/packages/raxol_acp/lib/raxol/acp/signer_sidecar.ex
+++ b/packages/raxol_acp/lib/raxol/acp/signer_sidecar.ex
@@ -35,7 +35,9 @@ defmodule Raxol.ACP.SignerSidecar do
   require Logger
 
   @default_port 4048
-  @default_health_timeout_ms 20_000
+  # Generous margin: on a cold, cpu-constrained VM the node process must spawn and
+  # `import` the acp-node-v2 SDK (~185 modules) before it answers /health.
+  @default_health_timeout_ms 30_000
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do

--- a/packages/raxol_acp/lib/raxol/acp/transport/sse.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/sse.ex
@@ -186,6 +186,15 @@ defmodule Raxol.ACP.Transport.SSE do
         url: url,
         method: :get,
         headers: headers,
+        # SSE is a long-lived stream. An idle provider (no jobs) receives no events for
+        # long stretches, so the default receive_timeout fires and drops a HEALTHY
+        # connection -- the reconnect churn we saw on fly. Wait generously between chunks
+        # (10 min, far longer than any server keepalive interval); a genuine drop
+        # surfaces as a transport ERROR (not a timeout) and the Agent reconnects, and a
+        # rare silent half-open still recovers within one window. Retries are the Agent's
+        # job, not Req's.
+        receive_timeout: 600_000,
+        retry: false,
         into: fn {:data, data}, {req, resp} ->
           handle_chunk(owner, data)
           {:cont, {req, resp}}

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_application.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_application.ex
@@ -117,7 +117,10 @@ defmodule Raxol.ACP.Xochi.SolverApplication do
          agent: agent_name(),
          provider: provider,
          wallet_address: wallet_address,
-         evaluator_address: System.fetch_env!("RAXOL_ACP_EVALUATOR"),
+         # Trusted-buyer mode: the evaluator (allowed to call complete/reject) defaults to
+         # the agent's OWN address. Legacy deploys may still pin it via RAXOL_ACP_EVALUATOR;
+         # delegated mode has no separate evaluator secret, so it falls back to the wallet.
+         evaluator_address: System.get_env("RAXOL_ACP_EVALUATOR", wallet_address),
          chain_id: @chain_id,
          acp_core_address: chain.acp_core_address,
          fee_bps: fee_bps(),


### PR DESCRIPTION
Follow-up fixes for the delegated Privy signer (#668/#669) that were made after those
PRs were cut and never merged. **Master currently rebuilds a broken raxol-solver image
without these** — every one was found by deploying to fly and diagnosing the crash
(the live fly image was built from the feature branch, so it already has them).

## The 6 fixes
1. **glibc mismatch** — `elixir:1.20-otp-29` builder is Debian trixie (glibc 2.41) but the
   runner was `node:22-bookworm-slim` (glibc 2.36) → `beam.smp: libm.so.6: version GLIBC_2.38
   not found` on every boot. Runner → `node:22-trixie-slim`.
2. **`RAXOL_ACP_EVALUATOR` crash** — delegated mode has no separate evaluator secret;
   `SolverAgent` `fetch_env!`'d it → boot crash. Default to `wallet_address` (trusted-buyer).
3. **arm64 build** — a transitive native module (`utf-8-validate`) has no arm64 prebuilt →
   `npm ci` needs a toolchain. Added `python3 make g++` to the sidecar-deps stage.
4. **SSE crash** — `Agent.handle_info/2` had no clause for the stream Task's
   `{ref, {:error, _}}` → `FunctionClauseError` on any drop. Agent now reconnects.
5. **SSE idle churn** — the default receive_timeout fires on an idle (no-jobs) stream →
   reconnect every ~20s, so the solver was up but not stably subscribed. `receive_timeout:
   600_000` + `retry: false` on the stream request.
6. **dockerignore** — drop `priv/plts` (49MB Dialyzer cache), `demos`, `doc` from the build
   context (was 145MB).

## Validation
All fixes validated on a live fly deploy (app `raxol-solver`): clean boot, guard=1 machine,
sidecar healthy, delegated auth + get_me vs prod, **SSE stays connected (0 churn / 95s)**.
Also see the staged-secrets deploy gotcha fixed in ansible-riddler `scripts/raxol-solver-fly.sh`
(separate repo). Native Elixir port of the adapter tracked in #667.
