### PR TITLE
De-flake nightly timing property + on_exit stop teardown race

### DIFF
--- a/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
@@ -43,17 +43,23 @@ defmodule Raxol.Agent.Session.SupervisorTest do
     # App-level singletons: tolerate an already-running instance.
     ensure_registry(:duplicate, EmitBus.registry_name())
 
-    ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
+    ensure_running(
+      {Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences}
+    )
 
     # The lifecycle's own DynamicSupervisor (used by Lifecycle.start_link).
-    ensure_running({DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one})
+    ensure_running(
+      {DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one}
+    )
 
     # Per-test singletons owned by ExUnit (auto-stopped at test end): the agent
     # Registry, the DynSup the session trees run under, and the named
     # SessionStreamer the sink emits into.
     start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
 
-    start_supervised!({DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one})
+    start_supervised!(
+      {DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one}
+    )
 
     start_supervised!(Raxol.Agent.SessionStreamer)
 
@@ -86,7 +92,9 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       # writer pid to prove it closes on teardown.
       :ok = SessionStreamer.subscribe(sid)
       :ok = Session.send_message(agent_id(session), {:say, "hi"})
-      assert_receive {:session_event, ^sid, %Event{type: :turn_completed}}, 1_000
+
+      assert_receive {:session_event, ^sid, %Event{type: :turn_completed}},
+                     1_000
 
       %{journal: %FileStore{writer: writer}} = :sys.get_state(bridge)
       assert Process.alive?(writer)
@@ -223,7 +231,9 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       :ok = Session.send_message(agent_id(session2), {:say, "after"})
 
       assert_receive {:session_event, ^sid, %Event{type: :turn_started}}, 1_000
-      assert_receive {:session_event, ^sid, %Event{type: :turn_completed}}, 1_000
+
+      assert_receive {:session_event, ^sid, %Event{type: :turn_completed}},
+                     1_000
 
       refute_receive {:session_event, ^sid, %Event{type: :turn_started}}, 200
 
@@ -284,7 +294,11 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       wait_until(fn -> get_model(session1) == {:ok, %{seen: ["one"]}} end)
 
       assert :ok = Session.Supervisor.stop_session(sid)
-      wait_until(fn -> not Process.alive?(sup1) and lifecycle_pid(sid) == nil end)
+
+      wait_until(fn ->
+        not Process.alive?(sup1) and lifecycle_pid(sid) == nil
+      end)
+
       refute Process.alive?(life1)
 
       # Same session_id again: a fresh subtree, a fresh lifecycle, and — the
@@ -359,7 +373,10 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       assert life2 != life0
 
       wait_until(fn ->
-        match?(%{lifecycle_pid: ^life2}, :sys.get_state(Session.Supervisor.whereis(sid)))
+        match?(
+          %{lifecycle_pid: ^life2},
+          :sys.get_state(Session.Supervisor.whereis(sid))
+        )
       end)
 
       # The crux: the fresh lifecycle carries the app's INIT model, NOT the
@@ -556,7 +573,14 @@ defmodule Raxol.Agent.Session.SupervisorTest do
           journal_opts: [base_dir: base]
         )
 
-      on_exit(fn -> if Process.alive?(session), do: GenServer.stop(session) end)
+      on_exit(fn ->
+        # Session may be mid-shutdown at teardown; swallow the stop's :exit.
+        try do
+          if Process.alive?(session), do: GenServer.stop(session)
+        catch
+          :exit, _ -> :ok
+        end
+      end)
 
       # Resolvable via the shared seam even though it was NOT started under the
       # tree (no {:session_supervisor, _} key exists for it).
@@ -566,6 +590,7 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       # stop_session falls back to stopping the standalone session directly.
       assert :ok = Session.Supervisor.stop_session(sid)
       wait_until(fn -> not Process.alive?(session) end)
+
       # Registry removes the {:session, _} key on the process's DOWN, which lands
       # just after GenServer.stop returns — wait for the key to clear.
       wait_until(fn -> Session.Supervisor.whereis(sid) == nil end)

--- a/packages/raxol_core/test/raxol/core/events/manager_test.exs
+++ b/packages/raxol_core/test/raxol/core/events/manager_test.exs
@@ -23,9 +23,11 @@ defmodule Raxol.Core.Events.EventManagerTest do
 
     # Clean up after tests
     on_exit(fn ->
-      case Process.alive?(pid) do
-        true -> GenServer.stop(pid)
-        false -> :ok
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
       end
     end)
 
@@ -83,7 +85,10 @@ defmodule Raxol.Core.Events.EventManagerTest do
       # Verify handler was registered only once
       handlers = EventManager.get_handlers()
       assert Map.has_key?(handlers, :test_event)
-      assert Map.get(handlers, :test_event) == [{__MODULE__, :dummy_handler, 50}]
+
+      assert Map.get(handlers, :test_event) == [
+               {__MODULE__, :dummy_handler, 50}
+             ]
     end
   end
 
@@ -102,6 +107,7 @@ defmodule Raxol.Core.Events.EventManagerTest do
 
       # Verify handler was unregistered
       handlers = EventManager.get_handlers()
+
       # When all handlers are removed, the key may be removed entirely or set to empty list
       event_handlers = Map.get(handlers, :test_event, [])
       assert event_handlers == []
@@ -118,7 +124,10 @@ defmodule Raxol.Core.Events.EventManagerTest do
       # Verify only that handler was unregistered
       handlers = EventManager.get_handlers()
       assert Map.has_key?(handlers, :test_event)
-      assert Map.get(handlers, :test_event) == [{__MODULE__, :another_handler, 50}]
+
+      assert Map.get(handlers, :test_event) == [
+               {__MODULE__, :another_handler, 50}
+             ]
     end
 
     test "does nothing for unregistered handler" do
@@ -147,7 +156,10 @@ defmodule Raxol.Core.Events.EventManagerTest do
       # Define handler module -- arity 2 because EventManager dispatches (event_type, event_data)
       defmodule DispatchTestHandler do
         def handle_test_event(event_type, event_data) do
-          send(Process.whereis(:dispatch_test_receiver), {event_type, event_data})
+          send(
+            Process.whereis(:dispatch_test_receiver),
+            {event_type, event_data}
+          )
         end
       end
 

--- a/packages/raxol_core/test/raxol/core/keyboard_navigator_test.exs
+++ b/packages/raxol_core/test/raxol/core/keyboard_navigator_test.exs
@@ -11,7 +11,12 @@ defmodule Raxol.Core.KeyboardNavigatorTest do
       NavigatorServer.start_link(name: name, config: %{})
 
     on_exit(fn ->
-      if Process.alive?(pid), do: GenServer.stop(pid)
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
     end)
 
     %{server: name}
@@ -49,7 +54,16 @@ defmodule Raxol.Core.KeyboardNavigatorTest do
 
     test "overwrites existing position", %{server: server} do
       NavigatorServer.register_component_position(server, "btn1", 0, 0, 10, 10)
-      NavigatorServer.register_component_position(server, "btn1", 50, 50, 20, 20)
+
+      NavigatorServer.register_component_position(
+        server,
+        "btn1",
+        50,
+        50,
+        20,
+        20
+      )
+
       spatial_map = NavigatorServer.get_spatial_map(server)
       assert spatial_map["btn1"].x == 50
     end

--- a/packages/raxol_core/test/raxol/core/runtime/plugins/resource_budget_test.exs
+++ b/packages/raxol_core/test/raxol/core/runtime/plugins/resource_budget_test.exs
@@ -11,7 +11,12 @@ defmodule Raxol.Core.Runtime.Plugins.ResourceBudgetTest do
     {:ok, pid} = ResourceBudget.start_link(interval_ms: 60_000)
 
     on_exit(fn ->
-      if Process.alive?(pid), do: GenServer.stop(pid)
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
     end)
 
     :ok

--- a/packages/raxol_terminal/test/raxol/terminal/cache/system_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/cache/system_test.exs
@@ -15,8 +15,13 @@ defmodule Raxol.Terminal.Cache.SystemTest do
     {:ok, pid} = System.start_link(name: cache_system_name)
 
     on_exit(fn ->
-      if Process.alive?(pid) do
-        GenServer.stop(pid)
+      # The server may already be dying (linked to the test process) when
+      # teardown runs; GenServer.stop then exits with :shutdown. Swallow it --
+      # teardown only needs the process gone.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
       end
     end)
 
@@ -132,7 +137,8 @@ defmodule Raxol.Terminal.Cache.SystemTest do
       result5 = System.get("key5", namespace: :general)
 
       # At least key1 should be evicted (oldest, never accessed after initial insert)
-      assert {:error, :not_found} = result1, "key1 should have been evicted (oldest)"
+      assert {:error, :not_found} = result1,
+             "key1 should have been evicted (oldest)"
 
       # key5 should definitely be present (just added)
       assert {:ok, _} = result5, "key5 should be present (just added)"

--- a/packages/raxol_terminal/test/raxol/terminal/mouse/mouse_server_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/mouse/mouse_server_test.exs
@@ -12,8 +12,11 @@ defmodule Raxol.Terminal.Mouse.MouseServerTest do
     {:ok, pid} = MouseServer.start_link(name: MouseServer)
 
     on_exit(fn ->
-      if Process.alive?(pid) do
-        GenServer.stop(pid)
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
       end
     end)
 

--- a/packages/raxol_terminal/test/raxol/terminal/plugin/plugin_server_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/plugin/plugin_server_test.exs
@@ -23,8 +23,11 @@ defmodule Raxol.Terminal.Plugin.UnifiedPluginTest do
       # Always restore the theme file after each test
       File.write!(theme_file, original_content)
 
-      if Process.alive?(pid) do
-        GenServer.stop(pid)
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
       end
     end)
 
@@ -235,7 +238,10 @@ defmodule Raxol.Terminal.Plugin.UnifiedPluginTest do
       # Verify both plugins are active
       assert {:ok, base_state} = PluginServer.get_plugin_state(base_id)
       assert base_state.status == :active
-      assert {:ok, dependent_state} = PluginServer.get_plugin_state(dependent_id)
+
+      assert {:ok, dependent_state} =
+               PluginServer.get_plugin_state(dependent_id)
+
       assert dependent_state.status == :active
     end
   end
@@ -338,7 +344,8 @@ defmodule Raxol.Terminal.Plugin.UnifiedPluginTest do
 
       try do
         # Attempt to reload - should fail
-        assert {:error, :reload_failed, _state} = PluginServer.reload_plugin(plugin_id)
+        assert {:error, :reload_failed, _state} =
+                 PluginServer.reload_plugin(plugin_id)
 
         # Verify plugin is in error state
         assert {:ok, plugin_state} = PluginServer.get_plugin_state(plugin_id)

--- a/packages/raxol_terminal/test/raxol/terminal/script/script_server_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/script/script_server_test.exs
@@ -18,8 +18,11 @@ defmodule Raxol.Terminal.Script.UnifiedScriptTest do
       )
 
     on_exit(fn ->
-      if Process.alive?(pid) do
-        GenServer.stop(pid)
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
       end
     end)
 

--- a/packages/raxol_terminal/test/raxol/terminal/sync/sync_server_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/sync/sync_server_test.exs
@@ -16,9 +16,11 @@ defmodule Raxol.Terminal.Sync.SyncServerTest do
       )
 
     on_exit(fn ->
-      case Process.alive?(pid) do
-        true -> GenServer.stop(pid)
-        false -> :ok
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
       end
     end)
 
@@ -113,7 +115,6 @@ defmodule Raxol.Terminal.Sync.SyncServerTest do
 
       assert resolved.value == "new"
     end
-
   end
 
   describe "error handling" do

--- a/packages/raxol_terminal/test/raxol/terminal/theme/theme_server_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/theme/theme_server_test.exs
@@ -11,7 +11,12 @@ defmodule Raxol.Terminal.Theme.ThemeServerTest do
       )
 
     on_exit(fn ->
-      if Process.alive?(pid), do: GenServer.stop(pid, :normal)
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid, :normal)
+      catch
+        :exit, _ -> :ok
+      end
     end)
 
     %{pid: pid}

--- a/packages/raxol_terminal/test/raxol/terminal/window/window_server_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/window/window_server_test.exs
@@ -14,8 +14,11 @@ defmodule Raxol.Terminal.Window.WindowServerTest do
     {:ok, pid} = Server.start_link(name: Server)
 
     on_exit(fn ->
-      if Process.alive?(pid) do
-        GenServer.stop(pid)
+      # Server may be mid-shutdown at teardown; swallow the stop's :exit.
+      try do
+        if Process.alive?(pid), do: GenServer.stop(pid)
+      catch
+        :exit, _ -> :ok
       end
     end)
 

--- a/test/property/core_property_test.exs
+++ b/test/property/core_property_test.exs
@@ -7,8 +7,10 @@ defmodule Raxol.Property.CoreTest do
 
   describe "Parser property tests" do
     property "parser handles all valid CSI sequences" do
-      check all sequence <- csi_sequence_generator(),
-                max_runs: 500 do
+      check all(
+              sequence <- csi_sequence_generator(),
+              max_runs: 500
+            ) do
         result = Parser.parse(sequence)
 
         # Should return a list of sequences
@@ -22,8 +24,10 @@ defmodule Raxol.Property.CoreTest do
     end
 
     property "parser never crashes on random input" do
-      check all input <- string(:printable, min_length: 1, max_length: 100),
-                max_runs: 1000 do
+      check all(
+              input <- string(:printable, min_length: 1, max_length: 100),
+              max_runs: 1000
+            ) do
         # Parser should handle any input without crashing
         result = Parser.parse(input)
         assert is_list(result)
@@ -31,8 +35,10 @@ defmodule Raxol.Property.CoreTest do
     end
 
     property "parser preserves text content" do
-      check all text <- string(:alphanumeric, min_length: 1, max_length: 50),
-                max_runs: 500 do
+      check all(
+              text <- string(:alphanumeric, min_length: 1, max_length: 50),
+              max_runs: 500
+            ) do
         # Pure text should be preserved
         parsed = Parser.parse(text)
 
@@ -43,8 +49,10 @@ defmodule Raxol.Property.CoreTest do
     end
 
     property "escape sequences are idempotent" do
-      check all sequence <- simple_escape_sequence(),
-                max_runs: 500 do
+      check all(
+              sequence <- simple_escape_sequence(),
+              max_runs: 500
+            ) do
         # Parsing twice should give same result
         parsed1 = Parser.parse(sequence)
         parsed2 = Parser.parse(sequence)
@@ -55,21 +63,27 @@ defmodule Raxol.Property.CoreTest do
 
     @tag :skip_on_ci
     property "parser performance scales sub-quadratically" do
-      check all size <- integer(100..1000),
-                max_runs: 50 do
+      check all(
+              size <- integer(100..1000),
+              max_runs: 50
+            ) do
         small_input = String.duplicate("a", 100)
         large_input = String.duplicate("a", size)
 
-        # Warm up
-        _ = Parser.parse(small_input)
-        _ = Parser.parse(large_input)
+        # Warm up both paths so JIT/allocation settle before timing.
+        for _ <- 1..5 do
+          _ = Parser.parse(small_input)
+          _ = Parser.parse(large_input)
+        end
 
-        # Use 100 iterations to get stable timing
-        {base_time, _} =
-          :timer.tc(fn -> for _ <- 1..100, do: Parser.parse(small_input) end)
-
-        {scaled_time, _} =
-          :timer.tc(fn -> for _ <- 1..100, do: Parser.parse(large_input) end)
+        # The ratio's denominator is a tiny measurement (100 parses of a
+        # 100-char string, single-digit microseconds), so one GC/scheduler
+        # spike in either sample used to blow the assertion on loaded CI.
+        # Interference only ADDS time, so the minimum across batches is the
+        # cleanest estimate of each path's true cost -- taking the min of both
+        # sides makes the ratio reflect algorithmic scaling, not a one-off.
+        base_time = min_batch_time(fn -> Parser.parse(small_input) end)
+        scaled_time = min_batch_time(fn -> Parser.parse(large_input) end)
 
         # If truly quadratic, ratio would be (size/100)^2
         # Allow up to 10x the linear expectation for GC, scheduling variance
@@ -84,9 +98,11 @@ defmodule Raxol.Property.CoreTest do
 
   describe "Buffer property tests" do
     property "buffer maintains dimensions" do
-      check all width <- integer(10..200),
-                height <- integer(10..100),
-                max_runs: 200 do
+      check all(
+              width <- integer(10..200),
+              height <- integer(10..100),
+              max_runs: 200
+            ) do
         buffer = Buffer.new({width, height})
 
         assert buffer.width == width
@@ -96,8 +112,10 @@ defmodule Raxol.Property.CoreTest do
     end
 
     property "buffer write operations preserve content" do
-      check all text <- string(:printable, min_length: 1, max_length: 50),
-                max_runs: 500 do
+      check all(
+              text <- string(:printable, min_length: 1, max_length: 50),
+              max_runs: 500
+            ) do
         buffer = Buffer.new({80, 24})
         updated = Buffer.write(buffer, text)
 
@@ -110,9 +128,11 @@ defmodule Raxol.Property.CoreTest do
 
   describe "Terminal state property tests" do
     property "terminal dimensions are valid" do
-      check all width <- integer(20..500),
-                height <- integer(10..200),
-                max_runs: 200 do
+      check all(
+              width <- integer(20..500),
+              height <- integer(10..200),
+              max_runs: 200
+            ) do
         terminal = %{width: width, height: height}
 
         assert terminal.width > 0
@@ -123,10 +143,12 @@ defmodule Raxol.Property.CoreTest do
     end
 
     property "color values are in valid range" do
-      check all r <- integer(0..255),
-                g <- integer(0..255),
-                b <- integer(0..255),
-                max_runs: 500 do
+      check all(
+              r <- integer(0..255),
+              g <- integer(0..255),
+              b <- integer(0..255),
+              max_runs: 500
+            ) do
         color = %{r: r, g: g, b: b}
 
         assert color.r in 0..255
@@ -136,15 +158,18 @@ defmodule Raxol.Property.CoreTest do
     end
 
     property "terminal modes are consistent" do
-      check all modes <- list_of(terminal_mode(), max_length: 20),
-                max_runs: 200 do
-        terminal_state = Enum.reduce(modes, %{modes: MapSet.new()}, fn mode, state ->
-          if :rand.uniform() > 0.5 do
-            %{state | modes: MapSet.put(state.modes, mode)}
-          else
-            %{state | modes: MapSet.delete(state.modes, mode)}
-          end
-        end)
+      check all(
+              modes <- list_of(terminal_mode(), max_length: 20),
+              max_runs: 200
+            ) do
+        terminal_state =
+          Enum.reduce(modes, %{modes: MapSet.new()}, fn mode, state ->
+            if :rand.uniform() > 0.5 do
+              %{state | modes: MapSet.put(state.modes, mode)}
+            else
+              %{state | modes: MapSet.delete(state.modes, mode)}
+            end
+          end)
 
         # Modes should be a valid set
         assert is_struct(terminal_state.modes, MapSet)
@@ -156,8 +181,11 @@ defmodule Raxol.Property.CoreTest do
   # Generator helpers
 
   defp csi_sequence_generator do
-    gen all cmd <- member_of(["A", "B", "C", "D", "H", "J", "K", "m", "n", "s", "u"]),
-            params <- list_of(integer(0..100), max_length: 3) do
+    gen all(
+          cmd <-
+            member_of(["A", "B", "C", "D", "H", "J", "K", "m", "n", "s", "u"]),
+          params <- list_of(integer(0..100), max_length: 3)
+        ) do
       if params == [] do
         "\e[#{cmd}"
       else
@@ -167,7 +195,9 @@ defmodule Raxol.Property.CoreTest do
   end
 
   defp simple_escape_sequence do
-    gen all type <- member_of([:cursor_up, :cursor_down, :clear_screen, :reset]) do
+    gen all(
+          type <- member_of([:cursor_up, :cursor_down, :clear_screen, :reset])
+        ) do
       case type do
         :cursor_up -> "\e[A"
         :cursor_down -> "\e[B"
@@ -183,6 +213,18 @@ defmodule Raxol.Property.CoreTest do
 
   # Helper functions
 
+  # Minimum wall-clock (microseconds) of 100 invocations, taken across several
+  # batches. Timing interference (GC, scheduling) only adds time, so the
+  # minimum is the sample least polluted by it.
+  defp min_batch_time(fun) do
+    1..5
+    |> Enum.map(fn _ ->
+      {t, _} = :timer.tc(fn -> for _ <- 1..100, do: fun.() end)
+      t
+    end)
+    |> Enum.min()
+  end
+
   defp extract_text(parsed) when is_list(parsed) do
     parsed
     |> Enum.map_join("", fn
@@ -191,6 +233,7 @@ defmodule Raxol.Property.CoreTest do
       _ -> ""
     end)
   end
+
   defp extract_text(text) when is_binary(text), do: text
   defp extract_text(_), do: ""
 end


### PR DESCRIPTION
Two teardown/timing flake fixes, both CI-only (no product code touched).

## 1. Nightly timing flake (the current red nightly)

`test/property/core_property_test.exs` -- "parser performance scales
sub-quadratically" was failing the nightly **Extended Test Scenarios** job,
which runs `:skip_on_ci`-tagged tests that normal CI skips.

Root cause: the ratio's denominator was a single `:timer.tc` over 100 parses of
a 100-char string (single-digit microseconds), so one GC/scheduler spike in
either measurement blew `assert ratio < max_ratio`.

Fix: measure each side as the **minimum of 5 timed batches**. Interference only
adds time, so the minimum is the cleanest estimate of each path's true cost and
the ratio reflects algorithmic scaling, not a one-off spike. Warmup bumped
1 -> 5 iterations. The sub-quadratic assertion is unchanged.

Evidence: 0 failures across 25 stress runs targeting exactly this property.

## 2. on_exit GenServer.stop shutdown race (11 sites)

A GenServer `start_link`'d to the test process may already be dying with
`:shutdown` at teardown; `GenServer.stop` (which expects `:normal`) then exits
and fails the `on_exit` callback -- a CI teardown flake independent of the
test's assertions. This is the class that took down PR #651's macOS leg.

Wrapped the stop in `try/catch :exit` across 11 setup/on_exit sites
(raxol_terminal x7, raxol_core x3, raxol_agent x1), normalizing three prior
shapes (`if..do..end`, `case..do`, single-line `if..do:`) to one guarded form.

## Manual testing

- `mix test test/property/core_property_test.exs --include skip_on_ci` -> 10 passed
- 25x stress of the timing property (varying seeds) -> 0 failures
- raxol_core edited tests -> 30 passed
- raxol_terminal edited tests -> 118 passed
- raxol_agent session_supervisor_test -> 14 passed
- `mix format --check-formatted` on all touched files -> clean
