### PR TITLE
Credo: mechanical cleanup in lib/

### DIFF
--- a/lib/mix/tasks/raxol.check_docs.ex
+++ b/lib/mix/tasks/raxol.check_docs.ex
@@ -73,8 +73,7 @@ defmodule Mix.Tasks.Raxol.CheckDocs do
 
     files
     |> Enum.filter(&String.ends_with?(&1, ".md"))
-    |> Enum.reject(&String.contains?(&1, "node_modules/"))
-    |> Enum.reject(&vendored?/1)
+    |> Enum.reject(&(String.contains?(&1, "node_modules/") or vendored?(&1)))
     |> Enum.flat_map(&ProseLint.check_file(&1, lint_opts))
     |> Enum.sort_by(&{&1.path, &1.line})
   end

--- a/lib/raxol/adaptive/layout_recommender.ex
+++ b/lib/raxol/adaptive/layout_recommender.ex
@@ -366,14 +366,12 @@ defmodule Raxol.Adaptive.LayoutRecommender do
   defp compute_trends(nil), do: %{}
 
   defp compute_trends(tracker_server) do
-    try do
-      aggregates =
-        Raxol.Adaptive.BehaviorTracker.get_aggregates(tracker_server, 5)
+    aggregates =
+      Raxol.Adaptive.BehaviorTracker.get_aggregates(tracker_server, 5)
 
-      TrendDetector.compute(aggregates)
-    catch
-      :exit, _ -> %{}
-    end
+    TrendDetector.compute(aggregates)
+  catch
+    :exit, _ -> %{}
   end
 
   defp apply_trend_guards(candidates, trends) when map_size(trends) == 0,

--- a/lib/raxol/recording/asciicast.ex
+++ b/lib/raxol/recording/asciicast.ex
@@ -182,30 +182,28 @@ defmodule Raxol.Recording.Asciicast do
   defp decode_events([], acc), do: Enum.reverse(acc)
 
   defp decode_events([line | rest], acc) do
-    cond do
-      blank?(line) ->
-        decode_events(rest, acc)
+    if blank?(line) do
+      decode_events(rest, acc)
+    else
+      case decode_event(line) do
+        {:ok, event} ->
+          decode_events(rest, [event | acc])
 
-      true ->
-        case decode_event(line) do
-          {:ok, event} ->
-            decode_events(rest, [event | acc])
+        :error when rest == [] ->
+          # No trailing newline: torn mid-write. Expected when the writer was
+          # killed; drop it silently and return the complete events.
+          Enum.reverse(acc)
 
-          :error when rest == [] ->
-            # No trailing newline: torn mid-write. Expected when the writer was
-            # killed; drop it silently and return the complete events.
-            Enum.reverse(acc)
+        :error ->
+          # Either an interior malformed line or a newline-terminated (fully
+          # flushed) but unparseable final line -- committed corruption, alarm.
+          Logger.warning(
+            "Raxol.Recording.Asciicast: malformed event line, stopping decode " <>
+              "and returning #{length(acc)} recovered event(s)"
+          )
 
-          :error ->
-            # Either an interior malformed line or a newline-terminated (fully
-            # flushed) but unparseable final line -- committed corruption, alarm.
-            Logger.warning(
-              "Raxol.Recording.Asciicast: malformed event line, stopping decode " <>
-                "and returning #{length(acc)} recovered event(s)"
-            )
-
-            Enum.reverse(acc)
-        end
+          Enum.reverse(acc)
+      end
     end
   end
 

--- a/lib/raxol/ui/components/harness/diff_viewer.ex
+++ b/lib/raxol/ui/components/harness/diff_viewer.ex
@@ -865,22 +865,20 @@ defmodule Raxol.UI.Components.Harness.DiffViewer do
   defp wrap_piece(piece, {rows_rev, current_rev, used}, budget) do
     width = TextMeasure.display_width(piece.text)
 
-    cond do
-      used + width <= budget ->
-        {rows_rev, [piece | current_rev], used + width}
+    if used + width <= budget do
+      {rows_rev, [piece | current_rev], used + width}
+    else
+      room = budget - used
+      {head_text, rest_text} = split_text_at_width(piece.text, room)
 
-      true ->
-        room = budget - used
-        {head_text, rest_text} = split_text_at_width(piece.text, room)
+      current_rev =
+        if head_text == "",
+          do: current_rev,
+          else: [%{piece | text: head_text} | current_rev]
 
-        current_rev =
-          if head_text == "",
-            do: current_rev,
-            else: [%{piece | text: head_text} | current_rev]
+      rest = %{piece | text: rest_text}
 
-        rest = %{piece | text: rest_text}
-
-        wrap_piece(rest, {[current_rev | rows_rev], [], 0}, budget)
+      wrap_piece(rest, {[current_rev | rows_rev], [], 0}, budget)
     end
   end
 

--- a/lib/raxol/workflow/runtime.ex
+++ b/lib/raxol/workflow/runtime.ex
@@ -1215,38 +1215,35 @@ defmodule Raxol.Workflow.Runtime do
     branch_ids
     |> Enum.with_index()
     |> Enum.reduce_while({:ok, [], count}, fn {id, index}, {:ok, slots, c} ->
-      cond do
-        monotonic_us() >= deadline_us ->
-          {:halt, {:error, :run_timeout, state, c}}
+      if monotonic_us() >= deadline_us do
+        {:halt, {:error, :run_timeout, state, c}}
+      else
+        result =
+          with_branch_id({join_target, index}, fn ->
+            step_branch(
+              compiled,
+              id,
+              state,
+              run_id,
+              deadline_us,
+              c,
+              join_target
+            )
+          end)
 
-        true ->
-          result =
-            with_branch_id({join_target, index}, fn ->
-              step_branch(
-                compiled,
-                id,
-                state,
-                run_id,
-                deadline_us,
-                c,
-                join_target
-              )
-            end)
+        case result do
+          {:branch_done, branch_state, new_count} ->
+            {:cont, {:ok, [{:done, branch_state} | slots], new_count}}
 
-          case result do
-            {:branch_done, branch_state, new_count} ->
-              {:cont, {:ok, [{:done, branch_state} | slots], new_count}}
+          {:branch_paused, value, state_at_interrupt, paused_node_id, new_count} ->
+            {:cont,
+             {:ok,
+              [{:paused, paused_node_id, state_at_interrupt, value} | slots],
+              new_count}}
 
-            {:branch_paused, value, state_at_interrupt, paused_node_id,
-             new_count} ->
-              {:cont,
-               {:ok,
-                [{:paused, paused_node_id, state_at_interrupt, value} | slots],
-                new_count}}
-
-            {:error, _reason, _state, _count} = err ->
-              {:halt, err}
-          end
+          {:error, _reason, _state, _count} = err ->
+            {:halt, err}
+        end
       end
     end)
     |> case do
@@ -1468,20 +1465,18 @@ defmodule Raxol.Workflow.Runtime do
          count,
          halt_at
        ) do
-    cond do
-      monotonic_us() >= deadline_us ->
-        {:error, :run_timeout, state, count}
-
-      true ->
-        execute_branch_node(
-          compiled,
-          current_id,
-          state,
-          run_id,
-          deadline_us,
-          count,
-          halt_at
-        )
+    if monotonic_us() >= deadline_us do
+      {:error, :run_timeout, state, count}
+    else
+      execute_branch_node(
+        compiled,
+        current_id,
+        state,
+        run_id,
+        deadline_us,
+        count,
+        halt_at
+      )
     end
   end
 

--- a/test/raxol/adaptive/layout_recommender_test.exs
+++ b/test/raxol/adaptive/layout_recommender_test.exs
@@ -177,4 +177,43 @@ defmodule Raxol.Adaptive.LayoutRecommenderTest do
       assert [_ | _] = rec.layout_changes
     end
   end
+
+  # Trends are pulled from the tracker with a GenServer.call, so a tracker that
+  # dies exits the caller. Absorbing that is what keeps one tracker crash from
+  # cascading into the recommender and every subscriber attached to it; the
+  # cost is a recommendation computed without trend guards, which is the
+  # degraded answer rather than no answer. Every other test here leaves
+  # `subscribe_to` unset, so this is the only one that reaches the tracker.
+  describe "tracker failure" do
+    test "a dead tracker degrades to no trends, it does not kill the recommender" do
+      Process.flag(:trap_exit, true)
+
+      {:ok, tracker} = BehaviorTracker.start_link(name: nil)
+
+      {:ok, pid} =
+        LayoutRecommender.start_link(
+          name: nil,
+          recommendation_cooldown_ms: 0,
+          subscribe_to: tracker
+        )
+
+      LayoutRecommender.subscribe(pid)
+
+      # A call lands after the subscribe_to continuation, so returning proves
+      # tracker_server is set -- otherwise it stays nil and never calls out.
+      assert LayoutRecommender.get_last_recommendation(pid) == nil
+
+      ref = Process.monitor(tracker)
+      Process.exit(tracker, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^tracker, :killed}, 500
+
+      aggregate = make_aggregate(%{analyst: 6.0, scout: 2.0, comms: 2.0})
+      send(pid, {:behavior_aggregate, aggregate})
+
+      assert_receive {:layout_recommendation, rec}, 500
+      assert [change | _] = rec.layout_changes
+      assert change.action == :expand
+      assert Process.alive?(pid)
+    end
+  end
 end


### PR DESCRIPTION
Scoped credo pass over `lib/` in the main repo, taking only the changes that are
mechanical and behaviour-preserving. `mix credo --strict` on `lib/` goes from
**124 issues to 118**.

Credo is advisory here -- CI runs `mix credo --strict || true` (ci-unified.yml)
and `mix raxol.check` records a credo failure as `{:credo, :warning}` -- so this
is cleanup, not a gate being unblocked.

## What changed

**Single-condition `cond` -> `if`** (4 sites). Each was one real clause plus a
`true ->` fallback.

- `lib/raxol/workflow/runtime.ex` (x2, the branch deadline checks)
- `lib/raxol/recording/asciicast.ex` (`decode_events/2`)
- `lib/raxol/ui/components/harness/diff_viewer.ex` (`wrap_piece/3`)

**Implicit `try`** (1 site). `compute_trends/1` in
`lib/raxol/adaptive/layout_recommender.ex` wrapped its whole body in an explicit
`try`; the `catch` now hangs off the function head.

**Two `Enum.reject/2` passes collapsed into one** (1 site) in
`lib/mix/tasks/raxol.check_docs.ex`.

## What I deliberately left

**The 12 "appending a single item to a list is inefficient" sites.** Every one is
an order-significant append to a bounded list: the completed-step log in
`editor_suspend.ex`, the clamped `order` list in `panel_projection.ex`, gap
sentinels in `flexbox/positioner.ex`, a cycle path in `lifecycle/dependencies.ex`,
and so on. One (`demo/dashboard.ex:19`) is a module attribute over a 4-element
list, evaluated at compile time. Rewriting `list ++ [x]` as `[x | list]` reverses
them, which is a bug; doing it correctly means accumulating reversed and calling
`Enum.reverse/1` at the end, which is a real restructure that reads worse for no
measurable gain at these sizes. The check is a heuristic for hot loops over large
lists, which none of these are.

**`lib/raxol/application.ex:876`** -- `apply(Raxol.Agent.Harness.McpTools, :register, [...])`.
The indirection is load-bearing. raxol_agent is not a dependency of main raxol,
and that module is not in the file's `@compile {:no_warn_undefined, [...]}` list,
so a direct call emits an undefined-module warning -- which under `MIX_ENV=prod`
(`warnings_as_errors`) is a build failure. Same class of break as #847/#848.

**The remaining ~105.** These are `Function is too complex` (ABC 31-72,
cyclomatic 10-17), `nested too deep`, `takes too many parameters`, and 4
duplicate-code findings (`text_input`/`text_area` mass 66,
`word_diff`/`line_diff` mass 45). None is mechanical -- each is a genuine
restructure of live logic. Sweeping ~105 of those in one PR is how a subtle bug
gets in. Better done case by case when the surrounding code is being touched
anyway.

## Manual testing

- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean
- [x] Full suite: 7 doctests, 258 properties, 6426 tests, 0 failures, 1 skipped
- [x] `mix raxol.check_docs` still passes (it backs the pre-commit Markdown gate,
      and this PR edits its `lint/2`)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` on `lib/`: 124 -> 118

Unrelated, noticed while baselining: a narrower run without the project's
standard `--exclude slow --exclude integration --exclude docker` shows 6 failures
on **clean master** -- 5 `Raxol.Workflow.Checkpoint.Saver.PostgrexTest` cases
needing live Postgres, plus
`Raxol.UI.Components.Harness.MarkdownBodyTest` "streaming prefixes of a large
document stay within budget". Identical before and after this branch. Flagging
the MarkdownBody one since it is not environment-dependent.

## Added after an adversarial review pass

The review's one HIGH finding: `compute_trends/1`'s `catch :exit, _` boundary was
both **untested** and, after the implicit-`try` rewrite, visually easy to miss.
`BehaviorTracker.get_aggregates/2` is a `GenServer.call`, so the exit is
reachable in production (tracker down, call timeout, shutdown), and every other
test in that file leaves `subscribe_to` unset -- so `tracker_server` stays `nil`
and nothing ever called out to the tracker. The behaviour-preservation claim
rested on argument, not on anything in the repo.

`test/raxol/adaptive/layout_recommender_test.exs` now covers it: start a real
tracker, wire the recommender to it, kill the tracker, then drive a rule pass.
The recommender must still emit its recommendation (computed without trend
guards) and still be alive.

RED-proven: deleting the `catch` makes exactly this test fail and no other.

Remaining review findings were all LOW and pre-existing rather than introduced
here -- `catch :exit, _` swallowing `:shutdown`/`:killed` without a log,
`vendored?/1` being an unanchored substring match, and `length(acc)` on
`decode_events/2`'s untrusted-input logging path. Left alone; none is this PR's
to fix.
