### PR TITLE
Cap ACP spend, and script the harbor workaround

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/budget.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/budget.ex
@@ -1,0 +1,73 @@
+defmodule Raxol.Agent.ClientProtocol.Budget do
+  @moduledoc """
+  Session-lifetime turn and spend cap for the ACP surface.
+
+  `raxol p` has honoured `RAXOL_MAX_COST_USD` and `RAXOL_MAX_TURNS` since the
+  benchmark profile landed, but the ACP surface never did, so an editor or a
+  harness could drive it until the provider account ran dry. Same env contract,
+  same arithmetic, same fail-closed parsing: this is a place to keep the
+  running total, not a second budget system.
+
+  Not started when neither cap is set, and `check/0` answers `:ok` when it is
+  not running, so callers never branch on whether budgeting is on.
+
+  The bound is the SESSION, not the turn. A turn already under way finishes;
+  the next one is refused. Interrupting mid-turn would abandon a half-applied
+  edit, which is worse than one turn of overshoot.
+  """
+
+  use Agent
+
+  alias Raxol.Agent.BenchmarkProfile
+
+  @name __MODULE__
+
+  @doc "Start only when a cap exists. Returns `:ignore` otherwise."
+  @spec start_link(BenchmarkProfile.t()) :: {:ok, pid()} | :ignore
+  def start_link(%BenchmarkProfile{max_cost_usd: nil, max_turns: nil}), do: :ignore
+
+  def start_link(%BenchmarkProfile{} = profile) do
+    Agent.start_link(fn -> %{profile: profile, usage: %{}, turns: 0} end, name: @name)
+  end
+
+  @doc "Whether another turn is affordable. `:ok` when no cap is running."
+  @spec check() :: :ok | {:exceeded, :max_turns | :max_cost_usd}
+  def check do
+    case Process.whereis(@name) do
+      nil -> :ok
+      pid -> Agent.get(pid, &BenchmarkProfile.budget_status(&1.profile, &1.turns, &1.usage))
+    end
+  end
+
+  @doc "Fold one completed turn's usage into the running total."
+  @spec record(map()) :: :ok
+  def record(usage) do
+    case Process.whereis(@name) do
+      nil ->
+        :ok
+
+      pid ->
+        Agent.update(pid, fn state ->
+          %{
+            state
+            | usage: BenchmarkProfile.add_usage(state.usage, usage),
+              turns: state.turns + 1
+          }
+        end)
+    end
+  end
+
+  @doc "Spend so far in USD, and turns taken. For `/usage`-style reporting."
+  @spec spent() :: %{cost_usd: float(), turns: non_neg_integer()}
+  def spent do
+    case Process.whereis(@name) do
+      nil ->
+        %{cost_usd: 0.0, turns: 0}
+
+      pid ->
+        Agent.get(pid, fn s ->
+          %{cost_usd: BenchmarkProfile.cost_usd(s.profile, s.usage), turns: s.turns}
+        end)
+    end
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/serve.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/serve.ex
@@ -101,6 +101,22 @@ defmodule Raxol.Agent.ClientProtocol.Serve do
     end
   end
 
+  # Same env contract `raxol p` already honours (RAXOL_MAX_COST_USD,
+  # RAXOL_MAX_TURNS, RAXOL_COST_PER_MTOK_IN/_OUT). A malformed or
+  # unenforceable value refuses to serve rather than running uncapped: the
+  # whole reason to set one is that nobody is watching.
+  defp start_budget do
+    case Raxol.Agent.BenchmarkProfile.from_env() do
+      {:ok, profile} ->
+        Raxol.Agent.ClientProtocol.Budget.start_link(profile)
+        :ok
+
+      {:error, message} ->
+        IO.puts(:stderr, "raxol acp: #{message}")
+        System.halt(64)
+    end
+  end
+
   @requested_model_env "HARBOR_ACP_REQUESTED_MODEL"
 
   @doc """
@@ -167,6 +183,7 @@ defmodule Raxol.Agent.ClientProtocol.Serve do
     System.put_env("RAXOL_SKIP_TERMINAL_INIT", "true")
     reroute_logs_to_stderr()
     {:ok, _apps} = Application.ensure_all_started(:raxol_agent)
+    start_budget()
 
     {:ok, handle} = Raxol.AgentClientProtocol.Transport.Stdio.start_self()
 

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/turn_runner.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/turn_runner.ex
@@ -117,6 +117,7 @@ defmodule Raxol.Agent.ClientProtocol.TurnRunner do
 
   require Logger
 
+  alias Raxol.Agent.ClientProtocol.Budget
   alias Raxol.Agent.Stream, as: AgentStream
 
   # Cross-package: raxol_agent_client_protocol is an optional peer (dev/test
@@ -277,6 +278,13 @@ defmodule Raxol.Agent.ClientProtocol.TurnRunner do
   # -- the turn body (runs inside the Session's supervised root Task) ----------
 
   defp run_turn(session, req, opts) do
+    case Budget.check() do
+      :ok -> start_turn(session, req, opts)
+      {:exceeded, cap} -> {:error, turn_error(:budget_exhausted, cap)}
+    end
+  end
+
+  defp start_turn(session, req, opts) do
     # Trap exits: the pump is LINKED (so a root crash can never leak a
     # streaming process) and killed with :kill on every exit path; the trapped
     # {:EXIT, pump, _} is dropped in the loop — the monitor drives the logic.
@@ -433,8 +441,9 @@ defmodule Raxol.Agent.ClientProtocol.TurnRunner do
 
   defp handle_event({:turn_complete, _info}, state), do: loop(state)
 
-  defp handle_event({:done, _info}, state) do
+  defp handle_event({:done, info}, state) do
     stop_pump(state)
+    Budget.record(Map.get(info, :usage) || %{})
     {:stop, :end_turn}
   end
 

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/budget_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/budget_test.exs
@@ -1,0 +1,83 @@
+defmodule Raxol.Agent.ClientProtocol.BudgetTest do
+  @moduledoc """
+  The ACP surface had no spend cap at all, so an editor or a harness could
+  drive it until the provider account ran dry -- which is exactly how the first
+  T-Bench smoke ended, with a 402 from a drained key.
+
+  The cap reuses `BenchmarkProfile`, so what is worth testing here is the
+  wiring: that it is off unless asked for, that `check/0` still answers when it
+  is off, and that turns are refused once the money or the turn count is gone.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.BenchmarkProfile
+  alias Raxol.Agent.ClientProtocol.Budget
+
+  defp profile(env), do: BenchmarkProfile.from_env(env) |> elem(1)
+
+  defp start(env) do
+    case Budget.start_link(profile(env)) do
+      {:ok, pid} -> on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
+      :ignore -> :ignore
+    end
+  end
+
+  describe "when no cap is configured" do
+    test "it does not start, and check/0 still answers" do
+      assert :ignore = Budget.start_link(profile(%{}))
+      assert Budget.check() == :ok
+      assert Budget.record(%{"input_tokens" => 10_000}) == :ok
+      assert Budget.spent() == %{cost_usd: 0.0, turns: 0}
+    end
+  end
+
+  describe "spend cap" do
+    setup do
+      start(%{
+        "RAXOL_MAX_COST_USD" => "0.01",
+        "RAXOL_COST_PER_MTOK_IN" => "1000",
+        "RAXOL_COST_PER_MTOK_OUT" => "1000"
+      })
+
+      :ok
+    end
+
+    test "allows turns until the money runs out" do
+      assert Budget.check() == :ok
+
+      # 1M tokens at $1000/Mtok = $1000, well past a 1 cent cap.
+      Budget.record(%{"input_tokens" => 1_000_000, "output_tokens" => 0})
+
+      assert {:exceeded, :max_cost_usd} = Budget.check()
+    end
+
+    test "accumulates across turns rather than judging each alone" do
+      for _ <- 1..3, do: Budget.record(%{"input_tokens" => 4_000, "output_tokens" => 0})
+
+      assert %{turns: 3, cost_usd: cost} = Budget.spent()
+      assert cost > 0.01
+      assert {:exceeded, :max_cost_usd} = Budget.check()
+    end
+
+    # Provider usage maps arrive in both naming families; the fold is
+    # BenchmarkProfile's, but a wiring slip would silently count nothing.
+    test "reads OpenAI-style keys too" do
+      Budget.record(%{"prompt_tokens" => 1_000_000, "completion_tokens" => 0})
+
+      assert {:exceeded, :max_cost_usd} = Budget.check()
+    end
+  end
+
+  describe "turn cap" do
+    test "refuses once the turn count is spent" do
+      start(%{"RAXOL_MAX_TURNS" => "2"})
+
+      assert Budget.check() == :ok
+      Budget.record(%{})
+      assert Budget.check() == :ok
+      Budget.record(%{})
+
+      assert {:exceeded, :max_turns} = Budget.check()
+    end
+  end
+end

--- a/packages/raxol_cli/tbench/harbor-patch.sh
+++ b/packages/raxol_cli/tbench/harbor-patch.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Work around a harbor bug that kills an ACP run before it prompts.
+#
+# With a model requested (`harbor run -m ...`), harbor's ACP runner calls
+# `conn.set_session_model(...)`, but installs `agent-client-protocol` UNPINNED.
+# A released SDK without that method raises AttributeError, and the runner
+# rescues only RequestError -- so the trial dies during setup, reporting
+# NonZeroAgentExitCodeError with nothing useful in the log.
+#
+# Guard the call on the attribute existing. Skipping the set_model attempt is
+# harmless for raxol: the model already arrives through
+# HARBOR_ACP_REQUESTED_MODEL, which `Raxol.Agent.ClientProtocol.Serve` reads.
+#
+# Implementing `session/set_model` agent-side would NOT help -- the crash is in
+# harbor's own process before anything reaches the wire.
+#
+# Idempotent. Run once per harbor venv:
+#   packages/raxol_cli/tbench/harbor-patch.sh /path/to/venv
+set -euo pipefail
+
+venv="${1:-}"
+if [[ -z "$venv" ]]; then
+  printf 'usage: %s <path-to-harbor-venv>\n' "$0" >&2
+  exit 64
+fi
+
+runner="$(find "$venv" -path '*/harbor/agents/installed/acp_runner.py' -print -quit)"
+if [[ -z "$runner" ]]; then
+  printf 'no harbor acp_runner.py under %s\n' "$venv" >&2
+  exit 1
+fi
+
+before='if requested_model:'
+after='if requested_model and hasattr(conn, "set_session_model"):'
+
+if grep -qF "$after" "$runner"; then
+  printf 'already patched: %s\n' "$runner"
+  exit 0
+fi
+
+if ! grep -qF "            $before" "$runner"; then
+  printf 'guard site not found in %s -- harbor may have fixed or moved it\n' "$runner" >&2
+  exit 1
+fi
+
+python3 - "$runner" "$before" "$after" <<'PY'
+import sys, pathlib
+path, before, after = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+old = "            " + before
+assert s.count(old) == 1, f"expected exactly one guard site, found {s.count(old)}"
+p.write_text(s.replace(old, "            " + after))
+PY
+
+printf 'patched: %s\n' "$runner"


### PR DESCRIPTION
Two loose ends from the first scored T-Bench trial.

## Spend cap

The ACP surface had no cap. `raxol p` has honoured `RAXOL_MAX_COST_USD` and `RAXOL_MAX_TURNS` since
the benchmark profile landed; this surface ignored both, so an editor or a harness could drive it
until the account ran dry. That is how the first smoke ended, on a 402 from a drained key.

`ClientProtocol.Budget` holds the running total and nothing else. `BenchmarkProfile` still owns the
env contract, the token fold and the arithmetic, so there is no second budget system to keep in
sync. It does not start unless a cap is set, and `check/0` answers when it is not running, so
callers never branch on whether budgeting is on. An exhausted budget reports through `turn_error/2`
from #828, so it logs and reaches the peer like any other failure.

The bound is the session, not the turn. A turn already running finishes; the next is refused.
Interrupting mid-turn would abandon a half-applied edit, which is worse than one turn of overshoot.

`Serve` halts 64 on an unenforceable cap rather than serving uncapped, matching BenchmarkProfile's
fail-closed parsing. The reason to set a cap is that nobody is watching.

## Harbor workaround

`tbench/harbor-patch.sh` replaces a venv edit I had been carrying by hand. With `-m` set, harbor
calls `conn.set_session_model(...)` while installing `agent-client-protocol` unpinned, and rescues
only `RequestError`, so an SDK without that method kills the trial during setup with
`NonZeroAgentExitCodeError` and nothing useful logged.

The script guards the call on `hasattr`, is idempotent, and refuses if the site moves rather than
patching something it does not recognise. Skipping the attempt costs nothing: the model already
arrives via `HARBOR_ACP_REQUESTED_MODEL`. Implementing `session/set_model` agent-side would not
help, since the crash is in harbor's own process before anything reaches the wire.

## Verification

- `raxol_agent` 2298, `raxol_agent_client_protocol` 857
- one unidentified failure in the first acp run did not reproduce across three subsequent full runs
- patch script: applies, re-applies safely, refuses a moved site, shellcheck clean

## Manual testing

- [x] cap off by default; `check/0` and `record/1` safe when not running
- [x] cost and turn caps both refuse once spent, accumulating across turns
- [x] OpenAI-style and Anthropic-style usage keys both counted
- [x] harbor-patch.sh verified idempotent against a reverted venv
