### PR TITLE
Answer in-flight ACP requests when stdin closes

### DIFF
--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/connection.ex
@@ -169,6 +169,12 @@ defmodule Raxol.AgentClientProtocol.Connection do
   # override per-connection via the `:max_inbound` start_link opt.
   @default_max_inbound 1_000
 
+  # How long a closed read side waits for in-flight inbound requests to answer
+  # before the connection stops anyway. Long enough for a handler that is
+  # already running to finish writing, short enough that a wedged one cannot
+  # keep the process resident.
+  @close_drain_ms 5_000
+
   defstruct role: :agent,
             transport_mod: nil,
             transport_state: nil,
@@ -701,12 +707,32 @@ defmodule Raxol.AgentClientProtocol.Connection do
     end
   end
 
+  # A closed READ side is not a closed connection when work is still in
+  # flight. `transport_down/2` terminates every inbound dispatch task, so
+  # stopping the instant stdin ends killed requests already being handled and
+  # answered them with nothing -- invisible over a pipe an editor holds open,
+  # fatal for a peer that sends its requests and closes stdin.
+  #
+  # Deliberately a bounded grace rather than "stop when `pending_in` drains":
+  # entries are retired at more than one site, and a fix wired to only some of
+  # them would hang the shutdown it was meant to shorten. The cost is waiting
+  # out the grace when work is in flight at EOF, which is a shutdown path.
   def handle_info({:acp_transport, ref, {:closed, reason}}, state) do
-    if ref == state.transport_ref do
-      {:stop, :normal, transport_down(reason, state)}
-    else
-      {:noreply, state}
+    cond do
+      ref != state.transport_ref ->
+        {:noreply, state}
+
+      state.phase != :closed and map_size(state.pending_in) > 0 ->
+        Process.send_after(self(), {:acp_close_drained, reason}, @close_drain_ms)
+        {:noreply, state}
+
+      true ->
+        {:stop, :normal, transport_down(reason, state)}
     end
+  end
+
+  def handle_info({:acp_close_drained, reason}, state) do
+    {:stop, :normal, transport_down(reason, state)}
   end
 
   # A torn/non-JSON inbound line, or a decoded-but-non-object top-level term

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport/stdio.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/transport/stdio.ex
@@ -253,6 +253,18 @@ defmodule Raxol.AgentClientProtocol.Transport.Stdio do
     {:noreply, state}
   end
 
+  # `:self` mode is HALF-closable, and the port was opened with `:eof`
+  # precisely so it is: fd 0 ending says the peer will send nothing more, not
+  # that it has stopped reading fd 1. Marking the transport closed here
+  # refused every subsequent `send_message/2` with `{:error, :closed}`, so a
+  # peer that piped its requests and closed stdin -- a script, a benchmark
+  # harness, anything not holding the pipe open -- got NO replies at all,
+  # including the reply to a request already being handled. The read side is
+  # done; the write side stays open until `close/1` or a failed write.
+  def handle_info({port, :eof}, %{port: port, closed: false, mode: :self} = state) do
+    {:noreply, emit(state, {:closed, :eof})}
+  end
+
   def handle_info({port, :eof}, %{port: port, closed: false} = state) do
     state = emit(state, {:closed, :eof})
     {:noreply, %{state | closed: true}}

--- a/packages/raxol_agent_client_protocol/test/connection_test.exs
+++ b/packages/raxol_agent_client_protocol/test/connection_test.exs
@@ -984,6 +984,50 @@ defmodule Raxol.AgentClientProtocol.ConnectionTest do
       ScriptedPeer.assert_no_frame(peer, 150)
     end
 
+    test "a closed read side lets an in-flight inbound request still answer" do
+      %{conn: conn, peer: peer} = start_agent_conn()
+      complete_handshake(peer)
+
+      ScriptedPeer.send_request(peer, 77, "session/new", new_session_params("/held"))
+
+      %{task_pid: task_pid} =
+        handle_next_invoke(:new_session, fn req, _ctx ->
+          receive do
+            :go ->
+              {:ok,
+               %Raxol.AgentClientProtocol.Schema.AgentTypes.NewSessionResponse{
+                 session_id: req.cwd
+               }}
+          end
+        end)
+
+      %{transport_ref: ref} = :sys.get_state(conn)
+      cmon = Process.monitor(conn)
+
+      # stdin ends while the handler is still running. This used to stop the
+      # connection at once, terminating the dispatch task, so a peer that
+      # piped its requests and closed stdin got no reply to a request the
+      # agent was already answering.
+      send(conn, {:acp_transport, ref, {:closed, :eof}})
+      refute_receive {:DOWN, ^cmon, :process, ^conn, _reason}, 200
+
+      send(task_pid, :go)
+      frame = ScriptedPeer.recv(peer)
+      assert frame["id"] == 77
+      assert frame["result"]["sessionId"] == "/held"
+    end
+
+    test "a closed read side with nothing in flight still stops at once" do
+      %{conn: conn, peer: peer} = start_agent_conn()
+      complete_handshake(peer)
+
+      %{transport_ref: ref} = :sys.get_state(conn)
+      cmon = Process.monitor(conn)
+
+      send(conn, {:acp_transport, ref, {:closed, :eof}})
+      assert_receive {:DOWN, ^cmon, :process, ^conn, :normal}, 500
+    end
+
     test "Inv-15: malformed frames never terminate the connection or disturb an in-flight request" do
       %{conn: conn, peer: peer} = start_agent_conn()
       complete_handshake(peer)


### PR DESCRIPTION
## Context

Found while trying to drive the ACP surface by hand. `bin/raxol-acp` with piped
stdin answers **nothing**:

```
$ ./bin/raxol-acp --backend mock < frames.jsonl
# exit 0, zero JSON-RPC frames
```

Hold the pipe open (`( cat frames.jsonl; sleep 12 ) | ./bin/raxol-acp`) and every
request is answered. That is why an editor never hits this and a script always
does: an editor keeps stdin open for the life of the session, a harness pipes its
requests and closes.

Reproduced on `master` before writing any fix, so it is not a regression from
recent ACP work.

## Two causes, one per layer

**The transport treated a half-close as a close.** `Transport.Stdio` in `:self`
mode opens `Port.open({:fd, 0, 1}, [:binary, :eof])` — the `:eof` option exists
precisely so the port survives stdin ending and stays writable. But the `{port,
:eof}` handler set `closed: true`, and `handle_call({:send, _}, ...)` refuses
every write once closed. So stdin EOF silently disabled the reply channel while
fd 1 was still perfectly open, and the peer was still reading it.

**The Connection stopped before its work finished.** `handle_info({:acp_transport,
ref, {:closed, _}}, ...)` stopped immediately, and `transport_down/2` terminates
every inbound dispatch task (`Task.Supervisor.terminate_child/2`). Anything
mid-handling when stdin ended was killed without a reply.

## The fix

A closed read side now means only what it says: no more requests are coming. The
write side stays open until `close/1` or a failed write. When the read side ends
with inbound work still in flight, the connection waits a bounded grace
(`@close_drain_ms`, 5s) before stopping.

The grace is deliberate rather than "stop as soon as `pending_in` drains".
Entries are retired at more than one site in `Connection`, and a fix wired to
only some of them would hang the very shutdown it was meant to shorten — the
one-call-site-out-of-N shape this repo keeps hitting. The cost is waiting out the
grace when work is in flight at EOF, which is a shutdown path only.

Behaviour that is unchanged and still tested: a close with nothing in flight
stops at once, so `raxol acp` still exits promptly on a clean editor disconnect
and does not leave a resident BEAM holding a provider key.

## Verification

- `raxol_agent_client_protocol` **859 passed** (18 properties, 841 tests), 0 failures
- `raxol_agent` **2373 passed** (19 properties, 2354 tests), 0 failures
- Clean under `--warnings-as-errors`, formatted

Two new tests, and the fix is RED-proven: disabling the drain branch fails
exactly `a closed read side lets an in-flight inbound request still answer`,
while `a closed read side with nothing in flight still stops at once` correctly
stays green.

End to end, the original failing command now answers all four requests.

## Manual testing

- [ ] `./bin/raxol-acp --backend mock < frames.jsonl` answers every request
- [ ] An editor (Zed) session still connects, prompts, and disconnects cleanly
- [ ] `raxol acp` exits rather than leaving a resident BEAM after disconnect

## Note on the environment

Unrelated to the diff, but it cost time: `mise trust --show` reported
`~/CODE/raxol: untrusted`, so `.tool-versions` (elixir 1.20.2-otp-29) was not
applied and PATH `mix` was Homebrew 1.19.5 against a 1.20.2 build tree, which
fails with `Enum.__in__/2 is undefined`. `mise trust` alone did not fix PATH;
`mise where` did.
