### PR TITLE
Require an explicit Tron recipient for the relay gate

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -421,6 +421,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     _ = fetch_env!("RAXOL_ACP_WALLET_ID")
     _ = fetch_env!("RAXOL_ACP_SIGNER_PRIVATE_KEY")
     address = fetch_env!("RAXOL_ACP_WALLET_ADDRESS")
+    check_7702_account(String.downcase(address), Sma7702Wallet.address())
 
     {:ok, _} = Raxol.Earn.SignerSidecar.start_link([])
 
@@ -470,6 +471,20 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   defp build_signer(other, _from, _rpc),
     do: Mix.raise("unknown --signer #{inspect(other)} (want privy | sca | eoa)")
+
+  # Sma7702Wallet's account is the verifyingContract of the replay-safe EIP-712
+  # domain it signs over, so pointing RAXOL_ACP_WALLET_ADDRESS at a different
+  # managed wallet signs the wrong account's hash: isValidSignature is called on
+  # the payer and rejects, surfacing as an opaque 401 after a sidecar round trip.
+  defp check_7702_account(account, account), do: :ok
+
+  defp check_7702_account(given, account) do
+    Mix.raise(
+      "RAXOL_ACP_WALLET_ADDRESS #{given} is not the 7702 account Sma7702Wallet " <>
+        "signs for (#{account}); the intent would be signed over the wrong " <>
+        "replay-safe hash"
+    )
+  end
 
   # The managed Privy provider is runtime state; Sma7702Wallet resolves it here at
   # call time so the wallet stays a plain behaviour module.

--- a/packages/raxol_earn/test/raxol/earn/relay/live_relay_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/relay/live_relay_test.exs
@@ -36,7 +36,6 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
   @moduletag :live_relay
   @moduletag timeout: 300_000
 
-  @usdc_base "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   @usdt_tron "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
 
   if System.get_env("RELAY_LIVE_URL") && System.get_env("RELAY_LIVE_KEY") &&
@@ -153,11 +152,15 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
       store = Raxol.Payments.Checkpoint.ETS.new()
       context = Map.merge(context, %{checkpoint: store, idempotency_key: "live-relay-resume"})
 
+      # Resolve the source the same way the settle test does: a hardcoded origin
+      # token here deposits an asset the caller never selected.
+      {src_token, _label} = hd(source_cells(from_chain))
+
       params = %{
         amount: System.get_env("RELAY_LIVE_AMOUNT", "0.10"),
         from_chain_id: from_chain,
-        to_chain_id: 728_126_428,
-        from_token: System.get_env("RELAY_LIVE_FROM_TOKEN", @usdc_base),
+        to_chain_id: @tron,
+        from_token: src_token,
         to_token: to_token(),
         to_address: recipient!()
       }

--- a/packages/raxol_earn/test/raxol/earn/relay/live_relay_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/relay/live_relay_test.exs
@@ -16,14 +16,17 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
       RELAY_LIVE_TOKEN="$(op read 'op://Employee/Xochi staging RIDDLER_API_TOKEN/credential')" \\
       RELAY_LIVE_KEY=0x<funded source-chain private key> \\
       RELAY_LIVE_RPC=https://mainnet.base.org \\
-        mix test --include live_relay test/raxol/acp/relay/live_relay_test.exs
+      RELAY_LIVE_TO_ADDRESS=T<Tron recipient wallet> \\
+        mix test --include live_relay test/raxol/earn/relay/live_relay_test.exs
+
+  RELAY_LIVE_TO_ADDRESS is REQUIRED and has no default: the destination is a
+  wallet you control, and a Tron settlement cannot be reversed.
 
   Multiple source tokens (each resolved per chain via `Raxol.Payments.Assets`)
   settle in one run via `RELAY_LIVE_TOKENS` (default `USDC`); the destination is
   always Tron. Defaults (Base -> Tron USDT, 0.10) are overridable via
   RELAY_LIVE_FROM_CHAIN, RELAY_LIVE_TOKENS, RELAY_LIVE_FROM_TOKEN (a raw origin
-  address that overrides the token list), RELAY_LIVE_TO_TOKEN, RELAY_LIVE_TO_ADDRESS,
-  RELAY_LIVE_AMOUNT.
+  address that overrides the token list), RELAY_LIVE_TO_TOKEN, RELAY_LIVE_AMOUNT.
 
   Or use the unified gate at the repo root: scripts/run_live_gates.sh --route relay
   """
@@ -103,7 +106,7 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
       from_chain: from_chain
     } do
       amount = System.get_env("RELAY_LIVE_AMOUNT", "0.10")
-      to_address = System.get_env("RELAY_LIVE_TO_ADDRESS", @usdt_tron)
+      to_address = recipient!()
       cells = source_cells(from_chain)
 
       # Preflight every cell read-only first: a dead corridor aborts the run
@@ -122,7 +125,7 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
           from_chain_id: from_chain,
           to_chain_id: @tron,
           from_token: src_token,
-          to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
+          to_token: to_token(),
           to_address: to_address
         }
 
@@ -155,8 +158,8 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
         from_chain_id: from_chain,
         to_chain_id: 728_126_428,
         from_token: System.get_env("RELAY_LIVE_FROM_TOKEN", @usdc_base),
-        to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
-        to_address: System.get_env("RELAY_LIVE_TO_ADDRESS", @usdt_tron)
+        to_token: to_token(),
+        to_address: recipient!()
       }
 
       assert {:ok, transfer} = ExecuteRelayTransfer.call(params, context)
@@ -178,6 +181,21 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
 
       assert status.status == "completed",
              "live transfer #{transfer.transfer_id} ended in #{status.status}, expected completed"
+    end
+
+    defp to_token, do: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron)
+
+    # The destination is a WALLET. The Tron USDT contract is a well-formed base58
+    # address that the relay will happily settle to, and nobody can spend it back
+    # out, so there is no default here and the token contract is refused outright.
+    defp recipient! do
+      to_address = System.fetch_env!("RELAY_LIVE_TO_ADDRESS")
+
+      refute to_address == to_token(),
+             "RELAY_LIVE_TO_ADDRESS is the destination token contract, not a wallet: " <>
+               "funds settled there are unrecoverable"
+
+      to_address
     end
 
     # A raw RELAY_LIVE_FROM_TOKEN overrides the token list with one custom cell;
@@ -211,7 +229,7 @@ defmodule Raxol.Earn.Relay.LiveRelayTest do
         from_chain_id: from_chain,
         to_chain_id: @tron,
         from_token: src_token,
-        to_token: System.get_env("RELAY_LIVE_TO_TOKEN", @usdt_tron),
+        to_token: to_token(),
         from_amount: atomic,
         from_address: LiveWallet.address(),
         to_address: to_address,

--- a/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
@@ -1,0 +1,118 @@
+defmodule Raxol.Earn.Xochi.SmartAccountWireTest do
+  @moduledoc """
+  Pins the wire shape of a SMART-ACCOUNT signature against the constraint that
+  currently rejects it downstream.
+
+  ## Why this exists
+
+  Every live gate that has ever passed used an EOA buyer. Nothing exercised an
+  ERC-1271 signature, and that gap let one assumption -- "a signature is 65
+  bytes" -- survive three layers into production:
+
+    1. raxol built the wrong ERC-1271 replay-safe domain (fixed, #773)
+    2. Xochi's ERC-1271 verification silently never ran, because no `RPC_URL_*`
+       was set in production, so every smart-account signer got a bare 401
+       (fixed, xochi-fi/xochi#364, deployed 2026-08-15)
+    3. Riddler's request schema constrains the signature to exactly 65 bytes,
+       `~r/^0x[a-fA-F0-9]{130}$/` (open, axol-io/Riddler#802)
+
+  Layer 3 is why a real funded order (job 73295) still fails today, at
+  `validation_failed: Request validation failed`.
+
+  ## What this test can and cannot do
+
+  It asserts OUR half: the ma-v2 envelope raxol produces is 72 bytes, and a
+  72-byte signature cannot match the 65-byte pattern the solver enforces. That
+  makes the incompatibility an executable fact rather than a note in an issue,
+  and it fails immediately if anyone changes the envelope.
+
+  It deliberately does NOT probe the live service, because there is no
+  fund-free way to reach the constraint. Xochi verifies the signature BEFORE
+  forwarding to Riddler: an intent signed with an unauthorized key is rejected
+  at Xochi's ERC-1271 check and never reaches the schema, while a validly
+  signed one executes the pull and moves the principal. A live probe would
+  therefore either test the wrong layer or spend real money.
+
+  When #802 lands, the confirmation is one funded run:
+  `mix raxol_earn.order --amount 3.00 --signer privy --fund` (~0.017 USDC).
+  """
+
+  use ExUnit.Case, async: true
+
+  # Verbatim from Riddler `integrations/xochi/schemas/execute_request.ex:42`,
+  # duplicated in `web/openapi/schema.ex:92` and `claim_submit_request.ex:63`,
+  # and published in `packages/api/src/spec.json` as
+  # `CommerceOrderRequest.properties.signature`.
+  @riddler_signature_pattern ~r/^0x[a-fA-F0-9]{130}$/
+
+  @account "0x468aeae798b3a6548ac2401d276f83afdc172283"
+  @chain 8453
+  @raw_sig :binary.copy(<<0xAB>>, 64) <> <<27>>
+
+  # Stands in for the managed Privy authority, in the ProviderAdapter shape the
+  # wallet dispatches through. It returns a fixed 65-byte signature, so this
+  # pins the ENVELOPE rather than secp256k1.
+  defmodule MockAuthority do
+    @moduledoc false
+    def new, do: %{adapter: __MODULE__, config: %{}}
+
+    def sign_typed_data(_provider, _chain_id, _typed_data),
+      do: {:ok, Raxol.Earn.Xochi.SmartAccountWireTest.raw_sig()}
+  end
+
+  def raw_sig, do: @raw_sig
+
+  def provider, do: MockAuthority.new()
+
+  defmodule Wallet do
+    @moduledoc false
+    use Raxol.Earn.Wallet.Sma7702,
+      account_address: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      chain_id: 8453,
+      provider: {Raxol.Earn.Xochi.SmartAccountWireTest, :provider}
+  end
+
+  defp envelope do
+    {:ok, sig} =
+      Wallet.sign_typed_data(
+        %{name: "XochiIntent", version: "1", chainId: @chain, verifyingContract: @account},
+        %{"Intent" => [{"amount", "uint256"}]},
+        %{"amount" => 3_000_000}
+      )
+
+    sig
+  end
+
+  describe "the ma-v2 ERC-1271 envelope" do
+    test "is 72 bytes: 0x00 || uint32(0) || 0xFF || 0x00 || sig65" do
+      sig = envelope()
+
+      assert <<0x00, 0::unsigned-big-32, 0xFF, 0x00, inner::binary>> = sig
+      assert byte_size(inner) == 65
+      assert byte_size(sig) == 72
+      assert inner == @raw_sig
+    end
+
+    test "does not satisfy Riddler's 65-byte signature pattern (axol-io/Riddler#802)" do
+      hex = "0x" <> Base.encode16(envelope(), case: :lower)
+
+      # 72 bytes = 144 hex chars; the pattern demands exactly 130.
+      assert String.length(hex) == 146
+      refute Regex.match?(@riddler_signature_pattern, hex)
+    end
+
+    test "a plain EOA signature does satisfy it -- the pattern is not simply broken" do
+      hex = "0x" <> Base.encode16(@raw_sig, case: :lower)
+
+      assert String.length(hex) == 132
+      assert Regex.match?(@riddler_signature_pattern, hex)
+    end
+  end
+
+  describe "the account itself" do
+    test "is the 7702 buyer the live gates use" do
+      assert Wallet.address() == @account
+      assert Wallet.chain_id() == @chain
+    end
+  end
+end

--- a/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
@@ -110,9 +110,11 @@ defmodule Raxol.Earn.Xochi.SmartAccountWireTest do
   end
 
   describe "the account itself" do
-    test "is the 7702 buyer the live gates use" do
-      assert Wallet.address() == @account
-      assert Wallet.chain_id() == @chain
+    test "matches the buyer `raxol_earn.order --signer privy` signs as" do
+      alias Mix.Tasks.RaxolEarn.Order.Sma7702Wallet
+
+      assert Wallet.address() == Sma7702Wallet.address()
+      assert Wallet.chain_id() == Sma7702Wallet.chain_id()
     end
   end
 end

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -54,6 +54,11 @@
 #                         asset (USDT needs GATE_RPC_42161; USDG needs GATE_RPC_4663)
 #                         on the acp route, and for the relay source chain.
 #   GATE_FROM_ADDRESS     EVM source address for the relay quote probe.
+#   GATE_TRON_ADDRESS     Tron recipient WALLET for the relay route. REQUIRED to
+#                         probe or settle relay; there is no default, because a
+#                         Tron settlement is final and the destination token
+#                         contract is a well-formed address that would swallow
+#                         the funds. A relay cell SKIPs without it.
 #
 # FLAGS:
 #   --asset A[,A...]      REQUIRED. USDC|USDT|USDG|all
@@ -79,6 +84,7 @@
 #
 #   # Launch rail: real USDC across all three routes:
 #   GATE_KEY=0x<funded> GATE_FROM_ADDRESS=0x<addr> GATE_RPC_8453=https://mainnet.base.org \
+#   GATE_TRON_ADDRESS=T<your Tron wallet> \
 #     ./scripts/run_live_gates.sh --asset USDC
 #
 #   # Just the ACP order path for USDC:
@@ -136,7 +142,8 @@ Usage: scripts/run_live_gates.sh --asset A[,A...] [--route R[,R...]] [options]
   -h, --help                     full docs are in the file header
 
 Secrets via env: GATE_KEY, GATE_XOCHI_TOKEN, GATE_RELAY_TOKEN,
-GATE_RPC_<chainid> (e.g. GATE_RPC_42161), GATE_FROM_ADDRESS.
+GATE_RPC_<chainid> (e.g. GATE_RPC_42161), GATE_FROM_ADDRESS,
+GATE_TRON_ADDRESS (relay recipient wallet; relay cells SKIP without it).
 EOF
 }
 
@@ -349,9 +356,24 @@ run_relay() {
     USDT) from_token="0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2" ;;
   esac
 
+  # The Tron recipient is a WALLET and there is no safe default: a Tron
+  # settlement is final, and the destination TOKEN contract is a well-formed
+  # base58 address the relay would settle to and nobody could spend back out.
+  local to_addr="${GATE_TRON_ADDRESS:-}"
+  if [[ -z "$to_addr" ]]; then
+    log "relay $asset: SKIP -- set GATE_TRON_ADDRESS to the Tron recipient wallet"
+    log "             you control. There is no default; a Tron settlement is final."
+    return 10
+  fi
+  if [[ "$to_addr" == "$to_token" ]]; then
+    err "relay $asset: GATE_TRON_ADDRESS is the destination token contract, not a"
+    err "             wallet. Funds settled there are unrecoverable. No funds moved."
+    return 1
+  fi
+
   atomic="$(awk -v a="$RELAY_AMOUNT" 'BEGIN { printf "%d", a * 1000000 }')"
   body="$(printf '{"transfer_id":"probe","from_chain_id":%s,"to_chain_id":728126428,"from_token":"%s","to_token":"%s","from_amount":"%s","from_address":"%s","to_address":"%s","slippage_bps":50}' \
-    "$from_chain" "$from_token" "$to_token" "$atomic" "$from_addr" "$to_token")"
+    "$from_chain" "$from_token" "$to_token" "$atomic" "$from_addr" "$to_addr")"
 
   log "relay preflight: probing /relay/quote for $tok (read-only, no funds)..."
   code="$(curl -sS -m 20 -o /dev/null -w '%{http_code}' \
@@ -374,9 +396,10 @@ run_relay() {
   export RELAY_LIVE_URL="$RELAY_URL" RELAY_LIVE_TOKEN="$RELAY_TOKEN"
   export RELAY_LIVE_KEY="$KEY" RELAY_LIVE_RPC="$rpc" RELAY_LIVE_FROM_ADDRESS="$from_addr"
   export RELAY_LIVE_FROM_CHAIN="$from_chain" RELAY_LIVE_TOKENS="$tok" RELAY_LIVE_AMOUNT="$RELAY_AMOUNT"
+  export RELAY_LIVE_TO_ADDRESS="$to_addr"
 
   cd "$ACP_DIR"
-  log "relay settle: EVM($from_chain) $tok -> Tron USDT (REAL, broadcasts a deposit)..."
+  log "relay settle: EVM($from_chain) $tok -> Tron USDT at $to_addr (REAL, broadcasts a deposit)..."
   env MIX_ENV=test mix test --include live_relay "$RELAY_TEST"
 }
 
@@ -460,7 +483,7 @@ confirm_funded() {
           if [[ "$a" == "USDG" ]]; then
             log "  $a / relay  -> skip (no Tron leg)"
           else
-            log "  $a / relay  -> Base $tok -> Tron USDT (~$RELAY_AMOUNT)"
+            log "  $a / relay  -> Base $tok -> Tron USDT at ${GATE_TRON_ADDRESS:-<unset: cell skips>} (~$RELAY_AMOUNT)"
           fi ;;
         fee) log "  $a / fee  -> take-rate check [$eff] (NO funds)" ;;
         *) log "  $a / $r  -> [$eff] token=$tok (~$AMOUNT/corridor)" ;;

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -399,7 +399,10 @@ run_relay() {
   export RELAY_LIVE_TO_ADDRESS="$to_addr"
 
   cd "$ACP_DIR"
-  log "relay settle: EVM($from_chain) $tok -> Tron USDT at $to_addr (REAL, broadcasts a deposit)..."
+  # The whole module runs, and the settle test and the resume test each broadcast
+  # one deposit of $tok -- which is what estimate_spend counts.
+  log "relay settle: EVM($from_chain) $tok -> Tron USDT at $to_addr"
+  log "              (REAL, broadcasts two deposits of $RELAY_AMOUNT: settle + resume)..."
   env MIX_ENV=test mix test --include live_relay "$RELAY_TEST"
 }
 
@@ -451,7 +454,8 @@ corridor_count() {
 }
 
 # Worst-case funded spend: per-corridor amount x corridor count over settling
-# cells (relay is a single corridor at RELAY_AMOUNT). This is a CEILING -- the
+# cells (relay is a single corridor at RELAY_AMOUNT, but its module broadcasts
+# two deposits: the settle test and the resume test). This is a CEILING -- the
 # tests settle only the fillable subset, so real spend is usually lower.
 estimate_spend() {
   local a r tok corr _p2 _pc eff n
@@ -462,7 +466,7 @@ estimate_spend() {
     for r in $ROUTE_LIST; do
       case "$r" in
         xochi|acp) n="$(corridor_count "$eff")"; pairs+=("$AMOUNT $n") ;;
-        relay)     [[ "$a" == "USDG" ]] && continue; pairs+=("$RELAY_AMOUNT 1") ;;
+        relay)     [[ "$a" == "USDG" ]] && continue; pairs+=("$RELAY_AMOUNT 2") ;;
       esac
     done
   done
@@ -483,7 +487,8 @@ confirm_funded() {
           if [[ "$a" == "USDG" ]]; then
             log "  $a / relay  -> skip (no Tron leg)"
           else
-            log "  $a / relay  -> Base $tok -> Tron USDT at ${GATE_TRON_ADDRESS:-<unset: cell skips>} (~$RELAY_AMOUNT)"
+            log "  $a / relay  -> Base $tok -> Tron USDT at ${GATE_TRON_ADDRESS:-<unset: cell skips>}"
+            log "                 two deposits of ~$RELAY_AMOUNT (settle + resume)"
           fi ;;
         fee) log "  $a / fee  -> take-rate check [$eff] (NO funds)" ;;
         *) log "  $a / $r  -> [$eff] token=$tok (~$AMOUNT/corridor)" ;;

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -99,9 +99,9 @@ PAYMENTS_DIR="$REPO_ROOT/packages/raxol_payments"
 ACP_DIR="$REPO_ROOT/packages/raxol_earn"
 
 XOCHI_TEST="test/raxol/payments/xochi/live_xochi_test.exs"
-ORDER_TEST="test/raxol/acp/xochi/live_order_test.exs"
-RELAY_TEST="test/raxol/acp/relay/live_relay_test.exs"
-SOLVER_FEE_TEST="test/raxol/acp/xochi/solver_fee_live_test.exs"
+ORDER_TEST="test/raxol/earn/xochi/live_order_test.exs"
+RELAY_TEST="test/raxol/earn/relay/live_relay_test.exs"
+SOLVER_FEE_TEST="test/raxol/earn/xochi/solver_fee_live_test.exs"
 
 # --- defaults / env inputs ---
 ASSETS=""


### PR DESCRIPTION
Supersedes #864 (same content, rebased onto master, plus the review fixes).

An adversarial review of #864 found that the live relay gate settles real funds
to a token contract, and records PASS.

## The defect

`run_relay` exports eight `RELAY_LIVE_*` variables and `RELAY_LIVE_TO_ADDRESS`
is not among them, so `live_relay_test.exs` fell back to its default:

```elixir
to_address = System.get_env("RELAY_LIVE_TO_ADDRESS", @usdt_tron)
```

`@usdt_tron` is `TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` -- the Tether TRC-20 token
contract. The same constant is correctly used as `to_token`, which is how a
token address became a recipient. The script did the same thing in the quote
probe, passing `"$to_token"` as `to_address`.

So a funded `--route relay` cell broadcast a real USDC deposit on Base and
settled the destination USDT to the USDT contract's own balance, unrecoverable.
Riddler still reported `completed`, so the cell recorded PASS and the matrix told
the operator the rail was healthy. Nothing downstream catches it:
`QuoteRequest.validate` only checks `TronAddress.valid?/1`, which a contract
address satisfies.

The bad default is older than #864. What made it this PR's problem is that the
`raxol_acp -> raxol_earn` rename had left `RELAY_TEST` pointing at a file that
does not exist, so the cell exited 1 and recorded FAIL. #864 repoints it and
re-arms the path.

## The fix

Fail closed rather than choose a better default. `GATE_TRON_ADDRESS` is now a
required input; a relay cell SKIPs without it, and the script refuses outright
when the value equals the destination token contract. The probe body passes the
recipient, the script exports `RELAY_LIVE_TO_ADDRESS`, and the test uses
`System.fetch_env!/1` with a guard that the recipient is not the token contract.

Two more from the same review:

- The cell runs the whole module, and the second test hardcoded Base USDC
  (`RELAY_LIVE_FROM_TOKEN` is never exported either), so `--asset USDT --route
  relay` broadcast a USDT deposit and a USDC deposit while the plan counted one.
  It now resolves its source the way the first test does, and the log says the
  cell broadcasts two deposits.
- The "is the 7702 buyer the live gates use" test asserted a locally re-declared
  literal against itself. It now points at the production `Sma7702Wallet`.

## Verification

- `bash -n` and `shellcheck -S error` clean on the gate script
- `raxol_earn`: format clean, `compile --force --warnings-as-errors` exit 0, full suite green
- No live or fund-moving test was run, by design. The relay guards are verified
  by reading and compilation; the script's fail-closed path was proven end to end.

## Manual testing

- [ ] `./scripts/run_live_gates.sh --asset USDC --route relay --dry-run` without
      `GATE_TRON_ADDRESS` SKIPs with the new message
- [ ] The same with `GATE_TRON_ADDRESS` set to the USDT contract FAILs before the probe
- [ ] A funded relay run settles to the wallet named in `GATE_TRON_ADDRESS`
