### PR TITLE
raxol-solver: normalize real ACP SSE event shape (post-#670)

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/agent.ex
@@ -316,9 +316,21 @@ defmodule Raxol.ACP.Agent do
 
   defp job_key(entry) do
     chain_id = entry["chainId"] || entry[:chainId] || entry["chain_id"] || entry[:chain_id]
-    job_id = entry["jobId"] || entry[:jobId] || entry["job_id"] || entry[:job_id]
-    {chain_id, job_id}
+    {chain_id, job_id_from(entry)}
   end
+
+  # The live ACP SSE carries the job id as `onChainJobId` (top-level and inside the
+  # nested `event` map); older/mock shapes use `jobId`/`job_id`. Accept all so a real
+  # `job.created` doesn't yield a nil id (which fails the JobSession registry :via guard).
+  defp job_id_from(entry) do
+    entry["jobId"] || entry[:jobId] || entry["job_id"] || entry[:job_id] ||
+      entry["onChainJobId"] || entry[:onChainJobId] || event_job_id(entry["event"] || entry[:event])
+  end
+
+  defp event_job_id(%{} = ev),
+    do: ev["onChainJobId"] || ev[:onChainJobId] || ev["jobId"] || ev[:jobId]
+
+  defp event_job_id(_), do: nil
 
   defp ensure_session(key, _entry, state) do
     case Map.fetch(state.sessions, key) do

--- a/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
@@ -53,7 +53,7 @@ defmodule Raxol.ACP.Transport.SSE.Parser do
 
       json ->
         case Jason.decode(json) do
-          {:ok, value} when is_map(value) -> {:ok, value}
+          {:ok, value} when is_map(value) -> {:ok, normalize(value)}
           _ -> {:error, :invalid_json}
         end
     end
@@ -62,4 +62,33 @@ defmodule Raxol.ACP.Transport.SSE.Parser do
   defp extract_data_line("data: " <> rest), do: [rest]
   defp extract_data_line("data:" <> rest), do: [String.trim_leading(rest, " ")]
   defp extract_data_line(_), do: []
+
+  # Normalize the wire shape of an ACP SSE entry into the shape the Agent +
+  # SolverAgent consume. The Virtuals server sends system events as
+  # `%{"kind" => "system", "event" => %{"type" => "job.created", "provider" => ...,
+  # "onChainJobId" => ...}}`, but our dispatch matches `"event" => "job.created"`
+  # (a string) and reads top-level `jobId`/`provider`. So for system entries we hoist
+  # the nested event map's fields to the top level and replace `event` with its type
+  # string. Message entries already carry top-level `content`/`contentType`/`from`.
+  # Both get `jobId` lifted from `onChainJobId`. This is the single boundary where the
+  # wire shape meets our code (the gate drives the provider in-process and never hits
+  # this path, which is why the mismatch went unseen until a real marketplace job).
+  defp normalize(%{"kind" => "system", "event" => %{"type" => type} = ev} = entry) do
+    entry
+    |> Map.merge(ev)
+    |> Map.put("event", type)
+    |> Map.put("jobId", job_id(entry, ev))
+  end
+
+  defp normalize(%{} = entry) do
+    Map.put(entry, "jobId", job_id(entry, entry["event"]))
+  end
+
+  defp job_id(entry, ev) do
+    entry["jobId"] || entry["job_id"] || entry["onChainJobId"] ||
+      map_get(ev, "onChainJobId") || map_get(ev, "jobId")
+  end
+
+  defp map_get(%{} = m, k), do: m[k]
+  defp map_get(_, _), do: nil
 end


### PR DESCRIPTION
Follow-up to #670 (merged): the last two fixes for the delegated `raxol-solver` ACP
signing node, found by the live end-to-end test after #670 got the node booting + SSE-stable.

**Validated end-to-end on fly** (app `raxol-solver`, managed wallet `0x939e...`): a real ACP
marketplace order from a buyer agent was filled by the deployed node entirely through the
delegated `send_calls` -- `setBudget` (0.005 USDC = 10 bps on $5) -> real Base->Arbitrum USDC
settlement via Xochi -> `submit` -> `job.completed`.

## Fixes
1. **`Agent.job_key` missed `onChainJobId`** -- the real SSE `job.created` carries the id as
   `onChainJobId`; the code only read `jobId`/`job_id`, so the id came through `nil` and
   crashed the Agent on the JobSession registry `:via` guard.
2. **SSE event-shape mismatch** -- the real Virtuals server sends system events as a map
   (`event: {"type": "job.created", "onChainJobId": ..., "provider": ...}`), but the
   SolverAgent dispatch matched `event` as a **string** and read top-level `jobId`/`provider`,
   so **no real marketplace event ever dispatched**. Fixed with a normalization layer in the
   SSE parser (`Parser.normalize/1`): hoist the nested event map's fields to the top level,
   map `event` -> its type string, and lift `onChainJobId` -> `jobId`. This is the single
   wire/code boundary. Unit-tested against a captured live `job.created`.

This path was never exercised before because the live settlement gate drives the provider
in-process (never through the SSE/Agent/SolverAgent), so the shape mismatch went unseen until
the first real marketplace job hit the deployed node.
