### PR TITLE
ci: stabilize nightly flakes (timing, starvation, capture)

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -320,7 +320,12 @@ jobs:
       
       - name: Run property tests
         run: |
-          mix test test/property
+          # Run test/property by path, but still honor skip_on_ci: some
+          # properties are wall-clock timing assertions (e.g. parser
+          # sub-quadratic scaling) tagged skip_on_ci precisely because they
+          # flake on shared CI runners. By path alone they would run and
+          # flake; exclude them like every other CI lane.
+          mix test test/property --exclude skip_on_ci
         env:
           MIX_TEST_PARTITION: 3
       

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,15 +117,21 @@ jobs:
       - name: Run full test suite
         run: |
           # --exclude property: the emulator-replay-heavy property tests
-          # (renderer seal-once keystones) are CPU/allocation-bound. Run
-          # inline inside the full ~6k-test process on slow matrix legs
-          # (older Elixir, macOS), scheduler/GC pressure pushes them past
-          # the 60s/180s bounds -- a runner-load artifact, not a hang (the
-          # newer/faster legs pass the same tests). They already run
-          # isolated at --timeout 300000 in the extended-scenarios job, so
-          # excluding them here removes the duplicate run without losing
-          # coverage.
-          mix test --exclude slow --exclude integration --exclude docker --exclude skip_on_ci --exclude property
+          # (renderer seal-once keystones) are CPU/allocation-bound. They
+          # already run isolated at --timeout 300000 in the extended-scenarios
+          # job, so excluding them here removes the duplicate run.
+          #
+          # --max-cases / --timeout: the harness surface suites (test/harness)
+          # are the same CPU-bound emulator-replay class but are NOT property
+          # tests, so --exclude property never covered them. On slow matrix
+          # legs (older Elixir, macOS 2-3 core runners) the default async pool
+          # (2x schedulers) co-schedules several of them and starves each of
+          # cores, pushing them past the default 60s bound -- a runner-load
+          # artifact, not a hang. Capping concurrency gives each a full core
+          # and raising the default bound to 120s absorbs the residual GC/
+          # scheduling jitter. ci-unified runs this same suite per-push on
+          # fast runners, so cross-version coverage is unchanged.
+          mix test --exclude slow --exclude integration --exclude docker --exclude skip_on_ci --exclude property --max-cases 4 --timeout 120000
         env:
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres
@@ -186,7 +192,13 @@ jobs:
           # gate (the matrix job excludes property). It passes reliably in
           # its own process, so a failure here is a genuine regression that
           # must fail the build, not be swallowed.
-          mix test --only property --timeout 300000
+          #
+          # `--exclude skip_on_ci`: some properties are tagged skip_on_ci
+          # BECAUSE they are wall-clock timing assertions (e.g. the parser
+          # sub-quadratic scaling check) that flake on shared CI runners.
+          # `--only property` alone does not honor that tag, so they ran here
+          # and flaked; exclude them like every other CI lane does.
+          mix test --only property --exclude skip_on_ci --timeout 300000
 
       - name: Generate extended test report
         run: |

--- a/test/cross_terminal/headless_golden_test.exs
+++ b/test/cross_terminal/headless_golden_test.exs
@@ -65,7 +65,7 @@ defmodule Raxol.CrossTerminal.HeadlessGoldenTest do
 
   test "initial render matches golden" do
     {:ok, id} = Headless.start(GoldenApp, id: :golden_initial)
-    {:ok, text} = Headless.screenshot(id)
+    {:ok, text} = screenshot_until(id, "Count: 0")
 
     assert text =~ "Count: 0"
     assert text =~ "Panel: a"
@@ -95,5 +95,30 @@ defmodule Raxol.CrossTerminal.HeadlessGoldenTest do
     assert model.count == 2
     assert text =~ "Count: 2"
     :ok = Headless.stop(id)
+  end
+
+  # The very first screenshot right after `start` can observe the buffer in
+  # the narrow window between `render_frame_sync` replying and the frame's
+  # cells committing to the buffer `get_buffer` reads -- on fast runners this
+  # races and returns an empty capture. Re-issue the synchronous screenshot
+  # (which re-renders each call) until the expected content lands; it
+  # converges within a couple of attempts. Bounded, no sleep -- a genuine
+  # never-render fails loudly at the bound rather than hanging.
+  defp screenshot_until(id, marker, attempts \\ 50)
+
+  defp screenshot_until(id, marker, 0) do
+    flunk("screenshot never contained #{inspect(marker)} for #{inspect(id)}")
+  end
+
+  defp screenshot_until(id, marker, attempts) do
+    case Headless.screenshot(id) do
+      {:ok, text} ->
+        if String.contains?(text, marker),
+          do: {:ok, text},
+          else: screenshot_until(id, marker, attempts - 1)
+
+      other ->
+        other
+    end
   end
 end

--- a/test/property/renderer_seal_once_property_test.exs
+++ b/test/property/renderer_seal_once_property_test.exs
@@ -24,6 +24,15 @@ defmodule Raxol.Property.RendererSealOnceTest do
   use ExUnit.Case, async: false
   use ExUnitProperties
 
+  # This suite is the CPU-bound emulator-replay keystone the nightly matrix
+  # excludes via `--exclude property`. Its `property` blocks are auto-tagged
+  # `:property`, but its plain `test` keystones (e.g. the 1000-block
+  # immutable-prefix streaming test) are NOT -- so they leaked into the
+  # matrix and timed out on slow legs. Module-tag the whole suite `:property`
+  # so every test here is excluded from the matrix and still covered by the
+  # by-path `mix test test/property` lane (ci-unified) + nightly extended.
+  @moduletag :property
+
   alias Raxol.Harness.Test.SealOracle
   alias Raxol.Terminal.Emulator
   alias Raxol.UI.Rendering.PaintAuthority.InlineAuthority


### PR DESCRIPTION
## What

Stabilizes the nightly build, red for several nights (#672, #664, #486). Root-caused three distinct **flake classes** — none is a product bug — from the actual run logs.

### 1. Timing-assertion flake (fails every night in Extended Scenarios)
`test/property/core_property_test.exs` "parser performance scales sub-quadratically" is a wall-clock `assert ratio < max_ratio`. It is already `@tag :skip_on_ci`, but two lanes ignored the tag:
- nightly `extended-scenarios` runs `mix test --only property` (no `--exclude skip_on_ci`)
- ci-unified `property` job runs `mix test test/property` **by path** (tags don't filter)

Both now pass `--exclude skip_on_ci`. Verified: `core_property_test.exs --exclude skip_on_ci` -> `9 passed, 1 excluded`.

### 2. Heavy emulator-replay starvation (fails multiple matrix cells, varies by night)
The `test/harness/` surface suites + `renderer_seal_once` are CPU-bound emulator replays. On slow matrix legs (Elixir 1.17/1.18, macOS 2-3 core) the default async pool co-schedules several and starves each of cores, blowing the 60s/180s bounds — a runner-load artifact the code already documents. Different suites tip over on different nights (`T13aSurfaceTest`, `ProjectionPanelsSurfaceTest`, `LiveSessionDriverTest`, `RendererSealOnceTest`, ...).

- Matrix run now caps `--max-cases 4` and raises `--timeout 120000`, so each replay suite gets a full core + headroom. ci-unified runs the same suites per-push on fast runners, so cross-version coverage is unchanged.
- `renderer_seal_once_property_test.exs` gets `@moduletag :property` so its plain `test` keystones (not just its `property` blocks) are actually excluded by the matrix's existing `--exclude property`. Verified: `--exclude property` -> `0 tests, 7 excluded`; by-path -> `7 passed` (and it runs in **25s uncontended** vs the 180s timeout when starved).

### 3. Headless first-frame capture race (1 cell this run)
`headless_golden_test.exs` "initial render matches golden" read an **empty** buffer even though the render logs show the frame positioned — the first `screenshot` after `start` can observe the buffer in the window between `render_frame_sync` replying and the cells committing. Now retries until content lands (bounded, no sleep). Verified: `3 passed`.

## Not changed
No product code. `mix.lock` churn (nx/circular_buffer dependabot drift) is deliberately excluded — separate concern.

## Manual testing
- [x] `mix test test/property/renderer_seal_once_property_test.exs --exclude property` -> 0 tests, 7 excluded
- [x] `mix test test/property/renderer_seal_once_property_test.exs` (by path) -> 7 passed
- [x] `mix test test/property/core_property_test.exs --exclude skip_on_ci` -> 9 passed, 1 excluded
- [x] `mix test test/cross_terminal/headless_golden_test.exs` -> 3 passed
- [x] both workflow YAMLs parse

Closes #672, #664, #486.
