### PR TITLE
raxol.code: per-repo .raxol/config.json provider/model pin (#702)

### DIFF
--- a/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.code.ex
@@ -38,7 +38,10 @@ defmodule Mix.Tasks.Raxol.Code do
   `task` tool. A `.raxol/hooks.json` in the working directory declares
   shell commands to run before/after tool calls and at turn end (a
   non-zero pre-tool hook vetoes the tool). A `.mcp.json` declares external
-  MCP servers, surfaced by `/mcp` (live tool-bridging is a follow-up).
+  MCP servers, surfaced by `/mcp` (live tool-bridging is a follow-up). A
+  `.raxol/config.json` pins a default `provider`/`model` for the repo
+  (references only, never a raw key), used when no `--backend`/`--model` flag
+  is given — see `Raxol.Agent.Code.ProjectConfig`.
 
   ## Providers
 
@@ -123,26 +126,36 @@ defmodule Mix.Tasks.Raxol.Code do
   end
 
   defp app_opts(opts) do
-    resolution = Raxol.Agent.Backend.Resolver.resolve(resolver_opts(opts))
+    project = Raxol.Agent.Code.ProjectConfig.load(File.cwd!())
+
+    resolution =
+      Raxol.Agent.Backend.Resolver.resolve(resolver_opts(opts, project))
 
     []
     |> put_if(:system, Keyword.get(opts, :system))
-    |> put_if(:model, Keyword.get(opts, :model))
+    |> put_if(:model, Keyword.get(opts, :model) || Map.get(project, :model))
     |> put_if(:session_key, resolve_session(opts))
     |> Keyword.put(:ascii, Keyword.get(opts, :ascii, false))
     |> apply_resolution(resolution)
   end
 
-  # The resolver inputs: an optional validated `--backend`, plus any inline
-  # `--model`/`--api-key`/`--base-url` overrides. The resolver's own input key
+  # The resolver inputs, in precedence order explicit flag > `.raxol/config.json`
+  # pin > env auto-detect: a `--backend`/`--model`/`--base-url` wins, else the
+  # per-repo pin, else the resolver auto-detects. The resolver's own input key
   # stays `:harness` (its internal provider vocabulary); only the user-facing
   # flag is renamed.
-  defp resolver_opts(opts) do
+  defp resolver_opts(opts, project) do
     []
-    |> maybe_put(:harness, validated_backend(opts))
-    |> maybe_put(:model, Keyword.get(opts, :model))
+    |> maybe_put(
+      :harness,
+      validated_backend(opts) || Map.get(project, :provider)
+    )
+    |> maybe_put(:model, Keyword.get(opts, :model) || Map.get(project, :model))
     |> maybe_put(:api_key, Keyword.get(opts, :api_key))
-    |> maybe_put(:base_url, Keyword.get(opts, :base_url))
+    |> maybe_put(
+      :base_url,
+      Keyword.get(opts, :base_url) || Map.get(project, :base_url)
+    )
   end
 
   # `{:ok, executor, source}` wires the executor and records how it was found;

--- a/packages/raxol_agent/lib/raxol/agent/code/project_config.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/project_config.ex
@@ -1,0 +1,77 @@
+defmodule Raxol.Agent.Code.ProjectConfig do
+  @moduledoc """
+  Per-repo defaults from `<cwd>/.raxol/config.json`.
+
+  A project can pin which provider and model its agents should use by
+  default — handy for a repo that should always run against, say, a specific
+  Anthropic model regardless of a contributor's global environment. This is
+  a *reference/preference* file only: it names a provider and model, never a
+  raw key. Credentials still resolve through `Raxol.Agent.Backend.Resolver`
+  (1Password reference, provider env var, or `AI_API_KEY`), so nothing secret
+  ever lands in a repo file. Any `key`/`api_key` field is deliberately ignored.
+
+  Precedence at launch is explicit flag > this file > environment
+  auto-detect: a `--backend`/`--model` on `mix raxol.code` still wins, and
+  with neither a flag nor a pin the resolver auto-detects as before.
+
+  ## File shape
+
+      {
+        "provider": "anthropic",
+        "model": "claude-sonnet-5",
+        "base_url": "https://api.anthropic.com"
+      }
+
+  A missing, unreadable, or malformed file is an empty config, never an
+  error — a bad `.raxol/config.json` never blocks agent boot.
+  """
+
+  @type t :: %{
+          optional(:provider) => atom(),
+          optional(:model) => String.t(),
+          optional(:base_url) => String.t()
+        }
+
+  @doc """
+  Load `<dir>/.raxol/config.json` into a sanitized config map.
+
+  Only the three known fields (`provider`, `model`, `base_url`) round-trip;
+  `provider` is mapped to a known backend atom via `Resolver.harness_from_string/1`
+  (an unknown provider name is dropped). Anything else in the file — including
+  a stray raw key — is ignored.
+  """
+  @spec load(String.t()) :: t()
+  def load(dir) do
+    path = Path.join(dir, ".raxol/config.json")
+
+    with {:ok, binary} <- File.read(path),
+         {:ok, json} when is_map(json) <- Jason.decode(binary) do
+      parse(json)
+    else
+      _ -> %{}
+    end
+  end
+
+  defp parse(json) do
+    %{}
+    |> put_provider(Map.get(json, "provider"))
+    |> put_string(:model, Map.get(json, "model"))
+    |> put_string(:base_url, Map.get(json, "base_url"))
+  end
+
+  # A provider string only lands when it names a backend the resolver knows;
+  # an unknown/typo'd name is dropped so it can never smuggle a bad atom in.
+  defp put_provider(config, name) when is_binary(name) do
+    case Raxol.Agent.Backend.Resolver.harness_from_string(name) do
+      {:ok, provider} -> Map.put(config, :provider, provider)
+      :error -> config
+    end
+  end
+
+  defp put_provider(config, _name), do: config
+
+  defp put_string(config, key, value) when is_binary(value) and value != "",
+    do: Map.put(config, key, value)
+
+  defp put_string(config, _key, _value), do: config
+end

--- a/packages/raxol_agent/test/raxol/agent/code/project_config_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/project_config_test.exs
@@ -1,0 +1,75 @@
+defmodule Raxol.Agent.Code.ProjectConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Code.ProjectConfig
+
+  defp project_with(config_json) do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-projcfg-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(dir, ".raxol"))
+
+    if config_json,
+      do: File.write!(Path.join(dir, ".raxol/config.json"), config_json)
+
+    on_exit(fn -> File.rm_rf(dir) end)
+    dir
+  end
+
+  test "loads a pinned provider, model, and base_url" do
+    dir =
+      project_with(~s({
+        "provider": "anthropic",
+        "model": "claude-sonnet-5",
+        "base_url": "https://api.anthropic.com"
+      }))
+
+    assert ProjectConfig.load(dir) == %{
+             provider: :anthropic,
+             model: "claude-sonnet-5",
+             base_url: "https://api.anthropic.com"
+           }
+  end
+
+  test "a missing file is an empty config" do
+    dir = project_with(nil)
+    assert ProjectConfig.load(dir) == %{}
+  end
+
+  test "malformed JSON is an empty config, never a crash" do
+    dir = project_with("{not json")
+    assert ProjectConfig.load(dir) == %{}
+  end
+
+  test "a non-object body is an empty config" do
+    dir = project_with(~s(["anthropic"]))
+    assert ProjectConfig.load(dir) == %{}
+  end
+
+  test "an unknown provider name is dropped" do
+    dir = project_with(~s({"provider": "not-a-provider", "model": "x"}))
+    assert ProjectConfig.load(dir) == %{model: "x"}
+  end
+
+  test "a raw key field is ignored (references only, never secrets)" do
+    dir =
+      project_with(~s({
+        "provider": "openai",
+        "api_key": "sk-should-be-ignored",
+        "key": "also-ignored"
+      }))
+
+    config = ProjectConfig.load(dir)
+    assert config == %{provider: :openai}
+    refute Map.has_key?(config, :api_key)
+    refute Map.has_key?(config, :key)
+  end
+
+  test "blank / non-string fields are dropped" do
+    dir = project_with(~s({"provider": "openai", "model": "", "base_url": 42}))
+    assert ProjectConfig.load(dir) == %{provider: :openai}
+  end
+end


### PR DESCRIPTION
Completes the **per-project config** follow-up of #702 (the `mix raxol.setup` + runtime resolver wiring landed in #710).

## What
A repo can pin a default provider/model via `.raxol/config.json`, so its agents run against the intended backend regardless of a contributor's global environment.

```json
{ "provider": "anthropic", "model": "claude-sonnet-5", "base_url": "https://api.anthropic.com" }
```

**References/preferences only — never a raw key.** Credentials still resolve through `Backend.Resolver` (1Password reference, provider env var, or `AI_API_KEY`); this file only names *which* provider/model to prefer. Any `key`/`api_key` field is deliberately ignored, so nothing secret lands in a repo file.

## Precedence
Explicit flag > `.raxol/config.json` pin > env auto-detect: a `--backend`/`--model`/`--base-url` on `mix raxol.code` still wins; with neither a flag nor a pin, the resolver auto-detects as before.

## Design
- `Raxol.Agent.Code.ProjectConfig.load/1` reads + sanitizes the file (mirrors the `hooks.json`/`.mcp.json` loaders): only `provider`/`model`/`base_url` round-trip; `provider` maps to a known backend atom via `Resolver.harness_from_string/1` (unknown → dropped); a missing/malformed/non-object file is an empty config (never blocks boot).
- `raxol.code` threads it into the resolver inputs + the app's model override.

## Tests
`project_config_test.exs` (7): pinned provider/model/base_url; missing file; malformed JSON; non-object body; unknown provider dropped; **raw key field ignored**; blank/non-string fields dropped.

Verified: `mix compile --warnings-as-errors` clean; code + setup + stream suites **123 passed**; format clean.

## Manual testing
- [ ] Add `.raxol/config.json` pinning a provider/model, run `mix raxol.code` with no flags → uses the pin; a `--backend`/`--model` flag overrides it
