### PR TITLE
Fix RATE self-hosted cold build: drop --no-deps-check

### DIFF
--- a/.github/workflows/rate-selfhosted.yml
+++ b/.github/workflows/rate-selfhosted.yml
@@ -62,7 +62,7 @@ jobs:
               test/termbox2_nif/termbox_model_test.exs \
               test/termbox2_nif/termbox2_loading_test.exs \
               test/termbox2_nif/termbox2_nif_test.exs \
-              test/termbox2_nif/oracle_equivalence_test.exs --no-deps-check" /dev/null
+              test/termbox2_nif/oracle_equivalence_test.exs" /dev/null
           '
 
       - name: Platform :requires_terminal suite (under a pseudo-terminal)
@@ -70,7 +70,7 @@ jobs:
           nix develop --command bash -lc '
             MIX_ENV=test mix deps.get
             script -qec "MIX_ENV=test mix test \
-              test/platform/terminal_test.exs --no-deps-check" /dev/null
+              test/platform/terminal_test.exs" /dev/null
           '
 
       # Pure render, no pseudo-terminal needed. First comparison of the
@@ -78,5 +78,5 @@ jobs:
       - name: RATE golden render on this architecture
         run: |
           nix develop --command bash -lc '
-            MIX_ENV=test mix test test/rate/golden_test.exs --no-deps-check
+            MIX_ENV=test mix test test/rate/golden_test.exs
           '


### PR DESCRIPTION
## Root cause

The first-ever RATE self-hosted run (run 31128639996, `nif (ARM64)` on
turing-node-1) failed compiling `packages/raxol_terminal` with
`module Raxol.Core.Behaviours.BaseManager is not loaded` at
`buffer_server.ex:9` / `monitor.ex:7`.

All three workflow steps pass `--no-deps-check` to `mix test`. On the
runner every checkout is fresh (`_build` is always cold), and
`mix deps.get` only fetches deps -- it does not compile them. The flag
then skips the deps check that would have compiled the `raxol_core`
path dep, so raxol_terminal's 397 lib files compile with no
`raxol_core` beams on the load path and `use
Raxol.Core.Behaviours.BaseManager` fails. The job log confirms it:
`warning: cannot infer signatures from :raxol_core because it is not
loaded` right before the error.

The flag leaked in with #445 from an authoring sandbox that needed it
for a stale-`_build` version-drift case; it was never valid for the
always-cold runner checkouts, and the workflow had never executed
before (no runners existed until 2026-08-06). Not an Elixir 1.20.3
regression: the identical failure reproduces on macOS with Elixir
1.20.2.

## Change

Remove `--no-deps-check` from all three `mix test` invocations in
`.github/workflows/rate-selfhosted.yml`. Without it, `mix test`
compiles the path deps first, which is the correct behavior for a
fresh checkout. Steps 2 and 3 (repo root, six path deps) would have
hit the same failure once step 1 passed.

## Manual testing

- [x] Reproduced the exact failure on a fresh clone of master
      (c81bc3405) at `packages/raxol_terminal`: `mix deps.get` then
      `mix test --include docker test/termbox2_nif/termbox_model_test.exs
      --no-deps-check` -> same `BaseManager is not loaded` CompileError,
      same `:raxol_core ... not loaded` warnings (Elixir 1.20.2/OTP 29)
- [x] Same fresh clone, same command without the flag: raxol_core
      compiles as a dep, NIF builds, 13 tests pass
- [x] Repo root on the same fresh clone (validates steps 2/3 cold):
      `mix deps.get` + `mix test test/rate/golden_test.exs` -> full
      cold compile of main raxol + path deps, 2 tests pass
- [ ] Real gate: merging this triggers the workflow (master push
      touching `rate-selfhosted.yml`); the ARM64 leg on the Pi is the
      final verification. The X64 leg has no runner yet and will sit
      queued (expected, `fail-fast: false`)
