### PR TITLE
Serve ACP without a provider, fail at the turn

### DIFF
--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -122,9 +122,52 @@ jobs:
           path: packages/raxol_cli/burrito_out/raxol_cli_macos
           if-no-files-found: error
 
+  windows-build:
+    name: windows-x86_64
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Erlang/Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '29.0.3'
+          elixir-version: '1.20.2'
+
+      - name: Install pinned Zig
+        shell: pwsh
+        run: |
+          curl.exe -fsSL -o zig.zip "https://ziglang.org/download/0.16.0/zig-x86_64-windows-0.16.0.zip"
+          Expand-Archive -Path zig.zip -DestinationPath $env:USERPROFILE
+          "$env:USERPROFILE\zig-x86_64-windows-0.16.0" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      # No NIF here: raxol_terminal drops :elixir_make on {:win32, _} and the
+      # driver uses the pure-Elixir IOTerminal, which the windows-2022 test leg
+      # already covers.
+      - name: Build runtime binary
+        working-directory: packages/raxol_cli
+        shell: pwsh
+        env:
+          MIX_ENV: prod
+          BURRITO_TARGET: windows
+        run: |
+          zig version
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only prod
+          mix release raxol_cli --overwrite
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-windows-x86_64
+          path: packages/raxol_cli/burrito_out/raxol_cli_windows.exe
+          if-no-files-found: error
+
   package:
     name: assemble npm package
-    needs: [linux-build, macos-build]
+    needs: [linux-build, macos-build, windows-build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -185,7 +228,7 @@ jobs:
   # which does not match `raxol-cli-v*`.
   release:
     name: attach release assets
-    needs: [linux-build, macos-build]
+    needs: [linux-build, macos-build, windows-build]
     if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
     runs-on: ubuntu-latest
     permissions:

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/serve.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/serve.ex
@@ -87,18 +87,43 @@ defmodule Raxol.Agent.ClientProtocol.Serve do
       Code.ensure_loaded?(Raxol.Agent.ClientProtocol.StdioAgent)
   end
 
-  # Provider first: a config problem exits before anything binds stdio, so a
-  # misconfigured agent fails loudly instead of opening a wire it cannot serve.
+  # An unresolved provider no longer stops the wire from opening.
+  #
+  # It used to: resolution came first and a failure exited 1 before binding
+  # stdio, on the reasoning that a misconfigured agent should fail loudly
+  # rather than serve a wire it cannot answer on. That was the wrong shape for
+  # this protocol. A client connects and negotiates BEFORE any model is
+  # configured -- ACP has authentication methods precisely so it can -- and the
+  # registry's own verifier runs `raxol acp` with no credentials at all and
+  # expects a handshake. Refusing to boot made a perfectly serviceable
+  # `initialize` impossible.
+  #
+  # Loudness is preserved, and now arrives twice: a warning on stderr the
+  # moment we know, and a structured per-turn error carrying the same message
+  # to the peer. That second channel is new -- it did not exist when the
+  # fail-early call was made -- so the failure is no quieter for moving later,
+  # it is better addressed.
   defp serve(opts) do
-    with {:ok, opts} <- apply_requested_model(opts),
-         {:ok, executor, _source} <-
-           Raxol.Agent.Backend.Cli.resolve_executor(opts, nil) do
-      start_serving(executor)
-    else
+    case apply_requested_model(opts) do
+      {:ok, opts} -> start_serving(resolve_provider(opts))
+      {:error, message} -> usage_error(message)
+    end
+  end
+
+  defp resolve_provider(opts) do
+    case Raxol.Agent.Backend.Cli.resolve_executor(opts, nil) do
+      {:ok, executor, _source} ->
+        {:ok, executor}
+
       {:error, message} ->
         IO.puts(:stderr, "raxol acp: #{message}")
-        1
+        {:error, message}
     end
+  end
+
+  defp usage_error(message) do
+    IO.puts(:stderr, "raxol acp: #{message}")
+    1
   end
 
   # Same env contract `raxol p` already honours (RAXOL_MAX_COST_USD,
@@ -178,7 +203,7 @@ defmodule Raxol.Agent.ClientProtocol.Serve do
     end
   end
 
-  defp start_serving(executor) do
+  defp start_serving(provider) do
     # No terminal driver: this process's stdio is the protocol wire, not a UI.
     System.put_env("RAXOL_SKIP_TERMINAL_INIT", "true")
     reroute_logs_to_stderr()
@@ -189,7 +214,7 @@ defmodule Raxol.Agent.ClientProtocol.Serve do
 
     serve_connection(
       {Raxol.AgentClientProtocol.Transport.Stdio, handle},
-      %{turn_opts: turn_opts(executor)}
+      %{turn_opts: turn_opts(provider)}
     )
   end
 
@@ -272,7 +297,12 @@ defmodule Raxol.Agent.ClientProtocol.Serve do
   # per turn. A client that refuses, times out, disconnects, or does not
   # implement permissions at all denies the write, so the read-only narrowing
   # this used to do is no longer what keeps the surface closed.
-  defp turn_opts(executor) do
+  # `:executor` carries the resolution OUTCOME, not just the executor. A turn
+  # started without a provider fails with the same message the operator already
+  # saw on stderr, instead of a shrug.
+  defp turn_opts({:error, message}), do: [provider_error: message]
+
+  defp turn_opts({:ok, executor}) do
     [
       executor: executor,
       actions: Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.all(),

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/turn_runner.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/turn_runner.ex
@@ -277,10 +277,32 @@ defmodule Raxol.Agent.ClientProtocol.TurnRunner do
 
   # -- the turn body (runs inside the Session's supervised root Task) ----------
 
+  # Two gates before any provider call, in the order that costs least. A turn
+  # with no provider can never succeed, and one over budget must not be paid
+  # for; both answer with the same structured error shape a stream failure
+  # does, so a client handles one case, not three.
+  # Two gates before any provider call, cheapest first. A turn with no provider
+  # can never succeed, and one over budget must not be paid for; both answer
+  # with the same structured error shape a stream failure does, so a client
+  # handles one case, not three.
   defp run_turn(session, req, opts) do
+    case refusal(opts) do
+      nil -> start_turn(session, req, opts)
+      {tag, detail} -> {:error, turn_error(tag, detail)}
+    end
+  end
+
+  defp refusal(opts) do
+    case Keyword.get(opts, :provider_error) do
+      nil -> budget_refusal()
+      message -> {:no_provider, message}
+    end
+  end
+
+  defp budget_refusal do
     case Budget.check() do
-      :ok -> start_turn(session, req, opts)
-      {:exceeded, cap} -> {:error, turn_error(:budget_exhausted, cap)}
+      :ok -> nil
+      {:exceeded, cap} -> {:budget_exhausted, cap}
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/turn_error_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/turn_error_test.exs
@@ -56,6 +56,16 @@ defmodule Raxol.Agent.ClientProtocol.TurnErrorTest do
       assert byte_size(err.data["reason"]) <= 2_000
     end
 
+    # The registry's own verifier runs `raxol acp` with no credentials and
+    # expects a handshake, so an unresolved provider can no longer stop the
+    # wire from opening -- it has to become a turn-time answer instead.
+    test "an unresolved provider is a turn error, not a refusal to boot" do
+      err = TurnRunner.turn_error(:no_provider, "no provider configured; set ANTHROPIC_API_KEY")
+
+      assert err.data["tag"] == "no_provider"
+      assert err.data["reason"] =~ "no provider configured"
+    end
+
     # inspect/2 defaults elide long structures with "..."; the message we most
     # need is usually at the end of a nested provider payload.
     test "a nested reason is not elided before the message" do

--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -38,7 +38,7 @@ defmodule RaxolCli.MixProject do
   defp releases do
     [
       raxol_cli: [
-        include_executables_for: [:unix],
+        include_executables_for: [:unix, :windows],
         steps: [:assemble, &Burrito.wrap/1],
         burrito: [targets: burrito_targets()]
       ]
@@ -47,11 +47,16 @@ defmodule RaxolCli.MixProject do
 
   # `skip_nifs: true`: each target is built natively (CI builds the arch it runs
   # on), so the termbox NIF from `mix release` assemble already matches the target.
+  # Windows carries no NIF to skip or ship: `raxol_terminal`'s mix.exs drops
+  # `:elixir_make` entirely on `{:win32, _}` and the driver falls back to the
+  # pure-Elixir `IOTerminal`, which is the path the windows-2022 CI leg already
+  # exercises. So the target is a native build like the others, minus the C.
   defp burrito_targets do
     [
       linux: [os: :linux, cpu: :x86_64, skip_nifs: true],
       linux_arm: [os: :linux, cpu: :aarch64, skip_nifs: true],
-      macos: [os: :darwin, cpu: :aarch64, skip_nifs: true]
+      macos: [os: :darwin, cpu: :aarch64, skip_nifs: true],
+      windows: [os: :windows, cpu: :x86_64, skip_nifs: true]
     ]
   end
 

--- a/packages/raxol_cli/npm/bin/launcher.js
+++ b/packages/raxol_cli/npm/bin/launcher.js
@@ -12,10 +12,12 @@ const os = require("node:os");
 const { withTerminalRestore } = require("./tty");
 
 // Maps `${platform}-${arch}` to the Burrito output name (`raxol_cli_<target>`).
+// Burrito appends `.exe` on Windows.
 const BINARIES = {
   "darwin-arm64": "raxol_cli_macos",
   "linux-x64": "raxol_cli_linux",
   "linux-arm64": "raxol_cli_linux_arm",
+  "win32-x64": "raxol_cli_windows.exe",
 };
 
 function resolveBinary() {


### PR DESCRIPTION
`raxol acp` resolved a provider before binding stdio and exited 1 when it could not, so an agent with no credentials refused to speak at all. The ACP registry's verifier runs the binary with no credentials and expects a handshake — it rejected us:

```
✗ Failed: raxol acp: no provider configured; run `mix raxol.setup` ...
```

The refusal was the wrong shape for the protocol regardless of the registry. A client connects and negotiates **before** a model is configured — ACP has authentication methods precisely so it can — and `initialize` needs no provider to answer.

## Change

Bind first, resolve into an outcome, let the turn carry the failure. `turn_opts` takes `{:ok, executor}` or `{:error, message}`; a turn started without a provider answers with the same structured error a stream failure does, so a client handles one case rather than three.

The original call was that failing early keeps it loud. That reasoning predated #828: the message now reaches the operator on stderr the moment we know **and** the peer as JSON-RPC error `data`. Moving it later made it louder, not quieter.

## Verification

On a `linux/arm64` binary built from this branch:

- no credentials at all → `{"id":1,...,"result":{"agentInfo":...}}` on a clean stdout wire, with the warning on stderr
- the verifier's exact invocation (no creds, `stdin=DEVNULL`) exits **0**, which is its `"Exited cleanly"` pass

`raxol_agent` 2299 tests pass.

## Manual testing

- [x] initialize answers with no credentials
- [x] stderr warning present at boot
- [x] verifier invocation exits 0
- [x] turn-time `no_provider` error carries the message in `data`

## Note

Depends on nothing, but pairs with #832 (Windows target). Together they clear both registry findings: the rejected verifier run and the missing-platform warning.