### PR TITLE
Pin the JobCreated fixture to the deployed V3 signature

### DIFF
--- a/packages/raxol_earn/config/buyer.example.exs
+++ b/packages/raxol_earn/config/buyer.example.exs
@@ -75,11 +75,17 @@ config :raxol_earn,
     server_url: "https://api-dev.acp.virtuals.io",
     chain_ids: [84_532]
   ],
-  # jobId resolution after createJob. Defaults to JobIdResolver.Receipt.
-  # CONFIRM the JobCreated event signature / indexed position in the dry-run,
-  # then override here:
+  # jobId resolution after createJob. Defaults to JobIdResolver.Receipt, whose
+  # default signature matches the deployed AgenticCommerceV3 core -- leave this
+  # nil unless you are pointing at a different core.
+  #
+  # An override is easy to get wrong and fails QUIETLY: a signature that does
+  # not match the emitted event decodes to :pending, not an error, so the buyer
+  # falls through to reconcile-by-tag instead of reporting a bad jobId. If you
+  # do override, take the signature from the core's verified ABI, not from here:
   #
   #     buyer_job_id_resolver:
   #       {Raxol.Earn.JobIdResolver.Receipt,
-  #        %{event_signature: "JobCreated(uint256)", topic_index: 1}}
+  #        %{event_signature: "JobCreated(uint256,address,address,address,uint256,address)",
+  #          topic_index: 1}}
   buyer_job_id_resolver: nil

--- a/packages/raxol_earn/test/raxol/earn/job_id_resolver_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/job_id_resolver_test.exs
@@ -42,8 +42,21 @@ defmodule Raxol.Earn.JobIdResolverTest do
   describe "Receipt" do
     test "resolve decodes the jobId from the createJob receipt logs" do
       adapter = Adapter.new()
-      topic = LogDecoder.event_topic("JobCreated(uint256)")
-      log = %{"topics" => [topic, "0x" <> String.duplicate("0", 62) <> "2a"]}
+
+      topic =
+        LogDecoder.event_topic("JobCreated(uint256,address,address,address,uint256,address)")
+
+      # The deployed AgenticCommerceV3 indexes jobId, client and provider, so a
+      # real JobCreated log carries four topics and jobId is topics[1].
+      log = %{
+        "topics" => [
+          topic,
+          "0x" <> String.duplicate("0", 62) <> "2a",
+          "0x" <> String.duplicate("0", 24) <> String.duplicate("11", 20),
+          "0x" <> String.duplicate("0", 24) <> String.duplicate("22", 20)
+        ]
+      }
+
       :ok = Adapter.set_receipt(adapter, "0xtx", %{"logs" => [log]})
 
       resolver = %{adapter: Receipt}


### PR DESCRIPTION
`JobIdResolverTest` has failed on master since #771 (2026-08-03). It is the pre-existing failure #773 noted, #858 re-confirmed, and the reason `raxol_earn` cannot be added to per-PR CI. **The test was wrong, not the resolver.**

## What happened

#771 fixed the resolver's event signature -- its own changelog line reads "Fix JobCreated event signature in Receipt resolver" -- changing `@default_event_signature` from the placeholder `JobCreated(uint256)` to the verified six-param signature. It did not update this test, which still computed the placeholder's topic0.

```
JobCreated(uint256)                                          -> 0x92447c6e...
JobCreated(uint256,address,address,address,uint256,address)  -> 0xb0f0239b...
```

The mismatch makes `LogDecoder.find_event/2` return `:error`, which `receipt.ex:80` deliberately maps to `:pending`. So the test asserted the OLD, wrong behaviour: it could only have gone green if the resolver used the wrong signature.

## Production is not affected

Verified against the live contract rather than trusting the comment. Base `0x238E541B...832E0` is an ERC1967Proxy resolving to `0x8e86FbEf...B77BC` (`AgenticCommerceV3`), whose verified ABI declares exactly `JobCreated(uint256,address,address,address,uint256,address)` with `jobId` indexed first, i.e. `topics[1]` -- matching `@default_topic_index 1`. Every real resolution site already uses it: `buyer/queue.ex:281` and `job_session/client.ex:125` default to `%{adapter: Receipt}`, and `raxol_earn.order.ex:289` sets it explicitly.

Note `priv/abi/acp_simple.json` is the **legacy v1** ABI (`JobCreated(uint256,address,address,address)`, jobId not indexed). It is not the active core and must not be used to judge this resolver.

## The fixture is now realistic, not just green

The deployed event indexes jobId, client and provider, so a real log carries four topics. The fixture now does too, which additionally pins `topic_index` -- a two-topic fixture would pass for the wrong reason.

Mutation-checked, both red as they should be:

| Mutation | Result |
| --- | --- |
| `@default_event_signature` back to `JobCreated(uint256)` | 1 failure |
| `@default_topic_index` 1 -> 2 | 1 failure |
| restored | 9 passed |

## Also: the same defect, pointed at operators

`config/buyer.example.exs` advertised `%{event_signature: "JobCreated(uint256)", topic_index: 1}` as the copy-paste override. Because a wrong signature degrades to `:pending` rather than erroring, an operator pasting that would silently break buyer jobId resolution. Updated to the verified signature, with the quiet-failure mode called out, and the obsolete "CONFIRM ... in the dry-run" wording dropped.

## Manual testing

- [x] `mix test test/raxol/earn/job_id_resolver_test.exs` -> 9 passed (was 8/9)
- [x] Both mutations red, `lib/` untouched afterwards
- [x] Contract ABI verified on-chain via Blockscout, not assumed
