### PR TITLE
ACP fee 8 bps + trust XochiPull contracts in pull pin

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,7 +43,10 @@ if config_env() == :prod do
   # signs against the deployed contract instead of a rejected `to`/`spender`.
   xochi_solver_allowlist =
     if Code.ensure_loaded?(Raxol.Payments.Xochi.PullContracts) do
-      Enum.uniq(xochi_env_solvers ++ Raxol.Payments.Xochi.PullContracts.pull_recipients())
+      Enum.uniq(
+        xochi_env_solvers ++
+          Raxol.Payments.Xochi.PullContracts.pull_recipients()
+      )
     else
       xochi_env_solvers
     end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,7 +18,7 @@ if config_env() == :prod do
   # a per-chain var is here for each of the five supported chains in case they
   # ever diverge. Permit2 is fail-closed regardless; set
   # XOCHI_PULL_REQUIRE_SOLVER_PIN=true to hard-pin ERC-3009 too.
-  xochi_solver_allowlist =
+  xochi_env_solvers =
     ~w(XOCHI_SOLVER_ETH XOCHI_SOLVER_BASE XOCHI_SOLVER_ARBITRUM XOCHI_SOLVER_OPTIMISM XOCHI_SOLVER_POLYGON)
     |> Enum.map(&System.get_env/1)
     |> Enum.reject(&(is_nil(&1) or &1 == ""))
@@ -32,10 +32,21 @@ if config_env() == :prod do
   # release without the payments app (the module is absent) skips the check.
   if Code.ensure_loaded?(Raxol.Payments.Protocols.Xochi) do
     Raxol.Payments.Protocols.Xochi.assert_origin_pull_pinned!(
-      xochi_solver_allowlist,
+      xochi_env_solvers,
       xochi_require_solver_pin
     )
   end
+
+  # With XochiPull enabled (Riddler #591), the origin pull routes to the verified
+  # per-chain pull contracts, not the bare solver EOA. Trust those verified
+  # recipients in addition to any XOCHI_SOLVER_* addresses so a real settlement
+  # signs against the deployed contract instead of a rejected `to`/`spender`.
+  xochi_solver_allowlist =
+    if Code.ensure_loaded?(Raxol.Payments.Xochi.PullContracts) do
+      Enum.uniq(xochi_env_solvers ++ Raxol.Payments.Xochi.PullContracts.pull_recipients())
+    else
+      xochi_env_solvers
+    end
 
   config :raxol_payments,
     pull_solver_allowlist: xochi_solver_allowlist,

--- a/fly.acp.toml
+++ b/fly.acp.toml
@@ -91,7 +91,7 @@ kill_timeout = '60s'
   # Storefront fee in basis points. SolverApplication defaults to 50 (0.5%); the
   # launch target is 8. Pinned here (non-secret) so the fee is independent of any
   # script. A change requires a redeploy (parsed via String.to_integer at boot).
-  XOCHI_FEE_BPS = '10'
+  XOCHI_FEE_BPS = '8'
 
   # --- Delegated (Privy + Alchemy managed wallet) signing config (non-secret) ---
   # The Virtuals ACP server that proxies wallet signing to Privy; the sidecar signs its

--- a/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
@@ -33,7 +33,7 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
 
   use Raxol.ACP.Offering,
     name: "xochi_usdc_public",
-    fee_bps: 10,
+    fee_bps: 8,
     sla_minutes: 10,
     cluster: "on_chain"
 

--- a/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
@@ -311,7 +311,11 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
         prior_allowlist = Application.get_env(:raxol_payments, :pull_solver_allowlist)
         prior_require = Application.get_env(:raxol_payments, :pull_require_solver_pin)
 
-        Application.put_env(:raxol_payments, :pull_solver_allowlist, [solver])
+        # With XochiPull enabled the origin pull routes to the verified per-chain
+        # pull contracts, not the bare solver EOA -- trust those alongside the
+        # pinned solver (Riddler #591; Raxol.Payments.Xochi.PullContracts).
+        allowlist = Enum.uniq([solver | Raxol.Payments.Xochi.PullContracts.pull_recipients()])
+        Application.put_env(:raxol_payments, :pull_solver_allowlist, allowlist)
         Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
 
         on_exit(fn ->

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_fee_live_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_fee_live_test.exs
@@ -1,0 +1,265 @@
+defmodule Raxol.ACP.Xochi.SolverFeeLiveTest do
+  @moduledoc """
+  Live gate: proves the deployed solver sizes the on-chain ACP budget at exactly
+  `XOCHI_FEE_BPS` basis points of the AUTHORITATIVE principal -- the number the
+  buyer signed against Xochi, read back off the live worker, not the relayed
+  `amount_atomic`. This is the take-rate validation: with `XOCHI_FEE_BPS=8` it
+  asserts the budget the solver would write on-chain is 8 bps of the principal.
+
+  What is real here:
+
+    * the buyer quotes + signs a real Xochi intent for a known principal
+      (`Raxol.Payments.Protocols.Xochi.quote_and_sign/3`, an off-chain EIP-712
+      signature -- NO funds move, NO settlement, NO on-chain tx);
+    * the real `Raxol.ACP.Xochi.SolverAgent` runs its production path
+      (`IntentDeriver.resolve/2` against the live Xochi worker -> `budget_for/2`
+      -> `HookClient.set_budget/6`), with `fee_bps` read from the same
+      `XOCHI_FEE_BPS` env the deployed solver reads.
+
+  What is faked, and why: the on-chain WRITE is captured via
+  `ProviderAdapter.Mock` rather than sent, because a real `setBudget` needs a real
+  on-chain job to exist (the full marketplace lifecycle). The budget VALUE is not
+  faked -- it is decoded straight out of the `setBudget(uint256,uint256,bytes)`
+  calldata the solver produced, so this asserts the exact on-chain wire amount.
+
+  Tagged `:live_solver_fee`; excluded by default, compiled only when the env is
+  present. Reuses the ACP order gate's env so it slots into the same run:
+
+      XOCHI_ORDER_LIVE_URL=https://api.xochi.fi \\
+      XOCHI_ORDER_LIVE_TOKEN=<Xochi Member token> XOCHI_ORDER_LIVE_KEY=0x<key> \\
+      XOCHI_FEE_BPS=8 \\
+        mix test --only live_solver_fee test/raxol/acp/xochi/solver_fee_live_test.exs
+
+  Optional overrides: `XOCHI_ORDER_AMOUNT` (human USDC principal, default "5.00"),
+  `XOCHI_ORDER_CORRIDORS` ("from>to", default "8453>42161").
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :live_solver_fee
+  @moduletag timeout: 120_000
+
+  if System.get_env("XOCHI_ORDER_LIVE_URL") && System.get_env("XOCHI_ORDER_LIVE_KEY") do
+    alias Raxol.ACP.{Agent, Chain, JobApi, ProviderAdapter, Transport}
+    alias Raxol.ACP.Xochi.SolverAgent
+    alias Raxol.Payments.Assets
+    alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
+    alias Raxol.Payments.Xochi.Schemas.QuoteRequest
+
+    defmodule LiveWallet do
+      @moduledoc false
+      use Raxol.Payments.Wallets.Env, env_var: "XOCHI_ORDER_LIVE_KEY"
+    end
+
+    setup do
+      pin_pull_recipients()
+
+      xochi_config = %{
+        base_url: System.fetch_env!("XOCHI_ORDER_LIVE_URL"),
+        auth_token: System.get_env("XOCHI_ORDER_LIVE_TOKEN", "")
+      }
+
+      {from, to} = corridor()
+
+      {:ok,
+       xochi_config: xochi_config,
+       fee_bps: String.to_integer(System.get_env("XOCHI_FEE_BPS", "8")),
+       from: from,
+       to: to,
+       amount: System.get_env("XOCHI_ORDER_AMOUNT", "5.00")}
+    end
+
+    test "the solver sizes the on-chain ACP budget at fee_bps of the live-signed principal",
+         ctx do
+      wallet = LiveWallet.address()
+
+      {:ok, src_token} = Assets.address(ctx.from, "USDC")
+      {:ok, dst_token} = Assets.address(ctx.to, "USDC")
+
+      principal_atomic =
+        Assets.to_atomic(Decimal.new(ctx.amount), Assets.decimals(ctx.from, src_token))
+
+      # 1. Buyer signs a real Xochi intent for `principal_atomic`. Off-chain only.
+      request = %QuoteRequest{
+        wallet: wallet,
+        from_chain_id: ctx.from,
+        to_chain_id: ctx.to,
+        from_token: src_token,
+        to_token: dst_token,
+        from_amount: Integer.to_string(principal_atomic),
+        settlement_preference: "public",
+        slippage_bps: 50
+      }
+
+      {:ok, bundle} = XochiProtocol.quote_and_sign(ctx.xochi_config, request, LiveWallet)
+
+      requirement = %{
+        "src_chain_id" => ctx.from,
+        "dst_chain_id" => ctx.to,
+        "src_token" => src_token,
+        "dst_token" => dst_token,
+        "amount_atomic" => Integer.to_string(principal_atomic),
+        "settlement_preference" => "public",
+        "signed_intent" => Map.new(bundle, fn {k, v} -> {to_string(k), v} end)
+      }
+
+      # 2. Real SolverAgent, production path. The on-chain write is captured (Mock)
+      #    but the budget VALUE it produces is real and asserted below.
+      {solver, provider} = start_solver(wallet, ctx)
+      job_id = Integer.to_string(System.unique_integer([:positive]))
+
+      Agent.start_stream(solver.agent)
+      Transport.Mock.deliver(solver.transport, job_created(ctx.from, job_id, wallet))
+      Transport.Mock.deliver(solver.transport, requirement_msg(ctx.from, job_id, requirement))
+
+      # 3. Solver resolves the intent off LIVE Xochi and proposes the budget.
+      session = await_budget(solver.pid, {ctx.from, job_id})
+
+      expected = div(principal_atomic * ctx.fee_bps, 10_000)
+
+      assert session.status == :budget_proposed,
+             "solver did not propose a budget (status #{inspect(session.status)})"
+
+      assert session.transfer_amount_atomic == principal_atomic,
+             "solver read a different authoritative principal from Xochi: " <>
+               "#{session.transfer_amount_atomic} != #{principal_atomic}"
+
+      assert session.budget_atomic == expected,
+             "computed budget #{session.budget_atomic} is not #{ctx.fee_bps} bps of #{principal_atomic}"
+
+      # 4. The ON-CHAIN calldata carries exactly that budget.
+      assert [{_chain, [call]}] = ProviderAdapter.Mock.sent_calls(provider)
+      assert call.to == Chain.mainnet().acp_core_address
+
+      assert onchain_amount(call.data) == expected,
+             "on-chain setBudget amount != #{ctx.fee_bps} bps of the principal"
+
+      realized_bps = Float.round(session.budget_atomic / principal_atomic * 10_000, 3)
+
+      IO.puts(
+        "[live_solver_fee] principal=#{principal_atomic} budget=#{session.budget_atomic} " <>
+          "=> #{realized_bps} bps (fee_bps=#{ctx.fee_bps}, corridor #{ctx.from}->#{ctx.to})"
+      )
+    end
+
+    # -- Harness --
+
+    defp start_solver(wallet, ctx) do
+      transport = Transport.Mock.new()
+      job_api = JobApi.Mock.new(me: %{wallet_address: wallet, name: "raxol"})
+      provider = ProviderAdapter.Mock.new(address: wallet, supported_chain_ids: [ctx.from])
+
+      {:ok, agent} =
+        Agent.start_link(
+          transport: transport,
+          api: job_api,
+          wallet_address: wallet,
+          supported_chain_ids: [ctx.from],
+          default_role: :provider
+        )
+
+      {:ok, pid} =
+        SolverAgent.start_link(
+          agent: agent,
+          provider: provider,
+          wallet_address: wallet,
+          evaluator_address: wallet,
+          chain_id: ctx.from,
+          acp_core_address: Chain.mainnet().acp_core_address,
+          fee_bps: ctx.fee_bps,
+          xochi_config: ctx.xochi_config
+        )
+
+      {%{pid: pid, agent: agent, transport: transport}, provider}
+    end
+
+    defp job_created(chain_id, job_id, provider) do
+      %{
+        "kind" => "system",
+        "event" => "job.created",
+        "chainId" => chain_id,
+        "jobId" => job_id,
+        "provider" => provider
+      }
+    end
+
+    defp requirement_msg(chain_id, job_id, requirement) do
+      %{
+        "kind" => "message",
+        "contentType" => "requirement",
+        "chainId" => chain_id,
+        "jobId" => job_id,
+        "content" => Jason.encode!(requirement)
+      }
+    end
+
+    # Poll until the solver proposes (or fails) the budget for this job. The only
+    # blocking step is the live IntentDeriver GET; 20s is generous.
+    defp await_budget(solver, key, remaining_ms \\ 20_000)
+
+    defp await_budget(_solver, key, remaining_ms) when remaining_ms <= 0 do
+      flunk("solver never proposed a budget for #{inspect(key)} within the deadline")
+    end
+
+    defp await_budget(solver, key, remaining_ms) do
+      case SolverAgent.session(solver, key) do
+        %{status: :budget_proposed} = session ->
+          session
+
+        %{status: :failed} = session ->
+          flunk("solver failed the job: #{inspect(session)}")
+
+        _ ->
+          Process.sleep(200)
+          await_budget(solver, key, remaining_ms - 200)
+      end
+    end
+
+    # setBudget(uint256 jobId, uint256 amount, bytes data): the amount is the
+    # second 32-byte word after the 4-byte selector.
+    defp onchain_amount(
+           <<_selector::binary-size(4), _job_id::binary-size(32),
+             amount::unsigned-big-integer-size(256), _rest::binary>>
+         ),
+         do: amount
+
+    defp corridor do
+      case System.get_env("XOCHI_ORDER_CORRIDORS") do
+        nil ->
+          {8453, 42_161}
+
+        spec ->
+          [from, to] = spec |> String.split(">", parts: 2)
+          {String.to_integer(String.trim(from)), String.to_integer(String.trim(to))}
+      end
+    end
+
+    # Pin the origin-pull recipient to the verified XochiPull contracts (Riddler
+    # #591; Raxol.Payments.Xochi.PullContracts) with the pin REQUIRED. Origin pull
+    # + ERC-3009 now route through those per-chain contracts, not the bare solver
+    # EOA the legacy pin matched, so this keeps the anti-drain guard ON (a quote
+    # whose pull `to` is not a verified contract still aborts before signing) and
+    # doubles as a fund-free check that live routing pulls to a known contract.
+    # Restored on exit.
+    defp pin_pull_recipients do
+      prior_allowlist = Application.get_env(:raxol_payments, :pull_solver_allowlist)
+      prior_require = Application.get_env(:raxol_payments, :pull_require_solver_pin)
+
+      Application.put_env(
+        :raxol_payments,
+        :pull_solver_allowlist,
+        Raxol.Payments.Xochi.PullContracts.pull_recipients()
+      )
+
+      Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
+
+      on_exit(fn ->
+        restore(:pull_solver_allowlist, prior_allowlist)
+        restore(:pull_require_solver_pin, prior_require)
+      end)
+    end
+
+    defp restore(key, nil), do: Application.delete_env(:raxol_payments, key)
+    defp restore(key, value), do: Application.put_env(:raxol_payments, key, value)
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
@@ -172,7 +172,7 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
       }
     end
 
-    test "derives the corridor from Xochi and sizes the fee at 10 bps of the principal" do
+    test "derives the corridor from Xochi and sizes the fee at 8 bps of the principal" do
       ctx = accept_ctx(intent_plug(intent_json()))
 
       assert {:ok, resolved, budget} = UsdcPublicOffering.resolve_accept(req(%{}), ctx)
@@ -184,8 +184,8 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
       assert resolved["dst_token"] == @usdc_arb
       assert resolved["amount_atomic"] == "1000000000"
 
-      # 10 bps of 1_000 USDC = 1 USDC = 1_000_000 base units.
-      assert budget.raw_amount == 1_000_000
+      # 8 bps of 1_000 USDC = 0.8 USDC = 800_000 base units.
+      assert budget.raw_amount == 800_000
       assert budget.symbol == "USDC"
     end
 
@@ -198,7 +198,7 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
                UsdcPublicOffering.resolve_accept(req(%{"amount_atomic" => "1"}), ctx)
 
       assert resolved["amount_atomic"] == "1000000000"
-      assert budget.raw_amount == 1_000_000
+      assert budget.raw_amount == 800_000
     end
 
     test "the derived request still passes the USDC + order-band gate" do

--- a/packages/raxol_acp/test/test_helper.exs
+++ b/packages/raxol_acp/test/test_helper.exs
@@ -5,6 +5,9 @@
 #   :live_xochi_order / :live_xochi_order_preflight -- a buyer orders the
 #     xochi_cross_chain_transfer offering; the settle variant moves real funds
 #     (see scripts/run_live_gates.sh --route acp). The preflight variant is read-only.
+#   :live_solver_fee -- validates the solver sizes the on-chain ACP budget at
+#     XOCHI_FEE_BPS of the live-signed principal (take-rate). Moves NO funds
+#     (off-chain intent signature + captured on-chain write).
 #   :cli_signer -- spawns the riddler-client CLI; auto-enabled when
 #     RIDDLER_CLI_DIR is set.
 #
@@ -16,7 +19,8 @@ live_exclude = [
   :live_acp_dev,
   :live_relay,
   :live_xochi_order,
-  :live_xochi_order_preflight
+  :live_xochi_order_preflight,
+  :live_solver_fee
 ]
 
 cli_exclude = if System.get_env("RIDDLER_CLI_DIR"), do: [], else: [:cli_signer]

--- a/packages/raxol_payments/lib/raxol/payments/xochi/pull_contracts.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/pull_contracts.ex
@@ -1,0 +1,61 @@
+defmodule Raxol.Payments.Xochi.PullContracts do
+  @moduledoc """
+  Verified XochiPull / XochiPullPermit2 origin-pull contracts (Riddler #591,
+  deployed 2026-07-23 from the solver wallet `0x97D4...80b`).
+
+  The Blockaid EOA-scam fix moved the origin pull off the bare solver EOA and onto
+  these verified, per-chain contracts. With them enabled on the solver side
+  (Riddler `xochi_pull_contract_enabled: true`), a live Xochi quote's origin-pull
+  recipient -- the ERC-3009 authorization `to`, or the Permit2 `spender` -- is one
+  of these contracts, NOT the solver EOA.
+
+  `pull_recipients/0` is the full set of legitimate origin-pull recipients for the
+  anti-drain pin (`config :raxol_payments, :pull_solver_allowlist`): the settlement
+  wallet plus every deployed pull proxy. Pinning to this set keeps the pin's
+  protection (an unknown `to`/`spender` is still rejected) while accepting the
+  verified contracts.
+
+  Mirror of Riddler `XOCHIPULL_DEPLOYMENTS.md`; keep in sync on redeploy. The USDC
+  proxy differs per chain (the token address enters the proxy initcode); the
+  Permit2 proxy is uniform across chains.
+  """
+
+  # The solver / settlement wallet -- still a legitimate direct recipient, and the
+  # deployer of the pull contracts.
+  @solver_wallet "0x97D447561fDe10E959E782a29411D8F89586d80b"
+
+  # XochiPull USDC (ERC-3009) proxies, per chain.
+  @erc3009_proxies %{
+    1 => "0xC955fE2d64fe40e7208e9Daf33acEC3b0f577025",
+    10 => "0xB5eE8694E4b3F0bC19fb73612cbE16Dc0ddfBa89",
+    137 => "0xaA7D2343Ef76Fd8594Ad836E682Dd270C700c528",
+    8453 => "0xaA8FDA73906293A0A3Cd8e057Db97670944A46F8",
+    42_161 => "0x0A00b656e2363eDa59055b285A1ba025c335D7C0"
+  }
+
+  # XochiPullPermit2 proxy -- uniform across all chains (incl. Robinhood 4663).
+  @permit2_proxy "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+
+  @doc "The solver / settlement wallet."
+  @spec solver_wallet() :: String.t()
+  def solver_wallet, do: @solver_wallet
+
+  @doc "The XochiPull USDC (ERC-3009) proxy for `chain_id`, or nil if none."
+  @spec erc3009_proxy(pos_integer()) :: String.t() | nil
+  def erc3009_proxy(chain_id), do: Map.get(@erc3009_proxies, chain_id)
+
+  @doc "The uniform XochiPullPermit2 proxy address."
+  @spec permit2_proxy() :: String.t()
+  def permit2_proxy, do: @permit2_proxy
+
+  @doc """
+  Every legitimate origin-pull recipient: the solver wallet, all per-chain
+  XochiPull USDC proxies, and the XochiPullPermit2 proxy. Use as the
+  `:pull_solver_allowlist` so the anti-drain pin accepts the verified pull
+  contracts while still rejecting an unknown `to`/`spender`.
+  """
+  @spec pull_recipients() :: [String.t()]
+  def pull_recipients do
+    [@solver_wallet | Map.values(@erc3009_proxies)] ++ [@permit2_proxy]
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -136,7 +136,11 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         prior_allowlist = Application.get_env(:raxol_payments, :pull_solver_allowlist)
         prior_require = Application.get_env(:raxol_payments, :pull_require_solver_pin)
 
-        Application.put_env(:raxol_payments, :pull_solver_allowlist, [solver])
+        # With XochiPull enabled the origin pull routes to the verified per-chain
+        # pull contracts, not the bare solver EOA -- trust those alongside the
+        # pinned solver (Riddler #591; Raxol.Payments.Xochi.PullContracts).
+        allowlist = Enum.uniq([solver | Raxol.Payments.Xochi.PullContracts.pull_recipients()])
+        Application.put_env(:raxol_payments, :pull_solver_allowlist, allowlist)
         Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
 
         on_exit(fn ->

--- a/packages/raxol_payments/test/raxol/payments/xochi/pull_contracts_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/pull_contracts_test.exs
@@ -1,0 +1,61 @@
+defmodule Raxol.Payments.Xochi.PullContractsTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Xochi.PullContracts
+
+  @solver "0x97D447561fDe10E959E782a29411D8F89586d80b"
+  @base_erc3009 "0xaA8FDA73906293A0A3Cd8e057Db97670944A46F8"
+  @permit2 "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+
+  test "solver_wallet is the settlement wallet" do
+    assert PullContracts.solver_wallet() == @solver
+  end
+
+  test "erc3009_proxy resolves the per-chain USDC pull proxy" do
+    assert PullContracts.erc3009_proxy(8453) == @base_erc3009
+    assert PullContracts.erc3009_proxy(1) == "0xC955fE2d64fe40e7208e9Daf33acEC3b0f577025"
+    assert PullContracts.erc3009_proxy(42_161) == "0x0A00b656e2363eDa59055b285A1ba025c335D7C0"
+  end
+
+  test "erc3009_proxy is nil for a chain with no deployed USDC proxy" do
+    # Robinhood (4663) is Permit2-only (no ERC-3009 USDC).
+    assert PullContracts.erc3009_proxy(4663) == nil
+    assert PullContracts.erc3009_proxy(999_999) == nil
+  end
+
+  test "permit2_proxy is the uniform cross-chain proxy" do
+    assert PullContracts.permit2_proxy() == @permit2
+  end
+
+  test "pull_recipients includes the solver, every ERC-3009 proxy, and the permit2 proxy" do
+    recipients = PullContracts.pull_recipients()
+
+    assert @solver in recipients
+    assert @base_erc3009 in recipients
+    assert @permit2 in recipients
+    # 1 solver + 5 per-chain ERC-3009 proxies + 1 permit2 proxy.
+    assert length(recipients) == 7
+  end
+
+  test "pull_recipients has no duplicates and all entries are 20-byte addresses" do
+    recipients = PullContracts.pull_recipients()
+
+    assert recipients == Enum.uniq(recipients)
+
+    for addr <- recipients do
+      assert Regex.match?(~r/^0x[0-9a-fA-F]{40}$/, addr), "malformed address: #{addr}"
+    end
+  end
+
+  test "pull_recipients normalize into the allowlist form used by the pin" do
+    # The pin compares EIP712.normalize_address(to) against the normalized list;
+    # normalization lowercases and strips the 0x prefix, so the match is case-
+    # and prefix-insensitive. Every recipient must survive it (non-empty).
+    for addr <- PullContracts.pull_recipients() do
+      normalized = EIP712.normalize_address(addr)
+      assert normalized != ""
+      assert normalized == addr |> String.downcase() |> String.replace_prefix("0x", "")
+    end
+  end
+end

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -15,6 +15,12 @@
 #            seller settles on delivery. Runs the raxol_acp order test.
 #   relay -- EVM->Tron rail via the Riddler solver (riddler.axol.io/relay). Runs
 #            the raxol_acp relay test. Tron-settled, so USDC/USDT only.
+#   fee   -- take-rate validation (opt-in; NOT in "all"). Drives the real
+#            SolverAgent: a buyer signs a live Xochi intent for a known
+#            principal, the solver proposes the budget, and the test asserts the
+#            on-chain setBudget == GATE_FEE_BPS (default 8) bps of the principal.
+#            Moves NO funds (off-chain signature + captured on-chain write), but
+#            needs a real GATE_KEY to sign. Runs the raxol_acp solver-fee test.
 #
 # The asset x route grid, and the corridor each cell rides, is fixed here to
 # match what Riddler and Xochi actually support (see the asset_cfg table):
@@ -78,6 +84,9 @@
 #   # Just the ACP order path for USDC:
 #   GATE_KEY=0x<funded> ./scripts/run_live_gates.sh --asset USDC --route acp
 #
+#   # Validate the live take-rate is 8 bps (NO funds; needs a real signing key):
+#   GATE_KEY=0x<key> GATE_FEE_BPS=8 ./scripts/run_live_gates.sh --asset USDC --route fee
+#
 #   # USDG drain rehearsal (Robinhood -> Base), acp route:
 #   GATE_KEY=0x<funded seller w/ USDG on 4663> GATE_RPC_4663=https://rpc.mainnet.chain.robinhood.com \
 #     ./scripts/run_live_gates.sh --asset USDG --route xochi,acp --dry-run
@@ -92,6 +101,7 @@ ACP_DIR="$REPO_ROOT/packages/raxol_acp"
 XOCHI_TEST="test/raxol/payments/xochi/live_xochi_test.exs"
 ORDER_TEST="test/raxol/acp/xochi/live_order_test.exs"
 RELAY_TEST="test/raxol/acp/relay/live_relay_test.exs"
+SOLVER_FEE_TEST="test/raxol/acp/xochi/solver_fee_live_test.exs"
 
 # --- defaults / env inputs ---
 ASSETS=""
@@ -116,8 +126,8 @@ usage() {
   cat >&2 <<'EOF'
 Usage: scripts/run_live_gates.sh --asset A[,A...] [--route R[,R...]] [options]
 
-  --asset   USDC|USDT|USDG|all   (required)
-  --route   xochi|acp|relay|all  (default all)
+  --asset   USDC|USDT|USDG|all      (required)
+  --route   xochi|acp|relay|fee|all (default all; fee is opt-in, fund-free)
   --amount  N                    human stablecoin amount for xochi/acp (default 5.00)
   --corridors SPEC               override corridors, "from>to,from>to" or "mesh"
   --auth    mandate|member       Xochi auth mode (default mandate)
@@ -162,7 +172,7 @@ for a in $ASSET_LIST; do
   case "$a" in USDC|USDT|USDG) ;; *) err "unknown asset: $a (want USDC|USDT|USDG)"; exit 2 ;; esac
 done
 for r in $ROUTE_LIST; do
-  case "$r" in xochi|acp|relay) ;; *) err "unknown route: $r (want xochi|acp|relay)"; exit 2 ;; esac
+  case "$r" in xochi|acp|relay|fee) ;; *) err "unknown route: $r (want xochi|acp|relay|fee)"; exit 2 ;; esac
 done
 
 # --- input validation (cheap, before any work) ---
@@ -214,7 +224,7 @@ rpc_for() { local v="GATE_RPC_$1"; printf '%s' "${!v:-}"; }
 # --- secret loading (lazy: only what the selected routes need) ---
 need_xochi=false; need_relay=false
 for r in $ROUTE_LIST; do
-  case "$r" in xochi|acp) need_xochi=true ;; relay) need_relay=true ;; esac
+  case "$r" in xochi|acp|fee) need_xochi=true ;; relay) need_relay=true ;; esac
 done
 
 # Funded key: required for a real run; dummy is fine for dry-run (tests compile
@@ -370,6 +380,43 @@ run_relay() {
   env MIX_ENV=test mix test --include live_relay "$RELAY_TEST"
 }
 
+# Take-rate validation. Drives the REAL SolverAgent: a buyer signs a live Xochi
+# intent for a known principal, the solver resolves the authoritative amount off
+# Xochi and proposes the budget, and the test asserts the on-chain setBudget
+# calldata == GATE_FEE_BPS (default 8) bps of the principal. Moves NO funds --
+# the intent signature is off-chain and the on-chain write is captured, not sent
+# -- so it runs the same whether or not --dry-run is set. It DOES need a real
+# signing key (a valid EOA; funding not required) to produce the intent.
+run_fee() {
+  local asset="$1" cfg tok corr _p2 _pc corridors
+  cfg="$(asset_cfg "$asset")"
+  IFS='|' read -r tok corr _p2 _pc <<<"$cfg"
+  corridors="${CORRIDORS_OVERRIDE:-$corr}"
+
+  if [[ "$KEY" == "0xdummy" ]]; then
+    log "fee $asset: SKIP -- needs a real GATE_KEY to sign the intent (no funds move)."
+    return 10
+  fi
+
+  export XOCHI_ORDER_LIVE_URL="$XOCHI_URL" XOCHI_ORDER_LIVE_KEY="$KEY" XOCHI_ORDER_LIVE_TOKEN="$XOCHI_TOKEN"
+  export XOCHI_ORDER_AMOUNT="$AMOUNT" XOCHI_ORDER_CORRIDORS="$corridors"
+  export XOCHI_FEE_BPS="${GATE_FEE_BPS:-8}"
+
+  cd "$ACP_DIR"
+  log "fee $asset: assert on-chain budget == ${XOCHI_FEE_BPS} bps of the live-signed principal [$corridors] (NO funds)..."
+  env MIX_ENV=test mix test --only live_solver_fee "$SOLVER_FEE_TEST"
+}
+
+# The routes that actually settle (and so gate on the funded-run confirmation).
+# `fee` is fund-free, so a fee-only run skips the prompt.
+has_settling_route() {
+  local r
+  for r in $ROUTE_LIST; do
+    case "$r" in xochi|acp|relay) return 0 ;; esac
+  done
+  return 1
+}
+
 # ================= plan / spend preview =================
 # corridor count for a spec: a "from>to" pair has one '>', mesh is the 5-chain
 # CCTP grid (20 ordered pairs).
@@ -415,6 +462,7 @@ confirm_funded() {
           else
             log "  $a / relay  -> Base $tok -> Tron USDT (~$RELAY_AMOUNT)"
           fi ;;
+        fee) log "  $a / fee  -> take-rate check [$eff] (NO funds)" ;;
         *) log "  $a / $r  -> [$eff] token=$tok (~$AMOUNT/corridor)" ;;
       esac
     done
@@ -455,6 +503,7 @@ run_cell() {
       xochi) run_xochi "$asset" ;;
       acp)   run_acp   "$asset" ;;
       relay) run_relay "$asset" ;;
+      fee)   run_fee   "$asset" ;;
     esac
   )
   rc=$?
@@ -466,7 +515,7 @@ run_cell() {
   esac
 }
 
-[[ -z "$DRY_RUN" ]] && confirm_funded
+[[ -z "$DRY_RUN" ]] && has_settling_route && confirm_funded
 
 log "live gates: assets=[$ASSET_LIST] routes=[$ROUTE_LIST] amount=$AMOUNT auth=$AUTH${DRY_RUN:+ dry-run}"
 for asset in $ASSET_LIST; do


### PR DESCRIPTION
## Summary
Sets the raxol ACP storefront take-rate to **8 bps** and makes the origin-pull anti-drain pin trust the verified XochiPull contracts (Riddler #591), so real settlements sign against the deployed pull contracts instead of a stale solver-EOA pin. Adds a fund-free live gate that validates the take-rate end-to-end.

## Changes
- **Fee -> 8 bps** (`b14fa40a0`): `XOCHI_FEE_BPS` in `fly.acp.toml` (the production lever the deployed solver reads) 10 -> 8, plus the `UsdcPublicOffering` module default + test for the Queue path.
- **Pull pin trusts XochiPull** (`07c3ba56f`): new `Raxol.Payments.Xochi.PullContracts` (solver wallet + 5 per-chain ERC-3009 proxies + Permit2 proxy, mirroring Riddler `XOCHIPULL_DEPLOYMENTS.md`) + unit test. Wired into `config/runtime.exs` (effective allowlist = `XOCHI_SOLVER_*` env + verified contracts; boot tripwire preserved) and the `live_xochi_test` / `live_order_test` pins. Fixes `{:authorization_mismatch, :pull_to}` now that the origin pull routes to the verified contracts (`xochi_pull_contract_enabled: true`), not the bare EOA.
- **Live take-rate gate** (`2d501d73b`): `solver_fee_live_test.exs` (`:live_solver_fee`, excluded by default) drives the real `SolverAgent` against a live-signed Xochi intent and asserts the on-chain `setBudget` calldata == `XOCHI_FEE_BPS` bps of the principal (moves NO funds). New `fee` route in `run_live_gates.sh` (opt-in, fund-free).

## Manual testing
- [x] `--route fee` gate PASS at 8 bps (pin ON, verified allowlist): `principal=5000000 budget=4000 => 8.0 bps`.
- [x] Real $3 USDC Base->Arbitrum settlement via `--route acp` round-tripped on-chain: Base 5.62 -> 2.62 (-3.00 pulled via ERC-3009), Arbitrum +2.990613 delivered. Settle tx `0x024f3f...bd938`. Pin ON accepted the XochiPull routing (no `authorization_mismatch`).
- [x] `raxol_acp` xochi suite green (173 passed) with the 8 bps + allowlist changes.
- [ ] `raxol_payments` `PullContracts` unit test + `live_xochi_test` — run in CI (blocked locally by pre-existing mix.lock drift; changes touch zero deps).

## Notes
- The `acp` gate mocks the on-chain ACP hooks, so it validates the settlement rail, not a real Virtuals-visible job or the on-chain fee escrow. The 8 bps escrow is validated separately by the `fee` gate.
- Deployed solver already carries `XOCHI_FEE_BPS=8` (machine v10).
- Follow-up: the solver min-fill floor is a dynamic gas floor (#222) that rejects sub-~$3 orders; filed axol-io/Riddler#754 + xochi-fi/xochi#362 to lower it to $1.
