### PR TITLE
raxol.setup: headless provider setup task (#702)

### DIFF
--- a/packages/raxol_agent/lib/mix/tasks/raxol.setup.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.setup.ex
@@ -1,0 +1,218 @@
+defmodule Mix.Tasks.Raxol.Setup do
+  @shortdoc "Connect/validate an LLM provider without the TUI (CI/headless)"
+
+  @moduledoc """
+  Headless provider setup — the non-TUI twin of the coding agent's `/login`.
+
+  Use this on CI, in scripts, or on a remote box where `mix raxol.code`'s
+  interactive `/login` panel is not reachable. It writes only 1Password
+  *references* to `~/.raxol/providers.json` (override with `$RAXOL_PROVIDERS`)
+  through the same `Raxol.Agent.Backend.{Credentials, Resolver}` front door
+  every surface resolves, so a provider connected here is picked up
+  identically by `raxol.code`, `raxol.p`, and the other agent surfaces.
+
+      # show what is connected (and why a provider is not)
+      mix raxol.setup
+      mix raxol.setup --status
+
+      # connect via an existing 1Password reference (+ optional model)
+      mix raxol.setup --provider anthropic \\
+        --op op://Employee/Anthropic/api_key --model claude-sonnet-5
+
+      # connect a raw key: creates a 1Password item, stores its reference
+      mix raxol.setup --provider openai --api-key sk-... --vault Private
+
+      # forget a provider's stored reference
+      mix raxol.setup --provider openai --remove
+
+  Each connect validates the credential (a token-free model-list call) and
+  exits non-zero if it does not authorize, so a CI step fails loudly on a
+  bad or expired reference.
+
+  ## Options
+
+    * `--provider` — provider name (`anthropic`, `openai`, `kimi`, `ollama`, ...)
+    * `--op`       — an existing `op://Vault/Item/field` reference to store
+    * `--api-key`  — a raw key to turn into a 1Password item (needs the `op` CLI)
+    * `--model`    — default model to store with the reference
+    * `--base-url` — base URL override to store with the reference
+    * `--vault`    — 1Password vault for `--api-key` (default `$RAXOL_OP_VAULT` or `Private`)
+    * `--remove`   — delete the provider's stored reference
+    * `--status`   — print provider status and exit (default when no action given)
+  """
+
+  use Mix.Task
+
+  alias Raxol.Agent.Setup
+
+  @switches [
+    provider: :string,
+    op: :string,
+    api_key: :string,
+    model: :string,
+    base_url: :string,
+    vault: :string,
+    remove: :boolean,
+    status: :boolean
+  ]
+
+  @impl Mix.Task
+  def run(argv) do
+    Mix.Task.run("app.start")
+
+    case OptionParser.parse(argv, strict: @switches) do
+      {opts, [], []} ->
+        dispatch(opts)
+
+      {_opts, _args, invalid} ->
+        usage_error("unknown options: #{inspect(invalid)}")
+    end
+  end
+
+  defp dispatch(opts) do
+    provider = Keyword.get(opts, :provider)
+
+    cond do
+      Keyword.get(opts, :status, false) or no_action?(opts) ->
+        print_status()
+
+      is_nil(provider) ->
+        usage_error("--provider is required for that action")
+
+      Keyword.get(opts, :remove, false) ->
+        do_remove(provider)
+
+      Keyword.get(opts, :op) ->
+        do_connect_ref(provider, opts)
+
+      Keyword.get(opts, :api_key) ->
+        do_connect_key(provider, opts)
+
+      true ->
+        usage_error("give one of --op, --api-key, or --remove for #{provider}")
+    end
+  end
+
+  defp no_action?(opts) do
+    not Enum.any?(
+      [:op, :api_key, :remove, :provider],
+      &Keyword.has_key?(opts, &1)
+    )
+  end
+
+  # -- actions ----------------------------------------------------------------
+
+  defp do_connect_ref(provider, opts) do
+    attrs = %{
+      op_ref: opts[:op],
+      model: opts[:model],
+      base_url: opts[:base_url]
+    }
+
+    provider
+    |> Setup.connect_ref(attrs)
+    |> report_connect()
+  end
+
+  defp do_connect_key(provider, opts) do
+    provider
+    |> Setup.connect_key(
+      opts[:api_key],
+      Keyword.take(opts, [:model, :base_url, :vault])
+    )
+    |> report_connect_key()
+  end
+
+  defp do_remove(provider) do
+    case Setup.remove(provider) do
+      {:ok, harness} ->
+        IO.puts("removed stored reference for #{harness}")
+
+      {:error, reason} ->
+        fail("could not remove #{provider}: #{inspect(reason)}")
+    end
+  end
+
+  # -- reporting --------------------------------------------------------------
+
+  defp report_connect({:ok, harness, validation}) do
+    IO.puts("stored reference for #{harness}")
+    report_validation(harness, validation)
+  end
+
+  defp report_connect({:error, reason}), do: fail(connect_error(reason))
+
+  defp report_connect_key({:ok, harness, ref, validation}) do
+    IO.puts("stored reference for #{harness}: #{ref}")
+    report_validation(harness, validation)
+  end
+
+  defp report_connect_key({:error, reason}), do: fail(connect_error(reason))
+
+  # A validation that authorizes prints a check and exits 0; anything else
+  # prints why and exits non-zero, so a CI step fails on a bad credential.
+  defp report_validation(harness, :valid),
+    do: IO.puts("#{harness} credential validated ✓")
+
+  defp report_validation(harness, {:rejected, status}),
+    do:
+      fail(
+        "#{harness} credential rejected (HTTP #{status}) — check the key/reference"
+      )
+
+  defp report_validation(harness, {:reachable_error, status}),
+    do: fail("#{harness} endpoint returned HTTP #{status}")
+
+  defp report_validation(harness, :unreachable),
+    do: fail("#{harness} endpoint unreachable")
+
+  defp report_validation(harness, :unsupported),
+    do: IO.puts("#{harness} stored (no validation endpoint for this provider)")
+
+  defp report_validation(harness, {:no_key, _}),
+    do:
+      fail(
+        "#{harness} reference stored but no key resolved — is `op` signed in?"
+      )
+
+  defp report_validation(harness, :no_provider),
+    do: fail("could not resolve a provider for #{harness}")
+
+  defp print_status do
+    %{op: op, providers: providers} = Setup.status()
+
+    IO.puts("1Password (op): #{op}")
+    IO.puts("providers:")
+
+    Enum.each(providers, fn p ->
+      mark = if p.available?, do: "●", else: "○"
+      src = if p.source, do: " (via #{p.source})", else: ""
+      note = if p[:note], do: "  — #{p.note}", else: ""
+      IO.puts("  #{mark} #{p.label}#{src}#{note}")
+    end)
+  end
+
+  # -- errors -----------------------------------------------------------------
+
+  defp connect_error({:unknown_provider, name}),
+    do: "unknown provider: #{name}"
+
+  defp connect_error(:not_an_op_ref),
+    do: "--op must be an op://Vault/Item/field reference"
+
+  defp connect_error(:op_unavailable),
+    do:
+      "the `op` (1Password) CLI is not installed — install it or use --op with an existing reference"
+
+  defp connect_error(reason), do: "setup failed: #{inspect(reason)}"
+
+  defp usage_error(message) do
+    IO.puts(:stderr, "raxol.setup: #{message}")
+    exit({:shutdown, 64})
+  end
+
+  defp fail(message) do
+    IO.puts(:stderr, "raxol.setup: #{message}")
+    exit({:shutdown, 1})
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/setup.ex
+++ b/packages/raxol_agent/lib/raxol/agent/setup.ex
@@ -1,0 +1,140 @@
+defmodule Raxol.Agent.Setup do
+  @moduledoc """
+  Non-TUI provider setup: the logic behind `mix raxol.setup`.
+
+  The coding TUI's `/login` is the interactive way to connect an LLM
+  provider, but it needs a terminal. This module is the headless twin —
+  store a provider's 1Password reference (or turn a raw key into one) and
+  validate it — for CI, scripts, and remote/headless boxes where the TUI is
+  not reachable. It reuses the same `Raxol.Agent.Backend.{Credentials,
+  Resolver}` front door, so a provider connected here is picked up
+  identically by every surface that resolves through them.
+
+  Nothing here holds a secret at rest: a raw key is turned into a
+  `op://...` reference via `Credentials.create_item/3` (1Password), and only
+  the reference is written to `~/.raxol/providers.json`.
+
+  The `:validator` and `:creator` seams are injectable so the store/validate
+  logic is testable without a network call or the `op` CLI.
+  """
+
+  alias Raxol.Agent.Backend.Credentials
+  alias Raxol.Agent.Backend.HTTP
+  alias Raxol.Agent.Backend.Resolver
+  alias Raxol.Agent.ExecutorConfig
+
+  @type validation ::
+          :valid
+          | {:rejected, non_neg_integer()}
+          | {:reachable_error, non_neg_integer()}
+          | :unreachable
+          | :unsupported
+          | {:no_key, atom()}
+          | :no_provider
+
+  @doc """
+  A point-in-time detection snapshot: the `op` CLI state plus each provider's
+  availability. Delegates to `Resolver.diagnostics/0`.
+  """
+  @spec status() :: %{op: atom(), providers: [map()]}
+  def status, do: Resolver.diagnostics()
+
+  @doc """
+  Store an `op://...` reference (plus optional `:model`/`:base_url`) for a
+  provider, then validate that the credential resolves and authorizes.
+
+  Returns `{:ok, harness, validation}` or `{:error, reason}`. `attrs` must
+  carry a non-empty `:op_ref`.
+  """
+  @spec connect_ref(atom() | String.t(), map() | keyword(), keyword()) ::
+          {:ok, atom(), validation()} | {:error, term()}
+  def connect_ref(harness, attrs, opts \\ []) do
+    attrs = Map.new(attrs)
+
+    with {:ok, provider} <- resolve_harness(harness),
+         {:ok, ref} <- require_op_ref(attrs),
+         :ok <- Credentials.put(provider, ref_entry(ref, attrs)) do
+      {:ok, provider, validate(provider, opts)}
+    end
+  end
+
+  @doc """
+  Turn a raw `key` into a 1Password item, store its reference for the
+  provider, then validate. Requires the `op` CLI (the `:creator` seam
+  defaults to `Credentials.create_item/3`).
+
+  Returns `{:ok, harness, op_ref, validation}` or `{:error, reason}`.
+  """
+  @spec connect_key(atom() | String.t(), String.t(), keyword()) ::
+          {:ok, atom(), String.t(), validation()} | {:error, term()}
+  def connect_key(harness, key, opts \\ []) do
+    creator = Keyword.get(opts, :creator, &Credentials.create_item/3)
+    attrs = Map.new(Keyword.take(opts, [:model, :base_url]))
+
+    with {:ok, provider} <- resolve_harness(harness),
+         {:ok, ref} <- creator.(provider, key, Keyword.take(opts, [:vault])),
+         :ok <- Credentials.put(provider, ref_entry(ref, attrs)) do
+      {:ok, provider, ref, validate(provider, opts)}
+    end
+  end
+
+  @doc "Remove a provider's stored reference. Returns `{:ok, harness}` or `{:error, reason}`."
+  @spec remove(atom() | String.t()) :: {:ok, atom()} | {:error, term()}
+  def remove(harness) do
+    with {:ok, provider} <- resolve_harness(harness),
+         :ok <- Credentials.delete(provider) do
+      {:ok, provider}
+    end
+  end
+
+  # -- validation -------------------------------------------------------------
+
+  defp validate(provider, opts) do
+    validator = Keyword.get(opts, :validator, &default_validate/1)
+    validator.(provider)
+  end
+
+  # Resolve the stored reference to a live executor and hit the provider's
+  # model-list endpoint (no tokens spent). A resolution that yields no key or
+  # no provider is surfaced verbatim so the caller can report it.
+  defp default_validate(provider) do
+    case Resolver.resolve(harness: provider) do
+      {:ok, executor, _source} ->
+        executor
+        |> ExecutorConfig.to_backend_opts()
+        |> Keyword.put(:provider, executor.backend)
+        |> HTTP.check_auth()
+
+      other ->
+        other
+    end
+  end
+
+  # -- helpers ----------------------------------------------------------------
+
+  defp resolve_harness(harness) when is_atom(harness), do: {:ok, harness}
+
+  defp resolve_harness(harness) when is_binary(harness) do
+    case Resolver.harness_from_string(harness) do
+      {:ok, provider} -> {:ok, provider}
+      :error -> {:error, {:unknown_provider, harness}}
+    end
+  end
+
+  defp require_op_ref(attrs) do
+    case Map.get(attrs, :op_ref) do
+      "op://" <> _ = ref -> {:ok, ref}
+      _ -> {:error, :not_an_op_ref}
+    end
+  end
+
+  defp ref_entry(ref, attrs) do
+    %{op_ref: ref}
+    |> maybe_put(:model, Map.get(attrs, :model))
+    |> maybe_put(:base_url, Map.get(attrs, :base_url))
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/packages/raxol_agent/lib/raxol/agent/stream.ex
+++ b/packages/raxol_agent/lib/raxol/agent/stream.ex
@@ -49,6 +49,13 @@ defmodule Raxol.Agent.Stream do
     (takes precedence over `:backend`)
   - `:backend` -- AIBackend module (default: `Raxol.Agent.Backend.Mock`); ignored
     when `:executor` is given
+  - `:auto_provider` -- when `true` and no `:executor` is given, resolve one from
+    the environment via `Raxol.Agent.Backend.Resolver` (the same op-ref ->
+    provider-env -> `AI_API_KEY` onboarding the coding TUI and `mix raxol.setup`
+    use). An optional `:provider` pins a specific one. Falls through to
+    `:backend`/Mock when nothing resolves, so it never crashes an unconfigured
+    caller. This is how a headless/embedded agent surface gets the same
+    credential story without hand-rolling a resolver call.
   - `:backend_opts` -- keyword list passed to backend (api_key, model, etc.);
     merged over the executor's resolved opts
   - `:model` -- per-request model override (wins over `:executor`/`:backend_opts`)
@@ -320,7 +327,8 @@ defmodule Raxol.Agent.Stream do
           |> Enum.map(&unexecuted_tool_call_event/1)
 
         done_event =
-          {:done, %{content: response.content, tool_results: [], usage: response.usage}}
+          {:done,
+           %{content: response.content, tool_results: [], usage: response.usage}}
 
         {unexecuted_events ++ [done_event], :done}
 
@@ -565,7 +573,7 @@ defmodule Raxol.Agent.Stream do
   end
 
   defp backend_from_opts(opts) do
-    case Keyword.get(opts, :executor) do
+    case Keyword.get(opts, :executor) || resolve_executor(opts) do
       %Raxol.Agent.ExecutorConfig{} = executor ->
         case Raxol.Agent.Backend.Selector.select(executor) do
           {:ok, backend, executor_opts} -> {backend, executor_opts}
@@ -574,6 +582,33 @@ defmodule Raxol.Agent.Stream do
 
       _ ->
         {fallback_backend(opts), []}
+    end
+  end
+
+  @doc false
+  # Opt-in environment/1Password onboarding for any programmatic agent surface.
+  # With `auto_provider: true` and no explicit `:executor`, resolve one through
+  # the shared `Raxol.Agent.Backend.Resolver` — the SAME op-ref -> provider-env
+  # (`ANTHROPIC_API_KEY`, ...) -> `AI_API_KEY`/`AI_BASE_URL` precedence the coding
+  # TUI and `mix raxol.setup` use — so a surface gets the same credential story
+  # for free instead of hand-rolling a resolver call. A resolution that finds no
+  # credential returns `nil`, so `backend_from_opts/1` falls through to
+  # `:backend`/Mock and the opt never crashes a caller with no provider set up.
+  def resolve_executor(opts) do
+    if Keyword.get(opts, :auto_provider, false) do
+      resolver_opts =
+        [
+          harness: Keyword.get(opts, :provider),
+          model: Keyword.get(opts, :model),
+          api_key: Keyword.get(opts, :api_key),
+          base_url: Keyword.get(opts, :base_url)
+        ]
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+
+      case Raxol.Agent.Backend.Resolver.resolve(resolver_opts) do
+        {:ok, executor, _source} -> executor
+        _ -> nil
+      end
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/setup_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/setup_test.exs
@@ -1,0 +1,128 @@
+defmodule Raxol.Agent.SetupTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Backend.Credentials
+  alias Raxol.Agent.Setup
+
+  # Provider env keys the resolver reads; cleared so the store is the only
+  # source of truth for these tests (mirrors app_login_test's isolation).
+  @managed_env ~w(
+    ANTHROPIC_API_KEY OPENAI_API_KEY KIMI_API_KEY MOONSHOT_API_KEY
+    OPENROUTER_API_KEY LONGCAT_API_KEY PROTON_ACCESS_TOKEN
+    AI_API_KEY AI_BASE_URL AI_MODEL
+  )
+
+  setup do
+    saved = Map.new(@managed_env, fn key -> {key, System.get_env(key)} end)
+    Enum.each(@managed_env, &System.delete_env/1)
+
+    store =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-setup-#{System.unique_integer([:positive])}.json"
+      )
+
+    prev = System.get_env("RAXOL_PROVIDERS")
+    System.put_env("RAXOL_PROVIDERS", store)
+
+    on_exit(fn ->
+      File.rm(store)
+
+      if prev,
+        do: System.put_env("RAXOL_PROVIDERS", prev),
+        else: System.delete_env("RAXOL_PROVIDERS")
+
+      Enum.each(saved, fn
+        {k, nil} -> System.delete_env(k)
+        {k, v} -> System.put_env(k, v)
+      end)
+    end)
+
+    # A validator that never touches the network.
+    %{ok_validator: fn _harness -> :valid end}
+  end
+
+  describe "connect_ref/3" do
+    test "stores the op reference and validates", %{ok_validator: v} do
+      assert {:ok, :anthropic, :valid} =
+               Setup.connect_ref(
+                 "anthropic",
+                 %{
+                   op_ref: "op://Vault/Anthropic/key",
+                   model: "claude-sonnet-5"
+                 },
+                 validator: v
+               )
+
+      assert {:ok, entry} = Credentials.fetch(:anthropic)
+      assert entry.op_ref == "op://Vault/Anthropic/key"
+      assert entry.model == "claude-sonnet-5"
+    end
+
+    test "surfaces a rejected credential from the validator" do
+      assert {:ok, :openai, {:rejected, 401}} =
+               Setup.connect_ref(
+                 :openai,
+                 %{op_ref: "op://Vault/OpenAI/key"},
+                 validator: fn _ -> {:rejected, 401} end
+               )
+    end
+
+    test "rejects a non-op reference and stores nothing", %{ok_validator: v} do
+      assert {:error, :not_an_op_ref} =
+               Setup.connect_ref(:openai, %{op_ref: "sk-raw-key"}, validator: v)
+
+      assert Credentials.fetch(:openai) == :none
+    end
+
+    test "rejects an unknown provider" do
+      assert {:error, {:unknown_provider, "nope"}} =
+               Setup.connect_ref("nope", %{op_ref: "op://V/I/f"})
+    end
+  end
+
+  describe "connect_key/3" do
+    test "creates a 1Password item, stores the returned reference, validates" do
+      creator = fn :openai, "sk-live", _opts ->
+        {:ok, "op://Private/abc/credential"}
+      end
+
+      assert {:ok, :openai, "op://Private/abc/credential", :valid} =
+               Setup.connect_key(:openai, "sk-live",
+                 creator: creator,
+                 validator: fn _ -> :valid end
+               )
+
+      assert {:ok, %{op_ref: "op://Private/abc/credential"}} =
+               Credentials.fetch(:openai)
+    end
+
+    test "surfaces a creator failure (no op CLI) and stores nothing" do
+      creator = fn _h, _k, _o -> {:error, :op_unavailable} end
+
+      assert {:error, :op_unavailable} =
+               Setup.connect_key(:openai, "sk-live", creator: creator)
+
+      assert Credentials.fetch(:openai) == :none
+    end
+  end
+
+  describe "remove/1" do
+    test "deletes a stored reference", %{ok_validator: v} do
+      {:ok, :kimi, _} =
+        Setup.connect_ref(:kimi, %{op_ref: "op://V/Kimi/key"}, validator: v)
+
+      assert {:ok, :kimi} = Setup.remove(:kimi)
+      assert Credentials.fetch(:kimi) == :none
+    end
+  end
+
+  describe "status/0" do
+    test "returns the op state and a provider list" do
+      status = Setup.status()
+      assert Map.has_key?(status, :op)
+      assert is_list(status.providers)
+      assert Enum.all?(status.providers, &Map.has_key?(&1, :harness))
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/stream_resolve_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/stream_resolve_test.exs
@@ -1,0 +1,76 @@
+defmodule Raxol.Agent.StreamResolveTest do
+  # Env-based (global) resolution, so not async.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Stream, as: AgentStream
+
+  @managed_env ~w(
+    ANTHROPIC_API_KEY OPENAI_API_KEY KIMI_API_KEY MOONSHOT_API_KEY
+    OPENROUTER_API_KEY LONGCAT_API_KEY PROTON_ACCESS_TOKEN
+    AI_API_KEY AI_BASE_URL AI_MODEL
+  )
+
+  setup do
+    saved = Map.new(@managed_env, fn key -> {key, System.get_env(key)} end)
+    Enum.each(@managed_env, &System.delete_env/1)
+
+    # Point the reference store at a path that does not exist, so a real
+    # ~/.raxol/providers.json can never leak into the test.
+    empty_store =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-noproviders-#{System.unique_integer([:positive])}.json"
+      )
+
+    prev_store = System.get_env("RAXOL_PROVIDERS")
+    System.put_env("RAXOL_PROVIDERS", empty_store)
+
+    on_exit(fn ->
+      if prev_store,
+        do: System.put_env("RAXOL_PROVIDERS", prev_store),
+        else: System.delete_env("RAXOL_PROVIDERS")
+
+      Enum.each(saved, fn
+        {key, nil} -> System.delete_env(key)
+        {key, value} -> System.put_env(key, value)
+      end)
+    end)
+
+    :ok
+  end
+
+  describe "resolve_executor/1 (auto_provider)" do
+    test "returns nil without auto_provider (default behavior is unchanged)" do
+      System.put_env("ANTHROPIC_API_KEY", "sk-ant")
+      assert AgentStream.resolve_executor([]) == nil
+    end
+
+    test "auto-detects a provider from an env key" do
+      System.put_env("ANTHROPIC_API_KEY", "sk-ant")
+
+      assert %Raxol.Agent.ExecutorConfig{backend: :anthropic} =
+               AgentStream.resolve_executor(auto_provider: true)
+    end
+
+    test "a pinned :provider resolves that provider's credential" do
+      System.put_env("OPENAI_API_KEY", "sk-openai")
+
+      assert %Raxol.Agent.ExecutorConfig{backend: :openai} =
+               AgentStream.resolve_executor(
+                 auto_provider: true,
+                 provider: :openai
+               )
+    end
+
+    test "the generic AI_API_KEY escape hatch resolves" do
+      System.put_env("AI_API_KEY", "sk-generic")
+
+      assert %Raxol.Agent.ExecutorConfig{} =
+               AgentStream.resolve_executor(auto_provider: true)
+    end
+
+    test "returns nil when no credential resolves (falls through to :backend/Mock)" do
+      assert AgentStream.resolve_executor(auto_provider: true) == nil
+    end
+  end
+end


### PR DESCRIPTION
Addresses #702 (the concrete, buildable parts).

## 1. `mix raxol.setup` — headless provider setup
The non-TUI twin of the coding agent's `/login`: connect + validate an LLM provider without a terminal, for CI/scripts/remote boxes. Writes only 1Password *references* to `~/.raxol/providers.json` through the same `Backend.{Credentials, Resolver}` front door every surface resolves.

- `--status` (default) · `--provider X --op op://...` · `--provider X --api-key KEY` (creates a 1Password item) · `--provider X --remove`
- Each connect validates via a token-free model-list call and **exits non-zero on a bad/expired credential** (CI fails loudly).
- `Raxol.Agent.Setup` holds the logic (injectable `:validator`/`:creator` seams, tested without network or `op`); the mix task is a thin wrapper.

## 2. Resolver onboarding in the shared runtime
`Agent.Stream` now takes `auto_provider: true` — when no `:executor` is given, it resolves one via `Backend.Resolver` (op-ref → provider-env → `AI_API_KEY`, the same precedence `raxol.code`/`raxol.setup` use). This is the **right layer to "wire the resolver into the surfaces"**: any programmatic agent surface (the react_agent example today; the telegram/gateway/headless handlers when they're built) gets the same 1Password/env onboarding declaratively, instead of hand-rolling a resolver call.

- Opt-in: absent the flag, behavior is unchanged (falls through to `:backend`/Mock); a resolution that finds no credential returns `nil`, so it never crashes an unconfigured caller.

### Why not edit telegram/gateway directly
Investigated: telegram delegates its TEA app to the consumer (no LLM backend of its own, doesn't dep on `raxol_agent`); the gateway's agent handler is explicitly **"NOT YET IMPLEMENTED"**; `Agent.Session` is a Lifecycle wrapper. There is no per-surface backend-selection code to modify yet — so the correct, non-speculative wiring is the shared runtime seam above, which those handlers will pick up for free when they land.

## Tests
- `setup_test.exs` (8), `stream_resolve_test.exs` (5): auto-detect from env key, pinned `:provider`, generic `AI_API_KEY`, nil without the flag, nil when nothing resolves.
- Verified: `mix compile --warnings-as-errors` clean; setup + stream + backend + code suites green; format clean; `mix raxol.setup --status` smoke-tested end-to-end.

## Remaining #702 follow-ups
- The telegram/gateway/headless **agent handlers** themselves (they'll set `auto_provider: true`) — blocked on those handlers being built.
- Optional per-project `.raxol/config` to pin a provider/model.
