### PR TITLE
Provider onboarding: shared resolver + /login for raxol.code

### DIFF
--- a/docs/features/CODING_AGENT.md
+++ b/docs/features/CODING_AGENT.md
@@ -31,12 +31,48 @@ The `bin/raxol-code` shim runs the task from the package while keeping the calle
 directory as the agent's workspace (the file and shell tools are scoped to it via
 `RAXOL_CLI_CWD`). It `exec`s `mix` so the full-screen UI inherits the real terminal.
 
+## Connecting a provider
+
+With no `--harness`, the agent auto-detects a provider through the shared
+`Raxol.Agent.Backend.Resolver`, in this precedence order:
+
+1. an explicit `--api-key` (or an `:api_key` opt),
+2. a 1Password reference stored by `/login` (resolved through the `op` CLI),
+3. a provider env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `KIMI_API_KEY`, `OPENROUTER_API_KEY`, `LONGCAT_API_KEY`, ...),
+4. the generic `AI_API_KEY` (plus optional `AI_BASE_URL` / `AI_MODEL`) for any OpenAI-compatible endpoint.
+
+If nothing resolves, the TUI opens on a setup panel instead of failing against
+a placeholder endpoint. Run `/login` to connect one live. The preferred path
+is a 1Password reference (no plaintext key on disk):
+
+```
+/login                                          # show connection status
+/login anthropic op://Vault/Anthropic/key       # store a 1Password reference (persisted)
+/login openai sk-...                             # a session-only key (never written)
+/login lm_studio                                 # a local server, no key
+```
+
+On connect, `/login` fires a cheap, async validation ping (a single-token
+completion) against the resolved backend and reports the outcome in the status
+line: `validated`, `key rejected (HTTP 401)`, or `endpoint unreachable`. The
+check runs off the UI process, so a slow or offline endpoint never blocks the
+TUI, and the connection is usable immediately regardless.
+
+Stored references live in `~/.raxol/providers.json` (override with
+`$RAXOL_PROVIDERS`), owner-readable only. That file holds `op://` references,
+models, and base URLs, never raw keys. Zero-config env usage still works: set
+`ANTHROPIC_API_KEY` (or another provider var) and launch.
+
+Supported providers: `anthropic`, `openai`, `kimi`, `openrouter`, `longcat`,
+`lumo`, `ollama`, `lm_studio`, `llm7`, `mock`.
+
 ## Flags
 
 | Flag | Effect |
 |------|--------|
-| `--harness NAME` | Backend harness, default `lm_studio`. Validated against `Backend.Selector.supported_harnesses/0`. |
+| `--harness NAME` | Pin a backend harness (auto-detected if omitted). Validated against `Backend.Selector.supported_harnesses/0`. |
 | `--model NAME` | Model override. |
+| `--api-key KEY` | API key for the selected harness (else resolved from op/env). |
 | `--base-url URL` | Override the backend base URL. |
 | `--system TEXT` | System-prompt override. |
 | `--continue` | Resume the most recently updated session. |
@@ -73,6 +109,7 @@ Typing, Enter, plan-mode toggles, and backspace are accepted only when the agent
 | Command | What it does |
 |---------|--------------|
 | `/help` | Show help |
+| `/login [provider]` | Connect an LLM provider (1Password reference, session key, or local server) |
 | `/clear` | Start a new session (the old file stays on disk) |
 | `/model <name>` | Switch model for the next turns (bare `/model` shows current) |
 | `/plan` | Toggle plan mode |

--- a/packages/raxol_agent/examples/agents/react_agent.exs
+++ b/packages/raxol_agent/examples/agents/react_agent.exs
@@ -115,33 +115,17 @@ end
 defmodule ReactExample.Config do
   @moduledoc false
 
+  # Resolve the backend through the shared `Backend.Resolver` — the same
+  # env/op/precedence path `mix raxol.code` uses — so this example never
+  # re-implements provider detection. Falls back to the Mock backend (which
+  # simulates the tool calls below) when nothing resolves.
   def detect_backend do
-    cond do
-      key = System.get_env("ANTHROPIC_API_KEY") ->
-        {Raxol.Agent.Backend.HTTP,
-         provider: :anthropic,
-         api_key: key,
-         base_url: "https://api.anthropic.com",
-         model: System.get_env("ANTHROPIC_MODEL") || "claude-haiku-3-5-20241022",
-         max_tokens: 512}
+    case Raxol.Agent.Backend.Resolver.resolve() do
+      {:ok, executor, _source} ->
+        {:ok, backend, opts} = Raxol.Agent.Backend.Selector.select(executor)
+        {backend, Keyword.put_new(opts, :max_tokens, 512)}
 
-      key = System.get_env("LONGCAT_API_KEY") ->
-        {Raxol.Agent.Backend.HTTP,
-         provider: :openai,
-         api_key: key,
-         base_url: "https://api.longcat.chat/openai",
-         model: System.get_env("LONGCAT_MODEL") || "LongCat-2.0",
-         max_tokens: 512}
-
-      key = System.get_env("AI_API_KEY") ->
-        {Raxol.Agent.Backend.HTTP,
-         provider: :openai,
-         api_key: key,
-         base_url: System.get_env("AI_BASE_URL") || "https://api.openai.com",
-         model: System.get_env("AI_MODEL") || "gpt-4o-mini",
-         max_tokens: 512}
-
-      true ->
+      _no_provider ->
         {Raxol.Agent.Backend.Mock, []}
     end
   end

--- a/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
@@ -29,8 +29,8 @@ defmodule Mix.Tasks.Raxol.Code do
 
   ## Slash commands
 
-  `/help` · `/clear` · `/model <name>` · `/plan` · `/compact` · `/context`
-  · `/sessions` · `/mcp` · `/hooks`
+  `/help` · `/login [provider]` · `/clear` · `/model <name>` · `/plan` ·
+  `/compact` · `/context` · `/sessions` · `/mcp` · `/hooks`
 
   ## Delegation, hooks, external config
 
@@ -40,11 +40,24 @@ defmodule Mix.Tasks.Raxol.Code do
   non-zero pre-tool hook vetoes the tool). A `.mcp.json` declares external
   MCP servers, surfaced by `/mcp` (live tool-bridging is a follow-up).
 
+  ## Providers
+
+  With no `--harness`, the agent auto-detects a provider from your
+  environment via `Raxol.Agent.Backend.Resolver`: a 1Password reference
+  stored by `/login` (read through the `op` CLI), then a provider env var
+  (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, ...), then the generic
+  `AI_API_KEY`/`AI_BASE_URL` pair. If nothing resolves, the TUI opens on a
+  setup panel — run `/login` to connect a provider instead of failing
+  against a placeholder endpoint. `--harness NAME` pins a provider and
+  resolves that one's credential; `--api-key` supplies a key inline.
+
   ## Options
 
-    * `--harness`  — backend harness atom (default `lm_studio`; also
-      `anthropic`, `openai`, `ollama`, ... see `Backend.Selector`)
+    * `--harness`  — backend harness (auto-detected if omitted; also
+      `anthropic`, `openai`, `kimi`, `ollama`, `lm_studio`, ... see
+      `Backend.Resolver`)
     * `--model`    — model override
+    * `--api-key`  — API key for the selected harness (else op/env)
     * `--base-url` — override the backend base URL
     * `--system`   — system prompt override
     * `--continue` — resume the most recently updated session
@@ -60,6 +73,7 @@ defmodule Mix.Tasks.Raxol.Code do
   @switches [
     harness: :string,
     model: :string,
+    api_key: :string,
     base_url: :string,
     system: :string,
     continue: :boolean,
@@ -104,19 +118,41 @@ defmodule Mix.Tasks.Raxol.Code do
   end
 
   defp app_opts(opts) do
-    executor = build_executor(opts)
-
-    backend_opts =
-      []
-      |> maybe_put(:base_url, Keyword.get(opts, :base_url))
+    resolution = Raxol.Agent.Backend.Resolver.resolve(resolver_opts(opts))
 
     []
-    |> put_if(:executor, executor)
-    |> Keyword.put(:backend_opts, backend_opts)
     |> put_if(:system, Keyword.get(opts, :system))
     |> put_if(:model, Keyword.get(opts, :model))
     |> put_if(:session_key, resolve_session(opts))
     |> Keyword.put(:ascii, Keyword.get(opts, :ascii, false))
+    |> apply_resolution(resolution)
+  end
+
+  # The resolver inputs: an optional validated `--harness`, plus any inline
+  # `--model`/`--api-key`/`--base-url` overrides.
+  defp resolver_opts(opts) do
+    []
+    |> maybe_put(:harness, validated_harness(opts))
+    |> maybe_put(:model, Keyword.get(opts, :model))
+    |> maybe_put(:api_key, Keyword.get(opts, :api_key))
+    |> maybe_put(:base_url, Keyword.get(opts, :base_url))
+  end
+
+  # `{:ok, executor, source}` wires the executor and records how it was found;
+  # `{:no_key, harness}` and `:no_provider` open the App on its setup panel
+  # (no executor) so the user can `/login` rather than hit a crash.
+  defp apply_resolution(app_opts, {:ok, executor, source}) do
+    app_opts
+    |> Keyword.put(:executor, executor)
+    |> Keyword.put(:provider_status, {:ready, executor.harness, source})
+  end
+
+  defp apply_resolution(app_opts, {:no_key, harness}) do
+    Keyword.put(app_opts, :provider_status, {:no_key, harness})
+  end
+
+  defp apply_resolution(app_opts, :no_provider) do
+    Keyword.put(app_opts, :provider_status, :no_provider)
   end
 
   defp resolve_session(opts) do
@@ -127,22 +163,22 @@ defmodule Mix.Tasks.Raxol.Code do
     end
   end
 
-  defp build_executor(opts) do
-    harness_name = Keyword.get(opts, :harness, "lm_studio")
-    supported = Raxol.Agent.Backend.Selector.supported_harnesses()
+  # Validate an explicit `--harness` against the supported set, returning the
+  # atom (or `nil` when omitted, which asks the resolver to auto-detect).
+  defp validated_harness(opts) do
+    case Keyword.get(opts, :harness) do
+      nil ->
+        nil
 
-    harness =
-      Enum.find(supported, &(Atom.to_string(&1) == harness_name)) ||
-        usage_error(
-          "unknown harness #{inspect(harness_name)}; supported: " <>
-            Enum.map_join(supported, ", ", &Atom.to_string/1)
-        )
+      name ->
+        supported = Raxol.Agent.Backend.Selector.supported_harnesses()
 
-    attrs =
-      [harness: harness]
-      |> maybe_put(:model, Keyword.get(opts, :model))
-
-    Raxol.Agent.ExecutorConfig.new(attrs)
+        Enum.find(supported, &(Atom.to_string(&1) == name)) ||
+          usage_error(
+            "unknown harness #{inspect(name)}; supported: " <>
+              Enum.map_join(supported, ", ", &Atom.to_string/1)
+          )
+    end
   end
 
   defp usage_error(message) do

--- a/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
@@ -1,0 +1,174 @@
+defmodule Raxol.Agent.Backend.Credentials do
+  @moduledoc """
+  1Password-first credential *reference* store for agent LLM providers.
+
+  This stores only references, never raw keys: a small JSON map at
+  `~/.raxol/providers.json` (override with `$RAXOL_PROVIDERS`) that ties a
+  provider harness to a `op://...` 1Password reference plus an optional model
+  and base URL. Resolving a reference shells out to the `op` CLI
+  (`op read op://...`), so the secret is fetched fresh at launch and no
+  plaintext key ever touches disk.
+
+  A raw key can still be supplied per session (an env var, or `/login` in the
+  coding TUI), but such a key is held in memory only and is never written here.
+
+  ## File shape
+
+      {
+        "anthropic": {"op_ref": "op://Employee/Anthropic/api_key", "model": "claude-sonnet-5"},
+        "openai":    {"op_ref": "op://Employee/OpenAI/api_key"}
+      }
+
+  Only the three known string fields (`op_ref`, `model`, `base_url`) round-trip;
+  the top-level keys are provider harness names, kept as strings on disk and
+  mapped back to known atoms by `Raxol.Agent.Backend.Resolver` (never
+  `String.to_atom/1` on file input).
+  """
+
+  @env_path "RAXOL_PROVIDERS"
+  @filename "providers.json"
+
+  @type ref_entry :: %{
+          optional(:op_ref) => String.t(),
+          optional(:model) => String.t(),
+          optional(:base_url) => String.t()
+        }
+
+  @doc "The reference-store path (`$RAXOL_PROVIDERS` or `~/.raxol/providers.json`)."
+  @spec path() :: String.t()
+  def path do
+    case System.get_env(@env_path) do
+      p when is_binary(p) and p != "" -> p
+      _ -> Path.join(home_base(), Path.join(".raxol", @filename))
+    end
+  end
+
+  defp home_base, do: System.user_home() || System.tmp_dir!()
+
+  @doc """
+  Load the reference map keyed by provider-harness string.
+
+  A missing or unreadable file is an empty map, not an error: the resolver
+  simply falls through to env vars. A malformed file logs nothing and yields
+  `%{}` so a corrupt store never crashes agent boot.
+  """
+  @spec load() :: %{optional(String.t()) => ref_entry()}
+  def load do
+    with {:ok, raw} <- File.read(path()),
+         {:ok, decoded} when is_map(decoded) <- Jason.decode(raw) do
+      Enum.reduce(decoded, %{}, &put_sanitized/2)
+    else
+      _ -> %{}
+    end
+  end
+
+  defp put_sanitized({provider, entry}, acc) do
+    case sanitize_entry(entry) do
+      sanitized when map_size(sanitized) == 0 -> acc
+      sanitized -> Map.put(acc, to_string(provider), sanitized)
+    end
+  end
+
+  # Keep only the three known string fields; drop everything else so a
+  # hand-edited file can never smuggle unexpected shapes downstream.
+  defp sanitize_entry(entry) when is_map(entry) do
+    ~w(op_ref model base_url)
+    |> Enum.reduce(%{}, fn field, acc ->
+      case Map.get(entry, field) do
+        value when is_binary(value) and value != "" ->
+          Map.put(acc, String.to_existing_atom(field), value)
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp sanitize_entry(_entry), do: %{}
+
+  @doc """
+  Look up the stored reference entry for a provider harness.
+
+  Returns `{:ok, entry}` when present, `:none` otherwise.
+  """
+  @spec fetch(atom() | String.t()) :: {:ok, ref_entry()} | :none
+  def fetch(harness) do
+    case Map.fetch(load(), to_string(harness)) do
+      {:ok, entry} -> {:ok, entry}
+      :error -> :none
+    end
+  end
+
+  @doc """
+  Store (or replace) a provider's reference entry and persist to disk.
+
+  `attrs` accepts `:op_ref`, `:model`, and `:base_url`; a raw key is refused
+  here on purpose (this store never holds secrets). The file is written with
+  owner-only (`0600`) permissions.
+  """
+  @spec put(atom() | String.t(), keyword() | map()) :: :ok | {:error, term()}
+  def put(harness, attrs) do
+    entry = sanitize_entry(stringify_keys(attrs))
+
+    if map_size(entry) == 0 do
+      {:error, :empty_entry}
+    else
+      updated = Map.put(load(), to_string(harness), entry)
+      write(updated)
+    end
+  end
+
+  @doc "Remove a provider's stored reference entry."
+  @spec delete(atom() | String.t()) :: :ok | {:error, term()}
+  def delete(harness) do
+    load() |> Map.delete(to_string(harness)) |> write()
+  end
+
+  defp write(map) do
+    file = path()
+
+    with :ok <- File.mkdir_p(Path.dirname(file)),
+         encoded = Jason.encode!(map, pretty: true),
+         :ok <- File.write(file, encoded) do
+      # Owner read/write only: the file holds references, but they still name
+      # a person's vault items and should not be world-readable.
+      _ = File.chmod(file, 0o600)
+      :ok
+    end
+  end
+
+  defp stringify_keys(attrs) when is_list(attrs) or is_map(attrs) do
+    Map.new(attrs, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  @doc "True when the `op` (1Password) CLI is available on PATH."
+  @spec op_available?() :: boolean()
+  def op_available?, do: not is_nil(System.find_executable("op"))
+
+  @doc """
+  Resolve a `op://...` reference to its secret via the 1Password CLI.
+
+  Returns `{:ok, secret}` (trimmed), or `{:error, reason}` when `op` is
+  missing, not signed in, or the reference does not resolve. The secret is
+  returned to the caller and never logged or persisted here.
+  """
+  @spec read_ref(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def read_ref("op://" <> _ = ref) do
+    if op_available?() do
+      "op" |> System.cmd(["read", ref], stderr_to_stdout: true) |> interpret_op_output()
+    else
+      {:error, :op_unavailable}
+    end
+  end
+
+  def read_ref(_other), do: {:error, :not_an_op_ref}
+
+  defp interpret_op_output({out, 0}) do
+    case String.trim(out) do
+      "" -> {:error, :empty_secret}
+      secret -> {:ok, secret}
+    end
+  end
+
+  defp interpret_op_output({out, code}), do: {:error, {:op_failed, code, String.trim(out)}}
+end

--- a/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
@@ -1,0 +1,382 @@
+defmodule Raxol.Agent.Backend.Resolver do
+  @moduledoc """
+  Single source of truth for "which provider, which key, which model" —
+  turning the user's environment and stored references into a ready
+  `Raxol.Agent.ExecutorConfig`.
+
+  This replaces the per-example `cond` blocks that each re-read env vars, and
+  fills the gap that left `mix raxol.code` blind (it defaulted to a local
+  server and never populated `auth`). Every agent surface — the coding TUI,
+  the agent framework, the MCP/headless default — resolves credentials here so
+  provider onboarding has one shape.
+
+  ## Precedence
+
+  For an explicit `:harness`, the key is resolved in this order:
+
+    1. an explicit `:api_key` opt,
+    2. a 1Password reference (from `Raxol.Agent.Backend.Credentials` or a
+       `RAXOL_<HARNESS>_OP` env var) read via the `op` CLI,
+    3. the provider's env var(s) (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, ...).
+
+  With no `:harness`, `resolve/1` auto-detects: it walks the provider registry
+  and returns the first provider that resolves a key (or a stored keyless
+  provider), then falls back to the generic `AI_API_KEY`/`AI_BASE_URL` trio,
+  and finally `:no_provider` — the honest signal that the caller should show a
+  setup prompt rather than crash against a placeholder endpoint.
+  """
+
+  alias Raxol.Agent.Backend.Credentials
+  alias Raxol.Agent.ExecutorConfig
+
+  # Provider registry. `keyless: true` providers need no API key (local
+  # servers, the free LLM7 endpoint, Mock); `env_keys` are checked in order.
+  # Detection walks this list top-to-bottom, so hosted/keyed providers rank
+  # ahead of local ones — a keyless provider is only auto-selected when the
+  # user has explicitly stored a reference for it.
+  @providers [
+    %{
+      harness: :anthropic,
+      label: "Anthropic (Claude)",
+      env_keys: ["ANTHROPIC_API_KEY"],
+      model_env: "ANTHROPIC_MODEL",
+      keyless: false
+    },
+    %{
+      harness: :openai,
+      label: "OpenAI",
+      env_keys: ["OPENAI_API_KEY"],
+      model_env: "OPENAI_MODEL",
+      keyless: false
+    },
+    %{
+      harness: :kimi,
+      label: "Kimi (Moonshot)",
+      env_keys: ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+      model_env: "KIMI_MODEL",
+      keyless: false
+    },
+    %{
+      harness: :openrouter,
+      label: "OpenRouter",
+      env_keys: ["OPENROUTER_API_KEY"],
+      model_env: "OPENROUTER_MODEL",
+      keyless: false
+    },
+    %{
+      harness: :longcat,
+      label: "LongCat (Meituan)",
+      env_keys: ["LONGCAT_API_KEY"],
+      model_env: "LONGCAT_MODEL",
+      keyless: false
+    },
+    %{
+      harness: :lumo,
+      label: "Proton Lumo",
+      env_keys: ["PROTON_ACCESS_TOKEN"],
+      model_env: nil,
+      keyless: false
+    },
+    %{
+      harness: :ollama,
+      label: "Ollama (local)",
+      env_keys: [],
+      model_env: "OLLAMA_MODEL",
+      keyless: true
+    },
+    %{
+      harness: :lm_studio,
+      label: "LM Studio (local)",
+      env_keys: [],
+      model_env: nil,
+      keyless: true
+    },
+    %{harness: :llm7, label: "LLM7 (free, no key)", env_keys: [], model_env: nil, keyless: true},
+    %{harness: :mock, label: "Mock (offline)", env_keys: [], model_env: nil, keyless: true}
+  ]
+
+  @by_string Map.new(@providers, &{to_string(&1.harness), &1.harness})
+
+  @type source :: :explicit | :op | :env | :generic | :configured
+  @type resolution ::
+          {:ok, ExecutorConfig.t(), source()}
+          | {:no_key, atom()}
+          | :no_provider
+
+  @doc """
+  Resolve `opts` to `{:ok, config, source}`, `{:no_key, harness}`, or
+  `:no_provider`.
+
+  Recognized opts: `:harness` (atom or string), `:api_key`, `:model`,
+  `:base_url`. A `{:no_key, harness}` means the harness was named explicitly
+  but no credential could be resolved for it.
+  """
+  @spec resolve(keyword()) :: resolution()
+  def resolve(opts \\ []) do
+    case explicit_harness(opts) do
+      nil -> auto_detect(opts)
+      harness -> resolve_explicit(harness, opts)
+    end
+  end
+
+  @doc """
+  Per-provider availability, for the setup panel and `/login` status.
+
+  Each entry is `%{harness, label, keyless?, available?, source}` where
+  `source` is the resolution source when available, else `nil`. Availability
+  probing may shell out to `op` for stored references, so treat this as a
+  point-in-time snapshot rather than a hot path.
+  """
+  @spec status() :: [map()]
+  def status do
+    Enum.map(@providers, fn spec ->
+      {available?, source} =
+        case detect_available(spec, []) do
+          {:ok, _config, src} -> {true, src}
+          _ -> {false, nil}
+        end
+
+      %{
+        harness: spec.harness,
+        label: spec.label,
+        keyless?: spec.keyless,
+        available?: available?,
+        source: source
+      }
+    end)
+  end
+
+  @doc "The provider registry as `%{harness, label, keyless?}` entries."
+  @spec providers() :: [map()]
+  def providers do
+    Enum.map(@providers, &%{harness: &1.harness, label: &1.label, keyless?: &1.keyless})
+  end
+
+  @doc "Map a harness string to its known atom without minting new atoms."
+  @spec harness_from_string(String.t()) :: {:ok, atom()} | :error
+  def harness_from_string(str) when is_binary(str) do
+    case Map.fetch(@by_string, str) do
+      {:ok, harness} -> {:ok, harness}
+      :error -> :error
+    end
+  end
+
+  # -- explicit harness -------------------------------------------------------
+
+  defp resolve_explicit(harness, opts) do
+    case spec_for(harness) do
+      nil ->
+        # Unknown to the registry (e.g. a native harness): build a bare config
+        # and let the Selector accept or reject it.
+        {:ok, build_config(harness, nil, model_opt(opts), base_url_opt(opts)), :explicit}
+
+      spec ->
+        resolve_explicit_spec(spec, opts)
+    end
+  end
+
+  defp resolve_explicit_spec(%{keyless: true} = spec, opts) do
+    {:ok, build_config(spec.harness, nil, resolve_model(spec, opts), base_url_opt(opts)),
+     :explicit}
+  end
+
+  defp resolve_explicit_spec(spec, opts) do
+    case resolve_key(spec, opts) do
+      {:ok, key, source} ->
+        {:ok, build_config(spec.harness, key, resolve_model(spec, opts), base_url_opt(opts)),
+         source}
+
+      :none ->
+        {:no_key, spec.harness}
+    end
+  end
+
+  # -- auto detection ---------------------------------------------------------
+
+  defp auto_detect(opts) do
+    Enum.find_value(@providers, fn spec -> ok_or_nil(detect_available(spec, opts)) end) ||
+      detect_generic(opts) ||
+      :no_provider
+  end
+
+  defp ok_or_nil({:ok, _config, _source} = ok), do: ok
+  defp ok_or_nil(_), do: nil
+
+  # A provider is auto-available when it resolves a key, or — for a keyless
+  # provider — only when the user has stored a reference for it (so a bare
+  # localhost server is never silently selected as the default).
+  defp detect_available(%{keyless: true} = spec, opts) do
+    if configured?(spec.harness) do
+      {:ok, build_config(spec.harness, nil, resolve_model(spec, opts), stored_base_url(spec)),
+       :configured}
+    else
+      :none
+    end
+  end
+
+  defp detect_available(spec, opts) do
+    case resolve_key(spec, Keyword.delete(opts, :api_key)) do
+      {:ok, key, source} ->
+        {:ok, build_config(spec.harness, key, resolve_model(spec, opts), stored_base_url(spec)),
+         source}
+
+      :none ->
+        :none
+    end
+  end
+
+  # The generic escape hatch: any OpenAI-compatible endpoint via AI_API_KEY
+  # (+ optional AI_BASE_URL / AI_MODEL), mapped onto the :openai harness.
+  defp detect_generic(opts) do
+    case env_first(["AI_API_KEY"]) do
+      nil ->
+        nil
+
+      key ->
+        base_url = Keyword.get(opts, :base_url) || System.get_env("AI_BASE_URL")
+        model = Keyword.get(opts, :model) || System.get_env("AI_MODEL")
+        {:ok, build_config(:openai, key, model, base_url), :generic}
+    end
+  end
+
+  # -- key resolution ---------------------------------------------------------
+
+  defp resolve_key(spec, opts) do
+    first_ok([
+      fn -> explicit_key(opts) end,
+      fn -> op_key(spec) end,
+      fn -> env_key(spec) end
+    ])
+  end
+
+  defp first_ok([]), do: :none
+
+  defp first_ok([f | rest]) do
+    case f.() do
+      {:ok, _key, _source} = ok -> ok
+      _ -> first_ok(rest)
+    end
+  end
+
+  defp explicit_key(opts) do
+    case Keyword.get(opts, :api_key) do
+      key when is_binary(key) and key != "" -> {:ok, key, :explicit}
+      _ -> :none
+    end
+  end
+
+  # A 1Password reference from the stored map or a RAXOL_<HARNESS>_OP env var,
+  # resolved via the `op` CLI. A missing `op` binary or an unresolved ref
+  # falls through to env-var resolution rather than failing.
+  defp op_key(spec) do
+    case op_ref(spec.harness) do
+      nil ->
+        :none
+
+      ref ->
+        case Credentials.read_ref(ref) do
+          {:ok, secret} -> {:ok, secret, :op}
+          {:error, _reason} -> :none
+        end
+    end
+  end
+
+  defp op_ref(harness) do
+    case Credentials.fetch(harness) do
+      {:ok, %{op_ref: ref}} -> ref
+      _ -> System.get_env("RAXOL_#{harness |> to_string() |> String.upcase()}_OP")
+    end
+  end
+
+  defp env_key(%{env_keys: keys}), do: wrap(env_first(keys), :env)
+
+  defp wrap(nil, _source), do: :none
+  defp wrap(value, source), do: {:ok, value, source}
+
+  defp env_first(keys) do
+    Enum.find_value(keys, fn key ->
+      case System.get_env(key) do
+        v when is_binary(v) and v != "" -> v
+        _ -> nil
+      end
+    end)
+  end
+
+  # -- config building --------------------------------------------------------
+
+  defp build_config(harness, key, model, base_url) do
+    ExecutorConfig.new(
+      harness: harness,
+      model: model,
+      auth: if(is_binary(key) and key != "", do: %{api_key: key}, else: %{}),
+      opts: base_url_kw(base_url)
+    )
+  end
+
+  defp base_url_kw(url) when is_binary(url) and url != "", do: [base_url: url]
+  defp base_url_kw(_url), do: []
+
+  # Model precedence: explicit opt > stored entry > provider model env var.
+  defp resolve_model(spec, opts) do
+    model_opt(opts) || stored_model(spec) || model_env(spec)
+  end
+
+  defp model_opt(opts) do
+    case Keyword.get(opts, :model) do
+      m when is_binary(m) and m != "" -> m
+      _ -> nil
+    end
+  end
+
+  defp model_env(%{model_env: env}) when is_binary(env) do
+    case System.get_env(env) do
+      m when is_binary(m) and m != "" -> m
+      _ -> nil
+    end
+  end
+
+  defp model_env(_spec), do: nil
+
+  defp stored_model(spec), do: stored_field(spec.harness, :model)
+  defp stored_base_url(spec), do: stored_field(spec.harness, :base_url)
+
+  defp stored_field(harness, field) do
+    case Credentials.fetch(harness) do
+      {:ok, entry} -> Map.get(entry, field)
+      :none -> nil
+    end
+  end
+
+  defp base_url_opt(opts), do: Keyword.get(opts, :base_url)
+
+  # -- helpers ----------------------------------------------------------------
+
+  defp configured?(harness) do
+    match?({:ok, _}, Credentials.fetch(harness)) or not is_nil(op_ref(harness))
+  end
+
+  defp explicit_harness(opts) do
+    case Keyword.get(opts, :harness) do
+      nil -> nil
+      harness when is_atom(harness) -> harness
+      harness when is_binary(harness) -> harness_atom(harness)
+    end
+  end
+
+  defp harness_atom(str) do
+    case harness_from_string(str) do
+      {:ok, harness} -> harness
+      # Unknown string harness: hand it back as-is via a safe existing-atom
+      # lookup so the Selector can raise the canonical unknown-harness error.
+      :error -> safe_existing_atom(str)
+    end
+  end
+
+  defp safe_existing_atom(str) do
+    String.to_existing_atom(str)
+  rescue
+    ArgumentError -> :__unknown_harness__
+  end
+
+  defp spec_for(harness), do: Enum.find(@providers, &(&1.harness == harness))
+end

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -111,6 +111,16 @@ defmodule Raxol.Agent.Code.App do
       auth_state: Engine.new(),
       ascii: Keyword.get(options, :ascii, false),
       executor: Keyword.get(options, :executor),
+      # How the provider was resolved: `:ready` / `{:ready, harness, source}`
+      # start straight into the loop; `{:no_key, harness}` / `:no_provider`
+      # open on the setup panel and gate turns until `/login` connects one.
+      provider_status: Keyword.get(options, :provider_status, :ready),
+      # The most recent `/login` validation token; a ping result is applied
+      # only when its ref still matches (a re-login supersedes an in-flight
+      # check). Injectable so tests drive validation without a network call.
+      login_ref: nil,
+      login_validator:
+        Keyword.get(options, :login_validator, &__MODULE__.default_login_validator/3),
       backend_opts: Keyword.get(options, :backend_opts, []),
       model_override: Keyword.get(options, :model),
       system: Keyword.get(options, :system, default_system()),
@@ -225,6 +235,16 @@ defmodule Raxol.Agent.Code.App do
     end
   end
 
+  # An async `/login` validation ping result. Applied only when its ref still
+  # matches the latest login (a newer `/login` supersedes an in-flight check).
+  def update({:command_result, {:login_validation, ref, harness, result}}, model) do
+    if ref == model.login_ref do
+      {%{model | status_line: validation_status(harness, result), login_ref: nil}, []}
+    else
+      {model, []}
+    end
+  end
+
   def update(_message, model), do: {model, []}
 
   # -- key handlers -----------------------------------------------------------
@@ -271,7 +291,7 @@ defmodule Raxol.Agent.Code.App do
     case String.trim(model.input) do
       "" -> {model, []}
       "/" <> _ = command -> dispatch_slash(%{model | input: ""}, command)
-      prompt -> {start_turn(model, prompt), []}
+      prompt -> {submit_prompt(model, prompt), []}
     end
   end
 
@@ -290,6 +310,21 @@ defmodule Raxol.Agent.Code.App do
     do: {interrupt(model), []}
 
   defp handle_key(_key, model), do: {model, []}
+
+  # A prompt only starts a turn once a provider is connected; otherwise the
+  # input is kept and a hint steers the user to `/login` (slash commands still
+  # run, so `/login` itself is always reachable).
+  defp submit_prompt(model, prompt) do
+    if provider_ready?(model) do
+      start_turn(model, prompt)
+    else
+      notice(model, provider_setup_hint(model))
+    end
+  end
+
+  defp provider_ready?(%{provider_status: :ready}), do: true
+  defp provider_ready?(%{provider_status: {:ready, _harness, _source}}), do: true
+  defp provider_ready?(_model), do: false
 
   # Plan mode only toggles when idle — flipping it mid-turn or mid-approval
   # would be surprising (the toolset/prompt are fixed at turn start).
@@ -626,6 +661,7 @@ defmodule Raxol.Agent.Code.App do
   end
 
   defp apply_command("help", _arg, model), do: {notice(model, help_text()), []}
+  defp apply_command("login", arg, model), do: {login(model, arg), []}
   defp apply_command("clear", _arg, model), do: {clear_session(model), []}
   defp apply_command("plan", _arg, model), do: {maybe_toggle_plan_mode(model), []}
   defp apply_command("model", arg, model), do: {set_model(model, arg), []}
@@ -651,6 +687,201 @@ defmodule Raxol.Agent.Code.App do
   defp hooks_text(%{hooks: config}) do
     "pre_tool_use: #{length(config.pre)} · post_tool_use: #{length(config.post)} · " <>
       "stop: #{length(config.stop)}"
+  end
+
+  # -- /login: connect a provider --------------------------------------------
+
+  # `/login`                         -> status + usage
+  # `/login <provider>`              -> connect via op/env (or keyless local)
+  # `/login <provider> op://ref`     -> store the 1Password reference + connect
+  # `/login <provider> <key>`        -> session-only key (never persisted)
+  # a trailing token is taken as a model override.
+  defp login(model, arg) do
+    case String.split(String.trim(arg), ~r/\s+/, trim: true) do
+      [] -> notice(model, login_status_text())
+      [provider] -> login_provider(model, provider, nil, nil)
+      [provider, secret] -> login_provider(model, provider, secret, nil)
+      [provider, secret, model_name | _] -> login_provider(model, provider, secret, model_name)
+    end
+  end
+
+  defp login_provider(model, provider_str, secret, model_name) do
+    case Raxol.Agent.Backend.Resolver.harness_from_string(provider_str) do
+      {:ok, harness} -> connect(model, harness, secret, model_name)
+      :error -> notice(model, "unknown provider: #{provider_str}\n\n" <> login_status_text())
+    end
+  end
+
+  # An op:// reference is stored (so it survives relaunch) then resolved; a raw
+  # key stays in memory for this session only; no secret connects via op/env.
+  defp connect(model, harness, "op://" <> _ = ref, model_name) do
+    case Raxol.Agent.Backend.Credentials.put(harness, put_model([op_ref: ref], model_name)) do
+      :ok -> resolve_and_connect(model, harness, [], "op reference stored")
+      {:error, reason} -> notice(model, "could not store reference: #{inspect(reason)}")
+    end
+  end
+
+  defp connect(model, harness, secret, model_name) when is_binary(secret) do
+    resolve_and_connect(
+      model,
+      harness,
+      put_model([api_key: secret], model_name),
+      "session key — not persisted"
+    )
+  end
+
+  defp connect(model, harness, nil, model_name) do
+    resolve_and_connect(model, harness, put_model([], model_name), nil)
+  end
+
+  defp resolve_and_connect(model, harness, extra_opts, note) do
+    opts = Keyword.put(extra_opts, :harness, harness)
+
+    case Raxol.Agent.Backend.Resolver.resolve(opts) do
+      {:ok, executor, source} ->
+        # Fire a cheap, async validation ping; its result arrives as a
+        # `{:login_validation, ...}` message and updates the status line. The
+        # connection is marked ready immediately either way — validation only
+        # annotates it, so a slow or offline check never blocks the TUI.
+        ref = start_login_validation(model, executor)
+
+        %{
+          model
+          | executor: executor,
+            provider_status: {:ready, harness, source},
+            model_override: executor.model || model.model_override,
+            login_ref: ref
+        }
+        |> notice(connect_note(harness, source, note))
+        |> put_status("connected to #{harness} — validating credential…")
+
+      {:no_key, ^harness} ->
+        notice(
+          model,
+          "no credential found for #{harness}. Supply one:\n" <>
+            "  /login #{harness} op://Vault/Item/field   (1Password)\n" <>
+            "  /login #{harness} <api-key>               (this session only)"
+        )
+
+      :no_provider ->
+        notice(model, "could not resolve a provider for #{harness}")
+    end
+  end
+
+  defp put_model(opts, nil), do: opts
+  defp put_model(opts, ""), do: opts
+  defp put_model(opts, model_name), do: Keyword.put(opts, :model, model_name)
+
+  defp connect_note(harness, source, nil), do: "connected to #{harness} (via #{source})"
+
+  defp connect_note(harness, source, note),
+    do: "connected to #{harness} (via #{source}) — #{note}"
+
+  defp put_status(model, text), do: %{model | status_line: text}
+
+  # Kick off the injectable validator, returning the ref that stamps its
+  # result. `self()` here is the app process, so the ping's reply message lands
+  # where `update/2` can fold it.
+  defp start_login_validation(model, executor) do
+    ref = make_ref()
+    model.login_validator.(executor, ref, self())
+    ref
+  end
+
+  @doc false
+  # The default validator: a cheap, single-token completion against the freshly
+  # resolved backend, off the app process so a hung endpoint never blocks the
+  # TUI. The normalized outcome rides back as a `:login_validation` message.
+  def default_login_validator(executor, ref, app) do
+    spawn(fn ->
+      result =
+        try do
+          do_validate_ping(executor)
+        rescue
+          _ -> :unreachable
+        catch
+          _, _ -> :unreachable
+        end
+
+      send(app, {:command_result, {:login_validation, ref, executor.harness, result}})
+    end)
+
+    :ok
+  end
+
+  defp do_validate_ping(executor) do
+    case Raxol.Agent.Backend.Selector.select(executor) do
+      {:ok, backend, opts} ->
+        ping_opts = opts |> Keyword.put(:max_tokens, 1) |> Keyword.put(:timeout, 10_000)
+        interpret_ping(backend.complete([%{role: :user, content: "ping"}], ping_opts))
+
+      {:error, reason} ->
+        {:select_error, reason}
+    end
+  end
+
+  @doc false
+  # Classify a backend `complete/2` return by what it says about the credential.
+  # Auth is the question: a 401/403 rejects; a reachable endpoint that answered
+  # (even a truncated/unparseable body) authorized the request, so it is valid.
+  def interpret_ping({:ok, _response}), do: :valid
+
+  def interpret_ping({:error, {:http_error, status, _body}}) when status in [401, 403],
+    do: {:rejected, status}
+
+  def interpret_ping({:error, {:http_error, status, _body}}), do: {:reachable_error, status}
+  def interpret_ping({:error, {:request_failed, _reason}}), do: :unreachable
+  def interpret_ping({:error, :req_not_available}), do: :req_unavailable
+  def interpret_ping({:error, _marker}), do: :valid
+
+  defp validation_status(harness, :valid), do: "#{harness} credential validated ●"
+
+  defp validation_status(harness, {:rejected, status}),
+    do: "#{harness} key rejected (HTTP #{status}) — check /login"
+
+  defp validation_status(harness, :unreachable),
+    do: "#{harness} endpoint unreachable — is it running?"
+
+  defp validation_status(harness, {:reachable_error, status}),
+    do: "#{harness} reachable but returned HTTP #{status}"
+
+  defp validation_status(harness, {:select_error, reason}),
+    do: "#{harness} cannot validate: #{inspect(reason)}"
+
+  defp validation_status(harness, :req_unavailable),
+    do: "#{harness} connected (Req unavailable, validation skipped)"
+
+  defp validation_status(harness, _other), do: "#{harness} connected"
+
+  defp login_status_text do
+    rows =
+      Raxol.Agent.Backend.Resolver.status()
+      |> Enum.map_join("\n", fn s ->
+        mark = if s.available?, do: "●", else: "○"
+        src = if s.source, do: " (#{s.source})", else: ""
+        "  #{mark} #{s.harness}#{src}"
+      end)
+
+    """
+    Connect a provider with /login:
+      /login anthropic op://Vault/Anthropic/key   1Password reference (persisted)
+      /login openai sk-...                         session key (not saved)
+      /login lm_studio                             local server (no key)
+
+    ● connected  ○ not connected
+    #{rows}
+    """
+    |> String.trim_trailing()
+  end
+
+  # Shown on the setup panel and as the hint when a prompt is sent with no
+  # provider connected.
+  defp provider_setup_hint(%{provider_status: {:no_key, harness}}) do
+    "harness #{harness} was selected but no key resolved.\n\n" <> login_status_text()
+  end
+
+  defp provider_setup_hint(_model) do
+    "No LLM provider connected.\n\n" <> login_status_text()
   end
 
   defp parse_command("/" <> rest) do
@@ -722,6 +953,7 @@ defmodule Raxol.Agent.Code.App do
   defp help_text do
     """
     /help              this help
+    /login [provider]  connect an LLM provider (op ref, key, or local)
     /clear             start a fresh session
     /model <name>      switch model for the next turns
     /plan              toggle plan mode
@@ -739,8 +971,31 @@ defmodule Raxol.Agent.Code.App do
   @impl true
   def view(model) do
     column style: %{padding: 1, gap: 1} do
-      [transcript(model), notice_block(model), status_strip(model), footer(model)]
+      [
+        transcript(model),
+        setup_block(model),
+        notice_block(model),
+        status_strip(model),
+        footer(model)
+      ]
       |> Enum.reject(&is_nil/1)
+    end
+  end
+
+  # The onboarding panel: shown until a provider is connected, so the TUI
+  # opens on "connect a provider" instead of failing an invisible request.
+  defp setup_block(model) do
+    if provider_ready?(model) do
+      nil
+    else
+      lines = String.split(provider_setup_hint(model), "\n")
+
+      box style: %{border: :single, padding: 0} do
+        column style: %{gap: 0} do
+          [text("connect a provider to begin", fg: :yellow, style: [:bold])] ++
+            Enum.map(lines, &text(&1, fg: :cyan))
+        end
+      end
     end
   end
 
@@ -795,6 +1050,8 @@ defmodule Raxol.Agent.Code.App do
 
   defp status_label(%{status_line: line}) when is_binary(line), do: line
   defp status_label(%{pending_approval: %{name: name}}), do: "awaiting approval: #{name}"
+  defp status_label(%{provider_status: {:no_key, harness}}), do: "no key for #{harness} — /login"
+  defp status_label(%{provider_status: :no_provider}), do: "no provider — /login"
   defp status_label(%{running?: true}), do: "working…"
   defp status_label(%{plan_mode: true}), do: "plan mode — read-only"
   defp status_label(_model), do: "ready"

--- a/packages/raxol_agent/test/raxol/agent/backend/credentials_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/credentials_test.exs
@@ -1,0 +1,105 @@
+defmodule Raxol.Agent.Backend.CredentialsTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Backend.Credentials
+
+  setup do
+    # Point the store at a throwaway file so tests never touch the real
+    # ~/.raxol/providers.json.
+    path = Path.join(System.tmp_dir!(), "raxol-creds-#{System.unique_integer([:positive])}.json")
+    prev = System.get_env("RAXOL_PROVIDERS")
+    System.put_env("RAXOL_PROVIDERS", path)
+
+    on_exit(fn ->
+      File.rm(path)
+
+      if prev,
+        do: System.put_env("RAXOL_PROVIDERS", prev),
+        else: System.delete_env("RAXOL_PROVIDERS")
+    end)
+
+    {:ok, path: path}
+  end
+
+  describe "path/0" do
+    test "honors $RAXOL_PROVIDERS", %{path: path} do
+      assert Credentials.path() == path
+    end
+  end
+
+  describe "put/2 and load/0" do
+    test "round-trips an op reference with model" do
+      assert :ok =
+               Credentials.put(:anthropic, op_ref: "op://Vault/Anthropic/key", model: "claude-x")
+
+      assert %{"anthropic" => %{op_ref: "op://Vault/Anthropic/key", model: "claude-x"}} =
+               Credentials.load()
+    end
+
+    test "fetch/1 returns a stored entry, :none otherwise" do
+      Credentials.put(:openai, op_ref: "op://Vault/OpenAI/key")
+      assert {:ok, %{op_ref: "op://Vault/OpenAI/key"}} = Credentials.fetch(:openai)
+      assert :none = Credentials.fetch(:anthropic)
+    end
+
+    test "refuses an entry with no known fields" do
+      assert {:error, :empty_entry} = Credentials.put(:openai, foo: "bar")
+    end
+
+    test "never persists a raw api_key field" do
+      Credentials.put(:openai, op_ref: "op://Vault/OpenAI/key", api_key: "sk-secret")
+      {:ok, entry} = Credentials.fetch(:openai)
+      refute Map.has_key?(entry, :api_key)
+      refute File.read!(Credentials.path()) =~ "sk-secret"
+    end
+
+    test "writes the file with owner-only permissions", %{path: path} do
+      Credentials.put(:openai, op_ref: "op://Vault/OpenAI/key")
+      %File.Stat{mode: mode} = File.stat!(path)
+      # low 9 bits: 0o600 == rw-------
+      assert Bitwise.band(mode, 0o777) == 0o600
+    end
+
+    test "delete/1 removes an entry" do
+      Credentials.put(:openai, op_ref: "op://Vault/OpenAI/key")
+      assert :ok = Credentials.delete(:openai)
+      assert :none = Credentials.fetch(:openai)
+    end
+  end
+
+  describe "load/0 resilience" do
+    test "a missing file is an empty map" do
+      assert Credentials.load() == %{}
+    end
+
+    test "a malformed file is an empty map, not a crash", %{path: path} do
+      File.write!(path, "{ not json")
+      assert Credentials.load() == %{}
+    end
+
+    test "unknown fields are dropped on read", %{path: path} do
+      File.write!(path, Jason.encode!(%{"openai" => %{"op_ref" => "op://v/i/f", "junk" => 1}}))
+      assert %{"openai" => entry} = Credentials.load()
+      assert entry == %{op_ref: "op://v/i/f"}
+    end
+  end
+
+  describe "read_ref/1" do
+    test "rejects a non-op reference" do
+      assert {:error, :not_an_op_ref} = Credentials.read_ref("sk-not-a-ref")
+    end
+
+    test "op_available?/0 returns a boolean" do
+      assert is_boolean(Credentials.op_available?())
+    end
+
+    test "an op ref errors cleanly when op is unavailable" do
+      # Only deterministic without the op CLI; with op installed the call
+      # depends on live vault state, so we just assert the error shape.
+      case Credentials.read_ref("op://__raxol_test__/nope/field") do
+        {:error, :op_unavailable} -> assert not Credentials.op_available?()
+        {:error, _other} -> assert Credentials.op_available?()
+      end
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
@@ -1,0 +1,183 @@
+defmodule Raxol.Agent.Backend.ResolverTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Backend.Credentials
+  alias Raxol.Agent.Backend.Resolver
+
+  # Every env var the resolver reads. Cleared in setup so a developer's real
+  # ANTHROPIC_API_KEY (etc.) can't leak into these assertions.
+  @managed_env ~w(
+    ANTHROPIC_API_KEY ANTHROPIC_MODEL OPENAI_API_KEY OPENAI_MODEL
+    KIMI_API_KEY MOONSHOT_API_KEY KIMI_MODEL OPENROUTER_API_KEY OPENROUTER_MODEL
+    LONGCAT_API_KEY LONGCAT_MODEL PROTON_ACCESS_TOKEN OLLAMA_MODEL
+    AI_API_KEY AI_BASE_URL AI_MODEL
+    RAXOL_ANTHROPIC_OP RAXOL_OPENAI_OP RAXOL_KIMI_OP RAXOL_OPENROUTER_OP
+    RAXOL_LONGCAT_OP RAXOL_LUMO_OP RAXOL_OLLAMA_OP RAXOL_LM_STUDIO_OP
+    RAXOL_LLM7_OP RAXOL_MOCK_OP
+  )
+
+  setup do
+    saved = Map.new(@managed_env, fn key -> {key, System.get_env(key)} end)
+    Enum.each(@managed_env, &System.delete_env/1)
+
+    store =
+      Path.join(System.tmp_dir!(), "raxol-resolver-#{System.unique_integer([:positive])}.json")
+
+    prev_store = System.get_env("RAXOL_PROVIDERS")
+    System.put_env("RAXOL_PROVIDERS", store)
+
+    on_exit(fn ->
+      File.rm(store)
+
+      if prev_store,
+        do: System.put_env("RAXOL_PROVIDERS", prev_store),
+        else: System.delete_env("RAXOL_PROVIDERS")
+
+      Enum.each(saved, fn
+        {key, nil} -> System.delete_env(key)
+        {key, val} -> System.put_env(key, val)
+      end)
+    end)
+
+    :ok
+  end
+
+  describe "auto-detect precedence" do
+    test "no provider anywhere yields :no_provider" do
+      assert :no_provider = Resolver.resolve()
+    end
+
+    test "a provider env key is detected" do
+      System.put_env("ANTHROPIC_API_KEY", "sk-ant")
+      assert {:ok, config, :env} = Resolver.resolve()
+      assert config.harness == :anthropic
+      assert config.auth == %{api_key: "sk-ant"}
+    end
+
+    test "registry order wins when several env keys are present" do
+      System.put_env("OPENAI_API_KEY", "sk-oai")
+      System.put_env("KIMI_API_KEY", "sk-kimi")
+      # openai precedes kimi in the registry.
+      assert {:ok, %{harness: :openai}, :env} = Resolver.resolve()
+    end
+
+    test "the generic AI_API_KEY maps onto :openai with its base URL" do
+      System.put_env("AI_API_KEY", "sk-generic")
+      System.put_env("AI_BASE_URL", "https://example.test")
+      System.put_env("AI_MODEL", "some-model")
+
+      assert {:ok, config, :generic} = Resolver.resolve()
+      assert config.harness == :openai
+      assert config.auth == %{api_key: "sk-generic"}
+      assert config.model == "some-model"
+      assert config.opts[:base_url] == "https://example.test"
+    end
+
+    test "a keyed provider outranks the generic escape hatch" do
+      System.put_env("ANTHROPIC_API_KEY", "sk-ant")
+      System.put_env("AI_API_KEY", "sk-generic")
+      assert {:ok, %{harness: :anthropic}, :env} = Resolver.resolve()
+    end
+
+    test "a stored keyless provider is auto-selected as :configured" do
+      Credentials.put(:lm_studio, base_url: "http://localhost:1234")
+      assert {:ok, config, :configured} = Resolver.resolve()
+      assert config.harness == :lm_studio
+      assert config.auth == %{}
+    end
+  end
+
+  describe "explicit harness" do
+    test "resolves the named provider's env key" do
+      System.put_env("OPENAI_API_KEY", "sk-oai")
+      assert {:ok, config, :env} = Resolver.resolve(harness: :openai)
+      assert config.harness == :openai
+      assert config.auth == %{api_key: "sk-oai"}
+    end
+
+    test "an explicit api_key opt wins over the env key" do
+      System.put_env("OPENAI_API_KEY", "sk-env")
+      assert {:ok, config, :explicit} = Resolver.resolve(harness: :openai, api_key: "sk-opt")
+      assert config.auth == %{api_key: "sk-opt"}
+    end
+
+    test "a keyed provider with no credential yields {:no_key, harness}" do
+      assert {:no_key, :anthropic} = Resolver.resolve(harness: :anthropic)
+    end
+
+    test "a keyless provider needs no key" do
+      assert {:ok, config, :explicit} = Resolver.resolve(harness: :lm_studio)
+      assert config.harness == :lm_studio
+      assert config.auth == %{}
+    end
+
+    test "a base_url opt flows into the config opts" do
+      assert {:ok, config, :explicit} =
+               Resolver.resolve(harness: :ollama, base_url: "http://host:11434")
+
+      assert config.opts[:base_url] == "http://host:11434"
+    end
+  end
+
+  describe "model precedence" do
+    test "explicit model opt beats the stored model and env model" do
+      Credentials.put(:anthropic, op_ref: "op://v/i/f", model: "stored-model")
+      System.put_env("ANTHROPIC_MODEL", "env-model")
+      System.put_env("ANTHROPIC_API_KEY", "sk-ant")
+      assert {:ok, config, _} = Resolver.resolve(harness: :anthropic, model: "opt-model")
+      assert config.model == "opt-model"
+    end
+
+    test "the provider model env var is used when no override is given" do
+      System.put_env("ANTHROPIC_MODEL", "env-model")
+      System.put_env("ANTHROPIC_API_KEY", "sk-ant")
+      assert {:ok, config, _} = Resolver.resolve(harness: :anthropic)
+      assert config.model == "env-model"
+    end
+  end
+
+  describe "1Password reference fall-through" do
+    test "a stored op ref that can't resolve falls through to the env key" do
+      # Deterministic only without the op CLI; a live op binary depends on
+      # vault state, so we skip the env-source assertion when op is present.
+      Credentials.put(:openai, op_ref: "op://__raxol_test__/nope/field")
+      System.put_env("OPENAI_API_KEY", "sk-env")
+
+      # A bogus op ref fails to resolve (op absent, or op present but the item
+      # does not exist), so the env key supplies the secret. If a live op
+      # binary somehow resolves the ref, the source is :op instead.
+      case Resolver.resolve(harness: :openai) do
+        {:ok, config, :env} ->
+          assert config.auth == %{api_key: "sk-env"}
+
+        {:ok, _config, :op} ->
+          assert Credentials.op_available?()
+      end
+    end
+  end
+
+  describe "status/0 and helpers" do
+    test "status marks a provider available once its key is present" do
+      System.put_env("OPENAI_API_KEY", "sk-oai")
+      status = Resolver.status()
+      openai = Enum.find(status, &(&1.harness == :openai))
+      assert openai.available?
+      assert openai.source == :env
+
+      anthropic = Enum.find(status, &(&1.harness == :anthropic))
+      refute anthropic.available?
+    end
+
+    test "harness_from_string maps known names and rejects unknown" do
+      assert {:ok, :anthropic} = Resolver.harness_from_string("anthropic")
+      assert {:ok, :lm_studio} = Resolver.harness_from_string("lm_studio")
+      assert :error = Resolver.harness_from_string("not_a_provider")
+    end
+
+    test "providers/0 lists harness + keyless flag" do
+      providers = Resolver.providers()
+      assert Enum.any?(providers, &(&1.harness == :anthropic and &1.keyless? == false))
+      assert Enum.any?(providers, &(&1.harness == :lm_studio and &1.keyless? == true))
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
@@ -1,0 +1,238 @@
+defmodule Raxol.Agent.Code.AppLoginTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Backend.Credentials
+  alias Raxol.Agent.Code.App
+  alias Raxol.Core.Events.Event
+
+  @managed_env ~w(
+    ANTHROPIC_API_KEY OPENAI_API_KEY KIMI_API_KEY MOONSHOT_API_KEY
+    OPENROUTER_API_KEY LONGCAT_API_KEY PROTON_ACCESS_TOKEN
+    AI_API_KEY AI_BASE_URL AI_MODEL
+    RAXOL_ANTHROPIC_OP RAXOL_OPENAI_OP RAXOL_LM_STUDIO_OP
+  )
+
+  setup do
+    saved = Map.new(@managed_env, fn key -> {key, System.get_env(key)} end)
+    Enum.each(@managed_env, &System.delete_env/1)
+
+    store =
+      Path.join(System.tmp_dir!(), "raxol-applogin-#{System.unique_integer([:positive])}.json")
+
+    prev_store = System.get_env("RAXOL_PROVIDERS")
+    System.put_env("RAXOL_PROVIDERS", store)
+
+    on_exit(fn ->
+      File.rm(store)
+
+      if prev_store,
+        do: System.put_env("RAXOL_PROVIDERS", prev_store),
+        else: System.delete_env("RAXOL_PROVIDERS")
+
+      Enum.each(saved, fn
+        {key, nil} -> System.delete_env(key)
+        {key, val} -> System.put_env(key, val)
+      end)
+    end)
+
+    :ok
+  end
+
+  defp stub_runner do
+    fn _session_id, _prompt, _opts, _app -> spawn(fn -> Process.sleep(60_000) end) end
+  end
+
+  # A no-op validator by default so connect tests never touch the network;
+  # validation-specific tests inject one that sends a canned result.
+  defp noop_validator, do: fn _executor, _ref, _app -> :ok end
+
+  defp validator_sending(result) do
+    fn executor, ref, app ->
+      send(app, {:command_result, {:login_validation, ref, executor.harness, result}})
+      :ok
+    end
+  end
+
+  defp new_model(provider_status, extra \\ []) do
+    options =
+      [
+        runner: stub_runner(),
+        login_validator: noop_validator(),
+        cwd:
+          Path.join(System.tmp_dir!(), "raxol-applogin-cwd-#{System.unique_integer([:positive])}"),
+        sessions_dir:
+          Path.join(
+            System.tmp_dir!(),
+            "raxol-applogin-sess-#{System.unique_integer([:positive])}"
+          ),
+        provider_status: provider_status
+      ]
+      |> Keyword.merge(extra)
+
+    App.init(%{options: options})
+  end
+
+  defp key(k, mods \\ []), do: Event.key_event(k, :pressed, mods)
+
+  defp type(model, text) do
+    {model, []} = App.update(key(:enter), %{model | input: text})
+    model
+  end
+
+  defp submit(model, prompt) do
+    {model, cmds} = App.update(key(:enter), %{model | input: prompt})
+    {model, cmds}
+  end
+
+  describe "turn gating" do
+    test "a prompt does not start a turn when no provider is connected" do
+      model = new_model(:no_provider)
+      {model, cmds} = submit(model, "write me a function")
+
+      refute model.running?
+      assert cmds == []
+      assert model.notice =~ "provider"
+    end
+
+    test "a prompt starts a turn once a provider is connected" do
+      model = new_model({:ready, :lm_studio, :explicit})
+      {model, _cmds} = submit(model, "write me a function")
+      assert model.running?
+    end
+  end
+
+  describe "/login" do
+    test "with no argument shows connection status" do
+      model = new_model(:no_provider) |> type("/login")
+      assert model.notice =~ "Connect a provider"
+      assert model.notice =~ "anthropic"
+    end
+
+    test "connects a keyless local provider" do
+      model = new_model(:no_provider) |> type("/login lm_studio")
+
+      assert {:ready, :lm_studio, _source} = model.provider_status
+      assert model.executor.harness == :lm_studio
+      assert model.notice =~ "connected to lm_studio"
+    end
+
+    test "connects with a session-only key that is not persisted" do
+      model = new_model(:no_provider) |> type("/login openai sk-session")
+
+      assert {:ready, :openai, :explicit} = model.provider_status
+      assert model.executor.auth == %{api_key: "sk-session"}
+      assert model.notice =~ "not persisted"
+      # Session key must never touch the reference store.
+      assert Credentials.fetch(:openai) == :none
+    end
+
+    test "stores an op reference (falling through to env keeps it deterministic)" do
+      System.put_env("ANTHROPIC_API_KEY", "sk-env")
+      model = new_model(:no_provider) |> type("/login anthropic op://Vault/Anthropic/key")
+
+      # The reference is persisted regardless of whether op or the env key
+      # ultimately supplied the secret.
+      assert {:ok, %{op_ref: "op://Vault/Anthropic/key"}} = Credentials.fetch(:anthropic)
+      assert {:ready, :anthropic, _source} = model.provider_status
+    end
+
+    test "rejects an unknown provider without connecting" do
+      model = new_model(:no_provider) |> type("/login not_a_provider sk-x")
+      assert model.notice =~ "unknown provider"
+      assert model.provider_status == :no_provider
+    end
+
+    test "a keyed provider with no credential explains how to supply one" do
+      model = new_model(:no_provider) |> type("/login anthropic")
+      assert model.notice =~ "no credential found for anthropic"
+      assert model.provider_status == :no_provider
+    end
+
+    test "connecting then submitting starts a turn" do
+      model = new_model(:no_provider) |> type("/login lm_studio")
+      {model, _cmds} = submit(model, "do the thing")
+      assert model.running?
+    end
+  end
+
+  describe "/login validation" do
+    test "connecting shows a validating status and stamps a login ref" do
+      model =
+        new_model(:no_provider, login_validator: noop_validator()) |> type("/login lm_studio")
+
+      assert model.status_line =~ "validating"
+      assert is_reference(model.login_ref)
+    end
+
+    test "a validated credential updates the status line" do
+      model = new_model(:no_provider, login_validator: validator_sending(:valid))
+      model = type(model, "/login openai sk-good")
+
+      assert_receive {:command_result, {:login_validation, ref, :openai, :valid}} = msg
+      assert ref == model.login_ref
+
+      {model, []} = App.update(msg, model)
+      assert model.status_line =~ "validated"
+      assert model.login_ref == nil
+    end
+
+    test "a rejected key surfaces the HTTP status" do
+      model = new_model(:no_provider, login_validator: validator_sending({:rejected, 401}))
+      model = type(model, "/login openai sk-bad")
+
+      assert_receive {:command_result, {:login_validation, _ref, :openai, {:rejected, 401}}} = msg
+      {model, []} = App.update(msg, model)
+      assert model.status_line =~ "rejected"
+      assert model.status_line =~ "401"
+    end
+
+    test "an unreachable local server is reported" do
+      model = new_model(:no_provider, login_validator: validator_sending(:unreachable))
+      model = type(model, "/login lm_studio")
+
+      assert_receive {:command_result, {:login_validation, _ref, :lm_studio, :unreachable}} = msg
+      {model, []} = App.update(msg, model)
+      assert model.status_line =~ "unreachable"
+    end
+
+    test "a stale validation result (superseded login) is ignored" do
+      model = new_model(:no_provider, login_validator: noop_validator())
+      model = type(model, "/login lm_studio")
+      before = model.status_line
+
+      stale = make_ref()
+
+      {model, []} =
+        App.update(
+          {:command_result, {:login_validation, stale, :openai, {:rejected, 401}}},
+          model
+        )
+
+      assert model.status_line == before
+      assert is_reference(model.login_ref)
+    end
+  end
+
+  describe "interpret_ping/1" do
+    test "a 2xx completion is valid" do
+      assert App.interpret_ping({:ok, %{content: "ok"}}) == :valid
+    end
+
+    test "401/403 mean the key was rejected" do
+      assert App.interpret_ping({:error, {:http_error, 401, "no"}}) == {:rejected, 401}
+      assert App.interpret_ping({:error, {:http_error, 403, "no"}}) == {:rejected, 403}
+    end
+
+    test "a transport failure is unreachable" do
+      assert App.interpret_ping({:error, {:request_failed, :econnrefused}}) == :unreachable
+    end
+
+    test "another HTTP status is reachable-but-errored" do
+      assert App.interpret_ping({:error, {:http_error, 500, ""}}) == {:reachable_error, 500}
+    end
+
+    test "a content-level marker still means the key is valid (auth succeeded)" do
+      assert App.interpret_ping({:error, "⚠ response truncated"}) == :valid
+    end
+  end
+end


### PR DESCRIPTION
## Why

`mix raxol.code` had no credential-resolution layer, so it never worked out of the box:

- With no `--harness` it defaulted to `lm_studio` → `http://localhost:1234`; with no local server that's `:econnrefused` → the `≡xx≡` error face.
- `--harness anthropic|openai|kimi` **crashed** with a `KeyError` — the Selector supplies an `api_key` only for `lm_studio`, and `Backend.HTTP` does `Keyword.fetch!(opts, :api_key)`. There was no `--api-key` flag and nothing read `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`.
- The provider auto-detection was copy-pasted inside example scripts, never in the framework.

The bug and the "let users connect their providers" onboarding gap are the same root cause: no single place resolves *which provider + which key + which base URL*.

## What

A shared **`Raxol.Agent.Backend.Resolver`** — the single source of truth turning environment + stored references into a ready `ExecutorConfig` — consumed by `mix raxol.code`, the `Code.App` TUI, and the `react_agent` example.

- **`Backend.Credentials`** — 1Password-first *reference* store at `~/.raxol/providers.json` (`op://` refs + model/base_url only, **never raw keys**, `0600`) + `op read` resolution that degrades gracefully when `op` is absent.
- **`Backend.Resolver`** — precedence: explicit `--api-key` → op reference → provider env var → generic `AI_API_KEY`/`AI_BASE_URL` → `:no_provider`. Registry of 10 providers, `status/0`, safe string→atom mapping.
- **`mix raxol.code`** — auto-detects (no blind `lm_studio` default); adds `--api-key`.
- **`Code.App`** — a friendly **setup panel** when nothing's connected, **turn gating** (a prompt with no provider shows the hint instead of firing an invisible request), and a live **`/login`** command:
  - `/login anthropic op://Vault/Anthropic/key` — store a 1Password reference (persisted)
  - `/login openai sk-...` — session-only key (never written)
  - `/login lm_studio` — local server, no key
- **Async validation ping** — on connect, a single-token completion runs off the UI process and reports `validated` / `key rejected (HTTP 401)` / `endpoint unreachable`. Auth-focused: a reachable-but-truncated answer still counts as valid; a slow/offline endpoint never blocks the TUI. Staleness-safe via a `login_ref`.

`raxol_mcp` runs no LLM turns itself (the LLM is the external MCP client), so there's nothing to wire there — the Resolver in `raxol_agent` is the shared front door.

## Manual testing

- [ ] `mix raxol.code` with no keys/refs → opens on the setup panel (not an error face); a prompt shows the "connect a provider" hint instead of starting a turn.
- [ ] `/login lm_studio` with LM Studio running → `connected` then `lm_studio credential validated`; with it stopped → `endpoint unreachable`.
- [ ] `/login openai sk-<real>` → `validated`; `/login openai sk-bad` → `key rejected (HTTP 401)`.
- [ ] `/login anthropic op://<vault>/<item>/<field>` → stored in `~/.raxol/providers.json` (refs only, no raw key), resolves via `op` on next launch.
- [ ] `export ANTHROPIC_API_KEY=...` then `mix raxol.code` → auto-detects anthropic, straight into the loop.
- [ ] `mix raxol.code --harness openai --api-key sk-...` → connects without touching env/op.

## Notes

- Touches zero deps; `mix.lock` unchanged.
- New tests are hermetic: env snapshot/restore, injected validator, no network calls.
- Full `raxol_agent` suite green (1674 passed); credo `--strict` clean; formatted; compiles under `--warnings-as-errors`.
