### PR TITLE
Attach raxol-cli release assets, ungate npm publish

### DIFF
--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -6,8 +6,11 @@ name: Release raxol npm package
 # their own runners, macOS arm64 on a macOS runner (native builds avoid the
 # termbox NIF cross-compile hazard -- see docker/Dockerfile.raxol-cli).
 #
-# The npm tarball is always produced as an artifact. Publishing is gated: a
-# `raxol-cli-v*` tag, or a manual run with `publish: true` and an `NPM_TOKEN`.
+# The npm tarball is always produced as an artifact. The two ship paths are
+# independent: a `raxol-cli-v*` tag attaches the binaries + checksums to a
+# GitHub Release (stable public URLs for the T-Bench installer), while npm
+# publishing happens only on a manual run with `publish: true` and an
+# `NPM_TOKEN`.
 
 on:
   push:
@@ -158,18 +161,56 @@ jobs:
           path: packages/raxol_cli/npm/*.tgz
           if-no-files-found: error
 
-      - name: Resolve publish flag
-        id: flags
-        run: |
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.publish }}" = "true" ]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-          fi
-
+      # npm publish is deliberately NOT wired to the tag. A `raxol-cli-v*` tag
+      # ships the release binaries (see the `release` job); claiming the `raxol`
+      # name on npm is a separate, deliberate act. Publish with a manual run:
+      #   gh workflow run release-raxol-cli.yml -f publish=true
       - name: Publish to npm
-        if: steps.flags.outputs.publish == 'true'
+        if: inputs.publish == true
         working-directory: packages/raxol_cli/npm
-        run: npm publish --access public
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::publish=true but the NPM_TOKEN secret is unset or empty." >&2
+            exit 1
+          fi
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # A `raxol-cli-v*` tag attaches the per-arch binaries to a GitHub Release, so
+  # they have stable unauthenticated download URLs. Actions artifacts cannot
+  # serve this: they need a token to fetch and expire after 90 days, and the
+  # T-Bench install script curls them from inside an arbitrary task container.
+  # The root `release.yml` does not cover these tags -- its filter is `v*`,
+  # which does not match `raxol-cli-v*`.
+  release:
+    name: attach release assets
+    needs: [linux-build, macos-build]
+    if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download built binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cli-*
+          merge-multiple: true
+          path: dist
+
+      - name: Checksum
+        working-directory: dist
+        run: |
+          chmod +x raxol_cli_*
+          sha256sum raxol_cli_* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          files: |
+            dist/raxol_cli_*
+            dist/SHA256SUMS
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cutting a `raxol-cli-v*` tag was the next step in the T-Bench campaign, on the
assumption it produces downloadable release assets for the agent install script.
It does not. Two defects, both only observable at tag time:

**No public assets.** `release-raxol-cli.yml` uploads the per-arch binaries as
Actions artifacts only. Those need a token to download and expire after 90 days,
but the T-Bench install script curls them unauthenticated from inside an
arbitrary task container. The root `release.yml` does not fill the gap either:
its trigger is `v*`, which does not match `raxol-cli-v2.6.1`, so no GitHub
Release is created at all.

**Unintended npm publish.** The `Resolve publish flag` step set `publish=true`
for any `push` event, so the tag would have attempted `npm publish` for the
(currently unclaimed) `raxol` name. There is no `NPM_TOKEN` secret on this repo
-- `gh secret list` shows CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN,
CODECOV_TOKEN, SNYK_TOKEN -- so the job would have failed red on a bare
`ENEEDAUTH` after the artifacts had already uploaded. Publishing is also
policy-gated (Harness DX decision 5: not until `raxol code` ships), so the tag
path should never have implied it.

## Changes

- New `release` job, gated on `startsWith(github.ref, 'refs/tags/raxol-cli-v')`,
  with job-scoped `contents: write`. Downloads the same `cli-*` artifacts,
  generates `SHA256SUMS`, and attaches binaries + checksums to a GitHub Release.
  Workflow-level permissions stay `contents: read`.
- npm publish now requires an explicit `workflow_dispatch` run with
  `publish: true`, and fails with a clear `::error::` when the token is unset
  instead of letting npm emit `ENEEDAUTH`.

Binary build, per-arch smoke gate, and tarball packaging are untouched.

## Manual testing

- `yaml.safe_load` parses the workflow; job graph is
  `linux-build, macos-build, package, release`.
- Trigger logic confirmed by inspection: on a tag push `inputs` is unset, so
  `inputs.publish == true` is false and npm is skipped; the `release` job's
  `if` matches `refs/tags/raxol-cli-v*` and not `refs/tags/v*`.
- Checksum round-trip tested against real `sha256sum` output: the recorded hash
  still verifies after the asset is renamed to `/usr/local/bin/raxol` on
  install, and a tampered file is correctly rejected.
- The corresponding install script (adapter spec section 5) is shellcheck-clean.

Not exercised end to end -- that needs the tag push this PR unblocks.
