### PR TITLE
Harden inbound email adapter (utf8 + drop visibility)

### DIFF
--- a/packages/raxol_gateway/lib/raxol/gateway/adapter/email.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/adapter/email.ex
@@ -178,7 +178,8 @@ defmodule Raxol.Gateway.Adapter.Email do
           user_id: from
         })
 
-      {:ok, route, %{text: strip_quoted(text), email: mail_meta(headers, from)}}
+      body = text |> ensure_utf8() |> strip_quoted()
+      {:ok, route, %{text: body, email: mail_meta(headers, from)}}
     else
       _other -> :ignore
     end
@@ -253,6 +254,25 @@ defmodule Raxol.Gateway.Adapter.Email do
     raw
     |> to_string()
     |> String.split(~r/\s+/, trim: true)
+  end
+
+  # `:mimemail` decodes transfer-encoding but does NOT transcode charset, so a
+  # non-UTF-8 body (Latin-1/Windows-1252 is the common case) comes back as
+  # invalid-UTF-8 bytes. Left as-is it would crash the first `Jason.encode` (the
+  # LLM request) or LiveView render downstream -- the same invalid-UTF-8 hazard
+  # `send_message/3` already guards with `String.valid?/1` on the outbound side.
+  # Guard the inbound side symmetrically: keep a valid body untouched, else
+  # best-effort reinterpret the bytes as Latin-1 (total -- every byte is a code
+  # point), which always yields valid UTF-8.
+  defp ensure_utf8(body) when is_binary(body) do
+    if String.valid?(body) do
+      body
+    else
+      case :unicode.characters_to_binary(body, :latin1) do
+        transcoded when is_binary(transcoded) -> transcoded
+        _error_or_incomplete -> String.replace_invalid(body)
+      end
+    end
   end
 
   # Trim quoted history: keep the reply text above the first quote marker

--- a/packages/raxol_gateway/lib/raxol/gateway/adapter/email/inbox.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/adapter/email/inbox.ex
@@ -48,9 +48,12 @@ defmodule Raxol.Gateway.Adapter.Email.Inbox do
       UIDVALIDITY/UID checkpoint), so a restart resumes where the transport
       left off rather than re-reading the mailbox.
     * `:on_message` (required) - 1-arity function called per raw message, in
-      order. A crash inside it is caught and logged; the loop continues and
-      the cursor still advances, so a consumer that needs exactly-once must
-      dedup on `Message-ID`.
+      order. A crash inside it is caught, logged, and reported as
+      `[:raxol_gateway, :email_inbox, :handler_error]` telemetry; the loop
+      continues and the cursor still advances (holding it would let one poison
+      message stall the feed), so the failed message is dropped -- a consumer
+      that needs exactly-once must dedup on `Message-ID`, and an operator should
+      alert on that telemetry to catch drops from a transient downstream outage.
     * `:interval_ms` - delay between polls (default 60_000). Applied after each
       completed poll, empty or not.
     * `:max_bytes` - a raw message larger than this is dropped before
@@ -166,7 +169,19 @@ defmodule Raxol.Gateway.Adapter.Email.Inbox do
         :ok
 
       {:error, reason} ->
-        Logger.warning("email inbox on_message failed: #{inspect(reason)}")
+        # The cursor still advances past this message (see moduledoc): holding it
+        # on a handler failure would re-deliver the whole batch and let one
+        # poison message stall the feed forever. The trade-off is that a
+        # transient downstream failure permanently drops this message, so make
+        # that drop observable -- an operator can alert on it and a consumer that
+        # needs exactly-once dedups on `Message-ID`.
+        :telemetry.execute(
+          [:raxol_gateway, :email_inbox, :handler_error],
+          %{count: 1},
+          %{reason: reason}
+        )
+
+        Logger.warning("email inbox on_message failed (message dropped): #{inspect(reason)}")
         :ok
     end
   end

--- a/packages/raxol_gateway/test/raxol/gateway/adapter/email/inbox_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/adapter/email/inbox_test.exs
@@ -63,6 +63,28 @@ defmodule Raxol.Gateway.Adapter.Email.InboxTest do
     assert_receive {:ok_msg, "b"}
   end
 
+  test "a dropped (crashing) message emits handler_error telemetry" do
+    test = self()
+    handler = {__MODULE__, :handler_error}
+
+    :telemetry.attach(
+      handler,
+      [:raxol_gateway, :email_inbox, :handler_error],
+      fn _event, meas, meta, _config -> send(test, {:handler_error, meas, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    start_inbox(
+      fetch_fn: fn _ -> {:ok, ["boom"], :done} end,
+      on_message: fn "boom" -> raise "kaboom" end,
+      interval_ms: 50
+    )
+
+    assert_receive {:handler_error, %{count: 1}, %{reason: _reason}}
+  end
+
   test "a fetch error backs off without delivering or crashing" do
     test = self()
 

--- a/packages/raxol_gateway/test/raxol/gateway/adapter/email_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/adapter/email_test.exs
@@ -102,6 +102,18 @@ defmodule Raxol.Gateway.Adapter.EmailTest do
       assert {:ok, _route, %{text: "before\n--\nafter"}} = Email.normalize_event(dashes)
     end
 
+    test "reinterprets a non-UTF-8 (Latin-1) body as valid UTF-8" do
+      # A lone 0xE9 byte is "é" in Latin-1 but invalid UTF-8. :mimemail does not
+      # transcode charset, so without the inbound guard this text would reach the
+      # agent turn as invalid UTF-8 and crash the first Jason.encode/LiveView
+      # render. The guard reinterprets it as Latin-1 -> valid UTF-8.
+      raw = raw_mail([{"From", "a@x.com"}, {"To", "bot@x"}], "caf" <> <<0xE9>>)
+
+      assert {:ok, _route, %{text: text}} = Email.normalize_event(raw)
+      assert String.valid?(text)
+      assert text == "café"
+    end
+
     test "surfaces threading metadata under :email" do
       raw =
         raw_mail(


### PR DESCRIPTION
Follow-up to #728 (merged as `74d8839a8`). Addresses two adversarial-review concerns on the merged inbound email adapter. No contract change.

## 1. Inbound body is now UTF-8-validated (MEDIUM)

`send_message/3` already guards outbound with `String.valid?/1`, but `normalize_event/1` returned `%{text: ...}` straight from `:mimemail.decode`, which decodes transfer-encoding but does **not** transcode charset. A Latin-1 / Windows-1252 message (the common non-UTF-8 case) came back as invalid-UTF-8 bytes -- which would crash the first `Jason.encode` (the LLM request) or LiveView render downstream in the agent turn.

`ensure_utf8/1` closes the asymmetry: a valid body passes through untouched; an invalid one is best-effort reinterpreted as Latin-1 (total -- every byte is a code point), which always yields valid UTF-8. Applied before `strip_quoted` so the quote-trimming regex never sees invalid input either.

## 2. Silent message drop is now observable (MEDIUM)

`Inbox` catches an `on_message` crash, logs, and advances the cursor -- so a transient downstream failure (SessionRouter briefly down, handler throw) permanently drops that message. Holding the cursor instead is worse: it would re-deliver the whole batch and let one poison message stall the feed forever, so the advance stays. Instead the drop is now emitted as `[:raxol_gateway, :email_inbox, :handler_error]` telemetry (`%{count: 1}`, `%{reason: reason}`) -- an operator can alert on it, and the moduledoc + `:on_message` docs now say so. Consumers that need exactly-once still dedup on `Message-ID`.

## Verification

- `raxol_gateway` suite: **166 passed, 1 excluded** (2 new: Latin-1 -> UTF-8 round-trip; handler_error telemetry on a dropped message).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo` -- clean on the changed files.

## Manual testing

- [x] `MIX_ENV=test mix test test/raxol/gateway/adapter/email_test.exs test/raxol/gateway/adapter/email/inbox_test.exs` -- 31 passed
- [x] `MIX_ENV=test mix test` (raxol_gateway) -- 166 passed
- [x] `mix format --check-formatted` + `mix credo` on changed files -- clean