### PR TITLE
Republish performance tables from measured run

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,18 @@ Headless environment (CI, containers, agents)? The [Development](#development) s
 
 ## Performance
 
-Full frame in 2.1ms on Apple M1 Pro (Elixir 1.19 / OTP 27), 13% of the 60fps budget.
+Full frame in 5.0ms on Apple M1 (Elixir 1.20 / OTP 29), 31% of the 60fps budget.
 
-| What                              | Time    |
-| --------------------------------- | ------- |
-| Full frame (create + fill + diff) | 2.1 ms  |
-| Tree diff (100 nodes)             | 4 us    |
-| Cell write                        | 0.97 us |
-| ANSI parse                        | 38 us   |
+| What                                     | Time    |
+| ---------------------------------------- | ------- |
+| Full frame (create + fill + diff)        | 5.0 ms  |
+| Tree diff (100 nodes, 1 changed)         | 32 us   |
+| Cell write (single)                      | 1.4 us  |
+| Buffer create (80x24)                    | 0.32 us |
+| Emulator ingest (parse + apply, plain)   | 1.7 ms  |
+| Memory per 80x24 buffer                  | 2 KB    |
+
+Measured 2026-08-07 at `fce2465bb` with `mix run bench/suites/comparison/framework_comparison.exs` (full mode). The ingest row is the whole emulator path (parse plus state application), not the standalone ANSI lexer, which handles plain text in under a microsecond (`mix raxol.bench parser`).
 
 Unix/macOS backend uses a termbox2 NIF; Windows uses a pure Elixir driver (usable, not yet tuned). See the [benchmark suite](docs/bench/README.md).
 

--- a/docs/bench/README.md
+++ b/docs/bench/README.md
@@ -20,56 +20,77 @@ mix raxol.bench --quick            # Shorter runs
 
 ## Latest results
 
-Measured on Apple M1 Pro, Elixir 1.19.0 / OTP 27.
+Measured 2026-08-07 at `fce2465bb` on Apple M1, Elixir 1.20.2 / OTP 29.0.3,
+with `mix run bench/suites/comparison/framework_comparison.exs` (full mode).
+Every number below comes from that one run on that one machine.
 
 ### Core operations
 
-| Operation                       | Time    | Throughput    |
-| ------------------------------- | ------- | ------------- |
-| Buffer create (80x24)           | 25 us   | 40K ops/sec   |
-| Cell write (single)             | 0.97 us | 1M ops/sec    |
-| Cell write (80 cells, line)     | 79 us   | 12.7K ops/sec |
-| Full screen write (1920 cells)  | 2.0 ms  | 496 ops/sec   |
-| ANSI parse (plain text)         | 38 us   | 26K ops/sec   |
-| ANSI parse (colored)            | 67 us   | 15K ops/sec   |
-| ANSI parse (50 CSI sequences)   | 2.0 ms  | 510 ops/sec   |
-| Tree diff (no change)           | 0.04 us | 27M ops/sec   |
-| Tree diff (1 node changed)      | 0.34 us | 3M ops/sec    |
-| Tree diff (100 nodes, 1 change) | 4.0 us  | 252K ops/sec  |
+| Operation                         | Time    | Throughput     |
+| --------------------------------- | ------- | -------------- |
+| Buffer create (80x24)             | 0.32 us | 3.2M ops/sec   |
+| Buffer create (200x50)            | 0.72 us | 1.4M ops/sec   |
+| Cell write (single)               | 1.4 us  | 718K ops/sec   |
+| Cell write (80 cells, line)       | 113 us  | 8.8K ops/sec   |
+| Full screen write (1920 cells)    | 2.6 ms  | 389 ops/sec    |
+| Emulator ingest (plain text)      | 1.7 ms  | 592 ops/sec    |
+| Emulator ingest (colored)         | 3.6 ms  | 275 ops/sec    |
+| Emulator ingest (50 CSI seqs)     | 69.5 ms | 14 ops/sec     |
+| Tree diff (no change)             | 0.10 us | 10.3M ops/sec  |
+| Tree diff (1 node changed)        | 1.3 us  | 776K ops/sec   |
+| Tree diff (100 nodes, 1 change)   | 32 us   | 31.3K ops/sec  |
+
+The emulator ingest rows measure the whole terminal path: parsing plus state
+application (buffer writes, cursor movement, style changes). The standalone
+ANSI lexer (`mix raxol.bench parser`) handles a short plain string in under a
+microsecond; the two paths differ by orders of magnitude, so any "ANSI parse"
+number is meaningless without naming which path it measures.
 
 ### Frame budget
 
 | Metric                            | Value   |
 | --------------------------------- | ------- |
-| Full frame (create + fill + diff) | 2.1 ms  |
-| Budget used (of 16ms @ 60fps)     | 13%     |
-| Headroom for app logic            | 13.9 ms |
-| Memory per 80x24 buffer           | 216 KB  |
+| Full frame (create + fill + diff) | 5.0 ms  |
+| Budget used (of 16ms @ 60fps)     | 31%     |
+| Headroom for app logic            | 11.0 ms |
+| Memory per 80x24 buffer           | 2 KB    |
+
+The memory figure is `erts_debug.size` on the buffer term; cells are stored
+in a map populated on write, so an empty buffer is small and memory grows
+with written cells, not dimensions.
 
 ### Cross-framework comparison
 
 | Operation           | Raxol   | Ratatui (Rust) | Bubble Tea (Go) | Textual (Python) |
 | ------------------- | ------- | -------------- | --------------- | ---------------- |
-| Buffer create 80x24 | 25 us   | ~0.5 us        | ~2 us           | ~50 us           |
-| Cell write (single) | 0.97 us | ~0.01 us       | ~0.1 us         | ~5 us            |
-| Full screen write   | 2.0 ms  | ~20 us         | ~50 us          | ~2 ms            |
-| ANSI parse (simple) | 38 us   | ~0.3 us        | ~1 us           | ~10 us           |
-| Tree/view diff      | 4.0 us  | ~5 us          | N/A             | ~100 us          |
+| Buffer create 80x24 | 0.32 us | ~0.5 us        | ~2 us           | ~50 us           |
+| Cell write (single) | 1.4 us  | ~0.01 us       | ~0.1 us         | ~5 us            |
+| Full screen write   | 2.6 ms  | ~20 us         | ~50 us          | ~2 ms            |
+| Tree/view diff      | 32 us   | ~5 us          | N/A             | ~100 us          |
 
 All values in microseconds unless noted. Lower is better.
 
-**Raxol**: measured on this hardware. **Others**: published/estimated benchmarks. Cross-framework numbers are approximate, from published benchmarks on different hardware. Direct comparison requires same-machine measurement.
+**Raxol**: measured on this hardware. **Others**: published/estimated numbers
+from different hardware, so the comparison is approximate at best; a
+same-machine harness is the only honest upgrade. The previous ANSI parse row
+is gone: published parser numbers for other frameworks measure lexers, while
+our comparison suite measures full emulator ingest, and comparing the two
+mislead more than it informed.
 
 ### Interpretation
 
-Raxol's per-operation latency is higher than Rust/Go (expected for a managed runtime), but:
+Raxol's per-operation latency is higher than Rust/Go (expected for a managed
+runtime), but:
 
-- **Full frame at 2.1ms** leaves 87% of the 60fps budget for application logic
-- **Tree diff at 4us** is competitive with Ratatui's immediate-mode approach and 25x faster than Textual
-- **Million+ cell writes/sec** is more than enough for any terminal UI
-- **OTP benefits**: crash isolation, hot reload, and distribution come built in to the runtime
+- **Full frame at 5.0ms** leaves 69% of the 60fps budget for application logic
+- **Tree diff at 32us** sits between Ratatui (~5us) and Textual (~100us)
+- **718K cell writes/sec** is more than enough for any terminal UI
+- **OTP benefits**: crash isolation, hot reload, and distribution come built
+  in to the runtime
 
-The BEAM is fast enough for 60fps terminal rendering while also providing fault tolerance and distribution primitives that would require significant additional infrastructure in compiled languages.
+The BEAM is fast enough for 60fps terminal rendering while also providing
+fault tolerance and distribution primitives that would require significant
+additional infrastructure in compiled languages.
 
 ## Suites
 

--- a/docs/bench/README.md
+++ b/docs/bench/README.md
@@ -118,13 +118,13 @@ mix raxol.bench --compare       # Compare with previous run
 
 ## Performance targets
 
-| Operation             | Target         | Status         |
-| --------------------- | -------------- | -------------- |
-| Full frame render     | < 16ms (60fps) | 2.1ms (pass)   |
-| Buffer operations     | < 1ms          | 0.97us (pass)  |
-| Tree diff (100 nodes) | < 1ms          | 4us (pass)     |
-| ANSI parse (simple)   | < 100us        | 38us (pass)    |
-| Memory per buffer     | < 500 KB       | 216 KB (pass)  |
+| Operation               | Target         | Status         |
+| ----------------------- | -------------- | -------------- |
+| Full frame render       | < 16ms (60fps) | 5.0ms (pass)   |
+| Buffer operations       | < 1ms          | 1.4us (pass)   |
+| Tree diff (100 nodes)   | < 1ms          | 32us (pass)    |
+| Emulator ingest (plain) | < 5ms          | 1.7ms (pass)   |
+| Memory per buffer       | < 500 KB       | 2 KB (pass)    |
 
 ## Tips
 


### PR DESCRIPTION
Closes review action #2 from the 2026-08-05 round: the published performance tables were stale and unreproducible by the tree's own suite, which discounts every other published number the moment someone runs it.

What the review measured against the old table: ANSI parse ~43x off (the published 38us came from the standalone lexer while the row's provenance suite measures full emulator ingest -- a ~5000x spread between the repo's two parse paths), buffer create ~80x better than published, full frame +45%, and the memory row printed "-2 KB" until #805 fixed the methodology.

This PR republishes both tables (README + docs/bench/README.md) from one full-mode run of `mix run bench/suites/comparison/framework_comparison.exs` at `fce2465bb` on Apple M1 / Elixir 1.20.2 / OTP 29.0.3, with command, commit, and date stated next to the numbers:

- Full frame 5.0 ms (31% of the 60fps budget) -- honest M1 number replacing the M1 Pro 2.1 ms
- Tree diff (100 nodes, 1 changed) 32 us; cell write 1.4 us; buffer create 0.32 us
- "ANSI parse" rows renamed to "Emulator ingest (parse + apply)" at their real 1.7 ms / 3.6 ms / 69.5 ms, with a note explaining the lexer-vs-ingest distinction and pointing at `mix raxol.bench parser` for the sub-microsecond lexer path
- Memory per 80x24 buffer: 2 KB via `erts_debug.size` (cells are written lazily; the old 216 KB was wrong in the flattering-to-nobody direction)
- Cross-framework table: raxol column updated to measured values, ANSI row dropped entirely (published numbers for other frameworks measure lexers; comparing them against our ingest path misled), interpretation section rewritten to the measured values (tree diff "25x faster than Textual" is gone -- it's ~3x)

## Manual testing

- [x] Full-mode suite run captured; every table number traces to that one log
- [x] Markdown pre-commit prose lint clean
- [ ] Numbers regenerate on the next full-mode run (expected drift: hardware/noise only)
