### PR TITLE
Bump raxol_cli to 0.2.5

### DIFF
--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.4"
+  @version "0.2.5"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raxol",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"


### PR DESCRIPTION
Ships #832 (Windows binary) and #833 (serve ACP without a provider).

Both are prerequisites for the ACP registry entry: #833 clears the verifier rejection, #832 clears the missing-platform warning. First tag to produce four platforms.

- [ ] After merge: tag `raxol-cli-v0.2.5` from master, then submit the registry PR