### PR TITLE
Fix the paymaster policy id rather than silence its warning

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -440,17 +440,23 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   end
 
   # A (--signer sca): direct ERC-4337 -- the EOA session key signs UserOps,
-  # submitted to your own bundler + paymaster. Needs ORDER_BUNDLER_URL (and
-  # ORDER_PAYMASTER_POLICY for sponsorship, else the SCA must hold ETH).
+  # submitted to your own bundler + paymaster. Needs ORDER_BUNDLER_URL and
+  # ORDER_PAYMASTER_POLICY: the adapter only ever sends sponsored UserOps,
+  # so there is no unsponsored fallback to fall back to.
+  # Alchemy multiplexes bundler + gas manager on one URL.
   defp build_signer("sca", from, rpc) do
     bundler = fetch_env!("ORDER_BUNDLER_URL")
-    policy = System.get_env("ORDER_PAYMASTER_POLICY")
+    policy = fetch_env!("ORDER_PAYMASTER_POLICY")
 
     provider =
       ProviderAdapter.SCA.new(
         wallet: ScaWallet,
         chains: %{from => rpc},
-        wallet_opts: [bundler_url: bundler, paymaster_policy_id: policy]
+        wallet_opts: [
+          bundler_url: bundler,
+          paymaster_url: bundler,
+          paymaster_policy_id: policy
+        ]
       )
 
     {provider, @sca_account, ScaWallet}

--- a/packages/raxol_earn/lib/raxol/earn/wallet/sca.ex
+++ b/packages/raxol_earn/lib/raxol/earn/wallet/sca.ex
@@ -164,8 +164,8 @@ defmodule Raxol.Earn.Wallet.SCA do
 
       @doc """
       Fill gas + paymaster data via the Alchemy gas manager, returning
-      a sponsored UserOp ready to sign and send. Requires
-      `:paymaster_policy_id` in config.
+      a sponsored UserOp ready to sign and send. Requires a
+      `:paymaster_policy_id`, from the compile-time config or the opts.
       """
       @spec sponsor(Raxol.Earn.Wallet.SCA.UserOp.t(), keyword()) ::
               {:ok, Raxol.Earn.Wallet.SCA.UserOp.t()} | {:error, term()}
@@ -181,26 +181,15 @@ defmodule Raxol.Earn.Wallet.SCA do
 
       @doc """
       One-shot gasless send: sponsor via the gas manager, then sign and
-      submit to the bundler. Requires `:paymaster_policy_id`.
+      submit to the bundler. Requires a `:paymaster_policy_id`, from the
+      compile-time config or the per-call opts.
       """
       @spec send_sponsored_user_operation(Raxol.Earn.Wallet.SCA.UserOp.t(), keyword()) ::
               {:ok, String.t()} | {:error, term()}
-      if unquote(paymaster_policy_id) do
-        def send_sponsored_user_operation(op, opts \\ []) do
-          with {:ok, sponsored} <- sponsor(op, opts) do
-            send_user_operation(sponsored, opts)
-          end
+      def send_sponsored_user_operation(op, opts \\ []) do
+        with {:ok, sponsored} <- sponsor(op, opts) do
+          send_user_operation(sponsored, opts)
         end
-      else
-        # Without a `:paymaster_policy_id` this wallet can never be sponsored:
-        # `SCA.sponsor/5` matches nil on its first clause and returns the error
-        # unconditionally. Generating the `with` anyway gives every policy-less
-        # instantiation an unreachable success branch, which the compiler
-        # correctly reports and `--warnings-as-errors` then fails on. The
-        # runtime contract is unchanged -- same error tuple, same arity -- the
-        # dead branch simply is not emitted.
-        def send_sponsored_user_operation(_op, _opts \\ []),
-          do: {:error, :no_paymaster_policy_id}
       end
 
       @doc "The configured EntryPoint address."
@@ -308,13 +297,13 @@ defmodule Raxol.Earn.Wallet.SCA do
           String.t(),
           keyword()
         ) :: {:ok, UserOp.t()} | {:error, term()}
-  def sponsor(_op, _url, nil, _entry_point, _opts), do: {:error, :no_paymaster_policy_id}
-
   def sponsor(op, paymaster_url, policy_id, entry_point, opts) do
-    configured = Keyword.get(opts, :paymaster_url, paymaster_url)
-
-    with {:ok, url} <- resolve_url(configured, :no_paymaster_url) do
-      Paymaster.sponsor(url, policy_id, entry_point, op, opts)
+    # Runtime opts override the compile-time config, as for the bundler URL:
+    # a policy id is usually only known to the deployment, not to the module.
+    with {:ok, id} <- resolve_policy_id(Keyword.get(opts, :paymaster_policy_id, policy_id)),
+         {:ok, url} <-
+           resolve_url(Keyword.get(opts, :paymaster_url, paymaster_url), :no_paymaster_url) do
+      Paymaster.sponsor(url, id, entry_point, op, opts)
     end
   end
 
@@ -350,6 +339,10 @@ defmodule Raxol.Earn.Wallet.SCA do
   end
 
   defp normalize_v(<<_::binary-size(64), _v::8>> = sig), do: sig
+
+  # An exported-but-empty env var reads as "", which is no policy at all.
+  defp resolve_policy_id(id) when is_binary(id) and id != "", do: {:ok, id}
+  defp resolve_policy_id(_absent), do: {:error, :no_paymaster_policy_id}
 
   # Resolve a URL that may be a literal string, a `{:system, var}`
   # env-var reference, or nil (returns the supplied error atom).

--- a/packages/raxol_earn/test/raxol/earn/wallet/sca_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/wallet/sca_test.exs
@@ -23,6 +23,16 @@ defmodule Raxol.Earn.Wallet.SCATest do
       paymaster_policy_id: "186aaa4a-5f57-4156-83fb-e456365a8820"
   end
 
+  # The shape `mix raxol_earn.order --signer sca` builds: the policy id is
+  # only known at runtime, so it arrives in the per-call opts.
+  defmodule NoPolicyAccount do
+    use Raxol.Earn.Wallet.SCA,
+      account_address: "0x1234567890123456789012345678901234567890",
+      chain_id: 8453,
+      signer: Raxol.Earn.Wallet.SCATest.SessionKey,
+      signer_entity_id: 1
+  end
+
   setup do
     System.put_env(@session_key_env, @session_privkey)
     on_exit(fn -> System.delete_env(@session_key_env) end)
@@ -208,25 +218,62 @@ defmodule Raxol.Earn.Wallet.SCATest do
     end
 
     test "errors when no policy id is configured" do
-      defmodule NoPolicyAccount do
-        use Raxol.Earn.Wallet.SCA,
-          account_address: "0x1234567890123456789012345678901234567890",
-          chain_id: 8453,
-          signer: Raxol.Earn.Wallet.SCATest.SessionKey,
-          signer_entity_id: 1
-      end
-
       assert {:error, :no_paymaster_policy_id} =
                NoPolicyAccount.sponsor(%UserOp{sender: @account})
     end
 
+    test "errors when the runtime policy id is blank" do
+      assert {:error, :no_paymaster_policy_id} =
+               NoPolicyAccount.sponsor(%UserOp{sender: @account}, paymaster_policy_id: "")
+    end
+
+    test "a runtime policy id sponsors a wallet configured without one" do
+      op = %UserOp{sender: @account, nonce: 0, call_data: <<0x12>>}
+
+      assert {:ok, sponsored} =
+               NoPolicyAccount.sponsor(op,
+                 paymaster_policy_id: "186aaa4a-5f57-4156-83fb-e456365a8820",
+                 paymaster_url: "http://alchemy.test",
+                 req: Req.new(plug: json_rpc_plug(@gm_result))
+               )
+
+      assert sponsored.paymaster == "0xabababababababababababababababababababab"
+    end
+
     test "send_sponsored_user_operation sponsors then signs then sends" do
       op = %UserOp{sender: @account, nonce: 0, call_data: <<0x12>>}
-      test_pid = self()
 
-      # One plug serving both the gas manager and the bundler, keyed on
-      # the JSON-RPC method.
-      plug = fn conn ->
+      assert {:ok, "0xfeedface"} =
+               Account.send_sponsored_user_operation(op,
+                 paymaster_url: "http://alchemy.test",
+                 bundler_url: "http://alchemy.test",
+                 req: Req.new(plug: sponsored_send_plug(self()))
+               )
+
+      # Both legs were called, in order.
+      assert_received {:rpc, "alchemy_requestGasAndPaymasterAndData"}
+      assert_received {:rpc, "eth_sendUserOperation"}
+    end
+
+    test "send_sponsored_user_operation honours a runtime policy id" do
+      op = %UserOp{sender: @account, nonce: 0, call_data: <<0x12>>}
+
+      assert {:ok, "0xfeedface"} =
+               NoPolicyAccount.send_sponsored_user_operation(op,
+                 paymaster_policy_id: "186aaa4a-5f57-4156-83fb-e456365a8820",
+                 paymaster_url: "http://alchemy.test",
+                 bundler_url: "http://alchemy.test",
+                 req: Req.new(plug: sponsored_send_plug(self()))
+               )
+
+      assert_received {:rpc, "alchemy_requestGasAndPaymasterAndData"}
+      assert_received {:rpc, "eth_sendUserOperation"}
+    end
+
+    # One plug serving both the gas manager and the bundler, keyed on
+    # the JSON-RPC method.
+    defp sponsored_send_plug(test_pid) do
+      fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         decoded = Jason.decode!(body)
         send(test_pid, {:rpc, decoded["method"]})
@@ -243,17 +290,6 @@ defmodule Raxol.Earn.Wallet.SCATest do
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.send_resp(200, payload)
       end
-
-      assert {:ok, "0xfeedface"} =
-               Account.send_sponsored_user_operation(op,
-                 paymaster_url: "http://alchemy.test",
-                 bundler_url: "http://alchemy.test",
-                 req: Req.new(plug: plug)
-               )
-
-      # Both legs were called, in order.
-      assert_received {:rpc, "alchemy_requestGasAndPaymasterAndData"}
-      assert_received {:rpc, "eth_sendUserOperation"}
     end
   end
 

--- a/packages/raxol_payments/test/test_helper.exs
+++ b/packages/raxol_payments/test/test_helper.exs
@@ -1,34 +1,36 @@
 ExUnit.start()
 
-# Tests tagged :cli_signer spawn the riddler-client CLI. Skipped
-# by default; enable with `mix test --include cli_signer` or by setting
-# RIDDLER_CLI_DIR in the environment so the helper can find the CLI repo.
+# Fund-moving suites are ALWAYS excluded. They spend real mainnet USDC, so
+# the presence of an endpoint/key in the environment must not be enough to
+# run them -- an explicit `--include live_xochi` (or `--only`) is the sole
+# opt-in, which is what scripts/run_live_gates.sh passes on every cell.
 #
-# Tests tagged :conformance read the shared EIP-712 fixture from the CLI
-# repo. Same skip-by-default rules as :cli_signer.
-# Each entry excludes a tag by default unless its enabling env var is set:
+#   :live_xochi -- drives the full intent lifecycle (and the :live_xochi_matrix
+#     / :live_xochi_preflight cells inside it) against a real Xochi endpoint
+#     with a funded wallet.
+#   :live_relay -- drives the EVM->Tron relay with a funded wallet.
+#   :live_property -- property runs against the live quote endpoints.
+live_exclude = [:live_xochi, :live_relay, :live_property]
+
+# Each entry excludes a tag by default unless its enabling env var is set.
+# These read fixtures or spawn a local CLI; none of them move funds.
 #
 #   :cli_signer / :conformance -- spawn the riddler-client CLI or read
 #     its shared EIP-712 fixture (RIDDLER_CLI_DIR / CONFORMANCE_FIXTURE_PATH).
 #   :stealth_conformance -- match the stealth scheme against a reference SDK
 #     fixture (STEALTH_VECTORS_PATH).
-#   :live_xochi -- drive the full intent lifecycle against a real (testnet)
-#     Xochi endpoint with a funded wallet (XOCHI_LIVE_URL).
 gated_tags = [
   {[:cli_signer, :conformance],
    System.get_env("RIDDLER_CLI_DIR") ||
      System.get_env("CONFORMANCE_FIXTURE_PATH")},
   {[:stealth_conformance],
    System.get_env("STEALTH_VECTORS_PATH") ||
-     File.exists?(Path.join(__DIR__, "fixtures/stealth_vectors.json"))},
-  {[:live_xochi], System.get_env("XOCHI_LIVE_URL")},
-  {[:live_relay], System.get_env("RELAY_LIVE_URL")},
-  {[:live_property], System.get_env("XOCHI_LIVE_URL") || System.get_env("RELAY_LIVE_URL")}
+     File.exists?(Path.join(__DIR__, "fixtures/stealth_vectors.json"))}
 ]
 
-excluded =
+gated_exclude =
   Enum.flat_map(gated_tags, fn {tags, enabled} ->
     if enabled, do: [], else: tags
   end)
 
-ExUnit.configure(exclude: excluded)
+ExUnit.configure(exclude: live_exclude ++ gated_exclude)


### PR DESCRIPTION
Follow-up to #862, which is already merged. Targets master directly.

#862 made `mix compile --warnings-as-errors` pass by wrapping
`send_sponsored_user_operation/2` in a compile-time
`if unquote(paymaster_policy_id)`, on the reasoning that the success branch was
provably unreachable without a compile-time policy id.

The branch was indeed unreachable. That was the bug, not the noise.

## What the warning was pointing at

`Raxol.Earn.Wallet.SCA.sponsor/5` matched the policy id **positionally**:

```elixir
def sponsor(_op, _url, nil, _entry_point, _opts), do: {:error, :no_paymaster_policy_id}
```

That `nil` comes from `unquote(paymaster_policy_id)`, bound at macro time from
the `use` options, and `_opts` is discarded. Meanwhile `raxol_earn.order.ex`
reads `ORDER_PAYMASTER_POLICY` at runtime and puts it in `wallet_opts`, which
`ProviderAdapter.SCA` threads verbatim into `send_sponsored_user_operation/2` --
where nothing reads it. `Order.ScaWallet` passes no compile-time policy id.

The asymmetry is the tell: `sca.ex` already honours runtime overrides for
`:bundler_url` and `:paymaster_url`. Only the policy id was compile-time-only.

Net effect: `mix raxol_earn.order --signer sca` can never send a UserOp. There is
no unsponsored fallback -- the adapter and the provisioner both call
`send_sponsored_user_operation/2` and nothing else -- so with `auto_provision` on,
the operator gets `** (MatchError) ... {:install_failed, :no_paymaster_policy_id}`
while `ORDER_PAYMASTER_POLICY` is exported and the moduledoc advertises it.

## The fix

`sponsor/5` resolves the policy id from `Keyword.get(opts, :paymaster_policy_id,
policy_id)`, so a runtime opt wins exactly as it does for the bundler URL. The
nil-matching head is gone. The success branch becomes reachable, so the compiler
warning clears on its own and #862's compile-time `if` is reverted.

`mix compile --force --warnings-as-errors` in `raxol_earn` exits 0. That is the
proof the diagnostic was a true positive fixed at its root rather than silenced.

## Second fix: the live-tag gate fails open

`packages/raxol_payments/test/test_helper.exs` excluded `:live_xochi`,
`:live_relay` and `:live_property` only when their env var was **absent**, so a
bare `mix test` in a live-configured shell spends mainnet USDC. Reproduced by
pointing `XOCHI_LIVE_URL` at a dead loopback port and watching the live test
execute. Those three tags are now excluded unconditionally; `--include` is the
sole opt-in, which is what `run_live_gates.sh` already passes on every cell.

## Manual testing

- [ ] `ORDER_BUNDLER_URL=... ORDER_PAYMASTER_POLICY=... mix raxol_earn.order --signer sca --dry-run`
      reaches the bundler instead of erroring on the policy id
