### PR TITLE
Bump raxol_cli to 0.2.4 for the ACP spend cap

### DIFF
--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.3"
+  @version "0.2.4"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raxol",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"


### PR DESCRIPTION
Ships #830.

Without it `RAXOL_MAX_COST_USD` is a silent no-op on the ACP path, so the registry entry should not point at a release that predates it.

Two lines. `raxol_cli` 14 tests pass locally (not in CI).

- [ ] After merge: tag `raxol-cli-v0.2.4` from master, repoint `agent.json`, then submit the registry PR