### PR TITLE
Pin submit non-blocking causally, not by clock

### DIFF
--- a/packages/raxol_agent/test/raxol/agent/red/u12_probe_runner_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u12_probe_runner_red_test.exs
@@ -72,6 +72,7 @@ defmodule Raxol.Agent.Red.U12ProbeRunnerRedTest do
     HangingProbe,
     LoopDraftProbe,
     MultiCallProbe,
+    GatedProbe,
     ShortParkProbe,
     SlowMultiCallProbe,
     TaintedTrustProbe,
@@ -148,21 +149,94 @@ defmodule Raxol.Agent.Red.U12ProbeRunnerRedTest do
     end
   end
 
+  # Submit `n` runs whose `build/1` is blocked on a gate this process owns, and
+  # return the submit results. The gate stays SHUT on return, so the caller can
+  # assert against a pool where no run has reached the provider.
+  #
+  # The 15s bound is a LIVENESS deadline, not a latency budget: it only elapses
+  # if a submit genuinely never returns (i.e. it ran the gated probe inline).
+  # Nothing here asserts how fast a submit is -- that was the flaw in the
+  # wall-clock form this replaced.
+  defp submit_gated!(rig, prefix, n) do
+    gate = self()
+    context = Map.put(ctx(), :gate, gate)
+
+    task =
+      Task.async(fn ->
+        for i <- 1..n do
+          Runner.submit("#{prefix}-#{i}", GatedProbe, submit_opts(rig, context))
+        end
+      end)
+
+    case Task.yield(task, 15_000) do
+      {:ok, results} ->
+        results
+
+      _ ->
+        Task.shutdown(task, :brutal_kill)
+
+        flunk(
+          "submit blocked: #{n} submit(s) never returned while every run was " <>
+            "held in build/1 — submit is waiting for the run"
+        )
+    end
+  end
+
+  # Open the gate and keep it open until every run is terminal. This is cleanup
+  # with teeth: the pool is a shared SINGLETON, so leaving workers parked in
+  # `build/1` would starve every other async test — exactly the cross-test
+  # interference this rewrite exists to stop causing.
+  defp release_gated(bus, run_ids) do
+    drain_and_release(
+      bus,
+      MapSet.new(run_ids),
+      System.monotonic_time(:millisecond) + 10_000
+    )
+  end
+
+  defp drain_and_release(bus, wanted, deadline) do
+    receive do
+      {:probe_gated, pid} ->
+        send(pid, :release)
+        drain_and_release(bus, wanted, deadline)
+    after
+      25 ->
+        cond do
+          all_terminal?(bus, wanted) -> :ok
+          System.monotonic_time(:millisecond) > deadline -> :ok
+          true -> drain_and_release(bus, wanted, deadline)
+        end
+    end
+  end
+
+  defp all_terminal?(bus, wanted) do
+    terminal =
+      for %{kind: :probe_run, run_id: id, status: s} <- L.events(bus),
+          s in L.terminal_statuses(),
+          into: MapSet.new(),
+          do: id
+
+    MapSet.subset?(wanted, terminal)
+  end
+
   describe "submit is non-blocking and total (red until U12 lands)" do
-    test "submit returns {:ok, run_id} immediately — never blocks, never returns results inline" do
+    test "submit returns {:ok, run_id} without waiting for the run" do
       rig = rig()
 
-      {micros, result} =
-        :timer.tc(fn ->
-          Runner.submit("u12-red", CacheRideProbe, submit_opts(rig, ctx()))
-        end)
+      # Causal, not timed. The run blocks inside `build/1`, which the Pool calls
+      # STRICTLY BEFORE the provider -- so a submit that returns here provably
+      # did not run its own probe inline. The old form asserted `micros <
+      # 50_000`, which measured `GenServer.call` queueing on a pool that is a
+      # shared singleton every other async test also submits to; that is
+      # contention, not the design property, and it flaked accordingly.
+      {:ok, run_id} = submit_gated!(rig, "u12-red", 1) |> hd()
 
-      assert {:ok, run_id} = result
       assert is_binary(run_id)
-      # Non-blocking: submit returns before any provider call completes.
-      assert micros < 50_000, "submit blocked for #{micros}µs"
-      # Never inline: the ok tuple carries a run_id and nothing else.
-      assert {:ok, _run_id} = result
+
+      assert L.provider_calls(rig.provider) == 0,
+             "submit returned only after the run reached the provider — it blocked"
+
+      release_gated(rig.bus, [run_id])
     end
 
     test "only an unknown probe fails submit — {:error, :unknown_probe}" do
@@ -249,38 +323,28 @@ defmodule Raxol.Agent.Red.U12ProbeRunnerRedTest do
       assert L.lifecycle_complete(events, [run_id]) == :ok
     end
 
-    test "submit under saturation never blocks (seed-reproducible burst)" do
+    test "submit under saturation never waits for the run (burst)" do
       rig = rig()
-      :rand.seed(:exsss, {@seed, @seed, @seed})
       n = 16
 
-      results =
-        for i <- 1..n do
-          Process.sleep(:rand.uniform(2) - 1)
-
-          {micros, result} =
-            :timer.tc(fn ->
-              Runner.submit(
-                "u12-red-#{i}",
-                CacheRideProbe,
-                submit_opts(rig, ctx())
-              )
-            end)
-
-          assert micros < 50_000,
-                 "seed=#{@seed}: submit ##{i} blocked for #{micros}µs"
-
-          result
-        end
+      # Real saturation, held open: every run is stuck in `build/1` for the
+      # whole burst, so the pool cannot drain between submits the way it could
+      # when the runs were instant. All 16 submits still return.
+      results = submit_gated!(rig, "u12-red", n)
 
       assert Enum.all?(results, &match?({:ok, _}, &1)),
-             "seed=#{@seed}: submit failed under saturation: #{inspect(results)}"
+             "submit failed under saturation: #{inspect(results)}"
 
-      assert results
-             |> Enum.map(fn {:ok, id} -> id end)
-             |> Enum.uniq()
-             |> length() == n,
-             "seed=#{@seed}: run_ids must be unique"
+      run_ids = Enum.map(results, fn {:ok, id} -> id end)
+      assert length(Enum.uniq(run_ids)) == n, "run_ids must be unique"
+
+      # THE PROPERTY, stated causally: 16 submits returned while not one run had
+      # reached the provider. A submit that ran its probe inline could not have
+      # gotten past the first shut gate, let alone returned 16 times.
+      assert L.provider_calls(rig.provider) == 0,
+             "a submit returned only after its run reached the provider — it blocked"
+
+      release_gated(rig.bus, run_ids)
     end
   end
 

--- a/packages/raxol_agent/test/support/red_probe_runner_lab.ex
+++ b/packages/raxol_agent/test/support/red_probe_runner_lab.ex
@@ -565,6 +565,80 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
     end
   end
 
+  defmodule GatedProbe do
+    @moduledoc """
+    A cache-riding probe whose `build/1` blocks until the test releases it.
+
+    Exists so "submit never blocks" can be pinned CAUSALLY instead of with a
+    wall-clock bound. `Raxol.Agent.Probe.Runner.Pool.one_call/1` calls
+    `build/1` STRICTLY BEFORE it touches the provider, so while the gate is
+    shut no run can reach the provider -- `provider_calls == 0` is then a fact
+    about ordering, not a race. A submit that returned under those conditions
+    provably did not run its own probe inline.
+
+    Set `context[:gate]` to the pid to hand control to. `build/1` announces
+    itself as `{:probe_gated, self()}` and waits for `:release`. With no
+    `:gate` in the context it behaves exactly like `CacheRideProbe`, so the
+    probe is safe to reuse anywhere.
+
+    The `receive` has a long backstop so a test that forgets to release cannot
+    wedge a pool worker forever -- the pool is a shared singleton and a stuck
+    worker would starve every other async test.
+    """
+    @behaviour Raxol.Agent.Probe
+
+    @gate_backstop_ms 30_000
+
+    @impl true
+    def spec do
+      %{
+        id: :c1_gate,
+        mode: :cache_riding,
+        max_calls: 1,
+        timeout_ms: 60_000,
+        default_budget: 500,
+        max_parked: 64,
+        park_timeout_ms: 60_000
+      }
+    end
+
+    @impl true
+    def build(context) do
+      await_release(Map.get(context, :gate))
+
+      {:ok,
+       %{
+         suffix: [%{role: "user", content: "gate?"}],
+         output: :structured,
+         max_output_tokens: 256
+       }}
+    end
+
+    @impl true
+    def interpret(_response, context) do
+      {:ok,
+       [
+         %{
+           type: :gate_decision,
+           refs: [context.tip_offset],
+           payload: %{choice: :allow}
+         }
+       ]}
+    end
+
+    defp await_release(gate) when is_pid(gate) do
+      send(gate, {:probe_gated, self()})
+
+      receive do
+        :release -> :ok
+      after
+        @gate_backstop_ms -> :ok
+      end
+    end
+
+    defp await_release(_no_gate), do: :ok
+  end
+
   defmodule ShortParkProbe do
     @moduledoc """
     A cache-riding probe with a SHORT `park_timeout_ms` (and small `max_parked`)


### PR DESCRIPTION
`submit under saturation never blocks` failed **2 of 10** full-suite runs.

## The bound was measuring the harness, not the property

It asserted `micros < 50_000` around `Runner.submit/3`, sixteen times in a burst. But `submit` is a `GenServer.call` into `Probe.Runner.Pool`, a shared **singleton**, and this module is `async: true` — so the number under assertion is mailbox queueing under whatever else the suite happens to be doing, not whether submit waits for the run.

The same file already reasons this way about the pool for `await_terminals` (adversarial-review #8a: *"the pool is a shared singleton, so a burst of runs from a parallel async test can add latency"*). The submit-latency asserts were never given the same treatment.

## Restated causally

`Pool.one_call/1` calls `probe.build/1` **strictly before** it touches the provider. A new `GatedProbe` blocks there, gated on a pid from the context, so while the gate is shut no run can reach the provider. The test then submits behind a shut gate and asserts:

```elixir
assert L.provider_calls(rig.provider) == 0
```

Ordering, not a race. Sixteen submits returning while not one run reached the provider is proof submit did not run its probe inline — a blocking submit could not have gotten past the first gate.

**No wall-clock threshold survives.** The one remaining bound is a 15s *liveness* deadline that elapses only if a submit never returns, turning what would be a 60s ExUnit timeout into a named failure. It is not a latency budget: a scheduler hiccup cannot cross it.

## Detection power verified, not assumed

With `Runner.submit/3` mutated to run the probe inline:

```
submit blocked: 1 submit(s) never returned while every run was held in build/1 — submit is waiting for the run
submit blocked: 16 submit(s) never returned while every run was held in build/1 — submit is waiting for the run
```

Both tests catch it, each naming the right condition. Restored, green.

## Cleanup with teeth

`release_gated/2` drains the gate until every run is terminal. The pool is a shared singleton, so leaving workers parked in `build/1` would starve every other async test — precisely the cross-test interference this rewrite exists to stop causing.

`GatedProbe` behaves exactly like `CacheRideProbe` when no `:gate` is in the context, and its `receive` has a 30s backstop so a test that forgets to release cannot wedge a pool worker.

## Manual testing

- [x] **10 full-suite runs: 0 occurrences** (was 2/10)
- [x] `packages/raxol_agent`: 2001 passed
- [x] Mutation test above: RED with a clear message, then restored green
