### PR TITLE
Report what the order task actually spends

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -128,6 +128,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
         {:ok, bundle} -> bundle
         {:error, reason} -> Mix.raise(sign_intent_error(reason))
       end
+
     requirement = requirement(cfg, bundle)
     log("signed Xochi intent: #{bundle[:intent_id] || bundle["intent_id"]}")
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -27,16 +27,26 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   drives a managed SCA agent:
 
     * `privy` (default) -- Virtuals-delegated signing via the Node signer sidecar
-      (`priv/signer_sidecar`); gas is Alchemy-sponsored (no ETH needed). The buyer
-      is the managed SCA at `RAXOL_ACP_WALLET_ADDRESS`; the intent is signed locally
-      as that SCA (`ORDER_KEY` session key -> ERC-1271).
+      (`priv/signer_sidecar`). No ETH needed, but gas is NOT free: an ERC-20
+      paymaster fronts the ETH and charges the buyer in USDC on every UserOp
+      (~0.0075 observed on Base). The buyer is the managed SCA at
+      `RAXOL_ACP_WALLET_ADDRESS`; the intent is signed by the account's own
+      managed authority (`Sma7702Wallet` -> ERC-1271), not by a session key.
     * `sca` -- direct ERC-4337: the `ORDER_KEY` session key signs UserOps submitted
       to your own bundler + paymaster (`ORDER_BUNDLER_URL`, `ORDER_PAYMASTER_POLICY`).
     * `eoa` -- raw EOA from `ORDER_KEY`. NOT a registered agent (messaging 404s);
       on-chain-only testing.
 
-  MOVES REAL FUNDS on `--fund` (the fee escrow + the Xochi settlement pull). Gas is
-  sponsored under `privy`. `--dry-run` stops after signing (step 1).
+  MOVES REAL FUNDS. Every non-`--dry-run` run spends USDC, because each UserOp pays
+  its own gas in USDC. `--fund` adds the fee escrow: `fee_bps` of the principal,
+  ~0.0024 USDC at the 3.00/8bps default.
+
+  The PRINCIPAL does not move in this task's writes. The signed intent only
+  AUTHORIZES the solver to pull up to that much during settlement, so a "3.00 USDC"
+  run costs ~0.0169 end to end, not 3.00. The task prints a spend plan before the
+  first write and receipt-derived actuals after each one.
+
+  `--dry-run` stops after signing and spends nothing.
 
   ## Env
 
@@ -142,6 +152,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # -- Orchestration --
 
   defp place(cfg, requirement, opts) do
+    print_plan(cfg, opts)
+
     {agent, resolver} = start_buyer(cfg)
 
     # 2. createJob on-chain (or resume an existing job with --job-id).
@@ -186,6 +198,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       })
 
     log("createJob tx: #{explorer(cfg.from)}#{tx}")
+    report_actuals(cfg, "createJob", tx)
 
     job_id = await_job_id(resolver, cfg, tx)
     log("jobId: #{job_id}")
@@ -223,11 +236,114 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     case ProviderAdapter.send_calls(cfg.provider_adapter, cfg.from, calls) do
       {:ok, txs} ->
         log("funded (approve+fund batched): #{inspect(txs)} -- provider will settle + deliver")
+        report_actuals(cfg, "approve+fund", txs)
 
       err ->
         Mix.raise("fund failed: #{inspect(err)}")
     end
   end
+
+  # -- Spend accounting --
+
+  # What this run CAN spend, printed before the first on-chain write. Every line
+  # is a bound or an expectation; actuals come from receipts afterwards.
+  #
+  # The principal is the trap. It is AUTHORIZED by the signed intent and pulled
+  # later by the solver during settlement -- it does not move in this task's
+  # writes. Reporting it as escrow overstates a $3.00 run by ~175x.
+  defp print_plan(cfg, opts), do: Enum.each(spend_plan_lines(cfg, opts), &log/1)
+
+  @doc false
+  # Public only so it can be tested: the escrow arithmetic and the wording of
+  # the principal line are the two things this exists to get right.
+  @spec spend_plan_lines(map(), keyword()) :: [String.t()]
+  def spend_plan_lines(cfg, opts) do
+    decimals = Assets.decimals(cfg.from, cfg.src_token)
+    expected_escrow = div(cfg.principal_atomic * cfg.fee_bps, 10_000)
+    funding? = Keyword.get(opts, :fund, false)
+
+    legs =
+      [
+        if(Keyword.get(opts, :job_id), do: nil, else: "createJob"),
+        if(funding?, do: "approve+fund", else: nil)
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    [
+      "SPEND PLAN -- buyer #{cfg.buyer} on chain #{cfg.from}, amounts in USDC",
+      "  escrow     ~#{Assets.to_human(expected_escrow, decimals)} expected " <>
+        "(#{cfg.fee_bps} bps of #{cfg.amount}) -> ACP Core #{cfg.core}",
+      "             the PROVIDER sets the real budget on-chain; --fund pays what it set",
+      "  gas         charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH " <>
+        "and NOT free; priced per UserOp, known only from the receipt",
+      "             UserOps this run: #{Enum.join(legs, ", ")}",
+      "  principal   #{cfg.amount} AUTHORIZED, not moved here -- the signed intent lets " <>
+        "the solver pull up to that during settlement"
+    ] ++
+      if funding?,
+        do: [],
+        else: ["  (no --fund: no escrow this run, but the createJob UserOp still costs USDC gas)"]
+  end
+
+  # What actually moved, decoded from receipts. Only USDC transfers OUT of the
+  # buyer count as spend; anything else in the tx is someone else's money.
+  @transfer_topic "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+  defp report_actuals(cfg, label, tx_hashes) do
+    client = Raxol.Earn.Onchain.RPC.client(url: cfg.rpc)
+    decimals = Assets.decimals(cfg.from, cfg.src_token)
+
+    transfers =
+      tx_hashes
+      |> List.wrap()
+      |> Enum.flat_map(&buyer_transfers(client, cfg, &1))
+
+    case transfers do
+      [] ->
+        log("SPEND ACTUAL (#{label}): no USDC left the buyer, or receipts not yet available")
+
+      transfers ->
+        total = transfers |> Enum.map(&elem(&1, 1)) |> Enum.sum()
+
+        log("SPEND ACTUAL (#{label}): #{Assets.to_human(total, decimals)} USDC left the buyer")
+
+        Enum.each(transfers, fn {to, amount} ->
+          log("  #{Assets.to_human(amount, decimals)} -> #{to}#{destination_note(cfg, to)}")
+        end)
+    end
+  rescue
+    # Accounting must never take down a run that already moved money.
+    e -> log("SPEND ACTUAL (#{label}): could not read receipts (#{Exception.message(e)})")
+  end
+
+  defp buyer_transfers(client, cfg, tx_hash) do
+    case Raxol.Earn.Onchain.RPC.await_receipt(client, tx_hash, timeout_ms: 20_000) do
+      {:ok, %{"logs" => logs}} when is_list(logs) ->
+        buyer_topic = pad_topic(cfg.buyer)
+
+        for %{"address" => addr, "topics" => [topic0, from, to | _], "data" => data} <- logs,
+            String.downcase(addr) == String.downcase(cfg.src_token),
+            String.downcase(topic0) == @transfer_topic,
+            String.downcase(from) == buyer_topic do
+          {"0x" <> String.slice(to, -40, 40), parse_uint(data)}
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp destination_note(cfg, to) do
+    if String.downcase(to) == String.downcase(cfg.core),
+      do: "  (ACP Core -- the fee escrow)",
+      else: "  (gas: ERC-20 paymaster)"
+  end
+
+  defp pad_topic("0x" <> addr),
+    do: String.downcase("0x" <> String.duplicate("0", 24) <> addr)
+
+  defp parse_uint("0x" <> hex), do: String.to_integer(hex, 16)
+  defp parse_uint(_), do: 0
 
   # -- Steps --
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -123,7 +123,11 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     )
 
     # 1. Sign the Xochi intent (off-chain).
-    {:ok, bundle} = sign_intent(cfg)
+    bundle =
+      case sign_intent(cfg) do
+        {:ok, bundle} -> bundle
+        {:error, reason} -> Mix.raise(sign_intent_error(reason))
+      end
     requirement = requirement(cfg, bundle)
     log("signed Xochi intent: #{bundle[:intent_id] || bundle["intent_id"]}")
 
@@ -532,6 +536,32 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       v -> v
     end
   end
+
+  # A bare `{:ok, _} =` here reported a transport failure as a MatchError on a
+  # Req struct, which reads like a Xochi outage. It is more often the local
+  # network: some ISPs null-route whole Cloudflare ranges, and api.xochi.fi
+  # resolves into one (188.114.96.0/20). Observed on Vodafone ES -- port 80 is
+  # intercepted with an "Acceso bloqueado" page and 443 is dropped, so every
+  # request dies at connect with no HTTP status to explain itself.
+  defp sign_intent_error(%{__struct__: Req.TransportError, reason: reason}) do
+    """
+    could not reach the Xochi API (transport #{inspect(reason)}).
+
+    This is usually the network path, not Xochi. Check, in order:
+
+      nc -z api.xochi.fi 443          # dropped => blocked upstream, not down
+      curl -sI http://api.xochi.fi    # a non-Cloudflare page here => intercepted
+      curl -s "https://r.jina.ai/https://xochi.fi"   # answers => the API is fine
+
+    A control host only proves anything if it shares the blocked IP range;
+    cloudflare.com and other Cloudflare sites sit elsewhere and will pass while
+    this one fails. Route around it with a VPN or an exit node in another
+    country. Confirm from off-network before reporting an outage upstream.
+    """
+  end
+
+  defp sign_intent_error(reason),
+    do: "could not sign the Xochi intent: #{inspect(reason)}"
 
   @explorers %{
     1 => "https://etherscan.io/tx/",

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -386,8 +386,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     {from, to} = parse_corridor(Keyword.get(opts, :corridor, "8453>42161"))
     amount = Keyword.get(opts, :amount, "3.00")
 
-    {:ok, src_token} = Assets.address(from, "USDC")
-    {:ok, dst_token} = Assets.address(to, "USDC")
+    src_token = usdc_address!(from, "origin")
+    dst_token = usdc_address!(to, "destination")
     principal_atomic = Assets.to_atomic(Decimal.new(amount), Assets.decimals(from, src_token))
 
     signer = Keyword.get(opts, :signer, "privy")
@@ -427,7 +427,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     _ = fetch_env!("RAXOL_ACP_SIGNER_PRIVATE_KEY")
     address = fetch_env!("RAXOL_ACP_WALLET_ADDRESS")
 
-    {:ok, _} = Raxol.Earn.SignerSidecar.start_link([])
+    start_sidecar!()
 
     provider =
       ProviderAdapter.Privy.new(
@@ -563,6 +563,57 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   defp sign_intent_error(reason),
     do: "could not sign the Xochi intent: #{inspect(reason)}"
+
+  # `Assets.address/2` answers a bare `:error` for an unsupported pair, so a
+  # bad --corridor used to surface as `no match of right hand side value: :error`
+  # with no hint of which side was wrong.
+  defp usdc_address!(chain_id, side) do
+    case Assets.address(chain_id, "USDC") do
+      {:ok, address} ->
+        address
+
+      :error ->
+        supported =
+          Assets.supported_chain_ids()
+          |> Enum.map(&"#{&1} (#{Assets.chain_name(&1)})")
+          |> Enum.join(", ")
+
+        Mix.raise("""
+        no USDC address for the #{side} chain #{chain_id}.
+
+        Check --corridor (origin>destination). Chains with a USDC address:
+          #{supported}
+        """)
+    end
+  end
+
+  # The sidecar is a Node process: it fails when node is missing, its deps are
+  # not installed, the port is taken, or the Privy credentials are rejected.
+  # Each of those used to arrive as a MatchError on a start_link tuple.
+  defp start_sidecar!() do
+    case Raxol.Earn.SignerSidecar.start_link([]) do
+      {:ok, pid} ->
+        pid
+
+      {:error, {:already_started, pid}} ->
+        pid
+
+      {:error, reason} ->
+        Mix.raise("""
+        the Privy signer sidecar did not start: #{inspect(reason)}
+
+        It is a Node process under packages/raxol_earn/priv/signer_sidecar.
+        Check, in order:
+
+          node --version                       # must be present on PATH
+          ls priv/signer_sidecar/node_modules  # run `npm install` there if absent
+          lsof -i :4048                        # default port, must be free
+
+        RAXOL_ACP_WALLET_ADDRESS / RAXOL_ACP_WALLET_ID / RAXOL_ACP_SIGNER_PRIVATE_KEY
+        must all be set: the sidecar reads them at boot and exits if any is missing.
+        """)
+    end
+  end
 
   @explorers %{
     1 => "https://etherscan.io/tx/",

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.rebalance.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.rebalance.ex
@@ -39,7 +39,19 @@ defmodule Mix.Tasks.RaxolEarn.Rebalance do
   defp sweep(acc, rpc_urls, solver) do
     # A throwaway ledger: the drain only tiebreaks refuel ordering, so an empty one
     # still yields correct balance-driven recommendations for a snapshot.
-    {:ok, ledger} = SettlementLedger.start_link(table_name: :raxol_earn_rebalance_task)
+    ledger =
+      case SettlementLedger.start_link(table_name: :raxol_earn_rebalance_task) do
+        {:ok, pid} ->
+          pid
+
+        # Re-running the sweep in one VM (or an ETS table left by a prior run)
+        # is not a failure -- the ledger is a throwaway either way.
+        {:error, {:already_started, pid}} ->
+          pid
+
+        {:error, reason} ->
+          Mix.raise("could not start the throwaway settlement ledger: #{inspect(reason)}")
+      end
 
     RebalanceMonitor.advise_once(
       ledger: ledger,

--- a/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
@@ -1,0 +1,83 @@
+defmodule Raxol.Earn.OrderSpendPlanTest do
+  @moduledoc """
+  The spend plan `mix raxol_earn.order` prints before its first on-chain write.
+
+  These assertions exist because the numbers were reported wrong in practice: a
+  3.00 USDC run was described as moving 3.00 into escrow, when it moves ~0.0024
+  (the fee) plus USDC-denominated gas, and the principal never moves in this
+  task's writes at all -- it is only authorized for the solver to pull later.
+  An overstatement of ~175x.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.RaxolEarn.Order
+
+  # 3.00 USDC on Base at the default 8 bps.
+  defp cfg do
+    %{
+      buyer: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      from: 8453,
+      src_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      core: "0x238E541BfefD82238730D00a2208E5497F1832E0",
+      amount: "3.00",
+      principal_atomic: 3_000_000,
+      fee_bps: 8
+    }
+  end
+
+  defp plan(opts), do: Order.spend_plan_lines(cfg(), opts) |> Enum.join("\n")
+
+  describe "escrow" do
+    test "is the fee, not the principal" do
+      text = plan(fund: true)
+
+      # 8 bps of 3.000000 USDC = 2400 atomic = 0.0024.
+      assert text =~ "0.0024"
+      refute text =~ "3.00 expected"
+    end
+
+    test "scales with fee_bps" do
+      lines = Order.spend_plan_lines(%{cfg() | fee_bps: 100}, fund: true) |> Enum.join("\n")
+      # 100 bps of 3.000000 = 30000 atomic = 0.03.
+      assert lines =~ "0.03"
+    end
+  end
+
+  describe "principal" do
+    test "is described as authorized, never as moved" do
+      text = plan(fund: true)
+
+      assert text =~ "principal   3.00 AUTHORIZED"
+      assert text =~ "not moved here"
+    end
+  end
+
+  describe "gas" do
+    test "is not claimed to be sponsored or free" do
+      text = plan(fund: true)
+
+      assert text =~ "NOT in ETH"
+      assert text =~ "NOT free"
+      refute text =~ "sponsored"
+    end
+  end
+
+  describe "legs" do
+    test "a funded run names both UserOps" do
+      assert plan(fund: true) =~ "UserOps this run: createJob, approve+fund"
+    end
+
+    test "an unfunded run still warns that createJob costs gas" do
+      text = plan([])
+
+      assert text =~ "UserOps this run: createJob"
+      assert text =~ "no --fund: no escrow this run"
+      assert text =~ "still costs USDC gas"
+    end
+
+    test "resuming an existing job drops the createJob leg" do
+      assert plan(job_id: 73_295, fund: true) =~ "UserOps this run: approve+fund"
+    end
+  end
+end


### PR DESCRIPTION
**Stacked on #860 -- merge that first.** Only the last commit is new here.

I reported a funded run as moving "$3.00 USDC into escrow". It moved **0.0169 USDC**, and I only established that afterwards by hand-decoding transfer logs. An overstatement of ~175x on a command whose entire purpose is spending real money.

The task knew every number up front and printed none of them.

## What a `--fund` run actually moves

Three buckets, only two of them real transfers:

| Bucket | Reality |
| --- | --- |
| **escrow** | `fee_bps` of the principal -- 0.002400 USDC at the 3.00/8bps default -- buyer -> ACP Core `0x238e541b` |
| **gas** | 0.0069-0.0075 USDC **per UserOp**, buyer -> `0x5d74bdab...`, pulled by the ERC-20 `VerifyingPaymaster` in postOp |
| **principal** | **never moves in this task's writes.** The signed intent only AUTHORIZES the solver to pull up to that during settlement |

## The moduledoc was wrong about gas

It said "gas is Alchemy-sponsored (no ETH needed)". Half right: no ETH is needed (the buyer's ETH balance is zero and a bundler EOA fronts it), but **the buyer reimburses in USDC on every single UserOp**. The paymaster's `TokenSponsored` amount matches the USDC transfer to the byte across four observed UserOps (6946, 7509, 6952, 7521). "Sponsored" implies free; it is not.

So even a run *without* `--fund` costs USDC, which the docs never said.

## The change

**A plan before the first write** -- bounds and expectations only, never a claim that value moved:

```
SPEND PLAN -- buyer 0x468a...2283 on chain 8453, amounts in USDC
  escrow     ~0.0024 expected (8 bps of 3.00) -> ACP Core 0x238E541B...
             the PROVIDER sets the real budget on-chain; --fund pays what it set
  gas        charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH
             and NOT free; priced per UserOp, known only from the receipt
             UserOps this run: createJob, approve+fund
  principal  3.00 AUTHORIZED, not moved here -- the signed intent lets the
             solver pull up to that during settlement
```

**Receipt-derived actuals after each write** -- only USDC transfers *out of the buyer* count, and each is labelled by destination:

```
SPEND ACTUAL (approve+fund): 0.009352 USDC left the buyer
  0.0024 -> 0x238e541b...  (ACP Core -- the fee escrow)
  0.006952 -> 0x5d74bdab...  (gas: ERC-20 paymaster)
```

Accounting is wrapped so it can never take down a run that already moved money -- a receipt it cannot read degrades to a line saying so.

## Verification

The decoder was run against the **real** fund transaction from job 73295 (`0xc8eba599...`), not a fixture:

```
buyer USDC transfers: [
  {"0x238e541bfefd82238730d00a2208e5497f1832e0", 2400},
  {"0x5d74bdab1ce9ddadd7e2e333d1d173830860694a", 6952}
]
total: 0.009352 USDC
```

which matches the hand-decode of both funded runs.

`spend_plan_lines/2` is public (`@doc false`) purely so the arithmetic is testable. **7 new tests** pin the two things that were wrong: escrow is the fee and scales with `fee_bps`, and the principal line says AUTHORIZED / not moved. One asserts the word "sponsored" no longer appears.

`raxol_earn`: 767/768, sole failure the pre-existing `JobIdResolverTest` fixed in #861.

## Manual testing

- [x] Decoder verified against the on-chain fund tx for job 73295
- [x] 7 spend-plan tests green
- [ ] Plan text reviewed on the next real funded run (it only prints on a non-dry-run)
