### PR TITLE
Give every published package the same Hex metadata

### DIFF
--- a/packages/raxol_agent/mix.exs
+++ b/packages/raxol_agent/mix.exs
@@ -16,7 +16,8 @@ defmodule RaxolAgent.MixProject do
       package: package(),
       docs: docs(),
       name: "Raxol Agent",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -94,7 +95,9 @@ defmodule RaxolAgent.MixProject do
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,
-        "Docs" => "https://hexdocs.pm/raxol_agent"
+        "Docs" => "https://hexdocs.pm/raxol_agent",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_core/mix.exs
+++ b/packages/raxol_core/mix.exs
@@ -16,7 +16,8 @@ defmodule RaxolCore.MixProject do
       package: package(),
       docs: docs(),
       name: "Raxol Core",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -59,6 +60,8 @@ defmodule RaxolCore.MixProject do
       links: %{
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_core",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_liveview/mix.exs
+++ b/packages/raxol_liveview/mix.exs
@@ -16,7 +16,8 @@ defmodule RaxolLiveView.MixProject do
       package: package(),
       docs: docs(),
       name: "Raxol LiveView",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -73,6 +74,8 @@ defmodule RaxolLiveView.MixProject do
       links: %{
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_liveview",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_mcp/mix.exs
+++ b/packages/raxol_mcp/mix.exs
@@ -16,7 +16,8 @@ defmodule RaxolMcp.MixProject do
       package: package(),
       docs: docs(),
       name: "Raxol MCP",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -63,6 +64,8 @@ defmodule RaxolMcp.MixProject do
       links: %{
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_mcp",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_payments/mix.exs
+++ b/packages/raxol_payments/mix.exs
@@ -24,7 +24,8 @@ defmodule RaxolPayments.MixProject do
       package: package(),
       docs: docs(),
       name: "Raxol Payments",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -76,11 +77,13 @@ defmodule RaxolPayments.MixProject do
   defp package do
     [
       name: "raxol_payments",
-      files: ~w(lib .formatter.exs mix.exs README.md LICENSE.md),
+      files: ~w(lib .formatter.exs mix.exs README.md LICENSE.md CHANGELOG.md),
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,
-        "Docs" => "https://hexdocs.pm/raxol_payments"
+        "Docs" => "https://hexdocs.pm/raxol_payments",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_payments/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_plugin/mix.exs
+++ b/packages/raxol_plugin/mix.exs
@@ -16,7 +16,8 @@ defmodule RaxolPlugin.MixProject do
       package: package(),
       docs: docs(),
       name: "Raxol Plugin",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -62,6 +63,8 @@ defmodule RaxolPlugin.MixProject do
       links: %{
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_plugin",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_sensor/mix.exs
+++ b/packages/raxol_sensor/mix.exs
@@ -15,7 +15,8 @@ defmodule RaxolSensor.MixProject do
       package: package(),
       docs: docs(),
       name: "Raxol Sensor",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -52,7 +53,9 @@ defmodule RaxolSensor.MixProject do
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,
-        "Docs" => "https://hexdocs.pm/raxol_sensor"
+        "Docs" => "https://hexdocs.pm/raxol_sensor",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_speech/mix.exs
+++ b/packages/raxol_speech/mix.exs
@@ -16,7 +16,8 @@ defmodule RaxolSpeech.MixProject do
       package: package(),
       docs: docs(),
       name: "RaxolSpeech",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -75,7 +76,8 @@ defmodule RaxolSpeech.MixProject do
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_speech",
         "Changelog" =>
-          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_speech/CHANGELOG.md"
+          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_speech/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]

--- a/packages/raxol_telegram/mix.exs
+++ b/packages/raxol_telegram/mix.exs
@@ -19,7 +19,8 @@ defmodule RaxolTelegram.MixProject do
       package: package(),
       docs: docs(),
       name: "RaxolTelegram",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -100,7 +101,8 @@ defmodule RaxolTelegram.MixProject do
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_telegram",
         "Changelog" =>
-          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_telegram/CHANGELOG.md"
+          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_telegram/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"],
       files: ~w(lib .formatter.exs mix.exs README.md LICENSE.md CHANGELOG.md)

--- a/packages/raxol_terminal/mix.exs
+++ b/packages/raxol_terminal/mix.exs
@@ -83,7 +83,9 @@ defmodule RaxolTerminal.MixProject do
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,
-        "Docs" => "https://hexdocs.pm/raxol_terminal"
+        "Docs" => "https://hexdocs.pm/raxol_terminal",
+        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]
@@ -93,6 +95,7 @@ defmodule RaxolTerminal.MixProject do
     [
       main: "readme",
       source_url: @source_url,
+      homepage_url: "https://raxol.io",
       source_ref: "v#{@version}",
       extras: ["README.md"]
     ]

--- a/packages/raxol_watch/mix.exs
+++ b/packages/raxol_watch/mix.exs
@@ -19,7 +19,8 @@ defmodule RaxolWatch.MixProject do
       package: package(),
       docs: docs(),
       name: "RaxolWatch",
-      source_url: @source_url
+      source_url: @source_url,
+      homepage_url: "https://raxol.io"
     ]
   end
 
@@ -74,7 +75,8 @@ defmodule RaxolWatch.MixProject do
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_watch",
         "Changelog" =>
-          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_watch/CHANGELOG.md"
+          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_watch/CHANGELOG.md",
+        "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]
     ]


### PR DESCRIPTION
Half the directories in the blitz crawl Hex, so a package page is the version of raxol a lot of people see first. The umbrella package carried GitHub + Documentation + Changelog + `homepage_url`; the eleven published sub-packages carried GitHub + Docs and nothing else.

All eleven now match. Descriptions were already specific audience one-liners and are untouched.

## Changelog links point per package, not blindly at the root

This was the part worth care rather than a sweep:

| packages | changelog link |
| --- | --- |
| `raxol_speech`, `raxol_telegram`, `raxol_watch` | already linked their **own** CHANGELOG — left alone |
| `raxol_payments` | has one, was pointed at it, and now ships it in `files` so HexDocs renders a Changelog tab |
| the other seven | have no changelog of their own, so they point at the umbrella's |

## Verified

`mix hex.build` per package, plus reading the resolved `Mix.Project.config` rather than trusting the source:

```
links: %{
  "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/CHANGELOG.md",
  "Docs" => "https://hexdocs.pm/raxol_core",
  "GitHub" => "https://github.com/DROOdotFOO/raxol",
  "Website" => "https://raxol.io"
}
homepage_url: "https://raxol.io"
```

Note this only reaches hex.pm on the **next publish** of each package — nothing changes on the existing releases.

## Manual testing

- [ ] `mix hex.build` succeeds for each published package
- [ ] A published package page shows four links and the website
- [ ] `raxol_payments` docs show a Changelog tab
