### PR TITLE
Fix harness click drift + non-left/stale release (H2, L3)

### DIFF
--- a/lib/raxol/harness/harness_app.ex
+++ b/lib/raxol/harness/harness_app.ex
@@ -83,17 +83,24 @@ defmodule Raxol.Harness.HarnessApp do
     do: {Model.tick(model, now), []}
 
   # -- resize rides the real Event (the system-event path, PumpContract §3) --
+  # Clear any armed press: the {x,y} it recorded points at a PRE-resize
+  # layout, so a release landing on the same cell after the reflow would
+  # hit-test against different geometry and toggle the wrong block. A resize
+  # mid-drag cancels the click.
   def update(%Event{type: :resize, data: %{width: w, height: h}}, model)
       when is_integer(w) and is_integer(h),
-      do: {Model.resize(model, w, h), []}
+      do: {%{Model.resize(model, w, h) | mouse_press: nil}, []}
 
   # -- mouse (click-to-fold; V's ruling) --
   #
   # Resolved HERE, not in the Model: hit-testing needs the view's own
   # geometry (footer fit, transcript window), and this module is the one
   # place that legitimately holds both halves. `View.hit_test/3` is pure
-  # geometry; `Model.click/2` is the pure fold. A left PRESS acts;
-  # releases/moves/other buttons fold away silently.
+  # geometry; `Model.click/2` is the pure fold. A left PRESS arms the site;
+  # the matching left RELEASE on the same cell acts. Moves, and any release
+  # that is not the left button, fold away silently — the arm is left-only,
+  # so completing on a right/middle release would toggle a block the user
+  # never left-clicked.
   # The LIVE shape: the pump normalizes every input event
   # (`PumpContract.key/1` → `InputEvent.normalize/1`), and a mouse Event
   # classifies `%{kind: :other, raw: %Event{type: :mouse}}` — the struct
@@ -171,14 +178,18 @@ defmodule Raxol.Harness.HarnessApp do
     {%{model | mouse_press: {x, y}}, []}
   end
 
+  # SGR (mode 1006) preserves the button on release, so a left release
+  # reports `button: :left`; `:release` is the legacy button-agnostic
+  # marker (both complete the click). A right/middle/wheel release does
+  # not match here and folds away via the catch-all.
   defp handle_mouse(
          %Event{
            type: :mouse,
-           data: %{action: :release, x: x, y: y}
+           data: %{action: :release, button: button, x: x, y: y}
          },
          model
        )
-       when is_integer(x) and is_integer(y) do
+       when button in [:left, :release] and is_integer(x) and is_integer(y) do
     armed = model.mouse_press
     model = %{model | mouse_press: nil}
 

--- a/lib/raxol/harness/harness_app.ex
+++ b/lib/raxol/harness/harness_app.ex
@@ -42,6 +42,8 @@ defmodule Raxol.Harness.HarnessApp do
 
   alias Raxol.Harness.HarnessApp.{Model, View}
 
+  require Logger
+
   # ── init ────────────────────────────────────────────────────────────────
 
   @impl true
@@ -97,10 +99,12 @@ defmodule Raxol.Harness.HarnessApp do
   # geometry (footer fit, transcript window), and this module is the one
   # place that legitimately holds both halves. `View.hit_test/3` is pure
   # geometry; `Model.click/2` is the pure fold. A left PRESS arms the site;
-  # the matching left RELEASE on the same cell acts. Moves, and any release
-  # that is not the left button, fold away silently — the arm is left-only,
-  # so completing on a right/middle release would toggle a block the user
-  # never left-clicked.
+  # the matching left RELEASE on the same cell acts. Moves fold away
+  # silently; a release outside the completion allowlist (`[:left,
+  # :release]`) also folds — the arm is left-only, so completing on a
+  # right/middle release would toggle a block the user never left-clicked —
+  # but that drop is LOGGED at debug (see `handle_mouse/2`), so a click that
+  # silently dies under an unmodeled button token leaves a breadcrumb.
   # The LIVE shape: the pump normalizes every input event
   # (`PumpContract.key/1` → `InputEvent.normalize/1`), and a mouse Event
   # classifies `%{kind: :other, raw: %Event{type: :mouse}}` — the struct
@@ -196,6 +200,25 @@ defmodule Raxol.Harness.HarnessApp do
     if armed == {x, y},
       do: {Model.click(model, View.hit_test(model, x, y)), []},
       else: {model, []}
+  end
+
+  # A release that is a release but did NOT satisfy the completion clause
+  # above — its button is missing, or outside the [:left, :release]
+  # allowlist (right/middle/wheel button-up, or an unmodeled token from a
+  # mouse mode we don't handle). We fold it (no toggle), but log at debug
+  # so the drop is observable: if a real left-click ever arrives under an
+  # unexpected button token, this breadcrumb explains the otherwise-silent
+  # dead click instead of it vanishing into the generic catch-all.
+  defp handle_mouse(
+         %Event{type: :mouse, data: %{action: :release} = data},
+         model
+       ) do
+    Logger.debug(fn ->
+      "harness: dropped unrecognized mouse release " <>
+        "button=#{inspect(Map.get(data, :button))}"
+    end)
+
+    {model, []}
   end
 
   defp handle_mouse(_event, model), do: {model, []}

--- a/lib/raxol/harness/harness_app.ex
+++ b/lib/raxol/harness/harness_app.ex
@@ -171,6 +171,15 @@ defmodule Raxol.Harness.HarnessApp do
   # selection attempt, not a click — it must never toggle the block under
   # the pointer. The press only arms the site; all state change waits for
   # the matching release.
+  #
+  # The press RESOLVES its target NOW, against the press-time geometry, and
+  # arms `{cell, target}`. The release acts on THAT stored target — it does
+  # NOT re-hit-test the cell. So any transcript reflow between press and
+  # release (a `:seal_lines` fold, streamed reasoning lines, a scroll) that
+  # slides a different block under the same cell can no longer toggle the
+  # WRONG block: the target was pinned at press. (Resize additionally nils
+  # the arm above, cancelling the click outright — a viewport change is a
+  # bigger disruption than a transcript reflow.)
   defp handle_mouse(
          %Event{
            type: :mouse,
@@ -179,7 +188,7 @@ defmodule Raxol.Harness.HarnessApp do
          model
        )
        when is_integer(x) and is_integer(y) do
-    {%{model | mouse_press: {x, y}}, []}
+    {%{model | mouse_press: {{x, y}, View.hit_test(model, x, y)}}, []}
   end
 
   # SGR (mode 1006) preserves the button on release, so a left release
@@ -197,9 +206,10 @@ defmodule Raxol.Harness.HarnessApp do
     armed = model.mouse_press
     model = %{model | mouse_press: nil}
 
-    if armed == {x, y},
-      do: {Model.click(model, View.hit_test(model, x, y)), []},
-      else: {model, []}
+    case armed do
+      {{^x, ^y}, target} -> {Model.click(model, target), []}
+      _drag_or_unarmed -> {model, []}
+    end
   end
 
   # A release that is a release but did NOT satisfy the completion clause

--- a/lib/raxol/harness/harness_app/model.ex
+++ b/lib/raxol/harness/harness_app/model.ex
@@ -131,9 +131,12 @@ defmodule Raxol.Harness.HarnessApp.Model do
             record_fold: %{},
             # click on the live reasoning preview toggles peek ⇄ expanded
             tail_expanded?: false,
-            # the pending left-button press site {x, y} — a click ACTS on
-            # RELEASE at the same cell, so a drag (a selection attempt)
-            # never toggles anything. See HarnessApp.handle_mouse/2.
+            # the pending left-button press as `{cell, target}` — the press
+            # resolves and pins its hit-test target, and a click ACTS on
+            # RELEASE at the same cell against THAT pinned target (never a
+            # release-time re-hit-test), so neither a drag nor a mid-press
+            # transcript reflow can toggle the wrong block. nil when unarmed.
+            # See HarnessApp.handle_mouse/2.
             mouse_press: nil,
             # the sole lane client (pid) or nil in fixture mode
             pump: nil

--- a/lib/raxol/harness/harness_app/view.ex
+++ b/lib/raxol/harness/harness_app/view.ex
@@ -48,14 +48,13 @@ defmodule Raxol.Harness.HarnessApp.View do
   @doc "Renders the model to a View-DSL element tree (with a root `:cursor`)."
   @spec render(Model.t()) :: map()
   def render(model) do
-    cw = Model.content_width(model)
-    inset = Model.frame_inset(model)
-
-    groups = footer_groups(model, cw)
-    budget_cap = max(model.rows - 1 - inset, 1)
-    natural = FooterStack.total_height(groups)
-    budget = natural |> min(budget_cap) |> max(1)
-    transcript_h = max(model.rows - budget - inset, 0)
+    %{
+      cw: cw,
+      inset: inset,
+      groups: groups,
+      budget: budget,
+      transcript_h: transcript_h
+    } = layout_geometry(model)
 
     base =
       frame(
@@ -85,6 +84,41 @@ defmodule Raxol.Harness.HarnessApp.View do
           AbsoluteLayer.dialog_overlay(w, h, surface)
         ])
     end
+  end
+
+  # The single geometry solve shared by `render/1` and `hit_test/3`:
+  # content width, painted inset, the fitted footer groups, the footer's
+  # row budget, and the transcript height above it. `hit_test/3` MUST
+  # resolve a click against the exact layout `render/1` paints, so a click
+  # can never land on a row the paint didn't put there. Extracting the
+  # derivation here is what makes that invariant a fact instead of a
+  # copy-paste convention that a future one-sided edit could silently break
+  # (`budget_cap`/`natural` stay local — pure intermediates neither caller
+  # consumes).
+  @spec layout_geometry(Model.t()) :: %{
+          cw: non_neg_integer(),
+          inset: non_neg_integer(),
+          groups: keyword(),
+          budget: pos_integer(),
+          transcript_h: non_neg_integer()
+        }
+  defp layout_geometry(model) do
+    cw = Model.content_width(model)
+    inset = Model.frame_inset(model)
+
+    groups = footer_groups(model, cw)
+    budget_cap = max(model.rows - 1 - inset, 1)
+    natural = FooterStack.total_height(groups)
+    budget = natural |> min(budget_cap) |> max(1)
+    transcript_h = max(model.rows - budget - inset, 0)
+
+    %{
+      cw: cw,
+      inset: inset,
+      groups: groups,
+      budget: budget,
+      transcript_h: transcript_h
+    }
   end
 
   # ── the slash autocomplete popup ─────────────────────────────────────────
@@ -182,9 +216,9 @@ defmodule Raxol.Harness.HarnessApp.View do
 
   @doc """
   Resolves a click at 1-based terminal `{x, y}` (the SGR mouse report's
-  own coordinates) against THIS view's geometry — the same groups/budget/
-  window `render/1` lays out, recomputed from the model so the answer
-  can never drift from the paint:
+  own coordinates) against THIS view's geometry — the SAME
+  `layout_geometry/1` solve `render/1` paints from, so the answer can
+  never drift from the paint:
 
     * a transcript row over a block record → `{:block, block}`
     * a footer row inside the live-tail preview group → `:tail`
@@ -196,14 +230,8 @@ defmodule Raxol.Harness.HarnessApp.View do
   @spec hit_test(Model.t(), pos_integer(), pos_integer()) ::
           {:block, term()} | :tail | :none
   def hit_test(model, _x, y) when is_integer(y) and y >= 1 do
-    cw = Model.content_width(model)
-    inset = Model.frame_inset(model)
-
-    groups = footer_groups(model, cw)
-    budget_cap = max(model.rows - 1 - inset, 1)
-    natural = FooterStack.total_height(groups)
-    budget = natural |> min(budget_cap) |> max(1)
-    transcript_h = max(model.rows - budget - inset, 0)
+    %{cw: cw, groups: groups, budget: budget, transcript_h: transcript_h} =
+      layout_geometry(model)
 
     row = y - 1
 

--- a/test/harness/harness_app_click_test.exs
+++ b/test/harness/harness_app_click_test.exs
@@ -161,7 +161,8 @@ defmodule Raxol.Harness.HarnessAppClickTest do
     # press alone arms but toggles nothing (the release is the acting edge)
     m2 = mouse(model, :press, 3, row)
     assert m2.record_fold == %{}
-    assert m2.mouse_press == {3, row}
+    # the arm pins {cell, resolved target} — the block, resolved at press
+    assert {{3, ^row}, {:block, _}} = m2.mouse_press
 
     {m3, []} =
       HarnessApp.update(
@@ -196,7 +197,7 @@ defmodule Raxol.Harness.HarnessAppClickTest do
 
     # left press arms the site ...
     armed = mouse(model, :press, 3, row)
-    assert armed.mouse_press == {3, row}
+    assert {{3, ^row}, {:block, _}} = armed.mouse_press
 
     # ... but a RIGHT-button release on that same cell is not the user's
     # click (the arm is left-only), so it must not toggle the block.
@@ -251,7 +252,7 @@ defmodule Raxol.Harness.HarnessAppClickTest do
     row = reasoning_row(model)
 
     armed = mouse(model, :press, 3, row)
-    assert armed.mouse_press == {3, row}
+    assert {{3, ^row}, {:block, _}} = armed.mouse_press
 
     # geometry moves under the armed cell ...
     {resized, []} =
@@ -262,8 +263,8 @@ defmodule Raxol.Harness.HarnessAppClickTest do
 
     assert resized.mouse_press == nil
 
-    # ... so the release on the old coordinates resolves nothing (a stale
-    # arm can no longer hit-test against the pre-resize layout).
+    # ... so the release on the old coordinates has no armed target: a
+    # resize cancels the click outright (mouse_press nilled above).
     {released, []} =
       HarnessApp.update(
         {:key,
@@ -275,6 +276,101 @@ defmodule Raxol.Harness.HarnessAppClickTest do
       )
 
     assert released.record_fold == %{}
+  end
+
+  # Two sealed reasoning blocks in a window too short to hold them plus a
+  # burst of marker lines — sealing the markers (tail anchor) scrolls the
+  # older block up and off the top, so a DIFFERENT record slides under the
+  # cell the press armed. The general reflow class the resize clear only
+  # closed for one kind of geometry change.
+  defp two_reasoning_model do
+    Model.build(width: 60, rows: 12)
+    |> Model.fold_batch([
+      {:event, ev(1, :turn_started, %{})},
+      {:event,
+       ev(2, :item_started, %{"item_id" => "a1", "item_type" => "reasoning"})},
+      {:event,
+       ev(3, :item_completed, %{
+         "item_id" => "a1",
+         "item_type" => "reasoning",
+         "content" => "ALPHA-THOUGHT-BODY"
+       })},
+      {:event,
+       ev(4, :item_completed, %{
+         "item_id" => "a2",
+         "item_type" => "message",
+         "content" => "alpha reply"
+       })},
+      {:event, ev(5, :turn_completed, %{})},
+      {:event, ev(6, :turn_started, %{})},
+      {:event,
+       ev(7, :item_started, %{"item_id" => "b1", "item_type" => "reasoning"})},
+      {:event,
+       ev(8, :item_completed, %{
+         "item_id" => "b1",
+         "item_type" => "reasoning",
+         "content" => "BETA-THOUGHT-BODY"
+       })},
+      {:event,
+       ev(9, :item_completed, %{
+         "item_id" => "b2",
+         "item_type" => "message",
+         "content" => "beta reply"
+       })},
+      {:event, ev(10, :turn_completed, %{})}
+    ])
+  end
+
+  defp first_block_row(model) do
+    Enum.find(1..model.rows, fn y ->
+      match?({:block, _}, View.hit_test(model, 3, y))
+    end)
+  end
+
+  test "a mid-press transcript reflow toggles the ORIGINAL target, not the block that slid under the cell" do
+    model = two_reasoning_model()
+
+    row = first_block_row(model)
+    assert row != nil, "no block visible to press on"
+    {:block, pressed} = View.hit_test(model, 3, row)
+
+    # arm the press on the topmost block, at its press-time row ...
+    armed = mouse(model, :press, 3, row)
+    assert {{3, ^row}, {:block, ^pressed}} = armed.mouse_press
+
+    # ... reflow the transcript so the window scrolls and a DIFFERENT record
+    # slides under that same cell (NOT a resize — the general reflow class).
+    reflowed = Model.seal_lines(armed, Enum.map(1..20, &"marker line #{&1}"))
+    slid_in = View.hit_test(reflowed, 3, row)
+
+    refute slid_in == {:block, pressed},
+           "reflow did not move a different record under the armed cell; " <>
+             "the test proves nothing (still #{inspect(slid_in)})"
+
+    # release at the SAME cell: it must toggle the block the PRESS resolved,
+    # never the one that slid under the cell after the reflow.
+    released =
+      HarnessApp.update(
+        {:key,
+         %Event{
+           type: :mouse,
+           data: %{action: :release, button: :left, x: 3, y: row}
+         }},
+        reflowed
+      )
+      |> elem(0)
+
+    assert Map.has_key?(released.record_fold, pressed.event_refs),
+           "the original press target was not toggled"
+
+    case slid_in do
+      {:block, other} ->
+        refute Map.has_key?(released.record_fold, other.event_refs),
+               "the block that slid under the cell was wrongly toggled"
+
+      _not_a_block ->
+        :ok
+    end
   end
 
   test "hit_test/3 resolves the block render paints, off it resolves no block" do

--- a/test/harness/harness_app_click_test.exs
+++ b/test/harness/harness_app_click_test.exs
@@ -214,6 +214,38 @@ defmodule Raxol.Harness.HarnessAppClickTest do
     refute screen_text(released) =~ "SECRET-THOUGHT-LINE-1"
   end
 
+  test "an unmodeled-button release is dropped, but the drop is logged" do
+    import ExUnit.CaptureLog
+
+    model = sealed_reasoning_model()
+    row = reasoning_row(model)
+    armed = mouse(model, :press, 3, row)
+
+    # A wheel button-up is a release whose button is outside the completion
+    # allowlist. It must not toggle the block -- but unlike the generic
+    # catch-all fold, the drop is observable (a breadcrumb for a mystery
+    # dead click), so we assert both the no-toggle AND the debug log.
+    log =
+      capture_log([level: :debug], fn ->
+        {released, []} =
+          HarnessApp.update(
+            {:key,
+             %Event{
+               type: :mouse,
+               data: %{action: :release, button: :wheel_up, x: 3, y: row}
+             }},
+            armed
+          )
+
+        send(self(), {:released, released})
+      end)
+
+    assert_received {:released, released}
+    assert released.record_fold == %{}
+    assert log =~ "dropped unrecognized mouse release"
+    assert log =~ "wheel_up"
+  end
+
   test "a resize between press and release cancels the click" do
     model = sealed_reasoning_model()
     row = reasoning_row(model)

--- a/test/harness/harness_app_click_test.exs
+++ b/test/harness/harness_app_click_test.exs
@@ -190,6 +190,73 @@ defmodule Raxol.Harness.HarnessAppClickTest do
     assert screen_text(clicked) =~ "SECRET-THOUGHT-LINE-1"
   end
 
+  test "a non-left release at the armed cell does not complete the click" do
+    model = sealed_reasoning_model()
+    row = reasoning_row(model)
+
+    # left press arms the site ...
+    armed = mouse(model, :press, 3, row)
+    assert armed.mouse_press == {3, row}
+
+    # ... but a RIGHT-button release on that same cell is not the user's
+    # click (the arm is left-only), so it must not toggle the block.
+    {released, []} =
+      HarnessApp.update(
+        {:key,
+         %Event{
+           type: :mouse,
+           data: %{action: :release, button: :right, x: 3, y: row}
+         }},
+        armed
+      )
+
+    assert released.record_fold == %{}
+    refute screen_text(released) =~ "SECRET-THOUGHT-LINE-1"
+  end
+
+  test "a resize between press and release cancels the click" do
+    model = sealed_reasoning_model()
+    row = reasoning_row(model)
+
+    armed = mouse(model, :press, 3, row)
+    assert armed.mouse_press == {3, row}
+
+    # geometry moves under the armed cell ...
+    {resized, []} =
+      HarnessApp.update(
+        %Event{type: :resize, data: %{width: 80, height: 30}},
+        armed
+      )
+
+    assert resized.mouse_press == nil
+
+    # ... so the release on the old coordinates resolves nothing (a stale
+    # arm can no longer hit-test against the pre-resize layout).
+    {released, []} =
+      HarnessApp.update(
+        {:key,
+         %Event{
+           type: :mouse,
+           data: %{action: :release, button: :left, x: 3, y: row}
+         }},
+        resized
+      )
+
+    assert released.record_fold == %{}
+  end
+
+  test "hit_test/3 resolves the block render paints, off it resolves no block" do
+    model = sealed_reasoning_model()
+    row = reasoning_row(model)
+
+    # Explicit hit_test/3 coverage (the finding noted it had none): the row
+    # the ⁖ header renders on resolves to a block; a pad row does not. Both
+    # read the SAME layout_geometry/1 solve render/1 paints from, so a
+    # one-sided geometry edit can no longer drift a click off the paint.
+    assert {:block, _block} = View.hit_test(model, 3, row)
+    refute match?({:block, _}, View.hit_test(model, 3, 1))
+  end
+
   test "a click on the streaming reasoning preview toggles peek ⇄ expanded" do
     lines = Enum.map_join(1..8, "\n", &"active thought line #{&1}")
 


### PR DESCRIPTION
## What

Fixes **H2** and **L3** from the #687 adversarial review of `integration/harness-endgame` — the click subsystem, flagged from two independent angles as one coherent failure (wrong block folds).

### H2 — duplicated footer geometry (click could drift from the paint)

`View.render/1` and `View.hit_test/3` each inlined a byte-identical derivation (`cw`, `inset`, `groups`, `budget_cap`, `natural`, `budget`, `transcript_h`) behind a docstring claiming the recompute means clicks "can never drift from the paint." That invariant was held only by manual copy-paste: a future edit reserving a footer row or changing the inset in `render/1` alone would silently make every click resolve to the wrong transcript row — no crash, no failing test (`hit_test/3` had zero direct coverage).

Extract `layout_geometry/1`; both callers read the one solve. Drift is now structurally impossible. `budget_cap`/`natural` stay local (pure intermediates neither caller consumes).

### L3 — release state machine

- **Button-agnostic release.** The release clause matched any `action: :release` with no `button:` guard. Since the arm is set only by a left press, a right/middle release on the armed cell completed a fold the user never left-clicked. SGR mode 1006 (`@mouse_on = "\e[?1000h\e[?1006h"`) preserves the button on release, so a left release reports `button: :left` — the fix filters to `button in [:left, :release]` (left, plus the legacy generic-release marker); other buttons fold away via the catch-all.
- **Arm survives resize.** `mouse_press` recorded a pre-resize `{x,y}`; a release after a reflow hit-tested against different geometry and toggled the wrong block. The resize clause now clears the arm (a resize mid-drag cancels the click).

## Tests (`harness_app_click_test.exs`)

- `hit_test/3` direct coverage: the row `render/1` paints the header on resolves to a block; a pad row does not (locks the shared-geometry guarantee).
- A right-button release on an armed cell does not complete the click.
- A resize between press and release clears the arm and cancels the click.

## Scope / notes

- Targets `integration/harness-endgame` — these files exist only on that branch, not master.
- Files: `lib/raxol/harness/harness_app/view.ex`, `lib/raxol/harness/harness_app.ex`, `test/harness/harness_app_click_test.exs`. `mix.lock` intentionally excluded (pre-existing branch drift).
- Credo: no new violations. `render/1` and `hit_test/3` remain flagged for ABC complexity exactly as pre-change (net across the two drops 82 to 79); the extraction's goal is removing the duplication, not the pre-existing complexity. Left per "don't refactor adjacent code."
- Pre-existing unused-`cw` warning in the test's `reasoning_row/1` left untouched.

## Manual testing

- [x] `mix test test/harness/harness_app_click_test.exs` — 35 passed (incl. 3 new)
- [x] `mix test test/harness/` — 734 passed, 1 skipped
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean (lib)
- [x] `mix format --check-formatted` clean on all three files
- [ ] Live: right-click a folded block, and resize mid-drag under `mix raxol.harness`, confirm neither toggles the wrong block (not covered by the pure-fold tests)
