### PR TITLE
Make a restart-window wait total, not exit-prone

### DIFF
--- a/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
@@ -372,12 +372,12 @@ defmodule Raxol.Agent.Session.SupervisorTest do
       life2 = lifecycle_pid(sid)
       assert life2 != life0
 
-      wait_until(fn ->
-        match?(
-          %{lifecycle_pid: ^life2},
-          :sys.get_state(Session.Supervisor.whereis(sid))
-        )
-      end)
+      # The session is the LAST `:rest_for_one` child, so it comes back AFTER
+      # the lifecycle it depends on — there is a real window here where `life2`
+      # already exists and the session does not. Resolve through a total helper:
+      # a bare `:sys.get_state(nil)` EXITS out of the predicate, which reads as
+      # a test failure rather than as "not restarted yet".
+      wait_until(fn -> session_lifecycle_pid(sid) == life2 end)
 
       # The crux: the fresh lifecycle carries the app's INIT model, NOT the
       # accumulated ["kept"] — proving it did not reattach to the dead runtime.
@@ -617,6 +617,19 @@ defmodule Raxol.Agent.Session.SupervisorTest do
     GenServer.call(session, :get_model)
   catch
     :exit, _ -> {:error, :down}
+  end
+
+  # The lifecycle the session has RESOLVED, or nil when there is no session to
+  # ask. Total by construction: absent (`whereis` -> nil), and dying between the
+  # lookup and the call, both read as nil so a caller polling on it keeps
+  # waiting instead of exiting.
+  defp session_lifecycle_pid(sid) do
+    case Session.Supervisor.whereis(sid) do
+      pid when is_pid(pid) -> Map.get(:sys.get_state(pid), :lifecycle_pid)
+      _ -> nil
+    end
+  catch
+    :exit, _ -> nil
   end
 
   defp registry_lookup(key), do: Registry.lookup(Raxol.Agent.Registry, key)


### PR DESCRIPTION
`lifecycle is REUSED after a session-only crash but FRESH after a bridge crash` failed **3 of 25** isolated runs (1 of 9 full-suite).

## Not a product bug

The session is the **last** `:rest_for_one` child, so a bridge crash brings the tree back as bridge -> lifecycle -> session, exactly as the supervisor's moduledoc documents. The test's preceding wait only blocked until the new *lifecycle* appeared, which leaves a real window where `life2` exists and the session does not yet. In that window:

```elixir
:sys.get_state(Session.Supervisor.whereis(sid))   # whereis -> nil
```

is `:sys.get_state(nil)`, which **exits**. The exit escapes the `wait_until` predicate, so a state the test should have kept polling through was reported as a failure instead.

## The fix

Resolved through a total helper: absent (`whereis` -> nil) and dying between the lookup and the call both read as nil, so the poll keeps waiting.

The sibling bridge-crash test in the same file never hit this because it proves liveness **before** calling `:sys.get_state`; this one called it inside the predicate.

## Non-vacuity checked, not assumed

With the helper stubbed to always return nil, the test fails `wait_until timed out` — so the wait is load-bearing, not decorative. The crux assertion (the fresh lifecycle carries the app's INIT model, not the accumulated `["kept"]`, proving it did not reattach to the dead runtime) is untouched.

## Manual testing

- [x] Reproduced 3/25 in isolation before the fix
- [x] **40 isolated runs after: 0 failures**
- [x] `packages/raxol_agent`: 2001 passed
- [x] Mutation test above: RED, then restored
