### PR TITLE
Durable poller offset + agent turn throttle

### DIFF
--- a/packages/raxol_core/lib/raxol/core/stores/dets.ex
+++ b/packages/raxol_core/lib/raxol/core/stores/dets.ex
@@ -83,6 +83,25 @@ defmodule Raxol.Core.Stores.Dets do
     end
   end
 
+  @doc """
+  Read a record straight from disk, or `default` when the key is absent.
+
+  For stores whose working set lives in ETS this is never needed (replay
+  covers boot); it exists for single-record stores with no ETS mirror, such
+  as a poller checkpoint. Returns `default` when persistence is disabled.
+  """
+  @spec get(handle(), term(), term()) :: term()
+  def get(handle, key, default \\ nil)
+
+  def get(nil, _key, default), do: default
+
+  def get(dets, key, default) do
+    case :dets.lookup(dets, key) do
+      [{^key, value}] -> value
+      _other -> default
+    end
+  end
+
   @doc "Write a record through to disk. No-op when persistence is disabled."
   @spec put(handle(), term(), term()) :: :ok
   def put(nil, _key, _value), do: :ok

--- a/packages/raxol_core/test/raxol/core/stores/dets_test.exs
+++ b/packages/raxol_core/test/raxol/core/stores/dets_test.exs
@@ -4,7 +4,12 @@ defmodule Raxol.Core.Stores.DetsTest do
   alias Raxol.Core.Stores.Dets
 
   setup do
-    dir = Path.join(System.tmp_dir!(), "core_stores_dets_#{System.unique_integer([:positive])}")
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "core_stores_dets_#{System.unique_integer([:positive])}"
+      )
+
     File.mkdir_p!(dir)
     on_exit(fn -> File.rm_rf!(dir) end)
     %{dir: dir}
@@ -12,7 +17,11 @@ defmodule Raxol.Core.Stores.DetsTest do
 
   describe "resolve_path/3" do
     test "prefers an explicit :dets_path option" do
-      assert Dets.resolve_path([dets_path: "/tmp/explicit.dets"], :raxol_core, :unused) ==
+      assert Dets.resolve_path(
+               [dets_path: "/tmp/explicit.dets"],
+               :raxol_core,
+               :unused
+             ) ==
                "/tmp/explicit.dets"
     end
 
@@ -41,7 +50,9 @@ defmodule Raxol.Core.Stores.DetsTest do
       assert :ok = Dets.close(handle)
 
       collected = :ets.new(:collect, [:set, :public])
-      reopened = Dets.open!(name, path, fn {k, v} -> :ets.insert(collected, {k, v}) end)
+
+      reopened =
+        Dets.open!(name, path, fn {k, v} -> :ets.insert(collected, {k, v}) end)
 
       assert :ets.lookup(collected, "k1") == [{"k1", %{v: 1}}]
       assert :ets.lookup(collected, "k2") == [{"k2", %{v: 2}}]
@@ -60,7 +71,12 @@ defmodule Raxol.Core.Stores.DetsTest do
       Dets.close(handle)
 
       after_delete = :ets.new(:after_delete, [:set, :public])
-      h2 = Dets.open!(name, path, fn {k, v} -> :ets.insert(after_delete, {k, v}) end)
+
+      h2 =
+        Dets.open!(name, path, fn {k, v} ->
+          :ets.insert(after_delete, {k, v})
+        end)
+
       assert :ets.lookup(after_delete, "a") == []
       assert :ets.lookup(after_delete, "b") == [{"b", 2}]
 
@@ -68,7 +84,10 @@ defmodule Raxol.Core.Stores.DetsTest do
       Dets.close(h2)
 
       after_clear = :ets.new(:after_clear, [:set, :public])
-      h3 = Dets.open!(name, path, fn {k, v} -> :ets.insert(after_clear, {k, v}) end)
+
+      h3 =
+        Dets.open!(name, path, fn {k, v} -> :ets.insert(after_clear, {k, v}) end)
+
       assert :ets.tab2list(after_clear) == []
       Dets.close(h3)
     end
@@ -83,12 +102,33 @@ defmodule Raxol.Core.Stores.DetsTest do
     end
   end
 
+  describe "get/3" do
+    test "reads a stored record and falls back to the default", %{dir: dir} do
+      path = Path.join(dir, "store.dets")
+      name = :"core_stores_dets_get_#{System.unique_integer([:positive])}"
+
+      handle = Dets.open!(name, path, fn _ -> :ok end)
+      Dets.put(handle, :offset, 42)
+
+      assert Dets.get(handle, :offset) == 42
+      assert Dets.get(handle, :absent) == nil
+      assert Dets.get(handle, :absent, :fallback) == :fallback
+
+      Dets.close(handle)
+    end
+  end
+
   describe "nil handle is a no-op" do
     test "put/delete/clear/close all return :ok with no handle" do
       assert :ok = Dets.put(nil, "k", 1)
       assert :ok = Dets.delete(nil, "k")
       assert :ok = Dets.clear(nil)
       assert :ok = Dets.close(nil)
+    end
+
+    test "get returns the default with no handle" do
+      assert Dets.get(nil, "k") == nil
+      assert Dets.get(nil, "k", 7) == 7
     end
   end
 end

--- a/packages/raxol_gateway/lib/raxol/gateway/handler/agent.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/handler/agent.ex
@@ -21,6 +21,15 @@ defmodule Raxol.Gateway.Handler.Agent do
       is added so the executor resolves from the environment (1Password ref ->
       provider env vars -> `AI_API_KEY`); resolution failure falls through to
       the Mock backend rather than crashing.
+    * `:max_turns_per_window` -- per-chat fixed-window turn cap. Unset means
+      no throttle. When the cap is hit, the event is answered with a short
+      rate-limit notice: no backend call is made and history is untouched,
+      so a burst cannot run up backend spend or evict context.
+    * `:window_ms` -- throttle window length in milliseconds (default 60000).
+      A window starts at the first allowed turn after the previous window
+      expires.
+    * `:now_fn` -- millisecond monotonic clock used by the throttle,
+      injectable for deterministic tests.
 
   ## Turn semantics
 
@@ -31,10 +40,10 @@ defmodule Raxol.Gateway.Handler.Agent do
   user message in history and replies with a short error message; the full
   reason is logged.
 
-  There is no per-chat turn rate limit yet: every text event is one backend
-  call, so gate the inbound feed (`Raxol.Gateway.Pairing.authorize/2`,
-  platform allowlists) before routing untrusted chats at a paid backend. A
-  per-chat throttle is a named follow-up on the gateway epic.
+  Every allowed text event is one backend call. The throttle bounds backend
+  spend per chat; it does not authenticate anyone, so still gate the inbound
+  feed (`Raxol.Gateway.Pairing.authorize/2`, platform allowlists) before
+  routing untrusted chats at a paid backend.
   """
 
   @behaviour Raxol.Gateway.Handler
@@ -46,6 +55,7 @@ defmodule Raxol.Gateway.Handler.Agent do
   alias Raxol.Core.ErrorHandling
 
   @default_max_history 40
+  @default_window_ms 60_000
 
   @impl true
   @spec init(Raxol.Gateway.Route.t(), keyword()) ::
@@ -53,14 +63,20 @@ defmodule Raxol.Gateway.Handler.Agent do
   def init(_route, opts) do
     if Code.ensure_loaded?(Raxol.Agent.Stream) do
       agent_opts = default_agent_opts(Keyword.get(opts, :agent_opts, []))
-      warn_if_unresolved(agent_opts, Keyword.get(opts, :resolve_probe, &default_probe/1))
+
+      warn_if_unresolved(
+        agent_opts,
+        Keyword.get(opts, :resolve_probe, &default_probe/1)
+      )
 
       {:ok,
        %{
          messages: [],
          system_prompt: Keyword.get(opts, :system_prompt),
          max_history: Keyword.get(opts, :max_history, @default_max_history),
-         agent_opts: agent_opts
+         agent_opts: agent_opts,
+         throttle: init_throttle(opts),
+         now_fn: Keyword.get(opts, :now_fn, &default_now/0)
        }}
     else
       {:error, :raxol_agent_not_loaded}
@@ -68,10 +84,24 @@ defmodule Raxol.Gateway.Handler.Agent do
   end
 
   @impl true
-  @spec handle_event(term(), map()) :: {:reply, String.t(), map()} | {:noreply, map()}
+  @spec handle_event(term(), map()) ::
+          {:reply, String.t(), map()} | {:noreply, map()}
   def handle_event(%{text: text}, state) when is_binary(text) and text != "" do
+    case check_throttle(state) do
+      {:allow, state} -> run_allowed_turn(text, state)
+      :deny -> {:reply, "Rate limited. Try again shortly.", state}
+    end
+  end
+
+  def handle_event(_event, state), do: {:noreply, state}
+
+  defp run_allowed_turn(text, state) do
     messages =
-      append_capped(state.messages, %{role: :user, content: text}, state.max_history)
+      append_capped(
+        state.messages,
+        %{role: :user, content: text},
+        state.max_history
+      )
 
     case run_turn(messages, state) do
       {:ok, content} ->
@@ -92,7 +122,41 @@ defmodule Raxol.Gateway.Handler.Agent do
     end
   end
 
-  def handle_event(_event, state), do: {:noreply, state}
+  defp init_throttle(opts) do
+    case Keyword.get(opts, :max_turns_per_window) do
+      nil ->
+        nil
+
+      max when is_integer(max) and max > 0 ->
+        %{
+          max: max,
+          window_ms: Keyword.get(opts, :window_ms, @default_window_ms),
+          count: 0,
+          window_start: nil
+        }
+    end
+  end
+
+  # Fixed window: a failed backend turn still counts (it consumed a call).
+  defp check_throttle(%{throttle: nil} = state), do: {:allow, state}
+
+  defp check_throttle(%{throttle: throttle} = state) do
+    now = state.now_fn.()
+
+    cond do
+      throttle.window_start == nil or
+          now - throttle.window_start >= throttle.window_ms ->
+        {:allow, %{state | throttle: %{throttle | window_start: now, count: 1}}}
+
+      throttle.count < throttle.max ->
+        {:allow, %{state | throttle: %{throttle | count: throttle.count + 1}}}
+
+      true ->
+        :deny
+    end
+  end
+
+  defp default_now, do: System.monotonic_time(:millisecond)
 
   # A backend that raises/exits mid-enumeration would otherwise crash the
   # session and drop this chat's events for the router's cooldown window.
@@ -107,10 +171,17 @@ defmodule Raxol.Gateway.Handler.Agent do
       end)
 
     case result do
-      {:ok, {:ok, %{content: content}}} when is_binary(content) -> {:ok, content}
-      {:ok, {:error, reason}} -> {:error, reason}
-      {:ok, other} -> {:error, {:unexpected_turn_result, other}}
-      {:error, crash} -> {:error, {:crashed, crash}}
+      {:ok, {:ok, %{content: content}}} when is_binary(content) ->
+        {:ok, content}
+
+      {:ok, {:error, reason}} ->
+        {:error, reason}
+
+      {:ok, other} ->
+        {:error, {:unexpected_turn_result, other}}
+
+      {:error, crash} ->
+        {:error, {:crashed, crash}}
     end
   end
 
@@ -126,13 +197,16 @@ defmodule Raxol.Gateway.Handler.Agent do
   end
 
   defp put_system_prompt(opts, nil), do: opts
-  defp put_system_prompt(opts, prompt), do: Keyword.put_new(opts, :system_prompt, prompt)
+
+  defp put_system_prompt(opts, prompt),
+    do: Keyword.put_new(opts, :system_prompt, prompt)
 
   # An unresolved auto_provider silently answers from the Mock backend; make
   # that loud once at session start. :resolve_probe is the injectable seam so
   # tests never touch real credential resolution (which may shell out to op).
   defp warn_if_unresolved(agent_opts, probe) do
-    if Keyword.get(agent_opts, :auto_provider, false) and is_nil(probe.(agent_opts)) do
+    if Keyword.get(agent_opts, :auto_provider, false) and
+         is_nil(probe.(agent_opts)) do
       Logger.warning(
         "no agent provider resolved from the environment; " <>
           "replies will come from the Mock backend"
@@ -142,7 +216,8 @@ defmodule Raxol.Gateway.Handler.Agent do
     :ok
   end
 
-  defp default_probe(agent_opts), do: Raxol.Agent.Stream.resolve_executor(agent_opts)
+  defp default_probe(agent_opts),
+    do: Raxol.Agent.Stream.resolve_executor(agent_opts)
 
   # Trim from the front, then drop any leading assistant messages: several
   # providers reject a history whose first message is not a user turn.
@@ -153,6 +228,8 @@ defmodule Raxol.Gateway.Handler.Agent do
     |> Enum.drop_while(&(&1.role == :assistant))
   end
 
-  defp error_text(reason) when is_atom(reason), do: "Agent error (#{reason}). Try again."
+  defp error_text(reason) when is_atom(reason),
+    do: "Agent error (#{reason}). Try again."
+
   defp error_text(_reason), do: "Agent error. Try again."
 end

--- a/packages/raxol_gateway/test/raxol/gateway/handler/agent_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/handler/agent_test.exs
@@ -8,18 +8,32 @@ defmodule Raxol.Gateway.Handler.AgentTest do
 
   @route Route.new(%{platform: :in_memory, chat_type: :dm, chat_id: "1"})
 
-  defp init!(opts \\ []) do
+  defp init!(opts) do
     {:ok, state} = Handler.Agent.init(@route, opts)
     state
   end
 
   defp mock_opts(backend_opts) do
-    [agent_opts: [backend: Raxol.Agent.Backend.Mock, backend_opts: backend_opts]]
+    [
+      agent_opts: [
+        backend: Raxol.Agent.Backend.Mock,
+        backend_opts: backend_opts
+      ]
+    ]
   end
 
   # Tests that leave auto_provider on inject :resolve_probe so init never
   # touches real credential resolution (which may shell out to op).
   defp resolved_probe, do: [resolve_probe: fn _opts -> :resolved end]
+
+  # Deterministic clock: the test owns time via an :atomics cell.
+  defp throttled_state(clock, backend_opts, throttle_opts) do
+    opts =
+      mock_opts(backend_opts) ++
+        [now_fn: fn -> :atomics.get(clock, 1) end] ++ throttle_opts
+
+    init!(opts)
+  end
 
   describe "init/2" do
     test "defaults: empty history, max_history 40, no system prompt" do
@@ -31,7 +45,8 @@ defmodule Raxol.Gateway.Handler.AgentTest do
     end
 
     test "adds auto_provider: true when no backend or executor is pinned" do
-      state = init!(Keyword.put(resolved_probe(), :agent_opts, model: "some-model"))
+      state =
+        init!(Keyword.put(resolved_probe(), :agent_opts, model: "some-model"))
 
       assert Keyword.get(state.agent_opts, :auto_provider) == true
     end
@@ -80,7 +95,8 @@ defmodule Raxol.Gateway.Handler.AgentTest do
     test "replies with the agent's answer and records both turns" do
       state = init!(mock_opts(response: "pong"))
 
-      assert {:reply, "pong", state} = Handler.Agent.handle_event(%{text: "ping"}, state)
+      assert {:reply, "pong", state} =
+               Handler.Agent.handle_event(%{text: "ping"}, state)
 
       assert state.messages == [
                %{role: :user, content: "ping"},
@@ -98,8 +114,11 @@ defmodule Raxol.Gateway.Handler.AgentTest do
 
       state = init!(mock_opts(response_fn: response_fn))
 
-      {:reply, "answer-1", state} = Handler.Agent.handle_event(%{text: "one"}, state)
-      {:reply, "answer-2", state} = Handler.Agent.handle_event(%{text: "two"}, state)
+      {:reply, "answer-1", state} =
+        Handler.Agent.handle_event(%{text: "one"}, state)
+
+      {:reply, "answer-2", state} =
+        Handler.Agent.handle_event(%{text: "two"}, state)
 
       assert state.messages == [
                %{role: :user, content: "one"},
@@ -114,7 +133,9 @@ defmodule Raxol.Gateway.Handler.AgentTest do
 
       state =
         Enum.reduce(1..3, state, fn n, acc ->
-          {:reply, "r", acc} = Handler.Agent.handle_event(%{text: "msg-#{n}"}, acc)
+          {:reply, "r", acc} =
+            Handler.Agent.handle_event(%{text: "msg-#{n}"}, acc)
+
           acc
         end)
 
@@ -133,7 +154,9 @@ defmodule Raxol.Gateway.Handler.AgentTest do
 
       log =
         capture_log(fn ->
-          assert {:reply, reply, state} = Handler.Agent.handle_event(%{text: "hi"}, state)
+          assert {:reply, reply, state} =
+                   Handler.Agent.handle_event(%{text: "hi"}, state)
+
           assert reply =~ "Agent error"
           assert state.messages == [%{role: :user, content: "hi"}]
         end)
@@ -162,12 +185,91 @@ defmodule Raxol.Gateway.Handler.AgentTest do
 
       log =
         capture_log(fn ->
-          assert {:reply, reply, state} = Handler.Agent.handle_event(%{text: "hi"}, state)
+          assert {:reply, reply, state} =
+                   Handler.Agent.handle_event(%{text: "hi"}, state)
+
           assert reply =~ "Agent error"
           assert state.messages == [%{role: :user, content: "hi"}]
         end)
 
       assert log =~ "boom"
+    end
+  end
+
+  describe "per-chat turn throttle" do
+    test "no throttle by default" do
+      state = init!(mock_opts(response: "r"))
+      assert state.throttle == nil
+    end
+
+    test "denies over-cap turns without a backend call or history writes" do
+      clock = :atomics.new(1, [])
+      calls = :counters.new(1, [])
+
+      response_fn = fn ->
+        :counters.add(calls, 1, 1)
+        "ok"
+      end
+
+      state =
+        throttled_state(clock, [response_fn: response_fn],
+          max_turns_per_window: 2,
+          window_ms: 1_000
+        )
+
+      {:reply, "ok", state} = Handler.Agent.handle_event(%{text: "one"}, state)
+      {:reply, "ok", state} = Handler.Agent.handle_event(%{text: "two"}, state)
+
+      assert {:reply, denied, denied_state} =
+               Handler.Agent.handle_event(%{text: "three"}, state)
+
+      assert denied =~ "Rate limited"
+      assert :counters.get(calls, 1) == 2
+      assert denied_state.messages == state.messages
+    end
+
+    test "a new window resets the counter" do
+      clock = :atomics.new(1, [])
+
+      state =
+        throttled_state(clock, [response: "ok"],
+          max_turns_per_window: 1,
+          window_ms: 1_000
+        )
+
+      {:reply, "ok", state} = Handler.Agent.handle_event(%{text: "one"}, state)
+
+      {:reply, denied, state} =
+        Handler.Agent.handle_event(%{text: "two"}, state)
+
+      assert denied =~ "Rate limited"
+
+      :atomics.put(clock, 1, 1_000)
+
+      assert {:reply, "ok", _state} =
+               Handler.Agent.handle_event(%{text: "three"}, state)
+    end
+
+    test "a failed backend turn still counts against the window" do
+      clock = :atomics.new(1, [])
+
+      state =
+        throttled_state(clock, [error: :boom],
+          max_turns_per_window: 1,
+          window_ms: 1_000
+        )
+
+      capture_log(fn ->
+        {:reply, first, state} =
+          Handler.Agent.handle_event(%{text: "one"}, state)
+
+        assert first =~ "Agent error"
+
+        {:reply, denied, _state} =
+          Handler.Agent.handle_event(%{text: "two"}, state)
+
+        assert denied =~ "Rate limited"
+      end)
     end
   end
 

--- a/packages/raxol_telegram/lib/raxol/telegram/update_poller.ex
+++ b/packages/raxol_telegram/lib/raxol/telegram/update_poller.ex
@@ -46,12 +46,22 @@ defmodule Raxol.Telegram.UpdatePoller do
       (default 30). The HTTP receive timeout is always set strictly above
       it, otherwise every quiet cycle would transport-timeout.
     * `:allowed_updates` - `getUpdates` filter (default `["message"]`)
+    * `:dets_path` - file path for durable offset storage; falls back to
+      `Application.get_env(:raxol_telegram, :update_poller_dets_path)`.
+      Unset means the offset lives in memory only.
+    * `:dets_name` - DETS table name for the offset file (default
+      `Raxol.Telegram.UpdatePoller.Offset`). Give each poller its own name
+      when running several durable pollers in one node.
     * `:name` - optional registered name
 
   ## Semantics
 
-  The update offset is in-memory only: a restart re-reads pending updates
-  from Telegram, so consumers may see a redelivered update after a crash.
+  The update offset is in-memory by default: a restart re-reads pending
+  updates from Telegram, so consumers may see a redelivered update after a
+  crash. With `:dets_path` set, the offset is checkpointed to disk after
+  each non-empty batch and reloaded on restart, shrinking redelivery to at
+  most the last unsynced write window. Redelivery is possible either way;
+  consumers that need exactly-once must dedup on `update_id`.
   Transport or Bot API errors back off exponentially (1s doubling, capped at
   30s) and reset on the next success. Errors are logged with the method name
   and classified reason only - never the request URL, which embeds the bot
@@ -63,6 +73,7 @@ defmodule Raxol.Telegram.UpdatePoller do
   require Logger
 
   alias Raxol.Core.ErrorHandling
+  alias Raxol.Core.Stores.Dets
   alias Raxol.Telegram.HTTP
 
   @default_poll_timeout_s 30
@@ -70,15 +81,26 @@ defmodule Raxol.Telegram.UpdatePoller do
   @receive_timeout_margin_ms 5_000
   @backoff_base_ms 1_000
   @backoff_cap_ms 30_000
+  @offset_key :offset
 
   @impl true
   def init_manager(opts) do
+    dets = open_offset_store(opts)
+
+    # terminate/2 (which syncs and closes the DETS file) only runs on a
+    # supervisor shutdown when the process traps exits; without persistence
+    # the default no-cleanup exit path stays.
+    if dets, do: Process.flag(:trap_exit, true)
+
     state = %{
       conn: Keyword.get(opts, :conn, []),
       on_update: Keyword.fetch!(opts, :on_update),
-      poll_timeout_s: Keyword.get(opts, :poll_timeout_s, @default_poll_timeout_s),
-      allowed_updates: Keyword.get(opts, :allowed_updates, @default_allowed_updates),
-      offset: nil,
+      poll_timeout_s:
+        Keyword.get(opts, :poll_timeout_s, @default_poll_timeout_s),
+      allowed_updates:
+        Keyword.get(opts, :allowed_updates, @default_allowed_updates),
+      offset: load_offset(dets),
+      dets: dets,
       failures: 0,
       timer: nil
     }
@@ -93,7 +115,10 @@ defmodule Raxol.Telegram.UpdatePoller do
 
     case HTTP.post("getUpdates", poll_body(state), poll_opts(state)) do
       {:ok, updates} when is_list(updates) ->
-        offset = Enum.reduce(updates, state.offset, &deliver(&1, &2, state.on_update))
+        offset =
+          Enum.reduce(updates, state.offset, &deliver(&1, &2, state.on_update))
+
+        persist_offset(state, offset)
         send(self(), :poll)
         {:noreply, %{state | offset: offset, failures: 0}}
 
@@ -117,8 +142,42 @@ defmodule Raxol.Telegram.UpdatePoller do
     end)
   end
 
+  @impl GenServer
+  def terminate(_reason, state) do
+    Dets.close(state.dets)
+    :ok
+  end
+
+  defp open_offset_store(opts) do
+    case Dets.resolve_path(opts, :raxol_telegram, :update_poller_dets_path) do
+      nil ->
+        nil
+
+      path ->
+        name = Keyword.get(opts, :dets_name, __MODULE__.Offset)
+        Dets.open!(name, path, fn _record -> :ok end)
+    end
+  end
+
+  # A foreign or corrupted record must not poison poll_body: anything but a
+  # positive integer restarts from Telegram's pending queue.
+  defp load_offset(dets) do
+    case Dets.get(dets, @offset_key) do
+      offset when is_integer(offset) and offset > 0 -> offset
+      _other -> nil
+    end
+  end
+
+  defp persist_offset(%{offset: same}, same), do: :ok
+
+  defp persist_offset(state, offset),
+    do: Dets.put(state.dets, @offset_key, offset)
+
   defp poll_body(state) do
-    body = %{timeout: state.poll_timeout_s, allowed_updates: state.allowed_updates}
+    body = %{
+      timeout: state.poll_timeout_s,
+      allowed_updates: state.allowed_updates
+    }
 
     case state.offset do
       nil -> body
@@ -164,7 +223,9 @@ defmodule Raxol.Telegram.UpdatePoller do
 
   defp backoff(state, reason) do
     failures = state.failures + 1
-    delay = min(@backoff_base_ms * Integer.pow(2, failures - 1), @backoff_cap_ms)
+
+    delay =
+      min(@backoff_base_ms * Integer.pow(2, failures - 1), @backoff_cap_ms)
 
     Logger.warning(
       "update_poller getUpdates failed (attempt #{failures}, retry in #{delay}ms): " <>

--- a/packages/raxol_telegram/test/raxol/telegram/update_poller_test.exs
+++ b/packages/raxol_telegram/test/raxol/telegram/update_poller_test.exs
@@ -42,7 +42,11 @@ defmodule Raxol.Telegram.UpdatePollerTest do
   end
 
   defp respond(pid, result) do
-    send(pid, {:respond, {:ok, %{status: 200, body: %{"ok" => true, "result" => result}}}})
+    send(
+      pid,
+      {:respond,
+       {:ok, %{status: 200, body: %{"ok" => true, "result" => result}}}}
+    )
   end
 
   defp update(id, text \\ "hi") do
@@ -97,6 +101,106 @@ defmodule Raxol.Telegram.UpdatePollerTest do
     send(pid, :poll)
     assert_receive {:poll_request, _, _}
     respond(pid, [])
+  end
+
+  # Durable-offset tests stop the poller gracefully (terminate must run so
+  # the DETS file is synced and closed), so they park it in backoff first
+  # and use a normal shutdown instead of the :brutal_kill helper.
+  defp start_durable_poller!(id, dets_opts) do
+    test_pid = self()
+
+    post_fn = fn url, req_opts ->
+      send(test_pid, {:poll_request, url, req_opts})
+
+      receive do
+        {:respond, resp} -> resp
+      after
+        2_000 -> {:error, :test_timeout}
+      end
+    end
+
+    start_supervised!(
+      %{
+        id: id,
+        start:
+          {UpdatePoller, :start_link,
+           [
+             [
+               conn: [bot_token: "test-token", post_fn: post_fn],
+               on_update: fn update -> send(test_pid, {:update, update}) end,
+               poll_timeout_s: 0
+             ] ++ dets_opts
+           ]},
+        shutdown: 5_000
+      },
+      restart: :temporary
+    )
+  end
+
+  defp park_in_backoff_and_stop(pid, id) do
+    capture_log(fn ->
+      send(pid, {:respond, {:error, :econnrefused}})
+      refute_receive {:poll_request, _, _}, 100
+      :ok = stop_supervised(id)
+    end)
+  end
+
+  test "with :dets_path the offset survives a restart" do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "poller_dets_#{System.unique_integer([:positive])}"
+      )
+
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    dets_opts = [
+      dets_path: Path.join(dir, "offset.dets"),
+      dets_name: :"poller_offset_#{System.unique_integer([:positive])}"
+    ]
+
+    pid = start_durable_poller!(:durable_a, dets_opts)
+
+    assert_receive {:poll_request, _url, req_opts}
+    refute Keyword.fetch!(req_opts, :json) |> Map.has_key?(:offset)
+
+    respond(pid, [update(10), update(11)])
+    assert_receive {:update, %{"update_id" => 11}}
+
+    assert_receive {:poll_request, _url, req_opts2}
+    assert Keyword.fetch!(req_opts2, :json).offset == 12
+
+    park_in_backoff_and_stop(pid, :durable_a)
+
+    pid2 = start_durable_poller!(:durable_b, dets_opts)
+
+    assert_receive {:poll_request, _url, req_opts3}
+    assert Keyword.fetch!(req_opts3, :json).offset == 12
+
+    park_in_backoff_and_stop(pid2, :durable_b)
+  end
+
+  test "a non-integer persisted offset is ignored" do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "poller_dets_#{System.unique_integer([:positive])}"
+      )
+
+    on_exit(fn -> File.rm_rf!(dir) end)
+    path = Path.join(dir, "offset.dets")
+    name = :"poller_offset_junk_#{System.unique_integer([:positive])}"
+
+    handle = Raxol.Core.Stores.Dets.open!(name, path, fn _ -> :ok end)
+    Raxol.Core.Stores.Dets.put(handle, :offset, "junk")
+    Raxol.Core.Stores.Dets.close(handle)
+
+    pid = start_durable_poller!(:durable_junk, dets_path: path, dets_name: name)
+
+    assert_receive {:poll_request, _url, req_opts}
+    refute Keyword.fetch!(req_opts, :json) |> Map.has_key?(:offset)
+
+    park_in_backoff_and_stop(pid, :durable_junk)
   end
 
   test "a crashing on_update is logged, skipped, and the offset advances" do


### PR DESCRIPTION
Lands the two named follow-ups from the #493 adversarial review (see the
2026-07-25 progress comment): durable `UpdatePoller` offset and a per-chat
turn throttle for `Gateway.Handler.Agent`.

## Durable UpdatePoller offset (raxol_telegram + raxol_core)

- `:dets_path` option (falls back to
  `Application.get_env(:raxol_telegram, :update_poller_dets_path)` via
  `Stores.Dets.resolve_path/3`); unset keeps today's in-memory behavior.
- A single `{:offset, n}` record, checkpointed after each non-empty batch
  and reloaded on restart.
- Adds `Raxol.Core.Stores.Dets.get/3`: the facade had no read primitive.
  Every existing caller replays into ETS on boot, which the poller does
  not have; the alternative (side-channel through the replay fun) was
  rejected as convoluted for one record.

Decisions, pre-empting review:

- **trap_exit only when persistence is on**: `terminate/2` (which syncs and
  closes the DETS file) never runs on supervisor shutdown unless the
  process traps exits. Without `:dets_path` the exit path is unchanged.
- **Persist only when the offset changed**: no DETS write per quiet
  long-poll cycle.
- **Load validation**: a foreign or corrupted record (anything but a
  positive integer) is ignored and the poller restarts from Telegram's
  pending queue - the redelivery-safe direction.
- **Durability is best-effort**: a SIGKILL can lose the last unsynced write
  window (documented on the Dets facade). The moduledoc now states that
  consumers needing exactly-once must dedup on `update_id` either way.
- **`:dets_name` option**: DETS table names are node-global, so several
  durable pollers on one node need distinct names. Default
  `Raxol.Telegram.UpdatePoller.Offset`.
- **Hex note**: raxol_telegram now calls `Dets.get/3`, new in raxol_core;
  the next publish will need the raxol_core constraint bump, which
  `check-lockstep-deps.sh` enforces at release time.

## Per-chat turn throttle (raxol_gateway)

- Opt-in: `:max_turns_per_window` + `:window_ms` (default 60s window).
  Unset means no throttle - Pairing/allowlists remain the authorization
  control; the throttle only bounds backend spend per chat.
- Fixed-window counter held in handler state, following the
  `Raxol.RateLimit` idiom (main-raxol only, not in gateway's dep graph,
  so the ~10-line idiom is reimplemented rather than depped).
- A denied turn replies "Rate limited" with **no backend call and no
  history write**, so a burst can neither run up spend nor evict context.
- A failed backend turn still counts against the window (it consumed a
  call).
- Injectable `:now_fn` (monotonic ms) makes the tests fully deterministic
  (an `:atomics` cell as the clock - no sleeps).

## Manual testing

- [x] `packages/raxol_core`: compile --warnings-as-errors, dets tests 9/9,
      credo --strict clean on touched files
- [x] `packages/raxol_telegram`: compile --warnings-as-errors, 227/227,
      credo --strict (3 pre-existing findings, none in touched files -
      verified identical on master via stash)
- [x] `packages/raxol_gateway`: compile --warnings-as-errors, 54/54,
      credo --strict clean
- [x] Root: compile --warnings-as-errors, format check,
      `mix test --exclude slow --exclude integration --exclude docker`:
      6577 passed / 0 failures
- [x] Durable-offset restart test drives a real DETS file through
      poller stop/start (graceful shutdown so terminate syncs), no mocks
