### PR TITLE
ACP: sync Xochi offering to full corridor set (USDT/USDG/stealth)

### DIFF
--- a/packages/raxol_acp/docs/xochi-offering-split.md
+++ b/packages/raxol_acp/docs/xochi-offering-split.md
@@ -21,6 +21,16 @@ L1 destinations (stealth is an **X→L1 / L1↔L1** product; cross-chain stealth
 
 This is a DX/clarity change, not a security change. Riddler remains the enforcer.
 
+The settlement-agnostic `xochi_cross_chain_transfer` document is retained as the single
+"covers-everything" listing: one offering whose schema spans public/private/stealth across
+every supported token and chain. It self-describes the live corridor set (kept in lockstep
+with `Raxol.ACP.Xochi.CorridorAllowlist`, which mirrors the deployed Riddler route tables in
+`ansible-riddler`): USDC and USDT each across the full 5-chain EVM mesh, USDG on Robinhood
+Chain (4663) cross-asset in both directions (in from and out to USDC/USDT on any mesh
+chain), USDC<->USDT conversion, and ERC-5564 stealth to Ethereum L1. Its generated artifact
+is `priv/offering.json` (`mix acp.register_offering --offering legacy`); the narrower
+USDC-only listing stays at `priv/offering.usdc_public.json`.
+
 ## The two offerings
 
 | | `xochi_stable_public` | `xochi_stable_stealth` |

--- a/packages/raxol_acp/lib/raxol/acp/xochi/corridor_allowlist.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/corridor_allowlist.ex
@@ -11,21 +11,20 @@ defmodule Raxol.ACP.Xochi.CorridorAllowlist do
   the solver cannot route -- e.g. USDT Arbitrum -> Base passes both leg checks but
   is not a relay corridor. This module adds the missing pair-level constraint.
 
-  ## The three stablecoin families (launch scope)
+  ## The corridor families (production scope)
 
     * **USDC** -- full mesh across the five CCTP chains `{1, 10, 137, 8453, 42161}`.
-      Settles via CCTP, not the relay route table, so every ordered pair is live.
-    * **USDT** -- the explicit relay corridor set only: Arbitrum <-> Polygon plus
-      the Polygon exits to the OP and Ethereum hubs. NOT Base (8453 is not a USDT
-      relay corridor). Mirrors Riddler's `Relay.Routes` `@usdt_corridors`
-      byte-for-byte.
-    * **USDG** -- Robinhood Chain (4663) drain only: `4663 -> USDC` on a hub
-      (Arbitrum or Base). Robinhood is USDG-in-only; there is no inbound route to
-      4663, and the fill is cross-asset (USDG on the Robinhood leg delivered as
-      USDC on the hub).
+      Settles via CCTP, so every ordered pair is live.
+    * **USDT** -- full mesh across the same five EVM chains via relay.link: every
+      ordered pair (Base included). Mirrors Riddler's `Relay.Routes` `@usdt_chains`.
+    * **USDG** -- Robinhood Chain (4663) is USDG-only, settling cross-asset in both
+      directions: an inbound entry (USDC or USDT on a mesh chain -> USDG on 4663)
+      and an exit drain (USDG on 4663 -> USDC or USDT on any mesh chain). Mirrors
+      Riddler's cross-token pairs + the relay drain to any USDC chain.
+    * **USDC <-> USDT** -- cross-asset conversion across the mesh, either direction
+      (Riddler `cross_token_pairs`). Inventory-bounded by the solver at quote time.
 
-  Everything else -- WETH/ETH, USDT on Base, USDG inbound, and any unlisted route
-  -- is declined.
+  Everything else -- WETH/ETH and any unlisted route -- is declined.
 
   ## Enforcement
 
@@ -34,32 +33,23 @@ defmodule Raxol.ACP.Xochi.CorridorAllowlist do
   in dev/test unless `config :raxol_acp, :stablecoin_corridors_only, true`, so the
   broader token-fillable behavior remains available for non-launch contexts.
 
-  TODO(xochi-fi/xochi#135 item 2): replace this hardcoded matrix with the solver's
+  This static matrix tracks the deployed Riddler route tables + cross-token pairs
+  (`ansible-riddler` `host_vars/riddler-axol.yml`); the finer per-corridor
+  inventory ceilings stay with the solver, which declines a drained float at quote
+  time. TODO(xochi-fi/xochi#135 item 2): replace it with the solver's
   machine-readable capability endpoint when it ships, so the gate tracks the
-  solver's real routes instead of a static list. Riddler already fills more USDG
-  hubs than the launch scope lists here (any USDC chain, not just Arb/Base); widen
-  once the endpoint confirms them.
+  solver's real routes instead of a static list.
   """
 
   # The five CCTP chains for USDC (full mesh). Mirrors Riddler's `@usdc_chains`.
   @usdc_chains [1, 10, 137, 8453, 42_161]
 
-  # The explicit USDT relay corridors (origin/dest both USDT). Arbitrum (42161)
-  # and Polygon (137) are the USDT0 sources; OP (10) and Ethereum (1) are hub
-  # exits. Byte-for-byte with Riddler's `Relay.Routes` `@usdt_corridors`.
-  @usdt_corridors [
-    {42_161, 137},
-    {137, 42_161},
-    {137, 10},
-    {137, 1}
-  ]
+  # USDT is a full any-direction relay mesh across the same five EVM chains (Base
+  # included). Mirrors Riddler's `Relay.Routes` `@usdt_chains` (riddler #526).
+  @usdt_chains [1, 10, 137, 8453, 42_161]
 
-  # USDG drain from Robinhood Chain (4663) to a USDC hub. Drain direction only --
-  # Robinhood is USDG-in with no inbound route.
-  @usdg_corridors [
-    {4663, 42_161},
-    {4663, 8453}
-  ]
+  # Robinhood Chain: USDG lives only here, so every USDG leg pivots on 4663.
+  @robinhood 4663
 
   @doc """
   Whether the corridor `from -> to` is allowed for the given resolved leg symbols.
@@ -72,9 +62,23 @@ defmodule Raxol.ACP.Xochi.CorridorAllowlist do
   def allowed?("USDC", "USDC", from, to),
     do: from != to and from in @usdc_chains and to in @usdc_chains
 
-  def allowed?("USDT", "USDT", from, to), do: {from, to} in @usdt_corridors
+  def allowed?("USDT", "USDT", from, to),
+    do: from != to and from in @usdt_chains and to in @usdt_chains
 
-  def allowed?("USDG", "USDC", from, to), do: {from, to} in @usdg_corridors
+  # USDG exit drain: Robinhood -> USDC or USDT on any mesh chain.
+  def allowed?("USDG", "USDC", @robinhood, to), do: to in @usdc_chains
+  def allowed?("USDG", "USDT", @robinhood, to), do: to in @usdt_chains
+
+  # USDG inbound entry: USDC or USDT on a mesh chain -> Robinhood USDG.
+  def allowed?("USDC", "USDG", from, @robinhood), do: from in @usdc_chains
+  def allowed?("USDT", "USDG", from, @robinhood), do: from in @usdt_chains
+
+  # USDC <-> USDT cross-asset conversion across the mesh, either direction.
+  def allowed?("USDC", "USDT", from, to),
+    do: from != to and from in @usdc_chains and to in @usdt_chains
+
+  def allowed?("USDT", "USDC", from, to),
+    do: from != to and from in @usdt_chains and to in @usdc_chains
 
   def allowed?(_src, _dst, _from, _to), do: false
 
@@ -99,11 +103,21 @@ defmodule Raxol.ACP.Xochi.CorridorAllowlist do
   """
   @spec corridors() :: [{String.t(), String.t(), pos_integer(), pos_integer()}]
   def corridors do
-    usdc =
-      for from <- @usdc_chains, to <- @usdc_chains, from != to, do: {"USDC", "USDC", from, to}
+    usdc = for from <- @usdc_chains, to <- @usdc_chains, from != to, do: {"USDC", "USDC", from, to}
+    usdt = for from <- @usdt_chains, to <- @usdt_chains, from != to, do: {"USDT", "USDT", from, to}
 
-    usdt = for {from, to} <- @usdt_corridors, do: {"USDT", "USDT", from, to}
-    usdg = for {from, to} <- @usdg_corridors, do: {"USDG", "USDC", from, to}
-    usdc ++ usdt ++ usdg
+    usdg_out =
+      (for to <- @usdc_chains, do: {"USDG", "USDC", @robinhood, to}) ++
+        (for to <- @usdt_chains, do: {"USDG", "USDT", @robinhood, to})
+
+    usdg_in =
+      (for from <- @usdc_chains, do: {"USDC", "USDG", from, @robinhood}) ++
+        (for from <- @usdt_chains, do: {"USDT", "USDG", from, @robinhood})
+
+    cross =
+      (for from <- @usdc_chains, to <- @usdt_chains, from != to, do: {"USDC", "USDT", from, to}) ++
+        (for from <- @usdt_chains, to <- @usdc_chains, from != to, do: {"USDT", "USDC", from, to})
+
+    usdc ++ usdt ++ usdg_out ++ usdg_in ++ cross
   end
 end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/offering.ex
@@ -76,8 +76,14 @@ defmodule Raxol.ACP.Xochi.Offering do
         "Cross-chain stablecoin settlement storefront. The buyer signs a Xochi " <>
           "intent, the storefront relays it and returns the settlement tx hashes; " <>
           "the buyer escrows only the storefront fee (a plain job, no fund hook). " <>
-          "The buyer may settle to a different recipient or an ERC-5564 stealth " <>
-          "address by signing it into their intent; the storefront relays it verbatim.",
+          "Supported settlement: USDC and USDT each across the full 5-chain EVM mesh " <>
+          "(Ethereum, Optimism, Polygon, Base, Arbitrum); USDG on Robinhood Chain (4663), " <>
+          "cross-asset in both directions (USDC/USDT in -> USDG, and USDG -> USDC/USDT out " <>
+          "on any mesh chain); and USDC<->USDT cross-asset conversion. Order size min " <>
+          "$1.00, max bounded by the solver's per-token caps (e.g. USDT ~$1,000, USDG " <>
+          "~$10,000). The buyer may settle publicly to a wallet, or privately to a " <>
+          "one-time ERC-5564 stealth address on Ethereum L1, by signing the choice into " <>
+          "their intent; the storefront relays it verbatim.",
       # No funds move through ACP: the buyer's capital moves via their signed Xochi
       # intent (off-ACP), so the job takes no fund hook. The listed fee is a
       # percentage (0.10 = 10 bps); price carries the value, not a USDC amount.
@@ -88,7 +94,18 @@ defmodule Raxol.ACP.Xochi.Offering do
       sla_minutes: 10,
       requirement_schema: requirement_schema(),
       deliverable_schema: deliverable_schema(),
-      tags: ["payments", "cross-chain", "stablecoin", "xochi"]
+      tags: [
+        "payments",
+        "cross-chain",
+        "stablecoin",
+        "xochi",
+        "usdc",
+        "usdt",
+        "usdg",
+        "robinhood",
+        "stealth",
+        "privacy"
+      ]
     }
   end
 
@@ -111,29 +128,40 @@ defmodule Raxol.ACP.Xochi.Offering do
       "properties" => %{
         "src_chain_id" => %{
           "type" => "integer",
-          "description" => "Source chain ID (e.g. 8453 for Base mainnet)."
+          "description" =>
+            "Source chain ID. Supported: 1 (Ethereum), 10 (Optimism), 137 (Polygon), " <>
+              "8453 (Base), 42161 (Arbitrum), and 4663 (Robinhood Chain). USDG lives " <>
+              "only on 4663."
         },
         "dst_chain_id" => %{
           "type" => "integer",
-          "description" => "Destination chain ID."
+          "description" =>
+            "Destination chain ID. Supported: 1 (Ethereum), 10 (Optimism), 137 " <>
+              "(Polygon), 8453 (Base), 42161 (Arbitrum), and 4663 (Robinhood Chain, as a " <>
+              "USDG destination). Stealth settles on Ethereum L1 (1)."
         },
         "src_token" => %{
           "type" => "string",
           "pattern" =>
             "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
           "description" =>
-            "Token address being sent on src_chain_id: 0x-hex (EVM), " <>
-              "Base58Check (Tron), or base58 mint (Solana). Validated " <>
-              "per-chain against the solver capability matrix before escrow."
+            "Token address being sent on src_chain_id, as a 0x-hex EVM address. " <>
+              "Supported tokens: USDC, USDT, and USDG (USDG on Robinhood Chain 4663 " <>
+              "only). All supported chains are EVM; non-EVM legs (Tron, Solana) are not " <>
+              "yet supported and are rejected before escrow. Validated per-chain against " <>
+              "the solver capability matrix before escrow."
         },
         "dst_token" => %{
           "type" => "string",
           "pattern" =>
             "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
           "description" =>
-            "Token address to be received on dst_chain_id: 0x-hex (EVM), " <>
-              "Base58Check (Tron), or base58 mint (Solana). Validated " <>
-              "per-chain against the solver capability matrix before escrow."
+            "Token address to be received on dst_chain_id, as a 0x-hex EVM address. " <>
+              "Supported tokens: USDC, USDT, and USDG (USDG only on Robinhood Chain " <>
+              "4663). Legs may be cross-asset (USDG in/out, or USDC<->USDT). All " <>
+              "supported chains are EVM; non-EVM legs (Tron, Solana) are not yet " <>
+              "supported and are rejected before escrow. Validated per-chain against the " <>
+              "solver capability matrix before escrow."
         },
         "amount_atomic" => %{
           "type" => "string",
@@ -192,8 +220,9 @@ defmodule Raxol.ACP.Xochi.Offering do
             "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
           "description" =>
             "Optional: the recipient the buyer signed into their Xochi intent, for " <>
-              "the buyer's or evaluator's audit trail. raxol does not use or enforce " <>
-              "it; the destination is fixed by the buyer's signature."
+              "the buyer's or evaluator's audit trail, as a 0x-hex EVM address (all " <>
+              "supported chains are EVM). raxol does not use or enforce it; the " <>
+              "destination is fixed by the buyer's signature."
         },
         "slippage_bps" => %{
           "type" => "integer",
@@ -208,8 +237,9 @@ defmodule Raxol.ACP.Xochi.Offering do
           "default" => "public",
           "description" =>
             "Optional audit hint of the privacy tier the buyer signed. \"stealth\" " <>
-              "records an ERC-5564 stealth delivery: the buyer signed the stealth " <>
-              "spending/viewing keys and an ephemeral recipient into their Xochi " <>
+              "records an ERC-5564 stealth delivery to a one-time address on Ethereum " <>
+              "L1 (chain 1; cross-chain stealth is not yet live): the buyer signed the " <>
+              "stealth spending/viewing keys and an ephemeral recipient into their Xochi " <>
               "intent, so funds land at a stealth address they control. raxol relays " <>
               "whatever the buyer signed and does not gate on this."
         }

--- a/packages/raxol_acp/priv/offering.json
+++ b/packages/raxol_acp/priv/offering.json
@@ -1,8 +1,8 @@
 {
   "jobs": [
     {
-      "description": "USDC-only cross-chain settlement to a wallet on the destination chain, across the CCTP mesh (Ethereum, Optimism, Polygon, Base, Arbitrum). The buyer signs a Xochi intent, the storefront relays it and returns the settlement tx hashes; the buyer escrows only the storefront fee (a plain job, no fund hook). Both legs must be USDC; other stablecoins are rejected before escrow. Order size is bounded (min 1 USDC, max 3,000 USDC).",
-      "name": "xochi_usdc_public",
+      "description": "Cross-chain stablecoin settlement storefront. The buyer signs a Xochi intent, the storefront relays it and returns the settlement tx hashes; the buyer escrows only the storefront fee (a plain job, no fund hook). Supported settlement: USDC and USDT each across the full 5-chain EVM mesh (Ethereum, Optimism, Polygon, Base, Arbitrum); USDG on Robinhood Chain (4663), cross-asset in both directions (USDC/USDT in -> USDG, and USDG -> USDC/USDT out on any mesh chain); and USDC<->USDT cross-asset conversion. Order size min $1.00, max bounded by the solver's per-token caps (e.g. USDT ~$1,000, USDG ~$10,000). The buyer may settle publicly to a wallet, or privately to a one-time ERC-5564 stealth address on Ethereum L1, by signing the choice into their intent; the storefront relays it verbatim.",
+      "name": "xochi_cross_chain_transfer",
       "price": 0.1,
       "priceType": "percentage",
       "requiredFunds": false,
@@ -20,26 +20,21 @@
             "type": "string"
           },
           "dst_chain_id": {
-            "description": "Destination chain. USDC settles across the CCTP mesh: 1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum).",
-            "enum": [
-              1,
-              10,
-              137,
-              8453,
-              42161
-            ],
+            "description": "Destination chain ID. Supported: 1 (Ethereum), 10 (Optimism), 137 (Polygon), 8453 (Base), 42161 (Arbitrum), and 4663 (Robinhood Chain, as a USDG destination). Stealth settles on Ethereum L1 (1).",
             "type": "integer"
           },
           "dst_token": {
-            "description": "The USDC contract on dst_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow.",
+            "description": "Token address to be received on dst_chain_id, as a 0x-hex EVM address. Supported tokens: USDC, USDT, and USDG (USDG only on Robinhood Chain 4663). Legs may be cross-asset (USDG in/out, or USDC<->USDT). All supported chains are EVM; non-EVM legs (Tron, Solana) are not yet supported and are rejected before escrow. Validated per-chain against the solver capability matrix before escrow.",
             "pattern": "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
             "type": "string"
           },
           "settlement_preference": {
             "default": "public",
-            "description": "Public settlement: the payout lands in a wallet on the destination chain.",
+            "description": "Optional audit hint of the privacy tier the buyer signed. \"stealth\" records an ERC-5564 stealth delivery to a one-time address on Ethereum L1 (chain 1; cross-chain stealth is not yet live): the buyer signed the stealth spending/viewing keys and an ephemeral recipient into their Xochi intent, so funds land at a stealth address they control. raxol relays whatever the buyer signed and does not gate on this.",
             "enum": [
-              "public"
+              "public",
+              "private",
+              "stealth"
             ],
             "type": "string"
           },
@@ -92,18 +87,11 @@
             "type": "integer"
           },
           "src_chain_id": {
-            "description": "Source chain. USDC settles across the CCTP mesh: 1 (Ethereum), 10 (OP), 137 (Polygon), 8453 (Base), 42161 (Arbitrum).",
-            "enum": [
-              1,
-              10,
-              137,
-              8453,
-              42161
-            ],
+            "description": "Source chain ID. Supported: 1 (Ethereum), 10 (Optimism), 137 (Polygon), 8453 (Base), 42161 (Arbitrum), and 4663 (Robinhood Chain). USDG lives only on 4663.",
             "type": "integer"
           },
           "src_token": {
-            "description": "The USDC contract on src_chain_id. Only USDC is accepted; a non-USDC token is rejected before escrow.",
+            "description": "Token address being sent on src_chain_id, as a 0x-hex EVM address. Supported tokens: USDC, USDT, and USDG (USDG on Robinhood Chain 4663 only). All supported chains are EVM; non-EVM legs (Tron, Solana) are not yet supported and are rejected before escrow. Validated per-chain against the solver capability matrix before escrow.",
             "pattern": "^(0x[0-9a-fA-F]{40}|T[1-9A-HJ-NP-Za-km-z]{33}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
             "type": "string"
           }

--- a/packages/raxol_acp/test/raxol/acp/xochi/corridor_allowlist_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/corridor_allowlist_test.exs
@@ -5,6 +5,8 @@ defmodule Raxol.ACP.Xochi.CorridorAllowlistTest do
   alias Raxol.ACP.Xochi.CorridorAllowlist
 
   @usdc_chains [1, 10, 137, 8453, 42_161]
+  @usdt_chains [1, 10, 137, 8453, 42_161]
+  @robinhood 4663
 
   describe "allowed?/4 -- USDC full mesh" do
     test "every ordered pair of the five CCTP chains is allowed" do
@@ -18,57 +20,82 @@ defmodule Raxol.ACP.Xochi.CorridorAllowlistTest do
       refute CorridorAllowlist.allowed?("USDC", "USDC", 8453, 8453)
     end
 
-    test "USDC to/from a non-CCTP chain (Robinhood) is declined" do
+    test "USDC to/from a non-CCTP chain (Robinhood) is not a same-asset corridor" do
       refute CorridorAllowlist.allowed?("USDC", "USDC", 8453, 4663)
       refute CorridorAllowlist.allowed?("USDC", "USDC", 4663, 8453)
     end
   end
 
-  describe "allowed?/4 -- USDT relay corridors only" do
-    test "the four explicit corridors are allowed" do
-      assert CorridorAllowlist.allowed?("USDT", "USDT", 42_161, 137)
-      assert CorridorAllowlist.allowed?("USDT", "USDT", 137, 42_161)
-      assert CorridorAllowlist.allowed?("USDT", "USDT", 137, 10)
-      assert CorridorAllowlist.allowed?("USDT", "USDT", 137, 1)
+  describe "allowed?/4 -- USDT full mesh (Base included)" do
+    test "every ordered pair of the five EVM chains is allowed" do
+      for from <- @usdt_chains, to <- @usdt_chains, from != to do
+        assert CorridorAllowlist.allowed?("USDT", "USDT", from, to),
+               "expected USDT #{from}->#{to} allowed"
+      end
     end
 
-    test "USDT on Base is not a relay corridor (either direction)" do
-      refute CorridorAllowlist.allowed?("USDT", "USDT", 8453, 42_161)
-      refute CorridorAllowlist.allowed?("USDT", "USDT", 42_161, 8453)
-      refute CorridorAllowlist.allowed?("USDT", "USDT", 137, 8453)
+    test "USDT on Base is now a corridor (either direction)" do
+      assert CorridorAllowlist.allowed?("USDT", "USDT", 8453, 42_161)
+      assert CorridorAllowlist.allowed?("USDT", "USDT", 42_161, 8453)
+      assert CorridorAllowlist.allowed?("USDT", "USDT", 137, 8453)
     end
 
-    test "an unlisted USDT hub direction (10->137) is declined" do
-      refute CorridorAllowlist.allowed?("USDT", "USDT", 10, 137)
-      refute CorridorAllowlist.allowed?("USDT", "USDT", 1, 137)
+    test "same-chain USDT is not a corridor" do
+      refute CorridorAllowlist.allowed?("USDT", "USDT", 137, 137)
     end
 
-    test "the USDT set matches Riddler's relay corridors exactly" do
-      # Cross-check against riddler Relay.Routes @usdt_corridors.
+    test "the USDT set matches Riddler's full relay mesh" do
+      # Cross-check against riddler Relay.Routes: all ordered pairs of @usdt_chains.
       usdt = for {"USDT", "USDT", from, to} <- CorridorAllowlist.corridors(), do: {from, to}
-      assert Enum.sort(usdt) == Enum.sort([{42_161, 137}, {137, 42_161}, {137, 10}, {137, 1}])
+      expected = for f <- @usdt_chains, t <- @usdt_chains, f != t, do: {f, t}
+      assert Enum.sort(usdt) == Enum.sort(expected)
     end
   end
 
-  describe "allowed?/4 -- USDG drain from Robinhood" do
-    test "Robinhood USDG -> USDC on a hub (Arb, Base) is allowed" do
-      assert CorridorAllowlist.allowed?("USDG", "USDC", 4663, 42_161)
-      assert CorridorAllowlist.allowed?("USDG", "USDC", 4663, 8453)
+  describe "allowed?/4 -- USDG cross-asset (Robinhood 4663)" do
+    test "USDG exit drains to USDC on any mesh chain" do
+      for to <- @usdc_chains do
+        assert CorridorAllowlist.allowed?("USDG", "USDC", @robinhood, to),
+               "expected USDG #{@robinhood}->#{to} (USDC) allowed"
+      end
     end
 
-    test "USDG inbound to Robinhood is declined (drain direction only)" do
-      refute CorridorAllowlist.allowed?("USDC", "USDG", 42_161, 4663)
-      refute CorridorAllowlist.allowed?("USDC", "USDG", 8453, 4663)
+    test "USDG exit drains to USDT on any mesh chain" do
+      for to <- @usdt_chains do
+        assert CorridorAllowlist.allowed?("USDG", "USDT", @robinhood, to)
+      end
     end
 
-    test "USDG to a non-hub USDC chain is declined at launch scope" do
-      refute CorridorAllowlist.allowed?("USDG", "USDC", 4663, 1)
-      refute CorridorAllowlist.allowed?("USDG", "USDC", 4663, 10)
-      refute CorridorAllowlist.allowed?("USDG", "USDC", 4663, 137)
+    test "USDG inbound entry from USDC/USDT on any mesh chain is allowed" do
+      for from <- @usdc_chains do
+        assert CorridorAllowlist.allowed?("USDC", "USDG", from, @robinhood)
+      end
+
+      for from <- @usdt_chains do
+        assert CorridorAllowlist.allowed?("USDT", "USDG", from, @robinhood)
+      end
+    end
+
+    test "USDG legs must pivot on Robinhood (4663)" do
+      # USDG only exists on 4663; a USDG leg on any other chain is not a corridor.
+      refute CorridorAllowlist.allowed?("USDG", "USDC", 8453, 42_161)
+      refute CorridorAllowlist.allowed?("USDC", "USDG", 8453, 42_161)
     end
 
     test "USDG same-asset (USDG->USDG) is not a corridor" do
       refute CorridorAllowlist.allowed?("USDG", "USDG", 4663, 8453)
+    end
+  end
+
+  describe "allowed?/4 -- USDC <-> USDT cross-asset" do
+    test "USDC->USDT and USDT->USDC are allowed across the mesh" do
+      assert CorridorAllowlist.allowed?("USDC", "USDT", 8453, 42_161)
+      assert CorridorAllowlist.allowed?("USDT", "USDC", 42_161, 8453)
+    end
+
+    test "same-chain cross-asset is not a corridor" do
+      refute CorridorAllowlist.allowed?("USDC", "USDT", 8453, 8453)
+      refute CorridorAllowlist.allowed?("USDT", "USDC", 137, 137)
     end
   end
 
@@ -83,16 +110,13 @@ defmodule Raxol.ACP.Xochi.CorridorAllowlistTest do
       refute CorridorAllowlist.allowed?("USDC", nil, 8453, 42_161)
       refute CorridorAllowlist.allowed?(nil, nil, 8453, 42_161)
     end
-
-    test "a cross-asset pair we do not support (USDC->USDT) is declined" do
-      refute CorridorAllowlist.allowed?("USDC", "USDT", 8453, 42_161)
-    end
   end
 
   describe "corridors/0" do
-    test "enumerates 20 USDC + 4 USDT + 2 USDG corridors" do
+    test "enumerates the full production matrix (20 USDC + 20 USDT + 20 USDG + 40 cross)" do
       corridors = CorridorAllowlist.corridors()
-      assert length(corridors) == 26
+      # 20 USDC mesh + 20 USDT mesh + 10 USDG-out + 10 USDG-in + 40 USDC<->USDT.
+      assert length(corridors) == 100
       assert Enum.all?(corridors, &corridor_allowed?/1)
     end
   end

--- a/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/offering_test.exs
@@ -18,6 +18,22 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
       assert "payments" in meta.tags
     end
 
+    test "advertises the full corridor set: USDC, USDT, USDG/Robinhood, and stealth" do
+      meta = Offering.offering_metadata()
+      desc = meta.description
+
+      assert desc =~ "USDC"
+      assert desc =~ "USDT"
+      assert desc =~ "USDG"
+      assert desc =~ "Robinhood"
+      assert desc =~ "4663"
+      assert desc =~ "stealth"
+
+      for tag <- ["usdt", "usdg", "robinhood", "stealth"] do
+        assert tag in meta.tags
+      end
+    end
+
     test "requirement and deliverable schemas are JSON-Schema 2020-12" do
       meta = Offering.offering_metadata()
 
@@ -57,6 +73,42 @@ defmodule Raxol.ACP.Xochi.OfferingTest do
       prop = schema["properties"]["settlement_preference"]
       assert prop["enum"] == ["public", "private", "stealth"]
       assert prop["default"] == "public"
+    end
+
+    test "chain and token descriptions advertise the Robinhood/USDT/USDG corridors" do
+      props = Offering.requirement_schema()["properties"]
+
+      # Robinhood Chain (4663) is discoverable as a source; USDG has no inbound.
+      assert props["src_chain_id"]["description"] =~ "4663"
+      assert props["src_chain_id"]["description"] =~ "Robinhood"
+      assert props["dst_chain_id"]["description"] =~ "Arbitrum"
+
+      # The three stablecoin families are named on the token legs.
+      assert props["src_token"]["description"] =~ "USDG"
+      assert props["src_token"]["description"] =~ "USDT"
+      assert props["dst_token"]["description"] =~ "cross-asset"
+    end
+
+    test "token/destination legs advertise EVM-only, not the unsupported Tron/Solana VMs" do
+      # Every advertised corridor is EVM (chains 1/10/137/8453/42161/4663), so the
+      # human-readable legs must not offer Tron/Solana as usable formats -- that
+      # would pass schema and fail at corridor gating (a late, confusing reject).
+      props = Offering.requirement_schema()["properties"]
+
+      for leg <- ["src_token", "dst_token", "destination"] do
+        desc = props[leg]["description"]
+        assert desc =~ "EVM"
+        refute desc =~ "Base58Check (Tron)"
+        refute desc =~ "base58 mint (Solana)"
+      end
+    end
+
+    test "every advertised chain is EVM (guards the EVM-only leg copy)" do
+      # If a non-EVM chain ever becomes supported, this fails and forces the
+      # Tron/Solana leg copy to be revisited in lockstep.
+      non_evm = [728_126_428]
+      supported = Raxol.Payments.Assets.supported_chain_ids()
+      assert Enum.all?(non_evm, &(&1 not in supported))
     end
   end
 

--- a/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/transfer_offering_test.exs
@@ -359,11 +359,10 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
       assert {:accept, ^to_base} = TransferOffering.handle_request(to_base, @ctx)
     end
 
-    test "USDT on Base is declined -- not a relay corridor" do
+    test "USDT on Base is now a corridor (full 5-chain relay mesh)" do
       r = req(%{"src_token" => @usdt_base, "dst_token" => @usdt_arb})
 
-      assert {:reject, {:unsupported_corridor, 8453, 42_161}} =
-               TransferOffering.handle_request(r, @ctx)
+      assert {:accept, ^r} = TransferOffering.handle_request(r, @ctx)
     end
 
     test "WETH is declined -- volatile, not a launch stablecoin" do
@@ -373,7 +372,7 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
                TransferOffering.handle_request(r, @ctx)
     end
 
-    test "USDG inbound to Robinhood is declined -- drain direction only" do
+    test "USDG inbound to Robinhood is now accepted (cross-token entry)" do
       r =
         req(%{
           "src_chain_id" => 42_161,
@@ -382,8 +381,7 @@ defmodule Raxol.ACP.Xochi.TransferOfferingTest do
           "dst_token" => @usdg_robinhood
         })
 
-      assert {:reject, {:unsupported_corridor, 42_161, 4663}} =
-               TransferOffering.handle_request(r, @ctx)
+      assert {:accept, ^r} = TransferOffering.handle_request(r, @ctx)
     end
   end
 end


### PR DESCRIPTION
## What

Adds a single registerable Virtuals ACP offering (`priv/offering.json`, the
settlement-agnostic `xochi_cross_chain_transfer` doc) and syncs raxol's
pre-escrow corridor gate to the deployed Riddler route tables. The prior live
listing was USDC-only; production now settles USDT and USDG (Robinhood Chain
4663) with Permit2 origin-pull and ERC-5564 stealth.

## Why

Verified against `ansible-riddler` (`host_vars/riddler-axol.yml`, deployed
riddler-axol) that the following are LIVE:

- `xochi_pull2_contract_enabled: true` (Permit2 pull, validated 2026-07-23; a
  real Base->Arb USDT pull settled with no revert) and `xochi_pull_contract_enabled: true`
  (USDC ERC-3009).
- `xochi_settlement_allowlist: ['public','stealth']` (stealth on since 2026-07-24).
- USDT full 5-chain relay mesh incl. Base; USDG on 4663 cross-asset both
  directions; USDC<->USDT cross-token (`enable_cross_token_fills: true`).

raxol's `CorridorAllowlist` had drifted behind this and would reject orders the
solver can fill (e.g. USDT Base->Arbitrum). This closes that gap and advertises
the real capability set.

Tron and Solana are confirmed NOT supported (`enable_tron: false`, Solana
unadvertised), so the offering schema is tightened to advertise EVM-only address
formats.

## Changes

- `lib/raxol/acp/xochi/corridor_allowlist.ex` — widened to the production matrix
  (100 corridors: 20 USDC mesh + 20 USDT mesh + 10 USDG-out + 10 USDG-in + 40
  USDC<->USDT). Mirrors Riddler `Relay.Routes` + `cross_token_pairs`.
- `lib/raxol/acp/xochi/offering.ex` — legacy `xochi_cross_chain_transfer`
  metadata + `requirement_schema/0` descriptions now self-describe the full scope
  and advertise EVM-only (no Tron/Solana copy).
- `priv/offering.json` — NEW, the single covers-everything listing to register.
- `priv/offering.usdc_public.json` — regenerated (only the destination-field
  EVM note changed; scope unchanged).
- Tests — `corridor_allowlist_test.exs` rewritten to the production model;
  `transfer_offering_test.exs` flips the two cases that changed behavior (USDT on
  Base now accepted, USDG inbound now accepted); `offering_test.exs` locks the
  advertised scope + guards against re-introducing Tron/Solana copy.

## Note

`CorridorAllowlist` is the pre-escrow gate and is now coupled to Riddler's route
tables. If Riddler narrows a corridor, this static list must follow or it will
advertise/accept a route the solver can't fill. The module TODO (consume the
solver capability endpoint) remains the durable fix.

## Manual testing

- [x] `MIX_ENV=test mix compile --warnings-as-errors` (raxol_acp) — clean
- [x] `MIX_ENV=test mix test` (raxol_acp) — 729 passed, 0 failures
- [x] `mix acp.register_offering --offering legacy --pretty --out priv/offering.json`
  produces a valid `{jobs:[...]}` doc; `requirement` has no `$schema`, `required
  == ["signed_intent"]`
- [x] `usdc_public` regen has no scope drift vs the committed file
