### PR TITLE
Symphony: opt-in prompt cache for session runner

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -40,6 +40,7 @@ defmodule Raxol.Symphony.Orchestrator do
   alias Raxol.Symphony.Orchestrator.Retry
   alias Raxol.Symphony.Orchestrator.State
   alias Raxol.Symphony.Runner
+  alias Raxol.Symphony.Runners.RaxolAgentSession
   alias Raxol.Symphony.Tracker
   alias Raxol.Symphony.Workflow.GraphAdapter
   alias Raxol.Symphony.WorkflowStore
@@ -1083,7 +1084,7 @@ defmodule Raxol.Symphony.Orchestrator do
         retry_with_refreshed_issue(state, issue, retry_entry)
 
       {:ok, []} ->
-        %{state | claimed: MapSet.delete(state.claimed, issue_id)}
+        release_issue(state, issue_id)
 
       {:error, _reason} ->
         requeue_retry(state, issue_id, retry_entry)
@@ -1097,14 +1098,24 @@ defmodule Raxol.Symphony.Orchestrator do
        ) do
     cond do
       Issue.terminal?(issue, state.config.tracker.terminal_states) ->
-        %{state | claimed: MapSet.delete(state.claimed, issue.id)}
+        release_issue(state, issue.id)
 
       Issue.active?(issue, state.config.tracker.active_states) ->
         dispatch_issue(state, issue, retry_entry.attempt)
 
       true ->
-        %{state | claimed: MapSet.delete(state.claimed, issue.id)}
+        release_issue(state, issue.id)
     end
+  end
+
+  # An issue is leaving the run set for good (terminal, gone, or no longer
+  # active): drop the claim AND flush any prompt-cache row it left behind. The
+  # session runner's `prompt_cache` writes a row on every fresh dispatch; a
+  # one-shot issue (or an odd-length continuation chain) leaves one unread row
+  # that only this terminal flush reclaims. No-op unless `prompt_cache` is set.
+  defp release_issue(%State{} = state, issue_id) do
+    RaxolAgentSession.flush_prompt_cache(state.config, issue_id)
+    %{state | claimed: MapSet.delete(state.claimed, issue_id)}
   end
 
   defp requeue_retry(%State{} = state, issue_id, retry_entry) do

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -182,9 +182,11 @@ defmodule Raxol.Symphony.Orchestrator do
         Process.demonitor(entry.worker_ref, [:flush])
         Process.exit(entry.worker_pid, :kill)
 
+        # Terminal: the user stopped the run, it is not re-dispatched.
         new_state =
           state
           |> remove_running(issue_id, :stopped_by_user)
+          |> reclaim_prompt_cache(issue_id)
           |> notify_listeners(:worker_stopped)
 
         {:reply, :ok, new_state}
@@ -192,10 +194,12 @@ defmodule Raxol.Symphony.Orchestrator do
       Map.has_key?(state.paused, issue_id) ->
         forget_paused(state.paused_saver, issue_id)
 
+        # Terminal: a paused run stopped by the user does not resume.
         new_state =
           state
           |> Map.put(:paused, Map.delete(state.paused, issue_id))
           |> Map.put(:claimed, MapSet.delete(state.claimed, issue_id))
+          |> reclaim_prompt_cache(issue_id)
           |> notify_listeners(:worker_stopped)
 
         {:reply, :ok, new_state}
@@ -814,8 +818,10 @@ defmodule Raxol.Symphony.Orchestrator do
           "symphony.orchestrator.worker_stopped_by_user issue=#{entry.issue.identifier}"
         )
 
+        # Terminal: user stop, no re-dispatch -- reclaim any cache row.
         state
         |> Map.put(:claimed, MapSet.delete(state.claimed, issue_id))
+        |> reclaim_prompt_cache(issue_id)
         |> notify_listeners(:worker_stopped)
 
       other ->
@@ -1112,10 +1118,21 @@ defmodule Raxol.Symphony.Orchestrator do
   # active): drop the claim AND flush any prompt-cache row it left behind. The
   # session runner's `prompt_cache` writes a row on every fresh dispatch; a
   # one-shot issue (or an odd-length continuation chain) leaves one unread row
-  # that only this terminal flush reclaims. No-op unless `prompt_cache` is set.
+  # that only this terminal flush reclaims.
   defp release_issue(%State{} = state, issue_id) do
+    state
+    |> reclaim_prompt_cache(issue_id)
+    |> Map.put(:claimed, MapSet.delete(state.claimed, issue_id))
+  end
+
+  # Flush the prompt-cache row an issue may have left behind. Pipeable; a no-op
+  # unless the session runner's `prompt_cache` is configured. Call this ONLY at
+  # genuinely-terminal release sites (the same `issue.id` is NOT about to be
+  # re-dispatched) -- flushing on a continuation/retry path would just force a
+  # needless re-render on the next dispatch.
+  defp reclaim_prompt_cache(%State{} = state, issue_id) do
     RaxolAgentSession.flush_prompt_cache(state.config, issue_id)
-    %{state | claimed: MapSet.delete(state.claimed, issue_id)}
+    state
   end
 
   defp requeue_retry(%State{} = state, issue_id, retry_entry) do
@@ -1228,6 +1245,10 @@ defmodule Raxol.Symphony.Orchestrator do
     end
   end
 
+  # Reconcile-kill: the tracker reports this issue terminal or no longer
+  # active, so the run is torn down for good and is NOT re-dispatched. Flush
+  # its prompt-cache row here (not in the shared `remove_running`, which the
+  # stall path also uses before a re-dispatch retry).
   defp terminate_running(%State{} = state, issue_id, entry, clean_workspace?) do
     Process.demonitor(entry.worker_ref, [:flush])
     Process.exit(entry.worker_pid, :kill)
@@ -1237,7 +1258,9 @@ defmodule Raxol.Symphony.Orchestrator do
       Workspace.remove(state.config, entry.workspace_path)
     end
 
-    %{state | claimed: MapSet.delete(state.claimed, issue_id)}
+    state
+    |> Map.put(:claimed, MapSet.delete(state.claimed, issue_id))
+    |> reclaim_prompt_cache(issue_id)
   end
 
   # -- Run events -------------------------------------------------------------

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -89,11 +89,25 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   `still_active?` check and so trades freshness for HTTP cost), this
   cache is **self-invalidating**: the rendered prompt is a pure
   function of the fingerprinted determinants, so any change to the
-  issue content, template, or attempt yields a new key. The TTL is
-  only an eviction/memory bound, never a staleness window. The hit
-  case is a continuation re-dispatch of an unchanged issue at the
-  same attempt. It is opt-in and **off by default** (`prompt_cache`
-  unset preserves the existing per-run render).
+  issue content, template, or attempt yields a new key. The hit case
+  is a continuation re-dispatch of an unchanged issue at the same
+  attempt. It is opt-in and **off by default** (`prompt_cache` unset
+  preserves the existing per-run render).
+
+  ### Bounding (read-once)
+
+  Each key is written once (on the render that misses) and read once
+  (by the single continuation re-dispatch that hits). The entry is
+  **deleted on that read**, so the cache holds at most one entry per
+  run currently awaiting its continuation -- it cannot accumulate a
+  permanent per-issue row. The TTL is NOT a reliable memory bound
+  here: `Cache.Ets` expires lazily (only a same-key `get` reclaims a
+  stale entry), and a write-once/read-once key is never `get` again,
+  so its TTL would never fire on its own. Delete-on-read, not the
+  TTL, is what keeps the cache from growing unbounded across issues;
+  the TTL only backstops the rare final render whose continuation
+  never comes (the issue reached a terminal state), which a periodic
+  `flush/1` or table drop reclaims.
 
   ### Relationship to `PromptBuilder`'s template memo
 
@@ -387,6 +401,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
     case Raxol.Agent.Cache.get(cache, key) do
       {:ok, cached} ->
+        # Read-once: the continuation re-dispatch is the only reader, so flush
+        # the entry as it is consumed. Otherwise this write-once/read-once key
+        # would linger permanently -- its lazy TTL is only reclaimed by a
+        # same-key `get`, which never comes for an issue that has moved on.
+        Raxol.Agent.Cache.delete(cache, key)
         cached
 
       :miss ->
@@ -423,7 +442,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
          attempt
        ) do
     fingerprint =
-      :crypto.hash(:sha256, :erlang.term_to_binary({issue, template, attempt}))
+      :crypto.hash(
+        :sha256,
+        :erlang.term_to_binary({issue, template, attempt}, [:deterministic])
+      )
 
     {:prompt, fingerprint}
   end

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -80,34 +80,57 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   Optional: set `agent.prompt_cache` to a `{module, config}` tuple
   (or a bare `Raxol.Agent.Cache`-impl module) and the runner will
   cache the rendered prompt across fresh runs. The cache key is
-  `{:prompt, sha256({issue, prompt_template, attempt})}` (the full
-  `%Issue{}` is fingerprinted, so the key can never drift from what
-  the template renders) and the TTL defaults to 300s, overridden by
-  `agent.prompt_cache_ttl_ms`.
+  `{:prompt, issue.id}` -- a stable per-issue slot. The stored value
+  is `{fingerprint, rendered}`, where `fingerprint` is
+  `sha256({issue, prompt_template, attempt})`. The TTL defaults to
+  300s, overridden by `agent.prompt_cache_ttl_ms`.
 
   Unlike `RaxolAgent`'s `tracker_cache` (which caches a network
   `still_active?` check and so trades freshness for HTTP cost), this
-  cache is **self-invalidating**: the rendered prompt is a pure
-  function of the fingerprinted determinants, so any change to the
-  issue content, template, or attempt yields a new key. The hit case
-  is a continuation re-dispatch of an unchanged issue at the same
-  attempt. It is opt-in and **off by default** (`prompt_cache` unset
-  preserves the existing per-run render).
+  cache is **self-invalidating**, but the freshness check lives in the
+  stored fingerprint rather than in the key. The rendered prompt is a
+  pure function of `{issue, template, attempt}` (the whole `%Issue{}`
+  is fingerprinted, so the check can never drift from what the template
+  renders -- and note `attempt` DOES affect the render, since
+  `PromptBuilder` exposes it as the `{{ attempt }}` Liquid variable).
+  On a `get`, a fingerprint mismatch (any change to the issue content,
+  template, or attempt -- including the initial `attempt: nil` dispatch
+  versus its `attempt: 1` continuation) is treated as a miss and the
+  entry is re-rendered and overwritten. A stale render is therefore
+  **never served**. It is opt-in and **off by default**
+  (`prompt_cache` unset preserves the existing per-run render).
 
-  ### Bounding (read-once)
+  ### Bounding
 
-  Each key is written once (on the render that misses) and read once
-  (by the single continuation re-dispatch that hits). The entry is
-  **deleted on that read**, so the cache holds at most one entry per
-  run currently awaiting its continuation -- it cannot accumulate a
-  permanent per-issue row. The TTL is NOT a reliable memory bound
-  here: `Cache.Ets` expires lazily (only a same-key `get` reclaims a
-  stale entry), and a write-once/read-once key is never `get` again,
-  so its TTL would never fire on its own. Delete-on-read, not the
-  TTL, is what keeps the cache from growing unbounded across issues;
-  the TTL only backstops the rare final render whose continuation
-  never comes (the issue reached a terminal state), which a periodic
-  `flush/1` or table drop reclaims.
+  Keying on the stable `issue.id` (not on the fingerprint) is what
+  makes the cache bounded, via three cooperating mechanisms:
+
+    * **Overwrite on the freshness miss.** A fingerprint mismatch
+      re-renders and `put`s under the same key, so an issue holds at
+      most one row at a time. The initial `attempt: nil` render is
+      reclaimed by the overwrite its first `attempt: 1` continuation
+      performs -- it is not a permanent orphan.
+    * **Read-once delete on the exact hit.** A continuation re-dispatch
+      of an unchanged issue at an unchanged attempt (the hit case:
+      consecutive `attempt: 1` continuations render the same prompt)
+      reads the entry and **deletes it on that read**, so a continued
+      issue oscillates between one and zero rows.
+    * **Terminal flush.** `flush_prompt_cache/2` deletes an issue's row
+      by `issue.id`. The orchestrator calls it when an issue leaves the
+      run set (reached a terminal state, or was dropped), which reclaims
+      the single row a one-shot issue (completes on first dispatch, no
+      continuation reads it) or an odd-length continuation chain leaves
+      behind. Because the key is `issue.id` alone, this works even
+      though the issue's content (and thus its fingerprint) has changed
+      by the time it is observed terminal.
+
+  Together these keep the live-entry count at `O(issues currently
+  in-flight)`, not `O(issues ever processed)`. The TTL is only a
+  backstop for the edge exits the orchestrator does not route through
+  `flush_prompt_cache/2`; it is not the primary bound, because
+  `Cache.Ets` expires lazily (only a same-key `get` reclaims a stale
+  entry) and a row whose issue has moved on is never `get` again. There
+  is no background sweeper.
 
   ### Relationship to `PromptBuilder`'s template memo
 
@@ -117,9 +140,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     * `PromptBuilder` memoizes the **parsed Liquid AST**, keyed by the
       template string. That is shared across *every* issue using a given
       `WORKFLOW.md` and always on -- it removes the re-parse cost.
-    * This `prompt_cache` memoizes the **fully rendered prompt**, keyed by
-      (issue, template, attempt). It removes the per-issue variable
-      substitution too, but only for the narrow hit case above.
+    * This `prompt_cache` memoizes the **fully rendered prompt**. It
+      removes the per-issue variable substitution too, but only for the
+      narrow hit case above.
 
   So on a continuation re-dispatch of an unchanged issue, the parse is
   skipped by `PromptBuilder` and the render is skipped here. The render
@@ -384,10 +407,23 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     do:
       "symphony-session-#{id}-#{attempt || 0}-#{:erlang.unique_integer([:positive])}"
 
+  @doc """
+  Removes any prompt-cache row for `issue_id`.
+
+  A no-op when no `prompt_cache` is configured. The orchestrator calls
+  this when an issue leaves the run set (terminal or dropped) so a
+  one-shot render -- written on the issue's only dispatch and never
+  read by a continuation -- does not linger. Keying on `issue.id`
+  alone (not the freshness fingerprint) means this reclaims the row
+  even though the issue's content, and thus its fingerprint, has
+  changed by the time it is observed terminal.
+  """
+  @spec flush_prompt_cache(Config.t(), term()) :: :ok
+  def flush_prompt_cache(%Config{} = config, issue_id) do
+    Raxol.Agent.Cache.delete(agent_prompt_cache(config), prompt_cache_key(issue_id))
+  end
+
   # Renders the seed prompt, optionally through the opt-in prompt cache.
-  # The rendered prompt is a pure function of the fingerprinted
-  # determinants, so the content-hash key is self-invalidating (see the
-  # "Prompt caching" moduledoc section).
   defp build_prompt(issue, config, attempt),
     do: render_cached(agent_prompt_cache(config), issue, config, attempt)
 
@@ -396,26 +432,34 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     do: render_prompt(issue, config, attempt)
 
   # Cache configured: reuse the memoized render, or compute and store it.
+  # The key is the stable `issue.id`; freshness is guarded by a fingerprint
+  # stored alongside the render, so the cache stays bounded per issue (see the
+  # "Prompt caching" moduledoc section).
   defp render_cached(cache, issue, config, attempt) do
-    key = prompt_cache_key(issue, config, attempt)
+    key = prompt_cache_key(issue.id)
+    fingerprint = prompt_fingerprint(issue, config.prompt_template, attempt)
 
     case Raxol.Agent.Cache.get(cache, key) do
-      {:ok, cached} ->
-        # Read-once: the continuation re-dispatch is the only reader, so flush
-        # the entry as it is consumed. Otherwise this write-once/read-once key
-        # would linger permanently -- its lazy TTL is only reclaimed by a
-        # same-key `get`, which never comes for an issue that has moved on.
+      {:ok, {^fingerprint, cached}} ->
+        # Exact hit (unchanged issue + template + attempt). Read-once: the
+        # continuation re-dispatch is the only reader, so flush the row as it
+        # is consumed. A continued issue thus oscillates between one and zero
+        # rows instead of lingering.
         Raxol.Agent.Cache.delete(cache, key)
         cached
 
-      :miss ->
+      _miss_or_stale ->
+        # Miss, or a stale fingerprint (issue/template/attempt changed --
+        # e.g. the initial `attempt: nil` row seen by an `attempt: 1`
+        # continuation). Re-render and overwrite under the same key, so the
+        # prior row is reclaimed and a stale render is never served.
         rendered = render_prompt(issue, config, attempt)
 
         :ok =
           Raxol.Agent.Cache.put(
             cache,
             key,
-            rendered,
+            {fingerprint, rendered},
             agent_prompt_cache_ttl_ms(config)
           )
 
@@ -430,24 +474,19 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     end
   end
 
+  defp prompt_cache_key(issue_id), do: {:prompt, issue_id}
+
   # The rendered prompt is a pure function of (issue, template, attempt), so
   # the whole `%Issue{}` is fingerprinted rather than a hand-listed subset:
-  # any field change -> a new key, with zero risk of drifting out of sync
-  # with what the template renders. Over-invalidation (a non-rendered field
-  # wobbling between identical re-dispatches) only costs a re-render, never a
-  # stale prompt -- the safe direction for a self-invalidating cache.
-  defp prompt_cache_key(
-         %Issue{} = issue,
-         %Config{prompt_template: template},
-         attempt
-       ) do
-    fingerprint =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({issue, template, attempt}, [:deterministic])
-      )
-
-    {:prompt, fingerprint}
+  # any field change -> a new fingerprint, with zero risk of drifting out of
+  # sync with what the template renders. A fingerprint mismatch only costs a
+  # re-render (never a stale prompt) -- the safe direction for a
+  # self-invalidating cache.
+  defp prompt_fingerprint(%Issue{} = issue, template, attempt) do
+    :crypto.hash(
+      :sha256,
+      :erlang.term_to_binary({issue, template, attempt}, [:deterministic])
+    )
   end
 
   # `config.runner` is always a map (`Config` builds it so), but `get_in`

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -74,6 +74,26 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   If the Session is no longer in the Registry (e.g. the BEAM
   restarted), resume returns `{:error, :session_not_found}` and
   the orchestrator's retry-on-error path kicks in.
+
+  ## Prompt caching
+
+  Optional: set `agent.prompt_cache` to a `{module, config}` tuple
+  (or a bare `Raxol.Agent.Cache`-impl module) and the runner will
+  cache the rendered prompt across fresh runs. The cache key is
+  `{:prompt, sha256({issue prompt-fields, prompt_template, attempt})}`
+  and the TTL defaults to 300s, overridden by
+  `agent.prompt_cache_ttl_ms`.
+
+  Unlike `RaxolAgent`'s `tracker_cache` (which caches a network
+  `still_active?` check and so trades freshness for HTTP cost), this
+  cache is **self-invalidating**: the rendered prompt is a pure
+  function of the fingerprinted determinants, so any change to the
+  issue content, template, or attempt yields a new key. The TTL is
+  only an eviction/memory bound, never a staleness window. The hit
+  case is a continuation re-dispatch of an unchanged issue at the
+  same attempt. It caches a CPU-bound Liquid render (not a network
+  call), so the win is modest; it is opt-in and **off by default**
+  (`prompt_cache` unset preserves the existing per-run render).
   """
 
   @behaviour Raxol.Symphony.Runner
@@ -84,12 +104,14 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
   @compile {:no_warn_undefined,
             [
+              Raxol.Agent.Cache,
               Raxol.Agent.Session,
               Raxol.Agent.Session.Supervisor,
               Raxol.Agent.SessionStreamer
             ]}
 
   @default_timeout_ms 60_000
+  @default_prompt_cache_ttl_ms 300_000
 
   @impl Runner
   def run(%Issue{} = issue, %Config{} = config, opts) do
@@ -320,12 +342,64 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   defp build_session_id(%Issue{id: id}, attempt),
     do: "symphony-session-#{id}-#{attempt || 0}-#{:erlang.unique_integer([:positive])}"
 
+  # Renders the seed prompt, optionally through the opt-in prompt cache.
+  # The rendered prompt is a pure function of the fingerprinted
+  # determinants, so the content-hash key is self-invalidating (see the
+  # "Prompt caching" moduledoc section). A `nil` cache renders directly.
   defp build_prompt(issue, config, attempt) do
+    case agent_prompt_cache(config) do
+      nil ->
+        render_prompt(issue, config, attempt)
+
+      cache ->
+        key = prompt_cache_key(issue, config, attempt)
+
+        case Raxol.Agent.Cache.get(cache, key) do
+          {:ok, cached} ->
+            cached
+
+          :miss ->
+            rendered = render_prompt(issue, config, attempt)
+            ttl = agent_prompt_cache_ttl_ms(config)
+            :ok = Raxol.Agent.Cache.put(cache, key, rendered, ttl)
+            rendered
+        end
+    end
+  end
+
+  defp render_prompt(issue, config, attempt) do
     case PromptBuilder.build(issue, config.prompt_template, attempt) do
       {:ok, rendered} -> rendered
       _ -> PromptBuilder.default_prompt()
     end
   end
+
+  defp prompt_cache_key(%Issue{} = issue, %Config{prompt_template: template}, attempt) do
+    fingerprint =
+      :crypto.hash(
+        :sha256,
+        :erlang.term_to_binary({prompt_fields(issue), template, attempt})
+      )
+
+    {:prompt, fingerprint}
+  end
+
+  # Exactly the fields `PromptBuilder.issue_to_liquid_map/1` renders into
+  # the template — the full determinant set of the rendered prompt.
+  defp prompt_fields(%Issue{} = issue) do
+    {issue.id, issue.identifier, issue.title, issue.description, issue.state, issue.url,
+     issue.labels, issue.priority, issue.branch_name, issue.created_at, issue.updated_at,
+     issue.blocked_by}
+  end
+
+  # `config.runner` is always a map (`Config` builds it so), but `get_in`
+  # tolerates a nil/blank runner or a missing `:agent`/key -- a single
+  # total clause, so there is no provably-dead catch-all to warn on.
+  defp agent_prompt_cache(%Config{runner: runner}),
+    do: Raxol.Agent.Cache.normalize(get_in(runner, [:agent, :prompt_cache]))
+
+  defp agent_prompt_cache_ttl_ms(%Config{runner: runner}),
+    do: get_in(runner, [:agent, :prompt_cache_ttl_ms]) || @default_prompt_cache_ttl_ms
 
   defp raxol_agent_loaded?, do: Code.ensure_loaded?(Raxol.Agent.Session)
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -116,21 +116,27 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
       reads the entry and **deletes it on that read**, so a continued
       issue oscillates between one and zero rows.
     * **Terminal flush.** `flush_prompt_cache/2` deletes an issue's row
-      by `issue.id`. The orchestrator calls it when an issue leaves the
-      run set (reached a terminal state, or was dropped), which reclaims
-      the single row a one-shot issue (completes on first dispatch, no
-      continuation reads it) or an odd-length continuation chain leaves
-      behind. Because the key is `issue.id` alone, this works even
-      though the issue's content (and thus its fingerprint) has changed
-      by the time it is observed terminal.
+      by `issue.id`. The orchestrator calls it at *every* site an issue
+      leaves the run set for good: a retry that finds it terminal, gone,
+      or no longer active; a user `stop_run` (whether it was running or
+      paused); and a reconcile-kill. This reclaims the single row a
+      one-shot issue (completes on first dispatch, no continuation reads
+      it), or an odd-length continuation chain, leaves behind. Because
+      the key is `issue.id` alone, this works even though the issue's
+      content (and thus its fingerprint) has changed by the time it is
+      observed terminal.
 
-  Together these keep the live-entry count at `O(issues currently
-  in-flight)`, not `O(issues ever processed)`. The TTL is only a
-  backstop for the edge exits the orchestrator does not route through
-  `flush_prompt_cache/2`; it is not the primary bound, because
-  `Cache.Ets` expires lazily (only a same-key `get` reclaims a stale
-  entry) and a row whose issue has moved on is never `get` again. There
-  is no background sweeper.
+  Together these give a true `O(issues currently in-flight)` bound, not
+  `O(issues ever processed)`: every path that drops an issue's claim also
+  flushes its row (the shared `remove_running` helper is *not* flushed
+  in-place, because the stall path reuses it before re-dispatching; the
+  terminal callers flush at their own call sites instead), so no row
+  outlives the run that wrote it. The TTL is therefore not a correctness
+  backstop for that bound -- a row whose issue has moved on is never
+  `get` again, so `Cache.Ets`'s lazy expiry (only a same-key `get`
+  reclaims a stale entry) could not fire for it in any case. The TTL's
+  sole job is to cap the staleness of a row that is rewritten in place
+  while its issue is still in-flight. There is no background sweeper.
 
   ### Relationship to `PromptBuilder`'s template memo
 
@@ -153,8 +159,6 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   """
 
   @behaviour Raxol.Symphony.Runner
-
-  require Logger
 
   alias Raxol.Symphony.{Config, Issue, PromptBuilder, Runner}
 

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -345,25 +345,26 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   # Renders the seed prompt, optionally through the opt-in prompt cache.
   # The rendered prompt is a pure function of the fingerprinted
   # determinants, so the content-hash key is self-invalidating (see the
-  # "Prompt caching" moduledoc section). A `nil` cache renders directly.
-  defp build_prompt(issue, config, attempt) do
-    case agent_prompt_cache(config) do
-      nil ->
-        render_prompt(issue, config, attempt)
+  # "Prompt caching" moduledoc section).
+  defp build_prompt(issue, config, attempt),
+    do: render_cached(agent_prompt_cache(config), issue, config, attempt)
 
-      cache ->
-        key = prompt_cache_key(issue, config, attempt)
+  # No cache configured (the default): render directly, unchanged behaviour.
+  defp render_cached(nil, issue, config, attempt),
+    do: render_prompt(issue, config, attempt)
 
-        case Raxol.Agent.Cache.get(cache, key) do
-          {:ok, cached} ->
-            cached
+  # Cache configured: reuse the memoized render, or compute and store it.
+  defp render_cached(cache, issue, config, attempt) do
+    key = prompt_cache_key(issue, config, attempt)
 
-          :miss ->
-            rendered = render_prompt(issue, config, attempt)
-            ttl = agent_prompt_cache_ttl_ms(config)
-            :ok = Raxol.Agent.Cache.put(cache, key, rendered, ttl)
-            rendered
-        end
+    case Raxol.Agent.Cache.get(cache, key) do
+      {:ok, cached} ->
+        cached
+
+      :miss ->
+        rendered = render_prompt(issue, config, attempt)
+        :ok = Raxol.Agent.Cache.put(cache, key, rendered, agent_prompt_cache_ttl_ms(config))
+        rendered
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -80,8 +80,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   Optional: set `agent.prompt_cache` to a `{module, config}` tuple
   (or a bare `Raxol.Agent.Cache`-impl module) and the runner will
   cache the rendered prompt across fresh runs. The cache key is
-  `{:prompt, sha256({issue prompt-fields, prompt_template, attempt})}`
-  and the TTL defaults to 300s, overridden by
+  `{:prompt, sha256({issue, prompt_template, attempt})}` (the full
+  `%Issue{}` is fingerprinted, so the key can never drift from what
+  the template renders) and the TTL defaults to 300s, overridden by
   `agent.prompt_cache_ttl_ms`.
 
   Unlike `RaxolAgent`'s `tracker_cache` (which caches a network
@@ -91,9 +92,27 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   issue content, template, or attempt yields a new key. The TTL is
   only an eviction/memory bound, never a staleness window. The hit
   case is a continuation re-dispatch of an unchanged issue at the
-  same attempt. It caches a CPU-bound Liquid render (not a network
-  call), so the win is modest; it is opt-in and **off by default**
-  (`prompt_cache` unset preserves the existing per-run render).
+  same attempt. It is opt-in and **off by default** (`prompt_cache`
+  unset preserves the existing per-run render).
+
+  ### Relationship to `PromptBuilder`'s template memo
+
+  This layers ON TOP of `PromptBuilder`'s parsed-template memo, it does
+  not duplicate it. The two cache different stages of the same pipeline:
+
+    * `PromptBuilder` memoizes the **parsed Liquid AST**, keyed by the
+      template string. That is shared across *every* issue using a given
+      `WORKFLOW.md` and always on -- it removes the re-parse cost.
+    * This `prompt_cache` memoizes the **fully rendered prompt**, keyed by
+      (issue, template, attempt). It removes the per-issue variable
+      substitution too, but only for the narrow hit case above.
+
+  So on a continuation re-dispatch of an unchanged issue, the parse is
+  skipped by `PromptBuilder` and the render is skipped here. The render
+  is CPU-bound (not a network call) and the AST is already memoized, so
+  this second layer's marginal win is small -- which is exactly why it is
+  off by default and worth enabling only for high-churn continuation
+  queues where the render cost is measured to matter.
   """
 
   @behaviour Raxol.Symphony.Runner
@@ -170,7 +189,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     end
   end
 
-  defp resume_run(%Issue{} = issue, %Config{} = config, opts, resume_token, resume_value) do
+  defp resume_run(
+         %Issue{} = issue,
+         %Config{} = config,
+         opts,
+         resume_token,
+         resume_value
+       ) do
     parent = Keyword.fetch!(opts, :parent)
     timeout_ms = session_timeout_ms(config)
     %{session_id: session_id} = resume_token
@@ -329,7 +354,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
   # -- Helpers --
 
-  defp agent_module(%Config{runner: %{agent: %{module: mod}}}) when is_atom(mod), do: mod
+  defp agent_module(%Config{runner: %{agent: %{module: mod}}})
+       when is_atom(mod), do: mod
+
   defp agent_module(_), do: nil
 
   defp session_timeout_ms(%Config{runner: %{agent: agent}}) do
@@ -340,7 +367,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   end
 
   defp build_session_id(%Issue{id: id}, attempt),
-    do: "symphony-session-#{id}-#{attempt || 0}-#{:erlang.unique_integer([:positive])}"
+    do:
+      "symphony-session-#{id}-#{attempt || 0}-#{:erlang.unique_integer([:positive])}"
 
   # Renders the seed prompt, optionally through the opt-in prompt cache.
   # The rendered prompt is a pure function of the fingerprinted
@@ -363,7 +391,15 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
       :miss ->
         rendered = render_prompt(issue, config, attempt)
-        :ok = Raxol.Agent.Cache.put(cache, key, rendered, agent_prompt_cache_ttl_ms(config))
+
+        :ok =
+          Raxol.Agent.Cache.put(
+            cache,
+            key,
+            rendered,
+            agent_prompt_cache_ttl_ms(config)
+          )
+
         rendered
     end
   end
@@ -375,22 +411,21 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     end
   end
 
-  defp prompt_cache_key(%Issue{} = issue, %Config{prompt_template: template}, attempt) do
+  # The rendered prompt is a pure function of (issue, template, attempt), so
+  # the whole `%Issue{}` is fingerprinted rather than a hand-listed subset:
+  # any field change -> a new key, with zero risk of drifting out of sync
+  # with what the template renders. Over-invalidation (a non-rendered field
+  # wobbling between identical re-dispatches) only costs a re-render, never a
+  # stale prompt -- the safe direction for a self-invalidating cache.
+  defp prompt_cache_key(
+         %Issue{} = issue,
+         %Config{prompt_template: template},
+         attempt
+       ) do
     fingerprint =
-      :crypto.hash(
-        :sha256,
-        :erlang.term_to_binary({prompt_fields(issue), template, attempt})
-      )
+      :crypto.hash(:sha256, :erlang.term_to_binary({issue, template, attempt}))
 
     {:prompt, fingerprint}
-  end
-
-  # Exactly the fields `PromptBuilder.issue_to_liquid_map/1` renders into
-  # the template — the full determinant set of the rendered prompt.
-  defp prompt_fields(%Issue{} = issue) do
-    {issue.id, issue.identifier, issue.title, issue.description, issue.state, issue.url,
-     issue.labels, issue.priority, issue.branch_name, issue.created_at, issue.updated_at,
-     issue.blocked_by}
   end
 
   # `config.runner` is always a map (`Config` builds it so), but `get_in`
@@ -400,7 +435,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     do: Raxol.Agent.Cache.normalize(get_in(runner, [:agent, :prompt_cache]))
 
   defp agent_prompt_cache_ttl_ms(%Config{runner: runner}),
-    do: get_in(runner, [:agent, :prompt_cache_ttl_ms]) || @default_prompt_cache_ttl_ms
+    do:
+      get_in(runner, [:agent, :prompt_cache_ttl_ms]) ||
+        @default_prompt_cache_ttl_ms
 
   defp raxol_agent_loaded?, do: Code.ensure_loaded?(Raxol.Agent.Session)
 end

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
@@ -51,6 +51,53 @@ defmodule Raxol.Symphony.OrchestratorTest do
     pid
   end
 
+  # An isolated ETS-backed prompt cache, mirroring the session-runner harness.
+  defp ets_cache_adapter do
+    table = :"orch_prompt_cache_test_#{:erlang.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+    end)
+
+    {Raxol.Agent.Cache.Ets, %{table: table}}
+  end
+
+  # A config whose session runner has `prompt_cache` wired, so the
+  # orchestrator's terminal flush actually reclaims rows. Dispatch still runs
+  # through the Noop runner (via `runner_module:`), which never writes the
+  # cache -- so the row is seeded directly, standing in for what a real
+  # `RaxolAgentSession` dispatch would have left behind.
+  defp cache_config(adapter) do
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{
+          kind: "memory",
+          active_states: ["Todo", "In Progress"],
+          terminal_states: ["Done", "Cancelled"]
+        },
+        polling: %{interval_ms: 60_000},
+        agent: %{max_concurrent_agents: 3, max_retry_backoff_ms: 60_000},
+        codex: %{stall_timeout_ms: 0},
+        runner: %{kind: "noop", agent: %{prompt_cache: adapter}}
+      },
+      prompt_template: ""
+    })
+  end
+
+  defp seed_prompt_row(adapter, issue_id) do
+    :ok =
+      Raxol.Agent.Cache.put(
+        adapter,
+        {:prompt, issue_id},
+        {<<0>>, "SEEDED"},
+        60_000
+      )
+  end
+
+  defp cache_size({_module, %{table: table}}) do
+    if :ets.whereis(table) == :undefined, do: 0, else: :ets.info(table, :size)
+  end
+
   defp wait_until(timeout_ms \\ 1_000, fun) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_until(deadline, fun)
@@ -317,6 +364,90 @@ defmodule Raxol.Symphony.OrchestratorTest do
       [paused] = Orchestrator.snapshot(pid).paused
       assert paused.turn_count == 1
       assert paused.tokens.total_tokens == 30
+    end
+  end
+
+  # Each terminal release site must flush the issue's prompt-cache row so a
+  # bounded (per-issue, single-slot) cache never leaks one permanent resident
+  # row per stopped/reconciled issue. The row is seeded directly here because
+  # dispatch goes through the Noop runner, which never writes the cache; the
+  # seed stands in for the row a real `RaxolAgentSession` dispatch leaves.
+  describe "prompt-cache flush on terminal exits" do
+    test "stop_run of a running issue reclaims its cache row" do
+      adapter = ets_cache_adapter()
+      config = cache_config(adapter)
+      Memory.put_issue(issue("a", "MT-1", "Todo"))
+      Noop.Director.set("MT-1", :stall)
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+      assert Orchestrator.snapshot(pid).counts.running == 1
+
+      seed_prompt_row(adapter, "a")
+      assert cache_size(adapter) == 1
+
+      assert :ok = Orchestrator.stop_run(pid, "a")
+      wait_until(fn -> Orchestrator.snapshot(pid).counts.running == 0 end)
+
+      assert cache_size(adapter) == 0
+    end
+
+    test "stop_run of a paused issue reclaims its cache row" do
+      adapter = ets_cache_adapter()
+      config = cache_config(adapter)
+      Memory.put_issue(issue("a", "MT-1", "Todo"))
+      Noop.Director.set("MT-1", {:pause, :awaiting_review, %{pr: 7}})
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+      wait_until(fn -> Orchestrator.snapshot(pid).counts.paused == 1 end)
+
+      seed_prompt_row(adapter, "a")
+      assert cache_size(adapter) == 1
+
+      assert :ok = Orchestrator.stop_run(pid, "a")
+
+      assert cache_size(adapter) == 0
+      assert Orchestrator.snapshot(pid).counts.paused == 0
+    end
+
+    test "reconcile-kill of a now-terminal issue reclaims its cache row" do
+      adapter = ets_cache_adapter()
+      config = cache_config(adapter)
+      Memory.put_issue(issue("a", "MT-1", "Todo"))
+      Noop.Director.set("MT-1", :stall)
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+      assert Orchestrator.snapshot(pid).counts.running == 1
+
+      seed_prompt_row(adapter, "a")
+      assert cache_size(adapter) == 1
+
+      # Tracker goes terminal -> reconcile terminates the run (terminate_running).
+      Memory.transition("a", "Done")
+      :ok = Orchestrator.tick_now(pid)
+      wait_until(fn -> Orchestrator.snapshot(pid).counts.running == 0 end)
+
+      assert cache_size(adapter) == 0
+    end
+
+    test "a normal exit (continuation) does NOT flush -- the row is re-used" do
+      adapter = ets_cache_adapter()
+      config = cache_config(adapter)
+      Memory.put_issue(issue("a", "MT-1", "Todo"))
+      Noop.Director.set("MT-1", {:succeed_after, 20})
+
+      seed_prompt_row(adapter, "a")
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+
+      # Worker exits :normal -> continuation retry, issue stays active (Todo),
+      # so the same issue.id is re-dispatched. The terminal flush must NOT run.
+      wait_until(fn -> Orchestrator.snapshot(pid).counts.retrying == 1 end)
+
+      assert cache_size(adapter) == 1
     end
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
@@ -1,0 +1,124 @@
+defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
+  @moduledoc """
+  Verifies the `agent.prompt_cache` opt-in on the session runner: the
+  rendered seed prompt is cached across fresh runs under a self-invalidating
+  content-hash key `{:prompt, sha256({issue prompt-fields, template, attempt})}`.
+
+  Strategy mirrors the `tracker_cache` test: configure an ETS-backed cache,
+  drive a real run, then read the ETS table directly. Cache HIT is proven
+  decisively by poisoning the populated key with a sentinel and showing a
+  second identical run leaves it untouched (a miss would re-render + overwrite).
+
+  Defaults: `prompt_cache` is `nil` (no caching); `prompt_cache_ttl_ms`
+  defaults to 300_000 (5 min).
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Config, Issue}
+  alias Raxol.Symphony.Runners.RaxolAgentSession
+  alias Raxol.Symphony.TestSupport.SessionAgentSucceed
+
+  setup do
+    case Process.whereis(Raxol.Agent.Registry) do
+      nil -> start_supervised!(Raxol.Agent.Supervisor)
+      _pid -> :ok
+    end
+
+    :ok
+  end
+
+  defp ets_cache_adapter do
+    table = :"sym_session_prompt_cache_test_#{:erlang.unique_integer([:positive])}"
+    on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table) end)
+    {Raxol.Agent.Cache.Ets, %{table: table}}
+  end
+
+  # `prompt_template` renders to the issue identifier ("MT-1"), so the cached
+  # prompt value is a known string.
+  defp config(agent_overrides) do
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{
+          kind: "memory",
+          active_states: ["Todo"],
+          terminal_states: ["Done"]
+        },
+        agent: %{max_turns: 1},
+        runner: %{
+          kind: "raxol_agent_session",
+          agent: Map.merge(%{module: SessionAgentSucceed}, agent_overrides)
+        }
+      },
+      prompt_template: "{{ issue.identifier }}"
+    })
+  end
+
+  defp issue, do: %Issue{id: "issue-1", identifier: "MT-1", title: "T", state: "Todo"}
+
+  defp run(cfg, attempt \\ nil) do
+    RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: attempt)
+  end
+
+  defp table_of({_module, %{table: table}}), do: table
+
+  describe "prompt_cache: nil (default)" do
+    test "no cache is consulted; the run still completes" do
+      assert :ok = run(config(%{}))
+    end
+  end
+
+  describe "prompt_cache: {Ets, ...}" do
+    test "a fresh run populates the cache with the rendered prompt" do
+      adapter = ets_cache_adapter()
+
+      assert :ok = run(config(%{prompt_cache: adapter}))
+
+      # Exactly one entry, holding the rendered template ("MT-1").
+      assert [{_key, "MT-1", _expiry}] = :ets.tab2list(table_of(adapter))
+    end
+
+    test "a second identical run hits the cache instead of re-rendering" do
+      adapter = ets_cache_adapter()
+      cfg = config(%{prompt_cache: adapter, prompt_cache_ttl_ms: 60_000})
+
+      assert :ok = run(cfg)
+      [{key, "MT-1", _}] = :ets.tab2list(table_of(adapter))
+
+      # Poison the populated key. A HIT returns this without re-rendering and
+      # never writes; a MISS would recompute "MT-1" and overwrite the sentinel.
+      :ok = Raxol.Agent.Cache.put(adapter, key, "SENTINEL-PROMPT", 60_000)
+
+      assert :ok = run(cfg)
+
+      assert {:ok, "SENTINEL-PROMPT"} = Raxol.Agent.Cache.get(adapter, key)
+      assert length(:ets.tab2list(table_of(adapter))) == 1
+    end
+
+    test "a different attempt is a distinct key (attempt is in the fingerprint)" do
+      adapter = ets_cache_adapter()
+      cfg = config(%{prompt_cache: adapter})
+
+      assert :ok = run(cfg, 1)
+      assert :ok = run(cfg, 2)
+
+      assert length(:ets.tab2list(table_of(adapter))) == 2
+    end
+
+    test "default TTL is 300s when prompt_cache_ttl_ms is unset" do
+      adapter = ets_cache_adapter()
+
+      assert :ok = run(config(%{prompt_cache: adapter}))
+
+      assert [{_key, "MT-1", %DateTime{} = expiry}] = :ets.tab2list(table_of(adapter))
+      # Well beyond a 30s window -> the 300s default, not some shorter TTL.
+      assert DateTime.diff(expiry, DateTime.utc_now()) > 60
+    end
+
+    test "bare-module form is accepted via Cache.normalize/1" do
+      # A bare module normalizes to `{module, %{}}` (default table). We only
+      # assert the run completes -- normalize/1 itself is covered elsewhere.
+      assert :ok = run(config(%{prompt_cache: Raxol.Agent.Cache.Ets}))
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
@@ -2,7 +2,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
   @moduledoc """
   Verifies the `agent.prompt_cache` opt-in on the session runner: the
   rendered seed prompt is cached across fresh runs under a self-invalidating
-  content-hash key `{:prompt, sha256({issue prompt-fields, template, attempt})}`.
+  content-hash key `{:prompt, sha256({issue, template, attempt})}`.
 
   Strategy mirrors the `tracker_cache` test: configure an ETS-backed cache,
   drive a real run, then read the ETS table directly. Cache HIT is proven
@@ -29,8 +29,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
   end
 
   defp ets_cache_adapter do
-    table = :"sym_session_prompt_cache_test_#{:erlang.unique_integer([:positive])}"
-    on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table) end)
+    table =
+      :"sym_session_prompt_cache_test_#{:erlang.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+    end)
+
     {Raxol.Agent.Cache.Ets, %{table: table}}
   end
 
@@ -54,7 +59,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
     })
   end
 
-  defp issue, do: %Issue{id: "issue-1", identifier: "MT-1", title: "T", state: "Todo"}
+  defp issue,
+    do: %Issue{id: "issue-1", identifier: "MT-1", title: "T", state: "Todo"}
 
   defp run(cfg, attempt \\ nil) do
     RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: attempt)
@@ -105,12 +111,38 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
       assert length(:ets.tab2list(table_of(adapter))) == 2
     end
 
+    test "the whole issue is fingerprinted: same render, differing field -> distinct keys" do
+      adapter = ets_cache_adapter()
+      cfg = config(%{prompt_cache: adapter})
+
+      # Both render to "MT-1" (template is {{ issue.identifier }}) but differ
+      # in `description`, which the template never renders. The key is the
+      # full %Issue{}, so they must NOT collide -- proving the key tracks all
+      # determinants, not just the rendered output, and can never drift from
+      # a hand-listed field subset.
+      assert :ok =
+               RaxolAgentSession.run(%{issue() | description: "A"}, cfg,
+                 parent: self()
+               )
+
+      assert :ok =
+               RaxolAgentSession.run(%{issue() | description: "B"}, cfg,
+                 parent: self()
+               )
+
+      entries = :ets.tab2list(table_of(adapter))
+      assert length(entries) == 2
+      assert Enum.all?(entries, fn {_k, rendered, _e} -> rendered == "MT-1" end)
+    end
+
     test "default TTL is 300s when prompt_cache_ttl_ms is unset" do
       adapter = ets_cache_adapter()
 
       assert :ok = run(config(%{prompt_cache: adapter}))
 
-      assert [{_key, "MT-1", %DateTime{} = expiry}] = :ets.tab2list(table_of(adapter))
+      assert [{_key, "MT-1", %DateTime{} = expiry}] =
+               :ets.tab2list(table_of(adapter))
+
       # Well beyond a 30s window -> the 300s default, not some shorter TTL.
       assert DateTime.diff(expiry, DateTime.utc_now()) > 60
     end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
@@ -1,13 +1,21 @@
 defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
   @moduledoc """
-  Verifies the `agent.prompt_cache` opt-in on the session runner: the
-  rendered seed prompt is cached across fresh runs under a self-invalidating
-  content-hash key `{:prompt, sha256({issue, template, attempt})}`.
+  Verifies the `agent.prompt_cache` opt-in on the session runner.
 
-  Strategy mirrors the `tracker_cache` test: configure an ETS-backed cache,
-  drive a real run, then read the ETS table directly. Cache HIT is proven
-  decisively by poisoning the populated key with a sentinel and showing a
-  second identical run leaves it untouched (a miss would re-render + overwrite).
+  The rendered seed prompt is cached across fresh runs under the stable
+  per-issue key `{:prompt, issue.id}`, with the stored value
+  `{sha256({issue, template, attempt}), rendered}`. The fingerprint (not
+  the key) guards freshness: a mismatch is a miss + overwrite, so a stale
+  render is never served and an issue holds at most one row.
+
+  Bounding comes from three mechanisms, each exercised below:
+
+    * overwrite on a freshness miss (the initial `attempt: nil` row is
+      reclaimed by its `attempt: 1` continuation),
+    * read-once delete on an exact hit (a continued issue oscillates
+      between one and zero rows), and
+    * `flush_prompt_cache/2`, which the orchestrator calls when an issue
+      leaves the run set, reclaiming the one row a one-shot issue leaves.
 
   Defaults: `prompt_cache` is `nil` (no caching); `prompt_cache_ttl_ms`
   defaults to 300_000 (5 min).
@@ -17,7 +25,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
 
   alias Raxol.Symphony.{Config, Issue}
   alias Raxol.Symphony.Runners.RaxolAgentSession
-  alias Raxol.Symphony.TestSupport.SessionAgentSucceed
+
+  alias Raxol.Symphony.TestSupport.{
+    SessionAgentEcho,
+    SessionAgentSucceed
+  }
 
   setup do
     case Process.whereis(Raxol.Agent.Registry) do
@@ -41,7 +53,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
 
   # `prompt_template` renders to the issue identifier ("MT-1"), so the cached
   # prompt value is a known string.
-  defp config(agent_overrides) do
+  defp config(agent_overrides, module \\ SessionAgentSucceed) do
     Config.from_workflow(%{
       config: %{
         tracker: %{
@@ -52,7 +64,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
         agent: %{max_turns: 1},
         runner: %{
           kind: "raxol_agent_session",
-          agent: Map.merge(%{module: SessionAgentSucceed}, agent_overrides)
+          agent: Map.merge(%{module: module}, agent_overrides)
         }
       },
       prompt_template: "{{ issue.identifier }}"
@@ -68,6 +80,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
 
   defp table_of({_module, %{table: table}}), do: table
 
+  defp entries(adapter), do: :ets.tab2list(table_of(adapter))
+
   describe "prompt_cache: nil (default)" do
     test "no cache is consulted; the run still completes" do
       assert :ok = run(config(%{}))
@@ -75,64 +89,136 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
   end
 
   describe "prompt_cache: {Ets, ...}" do
-    test "a fresh run populates the cache with the rendered prompt" do
+    test "a fresh run populates the cache with a fingerprinted rendered prompt" do
       adapter = ets_cache_adapter()
 
       assert :ok = run(config(%{prompt_cache: adapter}))
 
-      # Exactly one entry, holding the rendered template ("MT-1").
-      assert [{_key, "MT-1", _expiry}] = :ets.tab2list(table_of(adapter))
+      # Exactly one entry: value is `{fingerprint, rendered}` and renders the
+      # template ("MT-1"). Key is the stable per-issue slot.
+      assert [{{:prompt, "issue-1"}, {fp, "MT-1"}, _expiry}] = entries(adapter)
+      assert is_binary(fp)
     end
 
-    test "a second identical run hits the cache instead of re-rendering" do
+    test "a continuation of an unchanged issue hits the cache and serves the render" do
       adapter = ets_cache_adapter()
-      cfg = config(%{prompt_cache: adapter, prompt_cache_ttl_ms: 60_000})
+      cfg = config(%{prompt_cache: adapter, prompt_cache_ttl_ms: 60_000}, SessionAgentEcho)
 
-      assert :ok = run(cfg)
-      [{key, "MT-1", _}] = :ets.tab2list(table_of(adapter))
+      # First dispatch: miss -> render "MT-1" -> stored under fingerprint `fp`.
+      assert :ok = run(cfg, 1)
+      assert_receive {:run_event, "issue-1", %{event: :turn_complete, prompt: "MT-1"}}
+      [{key, {fp, "MT-1"}, _}] = entries(adapter)
 
-      # Poison the populated key. A HIT returns this without re-rendering and
-      # never writes; a MISS would recompute "MT-1" and overwrite the sentinel.
-      :ok = Raxol.Agent.Cache.put(adapter, key, "SENTINEL-PROMPT", 60_000)
-
-      assert :ok = run(cfg)
-
-      assert {:ok, "SENTINEL-PROMPT"} = Raxol.Agent.Cache.get(adapter, key)
-      assert length(:ets.tab2list(table_of(adapter))) == 1
-    end
-
-    test "a different attempt is a distinct key (attempt is in the fingerprint)" do
-      adapter = ets_cache_adapter()
-      cfg = config(%{prompt_cache: adapter})
+      # Poison the row's value under the SAME fingerprint. A HIT serves this
+      # sentinel (the agent echoes it back) and deletes it (read-once); a MISS
+      # would re-render "MT-1" and overwrite, so the sentinel would never show.
+      :ok = Raxol.Agent.Cache.put(adapter, key, {fp, "SENTINEL-PROMPT"}, 60_000)
 
       assert :ok = run(cfg, 1)
-      assert :ok = run(cfg, 2)
 
-      assert length(:ets.tab2list(table_of(adapter))) == 2
+      assert_receive {:run_event, "issue-1", %{event: :turn_complete, prompt: "SENTINEL-PROMPT"}}
+
+      # Read-once flushed the row on the hit.
+      assert :miss = Raxol.Agent.Cache.get(adapter, key)
+      assert entries(adapter) == []
     end
 
-    test "the whole issue is fingerprinted: same render, differing field -> distinct keys" do
+    test "the initial attempt: nil row is reclaimed by its attempt: 1 continuation" do
       adapter = ets_cache_adapter()
       cfg = config(%{prompt_cache: adapter})
 
-      # Both render to "MT-1" (template is {{ issue.identifier }}) but differ
-      # in `description`, which the template never renders. The key is the
-      # full %Issue{}, so they must NOT collide -- proving the key tracks all
-      # determinants, not just the rendered output, and can never drift from
-      # a hand-listed field subset.
+      # Initial dispatch writes the `attempt: nil` render.
+      assert :ok = run(cfg, nil)
+      assert [{{:prompt, "issue-1"}, {fp_nil, "MT-1"}, _}] = entries(adapter)
+
+      # The first continuation renders at `attempt: 1`. A distinct fingerprint
+      # (attempt feeds the render) makes it a miss, so it overwrites the SAME
+      # per-issue key instead of orphaning a second row. Old design (attempt in
+      # the key) left the nil row behind -> a permanent per-issue leak.
+      assert :ok = run(cfg, 1)
+      assert [{{:prompt, "issue-1"}, {fp_one, "MT-1"}, _}] = entries(adapter)
+
+      assert :ets.info(table_of(adapter), :size) == 1
+      refute fp_one == fp_nil
+    end
+
+    test "a differing attempt is a freshness miss, not a stale hit" do
+      adapter = ets_cache_adapter()
+      cfg = config(%{prompt_cache: adapter}, SessionAgentEcho)
+
+      assert :ok = run(cfg, 1)
+      [{key, {fp1, "MT-1"}, _}] = entries(adapter)
+
+      # Poison attempt-1's row (keeping its fingerprint). A run at attempt 2 has
+      # a different fingerprint, so it must NOT serve the sentinel -- it
+      # re-renders "MT-1" and overwrites.
+      :ok = Raxol.Agent.Cache.put(adapter, key, {fp1, "STALE"}, 60_000)
+
+      assert :ok = run(cfg, 2)
+
+      assert_receive {:run_event, "issue-1", %{event: :turn_complete, prompt: "MT-1"}}
+      refute_received {:run_event, "issue-1", %{event: :turn_complete, prompt: "STALE"}}
+      assert :ets.info(table_of(adapter), :size) == 1
+    end
+
+    test "a differing issue field is a freshness miss, not a stale hit" do
+      adapter = ets_cache_adapter()
+      cfg = config(%{prompt_cache: adapter})
+
+      # Both render "MT-1" (template is {{ issue.identifier }}) and share
+      # issue.id, but differ in `description`, which the fingerprint covers.
+      # The second run is a freshness miss that overwrites -- one row, never
+      # a stale serve -- proving the fingerprint tracks all determinants.
       assert :ok =
-               RaxolAgentSession.run(%{issue() | description: "A"}, cfg,
-                 parent: self()
-               )
+               RaxolAgentSession.run(%{issue() | description: "A"}, cfg, parent: self())
+
+      assert [{_key, {fp_a, "MT-1"}, _}] = entries(adapter)
 
       assert :ok =
-               RaxolAgentSession.run(%{issue() | description: "B"}, cfg,
-                 parent: self()
-               )
+               RaxolAgentSession.run(%{issue() | description: "B"}, cfg, parent: self())
 
-      entries = :ets.tab2list(table_of(adapter))
-      assert length(entries) == 2
-      assert Enum.all?(entries, fn {_k, rendered, _e} -> rendered == "MT-1" end)
+      assert [{_key, {fp_b, "MT-1"}, _}] = entries(adapter)
+      assert :ets.info(table_of(adapter), :size) == 1
+      refute fp_b == fp_a
+    end
+
+    test "flush_prompt_cache/2 reclaims a one-shot issue's row" do
+      adapter = ets_cache_adapter()
+      cfg = config(%{prompt_cache: adapter})
+
+      # A one-shot: written once, never read by a continuation.
+      assert :ok = run(cfg, nil)
+      assert :ets.info(table_of(adapter), :size) == 1
+
+      # The terminal flush (what the orchestrator calls) reclaims it.
+      assert :ok = RaxolAgentSession.flush_prompt_cache(cfg, "issue-1")
+      assert :ets.info(table_of(adapter), :size) == 0
+    end
+
+    test "processing many one-shot issues stays bounded with terminal flush" do
+      adapter = ets_cache_adapter()
+      cfg = config(%{prompt_cache: adapter})
+      table = table_of(adapter)
+
+      # 50 distinct one-shot issues. Each writes one row on its only dispatch;
+      # the terminal flush (orchestrator's `release_issue`) reclaims it. The
+      # live count is O(in-flight) = 1, never O(issues processed).
+      for n <- 1..50 do
+        id = "one-shot-#{n}"
+        iss = %Issue{id: id, identifier: id, title: "T", state: "Todo"}
+
+        assert :ok = RaxolAgentSession.run(iss, cfg, parent: self(), attempt: nil)
+        assert :ets.info(table, :size) == 1
+
+        assert :ok = RaxolAgentSession.flush_prompt_cache(cfg, id)
+        assert :ets.info(table, :size) == 0
+      end
+
+      assert :ets.info(table, :size) == 0
+    end
+
+    test "flush_prompt_cache/2 is a no-op when no prompt_cache is configured" do
+      assert :ok = RaxolAgentSession.flush_prompt_cache(config(%{}), "issue-1")
     end
 
     test "default TTL is 300s when prompt_cache_ttl_ms is unset" do
@@ -140,8 +226,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
 
       assert :ok = run(config(%{prompt_cache: adapter}))
 
-      assert [{_key, "MT-1", %DateTime{} = expiry}] =
-               :ets.tab2list(table_of(adapter))
+      assert [{_key, {_fp, "MT-1"}, %DateTime{} = expiry}] = entries(adapter)
 
       # Well beyond a 30s window -> the 300s default, not some shorter TTL.
       assert DateTime.diff(expiry, DateTime.utc_now()) > 60

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_test.exs
@@ -153,4 +153,57 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
       assert {:ok, RaxolAgentSession} = Raxol.Symphony.Runner.resolve(cfg)
     end
   end
+
+  describe "prompt cache bounding" do
+    setup do
+      table = :"prompt_cache_test_#{:erlang.unique_integer([:positive])}"
+      on_exit(fn -> if :ets.whereis(table) != :undefined, do: :ets.delete(table) end)
+      %{table: table, cache: {Raxol.Agent.Cache.Ets, %{table: table}}}
+    end
+
+    defp cached_config(cache) do
+      config(%{module: SessionAgentSucceed, prompt_cache: cache})
+    end
+
+    defp run_issue(cfg, id) do
+      issue = %Issue{id: id, identifier: id, title: "T", state: "Todo"}
+      assert :ok = RaxolAgentSession.run(issue, cfg, parent: self(), attempt: nil)
+    end
+
+    test "the continuation re-dispatch read flushes its entry", %{
+      table: table,
+      cache: cache
+    } do
+      cfg = cached_config(cache)
+
+      # First dispatch of an issue: cache miss -> render -> one stored entry.
+      run_issue(cfg, "MT-1")
+      assert :ets.info(table, :size) == 1
+
+      # The continuation re-dispatch of the SAME issue/attempt: cache hit,
+      # consumed and flushed on read.
+      run_issue(cfg, "MT-1")
+      assert :ets.info(table, :size) == 0
+    end
+
+    test "many distinct issues do not accumulate entries", %{
+      table: table,
+      cache: cache
+    } do
+      cfg = cached_config(cache)
+
+      # Each issue goes through its miss (write) then its continuation read
+      # (flush). Across 50 distinct issues the table never carries more than
+      # one in-flight entry and ends empty -- no permanent per-issue rows.
+      for n <- 1..50 do
+        id = "MT-#{n}"
+        run_issue(cfg, id)
+        assert :ets.info(table, :size) == 1
+        run_issue(cfg, id)
+        assert :ets.info(table, :size) == 0
+      end
+
+      assert :ets.info(table, :size) == 0
+    end
+  end
 end

--- a/packages/raxol_symphony/test/support/symphony_test_session_agent.ex
+++ b/packages/raxol_symphony/test/support/symphony_test_session_agent.ex
@@ -23,6 +23,33 @@ defmodule Raxol.Symphony.TestSupport.SessionAgentSucceed do
   def view(_model), do: %{type: :text, content: "ok"}
 end
 
+defmodule Raxol.Symphony.TestSupport.SessionAgentEcho do
+  @moduledoc """
+  TEA agent that echoes the seed prompt back in a `:turn_complete`
+  event (surfaced to the runner's parent as a `:run_event`) before
+  `:done`. Used to prove which rendered prompt the cache served.
+  """
+
+  def init(_args), do: {%{}, []}
+
+  def update({:agent_message, _, {:symphony_start, payload}}, model) do
+    if Code.ensure_loaded?(Raxol.Agent.SessionStreamer) do
+      Raxol.Agent.SessionStreamer.emit(
+        payload.session_id,
+        {:turn_complete, %{prompt: payload.prompt}}
+      )
+
+      Raxol.Agent.SessionStreamer.emit(payload.session_id, {:done, %{result: :ok}})
+    end
+
+    {model, []}
+  end
+
+  def update(_msg, model), do: {model, []}
+
+  def view(_model), do: %{type: :text, content: "echo"}
+end
+
 defmodule Raxol.Symphony.TestSupport.SessionAgentErrors do
   @moduledoc """
   TEA agent module that emits a `:error` event on `:symphony_start`.


### PR DESCRIPTION
Closes #519. Implements Part 1 of the [design posted on the issue](https://github.com/DROOdotFOO/raxol/issues/519#issuecomment-5084268909); Part 2 (template-AST memoization) is tracked in #739.

## What

`Runners.RaxolAgentSession` has no per-turn tracker poll (unlike `Runners.RaxolAgent`, whose `tracker_cache` caches a network `still_active?` check between turns), so "the same opt-in pattern" had no obvious hook — which is why #519 was deferred from #516. Investigation found the session runner's one deterministic, per-run-repeated artifact is the **rendered seed prompt** (`build_prompt/3` → `PromptBuilder.build/3`), a pure function of `(issue prompt-fields, prompt_template, attempt)`.

This adds an opt-in `agent.prompt_cache` mirroring the `tracker_cache` shape.

## Design

- **Config (no `Config`/`Schema` change):** `config.runner.agent` is a verbatim passthrough, so `prompt_cache` / `prompt_cache_ttl_ms` are read straight from it:
  ```
  runner:
    agent:
      prompt_cache: {Raxol.Agent.Cache.Ets, %{table: :symphony_prompt_cache}}
      prompt_cache_ttl_ms: 300_000   # optional, default 300_000
  ```
- **Self-invalidating key:** `{:prompt, sha256(term_to_binary({issue_prompt_fields, prompt_template, attempt}))}`, where `issue_prompt_fields` is exactly the set `PromptBuilder.issue_to_liquid_map/1` renders. Because the prompt is a *pure* function of these determinants, any change yields a new key — there is **no staleness window** (unlike `tracker_cache`, whose TTL trades freshness for HTTP cost). The TTL is only an eviction bound.
- **Off by default:** `prompt_cache` unset renders exactly as today. `Raxol.Agent.Cache.get(nil, _) == :miss` and `put(nil, ...)` is a no-op, so the unset path is byte-identical.
- **Reuses** the existing `Raxol.Agent.Cache` behaviour + `Cache.Ets` impl from `raxol_agent` (`get/2`, `put/4`, `normalize/1`).

**Honest value note:** this caches a sub-millisecond CPU Liquid render, not a network call — the win is modest (it hits on a continuation re-dispatch of an unchanged issue at the same attempt). It exists to give operators the knob and to complete opt-in symmetry with `RaxolAgent`. The larger, *shared* cost is the repeated template *parse*, addressed by #739.

## Implementation note

The two config helpers use a single total `%Config{runner: runner}` clause with `get_in/2` rather than the two-clause `%Config{runner: %{agent: agent}}` + catch-all that `RaxolAgent` uses — the catch-all is provably dead (callers always pass a `%Config{}`) and the compiler warns on it (as it already does in `raxol_agent.ex`). The single-clause form is total and warning-free.

## Files

- `packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex` — moduledoc "Prompt caching" section, `@default_prompt_cache_ttl_ms`, cache branch in `build_prompt/3`, `prompt_cache_key/3` + `prompt_fields/1` + the two config helpers.
- `packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs` — new.

## Tests

New `raxol_agent_session_prompt_cache_test.exs` (mirrors `raxol_agent_tracker_cache_test.exs`, real `Cache.Ets` + unique per-test table, no Mox):
- fresh run populates the cache with the rendered prompt;
- a second identical run **hits** (proven decisively: poison the populated key with a sentinel; a hit leaves it untouched, a miss would re-render + overwrite);
- a different `attempt` is a distinct key;
- default TTL is 300s when unset;
- bare-module form is accepted via `Cache.normalize/1`;
- `prompt_cache: nil` still completes (regression guard).

## Scope / notes

- Branched off master. `mix.lock` intentionally excluded (pre-existing package drift).
- **CI:** `raxol_symphony` is not in the CI matrix (`ci-unified.yml` runs only `raxol_gateway`/`raxol_telegram`), so it's a local gate — run below.
- No new compiler warnings (only the pre-existing unused `require Logger`, which is on master too and left untouched). No new credo issues (before/after diff clean on the changed file).

## Manual testing

- [x] `cd packages/raxol_symphony && MIX_ENV=test mix test` — 766 passed, 0 failures
- [x] `mix test test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs` — 6 passed
- [x] `mix test test/raxol/symphony/runners/raxol_agent_session_test.exs` — 8 passed (unchanged)
- [x] `mix format --check-formatted` clean on both files
- [x] `mix credo` — no new issues on the changed file
