### PR TITLE
Symphony: compile clean under Elixir 1.20 type checker

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
@@ -201,14 +201,17 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
          {:ok, compiled} <-
            AgentWorkflow.compile(max_turns, workflow_compile_opts(config)) do
       case resume_token do
-        %{workflow_run_id: run_id} when not is_nil(run_id) and not is_nil(resume_value) ->
+        %{workflow_run_id: run_id}
+        when not is_nil(run_id) and not is_nil(resume_value) ->
           compiled
           |> Compiled.resume(run_id, resume_value)
           |> translate_workflow_result(issue)
 
         _ ->
           run_id = generate_workflow_run_id(issue, opts)
-          state = build_workflow_state(issue, config, opts, backend, backend_opts)
+
+          state =
+            build_workflow_state(issue, config, opts, backend, backend_opts)
 
           compiled
           |> Compiled.invoke(state, run_id: run_id)
@@ -226,7 +229,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
     # Postgrex equivalent.
     saver =
       Map.get(agent, :workflow_saver) ||
-        {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: :raxol_symphony_agent_workflow}}
+        {Raxol.Workflow.Checkpoint.Saver.Ets,
+         %{table: :raxol_symphony_agent_workflow}}
 
     [saver: saver]
   end
@@ -400,7 +404,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
           system_prompt: state.system_prompt
         )
 
-      {:ok, collect_with_detector(stream, state.parent, state.issue.id, state.pause_detector)}
+      {:ok,
+       collect_with_detector(
+         stream,
+         state.parent,
+         state.issue.id,
+         state.pause_detector
+       )}
     end
 
     case Raxol.Agent.PolicyApplier.apply(policies, op, turn_payload) do
@@ -449,7 +459,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
     still_active?(state.issue, state.config)
   end
 
-  def __workflow_still_active__(%{tracker_cache: cache, issue: issue, config: config} = state) do
+  def __workflow_still_active__(
+        %{tracker_cache: cache, issue: issue, config: config} = state
+      ) do
     key = {:tracker, issue.id}
 
     case Raxol.Agent.Cache.get(cache, key) do
@@ -533,7 +545,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
       )
 
     if SelfImprove.configured?(config) do
-      {result, events} = forward_collecting(stream, ctx.parent, issue.id, ctx.pause_detector)
+      {result, events} =
+        forward_collecting(stream, ctx.parent, issue.id, ctx.pause_detector)
+
       SelfImprove.fire(config, issue, events)
       result
     else
@@ -560,7 +574,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
   # (apply_detector returns `:continue`).
   defp forward_collecting(stream, parent, issue_id, detector) do
     {result, events} =
-      Enum.reduce_while(stream, {{:error, :no_done}, []}, fn event, {_result, acc} ->
+      Enum.reduce_while(stream, {{:error, :no_done}, []}, fn event,
+                                                             {_result, acc} ->
         send(parent, {:run_event, issue_id, legacy_payload(event)})
         acc = [legacy_payload(event) | acc]
         {step, result} = collect_decision(event, detector)
@@ -572,8 +587,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
 
   defp collect_decision(event, detector) do
     case apply_detector(detector, event) do
-      {:pause, reason, token} when is_atom(reason) -> {:halt, {:pause, reason, token}}
-      _ -> done_decision(event)
+      {:pause, reason, token} when is_atom(reason) ->
+        {:halt, {:pause, reason, token}}
+
+      _ ->
+        done_decision(event)
     end
   end
 
@@ -648,7 +666,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
     :ok
   end
 
-  defp settle_one(%Raxol.Symphony.Sandboxes.BudgetCap{} = sandbox, event, payload) do
+  defp settle_one(
+         %Raxol.Symphony.Sandboxes.BudgetCap{} = sandbox,
+         event,
+         payload
+       ) do
     Raxol.Symphony.Sandboxes.BudgetCap.settle(sandbox, event, payload)
   end
 
@@ -794,55 +816,49 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
     Map.get(agent, :pause_detector)
   end
 
-  defp agent_tracker_cache(%Config{runner: %{agent: agent}}) do
-    Raxol.Agent.Cache.normalize(Map.get(agent, :tracker_cache))
-  end
+  # `Config` always builds `runner` as a map, so a single `%Config{}` clause
+  # is total -- `get_in` tolerates a missing `:agent` or key and yields nil
+  # (same as the old catch-all), leaving no provably-dead clause for the
+  # type checker to reject. Mirrors the session runner's `agent_prompt_cache`.
+  defp agent_tracker_cache(%Config{runner: runner}),
+    do: Raxol.Agent.Cache.normalize(get_in(runner, [:agent, :tracker_cache]))
 
-  defp agent_tracker_cache(_), do: nil
+  defp agent_tracker_cache_ttl_ms(%Config{runner: runner}),
+    do: get_in(runner, [:agent, :tracker_cache_ttl_ms]) || 30_000
 
-  defp agent_tracker_cache_ttl_ms(%Config{runner: %{agent: agent}}) do
-    Map.get(agent, :tracker_cache_ttl_ms, 30_000)
-  end
-
-  defp agent_tracker_cache_ttl_ms(_), do: 30_000
-
-  defp agent_thread_log(%Config{runner: %{agent: agent}} = config) do
-    case Raxol.Agent.ThreadLog.normalize(Map.get(agent, :thread_log)) do
+  defp agent_thread_log(%Config{runner: runner} = config) do
+    case Raxol.Agent.ThreadLog.normalize(get_in(runner, [:agent, :thread_log])) do
       nil -> Raxol.Symphony.AgentMetadata.read(agent_module(config)).thread_log
       tuple -> tuple
     end
   end
 
-  defp agent_thread_log(_), do: nil
-
-  defp agent_module(%Config{runner: %{agent: agent}}), do: Map.get(agent, :module)
-  defp agent_module(_), do: nil
+  defp agent_module(%Config{runner: runner}),
+    do: get_in(runner, [:agent, :module])
 
   defp build_thread_id(%Issue{id: id}, attempt) when not is_nil(id) do
     "symphony-agent-" <> to_string(id) <> "-" <> to_string(attempt || 0)
   end
 
-  defp agent_policies(%Config{runner: %{agent: agent}}) do
-    case Map.get(agent, :policies, []) do
+  defp agent_policies(%Config{runner: runner}) do
+    case get_in(runner, [:agent, :policies]) do
       list when is_list(list) -> list
       _ -> []
     end
   end
 
-  defp agent_policies(_), do: []
-
-  defp agent_sandboxes(%Config{runner: %{agent: agent}} = config) do
+  defp agent_sandboxes(%Config{runner: runner} = config) do
     direct =
-      case Map.get(agent, :sandboxes, []) do
+      case get_in(runner, [:agent, :sandboxes]) do
         list when is_list(list) -> list
         _ -> []
       end
 
-    module_declared = Raxol.Symphony.AgentMetadata.read(agent_module(config)).sandboxes
+    module_declared =
+      Raxol.Symphony.AgentMetadata.read(agent_module(config)).sandboxes
+
     direct ++ module_declared
   end
-
-  defp agent_sandboxes(_), do: []
 
   # -- Prompt building (Liquid via PromptBuilder) -----------------------------
 

--- a/packages/raxol_symphony/lib/raxol/symphony/surfaces/mcp.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/surfaces/mcp.ex
@@ -408,8 +408,10 @@ defmodule Raxol.Symphony.Surfaces.MCP do
 
   defp normalize_issue_number(_), do: nil
 
-  defp format_reason(reason) when is_binary(reason), do: reason
-  defp format_reason(reason), do: inspect(reason)
+  # One total clause (internal branch) so the checker sees no dead fallback:
+  # a binary passes through, anything else is inspected.
+  defp format_reason(reason),
+    do: if(is_binary(reason), do: reason, else: inspect(reason))
 
   # -- Helpers ----------------------------------------------------------------
 
@@ -449,14 +451,11 @@ defmodule Raxol.Symphony.Surfaces.MCP do
     Enum.find(list, fn run -> run.issue_id == id end)
   end
 
-  defp fetch_decision(args) when is_map(args) do
-    case Map.get(args, "decision", Map.get(args, :decision)) do
-      nil -> nil
-      decision -> decision
-    end
+  # One total clause (internal branch) so the checker sees no dead fallback:
+  # a map yields its string-or-atom "decision" key, anything else is nil.
+  defp fetch_decision(args) do
+    if is_map(args), do: Map.get(args, "decision", Map.get(args, :decision))
   end
-
-  defp fetch_decision(_), do: nil
 
   defp resume_run_response(orch, id, decision) do
     case OrchestratorClient.safe_call(fn ->


### PR DESCRIPTION
## What

Makes `raxol_symphony` compile under the repo's pinned **Elixir 1.20.2**. The
1.20 type checker hard-errors (`== Type checking failed with errors ==`) on
eight private clauses it proves unreachable, aborting the whole package build.

## Why

The checker unsoundly narrows `Config.runner` to always carry an `:agent`
key, so it treats each `defp foo(%Config{runner: %{agent: agent}})` head as
total and rejects the following catch-all as dead. Two more sites
(`format_reason/1`, `fetch_decision/1`) have call-site-provable dead
fallbacks.

## How

Collapse each two-clause form into one **total** clause that keeps the exact
defensive behavior:

- `runners/raxol_agent.ex` (6 sites): a single `%Config{runner: runner}`
  clause reading `get_in(runner, [:agent, key])` — nil-safe on a missing
  `:agent`/key, same as the old fallback. This is the same idiom the session
  runner already uses (`agent_prompt_cache`).
- `surfaces/mcp.ex` (2 sites): one clause with an internal `if` branch.

No behavior change; the fallbacks were behavior-preserving, just unreachable
per the checker.

## Testing

- [x] `MIX_ENV=test mix compile` — clean (was: type-check abort)
- [x] `MIX_ENV=test mix test` — **760 passed** (23 doctests, 737 tests), 6 excluded

## Manual testing

- [x] Confirmed the failure reproduces on `master` with these changes stashed
- [x] Confirmed the full suite is green after the fix
