### PR TITLE
Fix seed-dependent NIF loading test on master

### DIFF
--- a/packages/raxol_terminal/test/termbox2_nif/termbox2_loading_test.exs
+++ b/packages/raxol_terminal/test/termbox2_nif/termbox2_loading_test.exs
@@ -18,6 +18,11 @@ defmodule Termbox2LoadingTest do
 
     @tag :docker
     test "NIF functions are defined" do
+      # `function_exported?/3` reports false for a module that is simply not
+      # loaded yet, so load it here rather than depending on the sibling test
+      # above having been scheduled first -- ExUnit shuffles per seed.
+      Code.ensure_loaded!(:termbox2_nif)
+
       # Check that all expected functions exist
       expected_functions = [
         {:tb_init, 0},


### PR DESCRIPTION
Fixes the `nif (ARM64)` failure on master ([run 31348315095](https://github.com/DROOdotFOO/raxol/actions/runs/31348315095/job/93334327050)):

```
1) test NIF loading NIF functions are defined (Termbox2LoadingTest)
   Function tb_init/0 not exported
```

## What is actually wrong

`function_exported?/3` reports `false` for a module that is simply **not loaded yet** -- it does not load it. `Termbox2LoadingTest` has two tests in the same describe block:

- `"termbox2_nif module is loaded"` calls `Code.ensure_loaded?/1`, which loads the module
- `"NIF functions are defined"` calls `function_exported?/3`, which does not

The second only passed because the first happened to run before it. ExUnit shuffles per seed, so this was a coin flip from the day it was written. `--trace` on a failing seed shows it plainly -- the loading test runs last, and its 15.2ms is the module load the exporting test needed:

```
* test NIF loading NIF functions are defined [L#20]      (0.02ms)  FAILED
* test NIF loading termbox2_nif module is loaded [L#14]  (15.2ms)  ok
```

So this is not a regression from #838. That PR only added Changelog/Website links to `packages/raxol_terminal/mix.exs`, which matched the workflow's `packages/raxol_terminal/**` path filter and triggered the job. Every prior run of `rate-selfhosted.yml` is `cancelled` -- this was the first one to actually execute on the self-hosted runners, which is why a latent order dependency surfaced now.

`test/raxol/terminal/driver_io_terminal_test.exs:13` already pairs the two calls correctly; this was the only place that did not.

## Manual testing

- [x] Reproduced without the fix: seeds 1, 2, 7 fail with `Function tb_init/0 not exported`; seeds 3, 11 pass
- [x] With the fix, 10 seeds (1, 2, 3, 7, 11, 23, 42, 101, 777, 2026) all pass 9/9
- [x] The job's full file set (`termbox_model_test`, `termbox2_loading_test`, `termbox2_nif_test`, `oracle_equivalence_test`) with `--include docker` and `SKIP_TERMBOX2_TESTS` unset: 22 passed, 2 skipped across seeds 1, 2, 42 -- matching the 22/2 the CI job reports
- [x] `mix format --check-formatted`
