### PR TITLE
Bump raxol_cli to 0.2.1 for model steering

### DIFF
--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raxol",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"


### PR DESCRIPTION
Ships #823 in the packaged binary so a harbor run actually honours `harbor run -m <model>`.

`raxol-cli-v0.2.0` predates #823, so a benchmark against that release still ignores the requested
model and records one it did not use. Nothing else changed.

## Why a version bump rather than a re-tag

Burrito keys its extraction cache by app version: a same-version rebuild is silently shadowed by the
stale extraction, and a valid change appears not to have landed. Patch level, since this is a bug fix
to an existing surface rather than new capability.

## Verification

Built a `linux/arm64` binary from this branch through `docker/Dockerfile.raxol-cli` and probed the
binary itself, not the source:

| Probe | Result |
|---|---|
| `HARBOR_ACP_REQUESTED_MODEL=notaprovider/some-model` | `unknown backend "notaprovider"; supported: ...` -- the var is read, and `Backend.Cli`'s validation is reused rather than duplicated |
| `HARBOR_ACP_REQUESTED_MODEL=claude-sonnet-4-5` | `HARBOR_ACP_REQUESTED_MODEL must be provider/model` -- fails closed |
| `anthropic/claude-sonnet-4-5` + a key | ACP `initialize` answers on a clean one-line stdout wire |
| `--backend openai` alongside a bogus var | error names **openai** -- the flag wins and suppresses the request whole |

Also confirmed `raxol_mcp` compiles 27 files in the image, so #822's context fix still holds.

## Manual testing

- [x] `raxol_cli` suite: 14 passed
- [x] linux/arm64 image builds green, binary emitted
- [x] all four steering behaviours verified in the packaged binary
- [ ] After merge: tag `raxol-cli-v0.2.1`, repoint `agent.json`, rerun harbor `--install-only`

## Note

`raxol_cli` is not in CI; it is a local gate, so the suite result above is from a local run.
