### PR TITLE
Add T-Bench termios-restore launcher for raxol-p

### DIFF
--- a/packages/raxol_cli/tbench/launch.sh
+++ b/packages/raxol_cli/tbench/launch.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Terminal-Bench launcher for the headless raxol-p Burrito binary.
+#
+# The harness drives raxol-p inside a tmux PTY. If the BEAM child leaves the tty
+# in raw mode -- or dies abnormally mid-run (crash, SIGSEGV, kill) -- the pane is
+# wedged for every later command in that task, silently failing the run. Snapshot
+# the tty here and restore it unconditionally when the child exits, for any cause.
+#
+# This restore lives in the parent shell, so it survives a child SIGSEGV that no
+# in-VM handler could reach. It cannot cover this launcher itself being SIGKILL'd
+# (uncatchable) -- nothing in the same process can.
+#
+# The T-Bench adapter's install step points the agent command at this script
+# instead of the raw binary. Override the binary with RAXOL_P_BIN.
+set -u
+
+readonly BIN="${RAXOL_P_BIN:-raxol-p}"
+
+# `stty -g` prints all settings as a single token (portable Linux/BSD); read the
+# controlling terminal directly so a redirected stdin doesn't hide it. Empty when
+# there is no tty (piped/CI) -- then restore is a no-op and the child runs plain.
+saved=""
+if [[ -r /dev/tty ]]; then
+  saved="$(stty -g </dev/tty 2>/dev/null || true)"
+fi
+
+# shellcheck disable=SC2329  # invoked indirectly via the traps below
+restore() {
+  [[ -n "$saved" ]] && stty "$saved" </dev/tty 2>/dev/null || true
+}
+
+# EXIT covers the child returning (any status); the signal traps cover this
+# launcher being interrupted while the child runs. restore is idempotent.
+trap restore EXIT
+trap 'restore; exit 130' INT
+trap 'restore; exit 143' TERM
+trap 'restore; exit 129' HUP
+
+status=0
+"$BIN" "$@" || status=$?
+exit "$status"


### PR DESCRIPTION
Follow-up to #783 for the Terminal-Bench adapter path. #783 gave the interactive npm launchers a `stty -g` save/restore; the T-Bench harness drives a *different* entry point — the headless `raxol-p` Burrito binary — inside a tmux PTY. If the BEAM child leaves the tty raw or dies abnormally (crash, SIGSEGV, kill) mid-run, the pane is wedged for every later command in the task, silently failing it. Fable's "one artifact that unblocks the adapter."

## `packages/raxol_cli/tbench/launch.sh`
Snapshots `stty -g` (via `/dev/tty`), runs the binary (`RAXOL_P_BIN` override, default `raxol-p`), and restores **unconditionally on child exit for any cause** — `trap restore EXIT` plus `INT`/`TERM`/`HUP` traps, idempotent — then propagates the child's exit status. The restore lives in the parent shell, so it survives a child **SIGSEGV** (can't cover the launcher itself being `SIGKILL`'d). No tty (piped/CI) → a clean no-op pass-through.

The adapter's install step points the agent command at this wrapper instead of the raw binary.

## Verified
Under a real pty (`expect`): a fake `raxol-p` that does `stty raw` and exits 42 → after the launcher returns, `icanon` is restored (cooked mode back) **and** exit 42 is propagated. `shellcheck` clean; `bash -n` clean.

Companion to #783 (now merged). Note: the full T-Bench adapter (Harbor `AbstractInstalledAgent`, install script, `raxol-p` Burrito target) is still to be built; this lands the safety-critical wrapper first.