### PR TITLE
Symphony: SSH remote-exec transport for workers (#743)

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -162,6 +162,11 @@ defmodule Raxol.Symphony.Orchestrator do
       host_pool: build_host_pool(config)
     }
 
+    # Re-hold host slots for runs that were paused before a restart, so a
+    # rebuilt (all-free) pool does not hand a paused worker's host to another
+    # issue before it resumes.
+    state = rehold_paused_hosts(state)
+
     state = if auto_start_tick, do: schedule_tick(state, 0), else: state
 
     {:ok, state}
@@ -192,10 +197,14 @@ defmodule Raxol.Symphony.Orchestrator do
         {:reply, :ok, new_state}
 
       Map.has_key?(state.paused, issue_id) ->
+        paused_entry = Map.fetch!(state.paused, issue_id)
         forget_paused(state.paused_saver, issue_id)
 
         new_state =
           state
+          # A paused run keeps its host slot reserved; free it now that the run
+          # is being discarded rather than resumed.
+          |> release_host(Map.get(paused_entry, :host))
           |> Map.put(:paused, Map.delete(state.paused, issue_id))
           |> Map.put(:claimed, MapSet.delete(state.claimed, issue_id))
           |> notify_listeners(:worker_stopped)
@@ -519,6 +528,21 @@ defmodule Raxol.Symphony.Orchestrator do
 
   defp release_host(%State{host_pool: pool} = state, %HostSpec{} = host) do
     %State{state | host_pool: HostPool.release(pool, host)}
+  end
+
+  defp hold_host(%State{} = state, nil), do: state
+  defp hold_host(%State{host_pool: nil} = state, _host), do: state
+
+  defp hold_host(%State{host_pool: pool} = state, %HostSpec{} = host) do
+    %State{state | host_pool: HostPool.hold(pool, host)}
+  end
+
+  defp rehold_paused_hosts(%State{host_pool: nil} = state), do: state
+
+  defp rehold_paused_hosts(%State{paused: paused} = state) do
+    Enum.reduce(paused, state, fn {_id, entry}, acc ->
+      hold_host(acc, Map.get(entry, :host))
+    end)
   end
 
   defp maybe_start_capture(
@@ -876,7 +900,12 @@ defmodule Raxol.Symphony.Orchestrator do
 
   defp handle_worker_exit(%State{} = state, issue_id, reason) do
     entry = Map.fetch!(state.running, issue_id)
-    state = detach_worker(state, issue_id, entry)
+    pausing? = reason == :normal and entry.pending_pause != nil
+
+    # A pausing worker keeps its host slot reserved (the resume must re-hold
+    # the SAME remote host -- its workspace lives there); every other exit
+    # frees it.
+    state = detach_worker(state, issue_id, entry, not pausing?)
 
     case reason do
       :normal when entry.pending_pause != nil ->
@@ -921,14 +950,17 @@ defmodule Raxol.Symphony.Orchestrator do
   # its host slot (one-worker-lifetime-per-host; a nil host is a no-op), record
   # runtime, and drop the entry. Claimed-set handling is exit-reason-specific
   # and stays in `handle_worker_exit/3`.
-  defp detach_worker(%State{} = state, issue_id, entry) do
+  defp detach_worker(%State{} = state, issue_id, entry, release_host?) do
     Capture.stop(entry.capture_pid)
 
     state
-    |> release_host(entry.host)
+    |> maybe_release_host(entry.host, release_host?)
     |> record_runtime(entry)
     |> Map.put(:running, Map.delete(state.running, issue_id))
   end
+
+  defp maybe_release_host(%State{} = state, _host, false), do: state
+  defp maybe_release_host(%State{} = state, host, true), do: release_host(state, host)
 
   # Pause is signalled by a {:run_paused, ...} message arriving from the
   # worker BEFORE its :normal exit (same-process message order
@@ -955,6 +987,7 @@ defmodule Raxol.Symphony.Orchestrator do
       issue: entry.issue,
       attempt: entry.attempt,
       workspace_path: entry.workspace_path,
+      host: entry.host,
       interrupt_reason: interrupt_reason,
       resume_token: token,
       paused_at: System.monotonic_time(:millisecond),
@@ -1000,7 +1033,14 @@ defmodule Raxol.Symphony.Orchestrator do
   defp dispatch_resumption(%State{} = state, paused_entry, resume_value) do
     issue = paused_entry.issue
 
+    host = Map.get(paused_entry, :host)
+
     with {:ok, runner_mod} <- runner_module(state) do
+      # The slot was kept reserved across the pause; re-hold it (idempotent,
+      # and a real claim after a restart rebuilt the pool) so the resumed
+      # worker runs on its ORIGINAL host, never locally with host: nil.
+      state = hold_host(state, host)
+
       capture_pid =
         maybe_start_capture(
           state,
@@ -1027,9 +1067,7 @@ defmodule Raxol.Symphony.Orchestrator do
           paused_entry.workspace_path,
           task,
           capture_pid,
-          # Resume host re-claiming lands with the transport (issue #743);
-          # a resumed worker holds no host slot for now.
-          nil
+          host
         )
         |> Map.put(:turn_count, paused_entry.turn_count)
         |> Map.put(:tokens, paused_entry.tokens)

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -451,7 +451,7 @@ defmodule Raxol.Symphony.Orchestrator do
 
   defp do_dispatch_issue(state, issue, attempt, runner_mod, workspace_path, host) do
     capture_pid = maybe_start_capture(state, issue, attempt, workspace_path)
-    task = spawn_worker_task(state, runner_mod, issue, attempt, workspace_path)
+    task = spawn_worker_task(state, runner_mod, issue, attempt, workspace_path, host)
 
     entry =
       build_running_entry(issue, attempt, workspace_path, task, capture_pid, host)
@@ -548,7 +548,8 @@ defmodule Raxol.Symphony.Orchestrator do
          runner_mod,
          %Issue{} = issue,
          attempt,
-         workspace_path
+         workspace_path,
+         host
        ) do
     parent = self()
     config = state.config
@@ -563,6 +564,7 @@ defmodule Raxol.Symphony.Orchestrator do
           issue,
           attempt,
           workspace_path,
+          host,
           parent
         )
       end
@@ -576,6 +578,7 @@ defmodule Raxol.Symphony.Orchestrator do
          issue,
          attempt,
          workspace_path,
+         _host,
          parent
        ) do
     case GraphAdapter.from_workflow([]) do
@@ -605,12 +608,14 @@ defmodule Raxol.Symphony.Orchestrator do
          issue,
          attempt,
          workspace_path,
+         host,
          parent
        ) do
     runner_opts = [
       parent: parent,
       attempt: attempt,
-      workspace_path: workspace_path
+      workspace_path: workspace_path,
+      host: host
     ]
 
     run_runner(runner_mod, issue, config, runner_opts)

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator/state.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator/state.ex
@@ -42,6 +42,7 @@ defmodule Raxol.Symphony.Orchestrator.State do
           issue: Issue.t(),
           attempt: non_neg_integer() | nil,
           workspace_path: Path.t(),
+          host: Raxol.Symphony.Worker.HostSpec.t() | nil,
           interrupt_reason: atom(),
           resume_token: term(),
           paused_at: integer(),

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex.ex
@@ -69,6 +69,7 @@ defmodule Raxol.Symphony.Runners.Codex do
     parent = Keyword.fetch!(opts, :parent)
     attempt = Keyword.get(opts, :attempt)
     workspace_path = Keyword.fetch!(opts, :workspace_path)
+    host = Keyword.get(opts, :host)
     resume_value = Keyword.get(opts, :resume_value)
     resume_token = Keyword.get(opts, :resume_token)
 
@@ -82,6 +83,7 @@ defmodule Raxol.Symphony.Runners.Codex do
         parent: parent,
         attempt: attempt,
         workspace_path: workspace_path,
+        host: host,
         turn: 1,
         max_turns: config.agent.max_turns,
         auth_env: auth.env
@@ -115,7 +117,7 @@ defmodule Raxol.Symphony.Runners.Codex do
     policy = build_policy(config)
     env = Map.get(ctx, :auth_env, [])
 
-    case Session.start(ctx.workspace_path, config.codex.command, policy, env) do
+    case Session.start(ctx.workspace_path, config.codex.command, policy, env, Map.get(ctx, :host)) do
       {:ok, session} ->
         try do
           run_turns(session, issue, config, ctx)

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -19,6 +19,8 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   require Logger
 
   alias Raxol.Symphony.Runners.Codex.{Framing, Protocol}
+  alias Raxol.Symphony.Ssh
+  alias Raxol.Symphony.Worker.HostSpec
 
   @type session :: %{
           port: port(),
@@ -49,13 +51,15 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   Starts a Codex app-server session in `workspace`.
 
   `command` is the shell command Codex was launched with (per `codex.command`).
+  `host` (a `Raxol.Symphony.Worker.HostSpec` or `nil`) routes the session to a
+  remote worker over SSH when present; `nil` runs it locally (the default).
   """
-  @spec start(Path.t(), binary(), policy(), [{charlist(), charlist()}]) ::
+  @spec start(Path.t(), binary(), policy(), [{charlist(), charlist()}], HostSpec.t() | nil) ::
           {:ok, session()} | {:error, term()}
-  def start(workspace, command, %{} = policy, env \\ [])
+  def start(workspace, command, %{} = policy, env \\ [], host \\ nil)
       when is_binary(workspace) and is_binary(command) and is_list(env) do
     with {:ok, bash} <- find_bash(),
-         {:ok, port} <- open_port(bash, command, workspace, env),
+         {:ok, port} <- open_port(host, bash, command, workspace, env),
          :ok <- send_initialize(port, policy.read_timeout_ms),
          {:ok, thread_id} <- send_thread_start(port, workspace, policy) do
       {:ok,
@@ -316,25 +320,45 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
     end
   end
 
-  defp open_port(bash, command, workspace, env) do
-    opts = [
-      :binary,
-      :exit_status,
-      :stderr_to_stdout,
-      :hide,
-      {:cd, workspace},
-      {:line, @port_line_bytes},
-      {:args, ["-lc", command]}
-    ]
+  defp open_port(host, bash, command, workspace, env) do
+    with {:ok, {executable, opts}} <- launch_spec(host, bash, command, workspace, env) do
+      {:ok, Port.open({:spawn_executable, executable}, opts)}
+    end
+  rescue
+    e -> {:error, {:port_open_failed, e}}
+  end
+
+  # Pure: the `{executable, Port.open-opts}` for a local or remote launch.
+  #
+  # Local (`host == nil`): `bash -lc command`, cwd via `{:cd, workspace}`, env
+  # injected into the child. Remote (`%HostSpec{}`): `ssh <opts> host
+  # "bash -lc 'cd WS && command'"` — the remote login shell sources
+  # host-provisioned credentials, so no env is forwarded (see
+  # `Raxol.Symphony.Ssh`). Codex's JSON-RPC then streams over the port's
+  # stdio unchanged, whether that stdio is local bash or an ssh pipe.
+  @doc false
+  @spec launch_spec(HostSpec.t() | nil, binary(), binary(), Path.t(), list()) ::
+          {:ok, {binary(), keyword()}} | {:error, term()}
+  def launch_spec(nil, bash, command, workspace, env) do
+    opts = base_port_opts() ++ [{:cd, workspace}, {:args, ["-lc", command]}]
 
     # Only add {:env, _} when there is something to inject: an empty list still
     # scopes the child to an explicit env on some OTP versions, so `:inherit`
     # (env == []) must pass through untouched to keep the ambient environment.
     opts = if env == [], do: opts, else: opts ++ [{:env, env}]
 
-    {:ok, Port.open({:spawn_executable, bash}, opts)}
-  rescue
-    e -> {:error, {:port_open_failed, e}}
+    {:ok, {bash, opts}}
+  end
+
+  def launch_spec(%HostSpec{} = host, _bash, command, workspace, _env) do
+    with {:ok, ssh} <- Ssh.executable() do
+      args = Ssh.command_args(host, Ssh.remote_bash(workspace, command))
+      {:ok, {ssh, base_port_opts() ++ [{:args, args}]}}
+    end
+  end
+
+  defp base_port_opts do
+    [:binary, :exit_status, :stderr_to_stdout, :hide, {:line, @port_line_bytes}]
   end
 
   defp close_port(port) do

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -352,7 +352,10 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
 
   def launch_spec(%HostSpec{} = host, _bash, command, workspace, _env) do
     with {:ok, ssh} <- Ssh.executable() do
-      args = Ssh.command_args(host, Ssh.remote_bash(workspace, command))
+      # Reap the remote codex on disconnect so a `Port.close` (worker stop /
+      # pause / crash) never orphans it on the host.
+      remote = Ssh.remote_bash(workspace, Ssh.reap_on_disconnect(command))
+      args = Ssh.command_args(host, remote)
       {:ok, {ssh, base_port_opts() ++ [{:args, args}]}}
     end
   end

--- a/packages/raxol_symphony/lib/raxol/symphony/ssh.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/ssh.ex
@@ -1,0 +1,120 @@
+defmodule Raxol.Symphony.Ssh do
+  @moduledoc """
+  The single seam that runs a command on a remote worker host over SSH
+  (issue #743). Pure argv construction plus an allowlisted, injectable
+  executor — nothing here spawns a process except `exec/3`, and that is
+  injectable for tests.
+
+  A remote worker command is `ssh <opts> <user@host> "bash -lc 'cd WS && …'"`.
+  Two deliberate decisions:
+
+    * **The remote LOGIN shell provides credentials.** The orchestrator
+      forwards **no** environment over SSH — the remote `bash -lc` sources
+      the host's login profile, so worker credentials (API keys, etc.) are
+      provisioned host-side and never travel on a command line. Env
+      injection stays a local-worker concern (`Runners.Codex.Session`).
+    * **`ssh` is allowlisted.** `executable/0` refuses anything whose
+      basename is not `ssh` (mirrors the gateway transcribe allowlist).
+
+  The remote workspace path handling (creating `WS` on the host) is issue
+  #744; here the caller supplies whatever path the remote command should
+  `cd` into.
+  """
+
+  alias Raxol.Symphony.Worker.HostSpec
+
+  @allowed_binaries ~w(ssh)
+
+  # Non-interactive defaults: never prompt (BatchMode), and trust a new host
+  # key on first contact rather than hanging on the yes/no prompt.
+  @base_options ["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
+
+  @doc """
+  Resolve the `ssh` executable, refusing anything not named `ssh`.
+  """
+  @spec executable() :: {:ok, binary()} | {:error, :ssh_not_allowed}
+  def executable do
+    with path when is_binary(path) <- System.find_executable("ssh"),
+         true <- Path.basename(path) in @allowed_binaries do
+      {:ok, path}
+    else
+      _ -> {:error, :ssh_not_allowed}
+    end
+  end
+
+  @doc "The `user@host` (or bare `host`) SSH destination for a spec."
+  @spec target(HostSpec.t()) :: binary()
+  def target(%HostSpec{host: host, user: nil}), do: host
+  def target(%HostSpec{host: host, user: user}), do: "#{user}@#{host}"
+
+  @doc "The SSH option args for a spec (non-interactive base + port + identity)."
+  @spec option_args(HostSpec.t()) :: [binary()]
+  def option_args(%HostSpec{port: port, identity_file: identity}) do
+    @base_options ++ port_args(port) ++ identity_args(identity)
+  end
+
+  @doc """
+  The full `ssh` argv to run `remote_command` on the host:
+  `[options…, target, remote_command]`. `remote_command` is a single element
+  so SSH forwards it verbatim to the remote shell (no re-tokenization).
+  """
+  @spec command_args(HostSpec.t(), binary()) :: [binary()]
+  def command_args(%HostSpec{} = spec, remote_command) when is_binary(remote_command) do
+    option_args(spec) ++ [target(spec), remote_command]
+  end
+
+  @doc """
+  A remote `bash -lc` login-shell command that cds into `workspace` then runs
+  `command`. Quoted so it survives SSH's transport and the remote shell's
+  re-parse. The remote login shell sources host-provisioned credentials; no
+  env is forwarded from the orchestrator.
+  """
+  @spec remote_bash(binary(), binary()) :: binary()
+  def remote_bash(workspace, command) when is_binary(workspace) and is_binary(command) do
+    inner = "cd #{shell_quote(workspace)} && #{command}"
+    "bash -lc #{shell_quote(inner)}"
+  end
+
+  @doc """
+  Run `remote_command` on the host once and return `{output, exit_status}`.
+
+  The executor is injectable (`:exec_fn`, default `System.cmd/3` with
+  `stderr_to_stdout: true`) and the executable is resolvable (`:executable`,
+  default `executable/0`) so tests need no real `ssh`. Returns
+  `{:error, :ssh_not_allowed}` when the `ssh` binary can't be resolved.
+  """
+  @spec exec(HostSpec.t(), binary(), keyword()) ::
+          {binary(), non_neg_integer()} | {:error, :ssh_not_allowed}
+  def exec(%HostSpec{} = spec, remote_command, opts \\ []) do
+    exec_fn = Keyword.get(opts, :exec_fn, &System.cmd/3)
+
+    case resolve_executable(opts) do
+      {:ok, ssh} ->
+        exec_fn.(ssh, command_args(spec, remote_command), stderr_to_stdout: true)
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  # -- Internals --------------------------------------------------------------
+
+  defp resolve_executable(opts) do
+    case Keyword.get(opts, :executable) do
+      nil -> executable()
+      path when is_binary(path) -> {:ok, path}
+    end
+  end
+
+  defp port_args(nil), do: []
+  defp port_args(port) when is_integer(port), do: ["-p", Integer.to_string(port)]
+
+  defp identity_args(nil), do: []
+  defp identity_args(path) when is_binary(path), do: ["-i", path]
+
+  # POSIX single-quote escaping: wrap in single quotes, and end/re-open the
+  # quote around any embedded single quote (`'` -> `'\''`).
+  defp shell_quote(str) do
+    "'" <> String.replace(str, "'", "'\\''") <> "'"
+  end
+end

--- a/packages/raxol_symphony/lib/raxol/symphony/ssh.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/ssh.ex
@@ -25,9 +25,16 @@ defmodule Raxol.Symphony.Ssh do
 
   @allowed_binaries ~w(ssh)
 
-  # Non-interactive defaults: never prompt (BatchMode), and trust a new host
-  # key on first contact rather than hanging on the yes/no prompt.
-  @base_options ["-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]
+  # Fail fast on an unreachable host instead of wedging a worker slot on a
+  # stalled TCP connect.
+  @connect_timeout_seconds 15
+
+  # Detect a half-open connection (dropped network / dead remote) so a stuck
+  # worker frees its host slot instead of hanging forever: probe every 30s,
+  # give up after 3 unanswered probes (~90s), then the local `ssh` exits and
+  # the Port closes.
+  @server_alive_interval_seconds 30
+  @server_alive_count_max 3
 
   @doc """
   Resolve the `ssh` executable, refusing anything not named `ssh`.
@@ -47,10 +54,16 @@ defmodule Raxol.Symphony.Ssh do
   def target(%HostSpec{host: host, user: nil}), do: host
   def target(%HostSpec{host: host, user: user}), do: "#{user}@#{host}"
 
-  @doc "The SSH option args for a spec (non-interactive base + port + identity)."
+  @doc """
+  The SSH option args for a spec: non-interactive base (BatchMode, connect
+  timeout, server-alive keepalive), the spec's host-key policy
+  (`StrictHostKeyChecking` + optional `UserKnownHostsFile`), then port and
+  identity. Derived from the `HostSpec` so a deployment can force
+  `StrictHostKeyChecking=yes` against a pre-seeded `known_hosts`.
+  """
   @spec option_args(HostSpec.t()) :: [binary()]
-  def option_args(%HostSpec{port: port, identity_file: identity}) do
-    @base_options ++ port_args(port) ++ identity_args(identity)
+  def option_args(%HostSpec{port: port, identity_file: identity} = spec) do
+    base_options() ++ host_key_args(spec) ++ port_args(port) ++ identity_args(identity)
   end
 
   @doc """
@@ -73,6 +86,31 @@ defmodule Raxol.Symphony.Ssh do
   def remote_bash(workspace, command) when is_binary(workspace) and is_binary(command) do
     inner = "cd #{shell_quote(workspace)} && #{command}"
     "bash -lc #{shell_quote(inner)}"
+  end
+
+  @doc """
+  Wrap `command` so a dropped SSH connection can never orphan it.
+
+  Closing the local `ssh` Port (`Port.close`) tears down the ssh client but,
+  for a non-pty exec channel, sshd does NOT signal the remote command — it
+  reparents and lingers (the classic orphan). We can't force a pty here: the
+  remote `codex app-server` speaks newline-delimited JSON-RPC over stdio and a
+  pty's echo + CR/LF translation would corrupt that framing.
+
+  So the command runs with its stdio untouched (`<&0` keeps stdin wired to the
+  ssh channel, stdout/stderr inherited) and a co-resident watcher polls the
+  shell's parent (the sshd session process): when it dies, the watcher signals
+  the command. A normal exit falls straight through with the command's real
+  status (`wait`). Framing-safe: the watcher never reads the data channel.
+  """
+  @spec reap_on_disconnect(binary()) :: binary()
+  def reap_on_disconnect(command) when is_binary(command) do
+    # Single-quote-free so it survives `remote_bash/2`'s single-quoting intact.
+    command <>
+      " <&0 & __rx_pid=$!; __rx_ppid=$PPID; " <>
+      "while kill -0 $__rx_pid 2>/dev/null; do " <>
+      "ps -p $__rx_ppid >/dev/null 2>&1 || break; sleep 5; done; " <>
+      "kill $__rx_pid 2>/dev/null; wait $__rx_pid"
   end
 
   @doc """
@@ -105,6 +143,33 @@ defmodule Raxol.Symphony.Ssh do
       path when is_binary(path) -> {:ok, path}
     end
   end
+
+  # Never prompt (BatchMode); bound the TCP connect; keep the connection
+  # probed so a dead remote is noticed and the local `ssh` exits.
+  defp base_options do
+    [
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=#{@connect_timeout_seconds}",
+      "-o",
+      "ServerAliveInterval=#{@server_alive_interval_seconds}",
+      "-o",
+      "ServerAliveCountMax=#{@server_alive_count_max}"
+    ]
+  end
+
+  defp host_key_args(%HostSpec{strict_host_key_checking: mode, known_hosts: known_hosts}) do
+    ["-o", "StrictHostKeyChecking=#{ssh_host_key_mode(mode)}"] ++ known_hosts_args(known_hosts)
+  end
+
+  # HostSpec validated the mode; map to ssh's spelling (hyphenated accept-new).
+  defp ssh_host_key_mode(:yes), do: "yes"
+  defp ssh_host_key_mode(:no), do: "no"
+  defp ssh_host_key_mode(_accept_new), do: "accept-new"
+
+  defp known_hosts_args(nil), do: []
+  defp known_hosts_args(path) when is_binary(path), do: ["-o", "UserKnownHostsFile=#{path}"]
 
   defp port_args(nil), do: []
   defp port_args(port) when is_integer(port), do: ["-p", Integer.to_string(port)]

--- a/packages/raxol_symphony/lib/raxol/symphony/worker/host_pool.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/worker/host_pool.ex
@@ -118,6 +118,31 @@ defmodule Raxol.Symphony.Worker.HostPool do
     end
   end
 
+  @doc """
+  Re-hold a slot for `spec`, marking one matching free slot busy. Used to keep
+  a paused worker's host reserved across a resume and to re-hold slots after a
+  restart rebuilt the pool. Idempotent: if a matching slot is already busy the
+  pool is returned unchanged (no second slot is taken); a no-op when the host
+  is absent.
+  """
+  @spec hold(t() | nil, HostSpec.t()) :: t() | nil
+  def hold(nil, %HostSpec{}), do: nil
+
+  def hold(%__MODULE__{slots: slots} = pool, %HostSpec{} = spec) do
+    id = HostSpec.id(spec)
+
+    cond do
+      Enum.any?(slots, &(&1.busy? and HostSpec.id(&1.spec) == id)) ->
+        pool
+
+      true ->
+        case Enum.find_index(slots, &(not &1.busy? and HostSpec.id(&1.spec) == id)) do
+          nil -> pool
+          idx -> mark_at(pool, idx, true)
+        end
+    end
+  end
+
   @doc "Count of free slots."
   @spec free_count(t()) :: non_neg_integer()
   def free_count(%__MODULE__{slots: slots}),

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_host_pool_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_host_pool_test.exs
@@ -133,6 +133,57 @@ defmodule Raxol.Symphony.OrchestratorHostPoolTest do
     assert snap.counts.running == 2
   end
 
+  test "a paused worker keeps its host slot reserved and the resume re-holds it" do
+    Memory.put_issues([issue("a", "HP-1")])
+    Noop.Director.set("HP-1", {:pause_then, :awaiting_review, "rt", {:succeed_after, 10}})
+
+    pid = start_orchestrator(config(["ci@build-1"]))
+    :ok = Orchestrator.tick_now(pid)
+    wait_until(pid, fn s -> s.counts.paused == 1 end)
+
+    # The pausing exit does NOT free the slot -- it stays reserved for resume.
+    assert Orchestrator.snapshot(pid).hosts == %{total: 1, free: 0, busy: 1}
+
+    :ok = Orchestrator.resume_run(pid, "a", :approved)
+    wait_until(pid, fn s -> s.counts.paused == 0 and s.counts.running == 0 end)
+
+    # The resumed worker ran WITH its original host: on completion it releases
+    # that slot. Had it run with host: nil, the reserved slot would leak busy.
+    assert Orchestrator.snapshot(pid).hosts == %{total: 1, free: 1, busy: 0}
+  end
+
+  test "stopping a paused run frees its reserved host slot" do
+    Memory.put_issues([issue("a", "HP-1")])
+    Noop.Director.set("HP-1", {:pause, :awaiting_review, "rt"})
+
+    pid = start_orchestrator(config(["ci@build-1"]))
+    :ok = Orchestrator.tick_now(pid)
+    wait_until(pid, fn s -> s.counts.paused == 1 end)
+    assert Orchestrator.snapshot(pid).hosts.busy == 1
+
+    :ok = Orchestrator.stop_run(pid, "a")
+    assert Orchestrator.snapshot(pid).hosts == %{total: 1, free: 1, busy: 0}
+  end
+
+  defp wait_until(pid, fun, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(pid, fun, deadline)
+  end
+
+  defp do_wait_until(pid, fun, deadline) do
+    cond do
+      fun.(Orchestrator.snapshot(pid)) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("condition not met before timeout")
+
+      true ->
+        Process.sleep(10)
+        do_wait_until(pid, fun, deadline)
+    end
+  end
+
   defp start_orchestrator_with_store(store) do
     {:ok, pid} =
       start_supervised(

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_remote_dispatch_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_remote_dispatch_test.exs
@@ -1,0 +1,78 @@
+defmodule Raxol.Symphony.OrchestratorRemoteDispatchTest do
+  @moduledoc """
+  Gate activation (issue #743): the host claimed by the #742 pool is threaded
+  through dispatch into the runner's `opts[:host]`, so a runner (Codex) can
+  route its work to that host over SSH. With no hosts configured, the runner
+  receives `host: nil` and runs locally.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Config, Issue, Orchestrator}
+  alias Raxol.Symphony.Trackers.Memory
+  alias Raxol.Symphony.Worker.HostSpec
+
+  # A runner that reports the `:host` it was dispatched with back to the test
+  # pid stashed in the (passthrough) `runner.agent` config.
+  defmodule HostReportingRunner do
+    @behaviour Raxol.Symphony.Runner
+
+    @impl true
+    def run(_issue, %Config{runner: %{agent: agent}}, opts) do
+      case Map.get(agent, :report_to) do
+        pid when is_pid(pid) -> send(pid, {:runner_host, Keyword.get(opts, :host)})
+        _ -> :ok
+      end
+
+      :ok
+    end
+  end
+
+  setup do
+    start_supervised!({Task.Supervisor, name: Raxol.Symphony.TaskSupervisor})
+    start_supervised!({Memory, []})
+    Memory.put_issue(%Issue{id: "a", identifier: "RD-1", title: "T", state: "Todo"})
+    :ok
+  end
+
+  defp config(ssh_hosts) do
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{
+          kind: "memory",
+          active_states: ["Todo"],
+          terminal_states: ["Done"]
+        },
+        polling: %{interval_ms: 60_000},
+        agent: %{max_concurrent_agents: 10, max_retry_backoff_ms: 60_000},
+        runner: %{kind: "noop", agent: %{report_to: self()}},
+        worker: %{ssh_hosts: ssh_hosts}
+      },
+      prompt_template: ""
+    })
+  end
+
+  defp start_orchestrator(config) do
+    {:ok, pid} =
+      start_supervised(
+        {Orchestrator,
+         config: config, runner_module: HostReportingRunner, auto_start_tick: false, name: nil},
+        id: {Orchestrator, make_ref()}
+      )
+
+    pid
+  end
+
+  test "a claimed host is passed to the runner as opts[:host]" do
+    pid = start_orchestrator(config([%{host: "build-1", user: "ci"}]))
+    :ok = Orchestrator.tick_now(pid)
+
+    assert_receive {:runner_host, %HostSpec{host: "build-1", user: "ci"}}, 2_000
+  end
+
+  test "with no hosts the runner receives host: nil (local dispatch)" do
+    pid = start_orchestrator(config([]))
+    :ok = Orchestrator.tick_now(pid)
+
+    assert_receive {:runner_host, nil}, 2_000
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_launch_spec_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_launch_spec_test.exs
@@ -1,0 +1,60 @@
+defmodule Raxol.Symphony.Runners.Codex.SessionLaunchSpecTest do
+  @moduledoc """
+  `Session.launch_spec/5` (issue #743): the pure `{executable, Port.open-opts}`
+  decision for a local vs remote Codex launch. Isolated from the real
+  `Port.open` so the local/remote command construction is testable without a
+  process (or a real SSH server).
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.Runners.Codex.Session
+  alias Raxol.Symphony.Worker.HostSpec
+
+  describe "local (host == nil)" do
+    test "runs bash -lc command with cwd via {:cd, workspace}" do
+      assert {:ok, {"/bin/bash", opts}} =
+               Session.launch_spec(nil, "/bin/bash", "codex app-server", "/ws", [])
+
+      assert {:cd, "/ws"} in opts
+      assert {:args, ["-lc", "codex app-server"]} in opts
+      assert :exit_status in opts
+    end
+
+    test "injects env only when non-empty" do
+      {:ok, {_, no_env}} = Session.launch_spec(nil, "/bin/bash", "c", "/ws", [])
+      refute Enum.any?(no_env, &match?({:env, _}, &1))
+
+      {:ok, {_, with_env}} =
+        Session.launch_spec(nil, "/bin/bash", "c", "/ws", [{~c"K", ~c"V"}])
+
+      assert {:env, [{~c"K", ~c"V"}]} in with_env
+    end
+  end
+
+  describe "remote (%HostSpec{})" do
+    test "runs ssh with the wrapped remote bash command and forwards no env" do
+      host = %HostSpec{host: "build-1", user: "ci", port: 2222}
+
+      case Session.launch_spec(host, "/bin/bash", "codex app-server", "/ws", [{~c"K", ~c"V"}]) do
+        {:ok, {executable, opts}} ->
+          assert Path.basename(executable) == "ssh"
+          {:args, args} = List.keyfind(opts, :args, 0)
+
+          # ssh options + destination + the single remote-command element.
+          assert "ci@build-1" in args
+          assert ["-p", "2222"] == Enum.slice(args, -4, 2) or "-p" in args
+          assert List.last(args) =~ "bash -lc 'cd '\\''/ws'\\'' && codex app-server'"
+
+          # No {:cd, _} and no {:env, _} on the remote path (login shell owns
+          # cwd + credentials); stdio is the ssh pipe.
+          refute Enum.any?(opts, &match?({:cd, _}, &1))
+          refute Enum.any?(opts, &match?({:env, _}, &1))
+
+        {:error, :ssh_not_allowed} ->
+          # No ssh on this machine -> the remote launch fails closed, which is
+          # itself the contract.
+          :ok
+      end
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_launch_spec_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_launch_spec_test.exs
@@ -43,7 +43,12 @@ defmodule Raxol.Symphony.Runners.Codex.SessionLaunchSpecTest do
           # ssh options + destination + the single remote-command element.
           assert "ci@build-1" in args
           assert ["-p", "2222"] == Enum.slice(args, -4, 2) or "-p" in args
-          assert List.last(args) =~ "bash -lc 'cd '\\''/ws'\\'' && codex app-server'"
+          assert List.last(args) =~ "bash -lc 'cd '\\''/ws'\\'' && codex app-server"
+
+          # The remote codex is wrapped in the disconnect reaper so a
+          # Port.close never orphans it on the host.
+          assert List.last(args) =~ "codex app-server <&0 &"
+          assert List.last(args) =~ "wait $__rx_pid"
 
           # No {:cd, _} and no {:env, _} on the remote path (login shell owns
           # cwd + credentials); stdio is the ssh pipe.

--- a/packages/raxol_symphony/test/raxol/symphony/ssh_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/ssh_test.exs
@@ -14,10 +14,29 @@ defmodule Raxol.Symphony.SshTest do
   end
 
   describe "option_args/1" do
-    test "always includes non-interactive base options" do
+    test "always includes non-interactive base options and keepalive" do
       args = Ssh.option_args(spec())
       assert "BatchMode=yes" in args
+      assert "ConnectTimeout=15" in args
+      assert "ServerAliveInterval=30" in args
+      assert "ServerAliveCountMax=3" in args
+      # Default host-key policy is unchanged (trust-on-first-use).
       assert "StrictHostKeyChecking=accept-new" in args
+    end
+
+    test "honors a forced host-key mode and a known_hosts file" do
+      args =
+        Ssh.option_args(spec(strict_host_key_checking: :yes, known_hosts: "/etc/ssh/known_hosts"))
+
+      assert "StrictHostKeyChecking=yes" in args
+      assert "UserKnownHostsFile=/etc/ssh/known_hosts" in args
+      refute "StrictHostKeyChecking=accept-new" in args
+    end
+
+    test "maps the :no mode and omits UserKnownHostsFile when absent" do
+      args = Ssh.option_args(spec(strict_host_key_checking: :no))
+      assert "StrictHostKeyChecking=no" in args
+      refute Enum.any?(args, &String.starts_with?(&1, "UserKnownHostsFile="))
     end
 
     test "adds -p for a port and -i for an identity file" do
@@ -30,6 +49,29 @@ defmodule Raxol.Symphony.SshTest do
       args = Ssh.option_args(spec())
       refute "-p" in args
       refute "-i" in args
+    end
+  end
+
+  describe "reap_on_disconnect/1" do
+    test "ties the command to the ssh connection without touching its stdio" do
+      wrapped = Ssh.reap_on_disconnect("codex app-server")
+
+      # The command runs with stdin preserved (<&0), backgrounded, and a
+      # watcher polls the shell's parent, signalling the command when it dies.
+      assert wrapped =~ "codex app-server <&0 &"
+      assert wrapped =~ "__rx_ppid=$PPID"
+      assert wrapped =~ "ps -p $__rx_ppid"
+      assert wrapped =~ "kill $__rx_pid"
+      assert wrapped =~ "wait $__rx_pid"
+      # Framing-safe: no pty request, no single quotes to break remote_bash.
+      refute wrapped =~ "-t"
+      refute wrapped =~ "'"
+    end
+
+    test "is syntactically valid bash" do
+      # `-n` parses without executing: a syntax error would be non-zero.
+      {_out, status} = System.cmd("bash", ["-n", "-c", Ssh.reap_on_disconnect("codex")])
+      assert status == 0
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/ssh_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/ssh_test.exs
@@ -1,0 +1,109 @@
+defmodule Raxol.Symphony.SshTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.Ssh
+  alias Raxol.Symphony.Worker.HostSpec
+
+  defp spec(fields \\ []), do: struct(%HostSpec{host: "build-1"}, fields)
+
+  describe "target/1" do
+    test "is host alone or user@host" do
+      assert Ssh.target(spec()) == "build-1"
+      assert Ssh.target(spec(user: "ci")) == "ci@build-1"
+    end
+  end
+
+  describe "option_args/1" do
+    test "always includes non-interactive base options" do
+      args = Ssh.option_args(spec())
+      assert "BatchMode=yes" in args
+      assert "StrictHostKeyChecking=accept-new" in args
+    end
+
+    test "adds -p for a port and -i for an identity file" do
+      args = Ssh.option_args(spec(port: 2222, identity_file: "/keys/id_ci"))
+      assert ["-p", "2222"] == Enum.slice(args, -4, 2)
+      assert ["-i", "/keys/id_ci"] == Enum.slice(args, -2, 2)
+    end
+
+    test "omits -p and -i when absent" do
+      args = Ssh.option_args(spec())
+      refute "-p" in args
+      refute "-i" in args
+    end
+  end
+
+  describe "remote_bash/2" do
+    test "wraps a login shell that cds into a quoted workspace then runs the command" do
+      assert Ssh.remote_bash("/ws/app", "codex app-server") ==
+               ~s(bash -lc 'cd '\\''/ws/app'\\'' && codex app-server')
+    end
+
+    test "quoting survives two shell parses (ssh remote shell then bash -lc)" do
+      # A workspace path with a space AND a single quote is the hard case.
+      dir = Path.join(System.tmp_dir!(), "sym ssh 'q' #{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      # `bash -c <remote_bash>` simulates ssh handing the command to the
+      # remote login shell, which then runs the inner `bash -lc 'cd … && …'`.
+      {out, 0} = System.cmd("bash", ["-c", Ssh.remote_bash(dir, "pwd")])
+      assert String.trim(out) == dir
+    end
+  end
+
+  describe "command_args/2" do
+    test "is [options, target, remote_command] with the command as one element" do
+      remote = Ssh.remote_bash("/ws", "codex")
+      args = Ssh.command_args(spec(user: "ci", port: 22), remote)
+
+      assert List.last(args) == remote
+      assert Enum.at(args, -2) == "ci@build-1"
+      # the remote command is a single argv element (never split on spaces)
+      assert Enum.count(args, &(&1 == remote)) == 1
+    end
+  end
+
+  describe "executable/0" do
+    test "resolves ssh or refuses when unavailable" do
+      case Ssh.executable() do
+        {:ok, path} -> assert Path.basename(path) == "ssh"
+        {:error, :ssh_not_allowed} -> :ok
+      end
+    end
+  end
+
+  describe "exec/3" do
+    test "runs ssh with the built argv through an injected executor" do
+      test = self()
+
+      exec_fn = fn ssh, args, opts ->
+        send(test, {:ran, ssh, args, opts})
+        {"remote output\n", 0}
+      end
+
+      assert {"remote output\n", 0} =
+               Ssh.exec(spec(user: "ci"), "uptime",
+                 exec_fn: exec_fn,
+                 executable: "/usr/bin/ssh"
+               )
+
+      assert_received {:ran, "/usr/bin/ssh", args, stderr_to_stdout: true}
+      assert List.last(args) == "uptime"
+      assert "ci@build-1" in args
+    end
+
+    test "returns {:error, :ssh_not_allowed} when the executable can't be resolved" do
+      # A blank PATH makes the default resolver fail; the injected exec_fn
+      # must never be reached.
+      System.put_env("SYM_SSH_TEST_OLD_PATH", System.get_env("PATH") || "")
+      System.put_env("PATH", "")
+
+      assert Ssh.exec(spec(), "noop", exec_fn: fn _, _, _ -> flunk("should not run") end) ==
+               {:error, :ssh_not_allowed}
+    after
+      System.put_env("PATH", System.get_env("SYM_SSH_TEST_OLD_PATH") || "")
+      System.delete_env("SYM_SSH_TEST_OLD_PATH")
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/worker/host_pool_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/worker/host_pool_test.exs
@@ -168,4 +168,32 @@ defmodule Raxol.Symphony.Worker.HostPoolTest do
       assert HostPool.reconcile(pool, []) == nil
     end
   end
+
+  describe "hold/2 (re-hold across pause/resume or restart)" do
+    test "claims a matching free slot (restart rebuilt the pool)" do
+      [s1, s2] = specs(2)
+      pool = HostPool.new([s1, s2])
+
+      pool = HostPool.hold(pool, s1)
+      assert HostPool.busy_count(pool) == 1
+      # The held host is no longer free; the other stays claimable.
+      {:ok, ^s2, pool} = HostPool.claim(pool)
+      assert HostPool.claim(pool) == :none_free
+    end
+
+    test "is idempotent when a matching slot is already busy" do
+      [s1, s2] = specs(2)
+      pool = HostPool.new([s1, s2])
+      {:ok, ^s1, pool} = HostPool.claim(pool)
+
+      held = HostPool.hold(pool, s1)
+      assert HostPool.busy_count(held) == 1
+    end
+
+    test "is a no-op for an absent host or a nil pool" do
+      pool = HostPool.new(specs(1))
+      assert HostPool.hold(pool, %HostSpec{host: "gone"}) == pool
+      assert HostPool.hold(nil, %HostSpec{host: "x"}) == nil
+    end
+  end
 end


### PR DESCRIPTION
Closes #743. Second slice of SSH worker dispatch (#518). **Stacked on #742** (`feat/symphony-worker-host-pool`, PR #745) — review/merge that first; this branch includes it.

## What

Makes a claimed host actually run the worker's agent command over SSH.

- **`Raxol.Symphony.Ssh`** — the single seam that touches `ssh`. Pure argv construction (`command_args/2`, `remote_bash/2`, `option_args/1`, `target/1`), an **`ssh` executable allowlist** (`executable/0`), and an injectable one-shot `exec/3` (`:exec_fn` default `System.cmd/3`, `:executable` override) so tests need no real SSH.
- **Codex transport** — `Session.start/5` gains a `host`. The launch decision is extracted into the pure, unit-tested `Session.launch_spec/5`: local → `bash -lc command` with `{:cd, workspace}` + env (unchanged); remote → `ssh <opts> user@host "bash -lc 'cd WS && command'"`. Codex's JSON-RPC then streams over the port's stdio unchanged — whether that stdio is local bash or an ssh pipe. `Codex.run/3` reads `opts[:host]` and threads it through.
- **Gate activation** — the orchestrator threads the #742-claimed host through `spawn_worker_task` → `run_worker_payload` → `run_runner` into `runner_opts[:host]`. No host configured → `host: nil` → local dispatch, unchanged.

## Two deliberate decisions

- **Credentials stay host-side.** No environment is forwarded over SSH — the remote `bash -lc` login shell sources host-provisioned credentials. Secrets never travel on a command line, and env injection stays a local-worker concern.
- **`ssh` is allowlisted** (mirrors the gateway transcribe seam), refusing anything not named `ssh`.

## Out of scope (follow-ups)

- Remote **workspace** creation + the `PathSafety.assert_cwd!` invariant → #744 (this slice `cd`s into whatever path it's given; #744 makes it exist on the host).
- Resume host re-claiming (a resumed worker still gets `host: nil`).
- The `:graph`/`:graph_parallel` paths run local (host threaded only through the sequential runner path).

## Tests (no real SSH; injected transports + a fake runner)

- `ssh_test.exs` — `target`/`option_args`/`command_args`; `remote_bash` quoting proven by a **real `bash` round-trip** through two shell parses (ssh remote shell + `bash -lc`) with a space-and-quote path; `exec/3` via an injected executor + the not-allowed path.
- `session_launch_spec_test.exs` — the pure local vs remote launch spec (local: `{:cd, ws}` + `["-lc", command]` + env-only-when-present; remote: ssh executable, wrapped remote-bash arg, **no** `{:cd,_}`/`{:env,_}`).
- `orchestrator_remote_dispatch_test.exs` — a claimed host reaches the runner as `opts[:host]`; no hosts → `host: nil`.

## Scope / notes

- Branched off `feat/symphony-worker-host-pool` (includes the HostPool dup-id fix). `mix.lock` excluded.
- **CI:** `raxol_symphony` isn't in the CI matrix — local gate below.
- No new compiler warnings or credo issues on the changed files.

## Manual testing

- [x] `cd packages/raxol_symphony && MIX_ENV=test mix test` — 803 passed, 0 failures
- [x] `mix test` on the 3 new files + `codex_test.exs` (local path unchanged) — green
- [x] `mix format --check-formatted` clean on all changed files
- [x] `mix credo` — no new issues
- [ ] Live: run a worker against a real `sshd` host with `worker.ssh_hosts` set, confirming the Codex session streams over the ssh pipe (needs a real host + #744's remote workspace)
