### PR TITLE
fix(runtime): session-scope the command registry ETS table (#566)

### DIFF
--- a/lib/raxol/core/runtime/lifecycle.ex
+++ b/lib/raxol/core/runtime/lifecycle.ex
@@ -53,7 +53,7 @@ defmodule Raxol.Core.Runtime.Lifecycle do
             height: non_neg_integer(),
             debug_mode: boolean(),
             plugin_manager: pid() | nil,
-            command_registry_table: atom() | nil,
+            command_registry_table: :ets.table() | nil,
             initial_commands: list(),
             dispatcher_pid: pid() | nil,
             driver_pid: pid() | nil,

--- a/lib/raxol/core/runtime/lifecycle/initializer.ex
+++ b/lib/raxol/core/runtime/lifecycle/initializer.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Core.Runtime.Lifecycle.Initializer do
   Extracted from Lifecycle to reduce file size.
   """
 
-  alias Raxol.Core.CompilerState
   alias Raxol.Core.Runtime.Events.Dispatcher
   alias Raxol.Core.Runtime.Log
   alias Raxol.Core.Runtime.Plugins.PluginManager, as: Manager
@@ -94,22 +93,25 @@ defmodule Raxol.Core.Runtime.Lifecycle.Initializer do
   # --- private ---
 
   defp initialize_registry_table(app_module) do
-    registry_table_name =
-      Module.concat(CommandRegistryTable, Atom.to_string(app_module))
+    # UNNAMED ETS table: `:ets.new/2` returns a fresh tid, so each session
+    # owns a distinct table. A `:named_table` keyed by app_module (via
+    # `CompilerState.ensure_table`, which is idempotent BY NAME) let a second
+    # session of the SAME module adopt the first's table -- so tearing one
+    # session down deleted the other's command registry (#566). Nothing looks
+    # the table up by name; it is only ever threaded through as
+    # `command_registry_table`, so dropping the global name is transparent to
+    # every consumer and never shares or clobbers another session's table.
+    #
+    # The concat is only a debug LABEL (bounded per-module, pre-existing) --
+    # without `:named_table` it registers no name, so no per-session atom is
+    # minted (the atom leak the Registry via-names elsewhere already avoid).
+    label = Module.concat(CommandRegistryTable, Atom.to_string(app_module))
 
-    case CompilerState.ensure_table(registry_table_name, [
-           :set,
-           :protected,
-           :named_table,
-           {:read_concurrency, true}
-         ]) do
-      :ok ->
-        {:ok, registry_table_name}
-
-      {:error, _reason} ->
-        {:error, :registry_table_creation_failed,
-         fn -> CompilerState.safe_delete_table(registry_table_name) end}
-    end
+    table = :ets.new(label, [:set, :protected, {:read_concurrency, true}])
+    {:ok, table}
+  rescue
+    ArgumentError ->
+      {:error, :registry_table_creation_failed, fn -> :ok end}
   end
 
   defp start_plugin_manager(_options, :agent), do: {:ok, nil}

--- a/test/raxol/core/runtime/lifecycle/initializer_test.exs
+++ b/test/raxol/core/runtime/lifecycle/initializer_test.exs
@@ -1,7 +1,83 @@
 defmodule Raxol.Core.Runtime.Lifecycle.InitializerTest do
   use ExUnit.Case, async: true
 
+  alias Raxol.Core.Runtime.Lifecycle
   alias Raxol.Core.Runtime.Lifecycle.Initializer
+
+  defmodule RegTestApp do
+    @moduledoc false
+    def init(_), do: {:ok, %{n: 0}}
+    def update(_msg, model), do: {model, []}
+    def view(_model), do: %{type: :text, content: "ok"}
+  end
+
+  describe "session-scoped command registry table (#566)" do
+    setup do
+      a = start_lifecycle()
+      b = start_lifecycle()
+
+      on_exit(fn ->
+        for pid <- [a, b], do: stop_lifecycle(pid)
+      end)
+
+      %{a: a, b: b}
+    end
+
+    test "two concurrent same-module sessions own DISTINCT registry tables",
+         %{a: a, b: b} do
+      # The bug named the table by app_module alone, so a second session of
+      # the same module adopted the first's shared table.
+      assert registry_table(a) != registry_table(b)
+      assert :ets.info(registry_table(a)) != :undefined
+      assert :ets.info(registry_table(b)) != :undefined
+    end
+
+    test "stopping one session leaves the other session's table intact",
+         %{a: a, b: b} do
+      table_b = registry_table(b)
+      assert :ets.info(table_b) != :undefined
+
+      # Teardown of A used to :ets.delete the shared table, undefining it for
+      # the still-alive B and breaking B's next registry-touching command.
+      # Await A's DOWN so its terminate/cleanup has definitely run (stop/1 is
+      # an async cast) -- otherwise the check races the teardown.
+      :ok = stop_and_await(a)
+      refute Process.alive?(a)
+
+      assert Process.alive?(b)
+      assert :ets.info(table_b) != :undefined
+    end
+  end
+
+  defp start_lifecycle do
+    name = :"reg_566_#{System.unique_integer([:positive])}"
+    {:ok, pid} = Lifecycle.start_link(RegTestApp, environment: :agent, name: name)
+    Process.unlink(pid)
+    pid
+  end
+
+  defp stop_lifecycle(pid) do
+    if Process.alive?(pid), do: Lifecycle.stop(pid), else: :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  # stop/1 is an async cast, so wait for the process to actually terminate
+  # (its terminate/2 -- and registry-table cleanup -- runs before :DOWN).
+  defp stop_and_await(pid) do
+    ref = Process.monitor(pid)
+    Lifecycle.stop(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      5_000 -> :timeout
+    end
+  end
+
+  defp registry_table(pid) do
+    :sys.get_state(pid, 5_000).command_registry_table
+  end
 
   describe "detect_terminal_size/1" do
     test "falls back to option values when :io unavailable" do


### PR DESCRIPTION
## What

Fixes #566: concurrent same-module sessions shared one command-registry ETS table, and tearing one down deleted it out from under the others.

## Root cause

`Lifecycle.Initializer.initialize_registry_table/1` named the table `Module.concat(CommandRegistryTable, app_module)` — keyed by **app_module, not session** — and created it via `CompilerState.ensure_table`, which is **idempotent by name**. So a second session of the same module *adopted* the first's table, and `Shutdown.cleanup_registry_table` `:ets.delete`'d that shared table on the first session's teardown. The second session stayed alive but its registry became `:undefined`; any later registry-touching command/directive broke.

`start_session/2` (SS #558) made concurrent same-module sessions a first-class case, turning this latent bug into a reachable data-loss/crash path.

## Fix

Create an **unnamed** `:ets.new/2` table instead: each session owns a distinct tid.
- Nothing looks the table up by name — it's only ever threaded through as `command_registry_table` (verified: `CommandRegistryTable` appears nowhere else in the repo). So dropping the global name is transparent to every consumer.
- Access mode (`:protected`) and owner (the Lifecycle init process) are unchanged.
- **No per-session atom is minted** — the `Module.concat` is kept only as a non-unique debug label, so this doesn't reintroduce the atom leak the Registry via-names elsewhere already avoid.
- `command_registry_table` typespec widened `atom()` -> `:ets.table()`.

## Tests

Added a regression test reproducing the issue's exact scenario (two concurrent same-module sessions):
- **distinct tables** — each session's `command_registry_table` is a different tid.
- **teardown isolation** — after awaiting session A's `:DOWN` (stop/1 is an async cast, so the intact check waits for A's terminate/cleanup to actually run), session B is alive and its table is still `:ets.info != :undefined`.

Both fail on pre-fix code (`2/4`), pass on the fix (`4/4`) — proven by stashing the fix and re-running.

## Manual testing
- [x] `initializer_test.exs` — 4 passed (2 new #566, deterministic teeth both directions)
- [x] `test/raxol/core/runtime/lifecycle/ test/raxol/core/runtime/events/` — 140 passed
- [x] `concurrent_lifecycle_integration_test.exs` — 1 passed (logs show per-session `#Reference<>` tables deleted independently)
- [x] raxol_agent `session_test.exs` (real concurrent-session path) — 19 passed
- [x] `mix compile --warnings-as-errors` clean

Fixes #566.
