### PR TITLE
Fix Docker context dropping raxol_mcp library code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,16 @@ deps/
 # repo root, so every packages/*/test leaked into the context (8.3MB).
 # `*.md` stays root-anchored deliberately -- ex_keccak reads its own README.md
 # at compile time for @moduledoc.
+#
+# The re-include is load-bearing: `test` names a mix SUITE at a package root
+# but a NAMESPACE under lib/, and the recursive glob cannot tell them apart.
+# `packages/raxol_mcp/lib/raxol/mcp/test/` holds Raxol.MCP.Test.Session and
+# .Assertions -- shipped library code. Dropping them compiled raxol_mcp with
+# 25 files instead of 27, so Raxol.MCP.Test could not expand %Session{} and
+# every Linux release build died in `mix release`. macOS builds natively with
+# no Docker context, so it passed and the break reached a tag unseen.
 **/test/
+!**/lib/**/test/
 bench/
 scripts/
 


### PR DESCRIPTION
Restores two library files to the Docker build context. Without them, every Linux release build and
the Fly deploy fail to compile `raxol_mcp`.

## What broke

#819 tightened `test/` to `**/test/` in `.dockerignore`, correctly stopping every `packages/*/test`
suite from leaking into the context (8.3MB). But `test` names a mix SUITE at a package root and a
NAMESPACE under `lib/`, and a recursive glob cannot tell them apart. It also dropped
`packages/raxol_mcp/lib/raxol/mcp/test/`, which holds `Raxol.MCP.Test.Session` and
`Raxol.MCP.Test.Assertions` -- shipped library code, not tests.

`raxol_mcp` then compiled 25 files instead of 27, and `Raxol.MCP.Test` could not expand `%Session{}`:

```
error: Raxol.MCP.Test.Session.__struct__/1 is undefined, cannot expand struct
       Raxol.MCP.Test.Session ... you likely have cyclic module usage in your code
== Compilation error in file lib/raxol/mcp/test.ex ==
```

The "cyclic module usage" hint is a red herring; the defining module simply was not in the context.

## Why it reached a tag

`raxol-cli-v0.2.0` failed both Linux jobs and attached no assets. macOS passed, because it builds
natively with no Docker context and never consults `.dockerignore` -- so the one platform that
cannot see the bug is the one that stayed green.

Blast radius is wider than the CLI: `Dockerfile.web`, `.raxol-console` and `.raxol-earn` all
`COPY . .` from the same context, and `web/mix.exs` pulls `raxol_agent` into `raxol_mcp`. The Fly
deploy has been broken since #819 merged.

## The fix

```
**/test/
!**/lib/**/test/
```

Re-include rather than revert, so #819's context saving is kept. This also restores
`packages/raxol_terminal/lib/termbox2_nif/test/`, which the same glob had dropped.

## Verification

Run against the real build, not by inspection:

- `docker buildx build -f docker/Dockerfile.raxol-cli --platform linux/arm64`: was exit 1 at ~29s,
  now exit 0. `raxol_mcp` compiles 27 files. 19.8MB binary emitted.
- That binary, executed in a `debian:trixie-slim` arm64 container, reports `raxol 0.2.0` and lists
  both `code` and `acp`.
- Context probe: `lib/raxol/mcp/test/` present (`assertions.ex`, `session.ex`);
  `packages/raxol_mcp/test/` still excluded.

## Manual testing

- [x] linux/arm64 release build green end to end
- [x] built binary boots on Linux and exposes `acp`
- [x] mix suites still excluded from the context
- [ ] After merge: re-tag so the release attaches assets

## Note

Re-tagging needs a new tag name; `raxol-cli-v0.2.0` is consumed and its run produced nothing.
Either delete and re-cut that tag, or move to `v0.2.1`.
