### PR TITLE
Fix macOS flake in modal demo headless test

### DIFF
--- a/test/cross_terminal/modal_demo_headless_test.exs
+++ b/test/cross_terminal/modal_demo_headless_test.exs
@@ -60,10 +60,16 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
     {:ok, id} =
       Headless.start(Raxol.Playground.Demos.ModalDemo, id: :modal_demo_reflow)
 
+    # `start/2` does not render an initial frame and `get_buffer/1` does not
+    # force one (unlike `screenshot/1`, which does `:render_frame_sync`), so
+    # read the baseline through a render-sync to avoid racing the first frame
+    # on a loaded runner.
+    {:ok, _} = Headless.screenshot(id)
     {:ok, closed_buffer} = Headless.get_buffer(id)
 
     :ok = Headless.send_key(id, "o")
     Process.sleep(50)
+    {:ok, _} = Headless.screenshot(id)
     {:ok, open_buffer} = Headless.get_buffer(id)
 
     for y <- 0..3, x <- 0..35 do
@@ -81,6 +87,10 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
     {:ok, id} =
       Headless.start(Raxol.Playground.Demos.ModalDemo, id: :modal_demo_dim)
 
+    # Render-sync the baseline: `start/2` renders no initial frame and
+    # `get_buffer/1` does not force one, so reading it directly races the first
+    # frame (this was the macOS flake). `screenshot/1` does `:render_frame_sync`.
+    {:ok, _} = Headless.screenshot(id)
     {:ok, closed_buffer} = Headless.get_buffer(id)
     closed_title_cell = cell_at(closed_buffer, 0, 0)
     assert closed_title_cell.char == "M"
@@ -90,6 +100,7 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
 
     :ok = Headless.send_key(id, "o")
     Process.sleep(50)
+    {:ok, _} = Headless.screenshot(id)
     {:ok, open_buffer} = Headless.get_buffer(id)
     open_title_cell = cell_at(open_buffer, 0, 0)
     assert open_title_cell.char == "M"
@@ -103,6 +114,7 @@ defmodule Raxol.CrossTerminal.ModalDemoHeadlessTest do
 
     :ok = Headless.send_key(id, "n")
     Process.sleep(50)
+    {:ok, _} = Headless.screenshot(id)
     {:ok, closed_again_buffer} = Headless.get_buffer(id)
     closed_again_title_cell = cell_at(closed_again_buffer, 0, 0)
     assert closed_again_title_cell.style.foreground == closed_fg


### PR DESCRIPTION
## What

`test/cross_terminal/modal_demo_headless_test.exs` intermittently fails on `Test macos-latest` (e.g. PR #682's run) at the "background is dimmed" test: `assert closed_title_cell.char == "M"`.

## Root cause

The two tests that capture their baseline via `Headless.get_buffer/1` do so immediately after `Headless.start/2`. But `start/2` renders no initial frame and `get_buffer/1` reads the *current* buffer without forcing a render (unlike `screenshot/1`, which does `:render_frame_sync`). On a loaded runner the first frame hasn't landed, so cell (0,0) isn't `"M"` yet. It's a pure timing race -- the sibling test that uses `screenshot` never fails.

## Fix

Read every buffer through a render-sync: call `Headless.screenshot(id)` (which forces `:render_frame_sync`) before each `get_buffer/1`. Deterministic, no `sleep`-tuning.

## Manual testing

- [x] `mix test test/cross_terminal/modal_demo_headless_test.exs` x5 with varied seeds -> 3 passed each
- [x] `mix format --check-formatted`

## Notes

Pre-existing flake on `master`, unrelated to any feature PR -- surfaced on #682 (LongCat) and would bite any PR touching the macOS matrix. Landing on `master` clears it for all branches.
