### PR TITLE
Gate reattach-settle on on-chain funded status

### DIFF
--- a/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
+++ b/packages/raxol_acp/lib/raxol/acp/xochi/solver_agent.ex
@@ -53,9 +53,14 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
 
   require Logger
 
-  alias Raxol.ACP.{Agent, HookClient}
+  alias Raxol.ACP.{Agent, HookClient, ProviderAdapter}
   alias Raxol.ACP.Transport.SSE.Parser
   alias Raxol.ACP.Xochi.{IntentDeriver, Offering}
+
+  # On-chain AgenticCommerceV3 JobStatus for a funded job. Verified on Base
+  # mainnet (job 70759: `getJob().status == 1` once funded). The memoryless
+  # reattach path settles only at exactly this status.
+  @onchain_status_funded 1
 
   @type session_status ::
           :awaiting_requirement
@@ -298,24 +303,82 @@ defmodule Raxol.ACP.Xochi.SolverAgent do
   # Rebuild the lost session from the ACP job history and settle it. The history
   # (fetched off the Virtuals server) is authoritative: it carries the original
   # `job.created` (confirming this solver is the provider) and the buyer's
-  # `requirement` message (carrying the signed intent bundle we relay). Fails
-  # closed and stays silent on-chain if any of that can't be recovered or the
-  # job isn't ours -- reattach never invents a settlement.
+  # `requirement` message (carrying the signed intent bundle we relay). Before
+  # spending, it independently confirms on-chain that the job is actually funded
+  # (`confirm_funded_onchain/3`). Fails closed and stays silent on-chain if any of
+  # that can't be recovered, the job isn't ours, or it isn't funded on-chain --
+  # reattach never invents a settlement.
   defp reattach_and_settle(entry, key, state) do
     Logger.info("[xochi.solver] no live session for #{inspect(key)}; reattaching from history")
 
-    case rebuild_session(entry, key, state) do
-      {:ok, session} ->
-        emit(state, key, :reattached, :from_history)
-        Logger.info("[xochi.solver] reattached #{inspect(key)} from history; settling")
-        settle(put_session(state, key, session), key, session)
-
+    with {:ok, session} <- rebuild_session(entry, key, state),
+         :ok <- confirm_funded_onchain(state, key, session) do
+      emit(state, key, :reattached, :from_history)
+      Logger.info("[xochi.solver] reattached #{inspect(key)} from history; settling")
+      settle(put_session(state, key, session), key, session)
+    else
       {:error, reason} ->
         emit(state, key, :reattach_failed, reason)
-        Logger.warning("[xochi.solver] reattach failed for #{inspect(key)}: #{inspect(reason)}")
+        Logger.warning("[xochi.solver] reattach aborted for #{inspect(key)}: #{inspect(reason)}")
         state
     end
   end
+
+  # Defense-in-depth for the memoryless reattach path: `job.funded` is the trusted
+  # SSE trigger, but reattach fires for a job this process has no record of, so
+  # before settle/3 spends real funds it reads `getJob(jobId).status` on-chain and
+  # proceeds only when it is EXACTLY `funded`. A status below funded means the
+  # event was premature; a status past funded (submitted/completed) means the job
+  # was already settled -- both fail closed. An unreadable status fails closed too.
+  # The in-memory happy path (a live :budget_proposed/:awaiting_fund session) does
+  # not run this and is unchanged.
+  defp confirm_funded_onchain(state, key, %{job_id_uint: job_id_uint}) do
+    case job_status_onchain(state, job_id_uint) do
+      {:ok, @onchain_status_funded} ->
+        :ok
+
+      {:ok, other} ->
+        Logger.warning(
+          "[xochi.solver] reattach #{inspect(key)}: on-chain status #{inspect(other)} != funded; not settling"
+        )
+
+        {:error, {:not_funded_onchain, other}}
+
+      {:error, reason} ->
+        {:error, {:job_status_unavailable, reason}}
+    end
+  end
+
+  # Read `getJob(jobId).status` off the ACP Core via the provider's eth_call seam.
+  defp job_status_onchain(state, job_id_uint) do
+    params = %{
+      address: state.acp_core_address,
+      signature: "getJob(uint256)",
+      args: [{"uint256", job_id_uint}]
+    }
+
+    with {:ok, raw} <- ProviderAdapter.read_contract(state.provider, state.chain_id, params) do
+      decode_job_status(raw)
+    end
+  end
+
+  # getJob(uint256) -> (client, status, provider, expiredAt, evaluator, hook,
+  # budget, description): a dynamic-struct return, so a leading offset word
+  # precedes the head. `status` is head field 1, i.e. word index 2 overall --
+  # skip the offset word + `client`. An integer is accepted for a canned mock read.
+  defp decode_job_status(status) when is_integer(status) and status >= 0, do: {:ok, status}
+
+  defp decode_job_status("0x" <> hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, <<_::binary-size(2 * 32), status::unsigned-big-integer-size(256), _::binary>>} ->
+        {:ok, status}
+
+      _ ->
+        {:error, :undecodable_job_status}
+    end
+  end
+
+  defp decode_job_status(other), do: {:error, {:unexpected_job_status, other}}
 
   defp rebuild_session(entry, key, state) do
     with {:ok, entries} <- fetch_history(state, key),

--- a/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
+++ b/packages/raxol_acp/test/raxol/acp/xochi/solver_agent_test.exs
@@ -434,6 +434,9 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
         history_requirement(70_759)
       ])
 
+      # ...and the job is genuinely funded on-chain (the reattach gate reads it).
+      ProviderAdapter.Mock.set_contract_read(ctx.provider, @acp_core, "getJob(uint256)", 1)
+
       {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
       Agent.start_stream(ctx.agent)
 
@@ -474,6 +477,8 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
         history_created(70_760, @solver_wallet),
         history_requirement(70_760)
       ])
+
+      ProviderAdapter.Mock.set_contract_read(ctx.provider, @acp_core, "getJob(uint256)", 1)
 
       {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
       Agent.start_stream(ctx.agent)
@@ -522,6 +527,123 @@ defmodule Raxol.ACP.Xochi.SolverAgentTest do
 
       assert SolverAgent.session(solver, {8453, 70_762}) == nil
       assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "reattach fails closed when the job is not funded on-chain (premature event)", ctx do
+      settle_stub = fn _ -> flunk("must not settle a job that is not funded on-chain") end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_763}, [
+        history_created(70_763, @solver_wallet),
+        history_requirement(70_763)
+      ])
+
+      # History recoverable + our job, but on-chain the job has NOT been funded
+      # (still budget_set, status below funded). The gate must not spend.
+      ProviderAdapter.Mock.set_contract_read(ctx.provider, @acp_core, "getJob(uint256)", 0)
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_763))
+      Process.sleep(80)
+
+      assert SolverAgent.session(solver, {8453, 70_763}) == nil
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "reattach fails closed when the job already advanced past funded on-chain", ctx do
+      settle_stub = fn _ -> flunk("must not re-settle a job already past funded") end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_764}, [
+        history_created(70_764, @solver_wallet),
+        history_requirement(70_764)
+      ])
+
+      # On-chain status is past funded (e.g. already submitted) -- a stale/replayed
+      # funded event must not trigger a second settlement.
+      ProviderAdapter.Mock.set_contract_read(ctx.provider, @acp_core, "getJob(uint256)", 2)
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_764))
+      Process.sleep(80)
+
+      assert SolverAgent.session(solver, {8453, 70_764}) == nil
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "reattach fails closed when the on-chain status is unreadable", ctx do
+      settle_stub = fn _ -> flunk("must not settle when the on-chain status can't be read") end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_765}, [
+        history_created(70_765, @solver_wallet),
+        history_requirement(70_765)
+      ])
+
+      # No canned getJob read -> the Mock returns {:error, _}; the gate fails closed.
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_765))
+      Process.sleep(80)
+
+      assert SolverAgent.session(solver, {8453, 70_765}) == nil
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "reattach decodes the funded status from a real getJob struct return and settles", ctx do
+      test_pid = self()
+
+      settle_stub = fn args ->
+        send(test_pid, {:settled, args})
+
+        {:ok,
+         %{
+           intent_id: "xochi-decode",
+           settlement_tx_hash: "0x" <> String.duplicate("a", 64),
+           receiving_tx_hash: "0x" <> String.duplicate("b", 64),
+           status: "settled"
+         }}
+      end
+
+      Transport.Mock.set_history(ctx.transport, {8453, 70_766}, [
+        history_created(70_766, @solver_wallet),
+        history_requirement(70_766)
+      ])
+
+      # A real ABI-shaped getJob return: leading offset word, then the struct head
+      # [client, status, provider, expiredAt, evaluator, hook, budget]. status
+      # (word index 2) = 1 (funded). Proves the word-offset decoder, not just the
+      # integer canned-read shortcut.
+      ProviderAdapter.Mock.set_contract_read(
+        ctx.provider,
+        @acp_core,
+        "getJob(uint256)",
+        getjob_return_hex(1)
+      )
+
+      {:ok, solver} = start_solver([settle_fn: settle_stub], ctx)
+      Agent.start_stream(ctx.agent)
+
+      Transport.Mock.deliver(ctx.transport, funded(70_766))
+      Process.sleep(80)
+
+      assert_received {:settled, %{signed_intent: %{"intent_id" => "xi_1"}}}
+      assert SolverAgent.session(solver, {8453, 70_766}).status == :submitted
+    end
+
+    # Minimal ABI-encoded getJob(uint256) return: offset word (0x20) + the 7-word
+    # struct head, with only `status` (word index 2) set. Enough for the funded gate.
+    defp getjob_return_hex(status) do
+      words = [0x20, 0, status, 0, 0, 0, 0, 0]
+
+      body =
+        words
+        |> Enum.map(&<<&1::unsigned-big-integer-size(256)>>)
+        |> IO.iodata_to_binary()
+
+      "0x" <> Base.encode16(body, case: :lower)
     end
   end
 


### PR DESCRIPTION
## Summary
Hardens the memoryless solver reattach path (the #772 `funded -> settle` recovery) with a defense-in-depth on-chain check before it spends real funds.

Reattach fires for a job the process has **no record of** (the solver restarted between `setBudget` and `fund`), rebuilding the session from server-held job history and settling on the trusted `job.funded` SSE event. This adds an independent guard: read `getJob(jobId).status` on-chain via the provider's `read_contract` eth_call seam and settle **only when the status is exactly `funded`**.

## Behavior
- status **below** funded (premature/spurious event) -> fail closed, no settle
- status **past** funded (already submitted/completed) -> fail closed; an independent double-settle guard on top of the existing SSE dedup
- status **unreadable** (eth_call error / undecodable) -> fail closed

The in-memory happy path (a live `:budget_proposed`/`:awaiting_fund` session settling on `job.funded`) does **not** run the gate and is unchanged — this only tightens the reattach branch.

## Notes
- `funded == 1` verified on Base mainnet job 70759 (`getJob().status == 1` once funded); pinned as `@onchain_status_funded` with a comment.
- `getJob` returns a dynamic struct (leading offset word), so `status` is word index 2 (offset + `client`); the decoder skips `2 * 32` bytes.
- Fails closed on every unexpected shape, so a decode/enum drift can never cause a spurious settle — at worst it declines to reattach (the pre-#772 behavior for that job).

## Manual testing
- [x] `raxol_acp` xochi suite green: **181 passed** (7 properties, 174 tests).
- [x] 5 new/updated tests: funded settles; premature (status 0) fails closed; past-funded (status 2) fails closed; unreadable status fails closed; and a real ABI `getJob`-struct return decodes to funded and settles (KAT for the word-2 offset).
- [ ] Live `funded -> settle` on a restarted solver — exercised by the deployed release; not runnable in CI (`raxol_acp` has no CI job).
