### PR TITLE
Bump raxol_cli to 0.2.2 for the ACP write path

### DIFF
--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raxol",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"


### PR DESCRIPTION
Ships #825 so the packaged binary's ACP surface can actually edit files.

Against `raxol-cli-v0.2.1` the surface still holds `read`/`grep`/`glob` only, so a harbor run scores
0 on every task by construction. Two lines, no behaviour change of its own.

## Verification

Built a `linux/arm64` binary from this branch and probed the artifact:

- reports `raxol 0.2.2`, `acp` present, model steering (#823) still honoured
- **the release payload contains `Elixir.Raxol.Agent.ClientProtocol.Permission.beam`** plus
  `Actions.Code.{Write,Edit,Bash,Grep,Glob}`

That second check is deliberate rather than paranoid: a stale `raxol_agent` build has silently
shipped an "absent" feature in this repo before (adding a dep does not change the gated package's
sources, so Mix reuses the old build). Confirming the beam is in the payload rules that out.

- `raxol_mcp` compiles 27 files in the image, so #822's context fix still holds
- `raxol_cli` suite: 14 passed

## What this does NOT establish

The gate needs a model emitting a sensitive tool call and a client answering the ask. Neither happens
in a build probe. **The funded T-Bench smoke is what proves the write path end to end**, and that is
the next step — this bump only gets the code into a downloadable binary.

## Manual testing

- [x] linux/arm64 build green, binary emitted
- [x] version, `acp`, and steering verified in the packaged binary
- [x] `Permission` + all five Code action modules confirmed in the release payload
- [ ] After merge: tag `raxol-cli-v0.2.2`, repoint `agent.json`, free `--install-only` recheck, then
      the funded smoke

## Note

Tag from **master** this time — `git checkout master && git pull` first. The v0.2.1 tag initially
landed on a local pre-squash commit because the merged branch had been deleted remotely, and had to
be re-cut.

`raxol_cli` is not in CI; the suite result above is from a local run.
