### PR TITLE
Move the NIF caveat out of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,7 @@ Your application is a single [TEA](https://guide.elm-lang.org/architecture/) mod
                           +---> Agent (MCP tools)
 ```
 
-The interesting part is the runtime. Your app gets crash isolation per Component[\*](#the-nif-asterisk), hot code reload without restart, distributed clustering with CRDTs, and an agent surface where LLMs interact with structured Component trees instead of scraping pixels. Those are BEAM properties, from a VM built for systems that can't go down, can't lose state, and hot-swap code while running.
-
-### The NIF asterisk
-
-Crash isolation is a BEAM property, and it holds for every line of Elixir you write: a Component that raises takes down its own process, its supervisor restarts it, and the rest of the app keeps painting.
-
-It does not extend to native code. On Unix/macOS the terminal backend is a [termbox2](packages/raxol_terminal/lib/termbox2_nif/) NIF, which runs in the VM's address space — a segfault there takes down the whole node, and no supervisor can catch it. Two things bound that risk:
-
-- **The NIF only renders.** Input arrives over OTP's own `prim_tty`, not the NIF, so a keystroke never crosses the native boundary. A [per-PR canary](.github/workflows/ci-unified.yml) pins that input path against OTP changes.
-- **A build without the NIF has no asterisk.** The backend is picked at compile time by whether `:termbox2_nif` loaded; when it did not — Windows, or any build that skipped it — the driver falls back to the pure-Elixir `IOTerminal`, and nothing native is in the address space.
-
-If the VM does die hard, it dies without restoring your terminal. See [If the terminal is left in a bad state](docs/getting-started/QUICKSTART.md#if-the-terminal-is-left-in-a-bad-state).
+The interesting part is the runtime. Your app gets crash isolation per Component, hot code reload without restart, distributed clustering with CRDTs, and an agent surface where LLMs interact with structured Component trees instead of scraping pixels. Those are BEAM properties, from a VM built for systems that can't go down, can't lose state, and hot-swap code while running.
 
 Bubble Tea, Ratatui, and Textual are excellent renderers. A2UI and AG-UI define agent-UI wire formats. Raxol is the runtime that renders all four surfaces from one source module. See [Why OTP](docs/WHY_OTP.md) for the framework comparison, and [Why Raxol](docs/WHY_RAXOL.md) for how the runtime compares to Python agent stacks like Hermes and Omnigent.
 

--- a/docs/WHY_OTP.md
+++ b/docs/WHY_OTP.md
@@ -29,6 +29,21 @@ process_component(UnstableWidget, %{path: "/dev/random"})
 
 The supervisor restarts the component and renders the next frame. OTP was built for this.
 
+There is one place this stops. On Unix and macOS the terminal backend is a
+[termbox2](../packages/raxol_terminal/lib/termbox2_nif/) NIF, and a NIF runs
+inside the VM's own address space. Segfault there and the whole node goes down,
+supervisor or not.
+
+The blast radius is small, though. That NIF only draws: cell writes, cursor
+moves, present. Input never touches it. Keystrokes arrive over OTP's own
+`prim_tty`, and a [canary in CI](../.github/workflows/ci-unified.yml) watches
+that path in case OTP moves it. Windows skips the NIF entirely and falls back to
+the pure Elixir `IOTerminal`, so nothing native is loaded there at all.
+
+When the VM does die that way it dies without putting your terminal back. Run
+`reset`; there is [a note in the
+quickstart](getting-started/QUICKSTART.md#if-the-terminal-is-left-in-a-bad-state).
+
 ### Hot reload
 
 Erlang's code server supports hot swapping at the module level. Save a file, and the running app picks up the new `view/1` on the next render cycle. No reconnection, no state loss. Same mechanism that lets telecom switches upgrade without dropping calls.

--- a/docs/getting-started/QUICKSTART.md
+++ b/docs/getting-started/QUICKSTART.md
@@ -187,17 +187,24 @@ mix run --no-halt
 
 ## If the terminal is left in a bad state
 
-A Raxol app puts the terminal into raw mode and (for full-screen apps) the alternate screen, and restores both on exit. If the app dies *hard* — a `kill -9`, a VM crash, a segfault in the native rendering backend — nothing runs the restore, and you are left in a shell with no echo, no line editing, and possibly no visible cursor.
+A Raxol app puts your terminal into raw mode, and full-screen apps also switch to
+the alternate screen. Both get restored on the way out. But if the app dies hard,
+a `kill -9` or a VM crash, nothing runs that restore and you land back in a shell
+with no echo and no line editing.
 
-Nothing is broken. Reset the terminal:
+Nothing is broken. Reset it:
 
 ```bash
 reset
 ```
 
-If the shell is so far gone that you cannot see what you type, `reset` still works blind — type it and press Enter. `stty sane` is a lighter alternative that fixes echo and line editing without clearing the screen.
+If you cannot see what you are typing, that still works blind. Type it and hit
+Enter. `stty sane` is the lighter version, and it fixes echo without clearing the
+screen.
 
-This is a property of every full-screen terminal program (vim and tmux leave the same mess when SIGKILLed), not something specific to Raxol. See [the NIF asterisk](../../README.md#the-nif-asterisk) for what can and cannot take the VM down in the first place.
+vim and tmux leave the same mess when you SIGKILL them. It comes with the
+territory for full-screen terminal programs. [Why OTP](../WHY_OTP.md#crash-isolation)
+covers what can take the VM down that way in the first place.
 
 ## What You Just Built
 


### PR DESCRIPTION
Follow-up to #792, which put this in the wrong place.

The NIF asterisk sat two paragraphs into the README, between the runtime pitch and the framework comparison. It stopped the reader to explain a failure mode before they knew what the thing was, and the bolded two-item list read like a disclaimer rather than prose.

The content is still worth having. It just belongs where someone is already reading about the property being qualified, so it moves to `WHY_OTP.md` under **Crash isolation**, right after "OTP was built for this."

Rewritten while moving: no bold inline headers, no "Two things bound that risk", and the NIF's exported surface stated plainly (cell writes, cursor moves, present) instead of gestured at.

The quickstart `reset` note keeps its place, since a wedged shell is exactly when you go looking at a quickstart. Same rewrite treatment, and repointed at `WHY_OTP.md#crash-isolation` now that the README anchor is gone.

## Result

The README pitch now runs straight from the diagram into the framework comparison, uninterrupted.

## Manual testing

- [x] No dangling references to `#the-nif-asterisk` anywhere in the repo
- [x] All three link targets resolve (the NIF directory, `WHY_OTP.md#crash-isolation`, `QUICKSTART.md#if-the-terminal-is-left-in-a-bad-state`)
- [x] Every factual claim carried over unchanged from #792, where each was checked against the source
