### PR TITLE
Build a Windows binary for the CLI

### DIFF
--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -122,9 +122,52 @@ jobs:
           path: packages/raxol_cli/burrito_out/raxol_cli_macos
           if-no-files-found: error
 
+  windows-build:
+    name: windows-x86_64
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Erlang/Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '29.0.3'
+          elixir-version: '1.20.2'
+
+      - name: Install pinned Zig
+        shell: pwsh
+        run: |
+          curl.exe -fsSL -o zig.zip "https://ziglang.org/download/0.16.0/zig-x86_64-windows-0.16.0.zip"
+          Expand-Archive -Path zig.zip -DestinationPath $env:USERPROFILE
+          "$env:USERPROFILE\zig-x86_64-windows-0.16.0" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      # No NIF here: raxol_terminal drops :elixir_make on {:win32, _} and the
+      # driver uses the pure-Elixir IOTerminal, which the windows-2022 test leg
+      # already covers.
+      - name: Build runtime binary
+        working-directory: packages/raxol_cli
+        shell: pwsh
+        env:
+          MIX_ENV: prod
+          BURRITO_TARGET: windows
+        run: |
+          zig version
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only prod
+          mix release raxol_cli --overwrite
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-windows-x86_64
+          path: packages/raxol_cli/burrito_out/raxol_cli_windows.exe
+          if-no-files-found: error
+
   package:
     name: assemble npm package
-    needs: [linux-build, macos-build]
+    needs: [linux-build, macos-build, windows-build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -185,7 +228,7 @@ jobs:
   # which does not match `raxol-cli-v*`.
   release:
     name: attach release assets
-    needs: [linux-build, macos-build]
+    needs: [linux-build, macos-build, windows-build]
     if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
     runs-on: ubuntu-latest
     permissions:

--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -38,7 +38,7 @@ defmodule RaxolCli.MixProject do
   defp releases do
     [
       raxol_cli: [
-        include_executables_for: [:unix],
+        include_executables_for: [:unix, :windows],
         steps: [:assemble, &Burrito.wrap/1],
         burrito: [targets: burrito_targets()]
       ]
@@ -47,11 +47,16 @@ defmodule RaxolCli.MixProject do
 
   # `skip_nifs: true`: each target is built natively (CI builds the arch it runs
   # on), so the termbox NIF from `mix release` assemble already matches the target.
+  # Windows carries no NIF to skip or ship: `raxol_terminal`'s mix.exs drops
+  # `:elixir_make` entirely on `{:win32, _}` and the driver falls back to the
+  # pure-Elixir `IOTerminal`, which is the path the windows-2022 CI leg already
+  # exercises. So the target is a native build like the others, minus the C.
   defp burrito_targets do
     [
       linux: [os: :linux, cpu: :x86_64, skip_nifs: true],
       linux_arm: [os: :linux, cpu: :aarch64, skip_nifs: true],
-      macos: [os: :darwin, cpu: :aarch64, skip_nifs: true]
+      macos: [os: :darwin, cpu: :aarch64, skip_nifs: true],
+      windows: [os: :windows, cpu: :x86_64, skip_nifs: true]
     ]
   end
 

--- a/packages/raxol_cli/npm/bin/launcher.js
+++ b/packages/raxol_cli/npm/bin/launcher.js
@@ -12,10 +12,12 @@ const os = require("node:os");
 const { withTerminalRestore } = require("./tty");
 
 // Maps `${platform}-${arch}` to the Burrito output name (`raxol_cli_<target>`).
+// Burrito appends `.exe` on Windows.
 const BINARIES = {
   "darwin-arm64": "raxol_cli_macos",
   "linux-x64": "raxol_cli_linux",
   "linux-arm64": "raxol_cli_linux_arm",
+  "win32-x64": "raxol_cli_windows.exe",
 };
 
 function resolveBinary() {


### PR DESCRIPTION
We run the main suite on `windows-2022` every PR but shipped no Windows binary, so the ACP registry flags the entry as missing a platform and `npm i -g raxol` fails there.

## Nothing structural was in the way

`raxol_terminal/mix.exs` already drops `:elixir_make` on `{:win32, _}`, and the driver falls back to the pure-Elixir `IOTerminal` — the path the windows CI leg exercises. So the target has no NIF to cross-compile or skip.

What was missing: `include_executables_for: [:unix]` never named `:windows`, `burrito_targets/0` had no windows entry, and the release workflow had no runner.

## The release job now requires it

A broken Windows build fails the tag loudly rather than quietly shipping three platforms out of four. Same posture as the rest of the release path.

That raises the obvious risk — the workflow only fires on tags, so the job would have been unverified until a tag. Given this session already produced one tag that attached no assets, I dispatched it on the branch instead:

[run 31319485957](https://github.com/DROOdotFOO/raxol/actions/runs/31319485957) — all four platforms green, npm package assembled, `attach release assets` correctly skipped (tag-gated).

Artifact verified: `PE32+ executable (console) x86-64, for MS Windows`, 28MB.

## Manual testing

- [x] windows-x86_64 job green on a dispatched run
- [x] artifact is a real PE executable
- [x] linux/macos jobs unaffected
- [x] `raxol_cli` 14 tests pass
- [ ] Not run on Windows itself — no Windows machine here. CI proves it builds and links; first execution will be a user's or a later dispatch.

## Note

npm launcher maps `win32-x64`; Burrito appends `.exe`. Next `raxol-cli-v*` tag adds `windows-x86_64` to the registry entry.