### PR TITLE
render_diff: emit clear_line for blanked rows

### DIFF
--- a/docs/core/BUFFER_API.md
+++ b/docs/core/BUFFER_API.md
@@ -135,14 +135,14 @@ Calculates minimal updates between two buffers. Returns a list of operation tupl
 
 - `{:move, x, y}` - Move cursor to position
 - `{:write, text, style}` - Write text with style
-- `{:clear_line, y}` - Clear line at y
+- `{:clear_line, y}` - Clear line at y, emitted when a changed row becomes entirely blank (spaces with no visible style and no hyperlink)
 
 ```elixir
 diff = Renderer.render_diff(old_buffer, new_buffer)
 IO.write(Renderer.apply_diff(diff))
 ```
 
-Only generates updates for changed cells. Batches consecutive changes into single writes. < 2ms for 80x24 buffer.
+Only generates updates for changed cells. Batches consecutive changes into single writes; a row that goes fully blank collapses to a single `{:clear_line, y}`. < 2ms for 80x24 buffer.
 
 ### apply_diff/1
 

--- a/docs/core/BUFFER_API.md
+++ b/docs/core/BUFFER_API.md
@@ -135,7 +135,7 @@ Calculates minimal updates between two buffers. Returns a list of operation tupl
 
 - `{:move, x, y}` - Move cursor to position
 - `{:write, text, style}` - Write text with style
-- `{:clear_line, y}` - Clear line at y, emitted when a changed row becomes entirely blank (spaces with no visible style and no hyperlink)
+- `{:clear_line, y}` - Clear line at y, emitted when a changed row becomes entirely blank (spaces with no visible style and no hyperlink). Rendered as `ESC[2K`, which erases the entire physical terminal row - buffers narrower than the terminal should not rely on the diff staying inside the buffer's width when a row goes blank.
 
 ```elixir
 diff = Renderer.render_diff(old_buffer, new_buffer)

--- a/lib/raxol/core/renderer_compat.ex
+++ b/lib/raxol/core/renderer_compat.ex
@@ -57,7 +57,8 @@ defmodule Raxol.Core.Renderer do
   Returns a list of update tuples:
   - `{:move, x, y}` - Move cursor to position
   - `{:write, text, style}` - Write text with style
-  - `{:clear_line, y}` - Clear line at y
+  - `{:clear_line, y}` - Clear line at y, emitted when a changed row becomes
+    entirely blank (spaces with no visible style and no hyperlink)
 
   ## Example
 
@@ -131,6 +132,19 @@ defmodule Raxol.Core.Renderer do
   end
 
   defp generate_line_diff(old_cells, new_cells, y) do
+    cond do
+      blank_row?(new_cells) and blank_row?(old_cells) ->
+        []
+
+      blank_row?(new_cells) and old_cells != new_cells ->
+        [{:clear_line, y}]
+
+      true ->
+        cell_run_diff(old_cells, new_cells, y)
+    end
+  end
+
+  defp cell_run_diff(old_cells, new_cells, y) do
     old_cells
     |> Enum.zip(new_cells)
     |> Enum.with_index()
@@ -143,6 +157,19 @@ defmodule Raxol.Core.Renderer do
       |> Enum.reverse()
     end)
   end
+
+  # A row is blank when every cell renders as an unstyled space: clear_line
+  # erases with the default background, so any visible style or hyperlink
+  # disqualifies the row.
+  defp blank_row?(cells) do
+    Enum.all?(cells, &blank_cell?/1)
+  end
+
+  defp blank_cell?(%{char: " ", style: style}) do
+    Style.to_ansi(style) == "" and Map.get(style, :hyperlink) in [nil, ""]
+  end
+
+  defp blank_cell?(_cell), do: false
 
   defp diff_cell({ops, run_start, run_chars}, old_cell, new_cell, x, y, cells) do
     if cells_equal?(old_cell, new_cell) do

--- a/lib/raxol/core/renderer_compat.ex
+++ b/lib/raxol/core/renderer_compat.ex
@@ -60,6 +60,11 @@ defmodule Raxol.Core.Renderer do
   - `{:clear_line, y}` - Clear line at y, emitted when a changed row becomes
     entirely blank (spaces with no visible style and no hyperlink)
 
+  Note: `apply_diff/1` renders `:clear_line` as `ESC[2K`, which erases the
+  entire physical terminal row. Buffers narrower than the terminal that share
+  rows with unmanaged content should not rely on the diff staying inside the
+  buffer's width when a row goes blank.
+
   ## Example
 
       old_buffer = Raxol.Core.Buffer.create_blank_buffer(20, 5)
@@ -160,12 +165,14 @@ defmodule Raxol.Core.Renderer do
 
   # A row is blank when every cell renders as an unstyled space: clear_line
   # erases with the default background, so any visible style or hyperlink
-  # disqualifies the row.
+  # disqualifies the row. Non-map styles (set_cell has no style guard) fall
+  # through to non-blank so this fast path never crashes on shapes the diff
+  # path itself tolerates.
   defp blank_row?(cells) do
     Enum.all?(cells, &blank_cell?/1)
   end
 
-  defp blank_cell?(%{char: " ", style: style}) do
+  defp blank_cell?(%{char: " ", style: style}) when is_map(style) do
     Style.to_ansi(style) == "" and Map.get(style, :hyperlink) in [nil, ""]
   end
 

--- a/test/raxol/core/renderer_diff_test.exs
+++ b/test/raxol/core/renderer_diff_test.exs
@@ -83,6 +83,18 @@ defmodule Raxol.Core.RendererDiffTest do
       assert Enum.any?(ops, &match?({:write, "    ", ^style}, &1))
     end
 
+    test "space cells with a non-map style never crash the blank scan" do
+      # set_cell/5 has no guard on style, so nil styles are reachable via the
+      # public API; the fast path must fall through, not raise.
+      old = Buffer.set_cell(blank(), 3, 1, " ", nil)
+      new = Buffer.set_cell(blank(), 3, 1, " ", nil)
+
+      assert Renderer.render_diff(old, new) == []
+      # The nil-style cell is not blank (unknown style), so a diff to a truly
+      # blank row is a changed-row-to-blank: clear_line, no crash.
+      assert Renderer.render_diff(old, blank()) == [{:clear_line, 1}]
+    end
+
     test "row going from blank to text emits writes, not clear_line" do
       old = blank()
       new = Buffer.write_at(blank(), 2, 1, "hi")

--- a/test/raxol/core/renderer_diff_test.exs
+++ b/test/raxol/core/renderer_diff_test.exs
@@ -1,0 +1,141 @@
+defmodule Raxol.Core.RendererDiffTest do
+  @moduledoc """
+  Unit tests for `Raxol.Core.Renderer.render_diff/2` operation emission,
+  in particular the `{:clear_line, y}` fast path for rows that become
+  entirely blank.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.Buffer
+  alias Raxol.Core.Renderer
+  alias Raxol.Test.CrossTerminal.AnsiReplayer, as: Replayer
+
+  defp blank(width \\ 20, height \\ 4),
+    do: Buffer.create_blank_buffer(width, height)
+
+  describe "render_diff/2 clear_line emission" do
+    test "changed row that becomes fully blank emits exactly clear_line" do
+      old = Buffer.write_at(blank(), 3, 1, "hello world")
+      new = blank()
+
+      assert Renderer.render_diff(old, new) == [{:clear_line, 1}]
+    end
+
+    test "each blanked row emits its own clear_line" do
+      old =
+        blank()
+        |> Buffer.write_at(0, 0, "top")
+        |> Buffer.write_at(0, 2, "bottom")
+
+      new = blank()
+
+      assert Renderer.render_diff(old, new) == [
+               {:clear_line, 0},
+               {:clear_line, 2}
+             ]
+    end
+
+    test "unchanged blank row emits nothing" do
+      assert Renderer.render_diff(blank(), blank()) == []
+    end
+
+    test "visually blank rows with different style shapes emit nothing" do
+      # create_blank_buffer cells carry the full nil-map style; write_at with
+      # a space and default style leaves %{} - visually identical, structurally
+      # different. Neither a write nor a clear_line should appear.
+      old = blank()
+      new = Buffer.write_at(blank(), 5, 1, " ")
+
+      assert Buffer.to_string(old) == Buffer.to_string(new)
+      assert Renderer.render_diff(old, new) == []
+    end
+
+    test "partially blank row still emits move/write runs" do
+      old = Buffer.write_at(blank(), 0, 1, "hello world")
+      new = Buffer.write_at(blank(), 0, 1, "hello")
+
+      ops = Renderer.render_diff(old, new)
+
+      assert Enum.any?(ops, &match?({:move, _, 1}, &1))
+      assert Enum.any?(ops, &match?({:write, _, _}, &1))
+      refute Enum.any?(ops, &match?({:clear_line, _}, &1))
+    end
+
+    test "row of spaces with bg_color set stays a write" do
+      style = %{bg_color: :blue}
+      old = Buffer.write_at(blank(), 0, 1, "text", style)
+      new = Buffer.write_at(blank(), 0, 1, "    ", style)
+
+      ops = Renderer.render_diff(old, new)
+
+      refute Enum.any?(ops, &match?({:clear_line, _}, &1))
+      assert Enum.any?(ops, &match?({:write, "    ", ^style}, &1))
+    end
+
+    test "row of blank chars with a hyperlink stays a write" do
+      style = %{hyperlink: "https://raxol.io"}
+      old = Buffer.write_at(blank(), 0, 1, "link", style)
+      new = Buffer.write_at(blank(), 0, 1, "    ", style)
+
+      ops = Renderer.render_diff(old, new)
+
+      refute Enum.any?(ops, &match?({:clear_line, _}, &1))
+      assert Enum.any?(ops, &match?({:write, "    ", ^style}, &1))
+    end
+
+    test "row going from blank to text emits writes, not clear_line" do
+      old = blank()
+      new = Buffer.write_at(blank(), 2, 1, "hi")
+
+      assert [{:move, 2, 1}, {:write, "hi", %{}}] =
+               Renderer.render_diff(old, new)
+    end
+  end
+
+  describe "apply_diff/1 clear_line rendering" do
+    test "clear_line renders cursor move to column 1 plus erase-line" do
+      assert Renderer.apply_diff([{:clear_line, 3}]) == "\e[4;1H\e[2K"
+    end
+  end
+
+  describe "clear_line roundtrip through the reference emulator" do
+    test "a blanked line is actually cleared on the emulated grid" do
+      width = 20
+      height = 4
+
+      frame1 =
+        Buffer.create_blank_buffer(width, height)
+        |> Buffer.write_at(0, 0, "keep this line")
+        |> Buffer.write_at(0, 2, "clear this line")
+
+      frame2 =
+        Buffer.create_blank_buffer(width, height)
+        |> Buffer.write_at(0, 0, "keep this line")
+
+      ansi1 =
+        Buffer.create_blank_buffer(width, height)
+        |> Renderer.render_diff(frame1)
+        |> Renderer.apply_diff()
+
+      diff = Renderer.render_diff(frame1, frame2)
+      assert {:clear_line, 2} in diff
+      ansi2 = Renderer.apply_diff(diff)
+
+      emulator =
+        Replayer.replay_chunks([ansi1, ansi2], width: width, height: height)
+
+      assert normalized(Replayer.grid_text(emulator)) ==
+               normalized(Buffer.to_string(frame2))
+    end
+  end
+
+  defp normalized(text) do
+    text
+    |> String.split("\n")
+    |> Enum.map(&String.trim_trailing/1)
+    |> Enum.reverse()
+    |> Enum.drop_while(&(&1 == ""))
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+end


### PR DESCRIPTION
Closes #438.

`render_diff/2` documented a `{:clear_line, y}` op it never emitted; `apply_diff/1`
already renders it (`\e[y+1;1H\e[2K`). This implements option (2) from the issue:
the generator now emits `{:clear_line, y}` when a changed row becomes entirely
blank, collapsing a full-row run of spaces into one op.

## What counts as blank

A cell is blank when `char == " "`, `Style.to_ansi(style) == ""`, and the style
carries no non-empty `:hyperlink`. The two safety exclusions:

- `\e[2K` erases with the default background, so a row of spaces with `bg_color`
  set stays a `{:write, ...}`.
- `Style.to_ansi/1` never reads `:hyperlink`, but `apply_diff` wraps OSC 8 links
  independently, so a row of hyperlinked spaces also stays a write.

Branch order guards a subtle case: both-rows-blank emits `[]` first, because the
two blank cell shapes (`%{}` from `write_at` defaults vs the full nil-map style
from `create_blank_buffer`) are structurally different but visually identical -
without that branch every frame would emit a spurious `clear_line`.

## Notes for review

- No in-repo consumer pattern-matches the op tuples (exhaustive grep across lib/,
  test/, packages/); the only consumer is `apply_diff/1`, which already handles
  `:clear_line`. `demos/record_zero_system.exs` records cast bytes through this
  path, so recorded byte output changes shape (fewer bytes) - expected.
- The bg_color test row is deliberately uniform-styled: the pre-existing run bug
  (style taken from the first cell of a run, `renderer_compat.ex`) is out of
  scope and documented at `demos/record_landing_scene.exs`.
- Docs updated in the `@doc` and `docs/core/BUFFER_API.md` to state the emission
  condition.

## Manual testing

- [x] `MIX_ENV=test mix compile --warnings-as-errors`
- [x] New `test/raxol/core/renderer_diff_test.exs` (10 tests incl. an
      AnsiReplayer roundtrip: blanked line actually clears on the emulated grid)
- [x] `test/cross_terminal/renderer_roundtrip_test.exs` +
      `test/raxol/core/renderer_osc8_test.exs` still green
- [x] Full root suite: 6576 passed, 0 failures
- [x] `mix format --check-formatted`, `mix credo` on touched file (0 issues)
