### PR TITLE
Note Postgres prereq for unexcluded test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,12 @@ mix raxol.demo               # built-in demos (needs a terminal)
 ```
 
 `SKIP_TERMBOX2_TESTS=true` excludes the tests that need a real local terminal
-(pty lifecycle, timing-sensitive suites); CI sets the same variable. In
-sandboxes where `HOME` is read-only, point `MIX_HOME` and `HEX_HOME` at a
-writable directory before running mix.
+(pty lifecycle, timing-sensitive suites); CI sets the same variable. Plain
+`mix test` without the exclude flags also runs integration suites that need
+external services (the workflow checkpoint tests want PostgreSQL via
+`RAXOL_WORKFLOW_PG_URL`), so stick to the command above unless you have
+them. In sandboxes where `HOME` is read-only, point `MIX_HOME` and
+`HEX_HOME` at a writable directory before running mix.
 
 ## Origin
 

--- a/docs/getting-started/QUICKSTART.md
+++ b/docs/getting-started/QUICKSTART.md
@@ -38,8 +38,11 @@ MIX_ENV=test mix raxol.rate  # RATE: render-determinism golden suite
 ```
 
 `SKIP_TERMBOX2_TESTS=true` excludes the tests that need a real local terminal;
-CI sets the same variable. If `HOME` is read-only in your sandbox, point
-`MIX_HOME` and `HEX_HOME` at a writable directory first.
+CI sets the same variable. Plain `mix test` without the exclude flags also
+runs integration suites that need external services (PostgreSQL for the
+workflow checkpoint tests), so stick to the command above. If `HOME` is
+read-only in your sandbox, point `MIX_HOME` and `HEX_HOME` at a writable
+directory first.
 
 ## Your first app
 


### PR DESCRIPTION
Closes the one finding from the scored agent-readiness audit (2026-08-08, raxol 78/C, completed and validated): the audit agent ran plain `mix test`, reached the `:integration`-tagged workflow checkpoint tests, and hit their PostgreSQL requirement (`RAXOL_WORKFLOW_PG_URL`), recording a high-severity missing-prerequisite finding.

One sentence added to README Development and the QUICKSTART headless section: the documented command excludes integration suites, and what they need (Postgres) if you run without the excludes.

## Manual testing

- [x] Verified the tests in question are `@moduletag :integration` and excluded by the documented command (postgrex_test.exs:155)
- [x] Markdown prose lint clean on commit
