### PR TITLE
Onboarding wizard: interactive select, masked entry, 1Password save, launch validation

### DIFF
--- a/docs/features/CODING_AGENT.md
+++ b/docs/features/CODING_AGENT.md
@@ -41,22 +41,36 @@ With no `--harness`, the agent auto-detects a provider through the shared
 3. a provider env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `KIMI_API_KEY`, `OPENROUTER_API_KEY`, `LONGCAT_API_KEY`, ...),
 4. the generic `AI_API_KEY` (plus optional `AI_BASE_URL` / `AI_MODEL`) for any OpenAI-compatible endpoint.
 
-If nothing resolves, the TUI opens on a setup panel instead of failing against
-a placeholder endpoint. Run `/login` to connect one live. The preferred path
-is a 1Password reference (no plaintext key on disk):
+If nothing resolves, the TUI opens on an interactive setup wizard instead of
+failing against a placeholder endpoint:
+
+- a selectable provider list (`↑`/`↓` to move, `Enter` to connect, `Esc` to
+  dismiss), each row marked connected (`●`) or not (`○`) with an actionable
+  note when detection has a problem (a stored reference that needs
+  `op signin`, or an env var that is set but empty);
+- picking a keyed provider opens a masked credential entry: paste an `op://`
+  reference (shown in the clear, stored) or an API key (masked). After a raw
+  key connects, the wizard offers to save it to 1Password so no plaintext
+  persists;
+- picking a local provider (`lm_studio`, `ollama`) connects with no key.
+
+The `/login` text command remains for scripted/power use (it works alongside
+the wizard):
 
 ```
-/login                                          # show connection status
+/login                                          # open the wizard
 /login anthropic op://Vault/Anthropic/key       # store a 1Password reference (persisted)
 /login openai sk-...                             # a session-only key (never written)
 /login lm_studio                                 # a local server, no key
 ```
 
-On connect, `/login` fires a cheap, async validation ping (a single-token
-completion) against the resolved backend and reports the outcome in the status
-line: `validated`, `key rejected (HTTP 401)`, or `endpoint unreachable`. The
-check runs off the UI process, so a slow or offline endpoint never blocks the
-TUI, and the connection is usable immediately regardless.
+On connect (and once at launch for an auto-detected provider), the agent fires
+a cheap, async validation ping and reports the outcome in the status line:
+`validated`, `key rejected (HTTP 401)`, or `endpoint unreachable`. It prefers
+the provider's token-free model-list endpoint (`GET /v1/models`), falling back
+to a single-token completion only when that is unavailable. The check runs off
+the UI process, so a slow or offline endpoint never blocks the TUI, and the
+connection is usable immediately regardless.
 
 Stored references live in `~/.raxol/providers.json` (override with
 `$RAXOL_PROVIDERS`), owner-readable only. That file holds `op://` references,

--- a/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
@@ -146,6 +146,95 @@ defmodule Raxol.Agent.Backend.Credentials do
   def op_available?, do: not is_nil(System.find_executable("op"))
 
   @doc """
+  The 1Password CLI availability + auth state.
+
+    * `:absent`         — the `op` binary is not on PATH.
+    * `:not_signed_in`  — `op` is installed but no account session is active.
+    * `:ok`             — `op` is installed and signed in.
+
+  Used by the resolver's diagnostics so a stored `op://` reference that fails
+  to resolve can say *why* (needs `op signin`) instead of silently falling
+  through to env vars.
+  """
+  @spec op_status() :: :absent | :not_signed_in | :ok
+  def op_status do
+    cond do
+      not op_available?() -> :absent
+      match?({_out, 0}, System.cmd("op", ["whoami"], stderr_to_stdout: true)) -> :ok
+      true -> :not_signed_in
+    end
+  end
+
+  @doc """
+  Create a 1Password item holding `key` and return its `op://...` reference.
+
+  The secret is written to a `0600` temp template and passed to
+  `op item create` via `--template` (never on argv, so it can't leak to the
+  process list), then the temp file is removed. The vault defaults to
+  `$RAXOL_OP_VAULT` or `Private`. Returns `{:ok, ref}` or `{:error, reason}`.
+  """
+  @spec create_item(atom() | String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def create_item(harness, key, opts \\ [])
+
+  def create_item(harness, key, opts) when is_binary(key) and key != "" do
+    if op_available?() do
+      do_create_item(harness, key, opts)
+    else
+      {:error, :op_unavailable}
+    end
+  end
+
+  def create_item(_harness, _key, _opts), do: {:error, :empty_key}
+
+  defp do_create_item(harness, key, opts) do
+    vault = Keyword.get(opts, :vault) || System.get_env("RAXOL_OP_VAULT") || "Private"
+    template = op_template(harness, key)
+    path = Path.join(System.tmp_dir!(), "raxol-op-#{System.unique_integer([:positive])}.json")
+
+    with :ok <- File.write(path, template),
+         _ <- File.chmod(path, 0o600) do
+      try do
+        run_op_create(path, vault)
+      after
+        File.rm(path)
+      end
+    end
+  end
+
+  defp run_op_create(template_path, vault) do
+    args = ["item", "create", "--template", template_path, "--vault", vault, "--format", "json"]
+
+    case System.cmd("op", args, stderr_to_stdout: true) do
+      {out, 0} -> created_ref(out, vault)
+      {out, code} -> {:error, {:op_create_failed, code, String.trim(out)}}
+    end
+  end
+
+  defp op_template(harness, key) do
+    Jason.encode!(%{
+      "title" => "Raxol #{harness} API key",
+      "category" => "API_CREDENTIAL",
+      "fields" => [
+        %{"id" => "credential", "type" => "CONCEALED", "label" => "credential", "value" => key}
+      ]
+    })
+  end
+
+  defp created_ref(out, vault) do
+    case Jason.decode(out) do
+      {:ok, %{"id" => id, "vault" => %{"name" => vname}}} ->
+        {:ok, "op://#{vname}/#{id}/credential"}
+
+      {:ok, %{"id" => id}} ->
+        {:ok, "op://#{vault}/#{id}/credential"}
+
+      _ ->
+        {:error, :op_create_unparsable}
+    end
+  end
+
+  @doc """
   Resolve a `op://...` reference to its secret via the 1Password CLI.
 
   Returns `{:ok, secret}` (trimmed), or `{:error, reason}` when `op` is

--- a/packages/raxol_agent/lib/raxol/agent/backend/http.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/http.ex
@@ -82,6 +82,85 @@ defmodule Raxol.Agent.Backend.HTTP do
     Code.ensure_loaded?(Req)
   end
 
+  @doc """
+  Cheap credential check via the provider's model-list endpoint.
+
+  Unlike a completion, listing models costs no tokens, so this is the
+  preferred `/login` validation for the hosted providers. Returns:
+
+    * `:valid`                    — a 2xx (authorized),
+    * `{:rejected, status}`       — 401/403 (bad key),
+    * `{:reachable_error, status}`— reachable but another status,
+    * `:unreachable`              — transport failure,
+    * `:unsupported`             — no known model-list endpoint for this
+      provider (the caller should fall back to a completion ping).
+  """
+  @spec check_auth(keyword()) ::
+          :valid
+          | {:rejected, non_neg_integer()}
+          | {:reachable_error, non_neg_integer()}
+          | :unreachable
+          | :unsupported
+  def check_auth(opts) do
+    if available?() do
+      opts |> detect_provider() |> models_request(opts) |> run_auth_check(opts)
+    else
+      :unsupported
+    end
+  end
+
+  defp run_auth_check(:unsupported, _opts), do: :unsupported
+
+  defp run_auth_check({url, headers}, opts) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    req = Req.new(url: url, headers: headers, receive_timeout: timeout)
+
+    case Req.get(req) do
+      {:ok, %{status: status}} -> interpret_models_status(status)
+      {:error, _reason} -> :unreachable
+    end
+  rescue
+    _ -> :unreachable
+  end
+
+  @doc false
+  def interpret_models_status(status) when status in 200..299, do: :valid
+  def interpret_models_status(status) when status in [401, 403], do: {:rejected, status}
+  def interpret_models_status(status) when is_integer(status), do: {:reachable_error, status}
+
+  defp models_request(:anthropic, opts) do
+    case Keyword.get(opts, :api_key) do
+      key when is_binary(key) ->
+        base = Keyword.get(opts, :base_url, "https://api.anthropic.com")
+        {"#{base}/v1/models", [{"x-api-key", key}, {"anthropic-version", @anthropic_api_version}]}
+
+      _no_key ->
+        :unsupported
+    end
+  end
+
+  defp models_request(:openai, opts), do: bearer_models_request(opts, "https://api.openai.com")
+  defp models_request(:kimi, opts), do: bearer_models_request(opts, "https://api.moonshot.ai")
+
+  defp models_request(:ollama, opts) do
+    base = Keyword.get(opts, :base_url, "http://localhost:#{@default_ollama_port}")
+    {"#{base}/api/tags", []}
+  end
+
+  defp models_request(_provider, _opts), do: :unsupported
+
+  defp bearer_models_request(opts, default_base) do
+    case Keyword.get(opts, :api_key) do
+      key when is_binary(key) ->
+        base = Keyword.get(opts, :base_url, default_base)
+        {"#{base}/v1/models", [{"authorization", "Bearer #{key}"}]}
+
+      _no_key ->
+        :unsupported
+    end
+  end
+
   @impl true
   def name, do: "HTTP Backend"
 

--- a/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
@@ -152,6 +152,56 @@ defmodule Raxol.Agent.Backend.Resolver do
     Enum.map(@providers, &%{harness: &1.harness, label: &1.label, keyless?: &1.keyless})
   end
 
+  @doc """
+  Detection diagnostics for the setup panel: the `op` CLI state plus, per
+  provider, an actionable `note` when it is unavailable (a stored `op://`
+  reference that needs `op signin`, or an env var that is set but empty).
+
+  Returns `%{op: op_status, providers: [%{harness, label, keyless?,
+  available?, source, note}]}`. Probing may shell out to `op` for stored
+  references, so treat it as a point-in-time snapshot.
+  """
+  @spec diagnostics() :: %{op: atom(), providers: [map()]}
+  def diagnostics do
+    op = Credentials.op_status()
+    %{op: op, providers: Enum.map(@providers, &provider_diag(&1, op))}
+  end
+
+  defp provider_diag(spec, op) do
+    {available?, source} =
+      case detect_available(spec, []) do
+        {:ok, _config, src} -> {true, src}
+        _ -> {false, nil}
+      end
+
+    %{
+      harness: spec.harness,
+      label: spec.label,
+      keyless?: spec.keyless,
+      available?: available?,
+      source: source,
+      note: diag_note(spec, available?, op)
+    }
+  end
+
+  defp diag_note(_spec, true, _op), do: nil
+
+  defp diag_note(spec, false, op) do
+    cond do
+      op_ref(spec.harness) && op != :ok -> op_hint(op)
+      empty_env_key(spec) -> "#{empty_env_key(spec)} is set but empty"
+      true -> nil
+    end
+  end
+
+  defp op_hint(:not_signed_in), do: "op reference stored, run `op signin`"
+  defp op_hint(:absent), do: "op reference stored, but the `op` CLI is not installed"
+  defp op_hint(_status), do: nil
+
+  defp empty_env_key(%{env_keys: keys}) do
+    Enum.find(keys, fn key -> System.get_env(key) == "" end)
+  end
+
   @doc "Map a harness string to its known atom without minting new atoms."
   @spec harness_from_string(String.t()) :: {:ok, atom()} | :error
   def harness_from_string(str) when is_binary(str) do

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -76,7 +76,8 @@ defmodule Raxol.Agent.Code.App do
     {hooks, hooks_note} = load_hooks(cwd)
     {mcp_servers, mcp_note} = load_mcp(cwd)
 
-    Map.merge(config(options, context), %{
+    config(options, context)
+    |> Map.merge(%{
       # Seeded from a resumed session so the transcript + conversation
       # rebuild immediately; a fresh session starts these empty.
       events: events,
@@ -88,7 +89,23 @@ defmodule Raxol.Agent.Code.App do
       hooks: hooks,
       mcp_servers: mcp_servers
     })
+    |> maybe_open_initial_wizard()
+    |> maybe_arm_launch_validation()
   end
+
+  # No provider connected at boot -> open the onboarding wizard on its
+  # selectable provider list.
+  defp maybe_open_initial_wizard(model) do
+    if provider_ready?(model), do: model, else: open_browse(model)
+  end
+
+  # A provider connected at boot (auto-detected or --harness) -> validate it on
+  # the first update, so a stale key surfaces before the first prompt.
+  defp maybe_arm_launch_validation(%{executor: %{} = executor} = model) do
+    if provider_ready?(model), do: %{model | pending_validation: executor}, else: model
+  end
+
+  defp maybe_arm_launch_validation(model), do: model
 
   # Static + option-derived fields; the session and loaded config are merged
   # over these in init/1.
@@ -121,6 +138,16 @@ defmodule Raxol.Agent.Code.App do
       login_ref: nil,
       login_validator:
         Keyword.get(options, :login_validator, &__MODULE__.default_login_validator/3),
+      # The onboarding wizard overlay: nil (connected), or a step map
+      # (`:browse` selectable list, `:credential` masked entry, `:confirm_save`
+      # save-to-1Password prompt). Set in init when no provider is connected.
+      wizard: nil,
+      # An executor armed in init to validate on the first update (which runs
+      # in the dispatcher, so the ping's reply lands where update can fold it).
+      pending_validation: nil,
+      # Injectable so the save-to-1Password flow is testable without mutating a
+      # real vault; the default shells out to `op item create`.
+      op_saver: Keyword.get(options, :op_saver, &__MODULE__.default_op_saver/2),
       backend_opts: Keyword.get(options, :backend_opts, []),
       model_override: Keyword.get(options, :model),
       system: Keyword.get(options, :system, default_system()),
@@ -185,9 +212,13 @@ defmodule Raxol.Agent.Code.App do
 
   @impl true
   def update(%Raxol.Core.Events.Event{} = event, model) do
+    model = maybe_launch_validation(model)
     norm = InputEvent.normalize(event)
 
     cond do
+      # The credential/save steps are modal: they own the keyboard so a pasted
+      # key never leaks into the prompt buffer or a slash command.
+      modal_wizard?(model) -> handle_wizard(norm, model)
       InputEvent.shortcut?(norm) -> handle_shortcut(norm, model)
       InputEvent.text?(norm) -> handle_char(InputEvent.printable_char(norm), model)
       key = InputEvent.key(norm) -> handle_key(key, model)
@@ -247,6 +278,23 @@ defmodule Raxol.Agent.Code.App do
 
   def update(_message, model), do: {model, []}
 
+  # Fire the armed launch validation on the first update (dispatcher process).
+  defp maybe_launch_validation(%{pending_validation: nil} = model), do: model
+
+  defp maybe_launch_validation(%{pending_validation: executor} = model) do
+    ref = start_login_validation(model, executor)
+
+    %{
+      model
+      | pending_validation: nil,
+        login_ref: ref,
+        status_line: "validating #{executor.harness} credential…"
+    }
+  end
+
+  defp modal_wizard?(%{wizard: %{step: step}}) when step in [:credential, :confirm_save], do: true
+  defp modal_wizard?(_model), do: false
+
   # -- key handlers -----------------------------------------------------------
 
   defp handle_shortcut(%{char: "c", mods: %{ctrl: true}}, model) do
@@ -287,9 +335,15 @@ defmodule Raxol.Agent.Code.App do
   defp handle_key(:enter, %{pending_approval: %{}} = model), do: {model, []}
   defp handle_key(:enter, %{running?: true} = model), do: {model, []}
 
+  # In browse mode, ↑/↓ move the provider cursor; Enter on an empty prompt
+  # selects it. A typed prompt or slash command still takes precedence (so the
+  # `/login <provider> ...` text path stays reachable alongside the wizard).
+  defp handle_key(:up, %{wizard: %{step: :browse}} = model), do: {wizard_move(model, -1), []}
+  defp handle_key(:down, %{wizard: %{step: :browse}} = model), do: {wizard_move(model, +1), []}
+
   defp handle_key(:enter, model) do
     case String.trim(model.input) do
-      "" -> {model, []}
+      "" -> {maybe_wizard_select(model), []}
       "/" <> _ = command -> dispatch_slash(%{model | input: ""}, command)
       prompt -> {submit_prompt(model, prompt), []}
     end
@@ -308,6 +362,11 @@ defmodule Raxol.Agent.Code.App do
 
   defp handle_key(:escape, %{running?: true} = model),
     do: {interrupt(model), []}
+
+  # Esc closes the browse list (reopen with /login); the modal steps handle
+  # their own Esc in handle_wizard/2.
+  defp handle_key(:escape, %{wizard: %{step: :browse}} = model),
+    do: {close_wizard(model), []}
 
   defp handle_key(_key, model), do: {model, []}
 
@@ -698,7 +757,7 @@ defmodule Raxol.Agent.Code.App do
   # a trailing token is taken as a model override.
   defp login(model, arg) do
     case String.split(String.trim(arg), ~r/\s+/, trim: true) do
-      [] -> notice(model, login_status_text())
+      [] -> open_browse(model)
       [provider] -> login_provider(model, provider, nil, nil)
       [provider, secret] -> login_provider(model, provider, secret, nil)
       [provider, secret, model_name | _] -> login_provider(model, provider, secret, model_name)
@@ -750,7 +809,8 @@ defmodule Raxol.Agent.Code.App do
           | executor: executor,
             provider_status: {:ready, harness, source},
             model_override: executor.model || model.model_override,
-            login_ref: ref
+            login_ref: ref,
+            wizard: nil
         }
         |> notice(connect_note(harness, source, note))
         |> put_status("connected to #{harness} — validating credential…")
@@ -811,13 +871,27 @@ defmodule Raxol.Agent.Code.App do
 
   defp do_validate_ping(executor) do
     case Raxol.Agent.Backend.Selector.select(executor) do
-      {:ok, backend, opts} ->
-        ping_opts = opts |> Keyword.put(:max_tokens, 1) |> Keyword.put(:timeout, 10_000)
-        interpret_ping(backend.complete([%{role: :user, content: "ping"}], ping_opts))
-
-      {:error, reason} ->
-        {:select_error, reason}
+      {:ok, backend, opts} -> validate_backend(backend, opts)
+      {:error, reason} -> {:select_error, reason}
     end
+  end
+
+  # Prefer the token-free model-list auth check for the HTTP backend; only an
+  # ambiguous result (unsupported endpoint, or reachable-but-odd-status) falls
+  # back to the authoritative single-token completion ping.
+  defp validate_backend(Raxol.Agent.Backend.HTTP = backend, opts) do
+    case Raxol.Agent.Backend.HTTP.check_auth(opts) do
+      :unsupported -> ping_completion(backend, opts)
+      {:reachable_error, _status} -> ping_completion(backend, opts)
+      verdict -> verdict
+    end
+  end
+
+  defp validate_backend(backend, opts), do: ping_completion(backend, opts)
+
+  defp ping_completion(backend, opts) do
+    ping_opts = opts |> Keyword.put(:max_tokens, 1) |> Keyword.put(:timeout, 10_000)
+    interpret_ping(backend.complete([%{role: :user, content: "ping"}], ping_opts))
   end
 
   @doc false
@@ -852,6 +926,137 @@ defmodule Raxol.Agent.Code.App do
     do: "#{harness} connected (Req unavailable, validation skipped)"
 
   defp validation_status(harness, _other), do: "#{harness} connected"
+
+  # -- onboarding wizard ------------------------------------------------------
+
+  defp open_browse(model) do
+    entries = browse_entries()
+    cursor = default_cursor(entries)
+    %{model | wizard: %{step: :browse, cursor: cursor, entries: entries}, notice: nil}
+  end
+
+  # Provider rows for the list, carrying the diagnostics so the panel can show
+  # availability + an actionable note per provider.
+  defp browse_entries, do: Raxol.Agent.Backend.Resolver.diagnostics().providers
+
+  # Start the cursor on the first available provider, else the top.
+  defp default_cursor(entries) do
+    case Enum.find_index(entries, & &1.available?) do
+      nil -> 0
+      idx -> idx
+    end
+  end
+
+  defp wizard_move(%{wizard: %{entries: entries, cursor: cursor} = wizard} = model, delta) do
+    max = max(length(entries) - 1, 0)
+    next = min(max, max(0, cursor + delta))
+    %{model | wizard: %{wizard | cursor: next}}
+  end
+
+  defp maybe_wizard_select(%{wizard: %{step: :browse, entries: entries, cursor: cursor}} = model) do
+    case Enum.at(entries, cursor) do
+      nil -> model
+      entry -> select_provider(model, entry.harness, entry.keyless?)
+    end
+  end
+
+  defp maybe_wizard_select(model), do: model
+
+  # A keyless provider connects immediately; a keyed one opens masked entry.
+  defp select_provider(model, harness, true) do
+    model |> connect(harness, nil, nil) |> close_wizard_if_ready()
+  end
+
+  defp select_provider(model, harness, false) do
+    %{
+      model
+      | wizard: %{step: :credential, harness: harness, buffer: ""},
+        notice:
+          "#{harness}: paste an op:// reference (saved) or an API key (Enter to submit, Esc to cancel)"
+    }
+  end
+
+  defp close_wizard(model), do: %{model | wizard: nil}
+
+  defp close_wizard_if_ready(model) do
+    if provider_ready?(model), do: close_wizard(model), else: model
+  end
+
+  # -- wizard: modal steps (own the keyboard) ---------------------------------
+
+  defp handle_wizard(norm, %{wizard: %{step: :credential}} = model) do
+    cond do
+      InputEvent.text?(norm) -> {append_credential(model, InputEvent.printable_char(norm)), []}
+      InputEvent.key(norm) == :enter -> {submit_credential(model), []}
+      InputEvent.key(norm) == :backspace -> {backspace_credential(model), []}
+      InputEvent.key(norm) == :escape -> {open_browse(model), []}
+      true -> {model, []}
+    end
+  end
+
+  defp handle_wizard(norm, %{wizard: %{step: :confirm_save}} = model) do
+    cond do
+      InputEvent.printable_char(norm) in ["y", "Y"] -> {save_key_to_op(model), []}
+      InputEvent.printable_char(norm) in ["n", "N"] -> {decline_save(model), []}
+      InputEvent.key(norm) == :escape -> {decline_save(model), []}
+      true -> {model, []}
+    end
+  end
+
+  defp append_credential(%{wizard: wizard} = model, char),
+    do: %{model | wizard: %{wizard | buffer: wizard.buffer <> char}}
+
+  defp backspace_credential(%{wizard: %{buffer: buffer} = wizard} = model),
+    do: %{model | wizard: %{wizard | buffer: String.slice(buffer, 0..-2//1)}}
+
+  # An op:// reference stores + connects; a raw key connects for this session
+  # and (if op is available) offers to save it to 1Password.
+  defp submit_credential(%{wizard: %{harness: harness, buffer: buffer}} = model) do
+    trimmed = String.trim(buffer)
+
+    cond do
+      trimmed == "" ->
+        model
+
+      String.starts_with?(trimmed, "op://") ->
+        model |> connect(harness, trimmed, nil) |> close_wizard_if_ready()
+
+      true ->
+        model |> connect(harness, trimmed, nil) |> maybe_offer_save(harness, trimmed)
+    end
+  end
+
+  defp maybe_offer_save(model, harness, key) do
+    if Raxol.Agent.Backend.Credentials.op_available?() do
+      %{
+        model
+        | wizard: %{step: :confirm_save, harness: harness, key: key},
+          notice: "Save this #{harness} key to 1Password?  [y] yes   [n] keep for this session"
+      }
+    else
+      close_wizard(model)
+    end
+  end
+
+  defp save_key_to_op(%{wizard: %{harness: harness, key: key}} = model) do
+    case model.op_saver.(harness, key) do
+      {:ok, ref} ->
+        _ = Raxol.Agent.Backend.Credentials.put(harness, op_ref: ref)
+        model |> close_wizard() |> notice("saved #{harness} key to 1Password (#{ref})")
+
+      {:error, reason} ->
+        model
+        |> close_wizard()
+        |> notice("could not save to 1Password: #{inspect(reason)} — key kept for this session")
+    end
+  end
+
+  defp decline_save(%{wizard: %{harness: harness}} = model),
+    do: model |> close_wizard() |> notice("#{harness} key kept for this session only")
+
+  @doc false
+  def default_op_saver(harness, key),
+    do: Raxol.Agent.Backend.Credentials.create_item(harness, key)
 
   defp login_status_text do
     rows =
@@ -982,19 +1187,76 @@ defmodule Raxol.Agent.Code.App do
     end
   end
 
-  # The onboarding panel: shown until a provider is connected, so the TUI
-  # opens on "connect a provider" instead of failing an invisible request.
-  defp setup_block(model) do
-    if provider_ready?(model) do
-      nil
-    else
-      lines = String.split(provider_setup_hint(model), "\n")
+  # The onboarding panel: the wizard when one is open, else a static hint when
+  # unconnected, else nothing. Keeps the TUI on "connect a provider" instead of
+  # failing an invisible request.
+  defp setup_block(%{wizard: %{step: :browse} = wizard}), do: browse_panel(wizard)
+  defp setup_block(%{wizard: %{step: :credential} = wizard}), do: credential_panel(wizard)
+  defp setup_block(%{wizard: %{step: :confirm_save} = wizard}), do: confirm_save_panel(wizard)
 
-      box style: %{border: :single, padding: 0} do
-        column style: %{gap: 0} do
-          [text("connect a provider to begin", fg: :yellow, style: [:bold])] ++
-            Enum.map(lines, &text(&1, fg: :cyan))
-        end
+  defp setup_block(model) do
+    if provider_ready?(model), do: nil, else: hint_panel(model)
+  end
+
+  defp browse_panel(%{entries: entries, cursor: cursor}) do
+    rows =
+      entries
+      |> Enum.with_index()
+      |> Enum.map(fn {entry, index} -> provider_row(entry, index == cursor) end)
+
+    box style: %{border: :single, padding: 0} do
+      column style: %{gap: 0} do
+        [
+          text("connect a provider  (↑↓ move · Enter connect · Esc cancel)",
+            fg: :yellow,
+            style: [:bold]
+          )
+        ] ++ rows
+      end
+    end
+  end
+
+  defp provider_row(entry, selected?) do
+    marker = if selected?, do: "▸", else: " "
+    avail = if entry.available?, do: "●", else: "○"
+    note = if entry.note, do: "  #{entry.note}", else: ""
+    fg = if selected?, do: :cyan, else: :white
+    style = if selected?, do: [:bold], else: []
+    text("#{marker} #{avail} #{entry.label}#{note}", fg: fg, style: style)
+  end
+
+  defp credential_panel(%{harness: harness, buffer: buffer}) do
+    shown =
+      if String.starts_with?(buffer, "op://"),
+        do: buffer,
+        else: String.duplicate("•", String.length(buffer))
+
+    box style: %{border: :single, padding: 0} do
+      column style: %{gap: 0} do
+        [
+          text("connect #{harness}", fg: :yellow, style: [:bold]),
+          text("credential: #{shown}▌", fg: :cyan),
+          text("op:// reference is stored; a raw key can be saved to 1Password", style: [:dim])
+        ]
+      end
+    end
+  end
+
+  defp confirm_save_panel(%{harness: harness}) do
+    box style: %{border: :single, padding: 0} do
+      text("Save #{harness} key to 1Password?  [y] yes   [n] keep for this session",
+        fg: :yellow
+      )
+    end
+  end
+
+  defp hint_panel(model) do
+    lines = String.split(provider_setup_hint(model), "\n")
+
+    box style: %{border: :single, padding: 0} do
+      column style: %{gap: 0} do
+        [text("connect a provider to begin", fg: :yellow, style: [:bold])] ++
+          Enum.map(lines, &text(&1, fg: :cyan))
       end
     end
   end

--- a/packages/raxol_agent/test/raxol/agent/backend/credentials_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/credentials_test.exs
@@ -102,4 +102,32 @@ defmodule Raxol.Agent.Backend.CredentialsTest do
       end
     end
   end
+
+  describe "op_status/0" do
+    test "returns one of the three known states" do
+      assert Credentials.op_status() in [:absent, :not_signed_in, :ok]
+    end
+
+    test "is :absent exactly when op is unavailable" do
+      if Credentials.op_available?() do
+        assert Credentials.op_status() in [:ok, :not_signed_in]
+      else
+        assert Credentials.op_status() == :absent
+      end
+    end
+  end
+
+  describe "create_item/3" do
+    test "refuses an empty key" do
+      assert {:error, :empty_key} = Credentials.create_item(:openai, "")
+    end
+
+    test "errors when op is unavailable rather than raising" do
+      # Deterministic only without op; with op present a live create would
+      # mutate a real vault, so we do not exercise the success path here.
+      unless Credentials.op_available?() do
+        assert {:error, :op_unavailable} = Credentials.create_item(:openai, "sk-x")
+      end
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/backend/http_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/http_test.exs
@@ -416,4 +416,40 @@ defmodule Raxol.Agent.Backend.HTTPTest do
       assert length(result) == 2
     end
   end
+
+  describe "interpret_models_status/1" do
+    test "a 2xx is valid" do
+      assert HTTP.interpret_models_status(200) == :valid
+      assert HTTP.interpret_models_status(204) == :valid
+    end
+
+    test "401/403 mean the key was rejected" do
+      assert HTTP.interpret_models_status(401) == {:rejected, 401}
+      assert HTTP.interpret_models_status(403) == {:rejected, 403}
+    end
+
+    test "another status is reachable-but-errored" do
+      assert HTTP.interpret_models_status(404) == {:reachable_error, 404}
+      assert HTTP.interpret_models_status(500) == {:reachable_error, 500}
+    end
+  end
+
+  describe "check_auth/1" do
+    test "an unknown provider (no model-list endpoint) is unsupported" do
+      assert HTTP.check_auth(provider: :lumo, api_key: "x") == :unsupported
+    end
+
+    test "a keyed provider with no key is unsupported" do
+      assert HTTP.check_auth(provider: :openai) == :unsupported
+    end
+
+    test "an unreachable endpoint reports unreachable, not a crash" do
+      assert HTTP.check_auth(
+               provider: :openai,
+               api_key: "x",
+               base_url: "http://127.0.0.1:19876",
+               timeout: 100
+             ) == :unreachable
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
@@ -180,4 +180,28 @@ defmodule Raxol.Agent.Backend.ResolverTest do
       assert Enum.any?(providers, &(&1.harness == :lm_studio and &1.keyless? == true))
     end
   end
+
+  describe "diagnostics/0" do
+    test "reports the op state and a provider list" do
+      diag = Resolver.diagnostics()
+      assert diag.op in [:absent, :not_signed_in, :ok]
+      assert Enum.any?(diag.providers, &(&1.harness == :anthropic))
+    end
+
+    test "notes an env var that is set but empty" do
+      System.put_env("OPENAI_API_KEY", "")
+      diag = Resolver.diagnostics()
+      openai = Enum.find(diag.providers, &(&1.harness == :openai))
+      refute openai.available?
+      assert openai.note =~ "set but empty"
+    end
+
+    test "an available provider carries no note" do
+      System.put_env("ANTHROPIC_API_KEY", "sk-ant")
+      diag = Resolver.diagnostics()
+      anthropic = Enum.find(diag.providers, &(&1.harness == :anthropic))
+      assert anthropic.available?
+      assert anthropic.note == nil
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
@@ -102,10 +102,10 @@ defmodule Raxol.Agent.Code.AppLoginTest do
   end
 
   describe "/login" do
-    test "with no argument shows connection status" do
+    test "with no argument opens the browse wizard" do
       model = new_model(:no_provider) |> type("/login")
-      assert model.notice =~ "Connect a provider"
-      assert model.notice =~ "anthropic"
+      assert %{step: :browse, entries: entries} = model.wizard
+      assert Enum.any?(entries, &(&1.harness == :anthropic))
     end
 
     test "connects a keyless local provider" do

--- a/packages/raxol_agent/test/raxol/agent/code/app_wizard_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_wizard_test.exs
@@ -1,0 +1,263 @@
+defmodule Raxol.Agent.Code.AppWizardTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Backend.Credentials
+  alias Raxol.Agent.Code.App
+  alias Raxol.Agent.ExecutorConfig
+  alias Raxol.Core.Events.Event
+
+  @managed_env ~w(
+    ANTHROPIC_API_KEY OPENAI_API_KEY KIMI_API_KEY MOONSHOT_API_KEY
+    OPENROUTER_API_KEY LONGCAT_API_KEY PROTON_ACCESS_TOKEN
+    AI_API_KEY AI_BASE_URL AI_MODEL
+    RAXOL_ANTHROPIC_OP RAXOL_OPENAI_OP RAXOL_LM_STUDIO_OP
+  )
+
+  setup do
+    saved = Map.new(@managed_env, fn key -> {key, System.get_env(key)} end)
+    Enum.each(@managed_env, &System.delete_env/1)
+
+    store =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-wizard-#{System.unique_integer([:positive])}.json"
+      )
+
+    prev_store = System.get_env("RAXOL_PROVIDERS")
+    System.put_env("RAXOL_PROVIDERS", store)
+
+    on_exit(fn ->
+      File.rm(store)
+
+      if prev_store,
+        do: System.put_env("RAXOL_PROVIDERS", prev_store),
+        else: System.delete_env("RAXOL_PROVIDERS")
+
+      Enum.each(saved, fn
+        {key, nil} -> System.delete_env(key)
+        {key, val} -> System.put_env(key, val)
+      end)
+    end)
+
+    :ok
+  end
+
+  defp noop_validator, do: fn _executor, _ref, _app -> :ok end
+
+  defp validator_sending(result) do
+    fn executor, ref, app ->
+      send(
+        app,
+        {:command_result, {:login_validation, ref, executor.harness, result}}
+      )
+
+      :ok
+    end
+  end
+
+  defp new_model(extra \\ []) do
+    options =
+      [
+        login_validator: noop_validator(),
+        op_saver: fn _harness, _key -> {:ok, "op://Vault/Item/credential"} end,
+        cwd: tmp("cwd"),
+        sessions_dir: tmp("sess"),
+        provider_status: :no_provider
+      ]
+      |> Keyword.merge(extra)
+
+    App.init(%{options: options})
+  end
+
+  defp tmp(tag),
+    do:
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-wizard-#{tag}-#{System.unique_integer([:positive])}"
+      )
+
+  defp key(k, mods \\ []), do: Event.key_event(k, :pressed, mods)
+
+  defp press(model, k) do
+    {model, _cmds} = App.update(key(k), model)
+    model
+  end
+
+  describe "browse" do
+    test "init opens the browse wizard when no provider is connected" do
+      model = new_model()
+      assert %{step: :browse, entries: entries, cursor: cursor} = model.wizard
+      assert is_integer(cursor)
+      assert Enum.any?(entries, &(&1.harness == :anthropic))
+    end
+
+    test "arrow keys move the cursor within bounds" do
+      model = new_model()
+      start = model.wizard.cursor
+
+      model = press(model, :down)
+      assert model.wizard.cursor == start + 1
+
+      # Up past the top clamps at 0.
+      model = model |> press(:up) |> press(:up) |> press(:up)
+      assert model.wizard.cursor == 0
+    end
+
+    test "Esc closes the browse wizard" do
+      model = new_model() |> press(:escape)
+      assert model.wizard == nil
+    end
+
+    test "Enter on a keyed provider opens masked credential entry" do
+      # No keys set, so the cursor starts at index 0 (anthropic, keyed).
+      model = new_model()
+
+      assert Enum.at(model.wizard.entries, model.wizard.cursor).harness ==
+               :anthropic
+
+      model = press(model, :enter)
+
+      assert %{step: :credential, harness: :anthropic, buffer: ""} =
+               model.wizard
+    end
+
+    test "Enter on a keyless provider connects and closes the wizard" do
+      model = new_model()
+      index = Enum.find_index(model.wizard.entries, &(&1.harness == :lm_studio))
+      model = Enum.reduce(1..index, model, fn _, m -> press(m, :down) end)
+
+      assert Enum.at(model.wizard.entries, model.wizard.cursor).harness ==
+               :lm_studio
+
+      model = press(model, :enter)
+      assert {:ready, :lm_studio, _} = model.provider_status
+      assert model.wizard == nil
+    end
+  end
+
+  describe "credential entry" do
+    defp to_credential(model, harness) do
+      %{model | wizard: %{step: :credential, harness: harness, buffer: ""}}
+    end
+
+    test "typing accumulates into the buffer" do
+      model = new_model() |> to_credential(:openai)
+      model = model |> press("s") |> press("k") |> press("1")
+      assert model.wizard.buffer == "sk1"
+
+      model = press(model, :backspace)
+      assert model.wizard.buffer == "sk"
+    end
+
+    test "an op:// reference is stored and connects (env fallback keeps it deterministic)" do
+      System.put_env("ANTHROPIC_API_KEY", "sk-env")
+      model = new_model() |> to_credential(:anthropic)
+
+      model = %{
+        model
+        | wizard: %{model.wizard | buffer: "op://Vault/Anthropic/key"}
+      }
+
+      model = press(model, :enter)
+
+      assert {:ok, %{op_ref: "op://Vault/Anthropic/key"}} =
+               Credentials.fetch(:anthropic)
+
+      assert {:ready, :anthropic, _} = model.provider_status
+      assert model.wizard == nil
+    end
+
+    test "a raw key connects for the session and never persists to the store" do
+      model = new_model() |> to_credential(:openai)
+      model = %{model | wizard: %{model.wizard | buffer: "sk-raw"}}
+
+      model = press(model, :enter)
+
+      assert {:ready, :openai, :explicit} = model.provider_status
+      assert model.executor.auth == %{api_key: "sk-raw"}
+      # Either an offer to save (op present) or already closed (op absent) --
+      # but the raw key is never written to the reference store directly.
+      assert model.wizard == nil or match?(%{step: :confirm_save}, model.wizard)
+      assert Credentials.fetch(:openai) == :none
+    end
+
+    test "Esc from credential entry returns to the browse list" do
+      model = new_model() |> to_credential(:openai)
+      model = press(model, :escape)
+      assert %{step: :browse} = model.wizard
+    end
+  end
+
+  describe "save to 1Password" do
+    defp to_confirm_save(model, harness, key) do
+      %{model | wizard: %{step: :confirm_save, harness: harness, key: key}}
+    end
+
+    test "y saves the key via the op saver and stores the returned reference" do
+      model =
+        new_model(op_saver: fn _h, _k -> {:ok, "op://Vault/OpenAI/credential"} end)
+        |> to_confirm_save(:openai, "sk-raw")
+
+      model = press(model, "y")
+
+      assert {:ok, %{op_ref: "op://Vault/OpenAI/credential"}} =
+               Credentials.fetch(:openai)
+
+      assert model.wizard == nil
+      assert model.notice =~ "saved openai key to 1Password"
+    end
+
+    test "a failed save keeps the session key and reports it" do
+      model =
+        new_model(op_saver: fn _h, _k -> {:error, :op_create_failed} end)
+        |> to_confirm_save(:openai, "sk-raw")
+
+      model = press(model, "y")
+
+      assert Credentials.fetch(:openai) == :none
+      assert model.wizard == nil
+      assert model.notice =~ "could not save to 1Password"
+    end
+
+    test "n keeps the key for the session only" do
+      model = new_model() |> to_confirm_save(:openai, "sk-raw")
+      model = press(model, "n")
+
+      assert model.wizard == nil
+      assert model.notice =~ "kept for this session only"
+      assert Credentials.fetch(:openai) == :none
+    end
+  end
+
+  describe "validate at launch" do
+    test "an auto-detected provider is validated on the first update" do
+      executor = ExecutorConfig.new(harness: :openai, auth: %{api_key: "sk-x"})
+
+      model =
+        new_model(
+          provider_status: {:ready, :openai, :env},
+          executor: executor,
+          login_validator: validator_sending(:valid)
+        )
+
+      assert model.pending_validation == executor
+
+      # The first update fires the armed ping (in the dispatcher process).
+      model = press(model, "h")
+      assert model.pending_validation == nil
+      assert is_reference(model.login_ref)
+
+      assert_receive {:command_result, {:login_validation, ref, :openai, :valid}} = msg
+
+      assert ref == model.login_ref
+
+      {model, []} = App.update(msg, model)
+      assert model.status_line =~ "validated"
+    end
+
+    test "no launch validation is armed without an executor" do
+      model = new_model(provider_status: :ready)
+      assert model.pending_validation == nil
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #699 (provider onboarding). Implements the four highest-leverage improvements from the onboarding review; the remaining three are tracked as #700 / #701 / #702.

## 1. Interactive setup wizard

When no provider is connected, `mix raxol.code` opens a wizard instead of a static hint:

- an **arrow-selectable provider list** (`↑`/`↓` move, `Enter` connect, `Esc` dismiss), each row marked connected (`●`) / not (`○`) with an actionable note;
- picking a keyed provider opens **masked credential entry** — an `op://` reference is shown in the clear and stored; a raw API key is masked;
- after a raw key connects, the wizard **offers to save it to 1Password** (`op item create`) so no plaintext persists;
- picking a local provider (`lm_studio`, `ollama`) connects with no key.

The `/login <provider> ...` text path still works alongside the wizard for scripted use.

## 2. Detection diagnostics

`:no_provider` is no longer opaque. `Resolver.diagnostics/0` + `Credentials.op_status/0` surface *why* a provider isn't available: a stored `op://` reference that needs `op signin`, the `op` CLI missing, or an env var that is set but empty.

## 3. Token-free validation

`Backend.HTTP.check_auth/1` hits the provider's model-list endpoint (`GET /v1/models`, `/api/tags` for Ollama) — no token cost — and only falls back to the single-token completion ping when that endpoint is unavailable or ambiguous.

## 4. Validate at launch

An auto-detected provider is validated on the first update (which runs in the dispatcher process, so the async ping's reply lands correctly), so a stale env key surfaces before the first prompt rather than as a failed turn.

## Security notes

- `Credentials.create_item/3` writes the key to a `0600` temp template passed to `op item create` via `--template` — never on argv, so it can't leak to the process list.
- Session keys stay in memory; only `op://` references reach `~/.raxol/providers.json`.

## Manual testing

- [ ] `mix raxol.code` with no provider → wizard opens; `↑`/`↓` move, `Enter` on a keyed provider opens masked entry, `Esc` dismisses.
- [ ] Paste an `op://` ref in the wizard → stored + connected; shown in clear.
- [ ] Paste a raw key → masked, connects, then "save to 1Password? [y/n]"; `y` creates the item and stores the ref, `n` keeps it for the session.
- [ ] `lm_studio`/`ollama` selected → connects with no key; running → `validated`, stopped → `endpoint unreachable`.
- [ ] Real key → `validated` (via `/v1/models`, no tokens); bad key → `key rejected (HTTP 401)`.
- [ ] `op` installed but signed out, with a stored ref → diagnostics row shows "run `op signin`".
- [ ] `export ANTHROPIC_API_KEY=<stale>` → validated at launch, surfaces before the first prompt.

## Notes

- Touches zero deps; `mix.lock` unchanged.
- New tests are hermetic (injected op-saver + validator, env snapshot, no network): wizard flow, diagnostics, `check_auth`/`interpret_models_status`, launch validation.
- Full `raxol_agent` suite green (1701 passed); credo introduces zero new issues; changed files formatter-clean.
