### PR TITLE
Fix RaxolAgentSession deadlock (nested start_child on Raxol.Agent.DynSup)

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -61,9 +61,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
   The runner returns `{:pause, reason, token}` where `token` carries
   the `session_id` so the orchestrator's later `resume_run/3` call
-  can re-attach to the same live Session. The Session is started
-  under `Raxol.Agent.DynSup`, so it survives the worker exit that
-  follows the pause return.
+  can re-attach to the same live Session. The Session runs as a
+  supervised subtree under `Raxol.Agent.DynSup` (via
+  `Raxol.Agent.Session.Supervisor`), so it survives the worker exit
+  that follows the pause return.
 
   On resume the runner sends:
 
@@ -82,7 +83,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   alias Raxol.Symphony.{Config, Issue, PromptBuilder, Runner}
 
   @compile {:no_warn_undefined,
-            [Raxol.Agent.Session, Raxol.Agent.SessionStreamer]}
+            [
+              Raxol.Agent.Session,
+              Raxol.Agent.Session.Supervisor,
+              Raxol.Agent.SessionStreamer
+            ]}
 
   @default_timeout_ms 60_000
 
@@ -158,8 +163,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
           send_resume(session_id, resume_value)
 
           case loop(session_id, issue.id, parent, timeout_ms) do
-            :ok -> finalize(session_id, :ok)
-            {:error, _} = err -> finalize(session_id, err)
+            :ok ->
+              finalize(session_id, :ok)
+
+            {:error, _} = err ->
+              finalize(session_id, err)
+
             {:pause, _, _} = pause ->
               unsubscribe(session_id)
               pause
@@ -242,12 +251,20 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   end
 
   defp start_session(session_id, module) do
-    # Start the Session under DynSup so it survives the worker exit
-    # that follows a `{:pause, ...}` return; resume re-attaches by
-    # looking up `session_id` in the Registry.
-    spec = {Raxol.Agent.Session, [id: session_id, app_module: module]}
-
-    case DynamicSupervisor.start_child(Raxol.Agent.DynSup, spec) do
+    # Start the session as a supervised SUBTREE (EmitBridge -> Lifecycle ->
+    # Session, `:rest_for_one`) under `Raxol.Agent.DynSup`, not as a bare
+    # Session child. The tree still survives the worker exit that follows a
+    # `{:pause, ...}` return, but -- unlike a bare Session -- it cannot
+    # deadlock: a bare `Raxol.Agent.Session` starts its own EmitBridge under the
+    # SAME `Raxol.Agent.DynSup` during init, which blocks forever behind the
+    # in-progress start (a DynamicSupervisor runs a child's init synchronously
+    # inside its own call). The subtree owns the bridge as a sibling instead.
+    # `id` and `session_id` are pinned equal so registration, `send_message`,
+    # `subscribe`, and `stop_session` all key on the runner's `session_id`.
+    case Raxol.Agent.Session.Supervisor.start_session(module,
+           id: session_id,
+           session_id: session_id
+         ) do
       {:ok, pid} -> {:ok, pid}
       {:ok, pid, _info} -> {:ok, pid}
       {:error, {:already_started, pid}} -> {:ok, pid}
@@ -267,23 +284,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   end
 
   defp stop_session(session_id) do
-    case Registry.lookup(Raxol.Agent.Registry, session_id) do
-      [{pid, _}] ->
-        case DynamicSupervisor.terminate_child(Raxol.Agent.DynSup, pid) do
-          :ok ->
-            :ok
-
-          {:error, :not_found} ->
-            try do
-              GenServer.stop(pid, :normal, 1_000)
-            catch
-              :exit, _ -> :ok
-            end
-        end
-
-      [] ->
-        :ok
-    end
+    # Tears down the whole subtree (session -> lifecycle -> bridge), draining
+    # the durable tail first. Best-effort: a missing/already-gone session is a
+    # no-op, and a dying supervisor mid-teardown must not fail finalize.
+    Raxol.Agent.Session.Supervisor.stop_session(session_id)
+    :ok
+  catch
+    :exit, _ -> :ok
   end
 
   defp seed_agent(session_id, issue, config, attempt) do


### PR DESCRIPTION
Closes #733.

## The bug

`Raxol.Symphony.Runners.RaxolAgentSession` **deadlocked on every run**. `start_session/2` started the agent `Raxol.Agent.Session` as a child of `Raxol.Agent.DynSup`, but `Raxol.Agent.Session.init_manager/1` in turn starts its per-session `EmitBridge` under the **same** `Raxol.Agent.DynSup`. A `DynamicSupervisor` runs a child's `init` synchronously inside its own `handle_call`, so the nested `start_child` blocked forever behind the in-progress Session start.

Verified stuck-process stack (from a live repro):
```
Raxol.Agent.Session.init_manager/1        (session.ex:153)
  -> start_emit_bridge/2                    (session.ex:625)
    -> DynamicSupervisor.start_child(Raxol.Agent.DynSup, {EmitBridge, ...})
      -> GenServer.call  [never returns]
```
It's a genuine self-deadlock, not an environment dependency: `Lifecycle.start_link(environment: :agent)` alone returns fine, but `start_child(Raxol.Agent.DynSup, {Session, …})` hangs with the stack above. Standalone `Session.start_link` (every other raxol_agent test) is fine because the Session isn't a child of the DynSup then. Only this runner put the Session *under* it. It went unnoticed because `raxol_symphony` isn't in the CI matrix.

## The fix

Use the tree-owned mode the code already provides: `Raxol.Agent.Session.Supervisor.start_session/2` starts `EmitBridge -> Lifecycle -> Session` as `:rest_for_one` siblings under a **subtree supervisor**, with the Session run as `start_emit_bridge: false` / `manage_lifecycle: false` — the tree owns the bridge as a sibling, so there is no nested `start_child` on `Raxol.Agent.DynSup`.

- Pass `id: session_id, session_id: session_id` (equal) so process registration, `send_message`, `subscribe`, and `stop` all key on the runner's `session_id` (`derive_session_id/1` would otherwise append a fresh suffix and split the keys).
- Stop via `Session.Supervisor.stop_session/1`, which also drains the durable tail before teardown.
- Pause/resume is preserved: the subtree survives the worker exit after a `{:pause, …}`, and resume re-resolves the live Session by `session_id`.

One file changed; the only pre-existing credo/`require Logger` warnings in it are unchanged (present on master, out of scope for a bug fix).

## Verification

- `raxol_agent_session_test.exs`: **3/8 in 300s (5 × 60s timeouts) → 8/8 in 0.3s**.
- All **121 runner tests** pass.
- Full `raxol_symphony` suite: **742 passed, 0 failures, 6 excluded**, and now runs in **10.7s** (was ~300s — the deadlock was the slowness). `raxol_symphony` isn't in the CI matrix, so the local run is the gate.
- `mix format --check-formatted` clean; no new credo issues (the 3 in `fresh_run`/`resume_run` are pre-existing on master).

## Manual testing

- [x] `MIX_ENV=test mix test test/raxol/symphony/runners/raxol_agent_session_test.exs` — 8 passed (0.3s)
- [x] `MIX_ENV=test mix test test/raxol/symphony/runners/` — 121 passed
- [x] Full `MIX_ENV=test mix test` — 742 passed, 0 failures
