### PR TITLE
Rename cron guard to single-action + note re-resolution

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/scheduler/fire.ex
+++ b/packages/raxol_agent/lib/raxol/agent/scheduler/fire.ex
@@ -64,7 +64,7 @@ defmodule Raxol.Agent.Scheduler.Fire do
 
     react_opts =
       run_opts
-      |> Keyword.put(:actions, guard_context_actions(actions, run_opts))
+      |> Keyword.put(:actions, guard_cronjob_action(actions, run_opts))
       |> Keyword.put(:context, context)
 
     Stream.react(prompt, react_opts)
@@ -78,9 +78,14 @@ defmodule Raxol.Agent.Scheduler.Fire do
   # guard onto on that path, so fail closed: withhold the cronjob action entirely
   # rather than expose unpoliced schedule-more-work capability to a fresh fire.
   # The framework path enforces the guard in-process and keeps the action, which
-  # is why this only strips when the resolved backend is native (checked lazily,
-  # after the cheap membership test, so the common no-cronjob fire pays nothing).
-  defp guard_context_actions(actions, run_opts) do
+  # is why this only strips when the resolved backend is native. This guards ONE
+  # action by name; a second context-guarded action (e.g. #726's authorizer /
+  # hooks / owner enforcement over the native MCP path) needs its own clause here,
+  # it is not covered by adding this action to some list. `native_tool_loop?/1`
+  # re-resolves the backend (a second resolve if the turn also auto-provisions),
+  # but only after the cheap `Cronjob in actions` membership test, so the common
+  # no-cronjob fire never resolves twice and pays nothing.
+  defp guard_cronjob_action(actions, run_opts) do
     if Cronjob in actions and Stream.native_tool_loop?(run_opts) do
       Enum.reject(actions, &(&1 == Cronjob))
     else


### PR DESCRIPTION
Follow-up clarity fixes for #727 (merged as `8df84e103` before these landed). No behavior change.

Adversarial review flagged two maintainability issues on the merged cron native-tool guard:

- **Rename `guard_context_actions/2` -> `guard_cronjob_action/2`.** The generic name implied it guards all context-dependent actions; it strips exactly one (`Cronjob`) by name. A second context-guarded action -- e.g. #726's `:tool_authorizer`/`:tool_call_hooks`/owner enforcement over the native MCP path -- needs its own clause, not an entry in some list. The comment now says so.
- **Document the double backend resolution.** `native_tool_loop?/1` re-resolves the backend (a second resolve when the turn also auto-provisions), but only after the cheap `Cronjob in actions` membership test, so a no-cronjob fire never resolves twice. Noted in the comment rather than restructured, since the cost is gated to the narrow Cronjob+native case.

Private-function rename + comments only; `fire_test.exs` green (7 passed). raxol_agent is not in the CI matrix, so the local run is the gate.

## Manual testing
- [x] `MIX_ENV=test mix test test/raxol/agent/scheduler/fire_test.exs` -- 7 passed
- [x] `mix format --check-formatted` + `mix credo` on `fire.ex` -- clean