### PR TITLE
Add ACP Terminal + Agent Auth, and unhang stdin-reading ports

### DIFF
--- a/packages/raxol_agent/lib/mix/tasks/raxol.setup.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.setup.ex
@@ -22,6 +22,9 @@ defmodule Mix.Tasks.Raxol.Setup do
       # connect a raw key: creates a 1Password item, stores its reference
       mix raxol.setup --provider openai --api-key sk-... --vault Private
 
+      # sign in through a browser (providers that offer one; opt-in, see below)
+      mix raxol.setup --provider openrouter --browser
+
       # forget a provider's stored reference
       mix raxol.setup --provider openai --remove
 
@@ -37,12 +40,20 @@ defmodule Mix.Tasks.Raxol.Setup do
     * `--model`    — default model to store with the reference
     * `--base-url` — base URL override to store with the reference
     * `--vault`    — 1Password vault for `--api-key` (default `$RAXOL_OP_VAULT` or `Private`)
+    * `--browser`  — run the provider's browser sign-in (opens a browser; see below)
     * `--remove`   — delete the provider's stored reference
     * `--status`   — print provider status and exit (default when no action given)
+
+  `--browser` is opt-in rather than the default here, unlike `raxol login`.
+  This task is the CI/headless twin, and a build step must never block on a
+  browser that will not open. It also needs a browser on THIS machine: the
+  sign-in redirect lands on a loopback port.
   """
 
   use Mix.Task
 
+  alias Raxol.Agent.Auth.Flow
+  alias Raxol.Agent.Backend.Resolver
   alias Raxol.Agent.Setup
 
   @switches [
@@ -52,6 +63,7 @@ defmodule Mix.Tasks.Raxol.Setup do
     model: :string,
     base_url: :string,
     vault: :string,
+    browser: :boolean,
     remove: :boolean,
     status: :boolean
   ]
@@ -88,14 +100,19 @@ defmodule Mix.Tasks.Raxol.Setup do
       Keyword.get(opts, :api_key) ->
         do_connect_key(provider, opts)
 
+      Keyword.get(opts, :browser, false) ->
+        do_connect_browser(provider)
+
       true ->
-        usage_error("give one of --op, --api-key, or --remove for #{provider}")
+        usage_error(
+          "give one of --op, --api-key, --browser, or --remove for #{provider}"
+        )
     end
   end
 
   defp no_action?(opts) do
     not Enum.any?(
-      [:op, :api_key, :remove, :provider],
+      [:op, :api_key, :browser, :remove, :provider],
       &Keyword.has_key?(opts, &1)
     )
   end
@@ -121,6 +138,36 @@ defmodule Mix.Tasks.Raxol.Setup do
       Keyword.take(opts, [:model, :base_url, :vault])
     )
     |> report_connect_key()
+  end
+
+  # The flow stores through `Setup.connect_key/3` like every other path here,
+  # so what lands on disk is still only an `op://` reference.
+  defp do_connect_browser(provider) do
+    case Resolver.harness_from_string(provider) do
+      {:ok, harness} -> run_browser_flow(harness)
+      :error -> fail(connect_error({:unknown_provider, provider}))
+    end
+  end
+
+  defp run_browser_flow(harness) do
+    if Flow.supported?(harness) do
+      IO.puts("opening a browser to sign in to #{harness}...")
+      report_browser(Flow.run(harness), harness)
+    else
+      fail(
+        "#{harness} has no browser sign-in — use --op or --api-key " <>
+          "(browser sign-in: #{Enum.map_join(Flow.providers(), ", ", &to_string/1)})"
+      )
+    end
+  end
+
+  defp report_browser({:ok, %{provider: provider, validation: validation}}, _harness) do
+    IO.puts("stored reference for #{provider}")
+    report_validation(provider, validation)
+  end
+
+  defp report_browser({:error, reason}, harness) do
+    fail("#{harness} sign-in failed: #{Flow.describe(reason)}")
   end
 
   defp do_remove(provider) do

--- a/packages/raxol_agent/lib/raxol/agent/auth/flow.ex
+++ b/packages/raxol_agent/lib/raxol/agent/auth/flow.ex
@@ -1,0 +1,230 @@
+defmodule Raxol.Agent.Auth.Flow do
+  @moduledoc """
+  The browser OAuth sign-in, end to end: bind a loopback port, send the user to
+  the provider, catch the redirect, exchange the code, store the credential.
+
+  This is what ACP calls Agent Auth. `Raxol.Agent.ClientProtocol.StdioAgent`
+  advertises it and calls `run/2`; the flow itself knows nothing about ACP, so
+  the TUI's `/login` and `mix raxol.setup` can drive the same thing.
+
+  Only providers in `providers/0` have a real flow. Asking for any other is
+  `{:error, {:no_oauth_flow, provider}}` rather than a wait that never ends --
+  a sign-in that hangs is worse than one that was never offered.
+
+  The credential lands through `Raxol.Agent.Setup`, so a provider connected
+  here resolves identically on every surface, and nothing secret is written:
+  the minted key becomes a 1Password item and only its `op://` reference is
+  stored. Without the `op` CLI there is nowhere to put a key, and the flow
+  fails rather than falling back to plaintext.
+
+  Every step is a seam (`:browser_fn`, `:http_fn`, `:store_fn`) so the whole
+  path is testable without a browser or a network call.
+  """
+
+  alias Raxol.Agent.Auth.Loopback
+  alias Raxol.Agent.Auth.OpenRouter
+  alias Raxol.Agent.Auth.Pkce
+  alias Raxol.Agent.Setup
+
+  # Long enough for a real sign-in (password manager, MFA, an account switch),
+  # short enough that an abandoned tab returns the port.
+  @default_timeout 180_000
+
+  # The 1Password write, not the sign-in: see `default_store/2`.
+  @store_timeout 120_000
+
+  @providers [:openrouter]
+
+  @type result :: %{provider: atom(), validation: term()}
+
+  @doc "Providers with a browser sign-in raxol actually implements."
+  @spec providers() :: [atom()]
+  def providers, do: @providers
+
+  @doc "Whether `provider` has a browser sign-in."
+  @spec supported?(atom()) :: boolean()
+  def supported?(provider), do: provider in @providers
+
+  @doc """
+  Run the sign-in for `provider`.
+
+  Options: `:timeout` (ms to wait for the redirect), `:browser_fn`,
+  `:http_fn`, `:store_fn`, and `:path` for the callback path.
+
+  Returns `{:ok, %{provider: provider, validation: validation}}` or
+  `{:error, reason}`; `describe/1` renders a reason for a user.
+  """
+  @spec run(atom(), keyword()) :: {:ok, result()} | {:error, term()}
+  def run(provider, opts \\ [])
+
+  def run(:openrouter, opts) do
+    pkce = Pkce.new()
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    case Loopback.open(Keyword.take(opts, [:path])) do
+      {:ok, listener} ->
+        try do
+          collect(:openrouter, listener, pkce, timeout, opts)
+        after
+          Loopback.close(listener)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  def run(provider, _opts), do: {:error, {:no_oauth_flow, provider}}
+
+  defp collect(provider, listener, pkce, timeout, opts) do
+    url = OpenRouter.authorize_url(pkce, Loopback.redirect_uri(listener))
+    browser_fn = Keyword.get(opts, :browser_fn, &open_browser/1)
+
+    with :ok <- launch(browser_fn, url),
+         {:ok, code} <- Loopback.await(listener, timeout),
+         {:ok, key} <- OpenRouter.exchange(code, pkce, opts),
+         {:ok, validation} <- store(provider, key, opts) do
+      {:ok, %{provider: provider, validation: validation}}
+    end
+  end
+
+  # A browser we cannot launch is reported WITH the URL: the challenge in it is
+  # public by PKCE's design, the loopback port is still bound, and pasting it
+  # by hand completes the same flow. The verifier stays here.
+  defp launch(browser_fn, url) do
+    case browser_fn.(url) do
+      :ok ->
+        :ok
+
+      {:error, {:no_browser_opener, tool}} ->
+        {:error, {:no_browser_opener, tool, url}}
+
+      {:error, reason} ->
+        {:error, {:browser_failed, reason, url}}
+
+      _other ->
+        {:error, {:browser_failed, :unexpected_return, url}}
+    end
+  end
+
+  # A key the provider will not authorize is not a completed sign-in, so a
+  # rejection fails the flow even though the reference was stored. Every other
+  # validation outcome (including "could not check right now") is a success:
+  # the credential resolves, and the first turn is where a bad one surfaces.
+  defp store(provider, key, opts) do
+    store_fn = Keyword.get(opts, :store_fn, &default_store/2)
+
+    case store_fn.(provider, key) do
+      {:ok, _provider, _ref, {:rejected, status}} ->
+        {:error, {:key_rejected, status}}
+
+      {:ok, _provider, _ref, validation} ->
+        {:ok, validation}
+
+      {:error, reason} ->
+        {:error, {:store_failed, reason}}
+    end
+  end
+
+  # 1Password raises its approval prompt at the worst moment in this flow: the
+  # instant the user gets back from a browser tab, attention still there. The
+  # default `op` budget is 15s, and losing that race discards a key the
+  # provider has already minted -- so the user pays for the round trip twice
+  # and leaves a dangling key behind. This path buys a lot more room.
+  defp default_store(provider, key) do
+    Setup.connect_key(provider, key, timeout_ms: @store_timeout)
+  end
+
+  # -- browser ----------------------------------------------------------------
+
+  @doc """
+  Open `url` in the user's default browser.
+
+  Both output streams are captured, never inherited: on the ACP surface stdout
+  is the JSON-RPC wire, and one line from `xdg-open` would be a parse error at
+  the client.
+  """
+  @spec open_browser(String.t()) :: :ok | {:error, term()}
+  def open_browser(url) when is_binary(url) do
+    {tool, args} = browser_command(url)
+
+    case System.find_executable(tool) do
+      nil ->
+        {:error, {:no_browser_opener, tool}}
+
+      path ->
+        case System.cmd(path, args, stderr_to_stdout: true) do
+          {_output, 0} -> :ok
+          {output, status} -> {:error, {:exit, status, String.trim(output)}}
+        end
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  defp browser_command(url) do
+    case :os.type() do
+      {:unix, :darwin} -> {"open", [url]}
+      {:win32, _} -> {"cmd", ["/c", "start", "", url]}
+      {:unix, _} -> {"xdg-open", [url]}
+    end
+  end
+
+  # -- reporting --------------------------------------------------------------
+
+  @doc "Render a `run/2` failure for a person, without leaking the URL's twin secret."
+  @spec describe(term()) :: String.t()
+  def describe({:no_oauth_flow, provider}) do
+    "#{provider} has no browser sign-in; connect it with `raxol login #{provider}`"
+  end
+
+  def describe({:no_browser_opener, tool, url}) do
+    "could not find #{tool} to open a browser; open this URL to continue: #{url}"
+  end
+
+  def describe({:browser_failed, reason, url}) do
+    "could not open a browser (#{inspect(reason)}); open this URL to continue: #{url}"
+  end
+
+  def describe(:timeout), do: "timed out waiting for the browser redirect"
+
+  def describe({:oauth_error, error, nil}),
+    do: "the provider refused the sign-in: #{error}"
+
+  def describe({:oauth_error, _error, description}),
+    do: "the provider refused the sign-in: #{description}"
+
+  def describe({:exchange_rejected, status}),
+    do: "the provider rejected the authorization code (HTTP #{status})"
+
+  def describe({:exchange_unreachable, _reason}),
+    do: "could not reach the provider to exchange the code"
+
+  def describe(:no_http_client),
+    do: "no HTTP client available to exchange the code"
+
+  def describe({:no_key_in_response, _keys}), do: "the provider returned no key"
+
+  def describe(:no_key_in_response), do: "the provider returned no key"
+
+  def describe({:key_rejected, status}),
+    do: "the provider would not authorize the new key (HTTP #{status})"
+
+  def describe({:store_failed, :op_unavailable}) do
+    "signed in, but the 1Password CLI (`op`) is not available to store the key; " <>
+      "raxol never writes a key to disk"
+  end
+
+  def describe({:store_failed, :op_timeout}) do
+    "signed in, but 1Password did not answer in time to store the key -- " <>
+      "unlock the desktop app and run it again"
+  end
+
+  def describe({:store_failed, reason}),
+    do: "could not store the key: #{inspect(reason)}"
+
+  def describe({:listen_failed, reason}),
+    do: "could not bind a local port for the redirect: #{inspect(reason)}"
+
+  def describe(reason), do: inspect(reason)
+end

--- a/packages/raxol_agent/lib/raxol/agent/auth/loopback.ex
+++ b/packages/raxol_agent/lib/raxol/agent/auth/loopback.ex
@@ -1,0 +1,248 @@
+defmodule Raxol.Agent.Auth.Loopback do
+  @moduledoc """
+  The one-shot local HTTP listener a browser OAuth flow redirects back to.
+
+  ACP's Agent Auth is defined in terms of this: the agent binds a port on the
+  user's machine, sends them to the provider in a browser, and catches the
+  redirect. `open/1` binds, `redirect_uri/1` names the URL to hand the
+  provider, `await/2` blocks until the browser arrives, and `close/1` gives the
+  port back.
+
+  It binds `127.0.0.1` explicitly, so nothing off-box can reach it, and it
+  speaks just enough HTTP to answer one GET: a browser tab is the only client
+  it ever has. A request without an authorization code (a favicon probe, a
+  stray scan) is answered 404 and does not end the wait -- only a `code`, an
+  `error`, or the deadline does.
+
+  Nothing here writes to stdout. On the ACP surface stdout is the JSON-RPC
+  wire and a single stray line is a parse error at the client.
+  """
+
+  @loopback {127, 0, 0, 1}
+
+  # A browser sends a dozen headers at most; this bound just stops a
+  # malformed peer from holding the accept loop open header-by-header.
+  @max_headers 64
+
+  @type t :: %__MODULE__{
+          socket: :gen_tcp.socket(),
+          port: :inet.port_number(),
+          path: String.t()
+        }
+
+  @enforce_keys [:socket, :port, :path]
+  defstruct socket: nil, port: nil, path: "/callback"
+
+  @doc """
+  Bind an ephemeral loopback port.
+
+  Options: `:path`, the callback path to advertise (default `"/callback"`).
+  """
+  @spec open(keyword()) :: {:ok, t()} | {:error, term()}
+  def open(opts \\ []) do
+    path = Keyword.get(opts, :path, "/callback")
+
+    listen_opts = [
+      :binary,
+      ip: @loopback,
+      packet: :http_bin,
+      active: false,
+      reuseaddr: true,
+      backlog: 4
+    ]
+
+    with {:ok, socket} <- :gen_tcp.listen(0, listen_opts),
+         {:ok, port} <- :inet.port(socket) do
+      {:ok, %__MODULE__{socket: socket, port: port, path: path}}
+    else
+      {:error, reason} -> {:error, {:listen_failed, reason}}
+    end
+  end
+
+  @doc "The URL to give the provider as its redirect target."
+  @spec redirect_uri(t()) :: String.t()
+  def redirect_uri(%__MODULE__{port: port, path: path}) do
+    "http://localhost:#{port}#{path}"
+  end
+
+  @doc "Release the bound port. Safe to call twice."
+  @spec close(t()) :: :ok
+  def close(%__MODULE__{socket: socket}), do: :gen_tcp.close(socket)
+
+  @doc """
+  Wait up to `timeout` ms for the browser redirect.
+
+  Returns `{:ok, code}` for a redirect carrying one, `{:error, {:oauth_error,
+  error, description}}` for a provider-reported denial (the user pressed
+  "cancel"), and `{:error, :timeout}` if nobody arrives. The deadline covers
+  the whole wait, not each accept, so a stream of junk requests cannot extend
+  it.
+  """
+  @spec await(t(), timeout()) :: {:ok, String.t()} | {:error, term()}
+  def await(%__MODULE__{} = listener, timeout) when is_integer(timeout) do
+    accept_loop(listener, System.monotonic_time(:millisecond) + timeout)
+  end
+
+  defp accept_loop(listener, deadline) do
+    case remaining(deadline) do
+      0 ->
+        {:error, :timeout}
+
+      left ->
+        case :gen_tcp.accept(listener.socket, left) do
+          {:ok, conn} -> serve(listener, conn, deadline)
+          {:error, :timeout} -> {:error, :timeout}
+          {:error, reason} -> {:error, {:accept_failed, reason}}
+        end
+    end
+  end
+
+  defp serve(listener, conn, deadline) do
+    result = read_request(conn, deadline)
+    respond(conn, result)
+    :gen_tcp.close(conn)
+
+    case result do
+      {:done, outcome} -> outcome
+      :continue -> accept_loop(listener, deadline)
+    end
+  end
+
+  # Reads the request line, then drains headers so the response is not met by
+  # an unread request buffer -- closing on one makes the kernel send RST and
+  # the browser shows a connection error instead of the page we just wrote.
+  defp read_request(conn, deadline) do
+    case :gen_tcp.recv(conn, 0, remaining(deadline)) do
+      {:ok, {:http_request, :GET, {:abs_path, path}, _version}} ->
+        drain_headers(conn, deadline)
+        classify(path)
+
+      {:ok, {:http_request, _method, _uri, _version}} ->
+        drain_headers(conn, deadline)
+        :continue
+
+      _other ->
+        :continue
+    end
+  end
+
+  defp drain_headers(conn, deadline, seen \\ 0)
+
+  defp drain_headers(_conn, _deadline, seen) when seen >= @max_headers, do: :ok
+
+  defp drain_headers(conn, deadline, seen) do
+    :inet.setopts(conn, packet: :httph_bin)
+
+    case :gen_tcp.recv(conn, 0, remaining(deadline)) do
+      {:ok, {:http_header, _, _, _, _}} ->
+        drain_headers(conn, deadline, seen + 1)
+
+      _ ->
+        :ok
+    end
+  end
+
+  # `URI.decode_query/1` on the query string only: the path itself is ours and
+  # carries nothing we act on.
+  defp classify(path) do
+    params =
+      path
+      |> to_string()
+      |> URI.parse()
+      |> Map.get(:query)
+      |> decode_query()
+
+    case params do
+      %{"code" => code} when is_binary(code) and code != "" ->
+        {:done, {:ok, code}}
+
+      %{"error" => error} when is_binary(error) ->
+        {:done,
+         {:error, {:oauth_error, error, Map.get(params, "error_description")}}}
+
+      _ ->
+        :continue
+    end
+  end
+
+  defp decode_query(nil), do: %{}
+  defp decode_query(query), do: URI.decode_query(query)
+
+  defp respond(conn, {:done, {:ok, _code}}) do
+    write(
+      conn,
+      200,
+      "Connected",
+      "You can close this tab and return to your editor."
+    )
+  end
+
+  defp respond(conn, {:done, {:error, {:oauth_error, error, description}}}) do
+    write(conn, 200, "Sign-in cancelled", description || error)
+  end
+
+  defp respond(conn, _other) do
+    write(
+      conn,
+      404,
+      "Not found",
+      "This port is only listening for a sign-in redirect."
+    )
+  end
+
+  defp write(conn, status, title, message) do
+    body = page(title, message)
+
+    head = [
+      "HTTP/1.1 #{status} #{reason_phrase(status)}\r\n",
+      "Content-Type: text/html; charset=utf-8\r\n",
+      "Content-Length: #{byte_size(body)}\r\n",
+      "Connection: close\r\n\r\n"
+    ]
+
+    :inet.setopts(conn, packet: :raw)
+    :gen_tcp.send(conn, [head, body])
+    :gen_tcp.shutdown(conn, :write)
+  end
+
+  defp reason_phrase(200), do: "OK"
+  defp reason_phrase(404), do: "Not Found"
+  defp reason_phrase(_status), do: "OK"
+
+  # The only markup a user of this flow ever sees. Plain, self-contained, and
+  # escaped, since `message` can carry a provider-supplied description.
+  defp page(title, message) do
+    """
+    <!doctype html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <title>raxol</title>
+    <style>
+    body { font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+           margin: 4rem auto; max-width: 32rem; line-height: 1.5; }
+    h1 { font-size: 1.1rem; font-weight: 600; }
+    p { color: #555; }
+    </style>
+    </head>
+    <body>
+    <h1>#{escape(title)}</h1>
+    <p>#{escape(message)}</p>
+    </body>
+    </html>
+    """
+  end
+
+  defp escape(text) do
+    text
+    |> to_string()
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+  end
+
+  defp remaining(deadline) do
+    max(deadline - System.monotonic_time(:millisecond), 0)
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/auth/openrouter.ex
+++ b/packages/raxol_agent/lib/raxol/agent/auth/openrouter.ex
@@ -1,0 +1,114 @@
+defmodule Raxol.Agent.Auth.OpenRouter do
+  @moduledoc """
+  OpenRouter's OAuth PKCE flow: the one browser sign-in raxol can honestly run
+  for a user.
+
+  It is the only provider among the supported backends whose OAuth is built for
+  third-party local applications -- no client registration, no client secret,
+  the loopback callback URL is the whole identity of the app. Anthropic and
+  OpenAI have no public equivalent; their sign-in flows belong to their own
+  first-party clients, and driving one with a borrowed client id would be
+  impersonation that breaks the moment they rotate it. So this is the provider
+  Agent Auth advertises, and everything else stays on Terminal Auth.
+
+  What comes back is a user-controlled **API key**, not a bearer token with an
+  expiry. That is why this needed no new secret storage: the key goes straight
+  through `Raxol.Agent.Setup.connect_key/3` into a 1Password item, exactly like
+  a pasted one, and only the `op://` reference reaches
+  `~/.raxol/providers.json`. No refresh loop, no token at rest.
+
+  The `:http_fn` seam is injectable so the exchange is testable without a
+  network call.
+  """
+
+  alias Raxol.Agent.Auth.Pkce
+
+  @authorize_url "https://openrouter.ai/auth"
+  @keys_url "https://openrouter.ai/api/v1/auth/keys"
+
+  @default_timeout 30_000
+
+  @doc "The URL to open in the user's browser."
+  @spec authorize_url(Pkce.t(), String.t()) :: String.t()
+  def authorize_url(%Pkce{} = pkce, redirect_uri)
+      when is_binary(redirect_uri) do
+    query =
+      URI.encode_query(%{
+        "callback_url" => redirect_uri,
+        "code_challenge" => pkce.challenge,
+        "code_challenge_method" => pkce.method
+      })
+
+    @authorize_url <> "?" <> query
+  end
+
+  @doc """
+  Exchange an authorization code for a user-controlled API key.
+
+  Returns `{:ok, key}` or `{:error, reason}`. No reason this returns carries
+  the key or the verifier -- they must not reach a log or an ACP error
+  message.
+  """
+  @spec exchange(String.t(), Pkce.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def exchange(code, %Pkce{} = pkce, opts \\ []) when is_binary(code) do
+    http_fn = Keyword.get(opts, :http_fn, &post_json/3)
+
+    body = %{
+      "code" => code,
+      "code_verifier" => pkce.verifier,
+      "code_challenge_method" => pkce.method
+    }
+
+    case http_fn.(@keys_url, body, opts) do
+      {:ok, %{"key" => key}} when is_binary(key) and key != "" ->
+        {:ok, key}
+
+      {:ok, decoded} when is_map(decoded) ->
+        {:error, {:no_key_in_response, Map.keys(decoded)}}
+
+      {:ok, _other} ->
+        {:error, :no_key_in_response}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc "The endpoint the code is exchanged at, for tests and diagnostics."
+  @spec keys_url() :: String.t()
+  def keys_url, do: @keys_url
+
+  # -- default transport ------------------------------------------------------
+
+  defp post_json(url, body, opts) do
+    if Code.ensure_loaded?(Req) do
+      timeout = Keyword.get(opts, :http_timeout, @default_timeout)
+      request(url, body, timeout)
+    else
+      {:error, :no_http_client}
+    end
+  end
+
+  defp request(url, body, timeout) do
+    req = Req.new(url: url, json: body, receive_timeout: timeout)
+
+    case Req.post(req) do
+      {:ok, %{status: status, body: decoded}} when status in 200..299 ->
+        {:ok, decoded}
+
+      # Deliberately status-only: an error body is provider-controlled and
+      # this reason ends up in an ACP error message.
+      {:ok, %{status: status}} ->
+        {:error, {:exchange_rejected, status}}
+
+      {:error, reason} ->
+        {:error, {:exchange_unreachable, error_kind(reason)}}
+    end
+  rescue
+    error -> {:error, {:exchange_unreachable, error_kind(error)}}
+  end
+
+  defp error_kind(%{__struct__: module}), do: module
+  defp error_kind(other), do: other
+end

--- a/packages/raxol_agent/lib/raxol/agent/auth/pkce.ex
+++ b/packages/raxol_agent/lib/raxol/agent/auth/pkce.ex
@@ -1,0 +1,82 @@
+defmodule Raxol.Agent.Auth.Pkce do
+  @moduledoc """
+  A PKCE (RFC 7636) verifier/challenge pair for the browser OAuth flows raxol
+  runs itself.
+
+  PKCE is what makes a loopback redirect safe to use without a client secret.
+  The challenge travels to the provider in the browser URL; the verifier never
+  leaves this process until the code exchange. Any other local process can
+  connect to our loopback port and hand us an authorization code, but that code
+  was minted against *its* challenge, so exchanging it with *our* verifier
+  fails. That binding, not the port being loopback, is what keeps an injected
+  code from becoming a stored credential.
+
+  `new/1` takes an optional verifier so a test can pin the pair; production
+  callers use `new/0` and get 32 bytes of `:crypto.strong_rand_bytes/1`.
+  """
+
+  # RFC 7636 §4.1 allows 43..128 characters; 32 random bytes base64url-encode
+  # to exactly 43, the low end of the range and 256 bits of entropy.
+  @verifier_bytes 32
+
+  @method "S256"
+
+  @type t :: %__MODULE__{
+          verifier: String.t(),
+          challenge: String.t(),
+          method: String.t()
+        }
+
+  @enforce_keys [:verifier, :challenge]
+  defstruct verifier: nil, challenge: nil, method: @method
+
+  @doc "A fresh pair, or one derived from `verifier` when given."
+  @spec new(String.t() | nil) :: t()
+  def new(verifier \\ nil)
+
+  def new(nil), do: new(random_verifier())
+
+  def new(verifier) when is_binary(verifier) and verifier != "" do
+    %__MODULE__{
+      verifier: verifier,
+      challenge: challenge(verifier),
+      method: @method
+    }
+  end
+
+  @doc """
+  The S256 challenge for `verifier`: base64url of its SHA-256 digest, unpadded
+  per RFC 7636 §4.2.
+  """
+  @spec challenge(String.t()) :: String.t()
+  def challenge(verifier) when is_binary(verifier) do
+    :sha256
+    |> :crypto.hash(verifier)
+    |> Base.url_encode64(padding: false)
+  end
+
+  @doc "The challenge method these pairs use (`\"S256\"`)."
+  @spec method() :: String.t()
+  def method, do: @method
+
+  defp random_verifier do
+    @verifier_bytes
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
+  end
+end
+
+defimpl Inspect, for: Raxol.Agent.Auth.Pkce do
+  import Inspect.Algebra
+
+  # The verifier is the secret half of the pair: it is what turns an
+  # authorization code into a credential. Keep it out of logs and crash
+  # reports, the same way the wallet keys elsewhere in the tree are redacted.
+  def inspect(pkce, opts) do
+    concat([
+      "#Raxol.Agent.Auth.Pkce<challenge: ",
+      to_doc(pkce.challenge, opts),
+      ", verifier: [REDACTED]>"
+    ])
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
@@ -151,7 +151,10 @@ defmodule Raxol.Agent.Backend.Credentials do
   # op-shelling test). This Port-based runner bounds the wait and KILLS
   # the OS process on timeout; `Port.close/1` alone would leave the hung
   # `op` (and its auth prompt) alive. Generous default so an interactive
-  # signin approval still fits; `RAXOL_OP_TIMEOUT_MS` overrides.
+  # signin approval still fits; `RAXOL_OP_TIMEOUT_MS` overrides, and a caller
+  # that knows the user's attention is elsewhere (the browser sign-in, which
+  # raises the 1Password prompt the moment they come back from approving in a
+  # tab) passes its own `:timeout_ms`.
   @op_timeout_ms 15_000
 
   defp op_timeout_ms do
@@ -161,27 +164,49 @@ defmodule Raxol.Agent.Backend.Credentials do
     end
   end
 
-  defp run_op(args) do
+  defp run_op(args, timeout_ms \\ nil) do
     case System.find_executable("op") do
-      nil ->
-        {:error, :op_unavailable}
-
-      op ->
-        port =
-          Port.open(
-            {:spawn_executable, op},
-            [:binary, :exit_status, :stderr_to_stdout, args: args]
-          )
-
-        os_pid =
-          case Port.info(port, :os_pid) do
-            {:os_pid, pid} -> pid
-            _ -> nil
-          end
-
-        deadline = System.monotonic_time(:millisecond) + op_timeout_ms()
-        collect_op(port, os_pid, deadline, [])
+      nil -> {:error, :op_unavailable}
+      op -> run_executable(op, args, timeout_ms || op_timeout_ms())
     end
+  end
+
+  @doc false
+  # Spawn `executable` and collect its output, bounded by `timeout_ms`.
+  #
+  # `:in` is load-bearing, not tidiness. A port opened without it hands the
+  # child a stdin pipe that never delivers and never closes, so anything the
+  # child tries to READ from stdin blocks until the deadline. `op` decides
+  # whether to prompt by looking at stdin: given that pipe it waits for input
+  # forever, and given EOF it goes straight to the desktop-app integration and
+  # succeeds. That is why `op item create` hung here while the identical
+  # command run from a shell (whose stdin is a terminal, or `/dev/null`)
+  # returned in seconds -- and why the whole `connect_key` path, browser
+  # sign-in and pasted key alike, could not store a credential from the BEAM.
+  #
+  # Every caller here is read-only (nothing ever `Port.command`s), so closing
+  # the write half costs nothing.
+  @spec run_executable(String.t(), [String.t()], pos_integer()) ::
+          {String.t(), non_neg_integer()} | {:error, :op_timeout}
+  def run_executable(executable, args, timeout_ms) do
+    port =
+      Port.open(
+        {:spawn_executable, executable},
+        [:binary, :exit_status, :stderr_to_stdout, :in, args: args]
+      )
+
+    os_pid =
+      case Port.info(port, :os_pid) do
+        {:os_pid, pid} -> pid
+        _ -> nil
+      end
+
+    collect_op(
+      port,
+      os_pid,
+      System.monotonic_time(:millisecond) + timeout_ms,
+      []
+    )
   end
 
   defp collect_op(port, os_pid, deadline, acc) do
@@ -312,14 +337,14 @@ defmodule Raxol.Agent.Backend.Credentials do
          :ok <- IO.binwrite(io, template),
          :ok <- File.close(io) do
       try do
-        run_op_create(path, vault)
+        run_op_create(path, vault, Keyword.get(opts, :timeout_ms))
       after
         File.rm(path)
       end
     end
   end
 
-  defp run_op_create(template_path, vault) do
+  defp run_op_create(template_path, vault, timeout_ms) do
     args = [
       "item",
       "create",
@@ -331,7 +356,7 @@ defmodule Raxol.Agent.Backend.Credentials do
       "json"
     ]
 
-    case run_op(args) do
+    case run_op(args, timeout_ms) do
       {:error, reason} -> {:error, reason}
       {out, 0} -> created_ref(out, vault)
       {out, code} -> {:error, {:op_create_failed, code, String.trim(out)}}

--- a/packages/raxol_agent/lib/raxol/agent/backend/http.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/http.ex
@@ -104,10 +104,21 @@ defmodule Raxol.Agent.Backend.HTTP do
           | :unsupported
   def check_auth(opts) do
     if available?() do
-      opts |> detect_provider() |> models_request(opts) |> run_auth_check(opts)
+      opts |> auth_check_request() |> run_auth_check(opts)
     else
       :unsupported
     end
+  end
+
+  @doc false
+  # The `{url, headers}` `check_auth/1` would call, or `:unsupported` when the
+  # provider has no endpoint to check. Exposed so the routing can be tested
+  # without a socket: `:unsupported` here is precisely the silent failure that
+  # let unvalidated credentials report as merely "stored".
+  @spec auth_check_request(keyword()) ::
+          {String.t(), [{String.t(), String.t()}]} | :unsupported
+  def auth_check_request(opts) do
+    opts |> detect_provider() |> models_request(opts)
   end
 
   defp run_auth_check(:unsupported, _opts), do: :unsupported
@@ -215,11 +226,17 @@ defmodule Raxol.Agent.Backend.HTTP do
 
   defp models_request(_provider, _opts), do: :unsupported
 
+  # `:auth_check_path` lets a provider name an endpoint that actually requires
+  # the credential. `/v1/models` is the OpenAI-dialect default, but it is
+  # PUBLIC on some hosts -- OpenRouter serves it 200 with no key at all -- and
+  # validating against one of those reports a revoked key as valid, which is
+  # worse than not validating.
   defp bearer_models_request(opts, default_base) do
     case Keyword.get(opts, :api_key) do
       key when is_binary(key) ->
         base = Keyword.get(opts, :base_url, default_base)
-        {"#{base}/v1/models", [{"authorization", "Bearer #{key}"}]}
+        path = Keyword.get(opts, :auth_check_path, "/v1/models")
+        {"#{base}#{path}", [{"authorization", "Bearer #{key}"}]}
 
       _no_key ->
         :unsupported

--- a/packages/raxol_agent/lib/raxol/agent/backend/selector.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/selector.ex
@@ -51,6 +51,10 @@ defmodule Raxol.Agent.Backend.Selector do
          # The :openai build_request appends "/v1/chat/completions", so the base
          # URL stops at "/api" (never "/api/v1", which would double the "/v1").
          base_url: "https://openrouter.ai/api",
+         # OpenRouter serves /api/v1/models PUBLICLY (200 with no key), so the
+         # default auth check would call a revoked credential valid. /v1/key is
+         # the auth-required endpoint: 401 with no key and with a bad one.
+         auth_check_path: "/v1/key",
          extra_headers: [
            {"HTTP-Referer", "https://raxol.io"},
            {"X-OpenRouter-Title", "Raxol"},

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/login.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/login.ex
@@ -1,0 +1,125 @@
+defmodule Raxol.Agent.ClientProtocol.Login do
+  @moduledoc """
+  The interactive setup an ACP client launches for Terminal Auth.
+
+  ACP clients cannot hand raxol a credential over the wire: the surface reads
+  its provider from `Raxol.Agent.Backend.Resolver`, which wants a stored
+  `op://` reference or a provider env var. Terminal Auth is the protocol's
+  answer -- the client re-launches the SAME binary with the args the agent
+  advertised, the user completes an interactive flow in a real terminal, and
+  the client then starts a normal ACP session. That is what `raxol login` is.
+
+  The logic lives in `Raxol.Agent.Setup`, which `mix raxol.setup` also drives,
+  so a provider connected here resolves identically on every surface. This
+  module is prompts and exit codes over that, nothing more.
+
+  Nothing secret is written here. A raw key is turned into a 1Password
+  reference by `Setup.connect_key/3` and only the reference reaches
+  `~/.raxol/providers.json`.
+  """
+
+  alias Raxol.Agent.Setup
+
+  @usage """
+  Usage: raxol login [provider]
+
+  Connect an LLM provider for the coding agent and every ACP session.
+
+  With no provider, prints what is currently connected.
+
+  Options:
+    --status     print provider status and exit
+    -h, --help   print this help
+  """
+
+  @switches [status: :boolean, help: :boolean]
+  @aliases [h: :help]
+
+  @doc """
+  Run the interactive login. Returns an exit code.
+
+  0 connected or status printed, 64 a usage error, 1 a provider that could not
+  be stored or validated.
+  """
+  @spec run([String.t()], keyword()) :: non_neg_integer()
+  def run(argv, io \\ []) do
+    {opts, args, invalid} =
+      OptionParser.parse(argv, strict: @switches, aliases: @aliases)
+
+    cond do
+      Keyword.get(opts, :help, false) -> print(io, @usage) && 0
+      invalid != [] -> usage_error(io, invalid)
+      Keyword.get(opts, :status, false) -> print_status(io)
+      args == [] -> print_status(io)
+      true -> connect(io, hd(args))
+    end
+  end
+
+  defp usage_error(io, invalid) do
+    print(io, "raxol login: unknown options: #{inspect(invalid)}\n\n#{@usage}")
+    64
+  end
+
+  defp print_status(io) do
+    %{op: op, providers: providers} = Setup.status()
+
+    print(io, "1Password CLI: #{op}")
+
+    connected = Enum.filter(providers, & &1[:available?])
+
+    if connected == [] do
+      print(io, "No provider connected. Run `raxol login <provider>`.")
+    else
+      Enum.each(connected, fn p -> print(io, "  #{p[:harness]} (#{p[:source]})") end)
+    end
+
+    0
+  end
+
+  # A key typed at a prompt, never echoed back and never written to disk as
+  # itself -- Setup.connect_key/3 exchanges it for an `op://` reference.
+  defp connect(io, provider) do
+    case read_key(io, provider) do
+      "" ->
+        print(io, "raxol login: no key entered")
+        1
+
+      key ->
+        provider
+        |> Setup.connect_key(key)
+        |> report(io, provider)
+    end
+  end
+
+  defp report({:ok, _}, io, provider) do
+    print(io, "Connected #{provider}.")
+    0
+  end
+
+  defp report({:error, reason}, io, provider) do
+    print(io, "raxol login: could not connect #{provider}: #{inspect(reason)}")
+    1
+  end
+
+  defp read_key(io, provider) do
+    case Keyword.get(io, :read_fn) do
+      nil ->
+        "Paste the API key for #{provider} (it is exchanged for a 1Password reference): "
+        |> IO.gets()
+        |> to_string()
+        |> String.trim()
+
+      fun ->
+        fun.(provider)
+    end
+  end
+
+  defp print(io, message) do
+    case Keyword.get(io, :print_fn) do
+      nil -> IO.puts(message)
+      fun -> fun.(message)
+    end
+
+    true
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/login.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/login.ex
@@ -13,26 +13,39 @@ defmodule Raxol.Agent.ClientProtocol.Login do
   so a provider connected here resolves identically on every surface. This
   module is prompts and exit codes over that, nothing more.
 
-  Nothing secret is written here. A raw key is turned into a 1Password
-  reference by `Setup.connect_key/3` and only the reference reaches
-  `~/.raxol/providers.json`.
+  A provider with a browser sign-in (`Raxol.Agent.Auth.Flow.providers/0`) gets
+  it by default, since approving in a browser beats minting a key by hand.
+  `--paste` forces the typed-key path, which is what a remote box wants: the
+  flow's redirect lands on a loopback port, so the browser has to be on this
+  machine.
+
+  Nothing secret is written here either way. A raw key -- typed or minted by
+  the provider -- is turned into a 1Password reference by `Setup.connect_key/3`
+  and only the reference reaches `~/.raxol/providers.json`.
   """
 
+  alias Raxol.Agent.Auth.Flow
+  alias Raxol.Agent.Backend.Resolver
   alias Raxol.Agent.Setup
 
   @usage """
-  Usage: raxol login [provider]
+  Usage: raxol login [provider] [options]
 
   Connect an LLM provider for the coding agent and every ACP session.
 
   With no provider, prints what is currently connected.
 
+  Providers with a browser sign-in use it by default; the rest prompt for a
+  key. Pass --paste to type a key either way (use it over SSH: the sign-in
+  redirect lands on a loopback port and needs a browser on this machine).
+
   Options:
+    --paste      prompt for an API key instead of opening a browser
     --status     print provider status and exit
     -h, --help   print this help
   """
 
-  @switches [status: :boolean, help: :boolean]
+  @switches [paste: :boolean, status: :boolean, help: :boolean]
   @aliases [h: :help]
 
   @doc """
@@ -40,6 +53,10 @@ defmodule Raxol.Agent.ClientProtocol.Login do
 
   0 connected or status printed, 64 a usage error, 1 a provider that could not
   be stored or validated.
+
+  `io` is the injection bag: `:print_fn`, `:read_fn`, `:flow_fn` (the browser
+  sign-in) and `:open_fn` (launching the browser), so a test drives this
+  without a terminal and without opening a window.
   """
   @spec run([String.t()], keyword()) :: non_neg_integer()
   def run(argv, io \\ []) do
@@ -47,12 +64,17 @@ defmodule Raxol.Agent.ClientProtocol.Login do
       OptionParser.parse(argv, strict: @switches, aliases: @aliases)
 
     cond do
-      Keyword.get(opts, :help, false) -> print(io, @usage) && 0
+      Keyword.get(opts, :help, false) -> print_usage(io)
       invalid != [] -> usage_error(io, invalid)
       Keyword.get(opts, :status, false) -> print_status(io)
       args == [] -> print_status(io)
-      true -> connect(io, hd(args))
+      true -> connect(io, hd(args), opts)
     end
+  end
+
+  defp print_usage(io) do
+    print(io, @usage)
+    0
   end
 
   defp usage_error(io, invalid) do
@@ -70,15 +92,41 @@ defmodule Raxol.Agent.ClientProtocol.Login do
     if connected == [] do
       print(io, "No provider connected. Run `raxol login <provider>`.")
     else
-      Enum.each(connected, fn p -> print(io, "  #{p[:harness]} (#{p[:source]})") end)
+      Enum.each(connected, fn p ->
+        print(io, "  #{p[:harness]} (#{p[:source]})")
+      end)
     end
 
     0
   end
 
+  # Resolve the name before asking for anything: there is no reason to prompt
+  # for a secret we already know we cannot store.
+  defp connect(io, provider_str, opts) do
+    case Resolver.harness_from_string(provider_str) do
+      {:ok, provider} -> connect_provider(io, provider, opts)
+      :error -> unknown_provider(io, provider_str)
+    end
+  end
+
+  defp connect_provider(io, provider, opts) do
+    if Keyword.get(opts, :paste, false) or not Flow.supported?(provider) do
+      connect_key(io, provider)
+    else
+      connect_browser(io, provider)
+    end
+  end
+
+  defp unknown_provider(io, provider_str) do
+    print(io, "raxol login: unknown provider: #{provider_str}")
+    known = Enum.map_join(Resolver.providers(), ", ", &to_string(&1.harness))
+    print(io, "Known providers: #{known}")
+    64
+  end
+
   # A key typed at a prompt, never echoed back and never written to disk as
   # itself -- Setup.connect_key/3 exchanges it for an `op://` reference.
-  defp connect(io, provider) do
+  defp connect_key(io, provider) do
     case read_key(io, provider) do
       "" ->
         print(io, "raxol login: no key entered")
@@ -90,6 +138,58 @@ defmodule Raxol.Agent.ClientProtocol.Login do
         |> report(io, provider)
     end
   end
+
+  # The browser sign-in. The flow's own failure to launch a browser is NOT
+  # fatal here the way it is over ACP: a terminal can print the URL, the
+  # loopback port is still bound, and opening it by hand finishes the same
+  # flow. So the browser seam reports and returns :ok, and only the deadline
+  # ends the wait.
+  defp connect_browser(io, provider) do
+    flow_fn = Keyword.get(io, :flow_fn, &Flow.run/2)
+
+    case flow_fn.(provider, browser_fn: browser_fn(io)) do
+      {:ok, %{validation: validation}} ->
+        print(io, "Connected #{provider}. #{validation_note(validation)}")
+        0
+
+      {:error, reason} ->
+        print(io, "raxol login: #{Flow.describe(reason)}")
+
+        print(
+          io,
+          "Run `raxol login #{provider} --paste` to enter a key instead."
+        )
+
+        1
+    end
+  end
+
+  defp browser_fn(io) do
+    open_fn = Keyword.get(io, :open_fn, &Flow.open_browser/1)
+
+    fn url ->
+      case open_fn.(url) do
+        :ok ->
+          print(io, "Opened your browser. Approve the sign-in there to finish.")
+
+        {:error, _reason} ->
+          print(
+            io,
+            "Could not open a browser. Open this URL to continue:\n\n  #{url}\n"
+          )
+      end
+
+      :ok
+    end
+  end
+
+  defp validation_note(:valid), do: "Credential validated."
+  defp validation_note(:unsupported), do: "Stored (no validation endpoint)."
+
+  defp validation_note(:unreachable),
+    do: "Stored, but the provider was unreachable to validate."
+
+  defp validation_note(_other), do: "Stored."
 
   defp report({:ok, _}, io, provider) do
     print(io, "Connected #{provider}.")

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/parent_watch.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/parent_watch.ex
@@ -1,0 +1,117 @@
+defmodule Raxol.Agent.ClientProtocol.ParentWatch do
+  @moduledoc """
+  Stop serving when the process that spawned us dies.
+
+  Burrito's launcher forks the BEAM and waits, and it does not forward signals.
+  Kill the launcher alone -- `Popen.terminate()` in Python, or any client that
+  signals a pid rather than a process group -- and the launcher dies while the
+  BEAM keeps running, holding the provider credential, with stdin still open
+  because the client's end of the pipe is untouched. Nothing else notices: a
+  group kill reaches the BEAM directly, and a client that exits closes the pipe
+  and gives us EOF, but this case has no signal and no EOF.
+
+  What does change is our parent. The BEAM is reparented when the launcher
+  dies, so the fix is to notice that and stop.
+
+  A slow poll is deliberate. This is a janitor for an unusual shutdown, not a
+  liveness path, and the ordinary exits (EOF, group signal) are immediate and
+  already handled -- so paying for a fast check here would buy nothing.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @interval_ms 5_000
+
+  @doc """
+  Watch the current parent and run `on_orphan` when it changes.
+
+  `:ppid_fun` reads the parent pid; the default reads `/proc/self/stat` and
+  falls back to `ps` off Linux. Returns `:ignore` when the parent cannot be
+  read at all, since a watchdog that cannot see its subject would otherwise
+  either fire constantly or never.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: opts[:name] || __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    ppid_fun = Keyword.get(opts, :ppid_fun, &read_ppid/0)
+
+    case ppid_fun.() do
+      {:ok, ppid} ->
+        {:ok,
+         %{
+           ppid: ppid,
+           ppid_fun: ppid_fun,
+           interval: Keyword.get(opts, :interval_ms, @interval_ms),
+           on_orphan: Keyword.get(opts, :on_orphan, &default_orphan/0)
+         }, {:continue, :arm}}
+
+      :error ->
+        :ignore
+    end
+  end
+
+  @impl true
+  def handle_continue(:arm, state) do
+    Process.send_after(self(), :check, state.interval)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:check, state) do
+    case state.ppid_fun.() do
+      # Same parent, or a reading we cannot trust: keep waiting. Exiting on an
+      # unreadable ppid would kill a healthy session over a transient failure.
+      {:ok, ppid} when ppid == state.ppid ->
+        {:noreply, state, {:continue, :arm}}
+
+      :error ->
+        {:noreply, state, {:continue, :arm}}
+
+      {:ok, _orphaned} ->
+        Logger.info("[acp] launcher exited; stopping so the BEAM does not outlive it")
+        state.on_orphan.()
+        {:stop, :normal, state}
+    end
+  end
+
+  defp default_orphan, do: fn -> System.stop(0) end
+
+  @doc false
+  @spec read_ppid() :: {:ok, non_neg_integer()} | :error
+  def read_ppid do
+    case File.read("/proc/self/stat") do
+      {:ok, stat} -> parse_proc_stat(stat)
+      {:error, _} -> read_ppid_via_ps()
+    end
+  end
+
+  # Field 4 of /proc/self/stat is the ppid, but field 2 is the command name in
+  # parentheses and may itself contain spaces or parens -- so split after the
+  # last ')' rather than on whitespace from the start.
+  defp parse_proc_stat(stat) do
+    with [_, rest] <- String.split(stat, ") ", parts: 2),
+         [_state, ppid | _] <- String.split(rest, " "),
+         {n, ""} <- Integer.parse(ppid) do
+      {:ok, n}
+    else
+      _ -> :error
+    end
+  end
+
+  defp read_ppid_via_ps do
+    {out, status} = System.cmd("ps", ["-o", "ppid=", "-p", System.pid()], stderr_to_stdout: true)
+
+    case {status, Integer.parse(String.trim(out))} do
+      {0, {n, ""}} -> {:ok, n}
+      _ -> :error
+    end
+  rescue
+    _ -> :error
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/serve.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/serve.ex
@@ -209,6 +209,10 @@ defmodule Raxol.Agent.ClientProtocol.Serve do
     reroute_logs_to_stderr()
     {:ok, _apps} = Application.ensure_all_started(:raxol_agent)
     start_budget()
+    # Burrito's launcher does not forward signals, so a client that kills the
+    # launcher pid alone would otherwise leave this BEAM running with the
+    # provider credential and an open stdin.
+    Raxol.Agent.ClientProtocol.ParentWatch.start_link([])
 
     {:ok, handle} = Raxol.AgentClientProtocol.Transport.Stdio.start_self()
 

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/stdio_agent.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/stdio_agent.ex
@@ -25,6 +25,7 @@ if Code.ensure_loaded?(Raxol.AgentClientProtocol.Agent) do
 
     alias Raxol.Agent.ClientProtocol.TurnRunner
     alias Raxol.AgentClientProtocol.Error
+    alias Raxol.AgentClientProtocol.Schema.AgentTypes.AuthMethod
     alias Raxol.AgentClientProtocol.Schema.AgentTypes.Implementation
     alias Raxol.AgentClientProtocol.Schema.AgentTypes.InitializeResponse
     alias Raxol.AgentClientProtocol.Schema.AgentTypes.NewSessionResponse
@@ -39,8 +40,35 @@ if Code.ensure_loaded?(Raxol.AgentClientProtocol.Agent) do
     # record `agentInfo` as the agent under test, and a nil there is reported
     # as an unnamed agent.
     @impl true
+    # Terminal Auth, advertised because raxol takes its credential from a
+    # stored `op://` reference or a provider env var -- never from the wire.
+    # A client with no way to authenticate us would otherwise have to tell the
+    # user to go configure something out of band. Terminal Auth is the
+    # protocol's answer: relaunch this same binary with these args, let the
+    # user log in in a real terminal, then open a normal session.
+    #
+    # Agent Auth (the agent runs its own OAuth flow) is NOT claimed. We do not
+    # implement it, and a method advertised with no `type` silently defaults to
+    # `agent` at the registry validator -- so the `terminal-auth` marker is
+    # load-bearing, not decoration.
+    @doc false
+    def auth_methods do
+      [
+        %{
+          AuthMethod.new("terminal", "Run in terminal")
+          | description: "Connect a provider interactively with `raxol login`",
+            _meta: %{"terminal-auth" => %{"args" => ["login"]}}
+        }
+      ]
+    end
+
     def initialize(_req, _ctx) do
-      {:ok, %{InitializeResponse.new(1) | agent_info: implementation()}}
+      {:ok,
+       %{
+         InitializeResponse.new(1)
+         | agent_info: implementation(),
+           auth_methods: auth_methods()
+       }}
     end
 
     defp implementation do

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/stdio_agent.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/stdio_agent.ex
@@ -19,12 +19,19 @@ if Code.ensure_loaded?(Raxol.AgentClientProtocol.Agent) do
     no extra protocol traffic. A client that refuses, times out, disconnects,
     or does not implement permissions denies the write and keeps reading, so
     the surface is fail-closed on the DECISION rather than on the toolset.
+
+    Both of ACP's registry-accepted auth methods are advertised. `authenticate`
+    runs Agent Auth in-process via `Raxol.Agent.Auth.Flow` for the providers
+    that have a real browser flow; Terminal Auth (`raxol login`) covers every
+    other provider. See `auth_methods/0`.
     """
 
     use Raxol.AgentClientProtocol.Agent
 
+    alias Raxol.Agent.Auth.Flow
     alias Raxol.Agent.ClientProtocol.TurnRunner
     alias Raxol.AgentClientProtocol.Error
+    alias Raxol.AgentClientProtocol.Schema.AgentTypes.AuthenticateResponse
     alias Raxol.AgentClientProtocol.Schema.AgentTypes.AuthMethod
     alias Raxol.AgentClientProtocol.Schema.AgentTypes.Implementation
     alias Raxol.AgentClientProtocol.Schema.AgentTypes.InitializeResponse
@@ -36,32 +43,117 @@ if Code.ensure_loaded?(Raxol.AgentClientProtocol.Agent) do
     @impl true
     def init(arg), do: {:ok, arg}
 
+    # Both of the registry's accepted methods, in the order a client should
+    # prefer them.
+    #
+    # Agent Auth first: `authenticate` runs the OAuth flow in-process -- bind a
+    # loopback port, open a browser, catch the redirect, store the credential --
+    # so the user never leaves the editor. It is offered only for the providers
+    # in `Flow.providers/0`, because a method advertised without a flow behind
+    # it is a sign-in that hangs.
+    #
+    # Terminal Auth second, and still the general answer: raxol takes its
+    # credential from a stored `op://` reference or a provider env var, never
+    # from the wire, so for every provider without a browser flow the client
+    # relaunches this same binary and the user connects one in a real terminal.
+    #
+    # Each entry carries its `_meta` type marker. The registry validator infers
+    # the method from that key and silently defaults an untyped method to
+    # `agent` -- so the markers are load-bearing, not decoration: an untyped
+    # entry would claim Agent Auth for a flow that does not exist.
+    @doc false
+    def auth_methods do
+      Enum.map(Flow.providers(), &agent_auth_method/1) ++
+        [
+          %{
+            AuthMethod.new("terminal", "Run in terminal")
+            | description:
+                "Connect a provider interactively with `raxol login`",
+              _meta: %{"terminal-auth" => %{"args" => ["login"]}}
+          }
+        ]
+    end
+
+    # Total on purpose: a provider added to `Flow.providers/0` is advertised
+    # even before anyone writes copy for it here. A FunctionClauseError raised
+    # from this function would take out `initialize`, not just the new method.
+    defp agent_auth_method(provider) do
+      %{
+        AuthMethod.new(to_string(provider), "Sign in with #{label(provider)}")
+        | description:
+            "Approve in your browser; raxol catches the redirect locally",
+          _meta: %{"agent-auth" => %{"provider" => to_string(provider)}}
+      }
+    end
+
+    defp label(:openrouter), do: "OpenRouter"
+    defp label(provider), do: provider |> to_string() |> String.capitalize()
+
+    # The Agent Auth flow itself. Each inbound request already runs in its own
+    # dispatch task (Connection §4.1), so waiting here for a browser blocks
+    # only this request -- the wire keeps moving, and a `$/cancel_request`
+    # kills the task, which closes the loopback port with it.
+    #
+    # Fail-closed on the whole flow: a refusal, a timeout, a disconnect, or a
+    # key the provider will not authorize is an error, never a partial success
+    # that leaves a client thinking it can open a session.
+    @impl true
+    def authenticate(%{method_id: "terminal"}, _ctx) do
+      {:error,
+       Error.new(
+         -32_602,
+         "terminal auth does not run over the wire: relaunch this binary as `raxol login`"
+       )}
+    end
+
+    def authenticate(%{method_id: method_id}, ctx) do
+      case provider_for(method_id) do
+        {:ok, provider} ->
+          run_agent_auth(provider, ctx)
+
+        :error ->
+          {:error,
+           Error.new(-32_602, "unknown auth method #{inspect(method_id)}")}
+      end
+    end
+
+    defp run_agent_auth(provider, ctx) do
+      case Flow.run(provider, auth_opts(ctx)) do
+        {:ok, _result} ->
+          {:ok, AuthenticateResponse.new()}
+
+        {:error, reason} ->
+          {:error,
+           Error.new(
+             -32_603,
+             "#{provider} sign-in failed: #{Flow.describe(reason)}"
+           )}
+      end
+    end
+
+    # Never `String.to_atom/1` on wire input: a method id is matched against
+    # the advertised list and anything else is an unknown method.
+    defp provider_for(method_id) when is_binary(method_id) do
+      case Enum.find(Flow.providers(), &(to_string(&1) == method_id)) do
+        nil -> :error
+        provider -> {:ok, provider}
+      end
+    end
+
+    defp provider_for(_method_id), do: :error
+
+    # The flow's seams, injectable through `handler_arg` so a test drives the
+    # real loopback socket with no browser and no network.
+    defp auth_opts(%{handler_state: state}) when is_map(state) do
+      Map.get(state, :auth_opts, [])
+    end
+
+    defp auth_opts(_ctx), do: []
+
     # Identify ourselves in the handshake: clients and benchmark harnesses
     # record `agentInfo` as the agent under test, and a nil there is reported
     # as an unnamed agent.
     @impl true
-    # Terminal Auth, advertised because raxol takes its credential from a
-    # stored `op://` reference or a provider env var -- never from the wire.
-    # A client with no way to authenticate us would otherwise have to tell the
-    # user to go configure something out of band. Terminal Auth is the
-    # protocol's answer: relaunch this same binary with these args, let the
-    # user log in in a real terminal, then open a normal session.
-    #
-    # Agent Auth (the agent runs its own OAuth flow) is NOT claimed. We do not
-    # implement it, and a method advertised with no `type` silently defaults to
-    # `agent` at the registry validator -- so the `terminal-auth` marker is
-    # load-bearing, not decoration.
-    @doc false
-    def auth_methods do
-      [
-        %{
-          AuthMethod.new("terminal", "Run in terminal")
-          | description: "Connect a provider interactively with `raxol login`",
-            _meta: %{"terminal-auth" => %{"args" => ["login"]}}
-        }
-      ]
-    end
-
     def initialize(_req, _ctx) do
       {:ok,
        %{

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -159,6 +159,17 @@ defmodule Raxol.Agent.Code.App do
           :login_validator,
           &__MODULE__.default_login_validator/3
         ),
+      # `/login <provider> browser` runs the provider's OAuth sign-in off the
+      # app process — it waits on a human in a browser, which must never block
+      # the TEA loop — and the outcome rides back as a `:browser_signin`
+      # message matched by this ref. Injectable, mirroring `:login_validator`.
+      signin_ref: nil,
+      signin_runner:
+        Keyword.get(
+          options,
+          :signin_runner,
+          &__MODULE__.default_browser_signin/3
+        ),
       # `/model` with no arg fetches the connected provider's model list off
       # the app process; the result rides back as a `:models_list` message
       # matched by this ref. Injectable so tests drive it without a network
@@ -451,6 +462,19 @@ defmodule Raxol.Agent.Code.App do
          | status_line: validation_status(harness, result),
            login_ref: nil
        }, []}
+    else
+      {model, []}
+    end
+  end
+
+  # An async `/login <provider> browser` result. Same ref discipline as
+  # `:login_validation` — a newer sign-in supersedes an in-flight one.
+  def update(
+        {:command_result, {:browser_signin, ref, harness, result}},
+        model
+      ) do
+    if ref == model.signin_ref do
+      {apply_signin(%{model | signin_ref: nil}, harness, result), []}
     else
       {model, []}
     end
@@ -1734,12 +1758,59 @@ defmodule Raxol.Agent.Code.App do
       [provider] ->
         login_provider(model, provider, nil, nil)
 
+      # Spelled out rather than inferred: `/login <provider>` already means
+      # "resolve from op/env", and a browser opening on its own would be a
+      # surprise.
+      [provider, "browser"] ->
+        login_browser(model, provider)
+
       [provider, secret] ->
         login_provider(model, provider, secret, nil)
 
       [provider, secret, model_name | _] ->
         login_provider(model, provider, secret, model_name)
     end
+  end
+
+  defp login_browser(model, provider_str) do
+    case Raxol.Agent.Backend.Resolver.harness_from_string(provider_str) do
+      {:ok, harness} ->
+        start_browser_signin(model, harness)
+
+      :error ->
+        notice(
+          model,
+          "unknown provider: #{provider_str}\n\n" <> login_status_text()
+        )
+    end
+  end
+
+  defp start_browser_signin(model, harness) do
+    if Raxol.Agent.Auth.Flow.supported?(harness) do
+      ref = make_ref()
+      model.signin_runner.(harness, ref, self())
+
+      %{model | signin_ref: ref}
+      |> notice("opening a browser to sign in to #{harness}...")
+      |> put_status("waiting for #{harness} sign-in...")
+    else
+      notice(
+        model,
+        "#{harness} has no browser sign-in. Connect it with an api key or an " <>
+          "op:// reference:\n  /login #{harness} <api-key>"
+      )
+    end
+  end
+
+  defp apply_signin(model, harness, {:ok, _result}) do
+    resolve_and_connect(model, harness, [], "browser sign-in")
+  end
+
+  defp apply_signin(model, harness, {:error, reason}) do
+    notice(
+      model,
+      "#{harness} sign-in failed: #{Raxol.Agent.Auth.Flow.describe(reason)}"
+    )
   end
 
   defp login_provider(model, provider_str, secret, model_name) do
@@ -1833,6 +1904,25 @@ defmodule Raxol.Agent.Code.App do
   # Kick off the injectable validator, returning the ref that stamps its
   # result. `self()` here is the app process, so the ping's reply message lands
   # where `update/2` can fold it.
+  @doc false
+  # The default sign-in runner: the whole OAuth flow off the app process, so a
+  # user who wanders off mid-approval cannot wedge the TUI. The outcome rides
+  # back as a `:browser_signin` message, mirroring the validation ping.
+  def default_browser_signin(harness, ref, app) do
+    spawn(fn ->
+      result =
+        try do
+          Raxol.Agent.Auth.Flow.run(harness)
+        rescue
+          error -> {:error, error}
+        catch
+          _kind, reason -> {:error, reason}
+        end
+
+      send(app, {:command_result, {:browser_signin, ref, harness, result}})
+    end)
+  end
+
   defp start_login_validation(model, executor) do
     ref = make_ref()
     model.login_validator.(executor, ref, self())
@@ -2139,6 +2229,7 @@ defmodule Raxol.Agent.Code.App do
     Connect a provider with /login:
       /login anthropic op://Vault/Anthropic/key   1Password reference (persisted)
       /login openai sk-...                         session key (not saved)
+      /login openrouter browser                    sign in via browser (persisted)
       /login lm_studio                             local server (no key)
 
     ● connected  ○ not connected

--- a/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
+++ b/packages/raxol_agent/lib/raxol/agent/directive/executor.ex
@@ -47,12 +47,19 @@ defimpl Raxol.Core.Runtime.Directive.Executor,
           {String.to_charlist(to_string(k)), String.to_charlist(to_string(v))}
         end)
 
+      # `:in` closes the child's stdin. Without it an Erlang port hands the
+      # command a pipe that never delivers and never closes, so anything that
+      # READS stdin -- a bare `cat`, a tool that prompts, a `read` in a script
+      # -- blocks until the timeout instead of seeing EOF. Nothing here ever
+      # writes to the port, so there is no input to lose; this is what
+      # `sh -c '...' < /dev/null` gives every other non-interactive runner.
       port_opts =
         [
           :binary,
           :exit_status,
           :use_stdio,
           :stderr_to_stdout,
+          :in,
           args: ["-c", command]
         ]
         |> maybe_add_port_opt(:cd, cd)

--- a/packages/raxol_agent/lib/raxol/agent/setup.ex
+++ b/packages/raxol_agent/lib/raxol/agent/setup.ex
@@ -21,7 +21,7 @@ defmodule Raxol.Agent.Setup do
   alias Raxol.Agent.Backend.Credentials
   alias Raxol.Agent.Backend.HTTP
   alias Raxol.Agent.Backend.Resolver
-  alias Raxol.Agent.ExecutorConfig
+  alias Raxol.Agent.Backend.Selector
 
   @type validation ::
           :valid
@@ -63,6 +63,9 @@ defmodule Raxol.Agent.Setup do
   provider, then validate. Requires the `op` CLI (the `:creator` seam
   defaults to `Credentials.create_item/3`).
 
+  `:vault` and `:timeout_ms` reach the creator; the latter is for callers
+  whose user is looking somewhere else when 1Password raises its prompt.
+
   Returns `{:ok, harness, op_ref, validation}` or `{:error, reason}`.
   """
   @spec connect_key(atom() | String.t(), String.t(), keyword()) ::
@@ -72,7 +75,8 @@ defmodule Raxol.Agent.Setup do
     attrs = Map.new(Keyword.take(opts, [:model, :base_url]))
 
     with {:ok, provider} <- resolve_harness(harness),
-         {:ok, ref} <- creator.(provider, key, Keyword.take(opts, [:vault])),
+         {:ok, ref} <-
+           creator.(provider, key, Keyword.take(opts, [:vault, :timeout_ms])),
          :ok <- Credentials.put(provider, ref_entry(ref, attrs)) do
       {:ok, provider, ref, validate(provider, opts)}
     end
@@ -95,18 +99,31 @@ defmodule Raxol.Agent.Setup do
   end
 
   # Resolve the stored reference to a live executor and hit the provider's
-  # model-list endpoint (no tokens spent). A resolution that yields no key or
+  # auth-check endpoint (no tokens spent). A resolution that yields no key or
   # no provider is surfaced verbatim so the caller can report it.
   defp default_validate(provider) do
     case Resolver.resolve(harness: provider) do
-      {:ok, executor, _source} ->
-        executor
-        |> ExecutorConfig.to_backend_opts()
-        |> Keyword.put(:provider, executor.backend)
-        |> HTTP.check_auth()
+      {:ok, executor, _source} -> check_credential(executor)
+      other -> other
+    end
+  end
 
-      other ->
-        other
+  # Route through `Selector` rather than assembling backend opts here: it is
+  # the single source of truth for which wire dialect and base URL a harness
+  # speaks. Passing `executor.backend` as `:provider` looked equivalent only
+  # because the four original providers are named after their dialect. For
+  # openrouter, lm_studio, llm7 and longcat -- all of which speak `:openai` at
+  # their own base URL -- it named a dialect `Backend.HTTP` has never heard of,
+  # so each one silently validated as `:unsupported` and a dead credential
+  # reported "stored" instead of failing.
+  #
+  # Only the HTTP backend has an auth-check endpoint; Lumo, Native and Mock
+  # have nothing to hit, so they stay honestly unsupported.
+  defp check_credential(executor) do
+    case Selector.select(executor) do
+      {:ok, HTTP, opts} -> HTTP.check_auth(opts)
+      {:ok, _module, _opts} -> :unsupported
+      {:error, _reason} -> :unsupported
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/auth/flow_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/auth/flow_test.exs
@@ -1,0 +1,246 @@
+defmodule Raxol.Agent.Auth.FlowTest do
+  @moduledoc """
+  The whole Agent Auth path, browser included -- the browser is simulated by
+  fetching the callback URL the flow just handed it, so the loopback socket,
+  the redirect parse, and the PKCE binding are all the real ones. Only the
+  network call and the credential store are injected.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Auth.Flow
+
+  @key "sk-or-v1-minted"
+
+  defp exchange_ok do
+    fn _url, _body, _opts -> {:ok, %{"key" => @key}} end
+  end
+
+  # Stands in for the user approving in a browser: fetch the callback URL the
+  # flow put in the authorization URL, with a code attached.
+  defp browser(code \\ "the-code") do
+    fn url ->
+      url
+      |> callback_url()
+      |> Kernel.<>("?code=#{code}")
+      |> fetch()
+
+      :ok
+    end
+  end
+
+  defp callback_url(url) do
+    url
+    |> URI.parse()
+    |> Map.fetch!(:query)
+    |> URI.decode_query()
+    |> Map.fetch!("callback_url")
+  end
+
+  defp fetch(url) do
+    uri = URI.parse(url)
+
+    spawn_link(fn ->
+      {:ok, socket} =
+        :gen_tcp.connect(
+          ~c"127.0.0.1",
+          uri.port,
+          [:binary, active: false, packet: :raw],
+          2_000
+        )
+
+      path = uri.path <> "?" <> uri.query
+      :gen_tcp.send(socket, "GET #{path} HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      :gen_tcp.recv(socket, 0, 2_000)
+      :gen_tcp.close(socket)
+    end)
+
+    :ok
+  end
+
+  defp store_to(pid) do
+    fn provider, key ->
+      send(pid, {:stored, provider, key})
+      {:ok, provider, "op://Private/OpenRouter/api_key", :valid}
+    end
+  end
+
+  defp refute_stored do
+    refute_receive {:stored, _provider, _key}, 100
+  end
+
+  describe "providers without a flow" do
+    # Claiming a method we cannot run would hang the client at sign-in, which
+    # is strictly worse than never offering it.
+    test "are refused immediately rather than waiting on a browser" do
+      assert {:error, {:no_oauth_flow, :anthropic}} = Flow.run(:anthropic)
+      assert {:error, {:no_oauth_flow, :ollama}} = Flow.run(:ollama)
+    end
+
+    test "are pointed at the method that does work for them" do
+      assert Flow.describe({:no_oauth_flow, :anthropic}) =~
+               "raxol login anthropic"
+    end
+
+    test "are absent from the advertised list" do
+      assert Flow.providers() == [:openrouter]
+      assert Flow.supported?(:openrouter)
+      refute Flow.supported?(:anthropic)
+    end
+  end
+
+  describe "a completed sign-in" do
+    test "stores the minted key against the provider" do
+      assert {:ok, %{provider: :openrouter, validation: :valid}} =
+               Flow.run(:openrouter,
+                 browser_fn: browser(),
+                 http_fn: exchange_ok(),
+                 store_fn: store_to(self()),
+                 timeout: 2_000
+               )
+
+      assert_receive {:stored, :openrouter, @key}
+    end
+
+    test "releases its port, so a second sign-in can bind one" do
+      opts = [
+        browser_fn: browser(),
+        http_fn: exchange_ok(),
+        store_fn: store_to(self()),
+        timeout: 2_000
+      ]
+
+      assert {:ok, _first} = Flow.run(:openrouter, opts)
+      assert {:ok, _second} = Flow.run(:openrouter, opts)
+    end
+
+    # PKCE only binds if the verifier that redeems the code is the one whose
+    # challenge went to the provider.
+    test "redeems the code with the verifier behind the challenge it advertised" do
+      caller = self()
+
+      capture = fn url ->
+        send(
+          caller,
+          {:challenge,
+           url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()}
+        )
+
+        browser().(url)
+      end
+
+      http_fn = fn _url, body, _opts ->
+        send(caller, {:verifier, body["code_verifier"]})
+        {:ok, %{"key" => @key}}
+      end
+
+      assert {:ok, _result} =
+               Flow.run(:openrouter,
+                 browser_fn: capture,
+                 http_fn: http_fn,
+                 store_fn: store_to(self()),
+                 timeout: 2_000
+               )
+
+      assert_receive {:challenge, query}
+      assert_receive {:verifier, verifier}
+
+      assert query["code_challenge"] ==
+               Raxol.Agent.Auth.Pkce.challenge(verifier)
+    end
+  end
+
+  describe "a sign-in that does not complete" do
+    test "reports a browser it could not open, with the URL to finish by hand" do
+      assert {:error, {:no_browser_opener, "xdg-open", url}} =
+               Flow.run(:openrouter,
+                 browser_fn: fn _url ->
+                   {:error, {:no_browser_opener, "xdg-open"}}
+                 end,
+                 store_fn: store_to(self()),
+                 timeout: 2_000
+               )
+
+      assert url =~ "https://openrouter.ai/auth"
+      assert Flow.describe({:no_browser_opener, "xdg-open", url}) =~ url
+      refute_stored()
+    end
+
+    test "times out when nobody approves, and stores nothing" do
+      assert {:error, :timeout} =
+               Flow.run(:openrouter,
+                 browser_fn: fn _url -> :ok end,
+                 http_fn: exchange_ok(),
+                 store_fn: store_to(self()),
+                 timeout: 50
+               )
+
+      refute_stored()
+    end
+
+    test "stores nothing when the code will not exchange" do
+      assert {:error, {:exchange_rejected, 403}} =
+               Flow.run(:openrouter,
+                 browser_fn: browser(),
+                 http_fn: fn _url, _body, _opts ->
+                   {:error, {:exchange_rejected, 403}}
+                 end,
+                 store_fn: store_to(self()),
+                 timeout: 2_000
+               )
+
+      refute_stored()
+    end
+
+    # The reference is written before validation runs, but a key the provider
+    # will not authorize is not a sign-in the client should be told succeeded.
+    test "fails when the provider will not authorize the key it just minted" do
+      store_fn = fn provider, _key ->
+        {:ok, provider, "op://ref", {:rejected, 401}}
+      end
+
+      assert {:error, {:key_rejected, 401}} =
+               Flow.run(:openrouter,
+                 browser_fn: browser(),
+                 http_fn: exchange_ok(),
+                 store_fn: store_fn,
+                 timeout: 2_000
+               )
+    end
+
+    # No `op` means nowhere to put a key, and raxol does not fall back to
+    # writing one to disk.
+    test "fails rather than write a key to disk when 1Password is absent" do
+      store_fn = fn _provider, _key -> {:error, :op_unavailable} end
+
+      assert {:error, {:store_failed, :op_unavailable}} =
+               Flow.run(:openrouter,
+                 browser_fn: browser(),
+                 http_fn: exchange_ok(),
+                 store_fn: store_fn,
+                 timeout: 2_000
+               )
+
+      message = Flow.describe({:store_failed, :op_unavailable})
+
+      assert message =~ "op"
+      assert message =~ "never writes a key to disk"
+    end
+  end
+
+  describe "describe/1" do
+    test "renders each failure as a sentence a user can act on" do
+      assert Flow.describe(:timeout) =~ "timed out"
+
+      assert Flow.describe({:oauth_error, "access_denied", nil}) =~
+               "access_denied"
+
+      assert Flow.describe({:oauth_error, "access_denied", "User said no"}) =~
+               "User said no"
+
+      assert Flow.describe({:exchange_rejected, 400}) =~ "400"
+      assert Flow.describe(:no_http_client) =~ "HTTP client"
+      assert Flow.describe({:key_rejected, 401}) =~ "401"
+      assert Flow.describe({:listen_failed, :eaddrinuse}) =~ "local port"
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/auth/loopback_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/auth/loopback_test.exs
@@ -1,0 +1,131 @@
+defmodule Raxol.Agent.Auth.LoopbackTest do
+  @moduledoc """
+  The redirect catcher, driven with a real socket rather than a stub: the
+  browser is the one participant in this flow we cannot inject, so the HTTP it
+  speaks is the part worth testing for real.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Auth.Loopback
+
+  setup do
+    {:ok, listener} = Loopback.open()
+    on_exit(fn -> Loopback.close(listener) end)
+
+    {:ok, listener: listener}
+  end
+
+  test "advertises the loopback URL a provider redirects to", %{
+    listener: listener
+  } do
+    assert Loopback.redirect_uri(listener) ==
+             "http://localhost:#{listener.port}/callback"
+  end
+
+  # Bound to 127.0.0.1, not 0.0.0.0: an OAuth code in a URL is a bearer
+  # credential for the length of the flow and must not be catchable off-box.
+  test "binds the loopback interface only", %{listener: listener} do
+    assert {:ok, {{127, 0, 0, 1}, _port}} = :inet.sockname(listener.socket)
+  end
+
+  test "returns the code the browser arrives with", %{listener: listener} do
+    fire(listener.port, "/callback?code=abc123")
+
+    assert {:ok, "abc123"} = Loopback.await(listener, 2_000)
+  end
+
+  test "answers the browser a page rather than a dropped connection", %{
+    listener: listener
+  } do
+    caller = self()
+
+    spawn_link(fn ->
+      send(caller, {:response, request(listener.port, "/callback?code=abc123")})
+    end)
+
+    assert {:ok, "abc123"} = Loopback.await(listener, 2_000)
+    assert_receive {:response, response}, 2_000
+
+    assert response =~ "200 OK"
+    assert response =~ "close this tab"
+  end
+
+  test "reports a denial at the provider instead of waiting out the clock", %{
+    listener: listener
+  } do
+    fire(
+      listener.port,
+      "/callback?error=access_denied&error_description=User+said+no"
+    )
+
+    assert {:error, {:oauth_error, "access_denied", "User said no"}} =
+             Loopback.await(listener, 2_000)
+  end
+
+  # A browser fetches /favicon.ico unprompted. Treating any request as the
+  # redirect would end the wait before the user ever approved.
+  test "a request without a code does not end the wait", %{listener: listener} do
+    caller = self()
+
+    spawn_link(fn ->
+      send(caller, {:favicon, request(listener.port, "/favicon.ico")})
+      request(listener.port, "/callback?code=late-but-real")
+    end)
+
+    assert {:ok, "late-but-real"} = Loopback.await(listener, 3_000)
+    assert_receive {:favicon, favicon_response}, 2_000
+    assert favicon_response =~ "404 Not Found"
+  end
+
+  test "gives up on the deadline when the browser never arrives", %{
+    listener: listener
+  } do
+    assert {:error, :timeout} = Loopback.await(listener, 50)
+  end
+
+  test "close releases the port", %{listener: listener} do
+    :ok = Loopback.close(listener)
+
+    assert {:error, _reason} =
+             :gen_tcp.connect(
+               ~c"127.0.0.1",
+               listener.port,
+               [:binary, active: false],
+               500
+             )
+  end
+
+  # Send a request without waiting on its response: reading it inline would
+  # block until `await/2` accepts, which the caller has not reached yet.
+  defp fire(port, path) do
+    spawn_link(fn -> request(port, path) end)
+    :ok
+  end
+
+  defp request(port, path) do
+    {:ok, socket} =
+      :gen_tcp.connect(
+        ~c"127.0.0.1",
+        port,
+        [:binary, active: false, packet: :raw],
+        2_000
+      )
+
+    :ok =
+      :gen_tcp.send(
+        socket,
+        "GET #{path} HTTP/1.1\r\nHost: localhost\r\nUser-Agent: test\r\nAccept: */*\r\n\r\n"
+      )
+
+    response = read(socket, "")
+    :gen_tcp.close(socket)
+    response
+  end
+
+  defp read(socket, acc) do
+    case :gen_tcp.recv(socket, 0, 2_000) do
+      {:ok, data} -> read(socket, acc <> data)
+      {:error, _reason} -> acc
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/auth/openrouter_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/auth/openrouter_test.exs
@@ -1,0 +1,94 @@
+defmodule Raxol.Agent.Auth.OpenRouterTest do
+  @moduledoc """
+  The provider half of Agent Auth: what we put in the browser URL, and what we
+  will accept back as a credential. The transport is injected, so nothing here
+  reaches the network.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Auth.OpenRouter
+  alias Raxol.Agent.Auth.Pkce
+
+  @verifier "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+  defp pkce, do: Pkce.new(@verifier)
+
+  describe "the authorization URL" do
+    test "carries the callback and the S256 challenge OpenRouter expects" do
+      url = OpenRouter.authorize_url(pkce(), "http://localhost:4567/callback")
+
+      assert %URI{host: "openrouter.ai", path: "/auth", scheme: "https"} =
+               URI.parse(url)
+
+      query = url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert query["callback_url"] == "http://localhost:4567/callback"
+      assert query["code_challenge"] == Pkce.challenge(@verifier)
+      assert query["code_challenge_method"] == "S256"
+    end
+
+    # The whole point of PKCE: the browser (and anything watching it) sees the
+    # challenge, never the verifier that redeems the code.
+    test "never carries the verifier" do
+      url = OpenRouter.authorize_url(pkce(), "http://localhost:4567/callback")
+
+      refute url =~ @verifier
+    end
+  end
+
+  describe "the code exchange" do
+    test "sends the code with its verifier and returns the minted key" do
+      caller = self()
+
+      http_fn = fn url, body, _opts ->
+        send(caller, {:posted, url, body})
+        {:ok, %{"key" => "sk-or-v1-minted"}}
+      end
+
+      assert {:ok, "sk-or-v1-minted"} =
+               OpenRouter.exchange("the-code", pkce(), http_fn: http_fn)
+
+      assert_receive {:posted, url, body}
+
+      assert url == OpenRouter.keys_url()
+      assert body["code"] == "the-code"
+      assert body["code_verifier"] == @verifier
+      assert body["code_challenge_method"] == "S256"
+    end
+
+    test "a rejected exchange is an error, not an empty key" do
+      http_fn = fn _url, _body, _opts -> {:error, {:exchange_rejected, 400}} end
+
+      assert {:error, {:exchange_rejected, 400}} =
+               OpenRouter.exchange("stale-code", pkce(), http_fn: http_fn)
+    end
+
+    test "a 200 with no key is refused rather than stored" do
+      http_fn = fn _url, _body, _opts -> {:ok, %{"error" => "nope"}} end
+
+      assert {:error, {:no_key_in_response, ["error"]}} =
+               OpenRouter.exchange("the-code", pkce(), http_fn: http_fn)
+    end
+
+    test "an empty key is refused" do
+      http_fn = fn _url, _body, _opts -> {:ok, %{"key" => ""}} end
+
+      assert {:error, {:no_key_in_response, ["key"]}} =
+               OpenRouter.exchange("the-code", pkce(), http_fn: http_fn)
+    end
+
+    # The reason reaches an ACP error message, so it must name the failure
+    # without echoing a provider-controlled body back at the client.
+    test "a failure reason carries neither the key nor the verifier" do
+      http_fn = fn _url, _body, _opts ->
+        {:ok, %{"key" => "", "debug" => "sk-or-v1-leaked"}}
+      end
+
+      assert {:error, reason} =
+               OpenRouter.exchange("the-code", pkce(), http_fn: http_fn)
+
+      refute inspect(reason) =~ "sk-or-v1-leaked"
+      refute inspect(reason) =~ @verifier
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/auth/pkce_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/auth/pkce_test.exs
@@ -1,0 +1,63 @@
+defmodule Raxol.Agent.Auth.PkceTest do
+  @moduledoc """
+  PKCE is the only thing standing between our loopback port and a code any
+  local process could inject, so the challenge derivation is checked against
+  RFC 7636's own test vector rather than against itself.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.Auth.Pkce
+
+  # RFC 7636 Appendix B.
+  @rfc_verifier "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+  @rfc_challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+  test "derives the challenge RFC 7636 Appendix B specifies" do
+    assert Pkce.challenge(@rfc_verifier) == @rfc_challenge
+  end
+
+  test "a pair built from a verifier carries that vector's challenge" do
+    pkce = Pkce.new(@rfc_verifier)
+
+    assert pkce.verifier == @rfc_verifier
+    assert pkce.challenge == @rfc_challenge
+    assert pkce.method == "S256"
+  end
+
+  test "the challenge is unpadded base64url, not base64" do
+    challenge = Pkce.challenge("any verifier at all")
+
+    refute String.contains?(challenge, "=")
+    refute String.contains?(challenge, "+")
+    refute String.contains?(challenge, "/")
+  end
+
+  describe "a generated verifier" do
+    test "falls inside RFC 7636's 43..128 character range" do
+      length = String.length(Pkce.new().verifier)
+
+      assert length >= 43
+      assert length <= 128
+    end
+
+    test "uses only the unreserved characters the RFC allows" do
+      assert Pkce.new().verifier =~ ~r/\A[A-Za-z0-9\-._~]+\z/
+    end
+
+    test "differs every time, or the binding proves nothing" do
+      verifiers = for _ <- 1..50, do: Pkce.new().verifier
+
+      assert length(Enum.uniq(verifiers)) == 50
+    end
+  end
+
+  # The verifier is the half that turns a code into a credential. A crash
+  # report or a logged struct must not carry it.
+  test "inspect redacts the verifier and keeps the public challenge" do
+    inspected = inspect(Pkce.new(@rfc_verifier))
+
+    refute inspected =~ @rfc_verifier
+    assert inspected =~ "[REDACTED]"
+    assert inspected =~ @rfc_challenge
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/backend/credentials_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/credentials_test.exs
@@ -218,4 +218,45 @@ defmodule Raxol.Agent.Backend.CredentialsTest do
       end
     end
   end
+
+  describe "run_executable/3" do
+    # An Erlang port opened without `:in` hands the child a stdin pipe that
+    # never delivers and never closes, so any child that READS stdin blocks
+    # until the deadline. That is not hypothetical: it is why `op item create`
+    # hung from the BEAM while the identical command returned in seconds from a
+    # shell, which silently broke every path that stores a credential.
+    #
+    # `cat` with no arguments reads stdin to EOF, so it is the cheapest probe
+    # for the regression: EOF means it exits at once, an open pipe means it
+    # hangs until the timeout.
+    @tag :unix_only
+    test "closes the child's stdin, so a stdin-reading child sees EOF" do
+      cat = System.find_executable("cat")
+      assert cat, "cat is required for this test"
+
+      started = System.monotonic_time(:millisecond)
+      result = Credentials.run_executable(cat, [], 5_000)
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      assert {"", 0} = result
+      assert elapsed < 4_000, "cat blocked on stdin for #{elapsed}ms"
+    end
+
+    @tag :unix_only
+    test "returns the child's output and exit status" do
+      echo = System.find_executable("echo")
+      assert {output, 0} = Credentials.run_executable(echo, ["hello"], 5_000)
+      assert String.trim(output) == "hello"
+    end
+
+    # The bound is the whole point of the Port runner: a hung `op` must not
+    # freeze the caller (the TUI update loop, a test, an ACP turn).
+    @tag :unix_only
+    test "kills a child that outlives its deadline" do
+      sleep = System.find_executable("sleep")
+
+      assert {:error, :op_timeout} =
+               Credentials.run_executable(sleep, ["30"], 300)
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/backend/selector_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/selector_test.exs
@@ -124,4 +124,55 @@ defmodule Raxol.Agent.Backend.SelectorTest do
       refute :codex in supported
     end
   end
+
+  describe "credential validation routing" do
+    # A harness whose `:provider` is not a dialect Backend.HTTP recognizes gets
+    # NO auth check at all: `check_auth/1` returns :unsupported without a
+    # request, and a dead credential reports as merely "stored". That is how
+    # openrouter, lm_studio, llm7 and longcat went silently unvalidated -- the
+    # caller passed `executor.backend` as `:provider`, which only happens to be
+    # a dialect name for the four original providers.
+    test "every HTTP-backed harness builds an auth check request" do
+      for harness <- Selector.supported_backends() do
+        config =
+          ExecutorConfig.new(backend: harness, auth: %{api_key: "probe-key"})
+
+        case Selector.select(config) do
+          {:ok, Raxol.Agent.Backend.HTTP, opts} ->
+            refute Raxol.Agent.Backend.HTTP.auth_check_request(opts) ==
+                     :unsupported,
+                   "#{harness} resolves to HTTP but has no auth check"
+
+          {:ok, _other_backend, _opts} ->
+            :ok
+        end
+      end
+    end
+
+    # OpenRouter serves /api/v1/models publicly (200 with no key), so checking
+    # there would call a revoked credential valid -- worse than not checking.
+    test "openrouter checks the auth-required endpoint, not the public one" do
+      config =
+        ExecutorConfig.new(backend: :openrouter, auth: %{api_key: "probe-key"})
+
+      {:ok, _module, opts} = Selector.select(config)
+
+      assert {url, headers} =
+               Raxol.Agent.Backend.HTTP.auth_check_request(opts)
+
+      assert url == "https://openrouter.ai/api/v1/key"
+      refute url =~ "/models"
+      assert {"authorization", "Bearer probe-key"} in headers
+    end
+
+    test "an openai-dialect provider still checks the model list by default" do
+      config =
+        ExecutorConfig.new(backend: :openai, auth: %{api_key: "probe-key"})
+
+      {:ok, _module, opts} = Selector.select(config)
+
+      assert {"https://api.openai.com/v1/models", _headers} =
+               Raxol.Agent.Backend.HTTP.auth_check_request(opts)
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/agent_auth_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/agent_auth_test.exs
@@ -1,0 +1,290 @@
+defmodule Raxol.Agent.ClientProtocol.AgentAuthTest do
+  @moduledoc """
+  Agent Auth on the ACP surface: what `initialize` advertises, and what
+  `authenticate` actually does when a client picks it.
+
+  The sign-in runs over a real connection with a real loopback socket; only
+  the browser, the token exchange, and the credential store are injected, so
+  nothing here opens a window, reaches the network, or touches 1Password.
+  """
+  # async: false — uses the ACP package's named shared tree.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Auth.Flow
+  alias Raxol.Agent.ClientProtocol.StdioAgent
+  alias Raxol.AgentClientProtocol.Agent, as: AcpAgent
+  alias Raxol.AgentClientProtocol.Client, as: AcpClient
+  alias Raxol.AgentClientProtocol.Connection
+  alias Raxol.AgentClientProtocol.Schema.AgentTypes.AuthenticateRequest
+  alias Raxol.AgentClientProtocol.Schema.AgentTypes.InitializeRequest
+  alias Raxol.AgentClientProtocol.Session
+  alias Raxol.AgentClientProtocol.Transport.Paired
+
+  @key "sk-or-v1-minted"
+
+  defmodule MiniClient do
+    @moduledoc false
+    use Raxol.AgentClientProtocol.Client
+
+    @impl true
+    def init(arg), do: {:ok, arg}
+
+    @impl true
+    def session_update(_notification, _ctx), do: :ok
+  end
+
+  setup do
+    if Process.whereis(Session.registry()) == nil do
+      RaxolAgentClientProtocol.Application.children()
+      |> Enum.with_index()
+      |> Enum.each(fn {spec, i} ->
+        start_supervised!(Supervisor.child_spec(spec, id: {:acp_tree, i}))
+      end)
+    end
+
+    :ok
+  end
+
+  describe "what initialize advertises" do
+    test "offers both of the registry's accepted methods, Agent Auth first" do
+      assert [agent_method, terminal_method] = StdioAgent.auth_methods()
+
+      assert %{"agent-auth" => _} = agent_method._meta
+      assert %{"terminal-auth" => _} = terminal_method._meta
+    end
+
+    # The registry's parser reads the type off this key and defaults an
+    # untyped method to `agent`. An untyped entry would silently claim a flow
+    # we do not run.
+    test "types every method explicitly, since untyped defaults to agent" do
+      for method <- StdioAgent.auth_methods() do
+        assert Map.has_key?(method._meta, "agent-auth") or
+                 Map.has_key?(method._meta, "terminal-auth"),
+               "auth method #{method.id} carries no type marker"
+      end
+    end
+
+    # This is the honesty check: an advertised Agent Auth method whose provider
+    # has no flow behind it is a sign-in that hangs.
+    test "only claims Agent Auth for providers with a flow behind them" do
+      for method <- StdioAgent.auth_methods(),
+          Map.has_key?(method._meta, "agent-auth") do
+        assert Enum.any?(Flow.providers(), &(to_string(&1) == method.id)),
+               "advertised #{method.id} with no flow behind it"
+      end
+    end
+
+    test "reaches the client on the wire, not just the struct" do
+      {_client, init} = connect(auth_opts: [])
+
+      ids = Enum.map(init.auth_methods, & &1.id)
+
+      assert "openrouter" in ids
+      assert "terminal" in ids
+    end
+  end
+
+  describe "authenticate" do
+    test "runs the browser flow and reports success once the key is stored" do
+      caller = self()
+
+      {client, _init} =
+        connect(
+          auth_opts: [
+            browser_fn: browser(),
+            http_fn: fn _url, _body, _opts -> {:ok, %{"key" => @key}} end,
+            store_fn: fn provider, key ->
+              send(caller, {:stored, provider, key})
+              {:ok, provider, "op://Private/OpenRouter/api_key", :valid}
+            end,
+            timeout: 3_000
+          ]
+        )
+
+      assert {:ok, _response} =
+               Connection.request(
+                 client,
+                 "authenticate",
+                 AuthenticateRequest.new("openrouter"),
+                 8_000
+               )
+
+      assert_receive {:stored, :openrouter, @key}
+    end
+
+    # Fail-closed: a client must not come away thinking it can open a session.
+    test "is an error when the sign-in does not complete" do
+      {client, _init} =
+        connect(
+          auth_opts: [
+            browser_fn: fn _url -> :ok end,
+            store_fn: fn _provider, _key ->
+              flunk("stored a key for an incomplete sign-in")
+            end,
+            timeout: 50
+          ]
+        )
+
+      assert {:error, error} =
+               Connection.request(
+                 client,
+                 "authenticate",
+                 AuthenticateRequest.new("openrouter"),
+                 8_000
+               )
+
+      assert error.message =~ "timed out"
+    end
+
+    # Terminal Auth happens by relaunching the binary, not over the wire; say
+    # so instead of hanging or pretending it worked.
+    test "refuses the terminal method and names the command instead" do
+      {client, _init} = connect(auth_opts: [])
+
+      assert {:error, error} =
+               Connection.request(
+                 client,
+                 "authenticate",
+                 AuthenticateRequest.new("terminal"),
+                 2_000
+               )
+
+      assert error.message =~ "raxol login"
+    end
+
+    test "refuses a method id it never advertised" do
+      {client, _init} = connect(auth_opts: [])
+
+      assert {:error, error} =
+               Connection.request(
+                 client,
+                 "authenticate",
+                 AuthenticateRequest.new("anthropic"),
+                 2_000
+               )
+
+      assert error.message =~ "unknown auth method"
+    end
+  end
+
+  # -- scaffolding ------------------------------------------------------------
+
+  # Stands in for the user approving in a browser: fetch the callback URL the
+  # flow put in the authorization URL, with a code attached.
+  defp browser do
+    fn url ->
+      callback =
+        url
+        |> URI.parse()
+        |> Map.fetch!(:query)
+        |> URI.decode_query()
+        |> Map.fetch!("callback_url")
+
+      uri = URI.parse(callback <> "?code=the-code")
+
+      spawn_link(fn ->
+        {:ok, socket} =
+          :gen_tcp.connect(
+            ~c"127.0.0.1",
+            uri.port,
+            [:binary, active: false, packet: :raw],
+            2_000
+          )
+
+        :gen_tcp.send(
+          socket,
+          "GET #{uri.path}?#{uri.query} HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        )
+
+        :gen_tcp.recv(socket, 0, 2_000)
+        :gen_tcp.close(socket)
+      end)
+
+      :ok
+    end
+  end
+
+  # A live agent/client pair past the handshake: every other method is
+  # `:not_initialized` until `initialize` lands, so no test can skip it.
+  defp connect(handler_extra) do
+    {left, right} = Paired.create_pair()
+
+    on_exit(fn ->
+      for %Paired{pid: p} <- [left, right], is_pid(p) and Process.alive?(p) do
+        Process.exit(p, :kill)
+      end
+    end)
+
+    handler_arg =
+      Enum.into(handler_extra, %{
+        turn_opts: [
+          executor: Raxol.Agent.ExecutorConfig.new(backend: :mock),
+          actions: []
+        ]
+      })
+
+    agent_sup =
+      start_supervised!(
+        Map.put(
+          AcpAgent.child_spec(
+            id: {:auth_agent, make_ref()},
+            handler: StdioAgent,
+            handler_arg: handler_arg,
+            transport: {Paired, left}
+          ),
+          :restart,
+          :temporary
+        )
+      )
+
+    client_sup =
+      start_supervised!(
+        Map.put(
+          AcpClient.child_spec(
+            id: {:auth_client, make_ref()},
+            handler: MiniClient,
+            handler_arg: %{},
+            transport: {Paired, right}
+          ),
+          :restart,
+          :temporary
+        )
+      )
+
+    agent_conn = connection_of(agent_sup)
+    client_conn = connection_of(client_sup)
+
+    assert_adopted(agent_conn)
+    assert_adopted(client_conn)
+
+    {:ok, init} =
+      Connection.request(
+        client_conn,
+        "initialize",
+        InitializeRequest.new(1),
+        2_000
+      )
+
+    {client_conn, init}
+  end
+
+  defp connection_of(sup) do
+    sup
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn {_id, pid, _type, mods} ->
+      if is_pid(pid) and Connection in mods, do: pid
+    end)
+  end
+
+  defp assert_adopted(conn) do
+    wait_until(fn -> :sys.get_state(conn).phase != :booting end)
+  end
+
+  defp wait_until(fun, tries \\ 200) do
+    cond do
+      fun.() -> :ok
+      tries <= 0 -> flunk("condition not met in time")
+      true -> Process.sleep(5) && wait_until(fun, tries - 1)
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/login_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/login_test.exs
@@ -12,7 +12,8 @@ defmodule Raxol.Agent.ClientProtocol.LoginTest do
   alias Raxol.Agent.ClientProtocol.StdioAgent
 
   defp io(lines, read \\ fn _ -> "sk-test" end) do
-    [print_fn: fn msg -> send(self(), {:printed, msg}) end, read_fn: read] ++ lines
+    [print_fn: fn msg -> send(self(), {:printed, msg}) end, read_fn: read] ++
+      lines
   end
 
   defp captured do
@@ -20,6 +21,14 @@ defmodule Raxol.Agent.ClientProtocol.LoginTest do
       {:printed, msg} -> msg
     after
       0 -> nil
+    end
+  end
+
+  defp all_captured(acc \\ []) do
+    receive do
+      {:printed, msg} -> all_captured([msg | acc])
+    after
+      0 -> acc |> Enum.reverse() |> Enum.join("\n")
     end
   end
 
@@ -37,22 +46,134 @@ defmodule Raxol.Agent.ClientProtocol.LoginTest do
     assert captured() =~ "no key entered"
   end
 
-  describe "the advertised auth method" do
+  describe "a provider with a browser sign-in" do
+    # Approving in a browser beats minting a key by hand, so it is what
+    # `raxol login openrouter` does without being asked.
+    test "signs in through the browser by default, never prompting for a key" do
+      flow = fn provider, _opts ->
+        send(self(), {:flow_ran, provider})
+        {:ok, %{provider: provider, validation: :valid}}
+      end
+
+      read = fn _ -> flunk("prompted for a key when a browser flow exists") end
+
+      assert 0 = Login.run(["openrouter"], io([flow_fn: flow], read))
+      assert_received {:flow_ran, :openrouter}
+      assert all_captured() =~ "Connected openrouter"
+    end
+
+    # A remote box has no browser the loopback redirect can reach, so the
+    # typed-key path has to stay reachable.
+    test "--paste bypasses the browser and prompts instead" do
+      flow = fn _provider, _opts ->
+        flunk("opened a browser despite --paste")
+      end
+
+      assert 1 =
+               Login.run(
+                 ["openrouter", "--paste"],
+                 io([flow_fn: flow], fn _ -> "" end)
+               )
+
+      assert captured() =~ "no key entered"
+    end
+
+    test "reports a failed sign-in and points at the fallback" do
+      flow = fn _provider, _opts -> {:error, :timeout} end
+
+      assert 1 = Login.run(["openrouter"], io(flow_fn: flow))
+
+      output = all_captured()
+      assert output =~ "timed out"
+      assert output =~ "--paste"
+    end
+
+    # The flow's own browser launch is not fatal here the way it is over ACP:
+    # a terminal can print the URL, and the loopback port is still bound.
+    test "keeps waiting when the browser will not open, printing the URL" do
+      flow = fn provider, opts ->
+        # The seam returns :ok even though the launch failed, so the flow does
+        # not abandon a port the user can still redeem by hand.
+        assert :ok =
+                 Keyword.fetch!(opts, :browser_fn).(
+                   "https://openrouter.ai/auth?x=1"
+                 )
+
+        {:ok, %{provider: provider, validation: :valid}}
+      end
+
+      no_browser = fn _url -> {:error, {:no_browser_opener, "xdg-open"}} end
+
+      assert 0 =
+               Login.run(["openrouter"], io(flow_fn: flow, open_fn: no_browser))
+
+      assert all_captured() =~ "https://openrouter.ai/auth?x=1"
+    end
+
+    test "says so when the browser did open, and does not print a URL to paste" do
+      flow = fn provider, opts ->
+        :ok =
+          Keyword.fetch!(opts, :browser_fn).("https://openrouter.ai/auth?x=1")
+
+        {:ok, %{provider: provider, validation: :valid}}
+      end
+
+      opened = fn _url -> :ok end
+
+      assert 0 = Login.run(["openrouter"], io(flow_fn: flow, open_fn: opened))
+
+      output = all_captured()
+      assert output =~ "Opened your browser"
+      refute output =~ "Open this URL"
+    end
+  end
+
+  describe "a provider without a browser sign-in" do
+    test "prompts for a key rather than claiming a flow it lacks" do
+      flow = fn _provider, _opts ->
+        flunk("ran a browser flow for anthropic")
+      end
+
+      assert 1 = Login.run(["anthropic"], io([flow_fn: flow], fn _ -> "" end))
+      assert captured() =~ "no key entered"
+    end
+  end
+
+  # Resolved before anything is asked for: there is no reason to prompt for a
+  # secret we already know we cannot store.
+  test "an unknown provider is a usage error, and lists the known ones" do
+    read = fn _ -> flunk("prompted for a key for an unknown provider") end
+
+    assert 64 = Login.run(["nope"], io([], read))
+
+    output = all_captured()
+    assert output =~ "unknown provider: nope"
+    assert output =~ "openrouter"
+  end
+
+  describe "the advertised Terminal Auth method" do
     # The registry's validator infers `terminal` from this _meta key and
-    # defaults anything untyped to `agent` -- which we do not implement. The
-    # marker is what keeps the claim honest.
-    test "is terminal, and carries the args a client relaunches us with" do
-      assert [method] = StdioAgent.auth_methods()
+    # defaults anything untyped to `agent`. The marker is what keeps the claim
+    # honest, so it is asserted rather than assumed.
+    test "carries the args a client relaunches us with" do
+      method = terminal_method()
+
       assert method.id == "terminal"
       assert %{"terminal-auth" => %{"args" => ["login"]}} = method._meta
     end
 
     # If these drift, a client runs a subcommand that does not exist.
     test "names a subcommand the CLI actually dispatches" do
-      [method] = StdioAgent.auth_methods()
-      %{"terminal-auth" => %{"args" => [subcommand]}} = method._meta
+      %{"terminal-auth" => %{"args" => [subcommand]}} = terminal_method()._meta
 
       assert subcommand == "login"
     end
+  end
+
+  defp terminal_method do
+    Enum.find(
+      StdioAgent.auth_methods(),
+      &match?(%{"terminal-auth" => _}, &1._meta)
+    )
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/login_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/login_test.exs
@@ -1,0 +1,58 @@
+defmodule Raxol.Agent.ClientProtocol.LoginTest do
+  @moduledoc """
+  `raxol login` is the command an ACP client relaunches us with for Terminal
+  Auth, so its contract is the exit code and what it does with a typed key --
+  a client reads the former and a user pays for the latter.
+
+  Prompt and print are injected, so nothing here reads a terminal.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.ClientProtocol.Login
+  alias Raxol.Agent.ClientProtocol.StdioAgent
+
+  defp io(lines, read \\ fn _ -> "sk-test" end) do
+    [print_fn: fn msg -> send(self(), {:printed, msg}) end, read_fn: read] ++ lines
+  end
+
+  defp captured do
+    receive do
+      {:printed, msg} -> msg
+    after
+      0 -> nil
+    end
+  end
+
+  test "--help exits 0 and names the command" do
+    assert 0 = Login.run(["--help"], io([]))
+    assert captured() =~ "raxol login"
+  end
+
+  test "an unknown option is a usage error, not a silent success" do
+    assert 64 = Login.run(["--nope"], io([]))
+  end
+
+  test "an empty key is refused rather than stored" do
+    assert 1 = Login.run(["anthropic"], io([], fn _ -> "" end))
+    assert captured() =~ "no key entered"
+  end
+
+  describe "the advertised auth method" do
+    # The registry's validator infers `terminal` from this _meta key and
+    # defaults anything untyped to `agent` -- which we do not implement. The
+    # marker is what keeps the claim honest.
+    test "is terminal, and carries the args a client relaunches us with" do
+      assert [method] = StdioAgent.auth_methods()
+      assert method.id == "terminal"
+      assert %{"terminal-auth" => %{"args" => ["login"]}} = method._meta
+    end
+
+    # If these drift, a client runs a subcommand that does not exist.
+    test "names a subcommand the CLI actually dispatches" do
+      [method] = StdioAgent.auth_methods()
+      %{"terminal-auth" => %{"args" => [subcommand]}} = method._meta
+
+      assert subcommand == "login"
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/parent_watch_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/parent_watch_test.exs
@@ -1,0 +1,84 @@
+defmodule Raxol.Agent.ClientProtocol.ParentWatchTest do
+  @moduledoc """
+  Burrito's launcher forks the BEAM and does not forward signals. Kill the
+  launcher pid alone and the BEAM keeps running with the provider credential:
+  no signal reaches it, and stdin stays open because the client's end of the
+  pipe is untouched. Reproduced against the released binary before this
+  existed.
+
+  The two shutdowns that already worked stay covered by their own paths -- a
+  group signal reaches the BEAM directly, EOF on stdin ends the turn loop --
+  so what is tested here is only the third case: the parent changed.
+
+  The ppid reader is injected, so none of this depends on actually orphaning a
+  process.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.ClientProtocol.ParentWatch
+
+  defp start(ppid_fun, opts \\ []) do
+    test = self()
+
+    ParentWatch.start_link(
+      [
+        name: :"parent_watch_#{System.unique_integer([:positive])}",
+        ppid_fun: ppid_fun,
+        interval_ms: 5,
+        on_orphan: fn -> send(test, :orphaned) end
+      ] ++ opts
+    )
+  end
+
+  test "a stable parent keeps the watcher running and quiet" do
+    {:ok, pid} = start(fn -> {:ok, 42} end)
+
+    refute_receive :orphaned, 60
+    assert Process.alive?(pid)
+  end
+
+  test "a changed parent fires once and stops" do
+    counter = :counters.new(1, [])
+
+    {:ok, pid} =
+      start(fn ->
+        :counters.add(counter, 1, 1)
+        if :counters.get(counter, 1) > 2, do: {:ok, 1}, else: {:ok, 42}
+      end)
+
+    # Monitor before it can fire: the watcher stops promptly after orphaning,
+    # so monitoring afterwards races and reports :noproc.
+    ref = Process.monitor(pid)
+
+    assert_receive :orphaned, 500
+    assert_receive {:DOWN, ^ref, :process, _, :normal}, 500
+  end
+
+  # A transient read failure must not kill a healthy session: readable at boot,
+  # unreadable afterwards.
+  test "an unreadable parent is waited out, not treated as death" do
+    counter = :counters.new(1, [])
+
+    {:ok, pid} =
+      start(fn ->
+        :counters.add(counter, 1, 1)
+        if :counters.get(counter, 1) == 1, do: {:ok, 42}, else: :error
+      end)
+
+    refute_receive :orphaned, 80
+    assert Process.alive?(pid)
+  end
+
+  # A watchdog that cannot see its subject would fire constantly or never;
+  # refusing to start says so instead of pretending to guard.
+  test "it refuses to start when the parent cannot be read at boot" do
+    assert :ignore = start(fn -> :error end)
+  end
+
+  describe "read_ppid/0" do
+    test "returns this process's real parent" do
+      assert {:ok, ppid} = ParentWatch.read_ppid()
+      assert is_integer(ppid) and ppid > 0
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
@@ -202,6 +202,120 @@ defmodule Raxol.Agent.Code.AppLoginTest do
     end
   end
 
+  describe "/login <provider> browser" do
+    defp signin_recording do
+      caller = self()
+
+      fn harness, ref, app ->
+        send(caller, {:signin_started, harness, ref, app})
+        :ok
+      end
+    end
+
+    # The flow waits on a human in a browser. Running it inline would freeze
+    # the TEA loop for as long as they took, so `/login` must return at once
+    # with only a ref to match the result by.
+    test "starts the sign-in off the app process and returns immediately" do
+      model =
+        new_model(:no_provider, signin_runner: signin_recording())
+        |> type("/login openrouter browser")
+
+      assert_received {:signin_started, :openrouter, ref, app}
+      assert app == self()
+      assert model.signin_ref == ref
+      assert model.notice =~ "opening a browser"
+      assert model.status_line =~ "waiting for openrouter"
+      assert model.provider_status == :no_provider
+    end
+
+    test "a completed sign-in connects the provider" do
+      System.put_env("OPENROUTER_API_KEY", "sk-or-live")
+
+      model =
+        new_model(:no_provider,
+          signin_runner: signin_recording(),
+          login_validator: noop_validator()
+        )
+        |> type("/login openrouter browser")
+
+      assert_received {:signin_started, :openrouter, ref, _app}
+
+      {model, []} =
+        App.update(
+          {:command_result,
+           {:browser_signin, ref, :openrouter, {:ok, %{validation: :valid}}}},
+          model
+        )
+
+      assert {:ready, :openrouter, _source} = model.provider_status
+      assert model.signin_ref == nil
+      assert model.notice =~ "browser sign-in"
+    end
+
+    test "a failed sign-in says why and leaves the provider unconnected" do
+      model =
+        new_model(:no_provider, signin_runner: signin_recording())
+        |> type("/login openrouter browser")
+
+      assert_received {:signin_started, :openrouter, ref, _app}
+
+      {model, []} =
+        App.update(
+          {:command_result, {:browser_signin, ref, :openrouter, {:error, :timeout}}},
+          model
+        )
+
+      assert model.notice =~ "timed out"
+      assert model.provider_status == :no_provider
+      assert model.signin_ref == nil
+    end
+
+    # Same ref discipline as the validation ping: a superseded sign-in must not
+    # connect a provider the user has since moved on from.
+    test "a superseded sign-in result is ignored" do
+      model =
+        new_model(:no_provider, signin_runner: signin_recording())
+        |> type("/login openrouter browser")
+
+      assert_received {:signin_started, :openrouter, _ref, _app}
+      current = model.signin_ref
+
+      {model, []} =
+        App.update(
+          {:command_result,
+           {:browser_signin, make_ref(), :openrouter, {:ok, %{validation: :valid}}}},
+          model
+        )
+
+      assert model.provider_status == :no_provider
+      assert model.signin_ref == current
+    end
+
+    # Advertising a browser sign-in for a provider that has none would hang the
+    # user on a flow that never starts.
+    test "a provider without a browser flow is refused, and nothing is spawned" do
+      runner = fn _harness, _ref, _app -> flunk("spawned a flow for anthropic") end
+
+      model =
+        new_model(:no_provider, signin_runner: runner)
+        |> type("/login anthropic browser")
+
+      assert model.notice =~ "no browser sign-in"
+      assert model.signin_ref == nil
+    end
+
+    test "is refused in a jailed session like the rest of /login" do
+      runner = fn _harness, _ref, _app -> flunk("spawned a flow in a jail") end
+
+      model =
+        new_model(:no_provider, jail: true, signin_runner: runner)
+        |> type("/login openrouter browser")
+
+      assert model.notice =~ "disabled in a hosted session"
+      assert model.signin_ref == nil
+    end
+  end
+
   describe "/login validation" do
     test "connecting shows a validating status and stamps a login ref" do
       model =

--- a/packages/raxol_agent/test/raxol/agent/directive_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/directive_test.exs
@@ -69,7 +69,8 @@ defmodule Raxol.Agent.DirectiveTest do
       assert_receive {:command_result, :first, %{turn_id: "turn-orig"}}, 1_000
       assert_receive {:command_result, :second, %{turn_id: "turn-orig"}}, 1_000
 
-      assert_receive {:command_result, {:progress, 50}, %{turn_id: "turn-orig"}},
+      assert_receive {:command_result, {:progress, 50},
+                      %{turn_id: "turn-orig"}},
                      1_000
     end
 
@@ -91,7 +92,8 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("echo hello-from-shell")
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:shell_result, %{exit_status: 0, output: output}},
+      assert_receive {:command_result,
+                      {:shell_result, %{exit_status: 0, output: output}},
                       %{turn_id: nil}},
                      5_000
 
@@ -102,7 +104,8 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("exit 7")
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:shell_result, %{exit_status: 7}}, %{turn_id: nil}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 7}},
+                      %{turn_id: nil}},
                      5_000
     end
 
@@ -110,9 +113,38 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("sleep 5", timeout: 100)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:shell_result, %{exit_status: :timeout}},
+      assert_receive {:command_result,
+                      {:shell_result, %{exit_status: :timeout}},
                       %{turn_id: nil}},
                      2_000
+    end
+
+    # Nothing ever writes to this port, so a command that reads stdin can only
+    # ever wait. Without `:in` the Erlang port hands it a pipe that never
+    # delivers and never closes, and a bare `cat` burns the whole timeout
+    # instead of exiting at once -- so an agent's shell call looked hung.
+    @tag :unix_only
+    test "a command that reads stdin sees EOF instead of burning the timeout" do
+      directive = Directive.shell("cat", timeout: 5_000)
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result,
+                      {:shell_result, %{exit_status: 0, output: ""}},
+                      %{turn_id: nil}},
+                     2_000
+    end
+
+    @tag :unix_only
+    test "a pipeline whose head reads stdin still terminates" do
+      directive = Directive.shell("cat | wc -l", timeout: 5_000)
+      Executor.execute(directive, %{pid: self(), runtime_pid: self()})
+
+      assert_receive {:command_result,
+                      {:shell_result, %{exit_status: 0, output: output}},
+                      %{turn_id: nil}},
+                     2_000
+
+      assert String.trim(output) == "0"
     end
   end
 
@@ -121,7 +153,8 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.send_agent("nobody", :payload)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:send_agent_error, :not_found, "nobody"},
+      assert_receive {:command_result,
+                      {:send_agent_error, :not_found, "nobody"},
                       %{turn_id: nil}},
                      1_000
     end
@@ -143,7 +176,8 @@ defmodule Raxol.Agent.DirectiveTest do
       {:ok, _} =
         start_supervised({Registry, keys: :unique, name: Raxol.Agent.Registry})
 
-      {:ok, _} = Registry.register(Raxol.Agent.Registry, "causation-target", nil)
+      {:ok, _} =
+        Registry.register(Raxol.Agent.Registry, "causation-target", nil)
 
       _ = Raxol.Core.Telemetry.TraceContext.start_trace()
       %{span_id: span_id} = Raxol.Core.Telemetry.TraceContext.current()
@@ -151,7 +185,8 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.send_agent("causation-target", :payload)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:"$gen_cast", {:send_message, :payload, %{causation_id: ^span_id}}},
+      assert_receive {:"$gen_cast",
+                      {:send_message, :payload, %{causation_id: ^span_id}}},
                      1_000
     after
       Raxol.Core.Telemetry.TraceContext.clear()

--- a/packages/raxol_agent/test/raxol/agent/setup_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/setup_test.exs
@@ -105,6 +105,29 @@ defmodule Raxol.Agent.SetupTest do
 
       assert Credentials.fetch(:openai) == :none
     end
+
+    # The browser sign-in raises 1Password's prompt while the user is still
+    # looking at a browser tab, so it needs to widen the `op` budget. Losing
+    # that race discards a key the provider already minted.
+    test "passes :vault and :timeout_ms through to the creator" do
+      caller = self()
+
+      creator = fn _harness, _key, opts ->
+        send(caller, {:creator_opts, opts})
+        {:ok, "op://Private/abc/credential"}
+      end
+
+      Setup.connect_key(:openai, "sk-live",
+        creator: creator,
+        validator: fn _ -> :valid end,
+        vault: "Employee",
+        timeout_ms: 120_000
+      )
+
+      assert_receive {:creator_opts, opts}
+      assert Keyword.fetch!(opts, :vault) == "Employee"
+      assert Keyword.fetch!(opts, :timeout_ms) == 120_000
+    end
   end
 
   describe "remove/1" do

--- a/packages/raxol_cli/lib/raxol/cli.ex
+++ b/packages/raxol_cli/lib/raxol/cli.ex
@@ -191,7 +191,7 @@ defmodule Raxol.CLI do
       code          Full coding-agent TUI: gated tools, plan mode, sessions
       p "prompt"    Headless one-shot: answer to stdout, events to stderr
       acp           Serve over the Agent Client Protocol on stdio
-      login         Connect an LLM provider (ACP Terminal Auth)
+      login         Connect an LLM provider (browser sign-in, or a key)
       playground    Browse the interactive component catalog
       new [name]    Scaffold a new Raxol application
       help          Show this help

--- a/packages/raxol_cli/lib/raxol/cli.ex
+++ b/packages/raxol_cli/lib/raxol/cli.ex
@@ -23,6 +23,9 @@ defmodule Raxol.CLI do
   def main(["-p" | rest]), do: Raxol.Agent.P.run(rest)
   # Serve over ACP on stdio, for editors and agent harnesses that spawn us.
   def main(["acp" | rest]), do: Raxol.Agent.ClientProtocol.Serve.run(rest)
+  # The interactive setup an ACP client relaunches us for (Terminal Auth): the
+  # args here are the ones `initialize` advertises, so the two cannot drift.
+  def main(["login" | rest]), do: Raxol.Agent.ClientProtocol.Login.run(rest)
   def main(["playground" | _rest]), do: run_playground()
   def main(["new" | rest]), do: Raxol.CLI.New.run(rest)
   def main([help]) when help in ~w(help --help -h), do: help()
@@ -188,6 +191,7 @@ defmodule Raxol.CLI do
       code          Full coding-agent TUI: gated tools, plan mode, sessions
       p "prompt"    Headless one-shot: answer to stdout, events to stderr
       acp           Serve over the Agent Client Protocol on stdio
+      login         Connect an LLM provider (ACP Terminal Auth)
       playground    Browse the interactive component catalog
       new [name]    Scaffold a new Raxol application
       help          Show this help

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -215,6 +215,10 @@ defmodule Raxol.Symphony.Workspace do
         {:error, :bash_not_found}
 
       bash_path ->
+        # `:in` closes the child's stdin. Without it the port hands the script a
+        # pipe that never delivers and never closes, so a setup/verify step
+        # that reads stdin blocks until the timeout rather than seeing EOF.
+        # Nothing here writes to the port, so there is no input to lose.
         port =
           Port.open(
             {:spawn_executable, bash_path},
@@ -223,6 +227,7 @@ defmodule Raxol.Symphony.Workspace do
               :binary,
               :stderr_to_stdout,
               :hide,
+              :in,
               {:cd, cwd},
               {:args, ["-lc", script]}
             ]


### PR DESCRIPTION
Two commits. The first added Terminal Auth and stopped the BEAM outliving its launcher. The second adds Agent Auth and fixes three defects the live sign-in exposed.

Together these unblock the ACP registry submission, which needs a release advertising at least one accepted auth method. The published `raxol-cli-v0.2.5` advertises none: I drove that exact binary over stdio and it returns `authMethods: []`. So this wants a `0.2.6` bump behind it.

## Agent Auth

`authenticate` now runs the OAuth flow in-process: bind a loopback port, open a browser, catch the redirect, exchange the code, store the credential. The user never leaves the editor. Four new modules under `Raxol.Agent.Auth` (`Pkce`, `Loopback`, `OpenRouter`, `Flow`), plus the ACP glue in `StdioAgent`.

**Offered for OpenRouter alone, deliberately.** It is the only supported backend whose OAuth is built for third-party local applications: no client registration, no client secret, the loopback callback URL is the whole identity of the app. Anthropic and OpenAI have no public equivalent; their sign-in flows belong to their own first-party clients, and driving one with a borrowed client id is impersonation that breaks the moment they rotate it. The advertised list is derived from `Flow.providers/0`, and a test asserts every `agent-auth` method has a flow behind it, because a method advertised with nothing behind it is a sign-in that hangs.

OpenRouter returns a user-controlled API key rather than a bearer token with an expiry, so it lands through `Setup.connect_key/3` exactly like a pasted one. No new secret storage, no refresh loop, and nothing secret in `providers.json` beyond the `op://` reference.

Wired on three surfaces:

| surface | behaviour |
| --- | --- |
| `raxol login <provider>` | browser by default; `--paste` forces the typed key (what a remote box wants, since the redirect lands on a loopback port) |
| `mix raxol.setup --browser` | opt-in, because the CI twin must never block on a browser |
| TUI `/login <provider> browser` | runs off the app process, so a three-minute wait never touches the TEA loop |

## Three defects it exposed

**Ports hang children that read stdin.** Erlang hands a spawned port a stdin pipe that never delivers and never closes, so any child that reads stdin blocks until its deadline. `op item create` hung forever from the BEAM while the identical command returned in 5s from a shell, which meant `Setup.connect_key/3` could not store a credential at all, pasted or minted. `:in` closes the write half. Three sites never write to their port and now set it: the `op` runner, the agent's shell tool (a bare `cat` burned the whole timeout, now exits in 25ms), and Symphony's setup/verify script runner.

Not a blanket sweep. `raxol_earn`'s signer sidecar uses stdin EOF as its parent-death signal, so closing stdin there would kill it at startup; it keeps its pipe. The Codex session, LSP, ACP stdio transport and clipboard all write to their ports and are correct as they stand.

**Credential validation was silently off for half the providers.** `Setup` assembled backend opts by hand and passed `executor.backend` as `:provider`, bypassing `Selector`, which is the source of truth for wire dialect and base URL. That only looked equivalent because the four original providers are named after their dialect. `openrouter`, `lm_studio`, `llm7` and `longcat` all speak `:openai` at their own base URL, so each named a dialect `Backend.HTTP` has never heard of and validated as `:unsupported`. A dead credential reported as merely "stored".

**OpenRouter's model list is public.** `/api/v1/models` returns 200 with no key at all, so validating there would call a revoked credential valid, which is worse than not validating. `auth_check_path` points it at `/v1/key`, which 401s both bare and with a bogus key.

## Verification

- Registry's own parser reads the payload as types `agent` + `terminal`: *"Found 2 valid auth method(s)"*.
- Live end to end, twice (including after a credential rotation): browser, approval, loopback, exchange, store, exit 0. Real key validates, bogus key returns `{:rejected, 401}`.
- Both stdin fixes RED-proven: remove the option, watch the new tests fail, restore.
- Auth-check routing is tested without a socket.
- `raxol_agent` 2373 passed, `raxol_symphony` 869 passed, clean under `--warnings-as-errors`.

## Manual testing

- [ ] `raxol login openrouter` opens a browser, and approving connects the provider
- [ ] `raxol login openrouter --paste` prompts for a key instead of opening a browser
- [ ] `raxol login anthropic` still prompts for a key (no browser flow claimed)
- [ ] `raxol login nope` exits 64 and lists known providers
- [ ] `mix raxol.setup --provider openrouter --browser` connects; without `--browser` it does not open one
- [ ] `mix raxol.setup --provider openrouter --op op://...` reports the credential validated, and a bad reference exits non-zero
- [ ] TUI `/login openrouter browser` returns immediately and the UI stays responsive while the browser is open
- [ ] TUI `/login anthropic browser` is refused rather than hanging
- [ ] An agent shell call running `cat` returns at once instead of burning its timeout
- [ ] `raxol acp` still serves a normal session, and `initialize` lists both auth methods
- [ ] Symphony still runs a workflow's setup/verify scripts

## Follow-ups, not in this PR

- Bump `raxol_cli` to `0.2.6` and cut the release; then repoint `agent.json` at the new assets and checksums and open the registry PR.
- `Backend.HTTP.check_auth` has no clause for Lumo or the native backends; they stay honestly `:unsupported`.

Closes #731 phase 1.
