### PR TITLE
Fix 7702 buyer ERC-1271 intent signing + solver funded->settle reattach

### DIFF
--- a/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
+++ b/packages/raxol_acp/lib/mix/tasks/raxol_acp.order.ex
@@ -431,7 +431,12 @@ defmodule Mix.Tasks.RaxolAcp.Order do
         chains: %{from => rpc}
       )
 
-    {provider, address, ScaWallet}
+    # The 7702 buyer's ONLY authorized signer is its own managed authority, so the
+    # intent (and origin-pull) signature must be produced by the sidecar, not a
+    # local session key. Sma7702Wallet resolves this provider at call time.
+    :persistent_term.put({__MODULE__, :privy_provider}, provider)
+
+    {provider, address, Sma7702Wallet}
   end
 
   # A (--signer sca): direct ERC-4337 -- the EOA session key signs UserOps,
@@ -466,6 +471,12 @@ defmodule Mix.Tasks.RaxolAcp.Order do
   defp build_signer(other, _from, _rpc),
     do: Mix.raise("unknown --signer #{inspect(other)} (want privy | sca | eoa)")
 
+  # The managed Privy provider is runtime state; Sma7702Wallet resolves it here at
+  # call time so the wallet stays a plain behaviour module.
+  @doc false
+  @spec privy_provider() :: Raxol.ACP.ProviderAdapter.adapter()
+  def privy_provider, do: :persistent_term.get({__MODULE__, :privy_provider})
+
   # The buyer signs the Xochi intent with the same ORDER_KEY the provider adapter uses.
   # The EOA session key (0x10910...) -- signs on behalf of the SCA agent.
   defmodule Signer do
@@ -473,9 +484,9 @@ defmodule Mix.Tasks.RaxolAcp.Order do
     use Raxol.Payments.Wallets.Env, env_var: "ORDER_KEY"
   end
 
-  # The managed SCA agent (0x468a... "testing agent"): the Xochi intent is signed
-  # AS this account (EOA session key -> ERC-1271), regardless of which on-chain
-  # signer backend submits createJob/fund.
+  # The managed SCA agent (0x468a... "testing agent") as a DEPLOYED Modular
+  # Account v2 (the --signer sca path): the intent is signed by the session key
+  # through the installed single-signer validation module.
   defmodule ScaWallet do
     @moduledoc false
     use Raxol.ACP.Wallet.SCA,
@@ -483,6 +494,18 @@ defmodule Mix.Tasks.RaxolAcp.Order do
       chain_id: 8453,
       signer: Signer,
       signer_entity_id: 0
+  end
+
+  # The managed SCA agent as an EIP-7702 Semi-Modular Account (the default --signer
+  # privy path): the intent is signed AS the account by its managed authority via
+  # the Privy sidecar, wrapped for the account's native ERC-1271 fallback path. A
+  # local session key is NOT an authorized signer on a 7702 account.
+  defmodule Sma7702Wallet do
+    @moduledoc false
+    use Raxol.ACP.Wallet.Sma7702,
+      account_address: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      chain_id: 8453,
+      provider: {Mix.Tasks.RaxolAcp.Order, :privy_provider}
   end
 
   # Trust the verified XochiPull contracts so the intent's origin-pull authorization

--- a/packages/raxol_acp/lib/raxol/acp/agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/agent.ex
@@ -139,6 +139,18 @@ defmodule Raxol.ACP.Agent do
   @spec sessions(GenServer.server()) :: %{Transport.job_key() => pid()}
   def sessions(server), do: GenServer.call(server, :sessions)
 
+  @doc """
+  Fetch a job's entry history via the transport (one-shot REST read).
+
+  Used by the reattach path (`Raxol.ACP.Xochi.SolverAgent`) to recover a job's
+  requirement after a restart dropped the in-memory session. The SSE stream is
+  live-only and does not replay past entries on reconnect, so this is the only
+  way to see entries that predate the current connection.
+  """
+  @spec get_history(GenServer.server(), Transport.job_key()) ::
+          {:ok, [Transport.entry()]} | {:error, term()}
+  def get_history(server, key), do: GenServer.call(server, {:get_history, key})
+
   @doc "Convenience wrapper around `JobApi.browse_agents/3`."
   @spec browse_agents(GenServer.server(), String.t(), map()) ::
           {:ok, [JobApi.agent_detail()]} | {:error, term()}
@@ -225,6 +237,10 @@ defmodule Raxol.ACP.Agent do
   end
 
   def handle_call(:sessions, _from, state), do: {:reply, state.sessions, state}
+
+  def handle_call({:get_history, key}, _from, state) do
+    {:reply, Transport.get_history(state.transport, key), state}
+  end
 
   def handle_call({:browse_agents, keyword, params}, _from, state) do
     {:reply, JobApi.browse_agents(state.api, keyword, params), state}

--- a/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
+++ b/packages/raxol_acp/lib/raxol/acp/transport/sse/parser.ex
@@ -63,24 +63,30 @@ defmodule Raxol.ACP.Transport.SSE.Parser do
   defp extract_data_line("data:" <> rest), do: [String.trim_leading(rest, " ")]
   defp extract_data_line(_), do: []
 
-  # Normalize the wire shape of an ACP SSE entry into the shape the Agent +
-  # SolverAgent consume. The Virtuals server sends system events as
-  # `%{"kind" => "system", "event" => %{"type" => "job.created", "provider" => ...,
-  # "onChainJobId" => ...}}`, but our dispatch matches `"event" => "job.created"`
-  # (a string) and reads top-level `jobId`/`provider`. So for system entries we hoist
-  # the nested event map's fields to the top level and replace `event` with its type
-  # string. Message entries already carry top-level `content`/`contentType`/`from`.
-  # Both get `jobId` lifted from `onChainJobId`. This is the single boundary where the
-  # wire shape meets our code (the gate drives the provider in-process and never hits
-  # this path, which is why the mismatch went unseen until a real marketplace job).
-  defp normalize(%{"kind" => "system", "event" => %{"type" => type} = ev} = entry) do
+  @doc """
+  Normalize the wire shape of an ACP SSE entry into the shape the Agent +
+  SolverAgent consume. The Virtuals server sends system events as
+  `%{"kind" => "system", "event" => %{"type" => "job.created", "provider" => ...,
+  "onChainJobId" => ...}}`, but our dispatch matches `"event" => "job.created"`
+  (a string) and reads top-level `jobId`/`provider`. So for system entries we hoist
+  the nested event map's fields to the top level and replace `event` with its type
+  string. Message entries already carry top-level `content`/`contentType`/`from`.
+  Both get `jobId` lifted from `onChainJobId`. This is the single boundary where the
+  wire shape meets our code (the gate drives the provider in-process and never hits
+  this path, which is why the mismatch went unseen until a real marketplace job).
+
+  Also reused when replaying `get_history/2` entries (raw server JSON) so the
+  SolverAgent reattach path reads them through the same shape as the live stream.
+  """
+  @spec normalize(map()) :: map()
+  def normalize(%{"kind" => "system", "event" => %{"type" => type} = ev} = entry) do
     entry
     |> Map.merge(ev)
     |> Map.put("event", type)
     |> Map.put("jobId", job_id(entry, ev))
   end
 
-  defp normalize(%{} = entry) do
+  def normalize(%{} = entry) do
     Map.put(entry, "jobId", job_id(entry, entry["event"]))
   end
 

--- a/packages/raxol_acp/lib/raxol/acp/wallet/sca/modular_account.ex
+++ b/packages/raxol_acp/lib/raxol/acp/wallet/sca/modular_account.ex
@@ -166,34 +166,37 @@ defmodule Raxol.ACP.Wallet.SCA.ModularAccount do
   end
 
   @doc """
-  Compute the EIP-712 `ReplaySafeHash` digest a single-signer entity
-  signs for EIP-1271 (e.g. JWT auth challenges).
+  Compute the EIP-712 `ReplaySafeHash` digest a Semi-Modular Account's native
+  fallback signer signs for EIP-1271.
 
-  The domain binds the signature to the single-signer validation module
-  and the specific account via a salt of `bytes12(0) || accountAddress`:
+  A raxol-provisioned account is a Semi-Modular Account (7702 or the deployed
+  bytecode variant); its intent/message signatures validate through the entity-0
+  fallback path, whose replay-safe hash is bound to the ACCOUNT's own EIP-712
+  domain -- `EIP712Domain(uint256 chainId, address verifyingContract)` with
+  `verifyingContract = the account` and NO salt (verified byte-for-byte against
+  the live `SemiModularAccountBase._domainSeparator`/`_replaySafeHash` on Base):
 
-      domain  = EIP712Domain(uint256 chainId, address verifyingContract, bytes32 salt)
-                where verifyingContract = single-signer validation module,
-                      salt = 0x000000000000000000000000 || accountAddress
+      domain  = EIP712Domain(uint256 chainId, address verifyingContract)
+                where verifyingContract = the account itself
       struct  = ReplaySafeHash(bytes32 hash)
       digest  = keccak256(0x1901 || domainSeparator || structHash)
 
-  `inner_hash` is the application hash (e.g. `hashTypedData` of the
-  challenge, or `hashMessage` of a personal-sign payload).
+  `inner_hash` is the application hash (e.g. `hashTypedData` of the challenge, or
+  `hashMessage` of a personal-sign payload). This is NOT the single-signer
+  validation MODULE's replay-safe hash (module domain + account salt); an
+  installed single-signer module would compute that instead, but the fallback
+  path -- which every raxol SMA signature uses -- does not.
   """
   @spec replay_safe_digest(<<_::256>>, pos_integer(), String.t()) :: binary()
   def replay_safe_digest(inner_hash, chain_id, account_address) do
     domain_type_hash =
-      ExKeccak.hash_256("EIP712Domain(uint256 chainId,address verifyingContract,bytes32 salt)")
-
-    salt = <<0::96, decode_address!(account_address)::binary-size(20)>>
+      ExKeccak.hash_256("EIP712Domain(uint256 chainId,address verifyingContract)")
 
     domain_separator =
       ExKeccak.hash_256(
         domain_type_hash <>
           <<chain_id::unsigned-big-256>> <>
-          encode_address(@single_signer_validation) <>
-          salt
+          encode_address(account_address)
       )
 
     struct_hash =

--- a/packages/raxol_acp/lib/raxol/acp/wallet/sma7702.ex
+++ b/packages/raxol_acp/lib/raxol/acp/wallet/sma7702.ex
@@ -1,0 +1,139 @@
+defmodule Raxol.ACP.Wallet.Sma7702 do
+  @moduledoc """
+  A `Raxol.Payments.Wallet` that produces ERC-1271 signatures a live Alchemy
+  EIP-7702 Semi-Modular Account (`SemiModularAccount7702`) accepts, so a managed
+  7702 buyer can sign Xochi intents (and origin-pull authorizations) that Riddler
+  verifies on-chain via `isValidSignature`.
+
+  Unlike `Raxol.ACP.Wallet.SCA` -- which targets a DEPLOYED Modular Account v2
+  validating through an installed single-signer validation MODULE -- a 7702 SMA
+  validates through its NATIVE fallback path. Verified byte-for-byte on Base
+  against the live account (`isValidSignature -> 0x1626ba7e`), that path differs
+  in two ways:
+
+    * **Replay-safe digest domain.** The account wraps the app digest with its
+      OWN EIP-712 domain -- `EIP712Domain(uint256 chainId, address
+      verifyingContract)` where `verifyingContract` is the ACCOUNT itself, with no
+      `salt` and no name/version -- not the single-signer module's
+      `{module, salt = account}` domain that `Raxol.ACP.Wallet.SCA` builds.
+    * **Signer.** The only authorized signer is the account's fallback signer (the
+      7702 authority itself), NOT a local session key. Signing therefore goes
+      through the managed authority (the Privy/Alchemy `ProviderAdapter`), which
+      holds the key.
+
+  The managed signer has no raw-hash endpoint, so to make it sign the account's
+  replay-safe hash we hand it that wrapper AS EIP-712 typed data --
+  `ReplaySafeHash(bytes32 hash)` over the account domain, `hash` = the app digest
+  `D`. The signer hashes and signs it, yielding a signature over exactly
+  `_replaySafeHash(D)`. We then wrap the 65-byte ECDSA signature in the Modular
+  Account v2 fallback envelope `0x00 || uint32(0) || 0xFF || 0x00 || sig` (entity
+  id 0, global flag, no pre-validation hook data, `SignatureType.EOA`).
+
+  ## Usage
+
+      defmodule MyBuyer do
+        use Raxol.ACP.Wallet.Sma7702,
+          account_address: "0x468a...",
+          chain_id: 8453,
+          # {module, fun} resolved at call time -- the managed ProviderAdapter is
+          # runtime state (built from env), so the wallet stays a plain behaviour.
+          provider: {MyApp, :privy_provider}
+      end
+  """
+
+  alias Raxol.ACP.ProviderAdapter
+  alias Raxol.ACP.Wallet.SCA.ModularAccount
+  alias Raxol.Payments.EIP712
+
+  @replay_safe_types %{"ReplaySafeHash" => [%{name: "hash", type: "bytes32"}]}
+
+  defmacro __using__(opts) do
+    account = Keyword.fetch!(opts, :account_address)
+    chain = Keyword.fetch!(opts, :chain_id)
+    provider = Keyword.fetch!(opts, :provider)
+
+    quote do
+      @behaviour Raxol.Payments.Wallet
+
+      @impl true
+      def address, do: unquote(account)
+
+      @impl true
+      def chain_id, do: unquote(chain)
+
+      @impl true
+      def sign_message(message) do
+        Raxol.ACP.Wallet.Sma7702.sign_message(
+          message,
+          unquote(provider),
+          unquote(chain),
+          unquote(account)
+        )
+      end
+
+      @impl true
+      def sign_typed_data(domain, types, message) do
+        Raxol.ACP.Wallet.Sma7702.sign_typed_data(
+          domain,
+          types,
+          message,
+          unquote(provider),
+          unquote(chain),
+          unquote(account)
+        )
+      end
+
+      # Signing goes through the managed authority, never a raw local key.
+      @impl true
+      def sign_hash(_digest), do: {:error, :sma7702_requires_managed_signer}
+    end
+  end
+
+  @typedoc "A `{module, function}` resolving to the managed `ProviderAdapter` at call time."
+  @type provider_ref :: {module(), atom()}
+
+  @doc false
+  @spec sign_typed_data(map(), map(), map(), provider_ref(), pos_integer(), String.t()) ::
+          {:ok, binary()} | {:error, term()}
+  def sign_typed_data(domain, types, message, provider_ref, chain_id, account) do
+    with {:ok, inner} <- EIP712.hash(domain, types, message) do
+      sign_inner(inner, provider_ref, chain_id, account)
+    end
+  end
+
+  @doc false
+  @spec sign_message(binary(), provider_ref(), pos_integer(), String.t()) ::
+          {:ok, binary()} | {:error, term()}
+  def sign_message(message, provider_ref, chain_id, account) do
+    sign_inner(hash_message(message), provider_ref, chain_id, account)
+  end
+
+  # Sign the account's replay-safe wrapper of `inner_hash` via the managed
+  # authority, then pack it into the fallback ERC-1271 envelope.
+  defp sign_inner(inner_hash, {mod, fun}, chain_id, account) do
+    provider = apply(mod, fun, [])
+
+    wrapper = %{
+      domain: %{chainId: chain_id, verifyingContract: account},
+      types: @replay_safe_types,
+      message: %{"hash" => "0x" <> Base.encode16(inner_hash, case: :lower)}
+    }
+
+    with {:ok, raw} <- ProviderAdapter.sign_typed_data(provider, chain_id, wrapper) do
+      {:ok, ModularAccount.pack_1271_eoa_signature(normalize_v(raw), 0)}
+    end
+  end
+
+  # EIP-191 personal-sign hash of arbitrary-length data (matches
+  # `Raxol.ACP.Wallet.SCA`'s message hashing).
+  defp hash_message(message) do
+    prefix = "\x19Ethereum Signed Message:\n" <> Integer.to_string(byte_size(message))
+    ExKeccak.hash_256(prefix <> message)
+  end
+
+  # secp256k1 recovery id -> Ethereum v (27/28); leave already-normalized sigs.
+  defp normalize_v(<<r::binary-size(32), s::binary-size(32), v::8>>) when v < 27,
+    do: <<r::binary-size(32), s::binary-size(32), v + 27::8>>
+
+  defp normalize_v(<<_::binary-size(64), _v::8>> = sig), do: sig
+end

--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
@@ -51,7 +51,10 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
   use GenServer
 
+  require Logger
+
   alias Raxol.ACP.{Agent, HookClient}
+  alias Raxol.ACP.Transport.SSE.Parser
   alias Raxol.ACP.Xochi.{IntentDeriver, Offering}
 
   @type session_status ::
@@ -85,6 +88,10 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
           acp_core_address: String.t(),
           fee_bps: non_neg_integer(),
           settle_fn: fun(),
+          history_fn:
+            (Raxol.ACP.Transport.job_key() ->
+               {:ok, [map()]} | {:error, term()})
+            | nil,
           xochi_config: map(),
           sessions: %{Raxol.ACP.Transport.job_key() => session_state()}
         }
@@ -98,6 +105,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
     :acp_core_address,
     :xochi_config,
     settle_fn: nil,
+    history_fn: nil,
     fee_bps: 8,
     sessions: %{}
   ]
@@ -137,6 +145,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       acp_core_address: Keyword.fetch!(opts, :acp_core_address),
       fee_bps: Keyword.get(opts, :fee_bps, 8),
       settle_fn: Keyword.get(opts, :settle_fn, &default_settle/1),
+      history_fn: Keyword.get(opts, :history_fn),
       xochi_config: Keyword.get(opts, :xochi_config, %{})
     }
 
@@ -216,6 +225,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       }
 
       emit(state, key, :job_created, :await_requirement)
+      Logger.info("[xochi.solver] accepted job.created key=#{inspect(key)}; awaiting requirement")
       put_session(state, key, session)
     else
       state
@@ -245,9 +255,143 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
   # never fan-settle every pending session -- doing so spends real funds via
   # settle/3 for jobs that were not funded.
   defp handle_job_funded(entry, state) do
-    case settle_target(state.sessions, job_key(entry)) do
-      {:ok, key, session} -> settle(state, key, session)
-      :none -> state
+    key = job_key(entry)
+    live_status = live_session_status(state, key)
+
+    emit(state, key, :job_funded, %{session_status: live_status})
+
+    Logger.info(
+      "[xochi.solver] job.funded key=#{inspect(key)} live_session=#{inspect(live_status)}"
+    )
+
+    case settle_target(state.sessions, key) do
+      {:ok, key, session} ->
+        settle(state, key, session)
+
+      :none ->
+        # No settleable in-memory session. If the solver restarted between
+        # setBudget and fund (deploy/reschedule), the session is gone and the
+        # live-only SSE stream never replays the earlier entries -- so without a
+        # reattach the funded job stays stuck forever (issue #772). Rebuild from
+        # job history and settle. A session that exists but is NOT fundable
+        # (already settling/submitted/completed/failed) is a duplicate/late
+        # funded event and is left untouched.
+        if live_status == :absent do
+          reattach_and_settle(entry, key, state)
+        else
+          Logger.info(
+            "[xochi.solver] job.funded ignored for #{inspect(key)} (session #{inspect(live_status)})"
+          )
+
+          state
+        end
+    end
+  end
+
+  defp live_session_status(state, key) do
+    case Map.fetch(state.sessions, key) do
+      {:ok, %{status: status}} -> status
+      :error -> :absent
+    end
+  end
+
+  # Rebuild the lost session from the ACP job history and settle it. The history
+  # (fetched off the Virtuals server) is authoritative: it carries the original
+  # `job.created` (confirming this solver is the provider) and the buyer's
+  # `requirement` message (carrying the signed intent bundle we relay). Fails
+  # closed and stays silent on-chain if any of that can't be recovered or the
+  # job isn't ours -- reattach never invents a settlement.
+  defp reattach_and_settle(entry, key, state) do
+    Logger.info("[xochi.solver] no live session for #{inspect(key)}; reattaching from history")
+
+    case rebuild_session(entry, key, state) do
+      {:ok, session} ->
+        emit(state, key, :reattached, :from_history)
+        Logger.info("[xochi.solver] reattached #{inspect(key)} from history; settling")
+        settle(put_session(state, key, session), key, session)
+
+      {:error, reason} ->
+        emit(state, key, :reattach_failed, reason)
+        Logger.warning("[xochi.solver] reattach failed for #{inspect(key)}: #{inspect(reason)}")
+        state
+    end
+  end
+
+  defp rebuild_session(entry, key, state) do
+    with {:ok, entries} <- fetch_history(state, key),
+         normalized = Enum.map(entries, &Parser.normalize/1),
+         :ok <- confirm_provider(normalized, state),
+         {:ok, requirement} <- requirement_from_history(normalized),
+         {:ok, %{from_amount: transfer_atomic}} <-
+           IntentDeriver.resolve(state.xochi_config, requirement) do
+      {:ok, reattached_session(entry, key, requirement, transfer_atomic)}
+    else
+      # IntentDeriver returns {:reject, _} | {:error, _}; the history seams return
+      # {:error, _}. Normalize all to {:error, reason} so reattach fails closed.
+      {_reject_or_error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp reattached_session(entry, {chain_id, job_id}, requirement, transfer_atomic) do
+    id = entry["jobId"] || job_id
+
+    %{
+      job_id: id,
+      chain_id: entry["chainId"] || chain_id,
+      job_id_uint: parse_job_id(id),
+      status: :awaiting_fund,
+      requirement: requirement,
+      transfer_amount_atomic: transfer_atomic
+    }
+  end
+
+  defp fetch_history(%{history_fn: history_fn}, key) when is_function(history_fn, 1) do
+    history_fn.(key)
+  end
+
+  defp fetch_history(state, key), do: Agent.get_history(state.agent, key)
+
+  # Only settle a job whose recorded provider is this solver -- reattach must not
+  # spend on a job we never accepted. The provider is read from the historical
+  # `job.created` entry (authoritative), not the funded event, which may not
+  # carry it.
+  defp confirm_provider(entries, state) do
+    created =
+      Enum.find(entries, fn
+        %{"kind" => "system", "event" => "job.created"} -> true
+        _ -> false
+      end)
+
+    case created do
+      %{"provider" => provider} when is_binary(provider) ->
+        if normalize_address(provider) == state.wallet_address,
+          do: :ok,
+          else: {:error, :not_our_job}
+
+      _ ->
+        {:error, :no_created_in_history}
+    end
+  end
+
+  # The buyer's requirement (carrying the signed intent bundle) is the last
+  # valid `requirement` message in the history.
+  defp requirement_from_history(entries) do
+    entries
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %{"kind" => "message", "contentType" => "requirement", "content" => content} ->
+        case decode_requirement(content) do
+          {:ok, requirement} -> {:ok, requirement}
+          {:error, _} -> nil
+        end
+
+      _ ->
+        nil
+    end)
+    |> case do
+      {:ok, requirement} -> {:ok, requirement}
+      nil -> {:error, :no_requirement_in_history}
     end
   end
 
@@ -342,6 +486,10 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
       {:ok, tx_hash} ->
         emit(state, key, :budget_proposed, %{tx_hash: tx_hash, budget_atomic: budget_atomic})
 
+        Logger.info(
+          "[xochi.solver] setBudget #{budget_atomic} for #{inspect(key)} tx=#{tx_hash}; awaiting fund"
+        )
+
         updated =
           session
           |> Map.put(:status, :budget_proposed)
@@ -363,6 +511,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
     session = %{session | status: :settling}
     state = put_session(state, key, session)
     emit(state, key, :settling, :start)
+    Logger.info("[xochi.solver] settling #{inspect(key)} via Xochi relay")
 
     case state.settle_fn.(%{
            requirement: session.requirement,
@@ -370,10 +519,12 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
            transfer_amount_atomic: session.transfer_amount_atomic
          }) do
       {:ok, %{intent_id: intent_id} = deliverable} ->
+        Logger.info("[xochi.solver] settled #{inspect(key)} intent=#{intent_id}; submitting")
         submit_deliverable(state, key, session, deliverable, intent_id)
 
       {:error, reason} ->
         emit(state, key, :settle_error, reason)
+        Logger.error("[xochi.solver] settle failed for #{inspect(key)}: #{inspect(reason)}")
         put_session(state, key, %{session | status: :failed})
     end
   end
@@ -390,6 +541,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
          ) do
       {:ok, tx_hash} ->
         emit(state, key, :submitted, %{tx_hash: tx_hash, intent_id: intent_id})
+        Logger.info("[xochi.solver] submitted deliverable for #{inspect(key)} tx=#{tx_hash}")
 
         session =
           session
@@ -404,6 +556,7 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
       {:error, reason} ->
         emit(state, key, :submit_error, reason)
+        Logger.error("[xochi.solver] submit failed for #{inspect(key)}: #{inspect(reason)}")
         put_session(state, key, %{session | status: :failed})
     end
   end

--- a/packages/raxol_acp/test/raxol/acp/wallet/sca/modular_account_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/wallet/sca/modular_account_test.exs
@@ -114,12 +114,29 @@ defmodule Raxol.ACP.Wallet.SCA.ModularAccountTest do
 
       # Different chain id -> different digest
       assert base != ModularAccount.replay_safe_digest(inner, 1, account)
-      # Different account -> different digest (enters via the salt)
+      # Different account -> different digest (the account is the domain's verifyingContract)
       assert base !=
                ModularAccount.replay_safe_digest(inner, 8453, "0x" <> String.duplicate("22", 20))
 
       # Different inner hash -> different digest
       assert base != ModularAccount.replay_safe_digest(:binary.copy(<<0x33>>, 32), 8453, account)
+    end
+
+    test "matches the live SemiModularAccount _replaySafeHash (viem known-answer)" do
+      # For the account domain {chainId 8453, verifyingContract = the account} over
+      # ReplaySafeHash(hash = D), viem's hashTypedData -- and the live account's
+      # isValidSignature -- produce this exact digest. Signing it yields 0x1626ba7e.
+      inner =
+        Base.decode16!("0e76dbb9fde2c3fc894f0cb717cdeb91eabc3a06f50f9671bc4135d32c5710e7",
+          case: :mixed
+        )
+
+      account = "0x468aeae798b3a6548ac2401d276f83afdc172283"
+
+      assert ModularAccount.replay_safe_digest(inner, 8453, account) ==
+               Base.decode16!("f6897fc7499e39a29f708aee463fb6a8b1e59ada5e520b7ee1547905cdeabf7c",
+                 case: :mixed
+               )
     end
   end
 end

--- a/packages/raxol_acp/test/raxol/acp/wallet/sma7702_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/wallet/sma7702_test.exs
@@ -1,0 +1,91 @@
+defmodule Raxol.ACP.Wallet.Sma7702Test do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Payments.EIP712
+
+  @account "0x468aeae798b3a6548ac2401d276f83afdc172283"
+  @chain 8453
+  # A fixed raw 65-byte secp256k1 signature (v = 0x1b) the mock authority returns.
+  @raw_sig <<0xAB>> <> :binary.copy(<<0x11>>, 31) <> :binary.copy(<<0x22>>, 32) <> <<0x1B>>
+
+  # Mock managed-authority provider: an ACP.ProviderAdapter shape that records the
+  # typed data it is asked to sign and returns @raw_sig. `ProviderAdapter.sign_typed_data/3`
+  # dispatches through the `:adapter` module, so only that callback is needed.
+  defmodule MockProvider do
+    def new(test_pid), do: %{adapter: __MODULE__, config: %{test_pid: test_pid}}
+
+    def sign_typed_data(%{config: %{test_pid: pid}}, chain_id, typed_data) do
+      send(pid, {:signed, chain_id, typed_data})
+      {:ok, Raxol.ACP.Wallet.Sma7702Test.raw_sig()}
+    end
+  end
+
+  def raw_sig, do: @raw_sig
+
+  def stash_provider(pid),
+    do: :persistent_term.put({__MODULE__, :provider}, MockProvider.new(pid))
+
+  def provider, do: :persistent_term.get({__MODULE__, :provider})
+
+  defmodule Wallet do
+    use Raxol.ACP.Wallet.Sma7702,
+      account_address: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      chain_id: 8453,
+      provider: {Raxol.ACP.Wallet.Sma7702Test, :provider}
+  end
+
+  setup do
+    stash_provider(self())
+    :ok
+  end
+
+  test "address/0 and chain_id/0 come from config" do
+    assert Wallet.address() == @account
+    assert Wallet.chain_id() == @chain
+  end
+
+  test "sign_hash/1 refuses -- a 7702 account only validates its managed authority" do
+    assert Wallet.sign_hash(:binary.copy(<<0>>, 32)) ==
+             {:error, :sma7702_requires_managed_signer}
+  end
+
+  test "sign_typed_data wraps the app digest in the account ReplaySafeHash and packs the envelope" do
+    domain = %{name: "T", version: "1", chainId: @chain, verifyingContract: @account}
+    types = %{"Msg" => [{"n", "uint256"}]}
+    message = %{"n" => 7}
+
+    {:ok, wrapped} = Wallet.sign_typed_data(domain, types, message)
+
+    # Envelope: 0x00 || uint32(0) || 0xFF || 0x00 || <normalized 65-byte sig>.
+    assert <<0x00, 0::unsigned-big-32, 0xFF, 0x00, sig::binary>> = wrapped
+    assert byte_size(sig) == 65
+    # v already 0x1b (>= 27), so the sig is passed through unchanged.
+    assert sig == @raw_sig
+
+    # The provider was handed the ReplaySafeHash wrapper over the ACCOUNT domain
+    # (chainId + verifyingContract only), with hash = the app digest D.
+    {:ok, d} = EIP712.hash(domain, types, message)
+    expected_hash = "0x" <> Base.encode16(d, case: :lower)
+
+    assert_received {:signed, @chain, wrapper}
+    assert wrapper.domain == %{chainId: @chain, verifyingContract: @account}
+    assert wrapper.types == %{"ReplaySafeHash" => [%{name: "hash", type: "bytes32"}]}
+    assert wrapper.message == %{"hash" => expected_hash}
+  end
+
+  test "a recovery-id v (< 27) is normalized to 27/28 before packing" do
+    # Swap the mock to return v = 0 (raw recovery id); the pack must lift it to 27.
+    defmodule LowVProvider do
+      def new(pid), do: %{adapter: __MODULE__, config: %{pid: pid}}
+      def sign_typed_data(_a, _c, _td), do: {:ok, :binary.copy(<<0x33>>, 64) <> <<0x00>>}
+    end
+
+    :persistent_term.put({__MODULE__, :provider}, LowVProvider.new(self()))
+
+    {:ok, wrapped} =
+      Wallet.sign_typed_data(%{chainId: @chain}, %{"M" => [{"n", "uint256"}]}, %{"n" => 1})
+
+    <<_env::binary-size(7), _r::binary-size(32), _s::binary-size(32), v::8>> = wrapped
+    assert v == 27
+  end
+end

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
@@ -361,6 +361,170 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
     end
   end
 
+  describe "reattach after restart (deployed funded->settle path)" do
+    # Regression for #772: the deployed solver set the budget, then RESTARTED
+    # (deploy/reschedule) before the buyer funded. Its in-memory session was gone
+    # and the live-only SSE stream never replays the earlier entries, so the
+    # funded job stayed stuck at `funded` forever -- settle was never reached.
+    #
+    # This exercises the SolverAgent's own `handle_job_funded/2` with NO prior
+    # session, proving it rebuilds from job history and settles. (The passing
+    # `--route acp` gate drives `JobSession.Provider.deliver` directly, never this
+    # path -- which is why the bug shipped.)
+
+    # Raw wire-shaped history entries: a system `job.created` (nested event map,
+    # onChainJobId) and a `requirement` message. Parser.normalize/1 folds these
+    # into the shape the reattach reads, same as the live stream.
+    defp history_created(job_id, provider) do
+      %{
+        "kind" => "system",
+        "event" => %{"type" => "job.created", "provider" => provider, "onChainJobId" => job_id},
+        "chainId" => 8453
+      }
+    end
+
+    defp history_requirement(job_id) do
+      req = %{
+        "src_chain_id" => 8453,
+        "dst_chain_id" => 10,
+        "src_token" => "0x" <> String.duplicate("11", 20),
+        "dst_token" => "0x" <> String.duplicate("22", 20),
+        "amount_atomic" => "1000000",
+        "signed_intent" => %{
+          "intent_id" => "xi_1",
+          "quote_id" => "xq_1",
+          "signature" => "0x" <> String.duplicate("11", 65),
+          "nonce" => 7,
+          "pull_signature" => "0x" <> String.duplicate("22", 65)
+        }
+      }
+
+      %{
+        "kind" => "message",
+        "contentType" => "requirement",
+        "chainId" => 8453,
+        "onChainJobId" => job_id,
+        "content" => Jason.encode!(req)
+      }
+    end
+
+    defp funded(job_id) do
+      %{"kind" => "system", "event" => "job.funded", "chainId" => 8453, "jobId" => job_id}
+    end
+
+    test "rebuilds the session from history and settles a funded job the solver never saw created",
+         ctx do
+      test_pid = self()
+
+      settle_stub = fn args ->
+        send(test_pid, {:settled, args})
+
+        {:ok,
+         %{
+           intent_id: "xochi-reattach",
+           settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+           receiving_tx_hash: "0x" <> String.duplicate("b", 64),
+           status: "settled"
+         }}
+      end
+
+      # The ACP server holds the job's history; the solver's memory does not.
+      Transport.Mock.set_history(ctx.transport, {8453, 70_759}, [
+        history_created(70_759, @solver_wallet),
+        history_requirement(70_759)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      # ONLY a funded event arrives (post-restart) -- no job.created, no requirement.
+      Transport.Mock.deliver(ctx.transport, funded(70_759))
+      Process.sleep(80)
+
+      # The relay ran on the recovered signed intent...
+      assert_received {:settled, %{signed_intent: %{"intent_id" => "xi_1"}}}
+
+      # ...and the job advanced to submitted on-chain.
+      session = SolverAgent.session(solver, {8453, 70_759})
+      assert session.status == :submitted
+      assert session.deliverable.intent_id == "xochi-reattach"
+
+      # Only the submit call -- setBudget already happened before the restart, so
+      # reattach does NOT re-propose the budget.
+      assert [{8453, [call]}] = ProviderAdapter.Mock.sent_calls(ctx.provider)
+      assert call.to == @acp_core
+    end
+
+    test "a duplicate funded event does not re-settle an already-submitted job", ctx do
+      settle_count = :counters.new(1, [])
+
+      settle_stub = fn _ ->
+        :counters.add(settle_count, 1, 1)
+
+        {:ok,
+         %{
+           intent_id: "xochi-dup",
+           settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+           receiving_tx_hash: "0x" <> String.duplicate("b", 64),
+           status: "settled"
+         }}
+      end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_760}, [
+        history_created(70_760, @solver_wallet),
+        history_requirement(70_760)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_760))
+      Process.sleep(80)
+      assert SolverAgent.session(solver, {8453, 70_760}).status == :submitted
+
+      # A replayed funded event must not spend again.
+      Transport.Mock.deliver(ctx.transport, funded(70_760))
+      Process.sleep(80)
+
+      assert :counters.get(settle_count, 1) == 1
+    end
+
+    test "reattach fails closed when the funded job is not ours (no settle)", ctx do
+      settle_stub = fn _ -> flunk("must not settle a job we did not provide") end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_761}, [
+        history_created(70_761, "0xother0000000000000000000000000000000000"),
+        history_requirement(70_761)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_761))
+      Process.sleep(80)
+
+      assert SolverAgent.session(solver, {8453, 70_761}) == nil
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "reattach fails closed when history has no requirement (no settle)", ctx do
+      settle_stub = fn _ -> flunk("must not settle without a recovered requirement") end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_762}, [
+        history_created(70_762, @solver_wallet)
+      ])
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_762))
+      Process.sleep(80)
+
+      assert SolverAgent.session(solver, {8453, 70_762}) == nil
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+  end
+
   describe "completion" do
     test "job.completed event updates session status", ctx do
       {:ok, solver} = start_solver([], ctx)


### PR DESCRIPTION
Fixes the real root cause of #772 and hardens the solver's funded->settle path.

## Root cause (#772), verified on-chain

The deployed solver was never the problem: it accepts the job, sets the budget (8 bps), receives `job.funded`, and reaches settle. Xochi then rejects the buyer's intent with **HTTP 401 "Invalid signature"**, leaving the intent `quoted` and the job stuck at `funded` -- invisible because the deployed release logged only heartbeats.

The buyer (`0x468a…2283`) is a managed **EIP-7702 `SemiModularAccount7702`**. Its only authorized signer is its own authority; it validates ERC-1271 through the native fallback path with domain `EIP712Domain(uint256 chainId,address verifyingContract)` where `verifyingContract = the account` (no salt). The ACP order harness instead signed with an unauthorized session key and the deployed-Modular-Account module domain. The passing `--route acp` / `live_order` gates never caught it because they use an **EOA buyer** (ecrecover), which skips on-chain ERC-1271 entirely.

## Changes

- **`Raxol.ACP.Wallet.Sma7702`** — produces a 7702-valid ERC-1271 signature: sign the account's `ReplaySafeHash(bytes32 hash)` wrapper (over the account domain) via the managed Privy authority, then pack the ma-v2 fallback envelope `0x00‖uint32(0)‖0xFF‖0x00‖sig`. Wired as the `--signer privy` intent + origin-pull signer.
- **`Raxol.ACP.Wallet.SCA` digest fix (`--signer sca`)** — a raxol-provisioned account is a Semi-Modular Account validating through its entity-0 native fallback, so its replay-safe hash is the account's own domain, not the single-signer module's. Corrected `replay_safe_digest` accordingly (known-answer test pins it to the live account's `_replaySafeHash`). UserOp signing unaffected.
- **Solver diagnostics + reattach** — `[xochi.solver]` Logger milestones across accept/setBudget/funded/settle/submit (this is what surfaced the bug), and a reattach-from-history fallback so a `job.funded` after a restart (which drops the in-memory session; the SSE stream never replays) can still settle. Fails closed if the job isn't ours or the requirement can't be recovered.

## Verification

- Live probe on Base: `isValidSignature(D, sig) → 0x1626ba7e` for the `Sma7702Wallet` signature; raxol's `EIP712.hash` matches viem's `hashTypedData`.
- Deployed solver v12 (source build w/ logging + reattach) reproduced the 401 on job 70763, confirming the diagnosis.
- 8 new unit tests (4 signer, 4 reattach) + full `raxol_acp` suite green (the one `JobIdResolverTest` failure predates this branch). Format + credo clean.

## Manual testing (pending)
- [ ] `mix raxol_acp.order --amount 3.00 --signer privy --fund` → job reaches `completed` on-chain, intent `executed`. (~$3 real USDC; deferred.)

Stacked on #771 (buyer harness + pull-pin).
