### PR TITLE
Fix parity golden drift on Elixir 1.17 (stable escaping)

### DIFF
--- a/lib/raxol/harness/surface/parity.ex
+++ b/lib/raxol/harness/surface/parity.ex
@@ -70,6 +70,7 @@ defmodule Raxol.Harness.Surface.Parity do
   alias Raxol.Harness.Projection
   alias Raxol.LiveView.TerminalBridge
   alias Raxol.MCP.StructuredScreenshot
+  alias Raxol.StableInspect
   alias Raxol.UI.Components.Harness.Block
   alias Raxol.UI.Layout.Engine, as: LayoutEngine
   alias Raxol.UI.Renderer, as: UIRenderer
@@ -379,12 +380,13 @@ defmodule Raxol.Harness.Surface.Parity do
 
   # Row-major, one cell per line, style tokens spelled out. Mirrors
   # `Raxol.RATE`'s serialization so a cell-level divergence reads the same way
-  # in both matrices.
+  # in both matrices. Cell text goes through `StableInspect.quoted/1`, never
+  # `inspect/1`, so the artifact bytes match on every CI Elixir.
   defp cells_artifact(cells) do
     cells
     |> Enum.sort_by(fn {x, y, _c, _fg, _bg, _a} -> {y, x} end)
     |> Enum.map_join("\n", fn {x, y, char, fg, bg, attrs} ->
-      "#{y},#{x} #{inspect(char)} #{token(fg)} #{token(bg)} " <>
+      "#{y},#{x} #{StableInspect.quoted(char)} #{token(fg)} #{token(bg)} " <>
         inspect(Enum.sort(List.wrap(attrs)))
     end)
     |> newline_terminated()
@@ -415,7 +417,7 @@ defmodule Raxol.Harness.Surface.Parity do
     |> Regex.split(ansi, include_captures: true, trim: true)
     |> Enum.map_join("\n", fn
       <<0x1B, rest::binary>> -> "ESC" <> rest
-      text -> inspect(text)
+      text -> StableInspect.quoted(text)
     end)
     |> newline_terminated()
   end

--- a/lib/raxol/rate.ex
+++ b/lib/raxol/rate.ex
@@ -16,6 +16,7 @@ defmodule Raxol.RATE do
   corpus inside the normal suite, so CI exercises it on every arch it builds on.
   """
 
+  alias Raxol.StableInspect
   alias Raxol.UI.Renderer
 
   @refs_rel "rate/golden.refs"
@@ -99,12 +100,14 @@ defmodule Raxol.RATE do
     |> Base.encode16(case: :lower)
   end
 
-  # Row-major serialization; sort makes the hash independent of emission order.
+  # Row-major serialization; sort makes the hash independent of emission
+  # order. Cell text goes through `StableInspect.quoted/1`, never `inspect/1`,
+  # whose escaping varies across Elixir releases and would fork the hash.
   defp serialize(cells) do
     cells
     |> Enum.sort_by(fn {x, y, _c, _fg, _bg, _a} -> {y, x} end)
     |> Enum.map_join("\n", fn {x, y, char, fg, bg, attrs} ->
-      "#{y},#{x} #{inspect(char)} #{token(fg)} #{token(bg)} #{inspect(Enum.sort(List.wrap(attrs)))}"
+      "#{y},#{x} #{StableInspect.quoted(char)} #{token(fg)} #{token(bg)} #{inspect(Enum.sort(List.wrap(attrs)))}"
     end)
   end
 

--- a/lib/raxol/stable_inspect.ex
+++ b/lib/raxol/stable_inspect.ex
@@ -1,0 +1,86 @@
+defmodule Raxol.StableInspect do
+  @moduledoc """
+  Version-stable string quoting for golden artifacts.
+
+  `inspect/1`'s string escaping tracks the host Elixir release (1.18 started
+  printing zero-width and special-whitespace codepoints as `\\uXXXX`), so a
+  golden serialized with it drifts across CI's Elixir matrix even though the
+  render is identical. `Raxol.RATE` and `Raxol.Harness.Surface.Parity` both
+  pin cross-version artifacts, so their serializers use this frozen escape
+  table instead: byte-for-byte the 1.18+ `inspect/1` output for printable
+  strings (the encoding the committed artifacts already contain), emitted
+  identically on every supported release.
+
+  The table mirrors `Code.Identifier.escape_char/2` as of Elixir 1.18:
+  printable codepoints stay literal, the "confusing invisibles" become
+  `\\uXXXX`, control characters use their short escapes, and anything else
+  falls back to `\\xNN`. Unlike `inspect/1`, a non-printable string is still
+  quoted (escaped byte by byte) rather than shown as `<<...>>` -- a stricter
+  rule, and one that cannot vary by release.
+  """
+
+  # The 1.18+ "confusing invisibles": BOM, mathematical invisibles, bidi
+  # controls, interlinear annotations, joiners, zero-width and no-break
+  # spaces, line separators, and the fixed-width space block.
+  defguardp invisible?(char)
+            when char == 0xFEFF or
+                   char in 0x2061..0x2064 or
+                   char in [0x061C, 0x200E, 0x200F] or
+                   char in 0x202A..0x202E or
+                   char in 0x2066..0x2069 or
+                   char in 0xFFF9..0xFFFC or
+                   char in [0x200C, 0x200D, 0x034F] or
+                   char in [0x00A0, 0x200B, 0x2060] or
+                   char in [0x2028, 0x2029] or
+                   char in 0x2000..0x200A or
+                   char == 0x205F
+
+  @doc "Quote and escape `text` identically on every supported Elixir."
+  @spec quoted(String.t()) :: String.t()
+  def quoted(text) when is_binary(text),
+    do: <<?", escape_text(text, <<>>)::binary, ?">>
+
+  defp escape_text(<<>>, acc), do: acc
+
+  defp escape_text(<<?", rest::binary>>, acc),
+    do: escape_text(rest, <<acc::binary, "\\\"">>)
+
+  defp escape_text(<<"\#{", rest::binary>>, acc),
+    do: escape_text(rest, <<acc::binary, "\\\#{">>)
+
+  defp escape_text(<<char::utf8, rest::binary>>, acc),
+    do: escape_text(rest, <<acc::binary, escape_char(char)::binary>>)
+
+  defp escape_text(<<byte, rest::binary>>, acc),
+    do: escape_text(rest, <<acc::binary, "\\x", hex(byte, 2)::binary>>)
+
+  defp escape_char(?\0), do: "\\0"
+  defp escape_char(?\a), do: "\\a"
+  defp escape_char(?\b), do: "\\b"
+  defp escape_char(?\d), do: "\\d"
+  defp escape_char(?\e), do: "\\e"
+  defp escape_char(?\f), do: "\\f"
+  defp escape_char(?\n), do: "\\n"
+  defp escape_char(?\r), do: "\\r"
+  defp escape_char(?\t), do: "\\t"
+  defp escape_char(?\v), do: "\\v"
+  defp escape_char(?\\), do: "\\\\"
+
+  defp escape_char(char) when invisible?(char), do: "\\u" <> hex(char, 4)
+
+  defp escape_char(char)
+       when char in 0x20..0x7E
+       when char in 0xA0..0xD7FF
+       when char in 0xE000..0xFFFD
+       when char in 0x10000..0x10FFFF,
+       do: <<char::utf8>>
+
+  defp escape_char(char) when char < 0x100, do: "\\x" <> hex(char, 2)
+  defp escape_char(char), do: "\\x{" <> hex(char, 4) <> "}"
+
+  defp hex(value, digits) do
+    value
+    |> Integer.to_string(16)
+    |> String.pad_leading(digits, "0")
+  end
+end


### PR DESCRIPTION
Fixes the nightly failure in #806: `Raxol.Harness.SurfaceParityTest` drift on `unicode-heavy.cells` and `unicode-heavy.ssh_ansi`, only on the Elixir 1.17.3 matrix cells.

## Root cause

Elixir 1.18 changed `inspect/1` for strings: zero-width and special-whitespace codepoints now print as `\uXXXX` ([1.18 changelog](https://hexdocs.pm/elixir/1.18/changelog.html), "Inspect special whitespace and zero-width characters using their Unicode representation"). The `unicode-heavy` fixture contains ZWJs (U+200D) inside the family emoji. The parity artifacts were blessed on 1.18+, so a fresh render on 1.17.3 serialized the ZWJs literally and drifted -- on exactly the two surfaces whose serializers used `inspect/1` (`cells`, `ssh_ansi`); the two that don't (`liveview_dom`, `structured_json`) passed. The render itself is identical across versions.

## Fix

New `Raxol.StableInspect.quoted/1`: a frozen copy of the 1.18+ escape table (mirroring `Code.Identifier.escape_char/2` -- printable codepoints literal, the "confusing invisibles" as `\uXXXX`, control chars as short escapes, `\xNN` fallback), emitted identically on every supported release. Both golden serializers now use it instead of `inspect/1`:

- `Raxol.Harness.Surface.Parity` (`cells_artifact/1`, `normalize_ansi/1`) -- the failing case
- `Raxol.RATE.serialize/1` -- same latent bug in the mirrored serializer; its corpus has no affected codepoints today, but the first RATE fixture with a ZWJ would have reproduced this nightly break

Since the committed artifacts already contain the 1.18+ encoding, output is byte-identical: no artifact re-bless, `priv/rate/golden.refs` unchanged.

## Manual testing

- [x] `mix test test/harness/surface_parity_test.exs test/rate/golden_test.exs` on Elixir 1.20.2: 19 tests, 0 failures (drift test passing proves artifact byte-identity)
- [x] Same suites under Elixir 1.17.3/OTP 26 (mise, isolated `MIX_BUILD_ROOT`): 19 tests, 0 failures -- previously failing version
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted`, `mix credo` on touched files: no new issues

Closes #806
