### PR TITLE
Make the input canary say which stage broke

### DIFF
--- a/packages/raxol_terminal/test/fixtures/input_canary_app.exs
+++ b/packages/raxol_terminal/test/fixtures/input_canary_app.exs
@@ -10,7 +10,7 @@ defmodule InputCanaryApp do
     out = System.get_env("CANARY_OUT") || raise "CANARY_OUT not set"
     n = String.to_integer(System.get_env("CANARY_N") || "2")
 
-    {:ok, _pid} =
+    {:ok, pid} =
       Raxol.Terminal.InlineDriver.start_link(
         device: :standard_io,
         subscriber: self(),
@@ -20,15 +20,60 @@ defmodule InputCanaryApp do
         probe?: false
       )
 
-    # Signal that the reader is armed, so the driver sends keystrokes only after
-    # the pty is ready to receive them (avoids a send-before-listen race).
-    File.write!(out <> ".ready", "ok")
+    # Signal readiness -- and say what was actually established, not just that
+    # start_link returned. The driving test cannot see into this VM, so when it
+    # ends up with no keystrokes this file is the only evidence of whether the
+    # reader was armed and whether the tty was actually in raw mode. Without it
+    # a missed keystroke and a moved OTP protocol look identical.
+    File.write!(out <> ".ready", diagnostics(pid))
 
     tokens = collect(n, [])
     File.write!(out, Enum.join(tokens, "\n"))
+
     # Exit immediately so the pty closes and the driving test's `eof`/output wait
     # returns at once instead of blocking on a slow BEAM/mix shutdown.
     System.halt(0)
+  end
+
+  # What this VM can see about its own input path, as one greppable line.
+  defp diagnostics(pid) do
+    "otp=#{System.otp_release()} reader=#{reader_status()} raw=#{raw_status(pid)}"
+  end
+
+  # Is the prim_tty reader actually being traced? `start_stdin_reader/1` only
+  # traces `:user_drv_reader` `if reader` -- when the process is not registered
+  # it silently no-ops and the driver comes up looking healthy while no input
+  # can ever arrive. That distinction is invisible from outside the VM.
+  defp reader_status do
+    case Process.whereis(:user_drv_reader) do
+      nil ->
+        "absent"
+
+      reader ->
+        case :erlang.trace_info(reader, :flags) do
+          {:flags, flags} ->
+            if :send in flags, do: "traced", else: "untraced#{inspect(flags)}"
+
+          other ->
+            "unknown#{inspect(other)}"
+        end
+    end
+  end
+
+  # Raw mode is what makes a bare keystroke deliverable: in canonical mode the
+  # reader hands nothing over until a newline, and this canary types `a` and `b`
+  # with no newline. `boot_confirmed?` is the driver's own verify-then-assert
+  # result; `isig_off?` is the live flags.
+  defp raw_status(pid) do
+    case Raxol.Terminal.InlineDriver.isig_report(pid) do
+      %{boot_confirmed?: confirmed, isig_off?: off} ->
+        "boot_confirmed=#{confirmed},isig_off=#{off}"
+
+      other ->
+        "unexpected#{inspect(other)}"
+    end
+  catch
+    kind, reason -> "unavailable(#{inspect(kind)},#{inspect(reason)})"
   end
 
   defp collect(n, acc) when length(acc) >= n, do: Enum.reverse(acc)

--- a/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
@@ -7,8 +7,16 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   protocol underneath us (the reader's message shape, the `{:read, :infinity}`
   re-arm). This one drives a REAL pty: it boots the actual `InlineDriver` stdin
   reader inside a terminal multiplexer, types real keystrokes, and asserts they
-  decode into events. Its failure means "OTP moved" -- which is exactly the
-  signal a bump of `OTP_VERSION` in CI should surface loudly instead of shipping.
+  decode into events. That makes it the one test a bump of `OTP_VERSION` in CI
+  should surface loudly instead of shipping.
+
+  A red here does NOT on its own mean "OTP moved". Several things sit between a
+  keystroke and a decoded event, and most of them are ours: the app has to boot
+  and arm, the multiplexer has to accept the keystroke, and the reader has to be
+  traced. Only when all of those held and the bytes still did not arrive is the
+  protocol the remaining explanation. The failure report names the stage that
+  actually broke and prints what the app could see from inside its own VM, so
+  the two are told apart instead of guessed at.
 
   Two keystrokes (not one) with a gap between them: a drift that delivers the
   first read but breaks re-arming would sail through a single-byte test.
@@ -32,37 +40,106 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   # select loop is armed. Retry a few times to absorb cold-boot pty timing slop.
   @settle_ms 250
   @max_attempts 3
+  @ready_suffix ".ready"
+  @ready_tries 900
+  @output_tries 60
 
   test "real keystrokes decode through the live prim_tty reader" do
     driver = pty_driver()
 
     if driver == nil do
-      IO.puts(:stderr, "[input canary] skipped: neither tmux nor expect on PATH")
+      IO.puts(
+        :stderr,
+        "[input canary] skipped: neither tmux nor expect on PATH"
+      )
     else
-      {tokens, attempt} = drive_until(driver, @max_attempts)
+      {result, attempt} = drive_until(driver, @max_attempts)
 
-      assert tokens == ["a", "b"], """
-      prim_tty input protocol canary FAILED on OTP #{System.otp_release()} (driver: #{driver}) after #{attempt} attempt(s).
-      Expected two real keystrokes to decode as ["a", "b"], got #{inspect(tokens)}.
-      This retries #{@max_attempts}x, so a transient pty/tmux timing race would have
-      passed on a retry -- an empty [] after all attempts is a REAL failure. It
-      almost always means OTP changed the prim_tty reader's private message
-      protocol or its re-arm contract -- see Raxol.Terminal.Driver's `{:trace, ...}`
-      handler and `start_stdin_reader/1`.
-      """
+      assert result.tokens == ["a", "b"],
+             failure_report(result, driver, attempt)
     end
   end
+
+  # Name the stage that actually failed. Every one of these used to surface as
+  # `got []`, which said "OTP moved the protocol" no matter which of them it
+  # was -- and for most of them that claim is simply false.
+  defp failure_report(result, driver, attempt) do
+    """
+    prim_tty input protocol canary FAILED on OTP #{System.otp_release()} \
+    (driver: #{driver}) after #{attempt} attempt(s), at stage: #{result.stage}.
+    Expected ["a", "b"], got #{inspect(result.tokens)}.
+
+    #{stage_explanation(result.stage)}
+
+    In-VM diagnostics from the app (#{@ready_suffix} file):
+      #{result.diag}
+    """
+  end
+
+  defp stage_explanation(:ready_timeout) do
+    """
+    The app never signalled ready, so NO keystroke was ever sent. This is not a
+    protocol break: the app failed to boot or to arm its reader within the
+    #{@ready_tries * 100}ms budget. Look at the app's own startup, not at the
+    trace handler.
+    """
+  end
+
+  defp stage_explanation(:send_failed) do
+    """
+    The pty driver refused to deliver a keystroke (non-zero exit from send-keys).
+    Nothing reached the app, so this says nothing about the input path -- suspect
+    the tmux session or the CI environment.
+    """
+  end
+
+  defp stage_explanation(:no_output) do
+    """
+    Keystrokes were sent, but the app never wrote its output file at all -- it
+    is still blocked or it died before finishing. Check whether the app crashed
+    inside the pty.
+    """
+  end
+
+  defp stage_explanation(:partial) do
+    """
+    The FIRST keystroke decoded and a later one did not. This is the re-arm
+    break the two-keystroke design exists to catch: the reader delivered one
+    read and never re-armed. See `start_stdin_reader/1`'s `{:read, :infinity}`.
+    """
+  end
+
+  defp stage_explanation(:empty) do
+    """
+    The app armed and ran, keystrokes were sent, and it decoded NOTHING. Read
+    the diagnostics below before blaming the protocol:
+
+      * `reader=absent` -- `:user_drv_reader` was not registered, so
+        `start_stdin_reader/1` silently traced nothing. Not a protocol change.
+      * `reader=untraced...` -- the trace never attached.
+      * `raw=...isig_off=false` -- the tty was NOT in raw mode, so a bare
+        keystroke is held in the line discipline until a newline. This canary
+        types `a` and `b` with no newline, so nothing is delivered. A raw-mode
+        problem, not a protocol one.
+      * `reader=traced` AND `isig_off=true` -- everything this side controls was
+        in place and the bytes still did not arrive. THAT is the case that
+        points at OTP moving the reader's private message shape or its re-arm
+        contract (`Raxol.Terminal.Driver`'s `{:trace, ...}` handler).
+    """
+  end
+
+  defp stage_explanation(other), do: "Unrecognized stage: #{inspect(other)}."
 
   # A cold pty boot inside tmux/expect can drop the first keystroke if it lands
   # before the reader has armed its select loop -- a timing flake, not a protocol
   # failure. Retry the whole drive: a real OTP break fails every attempt, a race
   # succeeds on a later one.
   defp drive_until(driver, attempts_left, attempt \\ 1) do
-    tokens = attempt_drive(driver)
+    result = attempt_drive(driver)
 
     cond do
-      tokens == ["a", "b"] -> {tokens, attempt}
-      attempts_left <= 1 -> {tokens, attempt}
+      result.tokens == ["a", "b"] -> {result, attempt}
+      attempts_left <= 1 -> {result, attempt}
       true -> drive_until(driver, attempts_left - 1, attempt + 1)
     end
   end
@@ -71,15 +148,36 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     out = Path.join(System.tmp_dir!(), "raxol_input_canary_#{unique()}")
 
     try do
-      drive(driver, out)
+      stage = drive(driver, out)
+      diag = read_diagnostics(out)
 
-      case File.read(out) do
-        {:ok, body} -> String.split(body, "\n", trim: true)
-        {:error, _} -> []
+      case {stage, File.read(out)} do
+        {:sent, {:ok, body}} ->
+          tokens = String.split(body, "\n", trim: true)
+          %{tokens: tokens, stage: classify(tokens), diag: diag}
+
+        {:sent, {:error, _}} ->
+          %{tokens: [], stage: :no_output, diag: diag}
+
+        {stage, _} ->
+          %{tokens: [], stage: stage, diag: diag}
       end
     after
       File.rm(out)
-      File.rm(out <> ".ready")
+      File.rm(out <> @ready_suffix)
+    end
+  end
+
+  defp classify(["a", "b"]), do: :ok
+  defp classify([]), do: :empty
+  defp classify(_partial), do: :partial
+
+  # The app's own account of what it established. Absent when it never got far
+  # enough to write one, which is itself the answer.
+  defp read_diagnostics(out) do
+    case File.read(out <> @ready_suffix) do
+      {:ok, body} -> String.trim(body)
+      {:error, _} -> "(no ready file -- the app never signalled)"
     end
   end
 
@@ -107,15 +205,43 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
 
       # Only type once the reader signalled ready, then settle briefly so its
       # select loop is armed. `-l` sends the bytes literally (not as key names).
-      if wait_for_ready(out) == :ok do
-        Process.sleep(@settle_ms)
-        System.cmd("tmux", ["send-keys", "-t", session, "-l", "a"], stderr_to_stdout: true)
-        Process.sleep(@gap_ms)
-        System.cmd("tmux", ["send-keys", "-t", session, "-l", "b"], stderr_to_stdout: true)
-        wait_for_output(out)
+      case wait_for_ready(out) do
+        :ok ->
+          Process.sleep(@settle_ms)
+          type_both(session, out)
+
+        :timeout ->
+          :ready_timeout
       end
     after
-      System.cmd("tmux", ["kill-session", "-t", session], stderr_to_stdout: true)
+      System.cmd("tmux", ["kill-session", "-t", session],
+        stderr_to_stdout: true
+      )
+    end
+  end
+
+  defp type_both(session, out) do
+    with :ok <- send_key(session, "a"),
+         :ok <- gap_then_send(session, "b") do
+      wait_for_output(out)
+      :sent
+    end
+  end
+
+  defp gap_then_send(session, key) do
+    Process.sleep(@gap_ms)
+    send_key(session, key)
+  end
+
+  # A refused keystroke must not read as a decode failure. The exit status was
+  # dropped once, which made a dead tmux session and a moved protocol produce
+  # the same empty result.
+  defp send_key(session, key) do
+    case System.cmd("tmux", ["send-keys", "-t", session, "-l", key],
+           stderr_to_stdout: true
+         ) do
+      {_, 0} -> :ok
+      {_out, _status} -> :send_failed
     end
   end
 
@@ -136,11 +262,15 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     """
 
     System.cmd("expect", ["-c", script], cd: @pkg_dir, stderr_to_stdout: true)
+
+    # `expect` does its own waiting inside the script, so reaching here means
+    # the keystrokes were written to the pty.
+    :sent
   end
 
   # Type only once the reader is armed, so we never send before the pty listens.
-  defp wait_for_ready(out), do: poll(out <> ".ready", 900)
-  defp wait_for_output(out), do: poll(out, 60)
+  defp wait_for_ready(out), do: poll(out <> @ready_suffix, @ready_tries)
+  defp wait_for_output(out), do: poll(out, @output_tries)
 
   defp poll(_path, 0), do: :timeout
 


### PR DESCRIPTION
Closes the diagnosis half of #789.

All six OTP 27.2 nightly cells fail on this canary; every 28.2 and 29.0.3 cell passes. The only thing the failure tells you is:

```
Expected two real keystrokes to decode as ["a", "b"], got [].
... almost always means OTP changed the prim_tty reader's private message protocol
```

**That claim is usually wrong.** Five different things produce an empty result, and only the last is a protocol break:

| what happened | was it the protocol? |
| --- | --- |
| the app never booted or armed | no |
| tmux refused the keystroke | no |
| the app died before writing output | no |
| `:user_drv_reader` was never traced | no |
| everything held and the bytes still did not arrive | **yes** |

They were indistinguishable. Now each one is named and explained.

## What changed

**The drive returns where it stopped** (`:ready_timeout` / `:send_failed` / `:no_output` / `:partial` / `:empty` / `:ok`) instead of a bare token list, and the assertion prints an explanation per stage. `:partial` is called out specifically as the re-arm break the two-keystroke design exists to catch.

**`send-keys` gets its exit status checked again.** #787 dropped the `{_, 0} =` match, which made a dead tmux session read exactly like a moved protocol.

**`.ready` carries evidence instead of the string `"ok"`.** The test cannot see into the app's VM, so it now reports what it actually established:

```
otp=29 reader=traced raw=boot_confirmed=false,isig_off=false
```

That matters because `start_stdin_reader/1` traces only `if reader` — an unregistered `:user_drv_reader` silently no-ops and the driver comes up looking healthy while no input can ever arrive. That case now reads `reader=absent` instead of looking like OTP moved.

**The moduledoc's "Its failure means OTP moved" is softened** to match what the test can actually establish.

## It already changed my mind

On a **passing** OTP 29 run the app reports `raw=boot_confirmed=false,isig_off=false`. Raw mode is not confirmed even when input flows fine, so the raw-mode-timing theory I posted on #789 is not supported by this evidence. I have left that comment up rather than quietly editing it.

I am not claiming this fixes OTP 27.2. It makes the next nightly say what is actually wrong, which is the part I could establish without a working OTP 27 repro.

## Manual testing

Installed tmux locally so the **real CI driver path** is exercised, not just the `expect` fallback.

| injected | reported |
| --- | --- |
| ready file never appears | `at stage: ready_timeout` |
| `send-keys` to a bad target | `at stage: send_failed` |
| second keystroke never sent | `at stage: partial` |

- [x] Each restored to green after its injection
- [x] 5 consecutive canary runs green on the tmux path
- [x] Diagnostics line verified non-empty and informative in a forced failure
