### PR TITLE
Bump raxol_cli to 0.2.3

### DIFF
--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raxol",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"


### PR DESCRIPTION
Ships #827 (CA trust store) and #828 (turn errors surfaced). `v0.2.2` predates both, so its ACP
surface cannot complete any HTTPS request and reports failures as a bare `-32603`.

## Verified the network path in a release build, before tagging

That is the gap that let a missing trust store reach a published tag: every prior packaged-binary
check used the **Mock** backend, which makes no HTTP call, so the whole network path was never
exercised from a release build.

A `linux/arm64` binary built from this branch, driven over real stdio ACP against OpenRouter:

```
initialize      -> {"agentInfo":{"name":"raxol",...},"protocolVersion":1}
session/new     -> {"sessionId":"acp-201"}
session/update  -> tool_call        read_file (in_progress)
session/update  -> tool_call_update completed, "the quick brown fox\n"
id 3            -> {"stopReason":"end_turn"}
```

Clean stderr. That single run covers castore, the `openrouter` backend, model steering via
`HARBOR_ACP_REQUESTED_MODEL=openrouter/anthropic/claude-sonnet-4.5` (a doubly nested id, split on
the first slash only, per #823), tool dispatch, and the wire.

`read_file` is non-sensitive so no permission round trip fired — the intended design, since gating
reads would cost a round trip per read. The write path is exercised by the harness smoke, where the
client actually answers `session/request_permission`.

## Manual testing

- [x] linux/arm64 build green, castore compiles into the image
- [x] real OpenRouter turn completes end to end through the packaged binary, tool call included
- [x] `raxol_cli` 14 tests pass
- [ ] After merge: tag `raxol-cli-v0.2.3`, repoint `agent.json`, free `--install-only`, then the
      funded 1-task smoke

## Note

Tag from **master** (`git checkout master && git pull` first) — the v0.2.1 tag once landed on a local
pre-squash commit and had to be re-cut.

`raxol_cli` is not in CI; that suite result is from a local run.
