### PR TITLE
Wire the authz engine into the MCP seam

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/authorization/mcp_authorizer.ex
+++ b/packages/raxol_agent/lib/raxol/agent/authorization/mcp_authorizer.ex
@@ -1,0 +1,70 @@
+defmodule Raxol.Agent.Authorization.McpAuthorizer do
+  @moduledoc """
+  Adapts the ALLOW/ASK/DENY `Raxol.Agent.Authorization.Engine` into an MCP
+  `tools/call` authorizer -- the closure `Raxol.MCP.Server` evaluates before a
+  tool runs.
+
+  This is the "one engine, two enforcement points" wiring: the same policy engine
+  that gates `raxol.code`'s tool calls now gates the MCP surface, and it does so
+  from the `raxol_agent` side, so `raxol_mcp` never has to depend on `raxol_agent`
+  (which would be a dependency cycle). The MCP server owns only the seam; this
+  fills it with the real engine.
+
+  ## Usage
+
+      policies = [%Raxol.Agent.Authorization.Policy{...}, ...]
+      Raxol.MCP.Server.start_link(authorizer: McpAuthorizer.build(policies))
+
+  Each call is evaluated at the `:tool_call` phase with a context of
+  `%{tool: name, arguments: args}` merged over any static `:context`. The Engine
+  `Decision` maps to the MCP vocabulary:
+
+    * `:allow` -> `:allow`
+    * `:deny`  -> `{:deny, reason}`
+    * `:ask`   -> `{:ask, prompt}` -- MCP `tools/call` has no interactive channel,
+      so `Raxol.MCP.Server` turns this into a machine-readable deny-on-ASK. When a
+      client advertises elicitation, the same prompt drives a real approval.
+
+  Stateless by default: a fresh `Engine.State` per call, so approvals are not
+  remembered across MCP requests (deny-on-ASK needs no approval memory). Pass a
+  shared `:state` if you later wire an approval path.
+  """
+
+  alias Raxol.Agent.Authorization.{Engine, Policy}
+
+  @type decision :: :allow | {:ask, String.t()} | {:deny, term()}
+  @typedoc "The 3-arity closure `Raxol.MCP.Server` expects as its `:authorizer`."
+  @type authorizer :: (String.t(), map(), map() -> decision())
+
+  @doc """
+  Build an MCP authorizer closure backed by `policies`.
+
+  Options:
+
+    * `:context` -- a static map merged under the per-call `%{tool:, arguments:}`.
+    * `:state` -- a shared `Engine.State`; defaults to a fresh, empty one per call.
+  """
+  @spec build([Policy.t()], keyword()) :: authorizer()
+  def build(policies, opts \\ []) when is_list(policies) do
+    base = Keyword.get(opts, :context, %{})
+    state = Keyword.get(opts, :state, %Engine.State{})
+
+    fn tool, arguments, ctx ->
+      context =
+        base
+        |> Map.merge(ctx)
+        |> Map.merge(%{tool: tool, arguments: arguments})
+
+      policies
+      |> Engine.evaluate(:tool_call, context, state)
+      |> to_decision()
+    end
+  end
+
+  defp to_decision(%Engine.Decision{action: :allow}), do: :allow
+  defp to_decision(%Engine.Decision{action: :deny, reason: reason}), do: {:deny, reason}
+  defp to_decision(%Engine.Decision{action: :ask} = decision), do: {:ask, prompt(decision)}
+
+  defp prompt(%Engine.Decision{asks: [%{prompt: p} | _]}) when is_binary(p), do: p
+  defp prompt(_decision), do: "Approval required"
+end

--- a/packages/raxol_agent/test/raxol/agent/authorization/mcp_authorizer_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/authorization/mcp_authorizer_test.exs
@@ -1,0 +1,79 @@
+defmodule Raxol.Agent.Authorization.McpAuthorizerTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Authorization.{McpAuthorizer, Policy, Verdict}
+
+  # A policy that gates by tool name, exercising all three Engine actions.
+  defp gate do
+    Policy.new(
+      name: :gate,
+      phases: [:tool_call],
+      evaluate: fn ctx ->
+        case ctx.tool do
+          "danger" -> Verdict.deny(:mutating_financial)
+          "review" -> Verdict.ask("Approve #{ctx.tool}?")
+          _ -> Verdict.allow()
+        end
+      end
+    )
+  end
+
+  test "maps Engine allow/deny/ask to the MCP decision vocabulary" do
+    auth = McpAuthorizer.build([gate()])
+
+    assert :allow = auth.("safe_read", %{}, %{})
+    assert {:deny, :mutating_financial} = auth.("danger", %{}, %{})
+    assert {:ask, "Approve review?"} = auth.("review", %{}, %{})
+  end
+
+  test "no policies allow (the engine's default), matching a nil MCP authorizer" do
+    auth = McpAuthorizer.build([])
+    assert :allow = auth.("anything", %{"x" => 1}, %{})
+  end
+
+  test "threads tool, arguments, static context, and per-call context into the policy" do
+    test = self()
+
+    spy =
+      Policy.new(
+        name: :spy,
+        phases: [:tool_call],
+        evaluate: fn ctx ->
+          send(test, {:ctx, ctx})
+          Verdict.allow()
+        end
+      )
+
+    auth = McpAuthorizer.build([spy], context: %{env: :test})
+    auth.("greet", %{"name" => "ada"}, %{transport: :sse})
+
+    assert_received {:ctx, ctx}
+    assert ctx.tool == "greet"
+    assert ctx.arguments == %{"name" => "ada"}
+    assert ctx.env == :test
+    assert ctx.transport == :sse
+  end
+
+  test "per-call context does not override the authoritative tool/arguments" do
+    test = self()
+
+    spy =
+      Policy.new(
+        name: :spy,
+        phases: [:tool_call],
+        evaluate: fn ctx ->
+          send(test, {:ctx, ctx})
+          Verdict.allow()
+        end
+      )
+
+    # A client that tries to spoof `tool` in the extra context must not win.
+    McpAuthorizer.build([spy]).("real", %{"a" => 1}, %{tool: "spoofed"})
+    assert_received {:ctx, ctx}
+    assert ctx.tool == "real"
+  end
+
+  test "produces a 3-arity closure (the shape Raxol.MCP.Server expects)" do
+    assert is_function(McpAuthorizer.build([]), 3)
+  end
+end


### PR DESCRIPTION
Follow-up to #784. #784 added the MCP `tools/call` authorization *seam*; this fills it with the real engine, completing Fable's "one engine, two enforcement points."

`Raxol.Agent.Authorization.McpAuthorizer.build/2` adapts the ALLOW/ASK/DENY `Raxol.Agent.Authorization.Engine` (already gating `raxol.code`) into the closure `Raxol.MCP.Server` takes as `:authorizer`:

```elixir
Raxol.MCP.Server.start_link(authorizer: McpAuthorizer.build(policies))
```

- Lives on the **raxol_agent** side, so `raxol_mcp` never depends on `raxol_agent` (no cycle). The adapter references only the Engine — no compile coupling to #784's seam, so the two PRs merge in any order and compose on master.
- Evaluates each call at the `:tool_call` phase with `%{tool: name, arguments: args}` merged over a static `:context`; the authoritative `tool`/`arguments` can't be spoofed by per-call context (tested).
- Maps `%Decision{}` → MCP vocabulary: `:allow` → `:allow`, `:deny` → `{:deny, reason}`, `:ask` → `{:ask, prompt}` (which #784 turns into machine-readable deny-on-ASK; the same prompt drives elicitation once a client advertises it).
- Stateless per call by default (deny-on-ASK needs no approval memory); pass `:state` to share one.

## Manual testing
- [x] `mix test` (raxol_agent, local gate): **5 passed** — allow/deny/ask mapping, empty-policy allow, context threading, tool/arguments not spoofable, 3-arity closure shape
- [x] compiles clean; `mix format` clean

Pairs with #784; together the same policy engine gates both `raxol.code` and the MCP surface.