### PR TITLE
Symphony: memoize parsed prompt template

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
@@ -13,6 +13,11 @@ defmodule Raxol.Symphony.PromptBuilder do
   Fallback: when the prompt body is empty/blank, returns the SPEC's default
   `"You are working on an issue from Linear."` prompt instead of failing.
 
+  The parsed template AST is memoized in `:persistent_term` keyed by the
+  template string (a pure function of it), so a template is parsed once and
+  every subsequent render across both runners reuses the AST. Rendering is
+  never memoized (it varies per issue/attempt).
+
   Error returns:
 
   - `{:error, :solid_not_loaded}` -- consumer omitted `:solid`.
@@ -50,10 +55,32 @@ defmodule Raxol.Symphony.PromptBuilder do
     end
   end
 
+  # The parsed Liquid AST is a pure function of the template string, so it
+  # is memoized in `:persistent_term` keyed by the template itself. Both
+  # runners re-render the SAME `WORKFLOW.md` template on every fresh run of
+  # every issue; without this each run re-parses it. Templates are few and
+  # stable (one per `WORKFLOW.md`), so the read-often/write-rarely profile
+  # fits `:persistent_term` (each distinct template is parsed once; an
+  # edited template is a new key -> a fresh parse, and the superseded entry
+  # is harmless dead weight — not evicted, since distinct templates are few).
+  # The template string is the key, so there is no hash-collision risk.
+  # Parse errors are not memoized (cheap, rare, and must stay observable).
   defp parse_template(template) do
-    case Solid.parse(template) do
-      {:ok, parsed} -> {:ok, parsed}
-      {:error, error} -> {:error, {:template_parse_error, error}}
+    key = {__MODULE__, :parsed_template, template}
+
+    case :persistent_term.get(key, :miss) do
+      :miss ->
+        case Solid.parse(template) do
+          {:ok, parsed} ->
+            :persistent_term.put(key, parsed)
+            {:ok, parsed}
+
+          {:error, error} ->
+            {:error, {:template_parse_error, error}}
+        end
+
+      parsed ->
+        {:ok, parsed}
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
@@ -1,4 +1,15 @@
 defmodule Raxol.Symphony.PromptBuilder do
+  @memo_key {__MODULE__, :parsed_templates}
+  @empty_memo %{map: %{}, order: []}
+
+  # WHY 16: cap the parsed-template memo so a hot-reloaded `WORKFLOW.md`
+  # (every edit is a fresh template string, hence a new key) cannot grow it
+  # without bound. 16 comfortably covers the handful of workflow variants a
+  # deployment runs concurrently; an evicted template just re-parses on next
+  # use. Defined above the moduledoc so the doc can interpolate the attribute
+  # rather than restate the literal.
+  @max_memoized 16
+
   @moduledoc """
   Renders a `WORKFLOW.md` prompt template with strict Liquid semantics.
 
@@ -17,8 +28,18 @@ defmodule Raxol.Symphony.PromptBuilder do
   (a bounded, FIFO-evicted map from template string to AST), so a template
   is parsed once and every subsequent render across both runners reuses the
   AST. Rendering is never memoized (it varies per issue/attempt). The cache
-  is capped at #{16} templates so a live-reloaded `WORKFLOW.md` cannot grow
-  it without bound; a re-parse of an evicted template is the only cost.
+  is capped at #{@max_memoized} templates so a live-reloaded `WORKFLOW.md`
+  cannot grow it without bound; a re-parse of an evicted template is the only
+  cost. Writes funnel through `Raxol.Symphony.PromptBuilder.Memo` (a single
+  writer) so the cap holds under concurrent parses; reads stay lock-free
+  against `:persistent_term`.
+
+  On `:persistent_term` cost: every write is a `:persistent_term.put`, which
+  triggers a global GC. A WorkflowStore hot-reload of a changed template is a
+  new key, so a fresh parse -> put -> global GC; and once the memo is at the
+  cap, every new-template build rewrites the single entry (another put, another
+  global GC). This is acceptable only because template churn is low -- the
+  memo is read on every render but written rarely.
 
   Error returns:
 
@@ -29,6 +50,7 @@ defmodule Raxol.Symphony.PromptBuilder do
   """
 
   alias Raxol.Symphony.Issue
+  alias Raxol.Symphony.PromptBuilder.Memo
 
   @default_prompt "You are working on an issue from Linear."
 
@@ -61,50 +83,30 @@ defmodule Raxol.Symphony.PromptBuilder do
   # is memoized in ONE `:persistent_term` entry holding a bounded map from
   # template string to AST. Both runners re-render the SAME `WORKFLOW.md`
   # template on every fresh run of every issue; without this each run
-  # re-parses it. The read-often/write-rarely profile fits `:persistent_term`
-  # (a global GC fires only on a genuinely new template, which is rare).
+  # re-parses it. Reads are lock-free here; writes are serialized through the
+  # single-writer `Memo` so the FIFO bound holds under concurrent parses.
   #
   # A single entry, not one key per template, is deliberate: `WorkflowStore`
   # hot-reloads `WORKFLOW.md`, so a per-template key scheme would accumulate a
-  # never-evicted entry for every template ever seen. Here the map is capped
-  # at @max_memoized with FIFO eviction, so a live-edited template can never
-  # grow the cache without bound — an evicted template just re-parses on next
-  # use. Parse errors are not memoized (cheap, rare, and must stay observable).
-  @memo_key {__MODULE__, :parsed_templates}
-  @max_memoized 16
-
+  # never-evicted entry for every template ever seen. Parse errors are not
+  # memoized (cheap, rare, and must stay observable).
   defp parse_template(template) do
-    memo = :persistent_term.get(@memo_key, %{map: %{}, order: []})
+    memo = :persistent_term.get(@memo_key, @empty_memo)
 
     case Map.get(memo.map, template) do
-      nil -> parse_and_memoize(memo, template)
+      nil -> parse_and_memoize(template)
       parsed -> {:ok, parsed}
     end
   end
 
-  defp parse_and_memoize(memo, template) do
+  defp parse_and_memoize(template) do
     case Solid.parse(template) do
       {:ok, parsed} ->
-        :persistent_term.put(@memo_key, put_bounded(memo, template, parsed))
+        Memo.memoize(@memo_key, @max_memoized, template, parsed)
         {:ok, parsed}
 
       {:error, error} ->
         {:error, {:template_parse_error, error}}
-    end
-  end
-
-  # FIFO insert into the bounded memo: evict the oldest template when full so
-  # the entry never grows past @max_memoized across live template reloads.
-  defp put_bounded(%{map: map, order: order}, template, parsed) do
-    if map_size(map) >= @max_memoized do
-      {evict, rest} = List.pop_at(order, 0)
-
-      %{
-        map: map |> Map.delete(evict) |> Map.put(template, parsed),
-        order: rest ++ [template]
-      }
-    else
-      %{map: Map.put(map, template, parsed), order: order ++ [template]}
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
@@ -69,18 +69,19 @@ defmodule Raxol.Symphony.PromptBuilder do
     key = {__MODULE__, :parsed_template, template}
 
     case :persistent_term.get(key, :miss) do
-      :miss ->
-        case Solid.parse(template) do
-          {:ok, parsed} ->
-            :persistent_term.put(key, parsed)
-            {:ok, parsed}
+      :miss -> parse_and_memoize(key, template)
+      parsed -> {:ok, parsed}
+    end
+  end
 
-          {:error, error} ->
-            {:error, {:template_parse_error, error}}
-        end
-
-      parsed ->
+  defp parse_and_memoize(key, template) do
+    case Solid.parse(template) do
+      {:ok, parsed} ->
+        :persistent_term.put(key, parsed)
         {:ok, parsed}
+
+      {:error, error} ->
+        {:error, {:template_parse_error, error}}
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex
@@ -13,10 +13,12 @@ defmodule Raxol.Symphony.PromptBuilder do
   Fallback: when the prompt body is empty/blank, returns the SPEC's default
   `"You are working on an issue from Linear."` prompt instead of failing.
 
-  The parsed template AST is memoized in `:persistent_term` keyed by the
-  template string (a pure function of it), so a template is parsed once and
-  every subsequent render across both runners reuses the AST. Rendering is
-  never memoized (it varies per issue/attempt).
+  The parsed template AST is memoized in a single `:persistent_term` entry
+  (a bounded, FIFO-evicted map from template string to AST), so a template
+  is parsed once and every subsequent render across both runners reuses the
+  AST. Rendering is never memoized (it varies per issue/attempt). The cache
+  is capped at #{16} templates so a live-reloaded `WORKFLOW.md` cannot grow
+  it without bound; a re-parse of an evicted template is the only cost.
 
   Error returns:
 
@@ -56,28 +58,34 @@ defmodule Raxol.Symphony.PromptBuilder do
   end
 
   # The parsed Liquid AST is a pure function of the template string, so it
-  # is memoized in `:persistent_term` keyed by the template itself. Both
-  # runners re-render the SAME `WORKFLOW.md` template on every fresh run of
-  # every issue; without this each run re-parses it. Templates are few and
-  # stable (one per `WORKFLOW.md`), so the read-often/write-rarely profile
-  # fits `:persistent_term` (each distinct template is parsed once; an
-  # edited template is a new key -> a fresh parse, and the superseded entry
-  # is harmless dead weight — not evicted, since distinct templates are few).
-  # The template string is the key, so there is no hash-collision risk.
-  # Parse errors are not memoized (cheap, rare, and must stay observable).
-  defp parse_template(template) do
-    key = {__MODULE__, :parsed_template, template}
+  # is memoized in ONE `:persistent_term` entry holding a bounded map from
+  # template string to AST. Both runners re-render the SAME `WORKFLOW.md`
+  # template on every fresh run of every issue; without this each run
+  # re-parses it. The read-often/write-rarely profile fits `:persistent_term`
+  # (a global GC fires only on a genuinely new template, which is rare).
+  #
+  # A single entry, not one key per template, is deliberate: `WorkflowStore`
+  # hot-reloads `WORKFLOW.md`, so a per-template key scheme would accumulate a
+  # never-evicted entry for every template ever seen. Here the map is capped
+  # at @max_memoized with FIFO eviction, so a live-edited template can never
+  # grow the cache without bound — an evicted template just re-parses on next
+  # use. Parse errors are not memoized (cheap, rare, and must stay observable).
+  @memo_key {__MODULE__, :parsed_templates}
+  @max_memoized 16
 
-    case :persistent_term.get(key, :miss) do
-      :miss -> parse_and_memoize(key, template)
+  defp parse_template(template) do
+    memo = :persistent_term.get(@memo_key, %{map: %{}, order: []})
+
+    case Map.get(memo.map, template) do
+      nil -> parse_and_memoize(memo, template)
       parsed -> {:ok, parsed}
     end
   end
 
-  defp parse_and_memoize(key, template) do
+  defp parse_and_memoize(memo, template) do
     case Solid.parse(template) do
       {:ok, parsed} ->
-        :persistent_term.put(key, parsed)
+        :persistent_term.put(@memo_key, put_bounded(memo, template, parsed))
         {:ok, parsed}
 
       {:error, error} ->
@@ -85,10 +93,28 @@ defmodule Raxol.Symphony.PromptBuilder do
     end
   end
 
+  # FIFO insert into the bounded memo: evict the oldest template when full so
+  # the entry never grows past @max_memoized across live template reloads.
+  defp put_bounded(%{map: map, order: order}, template, parsed) do
+    if map_size(map) >= @max_memoized do
+      {evict, rest} = List.pop_at(order, 0)
+
+      %{
+        map: map |> Map.delete(evict) |> Map.put(template, parsed),
+        order: rest ++ [template]
+      }
+    else
+      %{map: Map.put(map, template, parsed), order: order ++ [template]}
+    end
+  end
+
   defp render_template(parsed, %Issue{} = issue, attempt) do
     vars = build_vars(issue, attempt)
 
-    case Solid.render(parsed, vars, strict_variables: true, strict_filters: true) do
+    case Solid.render(parsed, vars,
+           strict_variables: true,
+           strict_filters: true
+         ) do
       {:ok, iolist} ->
         {:ok, IO.iodata_to_binary(iolist)}
 

--- a/packages/raxol_symphony/lib/raxol/symphony/prompt_builder/memo.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/prompt_builder/memo.ex
@@ -24,6 +24,11 @@ defmodule Raxol.Symphony.PromptBuilder.Memo do
 
   @empty_memo %{map: %{}, order: []}
 
+  # Short write-path deadline: a wedged singleton (mailbox backup during a
+  # global-GC storm) must never stall a prompt build. On timeout the write
+  # degrades to a no-op, identical in cost to a cache miss (re-parse next call).
+  @write_timeout_ms 1_000
+
   @doc """
   Serialize a bounded FIFO insert of `parsed` under `template` into the
   `:persistent_term` memo at `key`, capped at `max` entries.
@@ -31,12 +36,25 @@ defmodule Raxol.Symphony.PromptBuilder.Memo do
   A no-op (no write, so no needless global GC) when `template` is already
   memoized -- which is what keeps two concurrent writers of the same new
   template from appending it to `order` twice.
+
+  The memo is a pure performance cache: a write is always best-effort. If the
+  single-writer is absent, dies mid-call (TOCTOU `:noproc`), or wedges past
+  `@write_timeout_ms` (`:timeout`), the write degrades to a silent no-op --
+  the caller's parse result is unaffected, the memo simply is not updated this
+  time and the template re-parses on the next call. A memo write failure must
+  never propagate out of `Raxol.Symphony.PromptBuilder.build/2`.
   """
   @spec memoize(term(), pos_integer(), binary(), term()) :: :ok
   def memoize(key, max, template, parsed)
       when is_integer(max) and max > 0 and is_binary(template) do
     ensure_started()
-    GenServer.call(__MODULE__, {:memoize, key, max, template, parsed})
+    GenServer.call(__MODULE__, {:memoize, key, max, template, parsed}, @write_timeout_ms)
+  catch
+    # A broken/absent/wedged writer degrades to a best-effort no-op. Exit
+    # shapes: `:noproc` (orphan died between `whereis` and `call`, or was never
+    # started), `:timeout` (call deadline), and the `{reason, {GenServer, :call, _}}`
+    # wrappers `GenServer.call` raises for a crash mid-call.
+    :exit, _reason -> :ok
   end
 
   @impl true

--- a/packages/raxol_symphony/lib/raxol/symphony/prompt_builder/memo.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/prompt_builder/memo.ex
@@ -1,0 +1,89 @@
+defmodule Raxol.Symphony.PromptBuilder.Memo do
+  @moduledoc """
+  Single-writer owner for the `Raxol.Symphony.PromptBuilder` parsed-template
+  memo.
+
+  Reads of the memo go straight to `:persistent_term` (lock-free, the hot
+  render path). Every WRITE funnels through this one GenServer so the
+  read-modify-write on the single memo entry -- a bounded FIFO map from
+  template string to parsed AST -- is serialized.
+
+  Without a single writer, concurrent parses of distinct new templates
+  race: each reads the same memo, each computes a new map, and the last
+  `:persistent_term.put` wins, so an update is lost and the FIFO `order`
+  can drift past the cap or evict the wrong slot. One writer makes the
+  bound hold.
+
+  The process is a lazily-started, unsupervised singleton (this package
+  ships no application tree, and `PromptBuilder` is also called
+  standalone). A crash loses nothing durable: `:persistent_term` retains
+  the last memo and the next write restarts the owner.
+  """
+
+  use GenServer
+
+  @empty_memo %{map: %{}, order: []}
+
+  @doc """
+  Serialize a bounded FIFO insert of `parsed` under `template` into the
+  `:persistent_term` memo at `key`, capped at `max` entries.
+
+  A no-op (no write, so no needless global GC) when `template` is already
+  memoized -- which is what keeps two concurrent writers of the same new
+  template from appending it to `order` twice.
+  """
+  @spec memoize(term(), pos_integer(), binary(), term()) :: :ok
+  def memoize(key, max, template, parsed)
+      when is_integer(max) and max > 0 and is_binary(template) do
+    ensure_started()
+    GenServer.call(__MODULE__, {:memoize, key, max, template, parsed})
+  end
+
+  @impl true
+  def init(_), do: {:ok, %{}}
+
+  @impl true
+  def handle_call({:memoize, key, max, template, parsed}, _from, state) do
+    memo = :persistent_term.get(key, @empty_memo)
+
+    case Map.has_key?(memo.map, template) do
+      true ->
+        :ok
+
+      false ->
+        :persistent_term.put(key, put_bounded(memo, max, template, parsed))
+    end
+
+    {:reply, :ok, state}
+  end
+
+  # FIFO insert into the bounded memo: evict the oldest template when full so
+  # the entry never grows past `max` across live template reloads.
+  defp put_bounded(%{map: map, order: order}, max, template, parsed) do
+    if map_size(map) >= max do
+      {evict, rest} = List.pop_at(order, 0)
+
+      %{
+        map: map |> Map.delete(evict) |> Map.put(template, parsed),
+        order: rest ++ [template]
+      }
+    else
+      %{map: Map.put(map, template, parsed), order: order ++ [template]}
+    end
+  end
+
+  defp ensure_started do
+    case GenServer.whereis(__MODULE__) do
+      nil ->
+        # start/3 (not start_link) so the singleton is not tied to a transient
+        # worker Task's lifetime; the name resolves the start race.
+        case GenServer.start(__MODULE__, :ok, name: __MODULE__) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+        end
+
+      _pid ->
+        :ok
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/prompt_builder_memo_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/prompt_builder_memo_test.exs
@@ -88,4 +88,46 @@ defmodule Raxol.Symphony.PromptBuilderMemoTest do
     assert Map.has_key?(m.map, List.last(templates))
     refute Map.has_key?(m.map, List.first(templates))
   end
+
+  test "distinct templates parsed concurrently keep the memo bounded and consistent" do
+    # Far more distinct new templates than the cap, all racing through the
+    # parse+memoize path at once. The single-writer memo owner serializes the
+    # read-modify-write so the bound holds and order/map cannot drift.
+    1..200
+    |> Task.async_stream(
+      fn n ->
+        assert {:ok, _} =
+                 PromptBuilder.build(issue(), "t#{n} {{ issue.identifier }}")
+      end,
+      max_concurrency: 50,
+      ordered: false
+    )
+    |> Stream.run()
+
+    m = memo()
+
+    assert map_size(m.map) == @max_memoized
+    assert length(m.order) == @max_memoized
+    # No duplicate order entries, and order agrees exactly with the map keys.
+    assert Enum.uniq(m.order) == m.order
+    assert MapSet.new(m.order) == MapSet.new(Map.keys(m.map))
+  end
+
+  test "concurrent parses of the same new template do not double-insert" do
+    template = "same {{ issue.identifier }}"
+
+    1..50
+    |> Task.async_stream(
+      fn _ -> assert {:ok, _} = PromptBuilder.build(issue(), template) end,
+      max_concurrency: 50,
+      ordered: false
+    )
+    |> Stream.run()
+
+    m = memo()
+
+    assert map_size(m.map) == 1
+    assert length(m.order) == 1
+    assert m.order == Map.keys(m.map)
+  end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/prompt_builder_memo_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/prompt_builder_memo_test.exs
@@ -10,6 +10,7 @@ defmodule Raxol.Symphony.PromptBuilderMemoTest do
   use ExUnit.Case, async: false
 
   alias Raxol.Symphony.{Issue, PromptBuilder}
+  alias Raxol.Symphony.PromptBuilder.Memo
 
   @memo_key {PromptBuilder, :parsed_templates}
   @max_memoized 16
@@ -129,5 +130,94 @@ defmodule Raxol.Symphony.PromptBuilderMemoTest do
     assert map_size(m.map) == 1
     assert length(m.order) == 1
     assert m.order == Map.keys(m.map)
+  end
+
+  describe "a broken memo writer degrades to a best-effort no-op" do
+    test "build renders correctly when the writer has been killed (it restarts)" do
+      kill_memo()
+      refute Process.whereis(Memo)
+
+      template = "K {{ issue.identifier }}"
+      assert {:ok, "K MT-1"} = PromptBuilder.build(issue(), template)
+      # The absent writer was lazily restarted and the write went through.
+      assert Map.has_key?(memo().map, template)
+    end
+
+    test "a writer that dies mid-call never crashes build; re-parse is identical" do
+      install_standin_writer(:crash_on_call)
+
+      template = "C {{ issue.identifier }}"
+
+      # First build: the writer crashes on the `GenServer.call`. build/2 must
+      # NOT crash/exit -- the parse result is returned, the write is a no-op.
+      assert {:ok, "C MT-1"} = PromptBuilder.build(issue(), template)
+      assert memo().map == %{}
+
+      # The crashing stand-in died on that one call, so the next build lazily
+      # starts the real writer. Output is identical (re-parsed), now memoized.
+      assert {:ok, "C MT-1"} = PromptBuilder.build(issue(), template)
+      assert Map.has_key?(memo().map, template)
+    end
+
+    test "a wedged writer cannot stall build past the write deadline" do
+      install_standin_writer(:never_reply)
+
+      template = "W {{ issue.identifier }}"
+
+      {micros, result} =
+        :timer.tc(fn -> PromptBuilder.build(issue(), template) end)
+
+      # Returns the correct prompt despite the wedged singleton, and the 1s
+      # write deadline means it never blocks for the old 5s GenServer default.
+      assert {:ok, "W MT-1"} = result
+      assert micros < 3_000_000
+      # The write timed out, so it was a silent no-op: nothing memoized.
+      assert memo().map == %{}
+    end
+  end
+
+  # Kill the (possibly running) singleton writer and wait for the name to free.
+  defp kill_memo do
+    case Process.whereis(Memo) do
+      nil ->
+        :ok
+
+      pid ->
+        ref = Process.monitor(pid)
+        Process.exit(pid, :kill)
+
+        receive do
+          {:DOWN, ^ref, :process, ^pid, _} -> :ok
+        after
+          1_000 -> :ok
+        end
+    end
+  end
+
+  # Register a fake process under the writer's name so `ensure_started` finds a
+  # live pid (skips the real start) but the `GenServer.call` into it fails --
+  # exercising the try/catch :exit no-op. Killed on test exit.
+  defp install_standin_writer(:crash_on_call) do
+    install_standin(fn ->
+      receive do
+        {:"$gen_call", _from, _req} -> exit(:writer_died_mid_call)
+      end
+    end)
+  end
+
+  defp install_standin_writer(:never_reply) do
+    install_standin(fn -> Process.sleep(:infinity) end)
+  end
+
+  defp install_standin(fun) do
+    kill_memo()
+    pid = spawn(fun)
+    Process.register(pid, Memo)
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: Process.exit(pid, :kill)
+    end)
+
+    pid
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/prompt_builder_memo_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/prompt_builder_memo_test.exs
@@ -1,0 +1,91 @@
+defmodule Raxol.Symphony.PromptBuilderMemoTest do
+  @moduledoc """
+  White-box coverage for the parsed-template memo. The memo is ONE
+  `:persistent_term` entry `{PromptBuilder, :parsed_templates}` holding a
+  bounded `%{map: %{template => ast}, order: [template]}` with FIFO eviction.
+
+  `async: false`: these poison and inspect the single shared entry, so no
+  other module may call `PromptBuilder.build/2` concurrently.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Issue, PromptBuilder}
+
+  @memo_key {PromptBuilder, :parsed_templates}
+  @max_memoized 16
+
+  defp issue(opts \\ []) do
+    struct(
+      %Issue{id: "abc", identifier: "MT-1", title: "T", state: "Todo"},
+      opts
+    )
+  end
+
+  defp memo, do: :persistent_term.get(@memo_key, %{map: %{}, order: []})
+
+  setup do
+    # Start each test from an empty memo, and leave it empty afterward, so
+    # eviction counts are deterministic and the cache is not left polluted.
+    :persistent_term.erase(@memo_key)
+    on_exit(fn -> :persistent_term.erase(@memo_key) end)
+    :ok
+  end
+
+  test "memoizes the parsed AST; a second build reuses it instead of re-parsing" do
+    template = "A {{ issue.identifier }}"
+    other = "B {{ issue.identifier }}"
+
+    assert {:ok, "A MT-1"} = PromptBuilder.build(issue(), template)
+
+    # Poison the memoized slot for `template` with a DIFFERENT template's AST.
+    # A re-parse would render "A ..."; a memo HIT renders the poisoned "B ...".
+    {:ok, other_ast} = Solid.parse(other)
+    m = memo()
+
+    :persistent_term.put(@memo_key, %{
+      m
+      | map: Map.put(m.map, template, other_ast)
+    })
+
+    assert {:ok, "B MT-1"} = PromptBuilder.build(issue(), template)
+  end
+
+  test "distinct templates each memoize and render their own text" do
+    assert {:ok, "one MT-1"} =
+             PromptBuilder.build(issue(), "one {{ issue.identifier }}")
+
+    assert {:ok, "two MT-1"} =
+             PromptBuilder.build(issue(), "two {{ issue.identifier }}")
+
+    assert Map.has_key?(memo().map, "one {{ issue.identifier }}")
+    assert Map.has_key?(memo().map, "two {{ issue.identifier }}")
+  end
+
+  test "renders stay per-issue/attempt; only the parse is shared" do
+    template = "s {{ issue.identifier }} a={{ attempt }}"
+
+    assert {:ok, "s MT-1 a="} = PromptBuilder.build(issue(), template, nil)
+
+    assert {:ok, "s MT-2 a=5"} =
+             PromptBuilder.build(issue(identifier: "MT-2"), template, 5)
+  end
+
+  test "the memo is bounded: a live-reloaded template cannot grow it past the cap" do
+    templates =
+      for i <- 1..(@max_memoized + 5), do: "t#{i} {{ issue.identifier }}"
+
+    Enum.each(templates, fn t ->
+      assert {:ok, _} = PromptBuilder.build(issue(), t)
+    end)
+
+    m = memo()
+    # Capped at @max_memoized despite building @max_memoized + 5 distinct
+    # templates -- the persistent_term entry never grows without bound.
+    assert map_size(m.map) == @max_memoized
+    assert length(m.order) == @max_memoized
+
+    # FIFO: the oldest templates were evicted, the newest retained.
+    assert Map.has_key?(m.map, List.last(templates))
+    refute Map.has_key?(m.map, List.first(templates))
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/prompt_builder_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/prompt_builder_test.exs
@@ -112,73 +112,25 @@ defmodule Raxol.Symphony.PromptBuilderTest do
 
     test "unknown filter fails rendering" do
       assert {:error, {:template_render_error, _}} =
-               PromptBuilder.build(issue(), "{{ issue.title | nonexistent_filter }}.")
+               PromptBuilder.build(
+                 issue(),
+                 "{{ issue.title | nonexistent_filter }}."
+               )
     end
 
     test "unknown nested issue field fails rendering" do
       assert {:error, {:template_render_error, _}} =
-               PromptBuilder.build(issue(), "{{ issue.totally_made_up_field }}.")
+               PromptBuilder.build(
+                 issue(),
+                 "{{ issue.totally_made_up_field }}."
+               )
     end
   end
 
   describe "default_prompt/0" do
     test "exposes the spec default" do
-      assert PromptBuilder.default_prompt() == "You are working on an issue from Linear."
-    end
-  end
-
-  # White-box: the memo key is `{PromptBuilder, :parsed_template, template}`
-  # in `:persistent_term`. Unique per-template tags keep these async-safe.
-  describe "template AST memoization" do
-    defp memo_key(template), do: {PromptBuilder, :parsed_template, template}
-
-    test "memoizes the parsed AST; a second build reuses it instead of re-parsing" do
-      tag = System.unique_integer([:positive])
-      template = "A#{tag} {{ issue.identifier }}"
-      other = "B#{tag} {{ issue.identifier }}"
-      on_exit(fn -> :persistent_term.erase(memo_key(template)) end)
-
-      # First build parses + memoizes `template`.
-      assert {:ok, rendered} = PromptBuilder.build(issue(), template)
-      assert rendered == "A#{tag} MT-1"
-
-      # Poison the memo with a DIFFERENT template's AST. A re-parse would
-      # render `template`'s text ("A..."); a memo HIT renders the poisoned
-      # AST's text ("B...").
-      {:ok, other_ast} = Solid.parse(other)
-      :persistent_term.put(memo_key(template), other_ast)
-
-      assert {:ok, hit} = PromptBuilder.build(issue(), template)
-      assert hit == "B#{tag} MT-1"
-    end
-
-    test "a different template is a distinct key and re-parses" do
-      tag = System.unique_integer([:positive])
-      t1 = "one#{tag} {{ issue.identifier }}"
-      t2 = "two#{tag} {{ issue.identifier }}"
-
-      on_exit(fn ->
-        :persistent_term.erase(memo_key(t1))
-        :persistent_term.erase(memo_key(t2))
-      end)
-
-      assert {:ok, r1} = PromptBuilder.build(issue(), t1)
-      assert r1 == "one#{tag} MT-1"
-
-      assert {:ok, r2} = PromptBuilder.build(issue(), t2)
-      assert r2 == "two#{tag} MT-1"
-    end
-
-    test "renders of the memoized template stay per-issue/attempt (only the parse is shared)" do
-      tag = System.unique_integer([:positive])
-      template = "s#{tag} {{ issue.identifier }} a={{ attempt }}"
-      on_exit(fn -> :persistent_term.erase(memo_key(template)) end)
-
-      assert {:ok, first} = PromptBuilder.build(issue(), template, nil)
-      assert first == "s#{tag} MT-1 a="
-
-      assert {:ok, retry} = PromptBuilder.build(issue(identifier: "MT-2"), template, 5)
-      assert retry == "s#{tag} MT-2 a=5"
+      assert PromptBuilder.default_prompt() ==
+               "You are working on an issue from Linear."
     end
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/prompt_builder_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/prompt_builder_test.exs
@@ -126,4 +126,59 @@ defmodule Raxol.Symphony.PromptBuilderTest do
       assert PromptBuilder.default_prompt() == "You are working on an issue from Linear."
     end
   end
+
+  # White-box: the memo key is `{PromptBuilder, :parsed_template, template}`
+  # in `:persistent_term`. Unique per-template tags keep these async-safe.
+  describe "template AST memoization" do
+    defp memo_key(template), do: {PromptBuilder, :parsed_template, template}
+
+    test "memoizes the parsed AST; a second build reuses it instead of re-parsing" do
+      tag = System.unique_integer([:positive])
+      template = "A#{tag} {{ issue.identifier }}"
+      other = "B#{tag} {{ issue.identifier }}"
+      on_exit(fn -> :persistent_term.erase(memo_key(template)) end)
+
+      # First build parses + memoizes `template`.
+      assert {:ok, rendered} = PromptBuilder.build(issue(), template)
+      assert rendered == "A#{tag} MT-1"
+
+      # Poison the memo with a DIFFERENT template's AST. A re-parse would
+      # render `template`'s text ("A..."); a memo HIT renders the poisoned
+      # AST's text ("B...").
+      {:ok, other_ast} = Solid.parse(other)
+      :persistent_term.put(memo_key(template), other_ast)
+
+      assert {:ok, hit} = PromptBuilder.build(issue(), template)
+      assert hit == "B#{tag} MT-1"
+    end
+
+    test "a different template is a distinct key and re-parses" do
+      tag = System.unique_integer([:positive])
+      t1 = "one#{tag} {{ issue.identifier }}"
+      t2 = "two#{tag} {{ issue.identifier }}"
+
+      on_exit(fn ->
+        :persistent_term.erase(memo_key(t1))
+        :persistent_term.erase(memo_key(t2))
+      end)
+
+      assert {:ok, r1} = PromptBuilder.build(issue(), t1)
+      assert r1 == "one#{tag} MT-1"
+
+      assert {:ok, r2} = PromptBuilder.build(issue(), t2)
+      assert r2 == "two#{tag} MT-1"
+    end
+
+    test "renders of the memoized template stay per-issue/attempt (only the parse is shared)" do
+      tag = System.unique_integer([:positive])
+      template = "s#{tag} {{ issue.identifier }} a={{ attempt }}"
+      on_exit(fn -> :persistent_term.erase(memo_key(template)) end)
+
+      assert {:ok, first} = PromptBuilder.build(issue(), template, nil)
+      assert first == "s#{tag} MT-1 a="
+
+      assert {:ok, retry} = PromptBuilder.build(issue(identifier: "MT-2"), template, 5)
+      assert retry == "s#{tag} MT-2 a=5"
+    end
+  end
 end


### PR DESCRIPTION
Closes #739 (Part 2 of #519).

## What

`Raxol.Symphony.PromptBuilder.parse_template/1` called `Solid.parse(template)` on **every** fresh run of **every** issue, for **both** runners (`RaxolAgent` and `RaxolAgentSession`). The parsed Liquid AST is a pure function of the template string, and templates are few and stable (one per `WORKFLOW.md`), so re-parsing on every run was pure waste.

This memoizes the parsed AST in `:persistent_term`, keyed by the template string itself. A template is parsed once; every subsequent render across both runners reuses the AST. Rendering is unchanged (it stays per-issue/attempt).

Complements #519 (PR #740): that added a per-issue rendered-prompt cache on the session runner; this is the shared, higher-value parse memo underneath both runners.

## Design

- **Key = the template string** (`{PromptBuilder, :parsed_template, template}`), so there is **no hash-collision risk** — a collision would return a wrong AST and render a wrong prompt.
- **No TTL / no invalidation** needed: the AST is a pure function of the key. An edited `WORKFLOW.md` yields a new template string -> a new key -> a fresh parse; the superseded entry is harmless dead weight (not evicted, since distinct templates are few — documented, per #739's "bound it if that assumption breaks").
- **Parse errors are not memoized** (cheap, rare, and must stay observable).
- **`:persistent_term` fit:** read-often / write-rarely (each distinct template is `put` once). Blank/nil/whitespace templates all resolve to the default prompt string before keying, so they share one entry.

## Files

- `packages/raxol_symphony/lib/raxol/symphony/prompt_builder.ex` — memoize `parse_template/1`; moduledoc note.
- `packages/raxol_symphony/test/raxol/symphony/prompt_builder_test.exs` — new "template AST memoization" describe.

## Tests

- **hit proven decisively**: build a template (memoizes it), poison its memo entry with a *different* template's AST, build again -> the render matches the poisoned AST (a re-parse would have rendered the original). Async-safe via unique per-template tags; `on_exit` erases the persistent_term keys.
- a different template is a distinct key and re-parses;
- renders stay per-issue/attempt (only the parse is shared).

## Scope / notes

- Branched off master. `mix.lock` intentionally excluded (pre-existing package drift).
- **CI:** `raxol_symphony` is not in the CI matrix (`ci-unified.yml` runs only `raxol_gateway`/`raxol_telegram`) — local gate, run below.
- No new compiler warnings, no new credo issues (before/after diff clean on the changed file).

## Manual testing

- [x] `cd packages/raxol_symphony && MIX_ENV=test mix test` — 763 passed, 0 failures
- [x] `mix test test/raxol/symphony/prompt_builder_test.exs` — 16 passed (13 existing + 3 new)
- [x] `mix format --check-formatted` clean on both files
- [x] `mix credo` — no new issues on the changed file
