### PR TITLE
Redact ExecutorConfig auth from model snapshots

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/executor_config.ex
+++ b/packages/raxol_agent/lib/raxol/agent/executor_config.ex
@@ -23,6 +23,12 @@ defmodule Raxol.Agent.ExecutorConfig do
       [model: "gpt-5", api_key: "sk-x"]
   """
 
+  # Snapshot safety: `auth` holds the API credential, so it is redacted from any
+  # durable snapshot while the routing fields persist. Left undeclared this
+  # struct would be dropped whole by the codec; declaring the slice makes the
+  # secret boundary explicit and keeps a session key out of a checkpoint on
+  # disk. See `Raxol.Agent.Snapshot.Persist`.
+  @derive {Raxol.Agent.Snapshot.Persist, persist: [:harness, :model, :opts], redact: [:auth]}
   @enforce_keys [:harness]
   defstruct harness: nil, model: nil, auth: %{}, opts: []
 

--- a/packages/raxol_agent/test/raxol/agent/executor_config_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/executor_config_test.exs
@@ -80,4 +80,42 @@ defmodule Raxol.Agent.ExecutorConfigTest do
       refute Keyword.has_key?(opts, :string_key)
     end
   end
+
+  # Regression guard for the session-key-to-disk leak class: a session-only key
+  # lives in `auth` (e.g. `/login openai sk-...` in the coding TUI). If the
+  # snapshot codec is ever wired to persist an agent model, `auth` must be
+  # redacted, never serialized. Removing the @derive (undeclared -> dropped
+  # whole) or moving `:auth` into `persist:` would regress this.
+  describe "snapshot redaction" do
+    alias Raxol.Agent.Snapshot
+
+    @secret "sk-SECRET-do-not-persist-1234"
+
+    test "dumping the struct redacts auth and keeps the routing fields" do
+      cfg = ExecutorConfig.new(harness: :openai, model: "gpt-x", auth: %{api_key: @secret})
+
+      {:ok, envelope} = Snapshot.dump(cfg)
+
+      refute Jason.encode!(envelope) =~ @secret
+      assert Enum.any?(envelope.redacted, &(&1["path"] == ["auth"]))
+
+      {:ok, restored} = Snapshot.load(envelope)
+      assert restored.harness == :openai
+      assert restored.model == "gpt-x"
+      # The secret comes back at its struct default, never the real value.
+      assert restored.auth == %{}
+    end
+
+    test "a model embedding an executor never leaks the key into the envelope" do
+      model = %{
+        input: "hello",
+        executor: ExecutorConfig.new(harness: :openai, auth: %{api_key: @secret})
+      }
+
+      {:ok, envelope} = Snapshot.dump(model)
+
+      refute Jason.encode!(envelope) =~ @secret
+      assert Enum.any?(envelope.redacted, &(&1["path"] == ["executor", "auth"]))
+    end
+  end
 end


### PR DESCRIPTION
Defensive hardening from the snapshot-persist verification (follow-up to the #703 onboarding work).

## Context

A session-only API key entered via `/login <provider> sk-...` lives in `ExecutorConfig.auth` in the coding agent's model. I traced whether it could reach disk:

- `Code.Store` persists only messages/events/cwd — never the executor.
- `time_travel: true` (`Raxol.Debug.TimeTravel`) is in-memory only.
- The disk-writing checkpoint/compaction/snapshot machinery has **no live callers** (`Compaction.compact/2`, the only path that checkpoints a model, is never invoked).

So there is **no live leak today**. This PR is belt-and-suspenders for the latent case where that machinery gets wired to a live agent model.

## Change

- **`ExecutorConfig`** declares its persistent slice: `@derive {Snapshot.Persist, persist: [:harness, :model, :opts], redact: [:auth]}`. Previously the struct was undeclared, so the codec dropped it whole (safe by accident). Declaring it makes the secret boundary explicit and preserves the useful routing fields while redacting `auth`.
- **Regression guard** (`executor_config_test.exs`): dumping the struct, and dumping a model that embeds one, must never serialize the key; `auth` appears in the redacted manifest and restores to its struct default. Removing the `@derive` or moving `:auth` into `persist:` fails these.

## Note on the remaining latent gap (not fixed here)

The interim surrogate paths — `Compaction.persist/1` (drops only `_`-prefixed keys) and `Checkpoint.FileBackend` (writes JSON-native models verbatim) — deliberately skip redaction until the model-snapshot codec is bound in (the code flags this: "re-bind redaction when MS lands"). Those don't consult `@derive`, so this PR doesn't close them; it hardens the codec path. Closing the surrogate gap belongs with the MS-codec work, not here.

## Testing

- `mix test` — full raxol_agent suite green (1676).
- Manually verified: `Snapshot.dump/1` of a model holding `%ExecutorConfig{auth: %{api_key: "sk-..."}}` yields an envelope whose JSON does not contain the key; `auth` is in `redacted`.
