### PR TITLE
Alias Sma7702Wallet so the order task's privy path can run

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   alias Raxol.Payments.Xochi.{PullContracts, Schemas.QuoteRequest}
 
   # Nested wallet modules (defined below) -- alias so they resolve everywhere.
-  alias __MODULE__.{ScaWallet, Signer}
+  alias __MODULE__.{ScaWallet, Signer, Sma7702Wallet}
 
   # The raxol agent (seller) wallet -- the provider a buyer hires by default.
   @default_provider "0x939ead944b5d28b86d91af1961812d3bbc46cac1"


### PR DESCRIPTION
One line. `Sma7702Wallet` is defined nested in `Mix.Tasks.RaxolEarn.Order` (`:503`) but was missing from the module's `alias` (`:92`), so `build_signer("privy", ...)` at `:439` returned a bare `Sma7702Wallet` -- which resolves to a top-level `Elixir.Sma7702Wallet` that does not exist.

Every `--signer privy` run therefore died at signing:

```
** (UndefinedFunctionError) function Sma7702Wallet.address/0 is undefined
   (module Sma7702Wallet is not available). Did you mean:
      * Mix.Tasks.RaxolEarn.Order.Sma7702Wallet.address/0
    (raxol_payments) lib/raxol/payments/protocols/xochi.ex:662: validate_pull_authorization/3
    (raxol_earn) lib/mix/tasks/raxol_earn.order.ex:126: Mix.Tasks.RaxolEarn.Order.run/1
```

## Why it survived review

`Sma7702Wallet` arrived in #773; the alias line dates from before it and lists only `ScaWallet` and `Signer`. The compiler does emit an undefined-module warning, but `raxol_earn` is not in the per-PR package matrix (`ci-unified.yml` runs `raxol_cli`, `raxol_gateway`, `raxol_telegram`), so nothing failed on it.

The consequence is worth stating plainly: **#773's 7702 signing fix had never once executed through the order task.** Its unchecked manual-verification box was not simply deferred for cost -- the run could not have reached the point of spending anything.

## Verification

Before, `--dry-run` crashed as above. After:

```
[order] buyer=0x468a...2283  provider=0x939e...cac1  corridor=8453->42161  amount=3.00 USDC
[order] signed Xochi intent: xi_a832a2334135a257d7699b4ed02aaed3
```

Both `signature` and `pull_signature` carry the ma-v2 native-fallback envelope (`0x00‖uint32(0)‖0xFF‖0x00‖sig65`, 72 bytes), and Xochi returned a quote.

A funded run then went end to end on Base: job **72993** created, budget set at exactly 8bps, escrow funded. Settlement still fails, but for a cause entirely outside this repo -- Xochi's production worker has no `RPC_URL_*` secret, so its ERC-1271 verification path never runs and rejects every smart-account signature EOA-only (xochi-fi/xochi#364). See DROOdotFOO/raxol#772 for the corrected diagnosis.

`raxol_earn` suite: 760/761. The one failure is `JobIdResolverTest` "decodes the jobId from the createJob receipt logs", which #773 also recorded as pre-existing; confirmed by running it on `origin/master` (8/9, same failure).

## Manual testing

- [x] `--dry-run` reaches intent signing and returns a Xochi quote
- [x] `--fund` completes createJob -> setBudget -> fund on Base mainnet (job 72993)
- [ ] Settlement to `completed` -- blocked on xochi-fi/xochi#364, re-run when `RPC_URL_8453` is set
