### PR TITLE
Harden session SSE surface: auth + scoped CORS

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/session_stream_server.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session_stream_server.ex
@@ -15,6 +15,33 @@ if Code.ensure_loaded?(Plug.Router) do
     - `GET /sessions/:id/events` -- SSE stream of real-time events
     - `GET /sessions/:id/history` -- recent event history (JSON)
 
+    ## Security
+
+    Every endpoint discloses live session content -- prompts, tool calls, and
+    the agent's reasoning -- so all of them are behind a shared-secret bearer
+    token and the surface is **fail-closed by default**: with no token
+    configured a request is refused (`503`) rather than served open. Configure
+    the token one of three ways (checked in this order):
+
+        config :raxol_agent, session_stream_token: "..."   # app env
+        RAXOL_SESSION_STREAM_TOKEN=...                       # system env
+
+    Present it as `Authorization: Bearer <token>` or, for a browser
+    `EventSource` (which cannot set headers), the `?access_token=<token>`
+    query parameter. Tokens are compared in constant time.
+
+    To run open on a trusted loopback bind (dev), opt out explicitly:
+
+        config :raxol_agent, session_stream_require_auth: false
+
+    Cross-origin reads are refused unless the request `Origin` is on an
+    allowlist (there is no `*` wildcard): a same-origin dashboard needs no
+    config; to permit specific web origins,
+
+        config :raxol_agent, session_stream_allowed_origins: ["https://ops.example.com"]
+
+    (`:all` echoes any `Origin` back -- opt into that only behind other auth).
+
     ## Usage
 
         # Start as part of supervision tree (requires Bandit or Plug.Cowboy)
@@ -56,6 +83,8 @@ if Code.ensure_loaded?(Plug.Router) do
       json_decoder: Jason
     )
 
+    plug(:enforce_session_auth)
+
     plug(:dispatch)
 
     @doc false
@@ -84,7 +113,7 @@ if Code.ensure_loaded?(Plug.Router) do
         |> put_resp_header("content-type", "text/event-stream")
         |> put_resp_header("cache-control", "no-cache")
         |> put_resp_header("connection", "keep-alive")
-        |> put_resp_header("access-control-allow-origin", "*")
+        |> put_stream_cors()
         |> send_chunked(200)
 
       Raxol.Agent.SessionStreamer.subscribe(session_id, streamer)
@@ -164,6 +193,107 @@ if Code.ensure_loaded?(Plug.Router) do
       end
     end
 
+    # -- Auth --------------------------------------------------------------------
+
+    # Every session endpoint discloses live prompts/tool-calls/reasoning, so the
+    # whole surface sits behind one bearer token and is fail-closed: an
+    # unconfigured server refuses (503) rather than serving open, and a wrong or
+    # absent token is 401. A deployment that deliberately wants an open loopback
+    # bind sets `session_stream_require_auth: false`. Config resolves from
+    # `conn.private` first (the seam tests and in-process wrappers use) then app
+    # env / system env (the Bandit-adapter production path), mirroring how the
+    # streamer itself is resolved.
+    defp enforce_session_auth(conn, _opts) do
+      conn = Plug.Conn.fetch_query_params(conn)
+
+      case check_auth(conn) do
+        :ok ->
+          conn
+
+        {:error, status, message} ->
+          conn |> send_json(status, %{error: message}) |> halt()
+      end
+    end
+
+    defp check_auth(conn) do
+      case auth_token(conn) do
+        token when is_binary(token) and token != "" ->
+          if valid_presented_token?(conn, token),
+            do: :ok,
+            else: {:error, 401, "unauthorized"}
+
+        _ ->
+          if require_auth?(conn) do
+            {:error, 503,
+             "session streaming requires an auth token " <>
+               "(set RAXOL_SESSION_STREAM_TOKEN or " <>
+               "config :raxol_agent, :session_stream_token)"}
+          else
+            :ok
+          end
+      end
+    end
+
+    # Constant-time comparison; a missing/blank presented token never matches.
+    defp valid_presented_token?(conn, token) do
+      case presented_token(conn) do
+        presented when is_binary(presented) and presented != "" ->
+          Plug.Crypto.secure_compare(presented, token)
+
+        _ ->
+          false
+      end
+    end
+
+    # `Authorization: Bearer <token>` when the client can set headers; the
+    # `?access_token=` query param is the fallback for a browser `EventSource`,
+    # which cannot.
+    defp presented_token(conn) do
+      bearer_token(conn) || conn.query_params["access_token"]
+    end
+
+    defp bearer_token(conn) do
+      case Plug.Conn.get_req_header(conn, "authorization") do
+        ["Bearer " <> token | _] -> token
+        _ -> nil
+      end
+    end
+
+    defp auth_token(conn) do
+      private_val(conn, :session_stream_token) ||
+        Application.get_env(:raxol_agent, :session_stream_token) ||
+        System.get_env("RAXOL_SESSION_STREAM_TOKEN")
+    end
+
+    defp require_auth?(conn) do
+      case private_val(conn, :session_stream_require_auth) do
+        nil -> Application.get_env(:raxol_agent, :session_stream_require_auth, true)
+        value -> value
+      end
+    end
+
+    # Scoped CORS: echo the request `Origin` only when it is explicitly
+    # allowlisted (or `:all` was opted into) -- never a bare `*`. With no
+    # allowlist configured the header is omitted entirely, so a browser holds
+    # the stream to same-origin reads.
+    defp put_stream_cors(conn) do
+      origin = List.first(Plug.Conn.get_req_header(conn, "origin"))
+      allowed = allowed_origins(conn)
+
+      if is_binary(origin) and (allowed == :all or origin in allowed) do
+        put_resp_header(conn, "access-control-allow-origin", origin)
+      else
+        conn
+      end
+    end
+
+    defp allowed_origins(conn) do
+      private_val(conn, :session_stream_allowed_origins) ||
+        Application.get_env(:raxol_agent, :session_stream_allowed_origins, [])
+    end
+
+    defp private_val(conn, key), do: Map.get(conn.private, key)
+
     defp parse_session_id(id) do
       case Integer.parse(id) do
         {n, ""} -> n
@@ -239,6 +369,11 @@ if Code.ensure_loaded?(Plug.Router) do
     defp serialize_event(other), do: {"unknown", %{data: inspect(other)}}
 
     defp send_json(conn, status, data) do
+      # Same origin-scoped CORS as the SSE stream: a cross-origin `fetch` of
+      # `/history` or `/sessions` discloses the same content, so it is held to
+      # the same allowlist rather than being readable from any web origin.
+      conn = put_stream_cors(conn)
+
       case Jason.encode(data) do
         {:ok, json} ->
           conn

--- a/packages/raxol_agent/test/raxol/agent/security_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/security_test.exs
@@ -189,8 +189,10 @@ defmodule Raxol.Agent.SecurityTest do
     end
 
     defp call_server(conn, streamer) do
-      conn = Plug.Conn.put_private(conn, :streamer, streamer)
-      SessionStreamServer.call(conn, SessionStreamServer.init([]))
+      conn
+      |> Plug.Conn.put_private(:streamer, streamer)
+      |> Plug.Conn.put_private(:session_stream_require_auth, false)
+      |> SessionStreamServer.call(SessionStreamServer.init([]))
     end
 
     test "numeric session id is parsed as integer", %{streamer: streamer} do

--- a/packages/raxol_agent/test/raxol/agent/session_stream_server_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_stream_server_test.exs
@@ -12,8 +12,12 @@ defmodule Raxol.Agent.SessionStreamServerTest do
   end
 
   defp call(conn, streamer) do
-    conn = Plug.Conn.put_private(conn, :streamer, streamer)
-    SessionStreamServer.call(conn, SessionStreamServer.init([]))
+    conn
+    |> Plug.Conn.put_private(:streamer, streamer)
+    # Routing/serialization tests run the surface in open mode; the
+    # "authentication" describe block below exercises the gate itself.
+    |> Plug.Conn.put_private(:session_stream_require_auth, false)
+    |> SessionStreamServer.call(SessionStreamServer.init([]))
   end
 
   describe "GET /sessions" do
@@ -88,6 +92,114 @@ defmodule Raxol.Agent.SessionStreamServerTest do
 
       assert conn.status == 404
       assert %{"error" => "not found"} = Jason.decode!(conn.resp_body)
+    end
+  end
+
+  describe "authentication" do
+    # Drive the surface the way production does (no `require_auth: false`
+    # escape hatch), varying only the configured/presented token.
+    defp auth_call(conn, streamer, private) do
+      conn
+      |> Plug.Conn.put_private(:streamer, streamer)
+      |> then(fn c ->
+        Enum.reduce(private, c, fn {k, v}, acc ->
+          Plug.Conn.put_private(acc, k, v)
+        end)
+      end)
+      |> SessionStreamServer.call(SessionStreamServer.init([]))
+    end
+
+    test "fail-closed: no token configured refuses with 503", %{
+      streamer: streamer
+    } do
+      conn = conn(:get, "/sessions") |> auth_call(streamer, %{})
+
+      assert conn.status == 503
+      assert %{"error" => msg} = Jason.decode!(conn.resp_body)
+      assert msg =~ "auth token"
+    end
+
+    test "401 when a token is configured but none is presented", %{
+      streamer: streamer
+    } do
+      conn =
+        conn(:get, "/sessions")
+        |> auth_call(streamer, %{session_stream_token: "s3cret"})
+
+      assert conn.status == 401
+    end
+
+    test "401 on a wrong bearer token", %{streamer: streamer} do
+      conn =
+        conn(:get, "/sessions")
+        |> put_req_header("authorization", "Bearer nope")
+        |> auth_call(streamer, %{session_stream_token: "s3cret"})
+
+      assert conn.status == 401
+    end
+
+    test "200 with the correct bearer token", %{streamer: streamer} do
+      conn =
+        conn(:get, "/sessions")
+        |> put_req_header("authorization", "Bearer s3cret")
+        |> auth_call(streamer, %{session_stream_token: "s3cret"})
+
+      assert conn.status == 200
+    end
+
+    test "200 with the correct ?access_token= query param (EventSource path)",
+         %{streamer: streamer} do
+      conn =
+        conn(:get, "/sessions?access_token=s3cret")
+        |> auth_call(streamer, %{session_stream_token: "s3cret"})
+
+      assert conn.status == 200
+    end
+
+    test "an enumerated session id is unreachable without the token", %{
+      streamer: streamer
+    } do
+      SessionStreamer.emit(0, {:text_delta, "secret prompt"}, streamer)
+      Process.sleep(20)
+
+      conn =
+        conn(:get, "/sessions/0/history")
+        |> auth_call(streamer, %{session_stream_token: "s3cret"})
+
+      assert conn.status == 401
+      refute conn.resp_body =~ "secret prompt"
+    end
+  end
+
+  describe "CORS" do
+    # Asserted on `/sessions` (JSON) rather than the SSE `/events` route, which
+    # blocks in its stream loop; the scoped-CORS helper is shared across both.
+    test "no access-control-allow-origin header by default (same-origin only)",
+         %{streamer: streamer} do
+      conn =
+        conn(:get, "/sessions")
+        |> put_req_header("origin", "https://evil.example")
+        |> Plug.Conn.put_private(:streamer, streamer)
+        |> Plug.Conn.put_private(:session_stream_require_auth, false)
+        |> SessionStreamServer.call(SessionStreamServer.init([]))
+
+      assert Plug.Conn.get_resp_header(conn, "access-control-allow-origin") == []
+    end
+
+    test "echoes an allowlisted origin, never a wildcard", %{streamer: streamer} do
+      conn =
+        conn(:get, "/sessions")
+        |> put_req_header("origin", "https://ops.example")
+        |> Plug.Conn.put_private(:streamer, streamer)
+        |> Plug.Conn.put_private(:session_stream_require_auth, false)
+        |> Plug.Conn.put_private(
+          :session_stream_allowed_origins,
+          ["https://ops.example"]
+        )
+        |> SessionStreamServer.call(SessionStreamServer.init([]))
+
+      assert Plug.Conn.get_resp_header(conn, "access-control-allow-origin") ==
+               ["https://ops.example"]
     end
   end
 


### PR DESCRIPTION
## What

Closes the security finding deferred from #690's adversarial review: the agent session SSE surface (`Raxol.Agent.SessionStreamServer`) was unauthenticated, wildcard-CORS (`access-control-allow-origin: *`), over enumerable integer session ids — and #690 widened what it discloses by adding `:reasoning` (chain-of-thought) to the stream. Any web origin could walk `/sessions/0..N/events` and read another session's prompts, tool calls, and reasoning.

## Changes

All endpoints now sit behind a shared-secret bearer token, **fail-closed by default**:

- **Auth** — a new `:enforce_session_auth` pipeline plug gates every route. Token resolves from `conn.private` (test/in-process seam) → `config :raxol_agent, :session_stream_token` → `RAXOL_SESSION_STREAM_TOKEN`. Presented as `Authorization: Bearer <token>` or, for a browser `EventSource` (which cannot set headers), `?access_token=<token>`. Constant-time compare (`Plug.Crypto.secure_compare/2`).
  - No token configured → `503` (refused), not served open. A deliberate loopback/dev bind opts out with `config :raxol_agent, session_stream_require_auth: false`.
  - Wrong/absent token when one is configured → `401`.
  - Auth blocks id-enumeration outright, so opaque ids aren't needed.
- **CORS** — scoped allowlist instead of `*`. The request `Origin` is echoed only when it's on `session_stream_allowed_origins` (or `:all`, an explicit opt-in); otherwise no CORS header is emitted, holding a browser to same-origin reads. Applied to the JSON endpoints too (`send_json`), since a cross-origin `fetch('/history')` is the same disclosure vector.

The HTTP server is never auto-started (only via an explicit Bandit/Plug.Cowboy adapter; Symphony uses the `SessionStreamer` pub/sub, not this HTTP server), so the fail-closed default breaks no boot path.

## Tests

New `describe "authentication"` + `describe "CORS"` blocks (8 tests): fail-closed 503, 401 on missing/wrong token, 200 on correct bearer and on `?access_token=` query, an enumerated id unreachable without the token (asserts the secret prompt body does not leak), no CORS header by default, allowlisted-origin echo (never `*`). Existing routing/serialization/parse tests pin open mode via `conn.private`.

- `MIX_ENV=test mix compile --warnings-as-errors` clean
- Full `raxol_agent` suite: 1827 passed at seed 0

## Manual testing

- [ ] Start `{Bandit, plug: Raxol.Agent.SessionStreamServer}` with no token → `curl /sessions` returns 503
- [ ] Set `RAXOL_SESSION_STREAM_TOKEN` → `curl -H 'Authorization: Bearer <t>' /sessions/:id/events` streams; wrong/absent token → 401
- [ ] Cross-origin `EventSource` from a non-allowlisted origin is blocked by the browser (no ACAO header)
