### PR TITLE
Symphony: clear pre-existing compile warnings

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
@@ -214,7 +214,8 @@ defmodule Raxol.Symphony.Evidence.Capture do
   defp truncate(text, limit) when byte_size(text) <= limit, do: text
 
   defp truncate(text, limit) do
-    <<head::binary-size(limit - 13), _::binary>> = text
+    head_size = limit - 13
+    <<head::binary-size(^head_size), _::binary>> = text
     head <> "...[truncated]"
   end
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/evidence/github.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/evidence/github.ex
@@ -20,8 +20,6 @@ defmodule Raxol.Symphony.Evidence.GitHub do
 
   @behaviour Raxol.Symphony.Evidence.Backend
 
-  require Logger
-
   alias Raxol.Symphony.{Config, Evidence}
 
   @default_endpoint "https://api.github.com"

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -78,8 +78,6 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
   @behaviour Raxol.Symphony.Runner
 
-  require Logger
-
   alias Raxol.Symphony.{Config, Issue, PromptBuilder, Runner}
 
   @compile {:no_warn_undefined,

--- a/packages/raxol_symphony/lib/raxol/symphony/surfaces/telegram/formatter.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/surfaces/telegram/formatter.ex
@@ -263,7 +263,7 @@ defmodule Raxol.Symphony.Surfaces.Telegram.Formatter do
     "\n<b>Pending retries</b>\n" <> rows
   end
 
-  defp snapshot_keyboard(running, paused \\ []) do
+  defp snapshot_keyboard(running, paused) do
     refresh = %{text: "Refresh", callback_data: "sym:refresh"}
 
     stop_buttons =

--- a/packages/raxol_symphony/lib/raxol/symphony/surfaces/watch/formatter.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/surfaces/watch/formatter.ex
@@ -127,6 +127,8 @@ defmodule Raxol.Symphony.Surfaces.Watch.Formatter do
     }
   end
 
+  def event_notification(_other, _snapshot), do: :skip
+
   defp paused_event_body(nil, _count) do
     {"A run is paused. Tap Refresh to see details.",
      [refresh_action(), dismiss_action()]}
@@ -153,8 +155,6 @@ defmodule Raxol.Symphony.Surfaces.Watch.Formatter do
 
     {body, actions}
   end
-
-  def event_notification(_other, _snapshot), do: :skip
 
   @doc """
   Builds a per-run notification with a tap-to-stop action. Useful for the


### PR DESCRIPTION
Clears the five pre-existing compile warnings in `raxol_symphony` so the package
passes `MIX_ENV=test mix compile --warnings-as-errors` again. These warnings were
in files untouched by the in-flight Symphony feature branches and were blocking
the warnings-as-errors gate package-wide; surfaced during adversarial review of
the current PR stack.

## Changes

| File | Warning | Fix |
| --- | --- | --- |
| `evidence/capture.ex:217` | variable in `binary-size(...)` must be pinned | bind `head_size = limit - 13` outside the match, use `^head_size` |
| `evidence/github.ex:23` | unused `require Logger` | removed (no `Logger.` calls in file) |
| `runners/raxol_agent_session.ex:81` | unused `require Logger` | removed (no `Logger.` calls in file) |
| `surfaces/telegram/formatter.ex:266` | never-used default arg on private `snapshot_keyboard/2` | dropped the dead `\\ []` (all 5 call sites pass both args) |
| `surfaces/watch/formatter.ex` | clauses with same name/arity not grouped | moved the `event_notification(_other, _snapshot)` catch-all to sit after the last `event_notification/2` clause (still last of 7 clauses, match order preserved) |

No logic or output changes; pure warning hygiene.

## Verification

- `MIX_ENV=test mix compile --force --warnings-as-errors` -> exit 0, clean
- `MIX_ENV=test mix test` -> 760 passed (23 doctests, 737 tests), 6 excluded, 0 failures
- `mix.lock` left at base (upstream dep drift from `deps.get` reverted)

## Manual testing

- [ ] `cd packages/raxol_symphony && MIX_ENV=test mix compile --force --warnings-as-errors` passes clean
- [ ] `cd packages/raxol_symphony && MIX_ENV=test mix test` green
