### PR TITLE
raxol.code: model picker after provider connect (#700)

### DIFF
--- a/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Raxol.Code do
 
   ## Slash commands
 
-  `/help` · `/login [provider]` · `/clear` · `/model <name>` · `/plan` ·
+  `/help` · `/login [provider]` · `/clear` · `/model [name]` · `/plan` ·
   `/compact` · `/context` · `/sessions` · `/mcp` · `/hooks`
 
   ## Delegation, hooks, external config

--- a/packages/raxol_agent/lib/raxol/agent/backend/http.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/http.ex
@@ -55,7 +55,8 @@ defmodule Raxol.Agent.Backend.HTTP do
     # unparseable body or an empty length-truncated turn is an honest error,
     # NOT assistant prose (the "cannot lie at the wire boundary" rule). The
     # with-chain surfaces either the transport error or the parse error.
-    with {:ok, response_body} <- do_request(url, headers, body, timeout, plugins),
+    with {:ok, response_body} <-
+           do_request(url, headers, body, timeout, plugins),
          {:ok, parsed} <- parse_response(provider, response_body) do
       {:ok, parsed}
     end
@@ -126,25 +127,89 @@ defmodule Raxol.Agent.Backend.HTTP do
 
   @doc false
   def interpret_models_status(status) when status in 200..299, do: :valid
-  def interpret_models_status(status) when status in [401, 403], do: {:rejected, status}
-  def interpret_models_status(status) when is_integer(status), do: {:reachable_error, status}
+
+  def interpret_models_status(status) when status in [401, 403],
+    do: {:rejected, status}
+
+  def interpret_models_status(status) when is_integer(status),
+    do: {:reachable_error, status}
+
+  @doc """
+  List a provider's available model ids via the SAME model-list endpoint
+  `check_auth/1` uses (so it costs no tokens and reuses the auth plumbing).
+
+  Returns `{:ok, ids}` (a possibly-empty list of model-id strings),
+  `{:error, reason}` (transport failure or non-2xx), or `:unsupported` (no
+  known model-list endpoint for this provider — the caller should fall back
+  to typing a model name).
+  """
+  @spec list_models(keyword()) ::
+          {:ok, [String.t()]} | {:error, term()} | :unsupported
+  def list_models(opts) do
+    if available?() do
+      provider = detect_provider(opts)
+      provider |> models_request(opts) |> fetch_models(provider, opts)
+    else
+      :unsupported
+    end
+  end
+
+  defp fetch_models(:unsupported, _provider, _opts), do: :unsupported
+
+  defp fetch_models({url, headers}, provider, opts) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    req = Req.new(url: url, headers: headers, receive_timeout: timeout)
+
+    case Req.get(req) do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        {:ok, parse_models(provider, body)}
+
+      {:ok, %{status: status}} ->
+        {:error, {:http_error, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    _ -> {:error, :request_failed}
+  end
+
+  @doc false
+  # Extract model-id strings from a model-list response body. Public for
+  # testing the two response shapes without a live endpoint.
+  # Ollama `/api/tags`: `%{"models" => [%{"name" => id}, ...]}`.
+  def parse_models(:ollama, %{"models" => models}) when is_list(models),
+    do: for(%{"name" => name} <- models, is_binary(name), do: name)
+
+  # OpenAI-compatible `/v1/models`: `%{"data" => [%{"id" => id}, ...]}`.
+  def parse_models(_provider, %{"data" => data}) when is_list(data),
+    do: for(%{"id" => id} <- data, is_binary(id), do: id)
+
+  def parse_models(_provider, _body), do: []
 
   defp models_request(:anthropic, opts) do
     case Keyword.get(opts, :api_key) do
       key when is_binary(key) ->
         base = Keyword.get(opts, :base_url, "https://api.anthropic.com")
-        {"#{base}/v1/models", [{"x-api-key", key}, {"anthropic-version", @anthropic_api_version}]}
+
+        {"#{base}/v1/models",
+         [{"x-api-key", key}, {"anthropic-version", @anthropic_api_version}]}
 
       _no_key ->
         :unsupported
     end
   end
 
-  defp models_request(:openai, opts), do: bearer_models_request(opts, "https://api.openai.com")
-  defp models_request(:kimi, opts), do: bearer_models_request(opts, "https://api.moonshot.ai")
+  defp models_request(:openai, opts),
+    do: bearer_models_request(opts, "https://api.openai.com")
+
+  defp models_request(:kimi, opts),
+    do: bearer_models_request(opts, "https://api.moonshot.ai")
 
   defp models_request(:ollama, opts) do
-    base = Keyword.get(opts, :base_url, "http://localhost:#{@default_ollama_port}")
+    base =
+      Keyword.get(opts, :base_url, "http://localhost:#{@default_ollama_port}")
+
     {"#{base}/api/tags", []}
   end
 
@@ -454,7 +519,8 @@ defmodule Raxol.Agent.Backend.HTTP do
       # the whole array per chunk + last-wins loses the name (the final
       # fragment is args-only). A single full-message tool_calls array is just
       # the degenerate one-fragment case, so this handles both.
-      is_list(tool_calls) and tool_calls != [] and {:tool_call_delta, tool_calls}
+      is_list(tool_calls) and tool_calls != [] and
+        {:tool_call_delta, tool_calls}
     )
     |> maybe_prepend(finish == "length" && {:marker, truncation_marker(choice)})
     |> Enum.reverse()
@@ -654,7 +720,11 @@ defmodule Raxol.Agent.Backend.HTTP do
        content: choice_text(msg),
        tool_calls: parse_openai_tool_calls(tool_calls),
        usage: Map.get(body, "usage", %{}),
-       metadata: %{backend: :http, provider: :openai, model: Map.get(body, "model")}
+       metadata: %{
+         backend: :http,
+         provider: :openai,
+         model: Map.get(body, "model")
+       }
      }
      |> put_reasoning(choice_reasoning(msg))}
   end
@@ -809,7 +879,8 @@ defmodule Raxol.Agent.Backend.HTTP do
     end
   end
 
-  defp resolve_tool_call_index(acc, _frag, pos), do: next_tool_call_index(acc) + pos
+  defp resolve_tool_call_index(acc, _frag, pos),
+    do: next_tool_call_index(acc) + pos
 
   defp find_tool_call_index_by_id(acc, id) do
     Enum.find_value(acc, fn
@@ -881,8 +952,12 @@ defmodule Raxol.Agent.Backend.HTTP do
 
   # The separate reasoning channel: `reasoning` (OpenRouter) or
   # `reasoning_content` (DeepSeek / LongCat); nil when absent/blank.
-  defp choice_reasoning(%{"reasoning_content" => t}) when is_binary(t) and t != "", do: t
-  defp choice_reasoning(%{"reasoning" => t}) when is_binary(t) and t != "", do: t
+  defp choice_reasoning(%{"reasoning_content" => t})
+       when is_binary(t) and t != "", do: t
+
+  defp choice_reasoning(%{"reasoning" => t}) when is_binary(t) and t != "",
+    do: t
+
   defp choice_reasoning(_msg), do: nil
 
   # Tolerate the wire-key variant: LongCat sends `finishreason` (no
@@ -917,7 +992,9 @@ defmodule Raxol.Agent.Backend.HTTP do
   end
 
   defp put_reasoning(response, nil), do: response
-  defp put_reasoning(response, reasoning), do: Map.put(response, :reasoning, reasoning)
+
+  defp put_reasoning(response, reasoning),
+    do: Map.put(response, :reasoning, reasoning)
 
   defp blank?(s) when is_binary(s), do: String.trim(s) == ""
   defp blank?(_), do: false

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -147,6 +147,17 @@ defmodule Raxol.Agent.Code.App do
           :login_validator,
           &__MODULE__.default_login_validator/3
         ),
+      # `/model` with no arg fetches the connected provider's model list off
+      # the app process; the result rides back as a `:models_list` message
+      # matched by this ref. Injectable so tests drive it without a network
+      # call, mirroring `:login_validator`.
+      models_ref: nil,
+      models_fetcher:
+        Keyword.get(
+          options,
+          :models_fetcher,
+          &__MODULE__.default_models_fetcher/3
+        ),
       # The onboarding wizard overlay: nil (connected), or a step map
       # (`:browse` selectable list, `:credential` masked entry, `:confirm_save`
       # save-to-1Password prompt). Set in init when no provider is connected.
@@ -304,6 +315,14 @@ defmodule Raxol.Agent.Code.App do
     end
   end
 
+  # An async `/model` model-list fetch result. Applied only when its ref still
+  # matches the latest fetch (a newer `/model` supersedes an in-flight one).
+  def update({:command_result, {:models_list, ref, result}}, model) do
+    if ref == model.models_ref,
+      do: {apply_models_result(model, result), []},
+      else: {model, []}
+  end
+
   def update(_message, model), do: {model, []}
 
   # Fire the armed launch validation on the first update (dispatcher process).
@@ -368,11 +387,13 @@ defmodule Raxol.Agent.Code.App do
   # In browse mode, ↑/↓ move the provider cursor; Enter on an empty prompt
   # selects it. A typed prompt or slash command still takes precedence (so the
   # `/login <provider> ...` text path stays reachable alongside the wizard).
-  defp handle_key(:up, %{wizard: %{step: :browse}} = model),
-    do: {wizard_move(model, -1), []}
+  defp handle_key(:up, %{wizard: %{step: step}} = model)
+       when step in [:browse, :models],
+       do: {wizard_move(model, -1), []}
 
-  defp handle_key(:down, %{wizard: %{step: :browse}} = model),
-    do: {wizard_move(model, +1), []}
+  defp handle_key(:down, %{wizard: %{step: step}} = model)
+       when step in [:browse, :models],
+       do: {wizard_move(model, +1), []}
 
   defp handle_key(:enter, model) do
     case String.trim(model.input) do
@@ -396,10 +417,11 @@ defmodule Raxol.Agent.Code.App do
   defp handle_key(:escape, %{running?: true} = model),
     do: {interrupt(model), []}
 
-  # Esc closes the browse list (reopen with /login); the modal steps handle
-  # their own Esc in handle_wizard/2.
-  defp handle_key(:escape, %{wizard: %{step: :browse}} = model),
-    do: {close_wizard(model), []}
+  # Esc closes the browse/model list (reopen with /login or /model); the modal
+  # steps handle their own Esc in handle_wizard/2.
+  defp handle_key(:escape, %{wizard: %{step: step}} = model)
+       when step in [:browse, :models],
+       do: {close_wizard(model), []}
 
   defp handle_key(_key, model), do: {model, []}
 
@@ -1115,6 +1137,21 @@ defmodule Raxol.Agent.Code.App do
     end
   end
 
+  defp maybe_wizard_select(
+         %{wizard: %{step: :models, entries: entries, cursor: cursor}} = model
+       ) do
+    case Enum.at(entries, cursor) do
+      nil ->
+        model
+
+      entry ->
+        notice(
+          %{model | model_override: entry.model, wizard: nil},
+          "model set to #{entry.model}"
+        )
+    end
+  end
+
   defp maybe_wizard_select(model), do: model
 
   # A keyless provider connects immediately; a keyed one opens masked entry.
@@ -1296,15 +1333,94 @@ defmodule Raxol.Agent.Code.App do
     }
   end
 
-  defp set_model(model, "") do
-    notice(
-      model,
-      "usage: /model <name>  (current: #{model.model_override || "default"})"
-    )
+  # `/model` with no arg on a connected provider fetches its model list and
+  # opens a selectable picker; otherwise it just shows the current model.
+  defp set_model(%{executor: %{}} = model, "") do
+    if provider_ready?(model),
+      do: open_model_picker(model),
+      else: model_usage(model)
   end
+
+  defp set_model(model, ""), do: model_usage(model)
 
   defp set_model(model, name) do
     notice(%{model | model_override: name}, "model set to #{name}")
+  end
+
+  defp model_usage(model),
+    do:
+      notice(
+        model,
+        "usage: /model <name>  (current: #{model.model_override || "default"})"
+      )
+
+  defp open_model_picker(model) do
+    ref = make_ref()
+    model.models_fetcher.(models_fetch_opts(model), ref, self())
+    %{model | models_ref: ref} |> put_status("fetching models…")
+  end
+
+  # The connected executor's backend opts, with `:provider` pinned so the
+  # model-list endpoint is chosen by the actual backend, not a URL guess.
+  defp models_fetch_opts(%{executor: executor}) do
+    executor
+    |> Raxol.Agent.ExecutorConfig.to_backend_opts()
+    |> Keyword.put(:provider, executor.backend)
+  end
+
+  @doc false
+  # Default fetcher: list the provider's models off the app process (so a slow
+  # endpoint never blocks the TUI); the outcome rides back as a `:models_list`
+  # message `update/2` folds.
+  def default_models_fetcher(opts, ref, app) do
+    spawn(fn ->
+      result = Raxol.Agent.Backend.HTTP.list_models(opts)
+      send(app, {:command_result, {:models_list, ref, result}})
+    end)
+  end
+
+  defp apply_models_result(model, {:ok, [_ | _] = ids}) do
+    entries = Enum.map(ids, &%{model: &1, label: &1})
+
+    %{
+      model
+      | models_ref: nil,
+        status_line: nil,
+        wizard: %{
+          step: :models,
+          entries: entries,
+          cursor: model_cursor(entries, model.model_override)
+        }
+    }
+  end
+
+  defp apply_models_result(model, {:ok, []}),
+    do:
+      notice(
+        %{model | models_ref: nil, status_line: nil},
+        "no models returned — usage: /model <name>"
+      )
+
+  defp apply_models_result(model, :unsupported),
+    do:
+      notice(
+        %{model | models_ref: nil, status_line: nil},
+        "model listing unavailable for this provider — usage: /model <name>"
+      )
+
+  defp apply_models_result(model, {:error, _reason}),
+    do:
+      notice(
+        %{model | models_ref: nil, status_line: nil},
+        "couldn't fetch models — usage: /model <name>"
+      )
+
+  # Start the cursor on the current model when it's in the list, else the top.
+  defp model_cursor(entries, current) do
+    case Enum.find_index(entries, &(&1.model == current)) do
+      nil -> 0
+      index -> index
+    end
   end
 
   # Heuristic context shrink: keep the last few exchanges, replace the rest
@@ -1351,7 +1467,7 @@ defmodule Raxol.Agent.Code.App do
     /help              this help
     /login [provider]  connect an LLM provider (op ref, key, or local)
     /clear             start a fresh session
-    /model <name>      switch model for the next turns
+    /model [name]      switch model (no name = pick from the provider's list)
     /plan              toggle plan mode
     /compact           shrink the conversation history
     /context           session stats
@@ -1390,8 +1506,36 @@ defmodule Raxol.Agent.Code.App do
   defp setup_block(%{wizard: %{step: :confirm_save} = wizard}),
     do: confirm_save_panel(wizard)
 
+  defp setup_block(%{wizard: %{step: :models} = wizard}),
+    do: models_panel(wizard)
+
   defp setup_block(model) do
     if provider_ready?(model), do: nil, else: hint_panel(model)
+  end
+
+  defp models_panel(%{entries: entries, cursor: cursor}) do
+    rows =
+      entries
+      |> Enum.with_index()
+      |> Enum.map(fn {entry, index} -> model_row(entry, index == cursor) end)
+
+    box style: %{border: :single, padding: 0} do
+      column style: %{gap: 0} do
+        [
+          text("pick a model  (↑↓ move · Enter select · Esc cancel)",
+            fg: :yellow,
+            style: [:bold]
+          )
+        ] ++ rows
+      end
+    end
+  end
+
+  defp model_row(entry, selected?) do
+    marker = if selected?, do: "▸", else: " "
+    fg = if selected?, do: :cyan, else: :white
+    style = if selected?, do: [:bold], else: []
+    text("#{marker} #{entry.label}", fg: fg, style: style)
   end
 
   defp browse_panel(%{entries: entries, cursor: cursor}) do

--- a/packages/raxol_agent/test/raxol/agent/backend/http_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/http_test.exs
@@ -3,6 +3,34 @@ defmodule Raxol.Agent.Backend.HTTPTest do
 
   alias Raxol.Agent.Backend.HTTP
 
+  describe "parse_models/2" do
+    test "OpenAI-compatible /v1/models: extracts data[].id" do
+      body = %{
+        "object" => "list",
+        "data" => [%{"id" => "gpt-4o"}, %{"id" => "gpt-4o-mini"}]
+      }
+
+      assert HTTP.parse_models(:openai, body) == ["gpt-4o", "gpt-4o-mini"]
+    end
+
+    test "Ollama /api/tags: extracts models[].name" do
+      body = %{"models" => [%{"name" => "llama3.2"}, %{"name" => "qwen2.5"}]}
+      assert HTTP.parse_models(:ollama, body) == ["llama3.2", "qwen2.5"]
+    end
+
+    test "skips non-string / malformed entries" do
+      assert HTTP.parse_models(:openai, %{
+               "data" => [%{"id" => 1}, %{"id" => "ok"}, %{}]
+             }) ==
+               ["ok"]
+    end
+
+    test "an unrecognized body shape yields an empty list, never a crash" do
+      assert HTTP.parse_models(:openai, %{"unexpected" => true}) == []
+      assert HTTP.parse_models(:ollama, "not a map") == []
+    end
+  end
+
   describe "complete/2" do
     test "accepts req_plugins option" do
       # Plugin that records it was called
@@ -276,16 +304,36 @@ defmodule Raxol.Agent.Backend.HTTPTest do
       # with last-wins loses the name (the final fragment is args-only) --
       # the :missing_tool_name bug. Accumulation by index fixes it.
       batches = [
-        [%{"index" => 0, "id" => "c1", "function" => %{"name" => "edit_file", "arguments" => ""}}],
-        [%{"index" => 0, "function" => %{"arguments" => "{\"path\":\"mix.exs\","}}],
-        [%{"index" => 0, "function" => %{"arguments" => "\"old\":\"a\",\"new\":\"b\"}"}}]
+        [
+          %{
+            "index" => 0,
+            "id" => "c1",
+            "function" => %{"name" => "edit_file", "arguments" => ""}
+          }
+        ],
+        [
+          %{
+            "index" => 0,
+            "function" => %{"arguments" => "{\"path\":\"mix.exs\","}
+          }
+        ],
+        [
+          %{
+            "index" => 0,
+            "function" => %{"arguments" => "\"old\":\"a\",\"new\":\"b\"}"}
+          }
+        ]
       ]
 
       assert [
                %{
                  "id" => "c1",
                  "name" => "edit_file",
-                 "arguments" => %{"path" => "mix.exs", "old" => "a", "new" => "b"}
+                 "arguments" => %{
+                   "path" => "mix.exs",
+                   "old" => "a",
+                   "new" => "b"
+                 }
                }
              ] = HTTP.accumulate_tool_calls(batches)
     end
@@ -296,12 +344,21 @@ defmodule Raxol.Agent.Backend.HTTPTest do
           %{
             "index" => 0,
             "id" => "c9",
-            "function" => %{"name" => "read_file", "arguments" => "{\"path\":\"a.txt\"}"}
+            "function" => %{
+              "name" => "read_file",
+              "arguments" => "{\"path\":\"a.txt\"}"
+            }
           }
         ]
       ]
 
-      assert [%{"id" => "c9", "name" => "read_file", "arguments" => %{"path" => "a.txt"}}] =
+      assert [
+               %{
+                 "id" => "c9",
+                 "name" => "read_file",
+                 "arguments" => %{"path" => "a.txt"}
+               }
+             ] =
                HTTP.accumulate_tool_calls(batches)
     end
 
@@ -320,13 +377,19 @@ defmodule Raxol.Agent.Backend.HTTPTest do
         [
           %{
             "id" => "c1",
-            "function" => %{"name" => "read_file", "arguments" => "{\"path\":\"a.txt\"}"}
+            "function" => %{
+              "name" => "read_file",
+              "arguments" => "{\"path\":\"a.txt\"}"
+            }
           }
         ],
         [
           %{
             "id" => "c2",
-            "function" => %{"name" => "list_dir", "arguments" => "{\"path\":\".\"}"}
+            "function" => %{
+              "name" => "list_dir",
+              "arguments" => "{\"path\":\".\"}"
+            }
           }
         ]
       ]
@@ -334,17 +397,38 @@ defmodule Raxol.Agent.Backend.HTTPTest do
       result = HTTP.accumulate_tool_calls(batches)
 
       assert length(result) == 2
-      assert %{"id" => "c1", "name" => "read_file", "arguments" => %{"path" => "a.txt"}} in result
-      assert %{"id" => "c2", "name" => "list_dir", "arguments" => %{"path" => "."}} in result
+
+      assert %{
+               "id" => "c1",
+               "name" => "read_file",
+               "arguments" => %{"path" => "a.txt"}
+             } in result
+
+      assert %{
+               "id" => "c2",
+               "name" => "list_dir",
+               "arguments" => %{"path" => "."}
+             } in result
     end
 
     test "an indexless continuation fragment that repeats the id still merges into the same call" do
       batches = [
-        [%{"id" => "c1", "function" => %{"name" => "edit_file", "arguments" => "{\"a\":"}}],
+        [
+          %{
+            "id" => "c1",
+            "function" => %{"name" => "edit_file", "arguments" => "{\"a\":"}
+          }
+        ],
         [%{"id" => "c1", "function" => %{"arguments" => "1}"}}]
       ]
 
-      assert [%{"id" => "c1", "name" => "edit_file", "arguments" => %{"a" => 1}}] =
+      assert [
+               %{
+                 "id" => "c1",
+                 "name" => "edit_file",
+                 "arguments" => %{"a" => 1}
+               }
+             ] =
                HTTP.accumulate_tool_calls(batches)
     end
 
@@ -354,7 +438,10 @@ defmodule Raxol.Agent.Backend.HTTPTest do
           %{
             "index" => 0,
             "id" => "c1",
-            "function" => %{"name" => "edit_file", "arguments" => "{not valid json"}
+            "function" => %{
+              "name" => "edit_file",
+              "arguments" => "{not valid json"
+            }
           }
         ]
       ]
@@ -381,14 +468,20 @@ defmodule Raxol.Agent.Backend.HTTPTest do
             %{
               "index" => bad_index,
               "id" => "c1",
-              "function" => %{"name" => "read_file", "arguments" => "{\"path\":\"a.txt\"}"}
+              "function" => %{
+                "name" => "read_file",
+                "arguments" => "{\"path\":\"a.txt\"}"
+              }
             }
           ],
           [
             %{
               "index" => bad_index,
               "id" => "c2",
-              "function" => %{"name" => "list_dir", "arguments" => "{\"path\":\".\"}"}
+              "function" => %{
+                "name" => "list_dir",
+                "arguments" => "{\"path\":\".\"}"
+              }
             }
           ]
         ]
@@ -397,7 +490,9 @@ defmodule Raxol.Agent.Backend.HTTPTest do
 
         # No crash; both distinct calls survive (resolved by id, not the
         # garbage index that would have cross-merged or blown up).
-        assert length(result) == 2, "bad index #{inspect(bad_index)} did not resolve to 2 calls"
+        assert length(result) == 2,
+               "bad index #{inspect(bad_index)} did not resolve to 2 calls"
+
         assert Enum.find(result, &(&1["id"] == "c1"))["name"] == "read_file"
         assert Enum.find(result, &(&1["id"] == "c2"))["name"] == "list_dir"
       end
@@ -407,8 +502,20 @@ defmodule Raxol.Agent.Backend.HTTPTest do
       # Regression guard: the tightened guard must not reject legitimate
       # integer indices (the normal streaming path).
       batches = [
-        [%{"index" => 0, "id" => "c1", "function" => %{"name" => "a", "arguments" => "{}"}}],
-        [%{"index" => 1, "id" => "c2", "function" => %{"name" => "b", "arguments" => "{}"}}],
+        [
+          %{
+            "index" => 0,
+            "id" => "c1",
+            "function" => %{"name" => "a", "arguments" => "{}"}
+          }
+        ],
+        [
+          %{
+            "index" => 1,
+            "id" => "c2",
+            "function" => %{"name" => "b", "arguments" => "{}"}
+          }
+        ],
         [%{"index" => 0, "function" => %{"arguments" => ""}}]
       ]
 

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -210,6 +210,155 @@ defmodule Raxol.Agent.Code.AppTest do
     end
   end
 
+  alias Raxol.Agent.ExecutorConfig
+
+  defp connected_model(opts \\ []) do
+    fetcher =
+      Keyword.get(opts, :models_fetcher, fn _opts, _ref, _app -> :ok end)
+
+    new_model(
+      executor: ExecutorConfig.new(backend: :openai, model: "gpt-4o"),
+      provider_status: {:ready, :openai, :env},
+      # A connected provider has a current model (set on connect from the
+      # executor); reflected here so the picker cursor has something to land on.
+      model: "gpt-4o",
+      models_fetcher: fetcher
+    )
+  end
+
+  defp slash(model, command),
+    do:
+      App.update(Event.key_event(:enter, :pressed, []), %{
+        model
+        | input: command
+      })
+
+  describe "/model picker" do
+    test "/model with no arg on a connected provider kicks off a fetch" do
+      test_pid = self()
+
+      model =
+        connected_model(
+          models_fetcher: fn opts, ref, _app ->
+            send(test_pid, {:fetched, opts, ref})
+          end
+        )
+
+      {model, []} = slash(model, "/model")
+
+      assert model.models_ref != nil
+      assert model.status_line == "fetching models…"
+      # opts carry the connected provider so the right endpoint is chosen.
+      assert_received {:fetched, opts, ref}
+      assert opts[:provider] == :openai
+      assert ref == model.models_ref
+    end
+
+    test "a model-list result opens a selectable picker, cursor on the current model" do
+      model = connected_model()
+      {model, []} = slash(model, "/model")
+      ref = model.models_ref
+
+      {model, []} =
+        App.update(
+          {:command_result,
+           {:models_list, ref, {:ok, ["gpt-4o-mini", "gpt-4o"]}}},
+          model
+        )
+
+      assert model.wizard.step == :models
+
+      assert Enum.map(model.wizard.entries, & &1.model) == [
+               "gpt-4o-mini",
+               "gpt-4o"
+             ]
+
+      # cursor lands on the current model_override ("gpt-4o", index 1)
+      assert model.wizard.cursor == 1
+      assert model.models_ref == nil
+    end
+
+    test "arrow keys move and Enter selects a model, closing the picker" do
+      model = connected_model()
+      {model, []} = slash(model, "/model")
+
+      {model, []} =
+        App.update(
+          {:command_result,
+           {:models_list, model.models_ref, {:ok, ["a", "b", "c"]}}},
+          model
+        )
+
+      # cursor starts at 0 ("gpt-4o" not in list); down twice -> "c"
+      {model, []} = App.update(key(:down), model)
+      {model, []} = App.update(key(:down), model)
+      {model, []} = App.update(key(:enter), model)
+
+      assert model.model_override == "c"
+      assert model.wizard == nil
+      assert model.notice =~ "model set to c"
+    end
+
+    test "Esc cancels the picker without changing the model" do
+      model = connected_model()
+      {model, []} = slash(model, "/model")
+
+      {model, []} =
+        App.update(
+          {:command_result, {:models_list, model.models_ref, {:ok, ["x"]}}},
+          model
+        )
+
+      {model, []} = App.update(key(:escape), model)
+      assert model.wizard == nil
+      assert model.model_override == "gpt-4o"
+    end
+
+    test "an empty / unsupported / errored list falls back to the usage notice" do
+      for result <- [{:ok, []}, :unsupported, {:error, :request_failed}] do
+        model = connected_model()
+        {model, []} = slash(model, "/model")
+
+        {model, []} =
+          App.update(
+            {:command_result, {:models_list, model.models_ref, result}},
+            model
+          )
+
+        assert model.wizard == nil
+        assert model.notice =~ "/model <name>"
+      end
+    end
+
+    test "/model <name> still sets the model directly (no fetch)" do
+      test_pid = self()
+
+      model =
+        connected_model(
+          models_fetcher: fn _o, _r, _a -> send(test_pid, :fetched) end
+        )
+
+      {model, []} = slash(model, "/model claude-sonnet-5")
+
+      assert model.model_override == "claude-sonnet-5"
+      refute_received :fetched
+    end
+
+    test "a stale models_list result (superseded ref) is ignored" do
+      model = connected_model()
+      {model, []} = slash(model, "/model")
+
+      {model, []} =
+        App.update(
+          {:command_result, {:models_list, make_ref(), {:ok, ["z"]}}},
+          model
+        )
+
+      # the stale ref did not open a picker
+      assert model.wizard == nil
+    end
+  end
+
   defp request(model, name) do
     ref = make_ref()
     msg = {:command_result, {:authorize_request, ref, self(), name}}


### PR DESCRIPTION
Closes #700.

## What
`/model` with no arg on a connected provider now **fetches the provider's model list and opens a selectable picker** instead of just printing the current model. `/model <name>` still sets a model directly.

- **`Backend.HTTP.list_models/1`** — hits the **same** model-list endpoint `check_auth/1` uses (`/v1/models`, or `/api/tags` for Ollama), so it costs no tokens and reuses the auth plumbing. `parse_models/2` pulls the ids per response shape (OpenAI `data[].id`, Ollama `models[].name`).
- **App picker** — reuses the wizard selectable-list machinery the `/login` browse list uses: a new `:models` wizard step, ↑↓ to move, Enter to select, Esc to cancel. Cursor starts on the current model.
- **Non-blocking** — the fetch runs off the app process via an injectable `models_fetcher` (mirrors `login_validator`), so a slow endpoint never freezes the TUI; the result folds back through a ref-matched `:models_list` message (a superseded `/model` is ignored).
- **Graceful fallback** — empty / `:unsupported` / errored list → the `usage: /model <name>` hint.

## Tests
- `app_test.exs` "/model picker" (8): kicks off fetch with the connected provider's opts; result opens the picker with cursor on the current model; arrows move + Enter selects + closes; Esc cancels; empty/unsupported/error fall back; `/model <name>` still direct; stale ref ignored.
- `http_test.exs` "parse_models/2" (4): OpenAI + Ollama shapes, skips malformed entries, unrecognized body → `[]` (never crashes).

Verified: `mix compile --warnings-as-errors` clean; code/ + http suites **134 passed**; format clean.

## Manual testing
- [ ] Connect a provider, run `/model` → picker lists real models, Enter switches; `/model gpt-4o` still sets directly; on lm_studio/unsupported → usage hint
