### PR TITLE
test(harness): de-flake LiveSessionDriverTest eventually polls

### DIFF
--- a/test/harness/live_session_driver_test.exs
+++ b/test/harness/live_session_driver_test.exs
@@ -144,7 +144,11 @@ defmodule Raxol.Harness.LiveSessionDriverTest do
   # unloaded; the earlier 5_000/10 budget flaked only under deliberate
   # 15-core `yes`-burner saturation, the signature of scheduling latency,
   # never a logic error -- the same assertions pass given the schedulers.)
-  defp eventually(fun, timeout \\ 15_000, interval \\ 50) do
+  # Raised 15_000 -> 30_000 after the 15s ceiling still timed out on real
+  # shared GitHub runners (macOS/Windows) under whole-suite contention; a green
+  # poll returns immediately, so the higher ceiling only costs wall-clock on a
+  # genuine failure, never on a passing run.
+  defp eventually(fun, timeout \\ 30_000, interval \\ 50) do
     deadline = System.monotonic_time(:millisecond) + timeout
     do_eventually(fun, deadline, interval, timeout)
   end
@@ -554,10 +558,15 @@ defmodule Raxol.Harness.LiveSessionDriverTest do
 
       assert_receive {:steer_dispatched, _request}, 2_000
 
-      # The queued-steer banner IS present right after Tab (Surface's own
-      # command_sink path sets it) -- before asserting it is gone.
+      # The queued-steer banner is rendered right after Tab (Surface's own
+      # command_sink path sets it). Assert it against the CUMULATIVE output, not
+      # the current footer frame: the stale-turn rejection clears the banner, and
+      # under CI load that clear can land between two 50ms polls -- so a
+      # current-frame check races the clear and flakes. `strip_ansi(raw)` is
+      # append-only, so once the banner is rendered the match is stable. The
+      # `refute footer_text` below still proves it was cleared from the frame.
       eventually(fn ->
-        footer_text(raw(device)) =~ "steer queued for next boundary"
+        strip_ansi(raw(device)) =~ "steer queued for next boundary"
       end)
 
       eventually(fn -> strip_ansi(raw(device)) =~ "NOT delivered" end)


### PR DESCRIPTION
## Summary

`Raxol.Harness.LiveSessionDriverTest` has been failing CI on unrelated PRs via
timing flakes — #676 (docs-only) on macOS, #680 (feat) on Windows — with
`condition not met within 15000ms`. Two distinct wall-clock flake modes; both
fixed here. No production code changes; no behavior change.

## Fixes

**1. Transient current-frame poll (test 5 — the #676 flake).**
The test polled the CURRENT footer frame for the "steer queued for next
boundary" banner, which is set right after Tab and then cleared by the
stale-turn rejection. Under load the clear lands between two 50ms polls, so
`footer_text(raw)` never observes the banner present → 15s timeout. Switched to
the CUMULATIVE `strip_ansi(raw)` (append-only StringIO output, so once the
banner is rendered the match is stable and can't be missed). The later
`refute footer_text(...) =~ "steer queued..."` still proves it was cleared from
the current frame, so the "present, then cleared" contract is preserved.

**2. `eventually` budget 15s → 30s (helps the #680 timeout mode).**
The helper's own comment already frames the budget as "calibrated for a LOADED
CI box" and notes *a green condition returns on the first poll regardless of the
budget — so the generous ceiling only ever costs time on a genuine failure.*
The 15s ceiling still timed out under whole-suite contention on real shared
runners, so the recalibration is consistent with the existing design: zero cost
on a passing run, more headroom on a loaded one.

## Manual testing

- [x] `mix test test/harness/live_session_driver_test.exs` — **17 passed**, 3/3
  consecutive local runs.
- [x] `mix format` — clean.

## Notes

This unblocks #676 and #680 (both were flaking on this file, not on their own
changes). The `Harness.LineDiff` `FunctionClauseError` seen once in #680's log is
a pre-existing, handled fallback warning (it does not touch `LineDiff`), not the
cause.
