### PR TITLE
docs: repair ADR-status + count drift (wave 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ nix develop github:DROOdotFOO/raxol   # dev shell with elixir, erlang, NIF + spe
 ```bash
 git clone https://github.com/DROOdotFOO/raxol.git
 cd raxol && mix deps.get
-mix raxol.playground          # 30 live demos, browse/search/filter
+mix raxol.playground          # 40 live demos, browse/search/filter
 ```
 
 The flagship demo is a live BEAM dashboard with scheduler utilization, memory sparklines, and a process table:

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ Complete guide to Raxol: multi-surface application runtime for Elixir.
 ## Examples
 
 - [Examples Learning Path](../examples/README.md): runnable examples, beginner to advanced
-- `mix raxol.playground`: interactive Component catalog with 30 demos
+- `mix raxol.playground`: interactive Component catalog with 40 demos
 
 ## Resources
 

--- a/docs/adr/0019-workflow-concurrency.md
+++ b/docs/adr/0019-workflow-concurrency.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed, 2026-06-16. Direct follow-up to ADR-0015 (Workflow Graph), which shipped the sequential single-branch runtime and explicitly deferred joins and channels. ADR-0017 (pause checkpoints) and ADR-0018 (operator-flow contract) layered on top of the sequential runtime; this ADR adds the parallel branches without invalidating either. Pre-requisite for any future work (Phase 26, distributed Symphony, cross-chain settlement) that wants fan-out + reduce inside a single workflow graph.
+Accepted, 2026-07-22 (implemented in `Raxol.Workflow.Graph` via `add_channel/3` + `add_join/4`). Originally proposed 2026-06-16. Direct follow-up to ADR-0015 (Workflow Graph), which shipped the sequential single-branch runtime and explicitly deferred joins and channels. ADR-0017 (pause checkpoints) and ADR-0018 (operator-flow contract) layered on top of the sequential runtime; this ADR adds the parallel branches without invalidating either. Pre-requisite for any future work (Phase 26, distributed Symphony, cross-chain settlement) that wants fan-out + reduce inside a single workflow graph.
 
 ## Context
 

--- a/docs/adr/0020-agent-sandbox-thread-policies.md
+++ b/docs/adr/0020-agent-sandbox-thread-policies.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed, 2026-06-16. Symmetric to ADR-0019 (Workflow concurrency) for the agent stack: ADR-0019 scopes the runtime-side parallel-branch primitive, this ADR scopes the agent-side isolation + audit + policy primitive. Together they frame the next 3-6 months of substrate work. Builds on ADR-0012 (MCP as rendering target), ADR-0017 (paused-run query), ADR-0018 (operator-flow contract), and Phase 24F (Command struct deletion, leaving Directive as the canonical effect shape).
+Accepted, 2026-07-22 (implemented in `Raxol.Agent.Sandbox`, `Raxol.Agent.ThreadLog`, and `Raxol.Agent.Policy`). Originally proposed 2026-06-16. Symmetric to ADR-0019 (Workflow concurrency) for the agent stack: ADR-0019 scopes the runtime-side parallel-branch primitive, this ADR scopes the agent-side isolation + audit + policy primitive. Together they frame the next 3-6 months of substrate work. Builds on ADR-0012 (MCP as rendering target), ADR-0017 (paused-run query), ADR-0018 (operator-flow contract), and Phase 24F (Command struct deletion, leaving Directive as the canonical effect shape).
 
 ## Context
 

--- a/docs/adr/0021-self-improving-agents-skills-curation.md
+++ b/docs/adr/0021-self-improving-agents-skills-curation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed, 2026-06-17. First of the Hermes-extraction Tier 1 ADRs (research deliverable at
+Accepted, 2026-07-22 (implemented in `Raxol.Agent.SelfImprove`, `Raxol.Agent.Curator`, and `Raxol.Agent.Skills.Store`). Originally proposed 2026-06-17. First of the Hermes-extraction Tier 1 ADRs (research deliverable at
 `~/Desktop/hermes-extraction-report.md`, items H1.1 self-improvement loop + H1.2 runtime skill
 authoring). Hermes (Nous Research) is the benchmark agent this work targets: its defining claim,
 "an agent that gets more capable the longer it runs," rests on agent-authored skills plus an

--- a/docs/adr/0022-memory-providers-fulltext-dialectic.md
+++ b/docs/adr/0022-memory-providers-fulltext-dialectic.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed, 2026-06-17. Second of the Hermes-extraction Tier 1 ADRs (`~/Desktop/hermes-extraction-report.md`,
+Accepted, 2026-07-22 (implemented in `Raxol.Agent.Memory.Stack`, `Raxol.Agent.Memory.SessionSearch`, and `Raxol.Agent.UserModel`). Originally proposed 2026-06-17. Second of the Hermes-extraction Tier 1 ADRs (`~/Desktop/hermes-extraction-report.md`,
 item H1.3). Companion to ADR-0021 (self-improving agents), which deliberately scoped memory OUT and
 deferred it here. Builds on the existing `Raxol.Agent.Memory` behaviour and the omnigent item-log
 (`Raxol.Agent.Conversation.{Store,Log}`). The following Tier 1 ADR is H1.4 (unified messaging gateway).

--- a/docs/adr/0023-unified-messaging-gateway.md
+++ b/docs/adr/0023-unified-messaging-gateway.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed, 2026-06-17. Third and last of the Hermes-extraction Tier 1 ADRs
+Accepted, 2026-07-22 (implemented as the `raxol_gateway` package). Originally proposed 2026-06-17. Third and last of the Hermes-extraction Tier 1 ADRs
 (`~/Desktop/hermes-extraction-report.md`, item H1.4). Companion to ADR-0021 (self-improving agents)
 and ADR-0022 (memory). Builds on the existing surface packages (`raxol_telegram`, `raxol_watch`,
 `raxol_speech`), the shared `Raxol.Core.Events.Event`, the `Lifecycle` environment system, the

--- a/docs/adr/0024-execution-backends-hibernation.md
+++ b/docs/adr/0024-execution-backends-hibernation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed, 2026-06-18. First of the Hermes-extraction Tier 2 ADRs (research deliverable at
+Accepted, 2026-07-22 (execution backends implemented in `Raxol.Agent.Backend.{Native,ClaudeCode,Cursor}` + `Raxol.Agent.NativeHarness`; serverless hibernation deferred). Originally proposed 2026-06-18. First of the Hermes-extraction Tier 2 ADRs (research deliverable at
 `~/Desktop/hermes-extraction-report.md`, item H2.1). Hermes is the benchmark agent this work targets.
 Builds on ADR-0020 (the `Raxol.Agent.Sandbox` protocol and the `CommandHook`/`ThreadLog` seams) and
 the omnigent item-log (`Raxol.Agent.Conversation.{Store,Log}`).

--- a/docs/adr/0027-delegate-task-subagents.md
+++ b/docs/adr/0027-delegate-task-subagents.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed, 2026-06-18. Hermes-extraction Tier 2 ADR (`~/Desktop/hermes-extraction-report.md`, item
+Accepted, 2026-07-22 (implemented in `Raxol.Agent.Actions.Task` via `run_subagent/3`). Originally proposed 2026-06-18. Hermes-extraction Tier 2 ADR (`~/Desktop/hermes-extraction-report.md`, item
 H2.4). Refines the deferred omnigent T2.1 ("sub-agents are async tools + auto-wake") into a clean
 summary-only contract. Builds on `Raxol.Agent.Session`, `Raxol.Agent.Team`, the omnigent item-log
 (`Raxol.Agent.Conversation.Log`), and `Raxol.Agent.Turn` (ADR-0021's wiring).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,19 +21,20 @@ ADRs for the Raxol project. Each one captures a single architectural decision: w
 | [0013](0013-event-dispatch-backpressure.md) | Event-dispatch Backpressure | Implemented | 2026-06-03 |
 | [0014](0014-telegram-ai-guardian.md) | Telegram AI Guardian admin behaviour | Accepted | 2026-06-13 |
 | [0015](0015-workflow-graph.md) | Workflow Graph (`Raxol.Workflow.*`) | Accepted | 2026-06-15 |
-| [0016](0016-acp-job-workflow.md) | raxol_acp Job migration to `Raxol.Workflow` | Implemented (Phase A + B) | 2026-06-16 |
-| [0017](0017-acp-workflow-paused-jobs.md) | Workflow paused-run query and pause-checkpoint contract | Implemented | 2026-06-16 |
+| [0016](0016-acp-job-workflow.md) | raxol_acp Job migration to `Raxol.Workflow` | Superseded (v1->v2) | 2026-06-16 |
+| [0017](0017-acp-workflow-paused-jobs.md) | Workflow paused-run query and pause-checkpoint contract | Superseded (v1->v2) | 2026-06-16 |
 | [0018](0018-operator-flow-contract.md) | Operator-flow contract for paused runs | Proposed | 2026-06-16 |
-| [0019](0019-workflow-concurrency.md) | Workflow concurrency (`add_join/4` + `add_channel/4`) | Proposed | 2026-06-16 |
-| [0020](0020-agent-sandbox-thread-policies.md) | Phase 26: Agent Sandbox, Thread log, declarative Policies | Proposed | 2026-06-16 |
-| [0021](0021-self-improving-agents-skills-curation.md) | Self-improving agents: runtime skills + background curation | Proposed | 2026-06-17 |
-| [0022](0022-memory-providers-fulltext-dialectic.md) | Memory provider stack, full-text recall, dialectic user modeling | Proposed | 2026-06-17 |
-| [0023](0023-unified-messaging-gateway.md) | Unified messaging gateway (`raxol_gateway`) | Proposed | 2026-06-17 |
-| [0024](0024-execution-backends-hibernation.md) | Pluggable execution backends and serverless hibernation | Proposed | 2026-06-18 |
+| [0019](0019-workflow-concurrency.md) | Workflow concurrency (`add_join/4` + `add_channel/4`) | Accepted | 2026-06-16 |
+| [0020](0020-agent-sandbox-thread-policies.md) | Phase 26: Agent Sandbox, Thread log, declarative Policies | Accepted | 2026-06-16 |
+| [0021](0021-self-improving-agents-skills-curation.md) | Self-improving agents: runtime skills + background curation | Accepted | 2026-06-17 |
+| [0022](0022-memory-providers-fulltext-dialectic.md) | Memory provider stack, full-text recall, dialectic user modeling | Accepted | 2026-06-17 |
+| [0023](0023-unified-messaging-gateway.md) | Unified messaging gateway (`raxol_gateway`) | Accepted | 2026-06-17 |
+| [0024](0024-execution-backends-hibernation.md) | Pluggable execution backends and serverless hibernation | Accepted | 2026-06-18 |
 | [0025](0025-cronjob-scheduled-tasks.md) | Cronjob scheduled-task tool | Proposed | 2026-06-18 |
 | [0026](0026-execute-code-pipeline-collapse.md) | `execute_code` programmatic tool-calling | Proposed | 2026-06-18 |
-| [0027](0027-delegate-task-subagents.md) | `delegate_task` summary-only subagents | Proposed | 2026-06-18 |
-| [0028](0028-auxiliary-model-routing.md) | Auxiliary-model routing | Proposed | 2026-06-18 |
+| [0027](0027-delegate-task-subagents.md) | `delegate_task` summary-only subagents | Accepted | 2026-06-18 |
+| [0028](0028-auxiliary-model-routing.md) | Auxiliary-model routing | Accepted | 2026-06-21 |
+| [0029](0029-the-terminal-cell-model.md) | The Terminal Cell Model | Accepted | 2026-07-14 |
 | [0030](0030-acp-session-update-delivery-ordering.md) | ACP session/update delivery ordering contract | Proposed | 2026-07-18 |
 
 ## Template
@@ -90,6 +91,7 @@ They preserve context for why decisions were made, help new contributors underst
 - [0003: Terminal Emulation Strategy](0003-terminal-emulation-strategy.md)
 - [0007: State Management Strategy](0007-state-management-strategy.md)
 - [0011: Terminal Module Consolidation](0011-terminal-module-consolidation.md)
+- [0029: The Terminal Cell Model](0029-the-terminal-cell-model.md)
 
 ### Performance
 - [0002: Parser Performance Optimization](0002-parser-performance-optimization.md)
@@ -130,4 +132,4 @@ They preserve context for why decisions were made, help new contributors underst
 
 ## Coverage
 
-26 active ADRs covering core framework, performance, web integration, extensibility, state management, code quality, AI/MCP architecture, surface-specific admin patterns, orchestration, the cross-layer operator-flow contract, Workflow concurrency, the agent-stack sandbox + audit + policies primitive, self-improving agents (runtime skills + curation), the memory provider stack with full-text recall and dialectic user modeling, the unified messaging gateway, and the Hermes-extraction Tier 2 agent capabilities (execution backends + hibernation, cronjob scheduling, execute_code pipeline collapse, delegate_task subagents, and auxiliary-model routing). (Numbers 0004 and 0006 are withdrawn placeholders.)
+28 authored ADRs (26 active; 0016 and 0017 are superseded by the raxol_acp v1->v2 seller-stack migration) covering core framework, performance, web integration, extensibility, state management, code quality, AI/MCP architecture, surface-specific admin patterns, orchestration, the cross-layer operator-flow contract, Workflow concurrency, the agent-stack sandbox + audit + policies primitive, self-improving agents (runtime skills + curation), the memory provider stack with full-text recall and dialectic user modeling, the unified messaging gateway, the Hermes-extraction Tier 2 agent capabilities (execution backends + hibernation, cronjob scheduling, execute_code pipeline collapse, delegate_task subagents, and auxiliary-model routing), the terminal cell model, and the ACP session/update delivery-ordering contract. (Numbers 0004 and 0006 are withdrawn placeholders.)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -51,7 +51,7 @@ regenerate the references with `mix raxol.fate --gen` and commit them.
 
 ### Development
 ```bash
-mix raxol.playground   # Component playground (30 demos)
+mix raxol.playground   # Component playground (40 demos)
 mix raxol.repl         # Interactive REPL with sandboxing
 iex -S mix            # Interactive shell
 ```

--- a/docs/getting-started/QUICKSTART.md
+++ b/docs/getting-started/QUICKSTART.md
@@ -189,7 +189,7 @@ mix run --no-halt
 
 That counter is a complete Raxol app: `init/update/view` is the whole API. Everything else builds on this loop.
 
-Try `mix raxol.playground` for an interactive catalog of 30 Component demos you can browse, search, and filter. It's the fastest way to see what's available.
+Try `mix raxol.playground` for an interactive catalog of 40 Component demos you can browse, search, and filter. It's the fastest way to see what's available.
 
 **Next steps:**
 

--- a/web/lib/raxol_playground/capabilities.ex
+++ b/web/lib/raxol_playground/capabilities.ex
@@ -23,15 +23,15 @@ defmodule RaxolPlayground.Capabilities do
   ]
 
   @packages [
-    %{name: "raxol", version: "~> 2.5", purpose: "Full framework"},
-    %{name: "raxol_agent", version: "~> 2.5", purpose: "AI agents"},
-    %{name: "raxol_mcp", version: "~> 2.5", purpose: "MCP server"},
+    %{name: "raxol", version: "~> 2.6", purpose: "Full framework"},
+    %{name: "raxol_agent", version: "~> 2.6", purpose: "AI agents"},
+    %{name: "raxol_mcp", version: "~> 2.6", purpose: "MCP server"},
     %{name: "raxol_payments", version: "~> 0.1", purpose: "Agent commerce"},
-    %{name: "raxol_liveview", version: "~> 2.5", purpose: "LiveView bridge"},
-    %{name: "raxol_sensor", version: "~> 2.5", purpose: "Sensor fusion"},
-    %{name: "raxol_terminal", version: "~> 2.5", purpose: "Terminal emulation"},
-    %{name: "raxol_core", version: "~> 2.5", purpose: "Behaviours, events"},
-    %{name: "raxol_plugin", version: "~> 2.5", purpose: "Plugin SDK"},
+    %{name: "raxol_liveview", version: "~> 2.6", purpose: "LiveView bridge"},
+    %{name: "raxol_sensor", version: "~> 2.6", purpose: "Sensor fusion"},
+    %{name: "raxol_terminal", version: "~> 2.6", purpose: "Terminal emulation"},
+    %{name: "raxol_core", version: "~> 2.6", purpose: "Behaviours, events"},
+    %{name: "raxol_plugin", version: "~> 2.6", purpose: "Plugin SDK"},
     %{name: "raxol_speech", version: "~> 0.2", purpose: "TTS/STT"},
     %{name: "raxol_telegram", version: "~> 0.2", purpose: "Telegram bot"},
     %{name: "raxol_watch", version: "~> 0.2", purpose: "Push notifications"}
@@ -83,7 +83,7 @@ defmodule RaxolPlayground.Capabilities do
 
   @doc """
   Packages with a ready-to-paste `mix.exs` dep tuple attached, e.g.
-  `{:raxol, "~> 2.5"}`. Used by the manifest and capabilities endpoints.
+  `{:raxol, "~> 2.6"}`. Used by the manifest and capabilities endpoints.
   """
   @spec package_specs() :: [map()]
   def package_specs do

--- a/web/priv/static/llms.txt
+++ b/web/priv/static/llms.txt
@@ -5,7 +5,7 @@
 ## Quick start
 
     ssh -p 2222 playground@raxol.io    # zero install
-    {:raxol, "~> 2.5"}                 # add to mix.exs
+    {:raxol, "~> 2.6"}                 # add to mix.exs
 
 ## Capability summary
 


### PR DESCRIPTION
Wave 0 of the docs drift-repair + gap-fill + beat-competitors program. Pure
correctness — status flips and count fixes only, no new prose. Surfaced by a
three-agent docs audit (drift / gaps / competitor doc-surface).

## What changed

**ADR status headers** — flip `Proposed` -> `Accepted` for ADRs whose modules
are shipped (each verified against code before flipping):
- 0019 workflow concurrency (`Raxol.Workflow.Graph` add_channel/3 + add_join/4)
- 0020 agent sandbox/thread/policies (`Raxol.Agent.Sandbox`/`ThreadLog`/`Policy`)
- 0021 self-improvement + curation (`SelfImprove`/`Curator`/`Skills.Store`)
- 0022 memory stack (`Memory.Stack`/`Memory.SessionSearch`/`UserModel`)
- 0023 unified gateway (`raxol_gateway` package)
- 0024 execution backends (`Backend.{Native,ClaudeCode,Cursor}`; hibernation still deferred)
- 0027 delegate_task (`Raxol.Agent.Actions.Task.run_subagent/3`)

0025 (cronjob) and 0026 (execute_code) stay Proposed — confirmed not built.

**`docs/adr/README.md` index** — mark 0016/0017 Superseded (files already say so),
correct 0028 Proposed->Accepted, insert the missing 0029 row + its By-Category
entry, and fix the stale "26 active ADRs" coverage count to "28 authored (26 active)".

**Count drift** — `mix raxol.playground` is 40 demos, not 30 (4 docs: README,
docs/README, docs/development/README, QUICKSTART). Verified: 40 in
`lib/raxol/playground/catalog.ex` and 40 demo files.

**Stale llms.txt version** — `web/priv/static/llms.txt` and its source
`web/lib/raxol_playground/capabilities.ex` pinned `~> 2.5`; repo is 2.6.0. Bumped
the tracking-package entries (independent-versioned packages left as-is). This file
gets fully regenerated in Wave 2; the bump keeps the live site correct in the interim.

## Manual testing

- [x] `mix format --check-formatted web/lib/raxol_playground/capabilities.ex` — clean
- [x] No residual `~> 2.5` in `web/`
- [x] All 7 flipped ADRs lead with `Accepted` in their Status block
- [x] ADR index table well-formed; 0018/0025/0026/0030 correctly remain Proposed
- [x] Each flipped ADR's cited module/function verified to exist in the tree
