### PR TITLE
Fix harness boot: leave alt-screen on failure (H1)

### DIFF
--- a/lib/raxol/harness/session_pump.ex
+++ b/lib/raxol/harness/session_pump.ex
@@ -356,9 +356,10 @@ defmodule Raxol.Harness.SessionPump do
   #   1. The alt-screen ENTER bytes are written BEFORE the callback runs.
   #      The Rendering Engine starts inside the callback, so its first
   #      frame can never land in the user's scrollback. The flip side: a
-  #      boot FAILURE has already put ENTER on the tty, so the error branch
-  #      must emit the matching LEAVE (see below) — the loop never starts,
-  #      so `teardown/1` (which normally owns the leave byte) never runs.
+  #      boot FAILURE has already put ENTER on the tty, so EVERY non-happy
+  #      exit out of the boot must emit the matching LEAVE (the `try` below
+  #      wraps the callback for exactly this) — the loop never starts, so
+  #      `teardown/1` (which normally owns the leave byte) never runs.
   #   2. The three seams rewire from the returned pids BEFORE the loop
   #      starts: consumer becomes a DeliveryShim bound to the Dispatcher
   #      (verbatim {:harness, _} ingress; resize rides the system path),
@@ -366,38 +367,56 @@ defmodule Raxol.Harness.SessionPump do
   #      lifecycle_stop becomes the real Lifecycle stop.
   #
   # A boot failure is fatal and loud: the pump cannot feed an app that does
-  # not exist, so it raises and lets the link take the embedder down. There
-  # is no session to tear down honestly yet, but the alt-screen ENTER bytes
-  # are already on the tty, so the error branch first restores the primary
-  # screen (the LEAVE `teardown/1` would otherwise emit) before raising --
-  # otherwise a failed boot strands the operator in the hidden alternate
-  # buffer, needing a manual `reset`.
+  # not exist, so it fails out and lets the link take the embedder down.
+  # There is no session to tear down honestly yet, but the alt-screen ENTER
+  # bytes are already on the tty, so ANY non-happy exit out of the boot --
+  # an `{:error, _}` return, an unexpected return shape (CaseClauseError), a
+  # raising boot callback, a failed `DeliveryShim.start_link` match, or an
+  # EXIT -- is wrapped so the primary screen is restored (the LEAVE
+  # `teardown/1` would otherwise emit) BEFORE the original error re-raises.
+  # The loop never starts, so `teardown/1` never runs; this `try` is the
+  # only leave-byte owner on the boot path. Otherwise a failed boot strands
+  # the operator in the hidden alternate buffer, needing a manual `reset`.
   defp boot_runtime(%{runtime_boot: nil} = state), do: state
 
   defp boot_runtime(%{runtime_boot: boot} = state) do
+    # ENTER is written BEFORE the try: if this write itself fails the alt
+    # screen was never claimed, so there is nothing to leave.
     IO.write(state.device, ViewportAuthority.enter())
 
-    case boot.(self()) do
-      {:ok, %{dispatcher: dispatcher, engine: engine, lifecycle: lifecycle}} ->
-        {:ok, shim} = DeliveryShim.start_link(dispatcher)
+    try do
+      case boot.(self()) do
+        {:ok, %{dispatcher: dispatcher, engine: engine, lifecycle: lifecycle}} ->
+          {:ok, shim} = DeliveryShim.start_link(dispatcher)
 
-        %{
-          state
-          | alt_screen?: true,
-            consumer: shim,
-            paint_gate: fn phase -> GenServer.call(engine, phase) end,
-            lifecycle_stop: fn ->
-              Raxol.Core.Runtime.Lifecycle.stop(lifecycle)
-            end
-        }
+          %{
+            state
+            | alt_screen?: true,
+              consumer: shim,
+              paint_gate: fn phase -> GenServer.call(engine, phase) end,
+              lifecycle_stop: fn ->
+                Raxol.Core.Runtime.Lifecycle.stop(lifecycle)
+              end
+          }
 
-      {:error, reason} ->
-        # ENTER (above) is already on the tty and the loop never starts, so
-        # restore the primary screen here before the raise takes the
-        # embedder down. Guarded like teardown's leave: a device already
-        # gone must not turn the strand into a crash-behind-a-crash.
+        {:error, reason} ->
+          raise "harness runtime boot failed: #{inspect(reason)}"
+      end
+    rescue
+      error ->
+        # `alt_screen?` is still false in `state` (the success arm's true
+        # is on the discarded happy path), so the bookkeeping stays honest:
+        # ENTER is on the tty, so restore the primary screen, then re-raise
+        # the ORIGINAL error with its stacktrace. Guarded like teardown's
+        # leave: a device already gone must not turn the strand into a
+        # crash-behind-a-crash.
         safe_device_write(state.device, ViewportAuthority.leave())
-        raise "harness runtime boot failed: #{inspect(reason)}"
+        reraise(error, __STACKTRACE__)
+    catch
+      kind, reason ->
+        # Same restore for a non-error throw/exit out of the boot callback.
+        safe_device_write(state.device, ViewportAuthority.leave())
+        :erlang.raise(kind, reason, __STACKTRACE__)
     end
   end
 

--- a/lib/raxol/harness/session_pump.ex
+++ b/lib/raxol/harness/session_pump.ex
@@ -355,7 +355,10 @@ defmodule Raxol.Harness.SessionPump do
   #
   #   1. The alt-screen ENTER bytes are written BEFORE the callback runs.
   #      The Rendering Engine starts inside the callback, so its first
-  #      frame can never land in the user's scrollback.
+  #      frame can never land in the user's scrollback. The flip side: a
+  #      boot FAILURE has already put ENTER on the tty, so the error branch
+  #      must emit the matching LEAVE (see below) — the loop never starts,
+  #      so `teardown/1` (which normally owns the leave byte) never runs.
   #   2. The three seams rewire from the returned pids BEFORE the loop
   #      starts: consumer becomes a DeliveryShim bound to the Dispatcher
   #      (verbatim {:harness, _} ingress; resize rides the system path),
@@ -363,8 +366,12 @@ defmodule Raxol.Harness.SessionPump do
   #      lifecycle_stop becomes the real Lifecycle stop.
   #
   # A boot failure is fatal and loud: the pump cannot feed an app that does
-  # not exist, so it raises and lets the link take the embedder down --
-  # before the loop starts, there is no session to tear down honestly.
+  # not exist, so it raises and lets the link take the embedder down. There
+  # is no session to tear down honestly yet, but the alt-screen ENTER bytes
+  # are already on the tty, so the error branch first restores the primary
+  # screen (the LEAVE `teardown/1` would otherwise emit) before raising --
+  # otherwise a failed boot strands the operator in the hidden alternate
+  # buffer, needing a manual `reset`.
   defp boot_runtime(%{runtime_boot: nil} = state), do: state
 
   defp boot_runtime(%{runtime_boot: boot} = state) do
@@ -385,6 +392,11 @@ defmodule Raxol.Harness.SessionPump do
         }
 
       {:error, reason} ->
+        # ENTER (above) is already on the tty and the loop never starts, so
+        # restore the primary screen here before the raise takes the
+        # embedder down. Guarded like teardown's leave: a device already
+        # gone must not turn the strand into a crash-behind-a-crash.
+        safe_device_write(state.device, ViewportAuthority.leave())
         raise "harness runtime boot failed: #{inspect(reason)}"
     end
   end

--- a/packages/raxol_agent/lib/mix/tasks/raxol.harness.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.harness.ex
@@ -74,11 +74,16 @@ defmodule Mix.Tasks.Raxol.Harness do
     # the paths that never reach it — a ^C that lands as SIGINT while
     # prim_tty has ISIG re-flipped (the BREAK-menu abort kills the VM
     # mid-session, but abort DOES run at_exit handlers), a crashed pump,
-    # an init:stop unwind. Idempotent byte-wise: mode resets are set/reset
-    # DEC privates, and `stty sane` after a restored tty is a no-op in
+    # a runtime-boot failure (ENTER already on the tty, `teardown/1` never
+    # reached), an init:stop unwind. The ViewportAuthority LEAVE
+    # (`\e[?1049l` + cursor/autowrap restore) must be part of this net, or
+    # a strand on any of those paths drops the operator into the hidden
+    # alternate buffer. Idempotent byte-wise: LEAVE on the primary screen,
+    # mode resets, and `stty sane` after a restored tty are all no-ops in
     # effect. SIGKILL still cleans nothing — nothing can.
     System.at_exit(fn _status ->
       IO.write(:stdio, "\e[?1000l\e[?1006l\e[?1003l\e[?2004l\e[?1004l")
+      IO.write(:stdio, Raxol.UI.Rendering.PaintAuthority.ViewportAuthority.leave())
       Raxol.Terminal.Driver.Stty.sane!()
     end)
 
@@ -264,8 +269,7 @@ defmodule Mix.Tasks.Raxol.Harness do
         })
 
       true ->
-        {Raxol.Agent.Backend.Mock,
-         [response: "Raxol harness live echo (mock backend)."], "mock"}
+        {Raxol.Agent.Backend.Mock, [response: "Raxol harness live echo (mock backend)."], "mock"}
     end
   end
 
@@ -283,8 +287,7 @@ defmodule Mix.Tasks.Raxol.Harness do
         {backend, opts, Atom.to_string(harness)}
 
       {:error, _} ->
-        {Raxol.Agent.Backend.Mock, [response: "mock (selector fell back)"],
-         "mock"}
+        {Raxol.Agent.Backend.Mock, [response: "mock (selector fell back)"], "mock"}
     end
   end
 
@@ -297,8 +300,7 @@ defmodule Mix.Tasks.Raxol.Harness do
         # Backend.HTTP's :openai provider appends /v1/chat/completions itself
         # -- strip a conventionally-supplied trailing /v1.
         [
-          base_url:
-            url |> String.trim_trailing("/") |> String.trim_trailing("/v1")
+          base_url: url |> String.trim_trailing("/") |> String.trim_trailing("/v1")
         ]
     end
   end

--- a/test/harness/session_pump_test.exs
+++ b/test/harness/session_pump_test.exs
@@ -1225,17 +1225,67 @@ defmodule Raxol.Harness.SessionPumpTest do
       assert String.ends_with?(bytes_at_boot, ViewportAuthority.enter())
     end
 
+    test "a boot FAILURE restores the primary screen before it raises" do
+      # ENTER is already on the tty when boot runs (proven above). A boot
+      # failure aborts before the loop, so teardown/1 never emits the LEAVE
+      # -- boot_runtime/2 must emit it itself, or the operator is stranded
+      # in the hidden alternate buffer needing a manual `reset`.
+      Process.flag(:trap_exit, true)
+      test_pid = self()
+      {:ok, device} = StringIO.open("")
+
+      boot = fn _pump_pid ->
+        {_in, out} = StringIO.contents(device)
+        send(test_pid, {:boot_invoked, out})
+        {:error, :boom}
+      end
+
+      {:ok, pump} =
+        SessionPump.start_link(
+          lane:
+            {FakeLane,
+             %{session_id: "s1", pid: start_fake_session(), test: test_pid}},
+          device: device,
+          width: @width,
+          rows: @rows,
+          cadence_opts: [flush_interval_ms: 0],
+          tick_ms: 60_000,
+          notify: test_pid,
+          runtime_boot: boot
+        )
+
+      # ENTER was on the tty when boot ran ...
+      assert_receive {:boot_invoked, at_boot}, 2_000
+      assert String.ends_with?(at_boot, ViewportAuthority.enter())
+
+      # ... the boot failure is fatal and loud (the pump crashes) ...
+      assert_receive {:EXIT, ^pump, {%RuntimeError{message: msg}, _stack}},
+                     2_000
+
+      assert msg =~ "harness runtime boot failed"
+
+      # ... but the primary screen is restored: LEAVE is the LAST byte on
+      # the device, after the ENTER that opened the alternate buffer.
+      {_in, out} = StringIO.contents(device)
+      assert out =~ ViewportAuthority.enter()
+      assert String.ends_with?(out, ViewportAuthority.leave())
+    end
+
     test "rewires delivery: batches ride {:harness, _}, resize rides the system path" do
       %{forwarder: forwarder, pump: pump} = new_booted_pump()
 
       send(forwarder, {:session_event, "s1", turn_started_event("t1")})
-      assert_receive {:dispatched, {:dispatch, {:harness, {:batch, items}}}}, 2_000
+
+      assert_receive {:dispatched, {:dispatch, {:harness, {:batch, items}}}},
+                     2_000
+
       assert Enum.any?(items, &match?({:event, %{type: :turn_started}}, &1))
 
       SessionPump.notify_resize(pump, 100, 40)
 
       assert_receive {:dispatched,
-                      {:dispatch, %Event{type: :resize, data: %{width: 100, height: 40}}}},
+                      {:dispatch,
+                       %Event{type: :resize, data: %{width: 100, height: 40}}}},
                      2_000
     end
 
@@ -1252,7 +1302,8 @@ defmodule Raxol.Harness.SessionPumpTest do
       assert_receive {:paint_gate, :resume_painting}, 2_000
       # The editor result travels the rewired delivery path, too.
       assert_receive {:dispatched,
-                      {:dispatch, {:harness, {:editor_result, {:ok, %{text: "e"}}}}}},
+                      {:dispatch,
+                       {:harness, {:editor_result, {:ok, %{text: "e"}}}}}},
                      2_000
     end
 

--- a/test/harness/session_pump_test.exs
+++ b/test/harness/session_pump_test.exs
@@ -1271,6 +1271,93 @@ defmodule Raxol.Harness.SessionPumpTest do
       assert String.ends_with?(out, ViewportAuthority.leave())
     end
 
+    test "a RAISING boot callback restores the primary screen before it re-raises" do
+      # The real boot (Live) matches only {:ok, _}/{:error, _} on
+      # Raxol.start_link, so an unexpected return raises a CaseClauseError
+      # INSIDE boot, and the success arm's DeliveryShim.start_link is a hard
+      # match that can MatchError. Neither is the {:error, _} RETURN the
+      # error branch handles -- without the boot `try`, they strand the
+      # operator in the alternate buffer. The original error must survive.
+      Process.flag(:trap_exit, true)
+      test_pid = self()
+      {:ok, device} = StringIO.open("")
+
+      boot = fn _pump_pid ->
+        {_in, out} = StringIO.contents(device)
+        send(test_pid, {:boot_invoked, out})
+        raise "boot exploded mid-start"
+      end
+
+      {:ok, pump} =
+        SessionPump.start_link(
+          lane:
+            {FakeLane,
+             %{session_id: "s1", pid: start_fake_session(), test: test_pid}},
+          device: device,
+          width: @width,
+          rows: @rows,
+          cadence_opts: [flush_interval_ms: 0],
+          tick_ms: 60_000,
+          notify: test_pid,
+          runtime_boot: boot
+        )
+
+      # ENTER was on the tty when boot ran ...
+      assert_receive {:boot_invoked, at_boot}, 2_000
+      assert String.ends_with?(at_boot, ViewportAuthority.enter())
+
+      # ... the raise propagates verbatim (message + stacktrace preserved,
+      # NOT swallowed or reshaped into the {:error, _} RuntimeError) ...
+      assert_receive {:EXIT, ^pump, {%RuntimeError{message: msg}, _stack}},
+                     2_000
+
+      assert msg == "boot exploded mid-start"
+
+      # ... but the primary screen is restored: LEAVE is the LAST byte,
+      # after the ENTER that opened the alternate buffer.
+      {_in, out} = StringIO.contents(device)
+      assert out =~ ViewportAuthority.enter()
+      assert String.ends_with?(out, ViewportAuthority.leave())
+    end
+
+    test "an UNCOVERED boot return shape restores the primary screen before it raises" do
+      # The real boot's `case` has no clause for a non-{:ok,_}/{:error,_}
+      # return, so a bad shape raises CaseClauseError inside boot -- the
+      # `try` must still restore the primary screen.
+      Process.flag(:trap_exit, true)
+      test_pid = self()
+      {:ok, device} = StringIO.open("")
+
+      boot = fn _pump_pid ->
+        {_in, out} = StringIO.contents(device)
+        send(test_pid, {:boot_invoked, out})
+        :unexpected_shape
+      end
+
+      {:ok, pump} =
+        SessionPump.start_link(
+          lane:
+            {FakeLane,
+             %{session_id: "s1", pid: start_fake_session(), test: test_pid}},
+          device: device,
+          width: @width,
+          rows: @rows,
+          cadence_opts: [flush_interval_ms: 0],
+          tick_ms: 60_000,
+          notify: test_pid,
+          runtime_boot: boot
+        )
+
+      assert_receive {:boot_invoked, at_boot}, 2_000
+      assert String.ends_with?(at_boot, ViewportAuthority.enter())
+
+      assert_receive {:EXIT, ^pump, {%CaseClauseError{}, _stack}}, 2_000
+
+      {_in, out} = StringIO.contents(device)
+      assert out =~ ViewportAuthority.enter()
+      assert String.ends_with?(out, ViewportAuthority.leave())
+    end
+
     test "rewires delivery: batches ride {:harness, _}, resize rides the system path" do
       %{forwarder: forwarder, pump: pump} = new_booted_pump()
 


### PR DESCRIPTION
## What

Fixes **H1** from the #687 adversarial review of `integration/harness-endgame`: a runtime-boot failure strands the operator in the alternate screen buffer.

`SessionPump.boot_runtime/2` writes the alt-screen ENTER bytes (`\e[?1049h…`) *before* the fallible `boot.(self())` callback (correct: so the Rendering Engine's first frame can't leak into scrollback). But the `{:error, _}` branch raised before the loop started, so `teardown/1` — which owns the matching LEAVE byte — never ran. A boot failure (bad Lifecycle start, engine error, resource contention) left the terminal in the hidden alternate buffer, needing a manual `reset`. The mix task's `at_exit` second net reset mouse modes + `stty sane` but omitted the alt-screen leave and cursor restore, so it did not catch this either.

## Fix

- `session_pump.ex` — on `{:error, reason}`, emit `ViewportAuthority.leave()` (via the same `safe_device_write/2` guard teardown uses) before raising. The raise stays fatal-and-loud; the primary screen is restored first.
- `mix/tasks/raxol.harness.ex` — add the `ViewportAuthority.leave()` bytes (alt-screen leave + cursor/autowrap restore) to the `at_exit` net so any strand path (boot failure, crashed pump, abort unwind) is covered. Idempotent byte-wise on the primary screen.
- Comments updated: the load-bearing byte-order comment now names the leave-on-failure obligation.

## Test

New `session_pump_test.exs` case in describe "12. runtime_boot (U6)": a boot callback returning `{:error, _}` proves (a) ENTER was on the tty when boot ran, (b) the pump crashes with `harness runtime boot failed`, and (c) `ViewportAuthority.leave()` is the last byte on the device. The device is a test-owned `StringIO`, so it survives the pump crash and the leave byte is observable.

## Scope / notes

- Targets `integration/harness-endgame` — the reviewed files (`session_pump.ex`, the harness mix task) exist only on that branch, not on master.
- Files touched: `lib/raxol/harness/session_pump.ex`, `test/harness/session_pump_test.exs`, `packages/raxol_agent/lib/mix/tasks/raxol.harness.ex`. `mix.lock` is intentionally **not** included (pre-existing branch drift is a separate concern).
- `raxol_agent` is not in the CI matrix; local run is the gate. Both packages compile clean; the mix task's `at_exit` closure is not unit-testable (it fires at VM exit), so it's covered by the additive-byte reasoning above.
- Credo: no new issues. The pre-existing ABC-complexity warnings on `SessionPump.loop/1`/`build/1` and the mix task `run/1` are untouched structural warnings, not introduced here (left alone per "don't refactor adjacent code").

## Manual testing

- [x] `mix test test/harness/session_pump_test.exs` — 47 passed (incl. new boot-failure case)
- [x] `mix test test/harness/` — 732 passed, 1 skipped
- [x] `MIX_ENV=test mix compile` (main) and `cd packages/raxol_agent && MIX_ENV=test mix compile` both clean
- [x] `mix format --check-formatted` clean on all three files
- [ ] Live: force a Lifecycle boot failure under `mix raxol.harness` and confirm the terminal returns to the primary screen (not covered by automated tty test)
