### PR TITLE
Fix terminal input decode on OTP 26/27

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,8 +115,11 @@ jobs:
           mix deps.compile
 
       # The local terminal input path traces prim_tty's reader (an OTP-internal
-      # private protocol). Run the real-pty canary on every OTP in the matrix so
-      # ambient drift is caught here even between the per-PR OTP bumps.
+      # private protocol) and depends on a raw termios `user_drv` only hands out
+      # from OTP 28 on. Run the real-pty tests on every OTP in the matrix so
+      # ambient drift is caught here even between the per-PR OTP bumps. Both
+      # files carry the same tag; they are listed explicitly because a new one
+      # would otherwise be silently skipped.
       - name: raxol_terminal prim_tty input canary
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
@@ -128,6 +131,7 @@ jobs:
           mix deps.get
           MIX_ENV=test TMPDIR=/tmp mix test \
             test/raxol/terminal/input_protocol_canary_test.exs \
+            test/raxol/terminal/input_isig_contract_test.exs \
             --only input_protocol_canary
 
       - name: Run full test suite

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/stty.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/stty.ex
@@ -1,8 +1,8 @@
 defmodule Raxol.Terminal.Driver.Stty do
   @moduledoc false
 
-  # stty operations against /dev/tty, ALL in the argv form
-  # `stty -f|-F /dev/tty ...` via `System.cmd/3` -- never a
+  # stty operations against the controlling terminal, ALL in the argv
+  # form `stty -f|-F DEVICE ...` via `System.cmd/3` -- never a
   # `sh -c "stty ... < /dev/tty"` shell redirect. Two reasons, both
   # learned the hard way (the real-terminal ^C trap):
   #
@@ -14,23 +14,98 @@ defmodule Raxol.Terminal.Driver.Stty do
   #   * argv means no shell in the loop at all, which is also why
   #     `restore/1`'s untrusted saved value was already using it.
   #
+  # DEVICE is resolved (see `tty_device/0`), never the literal
+  # `/dev/tty`. That distinction is the difference between this module
+  # working and silently doing nothing: the BEAM puts every port child
+  # in a FRESH SESSION, so a `System.cmd`-spawned `stty` has no
+  # controlling terminal of its own and `/dev/tty` fails ENXIO
+  # ("Device not configured") for it -- even when the BEAM itself is
+  # sitting on a perfectly good pty. Targeting the resolved device path
+  # sidesteps the child's missing ctty entirely.
+  #
   # `command_args/1` is the single constructor for every operation's
   # argv, public so the invocation form itself is pinned by test
   # (stty_test.exs, "command construction" describe).
 
   @raw_flags ~w(raw -echo -icanon -isig)
 
+  # Used only when the controlling terminal cannot be resolved. It is
+  # the honest target rather than a working one: if we could not name
+  # the device, the command was going to fail anyway, and failing
+  # against `/dev/tty` keeps the old behaviour instead of inventing a
+  # path that might belong to some other terminal.
+  @fallback_device "/dev/tty"
+
   @doc """
-  The argv for each stty operation -- always `[device_flag, "/dev/tty" |
-  operation_args]`. Public: the invocation form (device flag, never a
-  shell redirect) is itself a pinned regression surface.
+  The argv for each stty operation -- always `[device_flag,
+  tty_device() | operation_args]`. Public: the invocation form (device
+  flag, never a shell redirect) is itself a pinned regression surface.
   """
   @spec command_args(:raw | :save | :sane | :size | :flags) :: [String.t()]
-  def command_args(:raw), do: [file_flag(), "/dev/tty" | @raw_flags]
-  def command_args(:save), do: [file_flag(), "/dev/tty", "-g"]
-  def command_args(:sane), do: [file_flag(), "/dev/tty", "sane"]
-  def command_args(:size), do: [file_flag(), "/dev/tty", "size"]
-  def command_args(:flags), do: [file_flag(), "/dev/tty", "-a"]
+  def command_args(:raw), do: [file_flag(), tty_device() | @raw_flags]
+  def command_args(:save), do: [file_flag(), tty_device(), "-g"]
+  def command_args(:sane), do: [file_flag(), tty_device(), "sane"]
+  def command_args(:size), do: [file_flag(), tty_device(), "size"]
+  def command_args(:flags), do: [file_flag(), tty_device(), "-a"]
+
+  @doc """
+  The controlling terminal's device path (`/dev/ttys003`,
+  `/dev/pts/3`), or `/dev/tty` when it cannot be resolved.
+
+  Asked of `ps` rather than read from fd 0: `/proc/self/fd/0` is a
+  symlink only on Linux (macOS exposes a character device that cannot
+  be `readlink`ed), and fd 0 answers "what is stdin" -- which is a pipe
+  under any redirect -- where the termios calls here want "what is my
+  controlling terminal". `ps -o tty=` answers the second question on
+  both platforms.
+
+  Resolved once and cached: fd 0's terminal cannot change for the life
+  of the VM, and the guard path (`isig_off?/0`, potentially once per
+  input chunk) must not fork `ps` every time.
+
+  `config :raxol_terminal, :stty_device` overrides the resolution. That
+  seam exists because these commands really do mutate a real terminal
+  now: a test that exercises `restore/1` with a saved-settings value
+  would otherwise apply a FOREIGN termios dump to whatever terminal is
+  running the suite. Point it at a non-tty to keep a test honest about
+  the argv it builds without letting it reach for the developer's
+  session. Deliberately read per call, not cached, so it can be set and
+  unset around a single test.
+  """
+  @spec tty_device :: String.t()
+  def tty_device do
+    case Application.get_env(:raxol_terminal, :stty_device) do
+      device when is_binary(device) -> device
+      _unset -> resolved_device()
+    end
+  end
+
+  defp resolved_device do
+    case :persistent_term.get({__MODULE__, :tty_device}, :undefined) do
+      :undefined ->
+        device = resolve_tty_device()
+        :persistent_term.put({__MODULE__, :tty_device}, device)
+        device
+
+      device ->
+        device
+    end
+  end
+
+  defp resolve_tty_device do
+    case System.cmd("ps", ["-o", "tty=", "-p", to_string(:os.getpid())], stderr_to_stdout: true) do
+      {out, 0} -> normalize_device(String.trim(out))
+      _failed -> @fallback_device
+    end
+  rescue
+    _error -> @fallback_device
+  end
+
+  # `ps` reports the bare terminal name (`ttys003`, `pts/3`) and marks
+  # "no controlling terminal" as `?`/`??` depending on platform.
+  defp normalize_device(name) when name in ["", "?", "??"], do: @fallback_device
+  defp normalize_device("/dev/" <> _rest = path), do: path
+  defp normalize_device(name), do: "/dev/" <> name
 
   # Runs one constructed command. `{output, exit_status}`; never raises
   # (a missing binary or an un-openable /dev/tty degrades to `{"", 1}` --
@@ -58,9 +133,10 @@ defmodule Raxol.Terminal.Driver.Stty do
   end
 
   @doc """
-  Whether ISIG is currently OFF on /dev/tty -- read from the LIVE flags
-  (`stty -f /dev/tty -a`), the referent for "will ^C arrive as byte 0x03
-  or become a SIGINT". `false` when the flags cannot be read at all
+  Whether ISIG is currently OFF on the controlling terminal -- read
+  from the LIVE flags (`stty -f DEVICE -a`), the referent for "will ^C
+  arrive as byte 0x03 or become a SIGINT". `false` when the flags
+  cannot be read at all
   (no controlling tty): the honest answer is "cannot confirm", never a
   raise and never an assumed yes.
   """
@@ -93,13 +169,13 @@ defmodule Raxol.Terminal.Driver.Stty do
        shell) rather than `:os.cmd/1` -- `saved` is passed to `stty` as one
        literal argument, so there is no shell in the loop left to
        reinterpret it at all. `-F`/`-f DEVICE` (GNU/BSD respectively)
-       targets `/dev/tty` directly, the same device the old shell
-       redirect (`< /dev/tty`) pointed at.
+       targets the resolved device (see `tty_device/0`) directly, the
+       terminal the old shell redirect (`< /dev/tty`) was reaching for.
   """
   @spec restore(String.t() | nil) :: :ok
   def restore(saved) when is_binary(saved) and byte_size(saved) > 0 do
     if valid_saved_stty?(saved) do
-      _ = System.cmd("stty", [file_flag(), "/dev/tty", saved], stderr_to_stdout: true)
+      _ = System.cmd("stty", [file_flag(), tty_device(), saved], stderr_to_stdout: true)
       :ok
     else
       sane!()
@@ -122,20 +198,30 @@ defmodule Raxol.Terminal.Driver.Stty do
     end
   end
 
-  @doc "Reset TTY to sane defaults."
+  @doc """
+  Reset TTY to sane defaults.
+
+  This is the teardown fallback, so a silent no-op here is the worst
+  failure the module has: it strands a real terminal in raw mode with
+  no echo. It therefore runs through the same resolved-device argv form
+  as everything else -- the `sh -c "stty sane < /dev/tty"` it used to
+  run was exactly the shell redirect the moduledoc forbids, and it
+  failed for exactly the documented reason.
+  """
   @spec sane! :: :ok
   def sane! do
-    # credo:disable-for-next-line Credo.Check.Warning.UnsafeExec
-    _ = :os.cmd(~c"stty sane < /dev/tty 2>/dev/null")
+    _ = run(:sane)
     :ok
   end
 
   @doc "Query terminal size via `stty size`. Returns `{:ok, cols, rows}` or `:error`."
   @spec size :: {:ok, pos_integer(), pos_integer()} | :error
   def size do
-    # credo:disable-for-next-line Credo.Check.Warning.UnsafeExec
-    result = :os.cmd(~c"stty size < /dev/tty 2>/dev/null")
-    str = result |> List.to_string() |> String.trim()
+    str =
+      case run(:size) do
+        {out, 0} -> String.trim(out)
+        _failed -> ""
+      end
 
     case String.split(str) do
       [rows_s, cols_s] ->

--- a/packages/raxol_terminal/lib/raxol/terminal/inline_driver.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/inline_driver.ex
@@ -1052,6 +1052,22 @@ defmodule Raxol.Terminal.InlineDriver do
     _ -> start_stdin_reader(%{state | reader_mode: :prim_tty})
   end
 
+  # `input: :raw` is honoured from OTP 28 on and IGNORED before it. OTP 28's
+  # user_drv reads it for the noshell branch (`prim_tty:reinit(TTY, #{input =>
+  # Input, output => raw})`), which is what puts the tty in raw mode. OTP 26/27
+  # has no such branch: `initial_shell: :noshell` makes its `StartShell` false
+  # and it reinits with `#{tty => false}` unconditionally, never looking at
+  # `input` at all -- so the tty is left COOKED and every bare keystroke sits in
+  # the line discipline until a newline. Asking for a raw shell instead is not
+  # the way out: that spawns a real shell and drops user_drv into a JCL prompt
+  # that swallows all input.
+  #
+  # So on OTP 26/27 raw mode is ours to establish, and the post-arm
+  # `maybe_confirm_isig_boot/1` re-assert is what actually establishes it (it
+  # runs AFTER this reinit, so it wins). That only works because `Stty` targets
+  # the resolved device rather than `/dev/tty` -- see its moduledoc; with the
+  # `/dev/tty` form every stty here silently no-oped and OTP 26/27 decoded
+  # nothing at all.
   defp start_stdin_reader(%State{reader_mode: :prim_tty} = state) do
     user_drv = Process.whereis(:user_drv)
 

--- a/packages/raxol_terminal/lib/raxol/terminal/inline_driver/reader_gate.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/inline_driver/reader_gate.ex
@@ -31,7 +31,7 @@ defmodule Raxol.Terminal.InlineDriver.ReaderGate do
   `ref = monitor(process, reader, alias: :reply_demonitor)`, send
   `{ref, :disable | :enable}`, await `{ref, reply}`. While disabled the
   reader blocks in a selective receive waiting ONLY for the enable
-  message (verified against OTP kernel `prim_tty.erl`'s `reader_loop/2`):
+  message (verified against OTP kernel `prim_tty.erl`'s reader loop):
   it consumes no tty bytes, so kernel input queues for the editor. Its
   armed `{:read, :infinity}` state and the erlang trace flag both
   persist across the disable/enable bracket (same process, state map
@@ -58,23 +58,30 @@ defmodule Raxol.Terminal.InlineDriver.ReaderGate do
   ## Version coupling: pinned range and the drift failure mode
 
   This wire protocol is OTP-private. Tested/verified range: **OTP 26
-  through 29** (the disable/enable branch of `reader_loop/2` is
-  byte-identical across them; prim_tty itself first shipped the reader
-  in OTP 26). Below the floor, `disable/2`/`enable/2` refuse with
-  `{:error, {:unsupported_otp, release}}` rather than sending a message
-  whose receiver semantics were never verified.
+  through 29** (prim_tty itself first shipped the reader in OTP 26).
+  The reader loop was rewritten in OTP 28 -- `reader_loop/6` on OTP
+  26/27, `reader_loop/2` on 28+ -- but the disable/enable branch this
+  module speaks survived that rewrite unchanged, which is what makes
+  one implementation correct across the whole range. Below the floor,
+  `disable/2`/`enable/2` refuse with `{:error, {:unsupported_otp,
+  release}}` rather than sending a message whose receiver semantics
+  were never verified.
 
   If a FUTURE OTP changes the reader's message shape, the failure mode
-  is fail-closed by construction, not silent corruption: `reader_loop`'s
-  catch-all clause ignores unknown messages, so the gate's call times
-  out (`{:error, :timeout}`, bounded), and the one caller that matters
-  treats a disable failure as ABORT-the-suspend -- the tty is never
-  handed to an editor with the gate in an unknown state. Bumping the
-  pinned range above is a deliberate act: re-read `prim_tty.erl`'s
-  `reader_loop/2` for the new release and extend the ceiling in this
-  doc; the protocol suite (`reader_gate_test.exs`, scripted readers)
-  pins the wire shape this module SPEAKS, and the pty round-trip test
-  exercises it against the REAL reader.
+  is fail-closed by construction, not silent corruption: the gate's
+  call times out (`{:error, :timeout}`, bounded), and the one caller
+  that matters treats a disable failure as ABORT-the-suspend -- the tty
+  is never handed to an editor with the gate in an unknown state. What
+  becomes of the unmatched message differs by release and neither case
+  weakens that: OTP 28+ has a catch-all clause that discards it, while
+  OTP 26/27 has none, so it simply sits in the reader's mailbox. The
+  gate sends at most one message per call, so that is a bounded
+  remainder, not a leak. Bumping the pinned range above is a deliberate
+  act: re-read `prim_tty.erl`'s reader loop for the new release (the
+  OTP 28 rewrite is the precedent for how much can move) and extend the
+  ceiling in this doc; the protocol suite (`reader_gate_test.exs`,
+  scripted readers) pins the wire shape this module SPEAKS, and the pty
+  round-trip test exercises it against the REAL reader.
   """
 
   @default_timeout_ms 2_000

--- a/packages/raxol_terminal/test/fixtures/input_canary_app.exs
+++ b/packages/raxol_terminal/test/fixtures/input_canary_app.exs
@@ -81,8 +81,7 @@ defmodule InputCanaryApp do
   defp collect(n, acc) do
     receive do
       {:inline_input, %Raxol.Core.Events.Event{type: :key, data: data}} ->
-        token = to_string(data[:char] || data[:key])
-        collect(n, [token | acc])
+        collect(n, [token(data) | acc])
 
       _ ->
         collect(n, acc)
@@ -90,6 +89,13 @@ defmodule InputCanaryApp do
       4000 -> Enum.reverse(acc)
     end
   end
+
+  # `ctrl` is carried separately from the char, and byte 0x03 parses to
+  # `%{ctrl: true, char: "c"}` -- the same char a bare `c` keystroke
+  # produces. Without the prefix a decoded ^C and a typed `c` are the
+  # same token, which is exactly the distinction the isig test turns on.
+  defp token(%{ctrl: true} = data), do: "ctrl-" <> to_string(data[:char] || data[:key])
+  defp token(data), do: to_string(data[:char] || data[:key])
 end
 
 InputCanaryApp.run()

--- a/packages/raxol_terminal/test/raxol/terminal/driver/stty_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/stty_test.exs
@@ -12,6 +12,18 @@ defmodule Raxol.Terminal.Driver.SttyTest do
 
   alias Raxol.Terminal.Driver.Stty
 
+  # These tests really do invoke `stty`, and it now targets a resolved
+  # device instead of failing to open `/dev/tty` -- so without this it
+  # would apply a foreign saved-settings dump to whichever terminal is
+  # running the suite. Point it somewhere that is not a tty: the argv is
+  # still built and executed (which is what the injection test proves),
+  # the command just cannot touch a real session.
+  setup do
+    Application.put_env(:raxol_terminal, :stty_device, "/dev/null")
+    on_exit(fn -> Application.delete_env(:raxol_terminal, :stty_device) end)
+    :ok
+  end
+
   @tag :unix_only
   test "an injection payload does not execute -- falls through to sane! instead" do
     marker =
@@ -57,28 +69,56 @@ defmodule Raxol.Terminal.Driver.SttyTest do
     assert :ok = Stty.restore("")
   end
 
-  describe "command construction targets /dev/tty by device flag, never a shell redirect" do
+  describe "command construction targets the tty by device flag, never a shell redirect" do
     # The real-terminal ^C trap regression class: a `sh -c "stty ... <
     # /dev/tty"` invocation silently no-ops wherever the shell child
     # cannot open a controlling tty, and rides through /bin/sh where the
     # argv form needs no shell at all. Every mutating/reading stty
-    # command must be the argv form `stty -f|-F /dev/tty ...` (BSD/GNU
+    # command must be the argv form `stty -f|-F DEVICE ...` (BSD/GNU
     # device flag -- the same form restore/1 already uses).
-    test "raw! argv includes the device flag, /dev/tty, and -isig" do
+    test "raw! argv includes the device flag, the device, and -isig" do
       args = Stty.command_args(:raw)
 
-      assert Enum.take(args, 2) in [["-f", "/dev/tty"], ["-F", "/dev/tty"]]
+      assert [flag, device | _rest] = args
+      assert flag in ["-f", "-F"]
+      assert device == Stty.tty_device()
       assert "-isig" in args
       assert "raw" in args
     end
 
-    test "save/sane/size/flags argv all carry the device flag + /dev/tty" do
+    test "save/sane/size/flags argv all carry the device flag + the device" do
       for op <- [:save, :sane, :size, :flags] do
         args = Stty.command_args(op)
 
-        assert Enum.take(args, 2) in [["-f", "/dev/tty"], ["-F", "/dev/tty"]],
-               "#{op} must operate on /dev/tty via the device flag, got #{inspect(args)}"
+        assert [flag, device | _rest] = args
+        assert flag in ["-f", "-F"], "#{op} must use the device flag, got #{inspect(args)}"
+
+        assert device == Stty.tty_device(),
+               "#{op} must operate on the resolved device, got #{inspect(args)}"
       end
+    end
+
+    # The device is never the literal `/dev/tty` when one can be
+    # resolved: a `System.cmd`-spawned stty is in a fresh session with no
+    # controlling terminal, so `/dev/tty` fails ENXIO for it and every
+    # operation in this module silently no-ops. That is the bug this
+    # resolution exists to close, so pin that it produces a real path
+    # wherever the test host has a tty at all.
+    @tag :unix_only
+    test "tty_device/0 resolves a concrete device path, or falls back honestly" do
+      Application.delete_env(:raxol_terminal, :stty_device)
+
+      device = Stty.tty_device()
+
+      assert String.starts_with?(device, "/dev/")
+      assert device == Stty.tty_device(), "must be stable across calls (cached)"
+    end
+
+    test "the configured device overrides resolution" do
+      Application.put_env(:raxol_terminal, :stty_device, "/dev/null")
+
+      assert Stty.tty_device() == "/dev/null"
+      assert Enum.take(Stty.command_args(:raw), 2) |> List.last() == "/dev/null"
     end
 
     @tag :unix_only

--- a/packages/raxol_terminal/test/raxol/terminal/input_isig_contract_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/input_isig_contract_test.exs
@@ -1,0 +1,112 @@
+defmodule Raxol.Terminal.InputIsigContractTest do
+  @moduledoc """
+  The live `-isig` guarantee: ^C reaches the app as byte 0x03, not as a SIGINT.
+
+  `Raxol.Terminal.Driver.Stty.raw!/0` asks for `-isig` so that the arm-quit
+  protocol owns Ctrl-C, rather than the kernel turning it into a signal the app
+  never sees. Nothing else covers that end to end.
+
+  It is worth a real pty (via `Raxol.Terminal.PtyHarness`) because the two
+  outcomes are not "assert true vs false" -- they are different PROCESS fates.
+  With ISIG off, 0x03 is delivered and decodes to a ctrl-c key event. With ISIG
+  on, the line discipline raises SIGINT on the foreground group instead and the
+  app dies (or drops into the VM BREAK menu) without ever writing its output --
+  so a regression surfaces as `:no_output`, not as a wrong token. Verified by
+  reverting the fix that made `Stty` functional: this test failed at exactly
+  that stage while the protocol canary went on passing.
+
+  It asserts the in-VM termios diagnostics as well as the decode, and that is
+  deliberate. The decode alone is what let this contract stay vacuous for so
+  long: every `stty` call used to no-op silently (it targeted `/dev/tty`, which
+  a `System.cmd` child in a fresh session cannot open), so `isig_off` read false
+  on every OTP while the suite stayed green. Asserting the flags is what stops
+  it going quiet again.
+
+  Ctrl-C decodes to `%{ctrl: true, char: "c"}` -- the same char a bare `c`
+  keystroke produces -- so the fixture prefixes ctrl chords. Without that a
+  decoded ^C and a typed `c` are the same token and this test would pass for
+  the wrong reason.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Terminal.PtyHarness
+
+  @moduletag :unix_only
+  # Shares the nightly canary's tag: both are the real-pty input contract, and
+  # a bump of `OTP_VERSION` in CI must surface both together.
+  @moduletag :input_protocol_canary
+  @moduletag timeout: 180_000
+
+  @keys [{:named, "C-c"}]
+  @expected ["ctrl-c"]
+
+  test "^C arrives as byte 0x03 instead of raising SIGINT" do
+    case PtyHarness.driver() do
+      nil ->
+        IO.puts(:stderr, "[isig contract] skipped: neither tmux nor expect on PATH")
+
+      driver ->
+        result = PtyHarness.run(driver, @keys, @expected)
+
+        assert result.tokens == @expected,
+               PtyHarness.report(result, driver, @expected, explain(result.stage))
+
+        assert result.diag =~ "isig_off=true",
+               """
+               ^C decoded, but the app reports ISIG still ON. The keystroke got \
+               through on something other than the `-isig` this contract \
+               promises, so the guarantee is not actually in force.
+
+               #{result.diag}
+               """
+
+        assert result.diag =~ "boot_confirmed=true",
+               """
+               `-isig` was never confirmed during boot: the verify-then-assert \
+               loop (`reassert_raw_until_isig_off/1`) gave up. That is the \
+               signature of `stty` silently no-oping -- check \
+               `Stty.tty_device/0` resolution before anything else.
+
+               #{result.diag}
+               """
+    end
+  end
+
+  # What each stage means FOR THIS CLAIM -- which is mostly not what it means
+  # for the protocol canary.
+  defp explain(:no_output) do
+    """
+    THIS IS THE REGRESSION THIS TEST EXISTS TO CATCH. ^C was delivered and the
+    app then died without writing its output: the signature of ISIG being back
+    ON, the line discipline raising SIGINT on the foreground group instead of
+    passing byte 0x03 through. Check that `Stty.raw!/0`'s `-isig` is actually
+    reaching a real device (`Stty.tty_device/0`) rather than failing silently.
+    """
+  end
+
+  defp explain(:empty) do
+    """
+    The app survived (so ISIG is plausibly off) but decoded nothing at all.
+    That points at the input path in general rather than at this contract --
+    check the protocol canary first, since it isolates exactly that.
+    """
+  end
+
+  defp explain(:ready_timeout) do
+    """
+    The app never signalled ready, so no ^C was ever sent. Nothing to say about
+    ISIG: the app failed to boot within the #{PtyHarness.ready_budget_ms()}ms
+    budget.
+    """
+  end
+
+  defp explain(:send_failed) do
+    """
+    The pty driver refused to deliver the keystroke (non-zero exit from
+    send-keys) -- suspect the tmux session or the CI environment, not the
+    termios.
+    """
+  end
+
+  defp explain(other), do: "Unrecognized stage: #{inspect(other)}."
+end

--- a/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
@@ -24,6 +24,11 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   Driver: tmux when present (same mechanism the Terminal-Bench harness uses to
   drive agents), else `expect` as a portable fallback. Skips only when neither
   is installed. `unix_only` -- there is no pty to drive on Windows.
+
+  Runs on every OTP in the matrix, including those where `user_drv` will not
+  hand out a raw noshell tty and `Raxol.Terminal.Driver.Stty` has to establish
+  raw mode itself (OTP 26/27 -- see `Stty`'s moduledoc). Keeping it unskipped
+  there is the point: that path has no other end-to-end coverage.
   """
   use ExUnit.Case, async: false
 
@@ -117,14 +122,20 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
       * `reader=absent` -- `:user_drv_reader` was not registered, so
         `start_stdin_reader/1` silently traced nothing. Not a protocol change.
       * `reader=untraced...` -- the trace never attached.
-      * `raw=...isig_off=false` -- the tty was NOT in raw mode, so a bare
-        keystroke is held in the line discipline until a newline. This canary
-        types `a` and `b` with no newline, so nothing is delivered. A raw-mode
-        problem, not a protocol one.
-      * `reader=traced` AND `isig_off=true` -- everything this side controls was
-        in place and the bytes still did not arrive. THAT is the case that
-        points at OTP moving the reader's private message shape or its re-arm
-        contract (`Raxol.Terminal.Driver`'s `{:trace, ...}` handler).
+      * `reader=traced` -- everything this side controls was in place and the
+        bytes still did not arrive. THAT is the case that points at OTP moving
+        the reader's private message shape or its re-arm contract
+        (`Raxol.Terminal.Driver`'s `{:trace, ...}` handler).
+
+    Do NOT read `isig_off=false` as "not in raw mode, so of course nothing
+    arrived". It is not that evidence, in either direction. Once the reader is
+    armed, prim_tty owns the termios and re-applies ITS raw mode, which keeps
+    ISIG ENABLED (the whole reason `reassert_raw_until_isig_off/1` exists) --
+    so `isig_off=false` is the ordinary steady state, and keystrokes decode
+    through it perfectly well. It means "prim_tty won the termios race",
+    nothing more. `-icanon` is what governs whether a bare keystroke is
+    deliverable, and prim_tty's own raw mode sets it whether or not our `stty`
+    ever ran.
     """
   end
 
@@ -214,34 +225,7 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
           :ready_timeout
       end
     after
-      System.cmd("tmux", ["kill-session", "-t", session],
-        stderr_to_stdout: true
-      )
-    end
-  end
-
-  defp type_both(session, out) do
-    with :ok <- send_key(session, "a"),
-         :ok <- gap_then_send(session, "b") do
-      wait_for_output(out)
-      :sent
-    end
-  end
-
-  defp gap_then_send(session, key) do
-    Process.sleep(@gap_ms)
-    send_key(session, key)
-  end
-
-  # A refused keystroke must not read as a decode failure. The exit status was
-  # dropped once, which made a dead tmux session and a moved protocol produce
-  # the same empty result.
-  defp send_key(session, key) do
-    case System.cmd("tmux", ["send-keys", "-t", session, "-l", key],
-           stderr_to_stdout: true
-         ) do
-      {_, 0} -> :ok
-      {_out, _status} -> :send_failed
+      System.cmd("tmux", ["kill-session", "-t", session], stderr_to_stdout: true)
     end
   end
 
@@ -266,6 +250,29 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     # `expect` does its own waiting inside the script, so reaching here means
     # the keystrokes were written to the pty.
     :sent
+  end
+
+  defp type_both(session, out) do
+    with :ok <- send_key(session, "a"),
+         :ok <- gap_then_send(session, "b") do
+      wait_for_output(out)
+      :sent
+    end
+  end
+
+  defp gap_then_send(session, key) do
+    Process.sleep(@gap_ms)
+    send_key(session, key)
+  end
+
+  # A refused keystroke must not read as a decode failure. The exit status was
+  # dropped once, which made a dead tmux session and a moved protocol produce
+  # the same empty result.
+  defp send_key(session, key) do
+    case System.cmd("tmux", ["send-keys", "-t", session, "-l", key], stderr_to_stdout: true) do
+      {_, 0} -> :ok
+      {_out, _status} -> :send_failed
+    end
   end
 
   # Type only once the reader is armed, so we never send before the pty listens.

--- a/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
@@ -1,6 +1,13 @@
 defmodule Raxol.Terminal.InputProtocolCanaryTest do
   @moduledoc """
-  The one test permitted to claim prim_tty PROTOCOL coverage.
+  The real-pty input tests -- the only ones permitted to claim prim_tty PROTOCOL
+  coverage or a live `-isig` guarantee.
+
+  Two separate claims, sharing one harness because both need a REAL terminal and
+  neither can be had without one:
+
+    * the protocol canary -- keystrokes decode through the live reader;
+    * the `-isig` contract -- ^C arrives as byte 0x03 rather than a SIGINT.
 
   Every other input test fabricates the `{:trace, ...}` message it asserts on, so
   it can only fail if our handler changes -- never if OTP moves the private
@@ -49,30 +56,85 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   @ready_tries 900
   @output_tries 60
 
-  test "real keystrokes decode through the live prim_tty reader" do
-    driver = pty_driver()
+  @plain_keys [{:literal, "a"}, {:literal, "b"}]
+  @ctrl_c_keys [{:named, "C-c"}]
 
-    if driver == nil do
-      IO.puts(
-        :stderr,
-        "[input canary] skipped: neither tmux nor expect on PATH"
-      )
-    else
-      {result, attempt} = drive_until(driver, @max_attempts)
+  test "real keystrokes decode through the live prim_tty reader" do
+    with_pty(fn driver ->
+      {result, attempt} = drive_until(driver, @plain_keys, ["a", "b"], @max_attempts)
 
       assert result.tokens == ["a", "b"],
-             failure_report(result, driver, attempt)
+             failure_report(result, driver, attempt, ["a", "b"])
+    end)
+  end
+
+  # The `-isig` half of the raw-mode contract, which nothing else covers end to
+  # end. `Stty.raw!/0` asks for `-isig` so that ^C reaches the app as byte 0x03
+  # and the arm-quit protocol owns it, rather than the kernel turning it into a
+  # SIGINT the app never sees.
+  #
+  # This is worth a real pty because the two outcomes are not "assert true vs
+  # false" -- they are different PROCESS fates. With ISIG off, 0x03 is delivered
+  # and decodes to a ctrl-c key event. With ISIG on, the line discipline raises
+  # SIGINT on the foreground group instead, and the app dies (or drops into the
+  # VM BREAK menu) without ever writing its output file -- so a regression
+  # surfaces as `:no_output`/`:ready_timeout`, not as a wrong token.
+  #
+  # It also pins the thing that made this contract vacuous for so long: the
+  # in-VM diagnostics must show the termios was actually ESTABLISHED. Every
+  # `stty` call used to no-op silently (it targeted `/dev/tty`, which a port
+  # child in a fresh session cannot open), so `isig_off` read false on every
+  # OTP while the suite stayed green. Asserting the flags -- not just the
+  # decode -- is what stops that from going quiet again.
+  test "^C arrives as byte 0x03 instead of raising SIGINT (-isig holds)" do
+    with_pty(fn driver ->
+      {result, attempt} = drive_until(driver, @ctrl_c_keys, ["ctrl-c"], @max_attempts)
+
+      assert result.tokens == ["ctrl-c"],
+             failure_report(result, driver, attempt, ["ctrl-c"])
+
+      assert result.diag =~ "isig_off=true",
+             """
+             ^C decoded, but the app reports ISIG still ON. The keystroke got \
+             through on something other than the `-isig` this contract promises, \
+             so the guarantee is not actually in force.
+
+             #{result.diag}
+             """
+
+      assert result.diag =~ "boot_confirmed=true",
+             """
+             `-isig` was never confirmed during boot: the verify-then-assert loop \
+             (`reassert_raw_until_isig_off/1`) gave up. That is the signature of \
+             `stty` silently no-oping -- check `Stty.tty_device/0` resolution \
+             before anything else.
+
+             #{result.diag}
+             """
+    end)
+  end
+
+  defp with_pty(fun) do
+    case pty_driver() do
+      nil ->
+        IO.puts(
+          :stderr,
+          "[input canary] skipped: neither tmux nor expect on PATH"
+        )
+
+      driver ->
+        fun.(driver)
     end
   end
 
   # Name the stage that actually failed. Every one of these used to surface as
   # `got []`, which said "OTP moved the protocol" no matter which of them it
   # was -- and for most of them that claim is simply false.
-  defp failure_report(result, driver, attempt) do
+  defp failure_report(result, driver, attempt, expected) do
     """
-    prim_tty input protocol canary FAILED on OTP #{System.otp_release()} \
+    prim_tty real-pty input test FAILED on OTP #{System.otp_release()} \
     (driver: #{driver}) after #{attempt} attempt(s), at stage: #{result.stage}.
-    Expected ["a", "b"], got #{inspect(result.tokens)}.
+    Expected #{inspect(expected)}, got #{inspect(result.tokens)}.
 
     #{stage_explanation(result.stage)}
 
@@ -145,27 +207,27 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   # before the reader has armed its select loop -- a timing flake, not a protocol
   # failure. Retry the whole drive: a real OTP break fails every attempt, a race
   # succeeds on a later one.
-  defp drive_until(driver, attempts_left, attempt \\ 1) do
-    result = attempt_drive(driver)
+  defp drive_until(driver, keys, expected, attempts_left, attempt \\ 1) do
+    result = attempt_drive(driver, keys)
 
     cond do
-      result.tokens == ["a", "b"] -> {result, attempt}
+      result.tokens == expected -> {result, attempt}
       attempts_left <= 1 -> {result, attempt}
-      true -> drive_until(driver, attempts_left - 1, attempt + 1)
+      true -> drive_until(driver, keys, expected, attempts_left - 1, attempt + 1)
     end
   end
 
-  defp attempt_drive(driver) do
+  defp attempt_drive(driver, keys) do
     out = Path.join(System.tmp_dir!(), "raxol_input_canary_#{unique()}")
 
     try do
-      stage = drive(driver, out)
+      stage = drive(driver, out, keys)
       diag = read_diagnostics(out)
 
       case {stage, File.read(out)} do
         {:sent, {:ok, body}} ->
           tokens = String.split(body, "\n", trim: true)
-          %{tokens: tokens, stage: classify(tokens), diag: diag}
+          %{tokens: tokens, stage: classify(tokens, keys), diag: diag}
 
         {:sent, {:error, _}} ->
           %{tokens: [], stage: :no_output, diag: diag}
@@ -179,9 +241,9 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     end
   end
 
-  defp classify(["a", "b"]), do: :ok
-  defp classify([]), do: :empty
-  defp classify(_partial), do: :partial
+  defp classify([], _keys), do: :empty
+  defp classify(tokens, keys) when length(tokens) < length(keys), do: :partial
+  defp classify(_tokens, _keys), do: :ok
 
   # The app's own account of what it established. Absent when it never got far
   # enough to write one, which is itself the answer.
@@ -200,11 +262,12 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     end
   end
 
-  defp drive(:tmux, out) do
+  defp drive(:tmux, out, keys) do
     session = "raxol-input-canary-#{unique()}"
 
     cmd =
-      "cd #{@pkg_dir} && CANARY_OUT=#{out} CANARY_N=2 MIX_ENV=test mix run --no-compile #{@app}"
+      "cd #{@pkg_dir} && CANARY_OUT=#{out} CANARY_N=#{length(keys)} " <>
+        "MIX_ENV=test mix run --no-compile #{@app}"
 
     try do
       {_, 0} =
@@ -215,11 +278,11 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
         )
 
       # Only type once the reader signalled ready, then settle briefly so its
-      # select loop is armed. `-l` sends the bytes literally (not as key names).
+      # select loop is armed.
       case wait_for_ready(out) do
         :ok ->
           Process.sleep(@settle_ms)
-          type_both(session, out)
+          type_all(session, out, keys)
 
         :timeout ->
           :ready_timeout
@@ -229,19 +292,22 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     end
   end
 
-  defp drive(:expect, out) do
+  defp drive(:expect, out, keys) do
     # The canary app `System.halt/0`s right after writing output, so `eof`
     # returns promptly. `--no-compile`: the parent test already compiled, so the
     # nested run must not recompile under lock contention.
+    sends =
+      keys
+      |> Enum.map(&~s|send "#{expect_bytes(&1)}"\nafter #{@gap_ms}|)
+      |> Enum.join("\n")
+
     script = """
     set timeout 120
-    spawn env CANARY_OUT=#{out} CANARY_N=2 MIX_ENV=test mix run --no-compile #{@app}
+    spawn env CANARY_OUT=#{out} CANARY_N=#{length(keys)} MIX_ENV=test mix run --no-compile #{@app}
     set t 0
     while {![file exists "#{out}.ready"] && $t < 900} { after 100; incr t }
     after #{@settle_ms}
-    send "a"
-    after #{@gap_ms}
-    send "b"
+    #{sends}
     expect eof
     """
 
@@ -252,28 +318,51 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     :sent
   end
 
-  defp type_both(session, out) do
-    with :ok <- send_key(session, "a"),
-         :ok <- gap_then_send(session, "b") do
-      wait_for_output(out)
-      :sent
-    end
-  end
+  defp type_all(session, out, keys) do
+    result =
+      Enum.reduce_while(keys, :ok, fn key, _acc ->
+        case send_key(session, key) do
+          :ok ->
+            Process.sleep(@gap_ms)
+            {:cont, :ok}
 
-  defp gap_then_send(session, key) do
-    Process.sleep(@gap_ms)
-    send_key(session, key)
+          other ->
+            {:halt, other}
+        end
+      end)
+
+    case result do
+      :ok ->
+        wait_for_output(out)
+        :sent
+
+      other ->
+        other
+    end
   end
 
   # A refused keystroke must not read as a decode failure. The exit status was
   # dropped once, which made a dead tmux session and a moved protocol produce
   # the same empty result.
+  #
+  # `-l` sends the bytes literally; a `{:named, _}` key is a tmux key NAME
+  # (`C-c`), which must NOT be sent literally or tmux types the three
+  # characters `C`, `-`, `c` instead of the control byte.
   defp send_key(session, key) do
-    case System.cmd("tmux", ["send-keys", "-t", session, "-l", key], stderr_to_stdout: true) do
+    args =
+      case key do
+        {:literal, k} -> ["send-keys", "-t", session, "-l", k]
+        {:named, k} -> ["send-keys", "-t", session, k]
+      end
+
+    case System.cmd("tmux", args, stderr_to_stdout: true) do
       {_, 0} -> :ok
       {_out, _status} -> :send_failed
     end
   end
+
+  defp expect_bytes({:literal, k}), do: k
+  defp expect_bytes({:named, "C-c"}), do: "\\003"
 
   # Type only once the reader is armed, so we never send before the pty listens.
   defp wait_for_ready(out), do: poll(out <> @ready_suffix, @ready_tries)

--- a/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/input_protocol_canary_test.exs
@@ -1,21 +1,14 @@
 defmodule Raxol.Terminal.InputProtocolCanaryTest do
   @moduledoc """
-  The real-pty input tests -- the only ones permitted to claim prim_tty PROTOCOL
-  coverage or a live `-isig` guarantee.
-
-  Two separate claims, sharing one harness because both need a REAL terminal and
-  neither can be had without one:
-
-    * the protocol canary -- keystrokes decode through the live reader;
-    * the `-isig` contract -- ^C arrives as byte 0x03 rather than a SIGINT.
+  The one test permitted to claim prim_tty PROTOCOL coverage.
 
   Every other input test fabricates the `{:trace, ...}` message it asserts on, so
   it can only fail if our handler changes -- never if OTP moves the private
   protocol underneath us (the reader's message shape, the `{:read, :infinity}`
-  re-arm). This one drives a REAL pty: it boots the actual `InlineDriver` stdin
-  reader inside a terminal multiplexer, types real keystrokes, and asserts they
-  decode into events. That makes it the one test a bump of `OTP_VERSION` in CI
-  should surface loudly instead of shipping.
+  re-arm). This one drives a REAL pty via `Raxol.Terminal.PtyHarness`: it boots
+  the actual `InlineDriver` stdin reader inside a terminal multiplexer, types
+  real keystrokes, and asserts they decode into events. That makes it the one
+  test a bump of `OTP_VERSION` in CI should surface loudly instead of shipping.
 
   A red here does NOT on its own mean "OTP moved". Several things sit between a
   keystroke and a decoded event, and most of them are ours: the app has to boot
@@ -28,16 +21,17 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   Two keystrokes (not one) with a gap between them: a drift that delivers the
   first read but breaks re-arming would sail through a single-byte test.
 
-  Driver: tmux when present (same mechanism the Terminal-Bench harness uses to
-  drive agents), else `expect` as a portable fallback. Skips only when neither
-  is installed. `unix_only` -- there is no pty to drive on Windows.
-
   Runs on every OTP in the matrix, including those where `user_drv` will not
   hand out a raw noshell tty and `Raxol.Terminal.Driver.Stty` has to establish
   raw mode itself (OTP 26/27 -- see `Stty`'s moduledoc). Keeping it unskipped
   there is the point: that path has no other end-to-end coverage.
+
+  The `-isig` half of the raw-mode contract is a different claim and lives in
+  `input_isig_contract_test.exs`.
   """
   use ExUnit.Case, async: false
+
+  alias Raxol.Terminal.PtyHarness
 
   @moduletag :unix_only
   @moduletag :input_protocol_canary
@@ -45,114 +39,35 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
   # sub-second. Give the boot room so the canary never flakes on its own latency.
   @moduletag timeout: 180_000
 
-  @app Path.expand("../../fixtures/input_canary_app.exs", __DIR__)
-  @pkg_dir Path.expand("../../..", __DIR__)
-  @gap_ms 300
-  # Settle after the reader signals ready, before the first keystroke, so its
-  # select loop is armed. Retry a few times to absorb cold-boot pty timing slop.
-  @settle_ms 250
-  @max_attempts 3
-  @ready_suffix ".ready"
-  @ready_tries 900
-  @output_tries 60
-
-  @plain_keys [{:literal, "a"}, {:literal, "b"}]
-  @ctrl_c_keys [{:named, "C-c"}]
+  @keys [{:literal, "a"}, {:literal, "b"}]
+  @expected ["a", "b"]
 
   test "real keystrokes decode through the live prim_tty reader" do
-    with_pty(fn driver ->
-      {result, attempt} = drive_until(driver, @plain_keys, ["a", "b"], @max_attempts)
-
-      assert result.tokens == ["a", "b"],
-             failure_report(result, driver, attempt, ["a", "b"])
-    end)
-  end
-
-  # The `-isig` half of the raw-mode contract, which nothing else covers end to
-  # end. `Stty.raw!/0` asks for `-isig` so that ^C reaches the app as byte 0x03
-  # and the arm-quit protocol owns it, rather than the kernel turning it into a
-  # SIGINT the app never sees.
-  #
-  # This is worth a real pty because the two outcomes are not "assert true vs
-  # false" -- they are different PROCESS fates. With ISIG off, 0x03 is delivered
-  # and decodes to a ctrl-c key event. With ISIG on, the line discipline raises
-  # SIGINT on the foreground group instead, and the app dies (or drops into the
-  # VM BREAK menu) without ever writing its output file -- so a regression
-  # surfaces as `:no_output`/`:ready_timeout`, not as a wrong token.
-  #
-  # It also pins the thing that made this contract vacuous for so long: the
-  # in-VM diagnostics must show the termios was actually ESTABLISHED. Every
-  # `stty` call used to no-op silently (it targeted `/dev/tty`, which a port
-  # child in a fresh session cannot open), so `isig_off` read false on every
-  # OTP while the suite stayed green. Asserting the flags -- not just the
-  # decode -- is what stops that from going quiet again.
-  test "^C arrives as byte 0x03 instead of raising SIGINT (-isig holds)" do
-    with_pty(fn driver ->
-      {result, attempt} = drive_until(driver, @ctrl_c_keys, ["ctrl-c"], @max_attempts)
-
-      assert result.tokens == ["ctrl-c"],
-             failure_report(result, driver, attempt, ["ctrl-c"])
-
-      assert result.diag =~ "isig_off=true",
-             """
-             ^C decoded, but the app reports ISIG still ON. The keystroke got \
-             through on something other than the `-isig` this contract promises, \
-             so the guarantee is not actually in force.
-
-             #{result.diag}
-             """
-
-      assert result.diag =~ "boot_confirmed=true",
-             """
-             `-isig` was never confirmed during boot: the verify-then-assert loop \
-             (`reassert_raw_until_isig_off/1`) gave up. That is the signature of \
-             `stty` silently no-oping -- check `Stty.tty_device/0` resolution \
-             before anything else.
-
-             #{result.diag}
-             """
-    end)
-  end
-
-  defp with_pty(fun) do
-    case pty_driver() do
+    case PtyHarness.driver() do
       nil ->
-        IO.puts(
-          :stderr,
-          "[input canary] skipped: neither tmux nor expect on PATH"
-        )
+        IO.puts(:stderr, "[input canary] skipped: neither tmux nor expect on PATH")
 
       driver ->
-        fun.(driver)
+        result = PtyHarness.run(driver, @keys, @expected)
+
+        assert result.tokens == @expected,
+               PtyHarness.report(result, driver, @expected, explain(result.stage))
     end
   end
 
-  # Name the stage that actually failed. Every one of these used to surface as
+  # What each stage means FOR THIS CLAIM. Every one of these used to surface as
   # `got []`, which said "OTP moved the protocol" no matter which of them it
   # was -- and for most of them that claim is simply false.
-  defp failure_report(result, driver, attempt, expected) do
-    """
-    prim_tty real-pty input test FAILED on OTP #{System.otp_release()} \
-    (driver: #{driver}) after #{attempt} attempt(s), at stage: #{result.stage}.
-    Expected #{inspect(expected)}, got #{inspect(result.tokens)}.
-
-    #{stage_explanation(result.stage)}
-
-    In-VM diagnostics from the app (#{@ready_suffix} file):
-      #{result.diag}
-    """
-  end
-
-  defp stage_explanation(:ready_timeout) do
+  defp explain(:ready_timeout) do
     """
     The app never signalled ready, so NO keystroke was ever sent. This is not a
     protocol break: the app failed to boot or to arm its reader within the
-    #{@ready_tries * 100}ms budget. Look at the app's own startup, not at the
-    trace handler.
+    #{PtyHarness.ready_budget_ms()}ms budget. Look at the app's own startup, not
+    at the trace handler.
     """
   end
 
-  defp stage_explanation(:send_failed) do
+  defp explain(:send_failed) do
     """
     The pty driver refused to deliver a keystroke (non-zero exit from send-keys).
     Nothing reached the app, so this says nothing about the input path -- suspect
@@ -160,7 +75,7 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     """
   end
 
-  defp stage_explanation(:no_output) do
+  defp explain(:no_output) do
     """
     Keystrokes were sent, but the app never wrote its output file at all -- it
     is still blocked or it died before finishing. Check whether the app crashed
@@ -168,7 +83,7 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     """
   end
 
-  defp stage_explanation(:partial) do
+  defp explain(:partial) do
     """
     The FIRST keystroke decoded and a later one did not. This is the re-arm
     break the two-keystroke design exists to catch: the reader delivered one
@@ -176,7 +91,7 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     """
   end
 
-  defp stage_explanation(:empty) do
+  defp explain(:empty) do
     """
     The app armed and ran, keystrokes were sent, and it decoded NOTHING. Read
     the diagnostics below before blaming the protocol:
@@ -201,183 +116,5 @@ defmodule Raxol.Terminal.InputProtocolCanaryTest do
     """
   end
 
-  defp stage_explanation(other), do: "Unrecognized stage: #{inspect(other)}."
-
-  # A cold pty boot inside tmux/expect can drop the first keystroke if it lands
-  # before the reader has armed its select loop -- a timing flake, not a protocol
-  # failure. Retry the whole drive: a real OTP break fails every attempt, a race
-  # succeeds on a later one.
-  defp drive_until(driver, keys, expected, attempts_left, attempt \\ 1) do
-    result = attempt_drive(driver, keys)
-
-    cond do
-      result.tokens == expected -> {result, attempt}
-      attempts_left <= 1 -> {result, attempt}
-      true -> drive_until(driver, keys, expected, attempts_left - 1, attempt + 1)
-    end
-  end
-
-  defp attempt_drive(driver, keys) do
-    out = Path.join(System.tmp_dir!(), "raxol_input_canary_#{unique()}")
-
-    try do
-      stage = drive(driver, out, keys)
-      diag = read_diagnostics(out)
-
-      case {stage, File.read(out)} do
-        {:sent, {:ok, body}} ->
-          tokens = String.split(body, "\n", trim: true)
-          %{tokens: tokens, stage: classify(tokens, keys), diag: diag}
-
-        {:sent, {:error, _}} ->
-          %{tokens: [], stage: :no_output, diag: diag}
-
-        {stage, _} ->
-          %{tokens: [], stage: stage, diag: diag}
-      end
-    after
-      File.rm(out)
-      File.rm(out <> @ready_suffix)
-    end
-  end
-
-  defp classify([], _keys), do: :empty
-  defp classify(tokens, keys) when length(tokens) < length(keys), do: :partial
-  defp classify(_tokens, _keys), do: :ok
-
-  # The app's own account of what it established. Absent when it never got far
-  # enough to write one, which is itself the answer.
-  defp read_diagnostics(out) do
-    case File.read(out <> @ready_suffix) do
-      {:ok, body} -> String.trim(body)
-      {:error, _} -> "(no ready file -- the app never signalled)"
-    end
-  end
-
-  defp pty_driver do
-    cond do
-      System.find_executable("tmux") -> :tmux
-      System.find_executable("expect") -> :expect
-      true -> nil
-    end
-  end
-
-  defp drive(:tmux, out, keys) do
-    session = "raxol-input-canary-#{unique()}"
-
-    cmd =
-      "cd #{@pkg_dir} && CANARY_OUT=#{out} CANARY_N=#{length(keys)} " <>
-        "MIX_ENV=test mix run --no-compile #{@app}"
-
-    try do
-      {_, 0} =
-        System.cmd(
-          "tmux",
-          ["new-session", "-d", "-s", session, "-x", "80", "-y", "24", cmd],
-          stderr_to_stdout: true
-        )
-
-      # Only type once the reader signalled ready, then settle briefly so its
-      # select loop is armed.
-      case wait_for_ready(out) do
-        :ok ->
-          Process.sleep(@settle_ms)
-          type_all(session, out, keys)
-
-        :timeout ->
-          :ready_timeout
-      end
-    after
-      System.cmd("tmux", ["kill-session", "-t", session], stderr_to_stdout: true)
-    end
-  end
-
-  defp drive(:expect, out, keys) do
-    # The canary app `System.halt/0`s right after writing output, so `eof`
-    # returns promptly. `--no-compile`: the parent test already compiled, so the
-    # nested run must not recompile under lock contention.
-    sends =
-      keys
-      |> Enum.map(&~s|send "#{expect_bytes(&1)}"\nafter #{@gap_ms}|)
-      |> Enum.join("\n")
-
-    script = """
-    set timeout 120
-    spawn env CANARY_OUT=#{out} CANARY_N=#{length(keys)} MIX_ENV=test mix run --no-compile #{@app}
-    set t 0
-    while {![file exists "#{out}.ready"] && $t < 900} { after 100; incr t }
-    after #{@settle_ms}
-    #{sends}
-    expect eof
-    """
-
-    System.cmd("expect", ["-c", script], cd: @pkg_dir, stderr_to_stdout: true)
-
-    # `expect` does its own waiting inside the script, so reaching here means
-    # the keystrokes were written to the pty.
-    :sent
-  end
-
-  defp type_all(session, out, keys) do
-    result =
-      Enum.reduce_while(keys, :ok, fn key, _acc ->
-        case send_key(session, key) do
-          :ok ->
-            Process.sleep(@gap_ms)
-            {:cont, :ok}
-
-          other ->
-            {:halt, other}
-        end
-      end)
-
-    case result do
-      :ok ->
-        wait_for_output(out)
-        :sent
-
-      other ->
-        other
-    end
-  end
-
-  # A refused keystroke must not read as a decode failure. The exit status was
-  # dropped once, which made a dead tmux session and a moved protocol produce
-  # the same empty result.
-  #
-  # `-l` sends the bytes literally; a `{:named, _}` key is a tmux key NAME
-  # (`C-c`), which must NOT be sent literally or tmux types the three
-  # characters `C`, `-`, `c` instead of the control byte.
-  defp send_key(session, key) do
-    args =
-      case key do
-        {:literal, k} -> ["send-keys", "-t", session, "-l", k]
-        {:named, k} -> ["send-keys", "-t", session, k]
-      end
-
-    case System.cmd("tmux", args, stderr_to_stdout: true) do
-      {_, 0} -> :ok
-      {_out, _status} -> :send_failed
-    end
-  end
-
-  defp expect_bytes({:literal, k}), do: k
-  defp expect_bytes({:named, "C-c"}), do: "\\003"
-
-  # Type only once the reader is armed, so we never send before the pty listens.
-  defp wait_for_ready(out), do: poll(out <> @ready_suffix, @ready_tries)
-  defp wait_for_output(out), do: poll(out, @output_tries)
-
-  defp poll(_path, 0), do: :timeout
-
-  defp poll(path, tries) do
-    if File.exists?(path) do
-      :ok
-    else
-      Process.sleep(100)
-      poll(path, tries - 1)
-    end
-  end
-
-  defp unique, do: System.unique_integer([:positive])
+  defp explain(other), do: "Unrecognized stage: #{inspect(other)}."
 end

--- a/packages/raxol_terminal/test/support/pty_harness.ex
+++ b/packages/raxol_terminal/test/support/pty_harness.ex
@@ -1,0 +1,268 @@
+defmodule Raxol.Terminal.PtyHarness do
+  @moduledoc """
+  Drives the real `InlineDriver` inside a real pty and reports what it decoded.
+
+  The mechanism shared by every test that cannot be had without a genuine
+  terminal: the protocol canary and the `-isig` contract both need an actual
+  tty, a real multiplexer to type into, and the driver's own in-VM account of
+  what it established. What they DIFFER on is the claim, so this module stops
+  at the evidence: it returns the stage reached, the tokens decoded, and the
+  app's diagnostics, and leaves every interpretation to the caller. Stage prose
+  in particular belongs to the test -- `:no_output` means "the reader is wedged"
+  to one of them and "SIGINT killed the app" to the other, and a shared
+  explanation could only be vague enough to fit both.
+
+  ## The app under the pty
+
+  `test/fixtures/input_canary_app.exs`, booted through `mix run` inside the
+  multiplexer. It arms the driver, writes `<out>.ready` with its diagnostics,
+  collects `CANARY_N` key events, writes one token per line to `<out>`, and
+  halts. Everything here is bookkeeping around that file pair.
+
+  ## Keys
+
+  `{:literal, "a"}` sends bytes verbatim (tmux `-l`). `{:named, "C-c"}` sends a
+  tmux key NAME, which must NOT go through `-l` or tmux types the three
+  characters `C`, `-`, `c` instead of the control byte.
+
+  ## Retries
+
+  A cold pty boot can drop the first keystroke if it lands before the reader
+  has armed its select loop -- a timing flake, not a real failure. `run/3`
+  retries the whole drive, so a genuine break fails every attempt while a race
+  succeeds on a later one.
+  """
+
+  @app Path.expand("../fixtures/input_canary_app.exs", __DIR__)
+  @pkg_dir Path.expand("../..", __DIR__)
+  @gap_ms 300
+  # Settle after the reader signals ready, before the first keystroke, so its
+  # select loop is armed.
+  @settle_ms 250
+  @max_attempts 3
+  @ready_suffix ".ready"
+  @ready_tries 900
+  @output_tries 60
+
+  @type key :: {:literal, String.t()} | {:named, String.t()}
+  @type stage :: :ok | :empty | :partial | :no_output | :ready_timeout | :send_failed
+  @type result :: %{
+          tokens: [String.t()],
+          stage: stage(),
+          diag: String.t(),
+          attempts: pos_integer()
+        }
+
+  @doc """
+  The multiplexer to drive with, or `nil` when neither is installed.
+
+  tmux when present (the same mechanism the Terminal-Bench harness uses to
+  drive agents), else `expect` as a portable fallback.
+  """
+  @spec driver :: :tmux | :expect | nil
+  def driver do
+    cond do
+      System.find_executable("tmux") -> :tmux
+      System.find_executable("expect") -> :expect
+      true -> nil
+    end
+  end
+
+  @doc """
+  The budget the app is given to boot and signal ready, in ms. Only here so a
+  failure report can quote it.
+  """
+  @spec ready_budget_ms :: pos_integer()
+  def ready_budget_ms, do: @ready_tries * 100
+
+  @doc """
+  Type `keys` into a real pty and report what the app decoded.
+
+  Retries until the tokens match `expected` or the attempts run out, so
+  `expected` is a stopping condition, NOT an assertion -- the caller still has
+  to assert on the returned tokens. Passing them in is what lets a flake
+  retry while a real failure returns promptly with its evidence intact.
+  """
+  @spec run(:tmux | :expect, [key()], [String.t()]) :: result()
+  def run(driver, keys, expected, attempts_left \\ @max_attempts, attempt \\ 1) do
+    result = attempt_drive(driver, keys)
+
+    cond do
+      result.tokens == expected -> Map.put(result, :attempts, attempt)
+      attempts_left <= 1 -> Map.put(result, :attempts, attempt)
+      true -> run(driver, keys, expected, attempts_left - 1, attempt + 1)
+    end
+  end
+
+  @doc """
+  The common failure skeleton: what was expected, what arrived, how far it got,
+  and the app's own view from inside the pty. `explanation` is the caller's --
+  what the stage means for THAT claim.
+  """
+  @spec report(result(), :tmux | :expect, [String.t()], String.t()) :: String.t()
+  def report(result, driver, expected, explanation) do
+    """
+    Real-pty input test FAILED on OTP #{System.otp_release()} \
+    (driver: #{driver}) after #{result.attempts} attempt(s), \
+    at stage: #{result.stage}.
+    Expected #{inspect(expected)}, got #{inspect(result.tokens)}.
+
+    #{explanation}
+
+    In-VM diagnostics from the app (#{@ready_suffix} file):
+      #{result.diag}
+    """
+  end
+
+  defp attempt_drive(driver, keys) do
+    out = Path.join(System.tmp_dir!(), "raxol_input_canary_#{unique()}")
+
+    try do
+      stage = drive(driver, out, keys)
+      diag = read_diagnostics(out)
+
+      case {stage, File.read(out)} do
+        {:sent, {:ok, body}} ->
+          tokens = String.split(body, "\n", trim: true)
+          %{tokens: tokens, stage: classify(tokens, keys), diag: diag}
+
+        {:sent, {:error, _}} ->
+          %{tokens: [], stage: :no_output, diag: diag}
+
+        {stage, _} ->
+          %{tokens: [], stage: stage, diag: diag}
+      end
+    after
+      File.rm(out)
+      File.rm(out <> @ready_suffix)
+    end
+  end
+
+  defp classify([], _keys), do: :empty
+  defp classify(tokens, keys) when length(tokens) < length(keys), do: :partial
+  defp classify(_tokens, _keys), do: :ok
+
+  # The app's own account of what it established. Absent when it never got far
+  # enough to write one, which is itself the answer.
+  defp read_diagnostics(out) do
+    case File.read(out <> @ready_suffix) do
+      {:ok, body} -> String.trim(body)
+      {:error, _} -> "(no ready file -- the app never signalled)"
+    end
+  end
+
+  defp drive(:tmux, out, keys) do
+    session = "raxol-input-canary-#{unique()}"
+
+    cmd =
+      "cd #{@pkg_dir} && CANARY_OUT=#{out} CANARY_N=#{length(keys)} " <>
+        "MIX_ENV=test mix run --no-compile #{@app}"
+
+    try do
+      {_, 0} =
+        System.cmd(
+          "tmux",
+          ["new-session", "-d", "-s", session, "-x", "80", "-y", "24", cmd],
+          stderr_to_stdout: true
+        )
+
+      # Only type once the reader signalled ready, then settle briefly so its
+      # select loop is armed.
+      case wait_for_ready(out) do
+        :ok ->
+          Process.sleep(@settle_ms)
+          type_all(session, out, keys)
+
+        :timeout ->
+          :ready_timeout
+      end
+    after
+      System.cmd("tmux", ["kill-session", "-t", session], stderr_to_stdout: true)
+    end
+  end
+
+  defp drive(:expect, out, keys) do
+    # The app `System.halt/0`s right after writing output, so `eof` returns
+    # promptly. `--no-compile`: the parent test already compiled, so the nested
+    # run must not recompile under lock contention.
+    sends =
+      keys
+      |> Enum.map(&~s|send "#{expect_bytes(&1)}"\nafter #{@gap_ms}|)
+      |> Enum.join("\n")
+
+    script = """
+    set timeout 120
+    spawn env CANARY_OUT=#{out} CANARY_N=#{length(keys)} MIX_ENV=test mix run --no-compile #{@app}
+    set t 0
+    while {![file exists "#{out}.ready"] && $t < #{@ready_tries}} { after 100; incr t }
+    after #{@settle_ms}
+    #{sends}
+    expect eof
+    """
+
+    System.cmd("expect", ["-c", script], cd: @pkg_dir, stderr_to_stdout: true)
+
+    # `expect` does its own waiting inside the script, so reaching here means
+    # the keystrokes were written to the pty.
+    :sent
+  end
+
+  defp type_all(session, out, keys) do
+    result =
+      Enum.reduce_while(keys, :ok, fn key, _acc ->
+        case send_key(session, key) do
+          :ok ->
+            Process.sleep(@gap_ms)
+            {:cont, :ok}
+
+          other ->
+            {:halt, other}
+        end
+      end)
+
+    case result do
+      :ok ->
+        wait_for_output(out)
+        :sent
+
+      other ->
+        other
+    end
+  end
+
+  # A refused keystroke must not read as a decode failure. The exit status was
+  # dropped once, which made a dead tmux session and a moved protocol produce
+  # the same empty result.
+  defp send_key(session, key) do
+    args =
+      case key do
+        {:literal, k} -> ["send-keys", "-t", session, "-l", k]
+        {:named, k} -> ["send-keys", "-t", session, k]
+      end
+
+    case System.cmd("tmux", args, stderr_to_stdout: true) do
+      {_, 0} -> :ok
+      {_out, _status} -> :send_failed
+    end
+  end
+
+  defp expect_bytes({:literal, k}), do: k
+  defp expect_bytes({:named, "C-c"}), do: "\\003"
+
+  # Type only once the reader is armed, so we never send before the pty listens.
+  defp wait_for_ready(out), do: poll(out <> @ready_suffix, @ready_tries)
+  defp wait_for_output(out), do: poll(out, @output_tries)
+
+  defp poll(_path, 0), do: :timeout
+
+  defp poll(path, tries) do
+    if File.exists?(path) do
+      :ok
+    else
+      Process.sleep(100)
+      poll(path, tries - 1)
+    end
+  end
+
+  defp unique, do: System.unique_integer([:positive])
+end


### PR DESCRIPTION
Closes #801.

The nightly input canary failed on **every** OTP 27.2 job (ubuntu + macOS, Elixir 1.17/1.18/1.19) since it landed in #781, while OTP 28.2/29.0.3 passed. It was not a flake and not protocol drift. Terminal input genuinely never decoded on OTP 26/27.

## Root cause

`user_drv` only honours `input: :raw` for a noshell session from **OTP 28** on:

```erlang
%% OTP 28/29 -- noshell branch reads `input` and applies raw mode
not StartShell ->
    Input = maps:get(input, Args),
    prim_tty:reinit(TTY, #{ input => Input, output => raw })
```

OTP 26/27 has no such branch. `initial_shell: :noshell` makes its `StartShell` false, and it falls to:

```erlang
%% OTP 27 -- ignores `input` entirely, forces non-tty
true -> prim_tty:reinit(TTY, #{ tty => false })
```

So the tty is left **cooked** and every bare keystroke sits in the line discipline until a newline. Asking for a raw shell instead is not a way out: that spawns a real shell and drops `user_drv` into a JCL prompt that swallows all input.

Raw mode is therefore ours to set on OTP 26/27 — and `Stty` is what should have been setting it.

## Why Stty could not

It targeted the literal `/dev/tty`. The BEAM puts every port child in a **fresh session**, so a `System.cmd`-spawned `stty` has no controlling terminal of its own and `/dev/tty` fails `ENXIO` for it — even when the BEAM itself is sitting on a perfectly good pty.

**Every stty call in the module was silently no-oping, on every OTP.** That is also why the canary's diagnostic reported `boot_confirmed=false,isig_off=false` on passing OTP 29 runs. The fix resolves the device (`ps -o tty=`) and targets that path.

Two operations were still using the `sh -c "stty ... < /dev/tty"` shell redirect the moduledoc explicitly forbids, and their `command_args/1` clauses were built and tested but never actually called:

- `sane!/0` — the teardown fallback, so its silent failure stranded real terminals in raw mode with no echo
- `size/0`

## Evidence

Same arm sequence, same reader pid, traced `[:send, :receive]` under tmux:

**OTP 29** — select fires per keystroke, data delivered:
```
{:trace, #PID<0.68.0>, :receive, {:read, :infinity}}
{:trace, #PID<0.68.0>, :receive, {:select, #Ref<...>, #Ref<...>, :ready_input}}
{:trace, #PID<0.68.0>, :send, {#Ref<...>, {:data, "a"}}, #PID<0.66.0>}
```

**OTP 27 before** — the pane is `icanon isig echo` (fully cooked) and nothing arrives:
```
{:trace, #PID<0.68.0>, :receive, {:read, :infinity}}
```

**OTP 27 with a trailing newline** — proves the reader itself was fine all along, the line discipline was holding the bytes:
```
{:trace, #PID<0.68.0>, :send, {#Ref<...>, {:data, "ab\n"}}, #PID<0.65.0>}
```

**OTP 27 after this fix** — `icanon_off=true`, bare keystrokes delivered:
```
{:trace, #PID<0.69.0>, :send, {#Ref<...>, {:data, "a"}}, #PID<0.66.0>}
{:trace, #PID<0.69.0>, :send, {#Ref<...>, {:data, "b"}}, #PID<0.66.0>}
```

## Corrections to existing claims

Both were disproved while investigating and would have misdirected the next reader:

- The canary's `:empty` report treated `isig_off=false` as "not in raw mode, so of course nothing arrived". Once the reader is armed, prim_tty owns the termios and re-applies **its** raw mode with ISIG **enabled**, so that is the ordinary steady state — OTP 29 decodes keystrokes fine with `isig_off=false` and `stty` failing outright. `-icanon`, not `-isig`, is what governs deliverability.
- `ReaderGate` cited a `reader_loop/2` catch-all clause as its fail-closed argument. OTP 28 rewrote the loop; on OTP 26/27 it is `reader_loop/6` with **no** catch-all, so an unmatched message sits in the reader's mailbox instead. The bounded timeout still makes the gate fail closed, so the conclusion holds and only the reasoning changed.

Also fixes the pre-existing `defp drive/2 clauses not grouped together` compiler warning in the canary.

## Note on the new test seam

`Stty` now really does mutate a terminal, so `config :raxol_terminal, :stty_device` was added and the stty tests point at a non-tty. Without it, `stty_test.exs` would apply a hardcoded foreign `stty -g` dump to whatever terminal is running the suite. The canary is unaffected — it drives a separate `mix run` process with no override.

## Risk

On OTP 28/29 the `-isig` in `raw!/0` now actually applies where it previously failed silently, so `^C` reaches the app as byte `0x03` instead of raising SIGINT. That is this module's long-documented intent and the whole reason `reassert_raw_until_isig_off/1` exists, but it is a real behaviour change on those versions and the thing most worth a second opinion.

## Tests

Two real-pty tests, sharing `Raxol.Terminal.PtyHarness` (`test/support/pty_harness.ex`), which owns the mechanism and stops at the evidence: it returns the stage reached, the tokens decoded and the app's diagnostics, and interprets none of it.

- `input_protocol_canary_test.exs` — the existing protocol claim, now back to one claim
- `input_isig_contract_test.exs` — **new**, covering the OTP 28/29 behaviour change under Risk above: `^C` must arrive as byte `0x03` rather than raising SIGINT

The isig test asserts the in-VM termios diagnostics (`isig_off=true`, `boot_confirmed=true`) as well as the decode. That is the part that was vacuous before: every `stty` call no-oped silently, so `isig_off` read false on every OTP while the suite stayed green. A decode-only assertion would go quiet the same way.

**Proven non-vacuous.** Reverting only the `Stty` fix, the isig test fails at stage `:no_output` with `boot_confirmed=false,isig_off=false` while the protocol canary still passes — so it isolates this change rather than restating the canary. That stage also confirms the mechanism: with ISIG on, the line discipline signalled the foreground group and the app died before it could write.

Stage prose stays with each test rather than in the harness, because `:no_output` means "the reader is wedged" to the canary and "SIGINT killed the app" to the isig contract.

Both files carry the `:input_protocol_canary` tag and both are named in the nightly step, which lists files explicitly.

## Manual testing

- [x] Both real-pty tests pass on Linux + OTP 27 (Elixir 1.17.3, container, real tmux pty) — the previously failing configuration
- [x] Both real-pty tests pass on macOS + OTP 29
- [x] isig test proven to fail when the `Stty` fix is reverted (mutation-checked, twice: before and after the harness extraction)
- [x] Raw mode confirmed applied on OTP 27 by reading the pane termios from outside the BEAM (`icanon` -> `-icanon`)
- [x] `raxol_terminal` suite: no new failures. The 3 deterministic `RendererIntegrationTest` failures are pre-existing on master; at `--seed 0` master fails 5 and this branch fails 3
- [x] `stty_test.exs` (10), driver + inline_driver suites (80), `reader_gate_test.exs` + `editor_session_test.exs` (20) all pass
- [x] `mix format --check-formatted` clean
- [ ] Nightly matrix green on OTP 27.2 (the actual proof this closes #801)
