### PR TITLE
Clear the credo warnings, fix two real O(n^2) folds

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,7 @@ config :logger, :console,
     :category,
     :performance_impact,
     :suggestions_count,
-    :phase3_context
+    :optimization_context
   ]
 
 # Use Jason for JSON parsing in Phoenix

--- a/lib/raxol/adaptive/layout_recommender.ex
+++ b/lib/raxol/adaptive/layout_recommender.ex
@@ -326,9 +326,7 @@ defmodule Raxol.Adaptive.LayoutRecommender do
           |> then(fn confs -> Enum.sum(confs) / length(confs) end)
 
         reasoning =
-          selected
-          |> Enum.map(& &1.reasoning)
-          |> Enum.join("; ")
+          Enum.map_join(selected, "; ", & &1.reasoning)
 
         {:recommend, changes, avg_confidence, reasoning}
     end
@@ -409,18 +407,21 @@ defmodule Raxol.Adaptive.LayoutRecommender do
     end)
   end
 
+  # Carries the running count rather than calling `length/1` per candidate, and
+  # accumulates in reverse: both the count and the append were O(n) inside the
+  # fold. `conflicts_with_any?/2` only ever asks "does any", so it does not care
+  # which order it sees them in.
   defp select_non_conflicting(candidates, max) do
-    Enum.reduce(candidates, [], fn candidate, selected ->
-      if length(selected) >= max do
-        selected
-      else
-        if conflicts_with_any?(candidate, selected) do
-          selected
-        else
-          selected ++ [candidate]
-        end
+    candidates
+    |> Enum.reduce({[], 0}, fn candidate, {selected, count} = acc ->
+      cond do
+        count >= max -> acc
+        conflicts_with_any?(candidate, selected) -> acc
+        true -> {[candidate | selected], count + 1}
       end
     end)
+    |> elem(0)
+    |> Enum.reverse()
   end
 
   defp conflicts_with_any?(candidate, selected) do

--- a/lib/raxol/effects/border_beam/cell_applier.ex
+++ b/lib/raxol/effects/border_beam/cell_applier.ex
@@ -21,11 +21,11 @@ defmodule Raxol.Effects.BorderBeam.CellApplier do
   alias Raxol.Effects.BorderBeam.Effect
 
   alias Raxol.Effects.BorderBeam.Effects.{
-    Stroke,
-    Pulse,
-    Flames,
+    Clouds,
     Electric,
-    Clouds
+    Flames,
+    Pulse,
+    Stroke
   }
 
   @type cell ::

--- a/lib/raxol/harness/panel_projection.ex
+++ b/lib/raxol/harness/panel_projection.ex
@@ -247,14 +247,19 @@ defmodule Raxol.Harness.PanelProjection do
         }
 
         if Map.has_key?(lanes_map, lane) do
-          {lanes_order, Map.update!(lanes_map, lane, &(&1 ++ [entry]))}
+          {lanes_order, Map.update!(lanes_map, lane, &[entry | &1])}
         else
-          {lanes_order ++ [lane], Map.put(lanes_map, lane, [entry])}
+          {[lane | lanes_order], Map.put(lanes_map, lane, [entry])}
         end
       end)
 
-    Enum.map(lanes_order, fn lane ->
-      %{name: lane, items: Map.fetch!(lanes_map, lane)}
+    # Both accumulators build in reverse and are flipped once here. Appending
+    # per entry copied the lane's whole list each time, and `order` runs to
+    # `@max_entries` (500) on a path that rebuilds per projection.
+    lanes_order
+    |> Enum.reverse()
+    |> Enum.map(fn lane ->
+      %{name: lane, items: lanes_map |> Map.fetch!(lane) |> Enum.reverse()}
     end)
   end
 

--- a/lib/raxol/harness/surface.ex
+++ b/lib/raxol/harness/surface.ex
@@ -618,10 +618,10 @@ defmodule Raxol.Harness.Surface do
   alias Raxol.Harness.Projection
   alias Raxol.Harness.RecencyPolicy
   alias Raxol.Harness.SealFrontier
-  alias Raxol.Terminal.ScrollRegionManager
   alias Raxol.Harness.StatusStrip
   alias Raxol.Harness.Surface.ViewText
   alias Raxol.Harness.UnreadDivider
+  alias Raxol.Terminal.ScrollRegionManager
 
   alias Raxol.UI.Components.Harness.{Block, BlockBody, Composer}
   alias Raxol.UI.Harness.{InputEvent, Keymap, OverlayPanel, OverlayPicker}

--- a/lib/raxol/harness/surface/parity.ex
+++ b/lib/raxol/harness/surface/parity.ex
@@ -403,8 +403,7 @@ defmodule Raxol.Harness.Surface.Parity do
     html
     |> String.replace("><", ">\n<")
     |> String.split("\n")
-    |> Enum.map(&String.trim_trailing/1)
-    |> Enum.join("\n")
+    |> Enum.map_join("\n", &String.trim_trailing/1)
     |> newline_terminated()
   end
 

--- a/lib/raxol/ui/components/markdown_renderer.ex
+++ b/lib/raxol/ui/components/markdown_renderer.ex
@@ -328,8 +328,7 @@ defmodule Raxol.UI.Components.MarkdownRenderer do
     pattern =
       line
       |> String.split(" ")
-      |> Enum.map(&Regex.escape/1)
-      |> Enum.join("\\s+")
+      |> Enum.map_join("\\s+", &Regex.escape/1)
 
     case Regex.run(Regex.compile!(pattern, "u"), rest, return: :index) do
       [{offset, len}] -> {cursor + offset, len}

--- a/lib/raxol/ui/components/modal.ex
+++ b/lib/raxol/ui/components/modal.ex
@@ -39,8 +39,8 @@ defmodule Raxol.UI.Components.Modal do
   # alias Raxol.UI.Components.Input.TextInput # Example, avoid direct component usage in render
 
   # Alias the new modules
-  alias Raxol.UI.Components.Modal.{Core, Events, Rendering, State}
   alias Raxol.UI.Components.AbsoluteLayer
+  alias Raxol.UI.Components.Modal.{Core, Events, Rendering, State}
 
   # Define state struct
   defstruct id: nil,

--- a/lib/raxol/ui/layout/flexbox.ex
+++ b/lib/raxol/ui/layout/flexbox.ex
@@ -32,8 +32,8 @@ defmodule Raxol.UI.Layout.Flexbox do
   @default_order 0
 
   alias Raxol.UI.Layout.Engine
-  alias Raxol.UI.Layout.FlexItem
   alias Raxol.UI.Layout.Flexbox.{Calculator, Positioner, Solver, Wrapper}
+  alias Raxol.UI.Layout.FlexItem
   alias Raxol.UI.Layout.LayoutUtils
   alias Raxol.UI.Layout.MinContent
 

--- a/test/raxol/ui/components/code_block_test.exs
+++ b/test/raxol/ui/components/code_block_test.exs
@@ -68,7 +68,7 @@ defmodule Raxol.UI.Components.CodeBlockTest do
       result = CodeBlock.render(state, %{})
       assert result.type == :column
       assert is_list(result.children)
-      assert length(result.children) >= 1
+      assert result.children != []
     end
 
     test "rendered content preserves the source text" do

--- a/test/raxol/ui/components/harness/markdown_body_test.exs
+++ b/test/raxol/ui/components/harness/markdown_body_test.exs
@@ -281,7 +281,7 @@ defmodule Raxol.UI.Components.Harness.MarkdownBodyTest do
           not String.contains?(l, "─") and not String.contains?(l, "check")
         end)
 
-      assert length(body) >= 1
+      assert body != []
 
       for row <- body, cell <- table_cells(row) do
         refute cell == "",

--- a/test/raxol/ui/components/harness/picker_test.exs
+++ b/test/raxol/ui/components/harness/picker_test.exs
@@ -449,7 +449,7 @@ defmodule Raxol.UI.Components.Harness.PickerTest do
         Picker.render(state, default_context())
 
       assert %{type: :row, children: children} = row
-      assert length(children) >= 1
+      assert children != []
       assert Enum.any?(children, &(&1.content != ""))
     end
   end


### PR DESCRIPTION
Quality-residual pass. **All four credo warnings are gone** (232 → 221 total). Picked by reading each flag rather than driving the number down — roughly half the append-to-a-list flags are a legitimate idiom and are deliberately left alone.

## Dead logger metadata

`config :logger, :console` allow-listed `:phase3_context`, but the field was renamed to `:optimization_context` and the config never followed. Nothing in the tree emits the configured key, and the key the code *does* emit is silently dropped — so every `log_enhanced_error` line has been losing its most useful field. The old name survives only in a vendored dep copy under `packages/raxol_symphony/deps`.

## Two real O(n²) folds

`select_non_conflicting/2` called `length(selected)` per candidate **and** appended with `++` — quadratic twice over. It now carries the count and accumulates in reverse; `conflicts_with_any?/2` only asks "does any", so it does not care about order. That single rewrite clears three separate flags (append, length-in-a-loop, nested `if`).

`build_read_model/3` for `:worktracks` appended per entry to both the lane order and each lane's list, copying the lane's whole list every time, over an `order` that runs to `@max_entries` (500) on a path that rebuilds per projection. Both accumulators now build reversed and flip once.

## The rest

`Enum.map |> Enum.join` → `Enum.map_join` in three modules. Four alias-ordering fixes, including a `Raxol.Terminal.*` alias sitting inside a `Raxol.Harness.*` run. Three test `length(x) >= 1` → `x != []`.

## Deliberately not changed

`item_gaps ++ [0]`, `[0] ++ interior ++ [n]` and `tl(@panels) ++ [hd(@panels)]` are single appends — and the last is a **compile-time module attribute**, so it has no runtime cost at all. Rewriting those to prepend-and-reverse would be slower to read and no faster to run.

The remaining 161 refactoring flags are mostly ABC-complexity and nesting. Those over-flag in this codebase and want judgement per site rather than a sweep, so they are left for a targeted pass.

## Manual testing

- [ ] An enhanced error logs with `optimization_context` present in the formatted line
- [ ] A `:worktracks` panel projection renders lanes and items in the same order as before
- [ ] Adaptive layout recommendations still respect the `max` cap and skip conflicts
