### PR TITLE
ACP buyer runtime + spend gates (M3)

### DIFF
--- a/packages/raxol_acp/RUNBOOK.md
+++ b/packages/raxol_acp/RUNBOOK.md
@@ -100,11 +100,63 @@ tolerant and skips anything unrecognized):
 Kill the BEAM mid-flight (between funded -> submit -> complete) and restart: with
 `checkpoint` + `Resync` wired, it must resume without a second submit or charge.
 
-## 6. Promote to mainnet
+## 6. Buy side (autonomous buyer)
 
-Flip the table in section 2 to the mainnet column: `seller_chain_id: 8453`,
-`api.acp.virtuals.io`, canonical USDC (drop the `chain_overrides` block), and a
-durable checkpoint store. Re-run section 3 with the mainnet dashboard.
+The buyer is the mirror of the seller: it discovers an offering, funds a job
+within spend limits, evaluates the deliverable, and survives crashes without
+double-spending. It is opt-in via `buyer_enabled: true`. Copy the keys you need
+from `config/buyer.example.exs`.
+
+### 6a. Configure
+
+Set at minimum `buyer_provider_adapter` (the signing adapter), `buyer_address`,
+`buyer_chain_id: 84_532`, a `buyer_ledger` + `buyer_spending_policy` (the spend
+gate fails closed in production with no policy), and `buyer_job_api_opts` (for
+discovery + resync). Set `checkpoint` + `require_checkpoint: true` for crash
+safety. The `Buyer.Runtime` subscribes to `buyer_backend` for this buyer's job
+lifecycle events; the backend process is started by the host app (for the
+offline rehearsal, the shared `Seller.Backend.InMemory`).
+
+### 6b. Offline rehearsal (no funds, no network)
+
+Drive a purchase through the driver against mocks:
+
+    intent = %{
+      offering: "custom_console_agent",
+      provider: seller_wallet,
+      amount: Raxol.ACP.AssetToken.usdc(10, 84_532)
+    }
+    {:ok, job_id} = Raxol.ACP.Buyer.Planner.buy(intent)
+
+with `buyer_provider_adapter` = `ProviderAdapter.Mock` and
+`buyer_job_id_resolver` = `JobIdResolver.Mock`. The buyer reserves, writes
+`createJob`, resolves the job_id, and tracks the job; dispatching a `:budget_set`
+then a `:submitted` event drives `fund` -> evaluate -> `complete`. This is what
+`test/raxol/acp/buyer/queue_test.exs` exercises.
+
+### 6c. Live dry-run on Sepolia (operator)
+
+With `buyer_enabled: true` and a funded second wallet, `Buyer.Planner.buy/1`
+originates a real job against the registered offering. **Confirm during the run**
+(the reason `buyer_job_id_resolver` is a seam):
+
+1. The `JobCreated` event signature / indexed `jobId` position the
+   `JobIdResolver.Receipt` decodes -- override `event_signature`/`topic_index`
+   in config if they differ from the placeholder.
+2. That `createJob`'s `description` round-trips on-chain and is readable via
+   `get_active_jobs` -- the crash reconcile-by-tag path depends on it.
+3. The job-id form matches across the receipt, the REST API, and session keys.
+
+Kill the BEAM mid-flight (between reserve -> create -> fund) and restart: with
+`checkpoint` wired, `buy/1` resumes from the recorded phase -- exactly one
+`createJob` (reconciled by the request tag) and one `fund`, budget reserved once.
+
+## 7. Promote to mainnet
+
+Flip the table in section 2 to the mainnet column: `seller_chain_id: 8453`
+(and `buyer_chain_id: 8453`), `api.acp.virtuals.io`, canonical USDC (drop the
+`chain_overrides` block), and a durable checkpoint store. Re-run section 3 with
+the mainnet dashboard.
 
 ## Notes
 

--- a/packages/raxol_acp/config/buyer.example.exs
+++ b/packages/raxol_acp/config/buyer.example.exs
@@ -1,0 +1,85 @@
+import Config
+
+# Example configuration for running the ACP BUYER stack -- the autonomous client
+# that discovers an offering, funds a job within spend limits, and evaluates the
+# deliverable, with crash-safe idempotency (M3).
+#
+# This file is a REFERENCE, not loaded by the app. Copy the keys you need into
+# your own `config/runtime.exs`. Every key is read defensively with a safe
+# default, so an unset key just disables that feature.
+#
+# See RUNBOOK.md ("Buy side") for the offline rehearsal and the Sepolia dry-run
+# in which the buyer is the real second wallet driving create -> fund -> complete.
+
+# ---------------------------------------------------------------------------
+# Buyer stack (opt-in). Bring up Buyer.Supervisor: Queue + Resync + Runtime.
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  buyer_enabled: true,
+  # This buyer's wallet (0x string). Surfaced in the handler/evaluate ctx and
+  # used to filter our own jobs during resync.
+  buyer_address: System.get_env("RAXOL_ACP_BUYER_ADDRESS"),
+  # Chain the jobs live on. Defaults to 8453 (Base mainnet); Sepolia MUST be set.
+  buyer_chain_id: 84_532,
+  # ACP v2 core; defaults to Chain.mainnet/0 when unset.
+  buyer_acp_core_address: nil,
+  # Ledger agent id for spend accounting.
+  buyer_agent_id: :raxol_buyer
+
+# The signing adapter that writes createJob / fund / complete on-chain. Same
+# `Raxol.ACP.ProviderAdapter` the seller uses (SCA sponsored UserOps, a Privy
+# signer sidecar, or a plain JSONRPC EOA). Required to write -- with none, a
+# purchase drops with `:no_provider_adapter`.
+#
+#     config :raxol_acp, buyer_provider_adapter: my_adapter
+
+# ---------------------------------------------------------------------------
+# Spend gating (fail closed in production). The buyer reserves the quoted amount
+# atomically before any on-chain write; with no policy configured the gate
+# refuses to spend in production (require_policy defaults to
+# Raxol.Payments.Deployment.production?()).
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  # A running Raxol.Payments.Ledger server (name or pid).
+  buyer_ledger: Raxol.Payments.Ledger,
+  # Per-request / session / lifetime caps.
+  buyer_spending_policy: %Raxol.Payments.SpendingPolicy{
+    per_request_max: Decimal.new("15.00"),
+    session_max: Decimal.new("100.00"),
+    lifetime_max: Decimal.new("1000.00"),
+    currency: "USDC"
+  }
+
+# ---------------------------------------------------------------------------
+# Crash-safe idempotency (shared with the seller). The buyer keys a single
+# accreting record by a client-minted request_key. Set require_checkpoint: true
+# in a fund-moving deployment so a misconfigured buyer fails closed.
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  checkpoint: {:ets, :raxol_acp_checkpoint},
+  require_checkpoint: true
+
+# ---------------------------------------------------------------------------
+# Event source + discovery. The Runtime subscribes to the configured backend for
+# this buyer's job lifecycle events. For local rehearsal use the shared InMemory
+# backend; a production buyer points this at an SSE-backed source for its own
+# jobs (the Raxol.ACP.Agent stream -- the remaining integration item for the
+# Sepolia dry-run). The backend process itself is started by the host app, not
+# by Buyer.Supervisor.
+# ---------------------------------------------------------------------------
+config :raxol_acp,
+  buyer_backend: Raxol.ACP.Seller.Backend.InMemory,
+  # Off-chain REST discovery + active-job listing (for browse + resync).
+  # Forwarded to Raxol.ACP.JobApi.HTTP.new/1.
+  buyer_job_api_opts: [
+    server_url: "https://api-dev.acp.virtuals.io",
+    chain_ids: [84_532]
+  ],
+  # jobId resolution after createJob. Defaults to JobIdResolver.Receipt.
+  # CONFIRM the JobCreated event signature / indexed position in the dry-run,
+  # then override here:
+  #
+  #     buyer_job_id_resolver:
+  #       {Raxol.ACP.JobIdResolver.Receipt,
+  #        %{event_signature: "JobCreated(uint256)", topic_index: 1}}
+  buyer_job_id_resolver: nil

--- a/packages/raxol_acp/lib/raxol/acp/buyer/planner.ex
+++ b/packages/raxol_acp/lib/raxol/acp/buyer/planner.ex
@@ -1,0 +1,71 @@
+defmodule Raxol.ACP.Buyer.Planner do
+  @moduledoc """
+  Initiates purchases: discovery + hand-off to `Raxol.ACP.Buyer.Queue`.
+
+  `buy/1` takes a purchase intent (a map). If it already names a `:provider`
+  (seller wallet), it goes straight to `Queue.start_purchase/1`. Otherwise the
+  Planner discovers one via `JobApi.browse_agents/3` (using `:keyword` or the
+  `:offering` name, plus optional `:browse_params`) and picks the first match,
+  then hands off. Discovery uses the same job API the Queue reads from config.
+
+      Raxol.ACP.Buyer.Planner.buy(%{
+        offering: "custom_console_agent",
+        amount: Raxol.ACP.AssetToken.usdc(10, 84_532),
+        expired_at: expiry_ts
+      })
+
+  This is deliberately thin -- the crash-safe origination, spend gating, and
+  on-chain writes all live in `Raxol.ACP.JobSession.Client`, driven by the Queue.
+  """
+
+  alias Raxol.ACP.Buyer.Queue
+  alias Raxol.ACP.JobApi
+
+  @doc """
+  Discover a provider if needed and start the purchase. Returns
+  `{:ok, job_id}` | `{:rejected, reason}` | `{:error, reason}`.
+  """
+  @spec buy(map()) :: {:ok, non_neg_integer()} | {:rejected, term()} | {:error, term()}
+  def buy(intent) when is_map(intent) do
+    case ensure_provider(intent) do
+      {:ok, intent} -> Queue.start_purchase(intent)
+      {:error, _reason} = err -> err
+    end
+  end
+
+  @doc "Browse the registry for agents matching this intent's keyword/offering."
+  @spec discover(JobApi.t(), map()) :: {:ok, [JobApi.agent_detail()]} | {:error, term()}
+  def discover(api, intent) when is_map(intent) do
+    keyword = Map.get(intent, :keyword) || Map.get(intent, :offering) || ""
+    params = Map.get(intent, :browse_params, %{})
+    JobApi.browse_agents(api, keyword, params)
+  end
+
+  # -- Internals --
+
+  defp ensure_provider(%{provider: provider} = intent) when is_binary(provider), do: {:ok, intent}
+
+  defp ensure_provider(intent) do
+    with {:ok, api} <- job_api(),
+         {:ok, agents} <- discover(api, intent),
+         {:ok, provider} <- pick_provider(agents) do
+      {:ok, Map.put(intent, :provider, provider)}
+    end
+  end
+
+  defp job_api do
+    case Queue.defaults().api do
+      nil -> {:error, :no_job_api}
+      api -> {:ok, api}
+    end
+  end
+
+  defp pick_provider([agent | _]) do
+    case Map.get(agent, :wallet_address) do
+      addr when is_binary(addr) -> {:ok, addr}
+      _ -> {:error, :provider_missing_wallet}
+    end
+  end
+
+  defp pick_provider([]), do: {:error, :no_provider_found}
+end

--- a/packages/raxol_acp/lib/raxol/acp/buyer/queue.ex
+++ b/packages/raxol_acp/lib/raxol/acp/buyer/queue.ex
@@ -1,0 +1,312 @@
+defmodule Raxol.ACP.Buyer.Queue do
+  @moduledoc """
+  The buyer's dispatch authority -- the mirror of `Raxol.ACP.Seller.Queue`.
+
+  Owns the client half of the ACP flow. `start_purchase/1` originates a job:
+  it builds a `Raxol.ACP.JobSession.Client` from a purchase intent plus
+  `Application` config, reserves the spend, writes `createJob` on-chain, and
+  resolves the assigned `job_id`, then tracks the resulting client by `job_id`.
+  `dispatch/1` (called by `Raxol.ACP.Buyer.Runtime`) routes the job's later
+  lifecycle events to that client:
+
+  - `:budget_set` -- the seller set the budget: `Client.on_budget_set` funds the
+    escrow (asserting the budget does not exceed the reserved ceiling).
+  - `:submitted` -- the seller delivered: `Client.on_submitted` evaluates and
+    writes `complete`/`reject` (terminal; the client is dropped).
+  - `:job_expired` -- `Client.release` refunds the reservation; drop.
+
+  Unknown types and events for jobs we do not track drop with telemetry. Config
+  is read from `Application` on every call so it can rotate without a restart.
+
+  ## Configuration
+
+      config :raxol_acp,
+        buyer_address: "0x...",                    # this buyer's wallet (0x string)
+        buyer_provider_adapter: adapter,           # Raxol.ACP.ProviderAdapter (required to write)
+        buyer_chain_id: 8453,                      # chain the jobs live on (default 8453)
+        buyer_acp_core_address: "0x...",           # defaults to Chain.mainnet
+        buyer_agent_id: :raxol_buyer,              # ledger agent id for spend accounting
+        buyer_spending_policy: %SpendingPolicy{},  # fail-closed in prod when absent
+        buyer_ledger: MyLedger,                    # Raxol.Payments.Ledger server
+        buyer_job_api_opts: [...],                 # Raxol.ACP.JobApi.HTTP.new/1 opts
+        buyer_job_id_resolver: {mod, cfg}          # defaults to JobIdResolver.Receipt
+
+  ## Telemetry
+
+  - `[:raxol, :acp, :buyer, :queue, :purchased]` -- `%{job_id, offering}`.
+  - `[:raxol, :acp, :buyer, :queue, :dispatched]` -- `%{type, job_id}`.
+  - `[:raxol, :acp, :buyer, :queue, :dropped]` -- `%{type, job_id, reason}`.
+  """
+
+  use Raxol.Core.Behaviours.BaseManager
+
+  alias Raxol.ACP.{Chain, JobApi}
+  alias Raxol.ACP.JobSession.Client
+
+  @known_types [:budget_set, :submitted, :job_expired]
+
+  # -- Public API --
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Originate a purchase. `intent` is a map with at least `:provider` (seller
+  wallet) and `:amount` (an `AssetToken`); optional `:offering`, `:evaluator`,
+  `:hook_address`, `:expired_at`, `:description`, `:nonce`, `:evaluate_fn`.
+
+  Synchronous: reserves, writes `createJob`, resolves the job_id, and returns
+  `{:ok, job_id}` (or `{:rejected, reason}` / `{:error, reason}`).
+  """
+  @spec start_purchase(map()) :: {:ok, non_neg_integer()} | {:rejected, term()} | {:error, term()}
+  def start_purchase(intent) when is_map(intent) do
+    GenServer.call(__MODULE__, {:start_purchase, intent})
+  end
+
+  @doc "Dispatch a lifecycle event for a tracked job. Asynchronous."
+  @spec dispatch(map()) :: :ok
+  def dispatch(event) when is_map(event) do
+    GenServer.cast(__MODULE__, {:dispatch, event})
+  end
+
+  @doc """
+  Re-track an already-created job (used by `Raxol.ACP.Buyer.Resync` on restart).
+
+  Builds a client from `intent` (which must carry `:job_id`, `:provider`,
+  `:amount`, and an observed `:status`), starts/adopts its `JobSession` at that
+  status, and stores it so later lifecycle events route to it. Does NOT write
+  on-chain. The `request_key` is derived from the job identity (`nonce: job_id`)
+  so it is stable across restarts. Returns `{:ok, job_id}`.
+  """
+  @spec adopt(map()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def adopt(intent) when is_map(intent) do
+    GenServer.call(__MODULE__, {:adopt, intent})
+  end
+
+  @doc "Inspect the resolved defaults from `Application` config."
+  @spec defaults() :: map()
+  def defaults, do: read_defaults()
+
+  # -- BaseManager callbacks --
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def init_manager(_opts), do: {:ok, %{jobs: %{}}}
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call({:start_purchase, intent}, _from, state) do
+    defaults = read_defaults()
+
+    if defaults.provider_adapter == nil do
+      {:reply, {:error, :no_provider_adapter}, state}
+    else
+      purchase(intent, defaults, state)
+    end
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call({:adopt, intent}, _from, state) do
+    defaults = read_defaults()
+    job_id = Map.fetch!(intent, :job_id)
+    status = Map.get(intent, :status, :budget_set)
+
+    case ensure_session(defaults.chain_id, job_id, status) do
+      {:ok, session} ->
+        client =
+          intent
+          |> Map.put(:nonce, job_id)
+          |> build_client(defaults)
+          |> Map.merge(%{job_id: job_id, session: session})
+
+        {:reply, {:ok, job_id}, put_job(state, job_id, client)}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_cast({:dispatch, event}, state) do
+    {:noreply, handle_event(event, state)}
+  end
+
+  # -- Purchase origination --
+
+  defp purchase(intent, defaults, state) do
+    client = build_client(intent, defaults)
+
+    case Client.buy(client) do
+      {:ok, client, %{job_id: job_id}} ->
+        emit(:purchased, %{job_id: job_id, offering: Map.get(intent, :offering)})
+        {:reply, {:ok, job_id}, put_job(state, job_id, client)}
+
+      {:rejected, reason} ->
+        emit(:dropped, %{type: :start_purchase, job_id: nil, reason: {:rejected, reason}})
+        {:reply, {:rejected, reason}, state}
+
+      {:error, reason} ->
+        emit(:dropped, %{type: :start_purchase, job_id: nil, reason: reason})
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  # -- Event handling --
+
+  defp handle_event(%{type: :budget_set, job_id: job_id} = event, state) do
+    with_job(:budget_set, job_id, state, fn client ->
+      case Client.on_budget_set(client, Map.get(event, :budget_raw)) do
+        {:ok, client, _result} ->
+          _ = dispatched(:budget_set, job_id)
+          put_job(state, job_id, client)
+
+        {:ok, %{idempotent: true}} ->
+          _ = dispatched(:budget_set, job_id)
+          state
+
+        {:rejected, reason} ->
+          drop(:budget_set, job_id, {:rejected, reason}, drop_job(state, job_id))
+
+        {:error, reason} ->
+          drop(:budget_set, job_id, reason, state)
+      end
+    end)
+  end
+
+  defp handle_event(%{type: :submitted, job_id: job_id} = event, state) do
+    with_job(:submitted, job_id, state, fn client ->
+      deliverable = Map.get(event, :deliverable, %{})
+
+      case Client.on_submitted(client, deliverable) do
+        {:ok, _client, _result} ->
+          _ = dispatched(:submitted, job_id)
+          drop_job(state, job_id)
+
+        {:error, reason} ->
+          drop(:submitted, job_id, reason, state)
+      end
+    end)
+  end
+
+  defp handle_event(%{type: :job_expired, job_id: job_id}, state) do
+    with_job(:job_expired, job_id, state, fn client ->
+      :ok = Client.release(client)
+      _ = dispatched(:job_expired, job_id)
+      drop_job(state, job_id)
+    end)
+  end
+
+  # A known type reaching here is missing its `:job_id` (the typed clauses above
+  # require it in the head), so the id is nil by construction -- malformed.
+  defp handle_event(%{type: type}, state) when type in @known_types do
+    drop(type, nil, :malformed, state)
+  end
+
+  defp handle_event(%{type: type} = event, state) do
+    drop(type, Map.get(event, :job_id), :unknown_event, state)
+  end
+
+  # No `:type` key at all.
+  defp handle_event(event, state) do
+    drop(nil, Map.get(event, :job_id), :malformed, state)
+  end
+
+  # -- Client construction --
+
+  defp build_client(intent, defaults) do
+    Client.new(
+      adapter: defaults.provider_adapter,
+      api: defaults.api,
+      resolver: defaults.resolver,
+      chain_id: defaults.chain_id,
+      acp_core_address: defaults.acp_core_address,
+      buyer: defaults.buyer_address,
+      provider: Map.fetch!(intent, :provider),
+      evaluator: Map.get(intent, :evaluator),
+      hook_address: Map.get(intent, :hook_address),
+      offering: Map.get(intent, :offering),
+      amount: Map.fetch!(intent, :amount),
+      expired_at: Map.get(intent, :expired_at),
+      description: Map.get(intent, :description),
+      nonce: Map.get(intent, :nonce),
+      ledger: defaults.ledger,
+      policy: defaults.policy,
+      agent_id: defaults.agent_id,
+      checkpoint: defaults.checkpoint,
+      evaluate_fn: Map.get(intent, :evaluate_fn)
+    )
+  end
+
+  defp ensure_session(chain_id, job_id, status) do
+    case Raxol.ACP.JobSession.Supervisor.start_session(
+           chain_id: chain_id,
+           job_id: job_id,
+           role: :client,
+           initial_status: status
+         ) do
+      {:ok, _pid} -> {:ok, {chain_id, job_id}}
+      {:error, {:already_started, _pid}} -> {:ok, {chain_id, job_id}}
+      {:error, reason} -> {:error, {:session_start_failed, reason}}
+    end
+  end
+
+  # -- Defaults --
+
+  defp read_defaults do
+    %{
+      buyer_address: Application.get_env(:raxol_acp, :buyer_address),
+      provider_adapter: Application.get_env(:raxol_acp, :buyer_provider_adapter),
+      checkpoint: Raxol.ACP.Checkpoint.store(),
+      chain_id: Application.get_env(:raxol_acp, :buyer_chain_id, 8453),
+      acp_core_address:
+        Application.get_env(:raxol_acp, :buyer_acp_core_address) ||
+          Chain.mainnet().acp_core_address,
+      api: buyer_job_api(),
+      resolver: buyer_resolver(),
+      ledger: Application.get_env(:raxol_acp, :buyer_ledger),
+      policy: Application.get_env(:raxol_acp, :buyer_spending_policy),
+      agent_id: Application.get_env(:raxol_acp, :buyer_agent_id, :raxol_buyer)
+    }
+  end
+
+  defp buyer_job_api do
+    case Application.get_env(:raxol_acp, :buyer_job_api_opts) do
+      nil -> nil
+      opts when is_list(opts) -> JobApi.HTTP.new(opts)
+    end
+  end
+
+  defp buyer_resolver do
+    case Application.get_env(:raxol_acp, :buyer_job_id_resolver) do
+      nil -> %{adapter: Raxol.ACP.JobIdResolver.Receipt}
+      {module, config} when is_atom(module) -> %{adapter: module, config: config}
+      %{adapter: _} = resolver -> resolver
+    end
+  end
+
+  # -- Helpers --
+
+  defp with_job(type, job_id, state, fun) do
+    case Map.fetch(state.jobs, job_id) do
+      {:ok, client} -> fun.(client)
+      :error -> drop(type, job_id, :job_not_tracked, state)
+    end
+  end
+
+  defp put_job(state, job_id, client), do: %{state | jobs: Map.put(state.jobs, job_id, client)}
+  defp drop_job(state, job_id), do: %{state | jobs: Map.delete(state.jobs, job_id)}
+
+  defp dispatched(type, job_id) do
+    emit(:dispatched, %{type: type, job_id: job_id})
+    :ok
+  end
+
+  defp drop(type, job_id, reason, state) do
+    emit(:dropped, %{type: type, job_id: job_id, reason: reason})
+    state
+  end
+
+  defp emit(suffix, metadata) do
+    :telemetry.execute([:raxol, :acp, :buyer, :queue, suffix], %{}, metadata)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/buyer/resync.ex
+++ b/packages/raxol_acp/lib/raxol/acp/buyer/resync.ex
@@ -1,0 +1,174 @@
+defmodule Raxol.ACP.Buyer.Resync do
+  @moduledoc """
+  Drain-before-act on boot and after a backend restart, for the buyer -- the
+  mirror of `Raxol.ACP.Seller.Resync`.
+
+  A buyer that crashes mid-flight loses its in-memory `Raxol.ACP.Buyer.Queue`
+  tracking. On (re)start this reads the authoritative job list via
+  `JobApi.get_active_jobs/1`, filters to jobs where WE are the buyer and the
+  status is non-terminal, and re-tracks each through `Queue.adopt/1` so later
+  lifecycle events route to it. For a job observed at `:budget_set` -- the seller
+  set the budget but our fund was interrupted -- it also synthesizes a
+  `:budget_set` dispatch to resume the interrupted fund (idempotent: the escrow's
+  funded-state guard reverts a duplicate fund, and the checkpoint short-circuits
+  a fund already recorded).
+
+  Started before `Runtime` under the buyer supervisor's `:rest_for_one`, so
+  rehydration precedes live dispatch. A failed drain emits telemetry and does
+  NOT block buying (best-effort, like the seller). Requires `:buyer_job_api_opts`
+  to be configured; with no job API it is inert.
+
+  ## Resume boundary (flag for the Sepolia dry-run)
+
+  Re-tracking derives a fresh `request_key` from the job identity (`nonce:
+  job_id`), so the reservation made under the ORIGINAL pre-crash `request_key`
+  is not matched here. With the default ETS ledger a restart clears reservations
+  anyway; with a durable ledger the original reservation is reclaimed by the
+  ledger's reservation TTL sweep rather than here. The active-job field names /
+  status encoding normalized below, and the job-key form, are the same open
+  items `Seller.Resync` flags.
+
+  ## Telemetry
+
+  - `[:raxol, :acp, :buyer, :resync, :rehydrated]` -- `%{job_id, status}`.
+  - `[:raxol, :acp, :buyer, :resync, :skipped]` -- `%{job_id, reason}`.
+  - `[:raxol, :acp, :buyer, :resync, :drain_failed]` -- `%{reason}`.
+  """
+
+  use Raxol.Core.Behaviours.BaseManager
+
+  alias Raxol.ACP.Buyer.Queue
+  alias Raxol.ACP.JobApi
+  alias Raxol.ACP.JobSession.Status
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def init_manager(opts) do
+    # Drain on the next tick so the Queue (started ahead of us) is ready.
+    send(self(), :drain)
+    {:ok, %{api: Keyword.get(opts, :api, buyer_job_api())}}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info(:drain, %{api: nil} = state), do: {:noreply, state}
+
+  def handle_manager_info(:drain, %{api: api} = state) do
+    case JobApi.get_active_jobs(api) do
+      {:ok, jobs} ->
+        buyer = Application.get_env(:raxol_acp, :buyer_address)
+        Enum.each(jobs, &rehydrate(&1, buyer))
+
+      {:error, reason} ->
+        emit(:drain_failed, %{reason: reason})
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_manager_info(_msg, state), do: {:noreply, state}
+
+  # -- Rehydration --
+
+  defp rehydrate(job, buyer) do
+    case normalize(job, buyer) do
+      {:ok, intent} -> adopt(intent)
+      {:skip, job_id, reason} -> emit(:skipped, %{job_id: job_id, reason: reason})
+    end
+  end
+
+  defp adopt(intent) do
+    case Queue.adopt(intent) do
+      {:ok, job_id} ->
+        emit(:rehydrated, %{job_id: job_id, status: intent.status})
+        maybe_redrive(intent)
+
+      {:error, reason} ->
+        emit(:skipped, %{job_id: intent[:job_id], reason: reason})
+    end
+  end
+
+  # A job we should resume: we are the buyer, status is non-terminal, and the
+  # required fields (job_id, provider, budget) are present.
+  defp normalize(job, buyer) do
+    job_id = read(job, ["onChainJobId", "jobId", "job_id"]) |> coerce_id()
+    provider = read(job, ["provider", "providerAddress", "provider_address"])
+    job_buyer = read(job, ["buyer", "clientAddress", "client_address"])
+    status = job |> read(["status", "phase", "state"]) |> to_status()
+    budget_raw = read(job, ["budget", "budgetRaw", "budget_raw", "amount"]) |> coerce_id()
+
+    cond do
+      is_nil(job_id) -> {:skip, nil, :no_job_id}
+      not ours?(buyer, job_buyer) -> {:skip, job_id, :not_our_job}
+      is_nil(status) or Status.terminal?(status) -> {:skip, job_id, :terminal_or_unknown}
+      is_nil(provider) -> {:skip, job_id, :no_provider}
+      is_nil(budget_raw) -> {:skip, job_id, :no_budget}
+      true -> {:ok, build_intent(job_id, provider, status, budget_raw)}
+    end
+  end
+
+  defp build_intent(job_id, provider, status, budget_raw) do
+    chain_id = Application.get_env(:raxol_acp, :buyer_chain_id, 8453)
+
+    %{
+      job_id: job_id,
+      provider: provider,
+      status: status,
+      amount: Raxol.ACP.AssetToken.usdc_from_raw(budget_raw, chain_id)
+    }
+  end
+
+  # Only :budget_set has an interrupted action we can resume from on-chain data
+  # alone (the fund). :submitted needs the off-chain deliverable, which a live
+  # event carries -- so we adopt and wait rather than guess.
+  defp maybe_redrive(%{status: :budget_set, job_id: job_id, amount: amount}) do
+    Queue.dispatch(%{type: :budget_set, job_id: job_id, budget_raw: amount.raw_amount})
+  end
+
+  defp maybe_redrive(_intent), do: :ok
+
+  # -- Field readers (tolerant of the live vs mock shapes) --
+
+  defp ours?(nil, _job_buyer), do: true
+
+  defp ours?(buyer, job_buyer) when is_binary(buyer) and is_binary(job_buyer),
+    do: String.downcase(buyer) == String.downcase(job_buyer)
+
+  defp ours?(_buyer, _job_buyer), do: false
+
+  # Live active-job maps are string-keyed (mirroring `Seller.Resync`'s `pick/2`).
+  defp read(job, keys), do: Enum.find_value(keys, &Map.get(job, &1))
+
+  defp to_status(nil), do: nil
+  defp to_status(status) when is_atom(status), do: if(status in Status.all(), do: status)
+
+  defp to_status(status) when is_binary(status) do
+    Enum.find(Status.all(), &(Atom.to_string(&1) == status))
+  end
+
+  defp coerce_id(nil), do: nil
+  defp coerce_id(n) when is_integer(n), do: n
+
+  defp coerce_id(n) when is_binary(n) do
+    case Integer.parse(n) do
+      {i, _} -> i
+      :error -> nil
+    end
+  end
+
+  defp coerce_id(_), do: nil
+
+  defp buyer_job_api do
+    case Application.get_env(:raxol_acp, :buyer_job_api_opts) do
+      nil -> nil
+      opts when is_list(opts) -> JobApi.HTTP.new(opts)
+    end
+  end
+
+  defp emit(suffix, metadata) do
+    :telemetry.execute([:raxol, :acp, :buyer, :resync, suffix], %{}, metadata)
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/buyer/runtime.ex
+++ b/packages/raxol_acp/lib/raxol/acp/buyer/runtime.ex
@@ -1,0 +1,76 @@
+defmodule Raxol.ACP.Buyer.Runtime do
+  @moduledoc """
+  Subscribes to the configured buyer event source and forwards every
+  `{:acp_event, event}` message to `Raxol.ACP.Buyer.Queue` -- the mirror of
+  `Raxol.ACP.Seller.Runtime`.
+
+  Thin by design: it bridges an asynchronous message source (the backend) to the
+  dispatch layer (the Queue) and does not interpret events. If the backend dies,
+  `Raxol.ACP.Buyer.Supervisor`'s `:rest_for_one` strategy restarts the Runtime
+  too, which re-subscribes on its next `init/1`.
+
+  ## Configuration
+
+  The backend is any `Raxol.ACP.Seller.Backend` implementation (the behaviour is
+  a generic ACP event source, shared with the seller):
+
+      config :raxol_acp, buyer_backend: Raxol.ACP.Seller.Backend.InMemory
+
+  For tests and `mix` rehearsals the `InMemory` backend is the primary driver. A
+  production buyer points `:buyer_backend` at an SSE-backed source for its own
+  jobs (the `Raxol.ACP.Agent` stream) -- that adapter is the one remaining
+  integration item flagged for the Sepolia dry-run.
+
+  ## Telemetry
+
+  - `[:raxol, :acp, :buyer, :runtime, :event_received]` -- `%{type, job_id}`.
+  """
+
+  use Raxol.Core.Behaviours.BaseManager
+
+  alias Raxol.ACP.Buyer.Queue
+  alias Raxol.ACP.Seller.Backend
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc "Return the backend module the Runtime subscribed to."
+  @spec backend() :: module()
+  def backend, do: GenServer.call(__MODULE__, :backend)
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def init_manager(opts) do
+    backend =
+      Keyword.get(opts, :backend) ||
+        Application.get_env(:raxol_acp, :buyer_backend) ||
+        raise """
+        raxol_acp: no buyer backend configured. Set one of:
+
+          config :raxol_acp, buyer_backend: Raxol.ACP.Seller.Backend.InMemory
+        """
+
+    :ok = Backend.subscribe(backend, self())
+
+    {:ok, %{backend: backend}}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call(:backend, _from, state), do: {:reply, state.backend, state}
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info({:acp_event, event}, state) do
+    :telemetry.execute(
+      [:raxol, :acp, :buyer, :runtime, :event_received],
+      %{},
+      %{type: Map.get(event, :type), job_id: Map.get(event, :job_id)}
+    )
+
+    Queue.dispatch(event)
+
+    {:noreply, state}
+  end
+
+  def handle_manager_info(_msg, state), do: {:noreply, state}
+end

--- a/packages/raxol_acp/lib/raxol/acp/buyer/supervisor.ex
+++ b/packages/raxol_acp/lib/raxol/acp/buyer/supervisor.ex
@@ -1,0 +1,64 @@
+defmodule Raxol.ACP.Buyer.Supervisor do
+  @moduledoc """
+  Supervisor for the buyer half of the ACP package -- the mirror of
+  `Raxol.ACP.Seller.Supervisor`.
+
+  ## Strategy
+
+  `:rest_for_one`, ordered so a downstream crash takes the upstream listener
+  with it:
+
+  1. The checkpoint `Owner` (only for the `{:ets, name}` form) -- started first
+     so idempotency records survive a Queue/Runtime crash.
+  2. `Raxol.ACP.Buyer.Queue` -- the dispatch authority. Must outlive the Runtime
+     so in-flight purchases finish even if the backend reconnect cycles.
+  3. `Raxol.ACP.Buyer.Resync` -- drain-before-act: rehydrates in-flight jobs from
+     the job API before live dispatch. Inert without `:buyer_job_api_opts`.
+  4. `Raxol.ACP.Buyer.Runtime` -- subscribes to the buyer backend and forwards
+     events to the Queue. Restarted (and re-subscribed) whenever it crashes.
+
+  The buyer backend process itself is NOT started here: the Runtime subscribes
+  to whatever `:buyer_backend` names, which the host application (or a shared
+  seller backend) is expected to have running. This avoids a name clash when a
+  deployment runs both a seller and a buyer against one backend.
+
+  ## Opt-in
+
+  Started by `Raxol.ACP.Supervisor` only when
+  `config :raxol_acp, buyer_enabled: true`. Seller-only users pay nothing for the
+  buyer machinery.
+  """
+
+  use Supervisor
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    children =
+      checkpoint_owner_children() ++
+        [
+          Raxol.ACP.Buyer.Queue,
+          Raxol.ACP.Buyer.Resync,
+          Raxol.ACP.Buyer.Runtime
+        ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  # The `{:ets, name}` checkpoint form needs a supervisor-level table owner so
+  # idempotency records survive Queue/Runtime crashes. `Owner.init/1` returns
+  # `:ignore` for other checkpoint configs, so gating on shape keeps a durable
+  # `{module, handle}` backend (or no checkpointing) from starting a stray owner.
+  # The `Owner` is a singleton (`name: __MODULE__`); when the seller is also
+  # enabled it already starts it, so the buyer skips to avoid `:already_started`.
+  defp checkpoint_owner_children do
+    ets? = match?({:ets, _name}, Application.get_env(:raxol_acp, :checkpoint))
+    seller_owns? = Application.get_env(:raxol_acp, :seller_enabled, false)
+
+    if ets? and not seller_owns?, do: [Raxol.ACP.Checkpoint.Owner], else: []
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/checkpoint.ex
+++ b/packages/raxol_acp/lib/raxol/acp/checkpoint.ex
@@ -55,10 +55,25 @@ defmodule Raxol.ACP.Checkpoint do
   @spec required?() :: boolean()
   def required?, do: Application.get_env(:raxol_acp, :require_checkpoint, false)
 
-  @doc "Stable idempotency key for one lifecycle step of one job."
+  @doc "Stable idempotency key for one lifecycle step of one seller job."
   @spec key(pos_integer(), term(), :accept | :submit) :: String.t()
   def key(chain_id, job_id, step) when step in [:accept, :submit],
     do: Checkpoint.derive_key([chain_id, job_id, step])
+
+  @doc """
+  Stable idempotency key for one buyer purchase.
+
+  Unlike the seller (which keys by `job_id`, an id that already exists on the
+  incoming event), the buyer ORIGINATES the job, so `job_id` does not exist
+  until `create_job` lands and its `JobCreated` log is decoded. The buyer
+  therefore keys the whole reserve -> create -> fund progression by a single
+  client-minted `request_key` that exists before any side effect. The record
+  stored under this key accretes a `"phase"` field (see
+  `Raxol.ACP.JobSession.Client`) rather than using per-step keys.
+  """
+  @spec buyer_key(pos_integer(), String.t()) :: String.t()
+  def buyer_key(chain_id, request_key) when is_binary(request_key),
+    do: Checkpoint.derive_key([chain_id, :buyer, request_key])
 
   defmodule Owner do
     @moduledoc """

--- a/packages/raxol_acp/lib/raxol/acp/job_id_resolver.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_id_resolver.ex
@@ -1,0 +1,57 @@
+defmodule Raxol.ACP.JobIdResolver do
+  @moduledoc """
+  Behaviour for resolving the on-chain `jobId` that `createJob` assigns.
+
+  `Raxol.ACP.HookClient.create_job/4` returns only the transaction hash --
+  the assigned `jobId` is emitted in a `JobCreated` event log. A BUYER
+  (`Raxol.ACP.JobSession.Client`) originates the job, so unlike the seller it
+  must resolve that id before it can `fund`. This seam keeps that resolution
+  injectable (like `Raxol.ACP.ProviderAdapter` / `Raxol.ACP.JobApi`), so it is
+  fully exercisable in tests via `Mock` and the real receipt-decode path stays
+  behind one boundary that a Sepolia dry-run can confirm.
+
+  Two paths, both needed by the crash-safe buyer:
+
+  - `resolve/4` -- decode the id from the `createJob` receipt (the normal path
+    and the resume path where we DO have the tx hash). May return `:pending`
+    when the receipt is not yet available.
+  - `reconcile/4` -- when a crash left us without a tx hash (we broadcast
+    `createJob` but crashed before recording the hash), correlate an
+    already-created job by the `request_tag` the buyer stamped into the job's
+    `description`. This is what makes the non-idempotent `createJob` recoverable
+    without minting a second job + escrow.
+
+  ## Implementations
+
+  - `Raxol.ACP.JobIdResolver.Receipt` (default) -- reads the receipt via
+    `ProviderAdapter.get_transaction_receipt` and decodes the `JobCreated` topic
+    with `Raxol.ACP.Onchain.LogDecoder`; reconciles via `JobApi.get_active_jobs`.
+    The exact event signature, indexed position, and emitter address are config
+    with placeholders that **must be confirmed against the deployed
+    `AgenticCommerceV3` in the Sepolia dry-run** (see the module).
+  - `Raxol.ACP.JobIdResolver.Mock` -- canned tx->id and tag->id maps for tests.
+  """
+
+  alias Raxol.ACP.{JobApi, ProviderAdapter}
+
+  @type t :: %{required(:adapter) => module(), optional(:config) => map()}
+  @type job_id :: non_neg_integer()
+
+  @callback resolve(t(), ProviderAdapter.adapter(), pos_integer(), String.t()) ::
+              {:ok, job_id()} | :pending | {:error, term()}
+
+  @callback reconcile(t(), JobApi.t(), pos_integer(), String.t()) ::
+              {:ok, job_id()} | :none | {:error, term()}
+
+  @doc "Decode the `jobId` from the `createJob` receipt for `tx_hash`."
+  @spec resolve(t(), ProviderAdapter.adapter(), pos_integer(), String.t()) ::
+          {:ok, job_id()} | :pending | {:error, term()}
+  def resolve(resolver, adapter, chain_id, tx_hash),
+    do: resolver.adapter.resolve(resolver, adapter, chain_id, tx_hash)
+
+  @doc "Correlate an already-created job by the `request_tag` in its description."
+  @spec reconcile(t(), JobApi.t(), pos_integer(), String.t()) ::
+          {:ok, job_id()} | :none | {:error, term()}
+  def reconcile(resolver, api, chain_id, request_tag),
+    do: resolver.adapter.reconcile(resolver, api, chain_id, request_tag)
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_id_resolver/mock.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_id_resolver/mock.ex
@@ -1,0 +1,87 @@
+defmodule Raxol.ACP.JobIdResolver.Mock do
+  @moduledoc """
+  In-process mock for `Raxol.ACP.JobIdResolver`.
+
+  Tests pre-seed the tx-hash -> jobId and request-tag -> jobId maps; this module
+  returns them without touching a chain. A tx hash marked pending returns
+  `:pending` so the crash-recovery path (resolve -> reconcile) is exercisable.
+
+      resolver = Raxol.ACP.JobIdResolver.Mock.new()
+      Raxol.ACP.JobIdResolver.Mock.put_tx(resolver, "0xtx", 42)
+      Raxol.ACP.JobIdResolver.Mock.put_tag(resolver, "rk-abc", 42)
+      {:ok, 42} = Raxol.ACP.JobIdResolver.resolve(resolver, adapter, 84_532, "0xtx")
+  """
+
+  @behaviour Raxol.ACP.JobIdResolver
+
+  @doc "Construct a fresh mock resolver."
+  @spec new(keyword()) :: Raxol.ACP.JobIdResolver.t()
+  def new(_opts \\ []) do
+    table = :ets.new(:raxol_acp_jobid_mock, [:set, :public])
+    :ets.insert(table, {:by_tx, %{}})
+    :ets.insert(table, {:by_tag, %{}})
+    :ets.insert(table, {:pending, MapSet.new()})
+    :ets.insert(table, {:default, nil})
+    %{adapter: __MODULE__, config: %{table: table}}
+  end
+
+  @doc """
+  Resolve any tx hash not explicitly mapped (and not marked pending) to
+  `job_id`. Convenient for happy-path tests that do not know the minted tx hash.
+  """
+  @spec put_default(Raxol.ACP.JobIdResolver.t(), non_neg_integer()) :: :ok
+  def put_default(%{config: %{table: table}}, job_id) do
+    :ets.insert(table, {:default, job_id})
+    :ok
+  end
+
+  @doc "Map a `createJob` tx hash to the jobId it assigned."
+  @spec put_tx(Raxol.ACP.JobIdResolver.t(), String.t(), non_neg_integer()) :: :ok
+  def put_tx(%{config: %{table: table}}, tx_hash, job_id) do
+    [{:by_tx, m}] = :ets.lookup(table, :by_tx)
+    :ets.insert(table, {:by_tx, Map.put(m, tx_hash, job_id)})
+    :ok
+  end
+
+  @doc "Map a request tag (stamped into the job description) to a jobId."
+  @spec put_tag(Raxol.ACP.JobIdResolver.t(), String.t(), non_neg_integer()) :: :ok
+  def put_tag(%{config: %{table: table}}, tag, job_id) do
+    [{:by_tag, m}] = :ets.lookup(table, :by_tag)
+    :ets.insert(table, {:by_tag, Map.put(m, tag, job_id)})
+    :ok
+  end
+
+  @doc "Force `resolve/4` to return `:pending` for `tx_hash` (receipt not ready)."
+  @spec set_pending(Raxol.ACP.JobIdResolver.t(), String.t()) :: :ok
+  def set_pending(%{config: %{table: table}}, tx_hash) do
+    [{:pending, set}] = :ets.lookup(table, :pending)
+    :ets.insert(table, {:pending, MapSet.put(set, tx_hash)})
+    :ok
+  end
+
+  # -- Behaviour callbacks --
+
+  @impl Raxol.ACP.JobIdResolver
+  def resolve(%{config: %{table: table}}, _adapter, _chain_id, tx_hash) do
+    [{:pending, pending}] = :ets.lookup(table, :pending)
+    [{:by_tx, by_tx}] = :ets.lookup(table, :by_tx)
+    [{:default, default}] = :ets.lookup(table, :default)
+
+    cond do
+      MapSet.member?(pending, tx_hash) -> :pending
+      Map.has_key?(by_tx, tx_hash) -> {:ok, Map.fetch!(by_tx, tx_hash)}
+      not is_nil(default) -> {:ok, default}
+      true -> :pending
+    end
+  end
+
+  @impl Raxol.ACP.JobIdResolver
+  def reconcile(%{config: %{table: table}}, _api, _chain_id, request_tag) do
+    [{:by_tag, by_tag}] = :ets.lookup(table, :by_tag)
+
+    case Map.fetch(by_tag, request_tag) do
+      {:ok, job_id} -> {:ok, job_id}
+      :error -> :none
+    end
+  end
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_id_resolver/receipt.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_id_resolver/receipt.ex
@@ -1,0 +1,130 @@
+defmodule Raxol.ACP.JobIdResolver.Receipt do
+  @moduledoc """
+  Default `Raxol.ACP.JobIdResolver`: decode the `jobId` from the `createJob`
+  transaction receipt, and reconcile a lost `createJob` via the discovery API.
+
+  `resolve/4` reads the receipt through `ProviderAdapter.get_transaction_receipt`
+  and decodes the `JobCreated` event's indexed `uint256 jobId` from its topics
+  with `Raxol.ACP.Onchain.LogDecoder`. `reconcile/4` lists active jobs via
+  `JobApi.get_active_jobs` and matches the one whose `description` carries the
+  buyer's `request_tag` -- the recovery path when a crash lost the tx hash.
+
+  ## CONFIRM IN THE SEPOLIA DRY-RUN
+
+  These defaults are placeholders and are NOT yet verified against the deployed
+  `AgenticCommerceV3`. Override via the resolver config before a funded run:
+
+      %{adapter: Raxol.ACP.JobIdResolver.Receipt,
+        config: %{
+          event_signature: "JobCreated(uint256)",  # canonical name + arg types
+          topic_index: 1                            # 1-based; topic 0 is the hash
+        }}
+
+  Open items for the dry-run: (1) the exact `JobCreated` signature (its topic0
+  hash), (2) that `jobId` is the INDEXED parameter at `topic_index` (indexed
+  primitives live in `topics[]`, not `data`; this decoder only reads topics),
+  (3) which contract emits it, and (4) that `createJob`'s `description` string
+  round-trips on-chain and is readable back through `get_active_jobs` -- the
+  reconcile path depends on it.
+  """
+
+  @behaviour Raxol.ACP.JobIdResolver
+
+  alias Raxol.ACP.{JobApi, Onchain.LogDecoder, ProviderAdapter}
+
+  @default_event_signature "JobCreated(uint256)"
+  @default_topic_index 1
+
+  @impl Raxol.ACP.JobIdResolver
+  def resolve(resolver, adapter, chain_id, tx_hash) do
+    signature = cfg(resolver, :event_signature, @default_event_signature)
+    topic_index = cfg(resolver, :topic_index, @default_topic_index)
+
+    case ProviderAdapter.get_transaction_receipt(adapter, chain_id, tx_hash) do
+      # No receipt yet: the tx is not mined. Let the caller poll / reconcile.
+      {:ok, nil} ->
+        :pending
+
+      {:ok, receipt} ->
+        decode_from_logs(logs_of(receipt), signature, topic_index)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl Raxol.ACP.JobIdResolver
+  def reconcile(_resolver, api, _chain_id, request_tag) do
+    case JobApi.get_active_jobs(api) do
+      {:ok, jobs} ->
+        jobs
+        |> Enum.find(&description_matches?(&1, request_tag))
+        |> job_id_or_none()
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # -- Internals --
+
+  # An event that isn't present is treated as "not ready yet" (:pending) rather
+  # than a hard error, so the crash-recovery caller can fall through to
+  # reconcile. A genuinely wrong signature therefore surfaces as a reconcile
+  # `:none` -- which the buyer turns into a visible error -- instead of a silent
+  # wrong id, honoring the fail-closed posture.
+  defp decode_from_logs(logs, signature, topic_index) do
+    case LogDecoder.extract(logs, signature, topic_index, :uint256) do
+      {:ok, job_id} -> {:ok, job_id}
+      {:error, {:event_not_found, _}} -> :pending
+      {:error, {:topic_out_of_range, _}} -> :pending
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp logs_of(receipt) when is_map(receipt) do
+    receipt["logs"] || receipt[:logs] || []
+  end
+
+  defp logs_of(_), do: []
+
+  defp description_matches?(job, request_tag) when is_map(job) do
+    description = job["description"] || job[:description] || ""
+    is_binary(description) and String.contains?(description, request_tag)
+  end
+
+  defp job_id_or_none(nil), do: :none
+
+  defp job_id_or_none(job) do
+    case job_id_of(job) do
+      nil -> :none
+      id -> {:ok, id}
+    end
+  end
+
+  # Tolerant reader matching `Raxol.ACP.Agent.job_id_from/1`: the live SSE / API
+  # shapes spell the id `onChainJobId` / `jobId` / `job_id`. Coerce to integer.
+  defp job_id_of(job) do
+    raw =
+      job["onChainJobId"] || job[:onChainJobId] || job["jobId"] || job[:jobId] ||
+        job["job_id"] || job[:job_id]
+
+    coerce_id(raw)
+  end
+
+  defp coerce_id(id) when is_integer(id), do: id
+
+  defp coerce_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {n, _} -> n
+      :error -> nil
+    end
+  end
+
+  defp coerce_id(_), do: nil
+
+  defp cfg(%{config: config}, key, default) when is_map(config),
+    do: Map.get(config, key, default)
+
+  defp cfg(_resolver, _key, default), do: default
+end

--- a/packages/raxol_acp/lib/raxol/acp/job_session/client.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_session/client.ex
@@ -1,0 +1,546 @@
+defmodule Raxol.ACP.JobSession.Client do
+  @moduledoc """
+  Drives a `Raxol.ACP.JobSession` from the BUYER (client) side -- the mirror of
+  `Raxol.ACP.JobSession.Provider`. Where the provider reacts to a job that
+  already exists, the buyer ORIGINATES one: it discovers an offering (via the
+  `Raxol.ACP.Buyer` runtime), gates the spend, creates the job on-chain, funds
+  the escrow once the seller sets the budget, and evaluates the delivered work.
+
+  Like `Provider`, this is a plain struct built with `new/1`; its functions are
+  pure orchestration over the session, the adapter, the spend gate, and the
+  checkpoint (no process of its own -- the `Raxol.ACP.Buyer.Queue` calls them).
+  Unlike `Provider` it threads an EVOLVING struct: `job_id`/`session` start `nil`
+  and are filled once `create_job` lands, so each function returns the updated
+  client alongside its result.
+
+  ## Spend gating
+
+  Every fund-moving step goes through `Raxol.Payments.Actions.SpendGate`: `buy/1`
+  reserves the quoted amount atomically (`authorize` -> `Ledger.try_spend`) and
+  tags the reservation with the `request_key`. A completed job forgets the tag
+  (the spend stands); a rejected or expired one releases it (idempotent refund).
+  With no `SpendingPolicy` configured the gate fails closed in production
+  (`require_policy` defaults to `Raxol.Payments.Deployment.production?()`).
+
+  ## Crash-resume (checkpointing)
+
+  The seller keys its checkpoint by `job_id`, which pre-exists on the incoming
+  event. The buyer has no `job_id` until after `create_job`, so it keys a single
+  accreting record by a client-minted `request_key`
+  (`Raxol.ACP.Checkpoint.buyer_key/2`) whose `"phase"` field advances
+  `reserved -> creating -> created -> bound -> funding -> funded -> released`.
+  On any replay `buy/1`/`on_budget_set/2` fetch that record and resume from the
+  furthest recorded phase, so budget is reserved once and the escrow funded once.
+
+  `create_job` is the one non-idempotent on-chain write (each call mints a NEW
+  job + escrow; there is no phase guard to revert a duplicate, unlike
+  `fund`/`submit`). To make it recoverable the buyer stamps a short `request_tag`
+  derived from the `request_key` into the job's `description`; if a crash lands
+  in the `creating` window (broadcast sent, tx hash not yet recorded) the resume
+  path reconciles by that tag through `Raxol.ACP.JobIdResolver.reconcile/4`
+  before ever re-broadcasting, and only re-creates when reconcile proves no job
+  carries the tag. Honest semantics: **exactly-once-effective for reserve and
+  fund; create is at-least-once-attempted with deterministic tag reconcile.**
+  With `require_checkpoint: true` and no store, fund-adjacent writes fail closed
+  with `{:error, :checkpoint_required}` before any reserve or write.
+  """
+
+  alias Raxol.ACP.{AssetToken, HookClient, JobIdResolver, JobSession}
+  alias Raxol.Payments.Actions.SpendGate
+  alias Raxol.Payments.Checkpoint
+
+  @zero_address "0x" <> String.duplicate("0", 40)
+
+  @enforce_keys [:adapter, :chain_id, :acp_core_address, :buyer, :provider, :amount, :request_key]
+  defstruct [
+    :adapter,
+    :api,
+    :resolver,
+    :chain_id,
+    :acp_core_address,
+    :buyer,
+    :provider,
+    :evaluator,
+    :hook_address,
+    :offering,
+    :amount,
+    :request_key,
+    :expired_at,
+    :description,
+    :ledger,
+    :policy,
+    :agent_id,
+    :require_policy,
+    :checkpoint,
+    :evaluate_fn,
+    session: nil,
+    job_id: nil
+  ]
+
+  @type t :: %__MODULE__{
+          adapter: Raxol.ACP.ProviderAdapter.adapter(),
+          api: Raxol.ACP.JobApi.t() | nil,
+          resolver: JobIdResolver.t(),
+          chain_id: pos_integer(),
+          acp_core_address: String.t(),
+          buyer: String.t(),
+          provider: String.t(),
+          evaluator: String.t(),
+          hook_address: String.t(),
+          offering: String.t() | nil,
+          amount: AssetToken.t(),
+          request_key: String.t(),
+          expired_at: non_neg_integer() | nil,
+          description: String.t() | nil,
+          ledger: GenServer.server() | nil,
+          policy: Raxol.Payments.SpendingPolicy.t() | nil,
+          agent_id: term(),
+          require_policy: boolean() | nil,
+          checkpoint: Checkpoint.store() | nil,
+          evaluate_fn: (map(), map() -> {:approve, term()} | {:reject, term()}),
+          session: JobSession.job_key() | nil,
+          job_id: non_neg_integer() | nil
+        }
+
+  @doc """
+  Build a buyer driver.
+
+  Required: `:adapter`, `:chain_id`, `:acp_core_address`, `:buyer`, `:provider`,
+  `:amount` (an `AssetToken` -- the reserved spend ceiling). Optional but
+  usual: `:api`, `:resolver` (default `JobIdResolver.Receipt`), `:evaluator`
+  (default `:buyer`), `:hook_address` (default zero -- a plain job),
+  `:expired_at`, `:ledger`, `:policy`, `:agent_id`, `:require_policy`,
+  `:checkpoint`, `:evaluate_fn`, `:offering`, and `:nonce` (folded into the
+  minted `request_key` so two otherwise-identical buys stay distinct).
+  """
+  @spec new(keyword()) :: t()
+  def new(opts) do
+    {nonce, opts} = Keyword.pop(opts, :nonce)
+    opts = Keyword.put_new_lazy(opts, :request_key, fn -> derive_request_key(opts, nonce) end)
+
+    c = struct!(__MODULE__, opts)
+
+    %{
+      c
+      | resolver: c.resolver || %{adapter: Raxol.ACP.JobIdResolver.Receipt},
+        evaluator: c.evaluator || c.buyer,
+        hook_address: c.hook_address || @zero_address,
+        evaluate_fn: c.evaluate_fn || (&default_evaluate/2)
+    }
+  end
+
+  @doc """
+  Reserve the spend and create the job on-chain, resolving the assigned `job_id`.
+
+  Runs the fail-closed checkpoint gate, then resumes from any recorded phase:
+  a fresh call reserves (`SpendGate.authorize`), pins `creating`, writes
+  `createJob` (description carries the request tag), resolves the `job_id`, and
+  starts a `JobSession(:client)`. Returns `{:ok, client, %{status: :open,
+  job_id: id, tx_hash: tx}}` with the job_id/session filled in.
+  """
+  @spec buy(t()) ::
+          {:ok, t(), map()}
+          | {:rejected, term()}
+          | {:error, term()}
+  def buy(%__MODULE__{} = c) do
+    with :ok <- ensure_checkpoint(c) do
+      resume_from(c, ck_fetch(c))
+    end
+  end
+
+  # Resume from the furthest recorded checkpoint phase (or a fresh reserve).
+  defp resume_from(c, :error), do: reserve(c)
+  defp resume_from(c, {:ok, %{"phase" => "reserved"} = rec}), do: create(c, rec)
+  defp resume_from(c, {:ok, %{"phase" => "creating"} = rec}), do: reconcile_or_create(c, rec)
+  defp resume_from(c, {:ok, %{"phase" => "created"} = rec}), do: resolve_and_bind(c, rec)
+
+  defp resume_from(c, {:ok, %{"phase" => phase} = rec})
+       when phase in ~w(bound funding funded released),
+       do: resume(c, rec)
+
+  @doc """
+  Fund the escrow after the seller set the budget.
+
+  `observed_budget_raw` is the budget the seller set (from the `:budget_set`
+  event); when omitted the reserved amount is used. Asserts the budget does not
+  exceed what was reserved -- a seller that over-budgets is rejected (reservation
+  released, session expired). Otherwise mirrors `:budget_set` if needed, pins
+  `funding`, writes `fund`, and mirrors `:funded`. Idempotent by session status.
+  """
+  @spec on_budget_set(t(), non_neg_integer() | nil) ::
+          {:ok, t(), map()}
+          | {:ok, %{status: :funded, idempotent: true}}
+          | {:rejected, term()}
+          | {:error, term()}
+  def on_budget_set(%__MODULE__{} = c, observed_budget_raw \\ nil) do
+    case safe_status(c.session) do
+      status when status in [:open, :budget_set] -> fund_flow(c, observed_budget_raw)
+      :funded -> {:ok, %{status: :funded, idempotent: true}}
+      other -> {:error, {:cannot_fund, other}}
+    end
+  end
+
+  @doc """
+  Evaluate a submitted deliverable and settle the job (buyer as evaluator).
+
+  Runs `evaluate_fn/2`; `{:approve, info}` writes `complete` and forgets the
+  reservation (spend stands), `{:reject, reason}` writes `reject` and releases
+  the reservation (idempotent refund). Both are terminal.
+  """
+  @spec on_submitted(t(), map()) :: {:ok, t(), map()} | {:error, term()}
+  def on_submitted(%__MODULE__{} = c, deliverable) do
+    case c.evaluate_fn.(deliverable, ctx(c)) do
+      {:approve, info} -> finalize(c, deliverable, :completed, info)
+      {:reject, reason} -> finalize(c, deliverable, :rejected, reason)
+    end
+  end
+
+  @doc """
+  Release the reservation for a job that ended without completing (external
+  expiry). Idempotent -- safe to call more than once. Drops the checkpoint.
+  """
+  @spec release(t()) :: :ok
+  def release(%__MODULE__{} = c) do
+    _ = SpendGate.release_by_intent(spend_ctx(c), c.request_key)
+    cleanup(c)
+  end
+
+  @doc "Drop this purchase's checkpoint record. Safe with no store."
+  @spec cleanup(t()) :: :ok
+  def cleanup(%__MODULE__{} = c), do: Checkpoint.delete(c.checkpoint, ck_key(c))
+
+  @doc "The short tag stamped into the job description for reconcile-by-tag."
+  @spec request_tag(t()) :: String.t()
+  def request_tag(%__MODULE__{request_key: rk}), do: "raxol-acp:" <> String.slice(rk, 0, 16)
+
+  # -- buy/1 phases --
+
+  defp reserve(c) do
+    amount = AssetToken.to_human(c.amount)
+
+    case SpendGate.authorize(spend_ctx(c), amount, metadata: %{request_key: c.request_key}) do
+      :ok ->
+        :ok = SpendGate.tag_reservation(spend_ctx(c), c.request_key, amount)
+
+        rec = %{
+          "phase" => "reserved",
+          "request_key" => c.request_key,
+          "amount_raw" => c.amount.raw_amount
+        }
+
+        :ok = ck_put(c, rec)
+        create(c, rec)
+
+      {:error, reason} ->
+        {:rejected, {:spend_rejected, reason}}
+    end
+  end
+
+  # Pin the create parameters (including the tagged description) BEFORE
+  # broadcasting, so a resume re-broadcasts byte-identical params -- same tag,
+  # so reconcile can still find the job.
+  defp create(c, rec) do
+    params = create_params(c)
+    rec = Map.merge(rec, %{"phase" => "creating", "create_params" => params})
+    :ok = ck_put(c, rec)
+    broadcast_create(c, rec, params)
+  end
+
+  # `creating` on resume: we pinned params and may or may not have broadcast.
+  # Reconcile by the request tag first; adopt an existing job, else it is safe
+  # to (re)broadcast the pinned params.
+  defp reconcile_or_create(c, rec) do
+    case reconcile(c) do
+      {:ok, job_id} ->
+        bind(c, rec, job_id)
+
+      :none ->
+        broadcast_create(c, rec, rec["create_params"] || create_params(c))
+
+      {:error, reason} ->
+        {:error, {:reconcile_failed, reason}}
+    end
+  end
+
+  defp broadcast_create(c, rec, params) do
+    case HookClient.create_job(c.adapter, c.chain_id, c.acp_core_address, atomize_params(params)) do
+      {:ok, tx} ->
+        rec = Map.merge(rec, %{"phase" => "created", "create_tx" => tx})
+        :ok = ck_put(c, rec)
+        resolve_and_bind(c, rec)
+
+      {:error, reason} ->
+        {:error, {:create_failed, reason}}
+    end
+  end
+
+  # `created`: the tx landed and is pinned. Resolve the job_id from the receipt,
+  # falling back to reconcile-by-tag when the receipt is not yet available.
+  defp resolve_and_bind(c, rec) do
+    tx = rec["create_tx"]
+
+    case JobIdResolver.resolve(c.resolver, c.adapter, c.chain_id, tx) do
+      {:ok, job_id} ->
+        bind(c, rec, job_id)
+
+      :pending ->
+        case reconcile(c) do
+          {:ok, job_id} -> bind(c, rec, job_id)
+          :none -> {:error, :job_id_unresolved}
+          {:error, reason} -> {:error, {:reconcile_failed, reason}}
+        end
+
+      {:error, reason} ->
+        {:error, {:resolve_failed, reason}}
+    end
+  end
+
+  defp reconcile(%{api: nil}), do: {:error, :reconcile_unavailable}
+  defp reconcile(c), do: JobIdResolver.reconcile(c.resolver, c.api, c.chain_id, request_tag(c))
+
+  # Bind the resolved job_id, start the client session, and record `bound`.
+  defp bind(c, rec, job_id) do
+    with {:ok, session} <- start_session(c, job_id) do
+      c = %{c | job_id: job_id, session: session}
+      :ok = ck_put(c, Map.merge(rec, %{"phase" => "bound", "job_id" => job_id}))
+      {:ok, c, %{status: :open, job_id: job_id, tx_hash: rec["create_tx"]}}
+    end
+  end
+
+  # Resume a client already past `create`: rebuild job_id/session from the record.
+  defp resume(c, rec) do
+    job_id = rec["job_id"]
+
+    with {:ok, session} <- start_session(c, job_id) do
+      c = %{c | job_id: job_id, session: session}
+      {:ok, c, %{status: :resumed, job_id: job_id, phase: rec["phase"]}}
+    end
+  end
+
+  # -- on_budget_set/2 --
+
+  defp fund_flow(c, observed_budget_raw) do
+    with :ok <- ensure_checkpoint(c),
+         {:ok, rec} <- require_record(c) do
+      reserved = rec["amount_raw"] || c.amount.raw_amount
+      budget_raw = observed_budget_raw || reserved
+
+      cond do
+        budget_raw > reserved -> over_budget(c, budget_raw, reserved)
+        funded?(rec) -> resume_funded(c, rec)
+        true -> fund(c, rec, budget_raw)
+      end
+    end
+  end
+
+  defp fund(c, rec, budget_raw) do
+    mirror_budget_set(c)
+    :ok = ck_put(c, Map.put(rec, "phase", "funding"))
+
+    case HookClient.fund(c.adapter, c.chain_id, c.acp_core_address, c.job_id, budget_raw) do
+      {:ok, tx} ->
+        rec = Map.merge(rec, %{"phase" => "funded", "fund_tx" => tx, "funded_raw" => budget_raw})
+        :ok = ck_put(c, rec)
+        {:ok, :funded} = JobSession.apply_event(c.session, :funded, %{tx_hash: tx})
+        {:ok, c, %{status: :funded, tx_hash: tx}}
+
+      {:error, reason} ->
+        {:error, {:fund_failed, reason}}
+    end
+  end
+
+  # The fund write committed pre-crash but the mirror lagged: mirror and return,
+  # no second fund.
+  defp resume_funded(c, %{"fund_tx" => tx}) do
+    if safe_status(c.session) == :funded do
+      {:ok, %{status: :funded, idempotent: true}}
+    else
+      {:ok, :funded} = JobSession.apply_event(c.session, :funded, %{tx_hash: tx, resumed: true})
+      {:ok, c, %{status: :funded, tx_hash: tx, resumed: true}}
+    end
+  end
+
+  defp over_budget(c, budget_raw, reserved) do
+    _ = SpendGate.release_by_intent(spend_ctx(c), c.request_key)
+    JobSession.apply_event(c.session, :expired, %{reason: "budget_over_reserved"})
+    cleanup(c)
+    {:rejected, {:budget_over_reserved, budget_raw, reserved}}
+  end
+
+  # Mirror the observed :budget_set when the session is still :open, so the
+  # local status tracks the chain before we fund.
+  defp mirror_budget_set(c) do
+    if safe_status(c.session) == :open do
+      JobSession.apply_event(c.session, :budget_set, %{observed: true})
+    end
+  end
+
+  # -- on_submitted/2 --
+
+  defp finalize(c, deliverable, :completed, info) do
+    with {:ok, tx} <-
+           HookClient.complete(
+             c.adapter,
+             c.chain_id,
+             c.acp_core_address,
+             c.job_id,
+             deliverable_hash(deliverable)
+           ),
+         {:ok, :completed} <- JobSession.apply_event(c.session, :completed, %{tx_hash: tx}) do
+      # The spend stands: forget the tag but keep the ledger entry.
+      SpendGate.forget_reservation(spend_ctx(c), c.request_key)
+      cleanup(c)
+      {:ok, c, %{status: :completed, tx_hash: tx, info: info}}
+    end
+  end
+
+  defp finalize(c, deliverable, :rejected, reason) do
+    with {:ok, tx} <-
+           HookClient.reject(
+             c.adapter,
+             c.chain_id,
+             c.acp_core_address,
+             c.job_id,
+             deliverable_hash(deliverable)
+           ),
+         {:ok, :rejected} <- JobSession.apply_event(c.session, :rejected, %{tx_hash: tx}) do
+      # Rejected: the escrow returns, so release the reservation (idempotent).
+      _ = SpendGate.release_by_intent(spend_ctx(c), c.request_key)
+      cleanup(c)
+      {:ok, c, %{status: :rejected, tx_hash: tx, info: reason}}
+    end
+  end
+
+  # -- Checkpoint plumbing --
+
+  defp ensure_checkpoint(%{checkpoint: nil}) do
+    if Raxol.ACP.Checkpoint.required?(), do: {:error, :checkpoint_required}, else: :ok
+  end
+
+  defp ensure_checkpoint(_c), do: :ok
+
+  defp require_record(c) do
+    case ck_fetch(c) do
+      {:ok, rec} -> {:ok, rec}
+      # No record but a buy already ran (session exists): fall back to the
+      # reserved amount so funding can proceed without a store in dev.
+      :error -> {:ok, %{"amount_raw" => c.amount.raw_amount}}
+    end
+  end
+
+  defp ck_key(c), do: Raxol.ACP.Checkpoint.buyer_key(c.chain_id, c.request_key)
+  defp ck_fetch(c), do: Checkpoint.fetch(c.checkpoint, ck_key(c))
+  defp ck_put(c, rec), do: Checkpoint.put(c.checkpoint, ck_key(c), rec)
+
+  defp funded?(%{"fund_tx" => tx}) when is_binary(tx), do: true
+  defp funded?(_), do: false
+
+  # -- Spend gate context --
+
+  defp spend_ctx(c) do
+    %{policy: c.policy, ledger: c.ledger, agent_id: c.agent_id || :unknown}
+    |> maybe_put(:require_policy, c.require_policy)
+  end
+
+  # -- Session --
+
+  defp start_session(c, job_id) do
+    case Raxol.ACP.JobSession.Supervisor.start_session(
+           chain_id: c.chain_id,
+           job_id: job_id,
+           role: :client
+         ) do
+      {:ok, _pid} -> {:ok, {c.chain_id, job_id}}
+      {:error, {:already_started, _pid}} -> {:ok, {c.chain_id, job_id}}
+      {:error, reason} -> {:error, {:session_start_failed, reason}}
+    end
+  end
+
+  defp safe_status(nil), do: :none
+
+  defp safe_status(session) do
+    JobSession.status(session)
+  catch
+    :exit, _ -> :gone
+  end
+
+  # -- create params --
+
+  # Stored with string keys (checkpoint records round-trip as JSON) and rebuilt
+  # to the atom-keyed map HookClient.create_job/4 expects.
+  defp create_params(c) do
+    %{
+      "provider" => c.provider,
+      "evaluator" => c.evaluator || c.buyer,
+      "expired_at" => c.expired_at || 0,
+      "hook_address" => c.hook_address || @zero_address,
+      "description" => tagged_description(c)
+    }
+  end
+
+  defp atomize_params(params) do
+    %{
+      provider: params["provider"],
+      evaluator: params["evaluator"],
+      expired_at: params["expired_at"],
+      hook_address: params["hook_address"],
+      description: params["description"]
+    }
+  end
+
+  # The description always carries the request tag so reconcile-by-tag works,
+  # appended to any caller-provided base.
+  defp tagged_description(c) do
+    tag = request_tag(c)
+
+    case c.description do
+      nil -> tag
+      base when is_binary(base) -> base <> " [" <> tag <> "]"
+    end
+  end
+
+  # -- misc --
+
+  defp ctx(c) do
+    %{
+      job_id: c.job_id,
+      buyer: c.buyer,
+      seller: c.provider,
+      offering: c.offering,
+      state: safe_status(c.session)
+    }
+  end
+
+  # Default evaluator: accept a non-empty deliverable map, reject anything else.
+  # Callers pass a real schema check (or an offering's `handle_evaluate`) via
+  # `:evaluate_fn`.
+  defp default_evaluate(deliverable, _ctx) when is_map(deliverable) and map_size(deliverable) > 0,
+    do: {:approve, %{evaluator: :default}}
+
+  defp default_evaluate(_deliverable, _ctx), do: {:reject, :empty_deliverable}
+
+  # 32-byte commitment to the deliverable payload, matching Provider's
+  # convention (keccak256 of canonical JSON).
+  defp deliverable_hash(deliverable) do
+    deliverable
+    |> Jason.encode!()
+    |> ExKeccak.hash_256()
+  end
+
+  defp derive_request_key(opts, nonce) do
+    amount = Keyword.fetch!(opts, :amount)
+
+    Checkpoint.derive_key([
+      :acp_buy,
+      Keyword.fetch!(opts, :chain_id),
+      Keyword.fetch!(opts, :buyer),
+      Keyword.fetch!(opts, :provider),
+      Keyword.get(opts, :offering),
+      amount.raw_amount,
+      nonce || ""
+    ])
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/packages/raxol_acp/lib/raxol/acp/onchain/log_decoder.ex
+++ b/packages/raxol_acp/lib/raxol/acp/onchain/log_decoder.ex
@@ -1,0 +1,162 @@
+defmodule Raxol.ACP.Onchain.LogDecoder do
+  @moduledoc """
+  Decodes Ethereum event logs out of `eth_getTransactionReceipt` responses.
+
+  ## Background
+
+  An Ethereum event log has three pieces:
+
+  - `topics` -- an array of 32-byte hex strings. `topics[0]` is the event
+    signature hash (`keccak256(canonical_signature)`); subsequent topics are the
+    **indexed** parameters in declaration order, each padded to 32 bytes.
+  - `data` -- 0x-prefixed hex of the **non-indexed** parameters, encoded per the
+    Solidity ABI head/tail rules.
+  - `address` -- the contract that emitted the log.
+
+  This module covers the topic side (event signature hash, decoding indexed
+  primitives). Non-indexed parameter decoding is out of scope -- the only ACP
+  event a caller needs today is `JobCreated`, whose new `uint256 jobId` is an
+  indexed parameter. Add an ABI `data` decoder here if an event with a
+  non-indexed payload matters.
+
+  ## Use case
+
+  `Raxol.ACP.JobIdResolver.Receipt` uses this module to pull the new `jobId` out
+  of a `JobCreated` event in a `createJob` transaction receipt. The exact event
+  signature is not hard-coded here -- the resolver passes it in, so the
+  placeholder signature swaps cleanly once the deployed `AgenticCommerceV3` ABI
+  is confirmed against the Sepolia dry-run.
+
+  ## Examples
+
+      iex> Raxol.ACP.Onchain.LogDecoder.event_topic("Transfer(address,address,uint256)")
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+      iex> Raxol.ACP.Onchain.LogDecoder.decode_uint256("0x" <> String.duplicate("0", 62) <> "2a")
+      {:ok, 42}
+  """
+
+  @type log :: %{required(String.t()) => any()}
+
+  # -- Topic computation --
+
+  @doc """
+  Compute the 0x-prefixed lowercase hex of `keccak256(canonical_signature)`.
+
+  The canonical signature is the Solidity event declaration with parameter types
+  only, no spaces, e.g. `"Transfer(address,address,uint256)"`. Note this is the
+  full 32-byte hash, unlike `Raxol.ACP.ABI`'s function selector which truncates
+  to the first 4 bytes -- an event topic needs the whole hash.
+  """
+  @spec event_topic(String.t()) :: String.t()
+  def event_topic(canonical_signature) when is_binary(canonical_signature) do
+    "0x" <> Base.encode16(ExKeccak.hash_256(canonical_signature), case: :lower)
+  end
+
+  # -- Log lookup --
+
+  @doc """
+  Find the first log in `logs` whose `topics[0]` matches `event`.
+
+  Accepts either a precomputed topic hash (`"0x..."`) or a canonical event
+  signature; the latter is hashed automatically.
+
+  Returns `{:ok, log}` or `:error` (no matching log).
+  """
+  @spec find_event([log()], String.t()) :: {:ok, log()} | :error
+  def find_event(logs, "0x" <> _ = topic) when is_list(logs) do
+    do_find(logs, normalize(topic))
+  end
+
+  def find_event(logs, signature) when is_list(logs) and is_binary(signature) do
+    find_event(logs, event_topic(signature))
+  end
+
+  defp do_find([], _topic), do: :error
+
+  defp do_find([log | rest], topic) do
+    case Map.get(log, "topics", []) do
+      [first | _] ->
+        if normalize(first) == topic, do: {:ok, log}, else: do_find(rest, topic)
+
+      _ ->
+        do_find(rest, topic)
+    end
+  end
+
+  defp normalize("0x" <> hex), do: "0x" <> String.downcase(hex)
+  defp normalize(other) when is_binary(other), do: String.downcase(other)
+
+  # -- Indexed parameter decoders --
+
+  @doc """
+  Decode a 32-byte topic value (hex) as a `uint256`.
+
+  Topics are always 32 bytes; the integer is right-aligned, padded with zeros on
+  the left.
+  """
+  @spec decode_uint256(String.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def decode_uint256("0x" <> hex) when byte_size(hex) == 64 do
+    case Integer.parse(hex, 16) do
+      {n, ""} when n >= 0 -> {:ok, n}
+      _ -> {:error, {:bad_uint256, "0x" <> hex}}
+    end
+  end
+
+  def decode_uint256(other), do: {:error, {:bad_uint256, other}}
+
+  @doc """
+  Decode a 32-byte topic value (hex) as an `address` (last 20 bytes; the leading
+  12 bytes must be zero).
+  """
+  @spec decode_address(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def decode_address("0x" <> hex) when byte_size(hex) == 64 do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, <<padding::binary-size(12), addr::binary-size(20)>>} ->
+        if padding == <<0::8*12>> do
+          {:ok, "0x" <> Base.encode16(addr, case: :lower)}
+        else
+          {:error, {:bad_address_padding, "0x" <> hex}}
+        end
+
+      _ ->
+        {:error, {:bad_address_hex, "0x" <> hex}}
+    end
+  end
+
+  def decode_address(other), do: {:error, {:bad_address, other}}
+
+  # -- Convenience: extract an indexed parameter --
+
+  @doc """
+  Find a log matching `event` (canonical signature or topic hash) and decode the
+  parameter at `topic_index` (1-based; topic 0 is the event hash) as `type`.
+
+  Returns `{:ok, value}` or `{:error, reason}`. Used by
+  `Raxol.ACP.JobIdResolver.Receipt` to extract the new `jobId` from a
+  `JobCreated` event without spelling out the find/decode steps every time.
+  """
+  @spec extract([log()], String.t(), pos_integer(), :uint256 | :address) ::
+          {:ok, term()} | {:error, term()}
+  def extract(logs, event, topic_index, type)
+      when is_list(logs) and is_binary(event) and is_integer(topic_index) and topic_index > 0 do
+    with {:ok, log} <- find_or_error(logs, event),
+         topics <- Map.get(log, "topics", []),
+         {:ok, raw} <- nth_topic(topics, topic_index) do
+      decode_one(raw, type)
+    end
+  end
+
+  defp find_or_error(logs, event) do
+    case find_event(logs, event) do
+      {:ok, log} -> {:ok, log}
+      :error -> {:error, {:event_not_found, event}}
+    end
+  end
+
+  defp nth_topic(topics, index) when length(topics) > index, do: {:ok, Enum.at(topics, index)}
+  defp nth_topic(_topics, index), do: {:error, {:topic_out_of_range, index}}
+
+  defp decode_one(raw, :uint256), do: decode_uint256(raw)
+  defp decode_one(raw, :address), do: decode_address(raw)
+end

--- a/packages/raxol_acp/lib/raxol/acp/supervisor.ex
+++ b/packages/raxol_acp/lib/raxol/acp/supervisor.ex
@@ -21,6 +21,9 @@ defmodule Raxol.ACP.Supervisor do
   - `Raxol.ACP.Seller.Supervisor` -- only when
     `config :raxol_acp, seller_enabled: true`. Owns the Backend, the
     Queue, and the Runtime. Buyer-only deployments leave it off.
+  - `Raxol.ACP.Buyer.Supervisor` -- only when
+    `config :raxol_acp, buyer_enabled: true`. Owns the buyer Queue,
+    Resync, and Runtime. Seller-only deployments leave it off.
   """
 
   use Supervisor
@@ -39,14 +42,7 @@ defmodule Raxol.ACP.Supervisor do
       Raxol.ACP.JobSession.Supervisor
     ]
 
-    children =
-      if Application.get_env(:raxol_acp, :seller_enabled, false) do
-        base ++ [Raxol.ACP.Seller.Supervisor]
-      else
-        base
-      end
-
-    children = children ++ accounting_children()
+    children = base ++ seller_children() ++ buyer_children() ++ accounting_children()
 
     Supervisor.init(children,
       strategy: :rest_for_one,
@@ -72,6 +68,18 @@ defmodule Raxol.ACP.Supervisor do
       {:ok, n} -> {Raxol.ACP.Wallet.NonceServer, [initial_nonce: n]}
       :error -> Raxol.ACP.Wallet.NonceServer
     end
+  end
+
+  defp seller_children do
+    if Application.get_env(:raxol_acp, :seller_enabled, false),
+      do: [Raxol.ACP.Seller.Supervisor],
+      else: []
+  end
+
+  defp buyer_children do
+    if Application.get_env(:raxol_acp, :buyer_enabled, false),
+      do: [Raxol.ACP.Buyer.Supervisor],
+      else: []
   end
 
   # Settlement accounting + rebalance advisor (recommend-only). Off unless

--- a/packages/raxol_acp/test/raxol/acp/buyer/queue_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/buyer/queue_test.exs
@@ -1,0 +1,109 @@
+defmodule Raxol.ACP.Buyer.QueueTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.Buyer.Queue
+  alias Raxol.ACP.{AssetToken, JobSession}
+  alias Raxol.ACP.ProviderAdapter.Mock, as: Adapter
+  alias Raxol.ACP.JobIdResolver.Mock, as: Resolver
+  alias Raxol.Payments.{Ledger, SpendingPolicy}
+
+  @chain 84_532
+  @core "0x" <> String.duplicate("ab", 20)
+  @provider "0x" <> String.duplicate("cd", 20)
+  @buyer "0x" <> String.duplicate("ef", 20)
+
+  setup do
+    unless Process.whereis(JobSession.Registry) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: JobSession.Registry)
+    end
+
+    unless Process.whereis(JobSession.Supervisor) do
+      start_supervised!(JobSession.Supervisor)
+    end
+
+    {:ok, ledger} =
+      Ledger.start_link(table_name: :"bq_ledger_#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(ledger)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    adapter = Adapter.new()
+    resolver = Resolver.new()
+    :ok = Resolver.put_default(resolver, System.unique_integer([:positive]))
+
+    put_all(%{
+      buyer_provider_adapter: adapter,
+      buyer_chain_id: @chain,
+      buyer_acp_core_address: @core,
+      buyer_address: @buyer,
+      buyer_agent_id: :queue_buyer,
+      buyer_spending_policy: SpendingPolicy.unrestricted(),
+      buyer_ledger: ledger,
+      buyer_job_id_resolver: resolver
+    })
+
+    start_supervised!(Queue)
+
+    {:ok, adapter: adapter, ledger: ledger}
+  end
+
+  defp put_all(map) do
+    Enum.each(map, fn {k, v} -> Application.put_env(:raxol_acp, k, v) end)
+
+    on_exit(fn ->
+      Enum.each(Map.keys(map), &Application.delete_env(:raxol_acp, &1))
+    end)
+  end
+
+  defp poll_status(key, expected, attempts \\ 100)
+  defp poll_status(_key, _expected, 0), do: flunk("status never reached")
+
+  defp poll_status(key, expected, attempts) do
+    if status_or_gone(key) == expected do
+      :ok
+    else
+      Process.sleep(5)
+      poll_status(key, expected, attempts - 1)
+    end
+  end
+
+  defp status_or_gone(key) do
+    JobSession.status(key)
+  catch
+    :exit, _ -> :gone
+  end
+
+  test "start_purchase originates a job and dispatch drives it to completion" do
+    intent = %{provider: @provider, amount: AssetToken.usdc(10, @chain), offering: "svc"}
+
+    assert {:ok, job_id} = Queue.start_purchase(intent)
+    assert JobSession.status({@chain, job_id}) == :open
+
+    Queue.dispatch(%{type: :budget_set, job_id: job_id})
+    poll_status({@chain, job_id}, :funded)
+
+    Queue.dispatch(%{type: :submitted, job_id: job_id, deliverable: %{"result" => "ok"}})
+    poll_status({@chain, job_id}, :gone)
+  end
+
+  test "start_purchase fails closed when no provider adapter is configured" do
+    Application.delete_env(:raxol_acp, :buyer_provider_adapter)
+
+    assert {:error, :no_provider_adapter} =
+             Queue.start_purchase(%{provider: @provider, amount: AssetToken.usdc(10, @chain)})
+  end
+
+  test "events for jobs we do not track drop without crashing", %{adapter: adapter} do
+    Queue.dispatch(%{type: :budget_set, job_id: 999_999})
+    # The Queue survives an untracked event.
+    Process.sleep(20)
+    assert Process.alive?(Process.whereis(Queue))
+    # No on-chain writes happened for the phantom job.
+    assert Adapter.sent_calls(adapter) == []
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/buyer/resync_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/buyer/resync_test.exs
@@ -1,0 +1,124 @@
+defmodule Raxol.ACP.Buyer.ResyncTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.Buyer.{Queue, Resync}
+  alias Raxol.ACP.JobSession
+  alias Raxol.ACP.ProviderAdapter.Mock, as: Adapter
+  alias Raxol.ACP.JobIdResolver.Mock, as: Resolver
+  alias Raxol.ACP.JobApi.Mock, as: JobApiMock
+  alias Raxol.Payments.{Ledger, SpendingPolicy}
+
+  @chain 84_532
+  @core "0x" <> String.duplicate("ab", 20)
+  @provider "0x" <> String.duplicate("cd", 20)
+  @buyer "0x" <> String.duplicate("ef", 20)
+
+  setup do
+    unless Process.whereis(JobSession.Registry) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: JobSession.Registry)
+    end
+
+    unless Process.whereis(JobSession.Supervisor) do
+      start_supervised!(JobSession.Supervisor)
+    end
+
+    {:ok, ledger} =
+      Ledger.start_link(table_name: :"rs_ledger_#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(ledger)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    adapter = Adapter.new()
+    resolver = Resolver.new()
+
+    put_all(%{
+      buyer_provider_adapter: adapter,
+      buyer_chain_id: @chain,
+      buyer_acp_core_address: @core,
+      buyer_address: @buyer,
+      buyer_agent_id: :resync_buyer,
+      buyer_spending_policy: SpendingPolicy.unrestricted(),
+      buyer_ledger: ledger,
+      buyer_job_id_resolver: resolver
+    })
+
+    start_supervised!(Queue)
+
+    {:ok, adapter: adapter}
+  end
+
+  defp put_all(map) do
+    Enum.each(map, fn {k, v} -> Application.put_env(:raxol_acp, k, v) end)
+    on_exit(fn -> Enum.each(Map.keys(map), &Application.delete_env(:raxol_acp, &1)) end)
+  end
+
+  defp poll_status(key, expected, attempts \\ 100)
+  defp poll_status(_key, expected, 0), do: flunk("status never reached #{inspect(expected)}")
+
+  defp poll_status(key, expected, attempts) do
+    if status_or_gone(key) == expected do
+      :ok
+    else
+      Process.sleep(5)
+      poll_status(key, expected, attempts - 1)
+    end
+  end
+
+  defp status_or_gone(key) do
+    JobSession.status(key)
+  catch
+    :exit, _ -> :gone
+  end
+
+  test "rehydrates an interrupted budget_set job and resumes the fund", %{adapter: adapter} do
+    api = JobApiMock.new()
+
+    :ok =
+      JobApiMock.put_active_jobs(api, [
+        %{
+          "onChainJobId" => "321",
+          "provider" => @provider,
+          "buyer" => @buyer,
+          "status" => "budget_set",
+          "budget" => "10000000"
+        }
+      ])
+
+    start_supervised!({Resync, api: api})
+
+    # Resync adopts the job and redrives the interrupted fund.
+    poll_status({@chain, 321}, :funded)
+    assert length(Adapter.sent_calls(adapter)) == 1
+  end
+
+  test "skips jobs belonging to another buyer" do
+    api = JobApiMock.new()
+
+    :ok =
+      JobApiMock.put_active_jobs(api, [
+        %{
+          "onChainJobId" => "55",
+          "provider" => @provider,
+          "buyer" => "0x" <> String.duplicate("11", 20),
+          "status" => "budget_set",
+          "budget" => "10000000"
+        }
+      ])
+
+    start_supervised!({Resync, api: api})
+    Process.sleep(30)
+
+    assert status_or_gone({@chain, 55}) == :gone
+  end
+
+  test "is inert with no job api configured" do
+    start_supervised!({Resync, api: nil})
+    Process.sleep(20)
+    assert Process.alive?(Process.whereis(Resync))
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_id_resolver_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_id_resolver_test.exs
@@ -1,0 +1,97 @@
+defmodule Raxol.ACP.JobIdResolverTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.JobIdResolver
+  alias Raxol.ACP.JobIdResolver.{Mock, Receipt}
+  alias Raxol.ACP.Onchain.LogDecoder
+  alias Raxol.ACP.ProviderAdapter.Mock, as: Adapter
+
+  @chain 84_532
+
+  describe "Mock" do
+    test "resolve returns a mapped tx and :pending for an unknown one" do
+      r = Mock.new()
+      :ok = Mock.put_tx(r, "0xtx", 42)
+
+      assert {:ok, 42} = JobIdResolver.resolve(r, %{}, @chain, "0xtx")
+      assert :pending = JobIdResolver.resolve(r, %{}, @chain, "0xother")
+    end
+
+    test "put_default resolves any unmapped tx" do
+      r = Mock.new()
+      :ok = Mock.put_default(r, 7)
+      assert {:ok, 7} = JobIdResolver.resolve(r, %{}, @chain, "0xanything")
+    end
+
+    test "set_pending overrides the default" do
+      r = Mock.new()
+      :ok = Mock.put_default(r, 7)
+      :ok = Mock.set_pending(r, "0xtx")
+      assert :pending = JobIdResolver.resolve(r, %{}, @chain, "0xtx")
+    end
+
+    test "reconcile matches a request tag" do
+      r = Mock.new()
+      :ok = Mock.put_tag(r, "rk-abc", 99)
+
+      assert {:ok, 99} = JobIdResolver.reconcile(r, %{}, @chain, "rk-abc")
+      assert :none = JobIdResolver.reconcile(r, %{}, @chain, "rk-missing")
+    end
+  end
+
+  describe "Receipt" do
+    test "resolve decodes the jobId from the createJob receipt logs" do
+      adapter = Adapter.new()
+      topic = LogDecoder.event_topic("JobCreated(uint256)")
+      log = %{"topics" => [topic, "0x" <> String.duplicate("0", 62) <> "2a"]}
+      :ok = Adapter.set_receipt(adapter, "0xtx", %{"logs" => [log]})
+
+      resolver = %{adapter: Receipt}
+      assert {:ok, 42} = JobIdResolver.resolve(resolver, adapter, @chain, "0xtx")
+    end
+
+    test "resolve returns :pending when the receipt is not yet available" do
+      adapter = Adapter.new()
+      resolver = %{adapter: Receipt}
+      assert :pending = JobIdResolver.resolve(resolver, adapter, @chain, "0xmissing")
+    end
+
+    test "resolve honors an overridden event signature and topic index" do
+      adapter = Adapter.new()
+      topic = LogDecoder.event_topic("JobOpened(uint256,uint256)")
+
+      log = %{
+        "topics" => [
+          topic,
+          "0x" <> String.duplicate("0", 63) <> "1",
+          "0x" <> String.duplicate("0", 62) <> "63"
+        ]
+      }
+
+      :ok = Adapter.set_receipt(adapter, "0xtx", %{"logs" => [log]})
+
+      resolver = %{
+        adapter: Receipt,
+        config: %{event_signature: "JobOpened(uint256,uint256)", topic_index: 2}
+      }
+
+      assert {:ok, 99} = JobIdResolver.resolve(resolver, adapter, @chain, "0xtx")
+    end
+
+    test "reconcile correlates an active job by its description tag" do
+      api = Raxol.ACP.JobApi.Mock.new()
+
+      :ok =
+        Raxol.ACP.JobApi.Mock.put_active_jobs(api, [
+          %{"onChainJobId" => "17", "description" => "buy [raxol-acp:deadbeef00000000]"}
+        ])
+
+      resolver = %{adapter: Receipt}
+
+      assert {:ok, 17} =
+               JobIdResolver.reconcile(resolver, api, @chain, "raxol-acp:deadbeef00000000")
+
+      assert :none = JobIdResolver.reconcile(resolver, api, @chain, "raxol-acp:nomatch")
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_session/client_checkpoint_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/client_checkpoint_test.exs
@@ -1,0 +1,185 @@
+defmodule Raxol.ACP.JobSession.ClientCheckpointTest do
+  @moduledoc """
+  Crash-window coverage for the buyer driver: across a replay at any phase there
+  is exactly one `createJob` and one `fund`, and the budget is reserved once and
+  released at most once. A replay is simulated by rebuilding the client from
+  scratch with the SAME `request_key` (the checkpoint, not the in-memory struct,
+  carries the truth) and re-running the step.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{AssetToken, JobSession}
+  alias Raxol.ACP.JobSession.Client
+  alias Raxol.ACP.ProviderAdapter.Mock, as: Adapter
+  alias Raxol.ACP.JobIdResolver.Mock, as: Resolver
+  alias Raxol.Payments.{Checkpoint, Ledger, SpendingPolicy}
+
+  @chain 84_532
+  @core "0x" <> String.duplicate("ab", 20)
+  @provider "0x" <> String.duplicate("cd", 20)
+  @buyer "0x" <> String.duplicate("ef", 20)
+  @rk "fixed-request-key-000000000000000000000000000000000000000000000000"
+
+  @create_selector Raxol.ACP.ABI.encode_call(
+                     "createJob(address,address,uint256,string,address)",
+                     []
+                   )
+  @fund_selector Raxol.ACP.ABI.encode_call("fund(uint256,uint256,bytes)", [])
+
+  setup do
+    unless Process.whereis(JobSession.Registry) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: JobSession.Registry)
+    end
+
+    unless Process.whereis(JobSession.Supervisor) do
+      start_supervised!(JobSession.Supervisor)
+    end
+
+    {:ok, ledger} =
+      Ledger.start_link(table_name: :"ck_ledger_#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(ledger)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    adapter = Adapter.new()
+    resolver = Resolver.new()
+    :ok = Resolver.put_default(resolver, 4242)
+    store = Checkpoint.ETS.new()
+    api = Raxol.ACP.JobApi.Mock.new()
+
+    {:ok, adapter: adapter, resolver: resolver, store: store, ledger: ledger, api: api}
+  end
+
+  # A fresh client sharing the fixed request_key -- this is the "after a crash,
+  # a new process rebuilds the client" state.
+  defp client(ctx) do
+    Client.new(
+      adapter: ctx.adapter,
+      api: ctx.api,
+      resolver: ctx.resolver,
+      chain_id: @chain,
+      acp_core_address: @core,
+      buyer: @buyer,
+      provider: @provider,
+      amount: AssetToken.usdc(10, @chain),
+      ledger: ctx.ledger,
+      policy: SpendingPolicy.unrestricted(),
+      agent_id: :ck_buyer,
+      checkpoint: ctx.store,
+      request_key: @rk
+    )
+  end
+
+  defp count(ctx, selector) do
+    ctx.adapter
+    |> Adapter.sent_calls()
+    |> Enum.count(fn {_chain, [call | _]} ->
+      binary_part(call.data, 0, byte_size(selector)) == selector
+    end)
+  end
+
+  test "replaying buy after `bound` does not create a second job", ctx do
+    assert {:ok, _c, %{job_id: job_id}} = Client.buy(client(ctx))
+    assert count(ctx, @create_selector) == 1
+
+    # Crash + restart: fresh client, same request_key, re-run buy.
+    assert {:ok, c2, %{status: :resumed, job_id: ^job_id}} = Client.buy(client(ctx))
+    assert c2.job_id == job_id
+    assert count(ctx, @create_selector) == 1
+  end
+
+  test "a `creating` record reconciles by tag instead of double-creating", ctx do
+    c = client(ctx)
+    tag = Client.request_tag(c)
+    :ok = Resolver.put_tag(ctx.resolver, tag, 777)
+
+    # Pin the crash-in-`creating` state: params written, broadcast status unknown.
+    key = Raxol.ACP.Checkpoint.buyer_key(@chain, @rk)
+
+    :ok =
+      Checkpoint.put(ctx.store, key, %{
+        "phase" => "creating",
+        "request_key" => @rk,
+        "amount_raw" => AssetToken.usdc(10, @chain).raw_amount,
+        "create_params" => %{
+          "provider" => @provider,
+          "evaluator" => @buyer,
+          "expired_at" => 0,
+          "hook_address" => "0x" <> String.duplicate("0", 40),
+          "description" => tag
+        }
+      })
+
+    assert {:ok, c2, %{status: :open, job_id: 777}} = Client.buy(c)
+    assert c2.job_id == 777
+    # Reconcile adopted the existing job: NO createJob broadcast.
+    assert count(ctx, @create_selector) == 0
+  end
+
+  test "a `creating` record with no reconcilable job re-creates exactly once", ctx do
+    c = client(ctx)
+    key = Raxol.ACP.Checkpoint.buyer_key(@chain, @rk)
+
+    :ok =
+      Checkpoint.put(ctx.store, key, %{
+        "phase" => "creating",
+        "request_key" => @rk,
+        "amount_raw" => AssetToken.usdc(10, @chain).raw_amount,
+        "create_params" => %{
+          "provider" => @provider,
+          "evaluator" => @buyer,
+          "expired_at" => 0,
+          "hook_address" => "0x" <> String.duplicate("0", 40),
+          "description" => Client.request_tag(c)
+        }
+      })
+
+    # No tag seeded in the resolver and no active job -> reconcile :none -> create.
+    assert {:ok, _c2, %{status: :open, job_id: 4242}} = Client.buy(c)
+    assert count(ctx, @create_selector) == 1
+  end
+
+  test "a `created` record resolves the job_id from the tx without re-creating", ctx do
+    key = Raxol.ACP.Checkpoint.buyer_key(@chain, @rk)
+    :ok = Resolver.put_tx(ctx.resolver, "0xcreatetx", 555)
+
+    :ok =
+      Checkpoint.put(ctx.store, key, %{
+        "phase" => "created",
+        "request_key" => @rk,
+        "amount_raw" => AssetToken.usdc(10, @chain).raw_amount,
+        "create_tx" => "0xcreatetx"
+      })
+
+    assert {:ok, c2, %{status: :open, job_id: 555, tx_hash: "0xcreatetx"}} =
+             Client.buy(client(ctx))
+
+    assert c2.job_id == 555
+    assert count(ctx, @create_selector) == 0
+  end
+
+  test "replaying on_budget_set after `funded` does not double-fund", ctx do
+    {:ok, c, _} = Client.buy(client(ctx))
+    {:ok, _c, %{status: :funded}} = Client.on_budget_set(c)
+    assert count(ctx, @fund_selector) == 1
+
+    # Crash + restart mid-fund-mirror: rebuild, resume from the `funded` record.
+    {:ok, c2, %{job_id: _}} = Client.buy(client(ctx))
+    assert {:ok, %{status: :funded, idempotent: true}} = Client.on_budget_set(c2)
+    assert count(ctx, @fund_selector) == 1
+  end
+
+  test "budget reserved exactly once across a buy replay", ctx do
+    {:ok, _c, _} = Client.buy(client(ctx))
+    {:ok, _c2, _} = Client.buy(client(ctx))
+
+    # One reservation of 10 USDC, not two.
+    totals = Ledger.get_totals(ctx.ledger, :ck_buyer, SpendingPolicy.unrestricted())
+    assert Decimal.equal?(totals.lifetime, Decimal.new(10))
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_session/client_signing_boundary_property_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/client_signing_boundary_property_test.exs
@@ -1,0 +1,91 @@
+defmodule Raxol.ACP.JobSession.ClientSigningBoundaryPropertyTest do
+  @moduledoc """
+  The buy-side signing boundary: a spend the gate rejects must NEVER produce an
+  on-chain write. Across randomized amounts and policy caps, whenever `buy/1`
+  returns `{:rejected, ...}` for a spend reason, the `ProviderAdapter` recorded
+  zero calls -- no `createJob`, no signature. This is the buyer analogue of the
+  payments `SpendGate` signing-boundary property.
+  """
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  alias Raxol.ACP.{AssetToken, JobSession}
+  alias Raxol.ACP.JobSession.Client
+  alias Raxol.ACP.ProviderAdapter.Mock, as: Adapter
+  alias Raxol.ACP.JobIdResolver.Mock, as: Resolver
+  alias Raxol.Payments.{Ledger, SpendingPolicy}
+
+  @chain 84_532
+  @core "0x" <> String.duplicate("ab", 20)
+  @provider "0x" <> String.duplicate("cd", 20)
+  @buyer "0x" <> String.duplicate("ef", 20)
+
+  setup do
+    unless Process.whereis(JobSession.Registry) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: JobSession.Registry)
+    end
+
+    unless Process.whereis(JobSession.Supervisor) do
+      start_supervised!(JobSession.Supervisor)
+    end
+
+    :ok
+  end
+
+  property "a gate-rejected buy signs nothing on-chain" do
+    check all(
+            per_request <- StreamData.integer(1..50),
+            amount_usdc <- StreamData.integer(1..100),
+            max_runs: 60
+          ) do
+      {:ok, ledger} =
+        Ledger.start_link(table_name: :"sbp_ledger_#{System.unique_integer([:positive])}")
+
+      adapter = Adapter.new()
+      resolver = Resolver.new()
+      :ok = Resolver.put_default(resolver, System.unique_integer([:positive]))
+
+      # Bind a separate copy for the Decimal caps so `per_request` stays a clean
+      # integer for the `<=` comparison below (avoids a spurious struct-compare
+      # type warning from the flow analysis).
+      cap = Decimal.new(per_request)
+
+      policy = %SpendingPolicy{
+        per_request_max: cap,
+        session_max: cap,
+        lifetime_max: cap,
+        currency: "USDC"
+      }
+
+      client =
+        Client.new(
+          adapter: adapter,
+          resolver: resolver,
+          chain_id: @chain,
+          acp_core_address: @core,
+          buyer: @buyer,
+          provider: @provider,
+          amount: AssetToken.usdc(amount_usdc, @chain),
+          ledger: ledger,
+          policy: policy,
+          agent_id: :sbp_buyer,
+          checkpoint: Raxol.Payments.Checkpoint.ETS.new(),
+          nonce: System.unique_integer([:positive])
+        )
+
+      result = Client.buy(client)
+
+      case result do
+        {:rejected, {:spend_rejected, _}} ->
+          # The invariant under test: rejection implies no signature/write.
+          assert Adapter.sent_calls(adapter) == []
+
+        {:ok, _client, _} ->
+          # Accepted (amount within the cap): exactly one write (createJob).
+          assert length(Adapter.sent_calls(adapter)) == 1
+      end
+
+      GenServer.stop(ledger)
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/job_session/client_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/job_session/client_test.exs
@@ -1,0 +1,209 @@
+defmodule Raxol.ACP.JobSession.ClientTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.ACP.{AssetToken, JobSession}
+  alias Raxol.ACP.JobSession.Client
+  alias Raxol.ACP.ProviderAdapter.Mock, as: Adapter
+  alias Raxol.ACP.JobIdResolver.Mock, as: Resolver
+  alias Raxol.Payments.{Checkpoint, Ledger, SpendingPolicy}
+
+  @chain 84_532
+  @core "0x" <> String.duplicate("ab", 20)
+  @provider "0x" <> String.duplicate("cd", 20)
+  @buyer "0x" <> String.duplicate("ef", 20)
+
+  setup do
+    ensure_session_infra()
+
+    ledger = start_ledger()
+    adapter = Adapter.new()
+    resolver = Resolver.new()
+    :ok = Resolver.put_default(resolver, System.unique_integer([:positive]))
+    store = Checkpoint.ETS.new()
+
+    {:ok, adapter: adapter, resolver: resolver, store: store, ledger: ledger}
+  end
+
+  defp ensure_session_infra do
+    unless Process.whereis(JobSession.Registry) do
+      {:ok, _} = Registry.start_link(keys: :unique, name: JobSession.Registry)
+    end
+
+    unless Process.whereis(JobSession.Supervisor) do
+      start_supervised!(JobSession.Supervisor)
+    end
+  end
+
+  defp start_ledger do
+    {:ok, ledger} =
+      Ledger.start_link(table_name: :"client_test_ledger_#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(ledger)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    ledger
+  end
+
+  defp client(ctx, opts \\ []) do
+    Client.new(
+      Keyword.merge(
+        [
+          adapter: ctx.adapter,
+          resolver: ctx.resolver,
+          chain_id: @chain,
+          acp_core_address: @core,
+          buyer: @buyer,
+          provider: @provider,
+          amount: AssetToken.usdc(10, @chain),
+          ledger: ctx.ledger,
+          policy: SpendingPolicy.unrestricted(),
+          agent_id: :test_buyer,
+          checkpoint: ctx.store,
+          nonce: System.unique_integer([:positive])
+        ],
+        opts
+      )
+    )
+  end
+
+  defp call_sigs(ctx) do
+    ctx.adapter |> Adapter.sent_calls() |> Enum.map(fn {_chain, [call | _]} -> call.data end)
+  end
+
+  test "buy reserves, creates the job, resolves the job_id, and starts a client session", ctx do
+    c = client(ctx)
+
+    assert {:ok, c, %{status: :open, job_id: job_id, tx_hash: tx}} = Client.buy(c)
+    assert is_integer(job_id)
+    assert is_binary(tx)
+    assert c.job_id == job_id
+    assert JobSession.status({@chain, job_id}) == :open
+
+    # Exactly one on-chain write (createJob) so far.
+    assert length(Adapter.sent_calls(ctx.adapter)) == 1
+
+    # The purchase is checkpointed at the `bound` phase.
+    key = Raxol.ACP.Checkpoint.buyer_key(@chain, c.request_key)
+    assert {:ok, %{"phase" => "bound", "job_id" => ^job_id}} = Checkpoint.fetch(ctx.store, key)
+  end
+
+  test "on_budget_set funds the escrow and mirrors :funded", ctx do
+    {:ok, c, _} = Client.buy(client(ctx))
+
+    assert {:ok, c, %{status: :funded, tx_hash: _}} = Client.on_budget_set(c)
+    assert JobSession.status({@chain, c.job_id}) == :funded
+    # createJob + fund
+    assert length(Adapter.sent_calls(ctx.adapter)) == 2
+  end
+
+  test "on_submitted approves -> complete on-chain, spend stands", ctx do
+    {:ok, c, _} = Client.buy(client(ctx))
+    {:ok, c, _} = Client.on_budget_set(c)
+
+    deliverable = %{"result" => "ok"}
+    assert {:ok, c, %{status: :completed, tx_hash: _}} = Client.on_submitted(c, deliverable)
+
+    # createJob + fund + complete
+    assert length(Adapter.sent_calls(ctx.adapter)) == 3
+
+    # The reservation was forgotten but the spend stands (net 10 spent).
+    totals = Ledger.get_totals(ctx.ledger, :test_buyer, SpendingPolicy.unrestricted())
+    assert Decimal.equal?(totals.lifetime, Decimal.new(10))
+
+    # Checkpoint cleaned up at the terminal.
+    key = Raxol.ACP.Checkpoint.buyer_key(@chain, c.request_key)
+    assert :error = Checkpoint.fetch(ctx.store, key)
+  end
+
+  test "on_submitted rejects -> reject on-chain and releases the reservation", ctx do
+    reject_fn = fn _deliverable, _ctx -> {:reject, :bad} end
+    {:ok, c, _} = Client.buy(client(ctx, evaluate_fn: reject_fn))
+    {:ok, c, _} = Client.on_budget_set(c)
+
+    assert {:ok, c, %{status: :rejected}} = Client.on_submitted(c, %{"x" => 1})
+
+    # Reservation released: lifetime nets back to 0.
+    totals = Ledger.get_totals(ctx.ledger, :test_buyer, SpendingPolicy.unrestricted())
+    assert Decimal.equal?(totals.lifetime, Decimal.new(0))
+    assert_session_gone({@chain, c.job_id})
+  end
+
+  test "spend over the per-request cap is rejected before any on-chain write", ctx do
+    tight = %SpendingPolicy{
+      per_request_max: Decimal.new("1.00"),
+      session_max: Decimal.new("1.00"),
+      lifetime_max: Decimal.new("1.00"),
+      currency: "USDC"
+    }
+
+    c = client(ctx, policy: tight)
+
+    assert {:rejected, {:spend_rejected, {:over_budget, _}}} = Client.buy(c)
+    assert Adapter.sent_calls(ctx.adapter) == []
+  end
+
+  test "fail-closed: require_policy with no policy refuses before any write", ctx do
+    c = client(ctx, policy: nil, require_policy: true)
+
+    assert {:rejected, {:spend_rejected, {:policy_required, _}}} = Client.buy(c)
+    assert Adapter.sent_calls(ctx.adapter) == []
+  end
+
+  test "fail-closed: require_checkpoint with no store refuses before reserve", ctx do
+    Application.put_env(:raxol_acp, :require_checkpoint, true)
+    on_exit(fn -> Application.delete_env(:raxol_acp, :require_checkpoint) end)
+
+    c = client(ctx, checkpoint: nil)
+
+    assert {:error, :checkpoint_required} = Client.buy(c)
+    assert Adapter.sent_calls(ctx.adapter) == []
+  end
+
+  test "a budget exceeding the reserved ceiling is rejected and the reservation released", ctx do
+    {:ok, c, _} = Client.buy(client(ctx))
+    reserved_raw = AssetToken.usdc(10, @chain).raw_amount
+
+    assert {:rejected, {:budget_over_reserved, _, ^reserved_raw}} =
+             Client.on_budget_set(c, reserved_raw + 1)
+
+    # Only createJob was written; no fund. The session expired (terminal).
+    assert length(Adapter.sent_calls(ctx.adapter)) == 1
+    assert_session_gone({@chain, c.job_id})
+
+    totals = Ledger.get_totals(ctx.ledger, :test_buyer, SpendingPolicy.unrestricted())
+    assert Decimal.equal?(totals.lifetime, Decimal.new(0))
+  end
+
+  # createJob is the first sent call; assert its calldata starts with the
+  # createJob 4-byte selector (ABI.encode_call returns raw bytes).
+  test "buy writes createJob (not fund) as its first on-chain call", ctx do
+    {:ok, _c, _} = Client.buy(client(ctx))
+    [first_data | _] = call_sigs(ctx)
+    selector = Raxol.ACP.ABI.encode_call("createJob(address,address,uint256,string,address)", [])
+    assert binary_part(first_data, 0, byte_size(selector)) == selector
+  end
+
+  defp assert_session_gone(key), do: wait_gone(key, 50)
+
+  defp wait_gone(key, 0), do: flunk("session #{inspect(key)} still alive")
+
+  defp wait_gone(key, attempts) do
+    case Registry.lookup(JobSession.Registry, key) do
+      [] ->
+        :ok
+
+      [{pid, _}] ->
+        if Process.alive?(pid) do
+          Process.sleep(5)
+          wait_gone(key, attempts - 1)
+        else
+          :ok
+        end
+    end
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/onchain/log_decoder_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/onchain/log_decoder_test.exs
@@ -1,0 +1,39 @@
+defmodule Raxol.ACP.Onchain.LogDecoderTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.ACP.Onchain.LogDecoder
+
+  test "event_topic is the full keccak of the canonical signature" do
+    assert LogDecoder.event_topic("Transfer(address,address,uint256)") ==
+             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  end
+
+  test "decode_uint256 reads a right-aligned 32-byte topic" do
+    assert LogDecoder.decode_uint256("0x" <> String.duplicate("0", 62) <> "2a") == {:ok, 42}
+  end
+
+  test "decode_uint256 rejects a non-32-byte value" do
+    assert {:error, {:bad_uint256, _}} = LogDecoder.decode_uint256("0x2a")
+  end
+
+  test "find_event matches topics[0] by signature or precomputed hash" do
+    topic = LogDecoder.event_topic("JobCreated(uint256)")
+    log = %{"topics" => [topic, "0x" <> String.duplicate("0", 62) <> "07"]}
+
+    assert {:ok, ^log} = LogDecoder.find_event([log], "JobCreated(uint256)")
+    assert {:ok, ^log} = LogDecoder.find_event([log], topic)
+    assert :error = LogDecoder.find_event([log], "Nope(uint256)")
+  end
+
+  test "extract pulls the indexed uint256 jobId out of a JobCreated log" do
+    topic = LogDecoder.event_topic("JobCreated(uint256)")
+    log = %{"topics" => [topic, "0x" <> String.duplicate("0", 62) <> "63"]}
+
+    assert {:ok, 99} = LogDecoder.extract([log], "JobCreated(uint256)", 1, :uint256)
+  end
+
+  test "extract errors when the event is absent" do
+    assert {:error, {:event_not_found, _}} =
+             LogDecoder.extract([], "JobCreated(uint256)", 1, :uint256)
+  end
+end

--- a/test/cross_terminal/modal_demo_headless_test.exs
+++ b/test/cross_terminal/modal_demo_headless_test.exs
@@ -60,10 +60,16 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
     {:ok, id} =
       Headless.start(Raxol.Playground.Demos.ModalDemo, id: :modal_demo_reflow)
 
+    # `start/2` does not render an initial frame and `get_buffer/1` does not
+    # force one (unlike `screenshot/1`, which does `:render_frame_sync`), so
+    # read the baseline through a render-sync to avoid racing the first frame
+    # on a loaded runner.
+    {:ok, _} = Headless.screenshot(id)
     {:ok, closed_buffer} = Headless.get_buffer(id)
 
     :ok = Headless.send_key(id, "o")
     Process.sleep(50)
+    {:ok, _} = Headless.screenshot(id)
     {:ok, open_buffer} = Headless.get_buffer(id)
 
     for y <- 0..3, x <- 0..35 do
@@ -81,6 +87,10 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
     {:ok, id} =
       Headless.start(Raxol.Playground.Demos.ModalDemo, id: :modal_demo_dim)
 
+    # Render-sync the baseline: `start/2` renders no initial frame and
+    # `get_buffer/1` does not force one, so reading it directly races the first
+    # frame (this was the macOS flake). `screenshot/1` does `:render_frame_sync`.
+    {:ok, _} = Headless.screenshot(id)
     {:ok, closed_buffer} = Headless.get_buffer(id)
     closed_title_cell = cell_at(closed_buffer, 0, 0)
     assert closed_title_cell.char == "M"
@@ -90,6 +100,7 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
 
     :ok = Headless.send_key(id, "o")
     Process.sleep(50)
+    {:ok, _} = Headless.screenshot(id)
     {:ok, open_buffer} = Headless.get_buffer(id)
     open_title_cell = cell_at(open_buffer, 0, 0)
     assert open_title_cell.char == "M"
@@ -103,6 +114,7 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
 
     :ok = Headless.send_key(id, "n")
     Process.sleep(50)
+    {:ok, _} = Headless.screenshot(id)
     {:ok, closed_again_buffer} = Headless.get_buffer(id)
     closed_again_title_cell = cell_at(closed_again_buffer, 0, 0)
     assert closed_again_title_cell.style.foreground == closed_fg


### PR DESCRIPTION
## What

Closes **M3 (buy side)** of the raxol_acp economyOS scope: an autonomous buyer that discovers an offering, funds a job within spend limits, evaluates the deliverable, and survives crashes without double-spending. It's the mirror of the seller's `Provider` + `Queue`/`Runtime`/`Supervisor` tree.

Before this, raxol_acp could *write* the client-role hooks (`HookClient.create_job/fund/complete/reject`) but had no client-role driver, no discover -> create -> fund -> evaluate loop, and no spend gating on the fund path.

## How

- **`JobSession.Client`** -- pure driver (`buy/1`, `on_budget_set/2`, `on_submitted/2`), symmetric to `Provider`. Reuses `Raxol.Payments.Actions.SpendGate` for fail-closed reserve/tag/release and `HookClient` for the on-chain writes.
- **Buy-side idempotency.** The seller keys its checkpoint by `job_id` (which arrives on an event); the buyer *originates* the job, so `job_id` doesn't exist until after `createJob`. Fix: a client-minted `request_key` keying a single accreting record (`reserved -> creating -> created -> bound -> funding -> funded`). Since `createJob` is the one non-idempotent write (each call mints a new job + escrow), the buyer stamps a tag from the `request_key` into the job `description`; a crash in the create window **reconciles by that tag** before re-broadcasting. Honest semantics: *exactly-once-effective for reserve and fund; create is at-least-once-attempted with deterministic tag reconcile.*
- **`JobIdResolver`** seam (behaviour + `Mock` + a `Receipt` receipt/log-decode default explicitly flagged "confirm in Sepolia"); re-adds `Onchain.LogDecoder`.
- **Buyer runtime tree** -- `Buyer.{Queue, Runtime, Resync, Planner, Supervisor}`, opt-in via `buyer_enabled: true`, wired into `ACP.Supervisor`.
- **Fail-closed posture** -- `require_policy` + `require_checkpoint` default to `Raxol.Payments.Deployment.production?()`, matching `SpendGate` / `Provider`.
- `config/buyer.example.exs` + a RUNBOOK "Buy side" section (offline rehearsal + Sepolia dry-run confirm list).

## Tests

36 new tests, all green; full `raxol_acp` suite passes (723), credo strict clean, `--warnings-as-errors` clean. Includes crash-window coverage (exactly one create / one fund across replay at every phase), gate/fail-closed rejection, resolver + log-decoder units, buyer runtime, and a **signing-boundary property test** (gate-rejection => zero on-chain writes).

## Manual testing

- [x] `mix compile --warnings-as-errors` (clean master base, in an isolated worktree)
- [x] `mix test test/raxol/acp/job_session/ test/raxol/acp/buyer/ test/raxol/acp/job_id_resolver_test.exs test/raxol/acp/onchain/log_decoder_test.exs` -> 36 passed
- [x] `mix test` (full package) -> 723 passed, 0 failures
- [x] `mix credo --strict` on new files -> no issues
- [ ] Sepolia dry-run (operator, gated): confirm the `JobCreated` event ABI, `description` round-trip, and job-id form (documented in RUNBOOK)

## Notes

Independent of PR #682 (LongCat provider). An earlier shared-working-tree race bundled both changesets into one local commit; this PR was rebuilt in a clean worktree off `master` with only the 21 `packages/raxol_acp/**` files.
