### PR TITLE
MCP: real elicitation for ASK, refuse unguarded sensitive tools

### DIFF
--- a/packages/raxol_mcp/lib/raxol/mcp/authorizer.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/authorizer.ex
@@ -12,11 +12,15 @@ defmodule Raxol.MCP.Authorizer do
   ## Decisions
 
     * `:allow` -- run the tool.
-    * `{:ask, prompt}` -- the action would need interactive approval. `tools/call`
-      has no interactive channel, so the server DENIES with a machine-readable
-      `authorization_required` result (deny-on-ASK). A client that advertises
-      elicitation can upgrade this to a real prompt later; that is a follow-up,
-      not part of this seam.
+    * `{:ask, prompt}` -- the action needs interactive approval. What the server
+      does with it depends on whether the client can be asked:
+      - a client that advertised the `elicitation` capability at `initialize`
+        (and has a subscribed transport) is sent a real `elicitation/create`
+        request carrying `prompt`, and the call is parked until it answers;
+      - anything else gets the machine-readable `authorization_required` result
+        (deny-on-ASK), which is also what a decline, a cancel, an error, and a
+        timeout resolve to. Only an explicit approval runs the tool.
+      See `Raxol.MCP.Server`'s "Elicitation" section.
     * `{:deny, reason}` -- refuse, machine-readably.
 
   A `nil` authorizer means allow: a stdio transport already inherits the OS

--- a/packages/raxol_mcp/lib/raxol/mcp/registry.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/registry.ex
@@ -312,8 +312,7 @@ defmodule Raxol.MCP.Registry do
   def handle_manager_call({:register_resources, resources}, _from, state) do
     for resource <- resources do
       entry =
-        {:resource, resource.uri, resource_definition(resource),
-         resource.callback}
+        {:resource, resource.uri, resource_definition(resource), resource.callback}
 
       :ets.insert(state.table, {resource_key(resource.uri), entry})
     end
@@ -356,7 +355,12 @@ defmodule Raxol.MCP.Registry do
   defp prompt_key(name), do: {:prompt, name}
 
   defp tool_definition(tool) do
-    Map.take(tool, [:name, :description, :inputSchema])
+    # `:annotations` is an MCP spec field (destructiveHint, readOnlyHint, ...)
+    # and must survive onto the listed definition: clients read the hints from
+    # `tools/list`, and `Raxol.MCP.Server`'s sensitive-tool guard reads them
+    # back from here to decide what may run unguarded. `Map.take/2` ignores an
+    # absent key, so an unannotated tool is unchanged.
+    Map.take(tool, [:name, :description, :inputSchema, :annotations])
   end
 
   defp resource_definition(resource) do

--- a/packages/raxol_mcp/lib/raxol/mcp/server.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/server.ex
@@ -24,6 +24,41 @@ defmodule Raxol.MCP.Server do
 
   The server can push notifications to connected transports. Transports
   subscribe via `subscribe/2` and receive `{:mcp_notification, map()}` messages.
+
+  ## Elicitation
+
+  When `Raxol.MCP.Authorizer` returns `{:ask, prompt}`, what happens depends on
+  whether the client can be asked. A client that advertised the `elicitation`
+  capability at `initialize` (and has a subscribed transport) is sent a real
+  `elicitation/create` request; anything else gets the machine-readable
+  `authorization_required` deny.
+
+  The shape matters, because the transport seam is synchronous. `tools/call`
+  returns `nil` **immediately** and the call is parked:
+
+      client                     server                    transport
+      tools/call  ------------->  ASK -> park, return nil ->  (unblocked)
+                 <-------------  elicitation/create (push)
+      response   ------------->  resume, return nil
+                 <-------------  tools/call response (push)
+
+  Returning `nil` is what keeps this from deadlocking: the transport's
+  `handle_message` does not block, so it stays free to READ the client's
+  answer. Both the prompt and the eventual response ride the subscriber
+  channel, so no transport change was needed.
+
+  A parked call is always closed, exactly once, by one of four paths: an
+  approval (runs the tool), a decline/cancel/unapproved accept, an error
+  response, or a timeout (`:elicitation_timeout_ms`, default 60s). Every path
+  but approval resolves to the same deny -- silence is not consent.
+
+  ## Sensitive tools
+
+  A tool annotated `destructiveHint: true` or `sensitive: true` (see
+  `Raxol.MCP.ToolDef.sensitive?/1`) must not be served without an authorizer.
+  The server REFUSES TO BOOT when one is already registered, and denies at
+  `tools/call` for one registered afterwards -- the boot check alone would be
+  bypassable by registering late.
   """
 
   use Raxol.Core.Behaviours.BaseManager
@@ -36,6 +71,12 @@ defmodule Raxol.MCP.Server do
   alias Raxol.MCP.Protocol
   alias Raxol.MCP.Registry
   alias Raxol.MCP.ResourceRouter
+  alias Raxol.MCP.ToolDef
+
+  # A client that advertises elicitation but never answers must not park a
+  # `tools/call` forever: on expiry the call is answered with the same
+  # machine-readable deny it would have received without elicitation.
+  @default_elicitation_timeout_ms 60_000
 
   defstruct [
     :registry,
@@ -43,7 +84,11 @@ defmodule Raxol.MCP.Server do
     initialized: false,
     log_level: :info,
     subscribers: [],
-    resource_subscriptions: %{}
+    resource_subscriptions: %{},
+    client_capabilities: %{},
+    pending_elicitations: %{},
+    elicitation_seq: 0,
+    elicitation_timeout_ms: @default_elicitation_timeout_ms
   ]
 
   @type t :: %__MODULE__{
@@ -53,7 +98,22 @@ defmodule Raxol.MCP.Server do
           log_level:
             :debug | :info | :notice | :warning | :error | :critical | :alert | :emergency,
           subscribers: [pid()],
-          resource_subscriptions: %{String.t() => boolean()}
+          resource_subscriptions: %{String.t() => boolean()},
+          client_capabilities: map(),
+          pending_elicitations: %{String.t() => pending_elicitation()},
+          elicitation_seq: non_neg_integer(),
+          elicitation_timeout_ms: pos_integer()
+        }
+
+  @typedoc """
+  A `tools/call` parked awaiting the client's elicitation answer. `request_id`
+  is the ORIGINAL call's id -- the one the client is still waiting on.
+  """
+  @type pending_elicitation :: %{
+          request_id: term(),
+          tool: String.t(),
+          arguments: map(),
+          timer: reference()
         }
 
   @log_levels [:debug, :info, :notice, :warning, :error, :critical, :alert, :emergency]
@@ -114,7 +174,16 @@ defmodule Raxol.MCP.Server do
   def init_manager(opts) do
     registry = Keyword.get(opts, :registry, Registry)
     authorizer = Keyword.get(opts, :authorizer)
-    {:ok, %__MODULE__{registry: registry, authorizer: authorizer}}
+
+    refuse_unguarded_sensitive_tools!(registry, authorizer)
+
+    {:ok,
+     %__MODULE__{
+       registry: registry,
+       authorizer: authorizer,
+       elicitation_timeout_ms:
+         Keyword.get(opts, :elicitation_timeout_ms, @default_elicitation_timeout_ms)
+     }}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -149,18 +218,46 @@ defmodule Raxol.MCP.Server do
     {:noreply, %{state | subscribers: List.delete(state.subscribers, pid)}}
   end
 
+  # The client advertised elicitation, was asked, and never answered. Close the
+  # parked call with the same deny it would have got had it never advertised --
+  # an unanswered prompt is not an approval.
+  def handle_manager_info({:elicitation_timeout, id}, state) do
+    case Map.fetch(state.pending_elicitations, id) do
+      {:ok, pending} ->
+        {_pending, state} = take_pending(state, id)
+
+        broadcast(
+          state.subscribers,
+          authorization_required(pending.request_id, pending.tool, :ask, "elicitation timed out")
+        )
+
+        {:noreply, state}
+
+      :error ->
+        {:noreply, state}
+    end
+  end
+
   def handle_manager_info(_msg, state), do: {:noreply, state}
 
   # -- Dispatch -----------------------------------------------------------------
 
-  defp dispatch(%{method: "initialize", id: id}, state) do
+  defp dispatch(%{method: "initialize", id: id} = msg, state) do
     result = %{
       protocolVersion: Protocol.mcp_protocol_version(),
       capabilities: capabilities(),
       serverInfo: server_info()
     }
 
-    {Protocol.response(id, result), %{state | initialized: true}}
+    # Remember what the CLIENT can do. `elicitation` is the one that changes
+    # behaviour: it is the difference between denying an ASK and asking.
+    client_capabilities =
+      msg
+      |> Map.get(:params, %{})
+      |> fetch_field("capabilities", %{})
+
+    state = %{state | initialized: true, client_capabilities: client_capabilities}
+    {Protocol.response(id, result), state}
   end
 
   defp dispatch(%{method: "notifications/initialized"}, state) do
@@ -182,22 +279,38 @@ defmodule Raxol.MCP.Server do
     name = Map.get(params, "name") || Map.get(params, :name, "")
     arguments = Map.get(params, "arguments") || Map.get(params, :arguments, %{})
 
-    # Authorize before the tool runs. A nil authorizer allows (stdio inherits the
-    # OS boundary); ASK is denied here because tools/call has no interactive
-    # channel (deny-on-ASK) -- elicitation is a follow-up.
-    response =
-      case Authorizer.decide(state.authorizer, name, arguments, %{}) do
-        :allow ->
-          call_tool_response(id, name, Registry.call_tool(state.registry, name, arguments))
+    # A sensitive tool with no authorizer never runs, whatever the transport.
+    # The boot check catches this for tools present at start; this catches one
+    # registered afterwards, which would otherwise slip past it.
+    if state.authorizer == nil and sensitive_tool?(state.registry, name) do
+      {authorization_required(id, name, :deny, :sensitive_tool_unguarded), state}
+    else
+      authorize_and_call(id, name, arguments, state)
+    end
+  end
 
-        {:ask, prompt} ->
-          authorization_required(id, name, :ask, prompt)
+  # The client's answer to an `elicitation/create` we sent. It arrives as an
+  # ordinary inbound message, so it is dispatched like one -- but it is a
+  # RESPONSE (id + result, no method), and it resumes a `tools/call` that is
+  # still parked. Placed above the catch-all; an id we did not mint falls
+  # through to it and is ignored.
+  defp dispatch(%{id: id, result: result}, state)
+       when is_map_key(state.pending_elicitations, id) do
+    {pending, state} = take_pending(state, id)
+    Process.cancel_timer(pending.timer)
+    {nil, answer_parked(state, resume(pending, result, state))}
+  end
 
-        {:deny, reason} ->
-          authorization_required(id, name, :deny, reason)
-      end
+  # An error response to our elicitation is a refusal, not a crash.
+  defp dispatch(%{id: id, error: _}, state) when is_map_key(state.pending_elicitations, id) do
+    {pending, state} = take_pending(state, id)
+    Process.cancel_timer(pending.timer)
 
-    {response, state}
+    {nil,
+     answer_parked(
+       state,
+       authorization_required(pending.request_id, pending.tool, :ask, "elicitation failed")
+     )}
   end
 
   # -- Resources ---
@@ -333,6 +446,15 @@ defmodule Raxol.MCP.Server do
     {error, state}
   end
 
+  # An inbound RESPONSE (id + result/error, no method) whose id we did not mint:
+  # a late answer to an elicitation that already timed out, or a stray. JSON-RPC
+  # says ignore it. Answering "Missing method" would bounce an error response AT
+  # a response, which a strict peer can answer in turn -- a loop. Must sit above
+  # the malformed-message clause, which would otherwise claim it.
+  defp dispatch(msg, state) when is_map_key(msg, :result) or is_map_key(msg, :error) do
+    {nil, state}
+  end
+
   # Malformed message
   defp dispatch(%{id: id}, state) do
     error = Protocol.error_response(id, Protocol.invalid_request(), "Missing method")
@@ -411,6 +533,177 @@ defmodule Raxol.MCP.Server do
   defp normalize_content(result) when is_list(result), do: result
   defp normalize_content(text) when is_binary(text), do: [%{type: "text", text: text}]
   defp normalize_content(other), do: [%{type: "text", text: inspect(other, pretty: true)}]
+
+  # -- Sensitive-tool guard -----------------------------------------------------
+
+  defp authorize_and_call(id, name, arguments, state) do
+    # Authorize before the tool runs. A nil authorizer allows (stdio inherits
+    # the OS boundary).
+    case Authorizer.decide(state.authorizer, name, arguments, %{}) do
+      :allow ->
+        {call_tool_response(id, name, Registry.call_tool(state.registry, name, arguments)), state}
+
+      {:ask, prompt} ->
+        ask(id, name, arguments, prompt, state)
+
+      {:deny, reason} ->
+        {authorization_required(id, name, :deny, reason), state}
+    end
+  end
+
+  # Registering a tool that declares itself destructive/sensitive while no
+  # authorizer is configured is a REFUSAL, not a warning: the whole point of the
+  # annotation is that this tool must not run unattended, and booting anyway
+  # would serve it wide open. The fix is one line at the call site -- pass an
+  # authorizer (`Raxol.MCP.Authorizer.allow_all/0` if that is genuinely what you
+  # want, which is at least then visible in the code).
+  defp refuse_unguarded_sensitive_tools!(_registry, authorizer) when authorizer != nil, do: :ok
+
+  defp refuse_unguarded_sensitive_tools!(registry, _authorizer) do
+    case sensitive_tool_names(registry) do
+      [] ->
+        :ok
+
+      names ->
+        raise ArgumentError,
+              "Raxol.MCP.Server refuses to boot: #{length(names)} tool(s) are annotated " <>
+                "sensitive/destructive but no :authorizer is configured -- " <>
+                "#{Enum.join(names, ", ")}. Pass an authorizer to start_link/1 " <>
+                "(Raxol.MCP.Authorizer.allow_all/0 opts out, explicitly)."
+    end
+  end
+
+  defp sensitive_tool_names(registry) do
+    registry
+    |> Registry.list_tools()
+    |> Enum.filter(&ToolDef.sensitive?/1)
+    |> Enum.map(&(Map.get(&1, :name) || Map.get(&1, "name")))
+  catch
+    # A registry that is not up yet cannot be scanned. Absence of evidence is
+    # not evidence of absence, but refusing to boot on it would make the server
+    # un-startable in every registry-after-server tree -- the runtime backstop
+    # in tools/call is what actually holds the line there.
+    :exit, _ -> []
+  end
+
+  defp sensitive_tool?(registry, name) do
+    registry
+    |> Registry.list_tools()
+    |> Enum.any?(fn tool ->
+      (Map.get(tool, :name) || Map.get(tool, "name")) == name and ToolDef.sensitive?(tool)
+    end)
+  catch
+    :exit, _ -> false
+  end
+
+  # -- Elicitation --------------------------------------------------------------
+
+  # An ASK with no way to ask is a deny. Elicitation needs BOTH a client that
+  # advertised the capability AND a transport subscribed to carry the request --
+  # without a subscriber the prompt would go nowhere and the call would park
+  # until it timed out, which is strictly worse than answering now.
+  defp ask(id, tool, arguments, prompt, state) do
+    if elicitation_capable?(state) do
+      start_elicitation(id, tool, arguments, prompt, state)
+    else
+      {authorization_required(id, tool, :ask, prompt), state}
+    end
+  end
+
+  defp elicitation_capable?(state) do
+    state.subscribers != [] and
+      fetch_field(state.client_capabilities, "elicitation", nil) != nil
+  end
+
+  # Park the call and ask. Returning `nil` is what makes this safe on a
+  # synchronous transport: the transport's `handle_message` returns immediately
+  # instead of blocking, so it stays free to READ the client's answer. Both the
+  # prompt and the eventual response go out over the subscriber channel.
+  defp start_elicitation(request_id, tool, arguments, prompt, state) do
+    seq = state.elicitation_seq + 1
+    elicit_id = "raxol-elicit-#{seq}"
+
+    timer =
+      Process.send_after(self(), {:elicitation_timeout, elicit_id}, state.elicitation_timeout_ms)
+
+    pending = %{request_id: request_id, tool: tool, arguments: arguments, timer: timer}
+
+    state = %{
+      state
+      | elicitation_seq: seq,
+        pending_elicitations: Map.put(state.pending_elicitations, elicit_id, pending)
+    }
+
+    broadcast(state.subscribers, elicitation_request(elicit_id, tool, prompt))
+    {nil, state}
+  end
+
+  # A server-initiated id lives in the SERVER's id space; a string prefix keeps
+  # it from ever colliding with a client's integer request ids.
+  defp elicitation_request(elicit_id, tool, prompt) do
+    Protocol.request(elicit_id, "elicitation/create", %{
+      message: prompt,
+      requestedSchema: %{
+        type: "object",
+        properties: %{
+          approve: %{
+            type: "boolean",
+            description: "Approve running the #{tool} tool"
+          }
+        },
+        required: ["approve"]
+      }
+    })
+  end
+
+  # The parked call is answered by PUSH, never as the reply to the message that
+  # unparked it: what arrived was a JSON-RPC *response*, and a response never
+  # gets a reply. This also makes all three resolutions -- answered, errored,
+  # timed out -- take one identical path out.
+  defp answer_parked(state, response) do
+    broadcast(state.subscribers, response)
+    state
+  end
+
+  defp take_pending(state, id) do
+    {pending, rest} = Map.pop(state.pending_elicitations, id)
+    {pending, %{state | pending_elicitations: rest}}
+  end
+
+  # Only an explicit accept-with-approval runs the tool. Decline, cancel, a
+  # missing action, and accept-without-approval all fail closed -- the same
+  # direction absence takes everywhere else in this seam.
+  defp resume(pending, result, state) do
+    action = fetch_field(result, "action", nil)
+    content = fetch_field(result, "content", %{})
+
+    if action == "accept" and fetch_field(content, "approve", false) == true do
+      call_tool_response(
+        pending.request_id,
+        pending.tool,
+        Registry.call_tool(state.registry, pending.tool, pending.arguments)
+      )
+    else
+      authorization_required(
+        pending.request_id,
+        pending.tool,
+        :ask,
+        "user #{action || "declined"}"
+      )
+    end
+  end
+
+  # Decoded wire maps carry atom keys; hand-built ones may carry strings.
+  defp fetch_field(map, key, default) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, String.to_existing_atom(key), default)
+    end
+  rescue
+    ArgumentError -> default
+  end
+
+  defp fetch_field(_map, _key, default), do: default
 
   defp broadcast(subscribers, notification) do
     for pid <- subscribers, Process.alive?(pid) do

--- a/packages/raxol_mcp/lib/raxol/mcp/tool_def.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/tool_def.ex
@@ -58,6 +58,7 @@ defmodule Raxol.MCP.ToolDef do
     description = Keyword.get(opts, :description)
     callback = Keyword.get(opts, :callback)
     schema = Keyword.get(opts, :input_schema) || Keyword.get(opts, :inputSchema)
+    annotations = Keyword.get(opts, :annotations)
 
     errors =
       []
@@ -69,13 +70,14 @@ defmodule Raxol.MCP.ToolDef do
 
     case errors do
       [] ->
-        {:ok,
-         %{
-           name: name,
-           description: description,
-           inputSchema: schema,
-           callback: callback
-         }}
+        tool = %{
+          name: name,
+          description: description,
+          inputSchema: schema,
+          callback: callback
+        }
+
+        {:ok, put_annotations(tool, annotations)}
 
       errors ->
         {:error, errors}
@@ -162,4 +164,39 @@ defmodule Raxol.MCP.ToolDef do
   end
 
   defp validate_schema(errors, _), do: [:missing_input_schema | errors]
+
+  @doc """
+  Whether `tool` declares itself sensitive -- destructive, or otherwise
+  something that must not run unattended (moving money is the motivating case).
+
+  Recognized, any of which is enough:
+
+    * `annotations.destructiveHint == true` -- the MCP-standard hint;
+    * `annotations.sensitive == true` -- for a tool that is not destructive in
+      the MCP sense but still must be gated.
+
+  This predicate is deliberately **one-directional: an annotation can only ever
+  ADD an obligation, never remove one.** A tool claiming `destructiveHint:
+  false` or `readOnlyHint: true` gets no exemption from anything -- it is a
+  self-report, and the harness already rules elsewhere (U21-R3) that a
+  self-reported `mutating: false` cannot remove a call from the mutation set.
+  Declaring yourself dangerous is credible; declaring yourself safe is not.
+  """
+  @spec sensitive?(map()) :: boolean()
+  def sensitive?(%{} = tool) do
+    annotations = Map.get(tool, :annotations) || Map.get(tool, "annotations") || %{}
+
+    flag(annotations, :destructiveHint) or flag(annotations, :sensitive)
+  end
+
+  def sensitive?(_), do: false
+
+  defp flag(annotations, key) when is_map(annotations) do
+    (Map.get(annotations, key) || Map.get(annotations, Atom.to_string(key))) == true
+  end
+
+  defp flag(_annotations, _key), do: false
+
+  defp put_annotations(tool, nil), do: tool
+  defp put_annotations(tool, annotations), do: Map.put(tool, :annotations, annotations)
 end

--- a/packages/raxol_mcp/test/raxol/mcp/elicitation_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/elicitation_test.exs
@@ -1,0 +1,216 @@
+defmodule Raxol.MCP.ElicitationTest do
+  @moduledoc """
+  The ASK path: when a client advertises the `elicitation` capability at
+  `initialize`, an authorizer's `{:ask, prompt}` becomes a real MCP
+  `elicitation/create` round trip instead of the machine-readable deny.
+
+  The interesting property is not the happy path but the shape that makes it
+  safe on a synchronous transport: `tools/call` returns `nil` immediately, so
+  the transport never blocks and stays free to read the client's answer. Both
+  the prompt and the eventual response ride the subscriber channel.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.MCP.Registry
+  alias Raxol.MCP.Server
+
+  @elicit_id "raxol-elicit-1"
+
+  setup do
+    registry = start_supervised!({Registry, name: :"reg_#{System.unique_integer([:positive])}"})
+
+    :ok =
+      Registry.register_tools(registry, [
+        %{
+          name: "spend",
+          description: "move money",
+          inputSchema: %{type: "object"},
+          callback: fn args -> {:ok, "spent #{Map.get(args, "amount", 0)}"} end
+        }
+      ])
+
+    ask = fn _tool, _args, _ctx -> {:ask, "Approve moving money?"} end
+
+    server =
+      start_supervised!(
+        {Server,
+         name: :"srv_#{System.unique_integer([:positive])}",
+         registry: registry,
+         authorizer: ask,
+         elicitation_timeout_ms: 200}
+      )
+
+    {:ok, server: server, registry: registry}
+  end
+
+  defp initialize(server, capabilities) do
+    {:reply, _} =
+      Server.handle_message(server, %{
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: %{capabilities: capabilities}
+      })
+
+    :ok
+  end
+
+  defp call_spend(server, id \\ 2) do
+    Server.handle_message(server, %{
+      jsonrpc: "2.0",
+      id: id,
+      method: "tools/call",
+      params: %{"name" => "spend", "arguments" => %{"amount" => 5}}
+    })
+  end
+
+  defp answer(server, result, id \\ @elicit_id) do
+    Server.handle_message(server, %{jsonrpc: "2.0", id: id, result: result})
+  end
+
+  defp decoded_payload(%{result: %{content: [%{text: text} | _]}}), do: Jason.decode!(text)
+
+  describe "capability gating" do
+    test "a client that does not advertise elicitation still gets deny-on-ASK", %{server: server} do
+      :ok = initialize(server, %{})
+      Server.subscribe(server, self())
+
+      assert {:reply, response} = call_spend(server)
+
+      assert %{"error" => "authorization_required", "decision" => "ask"} =
+               decoded_payload(response)
+
+      refute_receive {:mcp_notification, %{method: "elicitation/create"}}, 100
+    end
+
+    test "an elicitation-capable client with NO subscribed transport gets deny-on-ASK",
+         %{server: server} do
+      # Nothing could carry the prompt, so parking the call until it timed out
+      # would be strictly worse than answering now.
+      :ok = initialize(server, %{elicitation: %{}})
+
+      assert {:reply, response} = call_spend(server)
+      assert %{"decision" => "ask"} = decoded_payload(response)
+    end
+  end
+
+  describe "the round trip" do
+    setup [:elicitation_client]
+
+    test "tools/call returns nil and emits an elicitation/create request", %{server: server} do
+      # nil is what keeps a synchronous transport unblocked and able to read
+      # the answer -- the whole reason this design works without deadlocking.
+      assert {:reply, nil} = call_spend(server)
+
+      assert_receive {:mcp_notification, request}, 500
+      assert request.method == "elicitation/create"
+      assert request.id == @elicit_id
+      assert request.params.message == "Approve moving money?"
+      assert request.params.requestedSchema.required == ["approve"]
+    end
+
+    test "accept with approval runs the tool and answers the ORIGINAL call id", %{server: server} do
+      assert {:reply, nil} = call_spend(server, 42)
+      assert_receive {:mcp_notification, %{method: "elicitation/create"}}, 500
+
+      assert {:reply, nil} = answer(server, %{action: "accept", content: %{approve: true}})
+
+      assert_receive {:mcp_notification, response}, 500
+      assert response.id == 42, "the client is waiting on its own request id"
+      assert %{content: [%{text: "spent 5"} | _]} = response.result
+      refute Map.get(response.result, :isError)
+    end
+
+    for {label, result} <- [
+          {"decline", %{action: "decline"}},
+          {"cancel", %{action: "cancel"}},
+          {"accept without approval", %{action: "accept", content: %{approve: false}}},
+          {"a missing action", %{content: %{approve: true}}}
+        ] do
+      test "#{label} fails closed and never runs the tool", %{server: server} do
+        assert {:reply, nil} = call_spend(server)
+        assert_receive {:mcp_notification, %{method: "elicitation/create"}}, 500
+
+        assert {:reply, nil} = answer(server, unquote(Macro.escape(result)))
+
+        assert_receive {:mcp_notification, response}, 500
+        assert response.id == 2
+        assert %{"error" => "authorization_required"} = decoded_payload(response)
+      end
+    end
+
+    test "an error response to the prompt is a refusal, not a crash", %{server: server} do
+      assert {:reply, nil} = call_spend(server)
+      assert_receive {:mcp_notification, %{method: "elicitation/create"}}, 500
+
+      assert {:reply, nil} =
+               Server.handle_message(server, %{
+                 jsonrpc: "2.0",
+                 id: @elicit_id,
+                 error: %{code: -32_601, message: "elicitation not supported after all"}
+               })
+
+      assert_receive {:mcp_notification, response}, 500
+      assert %{"error" => "authorization_required"} = decoded_payload(response)
+      assert Process.alive?(server)
+    end
+  end
+
+  describe "liveness" do
+    setup [:elicitation_client]
+
+    test "an unanswered prompt times out into the same deny", %{server: server} do
+      assert {:reply, nil} = call_spend(server)
+      assert_receive {:mcp_notification, %{method: "elicitation/create"}}, 500
+
+      # Never answered. The parked call must still be closed -- silence is not
+      # approval, and the client must not wait forever.
+      assert_receive {:mcp_notification, response}, 2_000
+      assert response.id == 2
+      assert %{"error" => "authorization_required"} = decoded_payload(response)
+    end
+
+    test "a late answer after the timeout is ignored, not double-replied", %{server: server} do
+      assert {:reply, nil} = call_spend(server)
+      assert_receive {:mcp_notification, %{method: "elicitation/create"}}, 500
+      assert_receive {:mcp_notification, %{id: 2}}, 2_000
+
+      assert {:reply, nil} = answer(server, %{action: "accept", content: %{approve: true}})
+      refute_receive {:mcp_notification, _}, 200
+      assert Process.alive?(server)
+    end
+
+    test "an answer to an id the server never minted is ignored", %{server: server} do
+      assert {:reply, nil} =
+               answer(server, %{action: "accept", content: %{approve: true}}, "forged-id")
+
+      refute_receive {:mcp_notification, _}, 200
+      assert Process.alive?(server)
+    end
+
+    test "concurrent asks get distinct ids and resolve independently", %{server: server} do
+      assert {:reply, nil} = call_spend(server, 10)
+      assert_receive {:mcp_notification, %{id: first, method: "elicitation/create"}}, 500
+      assert {:reply, nil} = call_spend(server, 11)
+      assert_receive {:mcp_notification, %{id: second, method: "elicitation/create"}}, 500
+
+      refute first == second
+
+      assert {:reply, nil} =
+               answer(server, %{action: "accept", content: %{approve: true}}, second)
+
+      assert_receive {:mcp_notification, %{id: 11} = approved}, 500
+      assert %{content: [%{text: "spent 5"} | _]} = approved.result
+    end
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  defp elicitation_client(%{server: server}) do
+    :ok = initialize(server, %{elicitation: %{}})
+    Server.subscribe(server, self())
+    # `subscribe/2` is a cast; make sure it landed before the first ask.
+    _ = Server.authorization_configured?(server)
+    :ok
+  end
+end

--- a/packages/raxol_mcp/test/raxol/mcp/sensitive_tool_guard_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/sensitive_tool_guard_test.exs
@@ -1,0 +1,184 @@
+defmodule Raxol.MCP.SensitiveToolGuardTest do
+  @moduledoc """
+  A tool that declares itself destructive/sensitive must not be served without
+  an authorizer. That is a refusal, not a warning: the annotation exists to say
+  "this must not run unattended", and booting anyway would serve it wide open.
+
+  Enforced twice, because one point is bypassable on its own:
+
+    * at boot, loudly, for tools already registered;
+    * at `tools/call`, for a tool registered AFTER boot, which the boot check
+      cannot have seen.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.MCP.Authorizer
+  alias Raxol.MCP.Registry
+  alias Raxol.MCP.Server
+  alias Raxol.MCP.ToolDef
+
+  defp registry! do
+    start_supervised!(
+      {Registry, name: :"reg_#{System.unique_integer([:positive])}"},
+      id: {:reg, System.unique_integer([:positive])}
+    )
+  end
+
+  defp tool(name, annotations) do
+    base = %{
+      name: name,
+      description: "moves money",
+      inputSchema: %{type: "object"},
+      callback: fn _ -> {:ok, "moved"} end
+    }
+
+    if annotations, do: Map.put(base, :annotations, annotations), else: base
+  end
+
+  defp start_server(registry, opts) do
+    Server.start_link(
+      Keyword.merge(
+        [name: :"srv_#{System.unique_integer([:positive])}", registry: registry],
+        opts
+      )
+    )
+  end
+
+  describe "ToolDef.sensitive?/1" do
+    test "the MCP destructiveHint and the raxol sensitive flag both count" do
+      assert ToolDef.sensitive?(tool("t", %{destructiveHint: true}))
+      assert ToolDef.sensitive?(tool("t", %{sensitive: true}))
+      assert ToolDef.sensitive?(tool("t", %{"destructiveHint" => true}))
+    end
+
+    test "an unannotated tool is not sensitive" do
+      refute ToolDef.sensitive?(tool("t", nil))
+      refute ToolDef.sensitive?(tool("t", %{}))
+    end
+
+    test "an annotation can only ADD an obligation, never remove one" do
+      # Self-reported safety buys nothing. Declaring yourself dangerous is
+      # credible; declaring yourself safe is not (the same ruling U21-R3 makes
+      # about a self-reported `mutating: false`).
+      refute ToolDef.sensitive?(tool("t", %{destructiveHint: false}))
+      refute ToolDef.sensitive?(tool("t", %{readOnlyHint: true}))
+
+      # ...and a "safe" hint cannot cancel a dangerous one.
+      assert ToolDef.sensitive?(tool("t", %{destructiveHint: true, readOnlyHint: true}))
+      assert ToolDef.sensitive?(tool("t", %{sensitive: true, destructiveHint: false}))
+    end
+
+    test "new/2 carries annotations onto the built definition" do
+      assert {:ok, built} =
+               ToolDef.new("spend",
+                 description: "moves money",
+                 input_schema: %{type: "object"},
+                 callback: fn _ -> :ok end,
+                 annotations: %{destructiveHint: true}
+               )
+
+      assert ToolDef.sensitive?(built)
+    end
+  end
+
+  describe "boot refusal" do
+    test "a sensitive tool with no authorizer refuses to boot, naming the tool" do
+      registry = registry!()
+      :ok = Registry.register_tools(registry, [tool("spend", %{destructiveHint: true})])
+
+      # The raise happens in init/1 of a LINKED process, so it comes back as a
+      # start_link error rather than propagating into this process.
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {%ArgumentError{message: message}, _stack}} = start_server(registry, [])
+      assert message =~ "refuses to boot"
+      assert message =~ "spend"
+    end
+
+    test "the same tool boots fine once an authorizer is configured" do
+      registry = registry!()
+      :ok = Registry.register_tools(registry, [tool("spend", %{destructiveHint: true})])
+
+      assert {:ok, server} = start_server(registry, authorizer: Authorizer.allow_all())
+      assert Process.alive?(server)
+    end
+
+    test "unannotated tools boot without an authorizer" do
+      # The guard must not turn into a blanket authorizer requirement -- stdio
+      # inherits the OS process boundary, and that stays true.
+      registry = registry!()
+      :ok = Registry.register_tools(registry, [tool("read_file", nil)])
+
+      assert {:ok, server} = start_server(registry, [])
+      assert Process.alive?(server)
+    end
+  end
+
+  describe "runtime backstop" do
+    test "a sensitive tool registered AFTER boot is denied, not run" do
+      # The boot check cannot have seen this tool. Without the second
+      # enforcement point, registering late would be a clean bypass.
+      registry = registry!()
+      {:ok, server} = start_server(registry, [])
+
+      ran = :counters.new(1, [])
+
+      :ok =
+        Registry.register_tools(registry, [
+          %{
+            name: "late_spend",
+            description: "moves money",
+            inputSchema: %{type: "object"},
+            annotations: %{destructiveHint: true},
+            callback: fn _ ->
+              :counters.add(ran, 1, 1)
+              {:ok, "moved"}
+            end
+          }
+        ])
+
+      assert {:reply, response} =
+               Server.handle_message(server, %{
+                 jsonrpc: "2.0",
+                 id: 7,
+                 method: "tools/call",
+                 params: %{"name" => "late_spend", "arguments" => %{}}
+               })
+
+      assert %{result: %{content: [%{text: text} | _], isError: true}} = response
+      payload = Jason.decode!(text)
+      assert payload["error"] == "authorization_required"
+      assert payload["detail"] =~ "sensitive_tool_unguarded"
+
+      assert :counters.get(ran, 1) == 0, "the sensitive tool must never have run"
+    end
+
+    test "an unannotated tool registered after boot still runs" do
+      registry = registry!()
+      {:ok, server} = start_server(registry, [])
+      :ok = Registry.register_tools(registry, [tool("safe", nil)])
+
+      assert {:reply, %{result: %{content: [%{text: "moved"} | _]}}} =
+               Server.handle_message(server, %{
+                 jsonrpc: "2.0",
+                 id: 8,
+                 method: "tools/call",
+                 params: %{"name" => "safe", "arguments" => %{}}
+               })
+    end
+
+    test "with an authorizer, a sensitive tool runs when allowed" do
+      registry = registry!()
+      :ok = Registry.register_tools(registry, [tool("spend", %{sensitive: true})])
+      {:ok, server} = start_server(registry, authorizer: Authorizer.allow_all())
+
+      assert {:reply, %{result: %{content: [%{text: "moved"} | _]}}} =
+               Server.handle_message(server, %{
+                 jsonrpc: "2.0",
+                 id: 9,
+                 method: "tools/call",
+                 params: %{"name" => "spend", "arguments" => %{}}
+               })
+    end
+  end
+end


### PR DESCRIPTION
> **Base is `mcp-authz-deny-on-ask` (#784), not master** — this stacks on the authz seam, so the diff shown here is only the follow-up work. Merge #784 first.

Two follow-ups #784 named as deferred.

## 1. Elicitation for a real ASK

#784 denies on ASK because `tools/call` has no interactive channel. When a client advertises the `elicitation` capability at `initialize` (and a transport is subscribed), `{:ask, prompt}` now becomes a real `elicitation/create` round trip instead.

The transport seam is synchronous, so the shape is what makes this safe:

```
client                     server                    transport
tools/call  ------------->  ASK -> park, return nil ->  (unblocked)
           <-------------  elicitation/create (push)
response   ------------->  resume, return nil
           <-------------  tools/call response (push)
```

`tools/call` returns `nil` **immediately** and the call is parked. That is what keeps it from deadlocking: the transport's `handle_message` does not block, so it stays free to READ the client's answer. Both the prompt and the eventual response ride the existing subscriber channel, so **neither transport needed a change**.

A parked call is always closed exactly once, by one of four paths: approval (runs the tool), decline/cancel/unapproved-accept, an error response, or a timeout (default 60s). Every path but approval resolves to the same deny — silence is not consent.

**Fixed on the way:** the server answered `"Missing method"` to an inbound JSON-RPC *response*, which would bounce an error response AT a response — a loop with a strict peer. Unminted responses are now ignored, per spec. This path only became reachable because the server now receives responses at all.

## 2. Boot-time refusal for sensitive tools

`ToolDef` gains `:annotations` and `sensitive?/1`, reading the MCP-standard `destructiveHint` plus a raxol `sensitive` flag.

The predicate is deliberately **one-directional: an annotation can only ADD an obligation, never remove one.** `destructiveHint: false` and `readOnlyHint: true` buy no exemption — declaring yourself dangerous is credible, declaring yourself safe is not. That is the same ruling U21-R3 already makes about a self-reported `mutating: false`.

Enforced at two points, because either alone is bypassable:

| point | catches |
| --- | --- |
| boot | a sensitive tool already registered with no authorizer — **refuses to start**, naming the tools |
| `tools/call` | one registered *after* boot, which the boot check cannot have seen |

The escape hatch is `Raxol.MCP.Authorizer.allow_all()` — one line, and visible in code rather than hidden in config.

**Fixed on the way:** `Registry.tool_definition/1` was dropping `:annotations`, so no annotation ever reached `tools/list`. That is an MCP spec gap independent of this guard — clients are supposed to see the hints.

## Manual testing

- [x] `packages/raxol_mcp`: **337 passed** (was 327; +23 new tests across two files)
- [x] Full main app: **6585 passed** (verifies the `tool_definition` change breaks no consumer)
- [x] `mix compile --warnings-as-errors`
- [x] Elicitation covered end to end: capability gating, no-subscriber fallback, accept/decline/cancel/unapproved-accept/missing-action, error response, timeout, late answer after timeout, forged id, concurrent asks resolving independently
- [x] Sensitive guard: boot refusal, boot-with-authorizer, unannotated-boots-fine, late registration denied with the callback proven never to have run

### Note

One property failed once in ~6 raxol_mcp runs early on and did not reproduce in 5 subsequent full-suite runs; I could not capture which one. Flagging it rather than claiming a clean sweep I did not observe.

Only files I touched were formatted — a bare `mix format` in this package reflows 7 unrelated files, so that churn was stripped from the commit.
