### PR TITLE
Release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## [Unreleased]
 
+## [2.6.1] - 2026-08-08
+
+### Fixed
+
+- **Benchmark regression machinery is real (#805)**: `--regression` detects (5% median gate, persisted baselines), `--compare` diffs the previous snapshot, the summary and dashboard report measured values, and the mix-task rendering suite benches the real buffer/tree-diff pipeline instead of a stub. The comparison suite's memory row uses `erts_debug.size`.
+- **benchee HTML reports no longer auto-open** in any suite (#810, #812): `System.cmd("xdg-open", ...)` crashed headless Linux runs and opened browsers mid-test on macOS.
+- **Cloud metrics export is real (#805)**: OTLP/HTTP JSON, Datadog v1 series, and Prometheus pushgateway senders replace `:ok` stubs, with async monitored export, ingestion-time validation, label escaping, and api_key redaction.
+- **postgrex 0.22.4** (EEF-CVE-2026-66838, SQL injection via the `:comment` option) (#812).
+
+### Changed
+
+- **README and QUICKSTART document the headless from-source path** (#810, #815): C-toolchain prerequisite, non-interactive Hex bootstrap, the full test-exclusion set (`SKIP_TERMBOX2_TESTS=true`), RATE, `MIX_HOME`/`HEX_HOME` for read-only sandboxes, and the PostgreSQL requirement of unexcluded integration suites.
+- **Performance tables republished from a measured run** (#813): single-provenance numbers (commit, hardware, command), emulator-ingest rows labeled as the full parse+apply path distinct from the sub-microsecond lexer, and the cross-framework ANSI row removed as lexer-vs-ingest comparisons mislead.
+
 ### Deprecated
 
 - **`Raxol.UI.VisualTest`, `Raxol.UI.ComponentTest`, `Raxol.UI.IntegrationTest`, `Raxol.UI.PerformanceTest`** are deprecated and scheduled for removal in 3.0. They have no callers; no replacement is planned.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,17 @@ mix run examples/demo.exs
 
 See [examples/README.md](examples/README.md) for the full learning path, including agent examples, swarm demos, and the sandboxed REPL.
 
-Headless environment (CI, containers, agents)? The [Development](#development) section is the terminal-free path: clone, compile, test, and the RATE golden suite all run without a tty.
+Headless environment (CI, containers, agents)? The whole build-and-test path needs no tty:
+
+```bash
+mix local.hex --force        # fresh machines and CI: install Hex without a prompt
+mix deps.get
+mix compile                  # termbox2 NIF needs make + a C compiler
+SKIP_TERMBOX2_TESTS=true MIX_ENV=test mix test --exclude slow --exclude integration --exclude docker
+MIX_ENV=test mix raxol.rate  # RATE: render-determinism golden suite
+```
+
+Prerequisites, the quality gate, and constrained-sandbox notes are in [Development](#development).
 
 ## Performance
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Raxol.MixProject do
   use Mix.Project
 
-  @version "2.6.0"
+  @version "2.6.1"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do


### PR DESCRIPTION
Patch release. The published hexdocs still serve 2.6.0 content, so none of this week's docs fixes (#810/#813/#815) reach anyone reading the docs site -- including the readiness-audit journey, whose agent demonstrably followed the stale Development section (bare `mix test`, no exclusion set). 2.6.1 ships the current README/QUICKSTART plus the code fixes merged since 2.6.0.

- Hoists the 6-line headless build/test block into Try it (top of README) so it is the first actionable block; Development keeps the full set
- Version bump 2.6.0 -> 2.6.1; changelog entry covering #805/#810/#812/#813/#815 main-package deltas
- check-lockstep-deps.sh: OK (patch bump, sibling constraints unaffected)

After merge: tag v2.6.1, HEX_BUILD=1 mix hex.publish, verify hexdocs readme carries SKIP_TERMBOX2_TESTS, then rerun the audit pair.

## Manual testing

- [x] check-lockstep-deps.sh OK; compile green; markdown lint clean on commit
- [ ] Post-publish: hexdocs readme.html contains the new Development section
