### PR TITLE
Gate raxol_payments and raxol_earn in per-PR CI

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -287,7 +287,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [raxol_gateway, raxol_telegram, raxol_cli]
+        # raxol_payments and raxol_earn move real money and were the two least
+        # gated packages in the repo: the Sma7702Wallet alias bug (#858) shipped
+        # with a compiler warning nobody could fail on, because nothing here ran
+        # them. Adding them required unbreaking both suites first -- see the PR.
+        package: [raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn]
 
     steps:
       - uses: actions/checkout@v7

--- a/packages/raxol_earn/config/buyer.example.exs
+++ b/packages/raxol_earn/config/buyer.example.exs
@@ -75,11 +75,17 @@ config :raxol_earn,
     server_url: "https://api-dev.acp.virtuals.io",
     chain_ids: [84_532]
   ],
-  # jobId resolution after createJob. Defaults to JobIdResolver.Receipt.
-  # CONFIRM the JobCreated event signature / indexed position in the dry-run,
-  # then override here:
+  # jobId resolution after createJob. Defaults to JobIdResolver.Receipt, whose
+  # default signature matches the deployed AgenticCommerceV3 core -- leave this
+  # nil unless you are pointing at a different core.
+  #
+  # An override is easy to get wrong and fails QUIETLY: a signature that does
+  # not match the emitted event decodes to :pending, not an error, so the buyer
+  # falls through to reconcile-by-tag instead of reporting a bad jobId. If you
+  # do override, take the signature from the core's verified ABI, not from here:
   #
   #     buyer_job_id_resolver:
   #       {Raxol.Earn.JobIdResolver.Receipt,
-  #        %{event_signature: "JobCreated(uint256)", topic_index: 1}}
+  #        %{event_signature: "JobCreated(uint256,address,address,address,uint256,address)",
+  #          topic_index: 1}}
   buyer_job_id_resolver: nil

--- a/packages/raxol_earn/lib/raxol/earn/wallet/sca.ex
+++ b/packages/raxol_earn/lib/raxol/earn/wallet/sca.ex
@@ -185,10 +185,22 @@ defmodule Raxol.Earn.Wallet.SCA do
       """
       @spec send_sponsored_user_operation(Raxol.Earn.Wallet.SCA.UserOp.t(), keyword()) ::
               {:ok, String.t()} | {:error, term()}
-      def send_sponsored_user_operation(op, opts \\ []) do
-        with {:ok, sponsored} <- sponsor(op, opts) do
-          send_user_operation(sponsored, opts)
+      if unquote(paymaster_policy_id) do
+        def send_sponsored_user_operation(op, opts \\ []) do
+          with {:ok, sponsored} <- sponsor(op, opts) do
+            send_user_operation(sponsored, opts)
+          end
         end
+      else
+        # Without a `:paymaster_policy_id` this wallet can never be sponsored:
+        # `SCA.sponsor/5` matches nil on its first clause and returns the error
+        # unconditionally. Generating the `with` anyway gives every policy-less
+        # instantiation an unreachable success branch, which the compiler
+        # correctly reports and `--warnings-as-errors` then fails on. The
+        # runtime contract is unchanged -- same error tuple, same arity -- the
+        # dead branch simply is not emitted.
+        def send_sponsored_user_operation(_op, _opts \\ []),
+          do: {:error, :no_paymaster_policy_id}
       end
 
       @doc "The configured EntryPoint address."

--- a/packages/raxol_earn/test/raxol/earn/job_id_resolver_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/job_id_resolver_test.exs
@@ -42,8 +42,21 @@ defmodule Raxol.Earn.JobIdResolverTest do
   describe "Receipt" do
     test "resolve decodes the jobId from the createJob receipt logs" do
       adapter = Adapter.new()
-      topic = LogDecoder.event_topic("JobCreated(uint256)")
-      log = %{"topics" => [topic, "0x" <> String.duplicate("0", 62) <> "2a"]}
+
+      topic =
+        LogDecoder.event_topic("JobCreated(uint256,address,address,address,uint256,address)")
+
+      # The deployed AgenticCommerceV3 indexes jobId, client and provider, so a
+      # real JobCreated log carries four topics and jobId is topics[1].
+      log = %{
+        "topics" => [
+          topic,
+          "0x" <> String.duplicate("0", 62) <> "2a",
+          "0x" <> String.duplicate("0", 24) <> String.duplicate("11", 20),
+          "0x" <> String.duplicate("0", 24) <> String.duplicate("22", 20)
+        ]
+      }
+
       :ok = Adapter.set_receipt(adapter, "0xtx", %{"logs" => [log]})
 
       resolver = %{adapter: Receipt}

--- a/packages/raxol_earn/test/raxol/earn/seller/backend/web_socket_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/seller/backend/web_socket_test.exs
@@ -38,10 +38,22 @@ defmodule Raxol.Earn.Seller.Backend.WebSocketTest do
     pid
   end
 
+  # `whereis` then `stop` is a time-of-check/time-of-use race: the backend can
+  # exit on its own between the two (a reconnect giving up, or an on_exit from a
+  # prior test), and `GenServer.stop/1` on a dead pid exits the CALLER, failing
+  # a test that has already finished its assertions. Teardown wants "ensure it
+  # is not running", which a already-dead process satisfies.
   defp stop_if_running(name) do
     case Process.whereis(name) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
+      nil ->
+        :ok
+
+      pid ->
+        try do
+          GenServer.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
     end
   end
 

--- a/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
@@ -55,8 +55,15 @@ defmodule Raxol.Payments.Req.MandateTest do
     |> ReqMandate.attach(agent_wallet: @agent)
   end
 
+  # `run_request/1` runs the ADAPTER as well as the steps, so without one this
+  # made a real HTTPS request to api.xochi.fi per test -- three Req retries each,
+  # and minutes of wall time on any network that cannot reach it. Only the
+  # OUTBOUND headers are under test here, so the transport is short-circuited.
+  # The tests that assert on responses use `plug: {Req.Test, __MODULE__}`.
+  defp offline(req), do: {req, %Req.Response{status: 200}}
+
   defp header_after_step(req) do
-    {ran, _resp} = Req.Request.run_request(req)
+    {ran, _resp} = Req.Request.run_request(%{req | adapter: &offline/1})
     Req.Request.get_header(ran, "x-xochi-delegation")
   end
 

--- a/packages/raxol_payments/test/support/conformance_fixture.ex
+++ b/packages/raxol_payments/test/support/conformance_fixture.ex
@@ -29,10 +29,34 @@ defmodule Raxol.Payments.Test.ConformanceFixture do
     path |> File.read!() |> Jason.decode!()
   end
 
-  @doc "Filter the fixture by `\"protocol\"` field."
+  @doc """
+  Filter the fixture by `"protocol"` field.
+
+  Returns `[]` when the fixture is absent, rather than raising. The conformance
+  files call this at test-module COMPILE time (`for vec <- by_protocol(...)`
+  inside a `describe`), so the `:conformance` moduletag -- a runtime exclusion --
+  cannot save a raise here: the whole suite dies before a single test runs. That
+  is what kept `raxol_payments` out of CI, where riddler-client is not checked
+  out beside the repo.
+
+  The absence is announced rather than swallowed: generating zero vectors is
+  legitimate here, but it must not look like coverage that passed.
+  """
   @spec by_protocol(String.t()) :: [map()]
   def by_protocol(protocol) do
-    Enum.filter(load!(), &(&1["protocol"] == protocol))
+    case do_locate() do
+      nil ->
+        IO.puts(
+          :stderr,
+          "[conformance] fixture absent -- 0 #{protocol} vectors generated. " <>
+            "Set CONFORMANCE_FIXTURE_PATH or RIDDLER_CLI_DIR to run them."
+        )
+
+        []
+
+      _path ->
+        Enum.filter(load!(), &(&1["protocol"] == protocol))
+    end
   end
 
   @doc "Return the single vector with the given `\"name\"`."


### PR DESCRIPTION
**Stacked on #861 -- merge that first.** Only the last commit is new here.

The per-PR package matrix was `[raxol_gateway, raxol_telegram, raxol_cli]`. The two packages that move real money were ungated. That is how the `Sma7702Wallet` alias bug (#858) shipped: the compiler emitted an undefined-module warning and nothing in CI could fail on it, so a code path that could never execute sat on master for twelve days while an issue blamed the solver.

Flipping the matrix alone would have red-ed both cells on the first run. Four fixes were needed first.

## raxol_payments: `mix test` died at compile time

`ConformanceFixture.by_protocol/1` raised when the riddler-client fixture is absent -- which it always is in CI. The conformance files call it at test-module **compile** time (`for vec <- by_protocol(...)` inside a `describe`), so the `:conformance` moduletag, a *runtime* exclusion, cannot save it. The whole suite died before running a single test.

Now returns `[]` when the fixture is missing, and **says so on stderr**. Generating zero vectors is legitimate here; looking like coverage that passed is not.

## raxol_payments: the suite made real HTTPS calls

`header_after_step/1` calls `Req.Request.run_request/1`, which runs the **adapter** as well as the steps. With no adapter, three tests made real requests to `api.xochi.fi` and `example.com`.

Only the outbound headers are under test, so the transport is now short-circuited. The tests that assert on *responses* already used `plug: {Req.Test, __MODULE__}`; these three just missed it.

Measured on a network that cannot reach Xochi (three Req retries per call):

| | before | after |
| --- | --- | --- |
| `raxol_payments` suite | **264.4s** | **5.6s** |
| result | 1149 passed | 1149 passed |

It would have been faster on a healthy network and still wrong -- the repo's own rule is no real network calls in tests.

## raxol_earn: `mix compile --warnings-as-errors` failed

`use Raxol.Earn.Wallet.SCA` injects `send_sponsored_user_operation/2` as a `with {:ok, sponsored} <- sponsor(op, opts)`. For an instantiation with no `:paymaster_policy_id` -- like `Order.ScaWallet` -- `SCA.sponsor/5` matches nil on its first clause and returns `{:error, :no_paymaster_policy_id}` unconditionally, so the success branch is provably unreachable and the compiler correctly says so.

Rather than making the type opaque to silence a true warning, the dead branch is no longer emitted: with a policy id the `with` is generated as before, without one the function returns the error directly.

**The runtime contract is identical** -- same arity, same error tuple. That matters because `provider_adapter/sca.ex:111` gates on `function_exported?(wallet, :send_sponsored_user_operation, 2)`; conditionally *omitting* the function would have broken that check.

## raxol_earn: a TOCTOU race in test teardown

`stop_if_running/1` did `Process.whereis` then `GenServer.stop`. The backend can exit between the two, and `GenServer.stop/1` on a dead pid exits the **caller**, failing a test that had already passed its assertions. Now catches the exit -- teardown wants "not running", which an already-dead process satisfies.

## Verification

Run exactly as the CI cell runs them (`deps.get`, `compile --warnings-as-errors`, `test`):

| | result |
| --- | --- |
| `raxol_earn` x5 consecutive | 761 passed every run, 0 failures |
| `raxol_payments` x3 consecutive | 1149 passed every run, 0 failures |
| previously-flaky `web_socket_test.exs` x8 isolated | 0 failures |
| `mix compile --warnings-as-errors` both packages | exit 0 |

No new step, service, credential or apt package is needed: `fail-fast: false` already isolates cells, the cache key already uses each package's own `mix.lock`, and the workflow env already supplies `MIX_ENV`/`TMPDIR`/`SKIP_TERMBOX2_TESTS`.

## Follow-up, deliberately not in this PR

**No package file is format-checked anywhere in CI.** The root `.formatter.exs` covers only root `lib/`, `config/`, `examples/`, `test/*.exs`, and the package cell runs no format step. I proved the gap accidentally: my own unformatted `order.ex` passed a green #860. Three of the five gated packages currently have drift (`raxol_gateway`, `raxol_telegram`, `raxol_payments`), so adding a format step here would red three cells and bury this diff in unrelated reformatting. Worth its own PR.

## Manual testing

- [ ] All five package cells green on this PR (raxol_payments and raxol_earn are new)
- [ ] Confirm the two new cells' wall time is acceptable (~30s and ~10s locally, cold)
