### PR TITLE
raxol.code: mid-session auth recovery (#701)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -612,10 +612,45 @@ defmodule Raxol.Agent.Code.App do
     end
   end
 
-  defp finalize_turn(model, %{type: :error}),
-    do: persist(%{model | turn_answer: ""})
+  defp finalize_turn(model, %{type: :error} = event) do
+    model = persist(%{model | turn_answer: ""})
+
+    # A credential rejected mid-session (revoked/expired key) routes back to
+    # onboarding instead of leaving the bare error face. The conversation is
+    # preserved (messages are untouched here), so `/login` reconnects and the
+    # user continues where they left off.
+    if auth_rejected?(error_reason(event)),
+      do: to_reauth(model),
+      else: model
+  end
 
   defp finalize_turn(model, _event), do: model
+
+  defp error_reason(%{payload: payload}) when is_map(payload),
+    do: Map.get(payload, :reason) || Map.get(payload, "reason")
+
+  defp error_reason(_event), do: nil
+
+  # Flip the provider back to its unconnected state so the setup panel shows
+  # and `submit_prompt/2` gates further turns until `/login` reconnects.
+  defp to_reauth(model) do
+    backend = current_backend(model)
+
+    %{
+      model
+      | provider_status: {:no_key, backend},
+        notice: "auth failed for #{backend} — run /login to reconnect"
+    }
+  end
+
+  defp current_backend(%{provider_status: {:ready, backend, _source}}),
+    do: backend
+
+  defp current_backend(%{executor: %{backend: backend}})
+       when not is_nil(backend),
+       do: backend
+
+  defp current_backend(_model), do: :unknown
 
   defp append_assistant(messages, answer) do
     case String.trim(answer) do
@@ -992,16 +1027,30 @@ defmodule Raxol.Agent.Code.App do
   # (even a truncated/unparseable body) authorized the request, so it is valid.
   def interpret_ping({:ok, _response}), do: :valid
 
-  def interpret_ping({:error, {:http_error, status, _body}})
-      when status in [401, 403],
-      do: {:rejected, status}
-
-  def interpret_ping({:error, {:http_error, status, _body}}),
-    do: {:reachable_error, status}
+  def interpret_ping({:error, {:http_error, status, _body} = reason}) do
+    if auth_rejected?(reason),
+      do: {:rejected, status},
+      else: {:reachable_error, status}
+  end
 
   def interpret_ping({:error, {:request_failed, _reason}}), do: :unreachable
   def interpret_ping({:error, :req_not_available}), do: :req_unavailable
   def interpret_ping({:error, _marker}), do: :valid
+
+  @doc false
+  # Shared credential-rejection classifier for a backend error term — used by
+  # both the `/login` ping (interpret_ping/1) and the mid-turn error fold
+  # (finalize_turn on a contract `:error` event). Recognizes the structured
+  # `complete/2` shape (`{:http_error, 401|403, _}`) and the streaming shape
+  # (the "HTTP 401"/"HTTP 403" string `Backend.HTTP.stream/2` surfaces as its
+  # error element).
+  def auth_rejected?({:http_error, status, _body}) when status in [401, 403],
+    do: true
+
+  def auth_rejected?(reason) when is_binary(reason),
+    do: reason =~ ~r/\bHTTP (401|403)\b/
+
+  def auth_rejected?(_reason), do: false
 
   defp validation_status(harness, :valid),
     do: "#{harness} credential validated ●"

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -23,7 +23,10 @@ defmodule Raxol.Agent.Code.AppTest do
   end
 
   defp tmp_dir do
-    Path.join(System.tmp_dir!(), "raxol-code-app-#{System.unique_integer([:positive])}")
+    Path.join(
+      System.tmp_dir!(),
+      "raxol-code-app-#{System.unique_integer([:positive])}"
+    )
   end
 
   defp key(k, mods \\ []), do: Event.key_event(k, :pressed, mods)
@@ -117,7 +120,11 @@ defmodule Raxol.Agent.Code.AppTest do
       model =
         send_ev(
           model,
-          ev(2, :item_completed, %{item_id: "i1", item_type: :tool_use, name: "grep"})
+          ev(2, :item_completed, %{
+            item_id: "i1",
+            item_type: :tool_use,
+            name: "grep"
+          })
         )
 
       assert model.face_state == :working
@@ -134,10 +141,71 @@ defmodule Raxol.Agent.Code.AppTest do
       assert model.running? == false
     end
 
+    test "a mid-session 401 routes back to onboarding, preserving the conversation" do
+      model =
+        %{
+          new_model(provider_status: {:ready, :anthropic, :env})
+          | running?: true,
+            messages: [%{role: :user, content: "hi"}]
+        }
+
+      model = send_ev(model, ev(9, :error, %{reason: {:http_error, 401, ""}}))
+
+      # Routed back to onboarding (setup panel + gate), not the bare error face.
+      assert model.provider_status == {:no_key, :anthropic}
+      assert model.notice =~ "/login"
+      # The conversation survives so /login reconnects and continues.
+      assert model.messages == [%{role: :user, content: "hi"}]
+
+      # A further prompt is now gated on reconnect, never starting a turn.
+      {gated, []} = submit(model, "again")
+      refute gated.running?
+    end
+
+    test "the streaming auth-error shape (\"HTTP 403\") also routes back to onboarding" do
+      model = %{
+        new_model(provider_status: {:ready, :openai, :env})
+        | running?: true
+      }
+
+      model = send_ev(model, ev(9, :error, %{reason: "HTTP 403"}))
+      assert model.provider_status == {:no_key, :openai}
+    end
+
+    test "a non-auth error keeps the provider connected" do
+      model = %{
+        new_model(provider_status: {:ready, :anthropic, :env})
+        | running?: true
+      }
+
+      model = send_ev(model, ev(9, :error, %{reason: :boom}))
+      assert model.provider_status == {:ready, :anthropic, :env}
+      assert model.face_state == :error
+    end
+
+    test "auth_rejected?/1 recognizes both the structured and streaming shapes" do
+      assert App.auth_rejected?({:http_error, 401, ""})
+      assert App.auth_rejected?({:http_error, 403, "body"})
+      assert App.auth_rejected?("HTTP 401")
+      refute App.auth_rejected?({:http_error, 500, ""})
+      refute App.auth_rejected?("HTTP 500")
+      refute App.auth_rejected?(:boom)
+    end
+
     test "malformed contract events are dropped, not folded" do
       model = new_model()
-      bad = %Contract.Event{id: -1, ts: 0, type: :turn_started, tier: :durable, payload: %{}}
-      {model2, []} = App.update({:command_result, {:contract_event, bad}}, model)
+
+      bad = %Contract.Event{
+        id: -1,
+        ts: 0,
+        type: :turn_started,
+        tier: :durable,
+        payload: %{}
+      }
+
+      {model2, []} =
+        App.update({:command_result, {:contract_event, bad}}, model)
+
       assert model2.events == []
     end
   end
@@ -252,7 +320,10 @@ defmodule Raxol.Agent.Code.AppTest do
       # {:command_result, _} messages we feed back into update/2.
       model =
         App.init(%{
-          options: [backend_opts: [response: "hello from mock"], sessions_dir: tmp_dir()]
+          options: [
+            backend_opts: [response: "hello from mock"],
+            sessions_dir: tmp_dir()
+          ]
         })
 
       model = %{model | input: "say hi"}
@@ -304,7 +375,11 @@ defmodule Raxol.Agent.Code.AppTest do
         |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
         |> send_ev(ev(2, :item_started, %{item_id: "i1", item_type: :message}))
         |> send_ev(
-          ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "hello there"})
+          ev(3, :item_completed, %{
+            item_id: "i1",
+            item_type: :message,
+            content: "hello there"
+          })
         )
         |> send_ev(ev(4, :turn_completed, %{final: true, usage: %{}}))
 
@@ -330,7 +405,13 @@ defmodule Raxol.Agent.Code.AppTest do
       model =
         model
         |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
-        |> send_ev(ev(2, :item_completed, %{item_id: "i1", item_type: :message, content: "done"}))
+        |> send_ev(
+          ev(2, :item_completed, %{
+            item_id: "i1",
+            item_type: :message,
+            content: "done"
+          })
+        )
         |> send_ev(ev(3, :turn_completed, %{final: true, usage: %{}}))
 
       assert List.last(model.messages) == %{role: :assistant, content: "done"}
@@ -342,12 +423,21 @@ defmodule Raxol.Agent.Code.AppTest do
   describe "resume" do
     test "init with a saved session_key reloads its messages" do
       dir = tmp_dir()
-      msgs = [%{role: :user, content: "earlier"}, %{role: :assistant, content: "reply"}]
+
+      msgs = [
+        %{role: :user, content: "earlier"},
+        %{role: :assistant, content: "reply"}
+      ]
+
       :ok = Raxol.Agent.Code.Store.save(dir, "sess-x", %{messages: msgs})
 
       model =
         App.init(%{
-          options: [runner: stub_runner(), sessions_dir: dir, session_key: "sess-x"]
+          options: [
+            runner: stub_runner(),
+            sessions_dir: dir,
+            session_key: "sess-x"
+          ]
         })
 
       assert model.messages == msgs
@@ -357,7 +447,11 @@ defmodule Raxol.Agent.Code.AppTest do
     test "resuming a missing session starts fresh with a notice" do
       model =
         App.init(%{
-          options: [runner: stub_runner(), sessions_dir: tmp_dir(), session_key: "nope"]
+          options: [
+            runner: stub_runner(),
+            sessions_dir: tmp_dir(),
+            session_key: "nope"
+          ]
         })
 
       assert model.messages == []
@@ -376,7 +470,11 @@ defmodule Raxol.Agent.Code.AppTest do
         |> send_ev(ev(1, :turn_started, %{prompt: "hi"}))
         |> send_ev(ev(2, :item_started, %{item_id: "i1", item_type: :message}))
         |> send_ev(
-          ev(3, :item_completed, %{item_id: "i1", item_type: :message, content: "restored answer"})
+          ev(3, :item_completed, %{
+            item_id: "i1",
+            item_type: :message,
+            content: "restored answer"
+          })
         )
         |> send_ev(ev(4, :turn_completed, %{final: true, usage: %{}}))
 
@@ -384,14 +482,17 @@ defmodule Raxol.Agent.Code.AppTest do
 
       # A fresh app resumes that session id.
       resumed =
-        App.init(%{options: [runner: stub_runner(), sessions_dir: dir, session_key: key]})
+        App.init(%{
+          options: [runner: stub_runner(), sessions_dir: dir, session_key: key]
+        })
 
       assert resumed.events != []
       blocks = Raxol.Harness.Projection.project(resumed.events).blocks
 
       assert Enum.any?(
                blocks,
-               &(Raxol.UI.Components.Harness.Block.search_text(&1) =~ "restored answer")
+               &(Raxol.UI.Components.Harness.Block.search_text(&1) =~
+                   "restored answer")
              )
 
       # And the resumed model renders.
@@ -442,10 +543,15 @@ defmodule Raxol.Agent.Code.AppTest do
         config_cwd(%{
           ".raxol/hooks.json" => Jason.encode!(%{"stop" => ["true"]}),
           ".mcp.json" =>
-            Jason.encode!(%{"mcpServers" => %{"fs" => %{"command" => "npx", "args" => []}}})
+            Jason.encode!(%{
+              "mcpServers" => %{"fs" => %{"command" => "npx", "args" => []}}
+            })
         })
 
-      model = App.init(%{options: [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir]})
+      model =
+        App.init(%{
+          options: [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir]
+        })
 
       assert model.hooks.stop == ["true"]
       assert [%{name: "fs"}] = model.mcp_servers
@@ -464,10 +570,16 @@ defmodule Raxol.Agent.Code.AppTest do
       dir =
         config_cwd(%{
           ".raxol/hooks.json" =>
-            Jason.encode!(%{"pre_tool_use" => [%{"match" => "*", "command" => "true"}]})
+            Jason.encode!(%{
+              "pre_tool_use" => [%{"match" => "*", "command" => "true"}]
+            })
         })
 
-      model = App.init(%{options: [runner: runner, sessions_dir: tmp_dir(), cwd: dir]})
+      model =
+        App.init(%{
+          options: [runner: runner, sessions_dir: tmp_dir(), cwd: dir]
+        })
+
       {_model, []} = App.update(key(:enter), %{model | input: "go"})
 
       assert_receive {:opts, opts}
@@ -475,7 +587,9 @@ defmodule Raxol.Agent.Code.AppTest do
       assert Map.has_key?(context, :subagent)
       assert context.tool_call_hooks == [Raxol.Agent.Code.Hooks]
 
-      names = Enum.map(Keyword.fetch!(opts, :actions), & &1.__action_meta__().name)
+      names =
+        Enum.map(Keyword.fetch!(opts, :actions), & &1.__action_meta__().name)
+
       assert "task" in names
     end
 
@@ -484,10 +598,15 @@ defmodule Raxol.Agent.Code.AppTest do
         config_cwd(%{
           ".raxol/hooks.json" => Jason.encode!(%{"stop" => ["true"]}),
           ".mcp.json" =>
-            Jason.encode!(%{"mcpServers" => %{"fs" => %{"command" => "npx", "args" => []}}})
+            Jason.encode!(%{
+              "mcpServers" => %{"fs" => %{"command" => "npx", "args" => []}}
+            })
         })
 
-      model = App.init(%{options: [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir]})
+      model =
+        App.init(%{
+          options: [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir]
+        })
 
       {model, []} = submit(model, "/hooks")
       assert model.notice =~ "stop: 1"


### PR DESCRIPTION
Closes #701.

## Problem
If a turn fails on a 401/403 mid-session (revoked/expired key), `raxol.code` shows the bare `≡xx≡` error face with no way forward.

## Fix
`finalize_turn/2` on a contract `:error` event now classifies the reason and, when it's a credential rejection, routes back to onboarding:
- flips `provider_status` → `{:no_key, backend}` so the setup panel shows and `submit_prompt/2` gates further turns until `/login` reconnects
- preserves the conversation (messages untouched), so the user continues where they left off
- shows a `run /login to reconnect` notice

`auth_rejected?/1` is the shared classifier the issue asked for — also used by `interpret_ping/1` (the `/login` ping). It handles **both** error shapes:
- structured `complete/2`: `{:http_error, 401|403, _}`
- streaming `stream/2`: the `"HTTP 401"`/`"HTTP 403"` string it surfaces as the error element (verified against `Backend.HTTP` lines 231-232 / 292-293)

## Tests (raxol_agent `app_test.exs`)
- mid-session 401 → `{:no_key, :anthropic}`, conversation preserved, next prompt gated
- streaming `"HTTP 403"` shape also routes back
- non-auth error keeps the provider connected (still shows error face)
- `auth_rejected?/1` recognizes both shapes, rejects 500/other

Verified: `mix compile --warnings-as-errors` clean; `app_test` 40 passed; `app_login`/`app_wizard` 33 passed (interpret_ping refactor unchanged behavior).

## Manual testing
- [ ] Connect a provider, revoke/expire the key, send a prompt → drops to setup panel with the reconnect hint; `/login` reconnects and the prior conversation is intact