### PR TITLE
Fold MCP env check into a compile-time constant

### DIFF
--- a/packages/raxol_mcp/lib/raxol/mcp/deployment.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/deployment.ex
@@ -13,9 +13,14 @@ defmodule Raxol.MCP.Deployment do
   # to :prod when Mix is gone rather than crash or read the wrong env.
   @mix_env if Code.ensure_loaded?(Mix), do: Mix.env(), else: :prod
 
+  # Resolved here rather than in the function body. Inlined into `production?/0`
+  # the membership test compares two atoms the type checker already knows are
+  # disjoint, which it reports as a typing violation on every build.
+  @production? @mix_env not in [:dev, :test]
+
   @doc "True in any non-dev/test build."
   @spec production?() :: boolean()
-  def production?, do: @mix_env not in [:dev, :test]
+  def production?, do: @production?
 
   @doc """
   Whether a network transport must refuse to expose tools without an authorizer.


### PR DESCRIPTION
`Raxol.MCP.Deployment.production?/0` compared a compile-time literal against a
list of atoms inside the function body, so the type checker saw a comparison it
already knew the answer to and reported it twice on every build:

```
warning: comparison between distinct types found:
    var === :dev
  given types:
    :prod === :dev
 18 │   def production?, do: @mix_env not in [:dev, :test]
    └─ (raxol_mcp 2.6.0) lib/raxol/mcp/deployment.ex:18
```

Folding the membership test into a second module attribute resolves it during
attribute evaluation, leaving the compiled function body a literal. Behaviour is
unchanged -- `@mix_env` still resolves the same way, including the release
fallback to `:prod` when `Mix` is absent.

This is noise rather than a failure: the warning comes from a dependency, and
`warnings_as_errors` (set in the root `mix.exs` for `MIX_ENV=prod`) only covers
the current project. It printed on every `mix mcp.server` start, twice.

## Manual testing

- [x] `MIX_ENV=prod mix compile --force` in `packages/raxol_mcp` -- no warnings
- [x] `mix test` in `packages/raxol_mcp` -- 31 properties, 319 tests, 0 failures,
      re-run across seeds 0-13
- [x] `mix format --check-formatted`

One run during this work reported a single failure that I could not capture
before the output scrolled; 14 subsequent runs across different seeds were all
green, and the change is a compile-time constant fold with identical semantics.
Flagging it in case it recurs.
