### PR TITLE
Surface why an ACP turn failed

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/turn_runner.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/turn_runner.ex
@@ -130,8 +130,13 @@ defmodule Raxol.Agent.ClientProtocol.TurnRunner do
               Raxol.AgentClientProtocol.Schema.ToolCall,
               Raxol.AgentClientProtocol.Schema.ToolCallUpdate,
               Raxol.AgentClientProtocol.Schema.ToolCallUpdateFields,
-              Raxol.AgentClientProtocol.Schema.LifecycleExtras.SessionNotification
+              Raxol.AgentClientProtocol.Schema.LifecycleExtras.SessionNotification,
+              Raxol.AgentClientProtocol.Error
             ]}
+
+  @error_mod Raxol.AgentClientProtocol.Error
+  # A runaway reason must not become an unbounded JSON-RPC frame.
+  @error_detail_limit 2_000
 
   @ctx Raxol.AgentClientProtocol.Ctx
   @content_block Raxol.AgentClientProtocol.Schema.ContentBlock
@@ -435,10 +440,7 @@ defmodule Raxol.Agent.ClientProtocol.TurnRunner do
 
   defp handle_event({:error, reason}, state) do
     stop_pump(state)
-    # The Session folds any non-{:stop,_}/non-PromptResponse root result to an
-    # internal-error prompt response (normalize_root_result/1) — the honest
-    # rendering of a backend/stream failure.
-    {:error, {:turn_stream_error, reason}}
+    {:error, turn_error(:turn_stream_error, reason)}
   end
 
   defp handle_event(_other, state), do: loop(state)
@@ -449,7 +451,37 @@ defmodule Raxol.Agent.ClientProtocol.TurnRunner do
   end
 
   defp handle_pump_down(reason, _state) do
-    {:error, {:turn_stream_crashed, reason}}
+    {:error, turn_error(:turn_stream_crashed, reason)}
+  end
+
+  # Say what broke, twice, because the two audiences are different and both
+  # were getting nothing.
+  #
+  # This used to return an opaque `{:turn_stream_error, reason}` tuple, which
+  # the Session folded to a bare `Error.internal_error()` — reason discarded —
+  # and nothing logged it. A provider answering "your credit balance is too
+  # low" surfaced to an editor as -32603 with no data, and to a benchmark
+  # harness as a non-zero exit with an empty stderr. Diagnosing it meant
+  # driving the agent stream by hand.
+  #
+  # `Logger.error` reaches the operator (this surface reroutes logs to stderr
+  # before the transport binds, so it lands beside the wire without corrupting
+  # it, and a harness captures it). The `data` payload reaches the peer, which
+  # is what an editor renders.
+  @doc false
+  @spec turn_error(atom(), term()) :: struct()
+  def turn_error(tag, reason) do
+    detail =
+      reason
+      |> inspect(limit: :infinity, printable_limit: :infinity)
+      |> String.slice(0, @error_detail_limit)
+
+    Logger.error("[acp] #{tag}: #{detail}")
+
+    @error_mod.with_data(@error_mod.internal_error(), %{
+      "reason" => detail,
+      "tag" => Atom.to_string(tag)
+    })
   end
 
   # -- cancellation ---------------------------------------------------------------

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/turn_error_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/turn_error_test.exs
@@ -1,0 +1,70 @@
+defmodule Raxol.Agent.ClientProtocol.TurnErrorTest do
+  @moduledoc """
+  A failed turn must SAY what failed.
+
+  The reason used to be dropped twice over: `TurnRunner` returned an opaque
+  `{:turn_stream_error, reason}` tuple, the Session folded any unrecognized
+  root result to a bare `Error.internal_error()`, and nothing logged it. A
+  provider answering "your credit balance is too low" reached an editor as
+  -32603 with no data, and a benchmark harness as a non-zero exit with an empty
+  stderr -- the only way to read it was to drive the agent stream by hand,
+  which is exactly how it was eventually found.
+
+  Both audiences are covered here because they are served by different
+  mechanisms: the peer by the error's `data`, the operator by the log.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Raxol.Agent.ClientProtocol.TurnRunner
+  alias Raxol.AgentClientProtocol.Error
+
+  @moduletag :unix_only
+
+  @provider_failure {:http_error, 400, %{"error" => %{"message" => "credit balance too low"}}}
+
+  describe "a failed turn" do
+    test "carries the reason to the peer as JSON-RPC error data" do
+      err = TurnRunner.turn_error(:turn_stream_error, @provider_failure)
+
+      assert %Error{code: -32_603} = err
+      assert err.data["tag"] == "turn_stream_error"
+      assert err.data["reason"] =~ "credit balance too low"
+    end
+
+    test "distinguishes a stream error from a crashed pump" do
+      crashed = TurnRunner.turn_error(:turn_stream_crashed, :killed)
+
+      assert crashed.data["tag"] == "turn_stream_crashed"
+    end
+
+    test "is logged, so an operator and a harness both see it" do
+      log =
+        capture_log(fn ->
+          TurnRunner.turn_error(:turn_stream_error, @provider_failure)
+        end)
+
+      assert log =~ "turn_stream_error"
+      assert log =~ "credit balance too low"
+    end
+
+    # An enormous reason must not become an enormous frame.
+    test "a runaway reason is truncated" do
+      err = TurnRunner.turn_error(:turn_stream_error, String.duplicate("x", 10_000))
+
+      assert byte_size(err.data["reason"]) <= 2_000
+    end
+
+    # inspect/2 defaults elide long structures with "..."; the message we most
+    # need is usually at the end of a nested provider payload.
+    test "a nested reason is not elided before the message" do
+      nested = {:http_error, 400, %{"error" => %{"message" => String.duplicate("a", 300)}}}
+
+      err = TurnRunner.turn_error(:turn_stream_error, nested)
+
+      refute err.data["reason"] =~ "..."
+      assert err.data["reason"] =~ String.duplicate("a", 300)
+    end
+  end
+end

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/session.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/session.ex
@@ -766,6 +766,15 @@ defmodule Raxol.AgentClientProtocol.Session do
   @spec normalize_root_result(term()) :: Turn.outcome()
   defp normalize_root_result({:stop, reason}) when is_atom(reason), do: {:stop, reason}
   defp normalize_root_result(%PromptResponse{stop_reason: reason}), do: {:stop, reason}
+
+  # A runner that has ALREADY built a protocol error keeps it, `data` included.
+  # Folding it into a bare `Error.internal_error()` like any other unrecognized
+  # shape discarded the only description of what went wrong: a provider
+  # refusing a request reached the peer as -32603 with no data, which is
+  # indistinguishable from a crash. The runner is trusted to have decided the
+  # code; this clause only stops the Session from overwriting it.
+  defp normalize_root_result({:error, %Error{} = err}), do: {:error, err}
+
   defp normalize_root_result(_other), do: {:error, Error.internal_error()}
 
   # Drain gate (§3.1): finish iff the task group is empty AND an outcome exists.

--- a/packages/raxol_agent_client_protocol/test/session_test.exs
+++ b/packages/raxol_agent_client_protocol/test/session_test.exs
@@ -372,6 +372,40 @@ defmodule Raxol.AgentClientProtocol.SessionTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Root-result error passthrough
+  # ---------------------------------------------------------------------------
+
+  describe "root result carrying a protocol error" do
+    # The Session used to fold EVERY unrecognized root result into a bare
+    # internal_error, so a runner that had already diagnosed the failure had
+    # its diagnosis discarded and the peer saw -32603 with no data --
+    # indistinguishable from a crash.
+    test "a runner's own Error survives with its data intact", ctx do
+      conn = new_conn()
+      err = Error.with_data(Error.internal_error(), %{"reason" => "credit balance too low"})
+
+      {session, _sid} =
+        start_session(ctx, conn, turn_runner: fn _s, _req -> {:error, err} end)
+
+      begin(session)
+
+      assert {:reply, _, {:error, %Error{data: %{"reason" => "credit balance too low"}}}} =
+               wait_for_reply(conn)
+    end
+
+    test "an unrecognized shape still folds to a bare internal error", ctx do
+      conn = new_conn()
+
+      {session, _sid} =
+        start_session(ctx, conn, turn_runner: fn _s, _req -> :nonsense end)
+
+      begin(session)
+
+      assert {:reply, _, {:error, %Error{code: -32_603, data: nil}}} = wait_for_reply(conn)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # I8 fail-closed permission matrix
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
A failed ACP turn discarded its own diagnosis, twice over.

`TurnRunner` returned an opaque `{:turn_stream_error, reason}` tuple; the Session folded any
unrecognized root result into a bare `Error.internal_error()`; nothing logged it. So a provider
answering

```
Your credit balance is too low to access the Anthropic API.
```

reached an editor as `-32603` with no `data`, and a benchmark harness as a non-zero exit with an
**empty stderr**. Reading it meant driving `Raxol.Agent.Stream` by hand — which is literally how it
was found, while chasing a failing T-Bench smoke.

## The fix

Two audiences, two mechanisms, both previously empty:

| Audience | Mechanism | Was | Now |
|---|---|---|---|
| Editor / harness peer | JSON-RPC error `data` | absent | `%{"reason" => ..., "tag" => ...}` |
| Operator / harness log | stderr | silent | `[acp] turn_stream_error: ...` |

The log lands on stderr because this surface reroutes logs there before the transport binds, so it
sits beside the wire without corrupting it, and a harness captures it into its agent log.

`Session` gains exactly one clause: a root result that is **already** a `%Error{}` is kept rather
than overwritten. The runner is trusted to have decided the code. Every other unrecognized shape
still folds to a bare internal error, so the fail-closed default is untouched.

Two details that are deliberate rather than incidental:

- detail is capped at 2000 bytes — a runaway reason must not become a runaway frame
- inspected with `limit: :infinity`, because `inspect/2`'s default elision hides the tail of a
  nested provider payload, which is exactly where the message sits (there is a test for this)

## Verification

- `raxol_agent` **2293**, `raxol_agent_client_protocol` **857**, both 0 failures
- **Mutation-proven:** dropping the log reds the log test; returning a bare internal error reds all
  four data tests; removing the Session clause reds the passthrough test

## Manual testing

- [x] both suites green
- [x] all three mutations red their intended tests
- [x] the real provider failure reproduced end to end and now appears in the log

## Note

Scope is limited to surfacing. It does not change which errors occur, retry, or map anything to a
different JSON-RPC code. `raxol_agent` is not in CI; that suite result is from a local run.
