### PR TITLE
Make the order task's operator guidance reachable

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -573,10 +573,15 @@ defmodule Mix.Tasks.RaxolEarn.Order do
         address
 
       :error ->
+        # Read the table `address/2` reads. `Assets.supported_chain_ids/0` is the
+        # union over every symbol, so it also lists chains that carry USDG or WETH
+        # but no USDC -- naming those here sends the operator round the same error.
         supported =
-          Assets.supported_chain_ids()
-          |> Enum.map(&"#{&1} (#{Assets.chain_name(&1)})")
-          |> Enum.join(", ")
+          Assets.evm_tokens()
+          |> Map.fetch!("USDC")
+          |> Map.keys()
+          |> Enum.sort()
+          |> Enum.map_join(", ", &"#{&1} (#{Assets.chain_name(&1)})")
 
         Mix.raise("""
         no USDC address for the #{side} chain #{chain_id}.

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -427,7 +427,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     _ = fetch_env!("RAXOL_ACP_SIGNER_PRIVATE_KEY")
     address = fetch_env!("RAXOL_ACP_WALLET_ADDRESS")
 
-    start_sidecar!()
+    start_sidecar!(address)
 
     provider =
       ProviderAdapter.Privy.new(
@@ -587,32 +587,48 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     end
   end
 
-  # The sidecar is a Node process: it fails when node is missing, its deps are
-  # not installed, the port is taken, or the Privy credentials are rejected.
-  # Each of those used to arrive as a MatchError on a start_link tuple.
-  defp start_sidecar!() do
-    case Raxol.Earn.SignerSidecar.start_link([]) do
-      {:ok, pid} ->
-        pid
-
-      {:error, {:already_started, pid}} ->
-        pid
-
-      {:error, reason} ->
-        Mix.raise("""
-        the Privy signer sidecar did not start: #{inspect(reason)}
-
-        It is a Node process under packages/raxol_earn/priv/signer_sidecar.
-        Check, in order:
-
-          node --version                       # must be present on PATH
-          ls priv/signer_sidecar/node_modules  # run `npm install` there if absent
-          lsof -i :4048                        # default port, must be free
-
-        RAXOL_ACP_WALLET_ADDRESS / RAXOL_ACP_WALLET_ID / RAXOL_ACP_SIGNER_PRIVATE_KEY
-        must all be set: the sidecar reads them at boot and exits if any is missing.
-        """)
+  # The sidecar is a Node process: it fails when node is missing, its deps are not
+  # installed, the port is taken, or the Privy credentials are rejected. A plain
+  # `start_link` cannot report any of those here -- the linked child's exit signal
+  # kills this task before the return value is read -- so go through the trapping
+  # start, which turns the exit back into a reason.
+  defp start_sidecar!(address) do
+    case Raxol.Earn.SignerSidecar.start_link_or_error(expect_address: address) do
+      {:ok, pid} -> pid
+      {:error, reason} -> Mix.raise(sidecar_error(reason))
     end
+  end
+
+  defp sidecar_error({:sidecar_unhealthy, {:sidecar_wrong_wallet, got, want}}) do
+    """
+    #{Raxol.Earn.SignerSidecar.base_url([])} answers /health for the WRONG wallet:
+    #{got}, expected #{want}.
+
+    Something else already holds the port -- most often a signer sidecar left over
+    from an earlier run, delegated to a different agent. Left alone it would sign
+    this order's intent and its on-chain calls as #{got}, while every log line here
+    said #{want}. Find and stop it:
+
+      lsof -i :4048
+
+    Or point this run elsewhere with RAXOL_ACP_SIGNER_PORT / RAXOL_ACP_SIDECAR_URL.
+    """
+  end
+
+  defp sidecar_error(reason) do
+    """
+    the Privy signer sidecar did not start: #{inspect(reason)}
+
+    It is a Node process under packages/raxol_earn/priv/signer_sidecar.
+    Check, in order:
+
+      node --version                       # must be present on PATH
+      ls priv/signer_sidecar/node_modules  # run `npm install` there if absent
+      lsof -i :4048                        # default port; the sidecar exits if taken
+
+    RAXOL_ACP_WALLET_ADDRESS / RAXOL_ACP_WALLET_ID / RAXOL_ACP_SIGNER_PRIVATE_KEY
+    must all be set: the sidecar reads them at boot and exits if any is missing.
+    """
   end
 
   @explorers %{

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -128,6 +128,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
         {:ok, bundle} -> bundle
         {:error, reason} -> Mix.raise(sign_intent_error(reason))
       end
+
     requirement = requirement(cfg, bundle)
     log("signed Xochi intent: #{bundle[:intent_id] || bundle["intent_id"]}")
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -605,16 +605,17 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   end
 
   defp sidecar_error({:sidecar_unhealthy, {:sidecar_wrong_wallet, got, want}}) do
-    """
-    #{Raxol.Earn.SignerSidecar.base_url([])} answers /health for the WRONG wallet:
-    #{got}, expected #{want}.
+    url = Raxol.Earn.SignerSidecar.base_url([])
 
-    Something else already holds the port -- most often a signer sidecar left over
+    """
+    #{url} answers /health for the WRONG wallet: #{got}, expected #{want}.
+
+    Something else already holds that port -- most often a signer sidecar left over
     from an earlier run, delegated to a different agent. Left alone it would sign
     this order's intent and its on-chain calls as #{got}, while every log line here
     said #{want}. Find and stop it:
 
-      lsof -i :4048
+      lsof -i :#{URI.parse(url).port}
 
     Or point this run elsewhere with RAXOL_ACP_SIGNER_PORT / RAXOL_ACP_SIDECAR_URL.
     """

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -123,7 +123,11 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     )
 
     # 1. Sign the Xochi intent (off-chain).
-    {:ok, bundle} = sign_intent(cfg)
+    bundle =
+      case sign_intent(cfg) do
+        {:ok, bundle} -> bundle
+        {:error, reason} -> Mix.raise(sign_intent_error(reason))
+      end
     requirement = requirement(cfg, bundle)
     log("signed Xochi intent: #{bundle[:intent_id] || bundle["intent_id"]}")
 
@@ -532,6 +536,32 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       v -> v
     end
   end
+
+  # A bare `{:ok, _} =` here reported a transport failure as a MatchError on a
+  # Req struct, which reads like a Xochi outage. It is more often the local
+  # network: some ISPs null-route whole Cloudflare ranges, and api.xochi.fi
+  # resolves into one (188.114.96.0/20). Observed on Vodafone ES -- port 80 is
+  # intercepted with an "Acceso bloqueado" page and 443 is dropped, so every
+  # request dies at connect with no HTTP status to explain itself.
+  defp sign_intent_error(%{__struct__: Req.TransportError, reason: reason}) do
+    """
+    could not reach the Xochi API (transport #{inspect(reason)}).
+
+    This is usually the network path, not Xochi. Check, in order:
+
+      nc -z api.xochi.fi 443          # dropped => blocked upstream, not down
+      curl -sI http://api.xochi.fi    # a non-Cloudflare page here => intercepted
+      curl -s "https://r.jina.ai/https://xochi.fi"   # answers => the API is fine
+
+    A control host only proves anything if it shares the blocked IP range;
+    cloudflare.com and other Cloudflare sites sit elsewhere and will pass while
+    this one fails. Route around it with a VPN or an exit node in another
+    country. Confirm from off-network before reporting an outage upstream.
+    """
+  end
+
+  defp sign_intent_error(reason),
+    do: "could not sign the Xochi intent: #{inspect(reason)}"
 
   @explorers %{
     1 => "https://etherscan.io/tx/",

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -386,8 +386,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     {from, to} = parse_corridor(Keyword.get(opts, :corridor, "8453>42161"))
     amount = Keyword.get(opts, :amount, "3.00")
 
-    {:ok, src_token} = Assets.address(from, "USDC")
-    {:ok, dst_token} = Assets.address(to, "USDC")
+    src_token = usdc_address!(from, "origin")
+    dst_token = usdc_address!(to, "destination")
     principal_atomic = Assets.to_atomic(Decimal.new(amount), Assets.decimals(from, src_token))
 
     signer = Keyword.get(opts, :signer, "privy")
@@ -427,7 +427,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     _ = fetch_env!("RAXOL_ACP_SIGNER_PRIVATE_KEY")
     address = fetch_env!("RAXOL_ACP_WALLET_ADDRESS")
 
-    {:ok, _} = Raxol.Earn.SignerSidecar.start_link([])
+    start_sidecar!()
 
     provider =
       ProviderAdapter.Privy.new(
@@ -563,6 +563,57 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   defp sign_intent_error(reason),
     do: "could not sign the Xochi intent: #{inspect(reason)}"
+
+  # `Assets.address/2` answers a bare `:error` for an unsupported pair, so a
+  # bad --corridor used to surface as `no match of right hand side value: :error`
+  # with no hint of which side was wrong.
+  defp usdc_address!(chain_id, side) do
+    case Assets.address(chain_id, "USDC") do
+      {:ok, address} ->
+        address
+
+      :error ->
+        supported =
+          Assets.supported_chain_ids()
+          |> Enum.map(&"#{&1} (#{Assets.chain_name(&1)})")
+          |> Enum.join(", ")
+
+        Mix.raise("""
+        no USDC address for the #{side} chain #{chain_id}.
+
+        Check --corridor (origin>destination). Chains with a USDC address:
+          #{supported}
+        """)
+    end
+  end
+
+  # The sidecar is a Node process: it fails when node is missing, its deps are
+  # not installed, the port is taken, or the Privy credentials are rejected.
+  # Each of those used to arrive as a MatchError on a start_link tuple.
+  defp start_sidecar!() do
+    case Raxol.Earn.SignerSidecar.start_link([]) do
+      {:ok, pid} ->
+        pid
+
+      {:error, {:already_started, pid}} ->
+        pid
+
+      {:error, reason} ->
+        Mix.raise("""
+        the Privy signer sidecar did not start: #{inspect(reason)}
+
+        It is a Node process under packages/raxol_earn/priv/signer_sidecar.
+        Check, in order:
+
+          node --version                       # must be present on PATH
+          ls priv/signer_sidecar/node_modules  # run `npm install` there if absent
+          lsof -i :4048                        # default port, must be free
+
+        RAXOL_ACP_WALLET_ADDRESS / RAXOL_ACP_WALLET_ID / RAXOL_ACP_SIGNER_PRIVATE_KEY
+        must all be set: the sidecar reads them at boot and exits if any is missing.
+        """)
+    end
+  end
 
   @explorers %{
     1 => "https://etherscan.io/tx/",

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.rebalance.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.rebalance.ex
@@ -39,7 +39,19 @@ defmodule Mix.Tasks.RaxolEarn.Rebalance do
   defp sweep(acc, rpc_urls, solver) do
     # A throwaway ledger: the drain only tiebreaks refuel ordering, so an empty one
     # still yields correct balance-driven recommendations for a snapshot.
-    {:ok, ledger} = SettlementLedger.start_link(table_name: :raxol_earn_rebalance_task)
+    ledger =
+      case SettlementLedger.start_link(table_name: :raxol_earn_rebalance_task) do
+        {:ok, pid} ->
+          pid
+
+        # Re-running the sweep in one VM (or an ETS table left by a prior run)
+        # is not a failure -- the ledger is a throwaway either way.
+        {:error, {:already_started, pid}} ->
+          pid
+
+        {:error, reason} ->
+          Mix.raise("could not start the throwaway settlement ledger: #{inspect(reason)}")
+      end
 
     RebalanceMonitor.advise_once(
       ledger: ledger,

--- a/packages/raxol_earn/lib/raxol/earn/signer_sidecar.ex
+++ b/packages/raxol_earn/lib/raxol/earn/signer_sidecar.ex
@@ -29,6 +29,9 @@ defmodule Raxol.Earn.SignerSidecar do
   - `:node_path` -- node executable (default: `System.find_executable("node")`).
   - `:script` -- server.mjs path (default: this app's `priv/signer_sidecar/server.mjs`).
   - `:health_timeout_ms` -- boot health-wait budget (default `20_000`).
+  - `:expect_address` -- the wallet `GET /health` must report (default
+    `RAXOL_ACP_WALLET_ADDRESS`). A listener answering for another wallet is
+    rejected rather than adopted as the signer.
   """
 
   use GenServer
@@ -42,6 +45,53 @@ defmodule Raxol.Earn.SignerSidecar do
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @doc """
+  Start the sidecar for a caller that does not trap exits, such as a Mix task.
+
+  `start_link/1` cannot report a boot failure to such a caller: `init/1` exits,
+  and the link delivers that exit signal before the `{:error, _}` return value is
+  ever inspected, so the caller dies with an opaque `** (EXIT from ...)`. This
+  traps exits for the duration of the start and hands the reason back. The link
+  is left intact on success, so a sidecar that dies later still takes the caller
+  with it.
+  """
+  @spec start_link_or_error(keyword()) :: {:ok, pid()} | {:error, term()}
+  def start_link_or_error(opts \\ []) do
+    trapping? = Process.flag(:trap_exit, true)
+
+    try do
+      opts |> start_link() |> settle()
+    after
+      Process.flag(:trap_exit, trapping?)
+    end
+  end
+
+  # Already running: no child was spawned, so there is no exit signal to collect.
+  defp settle({:error, {:already_started, pid}}), do: {:ok, pid}
+
+  # `init_fail/3` acks the caller before the child exits, so the signal lands just
+  # after start_link returns. Wait for it: leaving it queued would surface later as
+  # a stray message, or vanish once the flag is restored.
+  defp settle({:error, reason}) do
+    receive do
+      {:EXIT, _pid, _} -> :ok
+    after
+      1_000 -> :ok
+    end
+
+    {:error, reason}
+  end
+
+  # A sidecar that died in this window has already been converted to a message that
+  # restoring the flag cannot turn back into a kill, so report it rather than lose it.
+  defp settle({:ok, pid}) do
+    receive do
+      {:EXIT, ^pid, reason} -> {:error, reason}
+    after
+      0 -> {:ok, pid}
+    end
   end
 
   @doc "The sidecar base URL for the given (or default) options."
@@ -79,7 +129,8 @@ defmodule Raxol.Earn.SignerSidecar do
 
     case await_health(
            state.base_url,
-           Keyword.get(opts, :health_timeout_ms, @default_health_timeout_ms)
+           Keyword.get(opts, :health_timeout_ms, @default_health_timeout_ms),
+           expect_address(opts)
          ) do
       :ok ->
         Logger.info("signer sidecar healthy at #{state.base_url}")
@@ -129,24 +180,51 @@ defmodule Raxol.Earn.SignerSidecar do
     |> Application.app_dir("priv/signer_sidecar/server.mjs")
   end
 
-  # Poll GET /health until 200 or the budget elapses.
-  defp await_health(base_url, timeout_ms) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_await_health(base_url, deadline)
+  # The sidecar reads this env itself, so it is also what the sidecar will report.
+  defp expect_address(opts) do
+    Keyword.get(opts, :expect_address) || System.get_env("RAXOL_ACP_WALLET_ADDRESS")
   end
 
-  defp do_await_health(base_url, deadline) do
-    case Req.get(url: base_url <> "/health", retry: false, receive_timeout: 2_000) do
-      {:ok, %Req.Response{status: 200}} ->
-        :ok
+  # Poll GET /health until the sidecar answers as `expect_address`, or the budget
+  # elapses. Public so the identity gate is testable against a real loopback
+  # listener, without a node runtime.
+  @doc false
+  @spec await_health(String.t(), non_neg_integer(), String.t() | nil) :: :ok | {:error, term()}
+  def await_health(base_url, timeout_ms, expect_address \\ nil) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_await_health(base_url, deadline, expect_address)
+  end
 
-      _ ->
-        if System.monotonic_time(:millisecond) < deadline do
-          Process.sleep(250)
-          do_await_health(base_url, deadline)
-        else
-          {:error, :health_timeout}
-        end
+  defp do_await_health(base_url, deadline, expect) do
+    case Req.get(url: base_url <> "/health", retry: false, receive_timeout: 2_000) do
+      {:ok, %Req.Response{status: 200, body: body}} -> check_identity(body, expect)
+      _ -> retry_health(base_url, deadline, expect)
+    end
+  end
+
+  # A 200 is only liveness. An orphaned sidecar (or any other process) holding the
+  # port would otherwise become the money-path signer while callers keep reporting
+  # the configured wallet, so the reported wallet has to match -- and a mismatch
+  # never becomes a match by waiting, so it is returned rather than retried.
+  defp check_identity(_body, nil), do: :ok
+
+  defp check_identity(%{"address" => got}, want) when is_binary(got) do
+    case String.downcase(got) == String.downcase(want) do
+      true -> :ok
+      false -> {:error, {:sidecar_wrong_wallet, got, want}}
+    end
+  end
+
+  defp check_identity(_body, want), do: {:error, {:sidecar_wrong_wallet, nil, want}}
+
+  defp retry_health(base_url, deadline, expect) do
+    case System.monotonic_time(:millisecond) < deadline do
+      true ->
+        Process.sleep(250)
+        do_await_health(base_url, deadline, expect)
+
+      false ->
+        {:error, :health_timeout}
     end
   end
 end

--- a/packages/raxol_earn/priv/signer_sidecar/server.mjs
+++ b/packages/raxol_earn/priv/signer_sidecar/server.mjs
@@ -188,6 +188,14 @@ async function main() {
     }
   });
 
+  // An emitter error (EADDRINUSE, above all) is not reachable by main().catch, so
+  // without this the process would fault opaquely and leave whatever already holds
+  // the port answering /health in its place.
+  server.on("error", (err) => {
+    console.error(`[signer] cannot listen on ${HOST}:${PORT}: ${err.message}`);
+    process.exit(1);
+  });
+
   server.listen(PORT, HOST, () => {
     console.log(`[signer] listening on http://${HOST}:${PORT}`);
   });

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.RaxolEarn.OrderTest do
+  # async: false -- Mix.shell/1 and the task's env reads are process-global.
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.RaxolEarn.Order
+
+  setup do
+    shell = Mix.shell()
+    Mix.shell(Mix.Shell.Process)
+    on_exit(fn -> Mix.shell(shell) end)
+    :ok
+  end
+
+  describe "--corridor validation" do
+    test "an unsupported destination lists only the chains USDC actually exists on" do
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> Order.run(["--corridor", "8453>4663", "--dry-run"]) end)
+
+      assert message =~ "no USDC address for the destination chain 4663"
+
+      # 4663 (Robinhood Chain) carries USDG and WETH but no USDC, so offering it as
+      # an alternative sends the operator straight back into this same error.
+      refute message =~ "Robinhood Chain"
+
+      for chain <- ["1 (Ethereum)", "10 (Optimism)", "137 (Polygon)", "8453 (Base)"] do
+        assert message =~ chain
+      end
+    end
+
+    test "an unsupported origin is named as the origin" do
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> Order.run(["--corridor", "4663>8453", "--dry-run"]) end)
+
+      assert message =~ "no USDC address for the origin chain 4663"
+      refute message =~ "Robinhood Chain"
+    end
+  end
+end

--- a/packages/raxol_earn/test/raxol/earn/signer_sidecar_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/signer_sidecar_test.exs
@@ -4,8 +4,10 @@ defmodule Raxol.Earn.SignerSidecarTest do
 
   alias Raxol.Earn.SignerSidecar
 
-  # Only base_url/1 is unit-testable in isolation; init/1 opens a Node Port and
-  # blocks on GET /health, which needs the real sidecar (integration-level).
+  # init/1 opens a Node Port, so the boot tests below stop at the pre-Port checks;
+  # the health gate is exercised against a real loopback listener instead.
+
+  @wallet "0x468AEAE798B3a6548ac2401d276f83afdc172283"
 
   setup do
     prior_url = System.get_env("RAXOL_ACP_SIDECAR_URL")
@@ -51,4 +53,108 @@ defmodule Raxol.Earn.SignerSidecarTest do
       assert SignerSidecar.base_url(port: 8001) == "http://127.0.0.1:8001"
     end
   end
+
+  describe "start_link_or_error/1" do
+    test "start_link/1 kills a caller that does not trap exits" do
+      {_pid, ref} = spawn_monitor(fn -> SignerSidecar.start_link(boot_failure_opts()) end)
+
+      assert_receive {:DOWN, ^ref, :process, _pid, reason}, 5_000
+      assert reason != :normal
+    end
+
+    test "the same failure comes back as a reason, leaving the caller alive" do
+      parent = self()
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          send(parent, {:result, SignerSidecar.start_link_or_error(boot_failure_opts())})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:result, {:error, reason}}, 5_000
+      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 200
+      assert inspect(reason) =~ "signer sidecar script not found"
+
+      Process.exit(pid, :kill)
+    end
+  end
+
+  describe "await_health/3" do
+    test "no expected address accepts any 200, as before" do
+      url = health_listener(~s({"ok":true,"address":"#{@wallet}"}))
+      assert SignerSidecar.await_health(url, 2_000) == :ok
+    end
+
+    test "the sidecar's own wallet passes, whatever the checksum casing" do
+      url = health_listener(~s({"ok":true,"address":"#{String.downcase(@wallet)}"}))
+      assert SignerSidecar.await_health(url, 2_000, @wallet) == :ok
+    end
+
+    test "a listener answering for another wallet is rejected, not adopted" do
+      other = "0x939ead944b5d28b86d91af1961812d3bbc46cac1"
+      url = health_listener(~s({"ok":true,"address":"#{other}"}))
+
+      assert SignerSidecar.await_health(url, 2_000, @wallet) ==
+               {:error, {:sidecar_wrong_wallet, other, @wallet}}
+    end
+
+    test "a 200 that names no wallet is rejected" do
+      url = health_listener(~s({"ok":true}))
+
+      assert SignerSidecar.await_health(url, 2_000, @wallet) ==
+               {:error, {:sidecar_wrong_wallet, nil, @wallet}}
+    end
+
+    test "nothing listening times out" do
+      assert SignerSidecar.await_health(health_free_url(), 300, @wallet) ==
+               {:error, :health_timeout}
+    end
+  end
+
+  # A real loopback HTTP listener: the health gate reads a body off the wire, so a
+  # stubbed Req would test nothing.
+  defp health_listener(body) do
+    parent = self()
+
+    response =
+      "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n" <>
+        "content-length: #{byte_size(body)}\r\nconnection: close\r\n\r\n" <> body
+
+    pid =
+      spawn(fn ->
+        {:ok, listen} =
+          :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}, active: false, reuseaddr: true])
+
+        {:ok, port} = :inet.port(listen)
+        send(parent, {:listening, port})
+        serve(listen, response)
+      end)
+
+    on_exit(fn -> Process.exit(pid, :kill) end)
+
+    receive do
+      {:listening, port} -> "http://127.0.0.1:#{port}"
+    after
+      2_000 -> flunk("health listener never bound a port")
+    end
+  end
+
+  defp serve(listen, response) do
+    {:ok, socket} = :gen_tcp.accept(listen)
+    {:ok, _request} = :gen_tcp.recv(socket, 0, 2_000)
+    :ok = :gen_tcp.send(socket, response)
+    :ok = :gen_tcp.close(socket)
+    serve(listen, response)
+  end
+
+  # Bind then release a port, so the url is well-formed and reliably unserved.
+  defp health_free_url do
+    {:ok, listen} = :gen_tcp.listen(0, ip: {127, 0, 0, 1})
+    {:ok, port} = :inet.port(listen)
+    :ok = :gen_tcp.close(listen)
+    "http://127.0.0.1:#{port}"
+  end
+
+  # Fails in init/1 before the Node Port is opened, so no node runtime is needed.
+  defp boot_failure_opts, do: [name: nil, script: "/nonexistent/signer_sidecar/server.mjs"]
 end


### PR DESCRIPTION
Supersedes #860 (same three commits, rebased onto master, plus three review fixes).

An adversarial review found that #860's headline fix does not run.

## The sidecar checklist was in an unreachable branch

`start_sidecar!/0` matched `{:error, reason}` to print a four-point checklist.
A Mix task does not trap exits, so a linked GenServer whose `init/1` raises or
returns `{:stop, _}` kills the task **before** `start_link` returns. Every
failure the checklist enumerates -- node missing, deps not installed, port taken,
Privy credentials rejected -- takes that route. The clause never ran.

Proven by running it inside a real Mix task process: the caller dies with
`** (EXIT from #PID<...>) {:sidecar_unhealthy, :health_timeout}` and the line
after `start_link` never executes.

The fix adds `SignerSidecar.start_link_or_error/1`, which traps exits around the
start, restores the flag in an `after`, and drains the `{:EXIT, _, _}` so the
reason becomes a return value. It lives in `SignerSidecar` rather than inline in
the task so it is reachable from a test.

## The `/health` gate checked liveness, not identity

`do_await_health/2` accepted any 200 on the configured URL. A foreign listener on
`:4048` -- a sidecar left over from another run, holding another wallet -- answers
200, so it silently became the money-path signer while `get_address` still
reported the configured wallet. Meanwhile `server.mjs` had no
`server.on("error")`, so `EADDRINUSE` was an uncaught exception.

Both sides are fixed: the health gate now compares the wallet the sidecar
actually holds against the expected one and fails with `{:sidecar_wrong_wallet,
got, want}` without retrying, and `server.mjs` exits 1 with one actionable line
when the port is taken. Only then is the `lsof` guidance true, so it was
rewritten to say what now happens.

## The corridor error advertised a chain USDC is not on

`Assets.supported_chain_ids/0` is the union over every token, so the "Chains with
a USDC address" list included 4663 (Robinhood Chain), where
`Assets.address(4663, "USDC")` is `:error`. It now reads the same table
`address/2` reads.

## Verification

Format clean, `compile --force --warnings-as-errors` exit 0, `raxol_earn` suite
770 passed / 0 failures on the rebased branch. Each fix has a RED/GREEN proof:
the trap, the identity check and the chain list were each reverted in turn and
the corresponding tests went red.

The `server.mjs` `EADDRINUSE` path was not executed -- it needs `node_modules`
and live Privy credentials. The mechanism was proven with an isolated node probe
of the identical shape and the file was syntax-checked.

## Manual testing

- [ ] `PATH= mix raxol_earn.order --dry-run` prints the sidecar checklist instead of an EXIT
- [ ] Two sidecars on one port: the second exits 1 with the listen error
- [ ] `--corridor "8453>56"` names the side and omits 4663
