### PR TITLE
Explain operational failures in the money-path mix tasks

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -128,6 +128,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
         {:ok, bundle} -> bundle
         {:error, reason} -> Mix.raise(sign_intent_error(reason))
       end
+
     requirement = requirement(cfg, bundle)
     log("signed Xochi intent: #{bundle[:intent_id] || bundle["intent_id"]}")
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -123,7 +123,11 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     )
 
     # 1. Sign the Xochi intent (off-chain).
-    {:ok, bundle} = sign_intent(cfg)
+    bundle =
+      case sign_intent(cfg) do
+        {:ok, bundle} -> bundle
+        {:error, reason} -> Mix.raise(sign_intent_error(reason))
+      end
     requirement = requirement(cfg, bundle)
     log("signed Xochi intent: #{bundle[:intent_id] || bundle["intent_id"]}")
 
@@ -532,6 +536,32 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       v -> v
     end
   end
+
+  # A bare `{:ok, _} =` here reported a transport failure as a MatchError on a
+  # Req struct, which reads like a Xochi outage. It is more often the local
+  # network: some ISPs null-route whole Cloudflare ranges, and api.xochi.fi
+  # resolves into one (188.114.96.0/20). Observed on Vodafone ES -- port 80 is
+  # intercepted with an "Acceso bloqueado" page and 443 is dropped, so every
+  # request dies at connect with no HTTP status to explain itself.
+  defp sign_intent_error(%{__struct__: Req.TransportError, reason: reason}) do
+    """
+    could not reach the Xochi API (transport #{inspect(reason)}).
+
+    This is usually the network path, not Xochi. Check, in order:
+
+      nc -z api.xochi.fi 443          # dropped => blocked upstream, not down
+      curl -sI http://api.xochi.fi    # a non-Cloudflare page here => intercepted
+      curl -s "https://r.jina.ai/https://xochi.fi"   # answers => the API is fine
+
+    A control host only proves anything if it shares the blocked IP range;
+    cloudflare.com and other Cloudflare sites sit elsewhere and will pass while
+    this one fails. Route around it with a VPN or an exit node in another
+    country. Confirm from off-network before reporting an outage upstream.
+    """
+  end
+
+  defp sign_intent_error(reason),
+    do: "could not sign the Xochi intent: #{inspect(reason)}"
 
   @explorers %{
     1 => "https://etherscan.io/tx/",

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -386,8 +386,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     {from, to} = parse_corridor(Keyword.get(opts, :corridor, "8453>42161"))
     amount = Keyword.get(opts, :amount, "3.00")
 
-    {:ok, src_token} = Assets.address(from, "USDC")
-    {:ok, dst_token} = Assets.address(to, "USDC")
+    src_token = usdc_address!(from, "origin")
+    dst_token = usdc_address!(to, "destination")
     principal_atomic = Assets.to_atomic(Decimal.new(amount), Assets.decimals(from, src_token))
 
     signer = Keyword.get(opts, :signer, "privy")
@@ -427,7 +427,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     _ = fetch_env!("RAXOL_ACP_SIGNER_PRIVATE_KEY")
     address = fetch_env!("RAXOL_ACP_WALLET_ADDRESS")
 
-    {:ok, _} = Raxol.Earn.SignerSidecar.start_link([])
+    start_sidecar!()
 
     provider =
       ProviderAdapter.Privy.new(
@@ -563,6 +563,57 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   defp sign_intent_error(reason),
     do: "could not sign the Xochi intent: #{inspect(reason)}"
+
+  # `Assets.address/2` answers a bare `:error` for an unsupported pair, so a
+  # bad --corridor used to surface as `no match of right hand side value: :error`
+  # with no hint of which side was wrong.
+  defp usdc_address!(chain_id, side) do
+    case Assets.address(chain_id, "USDC") do
+      {:ok, address} ->
+        address
+
+      :error ->
+        supported =
+          Assets.supported_chain_ids()
+          |> Enum.map(&"#{&1} (#{Assets.chain_name(&1)})")
+          |> Enum.join(", ")
+
+        Mix.raise("""
+        no USDC address for the #{side} chain #{chain_id}.
+
+        Check --corridor (origin>destination). Chains with a USDC address:
+          #{supported}
+        """)
+    end
+  end
+
+  # The sidecar is a Node process: it fails when node is missing, its deps are
+  # not installed, the port is taken, or the Privy credentials are rejected.
+  # Each of those used to arrive as a MatchError on a start_link tuple.
+  defp start_sidecar!() do
+    case Raxol.Earn.SignerSidecar.start_link([]) do
+      {:ok, pid} ->
+        pid
+
+      {:error, {:already_started, pid}} ->
+        pid
+
+      {:error, reason} ->
+        Mix.raise("""
+        the Privy signer sidecar did not start: #{inspect(reason)}
+
+        It is a Node process under packages/raxol_earn/priv/signer_sidecar.
+        Check, in order:
+
+          node --version                       # must be present on PATH
+          ls priv/signer_sidecar/node_modules  # run `npm install` there if absent
+          lsof -i :4048                        # default port, must be free
+
+        RAXOL_ACP_WALLET_ADDRESS / RAXOL_ACP_WALLET_ID / RAXOL_ACP_SIGNER_PRIVATE_KEY
+        must all be set: the sidecar reads them at boot and exits if any is missing.
+        """)
+    end
+  end
 
   @explorers %{
     1 => "https://etherscan.io/tx/",

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.rebalance.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.rebalance.ex
@@ -39,7 +39,19 @@ defmodule Mix.Tasks.RaxolEarn.Rebalance do
   defp sweep(acc, rpc_urls, solver) do
     # A throwaway ledger: the drain only tiebreaks refuel ordering, so an empty one
     # still yields correct balance-driven recommendations for a snapshot.
-    {:ok, ledger} = SettlementLedger.start_link(table_name: :raxol_earn_rebalance_task)
+    ledger =
+      case SettlementLedger.start_link(table_name: :raxol_earn_rebalance_task) do
+        {:ok, pid} ->
+          pid
+
+        # Re-running the sweep in one VM (or an ETS table left by a prior run)
+        # is not a failure -- the ledger is a throwaway either way.
+        {:error, {:already_started, pid}} ->
+          pid
+
+        {:error, reason} ->
+          Mix.raise("could not start the throwaway settlement ledger: #{inspect(reason)}")
+      end
 
     RebalanceMonitor.advise_once(
       ledger: ledger,


### PR DESCRIPTION
Bare `{:ok, _} = ...` matches in the buyer tasks reported operational failures as `MatchError` on a struct or a bare `:error`. Each one reads like a bug in raxol when it is usually the environment.

I lost most of a session to the first one: a `Req.TransportError` on a blocked network looked like a Xochi outage, and I filed an issue against their infrastructure before finding the real cause.

## The three that were reachable

**1. Unreachable Xochi API** (`sign_intent`)

```
** (MatchError) no match of right hand side value:
    {:error, %Req.TransportError{reason: :timeout}}
```

`api.xochi.fi` resolves into `188.114.96.0/20`, and some ISPs null-route whole Cloudflare ranges. Observed live on Vodafone ES: 443 dropped, 80 intercepted with a Spanish `Acceso bloqueado` page. DNS is untouched, so it looks like the service is down. Now:

```
** (Mix) could not reach the Xochi API (transport :timeout).

This is usually the network path, not Xochi. Check, in order:

  nc -z api.xochi.fi 443          # dropped => blocked upstream, not down
  curl -sI http://api.xochi.fi    # a non-Cloudflare page here => intercepted
  curl -s "https://r.jina.ai/https://xochi.fi"   # answers => the API is fine

A control host only proves anything if it shares the blocked IP range;
cloudflare.com and other Cloudflare sites sit elsewhere and will pass while
this one fails. Route around it with a VPN or an exit node in another country.
Confirm from off-network before reporting an outage upstream.
```

**2. Unsupported corridor** (`Assets.address/2`)

It answers a bare `:error`, so `--corridor 8453>56` produced `no match of right hand side value: :error` with no clue which side was wrong. Now:

```
** (Mix) no USDC address for the destination chain 56.

Check --corridor (origin>destination). Chains with a USDC address:
  1 (Ethereum), 10 (Optimism), 137 (Polygon), 4663 (Robinhood Chain), 8453 (Base), 42161 (Arbitrum One)
```

**3. Signer sidecar refusing to start**

A Node process: fails when node is missing, `npm install` was never run, port 4048 is taken, or the Privy credentials are rejected. All four arrived as a MatchError on a `start_link` tuple. Now names the four checks, and treats `{:error, {:already_started, pid}}` as success rather than a crash.

Also `raxol_earn.rebalance`: its throwaway ledger now tolerates `already_started` instead of dying on a second sweep in one VM.

## The six I deliberately left alone

Padding every bare match would be noise, and three of these are the *correct* failure mode:

| Site | Why it stays |
| --- | --- |
| `order.ex:150` `:ok = send_requirement(...)` | `send_requirement/5` already `Mix.raise`s a clear message when its 12 retries are exhausted; the match cannot fail |
| `bench.ex:68,76` `EnvWallet.sign_*` | `bench.ex:53` sets `RAXOL_WALLET_KEY` itself, so a failure here means signing is genuinely broken -- crashing loudly is right for a benchmark |
| `bench.ex:121,122,143`, `anvil.ex:103`, `derive_caps.ex:41` | `Checkpoint`/`Ledger`/`Task.start_link`/`ensure_all_started(:req)` on a dev-only path; no plausible operational failure |

## Verification

- Transport path: output above, reproduced against the live ISP block
- Corridor path: `--corridor "8453>56" --dry-run` produces the message above
- `raxol_earn` suite unchanged; the one failure on this branch is `JobIdResolverTest`, fixed in #861
- `mix compile --warnings-as-errors` on this branch still trips the pre-existing `send_sponsored_user_operation` warning, fixed in #862 -- neither is introduced here

## Manual testing

- [x] Transport error prints guidance instead of a MatchError
- [x] Unsupported corridor names the side and lists supported chains
- [x] `--dry-run` success path unchanged (signs and quotes as before)
