### PR TITLE
Interactive coding agent (mix raxol.code) with the axol face

### DIFF
--- a/lib/raxol/ui/components/harness/axol_face.ex
+++ b/lib/raxol/ui/components/harness/axol_face.ex
@@ -1,0 +1,141 @@
+defmodule Raxol.UI.Components.Harness.AxolFace do
+  @moduledoc """
+  The axol face `≡··≡` — the harness identity/status layer.
+
+  A fixed four-display-column glyph: the gills (`≡`) are constant, the two
+  eyes carry the agent's state. The face swaps in place, no width jitter,
+  so it can sit in a status strip and never disturb layout.
+
+  ## States
+
+  | State | Cycle | Motif |
+  |---|---|---|
+  | `:boot` | `≡--≡` → `≡··≡` → `≡oo≡` → `≡··≡` | wake blink |
+  | `:idle` | `≡··≡` … `≡--≡` | neutral, slow blink |
+  | `:thinking` | `≡··≡` → `≡''≡` → `≡..≡` | eyes drift |
+  | `:working` | `≡oo≡` → `≡OO≡` | pupils pulse |
+  | `:done` | `≡^^≡` | happy squint |
+  | `:error` | `≡xx≡` | knocked-out eyes |
+
+  The state maps directly from harness contract events (see
+  `Raxol.UI.Components.Harness.AxolFace` usage in the `mix raxol.code`
+  surface): `turn_started` → `:thinking`, tool activity → `:working`,
+  `turn_completed{final}` → `:done`, `error` → `:error`, otherwise
+  `:idle`. Frame advance is event-driven (bump on each `item_delta`) or a
+  subscription tick.
+
+  ## Single source of truth
+
+  `glyph/3` is a pure function of `(state, frame, ascii?)` so every
+  surface — the CLI boot beat, this TUI component, an SSE status line —
+  renders the identical face. `ascii?: true` selects an ASCII-only
+  fallback (gills `=`, ASCII eyes) for terminals without a UTF-8 font;
+  the branded `≡` face is the default (it is single display-width and
+  renders in modern terminals).
+  """
+
+  alias Raxol.UI.Components.Harness.Ids
+  alias Raxol.UI.StyleHelper
+
+  use Raxol.UI.Components.Base.Component
+
+  @type face_state :: :boot | :idle | :thinking | :working | :done | :error
+
+  @type t :: %{
+          id: String.t() | atom(),
+          state: face_state(),
+          frame: non_neg_integer(),
+          ascii: boolean(),
+          style: map(),
+          theme: map()
+        }
+
+  # Branded (≡) faces, one frame list per state. Every entry is exactly four
+  # display columns.
+  @unicode %{
+    boot: ["≡--≡", "≡··≡", "≡oo≡", "≡··≡"],
+    idle: ["≡··≡", "≡··≡", "≡··≡", "≡--≡"],
+    thinking: ["≡··≡", "≡''≡", "≡..≡"],
+    working: ["≡oo≡", "≡OO≡"],
+    done: ["≡^^≡"],
+    error: ["≡xx≡"]
+  }
+
+  # ASCII-only fallback (gills `=`, ASCII eyes). Same four-column discipline.
+  @ascii %{
+    boot: ["=--=", "=..=", "=oo=", "=..="],
+    idle: ["=..=", "=..=", "=..=", "=--="],
+    thinking: ["=..=", "=''=", "=,,="],
+    working: ["=oo=", "=OO="],
+    done: ["=^^="],
+    error: ["=xx="]
+  }
+
+  @states [:boot, :idle, :thinking, :working, :done, :error]
+
+  @doc "The face states, in canonical order."
+  @spec states() :: [face_state()]
+  def states, do: @states
+
+  @doc """
+  The face glyph for `state` at `frame`, ASCII if `ascii?`.
+
+  Pure: the single source of truth shared by every surface. `frame` wraps
+  over the state's cycle length, so any non-negative integer is valid.
+  """
+  @spec glyph(face_state(), non_neg_integer(), boolean()) :: String.t()
+  def glyph(state, frame, ascii? \\ false)
+      when state in @states and is_integer(frame) and frame >= 0 do
+    frames = Map.fetch!(if(ascii?, do: @ascii, else: @unicode), state)
+    Enum.at(frames, rem(frame, length(frames)))
+  end
+
+  @doc "Foreground color for a state's face (nil = terminal default)."
+  @spec color(face_state()) :: atom() | nil
+  def color(:boot), do: :cyan
+  def color(:idle), do: nil
+  def color(:thinking), do: :cyan
+  def color(:working), do: :cyan
+  def color(:done), do: :green
+  def color(:error), do: :red
+
+  @impl true
+  @spec init(keyword()) :: {:ok, t()}
+  def init(props) do
+    state = %{
+      id: Ids.default_id(props, "axol-face"),
+      state: Keyword.get(props, :state, :idle),
+      frame: Keyword.get(props, :frame, 0),
+      ascii: Keyword.get(props, :ascii, false),
+      style: Keyword.get(props, :style, %{}),
+      theme: Keyword.get(props, :theme, %{})
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  @spec render(t(), map()) :: map()
+  def render(state, context) do
+    base_style = StyleHelper.merge_component_styles(state, context, :axol_face)
+
+    %{
+      type: :row,
+      style: base_style,
+      children: [
+        Raxol.View.Components.text(
+          id: "#{state.id}-face",
+          content: glyph(state.state, state.frame, state.ascii),
+          fg: color(state.state),
+          style: face_text_style(state.state)
+        )
+      ]
+    }
+  end
+
+  defp face_text_style(:idle), do: %{dim: true}
+  defp face_text_style(:working), do: %{bold: true}
+  defp face_text_style(:done), do: %{bold: true}
+  defp face_text_style(:error), do: %{bold: true}
+  defp face_text_style(_), do: %{}
+end

--- a/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
@@ -1,0 +1,107 @@
+defmodule Mix.Tasks.Raxol.Code do
+  @shortdoc "Interactive coding agent TUI (the axol face ≡··≡)"
+
+  @moduledoc """
+  An interactive, multi-turn coding assistant in the terminal — the
+  `mix raxol.code` surface, wearing the axol face `≡··≡`.
+
+      mix raxol.code
+      mix raxol.code --harness anthropic --model claude-sonnet-5
+      mix raxol.code --ascii            # ASCII-only face for legacy terminals
+
+  It boots `Raxol.Agent.Code.App`, a TEA app that owns a coding loop over
+  the harness contract: type a prompt, watch the agent stream reasoning,
+  read files, and (with your per-call approval) write files and run shell
+  commands scoped to the current working directory.
+
+  ## Keys
+
+    * type + Enter — send a prompt
+    * `y` / `n`     — answer a tool-approval prompt
+    * Esc           — deny a pending approval, else interrupt the turn
+    * Ctrl+C        — quit
+
+  ## Options
+
+    * `--harness`  — backend harness atom (default `lm_studio`; also
+      `anthropic`, `openai`, `ollama`, ... see `Backend.Selector`)
+    * `--model`    — model override
+    * `--base-url` — override the backend base URL
+    * `--system`   — system prompt override
+    * `--ascii`    — ASCII-only face (no `≡`/`·`)
+  """
+
+  use Mix.Task
+
+  @switches [
+    harness: :string,
+    model: :string,
+    base_url: :string,
+    system: :string,
+    ascii: :boolean
+  ]
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, _args, invalid} = OptionParser.parse(argv, strict: @switches)
+
+    case invalid do
+      [] -> launch(opts)
+      _ -> usage_error("unknown options: #{inspect(invalid)}")
+    end
+  end
+
+  defp launch(opts) do
+    Mix.Task.run("app.start")
+
+    {:ok, pid} = Raxol.start_link(Raxol.Agent.Code.App, app_opts(opts))
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    end
+  end
+
+  defp app_opts(opts) do
+    executor = build_executor(opts)
+
+    backend_opts =
+      []
+      |> maybe_put(:base_url, Keyword.get(opts, :base_url))
+
+    []
+    |> put_if(:executor, executor)
+    |> Keyword.put(:backend_opts, backend_opts)
+    |> put_if(:system, Keyword.get(opts, :system))
+    |> Keyword.put(:ascii, Keyword.get(opts, :ascii, false))
+  end
+
+  defp build_executor(opts) do
+    harness_name = Keyword.get(opts, :harness, "lm_studio")
+    supported = Raxol.Agent.Backend.Selector.supported_harnesses()
+
+    harness =
+      Enum.find(supported, &(Atom.to_string(&1) == harness_name)) ||
+        usage_error(
+          "unknown harness #{inspect(harness_name)}; supported: " <>
+            Enum.map_join(supported, ", ", &Atom.to_string/1)
+        )
+
+    attrs =
+      [harness: harness]
+      |> maybe_put(:model, Keyword.get(opts, :model))
+
+    Raxol.Agent.ExecutorConfig.new(attrs)
+  end
+
+  defp usage_error(message) do
+    IO.puts(:stderr, "raxol.code: #{message}")
+    exit({:shutdown, 64})
+  end
+
+  defp maybe_put(kw, _key, nil), do: kw
+  defp maybe_put(kw, key, value), do: Keyword.put(kw, key, value)
+
+  defp put_if(kw, _key, nil), do: kw
+  defp put_if(kw, key, value), do: Keyword.put(kw, key, value)
+end

--- a/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
@@ -29,7 +29,15 @@ defmodule Mix.Tasks.Raxol.Code do
   ## Slash commands
 
   `/help` · `/clear` · `/model <name>` · `/plan` · `/compact` · `/context`
-  · `/sessions`
+  · `/sessions` · `/mcp` · `/hooks`
+
+  ## Delegation, hooks, external config
+
+  The agent can delegate a focused subtask to a read-only sub-agent via the
+  `task` tool. A `.raxol/hooks.json` in the working directory declares
+  shell commands to run before/after tool calls and at turn end (a
+  non-zero pre-tool hook vetoes the tool). A `.mcp.json` declares external
+  MCP servers, surfaced by `/mcp` (live tool-bridging is a follow-up).
 
   ## Options
 

--- a/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
@@ -15,8 +15,9 @@ defmodule Mix.Tasks.Raxol.Code do
   It boots `Raxol.Agent.Code.App`, a TEA app that owns a coding loop over
   the harness contract: type a prompt, watch the agent stream reasoning,
   read files, and (with your per-call approval) write files and run shell
-  commands scoped to the current working directory. The conversation is
-  persisted per session, so `--continue`/`--resume` reattach it.
+  commands scoped to the current working directory. The conversation and
+  its transcript are persisted per session, so `--continue`/`--resume`
+  restore both the model context and the scrollback.
 
   ## Keys
 

--- a/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
@@ -7,19 +7,29 @@ defmodule Mix.Tasks.Raxol.Code do
 
       mix raxol.code
       mix raxol.code --harness anthropic --model claude-sonnet-5
-      mix raxol.code --ascii            # ASCII-only face for legacy terminals
+      mix raxol.code --continue          # resume the most recent session
+      mix raxol.code --resume sess-123-4  # resume a specific session
+      mix raxol.code --sessions          # list saved sessions and exit
+      mix raxol.code --ascii             # ASCII-only face for legacy terminals
 
   It boots `Raxol.Agent.Code.App`, a TEA app that owns a coding loop over
   the harness contract: type a prompt, watch the agent stream reasoning,
   read files, and (with your per-call approval) write files and run shell
-  commands scoped to the current working directory.
+  commands scoped to the current working directory. The conversation is
+  persisted per session, so `--continue`/`--resume` reattach it.
 
   ## Keys
 
-    * type + Enter — send a prompt
-    * `y` / `n`     — answer a tool-approval prompt
+    * type + Enter — send a prompt (or a `/command`)
+    * `a` / `s` / `d` — answer a tool-approval prompt (once / always / deny)
+    * Shift+Tab / Ctrl+P — toggle plan mode
     * Esc           — deny a pending approval, else interrupt the turn
     * Ctrl+C        — quit
+
+  ## Slash commands
+
+  `/help` · `/clear` · `/model <name>` · `/plan` · `/compact` · `/context`
+  · `/sessions`
 
   ## Options
 
@@ -28,16 +38,24 @@ defmodule Mix.Tasks.Raxol.Code do
     * `--model`    — model override
     * `--base-url` — override the backend base URL
     * `--system`   — system prompt override
+    * `--continue` — resume the most recently updated session
+    * `--resume ID`— resume a specific session by id
+    * `--sessions` — print saved sessions and exit
     * `--ascii`    — ASCII-only face (no `≡`/`·`)
   """
 
   use Mix.Task
+
+  alias Raxol.Agent.Code.Store
 
   @switches [
     harness: :string,
     model: :string,
     base_url: :string,
     system: :string,
+    continue: :boolean,
+    resume: :string,
+    sessions: :boolean,
     ascii: :boolean
   ]
 
@@ -45,9 +63,23 @@ defmodule Mix.Tasks.Raxol.Code do
   def run(argv) do
     {opts, _args, invalid} = OptionParser.parse(argv, strict: @switches)
 
-    case invalid do
-      [] -> launch(opts)
-      _ -> usage_error("unknown options: #{inspect(invalid)}")
+    cond do
+      invalid != [] -> usage_error("unknown options: #{inspect(invalid)}")
+      Keyword.get(opts, :sessions, false) -> print_sessions()
+      true -> launch(opts)
+    end
+  end
+
+  defp print_sessions do
+    dir = Store.default_dir()
+
+    case Store.list(dir) do
+      [] ->
+        IO.puts("no saved sessions in #{dir}")
+
+      sessions ->
+        IO.puts("saved sessions in #{dir}:")
+        Enum.each(sessions, fn s -> IO.puts("  #{s.id}  (#{s.message_count} msgs)") end)
     end
   end
 
@@ -73,7 +105,17 @@ defmodule Mix.Tasks.Raxol.Code do
     |> put_if(:executor, executor)
     |> Keyword.put(:backend_opts, backend_opts)
     |> put_if(:system, Keyword.get(opts, :system))
+    |> put_if(:model, Keyword.get(opts, :model))
+    |> put_if(:session_key, resolve_session(opts))
     |> Keyword.put(:ascii, Keyword.get(opts, :ascii, false))
+  end
+
+  defp resolve_session(opts) do
+    cond do
+      key = Keyword.get(opts, :resume) -> key
+      Keyword.get(opts, :continue, false) -> Store.latest(Store.default_dir())
+      true -> nil
+    end
   end
 
   defp build_executor(opts) do

--- a/packages/raxol_agent/lib/mix/tasks/raxol.p.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.p.ex
@@ -21,8 +21,12 @@ defmodule Mix.Tasks.Raxol.P do
       `item_completed{tool_use/tool_result/message}`, `turn_completed`,
       `error`. `2>events.jsonl` captures a machine-readable trace.
 
-  The agent gets read-only fs tools (`list_dir`, `read_file`, `file_stat`)
-  scoped under the current working directory.
+  The agent gets read-only tools scoped under the current working
+  directory: `list_dir`, `read_file`, `file_stat`, `grep`, `glob`. Pass
+  `--write` to also expose the mutating coding tools (`write_file`,
+  `edit_file`, `bash`) — these are `sensitive` and denied by default, so
+  the flag installs an allow-all tool authorizer for this (unattended)
+  run.
 
   ## Options
 
@@ -32,6 +36,7 @@ defmodule Mix.Tasks.Raxol.P do
     * `--base-url` — override the backend base URL
     * `--system`   — system prompt override
     * `--timeout`  — per-run timeout in seconds (default 180)
+    * `--write`    — expose write_file/edit_file/bash (opt-in; unattended)
     * `--no-tools` — plain completion, no tool loop
 
   ## Exit codes
@@ -52,6 +57,7 @@ defmodule Mix.Tasks.Raxol.P do
     base_url: :string,
     system: :string,
     timeout: :integer,
+    write: :boolean,
     tools: :boolean
   ]
 
@@ -157,13 +163,30 @@ defmodule Mix.Tasks.Raxol.P do
           "files when the question is about them. Be concise."
       )
 
+    write? = Keyword.get(opts, :write, false)
+
     [
       executor: executor,
       backend_opts: backend_opts,
       system_prompt: system,
-      actions: Raxol.Agent.Actions.Fs.all()
-    ]
+      actions: actions_for(write?)
+    ] ++ context_for(write?)
   end
+
+  # Read-only by default (fs read tools + grep/glob). `--write` adds the
+  # mutating coding tools (write_file/edit_file/bash), which are `sensitive`
+  # and denied under the default policy — so it also installs an allow-all
+  # authorizer to actually let them run in this unattended headless flow.
+  defp actions_for(false),
+    do: Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.read_only()
+
+  defp actions_for(true),
+    do: Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.all()
+
+  defp context_for(false), do: []
+
+  defp context_for(true),
+    do: [context: %{tool_authorizer: Raxol.Agent.ToolPolicy.allow_all()}]
 
   defp maybe_put(kw, _key, nil), do: kw
   defp maybe_put(kw, key, value), do: Keyword.put(kw, key, value)

--- a/packages/raxol_agent/lib/raxol/agent/actions/code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/code.ex
@@ -1,0 +1,629 @@
+defmodule Raxol.Agent.Actions.Code do
+  @moduledoc """
+  Mutating, cwd-scoped coding Actions for LLM tool use: `write_file`,
+  `edit_file`, `bash`, `grep`, `glob`.
+
+  These are the write/execute complement to the read-only
+  `Raxol.Agent.Actions.Fs` (`list_dir`/`read_file`/`file_stat`) and the
+  in-memory `Raxol.Agent.Actions.Vfs`. Together they make a ReAct run a
+  real coding agent that touches the actual filesystem the BEAM runs on.
+
+  ## Path discipline
+
+  Every path is expanded relative to the working directory and must stay
+  under it — `../` escapes and absolute paths outside cwd are rejected
+  with `:outside_cwd`. Path safety is shared with `Fs` (`Fs.resolve/1`,
+  `Fs.working_dir/0`); this module never re-implements it.
+
+  ## Gating
+
+  `write_file`, `edit_file`, and `bash` are marked `sensitive: true`, so
+  the default tool-call policy (`Raxol.Agent.ToolPolicy.deny_sensitive/0`)
+  DENIES them unless the run opts in — a prompt-injected model cannot
+  write to disk or run a shell just by emitting the tool call. A surface
+  enables them by installing a `:tool_authorizer` in the run context (an
+  interactive approval prompter, an allowlist, or `allow_all/0` for a
+  trusted operator). `grep` and `glob` are read-only and always allowed.
+
+  `bash` additionally honors a `Raxol.Agent.Sandbox.Shell` placed in the
+  context under `:shell_sandbox`: the command is checked against its
+  allow/deny policy before any process spawns. Absent, the command runs
+  (the `sensitive` gate already guards the LLM path).
+
+  ## Diff-shaped results
+
+  `write_file` and `edit_file` return `%{path, old, new, language}` so the
+  harness contract (`Raxol.Agent.Contract`) renders the change as a
+  foldable diff block rather than an opaque tool row. When either the
+  before or after image exceeds `#{div(32_768, 1024)}KB` the diff is
+  dropped in favor of a compact summary (byte counts) — a large-file
+  write must not blow up the transcript or the model's context.
+  """
+
+  alias Raxol.Agent.Actions.Fs
+
+  # Before/after images larger than this drop the diff for a summary, so a
+  # large-file write never bloats the transcript or the LLM tool-result echo.
+  @max_diff_image_bytes 32_768
+  # Cap for captured shell / read output.
+  @max_output_bytes 65_536
+  # Bound for the pure-Elixir grep fallback's file walk.
+  @grep_max_files_scanned 5_000
+  @grep_pruned_dirs ~w(.git _build deps node_modules .elixir_ls priv/plts)
+
+  defmodule Write do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "write_file",
+      sensitive: true,
+      description:
+        "Create a file (relative to the current working directory) with " <>
+          "the given content. Refuses to clobber an existing file unless " <>
+          "`overwrite` is true — use `edit_file` for targeted changes. " <>
+          "Parent directories are created as needed.",
+      schema: [
+        input: [
+          path: [type: :string, required: true, description: "File to write"],
+          content: [
+            type: :string,
+            required: true,
+            description: "Full file content to write"
+          ],
+          overwrite: [
+            type: :boolean,
+            default: false,
+            description: "Allow replacing an existing file (default false)"
+          ]
+        ],
+        output: [
+          path: [type: :string],
+          old: [type: :string],
+          new: [type: :string],
+          language: [type: :string],
+          created: [type: :boolean]
+        ]
+      ]
+
+    @impl true
+    def run(%{path: path, content: content} = params, _context) do
+      overwrite = Map.get(params, :overwrite, false)
+
+      with {:ok, abs} <- Fs.resolve(path) do
+        exists = File.regular?(abs)
+
+        cond do
+          exists and not overwrite ->
+            {:error, :file_exists}
+
+          true ->
+            old = if exists, do: File.read!(abs), else: ""
+            :ok = File.mkdir_p(Path.dirname(abs))
+
+            case File.write(abs, content) do
+              :ok ->
+                {:ok,
+                 Raxol.Agent.Actions.Code.diff_result(path, old, content, %{
+                   created: not exists
+                 })}
+
+              {:error, reason} ->
+                {:error, reason}
+            end
+        end
+      end
+    end
+  end
+
+  defmodule Edit do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "edit_file",
+      sensitive: true,
+      description:
+        "Replace `old_string` with `new_string` in a file (relative to " <>
+          "the current working directory). `old_string` must match exactly " <>
+          "once unless `replace_all` is true. Returns the before/after diff.",
+      schema: [
+        input: [
+          path: [type: :string, required: true, description: "File to edit"],
+          old_string: [
+            type: :string,
+            required: true,
+            description: "Exact text to replace (must be unique in the file)"
+          ],
+          new_string: [
+            type: :string,
+            required: true,
+            description: "Replacement text"
+          ],
+          replace_all: [
+            type: :boolean,
+            default: false,
+            description: "Replace every occurrence instead of requiring one"
+          ]
+        ],
+        output: [
+          path: [type: :string],
+          old: [type: :string],
+          new: [type: :string],
+          language: [type: :string],
+          replacements: [type: :integer]
+        ]
+      ]
+
+    @impl true
+    def run(%{path: path, old_string: old_string, new_string: new_string} = params, _context) do
+      replace_all = Map.get(params, :replace_all, false)
+
+      with :ok <- reject_noop(old_string, new_string),
+           {:ok, abs} <- Fs.resolve(path),
+           {:ok, content} <- File.read(abs),
+           {:ok, count} <- match_count(content, old_string, replace_all),
+           updated = apply_replacement(content, old_string, new_string, replace_all),
+           :ok <- File.write(abs, updated) do
+        {:ok,
+         Raxol.Agent.Actions.Code.diff_result(path, content, updated, %{
+           replacements: count
+         })}
+      end
+    end
+
+    defp reject_noop(same, same), do: {:error, :no_change}
+    defp reject_noop(_old, _new), do: :ok
+
+    defp match_count(content, old_string, replace_all) do
+      case {count_occurrences(content, old_string), replace_all} do
+        {0, _} -> {:error, :no_match}
+        {n, false} when n > 1 -> {:error, :not_unique}
+        {n, _} -> {:ok, n}
+      end
+    end
+
+    defp count_occurrences(content, needle) do
+      content |> String.split(needle) |> length() |> Kernel.-(1)
+    end
+
+    defp apply_replacement(content, old_string, new_string, true),
+      do: String.replace(content, old_string, new_string)
+
+    defp apply_replacement(content, old_string, new_string, false),
+      do: String.replace(content, old_string, new_string, global: false)
+  end
+
+  defmodule Bash do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "bash",
+      sensitive: true,
+      description:
+        "Run a shell command via `/bin/sh -c` in the current working " <>
+          "directory. Returns combined stdout+stderr and the exit status. " <>
+          "Output is captured (not interactive) and truncated past " <>
+          "#{div(65_536, 1024)}KB.",
+      schema: [
+        input: [
+          command: [
+            type: :string,
+            required: true,
+            description: "Shell command line to execute"
+          ],
+          timeout_ms: [
+            type: :integer,
+            description: "Max runtime in ms (default 30000)"
+          ],
+          cd: [
+            type: :string,
+            description: "Working directory for the command, relative to cwd"
+          ]
+        ],
+        output: [
+          command: [type: :string],
+          stdout: [type: :string],
+          exit_status: [type: :integer],
+          truncated: [type: :boolean]
+        ]
+      ]
+
+    @impl true
+    def run(%{command: command} = params, context) do
+      timeout = Map.get(params, :timeout_ms) || 30_000
+
+      with :ok <- Raxol.Agent.Actions.Code.sandbox_allow(context, command),
+           {:ok, cd} <- resolve_cd(Map.get(params, :cd)) do
+        {output, status} = Raxol.Agent.Actions.Code.run_shell(command, cd, timeout)
+        {truncated, output} = Raxol.Agent.Actions.Code.truncate_output(output)
+
+        {:ok,
+         %{
+           command: command,
+           stdout: output,
+           exit_status: status,
+           truncated: truncated
+         }}
+      end
+    end
+
+    # No `cd` given → run in the working dir. A `cd` must stay under cwd.
+    defp resolve_cd(nil), do: {:ok, Fs.working_dir()}
+    defp resolve_cd(rel), do: Fs.resolve(rel)
+  end
+
+  defmodule Grep do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "grep",
+      description:
+        "Search file contents for a regular expression under a directory " <>
+          "(relative to cwd). Uses ripgrep when available, else a pure " <>
+          "search. Returns matches as {path, line, text}.",
+      schema: [
+        input: [
+          pattern: [
+            type: :string,
+            required: true,
+            description: "Regular expression to search for"
+          ],
+          path: [
+            type: :string,
+            description: "Directory to search under (default \".\")"
+          ],
+          ignore_case: [
+            type: :boolean,
+            default: false,
+            description: "Case-insensitive match"
+          ],
+          max_results: [
+            type: :integer,
+            description: "Cap on returned matches (default 200)"
+          ]
+        ],
+        output: [
+          count: [type: :integer],
+          truncated: [type: :boolean],
+          matches: [type: :list]
+        ]
+      ]
+
+    @impl true
+    def run(%{pattern: pattern} = params, _context) do
+      path = Map.get(params, :path) || "."
+      ignore_case = Map.get(params, :ignore_case, false)
+      max_results = Map.get(params, :max_results) || 200
+
+      with {:ok, abs} <- Fs.resolve(path) do
+        Raxol.Agent.Actions.Code.grep(pattern, abs, ignore_case, max_results)
+      end
+    end
+  end
+
+  defmodule Glob do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "glob",
+      description:
+        "List files matching a wildcard pattern (e.g. \"**/*.ex\"), " <>
+          "relative to the current working directory. Returns cwd-relative " <>
+          "paths, sorted.",
+      schema: [
+        input: [
+          pattern: [
+            type: :string,
+            required: true,
+            description: "Wildcard, e.g. \"lib/**/*.ex\""
+          ],
+          path: [
+            type: :string,
+            description: "Base directory to glob under (default \".\")"
+          ]
+        ],
+        output: [
+          count: [type: :integer],
+          truncated: [type: :boolean],
+          paths: [type: {:list, :string}]
+        ]
+      ]
+
+    @max_paths 500
+
+    @impl true
+    def run(%{pattern: pattern} = params, _context) do
+      base = Map.get(params, :path) || "."
+
+      with {:ok, abs_base} <- Fs.resolve(base) do
+        cwd = Fs.working_dir()
+
+        all =
+          abs_base
+          |> Path.join(pattern)
+          |> Path.wildcard()
+          |> Enum.filter(&under?(&1, cwd))
+          |> Enum.map(&Path.relative_to(&1, cwd))
+          |> Enum.sort()
+
+        {truncated, paths} = cap(all, @max_paths)
+        {:ok, %{paths: paths, count: length(paths), truncated: truncated}}
+      end
+    end
+
+    defp under?(abs, cwd), do: abs == cwd or String.starts_with?(abs, cwd <> "/")
+
+    defp cap(list, max) when length(list) > max, do: {true, Enum.take(list, max)}
+    defp cap(list, _max), do: {false, list}
+  end
+
+  @doc "All coding actions (write/edit/bash + grep/glob), for a ReAct run's `actions:`."
+  @spec all() :: [module()]
+  def all, do: [Write, Edit, Bash, Grep, Glob]
+
+  @doc """
+  The read-only, non-sensitive subset (`grep`, `glob`). Safe to expose
+  without a `:tool_authorizer` opt-in, unlike the mutating actions.
+  """
+  @spec read_only() :: [module()]
+  def read_only, do: [Grep, Glob]
+
+  @doc """
+  Build a diff-shaped `write_file`/`edit_file` result.
+
+  Returns `%{path, old, new, language}` (plus `extra`) when both images
+  are within the diff cap, so the contract renders a diff block. For a
+  large before/after image the diff is dropped for a compact byte-count
+  summary — a big write must not bloat the transcript or the LLM echo.
+  """
+  @spec diff_result(String.t(), String.t(), String.t(), map()) :: map()
+  def diff_result(path, old, new, extra) do
+    base = Map.merge(extra, %{path: path, language: language_for(path)})
+
+    if byte_size(old) <= @max_diff_image_bytes and
+         byte_size(new) <= @max_diff_image_bytes do
+      Map.merge(base, %{old: old, new: new})
+    else
+      Map.merge(base, %{
+        old_bytes: byte_size(old),
+        new_bytes: byte_size(new),
+        truncated: true
+      })
+    end
+  end
+
+  @doc """
+  Check a shell command against a `Raxol.Agent.Sandbox.Shell` in the
+  context under `:shell_sandbox`. Absent → allowed.
+  """
+  @spec sandbox_allow(map(), String.t()) :: :ok | {:error, term()}
+  def sandbox_allow(context, command) do
+    case Map.get(context, :shell_sandbox) do
+      %Raxol.Agent.Sandbox.Shell{} = sandbox ->
+        if Raxol.Agent.Sandbox.Shell.allowed?(sandbox, command),
+          do: :ok,
+          else: {:error, {:shell_denied, command}}
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc false
+  @spec truncate_output(binary()) :: {boolean(), binary()}
+  def truncate_output(output) when byte_size(output) > @max_output_bytes,
+    do: {true, binary_part(output, 0, @max_output_bytes)}
+
+  def truncate_output(output), do: {false, output}
+
+  @doc """
+  Run `command` via `/bin/sh -c` in `cd`, returning `{combined_output,
+  exit_status}`. On timeout the port is closed and `exit_status` is
+  `:timeout`.
+  """
+  @spec run_shell(String.t(), String.t(), pos_integer()) :: {binary(), integer() | :timeout}
+  def run_shell(command, cd, timeout) do
+    port =
+      Port.open({:spawn_executable, "/bin/sh"}, [
+        :binary,
+        :exit_status,
+        :use_stdio,
+        :stderr_to_stdout,
+        {:args, ["-c", command]},
+        {:cd, cd}
+      ])
+
+    collect_port(port, [], timeout)
+  end
+
+  defp collect_port(port, acc, timeout) do
+    receive do
+      {^port, {:data, data}} ->
+        collect_port(port, [data | acc], timeout)
+
+      {^port, {:exit_status, status}} ->
+        {acc |> Enum.reverse() |> IO.iodata_to_binary(), status}
+    after
+      timeout ->
+        Port.close(port)
+        {acc |> Enum.reverse() |> IO.iodata_to_binary(), :timeout}
+    end
+  end
+
+  @doc false
+  @spec grep(String.t(), String.t(), boolean(), pos_integer()) ::
+          {:ok, map()} | {:error, term()}
+  def grep(pattern, abs_dir, ignore_case, max_results) do
+    case System.find_executable("rg") do
+      nil -> grep_native(pattern, abs_dir, ignore_case, max_results)
+      rg -> grep_ripgrep(rg, pattern, abs_dir, ignore_case, max_results)
+    end
+  end
+
+  # ripgrep: fast path. Args are passed as a list (no shell), so the pattern
+  # is never shell-interpreted.
+  defp grep_ripgrep(rg, pattern, abs_dir, ignore_case, max_results) do
+    cwd = Fs.working_dir()
+
+    args =
+      ["--line-number", "--no-heading", "--color=never"] ++
+        if(ignore_case, do: ["--ignore-case"], else: []) ++
+        ["--", pattern, abs_dir]
+
+    case System.cmd(rg, args, stderr_to_stdout: false) do
+      {out, status} when status in [0, 1] ->
+        matches =
+          out
+          |> String.split("\n", trim: true)
+          |> Enum.flat_map(&parse_rg_line(&1, cwd))
+
+        {truncated, capped} = cap_matches(matches, max_results)
+        {:ok, %{matches: capped, count: length(capped), truncated: truncated}}
+
+      {_out, _status} ->
+        # rg failed (e.g. bad regex) — fall back to the native scanner, which
+        # reports a regex compile error as {:error, _} rather than a crash.
+        grep_native(pattern, abs_dir, ignore_case, max_results)
+    end
+  end
+
+  # "path:line:text" → %{path (cwd-relative), line, text}. A path with no
+  # colon or a non-integer line is skipped rather than crashing the fold.
+  defp parse_rg_line(line, cwd) do
+    case String.split(line, ":", parts: 3) do
+      [path, num, text] ->
+        case Integer.parse(num) do
+          {n, ""} -> [%{path: Path.relative_to(path, cwd), line: n, text: text}]
+          _ -> []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp grep_native(pattern, abs_dir, ignore_case, max_results) do
+    opts = if ignore_case, do: [:caseless], else: []
+
+    case Regex.compile(pattern, opts) do
+      {:ok, regex} ->
+        cwd = Fs.working_dir()
+
+        matches =
+          abs_dir
+          |> list_files(@grep_max_files_scanned)
+          |> Enum.flat_map(&scan_file(&1, regex, cwd))
+
+        {truncated, capped} = cap_matches(matches, max_results)
+        {:ok, %{matches: capped, count: length(capped), truncated: truncated}}
+
+      {:error, _} ->
+        {:error, :bad_pattern}
+    end
+  end
+
+  defp scan_file(abs_path, regex, cwd) do
+    case File.read(abs_path) do
+      {:ok, content} ->
+        if String.valid?(content) do
+          rel = Path.relative_to(abs_path, cwd)
+
+          content
+          |> String.split("\n")
+          |> Enum.with_index(1)
+          |> Enum.filter(fn {line, _} -> Regex.match?(regex, line) end)
+          |> Enum.map(fn {line, n} -> %{path: rel, line: n, text: line} end)
+        else
+          []
+        end
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  # Bounded recursive file walk, pruning heavy/build dirs and hidden dirs.
+  defp list_files(root, limit) do
+    root |> do_walk([], limit) |> elem(0) |> Enum.reverse()
+  end
+
+  defp do_walk(_path, acc, 0), do: {acc, 0}
+
+  defp do_walk(path, acc, budget) do
+    cond do
+      File.regular?(path) ->
+        {[path | acc], budget - 1}
+
+      File.dir?(path) and not pruned?(path) ->
+        path
+        |> File.ls()
+        |> case do
+          {:ok, entries} ->
+            Enum.reduce(entries, {acc, budget}, fn entry, {a, b} ->
+              do_walk(Path.join(path, entry), a, b)
+            end)
+
+          {:error, _} ->
+            {acc, budget}
+        end
+
+      true ->
+        {acc, budget}
+    end
+  end
+
+  defp pruned?(path) do
+    base = Path.basename(path)
+    String.starts_with?(base, ".") or base in @grep_pruned_dirs
+  end
+
+  defp cap_matches(list, max) when length(list) > max, do: {true, Enum.take(list, max)}
+  defp cap_matches(list, _max), do: {false, list}
+
+  @doc """
+  Map a file path to a fenced-code language hint from its extension, for
+  the diff block's syntax label. Unknown extensions map to `"text"`.
+  """
+  @spec language_for(String.t()) :: String.t()
+  def language_for(path) do
+    ext = path |> Path.extname() |> String.downcase()
+    base = Path.basename(path)
+
+    cond do
+      Map.has_key?(language_by_ext(), ext) -> Map.fetch!(language_by_ext(), ext)
+      base in ~w(Dockerfile) -> "dockerfile"
+      base in ~w(Makefile) -> "makefile"
+      true -> "text"
+    end
+  end
+
+  defp language_by_ext do
+    %{
+      ".ex" => "elixir",
+      ".exs" => "elixir",
+      ".eex" => "eex",
+      ".heex" => "heex",
+      ".erl" => "erlang",
+      ".js" => "javascript",
+      ".ts" => "typescript",
+      ".tsx" => "tsx",
+      ".jsx" => "jsx",
+      ".json" => "json",
+      ".py" => "python",
+      ".rb" => "ruby",
+      ".go" => "go",
+      ".rs" => "rust",
+      ".c" => "c",
+      ".h" => "c",
+      ".cpp" => "cpp",
+      ".hpp" => "cpp",
+      ".lua" => "lua",
+      ".sh" => "bash",
+      ".bash" => "bash",
+      ".zsh" => "bash",
+      ".sql" => "sql",
+      ".toml" => "toml",
+      ".yaml" => "yaml",
+      ".yml" => "yaml",
+      ".md" => "markdown",
+      ".html" => "html",
+      ".css" => "css",
+      ".nr" => "rust",
+      ".sol" => "solidity"
+    }
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/actions/code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/code.ex
@@ -412,21 +412,28 @@ defmodule Raxol.Agent.Actions.Code do
 
   @doc """
   Run `command` via `/bin/sh -c` in `cd`, returning `{combined_output,
-  exit_status}`. On timeout the port is closed and `exit_status` is
-  `:timeout`.
+  exit_status}`. `env` adds environment variables (`{name, value}`
+  strings). On timeout the port is closed and `exit_status` is `:timeout`.
   """
-  @spec run_shell(String.t(), String.t(), pos_integer()) :: {binary(), integer() | :timeout}
-  def run_shell(command, cd, timeout) do
-    port =
-      Port.open({:spawn_executable, "/bin/sh"}, [
-        :binary,
-        :exit_status,
-        :use_stdio,
-        :stderr_to_stdout,
-        {:args, ["-c", command]},
-        {:cd, cd}
-      ])
+  @spec run_shell(String.t(), String.t(), pos_integer(), [{String.t(), String.t()}]) ::
+          {binary(), integer() | :timeout}
+  def run_shell(command, cd, timeout, env \\ []) do
+    charlist_env =
+      Enum.map(env, fn {k, v} ->
+        {String.to_charlist(to_string(k)), String.to_charlist(to_string(v))}
+      end)
 
+    base = [
+      :binary,
+      :exit_status,
+      :use_stdio,
+      :stderr_to_stdout,
+      {:args, ["-c", command]},
+      {:cd, cd}
+    ]
+
+    port_opts = if charlist_env == [], do: base, else: base ++ [{:env, charlist_env}]
+    port = Port.open({:spawn_executable, "/bin/sh"}, port_opts)
     collect_port(port, [], timeout)
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/actions/code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/code.ex
@@ -89,27 +89,7 @@ defmodule Raxol.Agent.Actions.Code do
       overwrite = Map.get(params, :overwrite, false)
 
       with {:ok, abs} <- Fs.resolve(path) do
-        exists = File.regular?(abs)
-
-        cond do
-          exists and not overwrite ->
-            {:error, :file_exists}
-
-          true ->
-            old = if exists, do: File.read!(abs), else: ""
-            :ok = File.mkdir_p(Path.dirname(abs))
-
-            case File.write(abs, content) do
-              :ok ->
-                {:ok,
-                 Raxol.Agent.Actions.Code.diff_result(path, old, content, %{
-                   created: not exists
-                 })}
-
-              {:error, reason} ->
-                {:error, reason}
-            end
-        end
+        Raxol.Agent.Actions.Code.write_file(abs, path, content, overwrite)
       end
     end
   end
@@ -158,13 +138,14 @@ defmodule Raxol.Agent.Actions.Code do
       with :ok <- reject_noop(old_string, new_string),
            {:ok, abs} <- Fs.resolve(path),
            {:ok, content} <- File.read(abs),
-           {:ok, count} <- match_count(content, old_string, replace_all),
-           updated = apply_replacement(content, old_string, new_string, replace_all),
-           :ok <- File.write(abs, updated) do
-        {:ok,
-         Raxol.Agent.Actions.Code.diff_result(path, content, updated, %{
-           replacements: count
-         })}
+           {:ok, count} <- match_count(content, old_string, replace_all) do
+        Raxol.Agent.Actions.Code.write_edit(
+          abs,
+          path,
+          content,
+          {old_string, new_string, replace_all},
+          count
+        )
       end
     end
 
@@ -182,12 +163,6 @@ defmodule Raxol.Agent.Actions.Code do
     defp count_occurrences(content, needle) do
       content |> String.split(needle) |> length() |> Kernel.-(1)
     end
-
-    defp apply_replacement(content, old_string, new_string, true),
-      do: String.replace(content, old_string, new_string)
-
-    defp apply_replacement(content, old_string, new_string, false),
-      do: String.replace(content, old_string, new_string, global: false)
   end
 
   defmodule Bash do
@@ -355,6 +330,47 @@ defmodule Raxol.Agent.Actions.Code do
   @spec all() :: [module()]
   def all, do: [Write, Edit, Bash, Grep, Glob]
 
+  @doc false
+  @spec write_file(String.t(), String.t(), String.t(), boolean()) ::
+          {:ok, map()} | {:error, term()}
+  def write_file(abs, path, content, overwrite) do
+    exists = File.regular?(abs)
+
+    if exists and not overwrite do
+      {:error, :file_exists}
+    else
+      persist_file(abs, path, content, exists)
+    end
+  end
+
+  defp persist_file(abs, path, content, exists) do
+    old = if exists, do: File.read!(abs), else: ""
+    :ok = File.mkdir_p(Path.dirname(abs))
+
+    case File.write(abs, content) do
+      :ok -> {:ok, diff_result(path, old, content, %{created: not exists})}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec write_edit(
+          String.t(),
+          String.t(),
+          String.t(),
+          {String.t(), String.t(), boolean()},
+          integer()
+        ) ::
+          {:ok, map()} | {:error, term()}
+  def write_edit(abs, path, content, {old_string, new_string, replace_all}, count) do
+    updated = String.replace(content, old_string, new_string, global: replace_all)
+
+    case File.write(abs, updated) do
+      :ok -> {:ok, diff_result(path, content, updated, %{replacements: count})}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @doc """
   The read-only, non-sensitive subset (`grep`, `glob`). Safe to expose
   without a `:tool_authorizer` opt-in, unlike the mutating actions.
@@ -432,7 +448,7 @@ defmodule Raxol.Agent.Actions.Code do
       {:cd, cd}
     ]
 
-    port_opts = if charlist_env == [], do: base, else: base ++ [{:env, charlist_env}]
+    port_opts = if charlist_env == [], do: base, else: [{:env, charlist_env} | base]
     port = Port.open({:spawn_executable, "/bin/sh"}, port_opts)
     collect_port(port, [], timeout)
   end
@@ -525,21 +541,20 @@ defmodule Raxol.Agent.Actions.Code do
 
   defp scan_file(abs_path, regex, cwd) do
     case File.read(abs_path) do
-      {:ok, content} ->
-        if String.valid?(content) do
-          rel = Path.relative_to(abs_path, cwd)
+      {:ok, content} -> scan_content(content, regex, Path.relative_to(abs_path, cwd))
+      {:error, _} -> []
+    end
+  end
 
-          content
-          |> String.split("\n")
-          |> Enum.with_index(1)
-          |> Enum.filter(fn {line, _} -> Regex.match?(regex, line) end)
-          |> Enum.map(fn {line, n} -> %{path: rel, line: n, text: line} end)
-        else
-          []
-        end
-
-      {:error, _} ->
-        []
+  defp scan_content(content, regex, rel) do
+    if String.valid?(content) do
+      content
+      |> String.split("\n")
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {line, _} -> Regex.match?(regex, line) end)
+      |> Enum.map(fn {line, n} -> %{path: rel, line: n, text: line} end)
+    else
+      []
     end
   end
 
@@ -552,23 +567,20 @@ defmodule Raxol.Agent.Actions.Code do
 
   defp do_walk(path, acc, budget) do
     cond do
-      File.regular?(path) ->
-        {[path | acc], budget - 1}
+      File.regular?(path) -> {[path | acc], budget - 1}
+      File.dir?(path) and not pruned?(path) -> walk_dir(path, acc, budget)
+      true -> {acc, budget}
+    end
+  end
 
-      File.dir?(path) and not pruned?(path) ->
-        path
-        |> File.ls()
-        |> case do
-          {:ok, entries} ->
-            Enum.reduce(entries, {acc, budget}, fn entry, {a, b} ->
-              do_walk(Path.join(path, entry), a, b)
-            end)
+  defp walk_dir(path, acc, budget) do
+    case File.ls(path) do
+      {:ok, entries} ->
+        Enum.reduce(entries, {acc, budget}, fn entry, {a, b} ->
+          do_walk(Path.join(path, entry), a, b)
+        end)
 
-          {:error, _} ->
-            {acc, budget}
-        end
-
-      true ->
+      {:error, _} ->
         {acc, budget}
     end
   end

--- a/packages/raxol_agent/lib/raxol/agent/actions/fs.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/fs.ex
@@ -61,35 +61,72 @@ defmodule Raxol.Agent.Actions.Fs do
       name: "read_file",
       description:
         "Read a text file (relative to the current working directory). " <>
-          "Returns at most the first 16KB.",
+          "Optionally read a line range with `offset` (1-based start line) " <>
+          "and `limit` (line count). Returns at most 256KB; `truncated` " <>
+          "flags when the content was longer.",
       schema: [
         input: [
-          path: [type: :string, required: true, description: "File to read"]
+          path: [type: :string, required: true, description: "File to read"],
+          offset: [
+            type: :integer,
+            description: "1-based line to start from (with `limit`)"
+          ],
+          limit: [
+            type: :integer,
+            description: "Number of lines to read from `offset`"
+          ]
         ],
         output: [
           path: [type: :string],
           content: [type: :string],
-          truncated: [type: :boolean]
+          truncated: [type: :boolean],
+          offset: [type: :integer],
+          line_count: [type: :integer]
         ]
       ]
 
-    @max_bytes 16_384
+    @max_bytes 262_144
 
     @impl true
-    def run(%{path: path}, _context) do
+    def run(%{path: path} = params, _context) do
       with {:ok, abs} <- Raxol.Agent.Actions.Fs.resolve(path),
            {:ok, content} <- File.read(abs) do
-        truncated = byte_size(content) > @max_bytes
-
-        {:ok,
-         %{
-           path: path,
-           content: binary_part(content, 0, min(byte_size(content), @max_bytes)),
-           truncated: truncated
-         }}
+        {:ok, slice(path, content, Map.get(params, :offset), Map.get(params, :limit))}
       else
         {:error, reason} -> {:error, reason}
       end
+    end
+
+    # Whole-file read: cap at @max_bytes.
+    defp slice(path, content, nil, nil) do
+      truncated = byte_size(content) > @max_bytes
+
+      %{
+        path: path,
+        content: binary_part(content, 0, min(byte_size(content), @max_bytes)),
+        truncated: truncated,
+        offset: 1,
+        line_count: content |> String.split("\n") |> length()
+      }
+    end
+
+    # Line-range read: 1-based `offset`, optional `limit` lines. A blank
+    # `limit` reads to end of file.
+    defp slice(path, content, offset, limit) do
+      start = max(offset || 1, 1)
+      lines = String.split(content, "\n")
+      dropped = Enum.drop(lines, start - 1)
+      taken = if is_integer(limit), do: Enum.take(dropped, limit), else: dropped
+      text = Enum.join(taken, "\n")
+      truncated = byte_size(text) > @max_bytes
+
+      %{
+        path: path,
+        content: binary_part(text, 0, min(byte_size(text), @max_bytes)),
+        truncated: truncated,
+        offset: start,
+        line_count: length(taken)
+      }
     end
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/actions/task.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/task.ex
@@ -1,0 +1,108 @@
+defmodule Raxol.Agent.Actions.Task do
+  @moduledoc """
+  The `task` Action: delegate a self-contained subtask to a fresh
+  read-only sub-agent and return its final answer.
+
+  A sub-agent is a nested `Raxol.Agent.Stream.react/2` run with its own
+  clean context and a restricted, **read-only** toolset (`list_dir`,
+  `read_file`, `file_stat`, `grep`, `glob`). It deliberately does NOT get
+  `write_file`/`edit_file`/`bash` or the `task` tool itself, so a
+  delegation can neither mutate the workspace nor recurse without bound.
+  The call blocks the parent tool loop until the sub-agent finishes, then
+  hands back a concise result — the same shape Claude Code's Task tool has.
+
+  The sub-agent's backend comes from `context[:subagent]` (a map with
+  `:executor` / `:backend` / `:backend_opts`), injected by the surface
+  running the parent loop, so the sub-agent talks to the same model.
+  """
+
+  alias Raxol.Agent.Actions.Code
+  alias Raxol.Agent.Actions.Fs
+  alias Raxol.Agent.Stream
+
+  @default_max_iterations 6
+
+  defmodule Delegate do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "task",
+      description:
+        "Delegate a self-contained subtask to a fresh read-only sub-agent " <>
+          "and return its final answer. Use for focused investigation " <>
+          "(searching, reading, summarizing across many files) that would " <>
+          "otherwise clutter the main conversation. The sub-agent has no " <>
+          "prior context and cannot write files or run commands — give it " <>
+          "everything it needs in `prompt`.",
+      schema: [
+        input: [
+          prompt: [
+            type: :string,
+            required: true,
+            description: "The self-contained subtask for the sub-agent"
+          ],
+          max_iterations: [
+            type: :integer,
+            description: "Sub-agent tool-loop guard (default 6)"
+          ]
+        ],
+        output: [
+          result: [type: :string]
+        ]
+      ]
+
+    @impl true
+    def run(%{prompt: prompt} = params, context) do
+      Raxol.Agent.Actions.Task.run_subagent(prompt, params, context)
+    end
+  end
+
+  @doc "All Task actions, for a ReAct run's `actions:`."
+  @spec all() :: [module()]
+  def all, do: [Delegate]
+
+  @doc false
+  @spec run_subagent(String.t(), map(), map()) :: {:ok, map()} | {:error, term()}
+  def run_subagent(prompt, params, context) do
+    opts = subagent_opts(params, context)
+
+    prompt
+    |> Stream.react(opts)
+    |> Stream.collect()
+    |> case do
+      {:ok, %{content: content}} when is_binary(content) ->
+        {:ok, %{result: content}}
+
+      {:error, reason} ->
+        {:error, {:subagent_failed, reason}}
+
+      _other ->
+        {:error, :subagent_no_result}
+    end
+  end
+
+  defp subagent_opts(params, context) do
+    sub = Map.get(context, :subagent, %{})
+
+    [
+      actions: Fs.all() ++ Code.read_only(),
+      max_iterations: Map.get(params, :max_iterations, @default_max_iterations),
+      system_prompt: subagent_system(),
+      # A clean context: read-only tools only, default deny_sensitive, and no
+      # human-in-the-loop authorizer (a sub-agent must never surface a prompt).
+      context: %{}
+    ]
+    |> maybe_put(:executor, Map.get(sub, :executor))
+    |> maybe_put(:backend, Map.get(sub, :backend))
+    |> maybe_put(:backend_opts, Map.get(sub, :backend_opts))
+    |> maybe_put(:model, Map.get(sub, :model))
+  end
+
+  defp subagent_system do
+    "You are a focused sub-agent with read-only tools. Complete the given " <>
+      "task by inspecting files, then reply with a concise, self-contained " <>
+      "result. Do not ask questions — you have no way to receive answers."
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -1,0 +1,424 @@
+defmodule Raxol.Agent.Code.App do
+  @moduledoc """
+  Interactive coding-agent TUI — the `mix raxol.code` surface.
+
+  A TEA app (`use Raxol.Core.Runtime.Application`) that owns a multi-turn
+  coding loop and wears the axol face `≡··≡` as its status layer. It is a
+  *thin Lifecycle shell*: it drives the loop itself but reuses the harness
+  rendering pieces rather than reinventing them —
+  `Raxol.Harness.Projection` folds contract events into blocks and
+  `Raxol.UI.Components.Harness.Block` renders them; the face comes from
+  `Raxol.UI.Components.Harness.AxolFace`.
+
+  ## The loop
+
+  On submit, `update/2` spawns a worker that subscribes to a
+  `Raxol.Agent.SessionStreamer` session, runs `Raxol.Agent.Stream.react/2`
+  through `Raxol.Agent.Contract.pump/3`, and relays every contract event
+  back to this app as `{:command_result, {:contract_event, event}}`. The
+  Dispatcher routes those to `update/2`, which normalizes them
+  (`Raxol.Harness.EventBoundary.normalize/1`) and appends them to the
+  projection source. Because `update/2` runs in the Dispatcher process,
+  the worker's `send(app, ...)` lands where the app can fold it.
+
+  ## Tools and approval
+
+  The agent gets the read-only fs tools plus the mutating coding tools
+  (`write_file`/`edit_file`/`bash`), which are `sensitive`. A per-run
+  `:tool_authorizer` gates each sensitive call through an interactive
+  prompt: it sends `{:approval_request, ...}` to this app and BLOCKS the
+  react loop's process until the user answers `y`/`n`, so a write or a
+  shell command never runs unattended.
+
+  ## Keys
+
+    * printable text → prompt buffer (when idle)
+    * Enter → submit the prompt / (when a tool is awaiting) ignored
+    * `y` / `n` → answer a pending approval
+    * Esc → deny a pending approval, else interrupt a running turn
+    * Ctrl+C → quit
+  """
+
+  use Raxol.Core.Runtime.Application
+
+  alias Raxol.Agent.Contract
+  alias Raxol.Agent.SessionStreamer
+  alias Raxol.Harness.EventBoundary
+  alias Raxol.Harness.Projection
+  alias Raxol.UI.Components.Harness.AxolFace
+  alias Raxol.UI.Components.Harness.Block
+  alias Raxol.UI.Harness.InputEvent
+
+  @approval_timeout_ms 300_000
+
+  # -- init -------------------------------------------------------------------
+
+  @impl true
+  def init(context) do
+    options = Map.get(context, :options, [])
+
+    %{
+      input: "",
+      # Normalized projection events (durable + ephemeral), arrival order.
+      events: [],
+      face_state: :idle,
+      face_frame: 0,
+      running?: false,
+      worker: nil,
+      session_id: nil,
+      pending_approval: nil,
+      status_line: nil,
+      ascii: Keyword.get(options, :ascii, false),
+      executor: Keyword.get(options, :executor),
+      backend_opts: Keyword.get(options, :backend_opts, []),
+      system: Keyword.get(options, :system, default_system()),
+      actions: Keyword.get(options, :actions, default_actions()),
+      # Injectable so tests drive the loop without spawning a real turn.
+      runner: Keyword.get(options, :runner, &__MODULE__.default_runner/4),
+      width: Map.get(context, :width, 80),
+      height: Map.get(context, :height, 24)
+    }
+  end
+
+  # -- update: keyboard -------------------------------------------------------
+
+  @impl true
+  def update(%Raxol.Core.Events.Event{} = event, model) do
+    norm = InputEvent.normalize(event)
+
+    cond do
+      InputEvent.shortcut?(norm) -> handle_shortcut(norm, model)
+      InputEvent.text?(norm) -> handle_char(InputEvent.printable_char(norm), model)
+      key = InputEvent.key(norm) -> handle_key(key, model)
+      true -> {model, []}
+    end
+  end
+
+  # -- update: async messages from the worker / authorizer --------------------
+
+  def update({:command_result, {:contract_event, event}}, model) do
+    case EventBoundary.normalize(event) do
+      {:ok, normalized} -> {fold_event(event, normalized, model), []}
+      {:error, _invalid} -> {model, []}
+    end
+  end
+
+  def update(
+        {:command_result, {:approval_request, ref, from, name}},
+        model
+      ) do
+    approval = %{ref: ref, from: from, name: name}
+    {%{model | pending_approval: approval, face_state: :working}, []}
+  end
+
+  def update(_message, model), do: {model, []}
+
+  # -- key handlers -----------------------------------------------------------
+
+  defp handle_shortcut(%{char: "c", mods: %{ctrl: true}}, model) do
+    {model, [Directive.stop()]}
+  end
+
+  defp handle_shortcut(_norm, model), do: {model, []}
+
+  # `y`/`n` answer a pending approval; otherwise printable text edits the
+  # prompt, but only when idle (no running turn, no pending approval).
+  defp handle_char(char, %{pending_approval: %{}} = model)
+       when char in ["y", "Y"],
+       do: {decide_approval(model, :allow), []}
+
+  defp handle_char(char, %{pending_approval: %{}} = model)
+       when char in ["n", "N"],
+       do: {decide_approval(model, :deny), []}
+
+  defp handle_char(_char, %{pending_approval: %{}} = model), do: {model, []}
+
+  defp handle_char(_char, %{running?: true} = model), do: {model, []}
+
+  defp handle_char(char, model) do
+    {%{model | input: model.input <> char}, []}
+  end
+
+  defp handle_key(:enter, %{pending_approval: %{}} = model), do: {model, []}
+  defp handle_key(:enter, %{running?: true} = model), do: {model, []}
+
+  defp handle_key(:enter, model) do
+    case String.trim(model.input) do
+      "" -> {model, []}
+      prompt -> {start_turn(model, prompt), []}
+    end
+  end
+
+  defp handle_key(:backspace, %{pending_approval: %{}} = model), do: {model, []}
+  defp handle_key(:backspace, %{running?: true} = model), do: {model, []}
+
+  defp handle_key(:backspace, model) do
+    {%{model | input: String.slice(model.input, 0..-2//1)}, []}
+  end
+
+  # Esc denies a pending approval first, then interrupts a running turn.
+  defp handle_key(:escape, %{pending_approval: %{}} = model),
+    do: {decide_approval(model, :deny), []}
+
+  defp handle_key(:escape, %{running?: true} = model),
+    do: {interrupt(model), []}
+
+  defp handle_key(_key, model), do: {model, []}
+
+  # -- turn lifecycle ---------------------------------------------------------
+
+  defp start_turn(model, prompt) do
+    session_id = "code-#{System.unique_integer([:positive])}"
+    ensure_streamer!()
+    app = self()
+
+    opts = [
+      backend_opts: model.backend_opts,
+      system_prompt: model.system,
+      actions: model.actions,
+      context: %{tool_authorizer: approval_authorizer(app)}
+    ]
+
+    opts = maybe_put(opts, :executor, model.executor)
+
+    worker = model.runner.(session_id, prompt, opts, app)
+
+    %{
+      model
+      | running?: true,
+        worker: worker,
+        session_id: session_id,
+        face_state: :thinking,
+        face_frame: 0,
+        status_line: nil,
+        input: ""
+    }
+  end
+
+  # The real worker: subscribe, then relay each contract event to the app.
+  # The pump runs in its OWN linked process because `Stream.react/2` sends its
+  # react events to whatever process CREATED the stream — so the stream must be
+  # created and consumed in the same process. The worker (the subscriber) stays
+  # free to run the relay receive-loop; the pump process only produces events
+  # into the streamer, which the worker then forwards.
+  @doc false
+  def default_runner(session_id, prompt, opts, app) do
+    spawn(fn ->
+      SessionStreamer.subscribe(session_id)
+
+      Task.async(fn ->
+        Contract.pump(session_id, Raxol.Agent.Stream.react(prompt, opts), prompt: prompt)
+      end)
+
+      relay(session_id, app)
+    end)
+  end
+
+  defp relay(session_id, app) do
+    receive do
+      {:session_event, ^session_id, event} ->
+        send(app, {:command_result, {:contract_event, event}})
+        unless terminal_event?(event), do: relay(session_id, app)
+    after
+      @approval_timeout_ms -> :ok
+    end
+  end
+
+  defp interrupt(model) do
+    if is_pid(model.worker) and Process.alive?(model.worker) do
+      Process.exit(model.worker, :kill)
+    end
+
+    reply_pending(model, :deny)
+
+    %{
+      model
+      | running?: false,
+        worker: nil,
+        face_state: :idle,
+        pending_approval: nil,
+        status_line: "interrupted"
+    }
+  end
+
+  # -- contract-event fold ----------------------------------------------------
+
+  defp fold_event(event, normalized, model) do
+    running? = model.running? and not terminal_event?(event)
+
+    %{
+      model
+      | events: model.events ++ [normalized],
+        face_state: face_for_event(event, model.face_state),
+        face_frame: model.face_frame + 1,
+        running?: running?,
+        worker: if(running?, do: model.worker, else: nil),
+        status_line: if(running?, do: model.status_line, else: nil)
+    }
+  end
+
+  # Map a contract event to the face state it should show.
+  defp face_for_event(%{type: :turn_started}, _current), do: :thinking
+
+  defp face_for_event(%{type: :turn_completed, payload: payload}, current) do
+    if final?(payload), do: :done, else: current
+  end
+
+  defp face_for_event(%{type: :error}, _current), do: :error
+
+  defp face_for_event(%{type: type, payload: payload}, current)
+       when type in [:item_started, :item_completed] do
+    case item_type(payload) do
+      it when it in [:tool_use, :tool_result] -> :working
+      it when it in [:message, :reasoning] -> :thinking
+      _other -> current
+    end
+  end
+
+  defp face_for_event(%{type: :item_delta}, current) do
+    # A delta during a tool phase (rare) shouldn't yank the face off :working;
+    # otherwise streaming text is thinking.
+    if current == :working, do: :working, else: :thinking
+  end
+
+  defp face_for_event(_event, current), do: current
+
+  defp terminal_event?(%{type: :error}), do: true
+
+  defp terminal_event?(%{type: :turn_completed, payload: payload}),
+    do: final?(payload)
+
+  defp terminal_event?(_event), do: false
+
+  defp final?(payload) when is_map(payload),
+    do: Map.get(payload, :final) == true or Map.get(payload, "final") == true
+
+  defp item_type(payload) when is_map(payload),
+    do: Map.get(payload, :item_type) || Map.get(payload, "item_type")
+
+  # -- approval ---------------------------------------------------------------
+
+  # Runs inside the react loop's process; blocks it until the app answers.
+  defp approval_authorizer(app) do
+    fn module, _params, _context ->
+      meta = module.__action_meta__()
+
+      if Map.get(meta, :sensitive, false) do
+        ref = make_ref()
+        send(app, {:command_result, {:approval_request, ref, self(), meta.name}})
+
+        receive do
+          {:approval_decision, ^ref, :allow} -> :ok
+          {:approval_decision, ^ref, :deny} -> {:deny, :user_denied}
+        after
+          @approval_timeout_ms -> {:deny, :approval_timeout}
+        end
+      else
+        :ok
+      end
+    end
+  end
+
+  defp decide_approval(%{pending_approval: %{}} = model, decision) do
+    reply_pending(model, decision)
+    face = if decision == :allow, do: :working, else: :thinking
+    %{model | pending_approval: nil, face_state: face}
+  end
+
+  defp decide_approval(model, _decision), do: model
+
+  defp reply_pending(%{pending_approval: %{ref: ref, from: from}}, decision)
+       when is_pid(from) do
+    send(from, {:approval_decision, ref, decision})
+    :ok
+  end
+
+  defp reply_pending(_model, _decision), do: :ok
+
+  # -- view -------------------------------------------------------------------
+
+  @impl true
+  def view(model) do
+    column style: %{padding: 1, gap: 1} do
+      [
+        transcript(model),
+        status_strip(model),
+        footer(model)
+      ]
+    end
+  end
+
+  defp transcript(model) do
+    projection = Projection.project(model.events)
+    context = %{theme: Raxol.UI.Theming.Theme.default_theme()}
+    blocks = Enum.map(projection.blocks, &Block.render(&1, context))
+    tail = tail_lines(projection.tail)
+
+    column style: %{gap: 0} do
+      blocks ++ tail
+    end
+  end
+
+  # In-flight streaming text (the live tail), one dim line per open item.
+  defp tail_lines(tail) when is_map(tail) do
+    tail
+    |> Map.values()
+    |> Enum.map(fn %{chunks: chunks} ->
+      text(chunks |> Enum.reverse() |> Enum.join(""), style: [:dim])
+    end)
+  end
+
+  defp status_strip(model) do
+    face = AxolFace.glyph(model.face_state, model.face_frame, model.ascii)
+
+    row style: %{gap: 1} do
+      [
+        text(face, fg: AxolFace.color(model.face_state), style: [:bold]),
+        text(status_label(model), style: [:dim])
+      ]
+    end
+  end
+
+  defp status_label(%{status_line: line}) when is_binary(line), do: line
+  defp status_label(%{pending_approval: %{name: name}}), do: "awaiting approval: #{name}"
+  defp status_label(%{running?: true}), do: "working…"
+  defp status_label(_model), do: "ready"
+
+  defp footer(%{pending_approval: %{name: name}}) do
+    box style: %{border: :single, padding: 0} do
+      text("Allow #{name}? [y/N]  ·  Esc denies", fg: :yellow)
+    end
+  end
+
+  defp footer(model) do
+    box style: %{border: :single, padding: 0} do
+      text("> " <> model.input <> cursor(model))
+    end
+  end
+
+  defp cursor(%{running?: true}), do: ""
+  defp cursor(_model), do: "▌"
+
+  # -- helpers ----------------------------------------------------------------
+
+  defp ensure_streamer! do
+    case SessionStreamer.start_link([]) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, reason} -> raise "cannot start SessionStreamer: #{inspect(reason)}"
+    end
+  end
+
+  defp default_actions do
+    Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.all()
+  end
+
+  defp default_system do
+    "You are a coding assistant running in a terminal at the user's " <>
+      "current working directory. Read files before editing them. Use " <>
+      "write_file/edit_file to change code and bash to run commands. Be concise."
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -76,14 +76,25 @@ defmodule Raxol.Agent.Code.App do
     {hooks, hooks_note} = load_hooks(cwd)
     {mcp_servers, mcp_note} = load_mcp(cwd)
 
+    Map.merge(config(options, context), %{
+      # Seeded from a resumed session so the transcript + conversation
+      # rebuild immediately; a fresh session starts these empty.
+      events: events,
+      messages: messages,
+      status_line: combine_notes([resume_notice, hooks_note, mcp_note]),
+      session_key: session_key,
+      sessions_dir: sessions_dir,
+      cwd: cwd,
+      hooks: hooks,
+      mcp_servers: mcp_servers
+    })
+  end
+
+  # Static + option-derived fields; the session and loaded config are merged
+  # over these in init/1.
+  defp config(options, context) do
     %{
       input: "",
-      # Normalized projection events (durable + ephemeral), arrival order.
-      # Seeded from a resumed session so the transcript rebuilds immediately.
-      events: events,
-      # The LLM conversation carried across turns (persisted per session).
-      messages: messages,
-      # Assistant text accumulated during the in-flight turn.
       turn_answer: "",
       face_state: :idle,
       face_frame: 0,
@@ -91,7 +102,6 @@ defmodule Raxol.Agent.Code.App do
       worker: nil,
       session_id: nil,
       pending_approval: nil,
-      status_line: combine_notes([resume_notice, hooks_note, mcp_note]),
       notice: nil,
       # Authorization: plan mode + per-tool "always allow" memory. The Engine
       # is the ALLOW/ASK/DENY decision core; per-tool memory is app state fed
@@ -99,13 +109,6 @@ defmodule Raxol.Agent.Code.App do
       plan_mode: false,
       always_allow: MapSet.new(),
       auth_state: Engine.new(),
-      # Session persistence.
-      session_key: session_key,
-      sessions_dir: sessions_dir,
-      # Delegation + config (Phase 5).
-      cwd: cwd,
-      hooks: hooks,
-      mcp_servers: mcp_servers,
       ascii: Keyword.get(options, :ascii, false),
       executor: Keyword.get(options, :executor),
       backend_opts: Keyword.get(options, :backend_opts, []),
@@ -301,6 +304,7 @@ defmodule Raxol.Agent.Code.App do
     ensure_streamer!()
     app = self()
 
+    # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
     messages = model.messages ++ [%{role: :user, content: prompt}]
 
     opts =
@@ -425,9 +429,12 @@ defmodule Raxol.Agent.Code.App do
   defp fold_event(event, normalized, model) do
     running? = model.running? and not terminal_event?(event)
 
+    # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+    events = model.events ++ [normalized]
+
     model = %{
       model
-      | events: model.events ++ [normalized],
+      | events: events,
         face_state: face_for_event(event, model.face_state),
         face_frame: model.face_frame + 1,
         running?: running?,
@@ -472,8 +479,12 @@ defmodule Raxol.Agent.Code.App do
 
   defp append_assistant(messages, answer) do
     case String.trim(answer) do
-      "" -> messages
-      trimmed -> messages ++ [%{role: :assistant, content: trimmed}]
+      "" ->
+        messages
+
+      trimmed ->
+        # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+        messages ++ [%{role: :assistant, content: trimmed}]
     end
   end
 
@@ -611,20 +622,21 @@ defmodule Raxol.Agent.Code.App do
 
   defp dispatch_slash(model, command) do
     {name, arg} = parse_command(command)
-
-    case name do
-      "help" -> {notice(model, help_text()), []}
-      "clear" -> {clear_session(model), []}
-      "plan" -> {maybe_toggle_plan_mode(model), []}
-      "model" -> {set_model(model, arg), []}
-      "context" -> {notice(model, context_text(model)), []}
-      "compact" -> {compact(model), []}
-      "sessions" -> {notice(model, sessions_text(model)), []}
-      "mcp" -> {notice(model, mcp_text(model)), []}
-      "hooks" -> {notice(model, hooks_text(model)), []}
-      other -> {notice(model, "unknown command: /#{other} — try /help"), []}
-    end
+    apply_command(name, arg, model)
   end
+
+  defp apply_command("help", _arg, model), do: {notice(model, help_text()), []}
+  defp apply_command("clear", _arg, model), do: {clear_session(model), []}
+  defp apply_command("plan", _arg, model), do: {maybe_toggle_plan_mode(model), []}
+  defp apply_command("model", arg, model), do: {set_model(model, arg), []}
+  defp apply_command("context", _arg, model), do: {notice(model, context_text(model)), []}
+  defp apply_command("compact", _arg, model), do: {compact(model), []}
+  defp apply_command("sessions", _arg, model), do: {notice(model, sessions_text(model)), []}
+  defp apply_command("mcp", _arg, model), do: {notice(model, mcp_text(model)), []}
+  defp apply_command("hooks", _arg, model), do: {notice(model, hooks_text(model)), []}
+
+  defp apply_command(other, _arg, model),
+    do: {notice(model, "unknown command: /#{other} — try /help"), []}
 
   defp mcp_text(%{mcp_servers: []}), do: "no MCP servers configured (.mcp.json)"
 
@@ -727,23 +739,22 @@ defmodule Raxol.Agent.Code.App do
   @impl true
   def view(model) do
     column style: %{padding: 1, gap: 1} do
-      [transcript(model)] ++ notice_block(model) ++ [status_strip(model), footer(model)]
+      [transcript(model), notice_block(model), status_strip(model), footer(model)]
+      |> Enum.reject(&is_nil/1)
     end
   end
 
   defp notice_block(%{notice: notice}) when is_binary(notice) do
     lines = String.split(notice, "\n")
 
-    [
-      box style: %{border: :single, padding: 0} do
-        column style: %{gap: 0} do
-          Enum.map(lines, &text(&1, fg: :cyan))
-        end
+    box style: %{border: :single, padding: 0} do
+      column style: %{gap: 0} do
+        Enum.map(lines, &text(&1, fg: :cyan))
       end
-    ]
+    end
   end
 
-  defp notice_block(_model), do: []
+  defp notice_block(_model), do: nil
 
   defp transcript(model) do
     projection = Projection.project(model.events)
@@ -775,12 +786,12 @@ defmodule Raxol.Agent.Code.App do
     status = text(status_label(model), style: [:dim])
 
     row style: %{gap: 1} do
-      [face] ++ plan_chip(model) ++ [status]
+      [face, plan_chip(model), status] |> Enum.reject(&is_nil/1)
     end
   end
 
-  defp plan_chip(%{plan_mode: true}), do: [text("PLAN", fg: :yellow, style: [:bold])]
-  defp plan_chip(_model), do: []
+  defp plan_chip(%{plan_mode: true}), do: text("PLAN", fg: :yellow, style: [:bold])
+  defp plan_chip(_model), do: nil
 
   defp status_label(%{status_line: line}) when is_binary(line), do: line
   defp status_label(%{pending_approval: %{name: name}}), do: "awaiting approval: #{name}"

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -71,7 +71,7 @@ defmodule Raxol.Agent.Code.App do
   @impl true
   def init(context) do
     options = Map.get(context, :options, [])
-    {sessions_dir, session_key, messages, resume_notice} = init_session(options)
+    {sessions_dir, session_key, messages, events, resume_notice} = init_session(options)
     cwd = Keyword.get(options, :cwd) || Raxol.Agent.Actions.Fs.working_dir()
     {hooks, hooks_note} = load_hooks(cwd)
     {mcp_servers, mcp_note} = load_mcp(cwd)
@@ -79,7 +79,8 @@ defmodule Raxol.Agent.Code.App do
     %{
       input: "",
       # Normalized projection events (durable + ephemeral), arrival order.
-      events: [],
+      # Seeded from a resumed session so the transcript rebuilds immediately.
+      events: events,
       # The LLM conversation carried across turns (persisted per session).
       messages: messages,
       # Assistant text accumulated during the in-flight turn.
@@ -126,15 +127,15 @@ defmodule Raxol.Agent.Code.App do
 
     case Keyword.get(options, :session_key) do
       nil ->
-        {dir, mint_session_key(), [], nil}
+        {dir, mint_session_key(), [], [], nil}
 
       key ->
         case Raxol.Agent.Code.Store.load(dir, key) do
-          {:ok, %{messages: messages}} ->
-            {dir, key, messages, "resumed #{length(messages)} messages"}
+          {:ok, %{messages: messages, events: events}} ->
+            {dir, key, messages, events, "resumed #{length(messages)} messages"}
 
           {:error, _} ->
-            {dir, key, [], "session #{key} not found — starting fresh"}
+            {dir, key, [], [], "session #{key} not found — starting fresh"}
         end
     end
   end
@@ -481,12 +482,17 @@ defmodule Raxol.Agent.Code.App do
 
   defp persist(model) do
     case Raxol.Agent.Code.Store.save(model.sessions_dir, model.session_key, %{
-           messages: model.messages
+           messages: model.messages,
+           events: durable_events(model.events)
          }) do
       :ok -> model
       {:error, reason} -> %{model | status_line: "session save failed: #{inspect(reason)}"}
     end
   end
+
+  # Only durable events rebuild the transcript on resume; ephemeral deltas are
+  # live-render-only and never persisted.
+  defp durable_events(events), do: Enum.filter(events, &(&1.tier == :durable))
 
   # Map a contract event to the face state it should show.
   defp face_for_event(%{type: :turn_started}, _current), do: :thinking

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -72,6 +72,9 @@ defmodule Raxol.Agent.Code.App do
   def init(context) do
     options = Map.get(context, :options, [])
     {sessions_dir, session_key, messages, resume_notice} = init_session(options)
+    cwd = Keyword.get(options, :cwd) || Raxol.Agent.Actions.Fs.working_dir()
+    {hooks, hooks_note} = load_hooks(cwd)
+    {mcp_servers, mcp_note} = load_mcp(cwd)
 
     %{
       input: "",
@@ -87,7 +90,7 @@ defmodule Raxol.Agent.Code.App do
       worker: nil,
       session_id: nil,
       pending_approval: nil,
-      status_line: resume_notice,
+      status_line: combine_notes([resume_notice, hooks_note, mcp_note]),
       notice: nil,
       # Authorization: plan mode + per-tool "always allow" memory. The Engine
       # is the ALLOW/ASK/DENY decision core; per-tool memory is app state fed
@@ -98,6 +101,10 @@ defmodule Raxol.Agent.Code.App do
       # Session persistence.
       session_key: session_key,
       sessions_dir: sessions_dir,
+      # Delegation + config (Phase 5).
+      cwd: cwd,
+      hooks: hooks,
+      mcp_servers: mcp_servers,
       ascii: Keyword.get(options, :ascii, false),
       executor: Keyword.get(options, :executor),
       backend_opts: Keyword.get(options, :backend_opts, []),
@@ -134,6 +141,30 @@ defmodule Raxol.Agent.Code.App do
 
   defp mint_session_key do
     "sess-#{System.system_time(:second)}-#{System.unique_integer([:positive])}"
+  end
+
+  defp load_hooks(cwd) do
+    case Raxol.Agent.Code.Hooks.load(cwd) do
+      {:ok, config} -> {config, "#{Raxol.Agent.Code.Hooks.count(config)} hooks"}
+      :none -> {nil, nil}
+      {:error, reason} -> {nil, "hooks config error: #{inspect(reason)}"}
+    end
+  end
+
+  defp load_mcp(cwd) do
+    case Raxol.Agent.Code.McpConfig.load(cwd) do
+      {:ok, []} -> {[], nil}
+      {:ok, servers} -> {servers, "#{length(servers)} MCP servers"}
+      :none -> {[], nil}
+      {:error, reason} -> {[], "mcp config error: #{inspect(reason)}"}
+    end
+  end
+
+  defp combine_notes(notes) do
+    case Enum.reject(notes, &is_nil/1) do
+      [] -> nil
+      list -> Enum.join(list, " · ")
+    end
   end
 
   # -- update: keyboard -------------------------------------------------------
@@ -277,7 +308,7 @@ defmodule Raxol.Agent.Code.App do
         system_prompt: system_prompt(model),
         actions: model.actions,
         messages: messages,
-        context: %{tool_authorizer: tool_authorizer(app)}
+        context: run_context(model, app)
       ]
       |> maybe_put(:executor, model.executor)
       |> maybe_put(:model, model.model_override)
@@ -345,6 +376,37 @@ defmodule Raxol.Agent.Code.App do
     }
   end
 
+  # The run context: the human-in-the-loop authorizer, the sub-agent backend
+  # (for the `task` tool), and any settings-file tool-call hooks.
+  defp run_context(model, app) do
+    %{
+      tool_authorizer: tool_authorizer(app),
+      subagent: %{
+        executor: model.executor,
+        backend_opts: model.backend_opts,
+        model: model.model_override
+      }
+    }
+    |> maybe_add_hooks(model)
+  end
+
+  defp maybe_add_hooks(context, %{hooks: nil}), do: context
+
+  defp maybe_add_hooks(context, %{hooks: config, cwd: cwd}) do
+    Map.merge(context, %{
+      tool_call_hooks: [Raxol.Agent.Code.Hooks],
+      code_hooks: config,
+      hook_cwd: cwd
+    })
+  end
+
+  defp run_stop_hooks(%{hooks: nil}), do: :ok
+
+  defp run_stop_hooks(%{hooks: config, cwd: cwd}) do
+    spawn(fn -> Raxol.Agent.Code.Hooks.run_stop(config, cwd) end)
+    :ok
+  end
+
   defp system_prompt(%{plan_mode: true, system: system}),
     do: system <> "\n\n" <> plan_directive()
 
@@ -397,6 +459,7 @@ defmodule Raxol.Agent.Code.App do
   defp finalize_turn(model, %{type: :turn_completed, payload: payload}) do
     if final?(payload) do
       messages = append_assistant(model.messages, model.turn_answer)
+      run_stop_hooks(model)
       persist(%{model | messages: messages, turn_answer: ""})
     else
       model
@@ -551,8 +614,25 @@ defmodule Raxol.Agent.Code.App do
       "context" -> {notice(model, context_text(model)), []}
       "compact" -> {compact(model), []}
       "sessions" -> {notice(model, sessions_text(model)), []}
+      "mcp" -> {notice(model, mcp_text(model)), []}
+      "hooks" -> {notice(model, hooks_text(model)), []}
       other -> {notice(model, "unknown command: /#{other} — try /help"), []}
     end
+  end
+
+  defp mcp_text(%{mcp_servers: []}), do: "no MCP servers configured (.mcp.json)"
+
+  defp mcp_text(%{mcp_servers: servers}) do
+    Enum.map_join(servers, "\n", fn s ->
+      "#{s.name}  →  #{s.command} #{Enum.join(s.args, " ")}"
+    end)
+  end
+
+  defp hooks_text(%{hooks: nil}), do: "no hooks configured (.raxol/hooks.json)"
+
+  defp hooks_text(%{hooks: config}) do
+    "pre_tool_use: #{length(config.pre)} · post_tool_use: #{length(config.post)} · " <>
+      "stop: #{length(config.stop)}"
   end
 
   defp parse_command("/" <> rest) do
@@ -630,6 +710,8 @@ defmodule Raxol.Agent.Code.App do
     /compact           shrink the conversation history
     /context           session stats
     /sessions          list saved sessions
+    /mcp               list configured MCP servers
+    /hooks             show configured lifecycle hooks
     """
     |> String.trim_trailing()
   end
@@ -728,7 +810,9 @@ defmodule Raxol.Agent.Code.App do
   end
 
   defp default_actions do
-    Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.all()
+    Raxol.Agent.Actions.Fs.all() ++
+      Raxol.Agent.Actions.Code.all() ++
+      Raxol.Agent.Actions.Task.all()
   end
 
   defp default_system do

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -71,27 +71,37 @@ defmodule Raxol.Agent.Code.App do
   @impl true
   def init(context) do
     options = Map.get(context, :options, [])
+    {sessions_dir, session_key, messages, resume_notice} = init_session(options)
 
     %{
       input: "",
       # Normalized projection events (durable + ephemeral), arrival order.
       events: [],
+      # The LLM conversation carried across turns (persisted per session).
+      messages: messages,
+      # Assistant text accumulated during the in-flight turn.
+      turn_answer: "",
       face_state: :idle,
       face_frame: 0,
       running?: false,
       worker: nil,
       session_id: nil,
       pending_approval: nil,
-      status_line: nil,
+      status_line: resume_notice,
+      notice: nil,
       # Authorization: plan mode + per-tool "always allow" memory. The Engine
       # is the ALLOW/ASK/DENY decision core; per-tool memory is app state fed
       # into the policy context (the Engine's own memory is per-policy).
       plan_mode: false,
       always_allow: MapSet.new(),
       auth_state: Engine.new(),
+      # Session persistence.
+      session_key: session_key,
+      sessions_dir: sessions_dir,
       ascii: Keyword.get(options, :ascii, false),
       executor: Keyword.get(options, :executor),
       backend_opts: Keyword.get(options, :backend_opts, []),
+      model_override: Keyword.get(options, :model),
       system: Keyword.get(options, :system, default_system()),
       actions: Keyword.get(options, :actions, default_actions()),
       # Injectable so tests drive the loop without spawning a real turn.
@@ -99,6 +109,31 @@ defmodule Raxol.Agent.Code.App do
       width: Map.get(context, :width, 80),
       height: Map.get(context, :height, 24)
     }
+  end
+
+  # Resolve the session to write to and any conversation to resume. A
+  # `:session_key` option (set by `--continue`/`--resume`) reattaches that
+  # session's messages; absent, a fresh session is minted.
+  defp init_session(options) do
+    dir = Keyword.get(options, :sessions_dir) || Raxol.Agent.Code.Store.default_dir()
+
+    case Keyword.get(options, :session_key) do
+      nil ->
+        {dir, mint_session_key(), [], nil}
+
+      key ->
+        case Raxol.Agent.Code.Store.load(dir, key) do
+          {:ok, %{messages: messages}} ->
+            {dir, key, messages, "resumed #{length(messages)} messages"}
+
+          {:error, _} ->
+            {dir, key, [], "session #{key} not found — starting fresh"}
+        end
+    end
+  end
+
+  defp mint_session_key do
+    "sess-#{System.system_time(:second)}-#{System.unique_integer([:positive])}"
   end
 
   # -- update: keyboard -------------------------------------------------------
@@ -200,6 +235,7 @@ defmodule Raxol.Agent.Code.App do
   defp handle_key(:enter, model) do
     case String.trim(model.input) do
       "" -> {model, []}
+      "/" <> _ = command -> dispatch_slash(%{model | input: ""}, command)
       prompt -> {start_turn(model, prompt), []}
     end
   end
@@ -233,14 +269,18 @@ defmodule Raxol.Agent.Code.App do
     ensure_streamer!()
     app = self()
 
-    opts = [
-      backend_opts: model.backend_opts,
-      system_prompt: system_prompt(model),
-      actions: model.actions,
-      context: %{tool_authorizer: tool_authorizer(app)}
-    ]
+    messages = model.messages ++ [%{role: :user, content: prompt}]
 
-    opts = maybe_put(opts, :executor, model.executor)
+    opts =
+      [
+        backend_opts: model.backend_opts,
+        system_prompt: system_prompt(model),
+        actions: model.actions,
+        messages: messages,
+        context: %{tool_authorizer: tool_authorizer(app)}
+      ]
+      |> maybe_put(:executor, model.executor)
+      |> maybe_put(:model, model.model_override)
 
     worker = model.runner.(session_id, prompt, opts, app)
 
@@ -249,9 +289,12 @@ defmodule Raxol.Agent.Code.App do
       | running?: true,
         worker: worker,
         session_id: session_id,
+        messages: messages,
+        turn_answer: "",
         face_state: :thinking,
         face_frame: 0,
         status_line: nil,
+        notice: nil,
         input: ""
     }
   end
@@ -319,7 +362,7 @@ defmodule Raxol.Agent.Code.App do
   defp fold_event(event, normalized, model) do
     running? = model.running? and not terminal_event?(event)
 
-    %{
+    model = %{
       model
       | events: model.events ++ [normalized],
         face_state: face_for_event(event, model.face_state),
@@ -328,6 +371,58 @@ defmodule Raxol.Agent.Code.App do
         worker: if(running?, do: model.worker, else: nil),
         status_line: if(running?, do: model.status_line, else: nil)
     }
+
+    model
+    |> accumulate_answer(event)
+    |> finalize_turn(event)
+  end
+
+  # A completed message item is assistant answer text — accumulate it so the
+  # conversation memory gets the reply when the turn closes.
+  defp accumulate_answer(model, %{type: :item_completed, payload: payload}) do
+    case item_type(payload) do
+      :message ->
+        %{model | turn_answer: model.turn_answer <> to_string(payload_content(payload))}
+
+      _other ->
+        model
+    end
+  end
+
+  defp accumulate_answer(model, _event), do: model
+
+  # On a successful turn boundary, append the assistant reply to the
+  # conversation and persist it. An error turn persists without appending a
+  # (possibly partial) reply.
+  defp finalize_turn(model, %{type: :turn_completed, payload: payload}) do
+    if final?(payload) do
+      messages = append_assistant(model.messages, model.turn_answer)
+      persist(%{model | messages: messages, turn_answer: ""})
+    else
+      model
+    end
+  end
+
+  defp finalize_turn(model, %{type: :error}), do: persist(%{model | turn_answer: ""})
+  defp finalize_turn(model, _event), do: model
+
+  defp append_assistant(messages, answer) do
+    case String.trim(answer) do
+      "" -> messages
+      trimmed -> messages ++ [%{role: :assistant, content: trimmed}]
+    end
+  end
+
+  defp payload_content(payload),
+    do: Map.get(payload, :content) || Map.get(payload, "content") || ""
+
+  defp persist(model) do
+    case Raxol.Agent.Code.Store.save(model.sessions_dir, model.session_key, %{
+           messages: model.messages
+         }) do
+      :ok -> model
+      {:error, reason} -> %{model | status_line: "session save failed: #{inspect(reason)}"}
+    end
   end
 
   # Map a contract event to the face state it should show.
@@ -443,18 +538,124 @@ defmodule Raxol.Agent.Code.App do
 
   defp reply_pending(_model, _verdict), do: :ok
 
+  # -- slash commands ---------------------------------------------------------
+
+  defp dispatch_slash(model, command) do
+    {name, arg} = parse_command(command)
+
+    case name do
+      "help" -> {notice(model, help_text()), []}
+      "clear" -> {clear_session(model), []}
+      "plan" -> {maybe_toggle_plan_mode(model), []}
+      "model" -> {set_model(model, arg), []}
+      "context" -> {notice(model, context_text(model)), []}
+      "compact" -> {compact(model), []}
+      "sessions" -> {notice(model, sessions_text(model)), []}
+      other -> {notice(model, "unknown command: /#{other} — try /help"), []}
+    end
+  end
+
+  defp parse_command("/" <> rest) do
+    case String.split(String.trim(rest), " ", parts: 2) do
+      [name] -> {name, ""}
+      [name, arg] -> {name, String.trim(arg)}
+    end
+  end
+
+  defp notice(model, text), do: %{model | notice: text}
+
+  # A fresh session preserves the old file on disk and starts a new key, so
+  # clearing is never destructive to a prior conversation.
+  defp clear_session(model) do
+    %{
+      model
+      | messages: [],
+        events: [],
+        turn_answer: "",
+        face_state: :idle,
+        face_frame: 0,
+        session_key: mint_session_key(),
+        notice: "cleared — new session"
+    }
+  end
+
+  defp set_model(model, "") do
+    notice(model, "usage: /model <name>  (current: #{model.model_override || "default"})")
+  end
+
+  defp set_model(model, name) do
+    notice(%{model | model_override: name}, "model set to #{name}")
+  end
+
+  # Heuristic context shrink: keep the last few exchanges, replace the rest
+  # with a marker. Not a semantic summary — an honest size reducer.
+  defp compact(model) do
+    keep = 6
+    count = length(model.messages)
+
+    if count <= keep do
+      notice(model, "nothing to compact (#{count} messages)")
+    else
+      {older, recent} = Enum.split(model.messages, count - keep)
+      marker = %{role: :system, content: "[#{length(older)} earlier messages compacted]"}
+      model = persist(%{model | messages: [marker | recent]})
+      notice(model, "compacted #{length(older)} messages")
+    end
+  end
+
+  defp context_text(model) do
+    "messages: #{length(model.messages)} · events: #{length(model.events)} · " <>
+      "plan: #{if model.plan_mode, do: "on", else: "off"} · " <>
+      "model: #{model.model_override || "default"} · session: #{model.session_key}"
+  end
+
+  defp sessions_text(model) do
+    case Raxol.Agent.Code.Store.list(model.sessions_dir) do
+      [] ->
+        "no saved sessions"
+
+      sessions ->
+        sessions
+        |> Enum.take(10)
+        |> Enum.map_join("\n", fn s -> "#{s.id}  (#{s.message_count} msgs)" end)
+    end
+  end
+
+  defp help_text do
+    """
+    /help              this help
+    /clear             start a fresh session
+    /model <name>      switch model for the next turns
+    /plan              toggle plan mode
+    /compact           shrink the conversation history
+    /context           session stats
+    /sessions          list saved sessions
+    """
+    |> String.trim_trailing()
+  end
+
   # -- view -------------------------------------------------------------------
 
   @impl true
   def view(model) do
     column style: %{padding: 1, gap: 1} do
-      [
-        transcript(model),
-        status_strip(model),
-        footer(model)
-      ]
+      [transcript(model)] ++ notice_block(model) ++ [status_strip(model), footer(model)]
     end
   end
+
+  defp notice_block(%{notice: notice}) when is_binary(notice) do
+    lines = String.split(notice, "\n")
+
+    [
+      box style: %{border: :single, padding: 0} do
+        column style: %{gap: 0} do
+          Enum.map(lines, &text(&1, fg: :cyan))
+        end
+      end
+    ]
+  end
+
+  defp notice_block(_model), do: []
 
   defp transcript(model) do
     projection = Projection.project(model.events)

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -21,26 +21,41 @@ defmodule Raxol.Agent.Code.App do
   projection source. Because `update/2` runs in the Dispatcher process,
   the worker's `send(app, ...)` lands where the app can fold it.
 
-  ## Tools and approval
+  ## Tools, authorization, and plan mode
 
   The agent gets the read-only fs tools plus the mutating coding tools
   (`write_file`/`edit_file`/`bash`), which are `sensitive`. A per-run
-  `:tool_authorizer` gates each sensitive call through an interactive
-  prompt: it sends `{:approval_request, ...}` to this app and BLOCKS the
-  react loop's process until the user answers `y`/`n`, so a write or a
-  shell command never runs unattended.
+  `:tool_authorizer` defers every sensitive call to this app, which runs
+  it through `Raxol.Agent.Authorization.Engine` (the ALLOW/ASK/DENY
+  reducer):
+
+    * **ALLOW** — the tool was previously approved "always" this session,
+      so it runs without prompting.
+    * **ASK** — an interactive prompt (allow once / always / deny) that
+      BLOCKS the react loop's process until the user answers, so a write
+      or a shell command never runs unattended.
+    * **DENY** — in **plan mode** any mutating tool is refused; the agent
+      can only read and propose.
+
+  **Plan mode** (toggle: Shift+Tab or Ctrl+P) swaps in a planning system
+  prompt and has the Engine deny mutations, so a turn researches and lays
+  out a plan without touching disk. Toggle it back off to execute.
 
   ## Keys
 
     * printable text → prompt buffer (when idle)
-    * Enter → submit the prompt / (when a tool is awaiting) ignored
-    * `y` / `n` → answer a pending approval
+    * Enter → submit the prompt
+    * `a` / `s` / `d` → answer a pending approval (allow once / always / deny)
+    * Shift+Tab or Ctrl+P → toggle plan mode
     * Esc → deny a pending approval, else interrupt a running turn
     * Ctrl+C → quit
   """
 
   use Raxol.Core.Runtime.Application
 
+  alias Raxol.Agent.Authorization.Engine
+  alias Raxol.Agent.Authorization.Policy
+  alias Raxol.Agent.Authorization.Verdict
   alias Raxol.Agent.Contract
   alias Raxol.Agent.SessionStreamer
   alias Raxol.Harness.EventBoundary
@@ -68,6 +83,12 @@ defmodule Raxol.Agent.Code.App do
       session_id: nil,
       pending_approval: nil,
       status_line: nil,
+      # Authorization: plan mode + per-tool "always allow" memory. The Engine
+      # is the ALLOW/ASK/DENY decision core; per-tool memory is app state fed
+      # into the policy context (the Engine's own memory is per-policy).
+      plan_mode: false,
+      always_allow: MapSet.new(),
+      auth_state: Engine.new(),
       ascii: Keyword.get(options, :ascii, false),
       executor: Keyword.get(options, :executor),
       backend_opts: Keyword.get(options, :backend_opts, []),
@@ -103,12 +124,35 @@ defmodule Raxol.Agent.Code.App do
     end
   end
 
+  # A sensitive tool call awaiting a verdict: run it through the Engine.
+  # ALLOW (remembered) and DENY (plan mode) answer immediately; ASK opens
+  # the interactive prompt.
   def update(
-        {:command_result, {:approval_request, ref, from, name}},
+        {:command_result, {:authorize_request, ref, from, name}},
         model
       ) do
-    approval = %{ref: ref, from: from, name: name}
-    {%{model | pending_approval: approval, face_state: :working}, []}
+    context = %{
+      tool: name,
+      mutating: true,
+      plan_mode: model.plan_mode,
+      always_allow: model.always_allow
+    }
+
+    decision = Engine.evaluate(auth_policies(), :tool_call, context, model.auth_state)
+
+    case decision.action do
+      :allow ->
+        send(from, {:authorize_decision, ref, :allow})
+        {model, []}
+
+      :deny ->
+        send(from, {:authorize_decision, ref, {:deny, decision.reason}})
+        {%{model | status_line: "denied in plan mode: #{name}"}, []}
+
+      :ask ->
+        approval = %{ref: ref, from: from, name: name}
+        {%{model | pending_approval: approval, face_state: :working}, []}
+    end
   end
 
   def update(_message, model), do: {model, []}
@@ -119,17 +163,25 @@ defmodule Raxol.Agent.Code.App do
     {model, [Directive.stop()]}
   end
 
+  # Ctrl+P toggles plan mode (Shift+Tab does too — see handle_key/2).
+  defp handle_shortcut(%{char: "p", mods: %{ctrl: true}}, model),
+    do: {maybe_toggle_plan_mode(model), []}
+
   defp handle_shortcut(_norm, model), do: {model, []}
 
-  # `y`/`n` answer a pending approval; otherwise printable text edits the
-  # prompt, but only when idle (no running turn, no pending approval).
+  # `a`/`s`/`d` (with `y`/`n` aliases) answer a pending approval; otherwise
+  # printable text edits the prompt, but only when idle.
   defp handle_char(char, %{pending_approval: %{}} = model)
-       when char in ["y", "Y"],
-       do: {decide_approval(model, :allow), []}
+       when char in ["a", "A", "y", "Y"],
+       do: {allow_once(model), []}
 
   defp handle_char(char, %{pending_approval: %{}} = model)
-       when char in ["n", "N"],
-       do: {decide_approval(model, :deny), []}
+       when char in ["s", "S"],
+       do: {allow_always(model), []}
+
+  defp handle_char(char, %{pending_approval: %{}} = model)
+       when char in ["d", "D", "n", "N"],
+       do: {deny_pending(model), []}
 
   defp handle_char(_char, %{pending_approval: %{}} = model), do: {model, []}
 
@@ -138,6 +190,9 @@ defmodule Raxol.Agent.Code.App do
   defp handle_char(char, model) do
     {%{model | input: model.input <> char}, []}
   end
+
+  # Shift+Tab toggles plan mode when idle.
+  defp handle_key(:backtab, model), do: {maybe_toggle_plan_mode(model), []}
 
   defp handle_key(:enter, %{pending_approval: %{}} = model), do: {model, []}
   defp handle_key(:enter, %{running?: true} = model), do: {model, []}
@@ -158,12 +213,18 @@ defmodule Raxol.Agent.Code.App do
 
   # Esc denies a pending approval first, then interrupts a running turn.
   defp handle_key(:escape, %{pending_approval: %{}} = model),
-    do: {decide_approval(model, :deny), []}
+    do: {deny_pending(model), []}
 
   defp handle_key(:escape, %{running?: true} = model),
     do: {interrupt(model), []}
 
   defp handle_key(_key, model), do: {model, []}
+
+  # Plan mode only toggles when idle — flipping it mid-turn or mid-approval
+  # would be surprising (the toolset/prompt are fixed at turn start).
+  defp maybe_toggle_plan_mode(%{running?: true} = model), do: model
+  defp maybe_toggle_plan_mode(%{pending_approval: %{}} = model), do: model
+  defp maybe_toggle_plan_mode(model), do: %{model | plan_mode: not model.plan_mode}
 
   # -- turn lifecycle ---------------------------------------------------------
 
@@ -174,9 +235,9 @@ defmodule Raxol.Agent.Code.App do
 
     opts = [
       backend_opts: model.backend_opts,
-      system_prompt: model.system,
+      system_prompt: system_prompt(model),
       actions: model.actions,
-      context: %{tool_authorizer: approval_authorizer(app)}
+      context: %{tool_authorizer: tool_authorizer(app)}
     ]
 
     opts = maybe_put(opts, :executor, model.executor)
@@ -229,7 +290,7 @@ defmodule Raxol.Agent.Code.App do
       Process.exit(model.worker, :kill)
     end
 
-    reply_pending(model, :deny)
+    reply_pending(model, {:deny, :interrupted})
 
     %{
       model
@@ -239,6 +300,18 @@ defmodule Raxol.Agent.Code.App do
         pending_approval: nil,
         status_line: "interrupted"
     }
+  end
+
+  defp system_prompt(%{plan_mode: true, system: system}),
+    do: system <> "\n\n" <> plan_directive()
+
+  defp system_prompt(%{system: system}), do: system
+
+  defp plan_directive do
+    "PLAN MODE: You are in read-only planning mode. Investigate with the " <>
+      "read-only tools (read_file, list_dir, grep, glob) and then propose a " <>
+      "concise, numbered plan. Do NOT call write_file, edit_file, or bash — " <>
+      "they are refused until the user leaves plan mode to execute."
   end
 
   # -- contract-event fold ----------------------------------------------------
@@ -296,20 +369,22 @@ defmodule Raxol.Agent.Code.App do
   defp item_type(payload) when is_map(payload),
     do: Map.get(payload, :item_type) || Map.get(payload, "item_type")
 
-  # -- approval ---------------------------------------------------------------
+  # -- authorization ----------------------------------------------------------
 
-  # Runs inside the react loop's process; blocks it until the app answers.
-  defp approval_authorizer(app) do
+  # The `:tool_authorizer`: runs inside the react loop's process and defers
+  # every sensitive tool call to the app for an Engine verdict, blocking until
+  # the app answers. Non-sensitive tools are allowed without a round-trip.
+  defp tool_authorizer(app) do
     fn module, _params, _context ->
       meta = module.__action_meta__()
 
       if Map.get(meta, :sensitive, false) do
         ref = make_ref()
-        send(app, {:command_result, {:approval_request, ref, self(), meta.name}})
+        send(app, {:command_result, {:authorize_request, ref, self(), meta.name}})
 
         receive do
-          {:approval_decision, ^ref, :allow} -> :ok
-          {:approval_decision, ^ref, :deny} -> {:deny, :user_denied}
+          {:authorize_decision, ^ref, :allow} -> :ok
+          {:authorize_decision, ^ref, {:deny, reason}} -> {:deny, reason}
         after
           @approval_timeout_ms -> {:deny, :approval_timeout}
         end
@@ -319,21 +394,54 @@ defmodule Raxol.Agent.Code.App do
     end
   end
 
-  defp decide_approval(%{pending_approval: %{}} = model, decision) do
-    reply_pending(model, decision)
-    face = if decision == :allow, do: :working, else: :thinking
-    %{model | pending_approval: nil, face_state: face}
+  # The ALLOW/ASK/DENY policy the Engine folds. Only sensitive (mutating)
+  # tools reach it — the closure allows the rest — so the `always_allow` and
+  # ASK arms already know the tool is mutating.
+  defp auth_policies do
+    [
+      Policy.new(
+        name: :coding_tools,
+        phases: [:tool_call],
+        scope: :session,
+        evaluate: fn ctx ->
+          cond do
+            ctx.plan_mode and ctx.mutating -> Verdict.deny(:plan_mode_read_only)
+            MapSet.member?(ctx.always_allow, ctx.tool) -> Verdict.allow()
+            true -> Verdict.ask("Allow #{ctx.tool}?")
+          end
+        end
+      )
+    ]
   end
 
-  defp decide_approval(model, _decision), do: model
+  defp allow_once(model) do
+    reply_pending(model, :allow)
+    %{model | pending_approval: nil, face_state: :working}
+  end
 
-  defp reply_pending(%{pending_approval: %{ref: ref, from: from}}, decision)
+  defp allow_always(%{pending_approval: %{name: name}} = model) do
+    reply_pending(model, :allow)
+
+    %{
+      model
+      | pending_approval: nil,
+        always_allow: MapSet.put(model.always_allow, name),
+        face_state: :working
+    }
+  end
+
+  defp deny_pending(model) do
+    reply_pending(model, {:deny, :user_denied})
+    %{model | pending_approval: nil, face_state: :thinking}
+  end
+
+  defp reply_pending(%{pending_approval: %{ref: ref, from: from}}, verdict)
        when is_pid(from) do
-    send(from, {:approval_decision, ref, decision})
+    send(from, {:authorize_decision, ref, verdict})
     :ok
   end
 
-  defp reply_pending(_model, _decision), do: :ok
+  defp reply_pending(_model, _verdict), do: :ok
 
   # -- view -------------------------------------------------------------------
 
@@ -369,24 +477,33 @@ defmodule Raxol.Agent.Code.App do
   end
 
   defp status_strip(model) do
-    face = AxolFace.glyph(model.face_state, model.face_frame, model.ascii)
+    face =
+      text(AxolFace.glyph(model.face_state, model.face_frame, model.ascii),
+        fg: AxolFace.color(model.face_state),
+        style: [:bold]
+      )
+
+    status = text(status_label(model), style: [:dim])
 
     row style: %{gap: 1} do
-      [
-        text(face, fg: AxolFace.color(model.face_state), style: [:bold]),
-        text(status_label(model), style: [:dim])
-      ]
+      [face] ++ plan_chip(model) ++ [status]
     end
   end
+
+  defp plan_chip(%{plan_mode: true}), do: [text("PLAN", fg: :yellow, style: [:bold])]
+  defp plan_chip(_model), do: []
 
   defp status_label(%{status_line: line}) when is_binary(line), do: line
   defp status_label(%{pending_approval: %{name: name}}), do: "awaiting approval: #{name}"
   defp status_label(%{running?: true}), do: "working…"
+  defp status_label(%{plan_mode: true}), do: "plan mode — read-only"
   defp status_label(_model), do: "ready"
 
   defp footer(%{pending_approval: %{name: name}}) do
     box style: %{border: :single, padding: 0} do
-      text("Allow #{name}? [y/N]  ·  Esc denies", fg: :yellow)
+      text("Allow #{name}?  [a]llow once · [s]always · [d]eny  ·  Esc denies",
+        fg: :yellow
+      )
     end
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/code/event_codec.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/event_codec.ex
@@ -1,0 +1,86 @@
+defmodule Raxol.Agent.Code.EventCodec do
+  @moduledoc """
+  Decode persisted durable contract events back into the projection wire
+  shape, so a resumed session can rebuild its visual transcript.
+
+  Live events are `Raxol.Harness.EventBoundary`-normalized maps — atom
+  top-level fields, an atom `type`/`family`/`tier`/`scope`, and a
+  **string-keyed** payload. Persisting them as JSON stringifies every
+  top-level key and those enum values (the payload already round-trips
+  unchanged). `decode_all/1` reverses that: it re-atomizes the top-level
+  keys and the enum values **from fixed vocabularies only** — an
+  unrecognized `type` string is left as a string (which
+  `Raxol.Harness.Projection` already demotes safely), never minted into an
+  atom. Nothing on disk can grow the atom table.
+
+  The output is exactly what `Raxol.Harness.Projection.project/1` consumes,
+  so a decoded stream renders identically to the live one it was saved from.
+  """
+
+  # The frozen loop vocabulary (mirrors Raxol.Agent.Contract's v0 types plus
+  # the approval/state markers the projection understands).
+  @loop_types ~w(
+    turn_started item_started item_delta item_completed turn_completed
+    error approval_requested approval_decided state_change idle
+  )a
+  @type_lookup Map.new(@loop_types, &{Atom.to_string(&1), &1})
+
+  @families %{"loop" => :loop, "meta" => :meta}
+  @tiers %{"durable" => :durable, "ephemeral" => :ephemeral}
+  @scopes %{"session" => :session, "global" => :global}
+  @sources %{"primary" => :primary, "meta" => :meta}
+  @trust %{"trusted" => :trusted, "tainted" => :tainted}
+
+  @doc "Decode a list of persisted event records into projection events."
+  @spec decode_all([map()]) :: [map()]
+  def decode_all(records) when is_list(records) do
+    records
+    |> Enum.map(&decode/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def decode_all(_other), do: []
+
+  @doc "Decode one persisted record; `nil` if it has no integer id."
+  @spec decode(map()) :: map() | nil
+  def decode(%{"id" => id} = record) when is_integer(id) do
+    %{
+      id: id,
+      turn_id: string_or_nil(Map.get(record, "turn_id")),
+      ts: integer(Map.get(record, "ts")),
+      family: Map.get(@families, Map.get(record, "family"), :loop),
+      # An unknown type stays a string — the projection demotes it safely
+      # (N-DORM-04) rather than us minting an atom from disk.
+      type: decode_type(Map.get(record, "type")),
+      tier: Map.get(@tiers, Map.get(record, "tier"), :durable),
+      scope: Map.get(@scopes, Map.get(record, "scope"), :session),
+      provenance: decode_provenance(Map.get(record, "provenance")),
+      payload: payload(Map.get(record, "payload"))
+    }
+  end
+
+  def decode(_other), do: nil
+
+  defp decode_type(type) when is_binary(type), do: Map.get(@type_lookup, type, type)
+  defp decode_type(_other), do: nil
+
+  defp decode_provenance(%{"source" => source, "trust" => trust}) do
+    %{
+      source: Map.get(@sources, source, :primary),
+      trust: Map.get(@trust, trust, :trusted)
+    }
+  end
+
+  defp decode_provenance(_other), do: %{source: :primary, trust: :trusted}
+
+  # Payload round-trips unchanged (string keys, JSON values) — exactly the
+  # fixture wire shape the projection reads.
+  defp payload(%{} = payload), do: payload
+  defp payload(_other), do: %{}
+
+  defp string_or_nil(value) when is_binary(value), do: value
+  defp string_or_nil(_other), do: nil
+
+  defp integer(value) when is_integer(value), do: value
+  defp integer(_other), do: 0
+end

--- a/packages/raxol_agent/lib/raxol/agent/code/hooks.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/hooks.ex
@@ -1,0 +1,169 @@
+defmodule Raxol.Agent.Code.Hooks do
+  @moduledoc """
+  Settings-file lifecycle hooks for `mix raxol.code`.
+
+  A `.raxol/hooks.json` in the working directory declares shell commands to
+  run around the tool loop:
+
+      {
+        "pre_tool_use":  [{"match": "bash", "command": "./scripts/guard.sh"}],
+        "post_tool_use": [{"match": "*", "command": "mix format"}],
+        "stop":          ["mix test --stale"]
+      }
+
+  * **pre_tool_use** — runs before a matching tool. A non-zero exit **vetoes**
+    the tool call (the loop is told the tool was refused), so a guard script
+    can block a dangerous command. Runs on the `ToolCall.Hook` `before_call`
+    seam.
+  * **post_tool_use** — runs after a matching tool; its exit status is
+    ignored and it cannot change the result (`after_call`).
+  * **stop** — runs once when a turn finishes (driven by the surface).
+
+  `match` is an exact tool name or `"*"` (any). The matched command runs via
+  `/bin/sh -c` in the working directory with `RAXOL_TOOL_NAME` set. Config
+  travels in the run context under `:code_hooks`, so this one module serves
+  every session without per-config module generation.
+  """
+
+  @behaviour Raxol.Agent.ToolCall.Hook
+
+  alias Raxol.Agent.Actions.Code
+
+  @hook_timeout_ms 30_000
+
+  @type rule :: %{match: String.t(), command: String.t()}
+  @type config :: %{pre: [rule()], post: [rule()], stop: [String.t()]}
+
+  # -- loading ----------------------------------------------------------------
+
+  @doc """
+  Load hooks from `<dir>/.raxol/hooks.json`.
+
+  Returns `{:ok, config}`, `:none` when there is no file, or `{:error,
+  reason}` for an unreadable/invalid file (never silently ignored).
+  """
+  @spec load(String.t()) :: {:ok, config()} | :none | {:error, term()}
+  def load(dir) do
+    path = Path.join(dir, ".raxol/hooks.json")
+
+    case File.read(path) do
+      {:error, :enoent} ->
+        :none
+
+      {:error, reason} ->
+        {:error, {:read_failed, reason}}
+
+      {:ok, binary} ->
+        case Jason.decode(binary) do
+          {:ok, json} when is_map(json) -> {:ok, parse(json)}
+          {:ok, _other} -> {:error, :not_an_object}
+          {:error, _} -> {:error, :invalid_json}
+        end
+    end
+  end
+
+  @doc "Total number of declared hooks in a config."
+  @spec count(config() | nil) :: non_neg_integer()
+  def count(%{pre: pre, post: post, stop: stop}),
+    do: length(pre) + length(post) + length(stop)
+
+  def count(_other), do: 0
+
+  defp parse(json) do
+    %{
+      pre: parse_rules(Map.get(json, "pre_tool_use", [])),
+      post: parse_rules(Map.get(json, "post_tool_use", [])),
+      stop: parse_commands(Map.get(json, "stop", []))
+    }
+  end
+
+  defp parse_rules(list) when is_list(list),
+    do: list |> Enum.map(&parse_rule/1) |> Enum.reject(&is_nil/1)
+
+  defp parse_rules(_other), do: []
+
+  defp parse_rule(%{"command" => command} = rule) when is_binary(command),
+    do: %{match: Map.get(rule, "match", "*"), command: command}
+
+  defp parse_rule(_other), do: nil
+
+  defp parse_commands(list) when is_list(list) do
+    Enum.flat_map(list, fn
+      %{"command" => c} when is_binary(c) -> [c]
+      c when is_binary(c) -> [c]
+      _other -> []
+    end)
+  end
+
+  defp parse_commands(_other), do: []
+
+  # -- ToolCall.Hook callbacks ------------------------------------------------
+
+  @impl true
+  def before_call(call, context) do
+    case run_pre(rules(context, :pre), call.name, cwd(context)) do
+      :ok ->
+        {:cont, call}
+
+      {:blocked, command, status} ->
+        {:halt, {:hook_blocked, call.name, command, status}}
+    end
+  end
+
+  @impl true
+  def after_call(call, result, context) do
+    run_post(rules(context, :post), call.name, cwd(context))
+    result
+  end
+
+  @doc """
+  Run a config's `stop` commands in `cwd`, returning a receipt per command.
+  Driven by the surface at turn end (not part of the tool-call pipeline).
+  """
+  @spec run_stop(config(), String.t()) :: [%{command: String.t(), exit_status: integer() | :timeout}]
+  def run_stop(%{stop: commands}, cwd) do
+    Enum.map(commands, fn command ->
+      {_out, status} = Code.run_shell(command, cwd, @hook_timeout_ms, env(nil))
+      %{command: command, exit_status: status}
+    end)
+  end
+
+  # -- running ----------------------------------------------------------------
+
+  # First matching pre-hook with a non-zero exit vetoes the call.
+  defp run_pre(rules, tool_name, cwd) do
+    rules
+    |> Enum.filter(&matches?(&1.match, tool_name))
+    |> Enum.reduce_while(:ok, fn rule, :ok ->
+      {_out, status} = Code.run_shell(rule.command, cwd, @hook_timeout_ms, env(tool_name))
+
+      if status == 0,
+        do: {:cont, :ok},
+        else: {:halt, {:blocked, rule.command, status}}
+    end)
+  end
+
+  # Post-hooks all run; their status is advisory only.
+  defp run_post(rules, tool_name, cwd) do
+    rules
+    |> Enum.filter(&matches?(&1.match, tool_name))
+    |> Enum.each(fn rule ->
+      Code.run_shell(rule.command, cwd, @hook_timeout_ms, env(tool_name))
+    end)
+  end
+
+  defp matches?("*", _tool_name), do: true
+  defp matches?(pattern, tool_name), do: pattern == tool_name
+
+  defp rules(context, key) do
+    case Map.get(context, :code_hooks) do
+      %{} = config -> Map.get(config, key, [])
+      _other -> []
+    end
+  end
+
+  defp cwd(context), do: Map.get(context, :hook_cwd) || File.cwd!()
+
+  defp env(nil), do: []
+  defp env(tool_name), do: [{"RAXOL_TOOL_NAME", tool_name}]
+end

--- a/packages/raxol_agent/lib/raxol/agent/code/hooks.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/hooks.ex
@@ -120,7 +120,9 @@ defmodule Raxol.Agent.Code.Hooks do
   Run a config's `stop` commands in `cwd`, returning a receipt per command.
   Driven by the surface at turn end (not part of the tool-call pipeline).
   """
-  @spec run_stop(config(), String.t()) :: [%{command: String.t(), exit_status: integer() | :timeout}]
+  @spec run_stop(config(), String.t()) :: [
+          %{command: String.t(), exit_status: integer() | :timeout}
+        ]
   def run_stop(%{stop: commands}, cwd) do
     Enum.map(commands, fn command ->
       {_out, status} = Code.run_shell(command, cwd, @hook_timeout_ms, env(nil))

--- a/packages/raxol_agent/lib/raxol/agent/code/mcp_config.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/mcp_config.ex
@@ -1,0 +1,100 @@
+defmodule Raxol.Agent.Code.McpConfig do
+  @moduledoc """
+  Loader for `.mcp.json` external MCP server config (the Claude Code
+  format) used by `mix raxol.code`.
+
+  Reads `<dir>/.mcp.json`:
+
+      {
+        "mcpServers": {
+          "filesystem": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+          }
+        }
+      }
+
+  and returns the declared servers. The surface uses this to discover and
+  list configured servers (`/mcp`).
+
+  ## Scope
+
+  This loads and surfaces the config. **Bridging a server's tools into the
+  live ReAct toolset is a deliberate follow-up**: the tool loop dispatches
+  to `Raxol.Agent.Action` *modules* (`ToolConverter.dispatch_tool_call/3`),
+  whereas MCP tools are discovered at runtime, so exposing them needs a
+  dispatch path for dynamic (non-module) tools. `Raxol.MCP.Client` already
+  connects to servers; the missing piece is that dynamic dispatch seam, not
+  this loader.
+  """
+
+  @type server :: %{
+          name: String.t(),
+          command: String.t(),
+          args: [String.t()],
+          env: map()
+        }
+
+  @doc """
+  Load MCP servers from `<dir>/.mcp.json`.
+
+  Returns `{:ok, servers}` (possibly empty), `:none` when there is no file,
+  or `{:error, reason}` for an unreadable/invalid file.
+  """
+  @spec load(String.t()) :: {:ok, [server()]} | :none | {:error, term()}
+  def load(dir) do
+    path = Path.join(dir, ".mcp.json")
+
+    case File.read(path) do
+      {:error, :enoent} ->
+        :none
+
+      {:error, reason} ->
+        {:error, {:read_failed, reason}}
+
+      {:ok, binary} ->
+        decode(binary)
+    end
+  end
+
+  defp decode(binary) do
+    case Jason.decode(binary) do
+      {:ok, json} when is_map(json) ->
+        case Map.get(json, "mcpServers") do
+          servers when is_map(servers) -> {:ok, parse(servers)}
+          _absent -> {:ok, []}
+        end
+
+      {:ok, _other} ->
+        {:error, :not_an_object}
+
+      {:error, _} ->
+        {:error, :invalid_json}
+    end
+  end
+
+  defp parse(servers) do
+    servers
+    |> Enum.map(&parse_server/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp parse_server({name, %{"command" => command} = spec})
+       when is_binary(name) and is_binary(command) do
+    %{
+      name: name,
+      command: command,
+      args: string_list(Map.get(spec, "args", [])),
+      env: env_map(Map.get(spec, "env", %{}))
+    }
+  end
+
+  defp parse_server(_other), do: nil
+
+  defp string_list(list) when is_list(list), do: Enum.filter(list, &is_binary/1)
+  defp string_list(_other), do: []
+
+  defp env_map(%{} = env), do: env
+  defp env_map(_other), do: %{}
+end

--- a/packages/raxol_agent/lib/raxol/agent/code/store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/store.ex
@@ -62,21 +62,24 @@ defmodule Raxol.Agent.Code.Store do
   def load(dir, session_key) do
     with {:ok, binary} <- File.read(path(dir, session_key)),
          {:ok, json} when is_map(json) <- Jason.decode(binary) do
-      {:ok,
-       %{
-         id: Map.get(json, "id", session_key),
-         updated_at: Map.get(json, "updated_at", 0),
-         cwd: Map.get(json, "cwd", ""),
-         messages:
-           json
-           |> Map.get("messages", [])
-           |> Enum.map(&decode_message/1)
-           |> Enum.reject(&is_nil/1),
-         events: Raxol.Agent.Code.EventCodec.decode_all(Map.get(json, "events", []))
-       }}
+      {:ok, build_session(json, session_key)}
     else
       _ -> {:error, :not_found}
     end
+  end
+
+  defp build_session(json, session_key) do
+    %{
+      id: Map.get(json, "id", session_key),
+      updated_at: Map.get(json, "updated_at", 0),
+      cwd: Map.get(json, "cwd", ""),
+      messages:
+        json
+        |> Map.get("messages", [])
+        |> Enum.map(&decode_message/1)
+        |> Enum.reject(&is_nil/1),
+      events: Raxol.Agent.Code.EventCodec.decode_all(Map.get(json, "events", []))
+    }
   end
 
   @doc "The most recently updated session id, or `nil` if none exist."
@@ -89,7 +92,9 @@ defmodule Raxol.Agent.Code.Store do
   end
 
   @doc "Saved sessions, most-recently-updated first: `%{id, updated_at, message_count}`."
-  @spec list(String.t()) :: [%{id: String.t(), updated_at: integer(), message_count: non_neg_integer()}]
+  @spec list(String.t()) :: [
+          %{id: String.t(), updated_at: integer(), message_count: non_neg_integer()}
+        ]
   def list(dir) do
     case File.ls(dir) do
       {:ok, files} ->

--- a/packages/raxol_agent/lib/raxol/agent/code/store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/store.ex
@@ -4,17 +4,15 @@ defmodule Raxol.Agent.Code.Store do
   session under a base directory, so a conversation survives across runs
   and `--continue` / `--resume` can reattach it.
 
-  A saved session is the LLM conversation (`messages`) plus a little
-  metadata (`updated_at`, `cwd`). Only the three known roles
-  (`:user`/`:assistant`/`:system`) round-trip; an unknown role on read is
-  dropped rather than minting an atom from disk. The session id is only
-  ever used as a filename via `Path.basename/1`, so a crafted id can never
-  escape the base directory.
-
-  This is the conversation-continuity layer. Reconstructing the visual
-  transcript (folded projection blocks) from a durable event journal is a
-  separate, heavier concern left for later; resuming the conversation is
-  what makes the assistant useful across runs.
+  A saved session is the LLM conversation (`messages`), the durable
+  contract `events` (so `--resume` can rebuild the visual transcript, not
+  just the model context), and a little metadata (`updated_at`, `cwd`).
+  Only the three known roles (`:user`/`:assistant`/`:system`) round-trip;
+  an unknown role on read is dropped rather than minting an atom from disk.
+  Events are decoded back into projection shape by
+  `Raxol.Agent.Code.EventCodec` (fixed vocabularies, no atom minting from
+  disk). The session id is only ever used as a filename via
+  `Path.basename/1`, so a crafted id can never escape the base directory.
   """
 
   @role_to_string %{user: "user", assistant: "assistant", system: "system"}
@@ -25,7 +23,8 @@ defmodule Raxol.Agent.Code.Store do
           id: String.t(),
           updated_at: integer(),
           cwd: String.t(),
-          messages: [message()]
+          messages: [message()],
+          events: [map()]
         }
 
   @doc "The default sessions directory (`$RAXOL_CODE_SESSIONS` or `~/.raxol/code_sessions`)."
@@ -48,7 +47,10 @@ defmodule Raxol.Agent.Code.Store do
           "id" => session_key,
           "updated_at" => System.system_time(:second),
           "cwd" => Map.get(attrs, :cwd, ""),
-          "messages" => attrs |> Map.get(:messages, []) |> Enum.map(&encode_message/1)
+          "messages" => attrs |> Map.get(:messages, []) |> Enum.map(&encode_message/1),
+          # Durable projection events, stored as-is (already JSON-encodable);
+          # EventCodec decodes them back to projection shape on load.
+          "events" => Map.get(attrs, :events, [])
         }
 
       File.write(path(dir, session_key), Jason.encode!(data))
@@ -69,7 +71,8 @@ defmodule Raxol.Agent.Code.Store do
            json
            |> Map.get("messages", [])
            |> Enum.map(&decode_message/1)
-           |> Enum.reject(&is_nil/1)
+           |> Enum.reject(&is_nil/1),
+         events: Raxol.Agent.Code.EventCodec.decode_all(Map.get(json, "events", []))
        }}
     else
       _ -> {:error, :not_found}

--- a/packages/raxol_agent/lib/raxol/agent/code/store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/store.ex
@@ -1,0 +1,130 @@
+defmodule Raxol.Agent.Code.Store do
+  @moduledoc """
+  On-disk persistence for `mix raxol.code` sessions — one JSON file per
+  session under a base directory, so a conversation survives across runs
+  and `--continue` / `--resume` can reattach it.
+
+  A saved session is the LLM conversation (`messages`) plus a little
+  metadata (`updated_at`, `cwd`). Only the three known roles
+  (`:user`/`:assistant`/`:system`) round-trip; an unknown role on read is
+  dropped rather than minting an atom from disk. The session id is only
+  ever used as a filename via `Path.basename/1`, so a crafted id can never
+  escape the base directory.
+
+  This is the conversation-continuity layer. Reconstructing the visual
+  transcript (folded projection blocks) from a durable event journal is a
+  separate, heavier concern left for later; resuming the conversation is
+  what makes the assistant useful across runs.
+  """
+
+  @role_to_string %{user: "user", assistant: "assistant", system: "system"}
+  @string_to_role %{"user" => :user, "assistant" => :assistant, "system" => :system}
+
+  @type message :: %{role: :user | :assistant | :system, content: String.t()}
+  @type session :: %{
+          id: String.t(),
+          updated_at: integer(),
+          cwd: String.t(),
+          messages: [message()]
+        }
+
+  @doc "The default sessions directory (`$RAXOL_CODE_SESSIONS` or `~/.raxol/code_sessions`)."
+  @spec default_dir() :: String.t()
+  def default_dir do
+    case System.get_env("RAXOL_CODE_SESSIONS") do
+      dir when is_binary(dir) and dir != "" -> dir
+      _ -> Path.join(home_base(), ".raxol/code_sessions")
+    end
+  end
+
+  defp home_base, do: System.user_home() || System.tmp_dir!()
+
+  @doc "Persist a session's messages + metadata. Returns `:ok` or `{:error, reason}`."
+  @spec save(String.t(), String.t(), map()) :: :ok | {:error, term()}
+  def save(dir, session_key, attrs) do
+    with :ok <- File.mkdir_p(dir) do
+      data =
+        %{
+          "id" => session_key,
+          "updated_at" => System.system_time(:second),
+          "cwd" => Map.get(attrs, :cwd, ""),
+          "messages" => attrs |> Map.get(:messages, []) |> Enum.map(&encode_message/1)
+        }
+
+      File.write(path(dir, session_key), Jason.encode!(data))
+    end
+  end
+
+  @doc "Load a session by id. Returns `{:ok, session}` or `{:error, :not_found}`."
+  @spec load(String.t(), String.t()) :: {:ok, session()} | {:error, :not_found}
+  def load(dir, session_key) do
+    with {:ok, binary} <- File.read(path(dir, session_key)),
+         {:ok, json} when is_map(json) <- Jason.decode(binary) do
+      {:ok,
+       %{
+         id: Map.get(json, "id", session_key),
+         updated_at: Map.get(json, "updated_at", 0),
+         cwd: Map.get(json, "cwd", ""),
+         messages:
+           json
+           |> Map.get("messages", [])
+           |> Enum.map(&decode_message/1)
+           |> Enum.reject(&is_nil/1)
+       }}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @doc "The most recently updated session id, or `nil` if none exist."
+  @spec latest(String.t()) :: String.t() | nil
+  def latest(dir) do
+    case list(dir) do
+      [%{id: id} | _] -> id
+      [] -> nil
+    end
+  end
+
+  @doc "Saved sessions, most-recently-updated first: `%{id, updated_at, message_count}`."
+  @spec list(String.t()) :: [%{id: String.t(), updated_at: integer(), message_count: non_neg_integer()}]
+  def list(dir) do
+    case File.ls(dir) do
+      {:ok, files} ->
+        files
+        |> Enum.filter(&String.ends_with?(&1, ".json"))
+        |> Enum.map(&summarize(dir, String.replace_suffix(&1, ".json", "")))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.sort_by(& &1.updated_at, :desc)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp summarize(dir, id) do
+    case load(dir, id) do
+      {:ok, session} ->
+        %{id: id, updated_at: session.updated_at, message_count: length(session.messages)}
+
+      {:error, _} ->
+        nil
+    end
+  end
+
+  # `Path.basename/1` neutralizes any path separators / `..` in a caller- or
+  # disk-supplied id, so a session key can never point outside `dir`.
+  defp path(dir, session_key), do: Path.join(dir, Path.basename(session_key) <> ".json")
+
+  defp encode_message(%{role: role, content: content}) do
+    %{"role" => Map.get(@role_to_string, role, "user"), "content" => to_string(content)}
+  end
+
+  defp decode_message(%{"role" => role, "content" => content}) when is_binary(content) do
+    case Map.get(@string_to_role, role) do
+      nil -> nil
+      atom -> %{role: atom, content: content}
+    end
+  end
+
+  defp decode_message(_other), do: nil
+end

--- a/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
@@ -1,0 +1,263 @@
+defmodule Raxol.Agent.Actions.CodeTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Action.ToolConverter
+  alias Raxol.Agent.Actions.Code
+  alias Raxol.Agent.Sandbox
+
+  setup do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-code-test-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "hello.ex"), "defmodule Hello do\n  :world\nend\n")
+
+    previous = System.get_env("RAXOL_CLI_CWD")
+    System.put_env("RAXOL_CLI_CWD", dir)
+
+    on_exit(fn ->
+      case previous do
+        nil -> System.delete_env("RAXOL_CLI_CWD")
+        value -> System.put_env("RAXOL_CLI_CWD", value)
+      end
+
+      File.rm_rf!(dir)
+    end)
+
+    %{dir: dir}
+  end
+
+  describe "Write" do
+    test "creates a new file and returns a diff-shaped result", %{dir: dir} do
+      assert {:ok, result} =
+               Code.Write.run(%{path: "new.ex", content: "x = 1\n"}, %{})
+
+      assert result.path == "new.ex"
+      assert result.old == ""
+      assert result.new == "x = 1\n"
+      assert result.language == "elixir"
+      assert result.created == true
+      assert File.read!(Path.join(dir, "new.ex")) == "x = 1\n"
+    end
+
+    test "creates parent directories as needed", %{dir: dir} do
+      assert {:ok, _} =
+               Code.Write.run(%{path: "lib/deep/mod.ex", content: "ok\n"}, %{})
+
+      assert File.read!(Path.join(dir, "lib/deep/mod.ex")) == "ok\n"
+    end
+
+    test "refuses to clobber an existing file without overwrite" do
+      assert {:error, :file_exists} =
+               Code.Write.run(%{path: "hello.ex", content: "nope"}, %{})
+    end
+
+    test "overwrites when overwrite is true", %{dir: dir} do
+      assert {:ok, result} =
+               Code.Write.run(
+                 %{path: "hello.ex", content: "new\n", overwrite: true},
+                 %{}
+               )
+
+      assert result.created == false
+      assert result.old =~ "defmodule Hello"
+      assert result.new == "new\n"
+      assert File.read!(Path.join(dir, "hello.ex")) == "new\n"
+    end
+
+    test "rejects paths outside the working dir" do
+      assert {:error, :outside_cwd} =
+               Code.Write.run(%{path: "../escape", content: "x"}, %{})
+    end
+  end
+
+  describe "Edit" do
+    test "replaces a unique match and returns the before/after images", %{dir: dir} do
+      assert {:ok, result} =
+               Code.Edit.run(
+                 %{path: "hello.ex", old_string: ":world", new_string: ":earth"},
+                 %{}
+               )
+
+      assert result.replacements == 1
+      assert result.old =~ ":world"
+      assert result.new =~ ":earth"
+      assert File.read!(Path.join(dir, "hello.ex")) =~ ":earth"
+    end
+
+    test "errors when the old_string is not found" do
+      assert {:error, :no_match} =
+               Code.Edit.run(
+                 %{path: "hello.ex", old_string: "absent", new_string: "x"},
+                 %{}
+               )
+    end
+
+    test "errors when the match is not unique" do
+      File.write!(Path.join(System.get_env("RAXOL_CLI_CWD"), "dup.txt"), "a a a")
+
+      assert {:error, :not_unique} =
+               Code.Edit.run(
+                 %{path: "dup.txt", old_string: "a", new_string: "b"},
+                 %{}
+               )
+    end
+
+    test "replace_all replaces every occurrence", %{dir: dir} do
+      File.write!(Path.join(dir, "dup.txt"), "a a a")
+
+      assert {:ok, %{replacements: 3}} =
+               Code.Edit.run(
+                 %{
+                   path: "dup.txt",
+                   old_string: "a",
+                   new_string: "b",
+                   replace_all: true
+                 },
+                 %{}
+               )
+
+      assert File.read!(Path.join(dir, "dup.txt")) == "b b b"
+    end
+
+    test "rejects a no-op edit" do
+      assert {:error, :no_change} =
+               Code.Edit.run(
+                 %{path: "hello.ex", old_string: "same", new_string: "same"},
+                 %{}
+               )
+    end
+  end
+
+  describe "Bash" do
+    test "runs a command and captures stdout + exit status" do
+      assert {:ok, result} =
+               Code.Bash.run(%{command: "echo hello"}, %{})
+
+      assert result.stdout == "hello\n"
+      assert result.exit_status == 0
+      assert result.truncated == false
+    end
+
+    test "captures a non-zero exit status" do
+      assert {:ok, %{exit_status: status}} =
+               Code.Bash.run(%{command: "exit 3"}, %{})
+
+      assert status == 3
+    end
+
+    test "runs in the working directory by default", %{dir: dir} do
+      # `/bin/sh pwd` reports the physical path (macOS resolves /var ->
+      # /private/var), so match on the unique dir basename rather than the
+      # possibly-symlinked absolute path.
+      assert {:ok, %{stdout: out}} = Code.Bash.run(%{command: "pwd"}, %{})
+      assert String.ends_with?(String.trim(out), Path.basename(dir))
+    end
+
+    test "honors a shell sandbox denylist in context" do
+      sandbox = Sandbox.Shell.denylist(["rm"])
+
+      assert {:error, {:shell_denied, "rm -rf /"}} =
+               Code.Bash.run(%{command: "rm -rf /"}, %{shell_sandbox: sandbox})
+    end
+
+    test "allows a command permitted by the sandbox allowlist" do
+      sandbox = Sandbox.Shell.allowlist(["echo"])
+
+      assert {:ok, %{exit_status: 0}} =
+               Code.Bash.run(%{command: "echo ok"}, %{shell_sandbox: sandbox})
+    end
+  end
+
+  describe "Grep" do
+    test "finds matches with path, line, and text", %{dir: dir} do
+      File.write!(Path.join(dir, "a.txt"), "alpha\nbeta\ngamma\n")
+
+      assert {:ok, %{matches: matches, count: count}} =
+               Code.Grep.run(%{pattern: "beta"}, %{})
+
+      assert count >= 1
+      assert Enum.any?(matches, &(&1.text =~ "beta" and &1.line == 2))
+    end
+
+    test "ignore_case matches case-insensitively", %{dir: dir} do
+      File.write!(Path.join(dir, "b.txt"), "HELLO\n")
+
+      assert {:ok, %{count: count}} =
+               Code.Grep.run(%{pattern: "hello", ignore_case: true}, %{})
+
+      assert count >= 1
+    end
+
+    test "rejects a directory outside the working dir" do
+      assert {:error, :outside_cwd} =
+               Code.Grep.run(%{pattern: "x", path: "../.."}, %{})
+    end
+  end
+
+  describe "Glob" do
+    test "returns sorted cwd-relative matches", %{dir: dir} do
+      File.mkdir_p!(Path.join(dir, "lib"))
+      File.write!(Path.join(dir, "lib/one.ex"), "1")
+      File.write!(Path.join(dir, "lib/two.ex"), "2")
+
+      assert {:ok, %{paths: paths}} = Code.Glob.run(%{pattern: "lib/**/*.ex"}, %{})
+      assert "lib/one.ex" in paths
+      assert "lib/two.ex" in paths
+      assert paths == Enum.sort(paths)
+    end
+  end
+
+  describe "diff_result/4 image cap" do
+    test "drops the diff for a large before/after image" do
+      big = String.duplicate("x", 40_000)
+      result = Code.diff_result("big.txt", "", big, %{created: true})
+
+      refute Map.has_key?(result, :new)
+      assert result.truncated == true
+      assert result.new_bytes == 40_000
+    end
+  end
+
+  describe "tool-call gating (the security seam)" do
+    test "sensitive write_file is denied under the default policy" do
+      call = %{"name" => "write_file", "arguments" => %{"path" => "x", "content" => "y"}}
+
+      assert {:error, {:tool_denied, "write_file", :sensitive_tool}} =
+               ToolConverter.dispatch_tool_call(call, Code.all(), %{})
+
+      refute File.exists?(Path.join(System.get_env("RAXOL_CLI_CWD"), "x"))
+    end
+
+    test "sensitive bash is denied under the default policy" do
+      call = %{"name" => "bash", "arguments" => %{"command" => "echo pwned"}}
+
+      assert {:error, {:tool_denied, "bash", :sensitive_tool}} =
+               ToolConverter.dispatch_tool_call(call, Code.all(), %{})
+    end
+
+    test "read-only grep is allowed under the default policy" do
+      call = %{"name" => "grep", "arguments" => %{"pattern" => "Hello"}}
+
+      assert {:ok, %{count: _}} =
+               ToolConverter.dispatch_tool_call(call, Code.all(), %{})
+    end
+
+    test "write_file runs when an allow-all authorizer opts in", %{dir: dir} do
+      call = %{
+        "name" => "write_file",
+        "arguments" => %{"path" => "opted.txt", "content" => "in\n"}
+      }
+
+      context = %{tool_authorizer: Raxol.Agent.ToolPolicy.allow_all()}
+
+      assert {:ok, %{path: "opted.txt"}} =
+               ToolConverter.dispatch_tool_call(call, Code.all(), context)
+
+      assert File.read!(Path.join(dir, "opted.txt")) == "in\n"
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/actions/task_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/task_test.exs
@@ -1,0 +1,29 @@
+defmodule Raxol.Agent.Actions.TaskTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Action.ToolConverter
+  alias Raxol.Agent.Actions.Task
+  alias Raxol.Agent.Backend.Mock
+
+  defp subagent_ctx(response) do
+    %{subagent: %{backend: Mock, backend_opts: [response: response]}}
+  end
+
+  test "delegates to a sub-agent and returns its final answer" do
+    assert {:ok, %{result: "sub result"}} =
+             Task.Delegate.run(%{prompt: "investigate"}, subagent_ctx("sub result"))
+  end
+
+  test "the task tool is allowed by the default policy (not sensitive)" do
+    call = %{"name" => "task", "arguments" => %{"prompt" => "look around"}}
+
+    assert {:ok, %{result: "ok"}} =
+             ToolConverter.dispatch_tool_call(call, Task.all(), subagent_ctx("ok"))
+  end
+
+  test "task is registered under the read-only-safe name" do
+    assert [Task.Delegate] = Task.all()
+    assert Task.Delegate.__action_meta__().name == "task"
+    refute Task.Delegate.__action_meta__().sensitive
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -114,43 +114,90 @@ defmodule Raxol.Agent.Code.AppTest do
     end
   end
 
-  describe "interactive approval" do
-    test "an approval request sets the pending state and working face" do
-      ref = make_ref()
-      msg = {:command_result, {:approval_request, ref, self(), "write_file"}}
-      {model, []} = App.update(msg, %{new_model() | running?: true})
+  defp request(model, name) do
+    ref = make_ref()
+    msg = {:command_result, {:authorize_request, ref, self(), name}}
+    {model, []} = App.update(msg, model)
+    {ref, model}
+  end
 
+  describe "interactive approval (Engine ASK)" do
+    test "a sensitive tool asks: pending state, working face" do
+      {_ref, model} = request(%{new_model() | running?: true}, "write_file")
       assert model.pending_approval.name == "write_file"
       assert model.face_state == :working
     end
 
-    test "'y' allows the pending tool and replies to the waiter" do
-      ref = make_ref()
-      {model, []} =
-        App.update(
-          {:command_result, {:approval_request, ref, self(), "bash"}},
-          %{new_model() | running?: true}
-        )
-
-      {model, []} = App.update(key("y"), model)
+    test "'a' allows once and replies to the waiter" do
+      {ref, model} = request(%{new_model() | running?: true}, "bash")
+      {model, []} = App.update(key("a"), model)
 
       assert model.pending_approval == nil
-      assert_receive {:approval_decision, ^ref, :allow}
+      assert_receive {:authorize_decision, ^ref, :allow}
     end
 
-    test "'n' and Esc both deny the pending tool" do
-      for denier <- [key("n"), key(:escape)] do
-        ref = make_ref()
-        {model, []} =
-          App.update(
-            {:command_result, {:approval_request, ref, self(), "write_file"}},
-            %{new_model() | running?: true}
-          )
-
+    test "'d' and Esc both deny the pending tool" do
+      for denier <- [key("d"), key(:escape)] do
+        {ref, model} = request(%{new_model() | running?: true}, "write_file")
         {model, []} = App.update(denier, model)
         assert model.pending_approval == nil
-        assert_receive {:approval_decision, ^ref, :deny}
+        assert_receive {:authorize_decision, ^ref, {:deny, :user_denied}}
       end
+    end
+  end
+
+  describe "approval memory (Engine ALLOW after 'always')" do
+    test "'s' remembers the tool; the next call auto-allows without a prompt" do
+      {ref1, model} = request(%{new_model() | running?: true}, "write_file")
+      {model, []} = App.update(key("s"), model)
+      assert_receive {:authorize_decision, ^ref1, :allow}
+      assert MapSet.member?(model.always_allow, "write_file")
+
+      # A second request for the same tool is ALLOWed by the Engine outright.
+      {ref2, model} = request(model, "write_file")
+      assert model.pending_approval == nil
+      assert_receive {:authorize_decision, ^ref2, :allow}
+    end
+
+    test "'a' (once) does NOT remember; the next call asks again" do
+      {ref1, model} = request(%{new_model() | running?: true}, "bash")
+      {model, []} = App.update(key("a"), model)
+      assert_receive {:authorize_decision, ^ref1, :allow}
+      refute MapSet.member?(model.always_allow, "bash")
+
+      {_ref2, model} = request(model, "bash")
+      assert model.pending_approval.name == "bash"
+    end
+  end
+
+  describe "plan mode (Engine DENY of mutations)" do
+    test "Shift+Tab and Ctrl+P toggle plan mode when idle" do
+      {model, []} = App.update(key(:backtab), new_model())
+      assert model.plan_mode == true
+      {model, []} = App.update(key("p", [:ctrl]), model)
+      assert model.plan_mode == false
+    end
+
+    test "plan mode does not toggle mid-turn" do
+      model = %{new_model() | running?: true}
+      {model, []} = App.update(key(:backtab), model)
+      assert model.plan_mode == false
+    end
+
+    test "a mutating tool is denied outright in plan mode (no prompt)" do
+      {ref, model} =
+        request(%{new_model() | running?: true, plan_mode: true}, "write_file")
+
+      assert model.pending_approval == nil
+      assert model.status_line =~ "plan mode"
+      assert_receive {:authorize_decision, ^ref, {:deny, :plan_mode_read_only}}
+    end
+
+    test "plan mode augments the system prompt with a planning directive" do
+      # Submitting in plan mode must not raise and keeps the loop consistent.
+      model = %{new_model() | plan_mode: true, input: "add a feature"}
+      {model, []} = App.update(key(:enter), model)
+      assert model.running? == true
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -47,6 +47,18 @@ defmodule Raxol.Agent.Code.AppTest do
 
   defp submit(model, text), do: App.update(key(:enter), %{model | input: text})
 
+  defp config_cwd(files) do
+    dir = tmp_dir()
+
+    Enum.each(files, fn {rel, content} ->
+      path = Path.join(dir, rel)
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, content)
+    end)
+
+    dir
+  end
+
   describe "init/1" do
     test "starts idle with an empty prompt" do
       model = new_model()
@@ -380,6 +392,67 @@ defmodule Raxol.Agent.Code.AppTest do
     test "an unknown command reports itself" do
       {model, []} = submit(new_model(), "/frobnicate")
       assert model.notice =~ "unknown command"
+    end
+  end
+
+  describe "delegation + config (Phase 5)" do
+    test "init loads .raxol/hooks.json and .mcp.json from cwd" do
+      dir =
+        config_cwd(%{
+          ".raxol/hooks.json" => Jason.encode!(%{"stop" => ["true"]}),
+          ".mcp.json" =>
+            Jason.encode!(%{"mcpServers" => %{"fs" => %{"command" => "npx", "args" => []}}})
+        })
+
+      model = App.init(%{options: [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir]})
+
+      assert model.hooks.stop == ["true"]
+      assert [%{name: "fs"}] = model.mcp_servers
+      assert model.status_line =~ "hooks"
+      assert model.status_line =~ "MCP"
+    end
+
+    test "a turn's run context carries the toolset, sub-agent config, and hooks" do
+      parent = self()
+
+      runner = fn _sid, _prompt, opts, _app ->
+        send(parent, {:opts, opts})
+        spawn(fn -> Process.sleep(60_000) end)
+      end
+
+      dir =
+        config_cwd(%{
+          ".raxol/hooks.json" =>
+            Jason.encode!(%{"pre_tool_use" => [%{"match" => "*", "command" => "true"}]})
+        })
+
+      model = App.init(%{options: [runner: runner, sessions_dir: tmp_dir(), cwd: dir]})
+      {_model, []} = App.update(key(:enter), %{model | input: "go"})
+
+      assert_receive {:opts, opts}
+      context = Keyword.fetch!(opts, :context)
+      assert Map.has_key?(context, :subagent)
+      assert context.tool_call_hooks == [Raxol.Agent.Code.Hooks]
+
+      names = Enum.map(Keyword.fetch!(opts, :actions), & &1.__action_meta__().name)
+      assert "task" in names
+    end
+
+    test "/hooks and /mcp report the loaded configuration" do
+      dir =
+        config_cwd(%{
+          ".raxol/hooks.json" => Jason.encode!(%{"stop" => ["true"]}),
+          ".mcp.json" =>
+            Jason.encode!(%{"mcpServers" => %{"fs" => %{"command" => "npx", "args" => []}}})
+        })
+
+      model = App.init(%{options: [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir]})
+
+      {model, []} = submit(model, "/hooks")
+      assert model.notice =~ "stop: 1"
+
+      {model, []} = submit(model, "/mcp")
+      assert model.notice =~ "fs"
     end
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -1,0 +1,228 @@
+defmodule Raxol.Agent.Code.AppTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Code.App
+  alias Raxol.Agent.Contract
+  alias Raxol.Core.Events.Event
+
+  # A runner that does not spawn a real turn: it returns a live, inert pid
+  # (so interrupt has something to kill) and never touches the network.
+  defp stub_runner do
+    fn _session_id, _prompt, _opts, _app ->
+      spawn(fn -> Process.sleep(60_000) end)
+    end
+  end
+
+  defp new_model(opts \\ []) do
+    App.init(%{options: Keyword.put_new(opts, :runner, stub_runner())})
+  end
+
+  defp key(k, mods \\ []), do: Event.key_event(k, :pressed, mods)
+
+  defp ev(id, type, payload, tier \\ :durable) do
+    %Contract.Event{
+      id: id,
+      ts: id,
+      turn_id: "t1",
+      family: :loop,
+      type: type,
+      tier: tier,
+      payload: payload
+    }
+  end
+
+  defp send_ev(model, event) do
+    {model, []} = App.update({:command_result, {:contract_event, event}}, model)
+    model
+  end
+
+  describe "init/1" do
+    test "starts idle with an empty prompt" do
+      model = new_model()
+      assert model.input == ""
+      assert model.face_state == :idle
+      assert model.running? == false
+      assert model.pending_approval == nil
+    end
+  end
+
+  describe "prompt editing" do
+    test "printable keys append to the prompt" do
+      {model, []} = App.update(key("h"), new_model())
+      {model, []} = App.update(key("i"), model)
+      assert model.input == "hi"
+    end
+
+    test "backspace deletes the last character" do
+      model = %{new_model() | input: "abc"}
+      {model, []} = App.update(key(:backspace), model)
+      assert model.input == "ab"
+    end
+
+    test "Ctrl+C requests quit" do
+      {_model, commands} = App.update(key("c", [:ctrl]), new_model())
+      assert commands != []
+    end
+  end
+
+  describe "submitting a turn" do
+    test "Enter with text starts a turn and clears the prompt" do
+      model = %{new_model() | input: "list files"}
+      {model, []} = App.update(key(:enter), model)
+
+      assert model.running? == true
+      assert model.input == ""
+      assert model.face_state == :thinking
+      assert is_pid(model.worker)
+      assert model.session_id != nil
+    end
+
+    test "Enter with a blank prompt does nothing" do
+      model = %{new_model() | input: "   "}
+      {model, []} = App.update(key(:enter), model)
+      assert model.running? == false
+    end
+  end
+
+  describe "contract-event fold drives the face" do
+    test "turn_started -> thinking, tool activity -> working, final -> done" do
+      model = %{new_model() | running?: true, face_state: :thinking}
+
+      model = send_ev(model, ev(1, :turn_started, %{prompt: "x"}))
+      assert model.face_state == :thinking
+
+      model = send_ev(model, ev(2, :item_completed, %{item_id: "i1", item_type: :tool_use, name: "grep"}))
+      assert model.face_state == :working
+
+      model = send_ev(model, ev(3, :turn_completed, %{final: true, usage: %{}}))
+      assert model.face_state == :done
+      assert model.running? == false
+    end
+
+    test "an error event shows the error face and ends the turn" do
+      model = %{new_model() | running?: true}
+      model = send_ev(model, ev(9, :error, %{reason: :boom}))
+      assert model.face_state == :error
+      assert model.running? == false
+    end
+
+    test "malformed contract events are dropped, not folded" do
+      model = new_model()
+      bad = %Contract.Event{id: -1, ts: 0, type: :turn_started, tier: :durable, payload: %{}}
+      {model2, []} = App.update({:command_result, {:contract_event, bad}}, model)
+      assert model2.events == []
+    end
+  end
+
+  describe "interactive approval" do
+    test "an approval request sets the pending state and working face" do
+      ref = make_ref()
+      msg = {:command_result, {:approval_request, ref, self(), "write_file"}}
+      {model, []} = App.update(msg, %{new_model() | running?: true})
+
+      assert model.pending_approval.name == "write_file"
+      assert model.face_state == :working
+    end
+
+    test "'y' allows the pending tool and replies to the waiter" do
+      ref = make_ref()
+      {model, []} =
+        App.update(
+          {:command_result, {:approval_request, ref, self(), "bash"}},
+          %{new_model() | running?: true}
+        )
+
+      {model, []} = App.update(key("y"), model)
+
+      assert model.pending_approval == nil
+      assert_receive {:approval_decision, ^ref, :allow}
+    end
+
+    test "'n' and Esc both deny the pending tool" do
+      for denier <- [key("n"), key(:escape)] do
+        ref = make_ref()
+        {model, []} =
+          App.update(
+            {:command_result, {:approval_request, ref, self(), "write_file"}},
+            %{new_model() | running?: true}
+          )
+
+        {model, []} = App.update(denier, model)
+        assert model.pending_approval == nil
+        assert_receive {:approval_decision, ^ref, :deny}
+      end
+    end
+  end
+
+  describe "interrupt" do
+    test "Esc while running kills the worker and marks interrupted" do
+      model = %{new_model() | input: "go"}
+      {model, []} = App.update(key(:enter), model)
+      worker = model.worker
+      assert Process.alive?(worker)
+
+      {model, []} = App.update(key(:escape), model)
+
+      assert model.running? == false
+      assert model.status_line == "interrupted"
+      refute Process.alive?(worker)
+    end
+  end
+
+  describe "end-to-end with the real runner (Mock backend)" do
+    test "a turn streams through pump/relay to the done face and lands in the transcript" do
+      # No stub: the real default_runner spawns a worker that subscribes to
+      # the streamer, pumps Stream.react through Contract, and relays contract
+      # events back here. `self()` is the app, so those events arrive as
+      # {:command_result, _} messages we feed back into update/2.
+      model = App.init(%{options: [backend_opts: [response: "hello from mock"]]})
+      model = %{model | input: "say hi"}
+      {model, []} = App.update(key(:enter), model)
+      assert model.running?
+
+      model = drain_turn(model)
+
+      assert model.face_state == :done
+      refute model.running?
+
+      projection = Raxol.Harness.Projection.project(model.events)
+
+      assert Enum.any?(projection.blocks, fn block ->
+               Raxol.UI.Components.Harness.Block.search_text(block) =~
+                 "hello from mock"
+             end)
+    end
+  end
+
+  # Feed every {:command_result, _} the worker relays back into update/2
+  # until the turn completes.
+  defp drain_turn(model) do
+    receive do
+      {:command_result, _payload} = msg ->
+        {model, []} = App.update(msg, model)
+        if model.running?, do: drain_turn(model), else: model
+    after
+      5_000 -> flunk("turn did not complete within 5s")
+    end
+  end
+
+  describe "view/1" do
+    test "renders idle without crashing" do
+      assert %{} = App.view(new_model())
+    end
+
+    test "renders a folded message turn through the projection + blocks" do
+      model =
+        new_model()
+        |> then(&%{&1 | running?: true})
+        |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
+        |> send_ev(ev(2, :item_started, %{item_id: "i1", item_type: :message}))
+        |> send_ev(ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "hello there"}))
+        |> send_ev(ev(4, :turn_completed, %{final: true, usage: %{}}))
+
+      assert model.face_state == :done
+      # The projection + Block.render path must not raise.
+      assert %{} = App.view(model)
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -14,7 +14,16 @@ defmodule Raxol.Agent.Code.AppTest do
   end
 
   defp new_model(opts \\ []) do
-    App.init(%{options: Keyword.put_new(opts, :runner, stub_runner())})
+    opts =
+      opts
+      |> Keyword.put_new(:runner, stub_runner())
+      |> Keyword.put_new(:sessions_dir, tmp_dir())
+
+    App.init(%{options: opts})
+  end
+
+  defp tmp_dir do
+    Path.join(System.tmp_dir!(), "raxol-code-app-#{System.unique_integer([:positive])}")
   end
 
   defp key(k, mods \\ []), do: Event.key_event(k, :pressed, mods)
@@ -35,6 +44,8 @@ defmodule Raxol.Agent.Code.AppTest do
     {model, []} = App.update({:command_result, {:contract_event, event}}, model)
     model
   end
+
+  defp submit(model, text), do: App.update(key(:enter), %{model | input: text})
 
   describe "init/1" do
     test "starts idle with an empty prompt" do
@@ -222,7 +233,11 @@ defmodule Raxol.Agent.Code.AppTest do
       # the streamer, pumps Stream.react through Contract, and relays contract
       # events back here. `self()` is the app, so those events arrive as
       # {:command_result, _} messages we feed back into update/2.
-      model = App.init(%{options: [backend_opts: [response: "hello from mock"]]})
+      model =
+        App.init(%{
+          options: [backend_opts: [response: "hello from mock"], sessions_dir: tmp_dir()]
+        })
+
       model = %{model | input: "say hi"}
       {model, []} = App.update(key(:enter), model)
       assert model.running?
@@ -237,6 +252,13 @@ defmodule Raxol.Agent.Code.AppTest do
       assert Enum.any?(projection.blocks, fn block ->
                Raxol.UI.Components.Harness.Block.search_text(block) =~
                  "hello from mock"
+             end)
+
+      # Conversation memory: the turn is now in the message history.
+      assert %{role: :user, content: "say hi"} in model.messages
+
+      assert Enum.any?(model.messages, fn m ->
+               m.role == :assistant and m.content =~ "hello from mock"
              end)
     end
   end
@@ -270,6 +292,94 @@ defmodule Raxol.Agent.Code.AppTest do
       assert model.face_state == :done
       # The projection + Block.render path must not raise.
       assert %{} = App.view(model)
+    end
+  end
+
+  describe "conversation memory" do
+    test "a submitted prompt enters the message history" do
+      model = %{new_model() | input: "list files"}
+      {model, []} = App.update(key(:enter), model)
+      assert %{role: :user, content: "list files"} in model.messages
+    end
+
+    test "a completed turn appends the assistant reply and persists it" do
+      dir = tmp_dir()
+      model = App.init(%{options: [runner: stub_runner(), sessions_dir: dir]})
+      model = %{model | input: "hi"}
+      {model, []} = App.update(key(:enter), model)
+
+      model =
+        model
+        |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
+        |> send_ev(ev(2, :item_completed, %{item_id: "i1", item_type: :message, content: "done"}))
+        |> send_ev(ev(3, :turn_completed, %{final: true, usage: %{}}))
+
+      assert List.last(model.messages) == %{role: :assistant, content: "done"}
+      assert {:ok, saved} = Raxol.Agent.Code.Store.load(dir, model.session_key)
+      assert List.last(saved.messages) == %{role: :assistant, content: "done"}
+    end
+  end
+
+  describe "resume" do
+    test "init with a saved session_key reloads its messages" do
+      dir = tmp_dir()
+      msgs = [%{role: :user, content: "earlier"}, %{role: :assistant, content: "reply"}]
+      :ok = Raxol.Agent.Code.Store.save(dir, "sess-x", %{messages: msgs})
+
+      model =
+        App.init(%{
+          options: [runner: stub_runner(), sessions_dir: dir, session_key: "sess-x"]
+        })
+
+      assert model.messages == msgs
+      assert model.status_line =~ "resumed 2"
+    end
+
+    test "resuming a missing session starts fresh with a notice" do
+      model =
+        App.init(%{
+          options: [runner: stub_runner(), sessions_dir: tmp_dir(), session_key: "nope"]
+        })
+
+      assert model.messages == []
+      assert model.status_line =~ "not found"
+    end
+  end
+
+  describe "slash commands" do
+    test "/help shows a notice and does not start a turn" do
+      {model, []} = submit(new_model(), "/help")
+      assert model.notice =~ "/clear"
+      assert model.running? == false
+    end
+
+    test "/model sets the override" do
+      {model, []} = submit(new_model(), "/model gpt-4o")
+      assert model.model_override == "gpt-4o"
+      assert model.notice =~ "gpt-4o"
+    end
+
+    test "/plan toggles plan mode" do
+      {model, []} = submit(new_model(), "/plan")
+      assert model.plan_mode == true
+    end
+
+    test "/clear starts a fresh session" do
+      model = %{new_model() | messages: [%{role: :user, content: "x"}]}
+      previous_key = model.session_key
+      {model, []} = submit(model, "/clear")
+      assert model.messages == []
+      assert model.session_key != previous_key
+    end
+
+    test "/context reports stats" do
+      {model, []} = submit(new_model(), "/context")
+      assert model.notice =~ "messages: 0"
+    end
+
+    test "an unknown command reports itself" do
+      {model, []} = submit(new_model(), "/frobnicate")
+      assert model.notice =~ "unknown command"
     end
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -114,7 +114,12 @@ defmodule Raxol.Agent.Code.AppTest do
       model = send_ev(model, ev(1, :turn_started, %{prompt: "x"}))
       assert model.face_state == :thinking
 
-      model = send_ev(model, ev(2, :item_completed, %{item_id: "i1", item_type: :tool_use, name: "grep"}))
+      model =
+        send_ev(
+          model,
+          ev(2, :item_completed, %{item_id: "i1", item_type: :tool_use, name: "grep"})
+        )
+
       assert model.face_state == :working
 
       model = send_ev(model, ev(3, :turn_completed, %{final: true, usage: %{}}))
@@ -298,7 +303,9 @@ defmodule Raxol.Agent.Code.AppTest do
         |> then(&%{&1 | running?: true})
         |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
         |> send_ev(ev(2, :item_started, %{item_id: "i1", item_type: :message}))
-        |> send_ev(ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "hello there"}))
+        |> send_ev(
+          ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "hello there"})
+        )
         |> send_ev(ev(4, :turn_completed, %{final: true, usage: %{}}))
 
       assert model.face_state == :done
@@ -368,7 +375,9 @@ defmodule Raxol.Agent.Code.AppTest do
         model
         |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
         |> send_ev(ev(2, :item_started, %{item_id: "i1", item_type: :message}))
-        |> send_ev(ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "restored answer"}))
+        |> send_ev(
+          ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "restored answer"})
+        )
         |> send_ev(ev(4, :turn_completed, %{final: true, usage: %{}}))
 
       key = model.session_key
@@ -379,7 +388,12 @@ defmodule Raxol.Agent.Code.AppTest do
 
       assert resumed.events != []
       blocks = Raxol.Harness.Projection.project(resumed.events).blocks
-      assert Enum.any?(blocks, &(Raxol.UI.Components.Harness.Block.search_text(&1) =~ "restored answer"))
+
+      assert Enum.any?(
+               blocks,
+               &(Raxol.UI.Components.Harness.Block.search_text(&1) =~ "restored answer")
+             )
+
       # And the resumed model renders.
       assert %{} = App.view(resumed)
     end

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -356,6 +356,33 @@ defmodule Raxol.Agent.Code.AppTest do
       assert model.messages == []
       assert model.status_line =~ "not found"
     end
+
+    test "resuming rebuilds the visual transcript from persisted events" do
+      dir = tmp_dir()
+
+      # A turn that persists its durable events on completion.
+      model = App.init(%{options: [runner: stub_runner(), sessions_dir: dir]})
+      {model, []} = App.update(key(:enter), %{model | input: "hi"})
+
+      model =
+        model
+        |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
+        |> send_ev(ev(2, :item_started, %{item_id: "i1", item_type: :message}))
+        |> send_ev(ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "restored answer"}))
+        |> send_ev(ev(4, :turn_completed, %{final: true, usage: %{}}))
+
+      key = model.session_key
+
+      # A fresh app resumes that session id.
+      resumed =
+        App.init(%{options: [runner: stub_runner(), sessions_dir: dir, session_key: key]})
+
+      assert resumed.events != []
+      blocks = Raxol.Harness.Projection.project(resumed.events).blocks
+      assert Enum.any?(blocks, &(Raxol.UI.Components.Harness.Block.search_text(&1) =~ "restored answer"))
+      # And the resumed model renders.
+      assert %{} = App.view(resumed)
+    end
   end
 
   describe "slash commands" do

--- a/packages/raxol_agent/test/raxol/agent/code/event_codec_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/event_codec_test.exs
@@ -1,0 +1,90 @@
+defmodule Raxol.Agent.Code.EventCodecTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Code.EventCodec
+  alias Raxol.Agent.Contract
+  alias Raxol.Harness.EventBoundary
+  alias Raxol.Harness.Projection
+  alias Raxol.UI.Components.Harness.Block
+
+  defp ev(id, type, payload) do
+    %Contract.Event{
+      id: id,
+      ts: id,
+      turn_id: "t1",
+      family: :loop,
+      type: type,
+      tier: :durable,
+      payload: payload
+    }
+  end
+
+  defp normalize(event) do
+    {:ok, norm} = EventBoundary.normalize(event)
+    norm
+  end
+
+  # Persist-then-load: normalized event -> JSON -> back to projection shape.
+  defp roundtrip(events) do
+    events
+    |> Enum.map(&normalize/1)
+    |> Jason.encode!()
+    |> Jason.decode!()
+    |> EventCodec.decode_all()
+  end
+
+  test "decodes a persisted event back to projection shape" do
+    [decoded] =
+      roundtrip([ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "hi"})])
+
+    assert decoded.id == 3
+    assert decoded.type == :item_completed
+    assert decoded.family == :loop
+    assert decoded.tier == :durable
+    assert decoded.turn_id == "t1"
+    # Payload stays string-keyed (the projection wire shape).
+    assert decoded.payload == %{"item_id" => "i1", "item_type" => "message", "content" => "hi"}
+  end
+
+  test "an unknown type string is left as a string (no atom minted from disk)" do
+    decoded =
+      EventCodec.decode(%{
+        "id" => 1,
+        "type" => "totally_unknown_type",
+        "tier" => "durable",
+        "family" => "loop",
+        "payload" => %{}
+      })
+
+    assert decoded.type == "totally_unknown_type"
+  end
+
+  test "a record without an integer id is dropped" do
+    assert EventCodec.decode(%{"type" => "error"}) == nil
+
+    assert [%{id: 1}] =
+             EventCodec.decode_all([
+               %{"id" => 1, "type" => "error", "tier" => "durable", "payload" => %{}},
+               %{"bad" => 1}
+             ])
+  end
+
+  test "decoded events project into the same blocks as the live ones" do
+    events = [
+      ev(1, :turn_started, %{prompt: "hi"}),
+      ev(2, :item_started, %{item_id: "i1", item_type: :message}),
+      ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "hello world"}),
+      ev(4, :turn_completed, %{final: true, usage: %{}})
+    ]
+
+    live = Enum.map(events, &normalize/1)
+    reloaded = roundtrip(events)
+
+    live_blocks = Projection.project(live).blocks
+    reloaded_blocks = Projection.project(reloaded).blocks
+
+    assert length(reloaded_blocks) == length(live_blocks)
+
+    assert Enum.any?(reloaded_blocks, &(Block.search_text(&1) =~ "hello world"))
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/code/hooks_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/hooks_test.exs
@@ -1,0 +1,92 @@
+defmodule Raxol.Agent.Code.HooksTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Code.Hooks
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "raxol-hooks-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    %{dir: dir}
+  end
+
+  defp write_config(dir, json) do
+    File.mkdir_p!(Path.join(dir, ".raxol"))
+    File.write!(Path.join(dir, ".raxol/hooks.json"), Jason.encode!(json))
+  end
+
+  describe "load/1" do
+    test "parses pre/post/stop rules", %{dir: dir} do
+      write_config(dir, %{
+        "pre_tool_use" => [%{"match" => "bash", "command" => "exit 0"}],
+        "post_tool_use" => [%{"match" => "*", "command" => "true"}],
+        "stop" => ["true"]
+      })
+
+      assert {:ok, config} = Hooks.load(dir)
+      assert config.pre == [%{match: "bash", command: "exit 0"}]
+      assert config.post == [%{match: "*", command: "true"}]
+      assert config.stop == ["true"]
+      assert Hooks.count(config) == 3
+    end
+
+    test "returns :none when there is no file", %{dir: dir} do
+      assert :none = Hooks.load(dir)
+    end
+
+    test "errors on invalid json", %{dir: dir} do
+      File.mkdir_p!(Path.join(dir, ".raxol"))
+      File.write!(Path.join(dir, ".raxol/hooks.json"), "{not json")
+      assert {:error, :invalid_json} = Hooks.load(dir)
+    end
+  end
+
+  describe "before_call/2 (pre-tool veto)" do
+    test "a matching pre-hook that exits non-zero vetoes the call", %{dir: dir} do
+      config = %{pre: [%{match: "bash", command: "exit 1"}], post: [], stop: []}
+      context = %{code_hooks: config, hook_cwd: dir}
+      call = %{action: __MODULE__, name: "bash", params: %{}, call_id: nil}
+
+      assert {:halt, {:hook_blocked, "bash", "exit 1", 1}} =
+               Hooks.before_call(call, context)
+    end
+
+    test "a matching pre-hook that exits zero allows the call", %{dir: dir} do
+      config = %{pre: [%{match: "bash", command: "exit 0"}], post: [], stop: []}
+      context = %{code_hooks: config, hook_cwd: dir}
+      call = %{action: __MODULE__, name: "bash", params: %{}, call_id: nil}
+
+      assert {:cont, ^call} = Hooks.before_call(call, context)
+    end
+
+    test "a non-matching tool runs no pre-hooks", %{dir: dir} do
+      config = %{pre: [%{match: "bash", command: "exit 1"}], post: [], stop: []}
+      context = %{code_hooks: config, hook_cwd: dir}
+      call = %{action: __MODULE__, name: "read_file", params: %{}, call_id: nil}
+
+      assert {:cont, ^call} = Hooks.before_call(call, context)
+    end
+  end
+
+  describe "after_call/3" do
+    test "runs post-hooks and returns the result unchanged", %{dir: dir} do
+      config = %{pre: [], post: [%{match: "*", command: "true"}], stop: []}
+      context = %{code_hooks: config, hook_cwd: dir}
+      call = %{action: __MODULE__, name: "write_file", params: %{}, call_id: nil}
+
+      assert {:ok, %{path: "x"}} = Hooks.after_call(call, {:ok, %{path: "x"}}, context)
+    end
+  end
+
+  describe "run_stop/2" do
+    test "runs each stop command and reports its exit status", %{dir: dir} do
+      config = %{pre: [], post: [], stop: ["exit 0", "exit 2"]}
+      receipts = Hooks.run_stop(config, dir)
+
+      assert receipts == [
+               %{command: "exit 0", exit_status: 0},
+               %{command: "exit 2", exit_status: 2}
+             ]
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/code/mcp_config_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/mcp_config_test.exs
@@ -1,0 +1,52 @@
+defmodule Raxol.Agent.Code.McpConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Code.McpConfig
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "raxol-mcp-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    %{dir: dir}
+  end
+
+  defp write(dir, content), do: File.write!(Path.join(dir, ".mcp.json"), content)
+
+  test "parses declared servers, sorted by name", %{dir: dir} do
+    write(
+      dir,
+      Jason.encode!(%{
+        "mcpServers" => %{
+          "zeta" => %{"command" => "npx", "args" => ["-y", "z"]},
+          "alpha" => %{"command" => "uvx", "args" => ["a"], "env" => %{"K" => "V"}}
+        }
+      })
+    )
+
+    assert {:ok, [alpha, zeta]} = McpConfig.load(dir)
+    assert alpha.name == "alpha"
+    assert alpha.command == "uvx"
+    assert alpha.args == ["a"]
+    assert alpha.env == %{"K" => "V"}
+    assert zeta.name == "zeta"
+  end
+
+  test "returns :none when there is no file", %{dir: dir} do
+    assert :none = McpConfig.load(dir)
+  end
+
+  test "a valid object with no servers is empty, not an error", %{dir: dir} do
+    write(dir, Jason.encode!(%{"other" => true}))
+    assert {:ok, []} = McpConfig.load(dir)
+  end
+
+  test "errors on invalid json", %{dir: dir} do
+    write(dir, "{bad")
+    assert {:error, :invalid_json} = McpConfig.load(dir)
+  end
+
+  test "a server missing a command is dropped", %{dir: dir} do
+    write(dir, Jason.encode!(%{"mcpServers" => %{"broken" => %{"args" => ["x"]}}}))
+    assert {:ok, []} = McpConfig.load(dir)
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/code/store_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/store_test.exs
@@ -22,6 +22,26 @@ defmodule Raxol.Agent.Code.StoreTest do
     assert session.id == "s1"
   end
 
+  test "persists and reloads durable events in projection shape", %{dir: dir} do
+    events = [
+      %{
+        id: 1,
+        turn_id: "t1",
+        ts: 1,
+        family: :loop,
+        type: :turn_completed,
+        tier: :durable,
+        scope: :session,
+        provenance: %{source: :primary, trust: :trusted},
+        payload: %{"final" => true}
+      }
+    ]
+
+    assert :ok = Store.save(dir, "s3", %{messages: [], events: events})
+    assert {:ok, session} = Store.load(dir, "s3")
+    assert [%{id: 1, type: :turn_completed, tier: :durable}] = session.events
+  end
+
   test "an unknown role is dropped on load (no atom minted from disk)", %{dir: dir} do
     File.mkdir_p!(dir)
 

--- a/packages/raxol_agent/test/raxol/agent/code/store_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/store_test.exs
@@ -65,7 +65,10 @@ defmodule Raxol.Agent.Code.StoreTest do
 
   test "latest and list order by most-recently-updated", %{dir: dir} do
     Store.save(dir, "old", %{messages: [%{role: :user, content: "a"}]})
-    Store.save(dir, "new", %{messages: [%{role: :user, content: "b"}, %{role: :assistant, content: "c"}]})
+
+    Store.save(dir, "new", %{
+      messages: [%{role: :user, content: "b"}, %{role: :assistant, content: "c"}]
+    })
 
     listed = Store.list(dir)
     assert Enum.map(listed, & &1.id) |> Enum.sort() == ["new", "old"]

--- a/packages/raxol_agent/test/raxol/agent/code/store_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/store_test.exs
@@ -1,0 +1,63 @@
+defmodule Raxol.Agent.Code.StoreTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Code.Store
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "raxol-store-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm_rf!(dir) end)
+    %{dir: dir}
+  end
+
+  test "save then load round-trips messages and roles", %{dir: dir} do
+    messages = [
+      %{role: :user, content: "hi"},
+      %{role: :assistant, content: "hello"},
+      %{role: :system, content: "note"}
+    ]
+
+    assert :ok = Store.save(dir, "s1", %{messages: messages})
+    assert {:ok, session} = Store.load(dir, "s1")
+    assert session.messages == messages
+    assert session.id == "s1"
+  end
+
+  test "an unknown role is dropped on load (no atom minted from disk)", %{dir: dir} do
+    File.mkdir_p!(dir)
+
+    File.write!(
+      Path.join(dir, "s2.json"),
+      Jason.encode!(%{
+        "messages" => [
+          %{"role" => "user", "content" => "ok"},
+          %{"role" => "wizard", "content" => "nope"}
+        ]
+      })
+    )
+
+    assert {:ok, session} = Store.load(dir, "s2")
+    assert session.messages == [%{role: :user, content: "ok"}]
+  end
+
+  test "load of a missing session errors", %{dir: dir} do
+    assert {:error, :not_found} = Store.load(dir, "absent")
+  end
+
+  test "latest and list order by most-recently-updated", %{dir: dir} do
+    Store.save(dir, "old", %{messages: [%{role: :user, content: "a"}]})
+    Store.save(dir, "new", %{messages: [%{role: :user, content: "b"}, %{role: :assistant, content: "c"}]})
+
+    listed = Store.list(dir)
+    assert Enum.map(listed, & &1.id) |> Enum.sort() == ["new", "old"]
+    assert Enum.find(listed, &(&1.id == "new")).message_count == 2
+    # Both written in the same second may tie; latest is one of them.
+    assert Store.latest(dir) in ["new", "old"]
+  end
+
+  test "a crafted session id cannot escape the base directory", %{dir: dir} do
+    Store.save(dir, "../escape", %{messages: [%{role: :user, content: "x"}]})
+    # basename neutralizes the traversal: the file lands inside dir.
+    assert File.exists?(Path.join(dir, "escape.json"))
+    assert {:ok, _} = Store.load(dir, "../escape")
+  end
+end

--- a/test/raxol/ui/components/harness/axol_face_test.exs
+++ b/test/raxol/ui/components/harness/axol_face_test.exs
@@ -10,6 +10,7 @@ defmodule Raxol.UI.Components.Harness.AxolFaceTest do
     test "every face is exactly four display columns wide" do
       for state <- AxolFace.states(), ascii? <- [false, true], frame <- 0..5 do
         glyph = AxolFace.glyph(state, frame, ascii?)
+
         assert Raxol.UI.TextMeasure.display_width(glyph) == 4,
                "#{state}/#{ascii?}/#{frame} = #{inspect(glyph)} not 4 cols"
       end

--- a/test/raxol/ui/components/harness/axol_face_test.exs
+++ b/test/raxol/ui/components/harness/axol_face_test.exs
@@ -1,0 +1,97 @@
+defmodule Raxol.UI.Components.Harness.AxolFaceTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.UI.Components.Harness.AxolFace
+
+  defp default_context, do: %{theme: Raxol.UI.Theming.Theme.default_theme()}
+  defp face_el(rendered), do: Enum.at(rendered.children, 0)
+
+  describe "glyph/3 (the shared core)" do
+    test "every face is exactly four display columns wide" do
+      for state <- AxolFace.states(), ascii? <- [false, true], frame <- 0..5 do
+        glyph = AxolFace.glyph(state, frame, ascii?)
+        assert Raxol.UI.TextMeasure.display_width(glyph) == 4,
+               "#{state}/#{ascii?}/#{frame} = #{inspect(glyph)} not 4 cols"
+      end
+    end
+
+    test "idle at rest is the branded neutral face" do
+      assert AxolFace.glyph(:idle, 0) == "≡··≡"
+    end
+
+    test "working pulses the pupils across frames" do
+      assert AxolFace.glyph(:working, 0) == "≡oo≡"
+      assert AxolFace.glyph(:working, 1) == "≡OO≡"
+      # wraps
+      assert AxolFace.glyph(:working, 2) == "≡oo≡"
+    end
+
+    test "done and error are their fixed motifs" do
+      assert AxolFace.glyph(:done, 3) == "≡^^≡"
+      assert AxolFace.glyph(:error, 7) == "≡xx≡"
+    end
+
+    test "ascii fallback uses = gills and ASCII eyes only" do
+      for state <- AxolFace.states(), frame <- 0..3 do
+        glyph = AxolFace.glyph(state, frame, true)
+        assert String.printable?(glyph)
+
+        assert glyph
+               |> String.to_charlist()
+               |> Enum.all?(&(&1 < 128)),
+               "#{state}/#{frame} = #{inspect(glyph)} is not ASCII"
+      end
+
+      assert AxolFace.glyph(:idle, 0, true) == "=..="
+    end
+
+    test "frame wraps over the cycle length for any non-negative integer" do
+      assert AxolFace.glyph(:thinking, 0) == AxolFace.glyph(:thinking, 3)
+      assert AxolFace.glyph(:thinking, 1) == AxolFace.glyph(:thinking, 4)
+    end
+  end
+
+  describe "color/1" do
+    test "maps state to a status color" do
+      assert AxolFace.color(:idle) == nil
+      assert AxolFace.color(:thinking) == :cyan
+      assert AxolFace.color(:done) == :green
+      assert AxolFace.color(:error) == :red
+    end
+  end
+
+  describe "init/1" do
+    test "defaults to idle, frame 0, unicode" do
+      assert {:ok, state} = AxolFace.init(id: :face)
+      assert state.state == :idle
+      assert state.frame == 0
+      assert state.ascii == false
+    end
+  end
+
+  describe "render/2" do
+    test "renders the glyph for the current state and frame with its color" do
+      {:ok, state} = AxolFace.init(id: :face, state: :working, frame: 1)
+      rendered = AxolFace.render(state, default_context())
+
+      assert face_el(rendered).content == "≡OO≡"
+      assert face_el(rendered).fg == :cyan
+      assert face_el(rendered).style == %{bold: true}
+    end
+
+    test "error face renders red and bold" do
+      {:ok, state} = AxolFace.init(id: :face, state: :error)
+      rendered = AxolFace.render(state, default_context())
+
+      assert face_el(rendered).content == "≡xx≡"
+      assert face_el(rendered).fg == :red
+    end
+
+    test "ascii prop swaps the glyph set in place" do
+      {:ok, state} = AxolFace.init(id: :face, state: :idle, ascii: true)
+      rendered = AxolFace.render(state, default_context())
+
+      assert face_el(rendered).content == "=..="
+    end
+  end
+end


### PR DESCRIPTION
## What

Turns the agent harness into an interactive, agentic **coding** assistant — a Claude Code equivalent built from Raxol's own components — with the axol face `≡··≡` as its identity/status layer. Lands the full five-phase roadmap plus a follow-up, isolated in `raxol_agent` (one new component in main raxol).

New surface: `mix raxol.code`.

## Why

The harness spine (streaming, staged-kill interrupt, durable journal, memory, compaction, skills, multi-backend, permissions) was already strong. What was missing was the coding surface: no real Write/Edit on disk, no Bash tool for the model, no interactive multi-turn TUI, no code search. This PR fills that gap by promoting existing engines to the tool/UI path and adding one TEA app over the existing `Contract`/`SessionStreamer` boundary.

## Phases (one commit each)

1. **Coding tools** — `Raxol.Agent.Actions.Code`: `write_file`/`edit_file` (`sensitive`, diff-shaped results the contract already renders as diff blocks), `bash` (`sensitive`, `Sandbox.Shell`-gated), `grep` (ripgrep or pure fallback), `glob`; deepened `read_file` with `offset`/`limit`. Wired into `raxol.p` behind `--write`.
2. **Interactive TUI + axol face** — `mix raxol.code` → `Raxol.Agent.Code.App`, a thin Lifecycle TEA app that owns the multi-turn loop but reuses `Harness.Projection` + `Block` for the transcript. New `Raxol.UI.Components.Harness.AxolFace` (`≡··≡` identity, unicode + ASCII fallback, boot/idle/thinking/working/done/error, always 4 display cols). A worker subscribes to `SessionStreamer`, pumps `Stream.react` through `Contract`, and relays events into `update/2`; Esc interrupts, Ctrl+C quits.
3. **Permission UX + plan mode** — sensitive tool calls resolve through `Authorization.Engine` (ALLOW/ASK/DENY): ASK prompts allow-once / always / deny; "always" is remembered per-tool; plan mode (Shift+Tab or Ctrl+P) adds a planning prompt and the Engine denies mutations.
4. **Sessions, resume, slash commands** — conversation memory across turns, persisted per session (`Raxol.Agent.Code.Store`, safe role/id handling); `--continue` / `--resume` / `--sessions`; a `/`-dispatcher (`/help /clear /model /plan /compact /context /sessions /mcp /hooks`).
5. **Delegation, hooks, MCP config** — a `task` tool that delegates to a fresh read-only sub-agent (can't recurse or mutate); `.raxol/hooks.json` lifecycle hooks over the `ToolCall.Hook` seam (pre-tool non-zero exit vetoes, post-tool, stop); `.mcp.json` server config surfaced by `/mcp`.
6. **Transcript replay on resume (follow-up)** — the Store also persists durable contract events; `Raxol.Agent.Code.EventCodec` decodes them back into projection shape (fixed vocabularies, no atom minting from disk), so `--resume` rebuilds the visual scrollback, not just the model context.

## Design notes

- The app lives in `raxol_agent` because it needs both main-raxol UI and the agent's `Stream`/`Contract` (main raxol can't depend on `raxol_agent`).
- Safe default posture: `write_file`/`edit_file`/`bash` are `sensitive`, so `raxol.p` stays read-only unless opted in; the TUI gates them through interactive approval.
- The one bug worth calling out: `Stream.react` sends events to the process that *created* the stream, so the pump must create and consume it in the same process — fixed in the TUI worker.

## Scoped follow-ups (documented, not regressions)

- Live MCP **tool-bridging** into the ReAct loop (config + discovery ship; needs a dynamic `ToolConverter` dispatch seam).
- `Composer` stateful-component embedding, `interrupt.ex` staged-kill vs worker-kill, one-key plan-to-execute handoff.

## Testing

- `MIX_ENV=test mix test test/raxol/agent/code/ test/raxol/agent/actions/` (raxol_agent) — 134 tests, 0 failures.
- `MIX_ENV=test mix test test/raxol/ui/components/harness/axol_face_test.exs` (main raxol) — 11 tests, 0 failures.
- `mix compile --warnings-as-errors` — clean, both projects.
- `mix credo --strict` — clean on all new files (one pre-existing `Fs.ListDir.run` nesting finding left untouched; unchanged from master).
- Not run here: dialyzer (no PLT in a fresh worktree), full-project security/docs/fate.

### Manual testing

- [ ] `mix raxol.code` with a real backend: type a prompt, watch the axol face cycle thinking → working → done.
- [ ] Ask it to create + edit a file and run a command; approve via `a`/`s`/`d`; confirm the files actually change on disk and diffs render.
- [ ] Toggle plan mode (Shift+Tab); confirm a mutation is denied and a plan is proposed.
- [ ] `--continue` / `--resume <id>`; confirm both the conversation context and the scrollback come back.
- [ ] Drop a `.raxol/hooks.json` with a `pre_tool_use` guard that exits non-zero; confirm the tool is vetoed.
- [ ] `/mcp` with a `.mcp.json` present lists the servers.
