### PR TITLE
Drop duplicate Styleable impl for Color

### DIFF
--- a/lib/raxol/protocols/styleable.ex
+++ b/lib/raxol/protocols/styleable.ex
@@ -98,30 +98,11 @@ defprotocol Raxol.Protocols.Styleable do
   def to_ansi(data)
 end
 
-# Implementation for Color struct
-defimpl Raxol.Protocols.Styleable, for: Raxol.Style.Colors.Color do
-  def apply_style(color, style) do
-    Map.merge(color, style)
-  end
-
-  def get_style(color) do
-    %{
-      foreground: {color.r, color.g, color.b}
-    }
-  end
-
-  def merge_styles(color, new_style) do
-    Map.merge(color, new_style)
-  end
-
-  def reset_style(color) do
-    %{color | r: 0, g: 0, b: 0}
-  end
-
-  def to_ansi(%{r: r, g: g, b: b}) do
-    "\e[38;2;#{r};#{g};#{b}m"
-  end
-end
+# The Color implementation lives in `Raxol.Protocols.ThemeImplementations`,
+# alongside the other theme-facing ones. It used to be duplicated here, which
+# left the winner up to compile order and made the two disagree: this copy
+# reported only `:foreground` from `get_style/1` and left `:hex`/`:name` stale
+# after `reset_style/1`.
 
 # Implementation for Maps (generic style containers)
 defimpl Raxol.Protocols.Styleable, for: Map do


### PR DESCRIPTION
`Raxol.Protocols.Styleable` was implemented twice for
`Raxol.Style.Colors.Color`: once in `lib/raxol/protocols/styleable.ex` and
again in `lib/raxol/protocols/theme_implementations.ex:365`. Only one survives
a build, and which one is decided by compile order.

The two do not agree:

| | `styleable.ex` (removed) | `theme_implementations.ex` (kept) |
| --- | --- | --- |
| `get_style/1` | `:foreground` only | `:foreground`, `:hex`, `:name` |
| `reset_style/1` | zeroes `r`/`g`/`b` | zeroes `r`/`g`/`b`, resets `hex`/`name` |

So the losing build leaves `:hex` and `:name` stale after a reset: the struct
reports black while `hex` still reads the old value. The kept implementation is
a strict superset and is the one that already wins today.

## How it surfaced

A Glama Docker build of the MCP server, which compiles with `MIX_ENV=prod`
(and therefore `warnings_as_errors: true`, see `mix.exs`):

```
warning: redefining module Raxol.Protocols.Styleable.Raxol.Style.Colors.Color
  (current version loaded from _build/prod/lib/raxol/ebin/...beam)
 365 │   defimpl Styleable, for: Raxol.Style.Colors.Color do
     └─ lib/raxol/protocols/theme_implementations.ex:365

Compilation failed due to warnings while using the --warnings-as-errors option
```

CI does not catch it. Debian trixie ships Elixir 1.18.3, which reports the
duplicate as a `redefining module` warning; on 1.19.5 and 1.20.2 (what CI runs)
the same tree compiles silently. The defect is version-independent -- only the
diagnostic is not.

A sweep of every `defimpl` under `lib/` and `packages/*/lib` found this as the
only protocol/target pair implemented twice.

## Manual testing

- [x] `grep` confirms one remaining `Styleable` impl for `Color`
- [x] `MIX_ENV=prod mix compile` on Elixir 1.20.2 / OTP 29.0.3 exits 0 with
      `warnings_as_errors` on, and no `redefining module` warning
- [x] `mix test test/raxol/protocols/` -- 55 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] No test asserts on the removed implementation's shape; the Color protocol
      test at `phase2_integration_test.exs:317` exercises `Renderable`, not
      `Styleable`
