### PR TITLE
Cadence drain floor + renderer unpainted-bg test alignment

### DIFF
--- a/lib/raxol/harness/cadence_policy.ex
+++ b/lib/raxol/harness/cadence_policy.ex
@@ -169,15 +169,24 @@ defmodule Raxol.Harness.CadencePolicy do
   The number of pending items to drain into a single flush batch: the
   lesser of `pending_count` and the configured max drain.
 
+  The configured cap is clamped to at least 1: a batch that drains
+  nothing makes no forward progress, and `StreamCadence`'s forced full
+  drain loops until pending hits zero -- a zero cap would spin it
+  forever. Zero pending still drains zero; only the cap has a floor.
+
   ## Options
 
     * `:max_drain_per_flush` -- override the module's default per-flush
-      cap.
+      cap (clamped to a minimum of 1).
   """
   @spec drain_count(pending_count :: non_neg_integer(), opts :: keyword()) ::
           non_neg_integer()
   def drain_count(pending_count, opts \\ []) do
-    max_drain = Keyword.get(opts, :max_drain_per_flush, @max_drain_per_flush)
+    max_drain =
+      opts
+      |> Keyword.get(:max_drain_per_flush, @max_drain_per_flush)
+      |> max(1)
+
     min(pending_count, max_drain)
   end
 

--- a/packages/raxol_terminal/test/raxol/terminal/renderer_integration_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/renderer_integration_test.exs
@@ -31,7 +31,8 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
         bright_black: "#808080"
       },
       background: %{
-        default: "#000000"
+        default: "#000000",
+        blue: "#0000FF"
       }
     }
 
@@ -74,7 +75,10 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
       end
 
       assert output =~ ansi_fg("#FFFFFF")
-      assert output =~ ansi_bg("#000000")
+      # An unpainted background emits no background escape at all --
+      # transparency survives (see build_ansi_prefix/2 in the renderer).
+      refute output =~ "\e[48;2;"
+      refute output =~ ~r/\e\[4[0-7]m/
       assert output =~ @ansi_reset
 
       # Delete text (delete 2 chars at 0,0)
@@ -311,9 +315,11 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
     test "handles empty buffer", %{renderer: renderer} do
       output = Renderer.render(renderer)
 
-      # All cells should have default theme colors
+      # Default foreground paints; unpainted backgrounds emit nothing
+      # so transparency survives.
       assert output =~ ansi_fg("#FFFFFF")
-      assert output =~ ansi_bg("#000000")
+      refute output =~ "\e[48;2;"
+      refute output =~ ~r/\e\[4[0-7]m/
       assert output =~ @ansi_reset
     end
 
@@ -328,7 +334,34 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
       output = Renderer.render(renderer)
 
       assert output =~ ansi_fg("#FFFFFF")
-      assert output =~ ansi_bg("#000000")
+      refute output =~ "\e[48;2;"
+      refute output =~ ~r/\e\[4[0-7]m/
+    end
+
+    test "paints an explicitly set background", %{
+      renderer: renderer,
+      buffer: buffer
+    } do
+      style =
+        struct(
+          Raxol.Terminal.ANSI.TextFormatting,
+          Map.merge(
+            Map.from_struct(Raxol.Terminal.ANSI.TextFormatting.new()),
+            %{background: :blue}
+          )
+        )
+
+      row =
+        [Raxol.Terminal.Cell.new("X", style)] ++
+          List.duplicate(Raxol.Terminal.Cell.new(), buffer.width - 1)
+
+      buffer = %{buffer | cells: [row | Enum.drop(buffer.cells, 1)]}
+      renderer = %{renderer | screen_buffer: buffer}
+
+      output = Renderer.render(renderer)
+
+      # Theme-resolved :blue -> #0000FF -> 24-bit background escape
+      assert output =~ ansi_bg("#0000FF")
     end
 
     test "handles buffer with special characters", %{

--- a/test/harness/cadence_policy_test.exs
+++ b/test/harness/cadence_policy_test.exs
@@ -129,6 +129,16 @@ defmodule Raxol.Harness.CadencePolicyTest do
     test "override does not raise the cap for small counts" do
       assert CadencePolicy.drain_count(5, max_drain_per_flush: 10) == 5
     end
+
+    # A zero cap would make StreamCadence's forced full drain spin
+    # forever (each pass drains nothing, pending never reaches zero).
+    test "a zero cap is clamped to 1 so every batch makes progress" do
+      assert CadencePolicy.drain_count(5, max_drain_per_flush: 0) == 1
+    end
+
+    test "zero pending drains zero even with a zero cap" do
+      assert CadencePolicy.drain_count(0, max_drain_per_flush: 0) == 0
+    end
   end
 
   describe "decide/5 -- consecutive-yield budget" do


### PR DESCRIPTION
Two small fixes.

## Floor cadence drain cap at 1 (#687 residual L4)

`StreamCadence`'s forced full drain (`full_drain_loop/2`) recurses until `pending_count == 0`, draining `CadencePolicy.drain_count/2` items per pass. `drain_count/2` had no floor, so a configured `max_drain_per_flush: 0` drained zero items per pass and `flush_now/1` with anything pending looped forever inside the cast handler. Misconfig-only (default 32 is safe), flagged as finding L4 in the #687 review; the fix on the campaign branch did not ride the extraction to master.

Fix: clamp the configured cap to at least 1 in `drain_count/2`. Zero pending still drains zero -- only the cap has a floor. Regression tests on the pure function (not via a hanging `flush_now`).

## Align renderer tests with unpainted-background design

Fixes #754. PR #520 deliberately made the renderer emit nothing for an unpainted background (a cell is transparent precisely when no background was set; emitting the theme default would punch opaque rectangles through transparent terminals), but missed three assertions in the raxol_terminal package suite, which is not in the CI matrix. All three asserted the old explicit `\e[48;2;0;0;0m` default-background emission and have been failing on master since.

Per the issue's decision framework: the renderer is correct, so the three assertions now refute background emission (both 24-bit and standard-code forms), and a new test adds positive coverage that an explicitly set background still paints through theme resolution (`:blue` -> `#0000FF` -> `\e[48;2;0;0;255m`).

## Manual testing

- [x] `mix test test/harness/cadence_policy_test.exs test/harness/stream_cadence_test.exs` -- 60 passed (includes 2 new)
- [x] `packages/raxol_terminal`: full package suite -- 2354 passed, 0 failures (was 3 failures)
- [x] Main suite with documented excludes -- 6651 passed, 0 failures
- [x] `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo` on changed files -- clean
