### PR TITLE
Fix readiness-audit failures: bench auto-open, headless docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ mix run examples/demo.exs
 
 See [examples/README.md](examples/README.md) for the full learning path, including agent examples, swarm demos, and the sandboxed REPL.
 
+Headless environment (CI, containers, agents)? The [Development](#development) section is the terminal-free path: clone, compile, test, and the RATE golden suite all run without a tty.
+
 ## Performance
 
 Full frame in 2.1ms on Apple M1 Pro (Elixir 1.19 / OTP 27), 13% of the 60fps budget.
@@ -141,15 +143,29 @@ Unix/macOS backend uses a termbox2 NIF; Windows uses a pure Elixir driver (usabl
 
 ## Development
 
+Working from source needs Elixir/OTP (versions in `.tool-versions`) and a C
+toolchain: the termbox2 NIF compiles with `make` and `cc` (on Debian/Ubuntu,
+`apt-get install build-essential`). `nix develop` provides all of it in one
+shell. Every command below runs headless: no terminal is required for the
+build, the test suite, or the golden checks.
+
 ```bash
 git clone https://github.com/DROOdotFOO/raxol.git
 cd raxol
+mix local.hex --force        # fresh machines and CI: install Hex without a prompt
 mix deps.get
-MIX_ENV=test mix test --exclude slow --exclude integration --exclude docker
-mix raxol.check              # format, compile, credo, dialyzer, security, docs, rate, test
+mix compile                  # builds the termbox2 NIF
+SKIP_TERMBOX2_TESTS=true MIX_ENV=test mix test --exclude slow --exclude integration --exclude docker
+MIX_ENV=test mix raxol.rate  # RATE: render-determinism golden suite
+mix raxol.check              # full gate: format, compile, credo, dialyzer, security, docs, rate, test
 mix raxol.check --quick      # skip dialyzer
-mix raxol.demo               # run built-in demos
+mix raxol.demo               # built-in demos (needs a terminal)
 ```
+
+`SKIP_TERMBOX2_TESTS=true` excludes the tests that need a real local terminal
+(pty lifecycle, timing-sensitive suites); CI sets the same variable. In
+sandboxes where `HOME` is read-only, point `MIX_HOME` and `HEX_HOME` at a
+writable directory before running mix.
 
 ## Origin
 

--- a/bench/scripts/ansi_parser_bench.exs
+++ b/bench/scripts/ansi_parser_bench.exs
@@ -39,7 +39,8 @@ defmodule ANSIParserBenchmark do
       memory_time: 2,
       formatters: [
         Benchee.Formatters.Console,
-        {Benchee.Formatters.HTML, file: "bench/output/ansi_parser.html"}
+        {Benchee.Formatters.HTML,
+         file: "bench/output/ansi_parser.html", auto_open: false}
       ]
     )
   end

--- a/bench/suites/core/performance_improvements_benchmark.exs
+++ b/bench/suites/core/performance_improvements_benchmark.exs
@@ -118,7 +118,7 @@ Benchee.run(
   formatters: [
     Benchee.Formatters.Console,
     {Benchee.Formatters.HTML,
-     file: "bench/output/performance_improvements.html"},
+     file: "bench/output/performance_improvements.html", auto_open: false},
     {Benchee.Formatters.JSON,
      file: "bench/output/performance_improvements.json"}
   ],

--- a/bench/suites/enhanced/performance_dashboard.exs
+++ b/bench/suites/enhanced/performance_dashboard.exs
@@ -19,63 +19,74 @@ defmodule PerformanceDashboard do
   alias Raxol.Terminal.Cursor.CursorManager
 
   @targets %{
-    "plain_text_parse" => 50,     # μs
-    "ansi_parse" => 10,           # μs  
-    "sgr_process" => 1,           # μs
-    "cursor_move" => 5,           # μs
-    "buffer_write" => 20,         # μs
-    "emulator_create" => 1000     # μs
+    # μs
+    "plain_text_parse" => 50,
+    # μs  
+    "ansi_parse" => 10,
+    # μs
+    "sgr_process" => 1,
+    # μs
+    "cursor_move" => 5,
+    # μs
+    "buffer_write" => 20,
+    # μs
+    "emulator_create" => 1000
   }
 
   def run do
     IO.puts("\n" <> String.duplicate("=", 100))
     IO.puts("              [RAXOL] RAXOL PERFORMANCE DASHBOARD v1.5.4")
     IO.puts(String.duplicate("=", 100))
-    
+
     # Create output directory structure
     File.mkdir_p!("bench/output/enhanced")
     File.mkdir_p!("bench/output/enhanced/json")
     File.mkdir_p!("bench/output/enhanced/html")
-    
+
     timestamp = DateTime.utc_now() |> DateTime.to_iso8601()
-    
+
     # Run all benchmark suites
     results = %{
       parser: run_parser_benchmarks(timestamp),
-      terminal: run_terminal_benchmarks(timestamp), 
+      terminal: run_terminal_benchmarks(timestamp),
       rendering: run_rendering_benchmarks(timestamp),
       memory: run_memory_benchmarks(timestamp)
     }
-    
+
     # Generate comprehensive reports
     generate_dashboard_report(results, timestamp)
     generate_regression_report(results, timestamp)
     generate_performance_insights(results, timestamp)
-    
+
     IO.puts("\n[OK] Performance dashboard complete!")
     IO.puts("[REPORT] Reports available in bench/output/enhanced/")
-    IO.puts("[WEB] Open bench/output/enhanced/dashboard.html for interactive view")
+
+    IO.puts(
+      "[WEB] Open bench/output/enhanced/dashboard.html for interactive view"
+    )
   end
 
   defp run_parser_benchmarks(timestamp) do
     IO.puts("\n[BENCHMARK] Running Parser Benchmarks...")
-    
+
     emulator = Emulator.new(80, 24)
-    
+
     # Test scenarios with realistic terminal content
     scenarios = %{
       "plain_text_short" => "Hello, World!",
-      "plain_text_long" => String.duplicate("Lorem ipsum dolor sit amet. ", 100),
+      "plain_text_long" =>
+        String.duplicate("Lorem ipsum dolor sit amet. ", 100),
       "ansi_basic_color" => "\e[31mRed Text\e[0m",
       "ansi_complex_sgr" => "\e[1;4;31;48;5;196mComplex Formatting\e[0m",
       "ansi_cursor_movement" => "\e[2J\e[H\e[10;20H\e[KCursor commands",
-      "ansi_scroll_region" => "\e[5;20r\e[?25l\e[33mScroll region\e[?25h\e[0;0r",
+      "ansi_scroll_region" =>
+        "\e[5;20r\e[?25l\e[33mScroll region\e[?25h\e[0;0r",
       "mixed_content" => mix_realistic_content(),
       "large_ansi_dump" => generate_large_ansi_content(),
       "rapid_color_changes" => generate_rapid_color_sequence(),
       "terminal_app_sim" => simulate_terminal_app_output()
     }
-    
+
     config = [
       time: 5,
       memory_time: 2,
@@ -83,63 +94,78 @@ defmodule PerformanceDashboard do
       pre_check: true,
       parallel: 1,
       formatters: [
-        {Benchee.Formatters.JSON, 
+        {Benchee.Formatters.JSON,
          file: "bench/output/enhanced/json/parser_#{timestamp}.json"},
-        {Benchee.Formatters.HTML, 
+        {Benchee.Formatters.HTML,
          file: "bench/output/enhanced/html/parser_#{timestamp}.html",
-         title: "Raxol Parser Performance - #{timestamp}"}
+         title: "Raxol Parser Performance - #{timestamp}",
+         auto_open: false}
       ]
     ]
-    
-    jobs = Enum.into(scenarios, %{}, fn {name, content} ->
-      {name, fn -> Parser.parse(emulator, content) end}
-    end)
-    
+
+    jobs =
+      Enum.into(scenarios, %{}, fn {name, content} ->
+        {name, fn -> Parser.parse(emulator, content) end}
+      end)
+
     Benchee.run(jobs, config)
   end
 
   defp run_terminal_benchmarks(timestamp) do
     IO.puts("\n[FAST] Running Terminal Component Benchmarks...")
-    
+
     buffer = Raxol.Terminal.ScreenBuffer.new(80, 24)
     cursor = CursorManager.new()
     style = %Raxol.Terminal.ANSI.TextFormatting{}
-    
+
     jobs = %{
       "emulator_creation" => fn -> Emulator.new(80, 24) end,
       "buffer_write_char" => fn -> Writer.write_char(buffer, 10, 5, "A") end,
-      "buffer_write_string" => fn -> Writer.write_string(buffer, 0, 0, "Hello World") end,
-      "cursor_move_simple" => fn -> CursorManager.set_position(cursor, 10, 5) end,
-      "cursor_move_bounds" => fn -> CursorManager.move_to_bounds(cursor, 40, 12, 80, 24) end,
-      "sgr_single_color" => fn -> SGRProcessor.process_sgr_codes([31], style) end,
-      "sgr_complex_format" => fn -> SGRProcessor.process_sgr_codes([1, 4, 31, 48, 5, 196], style) end,
-      "sgr_rgb_color" => fn -> SGRProcessor.process_sgr_codes([38, 2, 255, 128, 64], style) end
+      "buffer_write_string" => fn ->
+        Writer.write_string(buffer, 0, 0, "Hello World")
+      end,
+      "cursor_move_simple" => fn ->
+        CursorManager.set_position(cursor, 10, 5)
+      end,
+      "cursor_move_bounds" => fn ->
+        CursorManager.move_to_bounds(cursor, 40, 12, 80, 24)
+      end,
+      "sgr_single_color" => fn ->
+        SGRProcessor.process_sgr_codes([31], style)
+      end,
+      "sgr_complex_format" => fn ->
+        SGRProcessor.process_sgr_codes([1, 4, 31, 48, 5, 196], style)
+      end,
+      "sgr_rgb_color" => fn ->
+        SGRProcessor.process_sgr_codes([38, 2, 255, 128, 64], style)
+      end
     }
-    
+
     config = [
       time: 3,
       memory_time: 1,
       warmup: 0.5,
       formatters: [
-        {Benchee.Formatters.JSON, 
+        {Benchee.Formatters.JSON,
          file: "bench/output/enhanced/json/terminal_#{timestamp}.json"},
-        {Benchee.Formatters.HTML, 
+        {Benchee.Formatters.HTML,
          file: "bench/output/enhanced/html/terminal_#{timestamp}.html",
-         title: "Raxol Terminal Components - #{timestamp}"}
+         title: "Raxol Terminal Components - #{timestamp}",
+         auto_open: false}
       ]
     ]
-    
+
     Benchee.run(jobs, config)
   end
 
   defp run_rendering_benchmarks(timestamp) do
     IO.puts("\n[RENDER] Running Rendering Performance Benchmarks...")
-    
+
     # Simulate different rendering scenarios
     small_buffer = Raxol.Terminal.ScreenBuffer.new(20, 10)
     medium_buffer = Raxol.Terminal.ScreenBuffer.new(80, 24)
     large_buffer = Raxol.Terminal.ScreenBuffer.new(200, 50)
-    
+
     jobs = %{
       "render_small_buffer" => fn -> simulate_render(small_buffer) end,
       "render_medium_buffer" => fn -> simulate_render(medium_buffer) end,
@@ -147,63 +173,66 @@ defmodule PerformanceDashboard do
       "render_with_colors" => fn -> simulate_colored_render(medium_buffer) end,
       "render_with_unicode" => fn -> simulate_unicode_render(medium_buffer) end
     }
-    
+
     config = [
       time: 4,
       memory_time: 2,
       warmup: 1,
       formatters: [
-        {Benchee.Formatters.JSON, 
+        {Benchee.Formatters.JSON,
          file: "bench/output/enhanced/json/rendering_#{timestamp}.json"},
-        {Benchee.Formatters.HTML, 
+        {Benchee.Formatters.HTML,
          file: "bench/output/enhanced/html/rendering_#{timestamp}.html",
-         title: "Raxol Rendering Performance - #{timestamp}"}
+         title: "Raxol Rendering Performance - #{timestamp}",
+         auto_open: false}
       ]
     ]
-    
+
     Benchee.run(jobs, config)
   end
 
   defp run_memory_benchmarks(timestamp) do
     IO.puts("\n[MEMORY] Running Memory Usage Benchmarks...")
-    
+
     jobs = %{
-      "memory_emulator_80x24" => fn -> 
+      "memory_emulator_80x24" => fn ->
         emulator = Emulator.new(80, 24)
         # Force some memory allocation
         Parser.parse(emulator, generate_large_ansi_content())
       end,
       "memory_emulator_200x50" => fn ->
-        emulator = Emulator.new(200, 50) 
+        emulator = Emulator.new(200, 50)
         Parser.parse(emulator, generate_large_ansi_content())
       end,
       "memory_buffer_operations" => fn ->
         buffer = Raxol.Terminal.ScreenBuffer.new(100, 30)
+
         Enum.each(1..100, fn i ->
           Writer.write_string(buffer, 0, rem(i, 30), "Memory test line #{i}")
         end)
       end
     }
-    
+
     config = [
       time: 2,
       memory_time: 3,
       warmup: 0.5,
       formatters: [
-        {Benchee.Formatters.JSON, 
+        {Benchee.Formatters.JSON,
          file: "bench/output/enhanced/json/memory_#{timestamp}.json"},
-        {Benchee.Formatters.HTML, 
+        {Benchee.Formatters.HTML,
          file: "bench/output/enhanced/html/memory_#{timestamp}.html",
-         title: "Raxol Memory Usage - #{timestamp}"}
+         title: "Raxol Memory Usage - #{timestamp}",
+         auto_open: false}
       ]
     ]
-    
+
     Benchee.run(jobs, config)
   end
 
   defp generate_dashboard_report(results, timestamp) do
     IO.puts("\n[DASHBOARD] Generating Performance Dashboard...")
-    
+
     # Create a comprehensive HTML dashboard
     html_content = """
     <!DOCTYPE html>
@@ -318,89 +347,96 @@ defmodule PerformanceDashboard do
     </body>
     </html>
     """
-    
+
     File.write!("bench/output/enhanced/dashboard.html", html_content)
   end
 
   defp generate_regression_report(results, timestamp) do
     IO.puts("\n[BENCHMARK] Generating Regression Analysis...")
-    
+
     # Load previous results if they exist for comparison
     previous_files = Path.wildcard("bench/output/enhanced/json/parser_*.json")
-    
-    regression_data = if length(previous_files) > 1 do
-      # Sort by timestamp and get the previous one
-      sorted_files = Enum.sort(previous_files, :desc)
-      previous_file = Enum.at(sorted_files, 1) # Second most recent
-      
-      if previous_file do
-        case File.read(previous_file) do
-          {:ok, content} ->
-            case Jason.decode(content) do
-              {:ok, data} -> analyze_regressions(data)
-              _ -> "No previous data available for comparison"
-            end
-          _ -> "Could not read previous benchmark data"
+
+    regression_data =
+      if length(previous_files) > 1 do
+        # Sort by timestamp and get the previous one
+        sorted_files = Enum.sort(previous_files, :desc)
+        # Second most recent
+        previous_file = Enum.at(sorted_files, 1)
+
+        if previous_file do
+          case File.read(previous_file) do
+            {:ok, content} ->
+              case Jason.decode(content) do
+                {:ok, data} -> analyze_regressions(data)
+                _ -> "No previous data available for comparison"
+              end
+
+            _ ->
+              "Could not read previous benchmark data"
+          end
+        else
+          "No previous benchmark data found"
         end
       else
-        "No previous benchmark data found"
+        "This is the first benchmark run - no regression analysis available"
       end
-    else
-      "This is the first benchmark run - no regression analysis available"
-    end
-    
+
     report = """
     # Raxol Performance Regression Report
-    
+
     **Generated:** #{timestamp}
     **Version:** v1.5.4
-    
+
     ## Regression Analysis
-    
+
     #{regression_data}
-    
+
     ## Performance Thresholds
-    
+
     The following performance regressions are flagged:
     - Parser operations > 10% slower than previous run
     - Memory usage > 15% higher than previous run  
     - Rendering > 5% slower than previous run
-    
+
     ## Recommendations
-    
+
     [OK] All performance targets are currently being met
     [OK] Parser performance: 3.3μs/op (target: <10μs)
     [OK] Memory usage: <2.8MB (target: <5MB)
     [OK] Render performance: <1ms (target: <2ms)
     """
-    
-    File.write!("bench/output/enhanced/regression_report_#{timestamp}.md", report)
+
+    File.write!(
+      "bench/output/enhanced/regression_report_#{timestamp}.md",
+      report
+    )
   end
 
   defp generate_performance_insights(results, timestamp) do
     IO.puts("\n[ANALYSIS] Generating Performance Insights...")
-    
+
     insights = """
     # Raxol Performance Insights - #{timestamp}
-    
+
     ## Key Performance Achievements
-    
+
     ### [RAXOL] Parser Optimizations (30x improvement)
     - **Before:** ~100μs per ANSI sequence
     - **After:** ~3.3μs per ANSI sequence  
     - **Method:** Pattern matching vs map lookups for SGR codes
-    
+
     ### [FAST] Emulator Creation (4.6x improvement)  
     - **Before:** Heavy GenServer initialization
     - **After:** Minimal GenServer usage in critical paths
     - **Method:** Created EmulatorLite for performance scenarios
-    
+
     ### [MEMORY] Memory Efficiency
     - **Current:** <2.8MB for 80x24 terminal
     - **Optimization:** Efficient buffer management and cell structure
-    
+
     ## Performance Characteristics by Operation
-    
+
     | Operation | Time (μs) | Target (μs) | Status |
     |-----------|-----------|-------------|---------|
     | Plain text parse | ~34 | <50 | [OK] |
@@ -409,35 +445,35 @@ defmodule PerformanceDashboard do
     | Cursor movement | ~2 | <5 | [OK] |
     | Buffer write | ~8 | <20 | [OK] |
     | Emulator creation | ~58 | <1000 | [OK] |
-    
+
     ## Optimization Recommendations
-    
+
     1. **Continue monitoring parser performance** - maintain <10μs target
     2. **Memory usage tracking** - watch for memory leaks in long sessions  
     3. **Rendering optimization** - consider further buffer optimizations
     4. **Profiling in production** - monitor real-world performance patterns
-    
+
     ## Testing Performance
-    
+
     Current test suite performance:
     - **Total tests:** 2086
     - **Passing:** 2076 (99.5%)
     - **Performance tests:** Excluded from main suite
     - **Memory tests:** <2.8MB per session verified
-    
+
     ## Next Steps
-    
+
     - [ ] Implement continuous performance monitoring
     - [ ] Add performance regression CI checks  
     - [x] Create performance baseline for v1.5.4
     - [ ] Monitor production performance metrics
     """
-    
+
     File.write!("bench/output/enhanced/insights_#{timestamp}.md", insights)
   end
 
   # Helper functions for generating test content
-  
+
   defp mix_realistic_content do
     """
     \e[2J\e[H\e[1;37;44m Terminal Application \e[0m
@@ -450,20 +486,22 @@ defmodule PerformanceDashboard do
     \e[10;1H\e[?25l\e[33mPress any key to continue...\e[?25h
     """
   end
-  
+
   defp generate_large_ansi_content do
     Enum.map(1..100, fn i ->
       color = rem(i, 8) + 30
       "\e[#{color}mLine #{i} with color #{color}\e[0m\n"
-    end) |> Enum.join()
+    end)
+    |> Enum.join()
   end
-  
+
   defp generate_rapid_color_sequence do
     Enum.map(1..50, fn i ->
       "\e[#{rem(i, 8) + 30}m#{i}\e[0m"
-    end) |> Enum.join(" ")
+    end)
+    |> Enum.join(" ")
   end
-  
+
   defp simulate_terminal_app_output do
     """
     \e[?1049h\e[2J\e[H\e[?25l
@@ -475,34 +513,37 @@ defmodule PerformanceDashboard do
     \e[?25h
     """
   end
-  
+
   defp simulate_render(buffer) do
     # Simulate rendering by accessing buffer cells
     {width, height} = {buffer.width, buffer.height}
-    Enum.each(0..(height-1), fn y ->
-      Enum.each(0..(width-1), fn x ->
+
+    Enum.each(0..(height - 1), fn y ->
+      Enum.each(0..(width - 1), fn x ->
         # Simulate accessing cell at position
         _cell = Enum.at(Enum.at(buffer.cells, y, []), x)
       end)
     end)
   end
-  
+
   defp simulate_colored_render(buffer) do
     # Fill buffer with colored content then render
-    filled_buffer = Enum.reduce(0..23, buffer, fn y, acc_buffer ->
-      content = "\e[#{rem(y, 8) + 30}mColored line #{y}\e[0m"
-      Writer.write_string(acc_buffer, 0, y, content)
-    end)
+    filled_buffer =
+      Enum.reduce(0..23, buffer, fn y, acc_buffer ->
+        content = "\e[#{rem(y, 8) + 30}mColored line #{y}\e[0m"
+        Writer.write_string(acc_buffer, 0, y, content)
+      end)
+
     simulate_render(filled_buffer)
   end
-  
+
   defp simulate_unicode_render(buffer) do
     # Test with unicode characters
     unicode_content = "[RAXOL] Terminal → 中文 → العربية → [RENDER]"
     filled_buffer = Writer.write_string(buffer, 0, 0, unicode_content)
     simulate_render(filled_buffer)
   end
-  
+
   defp generate_targets_html do
     Enum.map(@targets, fn {operation, target} ->
       """
@@ -511,9 +552,10 @@ defmodule PerformanceDashboard do
           <span class="good">&lt;#{target}μs</span>
       </div>
       """
-    end) |> Enum.join()
+    end)
+    |> Enum.join()
   end
-  
+
   defp analyze_regressions(previous_data) do
     "Previous benchmark data loaded - regression analysis would compare with current results here."
   end

--- a/bench/suites/parser/parser_benchmark.exs
+++ b/bench/suites/parser/parser_benchmark.exs
@@ -11,69 +11,89 @@ defmodule ParserBenchmark do
 
     # Test cases
     simple_text = "Hello, World!"
-    
+
     ansi_colored = "\e[31mRed \e[32mGreen \e[34mBlue\e[0m Normal"
-    
+
     complex_sequence = """
     \e[2J\e[H\e[1;1H\e[31;47mHeader\e[0m
     \e[2;1HLine 2 with \e[1mbold\e[0m and \e[4munderline\e[0m
     \e[3;1H\e[?25l\e[33mYellow text\e[0m\e[?25h
     """
-    
-    cursor_heavy = Enum.map(1..100, fn i ->
-      "\e[#{i};1H\e[KLine #{i}"
-    end) |> Enum.join("")
-    
-    large_text = String.duplicate("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", 1000)
-    
-    Benchee.run(%{
-      "simple_text" => fn -> Parser.parse(emulator, simple_text) end,
-      "ansi_colored" => fn -> Parser.parse(emulator, ansi_colored) end,
-      "complex_sequence" => fn -> Parser.parse(emulator, complex_sequence) end,
-      "cursor_heavy" => fn -> Parser.parse(emulator, cursor_heavy) end,
-      "large_text" => fn -> Parser.parse(emulator, large_text) end
-    }, 
-    time: 10,
-    memory_time: 2,
-    warmup: 2,
-    formatters: [
-      Benchee.Formatters.Console,
-      {Benchee.Formatters.HTML, file: "bench/output/parser_benchmark.html"},
-      {Benchee.Formatters.JSON, file: "regression/performance/current/parser.json"}
-    ])
-    
+
+    cursor_heavy =
+      Enum.map(1..100, fn i ->
+        "\e[#{i};1H\e[KLine #{i}"
+      end)
+      |> Enum.join("")
+
+    large_text =
+      String.duplicate(
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ",
+        1000
+      )
+
+    Benchee.run(
+      %{
+        "simple_text" => fn -> Parser.parse(emulator, simple_text) end,
+        "ansi_colored" => fn -> Parser.parse(emulator, ansi_colored) end,
+        "complex_sequence" => fn -> Parser.parse(emulator, complex_sequence) end,
+        "cursor_heavy" => fn -> Parser.parse(emulator, cursor_heavy) end,
+        "large_text" => fn -> Parser.parse(emulator, large_text) end
+      },
+      time: 10,
+      memory_time: 2,
+      warmup: 2,
+      formatters: [
+        Benchee.Formatters.Console,
+        {Benchee.Formatters.HTML,
+         file: "bench/output/parser_benchmark.html", auto_open: false},
+        {Benchee.Formatters.JSON,
+         file: "regression/performance/current/parser.json"}
+      ]
+    )
+
     profile_csi_parsing(emulator)
     profile_state_transitions(emulator)
   end
-  
+
   defp profile_csi_parsing(emulator) do
     IO.puts("\nCSI Parsing Profile:")
-    
+
     csi_sequences = [
-      "\e[31m",     # SGR
-      "\e[1;1H",    # CUP
-      "\e[2J",      # ED
-      "\e[K",       # EL
-      "\e[10;20r",  # DECSTBM
-      "\e[?25h",    # DECTCEM show
-      "\e[?25l"     # DECTCEM hide
+      # SGR
+      "\e[31m",
+      # CUP
+      "\e[1;1H",
+      # ED
+      "\e[2J",
+      # EL
+      "\e[K",
+      # DECSTBM
+      "\e[10;20r",
+      # DECTCEM show
+      "\e[?25h",
+      # DECTCEM hide
+      "\e[?25l"
     ]
-    
-    results = Enum.map(csi_sequences, fn seq ->
-      {time, _} = :timer.tc(fn ->
-        Enum.each(1..10000, fn _ -> Parser.parse(emulator, seq) end)
+
+    results =
+      Enum.map(csi_sequences, fn seq ->
+        {time, _} =
+          :timer.tc(fn ->
+            Enum.each(1..10000, fn _ -> Parser.parse(emulator, seq) end)
+          end)
+
+        {seq, time / 10000}
       end)
-      {seq, time / 10000}
-    end)
-    
+
     Enum.each(results, fn {seq, avg_μs} ->
       IO.puts("  #{inspect(seq)} => #{Float.round(avg_μs, 2)} μs")
     end)
   end
-  
+
   defp profile_state_transitions(emulator) do
     IO.puts("\nState Transition Profile:")
-    
+
     transitions = [
       {"ground->escape", "\e"},
       {"escape->csi", "\e["},
@@ -81,14 +101,17 @@ defmodule ParserBenchmark do
       {"ground->osc", "\e]"},
       {"osc->ground", "\e]0;Title\e\\"}
     ]
-    
-    results = Enum.map(transitions, fn {name, seq} ->
-      {time, _} = :timer.tc(fn ->
-        Enum.each(1..10000, fn _ -> Parser.parse(emulator, seq) end)
+
+    results =
+      Enum.map(transitions, fn {name, seq} ->
+        {time, _} =
+          :timer.tc(fn ->
+            Enum.each(1..10000, fn _ -> Parser.parse(emulator, seq) end)
+          end)
+
+        {name, time / 10000}
       end)
-      {name, time / 10000}
-    end)
-    
+
     Enum.each(results, fn {transition, avg_μs} ->
       IO.puts("  #{transition} => #{Float.round(avg_μs, 2)} μs")
     end)
@@ -102,11 +125,15 @@ if System.argv() |> Enum.any?(&(&1 == "--json")) do
     timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
     module: "parser",
     statistics: %{
-      average: 1.25,  # Mock: 1.25μs average parse time
-      throughput: 800000,  # Mock: 800K operations/second
-      memory: 512  # Mock: 512KB memory usage
+      # Mock: 1.25μs average parse time
+      average: 1.25,
+      # Mock: 800K operations/second
+      throughput: 800_000,
+      # Mock: 512KB memory usage
+      memory: 512
     }
   }
+
   IO.puts(Jason.encode!(results))
 else
   # Human readable output

--- a/bench/suites/protocol_performance_benchmark.exs
+++ b/bench/suites/protocol_performance_benchmark.exs
@@ -20,7 +20,7 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
       warmup: Keyword.get(opts, :warmup, 2),
       memory_time: Keyword.get(opts, :memory_time, 1),
       formatters: [
-        Benchee.Formatters.HTML,
+        {Benchee.Formatters.HTML, auto_open: false},
         Benchee.Formatters.Console
       ]
     }
@@ -30,7 +30,9 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
         # Rendering benchmarks
         "Protocol: Render String" => fn data -> render_protocol_string(data) end,
         "Protocol: Render Map" => fn data -> render_protocol_map(data) end,
-        "Protocol: Render ScreenBuffer" => fn data -> render_protocol_buffer(data) end,
+        "Protocol: Render ScreenBuffer" => fn data ->
+          render_protocol_buffer(data)
+        end,
         "Protocol: Render Theme" => fn data -> render_protocol_theme(data) end,
 
         # Styling benchmarks
@@ -44,18 +46,25 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
         "Protocol: Subscribe" => fn data -> event_protocol_subscribe(data) end,
 
         # Serialization benchmarks
-        "Protocol: Serialize JSON" => fn data -> serialize_protocol_json(data) end,
-        "Protocol: Serialize Binary" => fn data -> serialize_protocol_binary(data) end,
+        "Protocol: Serialize JSON" => fn data ->
+          serialize_protocol_json(data)
+        end,
+        "Protocol: Serialize Binary" => fn data ->
+          serialize_protocol_binary(data)
+        end,
 
         # Traditional behaviour equivalents for comparison
-        "Behaviour: Render Buffer" => fn data -> render_behaviour_buffer(data) end,
+        "Behaviour: Render Buffer" => fn data ->
+          render_behaviour_buffer(data)
+        end,
         "Behaviour: Apply Theme" => fn data -> style_behaviour_theme(data) end
       },
-      before_scenario: fn _input ->
-        setup_benchmark_data()
-      end,
-      inputs: generate_benchmark_inputs(),
-      **config
+      [
+        before_scenario: fn _input ->
+          setup_benchmark_data()
+        end,
+        inputs: generate_benchmark_inputs()
+      ] ++ Map.to_list(config)
     )
   end
 
@@ -66,18 +75,19 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
     buffer = ScreenBuffer.new(80, 24)
     renderer = Renderer.new(buffer)
 
-    theme = Theme.new(%{
-      name: "Benchmark Theme",
-      colors: %{
-        primary: "#FF0000",
-        secondary: "#00FF00",
-        background: "#000000"
-      },
-      component_styles: %{
-        button: %{background: :blue, foreground: :white},
-        text: %{foreground: :black}
-      }
-    })
+    theme =
+      Theme.new(%{
+        name: "Benchmark Theme",
+        colors: %{
+          primary: "#FF0000",
+          secondary: "#00FF00",
+          background: "#000000"
+        },
+        component_styles: %{
+          button: %{background: :blue, foreground: :white},
+          text: %{foreground: :black}
+        }
+      })
 
     component = %{
       type: :test_component,
@@ -209,29 +219,31 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
     iterations = Keyword.get(opts, :iterations, 1000)
 
     # Protocol memory usage
-    protocol_memory = measure_memory_usage(fn ->
-      data = setup_benchmark_data()
+    protocol_memory =
+      measure_memory_usage(fn ->
+        data = setup_benchmark_data()
 
-      Enum.each(1..iterations, fn _i ->
-        Renderable.render(data.string_data)
-        Styleable.apply_style(data.map_data, data.style_data)
-        EventHandler.handle_event(data.component, data.event, %{})
-        Serializable.serialize(data.theme, :json)
+        Enum.each(1..iterations, fn _i ->
+          Renderable.render(data.string_data)
+          Styleable.apply_style(data.map_data, data.style_data)
+          EventHandler.handle_event(data.component, data.event, %{})
+          Serializable.serialize(data.theme, :json)
+        end)
       end)
-    end)
 
     # Behaviour memory usage
-    behaviour_memory = measure_memory_usage(fn ->
-      data = setup_benchmark_data()
+    behaviour_memory =
+      measure_memory_usage(fn ->
+        data = setup_benchmark_data()
 
-      Enum.each(1..iterations, fn _i ->
-        Renderer.render(data.renderer)
-        Theme.get_color(data.theme, :primary)
-        # Traditional event handling would be function calls
-        data.component.event_handlers.click.(data.component, data.event, %{})
-        Jason.encode!(data.theme)
+        Enum.each(1..iterations, fn _i ->
+          Renderer.render(data.renderer)
+          Theme.get_color(data.theme, :primary)
+          # Traditional event handling would be function calls
+          data.component.event_handlers.click.(data.component, data.event, %{})
+          Jason.encode!(data.theme)
+        end)
       end)
-    end)
 
     %{
       protocol_memory: protocol_memory,
@@ -257,20 +269,23 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
     end)
 
     # Measure protocol dispatch latency
-    protocol_times = Enum.map(1..test_iterations, fn _i ->
-      start_time = System.monotonic_time(:nanosecond)
-      Renderable.render(data.string_data)
-      end_time = System.monotonic_time(:nanosecond)
-      end_time - start_time
-    end)
+    protocol_times =
+      Enum.map(1..test_iterations, fn _i ->
+        start_time = System.monotonic_time(:nanosecond)
+        Renderable.render(data.string_data)
+        end_time = System.monotonic_time(:nanosecond)
+        end_time - start_time
+      end)
 
     # Measure function call latency for comparison
-    function_times = Enum.map(1..test_iterations, fn _i ->
-      start_time = System.monotonic_time(:nanosecond)
-      to_string(data.string_data)  # Direct function call
-      end_time = System.monotonic_time(:nanosecond)
-      end_time - start_time
-    end)
+    function_times =
+      Enum.map(1..test_iterations, fn _i ->
+        start_time = System.monotonic_time(:nanosecond)
+        # Direct function call
+        to_string(data.string_data)
+        end_time = System.monotonic_time(:nanosecond)
+        end_time - start_time
+      end)
 
     %{
       protocol_latency: calculate_stats(protocol_times),
@@ -285,18 +300,20 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
   def scalability_benchmark do
     sizes = [10, 50, 100, 500, 1000, 5000, 10000]
 
-    results = Enum.map(sizes, fn size ->
-      items = generate_items(size)
+    results =
+      Enum.map(sizes, fn size ->
+        items = generate_items(size)
 
-      time = measure_time(fn ->
-        Enum.each(items, fn item ->
-          Renderable.render(item)
-          Styleable.apply_style(item, %{bold: true})
-        end)
+        time =
+          measure_time(fn ->
+            Enum.each(items, fn item ->
+              Renderable.render(item)
+              Styleable.apply_style(item, %{bold: true})
+            end)
+          end)
+
+        {size, time}
       end)
-
-      {size, time}
-    end)
 
     %{
       results: results,
@@ -352,7 +369,9 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
   defp calculate_scaling_factor(results) do
     # Calculate if scaling is linear, logarithmic, etc.
     case length(results) do
-      n when n < 2 -> :insufficient_data
+      n when n < 2 ->
+        :insufficient_data
+
       _ ->
         {sizes, times} = Enum.unzip(results)
         correlation = calculate_correlation(sizes, times)
@@ -371,13 +390,17 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
     mean_x = Enum.sum(xs) / n
     mean_y = Enum.sum(ys) / n
 
-    numerator = xs
-    |> Enum.zip(ys)
-    |> Enum.map(fn {x, y} -> (x - mean_x) * (y - mean_y) end)
-    |> Enum.sum()
+    numerator =
+      xs
+      |> Enum.zip(ys)
+      |> Enum.map(fn {x, y} -> (x - mean_x) * (y - mean_y) end)
+      |> Enum.sum()
 
-    sum_sq_x = xs |> Enum.map(fn x -> (x - mean_x) * (x - mean_x) end) |> Enum.sum()
-    sum_sq_y = ys |> Enum.map(fn y -> (y - mean_y) * (y - mean_y) end) |> Enum.sum()
+    sum_sq_x =
+      xs |> Enum.map(fn x -> (x - mean_x) * (x - mean_x) end) |> Enum.sum()
+
+    sum_sq_y =
+      ys |> Enum.map(fn y -> (y - mean_y) * (y - mean_y) end) |> Enum.sum()
 
     denominator = :math.sqrt(sum_sq_x * sum_sq_y)
 
@@ -406,7 +429,8 @@ defmodule Raxol.Bench.ProtocolPerformanceBenchmark do
       memory_benchmark: memory_results,
       latency_benchmark: latency_results,
       scalability_benchmark: scaling_results,
-      summary: generate_summary(memory_results, latency_results, scaling_results)
+      summary:
+        generate_summary(memory_results, latency_results, scaling_results)
     }
 
     case Jason.encode(report, pretty: true) do

--- a/bench/suites/terminal/terminal_benchmarks.ex
+++ b/bench/suites/terminal/terminal_benchmarks.ex
@@ -58,7 +58,8 @@ defmodule Raxol.Benchmark.Suites.TerminalBenchmarks do
       },
       formatters: [
         {Benchee.Formatters.Console, extended_statistics: true},
-        {Benchee.Formatters.HTML, file: "bench/output/terminal_benchmarks.html"}
+        {Benchee.Formatters.HTML,
+         file: "bench/output/terminal_benchmarks.html", auto_open: false}
       ]
     ]
   end

--- a/bench/suites/validation/if_statement_refactoring_validation.exs
+++ b/bench/suites/validation/if_statement_refactoring_validation.exs
@@ -199,7 +199,7 @@ Benchee.run(
   formatters: [
     Benchee.Formatters.Console,
     {Benchee.Formatters.HTML,
-     file: "bench/output/if_refactoring_validation.html"},
+     file: "bench/output/if_refactoring_validation.html", auto_open: false},
     {Benchee.Formatters.JSON,
      file: "bench/output/if_refactoring_validation.json"}
   ],

--- a/docs/getting-started/QUICKSTART.md
+++ b/docs/getting-started/QUICKSTART.md
@@ -22,6 +22,25 @@ def deps do
 end
 ```
 
+## Headless / CI setup
+
+The tutorial app below needs a real terminal, but building and testing Raxol
+does not. Prerequisites: Elixir/OTP (versions in the repo's `.tool-versions`)
+and a C toolchain for the termbox2 NIF (`make` + `cc`; on Debian/Ubuntu,
+`apt-get install build-essential`). From a fresh clone:
+
+```bash
+mix local.hex --force        # fresh machines and CI: install Hex without a prompt
+mix deps.get
+mix compile                  # builds the termbox2 NIF
+SKIP_TERMBOX2_TESTS=true MIX_ENV=test mix test --exclude slow --exclude integration --exclude docker
+MIX_ENV=test mix raxol.rate  # RATE: render-determinism golden suite
+```
+
+`SKIP_TERMBOX2_TESTS=true` excludes the tests that need a real local terminal;
+CI sets the same variable. If `HOME` is read-only in your sandbox, point
+`MIX_HOME` and `HEX_HOME` at a writable directory first.
+
 ## Your first app
 
 Every Raxol app follows The Elm Architecture (TEA) with four callbacks:

--- a/lib/mix/tasks/raxol.bench.memory.ex
+++ b/lib/mix/tasks/raxol.bench.memory.ex
@@ -457,7 +457,8 @@ defmodule Mix.Tasks.Raxol.Bench.Memory do
       warmup: if(opts[:quick], do: 0.5, else: 1),
       formatters: [
         Benchee.Formatters.Console,
-        {Benchee.Formatters.HTML, file: "bench/output/memory_benchmarks.html"}
+        {Benchee.Formatters.HTML,
+         file: "bench/output/memory_benchmarks.html", auto_open: false}
       ]
     ]
 

--- a/lib/mix/tasks/raxol.bench.memory_analysis.ex
+++ b/lib/mix/tasks/raxol.bench.memory_analysis.ex
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Raxol.Bench.MemoryAnalysis do
   defp output_formatter(path) do
     case Path.extname(path) do
       ".json" -> {Benchee.Formatters.JSON, file: path}
-      _ -> {Benchee.Formatters.HTML, file: path}
+      _ -> {Benchee.Formatters.HTML, file: path, auto_open: false}
     end
   end
 

--- a/lib/raxol/benchmark/config.ex
+++ b/lib/raxol/benchmark/config.ex
@@ -509,7 +509,7 @@ defmodule Raxol.Benchmark.Config do
       Benchee.Formatters.Console,
       {Benchee.Formatters.JSON, file: paths.json},
       {Benchee.Formatters.HTML,
-       file: paths.html, title: "Raxol Performance Report"}
+       file: paths.html, title: "Raxol Performance Report", auto_open: false}
     ]
   end
 

--- a/lib/raxol/benchmark/runner.ex
+++ b/lib/raxol/benchmark/runner.ex
@@ -17,7 +17,8 @@ defmodule Raxol.Benchmark.Runner do
     parallel: 1,
     formatters: [
       Benchee.Formatters.Console,
-      {Benchee.Formatters.HTML, file: "bench/output/report.html"}
+      {Benchee.Formatters.HTML,
+       file: "bench/output/report.html", auto_open: false}
     ],
     save: [path: "bench/snapshots/", tag: "latest"],
     load: "bench/snapshots/*.benchee"


### PR DESCRIPTION
Closes the gap found by the first scored agent-readiness audit (2026-08-07: raxol 81/100 B vs Textual anchor 93/100 A). The entire 12-point deficit traced to one failed validation command -- the documented test invocation -- reproduced under mirrored sandbox limits (2 CPUs, 2GB, read-only root): 8 failures in two classes.

## Class 1: benchee_html auto-open (real defect, 2 failures)

`benchee_html` defaults `auto_open: true`, so every suite except the one #805 fixed execs a browser opener after a run: `System.cmd("xdg-open", ...)` crashes `:enoent` on headless Linux (this is exactly how `Raxol.Benchmark.RunnerTest` died in the sandbox), and on macOS it silently opens a browser mid-test. Added `auto_open: false` to the 14 remaining `Benchee.Formatters.HTML` sites (4 lib/, 10 bench/).

Along the way: `bench/suites/protocol_performance_benchmark.exs` never parsed -- it used a `**config` splat, which is not Elixir. Options now merge via `Map.to_list/1`. `bench/` sits outside `.formatter.exs` inputs, which is how the syntax error survived since the file was introduced.

## Class 2: documented test command incomplete (6 failures)

README's Development section documented `mix test --exclude slow --exclude integration --exclude docker` -- but CI and local dev always set `SKIP_TERMBOX2_TESTS=true`, which additionally excludes `:skip_on_ci` (pty lifecycle + timing tests that need a real local terminal). On a fresh headless machine the documented command runs those six tests and fails.

README Development is now a complete from-source headless quickstart: C-toolchain prerequisite (the NIF needs make + cc, previously documented only via Nix), non-interactive hex bootstrap, the full exclusion set with a one-sentence explanation, RATE labeled as the render-determinism golden suite, and a MIX_HOME/HEX_HOME note for read-only-HOME sandboxes. "Try it" points headless/CI/agent readers at it, and QUICKSTART gains the same setup section.

## Verification

- Full local suite: 6651 passed, 0 failures; `mix format --check-formatted` clean; `MIX_ENV=test mix compile --warnings-as-errors` clean.
- End-to-end in the exact environment that failed: fresh clone of this branch inside the readiness-audit sandbox mirror (2 CPUs, 2GB RAM, 256 pids, read-only root, tmpfs /tmp noexec), running the newly documented command sequence + `mix raxol.rate`: exit 0, 6651 passed / 0 failures in 182.7s (the same environment previously produced 8 failures and cost the audit criterion).
- `RunnerTest` no longer opens a browser locally.

## Manual testing

- [x] `MIX_ENV=test mix test test/raxol/benchmark/runner_test.exs` -- 8 passed, no browser popup
- [x] Full suite green locally
- [x] Documented command sequence green in the mirrored headless sandbox
- [ ] Post-merge: one funded readiness-audit rerun (expected floor 92/100)
