### PR TITLE
Let the packaged TUI find its terminal

### DIFF
--- a/assets/tapes/README.md
+++ b/assets/tapes/README.md
@@ -1,0 +1,53 @@
+# Screenshot recording
+
+Fixtures and notes for capturing the MCP-client screenshots used in directory
+listings (glama.ai, awesome-mcp-clients) and the docs.
+
+`workspace/` is the demo working directory. Its `.mcp.json` declares two
+tokenless servers (filesystem, memory), so nothing secret can appear on camera
+and the `/mcp` panel shows real third-party connections rather than raxol
+talking to itself.
+
+## Recording
+
+Drive the TUI by hand and record it:
+
+```bash
+npx -y @modelcontextprotocol/server-filesystem --help   # warm the npx cache
+cd assets/tapes/workspace
+asciinema rec --window-size 100x30 -c "raxol code" /tmp/mcp.cast
+```
+
+Then, in the session: wait for the servers to connect, run `/mcp`, ask for
+something that calls an MCP tool, answer the approval prompt with `a`, and quit.
+
+Render stills from the cast:
+
+```bash
+agg --font-size 20 --theme dracula /tmp/mcp.cast /tmp/mcp.gif
+magick /tmp/mcp.gif -coalesce -delete 0--2 shot.png   # last frame
+magick '/tmp/mcp.gif[120]' shot.png                    # a specific frame
+```
+
+## Why this is driven by hand
+
+Three automated drivers were tried and none can type into this TUI:
+
+- **VHS / ttyd** renders the TUI but never puts the terminal into raw mode, so
+  keystrokes echo to the shell instead of reaching the app.
+- **`asciinema rec --headless`** forwards stdin but leaves the pty at 80x24
+  regardless of `--window-size`, and the app renders against the wrong size.
+- **A hand-rolled `pty.fork` harness** with `TIOCSWINSZ` set correctly still
+  leaves the model's `input` field empty after writing bytes to the master fd.
+
+A human at a real terminal is unaffected; only unattended drivers are. If you
+automate this later, assert on something that can only come from the app --
+the typed token appearing in the model's `input` field, say. Asserting on
+`"filesystem"` or `●` appearing anywhere in the stream false-passes, because
+both also occur in the model-state dump the app prints.
+
+Also note the packaged binary is built with `skip_nifs: true`
+(`packages/raxol_cli/mix.exs`), so it has no termbox2 NIF and renders through a
+fallback path. Recordings of `burrito_out/raxol_cli_macos` show misaligned box
+borders and replacement glyphs; a source run does not. Record from a source
+build, or fix the packaging first.

--- a/assets/tapes/workspace/.mcp.json
+++ b/assets/tapes/workspace/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    },
+    "memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    }
+  }
+}

--- a/assets/tapes/workspace/README.md
+++ b/assets/tapes/workspace/README.md
@@ -1,0 +1,7 @@
+# Demo workspace
+
+A throwaway project used only as the working directory when recording the
+MCP-client screenshots in `assets/tapes/`. Nothing here is part of Raxol.
+
+The sibling `.mcp.json` points the agent at two tokenless MCP servers, so the
+recorded `/mcp` panel shows real connections without a credential on camera.

--- a/assets/tapes/workspace/counter.exs
+++ b/assets/tapes/workspace/counter.exs
@@ -1,0 +1,17 @@
+defmodule Counter do
+  @moduledoc "The smallest TEA app: a number and two keys."
+  use Raxol.UI, framework: :react
+
+  def init(_), do: %{count: 0}
+
+  def update(:increment, model), do: %{model | count: model.count + 1}
+  def update(:decrement, model), do: %{model | count: model.count - 1}
+  def update(_, model), do: model
+
+  def view(model) do
+    column do
+      text("count: #{model.count}", fg: :cyan, style: [:bold])
+      text("+/- to change, q to quit", fg: :white)
+    end
+  end
+end

--- a/assets/tapes/workspace/notes.md
+++ b/assets/tapes/workspace/notes.md
@@ -1,0 +1,4 @@
+# Notes
+
+- The counter needs a reset key.
+- Check whether the status line truncates on narrow terminals.

--- a/packages/raxol_cli/lib/raxol/cli.ex
+++ b/packages/raxol_cli/lib/raxol/cli.ex
@@ -168,11 +168,47 @@ defmodule Raxol.CLI do
     end
   end
 
-  defp interactive? do
+  # Is there a terminal for a full-screen TUI to draw on?
+  #
+  # Two different questions, because the packaged binary and a source run do not
+  # present stdio the same way.
+  #
+  # Under Burrito the answer CANNOT come from the group leader. Its launcher
+  # spawns the BEAM with stdout on a pipe so it can notice a downstream consumer
+  # going away (`app cmd | head -5`), which makes `:io.getopts()` report a
+  # non-terminal on every run, tty or not. Asking it there vetoes `raxol code`
+  # and `raxol playground` unconditionally -- the packaged binary could never
+  # open either one. Stdin is left inherited, so that is where the real answer
+  # lives, and it is the honest one: termbox2 opens /dev/tty directly
+  # (`tb_init/0` is `tb_init_file("/dev/tty")`), so the TUI never draws through
+  # the piped stdout anyway.
+  #
+  # Everywhere else keep reading the group leader. It is what `with_io/1` swaps,
+  # which is what lets the veto be tested without a tty deciding the outcome.
+  defp interactive?, do: interactive?(burrito?())
+
+  @doc false
+  # Split on the packaging so a test can pin the branch: the Burrito arm's
+  # answer comes from the real stdin of the OS process, which a unit test
+  # cannot pose either way.
+  def interactive?(true), do: tty_stdin?()
+  def interactive?(false), do: terminal_group_leader?()
+
+  defp burrito?, do: System.get_env("__BURRITO") == "1"
+
+  defp terminal_group_leader? do
     case :io.getopts() do
       opts when is_list(opts) -> Keyword.get(opts, :terminal, false) != false
       _ -> false
     end
+  rescue
+    _ -> false
+  end
+
+  defp tty_stdin? do
+    Code.ensure_loaded?(:prim_tty) and
+      function_exported?(:prim_tty, :isatty, 1) and
+      :prim_tty.isatty(:stdin) == true
   rescue
     _ -> false
   end

--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -39,10 +39,97 @@ defmodule RaxolCli.MixProject do
     [
       raxol_cli: [
         include_executables_for: [:unix, :windows],
-        steps: [:assemble, &Burrito.wrap/1],
+        steps: [:assemble, &patch_burrito_launcher/1, &Burrito.wrap/1],
         burrito: [targets: burrito_targets()]
       ]
     ]
+  end
+
+  # Burrito 1.6.0 spawns the BEAM with stdout on a pipe so its launcher can
+  # notice a downstream consumer going away (`raxol code | head -5`). That costs
+  # the child its terminal, and two separate gates then read as "no terminal":
+  # `:io.getopts()` (which vetoed `raxol code` and `raxol playground` outright)
+  # and `:prim_tty.isatty(:stdout)` behind
+  # `Raxol.Terminal.TerminalUtils.has_terminal_device?/0` (which made the driver
+  # skip raw mode and the alternate screen, so the TUI drew but ignored every
+  # keystroke). Inheriting a stdout that is already a tty loses nothing: the
+  # EPIPE this guards against needs a downstream consumer holding the far end,
+  # which is exactly the not-a-tty case.
+  #
+  # Upstream exposes no option for this, so patch the dependency on the way to
+  # wrapping it. `mix deps.get` restores the original and this runs again, which
+  # is what makes the fix survive a clean checkout. raxol carries its own
+  # defence for the same failure (see `has_terminal_device?/0`); this half fixes
+  # the cause rather than tolerating it. Remove once burrito ships the fix.
+  @burrito_patches [
+    {"    if (builtin.os.tag != .windows) {\n" <>
+       "        child = try std.process.spawn(io, .{\n" <>
+       "            .argv = final_args,\n" <>
+       "            .environ_map = env_map,\n" <>
+       "            .stdout = .pipe,\n" <>
+       "        });",
+     "    const stdout_is_tty = Io.File.stdout().isTty(io) catch false;\n\n" <>
+       "    if (builtin.os.tag != .windows and !stdout_is_tty) {\n" <>
+       "        child = try std.process.spawn(io, .{\n" <>
+       "            .argv = final_args,\n" <>
+       "            .environ_map = env_map,\n" <>
+       "            .stdout = .pipe,\n" <>
+       "        });"},
+    # Keyed on the copy thread rather than the OS: with an inherited tty there
+    # is no thread to join, and `copy_thread.?` would panic on that path.
+    {"    const term = if (builtin.os.tag != .windows)\n",
+     "    const term = if (copy_thread != null)\n"}
+  ]
+
+  @doc false
+  # Public only so the patch can be exercised without a full release build.
+  def patch_burrito_launcher(release) do
+    path =
+      Path.join([
+        Mix.Project.deps_path(),
+        "burrito",
+        "src",
+        "erlang_launcher.zig"
+      ])
+
+    original = File.read!(path)
+
+    patched =
+      Enum.reduce(
+        @burrito_patches,
+        original,
+        &apply_burrito_patch(&1, &2, path)
+      )
+
+    if patched != original, do: File.write!(path, patched)
+
+    release
+  end
+
+  defp apply_burrito_patch({from, to}, source, path) do
+    cond do
+      String.contains?(source, to) ->
+        source
+
+      String.contains?(source, from) ->
+        String.replace(source, from, to, global: false)
+
+      true ->
+        Mix.raise(burrito_patch_error(path))
+    end
+  end
+
+  # Fail the build rather than ship a binary whose TUI cannot be typed into.
+  defp burrito_patch_error(path) do
+    """
+    Could not apply the burrito stdout fix to #{path}.
+
+    Neither the original source nor the patched form was found, so burrito's
+    launcher has changed and this patch no longer describes it. Re-derive it
+    against the new source before releasing: without it the packaged `raxol
+    code` and `raxol playground` refuse to start, and lifting only that veto
+    leaves a TUI that renders and ignores the keyboard.
+    """
   end
 
   # `skip_nifs: true`: each target is built natively (CI builds the arch it runs

--- a/packages/raxol_cli/test/raxol/cli_test.exs
+++ b/packages/raxol_cli/test/raxol/cli_test.exs
@@ -96,6 +96,20 @@ defmodule Raxol.CLITest do
       assert stderr =~ "interactive terminal"
     end
 
+    test "the Burrito arm ignores the group leader" do
+      # Burrito's launcher puts the BEAM's stdout on a pipe, so the group leader
+      # reports a non-terminal on every packaged run. Reading it there vetoed
+      # `raxol code` and `raxol playground` unconditionally -- the packaged
+      # binary could not open either. Under a StringIO group leader, which is
+      # the strongest "no terminal" signal a test can produce, the non-Burrito
+      # arm must still veto while the Burrito arm must not consult it at all.
+      {{burrito, plain}, _io} =
+        with_io(fn -> {CLI.interactive?(true), CLI.interactive?(false)} end)
+
+      refute plain
+      assert burrito == (:prim_tty.isatty(:stdin) == true)
+    end
+
     test "code --ssh is NOT vetoed for a missing tty (serving needs none)" do
       # Without --authorized-keys the launcher rejects --ssh as a usage error
       # (64), which proves the tty veto (exit 1, "interactive terminal") did

--- a/packages/raxol_terminal/lib/raxol/terminal/terminal_utils.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/terminal_utils.ex
@@ -7,6 +7,7 @@ defmodule Raxol.Terminal.TerminalUtils do
   @default_width Raxol.Core.Defaults.terminal_width()
   @default_height Raxol.Core.Defaults.terminal_height()
 
+  @ctty_key {__MODULE__, :controlling_terminal?}
 
   # Check if termbox2_nif is available at compile time
   @termbox2_available Code.ensure_loaded?(:termbox2_nif)
@@ -137,7 +138,9 @@ defmodule Raxol.Terminal.TerminalUtils do
              {:ok, width, height}
            else
              {:error, reason} ->
-               Raxol.Core.Runtime.Log.debug("io.columns/rows error: #{inspect(reason)}")
+               Raxol.Core.Runtime.Log.debug(
+                 "io.columns/rows error: #{inspect(reason)}"
+               )
 
                {:error, reason}
 
@@ -153,7 +156,9 @@ defmodule Raxol.Terminal.TerminalUtils do
         result
 
       {:error, reason} ->
-        Raxol.Core.Runtime.Log.debug("Error in detect_with_io: #{inspect(reason)}")
+        Raxol.Core.Runtime.Log.debug(
+          "Error in detect_with_io: #{inspect(reason)}"
+        )
 
         {:error, reason}
     end
@@ -207,7 +212,9 @@ defmodule Raxol.Terminal.TerminalUtils do
                end
 
              {output, code} ->
-               Raxol.Core.Runtime.Log.debug("stty exited with code #{code}: #{inspect(output)}")
+               Raxol.Core.Runtime.Log.debug(
+                 "stty exited with code #{code}: #{inspect(output)}"
+               )
 
                {:error, {:exit_code, code}}
            end
@@ -216,7 +223,9 @@ defmodule Raxol.Terminal.TerminalUtils do
         result
 
       {:error, reason} ->
-        Raxol.Core.Runtime.Log.debug("Error in detect_with_stty: #{inspect(reason)}")
+        Raxol.Core.Runtime.Log.debug(
+          "Error in detect_with_stty: #{inspect(reason)}"
+        )
 
         {:error, reason}
     end
@@ -235,16 +244,65 @@ defmodule Raxol.Terminal.TerminalUtils do
   end
 
   @doc """
-  Checks if stdout is connected to a real terminal device.
+  Checks whether a real terminal is available to drive.
 
   Unlike `real_tty?/0` which uses Erlang's IO system (fails in -noshell mode),
   this checks at the OS level via prim_tty NIF. Use this for terminal
   initialization that needs to work with `mix run` (which sets -noshell).
+
+  Stdout answers this for an ordinary run. It is not the whole question,
+  though, because stdout being a terminal and a terminal being *available* come
+  apart whenever something interposes on the stream. Burrito's launcher does
+  exactly that: it spawns the BEAM with stdout on a pipe so it can notice a
+  downstream consumer going away, and a packaged `raxol code` then found
+  `isatty(:stdout)` false on every run and skipped terminal setup entirely --
+  no raw mode, no alternate screen, so the TUI drew and ignored the keyboard.
+
+  Nothing in the driver actually needs stdout to be the terminal. Raw mode goes
+  through `/dev/tty` (`Raxol.Terminal.Driver.Stty`), and the ANSI it writes
+  reaches the terminal through whatever is relaying stdout. So fall back to
+  asking whether this process still owns a controlling terminal.
   """
   @spec has_terminal_device?() :: boolean()
   def has_terminal_device? do
     # prim_tty:isatty checks the actual fd at the OS level (C isatty()),
     # which works regardless of Erlang's -noshell flag.
-    :prim_tty.isatty(:stdout) == true
+    :prim_tty.isatty(:stdout) == true or controlling_terminal?()
+  end
+
+  @doc """
+  Whether this process still has a controlling terminal, cached per VM.
+
+  Cached because `has_terminal_device?/0` is called per cursor move, and this
+  branch opens a file. The answer cannot change during a run: a process does
+  not acquire or lose its controlling terminal mid-flight.
+  """
+  @spec controlling_terminal?() :: boolean()
+  def controlling_terminal? do
+    case :persistent_term.get(@ctty_key, :unknown) do
+      :unknown ->
+        result = probe_controlling_terminal()
+        :persistent_term.put(@ctty_key, result)
+        result
+
+      cached ->
+        cached
+    end
+  end
+
+  # Opening /dev/tty is the question itself: it succeeds only for a process
+  # with a controlling terminal, and fails on Windows and under a daemon or a
+  # CI runner, which is the answer those cases want. Requiring stdin to be a
+  # tty as well keeps `raxol code < script.txt` reading as non-interactive.
+  defp probe_controlling_terminal do
+    with true <- :prim_tty.isatty(:stdin) == true,
+         {:ok, device} <- File.open("/dev/tty", [:read]) do
+      File.close(device)
+      true
+    else
+      _ -> false
+    end
+  rescue
+    _ -> false
   end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/terminal_utils_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/terminal_utils_test.exs
@@ -53,4 +53,27 @@ defmodule Raxol.Terminal.TerminalUtilsTest do
       assert bounds.height > 0
     end
   end
+
+  describe "has_terminal_device?/0" do
+    test "a terminal on either stdout or the controlling terminal counts" do
+      # Burrito's launcher puts the BEAM's stdout on a pipe, so asking stdout
+      # alone reported "no terminal" on every packaged run and the driver
+      # skipped raw mode and the alternate screen. The driver reaches the
+      # terminal through /dev/tty regardless, so either answer is sufficient.
+      stdout? = :prim_tty.isatty(:stdout) == true
+
+      assert TerminalUtils.has_terminal_device?() ==
+               (stdout? or TerminalUtils.controlling_terminal?())
+    end
+
+    test "the controlling-terminal answer is stable across calls" do
+      # It is cached in :persistent_term because has_terminal_device?/0 runs
+      # per cursor move and this branch opens a file. Reading it twice must
+      # not depend on which call populated the cache.
+      first = TerminalUtils.controlling_terminal?()
+
+      assert is_boolean(first)
+      assert TerminalUtils.controlling_terminal?() == first
+    end
+  end
 end


### PR DESCRIPTION
`raxol code` and `raxol playground` cannot open from the packaged binary, and
lifting only that veto leaves a TUI that draws and ignores the keyboard. Both
symptoms come from one cause, and this fixes the cause and tolerates it.

## What is wrong

Burrito's launcher spawns the BEAM with `.stdout = .pipe` on Unix, so it can
notice a downstream consumer going away (`raxol code | head -5`). That costs the
child its terminal, and two independent gates then answer "no terminal" on every
packaged run:

| Gate | Consequence |
| --- | --- |
| `:io.getopts()` in `Raxol.CLI.interactive?/0` | vetoed `raxol code` and `raxol playground` outright |
| `:prim_tty.isatty(:stdout)` in `TerminalUtils.has_terminal_device?/0` | driver skipped `Stty.raw!()` and the alternate screen, so the TUI rendered and ignored every keystroke |

Reproduced with plain Elixir, no raxol in the loop:

```
tty          -> terminal=true   reinit=:ok                got={:data,"abc"}
piped-stdout -> terminal=false  reinit={:error,:enotsup}  got=:timeout
```

OTP refuses raw mode when stdout is a pipe.

## What this does

**Fixes the cause.** A release step patches the launcher to inherit a stdout
that is already a tty. Nothing is lost: the EPIPE this guards against needs a
downstream consumer holding the far end, which is exactly the not-a-tty case.
Upstream 1.6.0 exposes no option and its plugin hook runs before the spawn, so
patching is the only route that avoids a fork. `mix deps.get` restores the
original and the step runs again, which is what makes it survive a clean
checkout. If burrito's source moves, the step calls `Mix.raise` and fails the
build rather than shipping a mute binary.

**And tolerates it.** Neither gate actually needs stdout to be the terminal:
raw mode goes through `/dev/tty` and the ANSI reaches the terminal through
whatever relays stdout. Both now accept a controlling terminal.
`controlling_terminal?/0` is cached in `:persistent_term` because
`has_terminal_device?/0` runs per cursor move and the fallback opens a file.

Either half alone is a trap, which is why both are here. The patch step can be
dropped the day burrito ships the fix; the raxol-side gates are correct
regardless and also cover `raxol code > log.txt`.

## Verification

- Patch step exercised against a pristine `burrito 1.6.0` fetched from Hex:
  applies both hunks, byte-identical to a hand-patch that compiled green, and a
  second run is a no-op.
- Rebuilt `raxol_cli_macos` with the patch: under a real pty it no longer
  refuses and both `.mcp.json` servers connect; with stdout redirected the piped
  path still works.
- `raxol_cli` 15 tests, `raxol_terminal` `terminal_utils` 4 tests, formatted.

The `interactive?/0` test pins both arms, because the Burrito arm's answer comes
from the real stdin of the OS process and a unit test cannot pose it either way.

## Also included

`assets/tapes/` — the demo workspace fixture used to record the MCP-client
screenshots for directory listings, plus notes on which automated drivers cannot
type into this TUI (VHS/ttyd, `asciinema --headless`, a hand-rolled `pty.fork`
harness) and how to avoid a false-passing assertion: asserting on `"filesystem"`
or `●` appearing anywhere in the stream passes even when nothing was typed,
because both also occur in the model-state dump.

## Manual testing

- [ ] `BURRITO_TARGET=macos MIX_ENV=prod mix release` in `packages/raxol_cli`
- [ ] Clear `~/Library/Application Support/.burrito/raxol_cli_*`, or the previously unpacked build runs instead
- [ ] `burrito_out/raxol_cli_macos code` in a real terminal: TUI draws, `/mcp` responds, keystrokes land
- [ ] `burrito_out/raxol_cli_macos help | head -2` still prints (piped path intact)
- [ ] `echo | burrito_out/raxol_cli_macos code` still refuses with the interactive-terminal message
- [ ] `mix raxol.code` from a source checkout is unaffected
