### PR TITLE
Enable skills tools in coding and headless agents

### DIFF
--- a/packages/raxol_agent/config/config.exs
+++ b/packages/raxol_agent/config/config.exs
@@ -1,0 +1,25 @@
+import Config
+
+# Procedural-memory (skills) subsystem.
+#
+# Setting :skills_provider starts Raxol.Agent.Skills.Store (the supervisor gate
+# in Raxol.Agent.Supervisor.skills_children/0). The surface wiring in
+# raxol/agent/code/app.ex and mix/tasks/raxol.p.ex then exposes the
+# skills_list / skill_view / skill_manage tools whenever this key is set.
+#
+#   skills_root          -- writable managed root for agent-authored skills
+#                           (the curation loop writes here); runtime state, left
+#                           unmanaged by chezmoi.
+#   skills_external_dirs  -- read-only skill sources, scanned for **/SKILL.md:
+#                              ~/.agents/skills        chezmoi external ->
+#                                                      DROOdotFOO/agent-skills
+#                              ~/.agents/skills-extra  chezmoi-vendored
+#                                                      third-party skills
+# Not enabled in :test — the suite must not depend on the machine's on-disk
+# skills; tests set :skills_provider explicitly to exercise both states.
+if config_env() != :test do
+  config :raxol_agent,
+    skills_provider: Raxol.Agent.Skills.Store,
+    skills_root: "~/.raxol/skills",
+    skills_external_dirs: ["~/.agents/skills", "~/.agents/skills-extra"]
+end

--- a/packages/raxol_agent/lib/mix/tasks/raxol.p.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.p.ex
@@ -184,15 +184,31 @@ defmodule Mix.Tasks.Raxol.P do
   # and denied under the default policy — so it also installs an allow-all
   # authorizer to actually let them run in this unattended headless flow.
   defp actions_for(false),
-    do: Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.read_only()
+    do:
+      Raxol.Agent.Actions.Fs.all() ++
+        Raxol.Agent.Actions.Code.read_only() ++ Raxol.Agent.Skills.enabled_actions()
 
   defp actions_for(true),
-    do: Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.all()
+    do:
+      Raxol.Agent.Actions.Fs.all() ++
+        Raxol.Agent.Actions.Code.all() ++ Raxol.Agent.Skills.enabled_actions()
 
-  defp context_for(false), do: []
+  defp context_for(false), do: maybe_skills_context(%{})
 
   defp context_for(true),
-    do: [context: %{tool_authorizer: Raxol.Agent.ToolPolicy.allow_all()}]
+    do: maybe_skills_context(%{tool_authorizer: Raxol.Agent.ToolPolicy.allow_all()})
+
+  # Add the configured skills store under context[:skills]; keep the empty-context
+  # `[]` shape when nothing (skills or authorizer) needs to be passed.
+  defp maybe_skills_context(base) do
+    base =
+      case Raxol.Agent.Skills.default_context() do
+        nil -> base
+        skills -> Map.put(base, :skills, skills)
+      end
+
+    if map_size(base) == 0, do: [], else: [context: base]
+  end
 
   defp maybe_put(kw, _key, nil), do: kw
   defp maybe_put(kw, key, value), do: Keyword.put(kw, key, value)

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -548,7 +548,17 @@ defmodule Raxol.Agent.Code.App do
         model: model.model_override
       }
     }
+    |> maybe_add_skills()
     |> maybe_add_hooks(model)
+  end
+
+  # Wire the configured skills store under context[:skills] so the skill actions
+  # can reach it. No-op when skills are disabled (default_context returns nil).
+  defp maybe_add_skills(context) do
+    case Raxol.Agent.Skills.default_context() do
+      nil -> context
+      skills -> Map.put(context, :skills, skills)
+    end
   end
 
   defp maybe_add_hooks(context, %{hooks: nil}), do: context
@@ -1705,7 +1715,8 @@ defmodule Raxol.Agent.Code.App do
   defp default_actions do
     Raxol.Agent.Actions.Fs.all() ++
       Raxol.Agent.Actions.Code.all() ++
-      Raxol.Agent.Actions.Task.all()
+      Raxol.Agent.Actions.Task.all() ++
+      Raxol.Agent.Skills.enabled_actions()
   end
 
   defp default_system do

--- a/packages/raxol_agent/lib/raxol/agent/skills.ex
+++ b/packages/raxol_agent/lib/raxol/agent/skills.ex
@@ -29,4 +29,23 @@ defmodule Raxol.Agent.Skills do
   def provider_context(provider \\ Store, opts \\ [])
   def provider_context(nil, _opts), do: nil
   def provider_context(provider, opts) when is_atom(provider), do: {provider, opts}
+
+  @doc """
+  The skill actions to expose on a surface, or `[]` when skills are disabled.
+
+  `skills_list` / `skill_view` / `skill_manage` are appended to a surface's
+  action list only when a provider is configured (`config :raxol_agent,
+  skills_provider: ...`), so a runtime can splice this in unconditionally.
+  """
+  @spec enabled_actions() :: [module()]
+  def enabled_actions do
+    if default_provider(), do: Raxol.Agent.Actions.Skills.actions(), else: []
+  end
+
+  @doc """
+  The `context[:skills]` tuple for the configured provider, or `nil` when skills
+  are disabled. Shorthand for `provider_context(default_provider())`.
+  """
+  @spec default_context() :: {module(), keyword()} | nil
+  def default_context, do: provider_context(default_provider())
 end

--- a/packages/raxol_agent/test/raxol/agent/code/app_skills_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_skills_test.exs
@@ -1,0 +1,51 @@
+defmodule Raxol.Agent.Code.AppSkillsTest do
+  # async: false -- these mutate the :raxol_agent app env.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Actions.Skills, as: SkillsActions
+  alias Raxol.Agent.Code.App
+  alias Raxol.Agent.Skills.Store
+
+  setup do
+    prev = Application.get_env(:raxol_agent, :skills_provider)
+
+    on_exit(fn ->
+      case prev do
+        nil -> Application.delete_env(:raxol_agent, :skills_provider)
+        val -> Application.put_env(:raxol_agent, :skills_provider, val)
+      end
+    end)
+
+    :ok
+  end
+
+  # A model built with the surface's default action list (no :actions override),
+  # so model.actions reflects default_actions/0 -> Skills.enabled_actions/0.
+  defp new_model do
+    App.init(%{
+      options: [
+        runner: fn _, _, _, _ -> :ok end,
+        sessions_dir:
+          Path.join(System.tmp_dir!(), "raxol-code-skills-#{System.unique_integer([:positive])}")
+      ]
+    })
+  end
+
+  test "the coding agent exposes skill actions when a provider is configured" do
+    Application.put_env(:raxol_agent, :skills_provider, Store)
+    model = new_model()
+
+    for action <- SkillsActions.actions() do
+      assert action in model.actions
+    end
+  end
+
+  test "the coding agent omits skill actions when no provider is configured" do
+    Application.delete_env(:raxol_agent, :skills_provider)
+    model = new_model()
+
+    for action <- SkillsActions.actions() do
+      refute action in model.actions
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/skills_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/skills_test.exs
@@ -1,0 +1,64 @@
+defmodule Raxol.Agent.SkillsTest do
+  # async: false -- these mutate the :raxol_agent app env.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Actions.Skills, as: SkillsActions
+  alias Raxol.Agent.Skills
+  alias Raxol.Agent.Skills.Store
+
+  setup do
+    prev = Application.get_env(:raxol_agent, :skills_provider)
+
+    on_exit(fn ->
+      case prev do
+        nil -> Application.delete_env(:raxol_agent, :skills_provider)
+        val -> Application.put_env(:raxol_agent, :skills_provider, val)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "with a skills provider configured" do
+    setup do
+      Application.put_env(:raxol_agent, :skills_provider, Store)
+      :ok
+    end
+
+    test "default_provider/0 returns the configured store" do
+      assert Skills.default_provider() == Store
+    end
+
+    test "enabled_actions/0 exposes skills_list, skill_view, and skill_manage" do
+      actions = Skills.enabled_actions()
+
+      assert actions == SkillsActions.actions()
+      assert SkillsActions.List in actions
+      assert SkillsActions.View in actions
+      assert SkillsActions.Manage in actions
+    end
+
+    test "default_context/0 wires the store under context[:skills]" do
+      assert Skills.default_context() == {Store, []}
+    end
+  end
+
+  describe "with no skills provider configured" do
+    setup do
+      Application.delete_env(:raxol_agent, :skills_provider)
+      :ok
+    end
+
+    test "default_provider/0 is nil" do
+      assert Skills.default_provider() == nil
+    end
+
+    test "enabled_actions/0 exposes no skill actions" do
+      assert Skills.enabled_actions() == []
+    end
+
+    test "default_context/0 is nil" do
+      assert Skills.default_context() == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Enable the procedural-memory (skills) subsystem for the two agent launch
surfaces so `skills_list` / `skill_view` / `skill_manage` are exposed when a
provider is configured. Previously the app-env `:skills_provider` key only
started `Raxol.Agent.Skills.Store` (supervisor gate) but nothing wired the
tools into `raxol.code` or `raxol.p`.

## Changes

- **Config.** New `packages/raxol_agent/config/config.exs` (mix auto-loads it;
  the `bin/raxol*` launchers run in this package) sets:
  - `skills_provider: Raxol.Agent.Skills.Store`
  - `skills_root: "~/.raxol/skills"` (writable managed root, agent-authored skills)
  - `skills_external_dirs: ["~/.agents/skills", "~/.agents/skills-extra"]`
  Gated out of `:test` so the suite does not depend on the machine's on-disk skills.
- **Centralized gate.** `Raxol.Agent.Skills.enabled_actions/0` and
  `default_context/0` return the skill actions / `context[:skills]` tuple only
  when a provider is configured.
- **Surface wiring.** `code/app.ex` (`default_actions/0`, `run_context/2`) and
  `mix/tasks/raxol.p.ex` (`actions_for/1`, `context_for/1`) append them.
- **Tests.** `skills_test.exs` and `code/app_skills_test.exs` assert tool
  exposure with and without a provider.

Note: all three skill tools (incl. `skill_manage`) are exposed even in
`raxol -p` read-only mode; `skill_manage` writes only to `~/.raxol/skills`,
never user code.

## Manual testing

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test test/raxol/agent/skills_test.exs test/raxol/agent/code/app_skills_test.exs test/raxol/agent/actions/skills_test.exs` -> 16 passed
- [x] Regression: `code/app_test.exs`, `turn_test.exs`, `skills/store_test.exs`, `supervisor_test.exs` -> all pass
- [x] End-to-end: `mix run` (dev) -> `Raxol.Agent.Skills.Store.list()` returns 59 skills incl. `humanizer` and `virtuals-protocol-acp`
- [x] `mix format --check-formatted` clean on changed files
