### PR TITLE
Format-check the packages in CI

### DIFF
--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -287,7 +287,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [raxol_gateway, raxol_telegram, raxol_cli]
+        # raxol_payments and raxol_earn move real money and were the two least
+        # gated packages in the repo: the Sma7702Wallet alias bug (#858) shipped
+        # with a compiler warning nobody could fail on, because nothing here ran
+        # them. Adding them required unbreaking both suites first -- see the PR.
+        package: [raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -317,6 +317,15 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
 
+      # The root Format Check reads the root .formatter.exs, whose inputs cover
+      # only root lib/config/examples/test -- so before this step NO file under
+      # packages/ was format-checked anywhere in CI. Drift accumulated silently
+      # across formatter versions (25 files over three packages when this was
+      # added), and an unformatted file could pass a fully green run.
+      - name: Check formatting
+        working-directory: packages/${{ matrix.package }}
+        run: mix format --check-formatted
+
       - name: Compile package
         working-directory: packages/${{ matrix.package }}
         run: |

--- a/packages/raxol_earn/config/buyer.example.exs
+++ b/packages/raxol_earn/config/buyer.example.exs
@@ -75,11 +75,17 @@ config :raxol_earn,
     server_url: "https://api-dev.acp.virtuals.io",
     chain_ids: [84_532]
   ],
-  # jobId resolution after createJob. Defaults to JobIdResolver.Receipt.
-  # CONFIRM the JobCreated event signature / indexed position in the dry-run,
-  # then override here:
+  # jobId resolution after createJob. Defaults to JobIdResolver.Receipt, whose
+  # default signature matches the deployed AgenticCommerceV3 core -- leave this
+  # nil unless you are pointing at a different core.
+  #
+  # An override is easy to get wrong and fails QUIETLY: a signature that does
+  # not match the emitted event decodes to :pending, not an error, so the buyer
+  # falls through to reconcile-by-tag instead of reporting a bad jobId. If you
+  # do override, take the signature from the core's verified ABI, not from here:
   #
   #     buyer_job_id_resolver:
   #       {Raxol.Earn.JobIdResolver.Receipt,
-  #        %{event_signature: "JobCreated(uint256)", topic_index: 1}}
+  #        %{event_signature: "JobCreated(uint256,address,address,address,uint256,address)",
+  #          topic_index: 1}}
   buyer_job_id_resolver: nil

--- a/packages/raxol_earn/lib/raxol/earn/wallet/sca.ex
+++ b/packages/raxol_earn/lib/raxol/earn/wallet/sca.ex
@@ -185,10 +185,22 @@ defmodule Raxol.Earn.Wallet.SCA do
       """
       @spec send_sponsored_user_operation(Raxol.Earn.Wallet.SCA.UserOp.t(), keyword()) ::
               {:ok, String.t()} | {:error, term()}
-      def send_sponsored_user_operation(op, opts \\ []) do
-        with {:ok, sponsored} <- sponsor(op, opts) do
-          send_user_operation(sponsored, opts)
+      if unquote(paymaster_policy_id) do
+        def send_sponsored_user_operation(op, opts \\ []) do
+          with {:ok, sponsored} <- sponsor(op, opts) do
+            send_user_operation(sponsored, opts)
+          end
         end
+      else
+        # Without a `:paymaster_policy_id` this wallet can never be sponsored:
+        # `SCA.sponsor/5` matches nil on its first clause and returns the error
+        # unconditionally. Generating the `with` anyway gives every policy-less
+        # instantiation an unreachable success branch, which the compiler
+        # correctly reports and `--warnings-as-errors` then fails on. The
+        # runtime contract is unchanged -- same error tuple, same arity -- the
+        # dead branch simply is not emitted.
+        def send_sponsored_user_operation(_op, _opts \\ []),
+          do: {:error, :no_paymaster_policy_id}
       end
 
       @doc "The configured EntryPoint address."

--- a/packages/raxol_earn/test/raxol/earn/job_id_resolver_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/job_id_resolver_test.exs
@@ -42,8 +42,21 @@ defmodule Raxol.Earn.JobIdResolverTest do
   describe "Receipt" do
     test "resolve decodes the jobId from the createJob receipt logs" do
       adapter = Adapter.new()
-      topic = LogDecoder.event_topic("JobCreated(uint256)")
-      log = %{"topics" => [topic, "0x" <> String.duplicate("0", 62) <> "2a"]}
+
+      topic =
+        LogDecoder.event_topic("JobCreated(uint256,address,address,address,uint256,address)")
+
+      # The deployed AgenticCommerceV3 indexes jobId, client and provider, so a
+      # real JobCreated log carries four topics and jobId is topics[1].
+      log = %{
+        "topics" => [
+          topic,
+          "0x" <> String.duplicate("0", 62) <> "2a",
+          "0x" <> String.duplicate("0", 24) <> String.duplicate("11", 20),
+          "0x" <> String.duplicate("0", 24) <> String.duplicate("22", 20)
+        ]
+      }
+
       :ok = Adapter.set_receipt(adapter, "0xtx", %{"logs" => [log]})
 
       resolver = %{adapter: Receipt}

--- a/packages/raxol_earn/test/raxol/earn/seller/backend/web_socket_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/seller/backend/web_socket_test.exs
@@ -38,10 +38,22 @@ defmodule Raxol.Earn.Seller.Backend.WebSocketTest do
     pid
   end
 
+  # `whereis` then `stop` is a time-of-check/time-of-use race: the backend can
+  # exit on its own between the two (a reconnect giving up, or an on_exit from a
+  # prior test), and `GenServer.stop/1` on a dead pid exits the CALLER, failing
+  # a test that has already finished its assertions. Teardown wants "ensure it
+  # is not running", which a already-dead process satisfies.
   defp stop_if_running(name) do
     case Process.whereis(name) do
-      nil -> :ok
-      pid -> GenServer.stop(pid)
+      nil ->
+        :ok
+
+      pid ->
+        try do
+          GenServer.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
     end
   end
 

--- a/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket.ex
@@ -94,10 +94,8 @@ defmodule Raxol.Gateway.Adapter.Discord.GatewaySocket do
       transport: Keyword.get(opts, :transport, MintTransport),
       transport_opts: Keyword.get(opts, :transport_opts, []),
       parent: Keyword.get(opts, :parent),
-      reconnect_base_ms:
-        Keyword.get(opts, :reconnect_base_ms, @default_reconnect_base_ms),
-      reconnect_max_ms:
-        Keyword.get(opts, :reconnect_max_ms, @default_reconnect_max_ms),
+      reconnect_base_ms: Keyword.get(opts, :reconnect_base_ms, @default_reconnect_base_ms),
+      reconnect_max_ms: Keyword.get(opts, :reconnect_max_ms, @default_reconnect_max_ms),
       jitter_fn: Keyword.get(opts, :jitter_fn, &:rand.uniform/0),
       conn: nil,
       phase: :disconnected,

--- a/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket/mint_transport.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket/mint_transport.ex
@@ -97,8 +97,7 @@ defmodule Raxol.Gateway.Adapter.Discord.GatewaySocket.MintTransport do
         {%{t | conn: conn, ws: ws}, [:upgraded | events]}
 
       {:error, conn, reason} ->
-        {%{t | conn: conn},
-         [{:transport_error, {:upgrade_failed, reason}} | events]}
+        {%{t | conn: conn}, [{:transport_error, {:upgrade_failed, reason}} | events]}
     end
   end
 

--- a/packages/raxol_payments/lib/mix/tasks/raxol.docs.tools.ex
+++ b/packages/raxol_payments/lib/mix/tasks/raxol.docs.tools.ex
@@ -54,14 +54,10 @@ defmodule Mix.Tasks.Raxol.Docs.Tools do
         Mix.shell().info("TOOL_CATALOG.md is up to date")
 
       {:ok, _stale} ->
-        Mix.raise(
-          "docs/reference/TOOL_CATALOG.md is stale. Run `mix raxol.docs.tools`."
-        )
+        Mix.raise("docs/reference/TOOL_CATALOG.md is stale. Run `mix raxol.docs.tools`.")
 
       {:error, _} ->
-        Mix.raise(
-          "docs/reference/TOOL_CATALOG.md is missing. Run `mix raxol.docs.tools`."
-        )
+        Mix.raise("docs/reference/TOOL_CATALOG.md is missing. Run `mix raxol.docs.tools`.")
     end
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/accounting.ex
+++ b/packages/raxol_payments/lib/raxol/payments/accounting.ex
@@ -85,8 +85,6 @@ defmodule Raxol.Payments.Accounting do
 
   @spec price_source() :: atom()
   defp price_source do
-    String.to_atom(
-      System.get_env("RAXOL_PRICE_SOURCE") || @default_price_source
-    )
+    String.to_atom(System.get_env("RAXOL_PRICE_SOURCE") || @default_price_source)
   end
 end

--- a/packages/raxol_payments/lib/raxol/payments/echo_server.ex
+++ b/packages/raxol_payments/lib/raxol/payments/echo_server.ex
@@ -184,8 +184,7 @@ defmodule Raxol.Payments.EchoServer do
       "payTo" => Keyword.fetch!(opts, :pay_to),
       "asset" => Keyword.fetch!(opts, :asset),
       "network" => Keyword.fetch!(opts, :network),
-      "nonce" =>
-        "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
+      "nonce" => "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
       "validAfter" => 0,
       "validBefore" => System.system_time(:second) + 3600
     }
@@ -193,8 +192,7 @@ defmodule Raxol.Payments.EchoServer do
 
   defp build_receipt(payload) do
     %{
-      "transactionHash" =>
-        "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
+      "transactionHash" => "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
       "network" => payload["network"],
       "success" => true,
       "settledBy" => "echo_server"

--- a/packages/raxol_payments/lib/raxol/payments/eip191.ex
+++ b/packages/raxol_payments/lib/raxol/payments/eip191.ex
@@ -15,9 +15,7 @@ defmodule Raxol.Payments.Eip191 do
   """
   @spec digest(binary()) :: binary()
   def digest(message) when is_binary(message) do
-    ExKeccak.hash_256(
-      @prefix <> Integer.to_string(byte_size(message)) <> message
-    )
+    ExKeccak.hash_256(@prefix <> Integer.to_string(byte_size(message)) <> message)
   end
 
   @doc """

--- a/packages/raxol_payments/lib/raxol/payments/eip712.ex
+++ b/packages/raxol_payments/lib/raxol/payments/eip712.ex
@@ -63,10 +63,7 @@ defmodule Raxol.Payments.EIP712 do
     with {:ok, domain_separator} <-
            hash_struct("EIP712Domain", domain, eip712_domain_types(domain)),
          {:ok, message_hash} <- hash_struct(primary_type(types), message, types) do
-      {:ok,
-       ExKeccak.hash_256(
-         <<0x19, 0x01, domain_separator::binary, message_hash::binary>>
-       )}
+      {:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}
     end
   end
 
@@ -119,8 +116,7 @@ defmodule Raxol.Payments.EIP712 do
   # (an EIP-155 chain-encoded v, or a buggy signer) would silently pack a
   # non-recovering signature, so fail loud rather than emit one.
   defp canonical_v(v),
-    do:
-      raise(ArgumentError, "non-canonical secp256k1 recovery id: #{inspect(v)}")
+    do: raise(ArgumentError, "non-canonical secp256k1 recovery id: #{inspect(v)}")
 
   # EIP-712 defines exactly five domain fields, in this order: name, version,
   # chainId, verifyingContract, salt. Only the keys present in the domain map are

--- a/packages/raxol_payments/lib/raxol/payments/mandate/store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/mandate/store.ex
@@ -145,6 +145,7 @@ defmodule Raxol.Payments.Mandate.Store do
   @impl Raxol.Core.Behaviours.BaseManager
   def init_manager(opts) do
     name = Naming.registered_name!(__MODULE__)
+
     tables = %{
       primary: primary_table(name),
       by_agent: by_agent_table(name),

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -197,9 +197,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
     signer =
       opts[:deposit_attestation_signer] ||
         Application.get_env(:raxol_payments, :xochi_deposit_attestation_signer) ||
-        Capabilities.deposit_attestation_signer(
-          deposit_capabilities(config, opts)
-        )
+        Capabilities.deposit_attestation_signer(deposit_capabilities(config, opts))
 
     case signer do
       s when is_binary(s) and s != "" -> {:ok, s}
@@ -615,7 +613,8 @@ defmodule Raxol.Payments.Protocols.Xochi do
   defp sign_pull_authorization(
          %QuoteResponse{pull_authorization: nil},
          _wallet
-       ), do: {:ok, nil}
+       ),
+       do: {:ok, nil}
 
   defp sign_pull_authorization(%QuoteResponse{pull_authorization: pull}, wallet) do
     domain = eip712_domain(pull)
@@ -691,11 +690,9 @@ defmodule Raxol.Payments.Protocols.Xochi do
     message = pull["message"] || %{}
 
     first_mismatch([
-      {:pull_type,
-       valid_envelope?(pull, @erc3009_primary_type, @erc3009_fields)},
+      {:pull_type, valid_envelope?(pull, @erc3009_primary_type, @erc3009_fields)},
       {:pull_from, addr_match?(message["from"], signer)},
-      {:pull_token,
-       addr_match?(domain["verifyingContract"], request.from_token)},
+      {:pull_token, addr_match?(domain["verifyingContract"], request.from_token)},
       {:pull_chain, int_match?(domain["chainId"], request.from_chain_id)},
       {:pull_value, int_within?(message["value"], request.from_amount)},
       {:pull_to, solver_allowed?(message["to"], :erc3009)},
@@ -716,8 +713,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
     permitted = message["permitted"] || %{}
 
     first_mismatch([
-      {:pull_type,
-       valid_envelope?(pull, @permit2_primary_type, @permit2_fields)},
+      {:pull_type, valid_envelope?(pull, @permit2_primary_type, @permit2_fields)},
       {:pull_token, addr_match?(permitted["token"], request.from_token)},
       {:pull_chain, int_match?(domain["chainId"], request.from_chain_id)},
       {:pull_value, int_within?(permitted["amount"], request.from_amount)},
@@ -788,9 +784,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
     do: Application.get_env(:raxol_payments, :pull_require_solver_pin, false)
 
   defp solver_allowlist do
-    normalize_solver_list(
-      Application.get_env(:raxol_payments, :pull_solver_allowlist, [])
-    )
+    normalize_solver_list(Application.get_env(:raxol_payments, :pull_solver_allowlist, []))
   end
 
   defp normalize_solver_list(list) do

--- a/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
@@ -297,9 +297,7 @@ defmodule Raxol.Payments.Xochi.AgentStream do
   end
 
   defp handle_response({:error, reason}, config) do
-    Logger.warning(
-      "[agent-stream] announce transport error: #{inspect(reason)}"
-    )
+    Logger.warning("[agent-stream] announce transport error: #{inspect(reason)}")
 
     emit_dropped(config, reason)
     {:error, reason}

--- a/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
@@ -207,6 +207,7 @@ defmodule Raxol.Payments.Xochi.Client do
   # invite). A `Raxol.Payments.Secret`-wrapped token is revealed only here, so
   # the token stays redacted in any config/state that a crash report might dump.
   defp auth_mode(%{auth: auth}), do: auth
+
   defp auth_mode(%{auth_token: %Raxol.Payments.Secret{} = token}),
     do: {:member, Raxol.Payments.Secret.reveal(token)}
 

--- a/packages/raxol_payments/mix.exs
+++ b/packages/raxol_payments/mix.exs
@@ -82,7 +82,8 @@ defmodule RaxolPayments.MixProject do
       links: %{
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_payments",
-        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_payments/CHANGELOG.md",
+        "Changelog" =>
+          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_payments/CHANGELOG.md",
         "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]

--- a/packages/raxol_payments/test/property/ledger_concurrent_property_test.exs
+++ b/packages/raxol_payments/test/property/ledger_concurrent_property_test.exs
@@ -64,9 +64,7 @@ defmodule Raxol.Payments.LedgerConcurrentPropertyTest do
             lifetime <- integer(50..200)
           ) do
       ledger =
-        case Ledger.start_link(
-               table_name: :"conc_ledger_#{:erlang.unique_integer([:positive])}"
-             ) do
+        case Ledger.start_link(table_name: :"conc_ledger_#{:erlang.unique_integer([:positive])}") do
           {:ok, pid} -> pid
           {:error, {:already_started, pid}} -> pid
         end
@@ -100,9 +98,7 @@ defmodule Raxol.Payments.LedgerConcurrentPropertyTest do
             amount <- integer(1..10)
           ) do
       ledger =
-        case Ledger.start_link(
-               table_name: :"frz_conc_#{:erlang.unique_integer([:positive])}"
-             ) do
+        case Ledger.start_link(table_name: :"frz_conc_#{:erlang.unique_integer([:positive])}") do
           {:ok, pid} -> pid
           {:error, {:already_started, pid}} -> pid
         end

--- a/packages/raxol_payments/test/property/ledger_model_property_test.exs
+++ b/packages/raxol_payments/test/property/ledger_model_property_test.exs
@@ -85,10 +85,7 @@ defmodule Raxol.Payments.LedgerModelPropertyTest do
   property "Ledger outcomes match the pure-Elixir reference model" do
     check all(cmds <- commands()) do
       ledger =
-        case Ledger.start_link(
-               table_name:
-                 :"model_ledger_#{:erlang.unique_integer([:positive])}"
-             ) do
+        case Ledger.start_link(table_name: :"model_ledger_#{:erlang.unique_integer([:positive])}") do
           {:ok, pid} -> pid
           {:error, {:already_started, pid}} -> pid
         end

--- a/packages/raxol_payments/test/property/policy_gate_property_test.exs
+++ b/packages/raxol_payments/test/property/policy_gate_property_test.exs
@@ -57,9 +57,7 @@ defmodule Raxol.Payments.PolicyGatePropertyTest do
       # Even with an always-:approve callback installed and an amount above
       # the threshold, an unapproved domain must deny on the domain reason.
       result =
-        PolicyGate.evaluate(policy, amount, attempted_host,
-          on_confirm: fn _, _ -> :approve end
-        )
+        PolicyGate.evaluate(policy, amount, attempted_host, on_confirm: fn _, _ -> :approve end)
 
       assert match?({:deny, {:domain_not_approved, _}}, result),
              "expected domain-deny for host #{attempted_host} not in #{approved_host}, got #{inspect(result)}"
@@ -85,9 +83,7 @@ defmodule Raxol.Payments.PolicyGatePropertyTest do
 
       assert match?(
                {:deny, {:domain_not_approved, _}},
-               PolicyGate.evaluate(policy, amount, attempted_host,
-                 on_confirm: canary
-               )
+               PolicyGate.evaluate(policy, amount, attempted_host, on_confirm: canary)
              )
     end
   end

--- a/packages/raxol_payments/test/raxol/payments/eip712_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/eip712_test.exs
@@ -223,8 +223,7 @@ defmodule Raxol.Payments.EIP712Test do
       "nonce" => 1,
       "deadline" => 1_900_000_000,
       "witness" => %{
-        "orderId" =>
-          "0xdeadbeef00000000000000000000000000000000000000000000000000000000"
+        "orderId" => "0xdeadbeef00000000000000000000000000000000000000000000000000000000"
       }
     }
 

--- a/packages/raxol_payments/test/raxol/payments/gate_parity_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/gate_parity_test.exs
@@ -106,9 +106,7 @@ defmodule Raxol.Payments.GateParityTest do
 
   defp hook_decision(%{policy: policy, amount: amount, host: host}) do
     {:ok, ledger} =
-      Ledger.start_link(
-        table_name: :"parity_hook_#{:erlang.unique_integer([:positive])}"
-      )
+      Ledger.start_link(table_name: :"parity_hook_#{:erlang.unique_integer([:positive])}")
 
     try do
       SpendingHook.set_config(%{ledger: ledger, policy: policy})
@@ -136,9 +134,7 @@ defmodule Raxol.Payments.GateParityTest do
 
   defp auto_pay_decision(%{policy: policy, amount: amount, host: host}) do
     {:ok, ledger} =
-      Ledger.start_link(
-        table_name: :"parity_auto_#{:erlang.unique_integer([:positive])}"
-      )
+      Ledger.start_link(table_name: :"parity_auto_#{:erlang.unique_integer([:positive])}")
 
     Process.put(:wallet_signal_target, self())
 

--- a/packages/raxol_payments/test/raxol/payments/ledger_subscribe_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/ledger_subscribe_test.exs
@@ -6,9 +6,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
   describe "freeze/unfreeze" do
     setup do
       {:ok, ledger} =
-        Ledger.start_link(
-          table_name: :"frz_ledger_#{:erlang.unique_integer([:positive])}"
-        )
+        Ledger.start_link(table_name: :"frz_ledger_#{:erlang.unique_integer([:positive])}")
 
       on_exit(fn ->
         try do
@@ -64,9 +62,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
   describe "telemetry events" do
     setup do
       {:ok, ledger} =
-        Ledger.start_link(
-          table_name: :"tel_ledger_#{:erlang.unique_integer([:positive])}"
-        )
+        Ledger.start_link(table_name: :"tel_ledger_#{:erlang.unique_integer([:positive])}")
 
       handler_id = :"telemetry_test_#{:erlang.unique_integer([:positive])}"
       parent = self()
@@ -103,8 +99,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
           %{protocol: "x402"}
         )
 
-      assert_receive {:telemetry, [:raxol, :payments, :spend], measurements,
-                      metadata}
+      assert_receive {:telemetry, [:raxol, :payments, :spend], measurements, metadata}
 
       assert Decimal.equal?(measurements.amount, Decimal.new("0.10"))
       assert metadata.agent_id == :tel_a
@@ -122,8 +117,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
       assert {:over_limit, :per_request} =
                Ledger.try_spend(ledger, :tel_b, Decimal.new("1.00"), policy)
 
-      assert_receive {:telemetry, [:raxol, :payments, :over_budget],
-                      measurements, metadata}
+      assert_receive {:telemetry, [:raxol, :payments, :over_budget], measurements, metadata}
 
       assert Decimal.equal?(measurements.amount, Decimal.new("1.00"))
       assert metadata.limit_type == :per_request
@@ -140,28 +134,23 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
                  SpendingPolicy.unrestricted()
                )
 
-      assert_receive {:telemetry, [:raxol, :payments, :over_budget], _,
-                      %{limit_type: :frozen}}
+      assert_receive {:telemetry, [:raxol, :payments, :over_budget], _, %{limit_type: :frozen}}
     end
 
     test "emits :freeze event on freeze/unfreeze", %{ledger: ledger} do
       :ok = Ledger.freeze(ledger)
 
-      assert_receive {:telemetry, [:raxol, :payments, :freeze], _,
-                      %{frozen?: true}}
+      assert_receive {:telemetry, [:raxol, :payments, :freeze], _, %{frozen?: true}}
 
       :ok = Ledger.unfreeze(ledger)
 
-      assert_receive {:telemetry, [:raxol, :payments, :freeze], _,
-                      %{frozen?: false}}
+      assert_receive {:telemetry, [:raxol, :payments, :freeze], _, %{frozen?: false}}
     end
   end
 
   setup do
     {:ok, ledger} =
-      Ledger.start_link(
-        table_name: :"sub_ledger_#{:erlang.unique_integer([:positive])}"
-      )
+      Ledger.start_link(table_name: :"sub_ledger_#{:erlang.unique_integer([:positive])}")
 
     on_exit(fn ->
       try do

--- a/packages/raxol_payments/test/raxol/payments/policy_gate_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/policy_gate_test.exs
@@ -126,7 +126,9 @@ defmodule Raxol.Payments.PolicyGateTest do
                PolicyGate.evaluate(
                  policy,
                  Decimal.new("10.00"),
-                 "api.example.com", on_confirm: callback)
+                 "api.example.com",
+                 on_confirm: callback
+               )
 
       assert_received {:saw, %Decimal{} = amount, "api.example.com"}
       assert Decimal.equal?(amount, Decimal.new("10.00"))

--- a/packages/raxol_payments/test/raxol/payments/protocols/permit2_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/permit2_test.exs
@@ -157,7 +157,8 @@ defmodule Raxol.Payments.Protocols.Permit2Test do
     end
 
     test "missing required field returns an error" do
-      bad_quote = put_in(@canonical_quote["gasless"], Map.delete(@canonical_quote["gasless"], "orderId"))
+      bad_quote =
+        put_in(@canonical_quote["gasless"], Map.delete(@canonical_quote["gasless"], "orderId"))
 
       assert {:error, {:missing_quote_field, :orderId}} =
                Permit2.sign_quote(bad_quote, 8453, StaticWallet)

--- a/packages/raxol_payments/test/raxol/payments/relay/live_relay_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/relay/live_relay_test.exs
@@ -44,8 +44,7 @@ defmodule Raxol.Payments.Relay.LiveRelayTest do
       }
 
       request = %QuoteRequest{
-        transfer_id:
-          "live_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower),
+        transfer_id: "live_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower),
         from_chain_id: env_int("RELAY_LIVE_FROM_CHAIN", 8453),
         to_chain_id: env_int("RELAY_LIVE_TO_CHAIN", 728_126_428),
         from_token: System.get_env("RELAY_LIVE_FROM_TOKEN", @usdc_base),

--- a/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/req/mandate_test.exs
@@ -55,8 +55,15 @@ defmodule Raxol.Payments.Req.MandateTest do
     |> ReqMandate.attach(agent_wallet: @agent)
   end
 
+  # `run_request/1` runs the ADAPTER as well as the steps, so without one this
+  # made a real HTTPS request to api.xochi.fi per test -- three Req retries each,
+  # and minutes of wall time on any network that cannot reach it. Only the
+  # OUTBOUND headers are under test here, so the transport is short-circuited.
+  # The tests that assert on responses use `plug: {Req.Test, __MODULE__}`.
+  defp offline(req), do: {req, %Req.Response{status: 200}}
+
   defp header_after_step(req) do
-    {ran, _resp} = Req.Request.run_request(req)
+    {ran, _resp} = Req.Request.run_request(%{req | adapter: &offline/1})
     Req.Request.get_header(ran, "x-xochi-delegation")
   end
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/settlement_matrix_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/settlement_matrix_test.exs
@@ -47,18 +47,18 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
   @chains [1, 10, 137, 8453, 42_161, 4663]
   @symbols Enum.sort(Assets.symbols())
 
-  @endpoints (for chain <- @chains,
-                  symbol <- @symbols,
-                  {:ok, address} <- [Assets.address(chain, symbol)],
-                  do: {chain, symbol, address})
+  @endpoints for chain <- @chains,
+                 symbol <- @symbols,
+                 {:ok, address} <- [Assets.address(chain, symbol)],
+                 do: {chain, symbol, address}
 
   # Every cross-chain (chain, token) -> (chain, token) pair. Cross-asset when the
   # two symbols differ (the norm for any Robinhood corridor: USDG lives only on
   # 4663), same-asset when they match.
-  @corridors (for {fc, fs, fa} <- @endpoints,
-                  {tc, ts, ta} <- @endpoints,
-                  fc != tc,
-                  do: {fc, fs, fa, tc, ts, ta})
+  @corridors for {fc, fs, fa} <- @endpoints,
+                 {tc, ts, ta} <- @endpoints,
+                 fc != tc,
+                 do: {fc, fs, fa, tc, ts, ta}
 
   @pubkey_re ~r/^0x0[23][a-f0-9]{64}$/
 
@@ -187,7 +187,7 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
       assert length(@corridors) == 240
 
       # USDG lives only on Robinhood Chain, and shows up as both origin and dest.
-      assert (for {c, "USDG", _} <- @endpoints, do: c) == [4663]
+      assert for({c, "USDG", _} <- @endpoints, do: c) == [4663]
 
       assert Enum.any?(@corridors, fn {fc, fs, _, tc, _, _} ->
                {fc, fs} == {4663, "USDG"} and tc != 4663
@@ -245,7 +245,10 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
         assert body["settlement_preference"] == "stealth"
         assert body["from_chain_id"] == fc
         assert body["to_chain_id"] == tc
-        assert Regex.match?(@pubkey_re, body["stealth_spending_pub_key"]), "#{label}: spending key"
+
+        assert Regex.match?(@pubkey_re, body["stealth_spending_pub_key"]),
+               "#{label}: spending key"
+
         assert Regex.match?(@pubkey_re, body["stealth_viewing_pub_key"]), "#{label}: viewing key"
       end
 
@@ -294,7 +297,10 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
       {:ok, to} = Assets.address(4663, "USDG")
 
       assert {:error, %Failure{reason: :delivery_below_floor}} =
-               run(ledger, 8453, from, 4663, to, "public", %{to_amount: "1", min_to_amount: "490000"})
+               run(ledger, 8453, from, 4663, to, "public", %{
+                 to_amount: "1",
+                 min_to_amount: "490000"
+               })
 
       refute_received :wallet_signed
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/stealth_e2e_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/stealth_e2e_test.exs
@@ -70,7 +70,10 @@ defmodule Raxol.Payments.Xochi.StealthE2ETest do
 
       # Sign a message with the stealth private key
       message = ExKeccak.hash_256("claim:#{settlement.stealth_address}")
-      {:ok, {r, s, _recovery_id}} = ExSecp256k1.sign(message, Secret.reveal(payment.stealth_priv_key))
+
+      {:ok, {r, s, _recovery_id}} =
+        ExSecp256k1.sign(message, Secret.reveal(payment.stealth_priv_key))
+
       signature = r <> s
       assert byte_size(signature) == 64
 

--- a/packages/raxol_payments/test/support/conformance_fixture.ex
+++ b/packages/raxol_payments/test/support/conformance_fixture.ex
@@ -29,10 +29,34 @@ defmodule Raxol.Payments.Test.ConformanceFixture do
     path |> File.read!() |> Jason.decode!()
   end
 
-  @doc "Filter the fixture by `\"protocol\"` field."
+  @doc """
+  Filter the fixture by `"protocol"` field.
+
+  Returns `[]` when the fixture is absent, rather than raising. The conformance
+  files call this at test-module COMPILE time (`for vec <- by_protocol(...)`
+  inside a `describe`), so the `:conformance` moduletag -- a runtime exclusion --
+  cannot save a raise here: the whole suite dies before a single test runs. That
+  is what kept `raxol_payments` out of CI, where riddler-client is not checked
+  out beside the repo.
+
+  The absence is announced rather than swallowed: generating zero vectors is
+  legitimate here, but it must not look like coverage that passed.
+  """
   @spec by_protocol(String.t()) :: [map()]
   def by_protocol(protocol) do
-    Enum.filter(load!(), &(&1["protocol"] == protocol))
+    case do_locate() do
+      nil ->
+        IO.puts(
+          :stderr,
+          "[conformance] fixture absent -- 0 #{protocol} vectors generated. " <>
+            "Set CONFORMANCE_FIXTURE_PATH or RIDDLER_CLI_DIR to run them."
+        )
+
+        []
+
+      _path ->
+        Enum.filter(load!(), &(&1["protocol"] == protocol))
+    end
   end
 
   @doc "Return the single vector with the given `\"name\"`."

--- a/packages/raxol_telegram/lib/raxol/telegram/update_poller.ex
+++ b/packages/raxol_telegram/lib/raxol/telegram/update_poller.ex
@@ -95,10 +95,8 @@ defmodule Raxol.Telegram.UpdatePoller do
     state = %{
       conn: Keyword.get(opts, :conn, []),
       on_update: Keyword.fetch!(opts, :on_update),
-      poll_timeout_s:
-        Keyword.get(opts, :poll_timeout_s, @default_poll_timeout_s),
-      allowed_updates:
-        Keyword.get(opts, :allowed_updates, @default_allowed_updates),
+      poll_timeout_s: Keyword.get(opts, :poll_timeout_s, @default_poll_timeout_s),
+      allowed_updates: Keyword.get(opts, :allowed_updates, @default_allowed_updates),
       offset: load_offset(dets),
       dets: dets,
       failures: 0,

--- a/packages/raxol_telegram/test/raxol/telegram/update_poller_test.exs
+++ b/packages/raxol_telegram/test/raxol/telegram/update_poller_test.exs
@@ -44,8 +44,7 @@ defmodule Raxol.Telegram.UpdatePollerTest do
   defp respond(pid, result) do
     send(
       pid,
-      {:respond,
-       {:ok, %{status: 200, body: %{"ok" => true, "result" => result}}}}
+      {:respond, {:ok, %{status: 200, body: %{"ok" => true, "result" => result}}}}
     )
   end
 


### PR DESCRIPTION
**Stacked on #862 -- merge that first.** Only the last commit is new here.

No file under `packages/` is format-checked anywhere in CI. The root `Format Check` job reads the root `.formatter.exs`, whose `inputs` are:

```elixir
inputs: ["*.{ex,exs}", "{config,lib,examples}/**/*.{ex,exs}", "test/*.exs", ...]
```

All root-relative. The package cell runs `deps.get`, `compile --warnings-as-errors` and `test`, and no format step. So eighteen packages have never been checked.

I proved the gap by accident: my own unformatted `order.ex` sailed through a fully green run on #860, and I only noticed because an adversarial verifier ran `mix format --check-formatted` inside the package.

## The drift that had accumulated

| Package | Files |
| --- | --- |
| `raxol_payments` | 21 |
| `raxol_gateway` | 2 |
| `raxol_telegram` | 2 |
| `raxol_cli`, `raxol_earn` | clean |

25 files, and every diff is pure line-wrapping -- the signature of formatter-version drift over time, not sloppy edits:

```diff
-      {:ok,
-       ExKeccak.hash_256(
-         <<0x19, 0x01, domain_separator::binary, message_hash::binary>>
-       )}
+      {:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}
```

Net `78 insertions, 110 deletions` across 26 files: the formatter mostly *unwrapped* lines that no longer need wrapping.

## The step

Added to the package cell, **before** `deps.get`, so it fails fast on the cheapest possible check. Verified safe to order there: no package's `.formatter.exs` declares `import_deps` or `plugins` (`raxol_cli` has an empty `import_deps: []`), and I confirmed empirically by moving `deps/` aside and running the check -- it passes without dependencies present.

With #862 also in flight, this covers all five gated packages including the two money ones.

## Verification

- [x] All five packages `mix format --check-formatted` clean after the change
- [x] `raxol_payments` 1149 passed, `raxol_gateway` 167 passed, `raxol_telegram` 244 passed -- reformatting changed no behaviour
- [x] YAML parses; step lands between "Install hex and rebar" and "Compile package"
- [x] Format check confirmed to work with `deps/` absent

## A note on scope

This is deliberately separate from #862. Mixing 25 reformatted files into the PR that unbreaks and gates the money packages would have buried a diff that deserves line-by-line review under mechanical whitespace.

## Manual testing

- [ ] All five package cells green, with the new format step visible in each
- [ ] Introduce deliberate drift in one package and confirm its cell goes red
