### PR TITLE
Live ACP buyer harness (mix raxol_acp.order) + 4 on-chain fixes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,7 +43,10 @@ if config_env() == :prod do
   # signs against the deployed contract instead of a rejected `to`/`spender`.
   xochi_solver_allowlist =
     if Code.ensure_loaded?(Raxol.Payments.Xochi.PullContracts) do
-      Enum.uniq(xochi_env_solvers ++ Raxol.Payments.Xochi.PullContracts.pull_recipients())
+      Enum.uniq(
+        xochi_env_solvers ++
+          Raxol.Payments.Xochi.PullContracts.pull_recipients()
+      )
     else
       xochi_env_solvers
     end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,7 +18,7 @@ if config_env() == :prod do
   # a per-chain var is here for each of the five supported chains in case they
   # ever diverge. Permit2 is fail-closed regardless; set
   # XOCHI_PULL_REQUIRE_SOLVER_PIN=true to hard-pin ERC-3009 too.
-  xochi_solver_allowlist =
+  xochi_env_solvers =
     ~w(XOCHI_SOLVER_ETH XOCHI_SOLVER_BASE XOCHI_SOLVER_ARBITRUM XOCHI_SOLVER_OPTIMISM XOCHI_SOLVER_POLYGON)
     |> Enum.map(&System.get_env/1)
     |> Enum.reject(&(is_nil(&1) or &1 == ""))
@@ -32,10 +32,21 @@ if config_env() == :prod do
   # release without the payments app (the module is absent) skips the check.
   if Code.ensure_loaded?(Raxol.Payments.Protocols.Xochi) do
     Raxol.Payments.Protocols.Xochi.assert_origin_pull_pinned!(
-      xochi_solver_allowlist,
+      xochi_env_solvers,
       xochi_require_solver_pin
     )
   end
+
+  # With XochiPull enabled (Riddler #591), the origin pull routes to the verified
+  # per-chain pull contracts, not the bare solver EOA. Trust those verified
+  # recipients in addition to any XOCHI_SOLVER_* addresses so a real settlement
+  # signs against the deployed contract instead of a rejected `to`/`spender`.
+  xochi_solver_allowlist =
+    if Code.ensure_loaded?(Raxol.Payments.Xochi.PullContracts) do
+      Enum.uniq(xochi_env_solvers ++ Raxol.Payments.Xochi.PullContracts.pull_recipients())
+    else
+      xochi_env_solvers
+    end
 
   config :raxol_payments,
     pull_solver_allowlist: xochi_solver_allowlist,

--- a/fly.acp.toml
+++ b/fly.acp.toml
@@ -91,7 +91,7 @@ kill_timeout = '60s'
   # Storefront fee in basis points. SolverApplication defaults to 50 (0.5%); the
   # launch target is 8. Pinned here (non-secret) so the fee is independent of any
   # script. A change requires a redeploy (parsed via String.to_integer at boot).
-  XOCHI_FEE_BPS = '10'
+  XOCHI_FEE_BPS = '8'
 
   # --- Delegated (Privy + Alchemy managed wallet) signing config (non-secret) ---
   # The Virtuals ACP server that proxies wallet signing to Privy; the sidecar signs its

--- a/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
+++ b/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
@@ -81,7 +81,8 @@ defmodule Mix.Tasks.RaxolAcp.Order do
           provider: :string,
           fee_bps: :integer,
           fund: :boolean,
-          dry_run: :boolean
+          dry_run: :boolean,
+          job_id: :integer
         ]
       )
 
@@ -102,32 +103,21 @@ defmodule Mix.Tasks.RaxolAcp.Order do
     if opts[:dry_run] do
       log("--dry-run: signed only, no on-chain writes. requirement=#{inspect(requirement)}")
     else
-      place(cfg, requirement, Keyword.get(opts, :fund, false))
+      place(cfg, requirement, opts)
     end
   end
 
   # -- Orchestration --
 
-  defp place(cfg, requirement, fund?) do
+  defp place(cfg, requirement, opts) do
     {agent, resolver} = start_buyer(cfg)
 
-    # 2. createJob on-chain.
-    expired_at = System.system_time(:second) + @sla_minutes * 60 + 60
-
-    {:ok, tx} =
-      HookClient.create_job(cfg.provider_adapter, cfg.from, cfg.core, %{
-        provider: cfg.provider,
-        evaluator: zero_address(),
-        expired_at: expired_at,
-        hook_address: zero_address(),
-        description: @offering
-      })
-
-    log("createJob tx: #{explorer(cfg.from)}#{tx}")
-
-    # 3. Resolve the on-chain jobId from the receipt (retries until mined).
-    job_id = await_job_id(resolver, cfg, tx)
-    log("jobId: #{job_id}")
+    # 2. createJob on-chain (or resume an existing job with --job-id).
+    job_id =
+      case Keyword.get(opts, :job_id) do
+        nil -> create_and_resolve(cfg, resolver)
+        existing -> tap(existing, fn id -> log("resuming job #{id} (skip createJob)") end)
+      end
 
     # 4. Send the requirement (retry: the chat room lags the on-chain job).
     :ok = send_requirement(agent, cfg.from, job_id, requirement)
@@ -148,7 +138,26 @@ defmodule Mix.Tasks.RaxolAcp.Order do
 
     log("job #{job_id} is live -- view it at https://app.virtuals.io/acp")
 
-    if fund?, do: fund_job(cfg, job_id, budget)
+    if Keyword.get(opts, :fund, false), do: fund_job(cfg, job_id, budget)
+  end
+
+  defp create_and_resolve(cfg, resolver) do
+    expired_at = System.system_time(:second) + @sla_minutes * 60 + 60
+
+    {:ok, tx} =
+      HookClient.create_job(cfg.provider_adapter, cfg.from, cfg.core, %{
+        provider: cfg.provider,
+        evaluator: zero_address(),
+        expired_at: expired_at,
+        hook_address: zero_address(),
+        description: @offering
+      })
+
+    log("createJob tx: #{explorer(cfg.from)}#{tx}")
+
+    job_id = await_job_id(resolver, cfg, tx)
+    log("jobId: #{job_id}")
+    job_id
   end
 
   defp fund_job(cfg, job_id, budget) do
@@ -239,7 +248,7 @@ defmodule Mix.Tasks.RaxolAcp.Order do
 
   # Retry, per acp-node-v2: the off-chain chat room may not exist immediately
   # after the on-chain createJob.
-  defp send_requirement(agent, chain_id, job_id, requirement, tries \\ 6)
+  defp send_requirement(agent, chain_id, job_id, requirement, tries \\ 12)
 
   defp send_requirement(_agent, _chain_id, job_id, _requirement, 0),
     do: Mix.raise("could not deliver requirement for job #{job_id} (chat room never ready)")
@@ -254,8 +263,9 @@ defmodule Mix.Tasks.RaxolAcp.Order do
       :ok ->
         :ok
 
-      _err ->
-        Process.sleep(2_000)
+      err ->
+        log("send_message attempt #{13 - tries} failed: #{inspect(err)}")
+        Process.sleep(3_000)
         send_requirement(agent, chain_id, job_id, requirement, tries - 1)
     end
   end

--- a/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
+++ b/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
@@ -66,8 +66,12 @@ defmodule Mix.Tasks.RaxolAcp.Order do
   alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
   alias Raxol.Payments.Xochi.{PullContracts, Schemas.QuoteRequest}
 
+  # Nested wallet modules (defined below) -- alias so they resolve everywhere.
+  alias __MODULE__.{ScaWallet, Signer}
+
   # The raxol agent (seller) wallet -- the provider a buyer hires by default.
   @default_provider "0x939ead944b5d28b86d91af1961812d3bbc46cac1"
+  @sca_account "0x468aeae798b3a6548ac2401d276f83afdc172283"
   @offering "xochi_crosschain"
   @sla_minutes 5
 
@@ -82,7 +86,8 @@ defmodule Mix.Tasks.RaxolAcp.Order do
           fee_bps: :integer,
           fund: :boolean,
           dry_run: :boolean,
-          job_id: :integer
+          job_id: :integer,
+          signer: :string
         ]
       )
 
@@ -181,7 +186,7 @@ defmodule Mix.Tasks.RaxolAcp.Order do
       slippage_bps: 50
     }
 
-    XochiProtocol.quote_and_sign(cfg.xochi_config, request, cfg.wallet_mod)
+    XochiProtocol.quote_and_sign(cfg.xochi_config, request, cfg.intent_wallet)
   end
 
   defp requirement(cfg, bundle) do
@@ -334,8 +339,7 @@ defmodule Mix.Tasks.RaxolAcp.Order do
   # -- Config / helpers --
 
   defp build_config(opts) do
-    key_hex = fetch_env!("ORDER_KEY")
-    rpc = fetch_env!("ORDER_RPC_8453")
+    rpc = System.get_env("ORDER_RPC_8453", Chain.mainnet().rpc_url)
     {from, to} = parse_corridor(Keyword.get(opts, :corridor, "8453>42161"))
     amount = Keyword.get(opts, :amount, "3.00")
 
@@ -343,12 +347,13 @@ defmodule Mix.Tasks.RaxolAcp.Order do
     {:ok, dst_token} = Assets.address(to, "USDC")
     principal_atomic = Assets.to_atomic(Decimal.new(amount), Assets.decimals(from, src_token))
 
-    provider_adapter =
-      ProviderAdapter.JSONRPC.new(chains: %{from => rpc}, private_key: decode_key(key_hex))
+    signer = Keyword.get(opts, :signer, "privy")
+    {provider_adapter, buyer, intent_wallet} = build_signer(signer, from, rpc)
+    log("signer backend: #{signer}")
 
     %{
-      buyer: wallet_mod().address(),
-      wallet_mod: wallet_mod(),
+      buyer: buyer,
+      intent_wallet: intent_wallet,
       provider_adapter: provider_adapter,
       provider: Keyword.get(opts, :provider, @default_provider),
       from: from,
@@ -368,13 +373,79 @@ defmodule Mix.Tasks.RaxolAcp.Order do
     }
   end
 
+  # -- Signer backends --
+
+  # B (default): Virtuals-delegated Privy signing via the Node sidecar; gas is
+  # Alchemy-sponsored. The buyer is the managed SCA agent. Needs (env, from op):
+  # RAXOL_ACP_WALLET_ADDRESS / RAXOL_ACP_WALLET_ID / RAXOL_ACP_SIGNER_PRIVATE_KEY
+  # (+ PRIVY_APP_ID). The intent is still signed locally as the SCA (EOA -> 1271).
+  defp build_signer("privy", from, rpc) do
+    _ = fetch_env!("RAXOL_ACP_WALLET_ID")
+    _ = fetch_env!("RAXOL_ACP_SIGNER_PRIVATE_KEY")
+    address = fetch_env!("RAXOL_ACP_WALLET_ADDRESS")
+
+    {:ok, _} = Raxol.ACP.SignerSidecar.start_link([])
+
+    provider =
+      ProviderAdapter.Privy.new(
+        sidecar_url: Raxol.ACP.SignerSidecar.base_url([]),
+        address: address,
+        chains: %{from => rpc}
+      )
+
+    {provider, address, ScaWallet}
+  end
+
+  # A (--signer sca): direct ERC-4337 -- the EOA session key signs UserOps,
+  # submitted to your own bundler + paymaster. Needs ORDER_BUNDLER_URL (and
+  # ORDER_PAYMASTER_POLICY for sponsorship, else the SCA must hold ETH).
+  defp build_signer("sca", from, rpc) do
+    bundler = fetch_env!("ORDER_BUNDLER_URL")
+    policy = System.get_env("ORDER_PAYMASTER_POLICY")
+
+    provider =
+      ProviderAdapter.SCA.new(
+        wallet: ScaWallet,
+        chains: %{from => rpc},
+        wallet_opts: [bundler_url: bundler, paymaster_policy_id: policy]
+      )
+
+    {provider, @sca_account, ScaWallet}
+  end
+
+  # EOA (--signer eoa): raw EOA. NOT a registered agent, so createJob works but
+  # send_message 404s -- kept for on-chain-only testing.
+  defp build_signer("eoa", from, rpc) do
+    provider =
+      ProviderAdapter.JSONRPC.new(
+        chains: %{from => rpc},
+        private_key: decode_key(fetch_env!("ORDER_KEY"))
+      )
+
+    {provider, Signer.address(), Signer}
+  end
+
+  defp build_signer(other, _from, _rpc),
+    do: Mix.raise("unknown --signer #{inspect(other)} (want privy | sca | eoa)")
+
   # The buyer signs the Xochi intent with the same ORDER_KEY the provider adapter uses.
-  defmodule Wallet do
+  # The EOA session key (0x10910...) -- signs on behalf of the SCA agent.
+  defmodule Signer do
     @moduledoc false
     use Raxol.Payments.Wallets.Env, env_var: "ORDER_KEY"
   end
 
-  defp wallet_mod, do: Wallet
+  # The managed SCA agent (0x468a... "testing agent"): the Xochi intent is signed
+  # AS this account (EOA session key -> ERC-1271), regardless of which on-chain
+  # signer backend submits createJob/fund.
+  defmodule ScaWallet do
+    @moduledoc false
+    use Raxol.ACP.Wallet.SCA,
+      account_address: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      chain_id: 8453,
+      signer: Signer,
+      signer_entity_id: 0
+  end
 
   # Trust the verified XochiPull contracts so the intent's origin-pull authorization
   # passes the anti-drain pin (Riddler #591; same set config/runtime.exs uses).

--- a/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
+++ b/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
@@ -1,0 +1,405 @@
+defmodule Mix.Tasks.RaxolAcp.Order do
+  @shortdoc "Place a real ACP order (buyer) against a live agent offering"
+
+  @moduledoc """
+  Live BUYER harness: creates a real on-chain ACP job for an agent's offering,
+  sends the requirement, and watches the provider set the budget on-chain. This
+  is the counterpart to the seller `SolverAgent` -- it produces a job the
+  Virtuals UI shows and exercises the deployed solver's real on-chain `setBudget`.
+
+  Flow (mirrors `acp-node-v2` `createJobFromOffering`):
+
+    1. Sign a Xochi intent for the transfer (`quote_and_sign`, off-chain EIP-712).
+    2. `createJob(provider, evaluator=0x0, expiredAt, description, hook=0x0)` on the
+       ACP Core (a real Base tx; the buyer EOA pays gas).
+    3. Resolve the assigned `jobId` from the `createJob` receipt.
+    4. `send_message(jobId, requirement, "requirement")` -- retried, since the
+       off-chain chat room lags the on-chain job.
+    5. Poll `getJob(jobId).budget` until the provider sets it, and assert it is
+       `fee_bps` of the principal.
+    6. With `--fund`: `fund(jobId, budget)` so the provider is paid and settlement
+       proceeds (a second Base tx).
+
+  MOVES REAL FUNDS: `createJob`/`fund` cost gas; the Xochi settlement pull moves
+  the principal (gasless via ERC-3009). `--dry-run` stops after signing (step 1),
+  no on-chain writes.
+
+  ## Env
+
+      ORDER_KEY         buyer EOA private key (0x-hex). Signs the intent AND the
+                        createJob/fund txs.
+      ORDER_RPC_8453    Base JSON-RPC URL (to broadcast createJob/fund).
+      ORDER_XOCHI_URL   Xochi worker (default https://api.xochi.fi).
+      ORDER_XOCHI_TOKEN Xochi Member token.
+
+  ## Flags
+
+      --amount N        principal in USDC (default 3.00; note the solver's dynamic
+                        gas floor rejects sub-~$3 today).
+      --corridor F>T    origin>destination chain ids (default 8453>42161).
+      --provider 0x..   the agent (seller) wallet to hire (default the raxol agent).
+      --fee-bps N       expected take-rate to assert (default 8).
+      --fund            after budget is observed, fund the escrow (extra Base tx).
+      --dry-run         sign only, no on-chain writes.
+
+  ## Example
+
+      ORDER_KEY=0x... ORDER_RPC_8453=https://mainnet.base.org \\
+      ORDER_XOCHI_TOKEN=<member token> \\
+        mix raxol_acp.order --amount 3.00
+  """
+
+  use Mix.Task
+
+  alias Raxol.ACP.{
+    Agent,
+    Auth,
+    Chain,
+    HookClient,
+    JobApi,
+    JobIdResolver,
+    ProviderAdapter,
+    Transport
+  }
+
+  alias Raxol.Payments.Assets
+  alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
+  alias Raxol.Payments.Xochi.{PullContracts, Schemas.QuoteRequest}
+
+  # The raxol agent (seller) wallet -- the provider a buyer hires by default.
+  @default_provider "0x939ead944b5d28b86d91af1961812d3bbc46cac1"
+  @offering "xochi_crosschain"
+  @sla_minutes 5
+
+  @impl Mix.Task
+  def run(argv) do
+    {opts, _, _} =
+      OptionParser.parse(argv,
+        strict: [
+          amount: :string,
+          corridor: :string,
+          provider: :string,
+          fee_bps: :integer,
+          fund: :boolean,
+          dry_run: :boolean
+        ]
+      )
+
+    Application.ensure_all_started(:raxol_acp)
+
+    cfg = build_config(opts)
+    trust_pull_contracts()
+
+    log(
+      "buyer=#{cfg.buyer}  provider=#{cfg.provider}  corridor=#{cfg.from}->#{cfg.to}  amount=#{cfg.amount} USDC"
+    )
+
+    # 1. Sign the Xochi intent (off-chain).
+    {:ok, bundle} = sign_intent(cfg)
+    requirement = requirement(cfg, bundle)
+    log("signed Xochi intent: #{bundle[:intent_id] || bundle["intent_id"]}")
+
+    if opts[:dry_run] do
+      log("--dry-run: signed only, no on-chain writes. requirement=#{inspect(requirement)}")
+    else
+      place(cfg, requirement, Keyword.get(opts, :fund, false))
+    end
+  end
+
+  # -- Orchestration --
+
+  defp place(cfg, requirement, fund?) do
+    {agent, resolver} = start_buyer(cfg)
+
+    # 2. createJob on-chain.
+    expired_at = System.system_time(:second) + @sla_minutes * 60 + 60
+
+    {:ok, tx} =
+      HookClient.create_job(cfg.provider_adapter, cfg.from, cfg.core, %{
+        provider: cfg.provider,
+        evaluator: zero_address(),
+        expired_at: expired_at,
+        hook_address: zero_address(),
+        description: @offering
+      })
+
+    log("createJob tx: #{explorer(cfg.from)}#{tx}")
+
+    # 3. Resolve the on-chain jobId from the receipt (retries until mined).
+    job_id = await_job_id(resolver, cfg, tx)
+    log("jobId: #{job_id}")
+
+    # 4. Send the requirement (retry: the chat room lags the on-chain job).
+    :ok = send_requirement(agent, cfg.from, job_id, requirement)
+    log("requirement sent for job #{job_id}")
+
+    # 5. Watch the provider set the budget on-chain and assert the take-rate.
+    budget = await_budget(cfg, job_id)
+    expected = div(cfg.principal_atomic * cfg.fee_bps, 10_000)
+    realized_bps = Float.round(budget / cfg.principal_atomic * 10_000, 3)
+
+    log("provider setBudget = #{budget} base units (#{realized_bps} bps)")
+
+    if budget == expected do
+      log("OK: budget == #{cfg.fee_bps} bps of the principal")
+    else
+      log("WARN: budget #{budget} != expected #{expected} (#{cfg.fee_bps} bps)")
+    end
+
+    log("job #{job_id} is live -- view it at https://app.virtuals.io/acp")
+
+    if fund?, do: fund_job(cfg, job_id, budget)
+  end
+
+  defp fund_job(cfg, job_id, budget) do
+    log("funding escrow: approving #{budget} USDC to the ACP Core, then fund(#{job_id})...")
+    :ok = approve_usdc(cfg, budget)
+    {:ok, tx} = HookClient.fund(cfg.provider_adapter, cfg.from, cfg.core, job_id, budget)
+    log("fund tx: #{explorer(cfg.from)}#{tx} -- provider will now settle + deliver")
+  end
+
+  # -- Steps --
+
+  defp sign_intent(cfg) do
+    request = %QuoteRequest{
+      wallet: cfg.buyer,
+      from_chain_id: cfg.from,
+      to_chain_id: cfg.to,
+      from_token: cfg.src_token,
+      to_token: cfg.dst_token,
+      from_amount: Integer.to_string(cfg.principal_atomic),
+      settlement_preference: "public",
+      slippage_bps: 50
+    }
+
+    XochiProtocol.quote_and_sign(cfg.xochi_config, request, cfg.wallet_mod)
+  end
+
+  defp requirement(cfg, bundle) do
+    %{
+      "src_chain_id" => cfg.from,
+      "dst_chain_id" => cfg.to,
+      "src_token" => cfg.src_token,
+      "dst_token" => cfg.dst_token,
+      "amount_atomic" => Integer.to_string(cfg.principal_atomic),
+      "settlement_preference" => "public",
+      "signed_intent" => Map.new(bundle, fn {k, v} -> {to_string(k), v} end)
+    }
+  end
+
+  defp start_buyer(cfg) do
+    {:ok, auth} =
+      Auth.start_link(
+        provider: cfg.provider_adapter,
+        server_url: cfg.server_url,
+        chain_id: cfg.from
+      )
+
+    transport =
+      Transport.SSE.new(auth: auth, server_url: cfg.server_url, supported_chain_ids: [cfg.from])
+
+    api = JobApi.HTTP.new(auth: auth, server_url: cfg.server_url, chain_ids: [cfg.from])
+
+    {:ok, agent} =
+      Agent.start_link(
+        provider: cfg.provider_adapter,
+        transport: transport,
+        api: api,
+        wallet_address: cfg.buyer,
+        supported_chain_ids: [cfg.from],
+        default_role: :client
+      )
+
+    Agent.subscribe(agent)
+    Agent.start_stream(agent)
+
+    resolver = %{
+      adapter: JobIdResolver.Receipt,
+      config: %{
+        event_signature: "JobCreated(uint256,address,address,address,uint256,address)",
+        topic_index: 1
+      }
+    }
+
+    {agent, resolver}
+  end
+
+  defp await_job_id(resolver, cfg, tx, tries \\ 30)
+
+  defp await_job_id(_resolver, _cfg, tx, 0),
+    do: Mix.raise("createJob #{tx} not mined / jobId not decodable in time")
+
+  defp await_job_id(resolver, cfg, tx, tries) do
+    case JobIdResolver.resolve(resolver, cfg.provider_adapter, cfg.from, tx) do
+      {:ok, job_id} -> job_id
+      :pending -> Process.sleep(2_000) && await_job_id(resolver, cfg, tx, tries - 1)
+      {:error, reason} -> Mix.raise("jobId resolve failed: #{inspect(reason)}")
+    end
+  end
+
+  # Retry, per acp-node-v2: the off-chain chat room may not exist immediately
+  # after the on-chain createJob.
+  defp send_requirement(agent, chain_id, job_id, requirement, tries \\ 6)
+
+  defp send_requirement(_agent, _chain_id, job_id, _requirement, 0),
+    do: Mix.raise("could not deliver requirement for job #{job_id} (chat room never ready)")
+
+  defp send_requirement(agent, chain_id, job_id, requirement, tries) do
+    case Agent.send_message(
+           agent,
+           {chain_id, to_string(job_id)},
+           Jason.encode!(requirement),
+           "requirement"
+         ) do
+      :ok ->
+        :ok
+
+      _err ->
+        Process.sleep(2_000)
+        send_requirement(agent, chain_id, job_id, requirement, tries - 1)
+    end
+  end
+
+  defp await_budget(cfg, job_id, tries \\ 60)
+
+  defp await_budget(_cfg, job_id, 0),
+    do: Mix.raise("provider never set a budget for job #{job_id}")
+
+  defp await_budget(cfg, job_id, tries) do
+    case read_budget(cfg, job_id) do
+      {:ok, budget} when budget > 0 -> budget
+      _ -> Process.sleep(3_000) && await_budget(cfg, job_id, tries - 1)
+    end
+  end
+
+  # -- On-chain reads/writes not covered by HookClient --
+
+  # getJob(jobId) -> (client, status, provider, expiredAt, evaluator, hook, budget, description).
+  # budget is the 7th static word (index 6). The trailing string is offset-encoded
+  # after the static head, so word 6 is the budget inline.
+  defp read_budget(cfg, job_id) do
+    selector = binary_part(ExKeccak.hash_256("getJob(uint256)"), 0, 4)
+
+    data =
+      "0x" <> Base.encode16(selector <> <<job_id::unsigned-big-integer-size(256)>>, case: :lower)
+
+    body = %{
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_call",
+      params: [%{to: cfg.core, data: data}, "latest"]
+    }
+
+    case Req.post(cfg.rpc, json: body) do
+      {:ok, %{status: 200, body: %{"result" => "0x" <> hex}}} when byte_size(hex) >= 14 * 64 ->
+        raw = Base.decode16!(hex, case: :mixed)
+
+        <<_head::binary-size(6 * 32), budget::unsigned-big-integer-size(256), _rest::binary>> =
+          raw
+
+        {:ok, budget}
+
+      _ ->
+        :not_ready
+    end
+  end
+
+  defp approve_usdc(cfg, amount) do
+    call = %{
+      to: cfg.src_token,
+      data:
+        Raxol.ACP.ABI.encode_call("approve(address,uint256)", [
+          {"address", cfg.core},
+          {"uint256", amount}
+        ]),
+      value: 0
+    }
+
+    case ProviderAdapter.send_calls(cfg.provider_adapter, cfg.from, [call]) do
+      {:ok, _} -> :ok
+      err -> Mix.raise("USDC approve failed: #{inspect(err)}")
+    end
+  end
+
+  # -- Config / helpers --
+
+  defp build_config(opts) do
+    key_hex = fetch_env!("ORDER_KEY")
+    rpc = fetch_env!("ORDER_RPC_8453")
+    {from, to} = parse_corridor(Keyword.get(opts, :corridor, "8453>42161"))
+    amount = Keyword.get(opts, :amount, "3.00")
+
+    {:ok, src_token} = Assets.address(from, "USDC")
+    {:ok, dst_token} = Assets.address(to, "USDC")
+    principal_atomic = Assets.to_atomic(Decimal.new(amount), Assets.decimals(from, src_token))
+
+    provider_adapter =
+      ProviderAdapter.JSONRPC.new(chains: %{from => rpc}, private_key: decode_key(key_hex))
+
+    %{
+      buyer: wallet_mod().address(),
+      wallet_mod: wallet_mod(),
+      provider_adapter: provider_adapter,
+      provider: Keyword.get(opts, :provider, @default_provider),
+      from: from,
+      to: to,
+      amount: amount,
+      principal_atomic: principal_atomic,
+      src_token: src_token,
+      dst_token: dst_token,
+      fee_bps: Keyword.get(opts, :fee_bps, 8),
+      rpc: rpc,
+      core: Chain.mainnet().acp_core_address,
+      server_url: Chain.mainnet().acp_server_url,
+      xochi_config: %{
+        base_url: System.get_env("ORDER_XOCHI_URL", "https://api.xochi.fi"),
+        auth_token: System.get_env("ORDER_XOCHI_TOKEN", "")
+      }
+    }
+  end
+
+  # The buyer signs the Xochi intent with the same ORDER_KEY the provider adapter uses.
+  defmodule Wallet do
+    @moduledoc false
+    use Raxol.Payments.Wallets.Env, env_var: "ORDER_KEY"
+  end
+
+  defp wallet_mod, do: Wallet
+
+  # Trust the verified XochiPull contracts so the intent's origin-pull authorization
+  # passes the anti-drain pin (Riddler #591; same set config/runtime.exs uses).
+  defp trust_pull_contracts do
+    Application.put_env(:raxol_payments, :pull_solver_allowlist, PullContracts.pull_recipients())
+    Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
+  end
+
+  defp parse_corridor(spec) do
+    [from, to] = String.split(spec, ">", parts: 2)
+    {String.to_integer(String.trim(from)), String.to_integer(String.trim(to))}
+  end
+
+  defp decode_key("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+  defp decode_key(hex), do: Base.decode16!(hex, case: :mixed)
+
+  defp zero_address, do: "0x0000000000000000000000000000000000000000"
+
+  defp fetch_env!(name) do
+    case System.get_env(name) do
+      nil -> Mix.raise("set #{name}")
+      "" -> Mix.raise("set #{name}")
+      v -> v
+    end
+  end
+
+  @explorers %{
+    1 => "https://etherscan.io/tx/",
+    10 => "https://optimistic.etherscan.io/tx/",
+    137 => "https://polygonscan.com/tx/",
+    8453 => "https://basescan.org/tx/",
+    42_161 => "https://arbiscan.io/tx/"
+  }
+
+  defp explorer(chain_id), do: Map.get(@explorers, chain_id, "")
+
+  defp log(msg), do: Mix.shell().info("[order] " <> msg)
+end

--- a/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
+++ b/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
@@ -9,43 +9,65 @@ defmodule Mix.Tasks.RaxolAcp.Order do
 
   Flow (mirrors `acp-node-v2` `createJobFromOffering`):
 
-    1. Sign a Xochi intent for the transfer (`quote_and_sign`, off-chain EIP-712).
+    1. Sign a Xochi intent for the transfer AS the buyer agent (off-chain EIP-712;
+       an SCA signs ERC-1271).
     2. `createJob(provider, evaluator=0x0, expiredAt, description, hook=0x0)` on the
-       ACP Core (a real Base tx; the buyer EOA pays gas).
+       ACP Core.
     3. Resolve the assigned `jobId` from the `createJob` receipt.
-    4. `send_message(jobId, requirement, "requirement")` -- retried, since the
-       off-chain chat room lags the on-chain job.
+    4. `send_message(jobId, requirement, "requirement")` to the chat room (retried,
+       since it lags the on-chain job).
     5. Poll `getJob(jobId).budget` until the provider sets it, and assert it is
        `fee_bps` of the principal.
-    6. With `--fund`: `fund(jobId, budget)` so the provider is paid and settlement
-       proceeds (a second Base tx).
+    6. With `--fund`: approve + `fund(jobId, budget)` so the provider is paid and
+       settlement proceeds.
 
-  MOVES REAL FUNDS: `createJob`/`fund` cost gas; the Xochi settlement pull moves
-  the principal (gasless via ERC-3009). `--dry-run` stops after signing (step 1),
-  no on-chain writes.
+  ## Signer backends (`--signer`)
+
+  The buyer must be a REGISTERED Virtuals agent to post messages, so the default
+  drives a managed SCA agent:
+
+    * `privy` (default) -- Virtuals-delegated signing via the Node signer sidecar
+      (`priv/signer_sidecar`); gas is Alchemy-sponsored (no ETH needed). The buyer
+      is the managed SCA at `RAXOL_ACP_WALLET_ADDRESS`; the intent is signed locally
+      as that SCA (`ORDER_KEY` session key -> ERC-1271).
+    * `sca` -- direct ERC-4337: the `ORDER_KEY` session key signs UserOps submitted
+      to your own bundler + paymaster (`ORDER_BUNDLER_URL`, `ORDER_PAYMASTER_POLICY`).
+    * `eoa` -- raw EOA from `ORDER_KEY`. NOT a registered agent (messaging 404s);
+      on-chain-only testing.
+
+  MOVES REAL FUNDS on `--fund` (the fee escrow + the Xochi settlement pull). Gas is
+  sponsored under `privy`. `--dry-run` stops after signing (step 1).
 
   ## Env
 
-      ORDER_KEY         buyer EOA private key (0x-hex). Signs the intent AND the
-                        createJob/fund txs.
-      ORDER_RPC_8453    Base JSON-RPC URL (to broadcast createJob/fund).
-      ORDER_XOCHI_URL   Xochi worker (default https://api.xochi.fi).
-      ORDER_XOCHI_TOKEN Xochi Member token.
+      ORDER_KEY          session-key EOA (0x-hex): signs the intent, and -- under
+                         sca/eoa -- the on-chain txs.
+      ORDER_RPC_8453     Base JSON-RPC (reads; eoa/sca broadcast). Default: mainnet.
+      ORDER_XOCHI_TOKEN  Xochi Member token.  ORDER_XOCHI_URL default api.xochi.fi.
+
+      # `privy` backend (delegated sidecar) -- from the agent's op item:
+      RAXOL_ACP_WALLET_ADDRESS      the managed SCA agent (the buyer).
+      RAXOL_ACP_WALLET_ID           Privy wallet id.
+      RAXOL_ACP_SIGNER_PRIVATE_KEY  P-256 authorization key (base64 PKCS#8).
+      PRIVY_APP_ID                  Virtuals Privy app id.
 
   ## Flags
 
-      --amount N        principal in USDC (default 3.00; note the solver's dynamic
-                        gas floor rejects sub-~$3 today).
-      --corridor F>T    origin>destination chain ids (default 8453>42161).
-      --provider 0x..   the agent (seller) wallet to hire (default the raxol agent).
-      --fee-bps N       expected take-rate to assert (default 8).
-      --fund            after budget is observed, fund the escrow (extra Base tx).
-      --dry-run         sign only, no on-chain writes.
+      --signer B         privy (default) | sca | eoa
+      --amount N         principal in USDC (default 3.00; the solver's dynamic gas
+                         floor rejects sub-~$3 today).
+      --corridor F>T     origin>destination chain ids (default 8453>42161).
+      --provider 0x..    the agent (seller) wallet to hire (default the raxol agent).
+      --fee-bps N        expected take-rate to assert (default 8).
+      --job-id N         resume an existing job (skip createJob).
+      --fund             after budget is observed, fund the escrow + settle.
+      --dry-run          sign only, no on-chain writes.
 
-  ## Example
+  ## Example (delegated Privy, the default)
 
-      ORDER_KEY=0x... ORDER_RPC_8453=https://mainnet.base.org \\
-      ORDER_XOCHI_TOKEN=<member token> \\
+      ORDER_KEY=0x<session key> ORDER_XOCHI_TOKEN=<member token> \\
+      RAXOL_ACP_WALLET_ADDRESS=0x<agent> RAXOL_ACP_WALLET_ID=<id> \\
+      RAXOL_ACP_SIGNER_PRIVATE_KEY=<p256> PRIVY_APP_ID=<app id> \\
         mix raxol_acp.order --amount 3.00
   """
 
@@ -306,10 +328,13 @@ defmodule Mix.Tasks.RaxolAcp.Order do
     }
 
     case Req.post(cfg.rpc, json: body) do
-      {:ok, %{status: 200, body: %{"result" => "0x" <> hex}}} when byte_size(hex) >= 14 * 64 ->
+      {:ok, %{status: 200, body: %{"result" => "0x" <> hex}}} when byte_size(hex) >= 8 * 64 ->
         raw = Base.decode16!(hex, case: :mixed)
 
-        <<_head::binary-size(6 * 32), budget::unsigned-big-integer-size(256), _rest::binary>> =
+        # Dynamic-struct return: a leading offset word, then the head (client,
+        # status, provider, expiredAt, evaluator, hook, budget). budget is word 7
+        # -- skip the offset word + the six preceding fields.
+        <<_lead::binary-size(7 * 32), budget::unsigned-big-integer-size(256), _rest::binary>> =
           raw
 
         {:ok, budget}

--- a/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
+++ b/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
@@ -431,7 +431,12 @@ defmodule Mix.Tasks.RaxolAcp.Order do
         chains: %{from => rpc}
       )
 
-    {provider, address, ScaWallet}
+    # The 7702 buyer's ONLY authorized signer is its own managed authority, so the
+    # intent (and origin-pull) signature must be produced by the sidecar, not a
+    # local session key. Sma7702Wallet resolves this provider at call time.
+    :persistent_term.put({__MODULE__, :privy_provider}, provider)
+
+    {provider, address, Sma7702Wallet}
   end
 
   # A (--signer sca): direct ERC-4337 -- the EOA session key signs UserOps,
@@ -466,6 +471,12 @@ defmodule Mix.Tasks.RaxolAcp.Order do
   defp build_signer(other, _from, _rpc),
     do: Mix.raise("unknown --signer #{inspect(other)} (want privy | sca | eoa)")
 
+  # The managed Privy provider is runtime state; Sma7702Wallet resolves it here at
+  # call time so the wallet stays a plain behaviour module.
+  @doc false
+  @spec privy_provider() :: Raxol.ACP.ProviderAdapter.adapter()
+  def privy_provider, do: :persistent_term.get({__MODULE__, :privy_provider})
+
   # The buyer signs the Xochi intent with the same ORDER_KEY the provider adapter uses.
   # The EOA session key (0x10910...) -- signs on behalf of the SCA agent.
   defmodule Signer do
@@ -473,9 +484,9 @@ defmodule Mix.Tasks.RaxolAcp.Order do
     use Raxol.Payments.Wallets.Env, env_var: "ORDER_KEY"
   end
 
-  # The managed SCA agent (0x468a... "testing agent"): the Xochi intent is signed
-  # AS this account (EOA session key -> ERC-1271), regardless of which on-chain
-  # signer backend submits createJob/fund.
+  # The managed SCA agent (0x468a... "testing agent") as a DEPLOYED Modular
+  # Account v2 (the --signer sca path): the intent is signed by the session key
+  # through the installed single-signer validation module.
   defmodule ScaWallet do
     @moduledoc false
     use Raxol.ACP.Wallet.SCA,
@@ -483,6 +494,18 @@ defmodule Mix.Tasks.RaxolAcp.Order do
       chain_id: 8453,
       signer: Signer,
       signer_entity_id: 0
+  end
+
+  # The managed SCA agent as an EIP-7702 Semi-Modular Account (the default --signer
+  # privy path): the intent is signed AS the account by its managed authority via
+  # the Privy sidecar, wrapped for the account's native ERC-1271 fallback path. A
+  # local session key is NOT an authorized signer on a 7702 account.
+  defmodule Sma7702Wallet do
+    @moduledoc false
+    use Raxol.ACP.Wallet.Sma7702,
+      account_address: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      chain_id: 8453,
+      provider: {Mix.Tasks.RaxolAcp.Order, :privy_provider}
   end
 
   # Trust the verified XochiPull contracts so the intent's origin-pull authorization

--- a/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
+++ b/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
@@ -187,11 +187,41 @@ defmodule Mix.Tasks.RaxolAcp.Order do
     job_id
   end
 
+  # approve (USDC) + fund (ACP Core) batched into ONE UserOp, per acp-node-v2. A
+  # standalone approve to a token contract is not sponsored by the Virtuals
+  # paymaster; batched with the ACP-core fund call, the whole UserOp is.
   defp fund_job(cfg, job_id, budget) do
-    log("funding escrow: approving #{budget} USDC to the ACP Core, then fund(#{job_id})...")
-    :ok = approve_usdc(cfg, budget)
-    {:ok, tx} = HookClient.fund(cfg.provider_adapter, cfg.from, cfg.core, job_id, budget)
-    log("fund tx: #{explorer(cfg.from)}#{tx} -- provider will now settle + deliver")
+    log("funding escrow: batched approve + fund(#{job_id}) in one sponsored UserOp...")
+
+    calls = [
+      %{
+        to: cfg.src_token,
+        data:
+          Raxol.ACP.ABI.encode_call("approve(address,uint256)", [
+            {"address", cfg.core},
+            {"uint256", budget}
+          ]),
+        value: 0
+      },
+      %{
+        to: cfg.core,
+        data:
+          Raxol.ACP.ABI.encode_call("fund(uint256,uint256,bytes)", [
+            {"uint256", job_id},
+            {"uint256", budget},
+            {"bytes", <<>>}
+          ]),
+        value: 0
+      }
+    ]
+
+    case ProviderAdapter.send_calls(cfg.provider_adapter, cfg.from, calls) do
+      {:ok, txs} ->
+        log("funded (approve+fund batched): #{inspect(txs)} -- provider will settle + deliver")
+
+      err ->
+        Mix.raise("fund failed: #{inspect(err)}")
+    end
   end
 
   # -- Steps --
@@ -341,23 +371,6 @@ defmodule Mix.Tasks.RaxolAcp.Order do
 
       _ ->
         :not_ready
-    end
-  end
-
-  defp approve_usdc(cfg, amount) do
-    call = %{
-      to: cfg.src_token,
-      data:
-        Raxol.ACP.ABI.encode_call("approve(address,uint256)", [
-          {"address", cfg.core},
-          {"uint256", amount}
-        ]),
-      value: 0
-    }
-
-    case ProviderAdapter.send_calls(cfg.provider_adapter, cfg.from, [call]) do
-      {:ok, _} -> :ok
-      err -> Mix.raise("USDC approve failed: #{inspect(err)}")
     end
   end
 

--- a/packages/raxol_acp/lib/raxol/acp/agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/agent.ex
@@ -139,6 +139,18 @@ defmodule Raxol.ACP.Agent do
   @spec sessions(GenServer.server()) :: %{Transport.job_key() => pid()}
   def sessions(server), do: GenServer.call(server, :sessions)
 
+  @doc """
+  Fetch a job's entry history via the transport (one-shot REST read).
+
+  Used by the reattach path (`Raxol.ACP.Xochi.SolverAgent`) to recover a job's
+  requirement after a restart dropped the in-memory session. The SSE stream is
+  live-only and does not replay past entries on reconnect, so this is the only
+  way to see entries that predate the current connection.
+  """
+  @spec get_history(GenServer.server(), Transport.job_key()) ::
+          {:ok, [Transport.entry()]} | {:error, term()}
+  def get_history(server, key), do: GenServer.call(server, {:get_history, key})
+
   @doc "Convenience wrapper around `JobApi.browse_agents/3`."
   @spec browse_agents(GenServer.server(), String.t(), map()) ::
           {:ok, [JobApi.agent_detail()]} | {:error, term()}
@@ -225,6 +237,10 @@ defmodule Raxol.ACP.Agent do
   end
 
   def handle_call(:sessions, _from, state), do: {:reply, state.sessions, state}
+
+  def handle_call({:get_history, key}, _from, state) do
+    {:reply, Transport.get_history(state.transport, key), state}
+  end
 
   def handle_call({:browse_agents, keyword, params}, _from, state) do
     {:reply, JobApi.browse_agents(state.api, keyword, params), state}

--- a/packages/raxol_acp/lib/raxol/acp/job_id_resolver/receipt.ex
+++ b/packages/raxol_acp/lib/raxol/acp/job_id_resolver/receipt.ex
@@ -9,30 +9,31 @@ defmodule Raxol.ACP.JobIdResolver.Receipt do
   `JobApi.get_active_jobs` and matches the one whose `description` carries the
   buyer's `request_tag` -- the recovery path when a crash lost the tx hash.
 
-  ## CONFIRM IN THE SEPOLIA DRY-RUN
+  ## Event signature (verified)
 
-  These defaults are placeholders and are NOT yet verified against the deployed
-  `AgenticCommerceV3`. Override via the resolver config before a funded run:
+  The defaults below are verified against the deployed `AgenticCommerceV3`
+  (Base `0x8e86FbEf...B77BC`, behind the ACP Core proxy): `JobCreated` carries
+  six params, with `jobId` the first indexed one, so topic 0 is
+  `keccak256("JobCreated(uint256,address,address,address,uint256,address)")`
+  and `jobId` is `topics[1]`. Override via the resolver config only if the core
+  is upgraded and the event changes:
 
       %{adapter: Raxol.ACP.JobIdResolver.Receipt,
         config: %{
-          event_signature: "JobCreated(uint256)",  # canonical name + arg types
+          event_signature: "JobCreated(uint256,address,address,address,uint256,address)",
           topic_index: 1                            # 1-based; topic 0 is the hash
         }}
 
-  Open items for the dry-run: (1) the exact `JobCreated` signature (its topic0
-  hash), (2) that `jobId` is the INDEXED parameter at `topic_index` (indexed
-  primitives live in `topics[]`, not `data`; this decoder only reads topics),
-  (3) which contract emits it, and (4) that `createJob`'s `description` string
-  round-trips on-chain and is readable back through `get_active_jobs` -- the
-  reconcile path depends on it.
+  `reconcile/4`'s recovery path depends on `createJob`'s `description` string
+  round-tripping on-chain and being readable back through `get_active_jobs`.
   """
 
   @behaviour Raxol.ACP.JobIdResolver
 
   alias Raxol.ACP.{JobApi, Onchain.LogDecoder, ProviderAdapter}
 
-  @default_event_signature "JobCreated(uint256)"
+  # Verified against the deployed AgenticCommerceV3 (see moduledoc).
+  @default_event_signature "JobCreated(uint256,address,address,address,uint256,address)"
   @default_topic_index 1
 
   @impl Raxol.ACP.JobIdResolver

--- a/packages/raxol_acp/lib/raxol/acp/transport/sse.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/sse.ex
@@ -150,7 +150,7 @@ defmodule Raxol.ACP.Transport.SSE do
   def post_message(%{config: cfg}, {chain_id, job_id}, content, content_type) do
     case Auth.token(cfg.auth) do
       {:ok, token} ->
-        url = cfg.server_url <> "/jobs/#{chain_id}/#{job_id}/messages"
+        url = cfg.server_url <> "/chats/#{chain_id}/#{job_id}/message"
 
         body = %{"content" => content, "contentType" => content_type}
 

--- a/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
@@ -63,24 +63,30 @@ defmodule Raxol.ACP.Transport.SSE.Parser do
   defp extract_data_line("data:" <> rest), do: [String.trim_leading(rest, " ")]
   defp extract_data_line(_), do: []
 
-  # Normalize the wire shape of an ACP SSE entry into the shape the Agent +
-  # SolverAgent consume. The Virtuals server sends system events as
-  # `%{"kind" => "system", "event" => %{"type" => "job.created", "provider" => ...,
-  # "onChainJobId" => ...}}`, but our dispatch matches `"event" => "job.created"`
-  # (a string) and reads top-level `jobId`/`provider`. So for system entries we hoist
-  # the nested event map's fields to the top level and replace `event` with its type
-  # string. Message entries already carry top-level `content`/`contentType`/`from`.
-  # Both get `jobId` lifted from `onChainJobId`. This is the single boundary where the
-  # wire shape meets our code (the gate drives the provider in-process and never hits
-  # this path, which is why the mismatch went unseen until a real marketplace job).
-  defp normalize(%{"kind" => "system", "event" => %{"type" => type} = ev} = entry) do
+  @doc """
+  Normalize the wire shape of an ACP SSE entry into the shape the Agent +
+  SolverAgent consume. The Virtuals server sends system events as
+  `%{"kind" => "system", "event" => %{"type" => "job.created", "provider" => ...,
+  "onChainJobId" => ...}}`, but our dispatch matches `"event" => "job.created"`
+  (a string) and reads top-level `jobId`/`provider`. So for system entries we hoist
+  the nested event map's fields to the top level and replace `event` with its type
+  string. Message entries already carry top-level `content`/`contentType`/`from`.
+  Both get `jobId` lifted from `onChainJobId`. This is the single boundary where the
+  wire shape meets our code (the gate drives the provider in-process and never hits
+  this path, which is why the mismatch went unseen until a real marketplace job).
+
+  Also reused when replaying `get_history/2` entries (raw server JSON) so the
+  SolverAgent reattach path reads them through the same shape as the live stream.
+  """
+  @spec normalize(map()) :: map()
+  def normalize(%{"kind" => "system", "event" => %{"type" => type} = ev} = entry) do
     entry
     |> Map.merge(ev)
     |> Map.put("event", type)
     |> Map.put("jobId", job_id(entry, ev))
   end
 
-  defp normalize(%{} = entry) do
+  def normalize(%{} = entry) do
     Map.put(entry, "jobId", job_id(entry, entry["event"]))
   end
 

--- a/packages/raxol_acp/lib/raxol/acp/wallet/sca/modular_account.ex
+++ b/packages/raxol_acp/lib/raxol/acp/wallet/sca/modular_account.ex
@@ -166,34 +166,37 @@ defmodule Raxol.ACP.Wallet.SCA.ModularAccount do
   end
 
   @doc """
-  Compute the EIP-712 `ReplaySafeHash` digest a single-signer entity
-  signs for EIP-1271 (e.g. JWT auth challenges).
+  Compute the EIP-712 `ReplaySafeHash` digest a Semi-Modular Account's native
+  fallback signer signs for EIP-1271.
 
-  The domain binds the signature to the single-signer validation module
-  and the specific account via a salt of `bytes12(0) || accountAddress`:
+  A raxol-provisioned account is a Semi-Modular Account (7702 or the deployed
+  bytecode variant); its intent/message signatures validate through the entity-0
+  fallback path, whose replay-safe hash is bound to the ACCOUNT's own EIP-712
+  domain -- `EIP712Domain(uint256 chainId, address verifyingContract)` with
+  `verifyingContract = the account` and NO salt (verified byte-for-byte against
+  the live `SemiModularAccountBase._domainSeparator`/`_replaySafeHash` on Base):
 
-      domain  = EIP712Domain(uint256 chainId, address verifyingContract, bytes32 salt)
-                where verifyingContract = single-signer validation module,
-                      salt = 0x000000000000000000000000 || accountAddress
+      domain  = EIP712Domain(uint256 chainId, address verifyingContract)
+                where verifyingContract = the account itself
       struct  = ReplaySafeHash(bytes32 hash)
       digest  = keccak256(0x1901 || domainSeparator || structHash)
 
-  `inner_hash` is the application hash (e.g. `hashTypedData` of the
-  challenge, or `hashMessage` of a personal-sign payload).
+  `inner_hash` is the application hash (e.g. `hashTypedData` of the challenge, or
+  `hashMessage` of a personal-sign payload). This is NOT the single-signer
+  validation MODULE's replay-safe hash (module domain + account salt); an
+  installed single-signer module would compute that instead, but the fallback
+  path -- which every raxol SMA signature uses -- does not.
   """
   @spec replay_safe_digest(<<_::256>>, pos_integer(), String.t()) :: binary()
   def replay_safe_digest(inner_hash, chain_id, account_address) do
     domain_type_hash =
-      ExKeccak.hash_256("EIP712Domain(uint256 chainId,address verifyingContract,bytes32 salt)")
-
-    salt = <<0::96, decode_address!(account_address)::binary-size(20)>>
+      ExKeccak.hash_256("EIP712Domain(uint256 chainId,address verifyingContract)")
 
     domain_separator =
       ExKeccak.hash_256(
         domain_type_hash <>
           <<chain_id::unsigned-big-256>> <>
-          encode_address(@single_signer_validation) <>
-          salt
+          encode_address(account_address)
       )
 
     struct_hash =

--- a/packages/raxol_acp/lib/raxol/acp/wallet/sma7702.ex
+++ b/packages/raxol_acp/lib/raxol/acp/wallet/sma7702.ex
@@ -1,0 +1,139 @@
+defmodule Raxol.ACP.Wallet.Sma7702 do
+  @moduledoc """
+  A `Raxol.Payments.Wallet` that produces ERC-1271 signatures a live Alchemy
+  EIP-7702 Semi-Modular Account (`SemiModularAccount7702`) accepts, so a managed
+  7702 buyer can sign Xochi intents (and origin-pull authorizations) that Riddler
+  verifies on-chain via `isValidSignature`.
+
+  Unlike `Raxol.ACP.Wallet.SCA` -- which targets a DEPLOYED Modular Account v2
+  validating through an installed single-signer validation MODULE -- a 7702 SMA
+  validates through its NATIVE fallback path. Verified byte-for-byte on Base
+  against the live account (`isValidSignature -> 0x1626ba7e`), that path differs
+  in two ways:
+
+    * **Replay-safe digest domain.** The account wraps the app digest with its
+      OWN EIP-712 domain -- `EIP712Domain(uint256 chainId, address
+      verifyingContract)` where `verifyingContract` is the ACCOUNT itself, with no
+      `salt` and no name/version -- not the single-signer module's
+      `{module, salt = account}` domain that `Raxol.ACP.Wallet.SCA` builds.
+    * **Signer.** The only authorized signer is the account's fallback signer (the
+      7702 authority itself), NOT a local session key. Signing therefore goes
+      through the managed authority (the Privy/Alchemy `ProviderAdapter`), which
+      holds the key.
+
+  The managed signer has no raw-hash endpoint, so to make it sign the account's
+  replay-safe hash we hand it that wrapper AS EIP-712 typed data --
+  `ReplaySafeHash(bytes32 hash)` over the account domain, `hash` = the app digest
+  `D`. The signer hashes and signs it, yielding a signature over exactly
+  `_replaySafeHash(D)`. We then wrap the 65-byte ECDSA signature in the Modular
+  Account v2 fallback envelope `0x00 || uint32(0) || 0xFF || 0x00 || sig` (entity
+  id 0, global flag, no pre-validation hook data, `SignatureType.EOA`).
+
+  ## Usage
+
+      defmodule MyBuyer do
+        use Raxol.ACP.Wallet.Sma7702,
+          account_address: "0x468a...",
+          chain_id: 8453,
+          # {module, fun} resolved at call time -- the managed ProviderAdapter is
+          # runtime state (built from env), so the wallet stays a plain behaviour.
+          provider: {MyApp, :privy_provider}
+      end
+  """
+
+  alias Raxol.ACP.ProviderAdapter
+  alias Raxol.ACP.Wallet.SCA.ModularAccount
+  alias Raxol.Payments.EIP712
+
+  @replay_safe_types %{"ReplaySafeHash" => [%{name: "hash", type: "bytes32"}]}
+
+  defmacro __using__(opts) do
+    account = Keyword.fetch!(opts, :account_address)
+    chain = Keyword.fetch!(opts, :chain_id)
+    provider = Keyword.fetch!(opts, :provider)
+
+    quote do
+      @behaviour Raxol.Payments.Wallet
+
+      @impl true
+      def address, do: unquote(account)
+
+      @impl true
+      def chain_id, do: unquote(chain)
+
+      @impl true
+      def sign_message(message) do
+        Raxol.ACP.Wallet.Sma7702.sign_message(
+          message,
+          unquote(provider),
+          unquote(chain),
+          unquote(account)
+        )
+      end
+
+      @impl true
+      def sign_typed_data(domain, types, message) do
+        Raxol.ACP.Wallet.Sma7702.sign_typed_data(
+          domain,
+          types,
+          message,
+          unquote(provider),
+          unquote(chain),
+          unquote(account)
+        )
+      end
+
+      # Signing goes through the managed authority, never a raw local key.
+      @impl true
+      def sign_hash(_digest), do: {:error, :sma7702_requires_managed_signer}
+    end
+  end
+
+  @typedoc "A `{module, function}` resolving to the managed `ProviderAdapter` at call time."
+  @type provider_ref :: {module(), atom()}
+
+  @doc false
+  @spec sign_typed_data(map(), map(), map(), provider_ref(), pos_integer(), String.t()) ::
+          {:ok, binary()} | {:error, term()}
+  def sign_typed_data(domain, types, message, provider_ref, chain_id, account) do
+    with {:ok, inner} <- EIP712.hash(domain, types, message) do
+      sign_inner(inner, provider_ref, chain_id, account)
+    end
+  end
+
+  @doc false
+  @spec sign_message(binary(), provider_ref(), pos_integer(), String.t()) ::
+          {:ok, binary()} | {:error, term()}
+  def sign_message(message, provider_ref, chain_id, account) do
+    sign_inner(hash_message(message), provider_ref, chain_id, account)
+  end
+
+  # Sign the account's replay-safe wrapper of `inner_hash` via the managed
+  # authority, then pack it into the fallback ERC-1271 envelope.
+  defp sign_inner(inner_hash, {mod, fun}, chain_id, account) do
+    provider = apply(mod, fun, [])
+
+    wrapper = %{
+      domain: %{chainId: chain_id, verifyingContract: account},
+      types: @replay_safe_types,
+      message: %{"hash" => "0x" <> Base.encode16(inner_hash, case: :lower)}
+    }
+
+    with {:ok, raw} <- ProviderAdapter.sign_typed_data(provider, chain_id, wrapper) do
+      {:ok, ModularAccount.pack_1271_eoa_signature(normalize_v(raw), 0)}
+    end
+  end
+
+  # EIP-191 personal-sign hash of arbitrary-length data (matches
+  # `Raxol.ACP.Wallet.SCA`'s message hashing).
+  defp hash_message(message) do
+    prefix = "\x19Ethereum Signed Message:\n" <> Integer.to_string(byte_size(message))
+    ExKeccak.hash_256(prefix <> message)
+  end
+
+  # secp256k1 recovery id -> Ethereum v (27/28); leave already-normalized sigs.
+  defp normalize_v(<<r::binary-size(32), s::binary-size(32), v::8>>) when v < 27,
+    do: <<r::binary-size(32), s::binary-size(32), v + 27::8>>
+
+  defp normalize_v(<<_::binary-size(64), _v::8>> = sig), do: sig
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
@@ -51,7 +51,10 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
   use GenServer
 
+  require Logger
+
   alias Raxol.ACP.{Agent, HookClient}
+  alias Raxol.ACP.Transport.SSE.Parser
   alias Raxol.ACP.Xochi.{IntentDeriver, Offering}
 
   @type session_status ::
@@ -85,6 +88,10 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
           acp_core_address: String.t(),
           fee_bps: non_neg_integer(),
           settle_fn: fun(),
+          history_fn:
+            (Raxol.ACP.Transport.job_key() ->
+               {:ok, [map()]} | {:error, term()})
+            | nil,
           xochi_config: map(),
           sessions: %{Raxol.ACP.Transport.job_key() => session_state()}
         }
@@ -98,6 +105,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
     :acp_core_address,
     :xochi_config,
     settle_fn: nil,
+    history_fn: nil,
     fee_bps: 8,
     sessions: %{}
   ]
@@ -137,6 +145,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       acp_core_address: Keyword.fetch!(opts, :acp_core_address),
       fee_bps: Keyword.get(opts, :fee_bps, 8),
       settle_fn: Keyword.get(opts, :settle_fn, &default_settle/1),
+      history_fn: Keyword.get(opts, :history_fn),
       xochi_config: Keyword.get(opts, :xochi_config, %{})
     }
 
@@ -216,6 +225,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       }
 
       emit(state, key, :job_created, :await_requirement)
+      Logger.info("[xochi.solver] accepted job.created key=#{inspect(key)}; awaiting requirement")
       put_session(state, key, session)
     else
       state
@@ -245,9 +255,143 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
   # never fan-settle every pending session -- doing so spends real funds via
   # settle/3 for jobs that were not funded.
   defp handle_job_funded(entry, state) do
-    case settle_target(state.sessions, job_key(entry)) do
-      {:ok, key, session} -> settle(state, key, session)
-      :none -> state
+    key = job_key(entry)
+    live_status = live_session_status(state, key)
+
+    emit(state, key, :job_funded, %{session_status: live_status})
+
+    Logger.info(
+      "[xochi.solver] job.funded key=#{inspect(key)} live_session=#{inspect(live_status)}"
+    )
+
+    case settle_target(state.sessions, key) do
+      {:ok, key, session} ->
+        settle(state, key, session)
+
+      :none ->
+        # No settleable in-memory session. If the solver restarted between
+        # setBudget and fund (deploy/reschedule), the session is gone and the
+        # live-only SSE stream never replays the earlier entries -- so without a
+        # reattach the funded job stays stuck forever (issue #772). Rebuild from
+        # job history and settle. A session that exists but is NOT fundable
+        # (already settling/submitted/completed/failed) is a duplicate/late
+        # funded event and is left untouched.
+        if live_status == :absent do
+          reattach_and_settle(entry, key, state)
+        else
+          Logger.info(
+            "[xochi.solver] job.funded ignored for #{inspect(key)} (session #{inspect(live_status)})"
+          )
+
+          state
+        end
+    end
+  end
+
+  defp live_session_status(state, key) do
+    case Map.fetch(state.sessions, key) do
+      {:ok, %{status: status}} -> status
+      :error -> :absent
+    end
+  end
+
+  # Rebuild the lost session from the ACP job history and settle it. The history
+  # (fetched off the Virtuals server) is authoritative: it carries the original
+  # `job.created` (confirming this solver is the provider) and the buyer's
+  # `requirement` message (carrying the signed intent bundle we relay). Fails
+  # closed and stays silent on-chain if any of that can't be recovered or the
+  # job isn't ours -- reattach never invents a settlement.
+  defp reattach_and_settle(entry, key, state) do
+    Logger.info("[xochi.solver] no live session for #{inspect(key)}; reattaching from history")
+
+    case rebuild_session(entry, key, state) do
+      {:ok, session} ->
+        emit(state, key, :reattached, :from_history)
+        Logger.info("[xochi.solver] reattached #{inspect(key)} from history; settling")
+        settle(put_session(state, key, session), key, session)
+
+      {:error, reason} ->
+        emit(state, key, :reattach_failed, reason)
+        Logger.warning("[xochi.solver] reattach failed for #{inspect(key)}: #{inspect(reason)}")
+        state
+    end
+  end
+
+  defp rebuild_session(entry, key, state) do
+    with {:ok, entries} <- fetch_history(state, key),
+         normalized = Enum.map(entries, &Parser.normalize/1),
+         :ok <- confirm_provider(normalized, state),
+         {:ok, requirement} <- requirement_from_history(normalized),
+         {:ok, %{from_amount: transfer_atomic}} <-
+           IntentDeriver.resolve(state.xochi_config, requirement) do
+      {:ok, reattached_session(entry, key, requirement, transfer_atomic)}
+    else
+      # IntentDeriver returns {:reject, _} | {:error, _}; the history seams return
+      # {:error, _}. Normalize all to {:error, reason} so reattach fails closed.
+      {_reject_or_error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp reattached_session(entry, {chain_id, job_id}, requirement, transfer_atomic) do
+    id = entry["jobId"] || job_id
+
+    %{
+      job_id: id,
+      chain_id: entry["chainId"] || chain_id,
+      job_id_uint: parse_job_id(id),
+      status: :awaiting_fund,
+      requirement: requirement,
+      transfer_amount_atomic: transfer_atomic
+    }
+  end
+
+  defp fetch_history(%{history_fn: history_fn}, key) when is_function(history_fn, 1) do
+    history_fn.(key)
+  end
+
+  defp fetch_history(state, key), do: Agent.get_history(state.agent, key)
+
+  # Only settle a job whose recorded provider is this solver -- reattach must not
+  # spend on a job we never accepted. The provider is read from the historical
+  # `job.created` entry (authoritative), not the funded event, which may not
+  # carry it.
+  defp confirm_provider(entries, state) do
+    created =
+      Enum.find(entries, fn
+        %{"kind" => "system", "event" => "job.created"} -> true
+        _ -> false
+      end)
+
+    case created do
+      %{"provider" => provider} when is_binary(provider) ->
+        if normalize_address(provider) == state.wallet_address,
+          do: :ok,
+          else: {:error, :not_our_job}
+
+      _ ->
+        {:error, :no_created_in_history}
+    end
+  end
+
+  # The buyer's requirement (carrying the signed intent bundle) is the last
+  # valid `requirement` message in the history.
+  defp requirement_from_history(entries) do
+    entries
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %{"kind" => "message", "contentType" => "requirement", "content" => content} ->
+        case decode_requirement(content) do
+          {:ok, requirement} -> {:ok, requirement}
+          {:error, _} -> nil
+        end
+
+      _ ->
+        nil
+    end)
+    |> case do
+      {:ok, requirement} -> {:ok, requirement}
+      nil -> {:error, :no_requirement_in_history}
     end
   end
 
@@ -342,6 +486,10 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       {:ok, tx_hash} ->
         emit(state, key, :budget_proposed, %{tx_hash: tx_hash, budget_atomic: budget_atomic})
 
+        Logger.info(
+          "[xochi.solver] setBudget #{budget_atomic} for #{inspect(key)} tx=#{tx_hash}; awaiting fund"
+        )
+
         updated =
           session
           |> Map.put(:status, :budget_proposed)
@@ -363,6 +511,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
     session = %{session | status: :settling}
     state = put_session(state, key, session)
     emit(state, key, :settling, :start)
+    Logger.info("[xochi.solver] settling #{inspect(key)} via Xochi relay")
 
     case state.settle_fn.(%{
            requirement: session.requirement,
@@ -370,10 +519,12 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
            transfer_amount_atomic: session.transfer_amount_atomic
          }) do
       {:ok, %{intent_id: intent_id} = deliverable} ->
+        Logger.info("[xochi.solver] settled #{inspect(key)} intent=#{intent_id}; submitting")
         submit_deliverable(state, key, session, deliverable, intent_id)
 
       {:error, reason} ->
         emit(state, key, :settle_error, reason)
+        Logger.error("[xochi.solver] settle failed for #{inspect(key)}: #{inspect(reason)}")
         put_session(state, key, %{session | status: :failed})
     end
   end
@@ -390,6 +541,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
          ) do
       {:ok, tx_hash} ->
         emit(state, key, :submitted, %{tx_hash: tx_hash, intent_id: intent_id})
+        Logger.info("[xochi.solver] submitted deliverable for #{inspect(key)} tx=#{tx_hash}")
 
         session =
           session
@@ -404,6 +556,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
       {:error, reason} ->
         emit(state, key, :submit_error, reason)
+        Logger.error("[xochi.solver] submit failed for #{inspect(key)}: #{inspect(reason)}")
         put_session(state, key, %{session | status: :failed})
     end
   end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/usdc_public_offering.ex
@@ -33,7 +33,7 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOffering do
 
   use Raxol.ACP.Offering,
     name: "xochi_usdc_public",
-    fee_bps: 10,
+    fee_bps: 8,
     sla_minutes: 10,
     cluster: "on_chain"
 

--- a/packages/raxol_acp/test/raxol/acp/wallet/sca/modular_account_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/wallet/sca/modular_account_test.exs
@@ -114,12 +114,29 @@ defmodule Raxol.ACP.Wallet.SCA.ModularAccountTest do
 
       # Different chain id -> different digest
       assert base != ModularAccount.replay_safe_digest(inner, 1, account)
-      # Different account -> different digest (enters via the salt)
+      # Different account -> different digest (the account is the domain's verifyingContract)
       assert base !=
                ModularAccount.replay_safe_digest(inner, 8453, "0x" <> String.duplicate("22", 20))
 
       # Different inner hash -> different digest
       assert base != ModularAccount.replay_safe_digest(:binary.copy(<<0x33>>, 32), 8453, account)
+    end
+
+    test "matches the live SemiModularAccount _replaySafeHash (viem known-answer)" do
+      # For the account domain {chainId 8453, verifyingContract = the account} over
+      # ReplaySafeHash(hash = D), viem's hashTypedData -- and the live account's
+      # isValidSignature -- produce this exact digest. Signing it yields 0x1626ba7e.
+      inner =
+        Base.decode16!("0e76dbb9fde2c3fc894f0cb717cdeb91eabc3a06f50f9671bc4135d32c5710e7",
+          case: :mixed
+        )
+
+      account = "0x468aeae798b3a6548ac2401d276f83afdc172283"
+
+      assert ModularAccount.replay_safe_digest(inner, 8453, account) ==
+               Base.decode16!("f6897fc7499e39a29f708aee463fb6a8b1e59ada5e520b7ee1547905cdeabf7c",
+                 case: :mixed
+               )
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/wallet/sma7702_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/wallet/sma7702_test.exs
@@ -1,0 +1,91 @@
+defmodule Raxol.ACP.Wallet.Sma7702Test do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.EIP712
+
+  @account "0x468aeae798b3a6548ac2401d276f83afdc172283"
+  @chain 8453
+  # A fixed raw 65-byte secp256k1 signature (v = 0x1b) the mock authority returns.
+  @raw_sig <<0xAB>> <> :binary.copy(<<0x11>>, 31) <> :binary.copy(<<0x22>>, 32) <> <<0x1B>>
+
+  # Mock managed-authority provider: an ACP.ProviderAdapter shape that records the
+  # typed data it is asked to sign and returns @raw_sig. `ProviderAdapter.sign_typed_data/3`
+  # dispatches through the `:adapter` module, so only that callback is needed.
+  defmodule MockProvider do
+    def new(test_pid), do: %{adapter: __MODULE__, config: %{test_pid: test_pid}}
+
+    def sign_typed_data(%{config: %{test_pid: pid}}, chain_id, typed_data) do
+      send(pid, {:signed, chain_id, typed_data})
+      {:ok, Raxol.ACP.Wallet.Sma7702Test.raw_sig()}
+    end
+  end
+
+  def raw_sig, do: @raw_sig
+
+  def stash_provider(pid),
+    do: :persistent_term.put({__MODULE__, :provider}, MockProvider.new(pid))
+
+  def provider, do: :persistent_term.get({__MODULE__, :provider})
+
+  defmodule Wallet do
+    use Raxol.ACP.Wallet.Sma7702,
+      account_address: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      chain_id: 8453,
+      provider: {Raxol.ACP.Wallet.Sma7702Test, :provider}
+  end
+
+  setup do
+    stash_provider(self())
+    :ok
+  end
+
+  test "address/0 and chain_id/0 come from config" do
+    assert Wallet.address() == @account
+    assert Wallet.chain_id() == @chain
+  end
+
+  test "sign_hash/1 refuses -- a 7702 account only validates its managed authority" do
+    assert Wallet.sign_hash(:binary.copy(<<0>>, 32)) ==
+             {:error, :sma7702_requires_managed_signer}
+  end
+
+  test "sign_typed_data wraps the app digest in the account ReplaySafeHash and packs the envelope" do
+    domain = %{name: "T", version: "1", chainId: @chain, verifyingContract: @account}
+    types = %{"Msg" => [{"n", "uint256"}]}
+    message = %{"n" => 7}
+
+    {:ok, wrapped} = Wallet.sign_typed_data(domain, types, message)
+
+    # Envelope: 0x00 || uint32(0) || 0xFF || 0x00 || <normalized 65-byte sig>.
+    assert <<0x00, 0::unsigned-big-32, 0xFF, 0x00, sig::binary>> = wrapped
+    assert byte_size(sig) == 65
+    # v already 0x1b (>= 27), so the sig is passed through unchanged.
+    assert sig == @raw_sig
+
+    # The provider was handed the ReplaySafeHash wrapper over the ACCOUNT domain
+    # (chainId + verifyingContract only), with hash = the app digest D.
+    {:ok, d} = EIP712.hash(domain, types, message)
+    expected_hash = "0x" <> Base.encode16(d, case: :lower)
+
+    assert_received {:signed, @chain, wrapper}
+    assert wrapper.domain == %{chainId: @chain, verifyingContract: @account}
+    assert wrapper.types == %{"ReplaySafeHash" => [%{name: "hash", type: "bytes32"}]}
+    assert wrapper.message == %{"hash" => expected_hash}
+  end
+
+  test "a recovery-id v (< 27) is normalized to 27/28 before packing" do
+    # Swap the mock to return v = 0 (raw recovery id); the pack must lift it to 27.
+    defmodule LowVProvider do
+      def new(pid), do: %{adapter: __MODULE__, config: %{pid: pid}}
+      def sign_typed_data(_a, _c, _td), do: {:ok, :binary.copy(<<0x33>>, 64) <> <<0x00>>}
+    end
+
+    :persistent_term.put({__MODULE__, :provider}, LowVProvider.new(self()))
+
+    {:ok, wrapped} =
+      Wallet.sign_typed_data(%{chainId: @chain}, %{"M" => [{"n", "uint256"}]}, %{"n" => 1})
+
+    <<_env::binary-size(7), _r::binary-size(32), _s::binary-size(32), v::8>> = wrapped
+    assert v == 27
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/live_order_test.exs
@@ -311,7 +311,11 @@ defmodule Raxol.ACP.Xochi.LiveOrderTest do
         prior_allowlist = Application.get_env(:raxol_payments, :pull_solver_allowlist)
         prior_require = Application.get_env(:raxol_payments, :pull_require_solver_pin)
 
-        Application.put_env(:raxol_payments, :pull_solver_allowlist, [solver])
+        # With XochiPull enabled the origin pull routes to the verified per-chain
+        # pull contracts, not the bare solver EOA -- trust those alongside the
+        # pinned solver (Riddler #591; Raxol.Payments.Xochi.PullContracts).
+        allowlist = Enum.uniq([solver | Raxol.Payments.Xochi.PullContracts.pull_recipients()])
+        Application.put_env(:raxol_payments, :pull_solver_allowlist, allowlist)
         Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
 
         on_exit(fn ->

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
@@ -361,6 +361,170 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
     end
   end
 
+  describe "reattach after restart (deployed funded->settle path)" do
+    # Regression for #772: the deployed solver set the budget, then RESTARTED
+    # (deploy/reschedule) before the buyer funded. Its in-memory session was gone
+    # and the live-only SSE stream never replays the earlier entries, so the
+    # funded job stayed stuck at `funded` forever -- settle was never reached.
+    #
+    # This exercises the SolverAgent's own `handle_job_funded/2` with NO prior
+    # session, proving it rebuilds from job history and settles. (The passing
+    # `--route acp` gate drives `JobSession.Provider.deliver` directly, never this
+    # path -- which is why the bug shipped.)
+
+    # Raw wire-shaped history entries: a system `job.created` (nested event map,
+    # onChainJobId) and a `requirement` message. Parser.normalize/1 folds these
+    # into the shape the reattach reads, same as the live stream.
+    defp history_created(job_id, provider) do
+      %{
+        "kind" => "system",
+        "event" => %{"type" => "job.created", "provider" => provider, "onChainJobId" => job_id},
+        "chainId" => 8453
+      }
+    end
+
+    defp history_requirement(job_id) do
+      req = %{
+        "src_chain_id" => 8453,
+        "dst_chain_id" => 10,
+        "src_token" => "0x" <> String.duplicate("11", 20),
+        "dst_token" => "0x" <> String.duplicate("22", 20),
+        "amount_atomic" => "1000000",
+        "signed_intent" => %{
+          "intent_id" => "xi_1",
+          "quote_id" => "xq_1",
+          "signature" => "0x" <> String.duplicate("11", 65),
+          "nonce" => 7,
+          "pull_signature" => "0x" <> String.duplicate("22", 65)
+        }
+      }
+
+      %{
+        "kind" => "message",
+        "contentType" => "requirement",
+        "chainId" => 8453,
+        "onChainJobId" => job_id,
+        "content" => Jason.encode!(req)
+      }
+    end
+
+    defp funded(job_id) do
+      %{"kind" => "system", "event" => "job.funded", "chainId" => 8453, "jobId" => job_id}
+    end
+
+    test "rebuilds the session from history and settles a funded job the solver never saw created",
+         ctx do
+      test_pid = self()
+
+      settle_stub = fn args ->
+        send(test_pid, {:settled, args})
+
+        {:ok,
+         %{
+           intent_id: "xochi-reattach",
+           settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+           receiving_tx_hash: "0x" <> String.duplicate("b", 64),
+           status: "settled"
+         }}
+      end
+
+      # The ACP server holds the job's history; the solver's memory does not.
+      Transport.Mock.set_history(ctx.transport, {8453, 70_759}, [
+        history_created(70_759, @solver_wallet),
+        history_requirement(70_759)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      # ONLY a funded event arrives (post-restart) -- no job.created, no requirement.
+      Transport.Mock.deliver(ctx.transport, funded(70_759))
+      Process.sleep(80)
+
+      # The relay ran on the recovered signed intent...
+      assert_received {:settled, %{signed_intent: %{"intent_id" => "xi_1"}}}
+
+      # ...and the job advanced to submitted on-chain.
+      session = SolverAgent.session(solver, {8453, 70_759})
+      assert session.status == :submitted
+      assert session.deliverable.intent_id == "xochi-reattach"
+
+      # Only the submit call -- setBudget already happened before the restart, so
+      # reattach does NOT re-propose the budget.
+      assert [{8453, [call]}] = ProviderAdapter.Mock.sent_calls(ctx.provider)
+      assert call.to == @acp_core
+    end
+
+    test "a duplicate funded event does not re-settle an already-submitted job", ctx do
+      settle_count = :counters.new(1, [])
+
+      settle_stub = fn _ ->
+        :counters.add(settle_count, 1, 1)
+
+        {:ok,
+         %{
+           intent_id: "xochi-dup",
+           settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+           receiving_tx_hash: "0x" <> String.duplicate("b", 64),
+           status: "settled"
+         }}
+      end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_760}, [
+        history_created(70_760, @solver_wallet),
+        history_requirement(70_760)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_760))
+      Process.sleep(80)
+      assert SolverAgent.session(solver, {8453, 70_760}).status == :submitted
+
+      # A replayed funded event must not spend again.
+      Transport.Mock.deliver(ctx.transport, funded(70_760))
+      Process.sleep(80)
+
+      assert :counters.get(settle_count, 1) == 1
+    end
+
+    test "reattach fails closed when the funded job is not ours (no settle)", ctx do
+      settle_stub = fn _ -> flunk("must not settle a job we did not provide") end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_761}, [
+        history_created(70_761, "0xother0000000000000000000000000000000000"),
+        history_requirement(70_761)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_761))
+      Process.sleep(80)
+
+      assert SolverAgent.session(solver, {8453, 70_761}) == nil
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "reattach fails closed when history has no requirement (no settle)", ctx do
+      settle_stub = fn _ -> flunk("must not settle without a recovered requirement") end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_762}, [
+        history_created(70_762, @solver_wallet)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_762))
+      Process.sleep(80)
+
+      assert SolverAgent.session(solver, {8453, 70_762}) == nil
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+  end
+
   describe "completion" do
     test "job.completed event updates session status", ctx do
       {:ok, solver} = start_solver([], ctx)

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_fee_live_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_fee_live_test.exs
@@ -1,0 +1,265 @@
+defmodule Raxol.ACP.Xochi.SolverFeeLiveTest do
+  @moduledoc """
+  Live gate: proves the deployed solver sizes the on-chain ACP budget at exactly
+  `XOCHI_FEE_BPS` basis points of the AUTHORITATIVE principal -- the number the
+  buyer signed against Xochi, read back off the live worker, not the relayed
+  `amount_atomic`. This is the take-rate validation: with `XOCHI_FEE_BPS=8` it
+  asserts the budget the solver would write on-chain is 8 bps of the principal.
+
+  What is real here:
+
+    * the buyer quotes + signs a real Xochi intent for a known principal
+      (`Raxol.Payments.Protocols.Xochi.quote_and_sign/3`, an off-chain EIP-712
+      signature -- NO funds move, NO settlement, NO on-chain tx);
+    * the real `Raxol.ACP.Xochi.SolverAgent` runs its production path
+      (`IntentDeriver.resolve/2` against the live Xochi worker -> `budget_for/2`
+      -> `HookClient.set_budget/6`), with `fee_bps` read from the same
+      `XOCHI_FEE_BPS` env the deployed solver reads.
+
+  What is faked, and why: the on-chain WRITE is captured via
+  `ProviderAdapter.Mock` rather than sent, because a real `setBudget` needs a real
+  on-chain job to exist (the full marketplace lifecycle). The budget VALUE is not
+  faked -- it is decoded straight out of the `setBudget(uint256,uint256,bytes)`
+  calldata the solver produced, so this asserts the exact on-chain wire amount.
+
+  Tagged `:live_solver_fee`; excluded by default, compiled only when the env is
+  present. Reuses the ACP order gate's env so it slots into the same run:
+
+      XOCHI_ORDER_LIVE_URL=https://api.xochi.fi \\
+      XOCHI_ORDER_LIVE_TOKEN=<Xochi Member token> XOCHI_ORDER_LIVE_KEY=0x<key> \\
+      XOCHI_FEE_BPS=8 \\
+        mix test --only live_solver_fee test/raxol/acp/xochi/solver_fee_live_test.exs
+
+  Optional overrides: `XOCHI_ORDER_AMOUNT` (human USDC principal, default "5.00"),
+  `XOCHI_ORDER_CORRIDORS` ("from>to", default "8453>42161").
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :live_solver_fee
+  @moduletag timeout: 120_000
+
+  if System.get_env("XOCHI_ORDER_LIVE_URL") && System.get_env("XOCHI_ORDER_LIVE_KEY") do
+    alias Raxol.ACP.{Agent, Chain, JobApi, ProviderAdapter, Transport}
+    alias Raxol.ACP.Xochi.SolverAgent
+    alias Raxol.Payments.Assets
+    alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
+    alias Raxol.Payments.Xochi.Schemas.QuoteRequest
+
+    defmodule LiveWallet do
+      @moduledoc false
+      use Raxol.Payments.Wallets.Env, env_var: "XOCHI_ORDER_LIVE_KEY"
+    end
+
+    setup do
+      pin_pull_recipients()
+
+      xochi_config = %{
+        base_url: System.fetch_env!("XOCHI_ORDER_LIVE_URL"),
+        auth_token: System.get_env("XOCHI_ORDER_LIVE_TOKEN", "")
+      }
+
+      {from, to} = corridor()
+
+      {:ok,
+       xochi_config: xochi_config,
+       fee_bps: String.to_integer(System.get_env("XOCHI_FEE_BPS", "8")),
+       from: from,
+       to: to,
+       amount: System.get_env("XOCHI_ORDER_AMOUNT", "5.00")}
+    end
+
+    test "the solver sizes the on-chain ACP budget at fee_bps of the live-signed principal",
+         ctx do
+      wallet = LiveWallet.address()
+
+      {:ok, src_token} = Assets.address(ctx.from, "USDC")
+      {:ok, dst_token} = Assets.address(ctx.to, "USDC")
+
+      principal_atomic =
+        Assets.to_atomic(Decimal.new(ctx.amount), Assets.decimals(ctx.from, src_token))
+
+      # 1. Buyer signs a real Xochi intent for `principal_atomic`. Off-chain only.
+      request = %QuoteRequest{
+        wallet: wallet,
+        from_chain_id: ctx.from,
+        to_chain_id: ctx.to,
+        from_token: src_token,
+        to_token: dst_token,
+        from_amount: Integer.to_string(principal_atomic),
+        settlement_preference: "public",
+        slippage_bps: 50
+      }
+
+      {:ok, bundle} = XochiProtocol.quote_and_sign(ctx.xochi_config, request, LiveWallet)
+
+      requirement = %{
+        "src_chain_id" => ctx.from,
+        "dst_chain_id" => ctx.to,
+        "src_token" => src_token,
+        "dst_token" => dst_token,
+        "amount_atomic" => Integer.to_string(principal_atomic),
+        "settlement_preference" => "public",
+        "signed_intent" => Map.new(bundle, fn {k, v} -> {to_string(k), v} end)
+      }
+
+      # 2. Real SolverAgent, production path. The on-chain write is captured (Mock)
+      #    but the budget VALUE it produces is real and asserted below.
+      {solver, provider} = start_solver(wallet, ctx)
+      job_id = Integer.to_string(System.unique_integer([:positive]))
+
+      Agent.start_stream(solver.agent)
+      Transport.Mock.deliver(solver.transport, job_created(ctx.from, job_id, wallet))
+      Transport.Mock.deliver(solver.transport, requirement_msg(ctx.from, job_id, requirement))
+
+      # 3. Solver resolves the intent off LIVE Xochi and proposes the budget.
+      session = await_budget(solver.pid, {ctx.from, job_id})
+
+      expected = div(principal_atomic * ctx.fee_bps, 10_000)
+
+      assert session.status == :budget_proposed,
+             "solver did not propose a budget (status #{inspect(session.status)})"
+
+      assert session.transfer_amount_atomic == principal_atomic,
+             "solver read a different authoritative principal from Xochi: " <>
+               "#{session.transfer_amount_atomic} != #{principal_atomic}"
+
+      assert session.budget_atomic == expected,
+             "computed budget #{session.budget_atomic} is not #{ctx.fee_bps} bps of #{principal_atomic}"
+
+      # 4. The ON-CHAIN calldata carries exactly that budget.
+      assert [{_chain, [call]}] = ProviderAdapter.Mock.sent_calls(provider)
+      assert call.to == Chain.mainnet().acp_core_address
+
+      assert onchain_amount(call.data) == expected,
+             "on-chain setBudget amount != #{ctx.fee_bps} bps of the principal"
+
+      realized_bps = Float.round(session.budget_atomic / principal_atomic * 10_000, 3)
+
+      IO.puts(
+        "[live_solver_fee] principal=#{principal_atomic} budget=#{session.budget_atomic} " <>
+          "=> #{realized_bps} bps (fee_bps=#{ctx.fee_bps}, corridor #{ctx.from}->#{ctx.to})"
+      )
+    end
+
+    # -- Harness --
+
+    defp start_solver(wallet, ctx) do
+      transport = Transport.Mock.new()
+      job_api = JobApi.Mock.new(me: %{wallet_address: wallet, name: "raxol"})
+      provider = ProviderAdapter.Mock.new(address: wallet, supported_chain_ids: [ctx.from])
+
+      {:ok, agent} =
+        Agent.start_link(
+          transport: transport,
+          api: job_api,
+          wallet_address: wallet,
+          supported_chain_ids: [ctx.from],
+          default_role: :provider
+        )
+
+      {:ok, pid} =
+        SolverAgent.start_link(
+          agent: agent,
+          provider: provider,
+          wallet_address: wallet,
+          evaluator_address: wallet,
+          chain_id: ctx.from,
+          acp_core_address: Chain.mainnet().acp_core_address,
+          fee_bps: ctx.fee_bps,
+          xochi_config: ctx.xochi_config
+        )
+
+      {%{pid: pid, agent: agent, transport: transport}, provider}
+    end
+
+    defp job_created(chain_id, job_id, provider) do
+      %{
+        "kind" => "system",
+        "event" => "job.created",
+        "chainId" => chain_id,
+        "jobId" => job_id,
+        "provider" => provider
+      }
+    end
+
+    defp requirement_msg(chain_id, job_id, requirement) do
+      %{
+        "kind" => "message",
+        "contentType" => "requirement",
+        "chainId" => chain_id,
+        "jobId" => job_id,
+        "content" => Jason.encode!(requirement)
+      }
+    end
+
+    # Poll until the solver proposes (or fails) the budget for this job. The only
+    # blocking step is the live IntentDeriver GET; 20s is generous.
+    defp await_budget(solver, key, remaining_ms \\ 20_000)
+
+    defp await_budget(_solver, key, remaining_ms) when remaining_ms <= 0 do
+      flunk("solver never proposed a budget for #{inspect(key)} within the deadline")
+    end
+
+    defp await_budget(solver, key, remaining_ms) do
+      case SolverAgent.session(solver, key) do
+        %{status: :budget_proposed} = session ->
+          session
+
+        %{status: :failed} = session ->
+          flunk("solver failed the job: #{inspect(session)}")
+
+        _ ->
+          Process.sleep(200)
+          await_budget(solver, key, remaining_ms - 200)
+      end
+    end
+
+    # setBudget(uint256 jobId, uint256 amount, bytes data): the amount is the
+    # second 32-byte word after the 4-byte selector.
+    defp onchain_amount(
+           <<_selector::binary-size(4), _job_id::binary-size(32),
+             amount::unsigned-big-integer-size(256), _rest::binary>>
+         ),
+         do: amount
+
+    defp corridor do
+      case System.get_env("XOCHI_ORDER_CORRIDORS") do
+        nil ->
+          {8453, 42_161}
+
+        spec ->
+          [from, to] = spec |> String.split(">", parts: 2)
+          {String.to_integer(String.trim(from)), String.to_integer(String.trim(to))}
+      end
+    end
+
+    # Pin the origin-pull recipient to the verified XochiPull contracts (Riddler
+    # #591; Raxol.Payments.Xochi.PullContracts) with the pin REQUIRED. Origin pull
+    # + ERC-3009 now route through those per-chain contracts, not the bare solver
+    # EOA the legacy pin matched, so this keeps the anti-drain guard ON (a quote
+    # whose pull `to` is not a verified contract still aborts before signing) and
+    # doubles as a fund-free check that live routing pulls to a known contract.
+    # Restored on exit.
+    defp pin_pull_recipients do
+      prior_allowlist = Application.get_env(:raxol_payments, :pull_solver_allowlist)
+      prior_require = Application.get_env(:raxol_payments, :pull_require_solver_pin)
+
+      Application.put_env(
+        :raxol_payments,
+        :pull_solver_allowlist,
+        Raxol.Payments.Xochi.PullContracts.pull_recipients()
+      )
+
+      Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
+
+      on_exit(fn ->
+        restore(:pull_solver_allowlist, prior_allowlist)
+        restore(:pull_require_solver_pin, prior_require)
+      end)
+    end
+
+    defp restore(key, nil), do: Application.delete_env(:raxol_payments, key)
+    defp restore(key, value), do: Application.put_env(:raxol_payments, key, value)
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/usdc_public_offering_test.exs
@@ -172,7 +172,7 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
       }
     end
 
-    test "derives the corridor from Xochi and sizes the fee at 10 bps of the principal" do
+    test "derives the corridor from Xochi and sizes the fee at 8 bps of the principal" do
       ctx = accept_ctx(intent_plug(intent_json()))
 
       assert {:ok, resolved, budget} = UsdcPublicOffering.resolve_accept(req(%{}), ctx)
@@ -184,8 +184,8 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
       assert resolved["dst_token"] == @usdc_arb
       assert resolved["amount_atomic"] == "1000000000"
 
-      # 10 bps of 1_000 USDC = 1 USDC = 1_000_000 base units.
-      assert budget.raw_amount == 1_000_000
+      # 8 bps of 1_000 USDC = 0.8 USDC = 800_000 base units.
+      assert budget.raw_amount == 800_000
       assert budget.symbol == "USDC"
     end
 
@@ -198,7 +198,7 @@ defmodule Raxol.ACP.Xochi.UsdcPublicOfferingTest do
                UsdcPublicOffering.resolve_accept(req(%{"amount_atomic" => "1"}), ctx)
 
       assert resolved["amount_atomic"] == "1000000000"
-      assert budget.raw_amount == 1_000_000
+      assert budget.raw_amount == 800_000
     end
 
     test "the derived request still passes the USDC + order-band gate" do

--- a/packages/raxol_acp/test/test_helper.exs
+++ b/packages/raxol_acp/test/test_helper.exs
@@ -5,6 +5,9 @@
 #   :live_xochi_order / :live_xochi_order_preflight -- a buyer orders the
 #     xochi_cross_chain_transfer offering; the settle variant moves real funds
 #     (see scripts/run_live_gates.sh --route acp). The preflight variant is read-only.
+#   :live_solver_fee -- validates the solver sizes the on-chain ACP budget at
+#     XOCHI_FEE_BPS of the live-signed principal (take-rate). Moves NO funds
+#     (off-chain intent signature + captured on-chain write).
 #   :cli_signer -- spawns the riddler-client CLI; auto-enabled when
 #     RIDDLER_CLI_DIR is set.
 #
@@ -16,7 +19,8 @@ live_exclude = [
   :live_acp_dev,
   :live_relay,
   :live_xochi_order,
-  :live_xochi_order_preflight
+  :live_xochi_order_preflight,
+  :live_solver_fee
 ]
 
 cli_exclude = if System.get_env("RIDDLER_CLI_DIR"), do: [], else: [:cli_signer]

--- a/packages/raxol_payments/lib/raxol/payments/xochi/pull_contracts.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/pull_contracts.ex
@@ -1,0 +1,61 @@
+defmodule Raxol.Payments.Xochi.PullContracts do
+  @moduledoc """
+  Verified XochiPull / XochiPullPermit2 origin-pull contracts (Riddler #591,
+  deployed 2026-07-23 from the solver wallet `0x97D4...80b`).
+
+  The Blockaid EOA-scam fix moved the origin pull off the bare solver EOA and onto
+  these verified, per-chain contracts. With them enabled on the solver side
+  (Riddler `xochi_pull_contract_enabled: true`), a live Xochi quote's origin-pull
+  recipient -- the ERC-3009 authorization `to`, or the Permit2 `spender` -- is one
+  of these contracts, NOT the solver EOA.
+
+  `pull_recipients/0` is the full set of legitimate origin-pull recipients for the
+  anti-drain pin (`config :raxol_payments, :pull_solver_allowlist`): the settlement
+  wallet plus every deployed pull proxy. Pinning to this set keeps the pin's
+  protection (an unknown `to`/`spender` is still rejected) while accepting the
+  verified contracts.
+
+  Mirror of Riddler `XOCHIPULL_DEPLOYMENTS.md`; keep in sync on redeploy. The USDC
+  proxy differs per chain (the token address enters the proxy initcode); the
+  Permit2 proxy is uniform across chains.
+  """
+
+  # The solver / settlement wallet -- still a legitimate direct recipient, and the
+  # deployer of the pull contracts.
+  @solver_wallet "0x97D447561fDe10E959E782a29411D8F89586d80b"
+
+  # XochiPull USDC (ERC-3009) proxies, per chain.
+  @erc3009_proxies %{
+    1 => "0xC955fE2d64fe40e7208e9Daf33acEC3b0f577025",
+    10 => "0xB5eE8694E4b3F0bC19fb73612cbE16Dc0ddfBa89",
+    137 => "0xaA7D2343Ef76Fd8594Ad836E682Dd270C700c528",
+    8453 => "0xaA8FDA73906293A0A3Cd8e057Db97670944A46F8",
+    42_161 => "0x0A00b656e2363eDa59055b285A1ba025c335D7C0"
+  }
+
+  # XochiPullPermit2 proxy -- uniform across all chains (incl. Robinhood 4663).
+  @permit2_proxy "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+
+  @doc "The solver / settlement wallet."
+  @spec solver_wallet() :: String.t()
+  def solver_wallet, do: @solver_wallet
+
+  @doc "The XochiPull USDC (ERC-3009) proxy for `chain_id`, or nil if none."
+  @spec erc3009_proxy(pos_integer()) :: String.t() | nil
+  def erc3009_proxy(chain_id), do: Map.get(@erc3009_proxies, chain_id)
+
+  @doc "The uniform XochiPullPermit2 proxy address."
+  @spec permit2_proxy() :: String.t()
+  def permit2_proxy, do: @permit2_proxy
+
+  @doc """
+  Every legitimate origin-pull recipient: the solver wallet, all per-chain
+  XochiPull USDC proxies, and the XochiPullPermit2 proxy. Use as the
+  `:pull_solver_allowlist` so the anti-drain pin accepts the verified pull
+  contracts while still rejecting an unknown `to`/`spender`.
+  """
+  @spec pull_recipients() :: [String.t()]
+  def pull_recipients do
+    [@solver_wallet | Map.values(@erc3009_proxies)] ++ [@permit2_proxy]
+  end
+end

--- a/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs
@@ -136,7 +136,11 @@ defmodule Raxol.Payments.Xochi.LiveXochiTest do
         prior_allowlist = Application.get_env(:raxol_payments, :pull_solver_allowlist)
         prior_require = Application.get_env(:raxol_payments, :pull_require_solver_pin)
 
-        Application.put_env(:raxol_payments, :pull_solver_allowlist, [solver])
+        # With XochiPull enabled the origin pull routes to the verified per-chain
+        # pull contracts, not the bare solver EOA -- trust those alongside the
+        # pinned solver (Riddler #591; Raxol.Payments.Xochi.PullContracts).
+        allowlist = Enum.uniq([solver | Raxol.Payments.Xochi.PullContracts.pull_recipients()])
+        Application.put_env(:raxol_payments, :pull_solver_allowlist, allowlist)
         Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
 
         on_exit(fn ->

--- a/packages/raxol_payments/test/raxol/payments/xochi/pull_contracts_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/pull_contracts_test.exs
@@ -1,0 +1,61 @@
+defmodule Raxol.Payments.Xochi.PullContractsTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Xochi.PullContracts
+
+  @solver "0x97D447561fDe10E959E782a29411D8F89586d80b"
+  @base_erc3009 "0xaA8FDA73906293A0A3Cd8e057Db97670944A46F8"
+  @permit2 "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+
+  test "solver_wallet is the settlement wallet" do
+    assert PullContracts.solver_wallet() == @solver
+  end
+
+  test "erc3009_proxy resolves the per-chain USDC pull proxy" do
+    assert PullContracts.erc3009_proxy(8453) == @base_erc3009
+    assert PullContracts.erc3009_proxy(1) == "0xC955fE2d64fe40e7208e9Daf33acEC3b0f577025"
+    assert PullContracts.erc3009_proxy(42_161) == "0x0A00b656e2363eDa59055b285A1ba025c335D7C0"
+  end
+
+  test "erc3009_proxy is nil for a chain with no deployed USDC proxy" do
+    # Robinhood (4663) is Permit2-only (no ERC-3009 USDC).
+    assert PullContracts.erc3009_proxy(4663) == nil
+    assert PullContracts.erc3009_proxy(999_999) == nil
+  end
+
+  test "permit2_proxy is the uniform cross-chain proxy" do
+    assert PullContracts.permit2_proxy() == @permit2
+  end
+
+  test "pull_recipients includes the solver, every ERC-3009 proxy, and the permit2 proxy" do
+    recipients = PullContracts.pull_recipients()
+
+    assert @solver in recipients
+    assert @base_erc3009 in recipients
+    assert @permit2 in recipients
+    # 1 solver + 5 per-chain ERC-3009 proxies + 1 permit2 proxy.
+    assert length(recipients) == 7
+  end
+
+  test "pull_recipients has no duplicates and all entries are 20-byte addresses" do
+    recipients = PullContracts.pull_recipients()
+
+    assert recipients == Enum.uniq(recipients)
+
+    for addr <- recipients do
+      assert Regex.match?(~r/^0x[0-9a-fA-F]{40}$/, addr), "malformed address: #{addr}"
+    end
+  end
+
+  test "pull_recipients normalize into the allowlist form used by the pin" do
+    # The pin compares EIP712.normalize_address(to) against the normalized list;
+    # normalization lowercases and strips the 0x prefix, so the match is case-
+    # and prefix-insensitive. Every recipient must survive it (non-empty).
+    for addr <- PullContracts.pull_recipients() do
+      normalized = EIP712.normalize_address(addr)
+      assert normalized != ""
+      assert normalized == addr |> String.downcase() |> String.replace_prefix("0x", "")
+    end
+  end
+end

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -15,6 +15,12 @@
 #            seller settles on delivery. Runs the raxol_acp order test.
 #   relay -- EVM->Tron rail via the Riddler solver (riddler.axol.io/relay). Runs
 #            the raxol_acp relay test. Tron-settled, so USDC/USDT only.
+#   fee   -- take-rate validation (opt-in; NOT in "all"). Drives the real
+#            SolverAgent: a buyer signs a live Xochi intent for a known
+#            principal, the solver proposes the budget, and the test asserts the
+#            on-chain setBudget == GATE_FEE_BPS (default 8) bps of the principal.
+#            Moves NO funds (off-chain signature + captured on-chain write), but
+#            needs a real GATE_KEY to sign. Runs the raxol_acp solver-fee test.
 #
 # The asset x route grid, and the corridor each cell rides, is fixed here to
 # match what Riddler and Xochi actually support (see the asset_cfg table):
@@ -78,6 +84,9 @@
 #   # Just the ACP order path for USDC:
 #   GATE_KEY=0x<funded> ./scripts/run_live_gates.sh --asset USDC --route acp
 #
+#   # Validate the live take-rate is 8 bps (NO funds; needs a real signing key):
+#   GATE_KEY=0x<key> GATE_FEE_BPS=8 ./scripts/run_live_gates.sh --asset USDC --route fee
+#
 #   # USDG drain rehearsal (Robinhood -> Base), acp route:
 #   GATE_KEY=0x<funded seller w/ USDG on 4663> GATE_RPC_4663=https://rpc.mainnet.chain.robinhood.com \
 #     ./scripts/run_live_gates.sh --asset USDG --route xochi,acp --dry-run
@@ -92,6 +101,7 @@ ACP_DIR="$REPO_ROOT/packages/raxol_acp"
 XOCHI_TEST="test/raxol/payments/xochi/live_xochi_test.exs"
 ORDER_TEST="test/raxol/acp/xochi/live_order_test.exs"
 RELAY_TEST="test/raxol/acp/relay/live_relay_test.exs"
+SOLVER_FEE_TEST="test/raxol/acp/xochi/solver_fee_live_test.exs"
 
 # --- defaults / env inputs ---
 ASSETS=""
@@ -116,8 +126,8 @@ usage() {
   cat >&2 <<'EOF'
 Usage: scripts/run_live_gates.sh --asset A[,A...] [--route R[,R...]] [options]
 
-  --asset   USDC|USDT|USDG|all   (required)
-  --route   xochi|acp|relay|all  (default all)
+  --asset   USDC|USDT|USDG|all      (required)
+  --route   xochi|acp|relay|fee|all (default all; fee is opt-in, fund-free)
   --amount  N                    human stablecoin amount for xochi/acp (default 5.00)
   --corridors SPEC               override corridors, "from>to,from>to" or "mesh"
   --auth    mandate|member       Xochi auth mode (default mandate)
@@ -162,7 +172,7 @@ for a in $ASSET_LIST; do
   case "$a" in USDC|USDT|USDG) ;; *) err "unknown asset: $a (want USDC|USDT|USDG)"; exit 2 ;; esac
 done
 for r in $ROUTE_LIST; do
-  case "$r" in xochi|acp|relay) ;; *) err "unknown route: $r (want xochi|acp|relay)"; exit 2 ;; esac
+  case "$r" in xochi|acp|relay|fee) ;; *) err "unknown route: $r (want xochi|acp|relay|fee)"; exit 2 ;; esac
 done
 
 # --- input validation (cheap, before any work) ---
@@ -214,7 +224,7 @@ rpc_for() { local v="GATE_RPC_$1"; printf '%s' "${!v:-}"; }
 # --- secret loading (lazy: only what the selected routes need) ---
 need_xochi=false; need_relay=false
 for r in $ROUTE_LIST; do
-  case "$r" in xochi|acp) need_xochi=true ;; relay) need_relay=true ;; esac
+  case "$r" in xochi|acp|fee) need_xochi=true ;; relay) need_relay=true ;; esac
 done
 
 # Funded key: required for a real run; dummy is fine for dry-run (tests compile
@@ -370,6 +380,43 @@ run_relay() {
   env MIX_ENV=test mix test --include live_relay "$RELAY_TEST"
 }
 
+# Take-rate validation. Drives the REAL SolverAgent: a buyer signs a live Xochi
+# intent for a known principal, the solver resolves the authoritative amount off
+# Xochi and proposes the budget, and the test asserts the on-chain setBudget
+# calldata == GATE_FEE_BPS (default 8) bps of the principal. Moves NO funds --
+# the intent signature is off-chain and the on-chain write is captured, not sent
+# -- so it runs the same whether or not --dry-run is set. It DOES need a real
+# signing key (a valid EOA; funding not required) to produce the intent.
+run_fee() {
+  local asset="$1" cfg tok corr _p2 _pc corridors
+  cfg="$(asset_cfg "$asset")"
+  IFS='|' read -r tok corr _p2 _pc <<<"$cfg"
+  corridors="${CORRIDORS_OVERRIDE:-$corr}"
+
+  if [[ "$KEY" == "0xdummy" ]]; then
+    log "fee $asset: SKIP -- needs a real GATE_KEY to sign the intent (no funds move)."
+    return 10
+  fi
+
+  export XOCHI_ORDER_LIVE_URL="$XOCHI_URL" XOCHI_ORDER_LIVE_KEY="$KEY" XOCHI_ORDER_LIVE_TOKEN="$XOCHI_TOKEN"
+  export XOCHI_ORDER_AMOUNT="$AMOUNT" XOCHI_ORDER_CORRIDORS="$corridors"
+  export XOCHI_FEE_BPS="${GATE_FEE_BPS:-8}"
+
+  cd "$ACP_DIR"
+  log "fee $asset: assert on-chain budget == ${XOCHI_FEE_BPS} bps of the live-signed principal [$corridors] (NO funds)..."
+  env MIX_ENV=test mix test --only live_solver_fee "$SOLVER_FEE_TEST"
+}
+
+# The routes that actually settle (and so gate on the funded-run confirmation).
+# `fee` is fund-free, so a fee-only run skips the prompt.
+has_settling_route() {
+  local r
+  for r in $ROUTE_LIST; do
+    case "$r" in xochi|acp|relay) return 0 ;; esac
+  done
+  return 1
+}
+
 # ================= plan / spend preview =================
 # corridor count for a spec: a "from>to" pair has one '>', mesh is the 5-chain
 # CCTP grid (20 ordered pairs).
@@ -415,6 +462,7 @@ confirm_funded() {
           else
             log "  $a / relay  -> Base $tok -> Tron USDT (~$RELAY_AMOUNT)"
           fi ;;
+        fee) log "  $a / fee  -> take-rate check [$eff] (NO funds)" ;;
         *) log "  $a / $r  -> [$eff] token=$tok (~$AMOUNT/corridor)" ;;
       esac
     done
@@ -455,6 +503,7 @@ run_cell() {
       xochi) run_xochi "$asset" ;;
       acp)   run_acp   "$asset" ;;
       relay) run_relay "$asset" ;;
+      fee)   run_fee   "$asset" ;;
     esac
   )
   rc=$?
@@ -466,7 +515,7 @@ run_cell() {
   esac
 }
 
-[[ -z "$DRY_RUN" ]] && confirm_funded
+[[ -z "$DRY_RUN" ]] && has_settling_route && confirm_funded
 
 log "live gates: assets=[$ASSET_LIST] routes=[$ROUTE_LIST] amount=$AMOUNT auth=$AUTH${DRY_RUN:+ dry-run}"
 for asset in $ASSET_LIST; do


### PR DESCRIPTION
## Summary
A live **buyer** harness (`mix raxol_acp.order`) that places a real on-chain Virtuals ACP order against an agent offering and drives it to **funded**, verifying the provider's on-chain take-rate. Closes the loop on the 8 bps fee work (#770): it produces a **UI-visible Virtuals job** and exercises the **deployed solver's real on-chain `setBudget`**.

Proven end-to-end on Base mainnet: job **70759**, created by the managed smart-account test-buyer agent `0x468a...`, with the deployed solver setting the budget to **2400 base units = exactly 8 bps of 3 USDC**, then **funded on-chain** -- all via sponsored (gasless) UserOps.

## Fixes it required (real raxol bugs)
- **`JobIdResolver.Receipt`**: the placeholder `JobCreated(uint256)` never matched the deployed `AgenticCommerceV3`; corrected to the verified `JobCreated(uint256,address,address,address,uint256,address)` (jobId = topic 1).
- **`Transport.SSE`**: the message endpoint was `/jobs/{c}/{j}/messages` (404); the server expects `/chats/{c}/{j}/message` (matches acp-node-v2).
- **`getJob` budget decode** (harness): the eth_call return is a dynamic struct with a leading offset word, so budget is word 7, not 6.
- **Batched approve+fund** (harness): a standalone USDC `approve` is not sponsored by the Virtuals paymaster; batching it with the ACP-core `fund` in one UserOp is (per acp-node-v2 `submitPrepared`).

## The harness (`mix raxol_acp.order`)
- Mirrors acp-node-v2 `createJobFromOffering`: sign Xochi intent -> `createJob` -> resolve jobId -> `send_message` requirement -> observe `getJob().budget == fee_bps` -> batched `--fund`.
- **Signer backends** (`--signer`): `privy` (default; Virtuals-delegated signing via the Node sidecar, Alchemy-sponsored gas, buyer = managed SCA agent), `sca` (direct ERC-4337 with your own bundler+paymaster), `eoa` (raw key; not a registered agent).
- `--job-id` resume, `--dry-run`, `--fund`.

## Manual testing (Base mainnet)
- [x] `--signer privy --dry-run`: sidecar boots, intent signed as the SCA agent (ERC-1271).
- [x] `--signer privy`: sponsored `createJob` (gasless), requirement delivered, deployed solver set budget on-chain at **8 bps** (jobs 70755/70756/70759; `getJob` = 2400 of 3 USDC).
- [x] Harness reads + asserts the on-chain 8 bps (`OK: budget == 8 bps of the principal`).
- [x] `--fund`: batched approve+fund landed as one sponsored UserOp; job 70759 advanced to **funded** on-chain (`getJob.status = 1`).

## Known follow-up (seller-side, not this PR)
The deployed solver sets the budget but does not settle the funded job -- the Xochi intent stays `quoted` (never executed). Tracked in **#772**. That is the provider-side `funded -> settle` handler on the deployed release, independent of this buyer harness.

Depends on #770's `PullContracts` pull-pin fix (branched off it).
