### PR TITLE
Fail-closed cronjob action on native tool loop

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/scheduler/fire.ex
+++ b/packages/raxol_agent/lib/raxol/agent/scheduler/fire.ex
@@ -28,6 +28,7 @@ defmodule Raxol.Agent.Scheduler.Fire do
       appended to.
   """
 
+  alias Raxol.Agent.Actions.Cronjob
   alias Raxol.Agent.Skills
   alias Raxol.Agent.Stream
 
@@ -63,10 +64,28 @@ defmodule Raxol.Agent.Scheduler.Fire do
 
     react_opts =
       run_opts
-      |> Keyword.put(:actions, actions)
+      |> Keyword.put(:actions, guard_context_actions(actions, run_opts))
       |> Keyword.put(:context, context)
 
     Stream.react(prompt, react_opts)
+  end
+
+  # The cronjob action's recursion guard lives in its `run/2` and reads
+  # `context[:in_cron]`. A native (vendor-owns-loop) backend runs its own tool
+  # loop and executes tools out-of-process over MCP, where that context never
+  # arrives -- so the guard would silently not fire and a scheduled agent could
+  # schedule, trigger, or re-arm more cron work. There is nothing to thread the
+  # guard onto on that path, so fail closed: withhold the cronjob action entirely
+  # rather than expose unpoliced schedule-more-work capability to a fresh fire.
+  # The framework path enforces the guard in-process and keeps the action, which
+  # is why this only strips when the resolved backend is native (checked lazily,
+  # after the cheap membership test, so the common no-cronjob fire pays nothing).
+  defp guard_context_actions(actions, run_opts) do
+    if Cronjob in actions and Stream.native_tool_loop?(run_opts) do
+      Enum.reject(actions, &(&1 == Cronjob))
+    else
+      actions
+    end
   end
 
   defp normalize({:ok, %{content: content}}) when is_binary(content), do: {:ok, content}

--- a/packages/raxol_agent/lib/raxol/agent/stream.ex
+++ b/packages/raxol_agent/lib/raxol/agent/stream.ex
@@ -166,6 +166,24 @@ defmodule Raxol.Agent.Stream do
     end
   end
 
+  @doc """
+  Whether the backend resolved from `opts` runs its own tool loop.
+
+  Native / vendor-owns-loop backends (`handles_tools_internally? == true`)
+  execute tools out-of-process over MCP, where the framework cannot thread run
+  context -- `:tool_authorizer`, `:tool_call_hooks`, and app flags such as the
+  cron `:in_cron` recursion guard -- into tool execution. A caller that exposes a
+  context-guarded tool uses this to fail closed: withhold the tool on that path
+  rather than hand over capability the guard cannot police. Resolution mirrors
+  `react/2` (executor / auto_provider / `:backend`), so the answer matches the
+  backend the turn will actually use.
+  """
+  @spec native_tool_loop?(keyword()) :: boolean()
+  def native_tool_loop?(opts) do
+    {backend, _backend_opts} = resolve_backend(opts)
+    Raxol.Agent.AIBackend.handles_tools_internally?(backend)
+  end
+
   # Vendor-owns-loop backends (native CLI harnesses) run their own tool loop with
   # Raxol's tools injected over MCP, so the framework just streams their output.
   defp native_react(messages, backend, backend_opts, opts) do

--- a/packages/raxol_agent/test/raxol/agent/scheduler/fire_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/scheduler/fire_test.exs
@@ -28,6 +28,36 @@ defmodule Raxol.Agent.Scheduler.FireTest.CapturingBackend do
   def capabilities, do: [:completion, :tool_use]
 end
 
+defmodule Raxol.Agent.Scheduler.FireTest.NativeCapturingBackend do
+  @moduledoc """
+  A native (vendor-owns-loop) AIBackend that records the actions injected into
+  its opts, so a fire can assert which tools reached the out-of-process loop.
+  """
+  @behaviour Raxol.Agent.AIBackend
+
+  @impl true
+  def stream(_messages, opts) do
+    send(Keyword.fetch!(opts, :collector), {:native_actions, Keyword.get(opts, :actions)})
+    response = %{content: "ok", usage: %{}, metadata: %{backend: :native_capturing}}
+    {:ok, [{:chunk, "ok"}, {:done, response}]}
+  end
+
+  @impl true
+  def complete(messages, opts) do
+    {:ok, _events} = stream(messages, opts)
+    {:ok, %{content: "ok", usage: %{}, metadata: %{backend: :native_capturing}}}
+  end
+
+  @impl true
+  def available?, do: true
+  @impl true
+  def name, do: "Native Capturing Backend"
+  @impl true
+  def capabilities, do: [:completion, :streaming, :tool_use]
+  @impl true
+  def handles_tools_internally?, do: true
+end
+
 defmodule Raxol.Agent.Scheduler.FireTest.RecordContext do
   @moduledoc "An action that reports the run context's in_cron flag to a collector."
   use Raxol.Agent.Action,
@@ -45,8 +75,10 @@ end
 defmodule Raxol.Agent.Scheduler.FireTest do
   use ExUnit.Case, async: false
 
+  alias Raxol.Agent.Actions.Cronjob
   alias Raxol.Agent.Scheduler.Fire
   alias Raxol.Agent.Scheduler.FireTest.CapturingBackend
+  alias Raxol.Agent.Scheduler.FireTest.NativeCapturingBackend
   alias Raxol.Agent.Scheduler.FireTest.RecordContext
   alias Raxol.Agent.Skills
 
@@ -129,6 +161,35 @@ defmodule Raxol.Agent.Scheduler.FireTest do
 
       assert {:ok, "done"} = Fire.run(%{prompt: "p", skills: []}, opts)
       assert_receive {:in_cron, true}
+    end
+  end
+
+  describe "run/2 with a native (vendor-owns-loop) backend" do
+    # A native backend executes tools out-of-process over MCP, where the
+    # in_cron context never arrives, so the cronjob recursion guard cannot fire.
+    # Fire withholds the cronjob action from that path (fail closed) rather than
+    # hand a fresh fire unpoliced schedule-more-work capability.
+    test "withholds the cronjob action from the injected toolset" do
+      opts = [
+        actions: [Cronjob],
+        agent_opts: [backend: NativeCapturingBackend, backend_opts: [collector: self()]]
+      ]
+
+      assert {:ok, "ok"} = Fire.run(%{prompt: "p", skills: []}, opts)
+      assert_receive {:native_actions, injected}
+      assert Cronjob not in (injected || [])
+    end
+
+    test "keeps non-guarded actions while stripping cronjob" do
+      opts = [
+        actions: [Cronjob, RecordContext],
+        agent_opts: [backend: NativeCapturingBackend, backend_opts: [collector: self()]]
+      ]
+
+      assert {:ok, "ok"} = Fire.run(%{prompt: "p", skills: []}, opts)
+      assert_receive {:native_actions, injected}
+      assert RecordContext in injected
+      assert Cronjob not in injected
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/stream_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/stream_test.exs
@@ -63,6 +63,26 @@ defmodule Raxol.Agent.StreamTest do
     def capabilities, do: [:completion, :tool_use]
   end
 
+  # -- Native (vendor-owns-loop) backend --------------------------------------
+
+  defmodule NativeToolLoopBackend do
+    @moduledoc "A backend that runs its own tool loop (tools injected over MCP)."
+    @behaviour Raxol.Agent.AIBackend
+
+    @impl true
+    def complete(_messages, _opts),
+      do: {:ok, %{content: "ok", usage: %{}, metadata: %{}}}
+
+    @impl true
+    def available?, do: true
+    @impl true
+    def name, do: "Native Tool Loop"
+    @impl true
+    def capabilities, do: [:completion, :tool_use]
+    @impl true
+    def handles_tools_internally?, do: true
+  end
+
   # -- Capturing Mock Backend ---------------------------------------------------
 
   defmodule CapturingBackend do
@@ -392,6 +412,20 @@ defmodule Raxol.Agent.StreamTest do
                AgentStream.react("Hello", opts) |> Enum.to_list()
 
       assert done.content == "I'm helpful."
+    end
+  end
+
+  describe "native_tool_loop?/1" do
+    test "true for a backend that runs its own tool loop" do
+      assert AgentStream.native_tool_loop?(backend: NativeToolLoopBackend)
+    end
+
+    test "false for a framework (Mock) backend" do
+      refute AgentStream.native_tool_loop?(backend: Raxol.Agent.Backend.Mock)
+    end
+
+    test "resolves the same backend react/2 will use (default fallback is framework)" do
+      refute AgentStream.native_tool_loop?([])
     end
   end
 


### PR DESCRIPTION
## Summary

Closes the out-of-scope follow-up #494 left open (tracked as #726): the `cronjob` action's `in_cron` recursion guard rides `framework_react`'s in-process tool dispatch. A native (vendor-owns-loop) backend runs its own tool loop and executes tools out-of-process over MCP, where run context (`:in_cron`, `:tool_authorizer`, `:tool_call_hooks`) never arrives -- so the guard would silently not fire and a scheduled agent could schedule, trigger, or re-arm more cron work unpoliced.

There is nothing to thread the guard onto on that path, so this fails closed: `Raxol.Agent.Scheduler.Fire` withholds the `cronjob` action entirely when the resolved backend is native, rather than expose unpoliced schedule-more-work capability to a fresh, history-free fire. The framework path enforces the guard in-process and keeps the action.

## Changes

- `Raxol.Agent.Stream.native_tool_loop?/1` -- resolves the backend `react/2` will actually use (executor / auto_provider / `:backend`) and reports `handles_tools_internally?`. Also the seam for future context-guarded tools.
- `Raxol.Agent.Scheduler.Fire` -- strips `cronjob` from the injected toolset on the native path (lazy check: cheap membership test before the backend resolve, so a no-cronjob fire pays nothing).

## Verification

`raxol_agent` is not in the Unified CI package matrix, so the local run is the gate:

- Full suite: **1947 passed / 0 failures**, 35 excluded
- `mix compile --warnings-as-errors`: clean
- `mix credo` on the two changed lib files: no issues
- New tests: fire_test (native backend withholds `cronjob`, keeps non-guarded actions), stream_test (`native_tool_loop?` true for native / false for framework / default fallback framework)

Note: `mix format --check-formatted` flags two pre-existing unrelated lines in `stream.ex`/`stream_test.exs` (formatter-version drift present on clean master, not touched by this change); left as-is per "don't reformat adjacent code."

## Manual testing

- [x] `MIX_ENV=test mix test` (raxol_agent) -- green
- [x] `MIX_ENV=test mix compile --warnings-as-errors` -- clean
- [x] `mix credo` on changed files -- clean
