### PR TITLE
Bump raxol_cli to 0.2.0 for the acp release

### DIFF
--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raxol",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"


### PR DESCRIPTION
Bumps `raxol_cli` to 0.2.0 so a new `raxol-cli-v*` tag can carry the `code` and `acp` subcommands.

## Why

`raxol-cli-v0.1.0` was cut at `f7aa14a6d`, one commit before #819. The published binaries therefore
carry `agent` / `p` / `playground` / `new` but neither `code` nor `acp`. Harbor's own install script
runs clean against that release (download, checksum, bare-binary install, Linux boot all pass) and
then answers `unknown command "acp"` -- the one remaining blocker on the T-Bench ACP registry path.

Both subcommands are already on master via #819; only the release assets are stale.

## Why bump the app version rather than reuse 0.1.0

Burrito keys its extraction cache by app version. A same-version rebuild is silently shadowed by
the stale extraction, so a valid subcommand still reports as `unknown command` -- the exact symptom
above, from a different cause. A fresh task container would not hit it, but local verification
would, and the two failure modes are indistinguishable from the outside.

Minor rather than patch: a new subcommand is a feature, and in 0.x that is the conventional signal.

`npm/package.json` tracks the same number. It vendors binaries rather than downloading by version,
so it is not load-bearing for asset URLs, but shipping 0.2.0 binaries under a 0.1.0 package version
is a trap for whoever reads it next.

## Scope

Two lines. No behaviour change. `lib/raxol/cli/new.ex`'s `version: "0.1.0"` is the scaffolder's
template for generated apps, not this package's own version, and is deliberately untouched.

Nothing here publishes to npm: that stays a manual `workflow_dispatch` (decision 5).

## Manual testing

- [x] `MIX_ENV=test mix test` in `packages/raxol_cli` -- 14 passed
- [x] `raxol help` reports `raxol 0.2.0` and lists both `code` and `acp`
- [x] `Code.ensure_loaded?(Raxol.Agent.ClientProtocol.Serve)` returns true in a test build
- [ ] After merge: tag `raxol-cli-v0.2.0`, confirm all five workflow jobs green and three binaries
      plus `SHA256SUMS` attached to the Release
- [ ] After release: repoint the three URLs and checksums in the ACP registry `agent.json`, rerun
      harbor's install script in a linux/arm64 container

## Note for reviewers

`raxol_cli` is not in CI; it is a local gate. Suite result above is from a local run.
