### PR TITLE
Add cron scheduler engine (Schedule + Scheduler)

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/schedule.ex
+++ b/packages/raxol_agent/lib/raxol/agent/schedule.ex
@@ -1,0 +1,332 @@
+defmodule Raxol.Agent.Schedule do
+  @moduledoc """
+  Parses a schedule string into a next-fire function, once, at creation time.
+
+  Four formats, one parser (`parse/1`):
+
+    * **relative** -- `"30m"`, `"2h"`, `"45s"`, `"1d"`. Fires once, `now + duration`
+      after creation. One-shot (`recurring?: false`).
+    * **interval** -- `"every 2h"`, `"every 30m"`. Fires every duration, forever.
+      Recurring.
+    * **cron** -- a 5-field crontab (`"0 9 * * 1-5"`): `minute hour
+      day-of-month month day-of-week`. Recurring. Fields accept `*`, single
+      values, ranges (`a-b`), steps (`*/n`, `a-b/n`), and lists (`a,b,c`).
+      Day-of-week is `0` or `7` for Sunday through `6` for Saturday, and follows
+      Vixie cron's rule: when both day-of-month and day-of-week are restricted, a
+      day matches when *either* does.
+    * **timestamp** -- an ISO 8601 instant (`"2026-08-01T09:00:00Z"`). Fires once,
+      at that instant. One-shot.
+
+  The parser is deterministic and never touches a clock or an LLM: a
+  natural-language schedule is expected to be lowered to one of these formats by
+  the agent at job-creation time, not here. `next_fire/2` takes the reference
+  time explicitly, so scheduling is a pure function of `(schedule, from)`.
+
+  A 5-field cron over a set of impossible constraints (e.g. `"0 0 30 2 *"`,
+  February 30th) has no next fire; `next_fire/2` returns `:never` after an
+  8-year search horizon rather than looping forever.
+  """
+
+  @enforce_keys [:kind, :source, :recurring?, :parsed]
+  defstruct [:kind, :source, :recurring?, :parsed]
+
+  @type kind :: :relative | :interval | :cron | :timestamp
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          source: String.t(),
+          recurring?: boolean(),
+          parsed: term()
+        }
+
+  # Field bounds for the 5 cron positions, in order.
+  @cron_fields [
+    {:minute, 0, 59},
+    {:hour, 0, 23},
+    {:day, 1, 31},
+    {:month, 1, 12},
+    # Day-of-week accepts 0-7; both 0 and 7 mean Sunday and are normalized to 0.
+    {:dow, 0, 7}
+  ]
+
+  # Cap the cron next-fire search so an impossible schedule terminates. Twelve
+  # years clears the widest real gap: a century year that is not a leap year
+  # (e.g. 2100) stretches the span between two Feb-29 fires to 8 years, so a
+  # 12-year horizon keeps comfortable margin above it.
+  @cron_horizon_days 12 * 366
+
+  @duration_units %{"s" => 1, "m" => 60, "h" => 3600, "d" => 86_400}
+
+  @doc """
+  Parse a schedule string into a `%Schedule{}`, or `{:error, reason}`.
+
+  The format is inferred from the string shape: an `"every "` prefix is an
+  interval, a bare `<n><unit>` is relative, five whitespace-separated fields is
+  cron, and a single token that is neither is tried as an ISO 8601 timestamp.
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, term()}
+  def parse(source) when is_binary(source) do
+    trimmed = String.trim(source)
+
+    cond do
+      trimmed == "" -> {:error, :empty_schedule}
+      String.starts_with?(trimmed, "every ") -> parse_interval(trimmed)
+      true -> parse_single_or_cron(trimmed)
+    end
+  end
+
+  def parse(_source), do: {:error, :invalid_schedule}
+
+  @doc """
+  The next fire time strictly after `from`, or `:never` when the schedule can
+  never fire again (a one-shot already in the past, or an impossible cron).
+  """
+  @spec next_fire(t(), DateTime.t()) :: {:ok, DateTime.t()} | :never
+  def next_fire(%__MODULE__{kind: kind, parsed: parsed}, %DateTime{} = from) do
+    case kind do
+      :relative -> {:ok, DateTime.add(from, parsed, :second)}
+      :interval -> {:ok, DateTime.add(from, parsed, :second)}
+      :timestamp -> timestamp_next(parsed, from)
+      :cron -> cron_next(parsed, from)
+    end
+  end
+
+  # -- interval / relative ----------------------------------------------------
+
+  defp parse_interval("every " <> rest) do
+    case parse_duration(String.trim(rest)) do
+      {:ok, seconds} ->
+        {:ok,
+         %__MODULE__{kind: :interval, source: "every " <> rest, recurring?: true, parsed: seconds}}
+
+      :error ->
+        {:error, {:bad_interval, rest}}
+    end
+  end
+
+  defp parse_single_or_cron(trimmed) do
+    case String.split(trimmed, ~r/\s+/, trim: true) do
+      [single] -> parse_single(single)
+      fields when length(fields) == 5 -> parse_cron(fields, trimmed)
+      _other -> {:error, {:unrecognized_schedule, trimmed}}
+    end
+  end
+
+  defp parse_single(token) do
+    case parse_duration(token) do
+      {:ok, seconds} ->
+        {:ok, %__MODULE__{kind: :relative, source: token, recurring?: false, parsed: seconds}}
+
+      :error ->
+        parse_timestamp(token)
+    end
+  end
+
+  # A duration is <positive-int><s|m|h|d>, e.g. "30m", "2h".
+  defp parse_duration(token) do
+    case Regex.run(~r/^(\d+)([smhd])$/, token) do
+      [_all, value, unit] ->
+        int = String.to_integer(value)
+        if int > 0, do: {:ok, int * @duration_units[unit]}, else: :error
+
+      _no_match ->
+        :error
+    end
+  end
+
+  # -- timestamp --------------------------------------------------------------
+
+  defp parse_timestamp(token) do
+    case DateTime.from_iso8601(token) do
+      {:ok, dt, _offset} ->
+        {:ok, %__MODULE__{kind: :timestamp, source: token, recurring?: false, parsed: dt}}
+
+      {:error, _reason} ->
+        {:error, {:unrecognized_schedule, token}}
+    end
+  end
+
+  defp timestamp_next(dt, from) do
+    if DateTime.compare(dt, from) == :gt, do: {:ok, dt}, else: :never
+  end
+
+  # -- cron -------------------------------------------------------------------
+
+  defp parse_cron(fields, source) do
+    case reduce_cron_fields(fields) do
+      {:error, _reason} = error ->
+        error
+
+      map when is_map(map) ->
+        {:ok, %__MODULE__{kind: :cron, source: source, recurring?: true, parsed: map}}
+    end
+  end
+
+  defp reduce_cron_fields(fields) do
+    fields
+    |> Enum.zip(@cron_fields)
+    |> Enum.reduce_while(%{}, &reduce_cron_field/2)
+  end
+
+  defp reduce_cron_field({field, {name, min, max}}, acc) do
+    case parse_cron_field(field, min, max) do
+      {:ok, set} -> {:cont, Map.put(acc, name, normalize_field(name, set))}
+      :error -> {:halt, {:error, {:bad_cron_field, name, field}}}
+    end
+  end
+
+  # Day-of-week 7 is an alias for Sunday (0); fold it in so `* * * * 7` and
+  # `* * * * 0` are identical and a full field is exactly 7 distinct days.
+  defp normalize_field(:dow, set) do
+    if MapSet.member?(set, 7),
+      do: set |> MapSet.delete(7) |> MapSet.put(0),
+      else: set
+  end
+
+  defp normalize_field(_name, set), do: set
+
+  # A field is a comma-separated list of items over `min..max`; `*` means the
+  # whole range. Returns a MapSet of the allowed integers, or :error.
+  defp parse_cron_field(field, min, max) do
+    field
+    |> String.split(",", trim: true)
+    |> Enum.reduce_while(MapSet.new(), fn item, acc ->
+      case parse_cron_item(item, min, max) do
+        {:ok, set} -> {:cont, MapSet.union(acc, set)}
+        :error -> {:halt, :error}
+      end
+    end)
+    |> case do
+      :error -> :error
+      set -> if MapSet.size(set) == 0, do: :error, else: {:ok, set}
+    end
+  end
+
+  defp parse_cron_item(item, min, max) do
+    case String.split(item, "/", parts: 2) do
+      [range] ->
+        parse_cron_range(range, min, max, 1)
+
+      [range, step] ->
+        with {:ok, s} <- positive_int(step), do: parse_cron_range(range, min, max, s)
+    end
+  end
+
+  defp parse_cron_range("*", min, max, step), do: stepped(min, max, step)
+
+  defp parse_cron_range(range, min, max, step) do
+    case String.split(range, "-", parts: 2) do
+      [single] -> parse_cron_point(single, min, max, step)
+      [lo, hi] -> parse_cron_bounds(lo, hi, min, max, step)
+    end
+  end
+
+  # A bare number with a step (`5/2`) means "from 5 to max, step"; without a
+  # step it is just that one value.
+  defp parse_cron_point(single, min, max, step) do
+    with {:ok, n} <- bounded_int(single, min, max) do
+      if step == 1, do: {:ok, MapSet.new([n])}, else: stepped(n, max, step)
+    end
+  end
+
+  defp parse_cron_bounds(lo, hi, min, max, step) do
+    with {:ok, low} <- bounded_int(lo, min, max),
+         {:ok, high} <- bounded_int(hi, min, max),
+         true <- low <= high do
+      stepped(low, high, step)
+    else
+      _ -> :error
+    end
+  end
+
+  defp stepped(lo, hi, step) do
+    {:ok, lo |> Stream.iterate(&(&1 + step)) |> Enum.take_while(&(&1 <= hi)) |> MapSet.new()}
+  end
+
+  defp bounded_int(str, min, max) do
+    case Integer.parse(str) do
+      {n, ""} when n >= min and n <= max -> {:ok, n}
+      _other -> :error
+    end
+  end
+
+  defp positive_int(str) do
+    case Integer.parse(str) do
+      {n, ""} when n > 0 -> {:ok, n}
+      _other -> :error
+    end
+  end
+
+  # Walk forward to the first matching minute strictly after `from`. To keep an
+  # impossible date (e.g. February 30th) cheap, whole non-matching days are
+  # skipped to the next midnight rather than stepped minute by minute; the
+  # horizon is counted in days so the search always terminates.
+  defp cron_next(cron, from) do
+    start =
+      from
+      |> DateTime.truncate(:second)
+      |> Map.put(:second, 0)
+      |> Map.put(:microsecond, {0, 0})
+      |> DateTime.add(60, :second)
+
+    search_cron(cron, start, @cron_horizon_days)
+  end
+
+  defp search_cron(_cron, _dt, 0), do: :never
+
+  defp search_cron(cron, dt, days_left) do
+    cond do
+      not date_match?(cron, dt) ->
+        search_cron(cron, next_midnight(dt), days_left - 1)
+
+      cron_match?(cron, dt) ->
+        {:ok, dt}
+
+      true ->
+        # The day matches but this minute does not; step within the day, and
+        # only spend a day of the horizon when the step crosses midnight.
+        next = DateTime.add(dt, 60, :second)
+
+        if DateTime.to_date(next) == DateTime.to_date(dt),
+          do: search_cron(cron, next, days_left),
+          else: search_cron(cron, next, days_left - 1)
+    end
+  end
+
+  defp next_midnight(dt) do
+    dt |> DateTime.to_date() |> Date.add(1) |> DateTime.new!(~T[00:00:00])
+  end
+
+  defp cron_match?(cron, dt) do
+    MapSet.member?(cron.minute, dt.minute) and
+      MapSet.member?(cron.hour, dt.hour) and
+      date_match?(cron, dt)
+  end
+
+  # The date (month + day) matches, independent of the time of day.
+  defp date_match?(cron, dt) do
+    MapSet.member?(cron.month, dt.month) and day_match?(cron, dt)
+  end
+
+  # Vixie cron: when both day-of-month and day-of-week are restricted, a day
+  # matches if either does; otherwise only the restricted field (if any) gates.
+  defp day_match?(cron, dt) do
+    dom_restricted = MapSet.size(cron.day) < 31
+    dow_restricted = MapSet.size(cron.dow) < 7
+
+    dom_ok = MapSet.member?(cron.day, dt.day)
+    dow_ok = MapSet.member?(cron.dow, cron_dow(dt))
+
+    cond do
+      dom_restricted and dow_restricted -> dom_ok or dow_ok
+      dom_restricted -> dom_ok
+      dow_restricted -> dow_ok
+      true -> true
+    end
+  end
+
+  # Date.day_of_week is 1 (Monday)..7 (Sunday); cron is 0 (Sunday)..6 (Saturday).
+  defp cron_dow(dt) do
+    dt |> DateTime.to_date() |> Date.day_of_week() |> rem(7)
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/scheduler.ex
+++ b/packages/raxol_agent/lib/raxol/agent/scheduler.ex
@@ -1,0 +1,601 @@
+defmodule Raxol.Agent.Scheduler do
+  @moduledoc """
+  A single-node scheduler for recurring and one-shot agent jobs.
+
+  Each job holds a `prompt`, a `schedule` (parsed once by `Raxol.Agent.Schedule`),
+  the `skills` to inject on each fire, a delivery `target`, and an `enabled` flag.
+  The scheduler keeps one `Process.send_after/3` timer per enabled job; when a
+  timer elapses it dispatches the job's run and, for a recurring schedule,
+  re-arms the next occurrence. Jobs are persisted to `Raxol.Core.Stores.Dets`
+  (when a path is configured) and replayed on boot, so a restart re-arms every
+  job from its stored next-fire time. Missed fires during downtime are not
+  back-filled: a recurring job re-arms forward from now, a one-shot whose time
+  passed fires once, promptly.
+
+  The BEAM owns the scheduling; there is no OS cron daemon. This is a single-node
+  scheduler -- a clustered variant sharded across the swarm is out of scope
+  (ADR-0025).
+
+  ## Firing
+
+  A fire never runs inline in the GenServer. The scheduler records the fire to
+  its thread log (single-writer, in mailbox order), advances the schedule, and
+  hands the actual work to an injectable `:dispatch` function (default: an
+  unlinked process), which calls the `:runner` and then `:deliver`. A slow or
+  crashing agent turn therefore cannot stall scheduling or drop another job.
+
+  ## Options
+
+    * `:name` -- registered name (default `#{inspect(__MODULE__)}`)
+    * `:now_fn` -- `(-> DateTime.t())`, the clock; injectable for deterministic
+      tests. Default `&DateTime.utc_now/0`.
+    * `:runner` -- `(job -> {:ok, String.t()} | {:error, term()})`, runs one
+      fire and returns its rendered output. Default logs and returns an error
+      (the real fresh-agent runner is wired by the surface layer).
+    * `:deliver` -- `(target, String.t() -> :ok | {:error, term()})`, delivers a
+      fire's output to the job's target. Default logs.
+    * `:dispatch` -- `((-> any()) -> any())`, runs the fire work. Default spawns
+      an unlinked process; tests pass a synchronous function.
+    * `:max_per_owner` -- cap on enabled + paused jobs per `owner` (default 50).
+    * `:thread_log` -- a `Raxol.Agent.ThreadLog` adapter (`module` or
+      `{module, config}`) that every fire is recorded to. Default: none.
+    * `:dets_path` / `:dets_name` -- durable job store; falls back to
+      `Application.get_env(:raxol_agent, :scheduler_dets_path)`. Unset means jobs
+      live in memory only.
+  """
+
+  use Raxol.Core.Behaviours.BaseManager
+
+  require Logger
+
+  alias Raxol.Agent.Schedule
+  alias Raxol.Agent.ThreadLog
+  alias Raxol.Core.ErrorHandling
+  alias Raxol.Core.Stores.Dets
+
+  @default_max_per_owner 50
+  # Process.send_after tops out near 49 days; re-arm well under it for long
+  # schedules (e.g. a yearly cron) so no single timer exceeds the limit.
+  @max_timer_ms 24 * 60 * 60 * 1000
+
+  @type job :: %{
+          id: String.t(),
+          owner: String.t() | nil,
+          prompt: String.t(),
+          schedule_spec: String.t(),
+          schedule: Schedule.t(),
+          skills: [String.t()],
+          target: String.t() | nil,
+          enabled: boolean(),
+          next_fire: DateTime.t() | nil,
+          created_at: DateTime.t(),
+          last_fired_at: DateTime.t() | nil,
+          fire_count: non_neg_integer()
+        }
+
+  # -- Public API -------------------------------------------------------------
+
+  @doc "Create a job from `attrs` (`prompt`, `schedule`, and optional `owner`, `skills`, `target`, `enabled`, `id`)."
+  @spec create(GenServer.server(), map()) :: {:ok, job()} | {:error, term()}
+  def create(server \\ __MODULE__, attrs) when is_map(attrs) do
+    GenServer.call(server, {:create, attrs})
+  end
+
+  @doc "List jobs, most-recently-created first. `:owner` filters to one owner."
+  @spec list(GenServer.server(), keyword()) :: [job()]
+  def list(server \\ __MODULE__, opts \\ []) do
+    GenServer.call(server, {:list, Keyword.get(opts, :owner)})
+  end
+
+  @doc "Fetch one job by id."
+  @spec get(GenServer.server(), String.t()) :: {:ok, job()} | {:error, :not_found}
+  def get(server \\ __MODULE__, id), do: GenServer.call(server, {:get, id})
+
+  @doc "Patch a job's `prompt`, `schedule`, `skills`, `target`, or `enabled` and re-arm."
+  @spec update(GenServer.server(), String.t(), map()) :: {:ok, job()} | {:error, term()}
+  def update(server \\ __MODULE__, id, changes) when is_map(changes) do
+    GenServer.call(server, {:update, id, changes})
+  end
+
+  @doc "Disable a job and cancel its timer. It keeps its definition."
+  @spec pause(GenServer.server(), String.t()) :: {:ok, job()} | {:error, :not_found}
+  def pause(server \\ __MODULE__, id), do: GenServer.call(server, {:set_enabled, id, false})
+
+  @doc "Re-enable a paused job and re-arm it from the next occurrence."
+  @spec resume(GenServer.server(), String.t()) :: {:ok, job()} | {:error, :not_found}
+  def resume(server \\ __MODULE__, id), do: GenServer.call(server, {:set_enabled, id, true})
+
+  @doc "Fire a job now, out of schedule, without disturbing its next scheduled fire."
+  @spec run(GenServer.server(), String.t()) :: :ok | {:error, :not_found}
+  def run(server \\ __MODULE__, id), do: GenServer.call(server, {:run_now, id})
+
+  @doc "Remove a job, cancel its timer, and delete it from the store."
+  @spec remove(GenServer.server(), String.t()) :: :ok
+  def remove(server \\ __MODULE__, id), do: GenServer.call(server, {:remove, id})
+
+  # -- BaseManager callbacks --------------------------------------------------
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def init_manager(opts) do
+    dets = open_store(opts)
+    if dets, do: Process.flag(:trap_exit, true)
+
+    now_fn = Keyword.get(opts, :now_fn, &DateTime.utc_now/0)
+
+    state = %{
+      jobs: %{},
+      timers: %{},
+      dets: dets,
+      now_fn: now_fn,
+      runner: Keyword.get(opts, :runner, &default_runner/1),
+      deliver: Keyword.get(opts, :deliver, &default_deliver/2),
+      dispatch: Keyword.get(opts, :dispatch, &default_dispatch/1),
+      max_per_owner: Keyword.get(opts, :max_per_owner, @default_max_per_owner),
+      thread_log: ThreadLog.normalize(Keyword.get(opts, :thread_log))
+    }
+
+    {:ok, replay(state)}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call({:create, attrs}, _from, state) do
+    case build_job(attrs, state) do
+      {:ok, job} ->
+        state = state |> put_job(job) |> arm(job.id)
+        {:reply, {:ok, fetch!(state, job.id)}, state}
+
+      {:error, _reason} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  def handle_manager_call({:list, owner}, _from, state) do
+    jobs =
+      state.jobs
+      |> Map.values()
+      |> Enum.filter(&(is_nil(owner) or &1.owner == owner))
+      |> Enum.sort_by(& &1.created_at, {:desc, DateTime})
+
+    {:reply, jobs, state}
+  end
+
+  def handle_manager_call({:get, id}, _from, state) do
+    case Map.fetch(state.jobs, id) do
+      {:ok, job} -> {:reply, {:ok, job}, state}
+      :error -> {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_manager_call({:update, id, changes}, _from, state) do
+    with {:ok, job} <- Map.fetch(state.jobs, id),
+         {:ok, updated} <- apply_changes(job, changes, state) do
+      state = state |> cancel(id) |> put_job(updated) |> arm(id)
+      {:reply, {:ok, fetch!(state, id)}, state}
+    else
+      :error -> {:reply, {:error, :not_found}, state}
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  def handle_manager_call({:set_enabled, id, enabled}, _from, state) do
+    case Map.fetch(state.jobs, id) do
+      {:ok, job} ->
+        state =
+          state
+          |> cancel(id)
+          |> put_job(%{job | enabled: enabled})
+          |> arm(id)
+
+        {:reply, {:ok, fetch!(state, id)}, state}
+
+      :error ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_manager_call({:run_now, id}, _from, state) do
+    case Map.fetch(state.jobs, id) do
+      {:ok, job} ->
+        state = dispatch_fire(state, job, :manual)
+        {:reply, :ok, state}
+
+      :error ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_manager_call({:remove, id}, _from, state) do
+    state = cancel(state, id)
+    Dets.delete(state.dets, id)
+    {:reply, :ok, %{state | jobs: Map.delete(state.jobs, id)}}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info({:fire, id}, state) do
+    case Map.fetch(state.jobs, id) do
+      {:ok, %{enabled: true} = job} -> {:noreply, fire(job, state)}
+      _other -> {:noreply, drop_timer(state, id)}
+    end
+  end
+
+  def handle_manager_info({:rearm, id}, state) do
+    {:noreply, state |> drop_timer(id) |> arm(id)}
+  end
+
+  def handle_manager_info(_msg, state), do: {:noreply, state}
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    Dets.close(state.dets)
+    :ok
+  end
+
+  # -- firing -----------------------------------------------------------------
+
+  # A scheduled fire: run the work, then advance to the next occurrence.
+  defp fire(job, state) do
+    state
+    |> dispatch_fire(job, :schedule)
+    |> advance(job)
+  end
+
+  # Record the fire and hand the run to the dispatcher. Shared by scheduled and
+  # manual (`run/1`) fires; a manual fire does not advance the schedule.
+  defp dispatch_fire(state, job, trigger) do
+    now = state.now_fn.()
+    record_fire(state, job, trigger, now)
+
+    runner = state.runner
+    deliver = state.deliver
+    state.dispatch.(fn -> run_and_deliver(job, runner, deliver) end)
+
+    updated = %{job | last_fired_at: now, fire_count: job.fire_count + 1}
+    put_job(state, updated)
+  end
+
+  defp advance(state, job) do
+    job = fetch!(state, job.id)
+    now = state.now_fn.()
+
+    if job.schedule.recurring? do
+      case Schedule.next_fire(job.schedule, now) do
+        {:ok, next} -> state |> put_job(%{job | next_fire: next}) |> arm(job.id)
+        :never -> retire(state, job)
+      end
+    else
+      # A one-shot has fired; retire it (keep the record).
+      retire(state, job)
+    end
+  end
+
+  # Retire a job that will not fire again: keep its record but drop the elapsed
+  # timer ref so `state.timers` stays bounded and means "currently armed".
+  defp retire(state, job) do
+    state |> drop_timer(job.id) |> put_job(%{job | next_fire: nil})
+  end
+
+  defp run_and_deliver(job, runner, deliver) do
+    case ErrorHandling.safe_call(fn -> runner.(job) end) do
+      {:ok, {:ok, output}} when is_binary(output) ->
+        deliver_output(job, output, deliver)
+
+      {:ok, {:error, reason}} ->
+        Logger.warning("scheduler job #{job.id} runner failed: #{inspect(reason)}")
+
+      {:ok, other} ->
+        Logger.warning("scheduler job #{job.id} runner returned #{inspect(other)}")
+
+      {:error, crash} ->
+        Logger.warning("scheduler job #{job.id} runner crashed: #{inspect(crash)}")
+    end
+  end
+
+  defp deliver_output(%{target: nil}, _output, _deliver), do: :ok
+
+  defp deliver_output(%{target: target} = job, output, deliver) do
+    case ErrorHandling.safe_call(fn -> deliver.(target, output) end) do
+      {:ok, :ok} ->
+        :ok
+
+      {:ok, {:error, reason}} ->
+        Logger.warning("scheduler job #{job.id} delivery failed: #{inspect(reason)}")
+
+      {:ok, other} ->
+        Logger.warning("scheduler job #{job.id} delivery returned #{inspect(other)}")
+
+      {:error, crash} ->
+        Logger.warning("scheduler job #{job.id} delivery crashed: #{inspect(crash)}")
+    end
+  end
+
+  defp record_fire(%{thread_log: nil}, _job, _trigger, _now), do: :ok
+
+  # Runs inline in the GenServer (single-writer per thread), so a raising or
+  # misbehaving thread-log adapter must never crash the scheduler -- that would
+  # drop every armed timer, and since recording precedes the schedule advance,
+  # replay would re-fire the same job into the same failing adapter in a loop.
+  defp record_fire(state, job, trigger, now) do
+    payload = %{job_id: job.id, prompt: job.prompt, trigger: trigger, fired_at: now}
+
+    result =
+      ErrorHandling.safe_call(fn ->
+        ThreadLog.append(state.thread_log, "cron:" <> job.id, :cron_fire, payload)
+      end)
+
+    case result do
+      {:ok, {:ok, _event}} ->
+        :ok
+
+      {:ok, {:error, reason}} ->
+        Logger.warning("scheduler job #{job.id} thread-log append failed: #{inspect(reason)}")
+
+      {:ok, other} ->
+        Logger.warning("scheduler job #{job.id} thread-log append returned #{inspect(other)}")
+
+      {:error, crash} ->
+        Logger.warning("scheduler job #{job.id} thread-log append crashed: #{inspect(crash)}")
+    end
+  end
+
+  # -- timers -----------------------------------------------------------------
+
+  # Arm (or re-arm) a job's timer. A next-fire beyond the timer ceiling parks a
+  # `:rearm` checkpoint that recomputes the delay on wake, so no single timer
+  # exceeds the send_after limit.
+  defp arm(state, id) do
+    job = fetch!(state, id)
+
+    cond do
+      not job.enabled -> state
+      is_nil(job.next_fire) -> state
+      true -> put_timer(state, id, arm_timer(state, id, job.next_fire))
+    end
+  end
+
+  defp arm_timer(state, id, target) do
+    delay = max(0, DateTime.diff(target, state.now_fn.(), :millisecond))
+
+    if delay > @max_timer_ms do
+      Process.send_after(self(), {:rearm, id}, @max_timer_ms)
+    else
+      Process.send_after(self(), {:fire, id}, delay)
+    end
+  end
+
+  defp cancel(state, id), do: drop_timer(state, id)
+
+  defp put_timer(state, id, ref), do: %{state | timers: Map.put(state.timers, id, ref)}
+
+  defp drop_timer(state, id) do
+    case Map.pop(state.timers, id) do
+      {nil, timers} ->
+        %{state | timers: timers}
+
+      {ref, timers} ->
+        Process.cancel_timer(ref)
+        flush_fire(id)
+        %{state | timers: timers}
+    end
+  end
+
+  # cancel_timer does not remove a `{:fire, id}` the timer already delivered to
+  # the mailbox. Without this, cancelling on a re-arm that keeps a job enabled
+  # (e.g. update/3) could let a stale fire slip through and drift the schedule.
+  defp flush_fire(id) do
+    receive do
+      {:fire, ^id} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  # -- job construction -------------------------------------------------------
+
+  defp build_job(attrs, state) do
+    with {:ok, prompt} <- require_string(attrs, :prompt),
+         {:ok, spec} <- require_string(attrs, :schedule),
+         {:ok, id} <- resolve_id(attrs),
+         {:ok, target} <- resolve_target(attrs),
+         {:ok, schedule} <- Schedule.parse(spec),
+         owner = attrs[:owner],
+         :ok <- check_owner_limit(owner, state) do
+      resolved = %{id: id, owner: owner, prompt: prompt, target: target, schedule: schedule}
+      job = new_job(resolved, attrs, state.now_fn.())
+
+      if Map.has_key?(state.jobs, job.id),
+        do: {:error, :duplicate_id},
+        else: {:ok, job}
+    end
+  end
+
+  defp new_job(resolved, attrs, now) do
+    %{
+      id: resolved.id,
+      owner: resolved.owner,
+      prompt: resolved.prompt,
+      schedule_spec: resolved.schedule.source,
+      schedule: resolved.schedule,
+      skills: normalize_skills(attrs[:skills]),
+      target: resolved.target,
+      enabled: Map.get(attrs, :enabled, true),
+      next_fire: initial_next_fire(resolved.schedule, now),
+      created_at: now,
+      last_fired_at: nil,
+      fire_count: 0
+    }
+  end
+
+  defp initial_next_fire(schedule, now) do
+    case Schedule.next_fire(schedule, now) do
+      {:ok, next} -> next
+      :never -> nil
+    end
+  end
+
+  defp apply_changes(job, changes, state) do
+    with {:ok, schedule_spec, schedule} <- maybe_reparse(job, changes) do
+      now = state.now_fn.()
+
+      updated =
+        job
+        |> maybe_put(:prompt, string_change(changes, :prompt))
+        |> maybe_put(:skills, skills_change(changes))
+        |> maybe_put(:target, target_change(changes))
+        |> maybe_put(:enabled, bool_change(changes, :enabled))
+        |> Map.put(:schedule_spec, schedule_spec)
+        |> Map.put(:schedule, schedule)
+
+      # A schedule change recomputes the next fire from now.
+      updated =
+        if Map.has_key?(changes, :schedule),
+          do: %{updated | next_fire: initial_next_fire(schedule, now)},
+          else: updated
+
+      {:ok, updated}
+    end
+  end
+
+  defp maybe_reparse(job, changes) do
+    case Map.fetch(changes, :schedule) do
+      {:ok, spec} when is_binary(spec) ->
+        case Schedule.parse(spec) do
+          {:ok, schedule} -> {:ok, schedule.source, schedule}
+          {:error, _reason} = error -> error
+        end
+
+      {:ok, _bad} ->
+        {:error, :invalid_schedule}
+
+      :error ->
+        {:ok, job.schedule_spec, job.schedule}
+    end
+  end
+
+  defp check_owner_limit(nil, _state), do: :ok
+
+  defp check_owner_limit(owner, state) do
+    count = Enum.count(state.jobs, fn {_id, job} -> job.owner == owner end)
+    if count >= state.max_per_owner, do: {:error, :owner_limit_reached}, else: :ok
+  end
+
+  # -- persistence ------------------------------------------------------------
+
+  defp open_store(opts) do
+    case Dets.resolve_path(opts, :raxol_agent, :scheduler_dets_path) do
+      nil ->
+        nil
+
+      path ->
+        Dets.open!(Keyword.get(opts, :dets_name, __MODULE__.Jobs), path, fn _record -> :ok end)
+    end
+  end
+
+  # Reload persisted jobs, reparse each schedule once, and re-arm from the
+  # stored next-fire time. A job whose schedule no longer parses is dropped.
+  defp replay(%{dets: nil} = state), do: state
+
+  defp replay(state) do
+    :dets.foldl(fn {id, stored}, acc -> replay_job(acc, id, stored) end, state, state.dets)
+  end
+
+  defp replay_job(state, id, stored) do
+    case Schedule.parse(stored.schedule_spec) do
+      {:ok, schedule} ->
+        job = Map.put(stored, :schedule, schedule)
+        state |> Map.update!(:jobs, &Map.put(&1, id, job)) |> arm(id)
+
+      {:error, reason} ->
+        Logger.warning("scheduler dropping job #{id}: unparseable schedule #{inspect(reason)}")
+        Dets.delete(state.dets, id)
+        state
+    end
+  end
+
+  # The `:schedule` struct is derived from `:schedule_spec`, so it is dropped
+  # before persisting and reparsed on replay -- no struct is stored on disk.
+  defp put_job(state, job) do
+    Dets.put(state.dets, job.id, Map.delete(job, :schedule))
+    %{state | jobs: Map.put(state.jobs, job.id, job)}
+  end
+
+  # -- change helpers ---------------------------------------------------------
+
+  defp string_change(changes, key) do
+    case Map.get(changes, key) do
+      value when is_binary(value) and value != "" -> value
+      _other -> nil
+    end
+  end
+
+  defp bool_change(changes, key) do
+    case Map.get(changes, key) do
+      value when is_boolean(value) -> value
+      _other -> nil
+    end
+  end
+
+  defp skills_change(changes) do
+    case Map.fetch(changes, :skills) do
+      {:ok, skills} -> normalize_skills(skills)
+      :error -> nil
+    end
+  end
+
+  defp target_change(changes) do
+    case Map.fetch(changes, :target) do
+      {:ok, nil} -> :unset
+      {:ok, target} when is_binary(target) -> target
+      _other -> nil
+    end
+  end
+
+  defp maybe_put(job, _key, nil), do: job
+  defp maybe_put(job, :target, :unset), do: %{job | target: nil}
+  defp maybe_put(job, key, value), do: Map.put(job, key, value)
+
+  # -- misc -------------------------------------------------------------------
+
+  defp fetch!(state, id), do: Map.fetch!(state.jobs, id)
+
+  defp require_string(attrs, key) do
+    case Map.get(attrs, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _other -> {:error, {:missing, key}}
+    end
+  end
+
+  # A caller-supplied id must be a non-empty binary (it keys the job map, the
+  # DETS store, and the `"cron:" <> id` thread-log id); otherwise generate one.
+  defp resolve_id(attrs) do
+    case Map.get(attrs, :id) do
+      nil -> {:ok, generate_id()}
+      id when is_binary(id) and id != "" -> {:ok, id}
+      _other -> {:error, :invalid_id}
+    end
+  end
+
+  # Validate `target` at creation the same way `update/3` does, so a malformed
+  # target can never reach the delivery seam.
+  defp resolve_target(attrs) do
+    case Map.get(attrs, :target) do
+      nil -> {:ok, nil}
+      target when is_binary(target) -> {:ok, target}
+      _other -> {:error, :invalid_target}
+    end
+  end
+
+  defp normalize_skills(nil), do: []
+  defp normalize_skills(skills) when is_list(skills), do: Enum.filter(skills, &is_binary/1)
+  defp normalize_skills(_other), do: []
+
+  defp generate_id, do: "job_" <> Base.url_encode64(:crypto.strong_rand_bytes(9), padding: false)
+
+  defp default_runner(_job), do: {:error, :no_runner_configured}
+
+  defp default_deliver(target, _output) do
+    Logger.debug(fn -> "scheduler: no deliver configured for target #{inspect(target)}" end)
+    :ok
+  end
+
+  defp default_dispatch(fun), do: spawn(fun)
+end

--- a/packages/raxol_agent/lib/raxol/agent/scheduler.ex
+++ b/packages/raxol_agent/lib/raxol/agent/scheduler.ex
@@ -13,8 +13,7 @@ defmodule Raxol.Agent.Scheduler do
   passed fires once, promptly.
 
   The BEAM owns the scheduling; there is no OS cron daemon. This is a single-node
-  scheduler -- a clustered variant sharded across the swarm is out of scope
-  (ADR-0025).
+  scheduler: a clustered variant sharded across the swarm is out of scope.
 
   ## Firing
 

--- a/packages/raxol_agent/lib/raxol/agent/supervisor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/supervisor.ex
@@ -11,6 +11,7 @@ defmodule Raxol.Agent.Supervisor do
   - `Raxol.Agent.Memory.Store.Ets` -- when configured as the memory provider
   - `Raxol.Agent.Skills.Store` -- when a skills provider is configured
   - `Raxol.Agent.Curator` -- when a `:curator` config is set
+  - `Raxol.Agent.Scheduler` -- when a `:scheduler` config is set
 
   Strategy is `:rest_for_one`: if the DynSup crashes, the Orchestrator
   restarts and rebuilds from ContextStore. If the Registry crashes,
@@ -40,7 +41,11 @@ defmodule Raxol.Agent.Supervisor do
         {DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one},
         Raxol.Agent.SessionStreamer,
         Raxol.Agent.Orchestrator
-      ] ++ memory_children() ++ skills_children() ++ curator_children()
+      ] ++
+        memory_children() ++
+        skills_children() ++
+        curator_children() ++
+        scheduler_children()
 
     Supervisor.init(children, strategy: :rest_for_one)
   end
@@ -67,6 +72,21 @@ defmodule Raxol.Agent.Supervisor do
     case Application.get_env(:raxol_agent, :curator) do
       opts when is_list(opts) -> [{Raxol.Agent.Curator, opts}]
       _ -> []
+    end
+  end
+
+  # Start the Scheduler only when a :scheduler config (a keyword list) is set,
+  # so the whole cronjob subsystem stays opt-in (ADR-0025).
+  defp scheduler_children do
+    case Application.get_env(:raxol_agent, :scheduler) do
+      opts when is_list(opts) ->
+        # BaseManager registers a name only when one is given; default it to the
+        # module so `Scheduler.create/2` and friends resolve without an explicit
+        # server argument.
+        [{Raxol.Agent.Scheduler, Keyword.put_new(opts, :name, Raxol.Agent.Scheduler)}]
+
+      _ ->
+        []
     end
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/schedule_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/schedule_test.exs
@@ -1,0 +1,183 @@
+defmodule Raxol.Agent.ScheduleTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Raxol.Agent.Schedule
+
+  @factors %{"s" => 1, "m" => 60, "h" => 3600, "d" => 86_400}
+
+  describe "parse/1 relative durations" do
+    test "parses <n><unit> as a one-shot relative schedule" do
+      assert {:ok, schedule} = Schedule.parse("30m")
+      assert schedule.kind == :relative
+      refute schedule.recurring?
+    end
+
+    test "next fire is the reference time plus the duration" do
+      {:ok, schedule} = Schedule.parse("2h")
+      from = ~U[2026-07-27 08:00:00Z]
+
+      assert {:ok, ~U[2026-07-27 10:00:00Z]} = Schedule.next_fire(schedule, from)
+    end
+
+    test "rejects a zero or non-positive duration" do
+      assert {:error, _} = Schedule.parse("0m")
+    end
+  end
+
+  describe "parse/1 intervals" do
+    test "parses \"every <duration>\" as a recurring schedule" do
+      assert {:ok, schedule} = Schedule.parse("every 2h")
+      assert schedule.kind == :interval
+      assert schedule.recurring?
+    end
+
+    test "next fire is the reference time plus the interval" do
+      {:ok, schedule} = Schedule.parse("every 15m")
+      from = ~U[2026-07-27 08:00:00Z]
+
+      assert {:ok, ~U[2026-07-27 08:15:00Z]} = Schedule.next_fire(schedule, from)
+    end
+
+    test "rejects a malformed interval" do
+      assert {:error, _} = Schedule.parse("every banana")
+    end
+  end
+
+  describe "parse/1 cron" do
+    test "parses a 5-field crontab as recurring" do
+      assert {:ok, schedule} = Schedule.parse("0 9 * * 1-5")
+      assert schedule.kind == :cron
+      assert schedule.recurring?
+    end
+
+    test "computes the next daily fire" do
+      {:ok, schedule} = Schedule.parse("30 14 * * *")
+      from = ~U[2026-07-27 08:00:00Z]
+
+      assert {:ok, ~U[2026-07-27 14:30:00Z]} = Schedule.next_fire(schedule, from)
+    end
+
+    test "rolls over to the next day when today's fire has passed" do
+      {:ok, schedule} = Schedule.parse("30 14 * * *")
+      from = ~U[2026-07-27 15:00:00Z]
+
+      assert {:ok, ~U[2026-07-28 14:30:00Z]} = Schedule.next_fire(schedule, from)
+    end
+
+    test "every-minute cron fires on the next minute boundary" do
+      {:ok, schedule} = Schedule.parse("* * * * *")
+      from = ~U[2026-07-27 08:00:30Z]
+
+      assert {:ok, ~U[2026-07-27 08:01:00Z]} = Schedule.next_fire(schedule, from)
+    end
+
+    test "weekday-only cron lands on a weekday at the right time" do
+      {:ok, schedule} = Schedule.parse("0 9 * * 1-5")
+      # A Saturday; the next weekday 9am is Monday.
+      from = ~U[2026-07-25 12:00:00Z]
+
+      assert {:ok, next} = Schedule.next_fire(schedule, from)
+      assert next.hour == 9 and next.minute == 0
+      assert Date.day_of_week(DateTime.to_date(next)) in 1..5
+    end
+
+    test "day-of-week 0 and 7 both mean Sunday" do
+      {:ok, zero} = Schedule.parse("0 12 * * 0")
+      {:ok, seven} = Schedule.parse("0 12 * * 7")
+      from = ~U[2026-07-27 00:00:00Z]
+
+      assert Schedule.next_fire(zero, from) == Schedule.next_fire(seven, from)
+      {:ok, next} = Schedule.next_fire(zero, from)
+      assert Date.day_of_week(DateTime.to_date(next)) == 7
+    end
+
+    test "supports lists and steps" do
+      {:ok, schedule} = Schedule.parse("0 */6 * * *")
+      from = ~U[2026-07-27 07:00:00Z]
+
+      assert {:ok, ~U[2026-07-27 12:00:00Z]} = Schedule.next_fire(schedule, from)
+    end
+
+    test "an impossible cron never fires" do
+      # February 30th does not exist.
+      {:ok, schedule} = Schedule.parse("0 0 30 2 *")
+      assert :never = Schedule.next_fire(schedule, ~U[2026-01-01 00:00:00Z])
+    end
+
+    test "a rare-but-valid date (Feb 29) lands on the next leap year" do
+      {:ok, schedule} = Schedule.parse("0 0 29 2 *")
+      # 2027 is not a leap year; the next Feb 29 is in 2028.
+      assert {:ok, ~U[2028-02-29 00:00:00Z]} = Schedule.next_fire(schedule, ~U[2026-03-01 00:00:00Z])
+    end
+
+    test "rejects an out-of-range field" do
+      assert {:error, {:bad_cron_field, :minute, "99"}} = Schedule.parse("99 9 * * *")
+    end
+
+    test "rejects an inverted range" do
+      assert {:error, {:bad_cron_field, :hour, "9-5"}} = Schedule.parse("0 9-5 * * *")
+    end
+  end
+
+  describe "parse/1 timestamps" do
+    test "parses an ISO 8601 instant as a one-shot" do
+      assert {:ok, schedule} = Schedule.parse("2026-08-01T09:00:00Z")
+      assert schedule.kind == :timestamp
+      refute schedule.recurring?
+    end
+
+    test "a future timestamp fires at that instant" do
+      {:ok, schedule} = Schedule.parse("2026-08-01T09:00:00Z")
+      from = ~U[2026-07-27 00:00:00Z]
+
+      assert {:ok, ~U[2026-08-01 09:00:00Z]} = Schedule.next_fire(schedule, from)
+    end
+
+    test "a past timestamp never fires" do
+      {:ok, schedule} = Schedule.parse("2020-01-01T00:00:00Z")
+      assert :never = Schedule.next_fire(schedule, ~U[2026-07-27 00:00:00Z])
+    end
+  end
+
+  describe "parse/1 errors" do
+    test "rejects an empty schedule" do
+      assert {:error, :empty_schedule} = Schedule.parse("   ")
+    end
+
+    test "rejects unrecognized input" do
+      assert {:error, {:unrecognized_schedule, "banana"}} = Schedule.parse("banana")
+    end
+
+    test "rejects a non-string" do
+      assert {:error, :invalid_schedule} = Schedule.parse(:not_a_string)
+    end
+  end
+
+  describe "properties" do
+    property "any positive relative duration parses and fires exactly one duration out" do
+      check all(
+              n <- integer(1..100_000),
+              unit <- member_of(["s", "m", "h", "d"])
+            ) do
+        {:ok, schedule} = Schedule.parse("#{n}#{unit}")
+        from = ~U[2026-07-27 08:00:00Z]
+
+        assert {:ok, next} = Schedule.next_fire(schedule, from)
+        assert DateTime.diff(next, from, :second) == n * @factors[unit]
+      end
+    end
+
+    property "every-minute cron always fires strictly within the next minute" do
+      {:ok, schedule} = Schedule.parse("* * * * *")
+
+      check all(offset <- integer(0..1_000_000)) do
+        from = DateTime.add(~U[2026-07-27 00:00:00Z], offset, :second)
+        assert {:ok, next} = Schedule.next_fire(schedule, from)
+        assert DateTime.compare(next, from) == :gt
+        assert DateTime.diff(next, from, :second) <= 60
+        assert next.second == 0
+      end
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/scheduler_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/scheduler_test.exs
@@ -1,0 +1,419 @@
+defmodule Raxol.Agent.SchedulerTest.RaisingThreadLog do
+  @moduledoc "A ThreadLog adapter whose append/5 always raises, for crash-isolation tests."
+  @behaviour Raxol.Agent.ThreadLog
+
+  @impl true
+  def append(_config, _thread_id, _kind, _payload, _opts), do: raise("boom")
+  @impl true
+  def list(_config, _thread_id, _opts), do: {:ok, []}
+  @impl true
+  def list_by_kind(_config, _thread_id, _kind, _opts), do: {:ok, []}
+  @impl true
+  def latest(_config, _thread_id), do: {:error, :not_found}
+  @impl true
+  def truncate(_config, _thread_id, _before), do: :ok
+end
+
+defmodule Raxol.Agent.SchedulerTest do
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Scheduler
+
+  # A controllable clock: the scheduler reads `:now_fn`, tests set the agent.
+  defp clock(dt) do
+    {:ok, agent} = Agent.start_link(fn -> dt end)
+    agent
+  end
+
+  defp now_fn(agent), do: fn -> Agent.get(agent, & &1) end
+
+  defp set_now(agent, dt), do: Agent.update(agent, fn _ -> dt end)
+
+  # A synchronous dispatcher so a fire's runner/deliver run inline: assertions
+  # see the effect immediately, with no sleeps.
+  defp sync_dispatch, do: fn fun -> fun.() end
+
+  # A runner + deliver pair that records every call into a collector agent.
+  defp recording_runner(collector, output \\ "done") do
+    fn job ->
+      Agent.update(collector, fn calls -> [{:run, job} | calls] end)
+      {:ok, output}
+    end
+  end
+
+  defp recording_deliver(collector) do
+    fn target, output ->
+      Agent.update(collector, fn calls -> [{:deliver, target, output} | calls] end)
+      :ok
+    end
+  end
+
+  defp calls(collector), do: collector |> Agent.get(& &1) |> Enum.reverse()
+
+  defp start_scheduler(opts) do
+    name = :"sched_#{System.unique_integer([:positive])}"
+    start_supervised!({Scheduler, [name: name] ++ opts})
+    name
+  end
+
+  describe "create/2" do
+    test "creates an enabled job and computes its next fire" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      sched = start_scheduler(now_fn: now_fn(clock))
+
+      assert {:ok, job} =
+               Scheduler.create(sched, %{prompt: "summarize", schedule: "every 1h"})
+
+      assert job.enabled
+      assert job.next_fire == ~U[2026-07-27 09:00:00Z]
+      assert job.fire_count == 0
+    end
+
+    test "rejects a job with a missing prompt" do
+      sched = start_scheduler([])
+      assert {:error, {:missing, :prompt}} = Scheduler.create(sched, %{schedule: "every 1h"})
+    end
+
+    test "rejects an unparseable schedule" do
+      sched = start_scheduler([])
+
+      assert {:error, {:unrecognized_schedule, _}} =
+               Scheduler.create(sched, %{prompt: "x", schedule: "nope"})
+    end
+
+    test "rejects a non-binary id" do
+      sched = start_scheduler([])
+
+      assert {:error, :invalid_id} =
+               Scheduler.create(sched, %{prompt: "x", schedule: "every 1h", id: 123})
+    end
+
+    test "rejects a non-binary target" do
+      sched = start_scheduler([])
+
+      assert {:error, :invalid_target} =
+               Scheduler.create(sched, %{prompt: "x", schedule: "every 1h", target: 123})
+    end
+
+    test "enforces the per-owner cap" do
+      sched = start_scheduler(max_per_owner: 2)
+      attrs = %{prompt: "x", schedule: "every 1h", owner: "alice"}
+
+      assert {:ok, _} = Scheduler.create(sched, attrs)
+      assert {:ok, _} = Scheduler.create(sched, attrs)
+      assert {:error, :owner_limit_reached} = Scheduler.create(sched, attrs)
+      # A different owner is unaffected.
+      assert {:ok, _} = Scheduler.create(sched, %{attrs | owner: "bob"})
+    end
+  end
+
+  describe "firing" do
+    test "a fired job runs the runner and delivers to its target" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+
+      sched =
+        start_scheduler(
+          now_fn: now_fn(clock),
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector),
+          deliver: recording_deliver(collector)
+        )
+
+      {:ok, job} =
+        Scheduler.create(sched, %{prompt: "hi", schedule: "every 1h", target: "telegram:-100"})
+
+      send_fire(sched, job.id)
+
+      assert [{:run, run_job}, {:deliver, "telegram:-100", "done"}] = calls(collector)
+      assert run_job.id == job.id
+    end
+
+    test "a recurring job re-arms its next fire after firing" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+
+      sched =
+        start_scheduler(
+          now_fn: now_fn(clock),
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector)
+        )
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "hi", schedule: "every 1h"})
+      assert job.next_fire == ~U[2026-07-27 09:00:00Z]
+
+      set_now(clock, ~U[2026-07-27 09:00:00Z])
+      send_fire(sched, job.id)
+
+      {:ok, after_fire} = Scheduler.get(sched, job.id)
+      assert after_fire.fire_count == 1
+      assert after_fire.last_fired_at == ~U[2026-07-27 09:00:00Z]
+      assert after_fire.next_fire == ~U[2026-07-27 10:00:00Z]
+    end
+
+    test "a one-shot job retires after firing" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+
+      sched =
+        start_scheduler(
+          now_fn: now_fn(clock),
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector)
+        )
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "once", schedule: "30m"})
+      set_now(clock, ~U[2026-07-27 08:30:00Z])
+      send_fire(sched, job.id)
+
+      {:ok, after_fire} = Scheduler.get(sched, job.id)
+      assert after_fire.fire_count == 1
+      assert after_fire.next_fire == nil
+    end
+
+    test "each fire runs a fresh job with no accumulated history" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+
+      sched =
+        start_scheduler(
+          now_fn: now_fn(clock),
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector)
+        )
+
+      {:ok, job} =
+        Scheduler.create(sched, %{prompt: "p", schedule: "every 1h", skills: ["greet"]})
+
+      send_fire(sched, job.id)
+      set_now(clock, ~U[2026-07-27 09:00:00Z])
+      send_fire(sched, job.id)
+
+      run_jobs = for {:run, j} <- calls(collector), do: j
+      assert length(run_jobs) == 2
+      # Both fires carry the same prompt and skills; the runner receives the job
+      # definition, never a growing conversation. History-freeness lives in the
+      # runner (verified in the surface layer), but the definition it fires from
+      # is stable across fires.
+      assert Enum.map(run_jobs, & &1.prompt) == ["p", "p"]
+      assert Enum.map(run_jobs, & &1.skills) == [["greet"], ["greet"]]
+    end
+
+    test "a disabled job's stale timer does not fire" do
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+
+      sched =
+        start_scheduler(
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector)
+        )
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+      {:ok, _} = Scheduler.pause(sched, job.id)
+
+      send_fire(sched, job.id)
+      assert calls(collector) == []
+    end
+
+    test "run/2 fires immediately without disturbing the schedule" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+
+      sched =
+        start_scheduler(
+          now_fn: now_fn(clock),
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector)
+        )
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+      assert :ok = Scheduler.run(sched, job.id)
+
+      assert [{:run, _}] = calls(collector)
+      {:ok, after_run} = Scheduler.get(sched, job.id)
+      # Manual run bumps fire_count but leaves the scheduled next fire intact.
+      assert after_run.fire_count == 1
+      assert after_run.next_fire == ~U[2026-07-27 09:00:00Z]
+    end
+  end
+
+  describe "lifecycle" do
+    test "pause then resume re-arms the job" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      sched = start_scheduler(now_fn: now_fn(clock))
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+      assert {:ok, paused} = Scheduler.pause(sched, job.id)
+      refute paused.enabled
+      assert {:ok, resumed} = Scheduler.resume(sched, job.id)
+      assert resumed.enabled
+    end
+
+    test "update/3 reparses a changed schedule and recomputes the next fire" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      sched = start_scheduler(now_fn: now_fn(clock))
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+
+      assert {:ok, updated} =
+               Scheduler.update(sched, job.id, %{schedule: "every 30m", prompt: "q"})
+
+      assert updated.prompt == "q"
+      assert updated.next_fire == ~U[2026-07-27 08:30:00Z]
+    end
+
+    test "update/3 rejects an invalid schedule and leaves the job unchanged" do
+      sched = start_scheduler([])
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+
+      assert {:error, _} = Scheduler.update(sched, job.id, %{schedule: "garbage"})
+      {:ok, unchanged} = Scheduler.get(sched, job.id)
+      assert unchanged.schedule_spec == "every 1h"
+    end
+
+    test "remove/2 drops the job" do
+      sched = start_scheduler([])
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+
+      assert :ok = Scheduler.remove(sched, job.id)
+      assert {:error, :not_found} = Scheduler.get(sched, job.id)
+    end
+
+    test "list/2 filters by owner" do
+      sched = start_scheduler([])
+      {:ok, _} = Scheduler.create(sched, %{prompt: "a", schedule: "every 1h", owner: "alice"})
+      {:ok, _} = Scheduler.create(sched, %{prompt: "b", schedule: "every 1h", owner: "bob"})
+
+      assert [job] = Scheduler.list(sched, owner: "alice")
+      assert job.owner == "alice"
+      assert length(Scheduler.list(sched)) == 2
+    end
+  end
+
+  describe "persistence" do
+    setup do
+      path = Path.join(System.tmp_dir!(), "sched_#{System.unique_integer([:positive])}.dets")
+      on_exit(fn -> File.rm(path) end)
+      %{path: path}
+    end
+
+    test "jobs survive a restart and re-arm from their next fire", %{path: path} do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      name = :"sched_durable_#{System.unique_integer([:positive])}"
+
+      pid1 = start_durable!(name, path, now_fn(clock))
+      {:ok, job} = Scheduler.create(name, %{prompt: "p", schedule: "0 9 * * *", target: "t:1"})
+      stop_durable(pid1)
+
+      # A fresh scheduler over the same file reloads the job.
+      _pid2 = start_durable!(name, path, now_fn(clock))
+      assert {:ok, reloaded} = Scheduler.get(name, job.id)
+      assert reloaded.id == job.id
+      assert reloaded.prompt == "p"
+      assert reloaded.target == "t:1"
+      assert reloaded.schedule_spec == "0 9 * * *"
+      # The parsed schedule is reconstructed from the spec on boot.
+      assert reloaded.schedule.kind == :cron
+    end
+
+    test "a removed job stays gone after restart", %{path: path} do
+      name = :"sched_durable_#{System.unique_integer([:positive])}"
+
+      pid1 = start_durable!(name, path, fn -> ~U[2026-07-27 08:00:00Z] end)
+      {:ok, job} = Scheduler.create(name, %{prompt: "p", schedule: "every 1h"})
+      :ok = Scheduler.remove(name, job.id)
+      stop_durable(pid1)
+
+      _pid2 = start_durable!(name, path, fn -> ~U[2026-07-27 08:00:00Z] end)
+      assert {:error, :not_found} = Scheduler.get(name, job.id)
+    end
+  end
+
+  describe "thread log" do
+    test "every fire is recorded to the thread log" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+      table = :"threads_#{System.unique_integer([:positive])}"
+
+      sched =
+        start_scheduler(
+          now_fn: now_fn(clock),
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector),
+          thread_log: {Raxol.Agent.ThreadLog.Ets, %{table: table}}
+        )
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+      send_fire(sched, job.id)
+
+      {:ok, events} =
+        Raxol.Agent.ThreadLog.list(
+          {Raxol.Agent.ThreadLog.Ets, %{table: table}},
+          "cron:" <> job.id
+        )
+
+      assert [event] = events
+      assert event.kind == :cron_fire
+      assert event.payload.job_id == job.id
+      assert event.payload.trigger == :schedule
+    end
+
+    test "a raising thread-log adapter does not crash the scheduler" do
+      clock = clock(~U[2026-07-27 08:00:00Z])
+      {:ok, collector} = Agent.start_link(fn -> [] end)
+
+      sched =
+        start_scheduler(
+          now_fn: now_fn(clock),
+          dispatch: sync_dispatch(),
+          runner: recording_runner(collector),
+          thread_log: Raxol.Agent.SchedulerTest.RaisingThreadLog
+        )
+
+      {:ok, job} = Scheduler.create(sched, %{prompt: "p", schedule: "every 1h"})
+      pid = GenServer.whereis(sched)
+
+      send_fire(sched, job.id)
+
+      # The scheduler survives, the run still happened, and the schedule advanced.
+      assert Process.alive?(pid)
+      assert [{:run, _}] = calls(collector)
+      {:ok, after_fire} = Scheduler.get(sched, job.id)
+      assert after_fire.fire_count == 1
+      assert after_fire.next_fire == ~U[2026-07-27 09:00:00Z]
+    end
+  end
+
+  # -- helpers ----------------------------------------------------------------
+
+  # Drive the timer deterministically: send the fire message the real timer
+  # would have sent, without waiting on wall-clock delay.
+  defp send_fire(sched, id) do
+    pid = GenServer.whereis(sched)
+    send(pid, {:fire, id})
+    # A trailing synchronous call flushes the async info message.
+    _ = Scheduler.get(sched, id)
+    :ok
+  end
+
+  defp start_durable!(name, path, now_fn) do
+    {:ok, pid} =
+      Scheduler.start_link(
+        name: name,
+        dets_path: path,
+        dets_name: :"#{name}_jobs",
+        now_fn: now_fn
+      )
+
+    pid
+  end
+
+  # Graceful stop so terminate/2 syncs and closes the DETS file. A brutal kill
+  # would lose the last write window.
+  defp stop_durable(pid) do
+    ref = Process.monitor(pid)
+    GenServer.stop(pid, :normal)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}, 2_000
+  end
+end


### PR DESCRIPTION
Part of #494 (cron scheduler, Hermes Fast-Follow P0) / ADR-0025. This is the
first of two focused PRs: the **engine**. A follow-up adds the surface (the
`cronjob` Action, the fresh-agent fire runner, and gateway delivery).

## What this adds

- **`Raxol.Agent.Schedule`** -- a pure parser for four schedule formats, one
  parser, no clock and no LLM:
  - relative (`"30m"`, `"2h"`) -- one-shot, `now + duration`
  - interval (`"every 2h"`) -- recurring
  - 5-field cron (`"0 9 * * 1-5"`) -- recurring; `*`, ranges, steps, lists,
    and the Vixie day-of-month/day-of-week "either matches" rule; `0`/`7`
    both mean Sunday
  - ISO 8601 timestamp -- one-shot
  `next_fire(schedule, from)` is a pure function of its arguments. An
  impossible cron (e.g. `"0 0 30 2 *"`) returns `:never`; whole non-matching
  days are skipped to the next midnight so the search terminates in ~2900
  steps instead of minute-stepping an 8-year horizon.

- **`Raxol.Agent.Scheduler`** -- a `BaseManager` GenServer: one
  `Process.send_after` timer per enabled job, reschedules recurring jobs on
  fire, retires one-shots, persists jobs to `Raxol.Core.Stores.Dets` and
  replays them on boot (re-arming from the stored next-fire time; missed fires
  are not back-filled). Public API: `create/2`, `list/2`, `get/2`, `update/3`,
  `pause/2`, `resume/2`, `run/2`, `remove/2`. A fire never runs inline: the
  scheduler records the fire to its thread log, advances the schedule, and
  hands the work to an injectable `:dispatch` (default: an unlinked process)
  that calls `:runner` then `:deliver`. Per-owner job cap, explicit `enabled`
  to fire, opt-in supervisor wiring (`config :raxol_agent, :scheduler, [...]`).

- **Opt-in wiring** in `Raxol.Agent.Supervisor`, mirroring the curator/skills
  pattern: no `:scheduler` config means no Scheduler is started (subsystem
  stays off by default, ADR-0025's "existing behavior unchanged").

## Decisions (open items from the ADR/issue)

- **Cron parser: hand-rolled subset, not a hex dep.** No cron library is in
  any `mix.lock`, and the repo favors minimal deps. The subset (min hour dom
  month dow with `*`/ranges/steps/lists and the Vixie either-match rule) is
  covered by example + property tests. Adding `{:crontab, "~> 1.1"}` was the
  alternative; declined to avoid a dependency for a well-bounded grammar.
- **Naming: `Scheduler`/`Schedule` (ADR-0025), not `Agent.Cron` (issue #494).**
  The ADR is newer and more specific.
- **Schedule parsing stays deterministic.** Natural-language schedules are
  lowered to one of the four formats by the agent at creation time (the
  surface PR's Action docstring); `Schedule.parse/1` never touches an LLM.

## Tests

`test/raxol/agent/schedule_test.exs` (25) -- all four formats parse to the
correct next-fire; relative/interval arithmetic; cron daily/rollover/weekday/
step/list/Sunday-alias; impossible + leap-year (Feb 29 -> next leap year) dates;
error paths; two properties (any positive relative duration; every-minute cron
fires within 60s).

`test/raxol/agent/scheduler_test.exs` (18) -- create/cap/validation; fire runs
runner + delivers; recurring re-arm vs one-shot retire; fresh definition per
fire; disabled stale timer no-op; manual `run/2` does not disturb the schedule;
pause/resume/update/remove/list; **restart replay** from a real DETS file
(graceful shutdown, not brutal kill); every fire recorded to the thread log.

Deterministic throughout: an injected `:now_fn` clock, a synchronous
`:dispatch`, and direct `{:fire, id}` sends -- no `Process.sleep`, no mocks
(injectable fns + in-memory recording agents).

## Manual testing

- `cd packages/raxol_agent && MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test test/raxol/agent/schedule_test.exs test/raxol/agent/scheduler_test.exs`
- `mix credo --strict lib/raxol/agent/schedule.ex lib/raxol/agent/scheduler.ex lib/raxol/agent/supervisor.ex`
- full package suite: `MIX_ENV=test mix test` (1913 passed)
- opt-in wiring: `config :raxol_agent, :scheduler, []` boots a named
  `Raxol.Agent.Scheduler` under `Raxol.Agent.Supervisor` and `create/2`
  resolves it without an explicit server arg (manually verified).

Note: `raxol_agent` is not in the Unified CI package matrix (only
`raxol_gateway`/`raxol_telegram` are) and is not a root dep, so CI does not run
these tests -- they were verified locally in `packages/raxol_agent`.

## Pre-review hardening

An adversarial pass over the two modules found and this PR fixes:

- **F1 (HIGH)** -- `record_fire` runs the thread-log adapter inline in the
  GenServer; a raising adapter would crash the scheduler (dropping every armed
  timer) and, since recording precedes the schedule advance, replay would
  re-fire into the same failing adapter in a loop. Now wrapped in `safe_call`
  (test: a raising adapter leaves the scheduler alive and the schedule
  advanced).
- **F2 (HIGH)** -- `create` took `:id` verbatim; a non-binary id crashed on the
  first fire at `"cron:" <> id`. Now validated (`{:error, :invalid_id}`).
- **F4 (LOW)** -- retiring a one-shot / `:never` job left its elapsed timer ref
  in `state.timers` (unbounded growth). Now dropped via a `retire/2` helper.
- **F5 (LOW)** -- `cancel_timer` does not remove a `{:fire, id}` already in the
  mailbox, so a re-arm that keeps a job enabled (`update/3`) could let a stale
  fire slip through and drift the schedule. `drop_timer` now flushes the
  pending fire.
- **F6 (LOW)** -- `create` accepted a non-string `:target` (asymmetric with
  `update`). Now validated (`{:error, :invalid_target}`).

Also widened the cron search horizon from 8 to 12 years so the widest real
Feb-29 gap (across a non-leap century year like 2100) keeps comfortable margin.
The parser itself was found clean (Vixie either-match rule, `7`->`0` Sunday
normalization, step/range/list rejection, persistence round-trip).
