### PR TITLE
Add custom_console_agent ACP offering + crash recovery

### DIFF
--- a/packages/raxol_acp/README.md
+++ b/packages/raxol_acp/README.md
@@ -53,6 +53,14 @@ See `Raxol.ACP.Supervisor` for the supervision tree. Subsystems:
 
 `handle_request/2` accepts a job only for a corridor it can settle now, so a customer is rejected before escrow rather than after a failed settlement: the live capability matrix, per-order caps (`:destination_caps`), closed origins (`:closed_origins`), and a rolling aggregate reservation (`Raxol.ACP.Xochi.CapacityLedger`, opt-in via `capacity_gate_enabled: true`). `mix raxol_acp.derive_caps` derives the config from the solver's on-chain balances and `Raxol.ACP.Xochi.CapacityRefresher` refreshes it periodically. See `config/destination_caps.example.exs` and `docs/features/ACP.md`.
 
+## Second offering: Custom Console Agent
+
+`Raxol.ACP.Console.AgentOffering` (`custom_console_agent`) sells a validated, deployment-ready Virtuals Console agent package as a **plain job** (`requiredFunds: false`, no escrowed principal, no corridor liquidity). The buyer sends a spec (purpose, runtime, persona, scheduled tasks, skills); the deliverable is a `soul.md` + `tasks.json` (+ `AGENTS.md`, `skills/`) package for **Hermes** or **OpenClaw**, statically validated and -- by default -- bench-validated on the actual open-source runtime with the transcript shipped as evidence. Generation runs on wallet-funded Virtuals compute.
+
+Crash-recovery (M1) is wired end to end: `JobSession.Provider` pins the encoded deliverable + keccak in a `Raxol.Payments.Checkpoint` store **before** signing, and `Raxol.ACP.Seller.Resync` drains `get_active_jobs` on boot/reconnect and re-drives interrupted jobs through the Queue's idempotent dispatch, so a BEAM restart resumes rather than double-submitting (**exactly-once-effective, at-least-once-attempted**). Enable with `require_checkpoint: true` in production.
+
+Config surface: `config/console_offering.example.exs`. Base Sepolia go-live: `RUNBOOK.md`. Emit the marketplace document with `mix acp.register_offering --offering console`.
+
 ## Dependencies
 
 - `raxol_payments` for wallet signing (`Raxol.Payments.EIP712`, `Raxol.Payments.Wallet`) and Xochi cross-chain settlement

--- a/packages/raxol_acp/RUNBOOK.md
+++ b/packages/raxol_acp/RUNBOOK.md
@@ -1,0 +1,117 @@
+# RUNBOOK: `custom_console_agent` on Base Sepolia
+
+How to take the `custom_console_agent` offering from a clean checkout to a live,
+funded, registered seller on Base Sepolia (chain `84532`), then promote to Base
+mainnet (`8453`). The console offering sells a validated Hermes/OpenClaw agent
+package as a **plain job** (`requiredFunds: false`) -- no escrowed principal, no
+corridor liquidity.
+
+Everything that moves funds or talks to Virtuals is an OPERATOR step (needs a
+funded wallet + network egress). The steps up to that -- code, config, offline
+rehearsal -- are reproducible offline.
+
+## 0. Prerequisites
+
+- Elixir/OTP toolchain; `mix deps.get` in `packages/raxol_acp`.
+- A wallet the agent signs with. Default: a bring-your-own Alchemy Modular
+  Account v2 SCA (`ProviderAdapter.SCA`); fallback: the Privy signer sidecar
+  (`ProviderAdapter.Privy`) if sandbox registration insists on a Virtuals-issued
+  wallet. Keys come from `Raxol.Payments.Wallets.{Env, Op}` -- never a literal.
+- The `@virtuals-protocol/acp-cli` for one-time identity provisioning only (it is
+  NOT in the runtime path).
+- For `bench_validated` delivery: an operator wrapper per runtime that boots the
+  open-source runtime against a package dir (see `console_bench` in
+  `config/console_offering.example.exs`).
+
+## 1. One-time identity + funding (operator, via the acp CLI / dashboard)
+
+1. `acp configure` (OAuth), then `acp agent create` (wallet + email) and
+   `acp agent add-signer` (browser-approved). Optionally `acp email provision`.
+2. Fund the wallet on Sepolia: native gas via a Base Sepolia faucet, plus the
+   sandbox test USDC (`acp wallet topup --chain-id 84532`, or the sandbox faucet).
+3. Register the agent on the Virtuals dashboard. None of this touches the runtime;
+   `Raxol.ACP.Auth` mints the API JWT at boot from an EIP-712 signature over the
+   same adapter, so there is no separate API credential to manage.
+
+## 2. Configure the seller (copy from the example)
+
+Copy the keys you need from `config/console_offering.example.exs` into your
+`config/runtime.exs`. The Sepolia-specific values:
+
+| Setting            | Sepolia dry-run                                   | Mainnet promote            |
+| ------------------ | ------------------------------------------------- | -------------------------- |
+| `seller_chain_id`  | `84_532` (Queue defaults to 8453 -- MUST set)     | `8453`                     |
+| ACP server / relay | `api-dev.acp.virtuals.io` / `acpx.virtuals.gg`    | `api.acp.virtuals.io`      |
+| USDC               | Virtuals sandbox test USDC via `chain_overrides`  | canonical Circle USDC      |
+| adapter            | `ProviderAdapter.SCA` (or `.Privy`)               | same, mainnet bundler keys |
+| checkpoint         | `{:ets, :raxol_acp_checkpoint}`                   | durable `{module, handle}` |
+| `require_checkpoint` | `true`                                          | `true`                     |
+
+`chain_overrides` is keyed by network name (`:sepolia`), not chain id. Sepolia
+defaults to Circle USDC (`0x036CbD53842c5426634e7929541eC2318f3dCF7e`); override
+`usdc_address` with the Virtuals sandbox test token for funding checks.
+
+Set `seller_job_api_opts` (auth + `server_url` + `chain_ids: [84_532]`) so the
+boot/reconnect `Resync` has an API to read `get_active_jobs` from and so
+delivered bodies are posted out-of-band.
+
+## 3. Register the offering on Virtuals
+
+```
+mix acp.register_offering --offering console --pretty --out console_offering.json
+```
+
+Emits the marketplace document (name `custom_console_agent`, `priceType: fixed`,
+`price: 10`, `requiredFunds: false`, `slaMinutes: 60`, and the `requirement` JSON
+Schema). Upload it in the dashboard ("Add Job"). Network/contract addresses are
+deliberately NOT in this document -- they live in the agent runtime.
+
+## 4. Offline rehearsal (no funds, no network)
+
+Prove the seller stack end-to-end against the in-memory backend + mock adapter
+before going live:
+
+```
+MIX_ENV=test mix test test/raxol/acp/console/ \
+  test/raxol/acp/job_session/provider_checkpoint_test.exs \
+  test/raxol/acp/seller/resync_recovery_test.exs
+mix raxol_acp.bench      # drives synthetic jobs through the seller stack
+```
+
+The provider-checkpoint and resync-recovery suites are the M1 acceptance gate:
+they inject a crash between handler-return / sign / mirror and assert exactly one
+on-chain submit through to completion.
+
+## 5. Live dry-run on Sepolia (operator)
+
+With the seller configured and running (`seller_enabled: true`), a scripted mock
+buyer -- a second wallet driving `HookClient.create_job` / `fund` / `complete` --
+exercises the registered offering. Confirm the deliverable hash lands on-chain via
+`submit` and the body is posted out-of-band; then approve to complete.
+
+Two assumptions only the live run can pin (the `Resync` normalizer is deliberately
+tolerant and skips anything unrecognized):
+
+1. The `get_active_jobs` field names / phase encoding match what `Seller.Resync`
+   normalizes (v2 names, acp-node aliases, numeric enum).
+2. The job-id form is consistent between the REST API and the Socket.IO relayer,
+   so session keys match across the two planes.
+
+Kill the BEAM mid-flight (between funded -> submit -> complete) and restart: with
+`checkpoint` + `Resync` wired, it must resume without a second submit or charge.
+
+## 6. Promote to mainnet
+
+Flip the table in section 2 to the mainnet column: `seller_chain_id: 8453`,
+`api.acp.virtuals.io`, canonical USDC (drop the `chain_overrides` block), and a
+durable checkpoint store. Re-run section 3 with the mainnet dashboard.
+
+## Notes
+
+- Wallet-funded compute: point `console_inference` at Virtuals compute
+  (`https://compute.virtuals.io/v1`, key `VIRTUALS_API_KEY`) so generation runs on
+  the agent wallet, not a separate API bill.
+- Semantics of the M1 guarantee: **exactly-once-effective, at-least-once-attempted.**
+  One deliverable hash can ever exist per job; a sign-then-crash replay can resubmit
+  that same hash, which reverts on the contract's phase guard (costs gas, corrupts
+  nothing).

--- a/packages/raxol_acp/config/console_offering.example.exs
+++ b/packages/raxol_acp/config/console_offering.example.exs
@@ -1,0 +1,110 @@
+import Config
+
+# Example configuration for running the `custom_console_agent` offering as a
+# seller, with M1 crash-recovery (checkpointing + boot resync) enabled and a
+# Base Sepolia dry-run profile.
+#
+# This file is a REFERENCE, not loaded by the app. Copy the keys you need into
+# your own `config/runtime.exs` (or a released config). Every key below is read
+# defensively with a safe default, so an unset key just disables that feature --
+# nothing here is required for the package's own test suite.
+#
+# See RUNBOOK.md for the end-to-end provisioning -> funding -> registration ->
+# live-on-Sepolia flow that consumes this config.
+
+# ---------------------------------------------------------------------------
+# Seller stack (opt-in). Bring up Seller.Supervisor and route jobs to the
+# console offering. `Seller.Supervisor` starts `Console.BenchSlots` automatically
+# when `AgentOffering` is in `:offerings`.
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  seller_enabled: true,
+  offerings: [Raxol.ACP.Console.AgentOffering],
+  # Socket.IO relayer for live jobs; use Backend.InMemory for local rehearsal.
+  seller_backend: Raxol.ACP.Seller.Backend.WebSocket,
+  # Chain the jobs live on. The Queue defaults to 8453 (Base mainnet); Sepolia
+  # MUST be set explicitly.
+  seller_chain_id: 84_532,
+  seller_max_active_jobs: 100
+
+# The signing adapter (SCA sponsored UserOps by default; Privy sidecar or plain
+# JSONRPC EOA are the alternatives). Build it from a wallet whose key comes from
+# `Raxol.Payments.Wallets.{Env, Op}` -- never a literal here.
+#
+#   config :raxol_acp,
+#     seller_provider_adapter: Raxol.ACP.ProviderAdapter.SCA.new(...),
+#     seller_acp_core_address: nil   # nil -> Chain.mainnet()/sepolia() default
+
+# ---------------------------------------------------------------------------
+# M1 durability: checkpoint store + fail-closed posture + boot/reconnect resync.
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  # `nil` (off) | `{:ets, name}` (supervisor-owned named table, survives
+  # Queue/session crashes but NOT a BEAM restart -- pair with the resync below)
+  # | `{module, handle}` (any Raxol.Payments.Checkpoint impl for cross-restart
+  # durability, e.g. a DETS-backed store).
+  checkpoint: {:ets, :raxol_acp_checkpoint},
+  # Release posture: refuse to sign a fund-adjacent write (setBudget/submit) with
+  # no durable store configured. Leave false in dev; true in production.
+  require_checkpoint: true,
+  # Off-chain JobApi for (a) boot/reconnect resync via get_active_jobs and (b)
+  # out-of-band deliverable posting after submit. Forwarded to JobApi.HTTP.new/1.
+  # nil disables both (resync becomes a no-op).
+  seller_job_api_opts: [
+    auth: Raxol.ACP.Auth,
+    server_url: "https://api-dev.acp.virtuals.io",
+    chain_ids: [84_532]
+  ]
+
+# ---------------------------------------------------------------------------
+# Console offering: wallet-funded inference, artifact hosting, and the bench.
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  # Wallet-funded Virtuals compute (OpenAI-compatible). Defaults shown; override
+  # api_key/model as needed. `{:system, "VAR"}` reads the key from the env.
+  console_inference: [
+    module: Raxol.ACP.Console.Inference.Compute,
+    base_url: "https://compute.virtuals.io/v1",
+    api_key: {:system, "VIRTUALS_API_KEY"},
+    model: "moonshotai/kimi-k2-0905",
+    receive_timeout: 120_000
+  ],
+  # Where generated package artifacts (tarball, transcript, report) are written.
+  # `Local` needs a `:dir`; `:base_url` turns file paths into fetchable URLs.
+  console_artifact_store: [
+    module: Raxol.ACP.Console.ArtifactStore.Local,
+    dir: "/var/lib/raxol_acp/console_artifacts",
+    base_url: "https://artifacts.example.com/console"
+  ],
+  # Bench harness: one operator-provided wrapper per runtime that boots the
+  # open-source runtime against the materialized package. `:cmd` is `{exe, args}`;
+  # the wrapper reads RAXOL_BENCH_CHECK / RAXOL_BENCH_PKG_DIR / RAXOL_BENCH_PROMPT
+  # / RAXOL_BENCH_TASK from its env and exits 0 on success.
+  console_bench: [
+    prompt: "Introduce yourself in one sentence.",
+    hermes: [cmd: {"/opt/raxol/bench/hermes.sh", []}],
+    openclaw: [cmd: {"/opt/raxol/bench/openclaw.sh", []}]
+  ],
+  # Bench-slot ledger (scarce-resource gate for bench_validated jobs).
+  console_bench_slots: 1,
+  console_bench_slot_ttl_ms: 2_700_000,
+  # Light pre-escrow content policy: downcased substrings rejected in purpose/persona.
+  console_deny_terms: [],
+  # Accepted soul.md size window (bytes) for the static validator.
+  console_soul_bytes: {50, 40_000}
+
+# ---------------------------------------------------------------------------
+# Base Sepolia network override. `chain_overrides` is keyed by NETWORK NAME
+# (`:sepolia` / `:mainnet`), not chain id, and shallow-merges over the built-in
+# `Raxol.ACP.Chain` config. Sepolia defaults to canonical Circle USDC
+# (0x036CbD53842c5426634e7929541eC2318f3dCF7e); the Virtuals sandbox issues its
+# own test USDC, so set that address here for funding checks. Leave this block
+# out entirely to use the Circle default.
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  chain_overrides: %{
+    sepolia: %{
+      # From the Virtuals dev/sandbox docs -- fill in the sandbox test-USDC token.
+      usdc_address: System.get_env("RAXOL_ACP_SEPOLIA_USDC") || "0x<virtuals-test-usdc>"
+    }
+  }

--- a/packages/raxol_acp/lib/mix/tasks/acp.register_offering.ex
+++ b/packages/raxol_acp/lib/mix/tasks/acp.register_offering.ex
@@ -32,7 +32,8 @@ defmodule Mix.Tasks.Acp.RegisterOffering do
   ## Options
 
   - `--offering` -- which offering to emit: `usdc_public` (default, the launch
-    offering `xochi_usdc_public`), `public`, `stealth`, or `legacy` (the
+    offering `xochi_usdc_public`), `public`, `stealth`, `console` (the
+    `custom_console_agent` package-delivery offering), or `legacy` (the
     deprecated token-agnostic `xochi_cross_chain_transfer`).
   - `--out PATH` -- write to a file instead of stdout.
   - `--pretty` -- emit pretty-printed JSON. Default is compact.
@@ -103,9 +104,26 @@ defmodule Mix.Tasks.Acp.RegisterOffering do
   defp offering_metadata(mode) when mode in [:usdc_public, :public, :stealth],
     do: Offering.offering_metadata(mode)
 
+  defp offering_metadata(:console) do
+    %{
+      name: Raxol.ACP.Console.AgentOffering.offering_name(),
+      description:
+        "A custom autonomous agent for your Virtuals Console, delivered as a " <>
+          "validated soul.md + scheduled-tasks package for Hermes or OpenClaw, " <>
+          "bench-tested on the open-source runtime with evidence. Deploy it to " <>
+          "your own Console in three clicks; your wallet, signers, and ACP " <>
+          "identity are preserved.",
+      price_usdc: Decimal.to_float(Raxol.ACP.Console.AgentOffering.price_usdc()),
+      price_type: "fixed",
+      sla_minutes: Raxol.ACP.Console.AgentOffering.sla_minutes(),
+      required_funds: false,
+      requirement_schema: Raxol.ACP.Console.Spec.requirement_schema()
+    }
+  end
+
   defp offering_metadata(other),
     do:
       Mix.raise(
-        "unknown --offering #{inspect(other)}; expected usdc_public, public, stealth, or legacy"
+        "unknown --offering #{inspect(other)}; expected usdc_public, public, stealth, console, or legacy"
       )
 end

--- a/packages/raxol_acp/lib/raxol/acp/checkpoint.ex
+++ b/packages/raxol_acp/lib/raxol/acp/checkpoint.ex
@@ -1,0 +1,84 @@
+defmodule Raxol.ACP.Checkpoint do
+  @moduledoc """
+  Config plumbing for the durable idempotency store the seller's
+  `Raxol.ACP.JobSession.Provider` uses to survive crashes between an offering
+  handler's decision and the on-chain commit (DESIGN.md §5).
+
+  The store itself is `Raxol.Payments.Checkpoint` — the same behaviour and
+  record semantics the payments Actions use — so a deployment can point both at
+  one backend. This module only resolves *which* store from config and derives
+  the per-job step keys.
+
+      config :raxol_acp,
+        checkpoint: {:ets, :raxol_acp_checkpoint},   # dev/test: supervised named table
+        # checkpoint: {MyDurableStore, handle},      # release: any Checkpoint impl
+        require_checkpoint: false                    # true => refuse to sign without a store
+
+  Accepted `:checkpoint` values:
+
+  - `nil` (default) — no checkpointing. With `require_checkpoint: true` the
+    Provider then **fails closed**: it refuses to run fund-adjacent writes
+    (`setBudget`, `submit`) rather than signing without a durable record.
+  - `{:ets, name}` — a named public ETS table owned by
+    `Raxol.ACP.Checkpoint.Owner`, which `Raxol.ACP.Seller.Supervisor` starts
+    ahead of the Queue when this form is configured. Survives Queue/session
+    crashes; does NOT survive BEAM restarts — pair with `Resync` (which reads
+    the authoritative phase from the job API) or use a durable backend.
+  - `{module, handle}` — any `Raxol.Payments.Checkpoint` implementation,
+    e.g. `Raxol.Payments.Checkpoint.ContextStore` bridged to an agent context
+    store for cross-restart durability.
+
+  Keys are `derive_key([chain_id, job_id, step])` with step ∈ `:accept` |
+  `:submit`, so a job's records are addressable from nothing but its identity —
+  exactly what a cold resync has.
+  """
+
+  alias Raxol.Payments.Checkpoint
+
+  @doc "Resolve the configured store, or `nil` when checkpointing is off."
+  @spec store() :: Checkpoint.store() | nil
+  def store do
+    case Application.get_env(:raxol_acp, :checkpoint) do
+      nil -> nil
+      {:ets, name} when is_atom(name) -> {Raxol.Payments.Checkpoint.ETS, name}
+      {module, _handle} = store when is_atom(module) -> store
+    end
+  end
+
+  @doc "Whether fund-adjacent writes must refuse to sign without a store."
+  @spec required?() :: boolean()
+  def required?, do: Application.get_env(:raxol_acp, :require_checkpoint, false)
+
+  @doc "Stable idempotency key for one lifecycle step of one job."
+  @spec key(pos_integer(), term(), :accept | :submit) :: String.t()
+  def key(chain_id, job_id, step) when step in [:accept, :submit],
+    do: Checkpoint.derive_key([chain_id, job_id, step])
+
+  defmodule Owner do
+    @moduledoc """
+    Supervisor-level owner for the `{:ets, name}` checkpoint form.
+
+    `Raxol.Payments.Checkpoint.ETS` tables are owned by the process that
+    creates them; created ad hoc by the Queue they would die with the crash
+    they exist to survive. This GenServer's only job is to call
+    `ETS.new(name)` from a stable supervision slot and then hold the table.
+    """
+
+    use GenServer
+
+    @spec start_link(keyword()) :: GenServer.on_start()
+    def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+    @impl true
+    def init(_opts) do
+      case Application.get_env(:raxol_acp, :checkpoint) do
+        {:ets, name} when is_atom(name) ->
+          {_module, _table} = Raxol.Payments.Checkpoint.ETS.new(name)
+          {:ok, %{name: name}}
+
+        _other ->
+          :ignore
+      end
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/checkpoint.ex
+++ b/packages/raxol_acp/lib/raxol/acp/checkpoint.ex
@@ -31,6 +31,12 @@ defmodule Raxol.ACP.Checkpoint do
   Keys are `derive_key([chain_id, job_id, step])` with step ∈ `:accept` |
   `:submit`, so a job's records are addressable from nothing but its identity —
   exactly what a cold resync has.
+
+  Durability, explicitly: the `{:ets, name}` form does NOT survive a BEAM restart
+  on its own. The full "resume across restarts" guarantee holds only when it is
+  paired with `Raxol.ACP.Seller.Resync` (which re-reads the authoritative phase
+  from the job API) OR when a durable `{module, handle}` backend is configured.
+  A production seller should set `require_checkpoint: true` and use one of those.
   """
 
   alias Raxol.Payments.Checkpoint

--- a/packages/raxol_acp/lib/raxol/acp/console/agent_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/agent_offering.ex
@@ -95,6 +95,12 @@ defmodule Raxol.ACP.Console.AgentOffering do
   @impl true
   def handle_deliver(request, ctx), do: Delivery.run(request, ctx)
 
+  # An accepted job that never delivers (rejected after accept, or expired) must
+  # give its bench slot back here -- otherwise the pre-escrow reservation leaks
+  # until the TTL sweep. Idempotent, and a no-op for package_only jobs.
+  @impl true
+  def handle_release(_request, ctx), do: BenchSlots.release(ctx.job_id)
+
   defp reserve_bench(%Spec{validation: :package_only}, _job_id), do: :ok
   defp reserve_bench(%Spec{validation: :bench_validated}, job_id), do: bench_result(job_id)
 

--- a/packages/raxol_acp/lib/raxol/acp/console/agent_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/agent_offering.ex
@@ -1,0 +1,107 @@
+defmodule Raxol.ACP.Console.AgentOffering do
+  @moduledoc """
+  `custom_console_agent` — a validated, deployment-ready Virtuals Console agent
+  package, sold as a **plain job** (`requiredFunds: false`, `hook =
+  address(0)`): zero liquidity, no principal at risk on either side.
+
+  The buyer sends a spec (purpose, runtime, persona, scheduled tasks, skills);
+  the deliverable is a `soul.md` + `tasks.json` (+ `AGENTS.md`, `skills/`)
+  package targeting **Hermes** or **OpenClaw**, statically validated and — by
+  default — bench-validated on the actual open-source runtime, with the
+  transcript shipped as evidence. The buyer's side of delivery is the
+  three-click *Deploy Instance* redeploy on their own Console dashboard
+  (instructions bundled in the package).
+
+  ## Lifecycle mapping
+
+  - `handle_request/2` — fail-closed pre-escrow gate: `Spec.validate/1`
+    (schema + content policy) then, for `bench_validated` jobs, a
+    `BenchSlots.reserve/1` so we never accept more concurrent bench work than
+    the SLA can absorb. Typed rejects: `{:invalid_requirement, field, detail}`,
+    `{:denied_purpose, term}`, `:at_bench_capacity`,
+    `{:error, :bench_unavailable}` (slots process not running — configuration
+    error, fail closed).
+  - `handle_deliver/2` — delegates to `Raxol.ACP.Console.Delivery.run/2`
+    (generate → validate → bench → package → store), releasing the slot in
+    `after` on every path.
+
+  Flat `price_usdc` for v1; dynamic sizing moves into `resolve_accept/2` once
+  the fixed-price E2E is proven (DESIGN.md §7).
+
+  ## Enabling
+
+      config :raxol_acp,
+        seller_enabled: true,
+        offerings: [Raxol.ACP.Console.AgentOffering],
+        console_artifact_store: [module: ..., dir: ..., base_url: ...],
+        console_inference: [api_key: {:system, "VIRTUALS_API_KEY"}],
+        console_bench: [hermes: [cmd: {"/opt/raxol/bench/hermes.sh", []}]]
+
+  `Seller.Supervisor` starts `BenchSlots` automatically when this module is in
+  `:offerings`. Emit the marketplace document with
+  `mix acp.register_offering --offering console`.
+  """
+
+  use Raxol.ACP.Offering,
+    name: "custom_console_agent",
+    price_usdc: 10,
+    sla_minutes: 60,
+    cluster: "software"
+
+  alias Raxol.ACP.Console.{BenchSlots, Delivery, Spec}
+
+  @impl true
+  def requirements_schema, do: Spec.requirement_schema()
+
+  @impl true
+  def deliverables_schema do
+    %{
+      "$schema" => "http://json-schema.org/draft-07/schema#",
+      "type" => "object",
+      "required" => ["package_tarball_url", "sha256", "manifest"],
+      "properties" => %{
+        "package_tarball_url" => %{"type" => "string"},
+        "sha256" => %{"type" => "string", "pattern" => "^[0-9a-f]{64}$"},
+        "manifest" => %{
+          "type" => "object",
+          "properties" => %{
+            "runtime" => %{"type" => "string", "enum" => ["hermes", "openclaw"]},
+            "files" => %{"type" => "array", "items" => %{"type" => "string"}}
+          }
+        },
+        "deploy_instructions_url" => %{"type" => "string"},
+        "validation_report_url" => %{"type" => "string"},
+        "evidence" => %{
+          "type" => ["object", "null"],
+          "properties" => %{
+            "bench_transcript_url" => %{"type" => "string"},
+            "checks" => %{"type" => "array", "items" => %{"type" => "string"}}
+          }
+        }
+      }
+    }
+  end
+
+  @impl true
+  def handle_request(request, ctx) do
+    with {:ok, spec} <- Spec.validate(request),
+         :ok <- reserve_bench(spec, ctx.job_id) do
+      {:accept, request}
+    else
+      {:error, reason} -> {:reject, reason}
+    end
+  end
+
+  @impl true
+  def handle_deliver(request, ctx), do: Delivery.run(request, ctx)
+
+  defp reserve_bench(%Spec{validation: :package_only}, _job_id), do: :ok
+  defp reserve_bench(%Spec{validation: :bench_validated}, job_id), do: bench_result(job_id)
+
+  defp bench_result(job_id) do
+    case BenchSlots.reserve(job_id) do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/artifact_store.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/artifact_store.ex
@@ -1,0 +1,64 @@
+defmodule Raxol.ACP.Console.ArtifactStore do
+  @moduledoc """
+  Storage seam for delivery artifacts (the package tarball, the evidence
+  transcript, the validation report). The deliverable carries URLs, so the
+  store's only contract is: bytes in, stable URL out — at a
+  **`job_id`-deterministic path**, which is what makes a replayed
+  `handle_deliver/2` re-find the same artifact instead of minting a second one
+  (DESIGN.md §5.3).
+
+      config :raxol_acp, :console_artifact_store,
+        module: Raxol.ACP.Console.ArtifactStore.Local,
+        dir: "/var/lib/raxol/console_artifacts",
+        base_url: "https://artifacts.example.com/console"
+
+  `Local` writes `dir/<job_id>/<filename>` and returns
+  `base_url/<job_id>/<filename>` (or a `file://` URL when `base_url` is unset —
+  fine for tests and bench runs, not for a live offering). An S3/R2 impl slots
+  in behind the same behaviour without touching delivery.
+  """
+
+  @callback put(job_id :: binary(), filename :: String.t(), bytes :: binary()) ::
+              {:ok, url :: String.t()} | {:error, term()}
+
+  @doc "Store through the configured module."
+  @spec put(binary(), String.t(), binary()) :: {:ok, String.t()} | {:error, term()}
+  def put(job_id, filename, bytes) do
+    cfg = Application.get_env(:raxol_acp, :console_artifact_store, [])
+    module = Keyword.get(cfg, :module, __MODULE__.Local)
+    module.put(job_id, filename, bytes)
+  end
+
+  defmodule Local do
+    @moduledoc false
+    @behaviour Raxol.ACP.Console.ArtifactStore
+
+    @impl true
+    def put(job_id, filename, bytes) do
+      cfg = Application.get_env(:raxol_acp, :console_artifact_store, [])
+
+      with {:ok, dir} <- fetch_dir(cfg),
+           safe_job = sanitize(job_id),
+           target_dir = Path.join(dir, safe_job),
+           :ok <- File.mkdir_p(target_dir),
+           path = Path.join(target_dir, filename),
+           :ok <- File.write(path, bytes) do
+        case Keyword.get(cfg, :base_url) do
+          nil -> {:ok, "file://" <> path}
+          base -> {:ok, Enum.join([String.trim_trailing(base, "/"), safe_job, filename], "/")}
+        end
+      else
+        {:error, reason} -> {:error, {:artifact_store, reason}}
+      end
+    end
+
+    defp fetch_dir(cfg) do
+      case Keyword.get(cfg, :dir) do
+        nil -> {:error, :no_dir_configured}
+        dir -> {:ok, dir}
+      end
+    end
+
+    defp sanitize(job_id), do: String.replace(to_string(job_id), ~r/[^A-Za-z0-9_.-]/, "_")
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/bench.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/bench.ex
@@ -1,0 +1,51 @@
+defmodule Raxol.ACP.Console.Bench do
+  @moduledoc """
+  Bench seam: run a generated package against a real agent runtime and return
+  evidence, or a typed failure that blocks delivery.
+
+  Both Console runtimes (Hermes, OpenClaw) are open source, so the SLA-path
+  bench does **not** touch the hosted Console at all: `Bench.Local` boots the
+  actual runtime on this machine against the materialized package — the same
+  artifacts the Console's Deploy Instance flow consumes — which keeps
+  `bench_validated` delivery fully autonomous (no dashboard auth, no per-job
+  hosting). Redeploying a hosted bench Console agent remains an
+  operator-assisted extra, outside the SLA path (DESIGN.md §7 R1).
+
+  Evidence shape: `%{checks: [{:boot | :prompt | :task_dry_run, :ok}],
+  transcript: binary()}` — the transcript is uploaded next to the tarball and
+  linked from the deliverable.
+
+  `Bench.Mock` (tests) returns `config :raxol_acp, :console_bench_mock`
+  verbatim, defaulting to a passing three-check result.
+  """
+
+  @type evidence :: %{checks: [{atom(), :ok}], transcript: binary()}
+
+  @callback run(pkg_dir :: Path.t(), spec :: Raxol.ACP.Console.Spec.t()) ::
+              {:ok, evidence()} | {:error, term()}
+
+  @doc "Run the configured bench module (`config :raxol_acp, :console_bench_module`)."
+  @spec run(Path.t(), Raxol.ACP.Console.Spec.t()) :: {:ok, evidence()} | {:error, term()}
+  def run(pkg_dir, spec) do
+    module = Application.get_env(:raxol_acp, :console_bench_module, __MODULE__.Local)
+    module.run(pkg_dir, spec)
+  end
+
+  defmodule Mock do
+    @moduledoc false
+    @behaviour Raxol.ACP.Console.Bench
+
+    @impl true
+    def run(_pkg_dir, _spec) do
+      Application.get_env(
+        :raxol_acp,
+        :console_bench_mock,
+        {:ok,
+         %{
+           checks: [boot: :ok, prompt: :ok, task_dry_run: :ok],
+           transcript: "mock bench: boot ok / prompt ok / task dry-run ok\n"
+         }}
+      )
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/bench/local.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/bench/local.ex
@@ -69,6 +69,42 @@ defmodule Raxol.ACP.Console.Bench.Local do
       {~c"RAXOL_BENCH_TASK", to_charlist(first_task(pkg_dir))}
     ]
 
+    case open_port(exe, args, env) do
+      {:error, reason} ->
+        # A missing/non-executable wrapper is an operator misconfig; fail the
+        # bench with a typed error rather than crashing the job session.
+        {:error, {:bench_spawn_failed, check, reason}}
+
+      {:ok, port} ->
+        timeout = Keyword.get(cfg, :timeout_ms, 120_000)
+
+        case collect(port, "", timeout) do
+          {:ok, 0, out} ->
+            entry = "== #{check} ==\n#{out}\n"
+
+            run_checks(
+              rest,
+              exe,
+              args,
+              pkg_dir,
+              cfg,
+              [{check, :ok} | done],
+              cap(transcript <> entry)
+            )
+
+          {:ok, status, out} ->
+            {:error, {:bench_failed, check, status, String.slice(out, -500..-1//1)}}
+
+          :timeout ->
+            Port.close(port)
+            {:error, {:bench_timeout, check}}
+        end
+    end
+  end
+
+  # Port.open/2 raises (e.g. :enoent) when the wrapper is missing or not
+  # executable; contain that so the pipeline sees a normal error.
+  defp open_port(exe, args, env) do
     port =
       Port.open({:spawn_executable, exe}, [
         :binary,
@@ -78,20 +114,11 @@ defmodule Raxol.ACP.Console.Bench.Local do
         env: env
       ])
 
-    timeout = Keyword.get(cfg, :timeout_ms, 120_000)
-
-    case collect(port, "", timeout) do
-      {:ok, 0, out} ->
-        entry = "== #{check} ==\n#{out}\n"
-        run_checks(rest, exe, args, pkg_dir, cfg, [{check, :ok} | done], cap(transcript <> entry))
-
-      {:ok, status, out} ->
-        {:error, {:bench_failed, check, status, String.slice(out, -500..-1//1)}}
-
-      :timeout ->
-        Port.close(port)
-        {:error, {:bench_timeout, check}}
-    end
+    {:ok, port}
+  rescue
+    # `rescue` catches the `:error`-class raise from open_port (e.g. :enoent for
+    # a missing wrapper) as an ErlangError, so no separate `catch` is needed.
+    e -> {:error, Exception.message(e)}
   end
 
   defp collect(port, acc, timeout) do

--- a/packages/raxol_acp/lib/raxol/acp/console/bench/local.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/bench/local.ex
@@ -1,0 +1,119 @@
+defmodule Raxol.ACP.Console.Bench.Local do
+  @moduledoc """
+  Runs bench checks by executing an operator-configured wrapper around the
+  open-source runtime, once per check, over a `Port`:
+
+      config :raxol_acp, :console_bench,
+        hermes: [cmd: {"/opt/raxol/bench/hermes.sh", []}],
+        openclaw: [cmd: {"/opt/raxol/bench/openclaw.sh", []}],
+        timeout_ms: 120_000,
+        prompt: "Introduce yourself in one sentence and state your purpose."
+
+  Wrapper contract (kept runtime-agnostic on purpose — the runtimes are moving
+  targets and the glue is a few lines of shell): the wrapper is invoked with
+  env `RAXOL_BENCH_CHECK` (`boot` | `prompt` | `task_dry_run`),
+  `RAXOL_BENCH_PKG_DIR` (the materialized package), `RAXOL_BENCH_PROMPT`
+  (prompt check), and `RAXOL_BENCH_TASK` (a task name, dry-run check). It must
+  boot the runtime against the package, perform the check, print the agent's
+  observable output to stdout, and exit 0 on success / non-zero on failure.
+  Like the signer sidecar, the wrapper must treat stdin close as shutdown —
+  that is how a timed-out or crashed BEAM reaps it.
+
+  Failure surfaces as `{:error, {:bench_failed, check, exit_status, tail}}` or
+  `{:error, {:bench_timeout, check}}`; either blocks delivery. Transcripts are
+  concatenated across checks and capped at 64 KiB.
+  """
+
+  @behaviour Raxol.ACP.Console.Bench
+
+  @cap 64 * 1024
+
+  @impl true
+  def run(pkg_dir, spec) do
+    cfg = Application.get_env(:raxol_acp, :console_bench, [])
+    runtime = package_runtime(pkg_dir)
+
+    case get_in(cfg, [runtime, :cmd]) do
+      {exe, args} when is_binary(exe) ->
+        checks =
+          [:boot, :prompt] ++
+            if(spec.scheduled_tasks == [], do: [], else: [:task_dry_run])
+
+        run_checks(checks, exe, args, pkg_dir, cfg, [], "")
+
+      _ ->
+        {:error, {:bench_unconfigured, runtime}}
+    end
+  end
+
+  # The manifest is the single source of truth for which runtime the generator
+  # targeted (`:either` resolution happens there); bench that runtime.
+  defp package_runtime(pkg_dir) do
+    with {:ok, raw} <- File.read(Path.join(pkg_dir, "manifest.json")),
+         {:ok, %{"runtime" => "openclaw"}} <- Jason.decode(raw) do
+      :openclaw
+    else
+      _ -> :hermes
+    end
+  end
+
+  defp run_checks([], _exe, _args, _dir, _cfg, done, transcript),
+    do: {:ok, %{checks: Enum.reverse(done), transcript: transcript}}
+
+  defp run_checks([check | rest], exe, args, pkg_dir, cfg, done, transcript) do
+    env = [
+      {~c"RAXOL_BENCH_CHECK", to_charlist(check)},
+      {~c"RAXOL_BENCH_PKG_DIR", to_charlist(pkg_dir)},
+      {~c"RAXOL_BENCH_PROMPT",
+       to_charlist(Keyword.get(cfg, :prompt, "Introduce yourself in one sentence."))},
+      {~c"RAXOL_BENCH_TASK", to_charlist(first_task(pkg_dir))}
+    ]
+
+    port =
+      Port.open({:spawn_executable, exe}, [
+        :binary,
+        :exit_status,
+        :stderr_to_stdout,
+        args: args,
+        env: env
+      ])
+
+    timeout = Keyword.get(cfg, :timeout_ms, 120_000)
+
+    case collect(port, "", timeout) do
+      {:ok, 0, out} ->
+        entry = "== #{check} ==\n#{out}\n"
+        run_checks(rest, exe, args, pkg_dir, cfg, [{check, :ok} | done], cap(transcript <> entry))
+
+      {:ok, status, out} ->
+        {:error, {:bench_failed, check, status, String.slice(out, -500..-1//1)}}
+
+      :timeout ->
+        Port.close(port)
+        {:error, {:bench_timeout, check}}
+    end
+  end
+
+  defp collect(port, acc, timeout) do
+    receive do
+      {^port, {:data, data}} -> collect(port, cap(acc <> data), timeout)
+      {^port, {:exit_status, status}} -> {:ok, status, acc}
+    after
+      timeout -> :timeout
+    end
+  end
+
+  defp cap(bin) when byte_size(bin) > @cap,
+    do: binary_part(bin, byte_size(bin) - @cap, @cap)
+
+  defp cap(bin), do: bin
+
+  defp first_task(pkg_dir) do
+    with {:ok, raw} <- File.read(Path.join(pkg_dir, "tasks.json")),
+         {:ok, %{"tasks" => [%{"name" => name} | _]}} <- Jason.decode(raw) do
+      name
+    else
+      _ -> ""
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/bench_slots.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/bench_slots.ex
@@ -1,0 +1,77 @@
+defmodule Raxol.ACP.Console.BenchSlots do
+  @moduledoc """
+  Bounds concurrent `bench_validated` jobs, the console offering's scarce
+  resource — the same reserve-at-accept / release-at-deliver / TTL-sweep shape
+  as the Xochi `CapacityLedger`, sized down to a slot counter.
+
+  `handle_request/2` reserves a slot (per `job_id`, idempotent) before
+  accepting; a full bench rejects with `:at_bench_capacity` **before escrow**,
+  so a buyer is never funded into a job we cannot validate in SLA. Delivery
+  releases in an `after` clause; the TTL sweep (default 45 min, ≈ SLA + margin)
+  reclaims slots from jobs that died without releasing.
+
+  Config: `config :raxol_acp, console_bench_slots: 1, console_bench_slot_ttl_ms:
+  2_700_000`. Started by `Raxol.ACP.Seller.Supervisor` ahead of the Queue (like
+  the capacity gate) only when the console offering is configured; when the
+  process is not running, `reserve/1` fails closed with
+  `{:error, :bench_unavailable}`.
+  """
+
+  use GenServer
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @doc "Reserve a slot for `job_id`. Idempotent per job."
+  @spec reserve(binary()) :: :ok | {:error, :at_bench_capacity | :bench_unavailable}
+  def reserve(job_id) do
+    case GenServer.whereis(__MODULE__) do
+      nil -> {:error, :bench_unavailable}
+      pid -> GenServer.call(pid, {:reserve, job_id})
+    end
+  end
+
+  @doc "Release the slot held by `job_id`. Idempotent; safe when not running."
+  @spec release(binary()) :: :ok
+  def release(job_id) do
+    case GenServer.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> GenServer.call(pid, {:release, job_id})
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %{
+       max: opts[:max] || Application.get_env(:raxol_acp, :console_bench_slots, 1),
+       ttl_ms:
+         opts[:ttl_ms] || Application.get_env(:raxol_acp, :console_bench_slot_ttl_ms, 2_700_000),
+       slots: %{}
+     }}
+  end
+
+  @impl true
+  def handle_call({:reserve, job_id}, _from, state) do
+    state = sweep(state)
+
+    cond do
+      Map.has_key?(state.slots, job_id) ->
+        {:reply, :ok, state}
+
+      map_size(state.slots) >= state.max ->
+        {:reply, {:error, :at_bench_capacity}, state}
+
+      true ->
+        {:reply, :ok, put_in(state.slots[job_id], System.monotonic_time(:millisecond))}
+    end
+  end
+
+  def handle_call({:release, job_id}, _from, state),
+    do: {:reply, :ok, %{state | slots: Map.delete(state.slots, job_id)}}
+
+  defp sweep(%{ttl_ms: ttl} = state) do
+    cutoff = System.monotonic_time(:millisecond) - ttl
+    %{state | slots: :maps.filter(fn _k, at -> at > cutoff end, state.slots)}
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/cron.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/cron.ex
@@ -1,0 +1,70 @@
+defmodule Raxol.ACP.Console.Cron do
+  @moduledoc """
+  Minimal validator for 5-field cron expressions (`minute hour day-of-month
+  month day-of-week`), the cadence format the delivered `tasks.json` must carry.
+
+  Buyers may submit natural-language cadences ("every 12h"); the generator
+  canonicalizes those to cron, and `Raxol.ACP.Console.Validator` requires the
+  *final* package to validate here. Supported per field: `*`, integers, ranges
+  `a-b`, steps `*/n` and `a-b/n`, and comma lists thereof. Month/day-of-week
+  names are not accepted — the generator is instructed to emit numerics.
+  """
+
+  @bounds [{0, 59}, {0, 23}, {1, 31}, {1, 12}, {0, 7}]
+
+  @doc "True when `expr` is a valid 5-field cron expression."
+  @spec valid?(String.t()) :: boolean()
+  def valid?(expr) when is_binary(expr) do
+    case String.split(expr, ~r/\s+/, trim: true) do
+      fields when length(fields) == 5 ->
+        fields |> Enum.zip(@bounds) |> Enum.all?(fn {f, b} -> field_valid?(f, b) end)
+
+      _ ->
+        false
+    end
+  end
+
+  def valid?(_), do: false
+
+  defp field_valid?(field, bounds) do
+    field |> String.split(",") |> Enum.all?(&part_valid?(&1, bounds))
+  end
+
+  defp part_valid?("*", _bounds), do: true
+
+  defp part_valid?(part, bounds) do
+    case String.split(part, "/") do
+      [range] -> range_valid?(range, bounds)
+      [range, step] -> range_valid?(range, bounds) and int_in?(step, {1, 59})
+      _ -> false
+    end
+  end
+
+  defp range_valid?("*", _bounds), do: true
+
+  defp range_valid?(range, bounds) do
+    case String.split(range, "-") do
+      [n] ->
+        int_in?(n, bounds)
+
+      [a, b] ->
+        with {:ok, a} <- parse_in(a, bounds), {:ok, b} <- parse_in(b, bounds) do
+          a <= b
+        else
+          _ -> false
+        end
+
+      _ ->
+        false
+    end
+  end
+
+  defp int_in?(s, bounds), do: match?({:ok, _}, parse_in(s, bounds))
+
+  defp parse_in(s, {lo, hi}) do
+    case Integer.parse(s) do
+      {n, ""} when n >= lo and n <= hi -> {:ok, n}
+      _ -> :error
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/delivery.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/delivery.ex
@@ -1,0 +1,125 @@
+defmodule Raxol.ACP.Console.Delivery do
+  @moduledoc """
+  The `handle_deliver/2` pipeline for `custom_console_agent`:
+
+      re-validate request → generate → static validate → materialize →
+      bench (when :bench_validated) → tar.gz → store artifacts → deliverable
+
+  Stateless by design: the accepted request map is the only input, so a resync
+  after a crash replays the same pipeline; the artifact path is
+  `job_id`-deterministic, and the JobSession checkpoint (DESIGN.md §5) stores
+  the computed deliverable + hash before the on-chain submit, so generation
+  nondeterminism can never yield two different submits for one job. The bench
+  slot reserved at accept time is released — and the scratch dir removed — in
+  an `after` clause on every path.
+
+  Every failure is a typed `{:error, reason}`, surfaced by the Queue as
+  `{:handler_error, reason}` telemetry.
+  """
+
+  alias Raxol.ACP.Console.{ArtifactStore, Bench, BenchSlots, Generator, Spec, Validator}
+
+  @doc "Run the full delivery pipeline. Returns `{:deliver, map}` or `{:error, term}`."
+  @spec run(map(), %{:job_id => binary(), optional(atom()) => any()}) ::
+          {:deliver, map()} | {:error, term()}
+  def run(request, %{job_id: job_id}) do
+    with {:ok, spec} <- Spec.validate(request),
+         {:ok, pkg} <- Generator.generate(spec, job_id),
+         {:ok, report} <- Validator.validate(pkg),
+         {:ok, dir} <- materialize(pkg, job_id) do
+      try do
+        with {:ok, evidence} <- maybe_bench(dir, spec),
+             {:ok, tarball} <- tar(dir, pkg),
+             sha = sha256(tarball),
+             {:ok, tar_url} <- ArtifactStore.put(job_id, "package.tar.gz", tarball),
+             {:ok, report_url} <-
+               ArtifactStore.put(job_id, "validation_report.json", report_json(report)),
+             {:ok, evidence_url} <- put_evidence(job_id, evidence),
+             {:ok, instructions_url} <-
+               ArtifactStore.put(
+                 job_id,
+                 "deploy_instructions.md",
+                 Map.fetch!(pkg.files, "deploy_instructions.md")
+               ) do
+          {:deliver,
+           %{
+             "package_tarball_url" => tar_url,
+             "sha256" => sha,
+             "manifest" => %{
+               "runtime" => Atom.to_string(pkg.runtime),
+               "files" => pkg.files |> Map.keys() |> Enum.sort()
+             },
+             "deploy_instructions_url" => instructions_url,
+             "validation_report_url" => report_url,
+             "evidence" => evidence_field(evidence, evidence_url)
+           }}
+        end
+      after
+        BenchSlots.release(job_id)
+        File.rm_rf(dir)
+      end
+    end
+  end
+
+  # -- pipeline steps --------------------------------------------------------
+
+  defp materialize(%{files: files}, job_id) do
+    dir = Path.join(System.tmp_dir!(), "raxol_console_" <> sanitize(job_id))
+    _ = File.rm_rf(dir)
+
+    Enum.reduce_while(files, {:ok, dir}, fn {rel, bytes}, {:ok, dir} ->
+      path = Path.join(dir, rel)
+
+      with :ok <- File.mkdir_p(Path.dirname(path)),
+           :ok <- File.write(path, bytes) do
+        {:cont, {:ok, dir}}
+      else
+        {:error, reason} -> {:halt, {:error, {:materialize, rel, reason}}}
+      end
+    end)
+  end
+
+  defp maybe_bench(_dir, %Spec{validation: :package_only}), do: {:ok, nil}
+  defp maybe_bench(dir, %Spec{validation: :bench_validated} = spec), do: Bench.run(dir, spec)
+
+  defp tar(dir, %{files: files}) do
+    out = dir <> ".tar.gz"
+
+    entries =
+      files
+      |> Map.keys()
+      |> Enum.sort()
+      |> Enum.map(fn rel -> {to_charlist(rel), to_charlist(Path.join(dir, rel))} end)
+
+    case :erl_tar.create(to_charlist(out), entries, [:compressed]) do
+      :ok ->
+        bytes = File.read!(out)
+        File.rm(out)
+        {:ok, bytes}
+
+      {:error, reason} ->
+        {:error, {:tar, reason}}
+    end
+  end
+
+  defp sha256(bytes), do: :crypto.hash(:sha256, bytes) |> Base.encode16(case: :lower)
+
+  defp put_evidence(_job_id, nil), do: {:ok, nil}
+
+  defp put_evidence(job_id, %{transcript: transcript}),
+    do: ArtifactStore.put(job_id, "bench_transcript.txt", transcript)
+
+  defp evidence_field(nil, _url), do: nil
+
+  defp evidence_field(%{checks: checks}, url),
+    do: %{
+      "bench_transcript_url" => url,
+      "checks" => Enum.map(checks, fn {c, :ok} -> Atom.to_string(c) end)
+    }
+
+  defp report_json(report),
+    do:
+      Jason.encode!(%{"static_checks" => Enum.map(report, fn {c, :ok} -> Atom.to_string(c) end)})
+
+  defp sanitize(job_id), do: String.replace(to_string(job_id), ~r/[^A-Za-z0-9_.-]/, "_")
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/delivery.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/delivery.ex
@@ -70,13 +70,30 @@ defmodule Raxol.ACP.Console.Delivery do
     Enum.reduce_while(files, {:ok, dir}, fn {rel, bytes}, {:ok, dir} ->
       path = Path.join(dir, rel)
 
-      with :ok <- File.mkdir_p(Path.dirname(path)),
-           :ok <- File.write(path, bytes) do
-        {:cont, {:ok, dir}}
-      else
-        {:error, reason} -> {:halt, {:error, {:materialize, rel, reason}}}
+      # Enforce that every key stays inside `dir`. The Generator already
+      # constrains its own keys, but materialize is the actual filesystem write,
+      # so it fails closed on any `..`/absolute path from any source rather than
+      # trusting the caller (defense in depth against a package-slip escape).
+      cond do
+        not safe_rel?(rel) ->
+          {:halt, {:error, {:unsafe_path, rel}}}
+
+        true ->
+          with :ok <- File.mkdir_p(Path.dirname(path)),
+               :ok <- File.write(path, bytes) do
+            {:cont, {:ok, dir}}
+          else
+            {:error, reason} -> {:halt, {:error, {:materialize, rel, reason}}}
+          end
       end
     end)
+  end
+
+  # A package-relative path is safe only when it is a non-empty, relative path
+  # with no `..` segment -- so `Path.join(dir, rel)` can never escape `dir`.
+  defp safe_rel?(rel) do
+    rel = to_string(rel)
+    rel != "" and not String.starts_with?(rel, "/") and ".." not in Path.split(rel)
   end
 
   defp maybe_bench(_dir, %Spec{validation: :package_only}), do: {:ok, nil}

--- a/packages/raxol_acp/lib/raxol/acp/console/generator.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/generator.ex
@@ -1,0 +1,216 @@
+defmodule Raxol.ACP.Console.Generator do
+  @moduledoc """
+  Turns a validated `Raxol.ACP.Console.Spec` into a Console agent package.
+
+  One structured inference call (through `Raxol.ACP.Console.Inference`) returns
+  a JSON envelope; this module parses it, canonicalizes cadences, and assembles
+  the file set the Console's Deploy Instance flow consumes:
+
+      soul.md                       # always
+      AGENTS.md                     # openclaw target only
+      tasks.json                    # scheduled tasks, cron cadences
+      skills/<name>/SKILL.md        # agentskills-format, one per skill
+      deploy_instructions.md        # buyer's three-click redeploy walkthrough
+      manifest.json                 # runtime, file list, generator metadata
+
+  Contract with the model (enforced downstream by `Validator`): the envelope is
+  a single JSON object `{"soul_md", "agents_md"?, "tasks": [{"name",
+  "description", "cron", "prompt"}], "skills": [{"name", "skill_md"}]}` — every
+  task `cron` a valid 5-field expression (NL cadences from the buyer are
+  canonicalized here), every skill a SKILL.md with `name`/`description` YAML
+  frontmatter. A malformed envelope fails delivery with a typed error rather
+  than shipping a broken package; there is deliberately no silent retry loop
+  (SLA discipline — the operator sees `{:generation_*, _}` in telemetry).
+  """
+
+  alias Raxol.ACP.Console.{Inference, Spec}
+
+  @type package :: %{
+          runtime: :hermes | :openclaw,
+          files: %{String.t() => binary()},
+          tasks: [map()]
+        }
+
+  @doc "Generate the package for `spec`, keyed by `job_id` for provenance."
+  @spec generate(Spec.t(), binary()) :: {:ok, package()} | {:error, term()}
+  def generate(%Spec{} = spec, job_id) do
+    runtime = resolve_runtime(spec)
+
+    with {:ok, raw} <- Inference.complete(system_prompt(runtime), user_prompt(spec, runtime)),
+         {:ok, env} <- decode(raw),
+         {:ok, soul} <- fetch_str(env, "soul_md"),
+         {:ok, tasks} <- normalize_tasks(env),
+         {:ok, skills} <- normalize_skills(env) do
+      files =
+        %{"soul.md" => soul}
+        |> put_agents_md(runtime, env)
+        |> Map.put("tasks.json", Jason.encode!(%{"tasks" => tasks}, pretty: true))
+        |> put_skills(skills)
+        |> Map.put("deploy_instructions.md", deploy_instructions(runtime, spec))
+
+      files =
+        Map.put(
+          files,
+          "manifest.json",
+          manifest(runtime, Enum.sort(["manifest.json" | Map.keys(files)]), job_id)
+        )
+
+      {:ok, %{runtime: runtime, files: files, tasks: tasks}}
+    end
+  end
+
+  # `:either` resolves per the requested feature set: OpenClaw when skills are
+  # requested (it ships ACP skills natively), hermes otherwise.
+  defp resolve_runtime(%Spec{runtime: :either, skills: []}), do: :hermes
+  defp resolve_runtime(%Spec{runtime: :either}), do: :openclaw
+  defp resolve_runtime(%Spec{runtime: runtime}), do: runtime
+
+  # -- prompts ---------------------------------------------------------------
+
+  defp system_prompt(runtime) do
+    """
+    You author configuration packages for hosted autonomous agents on the
+    Virtuals Console (runtime: #{runtime}). Respond with ONE JSON object and
+    nothing else — no prose, no code fences. Shape:
+    {"soul_md": string, #{if runtime == :openclaw, do: ~s("agents_md": string, ), else: ""}\
+    "tasks": [{"name": snake_case string, "description": string,
+    "cron": 5-field numeric cron string, "prompt": string}],
+    "skills": [{"name": snake_case string, "skill_md": string}]}
+    soul_md is a markdown document starting with a single `# <Agent Name>` H1,
+    describing identity, purpose, operating boundaries, and tone. Every skill_md
+    starts with YAML frontmatter delimited by `---` lines containing `name:` and
+    `description:`. Cron fields are numeric only (no month/day names). Do not
+    include placeholders like {{...}}, TODO, or FIXME, and never include
+    credentials, private keys, or seed phrases.
+    """
+  end
+
+  defp user_prompt(%Spec{} = spec, runtime) do
+    Jason.encode!(%{
+      "runtime" => runtime,
+      "agent_name" => spec.agent_name,
+      "purpose" => spec.purpose,
+      "persona" => spec.persona,
+      "scheduled_tasks" =>
+        Enum.map(spec.scheduled_tasks, fn t ->
+          %{"description" => t.description, "cadence" => cadence_hint(t.cadence)}
+        end),
+      "skills" => spec.skills,
+      "constraints" => spec.constraints
+    })
+  end
+
+  defp cadence_hint({:cron, c}), do: %{"cron" => c}
+  defp cadence_hint({:nl, text}), do: %{"natural_language" => text}
+
+  # -- envelope handling -----------------------------------------------------
+
+  defp decode(raw) do
+    raw
+    |> String.trim()
+    |> strip_fences()
+    |> Jason.decode()
+    |> case do
+      {:ok, %{} = env} -> {:ok, env}
+      {:ok, other} -> {:error, {:generation_bad_envelope, other}}
+      {:error, err} -> {:error, {:generation_not_json, Exception.message(err)}}
+    end
+  end
+
+  defp strip_fences("```" <> rest) do
+    rest
+    |> String.split("\n", parts: 2)
+    |> List.last()
+    |> String.trim_trailing()
+    |> String.trim_trailing("```")
+  end
+
+  defp strip_fences(raw), do: raw
+
+  defp fetch_str(env, key) do
+    case Map.get(env, key) do
+      v when is_binary(v) and v != "" -> {:ok, v}
+      v -> {:error, {:generation_missing, key, v}}
+    end
+  end
+
+  defp normalize_tasks(env) do
+    env
+    |> Map.get("tasks", [])
+    |> List.wrap()
+    |> Enum.reduce_while({:ok, []}, fn
+      %{"name" => n, "description" => d, "cron" => c, "prompt" => p} = _t, {:ok, acc}
+      when is_binary(n) and is_binary(d) and is_binary(c) and is_binary(p) ->
+        {:cont, {:ok, [%{"name" => n, "description" => d, "cron" => c, "prompt" => p} | acc]}}
+
+      t, _acc ->
+        {:halt, {:error, {:generation_bad_task, t}}}
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      e -> e
+    end
+  end
+
+  defp normalize_skills(env) do
+    env
+    |> Map.get("skills", [])
+    |> List.wrap()
+    |> Enum.reduce_while({:ok, []}, fn
+      %{"name" => n, "skill_md" => md}, {:ok, acc} when is_binary(n) and is_binary(md) ->
+        {:cont, {:ok, [%{"name" => n, "skill_md" => md} | acc]}}
+
+      s, _acc ->
+        {:halt, {:error, {:generation_bad_skill, s}}}
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      e -> e
+    end
+  end
+
+  defp put_agents_md(files, :openclaw, env) do
+    case Map.get(env, "agents_md") do
+      md when is_binary(md) and md != "" -> Map.put(files, "AGENTS.md", md)
+      _ -> files
+    end
+  end
+
+  defp put_agents_md(files, _runtime, _env), do: files
+
+  defp put_skills(files, skills) do
+    Enum.reduce(skills, files, fn %{"name" => name, "skill_md" => md}, acc ->
+      Map.put(acc, "skills/#{name}/SKILL.md", md)
+    end)
+  end
+
+  defp deploy_instructions(runtime, %Spec{} = spec) do
+    """
+    # Deploying this agent to your Virtuals Console
+
+    1. Open your agent in the Console dashboard and choose **Deploy Instance**.
+       Your wallet, signers, ACP identity, and Console agent record are
+       preserved across redeploys.
+    2. Pick the **#{runtime}** runtime.
+    3. Supply `soul.md` from this package as the instance's soul, and configure
+       the scheduled tasks from `tasks.json` (name, cadence, prompt).
+    #{if spec.skills == [], do: "", else: "4. Install the bundled `skills/` folders per your runtime's skill setup.\n"}
+    Everything is editable after deploying. This package was validated on the
+    open-source #{runtime} runtime before delivery; see the evidence link in the
+    job deliverable.
+    """
+  end
+
+  defp manifest(runtime, listed_files, job_id) do
+    Jason.encode!(
+      %{
+        "offering" => "custom_console_agent",
+        "runtime" => runtime,
+        "job_id" => job_id,
+        "files" => listed_files,
+        "generated_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      },
+      pretty: true
+    )
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/generator.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/generator.ex
@@ -25,6 +25,11 @@ defmodule Raxol.ACP.Console.Generator do
 
   alias Raxol.ACP.Console.{Inference, Spec}
 
+  # A skill name becomes a path segment (`skills/<name>/SKILL.md`), so it is
+  # constrained to a safe, single-segment slug -- never `..`, `/`, or absolute.
+  # Untrusted model output (steerable by buyer input) must not choose a file path.
+  @skill_name ~r/^[a-z0-9][a-z0-9_-]{0,63}$/
+
   @type package :: %{
           runtime: :hermes | :openclaw,
           files: %{String.t() => binary()},
@@ -157,8 +162,11 @@ defmodule Raxol.ACP.Console.Generator do
     |> Map.get("skills", [])
     |> List.wrap()
     |> Enum.reduce_while({:ok, []}, fn
-      %{"name" => n, "skill_md" => md}, {:ok, acc} when is_binary(n) and is_binary(md) ->
-        {:cont, {:ok, [%{"name" => n, "skill_md" => md} | acc]}}
+      %{"name" => n, "skill_md" => md}, {:ok, acc}
+      when is_binary(n) and is_binary(md) ->
+        if Regex.match?(@skill_name, n),
+          do: {:cont, {:ok, [%{"name" => n, "skill_md" => md} | acc]}},
+          else: {:halt, {:error, {:generation_unsafe_skill_name, n}}}
 
       s, _acc ->
         {:halt, {:error, {:generation_bad_skill, s}}}

--- a/packages/raxol_acp/lib/raxol/acp/console/inference.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/inference.ex
@@ -1,0 +1,108 @@
+defmodule Raxol.ACP.Console.Inference do
+  @moduledoc """
+  LLM seam for `Raxol.ACP.Console.Generator`.
+
+  The default implementation, `Inference.Compute`, is the wallet-funded
+  Virtuals compute endpoint (OpenAI-compatible chat completions), so the
+  offering's own generation is paid from the agent wallet — no separate API
+  billing. Configure with:
+
+      config :raxol_acp, :console_inference,
+        module: Raxol.ACP.Console.Inference.Compute,
+        base_url: "https://compute.virtuals.io/v1",
+        api_key: {:system, "VIRTUALS_API_KEY"},
+        model: "moonshotai/kimi-k2-0905",
+        receive_timeout: 120_000
+
+  `Inference.Static` is the test stub: it returns
+  `config :raxol_acp, :console_inference_static` verbatim.
+  """
+
+  @callback complete(config :: keyword(), system :: String.t(), user :: String.t()) ::
+              {:ok, String.t()} | {:error, term()}
+
+  @doc "Resolved `:console_inference` config with defaults applied."
+  @spec config() :: keyword()
+  def config do
+    Keyword.merge(
+      [
+        module: __MODULE__.Compute,
+        base_url: "https://compute.virtuals.io/v1",
+        api_key: {:system, "VIRTUALS_API_KEY"},
+        model: "moonshotai/kimi-k2-0905",
+        receive_timeout: 120_000
+      ],
+      Application.get_env(:raxol_acp, :console_inference, [])
+    )
+  end
+
+  @doc "Run a completion through the configured module."
+  @spec complete(String.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def complete(system, user) do
+    cfg = config()
+    cfg[:module].complete(cfg, system, user)
+  end
+
+  defmodule Compute do
+    @moduledoc "OpenAI-compatible chat completions against Virtuals compute."
+    @behaviour Raxol.ACP.Console.Inference
+
+    @impl true
+    def complete(cfg, system, user) do
+      with {:ok, key} <- api_key(cfg[:api_key]) do
+        req =
+          Req.new(
+            base_url: cfg[:base_url],
+            auth: {:bearer, key},
+            receive_timeout: cfg[:receive_timeout]
+          )
+
+        body = %{
+          model: cfg[:model],
+          messages: [
+            %{role: "system", content: system},
+            %{role: "user", content: user}
+          ]
+        }
+
+        case Req.post(req, url: "/chat/completions", json: body) do
+          {:ok, %{status: 200, body: %{"choices" => [%{"message" => %{"content" => c}} | _]}}} ->
+            {:ok, c}
+
+          {:ok, %{status: status, body: body}} ->
+            {:error, {:inference_http, status, summarize(body)}}
+
+          {:error, reason} ->
+            {:error, {:inference_transport, reason}}
+        end
+      end
+    end
+
+    defp api_key({:system, var}) do
+      case System.get_env(var) do
+        nil -> {:error, {:inference_no_api_key, var}}
+        key -> {:ok, key}
+      end
+    end
+
+    defp api_key(key) when is_binary(key), do: {:ok, key}
+    defp api_key(other), do: {:error, {:inference_bad_api_key, other}}
+
+    defp summarize(body) when is_binary(body), do: binary_part(body, 0, min(200, byte_size(body)))
+    defp summarize(body), do: body |> inspect() |> String.slice(0, 200)
+  end
+
+  defmodule Static do
+    @moduledoc "Test stub: returns `config :raxol_acp, :console_inference_static`."
+    @behaviour Raxol.ACP.Console.Inference
+
+    @impl true
+    def complete(_cfg, _system, _user) do
+      case Application.get_env(:raxol_acp, :console_inference_static) do
+        nil -> {:error, :console_inference_static_unset}
+        {:error, _} = e -> e
+        text when is_binary(text) -> {:ok, text}
+      end
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/spec.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/spec.ex
@@ -1,0 +1,221 @@
+defmodule Raxol.ACP.Console.Spec do
+  @moduledoc """
+  Validation + normalization of a `custom_console_agent` buyer requirement.
+
+  `handle_request/2` runs `validate/1` so a malformed or out-of-policy request
+  is rejected *before escrow* with a typed reason (mirroring the launch gate in
+  the Xochi offerings), and `handle_deliver/2` re-runs it so delivery is
+  stateless across restarts/resync — the accepted request map is the only
+  carried state.
+
+  Rejection reasons are `{:invalid_requirement, field, detail}`,
+  `{:denied_purpose, term}`, or (from the offering) `{:bench_unavailable, _}` /
+  `:at_bench_capacity`.
+
+  A light content policy checks `purpose`/`persona` against
+  `config :raxol_acp, :console_deny_terms` (list of downcased substrings,
+  default `[]`).
+  """
+
+  alias Raxol.ACP.Console.Cron
+
+  # String enum <-> atom maps. The atom literals here are interned at compile
+  # time, so the string->atom conversion below never depends on the atom having
+  # been created elsewhere first (a bare `String.to_existing_atom/1` on
+  # "openclaw" would raise if no other module happened to reference it yet).
+  @runtime_atom %{"hermes" => :hermes, "openclaw" => :openclaw, "either" => :either}
+  @validation_atom %{"bench_validated" => :bench_validated, "package_only" => :package_only}
+  @runtimes ~w(hermes openclaw either)
+  @validations ~w(bench_validated package_only)
+  @agent_name ~r/^[a-z][a-z0-9_-]{2,29}$/
+
+  defstruct purpose: nil,
+            runtime: :either,
+            agent_name: nil,
+            persona: nil,
+            scheduled_tasks: [],
+            skills: [],
+            constraints: %{},
+            validation: :bench_validated
+
+  @type cadence :: {:cron, String.t()} | {:nl, String.t()}
+  @type t :: %__MODULE__{
+          purpose: String.t(),
+          runtime: :hermes | :openclaw | :either,
+          agent_name: String.t() | nil,
+          persona: String.t() | nil,
+          scheduled_tasks: [%{description: String.t(), cadence: cadence()}],
+          skills: [String.t()],
+          constraints: map(),
+          validation: :bench_validated | :package_only
+        }
+
+  @doc "Validate and normalize a raw requirement map (string or atom keys)."
+  @spec validate(map()) :: {:ok, t()} | {:error, term()}
+  def validate(req) when is_map(req) do
+    with {:ok, purpose} <- str(req, "purpose", 1, 2000, :required),
+         {:ok, runtime} <- enum(req, "runtime", @runtimes, :required),
+         {:ok, agent_name} <- agent_name(req),
+         {:ok, persona} <- str(req, "persona", 1, 2000, :optional),
+         {:ok, tasks} <- tasks(req),
+         {:ok, skills} <- skills(req),
+         {:ok, constraints} <- constraints(req),
+         {:ok, validation} <- enum(req, "validation", @validations, {:default, "bench_validated"}),
+         :ok <- policy(purpose, persona) do
+      {:ok,
+       %__MODULE__{
+         purpose: purpose,
+         runtime: Map.fetch!(@runtime_atom, runtime),
+         agent_name: agent_name,
+         persona: persona,
+         scheduled_tasks: tasks,
+         skills: skills,
+         constraints: constraints,
+         validation: Map.fetch!(@validation_atom, validation)
+       }}
+    end
+  end
+
+  def validate(other), do: {:error, {:invalid_requirement, :root, {:not_a_map, other}}}
+
+  @doc "The offering's `requirement` JSON Schema (draft-07, string keys)."
+  @spec requirement_schema() :: map()
+  def requirement_schema do
+    %{
+      "$schema" => "http://json-schema.org/draft-07/schema#",
+      "type" => "object",
+      "additionalProperties" => false,
+      "required" => ["purpose", "runtime"],
+      "properties" => %{
+        "purpose" => %{"type" => "string", "minLength" => 1, "maxLength" => 2000},
+        "runtime" => %{"type" => "string", "enum" => @runtimes},
+        "agent_name" => %{"type" => "string", "pattern" => "^[a-z][a-z0-9_-]{2,29}$"},
+        "persona" => %{"type" => "string", "maxLength" => 2000},
+        "scheduled_tasks" => %{
+          "type" => "array",
+          "maxItems" => 5,
+          "items" => %{
+            "type" => "object",
+            "required" => ["description", "cadence"],
+            "additionalProperties" => false,
+            "properties" => %{
+              "description" => %{"type" => "string", "minLength" => 1, "maxLength" => 500},
+              "cadence" => %{
+                "type" => "string",
+                "maxLength" => 100,
+                "description" => "5-field cron, or natural language (canonicalized to cron)"
+              }
+            }
+          }
+        },
+        "skills" => %{
+          "type" => "array",
+          "maxItems" => 10,
+          "items" => %{"type" => "string", "minLength" => 1, "maxLength" => 200}
+        },
+        "constraints" => %{"type" => "object"},
+        "validation" => %{"type" => "string", "enum" => @validations}
+      }
+    }
+  end
+
+  # -- field validators ------------------------------------------------------
+
+  defp get(req, key), do: Map.get(req, key) || Map.get(req, String.to_existing_atom(key))
+
+  defp str(req, key, min, max, mode) do
+    case {get(req, key), mode} do
+      {nil, :required} -> {:error, {:invalid_requirement, key, :missing}}
+      {nil, :optional} -> {:ok, nil}
+      {v, _} when is_binary(v) and byte_size(v) >= min and byte_size(v) <= max -> {:ok, v}
+      {v, _} -> {:error, {:invalid_requirement, key, {:bad_string, v}}}
+    end
+  end
+
+  defp enum(req, key, allowed, mode) do
+    case {get(req, key), mode} do
+      {nil, :required} -> {:error, {:invalid_requirement, key, :missing}}
+      {nil, {:default, d}} -> {:ok, d}
+      {v, _} when is_binary(v) -> if v in allowed, do: {:ok, v}, else: bad_enum(key, v)
+      {v, _} -> bad_enum(key, v)
+    end
+  end
+
+  defp bad_enum(key, v), do: {:error, {:invalid_requirement, key, {:not_in_enum, v}}}
+
+  defp agent_name(req) do
+    case get(req, "agent_name") do
+      nil -> {:ok, nil}
+      v when is_binary(v) -> if v =~ @agent_name, do: {:ok, v}, else: bad(:agent_name, v)
+      v -> bad(:agent_name, v)
+    end
+  end
+
+  defp tasks(req) do
+    case get(req, "scheduled_tasks") do
+      nil ->
+        {:ok, []}
+
+      list when is_list(list) and length(list) <= 5 ->
+        list
+        |> Enum.reduce_while({:ok, []}, fn item, {:ok, acc} ->
+          case task(item) do
+            {:ok, t} -> {:cont, {:ok, [t | acc]}}
+            {:error, _} = e -> {:halt, e}
+          end
+        end)
+        |> case do
+          {:ok, acc} -> {:ok, Enum.reverse(acc)}
+          e -> e
+        end
+
+      v ->
+        bad(:scheduled_tasks, v)
+    end
+  end
+
+  defp task(%{} = item) do
+    with {:ok, desc} <- str(item, "description", 1, 500, :required),
+         {:ok, cad} <- str(item, "cadence", 1, 100, :required) do
+      cadence = if Cron.valid?(cad), do: {:cron, cad}, else: {:nl, cad}
+      {:ok, %{description: desc, cadence: cadence}}
+    end
+  end
+
+  defp task(other), do: bad(:scheduled_tasks, other)
+
+  defp skills(req) do
+    case get(req, "skills") do
+      nil ->
+        {:ok, []}
+
+      list when is_list(list) and length(list) <= 10 ->
+        if Enum.all?(list, &(is_binary(&1) and byte_size(&1) in 1..200)),
+          do: {:ok, list},
+          else: bad(:skills, list)
+
+      v ->
+        bad(:skills, v)
+    end
+  end
+
+  defp constraints(req) do
+    case get(req, "constraints") do
+      nil -> {:ok, %{}}
+      %{} = m -> {:ok, m}
+      v -> bad(:constraints, v)
+    end
+  end
+
+  defp policy(purpose, persona) do
+    deny = Application.get_env(:raxol_acp, :console_deny_terms, [])
+    haystack = String.downcase("#{purpose} #{persona}")
+
+    case Enum.find(deny, &String.contains?(haystack, String.downcase(&1))) do
+      nil -> :ok
+      term -> {:error, {:denied_purpose, term}}
+    end
+  end
+
+  defp bad(field, v), do: {:error, {:invalid_requirement, field, {:invalid, v}}}
+end

--- a/packages/raxol_acp/lib/raxol/acp/console/validator.ex
+++ b/packages/raxol_acp/lib/raxol/acp/console/validator.ex
@@ -1,0 +1,123 @@
+defmodule Raxol.ACP.Console.Validator do
+  @moduledoc """
+  Static validation of a generated Console package, run before the bench and
+  before anything is uploaded or submitted.
+
+  Checks are structural on purpose: the `soul.md` prose format belongs to the
+  runtimes (Virtuals/Nous own it — risk R2 in DESIGN.md §7), so this module
+  asserts invariants that hold across format drift — an H1 title, sane length,
+  no unresolved placeholders, no secret-shaped strings — plus hard contracts we
+  do own: unique task names with valid 5-field cron and non-empty prompts, and
+  agentskills-format frontmatter (`name:` + `description:`) on every SKILL.md.
+
+  Length bounds are overridable via
+  `config :raxol_acp, :console_soul_bytes, {min, max}` (default `{50, 40_000}`).
+  Returns `{:ok, report}` (a `[{check, :ok}]` keyword) or
+  `{:error, {check, detail}}` naming the first failing check.
+  """
+
+  alias Raxol.ACP.Console.Cron
+
+  @placeholder ~r/\{\{|\bTODO\b|\bFIXME\b/
+  @secretish ~r/sk-[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY|\b0x[0-9a-fA-F]{64}\b/
+  @frontmatter ~r/\A---\n(.*?)\n---\n/s
+
+  @checks [:soul, :placeholders, :secrets, :tasks, :skills, :manifest]
+
+  @spec validate(%{
+          :files => %{String.t() => binary()},
+          :tasks => [map()],
+          optional(atom()) => any()
+        }) :: {:ok, keyword()} | {:error, {atom(), term()}}
+  def validate(%{files: files, tasks: tasks}) do
+    Enum.reduce_while(@checks, {:ok, []}, fn check, {:ok, report} ->
+      case run(check, files, tasks) do
+        :ok -> {:cont, {:ok, [{check, :ok} | report]}}
+        {:error, detail} -> {:halt, {:error, {check, detail}}}
+      end
+    end)
+    |> case do
+      {:ok, report} -> {:ok, Enum.reverse(report)}
+      e -> e
+    end
+  end
+
+  defp run(:soul, files, _tasks) do
+    {min, max} = Application.get_env(:raxol_acp, :console_soul_bytes, {50, 40_000})
+
+    case Map.get(files, "soul.md") do
+      nil ->
+        {:error, :missing}
+
+      soul when byte_size(soul) < min ->
+        {:error, {:too_short, byte_size(soul)}}
+
+      soul when byte_size(soul) > max ->
+        {:error, {:too_long, byte_size(soul)}}
+
+      soul ->
+        if soul |> String.trim_leading() |> String.starts_with?("# "),
+          do: :ok,
+          else: {:error, :no_h1_title}
+    end
+  end
+
+  defp run(:placeholders, files, _tasks), do: screen(files, @placeholder, & &1)
+
+  defp run(:secrets, files, _tasks), do: screen(files, @secretish, fn _m -> :redacted end)
+
+  defp run(:tasks, files, tasks) do
+    names = Enum.map(tasks, & &1["name"])
+
+    cond do
+      not Map.has_key?(files, "tasks.json") and tasks != [] ->
+        {:error, :tasks_json_missing}
+
+      names != Enum.uniq(names) ->
+        {:error, {:duplicate_task_names, names -- Enum.uniq(names)}}
+
+      true ->
+        Enum.find_value(tasks, :ok, fn t ->
+          cond do
+            not Cron.valid?(t["cron"]) -> {:error, {:invalid_cron, t["name"], t["cron"]}}
+            String.trim(t["prompt"] || "") == "" -> {:error, {:empty_prompt, t["name"]}}
+            true -> nil
+          end
+        end)
+    end
+  end
+
+  defp run(:skills, files, _tasks) do
+    files
+    |> Enum.filter(fn {path, _} -> String.starts_with?(path, "skills/") end)
+    |> Enum.find_value(:ok, fn {path, md} ->
+      with [_, "SKILL.md"] <- path |> Path.split() |> Enum.take(-2),
+           [_, fm] <- Regex.run(@frontmatter, md),
+           true <- String.contains?(fm, "name:") and String.contains?(fm, "description:") do
+        nil
+      else
+        _ -> {:error, {:bad_skill, path}}
+      end
+    end)
+  end
+
+  defp run(:manifest, files, _tasks) do
+    with manifest when is_binary(manifest) <- Map.get(files, "manifest.json", {:error, :missing}),
+         {:ok, %{"files" => listed}} <- Jason.decode(manifest) do
+      actual = files |> Map.keys() |> Enum.sort()
+      if listed == actual, do: :ok, else: {:error, {:manifest_drift, listed -- actual}}
+    else
+      {:error, :missing} -> {:error, :missing}
+      _ -> {:error, :undecodable}
+    end
+  end
+
+  defp screen(files, regex, redact) do
+    Enum.find_value(files, :ok, fn {path, content} ->
+      case Regex.run(regex, content) do
+        nil -> nil
+        [m | _] -> {:error, {path, redact.(m)}}
+      end
+    end)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
@@ -279,6 +279,21 @@ defmodule Raxol.ACP.JobSession.Provider do
     :ok = Checkpoint.delete(p.checkpoint, ck_key(p, :submit))
   end
 
+  @doc """
+  Notify the offering that an accepted job ended without delivering, so it can
+  free anything reserved at accept time (optional `handle_release/2`). Called by
+  the seller runtime on the reject-after-accept and expiry paths; a no-op when
+  the offering does not implement the callback.
+  """
+  @spec release(t(), map()) :: :ok
+  def release(%__MODULE__{} = p, request) do
+    if function_exported?(p.handler, :handle_release, 2) do
+      _ = p.handler.handle_release(request, ctx(p))
+    end
+
+    :ok
+  end
+
   # -- Internals --
 
   defp finalize_evaluation(p, deliverable, :completed, info) do

--- a/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/provider.ex
@@ -24,10 +24,29 @@ defmodule Raxol.ACP.JobSession.Provider do
   A `Provider` is a plain struct built with `new/1`; its functions are pure
   orchestration over the session and the adapter (no process of its own -- a
   runtime such as the seller `Queue` calls them).
+
+  ## Crash-resume (checkpointing)
+
+  The status guards above make re-drives idempotent while the session process
+  survives. Across a BEAM restart the session is gone, so the guards alone
+  cannot stop a re-driven `deliver` from re-running a (nondeterministic,
+  inference-heavy) handler and submitting a *different* hash than an in-flight
+  first attempt. When a `:checkpoint` store is injected (see
+  `Raxol.ACP.Checkpoint`), `deliver/2` therefore pins the encoded deliverable
+  and its keccak **before** signing, reuses the pinned bytes on any replay, and
+  records the tx hash after the write -- so across a crash at any point exactly
+  one deliverable hash can ever reach the chain, and a duplicate submit of that
+  same hash reverts harmlessly on the phase guard. `accept_request/3` records
+  its `setBudget` tx the same way so an API-lagged resync cannot re-sign it.
+  With `require_checkpoint: true` and no store configured, both fund-adjacent
+  writes fail closed with `{:error, :checkpoint_required}` before invoking the
+  handler. Records use string keys and pre-encoded JSON so they survive
+  JSON-round-tripping stores byte-identically.
   """
 
   alias Raxol.ACP.{AssetToken, HookClient, JobSession}
   alias Raxol.ACP.JobSession.HandlerSeam
+  alias Raxol.Payments.Checkpoint
 
   @enforce_keys [:session, :handler, :adapter, :chain_id, :acp_core_address, :job_id]
   defstruct [
@@ -38,7 +57,8 @@ defmodule Raxol.ACP.JobSession.Provider do
     :acp_core_address,
     :job_id,
     buyer: nil,
-    seller: nil
+    seller: nil,
+    checkpoint: nil
   ]
 
   @type t :: %__MODULE__{
@@ -49,7 +69,8 @@ defmodule Raxol.ACP.JobSession.Provider do
           acp_core_address: String.t(),
           job_id: non_neg_integer(),
           buyer: String.t() | nil,
-          seller: String.t() | nil
+          seller: String.t() | nil,
+          checkpoint: Checkpoint.store() | nil
         }
 
   @type ok(status) ::
@@ -89,30 +110,49 @@ defmodule Raxol.ACP.JobSession.Provider do
     # on-chain event -- a re-accept must not re-invoke the handler or re-write
     # `setBudget`. Only `:open` runs the write.
     case safe_status(p.session) do
-      :open -> do_accept_request(p, request, budget)
+      :open -> accept_from_open(p, request, budget)
       :budget_set -> {:ok, %{status: :budget_set, idempotent: true}}
       other -> {:error, {:cannot_accept, other}}
     end
   end
 
-  defp do_accept_request(p, request, budget) do
-    case HandlerSeam.invoke(p.handler, :request, request, ctx(p)) do
-      {:accept, response} ->
-        with {:ok, tx} <-
-               HookClient.set_budget(
-                 p.adapter,
-                 p.chain_id,
-                 p.acp_core_address,
-                 p.job_id,
-                 budget.raw_amount
-               ),
-             {:ok, :budget_set} <-
-               JobSession.apply_event(p.session, :budget_set, %{tx_hash: tx}) do
-          {:ok, %{status: :budget_set, tx_hash: tx, response: response}}
+  # A rebuilt/lagging session can read `:open` while the `setBudget` tx already
+  # landed pre-crash. The accept checkpoint records the tx after the write; on
+  # a hit we mirror and return instead of re-invoking the handler or re-signing.
+  defp accept_from_open(p, request, budget) do
+    case ck_fetch(p, :accept) do
+      {:ok, %{"tx_hash" => tx}} when is_binary(tx) ->
+        with {:ok, :budget_set} <-
+               JobSession.apply_event(p.session, :budget_set, %{tx_hash: tx, resumed: true}) do
+          {:ok, %{status: :budget_set, tx_hash: tx, resumed: true}}
         end
 
-      {:reject, reason} ->
-        {:rejected, reason}
+      _ ->
+        do_accept_request(p, request, budget)
+    end
+  end
+
+  defp do_accept_request(p, request, budget) do
+    with :ok <- ensure_checkpoint(p) do
+      case HandlerSeam.invoke(p.handler, :request, request, ctx(p)) do
+        {:accept, response} ->
+          with {:ok, tx} <-
+                 HookClient.set_budget(
+                   p.adapter,
+                   p.chain_id,
+                   p.acp_core_address,
+                   p.job_id,
+                   budget.raw_amount
+                 ),
+               :ok = ck_put(p, :accept, %{"tx_hash" => tx}),
+               {:ok, :budget_set} <-
+                 JobSession.apply_event(p.session, :budget_set, %{tx_hash: tx}) do
+            {:ok, %{status: :budget_set, tx_hash: tx, response: response}}
+          end
+
+        {:reject, reason} ->
+          {:rejected, reason}
+      end
     end
   end
 
@@ -148,25 +188,66 @@ defmodule Raxol.ACP.JobSession.Provider do
   end
 
   defp do_deliver(p, request) do
+    with :ok <- ensure_checkpoint(p) do
+      case ck_fetch(p, :submit) do
+        # The write committed pre-crash but the mirror (or the API the session
+        # was rehydrated from) lagged: mirror and return, no handler, no tx.
+        {:ok, %{"tx_hash" => tx} = rec} when is_binary(tx) ->
+          with {:ok, :submitted} <-
+                 JobSession.apply_event(p.session, :submitted, %{tx_hash: tx, resumed: true}) do
+            {:ok, %{status: :submitted, tx_hash: tx, deliverable: pinned(rec), resumed: true}}
+          end
+
+        # The handler ran pre-crash but the write did not commit: reuse the
+        # pinned bytes so the exact same hash is (re)submitted.
+        {:ok, rec} ->
+          sign_submit(p, rec)
+
+        :error ->
+          run_handler_and_submit(p, request)
+      end
+    end
+  end
+
+  defp run_handler_and_submit(p, request) do
     case HandlerSeam.invoke(p.handler, :deliver, request, ctx(p)) do
       {:deliver, deliverable} ->
-        with {:ok, tx} <-
-               HookClient.submit(
-                 p.adapter,
-                 p.chain_id,
-                 p.acp_core_address,
-                 p.job_id,
-                 deliverable_hash(deliverable)
-               ),
-             {:ok, :submitted} <-
-               JobSession.apply_event(p.session, :submitted, %{tx_hash: tx}) do
-          {:ok, %{status: :submitted, tx_hash: tx, deliverable: deliverable}}
-        end
+        json = Jason.encode!(deliverable)
+        hash_hex = json |> ExKeccak.hash_256() |> Base.encode16(case: :lower)
+        rec = %{"deliverable_json" => json, "hash_hex" => hash_hex}
+        # Pin BEFORE signing: from here on, only these bytes can ever be
+        # submitted for this job, however many times we crash and replay.
+        :ok = ck_put(p, :submit, rec)
+        # Return the handler's own deliverable term on the fresh path; a resumed
+        # sign returns the decoded pinned form (the JSON bytes are identical).
+        sign_submit(p, rec, deliverable)
 
       {:error, reason} ->
         {:error, reason}
     end
   end
+
+  # Resume (pinned-but-unsigned) path: only the pinned bytes survived the crash.
+  defp sign_submit(p, %{"deliverable_json" => json} = rec),
+    do: sign_submit(p, rec, Jason.decode!(json))
+
+  defp sign_submit(p, %{"hash_hex" => hash_hex} = rec, deliverable) do
+    with {:ok, tx} <-
+           HookClient.submit(
+             p.adapter,
+             p.chain_id,
+             p.acp_core_address,
+             p.job_id,
+             Base.decode16!(hash_hex, case: :lower)
+           ),
+         :ok = ck_put(p, :submit, Map.put(rec, "tx_hash", tx)),
+         {:ok, :submitted} <-
+           JobSession.apply_event(p.session, :submitted, %{tx_hash: tx}) do
+      {:ok, %{status: :submitted, tx_hash: tx, deliverable: deliverable}}
+    end
+  end
+
+  defp pinned(%{"deliverable_json" => json}), do: Jason.decode!(json)
 
   @doc """
   Evaluate a submitted deliverable, when this provider is also the evaluator.
@@ -187,6 +268,17 @@ defmodule Raxol.ACP.JobSession.Provider do
     end
   end
 
+  @doc """
+  Drop this job's checkpoint records. Call once the job reaches a terminal
+  status through an *external* path (evaluator approval, expiry) -- the
+  `evaluate/2` terminals clean up on their own. Safe with no store configured.
+  """
+  @spec cleanup(t()) :: :ok
+  def cleanup(%__MODULE__{} = p) do
+    :ok = Checkpoint.delete(p.checkpoint, ck_key(p, :accept))
+    :ok = Checkpoint.delete(p.checkpoint, ck_key(p, :submit))
+  end
+
   # -- Internals --
 
   defp finalize_evaluation(p, deliverable, :completed, info) do
@@ -199,6 +291,7 @@ defmodule Raxol.ACP.JobSession.Provider do
              deliverable_hash(deliverable)
            ),
          {:ok, :completed} <- JobSession.apply_event(p.session, :completed, %{tx_hash: tx}) do
+      cleanup(p)
       {:ok, %{status: :completed, tx_hash: tx, info: info}}
     end
   end
@@ -213,9 +306,26 @@ defmodule Raxol.ACP.JobSession.Provider do
              deliverable_hash(deliverable)
            ),
          {:ok, :rejected} <- JobSession.apply_event(p.session, :rejected, %{tx_hash: tx}) do
+      cleanup(p)
       {:ok, %{status: :rejected, tx_hash: tx, info: info}}
     end
   end
+
+  # -- Checkpoint plumbing --
+
+  # Fail closed on fund-adjacent writes: with `require_checkpoint: true` and no
+  # injected store, refuse before invoking the handler or touching the chain.
+  defp ensure_checkpoint(%{checkpoint: nil}) do
+    if Raxol.ACP.Checkpoint.required?(), do: {:error, :checkpoint_required}, else: :ok
+  end
+
+  defp ensure_checkpoint(_p), do: :ok
+
+  defp ck_key(p, step), do: Raxol.ACP.Checkpoint.key(p.chain_id, p.job_id, step)
+
+  defp ck_fetch(p, step), do: Checkpoint.fetch(p.checkpoint, ck_key(p, step))
+
+  defp ck_put(p, step, record), do: Checkpoint.put(p.checkpoint, ck_key(p, step), record)
 
   # Handler ctx: the job id plus the parties and current status, matching the
   # v1 `Job.Server` ctx shape so offering handlers are unchanged.

--- a/packages/raxol_acp/lib/raxol/acp/offering/handler.ex
+++ b/packages/raxol_acp/lib/raxol/acp/offering/handler.ex
@@ -19,6 +19,10 @@ defmodule Raxol.ACP.Offering.Handler do
     `:transaction`); produce the deliverable.
   - `c:handle_evaluate/2` -- *(optional)* used only when this seller
     also acts as evaluator. The default lets the buyer act as evaluator.
+  - `c:handle_release/2` -- *(optional)* the seller runtime calls this when an
+    accepted job ends WITHOUT delivering (rejected after accept, or expired), so
+    the offering can free any resource it reserved at accept time (e.g. a bench
+    slot). Must be idempotent; a delivered job frees its own resources.
 
   Implementing modules typically `use Raxol.ACP.Offering` rather than
   declaring `@behaviour` directly. The DSL injects this behaviour plus
@@ -69,5 +73,7 @@ defmodule Raxol.ACP.Offering.Handler do
   @callback handle_evaluate(deliverable(), ctx()) ::
               {:approve, map()} | {:reject, term()}
 
-  @optional_callbacks handle_evaluate: 2, resolve_accept: 2
+  @callback handle_release(request(), ctx()) :: :ok
+
+  @optional_callbacks handle_evaluate: 2, resolve_accept: 2, handle_release: 2
 end

--- a/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
@@ -204,7 +204,10 @@ defmodule Raxol.ACP.Seller.Queue do
   end
 
   defp handle_event(event, state, _defaults) do
-    drop(Map.get(event, :type), Map.get(event, :job_id), %{}, :malformed, state)
+    # Reached only when `event` has no `:type` key (all typed clauses above are
+    # exhausted), so the type is nil by construction -- pass it explicitly rather
+    # than a `Map.get` the compiler knows can only return nil here.
+    drop(nil, Map.get(event, :job_id), %{}, :malformed, state)
   end
 
   # -- job_offered --

--- a/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
@@ -182,9 +182,12 @@ defmodule Raxol.ACP.Seller.Queue do
   end
 
   defp handle_event(%{type: :job_expired, job_id: job_id} = event, state, _defaults) do
-    with_job(:job_expired, job_id, state, fn %{provider: provider} ->
+    with_job(:job_expired, job_id, state, fn %{provider: provider} = job ->
       reason = Map.get(event, :reason, "expired")
       JobSession.apply_event(provider.session, :expired, %{reason: inspect(reason)})
+      # Free resources reserved at accept (e.g. a bench slot): the job ended
+      # without delivering, so nothing else will release them.
+      Provider.release(provider, Map.get(job, :request, %{}))
       Provider.cleanup(provider)
       _ = dispatched(:job_expired, job_id, state)
       drop_job(state, job_id)
@@ -234,7 +237,11 @@ defmodule Raxol.ACP.Seller.Queue do
                 JobSession.apply_event(session, :expired, %{rejected: reason})
                 drop(:job_offered, job_id, %{offering: name}, {:rejected, reason}, state)
 
+              # The handler accepted (and may have reserved resources) but the
+              # on-chain setBudget failed: release before dropping so an accept
+              # reservation does not leak on a write failure.
               {:error, reason} ->
+                Provider.release(provider, resolved_request)
                 drop(:job_offered, job_id, %{offering: name}, {:handler_error, reason}, state)
             end
 
@@ -262,7 +269,12 @@ defmodule Raxol.ACP.Seller.Queue do
         xochi_config: defaults.xochi_config
       })
     else
-      {:ok, request, AssetToken.usdc(spec.price_usdc, defaults.chain_id)}
+      # An offering with no flat price and no resolve_accept cannot be priced.
+      # Fall back to a zero budget instead of crashing the shared Queue on
+      # `AssetToken.usdc(nil, _)` -- handle_request still runs, so a reject-only
+      # offering rejects cleanly and a nil-price accept surfaces a visible zero
+      # budget rather than taking down job processing for every other offering.
+      {:ok, request, AssetToken.usdc(spec.price_usdc || 0, defaults.chain_id)}
     end
   end
 

--- a/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/queue.ex
@@ -97,6 +97,8 @@ defmodule Raxol.ACP.Seller.Queue do
       seller_address: Application.get_env(:raxol_acp, :seller_address),
       max_active_jobs: Application.get_env(:raxol_acp, :seller_max_active_jobs, 100),
       provider_adapter: Application.get_env(:raxol_acp, :seller_provider_adapter),
+      checkpoint: Raxol.ACP.Checkpoint.store(),
+      job_api: seller_job_api(),
       chain_id: Application.get_env(:raxol_acp, :seller_chain_id, 8453),
       acp_core_address:
         Application.get_env(:raxol_acp, :seller_acp_core_address) ||
@@ -146,7 +148,7 @@ defmodule Raxol.ACP.Seller.Queue do
     end
   end
 
-  defp handle_event(%{type: :payment_received, job_id: job_id} = event, state, _defaults) do
+  defp handle_event(%{type: :payment_received, job_id: job_id} = event, state, defaults) do
     with_job(:payment_received, job_id, state, fn %{provider: provider, request: request} ->
       # Only mirror `:funded` on the actual funding transition. Mirroring it
       # unconditionally would regress an already-`:submitted` session back to
@@ -158,8 +160,12 @@ defmodule Raxol.ACP.Seller.Queue do
       end
 
       case Provider.deliver(provider, request) do
-        {:ok, _} -> dispatched(:payment_received, job_id, state)
-        {:error, reason} -> drop(:payment_received, job_id, %{}, {:handler_error, reason}, state)
+        {:ok, result} ->
+          maybe_post_deliverable(defaults, job_id, result)
+          dispatched(:payment_received, job_id, state)
+
+        {:error, reason} ->
+          drop(:payment_received, job_id, %{}, {:handler_error, reason}, state)
       end
     end)
   end
@@ -169,6 +175,7 @@ defmodule Raxol.ACP.Seller.Queue do
       # External evaluator approved on-chain; mirror the terminal status. The
       # session stops itself; drop our context.
       JobSession.apply_event(provider.session, :completed, %{approval: Map.get(event, :payload)})
+      Provider.cleanup(provider)
       _ = dispatched(:approval_received, job_id, state)
       drop_job(state, job_id)
     end)
@@ -178,6 +185,7 @@ defmodule Raxol.ACP.Seller.Queue do
     with_job(:job_expired, job_id, state, fn %{provider: provider} ->
       reason = Map.get(event, :reason, "expired")
       JobSession.apply_event(provider.session, :expired, %{reason: inspect(reason)})
+      Provider.cleanup(provider)
       _ = dispatched(:job_expired, job_id, state)
       drop_job(state, job_id)
     end)
@@ -206,16 +214,31 @@ defmodule Raxol.ACP.Seller.Queue do
         {:ok, spec} = OfferingRegistry.lookup(name)
         provider = build_provider(session, spec, event, defaults, job_id)
 
-        with {:ok, resolved_request, budget} <- resolve_accept(spec, request, defaults),
-             {:ok, _} <- Provider.accept_request(provider, resolved_request, budget) do
-          emit(:dispatched, %{type: :job_offered, job_id: job_id, offering: name})
-          put_job(state, job_id, %{provider: provider, request: resolved_request})
-        else
-          {:reject, reason} ->
-            JobSession.apply_event(session, :expired, %{rejected: reason})
-            drop(:job_offered, job_id, %{offering: name}, {:rejected, reason}, state)
+        case resolve_accept(spec, request, defaults) do
+          {:ok, resolved_request, budget} ->
+            case Provider.accept_request(provider, resolved_request, budget) do
+              {:ok, _} ->
+                emit(:dispatched, %{type: :job_offered, job_id: job_id, offering: name})
+                put_job(state, job_id, %{provider: provider, request: resolved_request})
 
-          {:rejected, reason} ->
+              # Mid-flight adoption: the session already reflects a later phase
+              # (Queue crash lost its tracking, or a Resync rehydrated the
+              # session), so there is nothing to accept -- but the Queue must
+              # re-track the job so payment / approval / expiry events route to
+              # it instead of dropping `:job_not_running`.
+              {:error, {:cannot_accept, status}} when status in [:funded, :submitted] ->
+                emit(:dispatched, %{type: :job_offered, job_id: job_id, offering: name})
+                put_job(state, job_id, %{provider: provider, request: resolved_request})
+
+              {:rejected, reason} ->
+                JobSession.apply_event(session, :expired, %{rejected: reason})
+                drop(:job_offered, job_id, %{offering: name}, {:rejected, reason}, state)
+
+              {:error, reason} ->
+                drop(:job_offered, job_id, %{offering: name}, {:handler_error, reason}, state)
+            end
+
+          {:reject, reason} ->
             JobSession.apply_event(session, :expired, %{rejected: reason})
             drop(:job_offered, job_id, %{offering: name}, {:rejected, reason}, state)
 
@@ -269,6 +292,7 @@ defmodule Raxol.ACP.Seller.Queue do
       session: session,
       handler: spec.handler,
       adapter: defaults.provider_adapter,
+      checkpoint: defaults.checkpoint,
       chain_id: defaults.chain_id,
       acp_core_address: defaults.acp_core_address,
       job_id: parse_job_id(job_id),
@@ -297,6 +321,33 @@ defmodule Raxol.ACP.Seller.Queue do
   defp within_capacity?(%{max_active_jobs: max}) do
     DynamicSupervisor.count_children(JobSession.Supervisor).active < max
   end
+
+  # Optional off-chain JobApi, built per dispatch from `:seller_job_api_opts`
+  # (forwarded to `Raxol.ACP.JobApi.HTTP.new/1`: `auth:`, `server_url:`,
+  # `chain_ids:`). nil disables OOB deliverable posting here and resync boot
+  # drain in `Raxol.ACP.Seller.Resync`.
+  defp seller_job_api do
+    case Application.get_env(:raxol_acp, :seller_job_api_opts) do
+      nil -> nil
+      opts when is_list(opts) -> Raxol.ACP.JobApi.HTTP.new(opts)
+    end
+  end
+
+  # Post the deliverable body out-of-band so the evaluator can verify it
+  # against the on-chain hash. Best-effort: the submit already committed, so an
+  # OOB failure is telemetry (`:oob_post_failed`), not a dispatch failure --
+  # and a resumed replay carries the same pinned deliverable, so a retry of the
+  # payment event re-posts idempotently.
+  defp maybe_post_deliverable(%{job_api: nil}, _job_id, _result), do: :ok
+
+  defp maybe_post_deliverable(%{job_api: api} = defaults, job_id, %{deliverable: deliverable}) do
+    case Raxol.ACP.JobApi.post_deliverable(api, defaults.chain_id, job_id, deliverable) do
+      :ok -> :ok
+      {:error, reason} -> emit(:oob_post_failed, %{job_id: job_id, reason: reason})
+    end
+  end
+
+  defp maybe_post_deliverable(_defaults, _job_id, _result), do: :ok
 
   defp put_job(state, job_id, ctx), do: %{state | jobs: Map.put(state.jobs, job_id, ctx)}
   defp drop_job(state, job_id), do: %{state | jobs: Map.delete(state.jobs, job_id)}

--- a/packages/raxol_acp/lib/raxol/acp/seller/resync.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/resync.ex
@@ -37,10 +37,12 @@ defmodule Raxol.ACP.Seller.Resync do
   ## Phase mapping
 
   Accepts the v2 names (`open`, `budget_set`, `funded`, `submitted`,
-  `completed`, `rejected`, `expired`), the acp-node-v2 aliases (`request`,
-  `negotiation`, `transaction`, `evaluation`) in any case/camelCase, and the
-  numeric enum 0..6 in that order. Unknown phases skip the job with telemetry
-  rather than acting on a state we do not understand.
+  `completed`, `rejected`, `expired`) and the acp-node-v2 aliases (`request`,
+  `negotiation`, `transaction`, `evaluation`) in any case/camelCase. A numeric
+  phase is skipped, not mapped: the integer enum order is not pinned here, so
+  acting on a guessed mapping could re-drive the wrong phase. Unknown or numeric
+  phases skip the job with telemetry rather than acting on a state we do not
+  understand.
   """
 
   use GenServer
@@ -241,10 +243,13 @@ defmodule Raxol.ACP.Seller.Resync do
     end
   end
 
-  @phase_by_index [:open, :budget_set, :funded, :submitted, :completed, :rejected, :expired]
-
   defp phase(nil), do: {:skip, :no_phase}
-  defp phase(n) when is_integer(n) and n in 0..6, do: {:ok, Enum.at(@phase_by_index, n)}
+
+  # Numeric phases are NOT mapped positionally. The on-chain / API integer enum
+  # order is not pinned in this package, so guessing it risks acting on the wrong
+  # phase (e.g. treating `funded` as `submitted` and re-arming a delivery). Skip
+  # loudly until a dry-run confirms the encoding; string phases are unambiguous.
+  defp phase(n) when is_integer(n), do: {:skip, {:ambiguous_numeric_phase, n}}
 
   defp phase(s) when is_binary(s) do
     case s |> Macro.underscore() |> String.downcase() do

--- a/packages/raxol_acp/lib/raxol/acp/seller/resync.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/resync.ex
@@ -1,0 +1,283 @@
+defmodule Raxol.ACP.Seller.Resync do
+  @moduledoc """
+  Drain-before-act: on seller boot (and after every Backend restart, via
+  `:rest_for_one` ordering), read the authoritative set of in-flight jobs from
+  the ACP job API and reconcile local state to it — rebuilding the
+  `JobSession`s a BEAM restart destroyed and re-enqueueing any delivery the
+  crash interrupted, before live events are acted on.
+
+  This closes the restart half of M1. The `Provider` checkpoints close the
+  step half: a re-enqueued delivery finds the pinned deliverable/tx record and
+  resumes instead of re-doing work or double-submitting (see
+  `Raxol.ACP.JobSession.Provider`).
+
+  ## Mechanism
+
+  Everything flows through the Queue's existing, idempotent dispatch — Resync
+  owns no job state:
+
+  1. `Raxol.ACP.JobApi.get_active_jobs/1` (the API configured by
+     `:seller_job_api_opts`; when unset, resync is disabled and boot proceeds).
+  2. Per job on the seller chain: rehydrate the session with
+     `initial_status:` = the API phase (an already-live session is advanced
+     with `apply_event/3` only if it lags).
+  3. Synthesize `:job_offered` — the Queue re-tracks the job: a still-`:open`
+     job runs the normal accept; `:budget_set` no-ops idempotently; `:funded` /
+     `:submitted` take the Queue's mid-flight adoption path.
+  4. For `:funded`, additionally synthesize `:payment_received` — re-enqueueing
+     the pending delivery.
+  5. Terminal phases only clear any leftover checkpoint records.
+
+  A failed drain emits `[:raxol, :acp, :seller, :resync, :failed]` and does
+  **not** crash the seller tree: inability to reach the API must not stop new
+  live jobs. Job ids are used exactly as the API returns them; the session key
+  must match the form the live backend delivers (verified in the Sepolia
+  dry-run).
+
+  ## Phase mapping
+
+  Accepts the v2 names (`open`, `budget_set`, `funded`, `submitted`,
+  `completed`, `rejected`, `expired`), the acp-node-v2 aliases (`request`,
+  `negotiation`, `transaction`, `evaluation`) in any case/camelCase, and the
+  numeric enum 0..6 in that order. Unknown phases skip the job with telemetry
+  rather than acting on a state we do not understand.
+  """
+
+  use GenServer
+
+  alias Raxol.ACP.{JobApi, JobSession}
+  alias Raxol.ACP.Offering.Registry, as: OfferingRegistry
+  alias Raxol.ACP.Seller.Queue
+
+  @live_phases [:open, :budget_set, :funded, :submitted]
+  @terminal_phases [:completed, :rejected, :expired]
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(opts) do
+    {:ok, %{opts: opts}, {:continue, :resync}}
+  end
+
+  @impl true
+  def handle_continue(:resync, state) do
+    _ = run()
+    {:noreply, state}
+  end
+
+  @doc """
+  Run one drain now. `api` defaults to the Queue's configured
+  `:seller_job_api_opts` API; with none configured this is a no-op `{:ok,
+  :disabled}`. Returns `{:ok, summary}` with per-outcome counts.
+  """
+  @spec run(JobApi.t() | nil) :: {:ok, map() | :disabled} | {:error, term()}
+  def run(api \\ nil) do
+    case api || Queue.defaults().job_api do
+      nil ->
+        {:ok, :disabled}
+
+      api ->
+        case JobApi.get_active_jobs(api) do
+          {:ok, jobs} -> {:ok, reconcile(jobs, Queue.defaults())}
+          {:error, reason} -> failed(reason)
+        end
+    end
+  end
+
+  # -- Reconciliation --
+
+  defp reconcile(jobs, defaults) do
+    summary =
+      Enum.reduce(jobs, %{adopted: 0, redelivered: 0, cleaned: 0, skipped: 0}, fn job, acc ->
+        case normalize(job, defaults) do
+          {:ok, norm} -> reconcile_job(norm, defaults, acc)
+          {:skip, reason} -> skip(job, reason, acc)
+        end
+      end)
+
+    emit(:completed, Map.put(summary, :jobs, length(jobs)))
+    summary
+  end
+
+  defp reconcile_job(%{phase: phase} = norm, defaults, acc) when phase in @terminal_phases do
+    clear_checkpoints(defaults.chain_id, norm.job_id)
+    %{acc | cleaned: acc.cleaned + 1}
+  end
+
+  defp reconcile_job(%{phase: phase} = norm, defaults, acc) when phase in @live_phases do
+    rehydrate_session(defaults.chain_id, norm.job_id, phase)
+
+    Queue.dispatch(%{
+      type: :job_offered,
+      job_id: norm.job_id,
+      offering: norm.offering,
+      request: norm.request,
+      buyer: norm.buyer
+    })
+
+    if phase == :funded do
+      Queue.dispatch(%{type: :payment_received, job_id: norm.job_id, payload: %{resync: true}})
+      %{acc | redelivered: acc.redelivered + 1}
+    else
+      %{acc | adopted: acc.adopted + 1}
+    end
+  end
+
+  # Rebuild the session at the authoritative phase; advance a surviving
+  # session only when it lags (apply_event is an observed transition and
+  # bypasses adjacency, so catching up is always legal).
+  defp rehydrate_session(chain_id, job_id, phase) do
+    case JobSession.Supervisor.start_session(
+           chain_id: chain_id,
+           job_id: job_id,
+           role: :provider,
+           initial_status: phase
+         ) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        advance_if_lagging({chain_id, job_id}, phase)
+
+      {:error, reason} ->
+        emit(:skipped, %{job_id: job_id, reason: {:session_start_failed, reason}})
+        :ok
+    end
+  end
+
+  # The session can stop (terminal) between the API read and this call; a gone
+  # session is fine -- the Queue's own guards handle whatever comes next.
+  defp advance_if_lagging(key, phase) do
+    if JobSession.status(key) != phase, do: JobSession.apply_event(key, phase, %{resync: true})
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp clear_checkpoints(chain_id, job_id) do
+    case Raxol.ACP.Checkpoint.store() do
+      nil ->
+        :ok
+
+      store ->
+        for step <- [:accept, :submit] do
+          Raxol.Payments.Checkpoint.delete(
+            store,
+            Raxol.ACP.Checkpoint.key(chain_id, job_id, step)
+          )
+        end
+
+        :ok
+    end
+  end
+
+  # -- Normalization --
+
+  defp normalize(job, defaults) do
+    with {:ok, job_id} <- field(job, ["id", "jobId", "job_id", "onChainJobId"], :no_job_id),
+         {:ok, phase} <- phase(pick(job, ["phase", "status"])),
+         :ok <- chain_ok(pick(job, ["chainId", "chain_id"]), defaults.chain_id),
+         {:ok, offering} <- offering_name(job) do
+      {:ok,
+       %{
+         job_id: job_id,
+         phase: phase,
+         offering: offering,
+         request: request_of(job),
+         buyer: pick(job, ["clientAddress", "client", "buyer", "buyerAddress"])
+       }}
+    end
+  end
+
+  defp field(job, keys, error) do
+    case pick(job, keys) do
+      nil -> {:skip, error}
+      value -> {:ok, value}
+    end
+  end
+
+  defp pick(job, keys), do: Enum.find_value(keys, &Map.get(job, &1))
+
+  defp chain_ok(nil, _default), do: :ok
+  defp chain_ok(chain, chain), do: :ok
+
+  defp chain_ok(chain, default) when is_binary(chain) do
+    case Integer.parse(chain) do
+      {^default, ""} -> :ok
+      _ -> {:skip, {:other_chain, chain}}
+    end
+  end
+
+  defp chain_ok(chain, _default), do: {:skip, {:other_chain, chain}}
+
+  defp offering_name(job) do
+    named =
+      case pick(job, ["offering", "jobOffering"]) do
+        %{"name" => name} when is_binary(name) -> name
+        name when is_binary(name) -> name
+        _ -> pick(job, ["offeringName", "name"])
+      end
+
+    cond do
+      is_binary(named) and match?({:ok, _}, OfferingRegistry.lookup(named)) -> {:ok, named}
+      is_binary(named) -> {:skip, {:offering_not_registered, named}}
+      true -> sole_registered_offering()
+    end
+  end
+
+  # An unlabelled job is only unambiguous when exactly one offering is live.
+  defp sole_registered_offering do
+    case Raxol.ACP.Seller.Offerings.configured() do
+      [only] -> {:ok, only.offering_name()}
+      _ -> {:skip, :offering_unlabelled}
+    end
+  end
+
+  defp request_of(job) do
+    case pick(job, ["requirement", "serviceRequirement", "request", "memo"]) do
+      %{} = req -> req
+      _ -> %{}
+    end
+  end
+
+  @phase_by_index [:open, :budget_set, :funded, :submitted, :completed, :rejected, :expired]
+
+  defp phase(nil), do: {:skip, :no_phase}
+  defp phase(n) when is_integer(n) and n in 0..6, do: {:ok, Enum.at(@phase_by_index, n)}
+
+  defp phase(s) when is_binary(s) do
+    case s |> Macro.underscore() |> String.downcase() do
+      "open" -> {:ok, :open}
+      "request" -> {:ok, :open}
+      "budget_set" -> {:ok, :budget_set}
+      "negotiation" -> {:ok, :budget_set}
+      "funded" -> {:ok, :funded}
+      "transaction" -> {:ok, :funded}
+      "submitted" -> {:ok, :submitted}
+      "evaluation" -> {:ok, :submitted}
+      "completed" -> {:ok, :completed}
+      "rejected" -> {:ok, :rejected}
+      "expired" -> {:ok, :expired}
+      other -> {:skip, {:unknown_phase, other}}
+    end
+  end
+
+  defp phase(other), do: {:skip, {:unknown_phase, other}}
+
+  # -- Telemetry --
+
+  defp skip(job, reason, acc) do
+    emit(:skipped, %{job_id: Map.get(job, "id"), reason: reason})
+    %{acc | skipped: acc.skipped + 1}
+  end
+
+  defp failed(reason) do
+    emit(:failed, %{reason: reason})
+    {:error, reason}
+  end
+
+  defp emit(suffix, metadata) do
+    :telemetry.execute([:raxol, :acp, :seller, :resync, suffix], %{}, metadata)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/seller/supervisor.ex
+++ b/packages/raxol_acp/lib/raxol/acp/seller/supervisor.ex
@@ -62,13 +62,37 @@ defmodule Raxol.ACP.Seller.Supervisor do
 
     children =
       capacity_gate_children() ++
+        console_children() ++
+        checkpoint_owner_children() ++
         [
           Raxol.ACP.Seller.Queue,
           backend_module,
+          Raxol.ACP.Seller.Resync,
           Raxol.ACP.Seller.Runtime
         ]
 
     Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  # The `{:ets, name}` checkpoint form needs a supervisor-level table owner so
+  # the idempotency records survive Queue/session crashes; started ahead of the
+  # Queue for the same reason as the capacity gate. `Owner.init/1` returns
+  # `:ignore` for other checkpoint configs, so it is safe to gate on shape.
+  defp checkpoint_owner_children do
+    case Application.get_env(:raxol_acp, :checkpoint) do
+      {:ets, _name} -> [Raxol.ACP.Checkpoint.Owner]
+      _ -> []
+    end
+  end
+
+  # Like the capacity gate: the console bench-slot ledger starts ahead of the
+  # Queue so a listener crash never resets in-flight bench reservations. Only
+  # started when the console offering is actually configured, so other sellers
+  # pay nothing for it.
+  defp console_children do
+    if Raxol.ACP.Console.AgentOffering in Raxol.ACP.Seller.Offerings.configured(),
+      do: [Raxol.ACP.Console.BenchSlots],
+      else: []
   end
 
   # The liquidity gate is optional and isolated (its own `:one_for_one`

--- a/packages/raxol_acp/test/raxol/acp/console/delivery_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/console/delivery_test.exs
@@ -91,6 +91,18 @@ defmodule Raxol.ACP.Console.DeliveryTest do
       assert {:reject, {:invalid_requirement, "purpose", :missing}} =
                AgentOffering.handle_request(Map.delete(@request, "purpose"), @ctx)
     end
+
+    test "handle_release frees a reserved bench slot (no leak on non-delivery)" do
+      start_supervised!({BenchSlots, max: 1})
+
+      assert {:accept, _} = AgentOffering.handle_request(@request, @ctx)
+      other = %{@ctx | job_id: "job-console-rel"}
+      assert {:reject, :at_bench_capacity} = AgentOffering.handle_request(@request, other)
+
+      # the accepted job ends without delivering -> release its slot
+      assert :ok = AgentOffering.handle_release(@request, @ctx)
+      assert {:accept, _} = AgentOffering.handle_request(@request, other)
+    end
   end
 
   describe "Delivery.run/2" do
@@ -141,6 +153,27 @@ defmodule Raxol.ACP.Console.DeliveryTest do
     test "a malformed generation envelope blocks delivery" do
       Application.put_env(:raxol_acp, :console_inference_static, "not json at all")
       assert {:error, {:generation_not_json, _}} = Delivery.run(@request, @ctx)
+    end
+
+    test "a skill name that would escape the package dir is rejected before any write" do
+      evil =
+        Jason.encode!(%{
+          "soul_md" =>
+            "# Scout\n\nIdentity: a watcher.\nPurpose: summarize.\nBoundaries: read-only.\n",
+          "agents_md" => "# Agents\n",
+          "tasks" => [],
+          "skills" => [
+            %{
+              "name" => "../../../../etc/evil",
+              "skill_md" => "---\nname: x\ndescription: y\n---\n"
+            }
+          ]
+        })
+
+      Application.put_env(:raxol_acp, :console_inference_static, evil)
+
+      assert {:error, {:generation_unsafe_skill_name, "../../../../etc/evil"}} =
+               Delivery.run(@request, @ctx)
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/console/delivery_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/console/delivery_test.exs
@@ -1,0 +1,146 @@
+defmodule Raxol.ACP.Console.DeliveryTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.Console.{AgentOffering, BenchSlots, Delivery, Inference}
+
+  @ctx %{job_id: "job-console-1", buyer: "0xb", seller: "0xs", state: :open}
+
+  @request %{
+    "purpose" => "Watch my repo and summarize new issues every morning.",
+    "runtime" => "openclaw",
+    "scheduled_tasks" => [%{"description" => "Morning digest", "cadence" => "0 7 * * *"}],
+    "skills" => ["summarize github issues"]
+  }
+
+  @envelope Jason.encode!(%{
+              "soul_md" =>
+                "# Issue Scout\n\nIdentity: a terse repository watcher for one repo.\n" <>
+                  "Purpose: summarize new issues each morning. Boundaries: read-only.\n",
+              "agents_md" => "# Agents\n\nSingle agent: issue scout.\n",
+              "tasks" => [
+                %{
+                  "name" => "morning_digest",
+                  "description" => "Summarize new issues",
+                  "cron" => "0 7 * * *",
+                  "prompt" => "Summarize issues opened in the last 24h."
+                }
+              ],
+              "skills" => [
+                %{
+                  "name" => "issue_summarizer",
+                  "skill_md" =>
+                    "---\nname: issue_summarizer\ndescription: summarizes issues\n---\n\n# Use\n"
+                }
+              ]
+            })
+
+  setup do
+    tmp =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol_console_artifacts_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tmp)
+
+    Application.put_env(:raxol_acp, :console_inference, module: Inference.Static)
+    Application.put_env(:raxol_acp, :console_inference_static, @envelope)
+    Application.put_env(:raxol_acp, :console_bench_module, Raxol.ACP.Console.Bench.Mock)
+
+    Application.put_env(:raxol_acp, :console_artifact_store,
+      module: Raxol.ACP.Console.ArtifactStore.Local,
+      dir: tmp
+    )
+
+    on_exit(fn ->
+      for key <- [
+            :console_inference,
+            :console_inference_static,
+            :console_bench_module,
+            :console_artifact_store,
+            :console_bench_mock
+          ],
+          do: Application.delete_env(:raxol_acp, key)
+
+      File.rm_rf(tmp)
+    end)
+
+    {:ok, tmp: tmp}
+  end
+
+  describe "AgentOffering.handle_request/2 (pre-escrow gate)" do
+    test "rejects fail-closed when the bench-slot ledger is not running" do
+      assert {:reject, :bench_unavailable} = AgentOffering.handle_request(@request, @ctx)
+    end
+
+    test "accepts with a slot, rejects at capacity, package_only bypasses" do
+      start_supervised!({BenchSlots, max: 1})
+
+      assert {:accept, @request} = AgentOffering.handle_request(@request, @ctx)
+      # same job re-offered: idempotent reserve, still accepted
+      assert {:accept, @request} = AgentOffering.handle_request(@request, @ctx)
+
+      other = %{@ctx | job_id: "job-console-2"}
+      assert {:reject, :at_bench_capacity} = AgentOffering.handle_request(@request, other)
+
+      pkg_only = Map.put(@request, "validation", "package_only")
+      assert {:accept, ^pkg_only} = AgentOffering.handle_request(pkg_only, other)
+    end
+
+    test "rejects malformed requirements with a typed reason" do
+      assert {:reject, {:invalid_requirement, "purpose", :missing}} =
+               AgentOffering.handle_request(Map.delete(@request, "purpose"), @ctx)
+    end
+  end
+
+  describe "Delivery.run/2" do
+    test "full bench-validated pipeline yields the deliverable contract", %{tmp: tmp} do
+      start_supervised!({BenchSlots, max: 1})
+      assert :ok = BenchSlots.reserve(@ctx.job_id)
+
+      assert {:deliver, deliverable} = Delivery.run(@request, @ctx)
+
+      assert %{
+               "package_tarball_url" => tar_url,
+               "sha256" => sha,
+               "manifest" => %{"runtime" => "openclaw", "files" => files},
+               "evidence" => %{"checks" => ["boot", "prompt", "task_dry_run"]}
+             } = deliverable
+
+      assert "soul.md" in files and "AGENTS.md" in files and "tasks.json" in files
+      assert "skills/issue_summarizer/SKILL.md" in files
+
+      "file://" <> tar_path = tar_url
+      assert sha == :crypto.hash(:sha256, File.read!(tar_path)) |> Base.encode16(case: :lower)
+
+      # slot released in `after`: a new job can reserve immediately
+      assert :ok = BenchSlots.reserve("job-console-3")
+
+      # replay lands at the same job-deterministic artifact path
+      assert {:deliver, %{"package_tarball_url" => ^tar_url}} = Delivery.run(@request, @ctx)
+      assert File.dir?(Path.join(tmp, @ctx.job_id |> String.replace(~r/[^A-Za-z0-9_.-]/, "_")))
+    end
+
+    test "package_only skips the bench and carries nil evidence" do
+      req = Map.put(@request, "validation", "package_only")
+      assert {:deliver, %{"evidence" => nil}} = Delivery.run(req, @ctx)
+    end
+
+    test "a failing bench blocks delivery with the typed reason" do
+      start_supervised!({BenchSlots, max: 1})
+
+      Application.put_env(
+        :raxol_acp,
+        :console_bench_mock,
+        {:error, {:bench_failed, :boot, 1, ""}}
+      )
+
+      assert {:error, {:bench_failed, :boot, 1, ""}} = Delivery.run(@request, @ctx)
+    end
+
+    test "a malformed generation envelope blocks delivery" do
+      Application.put_env(:raxol_acp, :console_inference_static, "not json at all")
+      assert {:error, {:generation_not_json, _}} = Delivery.run(@request, @ctx)
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/console/spec_validator_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/console/spec_validator_test.exs
@@ -1,0 +1,111 @@
+defmodule Raxol.ACP.Console.SpecValidatorTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.Console.{Cron, Spec, Validator}
+
+  @valid %{
+    "purpose" => "Watch my repo and summarize new issues every morning.",
+    "runtime" => "hermes",
+    "agent_name" => "issue-scout",
+    "scheduled_tasks" => [
+      %{"description" => "Summarize new issues", "cadence" => "0 7 * * *"},
+      %{"description" => "Weekly digest", "cadence" => "every friday afternoon"}
+    ],
+    "skills" => ["summarize github issues"],
+    "constraints" => %{"tone" => "terse"}
+  }
+
+  describe "Cron.valid?/1" do
+    test "accepts *, values, ranges, steps, lists" do
+      for expr <- ["* * * * *", "0 7 * * *", "*/5 0-12 1,15 * 1-5", "0 0 1-31/2 * *"] do
+        assert Cron.valid?(expr), expr
+      end
+    end
+
+    test "rejects wrong arity, out-of-bounds, names, garbage" do
+      for expr <- ["* * * *", "60 * * * *", "* 24 * * *", "0 7 * * mon", "not cron", ""] do
+        refute Cron.valid?(expr), expr
+      end
+    end
+  end
+
+  describe "Spec.validate/1" do
+    test "normalizes a valid request; cron kept, NL flagged for canonicalization" do
+      assert {:ok, %Spec{} = spec} = Spec.validate(@valid)
+      assert spec.runtime == :hermes
+      assert spec.validation == :bench_validated
+      assert [%{cadence: {:cron, "0 7 * * *"}}, %{cadence: {:nl, _}}] = spec.scheduled_tasks
+    end
+
+    test "rejects missing purpose, bad runtime, bad agent_name, oversize task list" do
+      assert {:error, {:invalid_requirement, "purpose", :missing}} =
+               Spec.validate(Map.delete(@valid, "purpose"))
+
+      assert {:error, {:invalid_requirement, "runtime", {:not_in_enum, "raxol"}}} =
+               Spec.validate(%{@valid | "runtime" => "raxol"})
+
+      assert {:error, {:invalid_requirement, :agent_name, _}} =
+               Spec.validate(Map.put(@valid, "agent_name", "Bad Name!"))
+
+      too_many = List.duplicate(%{"description" => "t", "cadence" => "* * * * *"}, 6)
+
+      assert {:error, {:invalid_requirement, :scheduled_tasks, _}} =
+               Spec.validate(Map.put(@valid, "scheduled_tasks", too_many))
+    end
+
+    test "content policy rejects configured deny terms before escrow" do
+      Application.put_env(:raxol_acp, :console_deny_terms, ["clone of"])
+      on_exit(fn -> Application.delete_env(:raxol_acp, :console_deny_terms) end)
+
+      assert {:error, {:denied_purpose, "clone of"}} =
+               Spec.validate(%{@valid | "purpose" => "An exact CLONE OF another agent's soul"})
+    end
+  end
+
+  describe "Validator.validate/1" do
+    defp pkg(files, tasks) do
+      listed = Enum.sort(["manifest.json" | Map.keys(files)])
+      files = Map.put(files, "manifest.json", Jason.encode!(%{"files" => listed}))
+      %{files: files, tasks: tasks}
+    end
+
+    @soul "# Issue Scout\n\nIdentity: a terse repository watcher.\nPurpose: summarize issues.\n"
+    @task %{"name" => "digest", "description" => "d", "cron" => "0 7 * * *", "prompt" => "go"}
+
+    test "passes a well-formed package and reports every check" do
+      files = %{
+        "soul.md" => @soul,
+        "tasks.json" => Jason.encode!(%{"tasks" => [@task]}),
+        "skills/greet/SKILL.md" => "---\nname: greet\ndescription: says hi\n---\n\n# Greet\n"
+      }
+
+      assert {:ok, report} = Validator.validate(pkg(files, [@task]))
+      assert Keyword.keys(report) == [:soul, :placeholders, :secrets, :tasks, :skills, :manifest]
+    end
+
+    test "fails on missing H1, placeholders, secret-shaped strings, bad cron, bad skill" do
+      base = %{"soul.md" => @soul, "tasks.json" => Jason.encode!(%{"tasks" => []})}
+
+      assert {:error, {:soul, :no_h1_title}} =
+               Validator.validate(pkg(%{base | "soul.md" => String.duplicate("plain\n", 20)}, []))
+
+      assert {:error, {:placeholders, {"soul.md", _}}} =
+               Validator.validate(pkg(%{base | "soul.md" => @soul <> "{{agent_name}}"}, []))
+
+      assert {:error, {:secrets, {"soul.md", :redacted}}} =
+               Validator.validate(
+                 pkg(%{base | "soul.md" => @soul <> "key sk-abcdefghijklmnop1234"}, [])
+               )
+
+      bad_task = %{@task | "cron" => "every day"}
+
+      assert {:error, {:tasks, {:invalid_cron, "digest", "every day"}}} =
+               Validator.validate(pkg(base, [bad_task]))
+
+      bad_skill = Map.put(base, "skills/x/SKILL.md", "# no frontmatter\n")
+
+      assert {:error, {:skills, {:bad_skill, "skills/x/SKILL.md"}}} =
+               Validator.validate(pkg(bad_skill, []))
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_session/provider_checkpoint_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/provider_checkpoint_test.exs
@@ -1,0 +1,201 @@
+defmodule Raxol.ACP.JobSession.ProviderCheckpointTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{AssetToken, JobSession}
+  alias Raxol.ACP.JobSession.Provider
+  alias Raxol.ACP.ProviderAdapter.Mock
+  alias Raxol.Payments.Checkpoint
+
+  @chain 84_532
+  @counter :provider_ck_test_counters
+
+  # Deliberately NOT deterministic: every invocation yields different bytes, so
+  # any second handler run would produce a different hash -- exactly what the
+  # checkpoint must make impossible.
+  defmodule Handler do
+    def handle_request(request, _ctx) do
+      :ets.update_counter(:provider_ck_test_counters, :request, 1, {:request, 0})
+      {:accept, request}
+    end
+
+    def handle_deliver(_request, _ctx) do
+      :ets.update_counter(:provider_ck_test_counters, :deliver, 1, {:deliver, 0})
+      {:deliver, %{"payload" => "run-#{System.unique_integer([:positive])}"}}
+    end
+  end
+
+  setup do
+    if :ets.whereis(@counter) == :undefined,
+      do: :ets.new(@counter, [:set, :public, :named_table])
+
+    :ets.insert(@counter, [{:request, 0}, {:deliver, 0}])
+
+    ensure_session_infra()
+
+    job_id = System.unique_integer([:positive])
+    store = Checkpoint.ETS.new()
+    adapter = Mock.new()
+
+    {:ok, job_id: job_id, store: store, adapter: adapter}
+  end
+
+  defp ensure_session_infra do
+    unless Process.whereis(Raxol.ACP.JobSession.Registry) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: Raxol.ACP.JobSession.Registry)
+    end
+
+    unless Process.whereis(Raxol.ACP.JobSession.Supervisor) do
+      start_supervised!(Raxol.ACP.JobSession.Supervisor)
+    end
+  end
+
+  defp provider(ctx, opts \\ []) do
+    Provider.new(
+      session: {@chain, ctx.job_id},
+      handler: Handler,
+      adapter: ctx.adapter,
+      chain_id: @chain,
+      acp_core_address: "0x" <> String.duplicate("ab", 20),
+      job_id: ctx.job_id,
+      checkpoint: Keyword.get(opts, :checkpoint, ctx.store)
+    )
+  end
+
+  defp start_session!(ctx, status) do
+    {:ok, pid} =
+      JobSession.Supervisor.start_session(
+        chain_id: @chain,
+        job_id: ctx.job_id,
+        role: :provider,
+        initial_status: status
+      )
+
+    pid
+  end
+
+  # The Supervisor is transient, so a killed session is auto-restarted with its
+  # original opts (initial_status) -- this IS the BEAM-restart simulation: the
+  # session comes back at the pre-submit phase, and only the checkpoint carries
+  # the fact that the write already landed. Wait for that restart rather than
+  # racing the supervisor with a manual start_session.
+  defp kill_and_restart!(ctx, pid, _status) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+    wait_for_restart(ctx, 50)
+  end
+
+  defp wait_for_restart(ctx, attempts) do
+    JobSession.status({@chain, ctx.job_id})
+  catch
+    :exit, _ when attempts > 0 ->
+      Process.sleep(10)
+      wait_for_restart(ctx, attempts - 1)
+  end
+
+  defp counter(key), do: :ets.lookup_element(@counter, key, 2)
+  defp submits(ctx), do: length(Mock.sent_calls(ctx.adapter))
+  defp ck_key(ctx, step), do: Raxol.ACP.Checkpoint.key(@chain, ctx.job_id, step)
+
+  test "deliver pins encoded deliverable + hash before signing, records tx after", ctx do
+    start_session!(ctx, :funded)
+    p = provider(ctx)
+
+    assert {:ok, %{status: :submitted, tx_hash: tx, deliverable: d}} = Provider.deliver(p, %{})
+    assert counter(:deliver) == 1
+    assert submits(ctx) == 1
+
+    assert {:ok, rec} = Checkpoint.fetch(ctx.store, ck_key(ctx, :submit))
+    assert rec["tx_hash"] == tx
+    assert Jason.decode!(rec["deliverable_json"]) == d
+
+    expected = rec["deliverable_json"] |> ExKeccak.hash_256() |> Base.encode16(case: :lower)
+    assert rec["hash_hex"] == expected
+  end
+
+  test "replay across a dead session resumes the recorded tx: no handler, no second submit",
+       ctx do
+    pid = start_session!(ctx, :funded)
+    p = provider(ctx)
+    assert {:ok, %{tx_hash: tx}} = Provider.deliver(p, %{})
+
+    # BEAM-restart simulation: session gone, rebuilt at the (API-lagged)
+    # pre-submit phase. The checkpoint, not the session, must carry the truth.
+    kill_and_restart!(ctx, pid, :funded)
+
+    assert {:ok, %{status: :submitted, tx_hash: ^tx, resumed: true, deliverable: d}} =
+             Provider.deliver(p, %{})
+
+    assert counter(:deliver) == 1
+    assert submits(ctx) == 1
+    assert is_map(d)
+    assert JobSession.status({@chain, ctx.job_id}) == :submitted
+  end
+
+  test "a pinned-but-unsigned record is submitted verbatim, handler skipped", ctx do
+    start_session!(ctx, :funded)
+    p = provider(ctx)
+
+    json = Jason.encode!(%{"payload" => "pinned-before-crash"})
+    hex = json |> ExKeccak.hash_256() |> Base.encode16(case: :lower)
+
+    :ok =
+      Checkpoint.put(ctx.store, ck_key(ctx, :submit), %{
+        "deliverable_json" => json,
+        "hash_hex" => hex
+      })
+
+    assert {:ok, %{status: :submitted, deliverable: %{"payload" => "pinned-before-crash"}}} =
+             Provider.deliver(p, %{})
+
+    assert counter(:deliver) == 0
+    assert submits(ctx) == 1
+    assert {:ok, %{"tx_hash" => _}} = Checkpoint.fetch(ctx.store, ck_key(ctx, :submit))
+  end
+
+  test "fail-closed: require_checkpoint with no store refuses before the handler", ctx do
+    Application.put_env(:raxol_acp, :require_checkpoint, true)
+    on_exit(fn -> Application.delete_env(:raxol_acp, :require_checkpoint) end)
+
+    start_session!(ctx, :funded)
+    p = provider(ctx, checkpoint: nil)
+
+    assert {:error, :checkpoint_required} = Provider.deliver(p, %{})
+    assert counter(:deliver) == 0
+    assert submits(ctx) == 0
+
+    # accept_request only reaches the checkpoint gate from `:open` (the status
+    # guard fires first on a later phase), so exercise it on its own session.
+    open_ctx = %{ctx | job_id: System.unique_integer([:positive])}
+    start_session!(open_ctx, :open)
+    open_p = provider(open_ctx, checkpoint: nil)
+
+    assert {:error, :checkpoint_required} =
+             Provider.accept_request(open_p, %{}, AssetToken.usdc(Decimal.new(1), @chain))
+
+    assert counter(:request) == 0
+  end
+
+  test "accept resumes a recorded setBudget instead of re-signing", ctx do
+    start_session!(ctx, :open)
+    p = provider(ctx)
+    :ok = Checkpoint.put(ctx.store, ck_key(ctx, :accept), %{"tx_hash" => "0xrecorded"})
+
+    assert {:ok, %{status: :budget_set, tx_hash: "0xrecorded", resumed: true}} =
+             Provider.accept_request(p, %{}, AssetToken.usdc(Decimal.new(1), @chain))
+
+    assert counter(:request) == 0
+    assert submits(ctx) == 0
+    assert JobSession.status({@chain, ctx.job_id}) == :budget_set
+  end
+
+  test "cleanup drops both step records", ctx do
+    start_session!(ctx, :funded)
+    p = provider(ctx)
+    assert {:ok, _} = Provider.deliver(p, %{})
+
+    assert :ok = Provider.cleanup(p)
+    assert :error = Checkpoint.fetch(ctx.store, ck_key(ctx, :submit))
+    assert :error = Checkpoint.fetch(ctx.store, ck_key(ctx, :accept))
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/seller/resync_recovery_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/resync_recovery_test.exs
@@ -204,12 +204,15 @@ defmodule Raxol.ACP.Seller.ResyncRecoveryTest do
     eventually(fn -> status(job) == :gone end)
   end
 
-  test "unknown phases and foreign chains are skipped, not acted on" do
-    assert {:ok, %{skipped: 2, adopted: 0, redelivered: 0}} =
+  test "unknown, numeric, and foreign-chain phases are skipped, not acted on" do
+    # x3 carries a numeric phase: the integer enum order is not pinned, so it is
+    # skipped (fail closed) rather than positionally mapped to a guessed phase.
+    assert {:ok, %{skipped: 3, adopted: 0, redelivered: 0}} =
              Resync.run(
                api([
                  %{"id" => "x1", "phase" => "haggling", "chainId" => @chain},
-                 %{"id" => "x2", "phase" => "funded", "chainId" => 1}
+                 %{"id" => "x2", "phase" => "funded", "chainId" => 1},
+                 %{"id" => "x3", "phase" => 2, "chainId" => @chain}
                ])
              )
   end

--- a/packages/raxol_acp/test/raxol/acp/seller/resync_recovery_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/seller/resync_recovery_test.exs
@@ -1,0 +1,216 @@
+defmodule Raxol.ACP.Seller.ResyncRecoveryTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.JobSession
+  alias Raxol.ACP.ProviderAdapter.Mock
+  alias Raxol.ACP.Seller.{Queue, Resync}
+  alias Raxol.Payments.Checkpoint
+
+  @chain 84_532
+  @counter :resync_test_counters
+
+  defmodule Offering do
+    use Raxol.ACP.Offering,
+      name: "resync_probe",
+      price_usdc: 1,
+      sla_minutes: 5,
+      cluster: "test"
+
+    @impl true
+    def handle_request(request, _ctx), do: {:accept, request}
+
+    @impl true
+    def handle_deliver(_request, _ctx) do
+      :ets.update_counter(:resync_test_counters, :deliver, 1, {:deliver, 0})
+      {:deliver, %{"payload" => "run-#{System.unique_integer([:positive])}"}}
+    end
+  end
+
+  defmodule StubApi do
+    def get_active_jobs(%{config: %{jobs: jobs}}), do: {:ok, jobs}
+  end
+
+  setup do
+    if :ets.whereis(@counter) == :undefined,
+      do: :ets.new(@counter, [:set, :public, :named_table])
+
+    :ets.insert(@counter, {:deliver, 0})
+
+    unless Process.whereis(Raxol.ACP.JobSession.Registry) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: Raxol.ACP.JobSession.Registry)
+    end
+
+    unless Process.whereis(Raxol.ACP.JobSession.Supervisor) do
+      start_supervised!(Raxol.ACP.JobSession.Supervisor)
+    end
+
+    case Offering.register() do
+      {:ok, _} -> :ok
+      {:error, {:already_registered, _}} -> :ok
+    end
+
+    adapter = Mock.new()
+
+    env = [
+      seller_provider_adapter: adapter,
+      seller_chain_id: @chain,
+      seller_address: "0x" <> String.duplicate("cd", 20),
+      checkpoint: {:ets, :resync_test_checkpoint},
+      offerings: [Offering]
+    ]
+
+    for {k, v} <- env, do: Application.put_env(:raxol_acp, k, v)
+    on_exit(fn -> for {k, _} <- env, do: Application.delete_env(:raxol_acp, k) end)
+
+    start_supervised!(Raxol.ACP.Checkpoint.Owner)
+    # The seller Queue is already running (test_helper starts the seller stack);
+    # it reads its defaults from Application on every dispatch, so the env set
+    # above takes effect without recycling the singleton.
+
+    {:ok, adapter: adapter}
+  end
+
+  defp api(jobs), do: %{adapter: StubApi, config: %{jobs: jobs}}
+  defp calls(ctx), do: length(Mock.sent_calls(ctx.adapter))
+  defp deliver_count, do: :ets.lookup_element(@counter, :deliver, 2)
+
+  defp eventually(fun, attempts \\ 100) do
+    if fun.() do
+      :ok
+    else
+      if attempts == 0, do: flunk("condition never became true")
+      Process.sleep(20)
+      eventually(fun, attempts - 1)
+    end
+  end
+
+  defp status(job_id) do
+    JobSession.status({@chain, job_id})
+  catch
+    :exit, _ -> :gone
+  end
+
+  # Simulate a Queue crash: kill the running singleton and let the seller
+  # supervisor (:rest_for_one) restart it with an empty in-memory job map. The
+  # test-owned checkpoint table lives under the test supervisor, so it survives.
+  defp restart_queue! do
+    pid = Process.whereis(Queue)
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, _, _}
+
+    eventually(fn ->
+      case Process.whereis(Queue) do
+        nil -> false
+        new -> new != pid
+      end
+    end)
+  end
+
+  test "kill-and-restart mid-lifecycle: exactly one handler run, one submit, escrow completes",
+       ctx do
+    job = "rj-#{System.unique_integer([:positive])}"
+
+    # live path: offered -> budget_set -> funded -> submitted
+    Queue.dispatch(%{
+      type: :job_offered,
+      job_id: job,
+      offering: "resync_probe",
+      request: %{"p" => 1}
+    })
+
+    eventually(fn -> status(job) == :budget_set end)
+    assert calls(ctx) == 1
+
+    Queue.dispatch(%{type: :payment_received, job_id: job})
+    eventually(fn -> status(job) == :submitted end)
+    assert deliver_count() == 1
+    assert calls(ctx) == 2
+
+    # simulated restart: session killed, Queue restarted with empty job map.
+    # The checkpoint table (supervisor-owned) survives.
+    session_pid = GenServer.whereis(Raxol.ACP.JobSession.Registry.via({@chain, job}))
+    ref = Process.monitor(session_pid)
+    Process.exit(session_pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, _, :killed}
+    restart_queue!()
+
+    # authoritative state still says :funded (submit landed but API lags --
+    # the worst window). Resync rehydrates + re-enqueues the delivery; the
+    # Provider resumes from the pinned record instead of re-submitting.
+    assert {:ok, %{redelivered: 1}} =
+             Resync.run(
+               api([
+                 %{
+                   "id" => job,
+                   "phase" => "funded",
+                   "chainId" => @chain,
+                   "offering" => %{"name" => "resync_probe"},
+                   "requirement" => %{"p" => 1}
+                 }
+               ])
+             )
+
+    eventually(fn -> status(job) == :submitted end)
+    assert deliver_count() == 1
+    assert calls(ctx) == 2
+
+    # external evaluator approval routes through the re-adopted job and
+    # completes it; terminal cleanup drops the checkpoint records.
+    Queue.dispatch(%{type: :approval_received, job_id: job, payload: %{}})
+    eventually(fn -> status(job) == :gone end)
+
+    store = Raxol.ACP.Checkpoint.store()
+    assert :error = Checkpoint.fetch(store, Raxol.ACP.Checkpoint.key(@chain, job, :submit))
+    assert :error = Checkpoint.fetch(store, Raxol.ACP.Checkpoint.key(@chain, job, :accept))
+  end
+
+  test "an :open job resyncs through the normal accept path" do
+    job = "rj-open-#{System.unique_integer([:positive])}"
+
+    assert {:ok, %{adopted: 1}} =
+             Resync.run(
+               api([
+                 %{
+                   "id" => job,
+                   "phase" => "open",
+                   "chainId" => @chain,
+                   "offering" => %{"name" => "resync_probe"}
+                 }
+               ])
+             )
+
+    eventually(fn -> status(job) == :budget_set end)
+  end
+
+  test "a :submitted job is adopted so a later approval still completes it" do
+    job = "rj-sub-#{System.unique_integer([:positive])}"
+
+    assert {:ok, %{adopted: 1}} =
+             Resync.run(
+               api([
+                 %{
+                   "id" => job,
+                   "phase" => "evaluation",
+                   "chainId" => @chain,
+                   "offering" => %{"name" => "resync_probe"}
+                 }
+               ])
+             )
+
+    eventually(fn -> status(job) == :submitted end)
+
+    Queue.dispatch(%{type: :approval_received, job_id: job, payload: %{}})
+    eventually(fn -> status(job) == :gone end)
+  end
+
+  test "unknown phases and foreign chains are skipped, not acted on" do
+    assert {:ok, %{skipped: 2, adopted: 0, redelivered: 0}} =
+             Resync.run(
+               api([
+                 %{"id" => "x1", "phase" => "haggling", "chainId" => @chain},
+                 %{"id" => "x2", "phase" => "funded", "chainId" => 1}
+               ])
+             )
+  end
+end

--- a/packages/raxol_payments/lib/raxol/payments/checkpoint.ex
+++ b/packages/raxol_payments/lib/raxol/payments/checkpoint.ex
@@ -38,13 +38,16 @@ defmodule Raxol.Payments.Checkpoint do
   @type handle :: term()
   @type store :: {module(), handle()}
   @type key :: String.t()
-  @type record :: map()
+  # Named `entry`, not `record`: `record` shadows a dialyzer built-in type, which
+  # makes callers' map patterns/args (e.g. `%{"tx_hash" => _}`) look like they can
+  # never match `record()`. `entry` is a plain map alias with no such collision.
+  @type entry :: map()
 
   @doc "Fetch the record stored under `key`, or `:error` if none."
-  @callback fetch(handle(), key()) :: {:ok, record()} | :error
+  @callback fetch(handle(), key()) :: {:ok, entry()} | :error
 
   @doc "Store `record` under `key`, overwriting any existing record."
-  @callback put(handle(), key(), record()) :: :ok
+  @callback put(handle(), key(), entry()) :: :ok
 
   @doc "Remove any record stored under `key`."
   @callback delete(handle(), key()) :: :ok
@@ -55,12 +58,12 @@ defmodule Raxol.Payments.Checkpoint do
   Returns `:error` when no store is configured (`nil`), so a caller can treat a
   missing checkpoint and a disabled checkpoint identically.
   """
-  @spec fetch(store() | nil, key()) :: {:ok, record()} | :error
+  @spec fetch(store() | nil, key()) :: {:ok, entry()} | :error
   def fetch(nil, _key), do: :error
   def fetch({module, handle}, key) when is_atom(module), do: module.fetch(handle, key)
 
   @doc "Store the in-flight record for `key`. No-op when no store is configured."
-  @spec put(store() | nil, key(), record()) :: :ok
+  @spec put(store() | nil, key(), entry()) :: :ok
   def put(nil, _key, _record), do: :ok
   def put({module, handle}, key, record) when is_atom(module), do: module.put(handle, key, record)
 


### PR DESCRIPTION
## Summary

Adds a second ACP offering, `custom_console_agent`, and the crash-recovery
(durability) layer for the seller stack. The offering sells a validated,
deployment-ready Virtuals Console agent package (soul.md + scheduled tasks for
Hermes or OpenClaw) as a **plain job** (`requiredFunds: false`) — no escrowed
principal, no corridor liquidity. Because its handler is inference-backed and
nondeterministic, the M1 work makes a mid-flight BEAM restart resume rather than
double-submit a different deliverable.

Ported from hand-authored, reviewed-but-never-compiled source; merged carefully
onto `master` (the four touched seller/task files were verified additive
supersets, not wholesale overwrites) and made to compile, pass, and clear the
quality gate.

## What's in it

- **`custom_console_agent` offering** (`Raxol.ACP.Console.*`): spec validation +
  content policy, wallet-funded generation on Virtuals compute, static validation,
  a bench harness that boots the real open-source runtime for evidence, a
  bench-slot capacity gate, artifact storage, and the delivery pipeline.
  `mix acp.register_offering --offering console` emits the marketplace document.
- **Crash-recovery (M1)**: `JobSession.Provider` pins the encoded deliverable +
  keccak in a `Raxol.Payments.Checkpoint` store **before** signing and resumes
  from the pinned bytes on any replay — one deliverable hash per job, ever
  (*exactly-once-effective, at-least-once-attempted*). `Raxol.ACP.Seller.Resync`
  drains `get_active_jobs` on boot/reconnect and re-drives interrupted jobs through
  the Queue's idempotent dispatch; the Queue adopts mid-flight jobs on re-offer and
  posts deliverables out-of-band. `require_checkpoint: true` fails fund-adjacent
  writes closed with no store.
- **Prerequisite type fix** (`raxol_payments`): renames the `Checkpoint` `record`
  type to `entry` (it shadowed a dialyzer built-in). Types only, no runtime change;
  removes a pre-existing compile warning and downstream dialyzer false positives.
- **Config + docs**: `config/console_offering.example.exs`, `RUNBOOK.md`
  (provisioning → funding → registration → live on Base Sepolia), README section.

## Notable fixes made during integration

- Interned `:hermes`/`:openclaw` atoms at compile time (the source relied on
  `String.to_existing_atom/1` and would crash).
- Adapted the tests to the package's harness (the seller `Queue` singleton is
  already started by `test_helper`; a transient-supervisor restart race; a
  fail-closed test that needed an `:open` session for the accept path).
- Preserved existing behaviour: `deliver/2` still returns the handler's own
  deliverable term on the happy path; the on-chain hash is byte-identical.
- Corrected two `@spec`s dialyzer flagged (`Validator.validate/1` closed-map,
  `Delivery.run/2` ctx) and two `list ++ [x]` idioms.

## Manual testing

- [x] `MIX_ENV=test mix test` in `packages/raxol_acp` — **685 passed, 0 failures**
  (+24 new; 661 → 685).
- [x] `packages/raxol_payments` suite — **1062 passed, 0 failures** (checkpoint
  tests included; one conformance file skipped, it needs the external
  `riddler-client` fixture).
- [x] `mix compile --warnings-as-errors` — same warning profile as `master` (my
  changes add zero new warnings).
- [x] `mix format --check-formatted` on all changed files — clean.
- [x] `mix credo --strict` — parity with `master` (no new warnings/readability/
  design issues).
- [x] `mix dialyzer` — 38 → 16 warnings; every warning introduced by this change
  is fixed; the remaining 16 are all pre-existing in untouched files.
- [x] `mix acp.register_offering --offering console` emits a valid marketplace
  doc; `--offering usdc_public` still works (no regression).

## Out of scope

M3 buy-side driver, M4 wallet-funded compute wiring, and the actual funded/network
execution of the Sepolia dry-run (operator-run; the RUNBOOK + example config prep
everything up to that point).
