### PR TITLE
npm launchers: restore tty on child exit

### DIFF
--- a/packages/raxol_cli/npm/bin/launcher.js
+++ b/packages/raxol_cli/npm/bin/launcher.js
@@ -9,6 +9,7 @@ const { spawnSync } = require("node:child_process");
 const { join } = require("node:path");
 const { existsSync } = require("node:fs");
 const os = require("node:os");
+const { withTerminalRestore } = require("./tty");
 
 // Maps `${platform}-${arch}` to the Burrito output name (`raxol_cli_<target>`).
 const BINARIES = {
@@ -49,7 +50,11 @@ function main() {
   // starve the interactive agent), and `--no-halt` stops it halting the VM. The
   // binary strips the `--no-halt --` prefix when reading its arguments.
   const args = ["--no-halt", "--", ...process.argv.slice(2)];
-  const result = spawnSync(binary, args, { stdio: "inherit" });
+  // The interactive agent puts the tty in raw mode; if the BEAM child dies there
+  // (crash, SIGSEGV), restore the shell's line settings so it isn't left wedged.
+  const result = withTerminalRestore(() =>
+    spawnSync(binary, args, { stdio: "inherit" }),
+  );
 
   if (result.error) {
     console.error(`raxol: failed to launch: ${result.error.message}`);

--- a/packages/raxol_cli/npm/bin/tty.js
+++ b/packages/raxol_cli/npm/bin/tty.js
@@ -1,0 +1,67 @@
+"use strict";
+// Snapshot the controlling terminal's line settings before running a child that
+// may switch the tty to raw mode, and restore them unconditionally when the
+// child exits -- for ANY cause: a clean exit, a signal, or a crash/segfault of
+// the child. Without this a BEAM child that dies while the tty is raw leaves the
+// parent shell wedged (no echo, no line editing) until the user blindly types
+// `reset`. This restore lives in the parent process, so it survives a child
+// SIGSEGV that no in-VM handler could. It cannot cover the parent itself being
+// SIGKILL'd -- that is uncatchable, and nothing in-process can help.
+const { execFileSync } = require("node:child_process");
+const { openSync } = require("node:fs");
+
+function openControllingTty() {
+  // A real tty on stdin means we're interactive and have settings worth saving.
+  // Open /dev/tty directly so we still target the terminal if stdin/stdout are
+  // redirected.
+  if (process.stdin.isTTY !== true) return null;
+  try {
+    return openSync("/dev/tty", "r+");
+  } catch {
+    return null;
+  }
+}
+
+function snapshot(fd) {
+  try {
+    // `stty -g` prints all settings as a single token, portable across Linux
+    // (colon-hex) and BSD/macOS. Feed /dev/tty as stdin so stty targets the
+    // terminal without the non-portable -F/-f device flag.
+    return execFileSync("stty", ["-g"], {
+      stdio: [fd, "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function restore(fd, saved) {
+  if (fd == null || !saved) return;
+  try {
+    execFileSync("stty", [saved], { stdio: [fd, "ignore", "ignore"] });
+  } catch {
+    // Best effort: a failed restore must never mask the child's exit status.
+  }
+}
+
+// Run `child()` (which spawns and returns the sync result) with the terminal
+// snapshotted first and restored no matter how the child exits. The `finally`
+// covers the normal return; the `exit` backstop covers an internal
+// `process.exit` or a late signal. `restore` is idempotent, so running twice is
+// harmless. The /dev/tty fd is intentionally left open -- the process is exiting
+// imminently, and keeping it lets the backstop restore too.
+function withTerminalRestore(child) {
+  const fd = openControllingTty();
+  const saved = fd == null ? null : snapshot(fd);
+
+  process.once("exit", () => restore(fd, saved));
+
+  try {
+    return child();
+  } finally {
+    restore(fd, saved);
+  }
+}
+
+module.exports = { withTerminalRestore };

--- a/packages/raxol_console/npm/bin/launcher.js
+++ b/packages/raxol_console/npm/bin/launcher.js
@@ -9,6 +9,7 @@ const { spawnSync } = require("node:child_process");
 const { join } = require("node:path");
 const { existsSync } = require("node:fs");
 const os = require("node:os");
+const { withTerminalRestore } = require("./tty");
 
 // Maps `${platform}-${arch}` to the Burrito output name (`raxol_console_<target>`).
 const BINARIES = {
@@ -53,7 +54,11 @@ function main() {
     args = [];
   }
 
-  const result = spawnSync(binary, args, { stdio: "inherit" });
+  // Restore the shell's tty settings if the runtime child dies in raw mode, so
+  // an abnormal exit (crash, SIGSEGV) never leaves the terminal wedged.
+  const result = withTerminalRestore(() =>
+    spawnSync(binary, args, { stdio: "inherit" }),
+  );
   if (result.error) {
     console.error(`raxol-console: failed to launch runtime: ${result.error.message}`);
     process.exit(1);

--- a/packages/raxol_console/npm/bin/tty.js
+++ b/packages/raxol_console/npm/bin/tty.js
@@ -1,0 +1,67 @@
+"use strict";
+// Snapshot the controlling terminal's line settings before running a child that
+// may switch the tty to raw mode, and restore them unconditionally when the
+// child exits -- for ANY cause: a clean exit, a signal, or a crash/segfault of
+// the child. Without this a BEAM child that dies while the tty is raw leaves the
+// parent shell wedged (no echo, no line editing) until the user blindly types
+// `reset`. This restore lives in the parent process, so it survives a child
+// SIGSEGV that no in-VM handler could. It cannot cover the parent itself being
+// SIGKILL'd -- that is uncatchable, and nothing in-process can help.
+const { execFileSync } = require("node:child_process");
+const { openSync } = require("node:fs");
+
+function openControllingTty() {
+  // A real tty on stdin means we're interactive and have settings worth saving.
+  // Open /dev/tty directly so we still target the terminal if stdin/stdout are
+  // redirected.
+  if (process.stdin.isTTY !== true) return null;
+  try {
+    return openSync("/dev/tty", "r+");
+  } catch {
+    return null;
+  }
+}
+
+function snapshot(fd) {
+  try {
+    // `stty -g` prints all settings as a single token, portable across Linux
+    // (colon-hex) and BSD/macOS. Feed /dev/tty as stdin so stty targets the
+    // terminal without the non-portable -F/-f device flag.
+    return execFileSync("stty", ["-g"], {
+      stdio: [fd, "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function restore(fd, saved) {
+  if (fd == null || !saved) return;
+  try {
+    execFileSync("stty", [saved], { stdio: [fd, "ignore", "ignore"] });
+  } catch {
+    // Best effort: a failed restore must never mask the child's exit status.
+  }
+}
+
+// Run `child()` (which spawns and returns the sync result) with the terminal
+// snapshotted first and restored no matter how the child exits. The `finally`
+// covers the normal return; the `exit` backstop covers an internal
+// `process.exit` or a late signal. `restore` is idempotent, so running twice is
+// harmless. The /dev/tty fd is intentionally left open -- the process is exiting
+// imminently, and keeping it lets the backstop restore too.
+function withTerminalRestore(child) {
+  const fd = openControllingTty();
+  const saved = fd == null ? null : snapshot(fd);
+
+  process.once("exit", () => restore(fd, saved));
+
+  try {
+    return child();
+  } finally {
+    restore(fd, saved);
+  }
+}
+
+module.exports = { withTerminalRestore };


### PR DESCRIPTION
The `raxol` and `raxol-console` npm wrappers `spawnSync` the Burrito binary with `stdio: inherit` and do nothing about terminal state. The interactive agent puts the tty in raw mode; if the BEAM child dies there (crash, SIGSEGV, signal), the parent shell is left wedged — no echo, no line editing — until the user blindly types `reset`. Fable's flag.

## Change
Add `bin/tty.js` to both npm packages (self-contained, since each publishes independently):
- Snapshot `stty -g` (via a `/dev/tty` fd, portable across Linux colon-hex and BSD/macOS) before spawning.
- Restore it **unconditionally** when the child exits — for any cause — via `finally` plus a `process.once('exit')` backstop (restore is idempotent).
- Guarded on an interactive tty (`process.stdin.isTTY`): a piped/CI invocation is a clean pass-through.

This is the one restore that survives a child **SIGSEGV** — it lives in the parent process, not the VM. It cannot cover the parent itself being `SIGKILL`'d (uncatchable); nothing in-process can.

## Verified
Under a real pty (`expect`): a child that enters `stty raw` and exits leaves the terminal with `icanon` restored (false → true across the wrapper). Non-tty path returns the child result unchanged and never throws. Both launchers `node --check` clean.

## Manual testing
- [x] pty: child raw-mode exit → `icanon` restored
- [x] non-tty pass-through returns child result, no throw
- [x] `node --check` both launchers + both `tty.js`

Follow-up: same pattern belongs in the Burrito launcher for the T-Bench adapter (the tmux-driven harness) — this covers the npm wrappers, which was the shipped surface.