### PR TITLE
Bump raxol_cli to 0.2.6

### DIFF
--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.5"
+  @version "0.2.6"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raxol",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"


### PR DESCRIPTION
Ships #835: ACP Agent Auth (browser sign-in over OpenRouter PKCE) alongside the Terminal Auth in the same PR, plus the port stdin hang that left `Setup.connect_key/3` unable to store a credential from the BEAM at all — pasted key and minted key alike, in every shipped version.

Cutting this is what unblocks the ACP registry entry. The registry requires an agent to advertise Agent Auth or Terminal Auth, and the published `0.2.5` advertises neither. Driven over real stdio it returns:

```
authMethods: []          authenticate -> "Method not found"
```

Both auth commits landed after that release was tagged. With `0.2.6` released, `agent.json` gets repointed at the new assets and checksums and the registry PR can go up.

## Manual testing

- [ ] Tag `raxol-cli-v0.2.6` builds all four platform binaries plus `SHA256SUMS`
- [ ] The built binary answers `initialize` with both auth methods over stdio
- [ ] `raxol --version` reports 0.2.6
