### PR TITLE
Keep the MCP stdio stream clean and exit on client EOF

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["DROOdotFOO"]
+}

--- a/packages/raxol_mcp/lib/mix/tasks/mcp.server.ex
+++ b/packages/raxol_mcp/lib/mix/tasks/mcp.server.ex
@@ -26,11 +26,16 @@ defmodule Mix.Tasks.Mcp.Server do
 
   use Mix.Task
 
-
   @impl true
   def run(_args) do
-    # Configure logger to stderr so it doesn't corrupt the JSON-RPC stream
-    :logger.update_handler_config(:default, :config, %{type: :standard_error})
+    # The client owns stdout: only JSON-RPC frames may appear there. Keep the
+    # real stdio device for the transport, then point this process's group
+    # leader at stderr so that everything writing to `:stdio` -- Mix's `==> app`
+    # / `Compiling N files` banners and the `make` output from elixir_make --
+    # lands on stderr instead of mid-stream.
+    stdio = Process.group_leader()
+    divert_group_leader_to_stderr()
+    divert_logger_to_stderr()
 
     # Use lightweight MCP startup mode -- skip terminal driver, cache, Phoenix, etc.
     Application.put_env(:raxol, :skip_endpoint, true)
@@ -39,14 +44,54 @@ defmodule Mix.Tasks.Mcp.Server do
     # Start the application (includes MCP.Supervisor, Headless, etc.)
     Mix.Task.run("app.start")
 
+    # `app.start` reloads config, which can restart :logger and reinstall the
+    # default handler, so pin it to stderr again once the app is up.
+    divert_logger_to_stderr()
+
     # Start stdio transport connected to the MCP server
-    {:ok, _pid} =
+    {:ok, transport} =
       Raxol.MCP.Transport.Stdio.start_link(
         server: Raxol.MCP.Server,
-        name: Raxol.MCP.Transport.Stdio
+        name: Raxol.MCP.Transport.Stdio,
+        io_device: stdio,
+        output_device: stdio
       )
 
-    # Block forever -- the transport handles I/O in its reader process
-    Process.sleep(:infinity)
+    # The transport stops when the client closes stdin. Exit with it rather
+    # than leaving an orphaned VM holding the session's resources.
+    await_exit(transport)
+  end
+
+  # Both halves matter: the application env is what a :logger restart during
+  # `app.start` reads back, and the handler update is what takes effect for the
+  # already-running handler.
+  defp divert_logger_to_stderr do
+    handler = Application.get_env(:logger, :default_handler, [])
+    config = Keyword.get(handler, :config, %{})
+
+    Application.put_env(
+      :logger,
+      :default_handler,
+      Keyword.put(handler, :config, Map.put(config, :type, :standard_error)),
+      persistent: true
+    )
+
+    _ = :logger.update_handler_config(:default, :config, %{type: :standard_error})
+    :ok
+  end
+
+  defp divert_group_leader_to_stderr do
+    case Process.whereis(:standard_error) do
+      nil -> :ok
+      pid -> Process.group_leader(self(), pid)
+    end
+  end
+
+  defp await_exit(transport) do
+    ref = Process.monitor(transport)
+
+    receive do
+      {:DOWN, ^ref, :process, ^transport, _reason} -> :ok
+    end
   end
 end


### PR DESCRIPTION
Found while setting up the [glama.ai](https://glama.ai/mcp/servers/DROOdotFOO/raxol) listing, which runs `mix mcp.server` behind `mcp-proxy` in a Debian container. Two defects showed up that also affect every local client, Claude Code included.

## Boot logs were landing on stdout

The client owns stdout: only JSON-RPC frames may appear there. The existing redirect

```elixir
:logger.update_handler_config(:default, :config, %{type: :standard_error})
```

ran *before* `Mix.Task.run("app.start")`, and `app.start` reloads config, restarts `:logger`, and reinstalls the default stdout handler -- silently undoing it. Every boot log went into the JSON-RPC stream:

```
01:18:04.858 [error] `inotify-tools` is needed to run `file_system` ...
01:18:05.079 [info] Starting in mcp mode
01:18:05.159 [info] Started in 91017us (mcp mode)
{"id":1,"result":{"protocolVersion":"2024-11-05", ...
```

Fixed by setting `:logger`'s application env too (that is what a logger restart reads back) and reapplying the handler update once the app is up. The group leader is also pointed at stderr and the real stdio device handed to the transport explicitly, so Mix's `==> app` banners and `elixir_make`'s `make` output cannot corrupt the stream either.

## The task never exited when the client closed stdin

`Raxol.MCP.Transport.Stdio` stops correctly on EOF, but the task then sat in `Process.sleep(:infinity)`. A `:normal` exit does not propagate across a link, so the VM stayed up holding the session's resources until something killed it -- in a container, until SIGTERM. It now monitors the transport and exits with it.

## Also

`glama.json` declares the maintainer per [Glama's schema](https://glama.ai/mcp/schemas/server.json).

## Manual testing

- [x] `cd packages/raxol_mcp && MIX_ENV=test mix test` -- 350 passed (31 properties, 319 tests)
- [x] `mix format --check-formatted` and `MIX_ENV=test mix compile --warnings-as-errors` clean
- [x] Built the Glama container (`debian:trixie-slim`, Elixir 1.18.3 / OTP 27.3 from apt) and drove `mix mcp.server` over a stdio pipe: stdout drops from 17 lines to 3, all 14 removed lines being logger output. The 3 that remain (`==> raxol_mcp`, `==> raxol_terminal`, `make: Nothing to be done for 'all'.`) are Mix's path-dep check, emitted before the task module can be loaded, so they are out of reach from inside `run/1`.
- [x] Same container, stdin closed: exits 0 immediately instead of hanging until SIGTERM.
- [x] End to end through `mcp-proxy` on `/mcp`: `initialize` -> `notifications/initialized` -> `tools/list` returns 11 tools -> `tools/call raxol_list` returns `"No active sessions."`
