### PR TITLE
Asterisk the crash-isolation claim; restructure README tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,18 @@ Your application is a single [TEA](https://guide.elm-lang.org/architecture/) mod
                           +---> Agent (MCP tools)
 ```
 
-The interesting part is the runtime. Your app gets crash isolation per Component, hot code reload without restart, distributed clustering with CRDTs, and an agent surface where LLMs interact with structured Component trees instead of scraping pixels. Those are BEAM properties, from a VM built for systems that can't go down, can't lose state, and hot-swap code while running.
+The interesting part is the runtime. Your app gets crash isolation per Component[\*](#the-nif-asterisk), hot code reload without restart, distributed clustering with CRDTs, and an agent surface where LLMs interact with structured Component trees instead of scraping pixels. Those are BEAM properties, from a VM built for systems that can't go down, can't lose state, and hot-swap code while running.
+
+### The NIF asterisk
+
+Crash isolation is a BEAM property, and it holds for every line of Elixir you write: a Component that raises takes down its own process, its supervisor restarts it, and the rest of the app keeps painting.
+
+It does not extend to native code. On Unix/macOS the terminal backend is a [termbox2](packages/raxol_terminal/lib/termbox2_nif/) NIF, which runs in the VM's address space — a segfault there takes down the whole node, and no supervisor can catch it. Two things bound that risk:
+
+- **The NIF only renders.** Input arrives over OTP's own `prim_tty`, not the NIF, so a keystroke never crosses the native boundary. A [per-PR canary](.github/workflows/ci-unified.yml) pins that input path against OTP changes.
+- **A build without the NIF has no asterisk.** The backend is picked at compile time by whether `:termbox2_nif` loaded; when it did not — Windows, or any build that skipped it — the driver falls back to the pure-Elixir `IOTerminal`, and nothing native is in the address space.
+
+If the VM does die hard, it dies without restoring your terminal. See [If the terminal is left in a bad state](docs/getting-started/QUICKSTART.md#if-the-terminal-is-left-in-a-bad-state).
 
 Bubble Tea, Ratatui, and Textual are excellent renderers. A2UI and AG-UI define agent-UI wire formats. Raxol is the runtime that renders all four surfaces from one source module. See [Why OTP](docs/WHY_OTP.md) for the framework comparison, and [Why Raxol](docs/WHY_RAXOL.md) for how the runtime compares to Python agent stacks like Hermes and Omnigent.
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ If the VM does die hard, it dies without restoring your terminal. See [If the te
 
 Bubble Tea, Ratatui, and Textual are excellent renderers. A2UI and AG-UI define agent-UI wire formats. Raxol is the runtime that renders all four surfaces from one source module. See [Why OTP](docs/WHY_OTP.md) for the framework comparison, and [Why Raxol](docs/WHY_RAXOL.md) for how the runtime compares to Python agent stacks like Hermes and Omnigent.
 
-## Built with Raxol
-
-**[Xochi](https://xochi.fi)** is a private cross-chain DEX: intent-based swaps across 6 chains, sub-3s settlement, stealth addresses by default, ZKSAR compliance proofs. Its entire trading surface is raxol. A trader terminal serves over SSH with a dark-pool aesthetic, the same TEA module renders as a LiveView web UI, a solver-agent surface projects the same Component tree for Riddler's sub-2ms solver, and an ops cockpit runs sensor fusion on solver health. The solver executes behind a dedicated fail-closed stack (buyer-pre-signed intents, ledger-enforced spend gates, deployment guards that refuse to run unconfigured), kept deliberately off the MCP surface, so no fund-moving action is reachable as a generic tool call. The solver agent and the human trader read the same Component tree through different projections.
-
-**[foglet-bbs](https://github.com/bmanturner/foglet-bbs)** by [Brendan Turner](https://foglet.io) is an SSH-only retro bulletin board ([bbs.foglet.io](https://bbs.foglet.io), `ssh bbs.foglet.io`) that stress-tested raxol's SSH path into shape.
-
 ## Agents
 
 Raxol is a runtime for agents as much as for humans. Every interactive Component automatically exposes MCP tools (Button gives `click`, TextInput gives `type_into`/`clear`/`get_value`), and a focus lens filters to roughly 15 relevant tools per interaction. Where A2UI and AG-UI define how agents talk to UIs at the wire level, raxol generates the UI and the agent surface from one Component tree: same source, two projections.
@@ -171,6 +165,12 @@ mix raxol.demo               # run built-in demos
 ## Origin
 
 Raxol started as two converging ideas: a terminal for AGI, where AI agents interact with a real terminal emulator the same way humans do; and an interface for the cockpit of a Gundam Wing Suit, where fault isolation, real-time responsiveness, and sensor fusion are survival-critical. The Gundam thing sounds like a joke. Then you look at the constraint set and it's exactly what OTP was built for: systems that can't go down, can't lose state, and have to hot-swap components while running.
+
+## Built with Raxol
+
+**[Xochi](https://xochi.fi)** is a private cross-chain DEX (intent-based swaps across 6 chains, sub-3s settlement, stealth addresses by default, ZKSAR compliance proofs) whose entire trading surface is raxol. One Component tree projects four ways: an SSH trader terminal, a LiveView web UI, a solver-agent surface for Riddler's sub-2ms solver, and an ops cockpit running sensor fusion on solver health. The solver executes behind a dedicated fail-closed stack (buyer-pre-signed intents, ledger-enforced spend gates, deployment guards that refuse to run unconfigured), kept deliberately off the MCP surface, so no fund-moving action is reachable as a generic tool call.
+
+**[foglet-bbs](https://github.com/bmanturner/foglet-bbs)** by [Brendan Turner](https://foglet.io) is an SSH-only retro bulletin board ([bbs.foglet.io](https://bbs.foglet.io), `ssh bbs.foglet.io`) that stress-tested raxol's SSH path into shape.
 
 ## License
 

--- a/docs/getting-started/QUICKSTART.md
+++ b/docs/getting-started/QUICKSTART.md
@@ -185,6 +185,20 @@ This generates an Application module with a supervision tree. Run with:
 mix run --no-halt
 ```
 
+## If the terminal is left in a bad state
+
+A Raxol app puts the terminal into raw mode and (for full-screen apps) the alternate screen, and restores both on exit. If the app dies *hard* — a `kill -9`, a VM crash, a segfault in the native rendering backend — nothing runs the restore, and you are left in a shell with no echo, no line editing, and possibly no visible cursor.
+
+Nothing is broken. Reset the terminal:
+
+```bash
+reset
+```
+
+If the shell is so far gone that you cannot see what you type, `reset` still works blind — type it and press Enter. `stty sane` is a lighter alternative that fixes echo and line editing without clearing the screen.
+
+This is a property of every full-screen terminal program (vim and tmux leave the same mess when SIGKILLed), not something specific to Raxol. See [the NIF asterisk](../../README.md#the-nif-asterisk) for what can and cannot take the VM down in the first place.
+
 ## What You Just Built
 
 That counter is a complete Raxol app: `init/update/view` is the whole API. Everything else builds on this loop.


### PR DESCRIPTION
Two independent doc changes.

## 1. Asterisk the crash-isolation claim

The README says your app gets crash isolation per Component. True for every line of Elixir, and **not** true across the native boundary: on Unix/macOS the terminal backend is a termbox2 NIF running in the VM's address space, where a segfault takes the whole node down and no supervisor catches it.

Rather than soften the claim, bound it. Two facts do that honestly, both verified against the code:

- **The NIF only renders.** Its entire exported surface is `tb_print` / `tb_set_cell` / `tb_present` / `tb_clear` / sizing / cursor / `tb_init` / `tb_shutdown`. There is no `tb_poll_event` (deleted in #781), so input arrives over OTP's `prim_tty` and a keystroke never crosses the native boundary — and the per-PR canary pins that path.
- **A build without the NIF has no asterisk at all.** The backend is picked at compile time by `Code.ensure_loaded?(:termbox2_nif)`; when it did not load (Windows, or any build that skipped it) the driver falls back to the pure-Elixir `IOTerminal` and nothing native is in the address space.

Plus the practical consequence nobody documents: a VM that dies hard dies without restoring the terminal, leaving raw mode and the alternate screen behind. Quickstart now has **"If the terminal is left in a bad state"** — run `reset`, and it works blind, which is the part you need when you cannot see what you type. Framed as true of every full-screen terminal program (vim and tmux leave the same mess when SIGKILLed) rather than as a Raxol defect.

## 2. Move "Built with Raxol" to the bottom, compact Xochi

The section sat between the runtime pitch and Agents, pushing the substance of the README down. It reads as a credential, so it belongs with Origin at the end, above License, rather than in the path of someone deciding whether to use this.

Xochi trimmed **140 -> 94 words**: the four projections become one list instead of four clauses, and the closing sentence about the solver agent and the human trader reading the same tree is dropped, since the list above it already says that.

**The solver sentence is kept verbatim.** PR #782 tightened that specific wording ("off the MCP surface", "no fund-moving action"); a compaction pass is not the place to re-blur an audited claim, so it survives the edit unchanged. (My first draft did soften it to "outside that surface" / "no payment" — caught and reverted.)

## Manual testing

- [x] Every factual claim checked against the source: NIF export list, absence of `tb_poll_event`, the `Code.ensure_loaded?` backend switch, the `input-canary` CI job
- [x] `reset` and `stty sane` both present on the documented platforms
- [x] Both new anchors resolve (`#the-nif-asterisk`, `#if-the-terminal-is-left-in-a-bad-state`); no dangling links to the moved section
