### PR TITLE
Cover smart-account signatures, and unbreak three live gate paths

### DIFF
--- a/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
@@ -1,0 +1,118 @@
+defmodule Raxol.Earn.Xochi.SmartAccountWireTest do
+  @moduledoc """
+  Pins the wire shape of a SMART-ACCOUNT signature against the constraint that
+  currently rejects it downstream.
+
+  ## Why this exists
+
+  Every live gate that has ever passed used an EOA buyer. Nothing exercised an
+  ERC-1271 signature, and that gap let one assumption -- "a signature is 65
+  bytes" -- survive three layers into production:
+
+    1. raxol built the wrong ERC-1271 replay-safe domain (fixed, #773)
+    2. Xochi's ERC-1271 verification silently never ran, because no `RPC_URL_*`
+       was set in production, so every smart-account signer got a bare 401
+       (fixed, xochi-fi/xochi#364, deployed 2026-08-15)
+    3. Riddler's request schema constrains the signature to exactly 65 bytes,
+       `~r/^0x[a-fA-F0-9]{130}$/` (open, axol-io/Riddler#802)
+
+  Layer 3 is why a real funded order (job 73295) still fails today, at
+  `validation_failed: Request validation failed`.
+
+  ## What this test can and cannot do
+
+  It asserts OUR half: the ma-v2 envelope raxol produces is 72 bytes, and a
+  72-byte signature cannot match the 65-byte pattern the solver enforces. That
+  makes the incompatibility an executable fact rather than a note in an issue,
+  and it fails immediately if anyone changes the envelope.
+
+  It deliberately does NOT probe the live service, because there is no
+  fund-free way to reach the constraint. Xochi verifies the signature BEFORE
+  forwarding to Riddler: an intent signed with an unauthorized key is rejected
+  at Xochi's ERC-1271 check and never reaches the schema, while a validly
+  signed one executes the pull and moves the principal. A live probe would
+  therefore either test the wrong layer or spend real money.
+
+  When #802 lands, the confirmation is one funded run:
+  `mix raxol_earn.order --amount 3.00 --signer privy --fund` (~0.017 USDC).
+  """
+
+  use ExUnit.Case, async: true
+
+  # Verbatim from Riddler `integrations/xochi/schemas/execute_request.ex:42`,
+  # duplicated in `web/openapi/schema.ex:92` and `claim_submit_request.ex:63`,
+  # and published in `packages/api/src/spec.json` as
+  # `CommerceOrderRequest.properties.signature`.
+  @riddler_signature_pattern ~r/^0x[a-fA-F0-9]{130}$/
+
+  @account "0x468aeae798b3a6548ac2401d276f83afdc172283"
+  @chain 8453
+  @raw_sig :binary.copy(<<0xAB>>, 64) <> <<27>>
+
+  # Stands in for the managed Privy authority, in the ProviderAdapter shape the
+  # wallet dispatches through. It returns a fixed 65-byte signature, so this
+  # pins the ENVELOPE rather than secp256k1.
+  defmodule MockAuthority do
+    @moduledoc false
+    def new, do: %{adapter: __MODULE__, config: %{}}
+
+    def sign_typed_data(_provider, _chain_id, _typed_data),
+      do: {:ok, Raxol.Earn.Xochi.SmartAccountWireTest.raw_sig()}
+  end
+
+  def raw_sig, do: @raw_sig
+
+  def provider, do: MockAuthority.new()
+
+  defmodule Wallet do
+    @moduledoc false
+    use Raxol.Earn.Wallet.Sma7702,
+      account_address: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      chain_id: 8453,
+      provider: {Raxol.Earn.Xochi.SmartAccountWireTest, :provider}
+  end
+
+  defp envelope do
+    {:ok, sig} =
+      Wallet.sign_typed_data(
+        %{name: "XochiIntent", version: "1", chainId: @chain, verifyingContract: @account},
+        %{"Intent" => [{"amount", "uint256"}]},
+        %{"amount" => 3_000_000}
+      )
+
+    sig
+  end
+
+  describe "the ma-v2 ERC-1271 envelope" do
+    test "is 72 bytes: 0x00 || uint32(0) || 0xFF || 0x00 || sig65" do
+      sig = envelope()
+
+      assert <<0x00, 0::unsigned-big-32, 0xFF, 0x00, inner::binary>> = sig
+      assert byte_size(inner) == 65
+      assert byte_size(sig) == 72
+      assert inner == @raw_sig
+    end
+
+    test "does not satisfy Riddler's 65-byte signature pattern (axol-io/Riddler#802)" do
+      hex = "0x" <> Base.encode16(envelope(), case: :lower)
+
+      # 72 bytes = 144 hex chars; the pattern demands exactly 130.
+      assert String.length(hex) == 146
+      refute Regex.match?(@riddler_signature_pattern, hex)
+    end
+
+    test "a plain EOA signature does satisfy it -- the pattern is not simply broken" do
+      hex = "0x" <> Base.encode16(@raw_sig, case: :lower)
+
+      assert String.length(hex) == 132
+      assert Regex.match?(@riddler_signature_pattern, hex)
+    end
+  end
+
+  describe "the account itself" do
+    test "is the 7702 buyer the live gates use" do
+      assert Wallet.address() == @account
+      assert Wallet.chain_id() == @chain
+    end
+  end
+end

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -99,9 +99,9 @@ PAYMENTS_DIR="$REPO_ROOT/packages/raxol_payments"
 ACP_DIR="$REPO_ROOT/packages/raxol_earn"
 
 XOCHI_TEST="test/raxol/payments/xochi/live_xochi_test.exs"
-ORDER_TEST="test/raxol/acp/xochi/live_order_test.exs"
-RELAY_TEST="test/raxol/acp/relay/live_relay_test.exs"
-SOLVER_FEE_TEST="test/raxol/acp/xochi/solver_fee_live_test.exs"
+ORDER_TEST="test/raxol/earn/xochi/live_order_test.exs"
+RELAY_TEST="test/raxol/earn/relay/live_relay_test.exs"
+SOLVER_FEE_TEST="test/raxol/earn/xochi/solver_fee_live_test.exs"
 
 # --- defaults / env inputs ---
 ASSETS=""


### PR DESCRIPTION
Every live gate that has ever passed used an **EOA buyer**. Nothing exercised an ERC-1271 signature, and that gap let one assumption -- "a signature is 65 bytes" -- survive three layers into production:

1. raxol built the wrong ERC-1271 replay-safe domain (fixed, #773)
2. Xochi's ERC-1271 verification silently never ran, because no `RPC_URL_*` was set in production (fixed, xochi-fi/xochi#364, deployed 2026-08-15)
3. Riddler's request schema constrains the signature to exactly 65 bytes (**open**, axol-io/Riddler#802)

Layer 3 is why a real funded order still fails today, at `validation_failed: Request validation failed`.

## Three live gate cells were dead

The `raxol_acp` -> `raxol_earn` rename (#779) left `scripts/run_live_gates.sh` pointing at paths that no longer exist:

```
ORDER_TEST      test/raxol/acp/xochi/live_order_test.exs        MISSING
RELAY_TEST      test/raxol/acp/relay/live_relay_test.exs        MISSING
SOLVER_FEE_TEST test/raxol/acp/xochi/solver_fee_live_test.exs   MISSING
```

Every `acp`, `relay` and `fee` cell has been hard-failing on "Paths given to mix test did not match any directory/file" -- failing for a typo, before running anything. Repointed at `test/raxol/earn/...`, all three verified present. A new smart-account row next to three rows failing for a rename would have been worthless.

## What this adds

`smart_account_wire_test.exs` pins our half as an executable fact: the ma-v2 envelope is **72 bytes** (`0x00 || uint32(0) || 0xFF || 0x00 || sig65`), and a 72-byte signature **cannot** match `~r/^0x[a-fA-F0-9]{130}$/` -- the pattern copied verbatim from Riddler's `execute_request.ex:42`. A control assertion proves the pattern is not simply broken: a plain EOA signature does match it.

So the incompatibility now lives in CI rather than in an issue, and it fails the moment anyone changes the envelope. With #862 gating `raxol_earn`, it actually runs on every PR.

Mutation-proven against the real packer (`ModularAccount.pack_1271_eoa_signature/2`):

| Mutation | Result |
| --- | --- |
| marker byte `0xFF` -> `0xFE` | 1 failure |
| drop the leading `0x00` (71-byte envelope) | 2 failures |
| restored | 4 passed |

## Why there is no live cell, contrary to the original plan

I set out to add a fund-free live probe that would flip green when #802 lands, signing with a throwaway key so it could never move funds. **That design gates the wrong layer**, and I only caught it by re-reading Xochi's handler.

Xochi verifies the signature **before** forwarding to Riddler. An intent signed with an unauthorized key is rejected at Xochi's own ERC-1271 check (401) and never reaches Riddler's schema -- so the probe would have reported on layer 2, which is already fixed, while claiming to watch layer 3. And the only way to reach Riddler's validation is a *validly* signed intent, which executes the pull and moves the principal.

There is therefore no fund-free path to the constraint, and I would rather ship a smaller true thing than a live cell that lies about what it watches.

When #802 lands, the confirmation is one command, ~0.017 USDC:

```
mix raxol_earn.order --amount 3.00 --signer privy --fund
```

That is recorded in the test's moduledoc, so the next person finds it there.

## Verification

- [x] `bash -n` and `shellcheck -S error` clean on the gate script
- [x] All four repointed/existing test paths confirmed present on disk
- [x] 4 new tests green; both envelope mutations red
- [x] `raxol_earn` 764/765, sole failure the pre-existing `JobIdResolverTest` fixed in #861

## Manual testing

- [ ] `./scripts/run_live_gates.sh --asset USDC --route acp --dry-run` reaches the test instead of failing on a missing path
- [ ] Re-run the funded order once Riddler#802 lands
