### PR TITLE
MCP: authorize tools/call, deny-on-ASK

### DIFF
--- a/packages/raxol_mcp/lib/raxol/mcp/authorizer.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/authorizer.ex
@@ -1,0 +1,57 @@
+defmodule Raxol.MCP.Authorizer do
+  @moduledoc """
+  The authorization seam in front of MCP `tools/call`.
+
+  An authorizer is a 3-arity function `(tool_name, arguments, context) -> decision`,
+  evaluated by `Raxol.MCP.Server` before a tool runs. `raxol_mcp` deliberately
+  owns only the seam, not a policy engine: richer ALLOW/ASK/DENY logic (e.g.
+  `Raxol.Agent.Authorization.Engine`) lives upstream and plugs in as a closure,
+  so the engine and this enforcement point share one vocabulary without
+  `raxol_mcp` depending on `raxol_agent` (which would be a dependency cycle).
+
+  ## Decisions
+
+    * `:allow` -- run the tool.
+    * `{:ask, prompt}` -- the action would need interactive approval. `tools/call`
+      has no interactive channel, so the server DENIES with a machine-readable
+      `authorization_required` result (deny-on-ASK). A client that advertises
+      elicitation can upgrade this to a real prompt later; that is a follow-up,
+      not part of this seam.
+    * `{:deny, reason}` -- refuse, machine-readably.
+
+  A `nil` authorizer means allow: a stdio transport already inherits the OS
+  process boundary. The SSE transport, which exposes tools over the network, is
+  guarded separately -- see `Raxol.MCP.Deployment`.
+  """
+
+  @type context :: map()
+  @type decision :: :allow | {:ask, String.t()} | {:deny, term()}
+  @type t :: (String.t(), map(), context() -> decision())
+
+  @doc "Allow every call. The implicit behaviour when no authorizer is configured."
+  @spec allow_all() :: t()
+  def allow_all, do: fn _tool, _args, _ctx -> :allow end
+
+  @doc "Deny every call with `reason`."
+  @spec deny_all(term()) :: t()
+  def deny_all(reason \\ :denied), do: fn _tool, _args, _ctx -> {:deny, reason} end
+
+  @doc """
+  Allow only tools whose name is in `names`; deny the rest. This is the allowlist
+  exposure mode: pair it with a narrow set to expose a safe subset of the
+  auto-derived tool surface over an untrusted transport.
+  """
+  @spec allowlist([String.t()]) :: t()
+  def allowlist(names) do
+    set = MapSet.new(names)
+
+    fn tool, _args, _ctx ->
+      if MapSet.member?(set, tool), do: :allow, else: {:deny, :not_allowlisted}
+    end
+  end
+
+  @doc "Evaluate an authorizer, treating `nil` as `:allow`."
+  @spec decide(t() | nil, String.t(), map(), context()) :: decision()
+  def decide(nil, _tool, _args, _ctx), do: :allow
+  def decide(fun, tool, args, ctx) when is_function(fun, 3), do: fun.(tool, args, ctx)
+end

--- a/packages/raxol_mcp/lib/raxol/mcp/deployment.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/deployment.ex
@@ -1,0 +1,52 @@
+defmodule Raxol.MCP.Deployment do
+  @moduledoc """
+  Fail-closed environment gate for MCP authorization.
+
+  Mirrors the posture the payments stack uses (`require_policy`): outside a
+  dev/test build, a network-exposed MCP transport must not serve tools without an
+  authorizer configured. stdio is exempt (it inherits the OS process boundary);
+  this guards SSE.
+  """
+
+  # Captured at compile time: `Mix` is absent in a release, and a path-dep
+  # package compiles under :prod regardless of the umbrella's env, so fall back
+  # to :prod when Mix is gone rather than crash or read the wrong env.
+  @mix_env if Code.ensure_loaded?(Mix), do: Mix.env(), else: :prod
+
+  @doc "True in any non-dev/test build."
+  @spec production?() :: boolean()
+  def production?, do: @mix_env not in [:dev, :test]
+
+  @doc """
+  Whether a network transport must refuse to expose tools without an authorizer.
+
+  Defaults to `production?/0`; override with
+  `config :raxol_mcp, require_authorization: boolean`.
+  """
+  @spec require_authorization?() :: boolean()
+  def require_authorization? do
+    Application.get_env(:raxol_mcp, :require_authorization, production?())
+  end
+
+  @doc """
+  Fail-closed boot check. Raises when authorization is required in this
+  environment but the fronted server has no authorizer configured; a no-op
+  otherwise. `context` names the caller for the error message.
+  """
+  @spec enforce_authorization!(boolean(), String.t()) :: :ok
+  def enforce_authorization!(authorizer_configured?, context \\ "MCP transport")
+
+  def enforce_authorization!(true, _context), do: :ok
+
+  def enforce_authorization!(false, context) do
+    if require_authorization?() do
+      raise ArgumentError,
+            "#{context} refuses to boot: authorization is required in this environment " <>
+              "but no authorizer is configured on the MCP server. Configure an :authorizer " <>
+              "on Raxol.MCP.Server, or override with " <>
+              "`config :raxol_mcp, require_authorization: false`."
+    else
+      :ok
+    end
+  end
+end

--- a/packages/raxol_mcp/lib/raxol/mcp/server.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/server.ex
@@ -32,12 +32,14 @@ defmodule Raxol.MCP.Server do
 
   @compile {:no_warn_undefined, Raxol.Headless}
 
+  alias Raxol.MCP.Authorizer
   alias Raxol.MCP.Protocol
   alias Raxol.MCP.Registry
   alias Raxol.MCP.ResourceRouter
 
   defstruct [
     :registry,
+    :authorizer,
     initialized: false,
     log_level: :info,
     subscribers: [],
@@ -46,6 +48,7 @@ defmodule Raxol.MCP.Server do
 
   @type t :: %__MODULE__{
           registry: GenServer.server(),
+          authorizer: Authorizer.t() | nil,
           initialized: boolean(),
           log_level:
             :debug | :info | :notice | :warning | :error | :critical | :alert | :emergency,
@@ -93,18 +96,36 @@ defmodule Raxol.MCP.Server do
     GenServer.cast(server, {:notify, method, params})
   end
 
+  @doc """
+  Whether an authorizer is configured on this server. Network transport boot
+  guards use this to fail closed (see `Raxol.MCP.Deployment`). Returns `false` if
+  the server is unreachable.
+  """
+  @spec authorization_configured?(GenServer.server()) :: boolean()
+  def authorization_configured?(server \\ __MODULE__) do
+    GenServer.call(server, :authorization_configured?)
+  catch
+    :exit, _ -> false
+  end
+
   # -- GenServer Callbacks -------------------------------------------------------
 
   @impl Raxol.Core.Behaviours.BaseManager
   def init_manager(opts) do
     registry = Keyword.get(opts, :registry, Registry)
-    {:ok, %__MODULE__{registry: registry}}
+    authorizer = Keyword.get(opts, :authorizer)
+    {:ok, %__MODULE__{registry: registry, authorizer: authorizer}}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_call({:handle_message, message}, _from, state) do
     {response, state} = dispatch(message, state)
     {:reply, {:reply, response}, state}
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_call(:authorization_configured?, _from, state) do
+    {:reply, state.authorizer != nil, state}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -161,31 +182,22 @@ defmodule Raxol.MCP.Server do
     name = Map.get(params, "name") || Map.get(params, :name, "")
     arguments = Map.get(params, "arguments") || Map.get(params, :arguments, %{})
 
-    case Registry.call_tool(state.registry, name, arguments) do
-      {:ok, result} ->
-        content = normalize_content(result)
-        {Protocol.response(id, %{content: content}), state}
+    # Authorize before the tool runs. A nil authorizer allows (stdio inherits the
+    # OS boundary); ASK is denied here because tools/call has no interactive
+    # channel (deny-on-ASK) -- elicitation is a follow-up.
+    response =
+      case Authorizer.decide(state.authorizer, name, arguments, %{}) do
+        :allow ->
+          call_tool_response(id, name, Registry.call_tool(state.registry, name, arguments))
 
-      {:error, :tool_not_found} ->
-        error =
-          Protocol.error_response(id, Protocol.method_not_found(), "Tool not found: #{name}")
+        {:ask, prompt} ->
+          authorization_required(id, name, :ask, prompt)
 
-        {error, state}
+        {:deny, reason} ->
+          authorization_required(id, name, :deny, reason)
+      end
 
-      {:error, :circuit_open} ->
-        content = [
-          %{
-            type: "text",
-            text: "Tool temporarily unavailable (circuit open after repeated failures)"
-          }
-        ]
-
-        {Protocol.response(id, %{content: content, isError: true}), state}
-
-      {:error, reason} ->
-        content = [%{type: "text", text: "Error: #{inspect(reason)}"}]
-        {Protocol.response(id, %{content: content, isError: true}), state}
-    end
+    {response, state}
   end
 
   # -- Resources ---
@@ -354,6 +366,47 @@ defmodule Raxol.MCP.Server do
       {:error, _} -> {inspect(data, pretty: true), "text/plain"}
     end
   end
+
+  defp call_tool_response(id, name, result) do
+    case result do
+      {:ok, result} ->
+        Protocol.response(id, %{content: normalize_content(result)})
+
+      {:error, :tool_not_found} ->
+        Protocol.error_response(id, Protocol.method_not_found(), "Tool not found: #{name}")
+
+      {:error, :circuit_open} ->
+        content = [
+          %{
+            type: "text",
+            text: "Tool temporarily unavailable (circuit open after repeated failures)"
+          }
+        ]
+
+        Protocol.response(id, %{content: content, isError: true})
+
+      {:error, reason} ->
+        content = [%{type: "text", text: "Error: #{inspect(reason)}"}]
+        Protocol.response(id, %{content: content, isError: true})
+    end
+  end
+
+  # A denied tool call returns a machine-readable error result the agent can act
+  # on (learn the tool is gated) instead of a silent failure or a retry loop.
+  defp authorization_required(id, tool, decision, detail) do
+    payload = %{
+      "error" => "authorization_required",
+      "tool" => tool,
+      "decision" => Atom.to_string(decision),
+      "detail" => authz_detail(detail)
+    }
+
+    content = [%{type: "text", text: Jason.encode!(payload)}]
+    Protocol.response(id, %{content: content, isError: true})
+  end
+
+  defp authz_detail(detail) when is_binary(detail), do: detail
+  defp authz_detail(detail), do: inspect(detail)
 
   defp normalize_content(result) when is_list(result), do: result
   defp normalize_content(text) when is_binary(text), do: [%{type: "text", text: text}]

--- a/packages/raxol_mcp/lib/raxol/mcp/transport/sse.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/transport/sse.ex
@@ -22,14 +22,26 @@ if Code.ensure_loaded?(Plug.Router) do
     use Plug.Router
     require Logger
 
-    alias Raxol.MCP.{Protocol, Server}
+    alias Raxol.MCP.{Deployment, Protocol, Server}
 
     plug(:match)
     plug(Plug.Parsers, parsers: [:json], json_decoder: Jason)
     plug(:dispatch)
 
+    # SSE exposes tools over the network, so unlike stdio it fails closed: outside
+    # dev/test it refuses to boot unless the server it fronts has an authorizer
+    # configured. Override with `config :raxol_mcp, require_authorization: false`.
     @doc false
-    def init(opts), do: opts
+    def init(opts) do
+      server = Keyword.get(opts, :server, Server)
+
+      Deployment.enforce_authorization!(
+        Server.authorization_configured?(server),
+        "MCP SSE transport"
+      )
+
+      opts
+    end
 
     post "/mcp" do
       server = conn.private[:mcp_server] || Server
@@ -64,7 +76,10 @@ if Code.ensure_loaded?(Plug.Router) do
         rescue
           e ->
             Logger.error("[MCP.SSE] Error handling message: #{Exception.message(e)}")
-            error = Protocol.error_response(nil, Protocol.internal_error(), "Internal server error")
+
+            error =
+              Protocol.error_response(nil, Protocol.internal_error(), "Internal server error")
+
             json = Jason.encode!(error)
 
             conn

--- a/packages/raxol_mcp/test/raxol/mcp/authorizer_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/authorizer_test.exs
@@ -1,0 +1,152 @@
+defmodule Raxol.MCP.AuthorizerTest do
+  # async: false -- the Deployment tests mutate the global :raxol_mcp app env.
+  use ExUnit.Case, async: false
+
+  alias Raxol.MCP.{Authorizer, Deployment, Registry, Server}
+
+  defp add_tool do
+    %{
+      name: "add",
+      description: "Add numbers",
+      inputSchema: %{type: "object"},
+      callback: fn args ->
+        {:ok, [%{type: "text", text: "#{Map.get(args, "a", 0) + Map.get(args, "b", 0)}"}]}
+      end
+    }
+  end
+
+  defp start_server(authorizer, tools \\ nil) do
+    tools = tools || [add_tool()]
+    reg = :"reg_#{System.unique_integer([:positive])}"
+    srv = :"srv_#{System.unique_integer([:positive])}"
+    {:ok, _} = Registry.start_link(name: reg)
+    Registry.register_tools(reg, tools)
+    {:ok, _} = Server.start_link(name: srv, registry: reg, authorizer: authorizer)
+    srv
+  end
+
+  defp call(srv, name \\ "add") do
+    msg = %{
+      id: 1,
+      method: "tools/call",
+      params: %{"name" => name, "arguments" => %{"a" => 2, "b" => 3}}
+    }
+
+    {:reply, resp} = Server.handle_message(srv, msg)
+    resp
+  end
+
+  defp payload(resp) do
+    resp.result.content |> hd() |> Map.fetch!(:text) |> Jason.decode!()
+  end
+
+  describe "Authorizer builders" do
+    test "allow_all, deny_all, allowlist, and nil->allow" do
+      assert :allow = Authorizer.decide(Authorizer.allow_all(), "x", %{}, %{})
+      assert {:deny, :nope} = Authorizer.decide(Authorizer.deny_all(:nope), "x", %{}, %{})
+
+      allow = Authorizer.allowlist(["ok"])
+      assert :allow = Authorizer.decide(allow, "ok", %{}, %{})
+      assert {:deny, :not_allowlisted} = Authorizer.decide(allow, "no", %{}, %{})
+
+      # nil authorizer allows -- stdio inherits the OS process boundary.
+      assert :allow = Authorizer.decide(nil, "anything", %{}, %{})
+    end
+  end
+
+  describe "tools/call authorization" do
+    test "no authorizer allows the tool to run (default)" do
+      resp = call(start_server(nil))
+      assert resp.result.content == [%{type: "text", text: "5"}]
+      refute resp.result[:isError]
+    end
+
+    test "allow_all runs the tool" do
+      resp = call(start_server(Authorizer.allow_all()))
+      assert resp.result.content == [%{type: "text", text: "5"}]
+    end
+
+    test "deny returns a machine-readable authorization_required result, not the tool output" do
+      resp = call(start_server(Authorizer.deny_all(:blocked)))
+      assert resp.result.isError == true
+      p = payload(resp)
+      assert p["error"] == "authorization_required"
+      assert p["tool"] == "add"
+      assert p["decision"] == "deny"
+      assert p["detail"] == ":blocked"
+    end
+
+    test "ASK is denied here (deny-on-ASK), surfacing decision=ask and the prompt as detail" do
+      ask = fn _tool, _args, _ctx -> {:ask, "Approve add?"} end
+      resp = call(start_server(ask))
+      assert resp.result.isError == true
+      p = payload(resp)
+      assert p["error"] == "authorization_required"
+      assert p["decision"] == "ask"
+      assert p["detail"] == "Approve add?"
+    end
+
+    test "allowlist blocks tools not on the list" do
+      resp = call(start_server(Authorizer.allowlist(["something_else"])))
+      assert resp.result.isError == true
+      assert payload(resp)["decision"] == "deny"
+    end
+
+    test "a denied call never reaches the tool callback" do
+      test = self()
+
+      spy = %{
+        name: "spy",
+        description: "records if it ran",
+        inputSchema: %{type: "object"},
+        callback: fn _args ->
+          send(test, :callback_ran)
+          {:ok, "x"}
+        end
+      }
+
+      srv = start_server(Authorizer.deny_all(), [spy])
+      call(srv, "spy")
+      refute_received :callback_ran
+    end
+  end
+
+  describe "authorization_configured?/1" do
+    test "reflects whether an authorizer is set" do
+      assert Server.authorization_configured?(start_server(Authorizer.allow_all()))
+      refute Server.authorization_configured?(start_server(nil))
+    end
+
+    test "returns false for an unreachable server" do
+      refute Server.authorization_configured?(:no_such_server)
+    end
+  end
+
+  describe "Deployment gate" do
+    setup do
+      on_exit(fn -> Application.delete_env(:raxol_mcp, :require_authorization) end)
+    end
+
+    test "require_authorization? defaults to false in test and honors the override" do
+      refute Deployment.require_authorization?()
+      Application.put_env(:raxol_mcp, :require_authorization, true)
+      assert Deployment.require_authorization?()
+    end
+
+    test "enforce_authorization! is a no-op when configured or not required" do
+      assert :ok = Deployment.enforce_authorization!(true, "x")
+      assert :ok = Deployment.enforce_authorization!(false, "x")
+    end
+
+    test "enforce_authorization! fails closed when required and no authorizer is configured" do
+      Application.put_env(:raxol_mcp, :require_authorization, true)
+
+      assert_raise ArgumentError, ~r/refuses to boot/, fn ->
+        Deployment.enforce_authorization!(false, "MCP SSE transport")
+      end
+
+      # ...but a configured authorizer boots even when required.
+      assert :ok = Deployment.enforce_authorization!(true, "MCP SSE transport")
+    end
+  end
+end


### PR DESCRIPTION
`tools/call` ran any registered tool with no authorization check. This adds the enforcement point Fable called for — one policy engine, two enforcement points — without `raxol_mcp` depending on `raxol_agent` (which would be a dependency cycle).

## The seam (`Raxol.MCP.Authorizer`)
An authorizer is an injected `(tool, arguments, context) -> :allow | {:ask, prompt} | {:deny, reason}` function, evaluated in `Server`'s `tools/call` dispatch **before** the tool runs. The richer ALLOW/ASK/DENY logic (`Raxol.Agent.Authorization.Engine`, already pure) plugs in upstream as a closure, so engine and enforcement share one vocabulary. Ships `allow_all` / `deny_all` / `allowlist` builders (allowlist = the exposure mode alongside `mcp_exclude`).

## Behaviour
- **nil authorizer → allow**: a stdio transport already inherits the OS process boundary.
- **deny-on-ASK**: `tools/call` has no interactive channel, so `{:ask, _}` is denied here with a **machine-readable** `authorization_required` result (`error`/`tool`/`decision`/`detail`) the agent can learn from instead of retry-looping. A client that advertises **elicitation** can upgrade this later — clean follow-up, not a blocker.
- **`{:deny, _}` → same structured error**, never reaching the tool callback (tested).
- **SSE fails closed** (`Raxol.MCP.Deployment`): the transport's `init/1` refuses to boot outside dev/test unless the fronted server has an authorizer configured. Mirrors the payments `require_policy` pattern; override with `config :raxol_mcp, require_authorization: false`.

## Not in this slice (follow-ups)
- Wiring the raxol_agent Engine as the concrete authorizer (the closure adapter, on the raxol_agent side).
- MCP elicitation for a real ASK prompt.
- Boot-time refusal to register a spend/mutating-financial tool with no authorizer (needs a tool-annotation design; deferred).

## Manual testing
- [x] `mix test` raxol_mcp: **314 passed** (12 new: allow/deny/ask/allowlist, denied call never hits the callback, `authorization_configured?`, the deployment fail-closed gate)
- [x] `mix compile --warnings-as-errors` clean; `mix format` clean