### PR TITLE
Harden input canary against pty timing flakes

### DIFF
--- a/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
@@ -28,6 +28,10 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   @app Path.expand("../../fixtures/input_canary_app.exs", __DIR__)
   @pkg_dir Path.expand("../../..", __DIR__)
   @gap_ms 300
+  # Settle after the reader signals ready, before the first keystroke, so its
+  # select loop is armed. Retry a few times to absorb cold-boot pty timing slop.
+  @settle_ms 250
+  @max_attempts 3
 
   test "real keystrokes decode through the live prim_tty reader" do
     driver = pty_driver()
@@ -35,28 +39,47 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     if driver == nil do
       IO.puts(:stderr, "[input canary] skipped: neither tmux nor expect on PATH")
     else
-      out = Path.join(System.tmp_dir!(), "raxol_input_canary_#{unique()}")
-
-      on_exit(fn ->
-        File.rm(out)
-        File.rm(out <> ".ready")
-      end)
-
-      drive(driver, out)
-
-      tokens =
-        case File.read(out) do
-          {:ok, body} -> body |> String.split("\n", trim: true)
-          {:error, _} -> []
-        end
+      {tokens, attempt} = drive_until(driver, @max_attempts)
 
       assert tokens == ["a", "b"], """
-      prim_tty input protocol canary FAILED on OTP #{System.otp_release()} (driver: #{driver}).
+      prim_tty input protocol canary FAILED on OTP #{System.otp_release()} (driver: #{driver}) after #{attempt} attempt(s).
       Expected two real keystrokes to decode as ["a", "b"], got #{inspect(tokens)}.
-      A red here almost always means OTP changed the prim_tty reader's private
-      message protocol or its re-arm contract -- see Raxol.Terminal.Driver's
-      `{:trace, ...}` handler and `start_stdin_reader/1`.
+      This retries #{@max_attempts}x, so a transient pty/tmux timing race would have
+      passed on a retry -- an empty [] after all attempts is a REAL failure. It
+      almost always means OTP changed the prim_tty reader's private message
+      protocol or its re-arm contract -- see Raxol.Terminal.Driver's `{:trace, ...}`
+      handler and `start_stdin_reader/1`.
       """
+    end
+  end
+
+  # A cold pty boot inside tmux/expect can drop the first keystroke if it lands
+  # before the reader has armed its select loop -- a timing flake, not a protocol
+  # failure. Retry the whole drive: a real OTP break fails every attempt, a race
+  # succeeds on a later one.
+  defp drive_until(driver, attempts_left, attempt \\ 1) do
+    tokens = attempt_drive(driver)
+
+    cond do
+      tokens == ["a", "b"] -> {tokens, attempt}
+      attempts_left <= 1 -> {tokens, attempt}
+      true -> drive_until(driver, attempts_left - 1, attempt + 1)
+    end
+  end
+
+  defp attempt_drive(driver) do
+    out = Path.join(System.tmp_dir!(), "raxol_input_canary_#{unique()}")
+
+    try do
+      drive(driver, out)
+
+      case File.read(out) do
+        {:ok, body} -> String.split(body, "\n", trim: true)
+        {:error, _} -> []
+      end
+    after
+      File.rm(out)
+      File.rm(out <> ".ready")
     end
   end
 
@@ -70,23 +93,30 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
 
   defp drive(:tmux, out) do
     session = "raxol-input-canary-#{unique()}"
-    on_exit(fn -> System.cmd("tmux", ["kill-session", "-t", session], stderr_to_stdout: true) end)
 
     cmd =
       "cd #{@pkg_dir} && CANARY_OUT=#{out} CANARY_N=2 MIX_ENV=test mix run --no-compile #{@app}"
 
-    {_, 0} =
-      System.cmd(
-        "tmux",
-        ["new-session", "-d", "-s", session, "-x", "80", "-y", "24", cmd],
-        stderr_to_stdout: true
-      )
+    try do
+      {_, 0} =
+        System.cmd(
+          "tmux",
+          ["new-session", "-d", "-s", session, "-x", "80", "-y", "24", cmd],
+          stderr_to_stdout: true
+        )
 
-    wait_for_ready(out)
-    {_, 0} = System.cmd("tmux", ["send-keys", "-t", session, "a"])
-    Process.sleep(@gap_ms)
-    {_, 0} = System.cmd("tmux", ["send-keys", "-t", session, "b"])
-    wait_for_output(out)
+      # Only type once the reader signalled ready, then settle briefly so its
+      # select loop is armed. `-l` sends the bytes literally (not as key names).
+      if wait_for_ready(out) == :ok do
+        Process.sleep(@settle_ms)
+        System.cmd("tmux", ["send-keys", "-t", session, "-l", "a"], stderr_to_stdout: true)
+        Process.sleep(@gap_ms)
+        System.cmd("tmux", ["send-keys", "-t", session, "-l", "b"], stderr_to_stdout: true)
+        wait_for_output(out)
+      end
+    after
+      System.cmd("tmux", ["kill-session", "-t", session], stderr_to_stdout: true)
+    end
   end
 
   defp drive(:expect, out) do
@@ -98,6 +128,7 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     spawn env CANARY_OUT=#{out} CANARY_N=2 MIX_ENV=test mix run --no-compile #{@app}
     set t 0
     while {![file exists "#{out}.ready"] && $t < 900} { after 100; incr t }
+    after #{@settle_ms}
     send "a"
     after #{@gap_ms}
     send "b"
@@ -111,7 +142,7 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   defp wait_for_ready(out), do: poll(out <> ".ready", 900)
   defp wait_for_output(out), do: poll(out, 60)
 
-  defp poll(_path, 0), do: :ok
+  defp poll(_path, 0), do: :timeout
 
   defp poll(path, tries) do
     if File.exists?(path) do


### PR DESCRIPTION
The prim_tty input canary (added in #781, per-PR gating) went **flaky**: it red on #784 with `got []` under tmux on CI, though it passed twice on #781 and reliably locally. A flaky *gating* canary reds every unrelated PR — worse than no canary.

Two root causes:
1. `poll(_, 0) -> :ok` returned success on **timeout**, so `wait_for_ready` let the drive send keystrokes even when the app never signalled ready.
2. A cold pty boot inside tmux can drop the first keystroke if it lands before the reader arms its select loop — a timing flake, not a protocol failure.

Fix:
- **Retry the drive up to 3x.** A transient race passes on a retry; a real OTP break fails every attempt deterministically — so the test still catches the thing it exists to catch (the failure message spells this out). An empty `[]` after all attempts is a real failure.
- Gate sends on a **real ready signal** (`poll` now returns `:timeout`) and **settle 250ms** before the first keystroke.
- `tmux send-keys -l` (literal bytes); per-attempt session, killed in an `after` block.

Verified locally across repeated runs. This unblocks #784/#785/#786 (all run the per-PR canary).