### PR TITLE
Stop the spend report printing figures it cannot back

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -19,7 +19,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     5. Poll `getJob(jobId).budget` until the provider sets it, and assert it is
        `fee_bps` of the principal.
     6. With `--fund`: approve + `fund(jobId, budget)` so the provider is paid and
-       settlement proceeds.
+       settlement proceeds. The provider writes that budget, so `--fund` refuses
+       anything above the `--fee-bps` take-rate unless `--max-escrow` raises the
+       ceiling.
 
   ## Signer backends (`--signer`)
 
@@ -43,8 +45,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   The PRINCIPAL does not move in this task's writes. The signed intent only
   AUTHORIZES the solver to pull up to that much during settlement, so a "3.00 USDC"
-  run costs ~0.0169 end to end, not 3.00. The task prints a spend plan before the
-  first write and receipt-derived actuals after each one.
+  run costs ~0.0169 end to end, not 3.00. The task prints a spend plan before it
+  does anything -- including under `--dry-run`, which is the mode you want the
+  plan in -- and receipt-derived actuals after each write.
 
   `--dry-run` stops after signing and spends nothing.
 
@@ -69,6 +72,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       --corridor F>T     origin>destination chain ids (default 8453>42161).
       --provider 0x..    the agent (seller) wallet to hire (default the raxol agent).
       --fee-bps N        expected take-rate to assert (default 8).
+      --max-escrow N     ceiling in USDC on what --fund will pay. Defaults to the
+                         --fee-bps take-rate; a larger on-chain budget is refused.
       --job-id N         resume an existing job (skip createJob).
       --fund             after budget is observed, fund the escrow + settle.
       --dry-run          sign only, no on-chain writes.
@@ -116,6 +121,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
           corridor: :string,
           provider: :string,
           fee_bps: :integer,
+          max_escrow: :string,
           fund: :boolean,
           dry_run: :boolean,
           job_id: :integer,
@@ -131,6 +137,10 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     log(
       "buyer=#{cfg.buyer}  provider=#{cfg.provider}  corridor=#{cfg.from}->#{cfg.to}  amount=#{cfg.amount} USDC"
     )
+
+    # Before anything, including under --dry-run: rehearsing a run is the reason
+    # the plan exists, so the costless mode must be the one that shows it.
+    print_plan(cfg, opts)
 
     # 1. Sign the Xochi intent (off-chain).
     bundle =
@@ -152,8 +162,6 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # -- Orchestration --
 
   defp place(cfg, requirement, opts) do
-    print_plan(cfg, opts)
-
     {agent, resolver} = start_buyer(cfg)
 
     # 2. createJob on-chain (or resume an existing job with --job-id).
@@ -167,22 +175,25 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     :ok = send_requirement(agent, cfg.from, job_id, requirement)
     log("requirement sent for job #{job_id}")
 
-    # 5. Watch the provider set the budget on-chain and assert the take-rate.
+    # 5. Watch the provider set the budget on-chain and enforce the take-rate.
     budget = await_budget(cfg, job_id)
-    expected = div(cfg.principal_atomic * cfg.fee_bps, 10_000)
     realized_bps = Float.round(budget / cfg.principal_atomic * 10_000, 3)
+    funding? = Keyword.get(opts, :fund, false)
 
     log("provider setBudget = #{budget} base units (#{realized_bps} bps)")
 
-    if budget == expected do
-      log("OK: budget == #{cfg.fee_bps} bps of the principal")
-    else
-      log("WARN: budget #{budget} != expected #{expected} (#{cfg.fee_bps} bps)")
+    # The budget is the counterparty's number, and --fund approves and pays it.
+    # Over the ceiling it is refused rather than logged, but only when this run
+    # would actually spend it: without --fund the mismatch is just disclosure.
+    case {budget_verdict(cfg, budget, escrow_ceiling(cfg, opts)), funding?} do
+      {{:ok, line}, _} -> log(line)
+      {{:error, message}, false} -> log("WARN: " <> message)
+      {{:error, message}, true} -> Mix.raise(message)
     end
 
     log("job #{job_id} is live -- view it at https://app.virtuals.io/acp")
 
-    if Keyword.get(opts, :fund, false), do: fund_job(cfg, job_id, budget)
+    if funding?, do: fund_job(cfg, job_id, budget)
   end
 
   defp create_and_resolve(cfg, resolver) do
@@ -254,44 +265,159 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   # -- Spend accounting --
 
-  # What this run CAN spend, printed before the first on-chain write. Every line
-  # is a bound or an expectation; actuals come from receipts afterwards.
+  # What this run CAN spend, printed before anything else happens. Every line is a
+  # bound or an expectation; actuals come from receipts afterwards.
   #
   # The principal is the trap. It is AUTHORIZED by the signed intent and pulled
   # later by the solver during settlement -- it does not move in this task's
   # writes. Reporting it as escrow overstates a $3.00 run by ~175x.
-  defp print_plan(cfg, opts), do: Enum.each(spend_plan_lines(cfg, opts), &log/1)
+  defp print_plan(cfg, opts) do
+    cfg
+    |> spend_plan_lines(opts, resume_escrow(cfg, opts))
+    |> Enum.each(&log/1)
+  end
+
+  # --amount and --fee-bps describe a job this run CREATES. On --job-id they
+  # describe nothing: whoever created that job set its budget. Read it instead of
+  # printing an expectation derived from flags the resumed job never saw.
+  defp resume_escrow(cfg, opts) do
+    with job_id when not is_nil(job_id) <- Keyword.get(opts, :job_id),
+         {:ok, budget} <- read_budget(cfg, job_id) do
+      {:ok, budget}
+    else
+      nil -> :new_job
+      :not_ready -> :unreadable
+    end
+  end
 
   @doc false
-  # Public only so it can be tested: the escrow arithmetic and the wording of
-  # the principal line are the two things this exists to get right.
-  @spec spend_plan_lines(map(), keyword()) :: [String.t()]
-  def spend_plan_lines(cfg, opts) do
+  # Public only so it can be tested: the escrow arithmetic, the enforced ceiling
+  # and the wording of the principal line are what this exists to get right.
+  @spec spend_plan_lines(map(), keyword(), :new_job | :unreadable | {:ok, non_neg_integer()}) ::
+          [String.t()]
+  def spend_plan_lines(cfg, opts, escrow) do
     decimals = Assets.decimals(cfg.from, cfg.src_token)
-    expected_escrow = div(cfg.principal_atomic * cfg.fee_bps, 10_000)
-    funding? = Keyword.get(opts, :fund, false)
 
+    ["SPEND PLAN -- buyer #{cfg.buyer} on chain #{cfg.from}, amounts in USDC"] ++
+      escrow_lines(cfg, decimals, escrow_ceiling(cfg, opts), escrow) ++
+      [
+        "  gas         charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH " <>
+          "and NOT free; priced per UserOp, known only from the receipt",
+        "             UserOps this run: #{userops(opts)}",
+        "  principal   #{cfg.amount} AUTHORIZED, not moved here -- the signed intent lets " <>
+          "the solver pull up to that during settlement"
+      ] ++ plan_footer(opts)
+  end
+
+  defp escrow_lines(cfg, decimals, ceiling, :new_job) do
+    [
+      "  escrow     ~#{Assets.to_human(expected_escrow(cfg), decimals)} expected " <>
+        "(#{cfg.fee_bps} bps of #{cfg.amount}) -> ACP Core #{cfg.core}",
+      "             the PROVIDER sets the real budget on-chain; --fund pays what it set, " <>
+        ceiling_note(ceiling, decimals)
+    ]
+  end
+
+  defp escrow_lines(cfg, decimals, ceiling, {:ok, budget}) do
+    [
+      "  escrow      #{Assets.to_human(budget, decimals)} ON-CHAIN -- the resumed job's own " <>
+        "budget -> ACP Core #{cfg.core}",
+      "             --amount/--fee-bps do not describe a resumed job; --fund pays it, " <>
+        ceiling_note(ceiling, decimals)
+    ]
+  end
+
+  defp escrow_lines(cfg, decimals, ceiling, :unreadable) do
+    [
+      "  escrow      UNKNOWN -- could not read the resumed job's budget on chain #{cfg.from}",
+      "             --amount/--fee-bps do not describe a resumed job; --fund pays what the " <>
+        "provider set, " <> ceiling_note(ceiling, decimals)
+    ]
+  end
+
+  defp ceiling_note(ceiling, decimals),
+    do:
+      "refusing anything above #{Assets.to_human(ceiling, decimals)} (raise it with --max-escrow)"
+
+  defp userops(opts) do
     legs =
       [
         if(Keyword.get(opts, :job_id), do: nil, else: "createJob"),
-        if(funding?, do: "approve+fund", else: nil)
+        if(Keyword.get(opts, :fund, false), do: "approve+fund", else: nil)
       ]
       |> Enum.reject(&is_nil/1)
 
-    [
-      "SPEND PLAN -- buyer #{cfg.buyer} on chain #{cfg.from}, amounts in USDC",
-      "  escrow     ~#{Assets.to_human(expected_escrow, decimals)} expected " <>
-        "(#{cfg.fee_bps} bps of #{cfg.amount}) -> ACP Core #{cfg.core}",
-      "             the PROVIDER sets the real budget on-chain; --fund pays what it set",
-      "  gas         charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH " <>
-        "and NOT free; priced per UserOp, known only from the receipt",
-      "             UserOps this run: #{Enum.join(legs, ", ")}",
-      "  principal   #{cfg.amount} AUTHORIZED, not moved here -- the signed intent lets " <>
-        "the solver pull up to that during settlement"
-    ] ++
-      if funding?,
-        do: [],
-        else: ["  (no --fund: no escrow this run, but the createJob UserOp still costs USDC gas)"]
+    describe_userops(Keyword.get(opts, :dry_run, false), legs)
+  end
+
+  defp describe_userops(true, _legs), do: "none (--dry-run writes nothing on-chain)"
+  defp describe_userops(false, []), do: "none"
+  defp describe_userops(false, legs), do: Enum.join(legs, ", ")
+
+  defp plan_footer(opts) do
+    footer(
+      Keyword.get(opts, :dry_run, false),
+      Keyword.get(opts, :fund, false),
+      Keyword.get(opts, :job_id) != nil
+    )
+  end
+
+  defp footer(true, _funding?, _resuming?),
+    do: ["  (--dry-run: signs the intent and stops, spends nothing)"]
+
+  defp footer(false, true, _resuming?), do: []
+
+  defp footer(false, false, false),
+    do: ["  (no --fund: no escrow this run, but the createJob UserOp still costs USDC gas)"]
+
+  defp footer(false, false, true),
+    do: ["  (no --fund and no createJob: this run writes nothing on-chain)"]
+
+  defp expected_escrow(cfg), do: div(cfg.principal_atomic * cfg.fee_bps, 10_000)
+
+  # The most --fund may pay. Default: the take-rate the operator asserted with
+  # --fee-bps, so a provider that writes a bigger budget on-chain cannot be paid
+  # without the operator naming the number.
+  defp escrow_ceiling(cfg, opts) do
+    case Keyword.get(opts, :max_escrow) do
+      nil -> expected_escrow(cfg)
+      human -> parse_max_escrow(human, Assets.decimals(cfg.from, cfg.src_token))
+    end
+  end
+
+  defp parse_max_escrow(human, decimals) do
+    case Decimal.parse(human) do
+      {value, ""} ->
+        Assets.to_atomic(value, decimals)
+
+      _ ->
+        Mix.raise("--max-escrow #{inspect(human)} is not a USDC amount (e.g. --max-escrow 0.05)")
+    end
+  end
+
+  @doc false
+  # Public only so the ceiling decision can be tested without an on-chain run.
+  @spec budget_verdict(map(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def budget_verdict(cfg, budget, ceiling) do
+    expected = expected_escrow(cfg)
+
+    cond do
+      budget == expected ->
+        {:ok, "OK: budget == #{cfg.fee_bps} bps of the principal"}
+
+      budget <= ceiling ->
+        {:ok,
+         "budget #{budget} != expected #{expected} (#{cfg.fee_bps} bps), " <>
+           "within the ceiling #{ceiling}"}
+
+      true ->
+        {:error,
+         "provider set budget #{budget} base units, above the #{ceiling} ceiling -- " <>
+           "refusing to fund. The ceiling is #{cfg.fee_bps} bps of --amount #{cfg.amount}; " <>
+           "on --job-id it does not describe the resumed job at all. Accept this budget " <>
+           "with --max-escrow <USDC>."}
+    end
   end
 
   # What actually moved, decoded from receipts. Only USDC transfers OUT of the

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -205,11 +205,11 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     job_id
   end
 
-  # approve (USDC) + fund (ACP Core) batched into ONE UserOp, per acp-node-v2. A
-  # standalone approve to a token contract is not sponsored by the Virtuals
-  # paymaster; batched with the ACP-core fund call, the whole UserOp is.
+  # approve (USDC) + fund (ACP Core) batched into ONE UserOp, per acp-node-v2. The
+  # Virtuals paymaster refuses a standalone approve to a token contract; batched
+  # with the ACP-core fund call it accepts the UserOp and bills the buyer in USDC.
   defp fund_job(cfg, job_id, budget) do
-    log("funding escrow: batched approve + fund(#{job_id}) in one sponsored UserOp...")
+    log(funding_line(job_id))
 
     calls = [
       %{
@@ -242,6 +242,15 @@ defmodule Mix.Tasks.RaxolEarn.Order do
         Mix.raise("fund failed: #{inspect(err)}")
     end
   end
+
+  @doc false
+  # Public only so the wording can be tested: this line used to call the UserOp
+  # sponsored, contradicting the plan printed a few lines earlier in the same run.
+  @spec funding_line(non_neg_integer()) :: String.t()
+  def funding_line(job_id),
+    do:
+      "funding escrow: batched approve + fund(#{job_id}) in one UserOp -- " <>
+        "gas billed to the buyer in USDC"
 
   # -- Spend accounting --
 
@@ -291,52 +300,94 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   defp report_actuals(cfg, label, tx_hashes) do
     client = Raxol.Earn.Onchain.RPC.client(url: cfg.rpc)
-    decimals = Assets.decimals(cfg.from, cfg.src_token)
 
-    transfers =
+    reads =
       tx_hashes
       |> List.wrap()
-      |> Enum.flat_map(&buyer_transfers(client, cfg, &1))
+      |> Enum.map(&{&1, buyer_transfers(client, cfg, &1)})
 
-    case transfers do
-      [] ->
-        log("SPEND ACTUAL (#{label}): no USDC left the buyer, or receipts not yet available")
-
-      transfers ->
-        total = transfers |> Enum.map(&elem(&1, 1)) |> Enum.sum()
-
-        log("SPEND ACTUAL (#{label}): #{Assets.to_human(total, decimals)} USDC left the buyer")
-
-        Enum.each(transfers, fn {to, amount} ->
-          log("  #{Assets.to_human(amount, decimals)} -> #{to}#{destination_note(cfg, to)}")
-        end)
-    end
+    Enum.each(spend_actual_lines(cfg, label, reads), &log/1)
   rescue
     # Accounting must never take down a run that already moved money.
     e -> log("SPEND ACTUAL (#{label}): could not read receipts (#{Exception.message(e)})")
   end
+
+  @doc false
+  # Public only so it can be tested. A receipt that could NOT be read must not
+  # read like a receipt that showed nothing: the first is an unknown, the second
+  # is a zero, and printing them the same way is how a real spend gets reported
+  # as no spend.
+  @spec spend_actual_lines(map(), String.t(), [
+          {String.t(), {:ok, [{String.t(), non_neg_integer()}]} | {:error, term()}}
+        ]) :: [String.t()]
+  def spend_actual_lines(cfg, label, reads) do
+    decimals = Assets.decimals(cfg.from, cfg.src_token)
+    {read, failed} = Enum.split_with(reads, &match?({_hash, {:ok, _}}, &1))
+    transfers = Enum.flat_map(read, fn {_hash, {:ok, transfers}} -> transfers end)
+
+    headline(label, decimals, transfers, failed) ++
+      Enum.map(transfers, fn {to, amount} ->
+        "  #{Assets.to_human(amount, decimals)} -> #{to}#{destination_note(cfg, to)}"
+      end) ++
+      Enum.map(failed, fn {hash, {:error, reason}} ->
+        "  UNREAD receipt #{hash} (#{inspect(reason)}) -- check #{explorer(cfg.from)}#{hash}"
+      end)
+  end
+
+  defp headline(label, _decimals, [], []),
+    do: ["SPEND ACTUAL (#{label}): no USDC left the buyer"]
+
+  defp headline(label, decimals, transfers, []) do
+    [
+      "SPEND ACTUAL (#{label}): #{Assets.to_human(total(transfers), decimals)} USDC left the buyer"
+    ]
+  end
+
+  defp headline(label, decimals, transfers, failed) do
+    [
+      "SPEND ACTUAL (#{label}): at least #{Assets.to_human(total(transfers), decimals)} USDC " <>
+        "left the buyer -- LOWER BOUND, #{length(failed)} receipt(s) unread"
+    ]
+  end
+
+  defp total(transfers), do: transfers |> Enum.map(&elem(&1, 1)) |> Enum.sum()
 
   defp buyer_transfers(client, cfg, tx_hash) do
     case Raxol.Earn.Onchain.RPC.await_receipt(client, tx_hash, timeout_ms: 20_000) do
       {:ok, %{"logs" => logs}} when is_list(logs) ->
         buyer_topic = pad_topic(cfg.buyer)
 
-        for %{"address" => addr, "topics" => [topic0, from, to | _], "data" => data} <- logs,
-            String.downcase(addr) == String.downcase(cfg.src_token),
-            String.downcase(topic0) == @transfer_topic,
-            String.downcase(from) == buyer_topic do
-          {"0x" <> String.slice(to, -40, 40), parse_uint(data)}
-        end
+        transfers =
+          for %{"address" => addr, "topics" => [topic0, from, to | _], "data" => data} <- logs,
+              String.downcase(addr) == String.downcase(cfg.src_token),
+              String.downcase(topic0) == @transfer_topic,
+              String.downcase(from) == buyer_topic do
+            {"0x" <> String.slice(to, -40, 40), parse_uint(data)}
+          end
 
-      _ ->
-        []
+        {:ok, transfers}
+
+      {:ok, other} ->
+        {:error, {:receipt_without_logs, other}}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
+  # The ERC-20 paymaster that fronts the ETH for the Virtuals-managed SCA and
+  # bills the buyer in USDC, observed across four UserOps on Base. Anything else
+  # is money going somewhere nobody planned, and must not read as routine gas.
+  @paymaster "0x5d74bdab1ce9ddadd7e2e333d1d173830860694a"
+
   defp destination_note(cfg, to) do
-    if String.downcase(to) == String.downcase(cfg.core),
-      do: "  (ACP Core -- the fee escrow)",
-      else: "  (gas: ERC-20 paymaster)"
+    core = String.downcase(cfg.core)
+
+    case String.downcase(to) do
+      ^core -> "  (ACP Core -- the fee escrow)"
+      @paymaster -> "  (gas: ERC-20 paymaster)"
+      _ -> "  (UNEXPECTED recipient -- neither the fee escrow nor the known paymaster)"
+    end
   end
 
   defp pad_topic("0x" <> addr),
@@ -534,10 +585,11 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   # -- Signer backends --
 
-  # B (default): Virtuals-delegated Privy signing via the Node sidecar; gas is
-  # Alchemy-sponsored. The buyer is the managed SCA agent. Needs (env, from op):
+  # B (default): Virtuals-delegated Privy signing via the Node sidecar. Gas is not
+  # free -- an ERC-20 paymaster fronts the ETH and charges the buyer in USDC per
+  # UserOp. The buyer is the managed SCA agent. Needs (env, from op):
   # RAXOL_ACP_WALLET_ADDRESS / RAXOL_ACP_WALLET_ID / RAXOL_ACP_SIGNER_PRIVATE_KEY
-  # (+ PRIVY_APP_ID). The intent is still signed locally as the SCA (EOA -> 1271).
+  # (+ PRIVY_APP_ID).
   defp build_signer("privy", from, rpc) do
     _ = fetch_env!("RAXOL_ACP_WALLET_ID")
     _ = fetch_env!("RAXOL_ACP_SIGNER_PRIVATE_KEY")

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -27,16 +27,26 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   drives a managed SCA agent:
 
     * `privy` (default) -- Virtuals-delegated signing via the Node signer sidecar
-      (`priv/signer_sidecar`); gas is Alchemy-sponsored (no ETH needed). The buyer
-      is the managed SCA at `RAXOL_ACP_WALLET_ADDRESS`; the intent is signed locally
-      as that SCA (`ORDER_KEY` session key -> ERC-1271).
+      (`priv/signer_sidecar`). No ETH needed, but gas is NOT free: an ERC-20
+      paymaster fronts the ETH and charges the buyer in USDC on every UserOp
+      (~0.0075 observed on Base). The buyer is the managed SCA at
+      `RAXOL_ACP_WALLET_ADDRESS`; the intent is signed by the account's own
+      managed authority (`Sma7702Wallet` -> ERC-1271), not by a session key.
     * `sca` -- direct ERC-4337: the `ORDER_KEY` session key signs UserOps submitted
       to your own bundler + paymaster (`ORDER_BUNDLER_URL`, `ORDER_PAYMASTER_POLICY`).
     * `eoa` -- raw EOA from `ORDER_KEY`. NOT a registered agent (messaging 404s);
       on-chain-only testing.
 
-  MOVES REAL FUNDS on `--fund` (the fee escrow + the Xochi settlement pull). Gas is
-  sponsored under `privy`. `--dry-run` stops after signing (step 1).
+  MOVES REAL FUNDS. Every non-`--dry-run` run spends USDC, because each UserOp pays
+  its own gas in USDC. `--fund` adds the fee escrow: `fee_bps` of the principal,
+  ~0.0024 USDC at the 3.00/8bps default.
+
+  The PRINCIPAL does not move in this task's writes. The signed intent only
+  AUTHORIZES the solver to pull up to that much during settlement, so a "3.00 USDC"
+  run costs ~0.0169 end to end, not 3.00. The task prints a spend plan before the
+  first write and receipt-derived actuals after each one.
+
+  `--dry-run` stops after signing and spends nothing.
 
   ## Env
 
@@ -142,6 +152,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # -- Orchestration --
 
   defp place(cfg, requirement, opts) do
+    print_plan(cfg, opts)
+
     {agent, resolver} = start_buyer(cfg)
 
     # 2. createJob on-chain (or resume an existing job with --job-id).
@@ -186,6 +198,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       })
 
     log("createJob tx: #{explorer(cfg.from)}#{tx}")
+    report_actuals(cfg, "createJob", tx)
 
     job_id = await_job_id(resolver, cfg, tx)
     log("jobId: #{job_id}")
@@ -223,11 +236,114 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     case ProviderAdapter.send_calls(cfg.provider_adapter, cfg.from, calls) do
       {:ok, txs} ->
         log("funded (approve+fund batched): #{inspect(txs)} -- provider will settle + deliver")
+        report_actuals(cfg, "approve+fund", txs)
 
       err ->
         Mix.raise("fund failed: #{inspect(err)}")
     end
   end
+
+  # -- Spend accounting --
+
+  # What this run CAN spend, printed before the first on-chain write. Every line
+  # is a bound or an expectation; actuals come from receipts afterwards.
+  #
+  # The principal is the trap. It is AUTHORIZED by the signed intent and pulled
+  # later by the solver during settlement -- it does not move in this task's
+  # writes. Reporting it as escrow overstates a $3.00 run by ~175x.
+  defp print_plan(cfg, opts), do: Enum.each(spend_plan_lines(cfg, opts), &log/1)
+
+  @doc false
+  # Public only so it can be tested: the escrow arithmetic and the wording of
+  # the principal line are the two things this exists to get right.
+  @spec spend_plan_lines(map(), keyword()) :: [String.t()]
+  def spend_plan_lines(cfg, opts) do
+    decimals = Assets.decimals(cfg.from, cfg.src_token)
+    expected_escrow = div(cfg.principal_atomic * cfg.fee_bps, 10_000)
+    funding? = Keyword.get(opts, :fund, false)
+
+    legs =
+      [
+        if(Keyword.get(opts, :job_id), do: nil, else: "createJob"),
+        if(funding?, do: "approve+fund", else: nil)
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    [
+      "SPEND PLAN -- buyer #{cfg.buyer} on chain #{cfg.from}, amounts in USDC",
+      "  escrow     ~#{Assets.to_human(expected_escrow, decimals)} expected " <>
+        "(#{cfg.fee_bps} bps of #{cfg.amount}) -> ACP Core #{cfg.core}",
+      "             the PROVIDER sets the real budget on-chain; --fund pays what it set",
+      "  gas         charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH " <>
+        "and NOT free; priced per UserOp, known only from the receipt",
+      "             UserOps this run: #{Enum.join(legs, ", ")}",
+      "  principal   #{cfg.amount} AUTHORIZED, not moved here -- the signed intent lets " <>
+        "the solver pull up to that during settlement"
+    ] ++
+      if funding?,
+        do: [],
+        else: ["  (no --fund: no escrow this run, but the createJob UserOp still costs USDC gas)"]
+  end
+
+  # What actually moved, decoded from receipts. Only USDC transfers OUT of the
+  # buyer count as spend; anything else in the tx is someone else's money.
+  @transfer_topic "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+  defp report_actuals(cfg, label, tx_hashes) do
+    client = Raxol.Earn.Onchain.RPC.client(url: cfg.rpc)
+    decimals = Assets.decimals(cfg.from, cfg.src_token)
+
+    transfers =
+      tx_hashes
+      |> List.wrap()
+      |> Enum.flat_map(&buyer_transfers(client, cfg, &1))
+
+    case transfers do
+      [] ->
+        log("SPEND ACTUAL (#{label}): no USDC left the buyer, or receipts not yet available")
+
+      transfers ->
+        total = transfers |> Enum.map(&elem(&1, 1)) |> Enum.sum()
+
+        log("SPEND ACTUAL (#{label}): #{Assets.to_human(total, decimals)} USDC left the buyer")
+
+        Enum.each(transfers, fn {to, amount} ->
+          log("  #{Assets.to_human(amount, decimals)} -> #{to}#{destination_note(cfg, to)}")
+        end)
+    end
+  rescue
+    # Accounting must never take down a run that already moved money.
+    e -> log("SPEND ACTUAL (#{label}): could not read receipts (#{Exception.message(e)})")
+  end
+
+  defp buyer_transfers(client, cfg, tx_hash) do
+    case Raxol.Earn.Onchain.RPC.await_receipt(client, tx_hash, timeout_ms: 20_000) do
+      {:ok, %{"logs" => logs}} when is_list(logs) ->
+        buyer_topic = pad_topic(cfg.buyer)
+
+        for %{"address" => addr, "topics" => [topic0, from, to | _], "data" => data} <- logs,
+            String.downcase(addr) == String.downcase(cfg.src_token),
+            String.downcase(topic0) == @transfer_topic,
+            String.downcase(from) == buyer_topic do
+          {"0x" <> String.slice(to, -40, 40), parse_uint(data)}
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp destination_note(cfg, to) do
+    if String.downcase(to) == String.downcase(cfg.core),
+      do: "  (ACP Core -- the fee escrow)",
+      else: "  (gas: ERC-20 paymaster)"
+  end
+
+  defp pad_topic("0x" <> addr),
+    do: String.downcase("0x" <> String.duplicate("0", 24) <> addr)
+
+  defp parse_uint("0x" <> hex), do: String.to_integer(hex, 16)
+  defp parse_uint(_), do: 0
 
   # -- Steps --
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -112,22 +112,21 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   @offering "xochi_crosschain"
   @sla_minutes 5
 
+  @switches [
+    amount: :string,
+    corridor: :string,
+    provider: :string,
+    fee_bps: :integer,
+    max_escrow: :string,
+    fund: :boolean,
+    dry_run: :boolean,
+    job_id: :integer,
+    signer: :string
+  ]
+
   @impl Mix.Task
   def run(argv) do
-    {opts, _, _} =
-      OptionParser.parse(argv,
-        strict: [
-          amount: :string,
-          corridor: :string,
-          provider: :string,
-          fee_bps: :integer,
-          max_escrow: :string,
-          fund: :boolean,
-          dry_run: :boolean,
-          job_id: :integer,
-          signer: :string
-        ]
-      )
+    opts = parse_argv(argv)
 
     Application.ensure_all_started(:raxol_earn)
 
@@ -159,6 +158,16 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     end
   end
 
+  @doc false
+  # Public only so the spend gate can be exercised against the flags an operator
+  # really types, rather than a hand-built keyword list that could drift from
+  # @switches.
+  @spec parse_argv([String.t()]) :: keyword()
+  def parse_argv(argv) do
+    {opts, _argv, _invalid} = OptionParser.parse(argv, strict: @switches)
+    opts
+  end
+
   # -- Orchestration --
 
   defp place(cfg, requirement, opts) do
@@ -181,15 +190,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     funding? = Keyword.get(opts, :fund, false)
 
     log("provider setBudget = #{budget} base units (#{realized_bps} bps)")
-
-    # The budget is the counterparty's number, and --fund approves and pays it.
-    # Over the ceiling it is refused rather than logged, but only when this run
-    # would actually spend it: without --fund the mismatch is just disclosure.
-    case {budget_verdict(cfg, budget, escrow_ceiling(cfg, opts)), funding?} do
-      {{:ok, line}, _} -> log(line)
-      {{:error, message}, false} -> log("WARN: " <> message)
-      {{:error, message}, true} -> Mix.raise(message)
-    end
+    enforce_budget!(cfg, budget, opts)
 
     log("job #{job_id} is live -- view it at https://app.virtuals.io/acp")
 
@@ -396,6 +397,24 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   end
 
   @doc false
+  # Public only so the whole gate -- ceiling, verdict and the --fund branch --
+  # can be exercised from parsed options without an on-chain run.
+  @spec enforce_budget!(map(), non_neg_integer(), keyword()) :: :ok
+  def enforce_budget!(cfg, budget, opts) do
+    cfg
+    |> budget_verdict(budget, escrow_ceiling(cfg, opts))
+    |> act_on_verdict(Keyword.get(opts, :fund, false))
+  end
+
+  defp act_on_verdict({:ok, line}, _funding?), do: log(line)
+
+  # An over-ceiling budget only threatens a run that would escrow it. Without
+  # --fund nothing is approved, so the mismatch is disclosure rather than cause
+  # to abandon a job that is already on chain.
+  defp act_on_verdict({:error, message}, false), do: log("WARN: " <> message)
+  defp act_on_verdict({:error, message}, true), do: Mix.raise(message)
+
+  @doc false
   # Public only so the ceiling decision can be tested without an on-chain run.
   @spec budget_verdict(map(), non_neg_integer(), non_neg_integer()) ::
           {:ok, String.t()} | {:error, String.t()}
@@ -414,9 +433,12 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       true ->
         {:error,
          "provider set budget #{budget} base units, above the #{ceiling} ceiling -- " <>
-           "refusing to fund. The ceiling is #{cfg.fee_bps} bps of --amount #{cfg.amount}; " <>
-           "on --job-id it does not describe the resumed job at all. Accept this budget " <>
-           "with --max-escrow <USDC>."}
+           "refusing to fund. The budget is what --fund approves and escrows, so a " <>
+           "provider that sets its own number is simply paid it. Either the offering's " <>
+           "fee changed, in which case re-run with a matching --fee-bps, or this " <>
+           "provider is not charging what it advertises. The ceiling is #{cfg.fee_bps} " <>
+           "bps of --amount #{cfg.amount}; on --job-id it does not describe the resumed " <>
+           "job at all. Accept this budget with --max-escrow <USDC>."}
     end
   end
 

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -11,6 +11,24 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
     :ok
   end
 
+  # 3.00 USDC on Base at the default 8 bps, so the take rate -- and with it the
+  # default ceiling -- is 2400 base units.
+  defp cfg do
+    %{
+      buyer: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      from: 8453,
+      src_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      core: "0x238E541BfefD82238730D00a2208E5497F1832E0",
+      amount: "3.00",
+      principal_atomic: 3_000_000,
+      fee_bps: 8
+    }
+  end
+
+  # The real flag surface, so a ceiling raised on the command line is the ceiling
+  # under test.
+  defp gate(budget, argv), do: Order.enforce_budget!(cfg(), budget, Order.parse_argv(argv))
+
   describe "--corridor validation" do
     test "an unsupported destination lists only the chains USDC actually exists on" do
       %Mix.Error{message: message} =
@@ -33,6 +51,56 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
 
       assert message =~ "no USDC address for the origin chain 4663"
       refute message =~ "Robinhood Chain"
+    end
+  end
+
+  describe "the escrow ceiling gate" do
+    test "a budget above the ceiling aborts a --fund run before anything is approved" do
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> gate(2_000_000_000, ["--fund"]) end)
+
+      assert message =~ "above the 2400 ceiling"
+      assert message =~ "refusing to fund"
+
+      # Why the number matters: it is the provider's, and --fund pays it.
+      assert message =~ "what --fund approves and escrows"
+      assert message =~ "re-run with a matching --fee-bps"
+      assert message =~ "not charging what it advertises"
+      assert message =~ "--max-escrow"
+    end
+
+    test "a budget exactly at the take rate passes" do
+      assert gate(2_400, ["--fund"]) == :ok
+      assert_received {:mix_shell, :info, ["[order] OK: budget == 8 bps of the principal"]}
+    end
+
+    test "a budget under the take rate is accepted, with the shortfall disclosed" do
+      # Charging less than advertised costs the buyer nothing, so it must not abort.
+      assert gate(2_000, ["--fund"]) == :ok
+
+      assert_received {:mix_shell, :info,
+                       ["[order] budget 2000 != expected 2400 (8 bps), within the ceiling 2400"]}
+    end
+
+    test "a run without --fund discloses a mismatch instead of stranding the job" do
+      # By this point createJob has landed and the requirement is sent. A run that
+      # escrows nothing has nothing to refuse.
+      assert gate(2_000_000_000, []) == :ok
+      assert_received {:mix_shell, :info, ["[order] WARN: provider set budget 2000000000" <> _]}
+    end
+
+    test "--max-escrow raises the ceiling so a refused budget is accepted" do
+      assert_raise(Mix.Error, fn -> gate(50_000, ["--fund"]) end)
+
+      assert gate(50_000, ["--fund", "--max-escrow", "0.05"]) == :ok
+      assert_received {:mix_shell, :info, ["[order] budget 50000 != expected 2400" <> _]}
+    end
+
+    test "--max-escrow that is not a USDC amount is refused" do
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> gate(2_400, ["--fund", "--max-escrow", "lots"]) end)
+
+      assert message =~ "is not a USDC amount"
     end
   end
 end

--- a/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
@@ -10,8 +10,9 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
   An overstatement of ~175x.
 
   The accounting can misreport in its own right, so the same scrutiny applies to
-  it: an unread receipt must not print as a zero, and an unplanned recipient must
-  not print as routine gas.
+  it: an unread receipt must not print as a zero, an unplanned recipient must not
+  print as routine gas, and a resumed job's escrow must not be invented from
+  flags that job never saw.
   """
 
   use ExUnit.Case, async: true
@@ -34,7 +35,8 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
     }
   end
 
-  defp plan(opts), do: Order.spend_plan_lines(cfg(), opts) |> Enum.join("\n")
+  defp plan(opts, escrow \\ :new_job),
+    do: Order.spend_plan_lines(cfg(), opts, escrow) |> Enum.join("\n")
 
   defp actual(reads),
     do: Order.spend_actual_lines(cfg(), "approve+fund", reads) |> Enum.join("\n")
@@ -49,7 +51,7 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
     end
 
     test "scales with fee_bps" do
-      lines = Order.spend_plan_lines(%{cfg() | fee_bps: 100}, fund: true)
+      lines = Order.spend_plan_lines(%{cfg() | fee_bps: 100}, [fund: true], :new_job)
       # 100 bps of 3.000000 = 30000 atomic = 0.03.
       assert Enum.join(lines, "\n") =~ "0.03"
     end
@@ -95,7 +97,72 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
     end
 
     test "resuming an existing job drops the createJob leg" do
-      assert plan(job_id: 73_295, fund: true) =~ "UserOps this run: approve+fund"
+      assert plan([job_id: 73_295, fund: true], {:ok, 2_400}) =~ "UserOps this run: approve+fund"
+    end
+
+    test "a dry run names no UserOps at all" do
+      text = plan(dry_run: true, fund: true)
+
+      assert text =~ "SPEND PLAN"
+      assert text =~ "UserOps this run: none (--dry-run writes nothing on-chain)"
+      assert text =~ "spends nothing"
+    end
+  end
+
+  describe "resumed jobs" do
+    test "print the job's own on-chain budget, not the --amount/--fee-bps default" do
+      text = plan([job_id: 73_295, fund: true], {:ok, 5_000})
+
+      assert text =~ "escrow      0.005 ON-CHAIN"
+      assert text =~ "the resumed job's own budget"
+      # 8 bps of the default 3.00 has nothing to do with this job.
+      refute text =~ "0.0024 expected"
+    end
+
+    test "say so when the budget cannot be read, rather than inventing one" do
+      text = plan([job_id: 73_295, fund: true], :unreadable)
+
+      assert text =~ "escrow      UNKNOWN"
+      assert text =~ "could not read the resumed job's budget"
+      refute text =~ "0.0024 expected"
+    end
+
+    test "note that the flags do not describe the resumed job" do
+      assert plan([job_id: 73_295], {:ok, 5_000}) =~
+               "--amount/--fee-bps do not describe a resumed job"
+    end
+  end
+
+  describe "escrow ceiling" do
+    test "the plan names the ceiling --fund will refuse to exceed" do
+      assert plan(fund: true) =~ "refusing anything above 0.0024 (raise it with --max-escrow)"
+    end
+
+    test "--max-escrow raises the printed ceiling" do
+      assert plan(fund: true, max_escrow: "0.05") =~ "refusing anything above 0.05"
+    end
+
+    test "a budget matching the asserted take-rate passes" do
+      assert {:ok, line} = Order.budget_verdict(cfg(), 2_400, 2_400)
+      assert line =~ "OK: budget == 8 bps"
+    end
+
+    test "a budget under the ceiling passes with the mismatch named" do
+      assert {:ok, line} = Order.budget_verdict(cfg(), 2_000, 2_400)
+      assert line =~ "budget 2000 != expected 2400"
+      assert line =~ "within the ceiling 2400"
+    end
+
+    test "a budget over the ceiling is refused, not warned about" do
+      assert {:error, message} = Order.budget_verdict(cfg(), 2_000_000_000, 2_400)
+      assert message =~ "above the 2400 ceiling"
+      assert message =~ "refusing to fund"
+      assert message =~ "--max-escrow"
+    end
+
+    test "--max-escrow accepts a budget that would otherwise be refused" do
+      assert {:ok, line} = Order.budget_verdict(cfg(), 3_000_000, 3_000_000)
+      assert line =~ "within the ceiling 3000000"
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
@@ -1,17 +1,25 @@
 defmodule Raxol.Earn.OrderSpendPlanTest do
   @moduledoc """
-  The spend plan `mix raxol_earn.order` prints before its first on-chain write.
+  The spend plan `mix raxol_earn.order` prints before its first on-chain write,
+  and the receipt-derived actuals it prints after each one.
 
   These assertions exist because the numbers were reported wrong in practice: a
   3.00 USDC run was described as moving 3.00 into escrow, when it moves ~0.0024
   (the fee) plus USDC-denominated gas, and the principal never moves in this
   task's writes at all -- it is only authorized for the solver to pull later.
   An overstatement of ~175x.
+
+  The accounting can misreport in its own right, so the same scrutiny applies to
+  it: an unread receipt must not print as a zero, and an unplanned recipient must
+  not print as routine gas.
   """
 
   use ExUnit.Case, async: true
 
   alias Mix.Tasks.RaxolEarn.Order
+
+  @core "0x238E541BfefD82238730D00a2208E5497F1832E0"
+  @paymaster "0x5d74bdab1ce9ddadd7e2e333d1d173830860694a"
 
   # 3.00 USDC on Base at the default 8 bps.
   defp cfg do
@@ -19,7 +27,7 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       buyer: "0x468aeae798b3a6548ac2401d276f83afdc172283",
       from: 8453,
       src_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-      core: "0x238E541BfefD82238730D00a2208E5497F1832E0",
+      core: @core,
       amount: "3.00",
       principal_atomic: 3_000_000,
       fee_bps: 8
@@ -27,6 +35,9 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
   end
 
   defp plan(opts), do: Order.spend_plan_lines(cfg(), opts) |> Enum.join("\n")
+
+  defp actual(reads),
+    do: Order.spend_actual_lines(cfg(), "approve+fund", reads) |> Enum.join("\n")
 
   describe "escrow" do
     test "is the fee, not the principal" do
@@ -38,9 +49,9 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
     end
 
     test "scales with fee_bps" do
-      lines = Order.spend_plan_lines(%{cfg() | fee_bps: 100}, fund: true) |> Enum.join("\n")
+      lines = Order.spend_plan_lines(%{cfg() | fee_bps: 100}, fund: true)
       # 100 bps of 3.000000 = 30000 atomic = 0.03.
-      assert lines =~ "0.03"
+      assert Enum.join(lines, "\n") =~ "0.03"
     end
   end
 
@@ -61,6 +72,13 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       assert text =~ "NOT free"
       refute text =~ "sponsored"
     end
+
+    test "the funding log line does not contradict the plan" do
+      line = Order.funding_line(72_993)
+
+      refute line =~ "sponsored"
+      assert line =~ "gas billed to the buyer in USDC"
+    end
   end
 
   describe "legs" do
@@ -78,6 +96,64 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
 
     test "resuming an existing job drops the createJob leg" do
       assert plan(job_id: 73_295, fund: true) =~ "UserOps this run: approve+fund"
+    end
+  end
+
+  describe "spend actual" do
+    test "a read receipt with no buyer transfers is a definite zero" do
+      text = actual([{"0xaaa", {:ok, []}}])
+
+      assert text =~ "no USDC left the buyer"
+      refute text =~ "LOWER BOUND"
+      refute text =~ "not yet available"
+    end
+
+    test "read receipts total authoritatively" do
+      text = actual([{"0xaaa", {:ok, [{@core, 2_400}]}}, {"0xbbb", {:ok, [{@paymaster, 7_500}]}}])
+
+      # 2400 + 7500 = 9900 atomic = 0.0099.
+      assert text =~ "0.0099 USDC left the buyer"
+      refute text =~ "LOWER BOUND"
+    end
+
+    test "an unread receipt makes the total a lower bound, and names the hash" do
+      text =
+        actual([
+          {"0xaaa", {:ok, [{@core, 2_400}]}},
+          {"0xbbb", {:error, {:transport, {:http_status, 429, ""}}}}
+        ])
+
+      assert text =~ "at least 0.0024 USDC left the buyer -- LOWER BOUND"
+      assert text =~ "1 receipt(s) unread"
+      assert text =~ "UNREAD receipt 0xbbb"
+      assert text =~ "http_status, 429"
+      assert text =~ "https://basescan.org/tx/0xbbb"
+    end
+
+    test "a wholly unread read is a lower bound of zero, never a reported zero" do
+      text = actual([{"0xbbb", {:error, :timeout}}])
+
+      assert text =~ "LOWER BOUND"
+      assert text =~ "UNREAD receipt 0xbbb"
+      refute text =~ "no USDC left the buyer"
+    end
+  end
+
+  describe "destination notes" do
+    test "the ACP Core is the fee escrow" do
+      assert actual([{"0xaaa", {:ok, [{@core, 2_400}]}}]) =~ "(ACP Core -- the fee escrow)"
+    end
+
+    test "the known paymaster is gas" do
+      assert actual([{"0xaaa", {:ok, [{@paymaster, 7_500}]}}]) =~ "(gas: ERC-20 paymaster)"
+    end
+
+    test "any other recipient is flagged unexpected, not explained away as gas" do
+      text =
+        actual([{"0xaaa", {:ok, [{"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", 3_000_000}]}}])
+
+      assert text =~ "(UNEXPECTED recipient -- neither the fee escrow nor the known paymaster)"
+      refute text =~ "gas: ERC-20 paymaster"
     end
   end
 end

--- a/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
@@ -1,0 +1,83 @@
+defmodule Raxol.Earn.OrderSpendPlanTest do
+  @moduledoc """
+  The spend plan `mix raxol_earn.order` prints before its first on-chain write.
+
+  These assertions exist because the numbers were reported wrong in practice: a
+  3.00 USDC run was described as moving 3.00 into escrow, when it moves ~0.0024
+  (the fee) plus USDC-denominated gas, and the principal never moves in this
+  task's writes at all -- it is only authorized for the solver to pull later.
+  An overstatement of ~175x.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.RaxolEarn.Order
+
+  # 3.00 USDC on Base at the default 8 bps.
+  defp cfg do
+    %{
+      buyer: "0x468aeae798b3a6548ac2401d276f83afdc172283",
+      from: 8453,
+      src_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      core: "0x238E541BfefD82238730D00a2208E5497F1832E0",
+      amount: "3.00",
+      principal_atomic: 3_000_000,
+      fee_bps: 8
+    }
+  end
+
+  defp plan(opts), do: Order.spend_plan_lines(cfg(), opts) |> Enum.join("\n")
+
+  describe "escrow" do
+    test "is the fee, not the principal" do
+      text = plan(fund: true)
+
+      # 8 bps of 3.000000 USDC = 2400 atomic = 0.0024.
+      assert text =~ "0.0024"
+      refute text =~ "3.00 expected"
+    end
+
+    test "scales with fee_bps" do
+      lines = Order.spend_plan_lines(%{cfg() | fee_bps: 100}, fund: true) |> Enum.join("\n")
+      # 100 bps of 3.000000 = 30000 atomic = 0.03.
+      assert lines =~ "0.03"
+    end
+  end
+
+  describe "principal" do
+    test "is described as authorized, never as moved" do
+      text = plan(fund: true)
+
+      assert text =~ "principal   3.00 AUTHORIZED"
+      assert text =~ "not moved here"
+    end
+  end
+
+  describe "gas" do
+    test "is not claimed to be sponsored or free" do
+      text = plan(fund: true)
+
+      assert text =~ "NOT in ETH"
+      assert text =~ "NOT free"
+      refute text =~ "sponsored"
+    end
+  end
+
+  describe "legs" do
+    test "a funded run names both UserOps" do
+      assert plan(fund: true) =~ "UserOps this run: createJob, approve+fund"
+    end
+
+    test "an unfunded run still warns that createJob costs gas" do
+      text = plan([])
+
+      assert text =~ "UserOps this run: createJob"
+      assert text =~ "no --fund: no escrow this run"
+      assert text =~ "still costs USDC gas"
+    end
+
+    test "resuming an existing job drops the createJob leg" do
+      assert plan(job_id: 73_295, fund: true) =~ "UserOps this run: approve+fund"
+    end
+  end
+end


### PR DESCRIPTION
Supersedes #863. **Stacked on the #860 replacement -- merge that first.**

#863 added a SPEND PLAN and receipt-derived actuals to `raxol_earn.order`. An
adversarial review found the new accounting can itself print a wrong money
figure, which is the failure it exists to prevent.

## Four ways it could still lie

- `buyer_transfers/3` collapsed every RPC error and timeout into `[]`, so a
  failed receipt read printed the same hedged line as a genuine zero, and with
  several hashes a partial total printed as authoritative. It now distinguishes
  the two, labels a partial total as a LOWER BOUND, and names each unreadable
  hash with its explorer URL.
- `destination_note/2` labelled every non-Core recipient `(gas: ERC-20
  paymaster)` without knowing any paymaster address, so an unexpected outflow
  read as routine. A third branch now says the recipient is UNEXPECTED.
- The word "sponsored" survived in the runtime log and comments while the new
  moduledoc retracted it -- one run printed both claims.
- On `--job-id`, the escrow line came from the `--amount`/`--fee-bps` defaults,
  which describe nothing about a job someone else created. The resume path now
  reads `getJob(id).budget` and says UNKNOWN when it cannot.

`--dry-run` is advertised as the costless rehearsal and was the one mode that
never showed the plan, because `print_plan/2` ran from `place/3`. Hoisted into
`run/1`.

## The escrow ceiling

The provider writes the budget on-chain and `--fund` approved and paid whatever
it wrote; a mismatch against the asserted `--fee-bps` only logged a WARN. The
take rate is now a ceiling: over it `--fund` refuses, and `--max-escrow N` is the
explicit override. The plan prints the ceiling it will enforce.

This gate was drafted twice, once here and once against #860. This is the
reconciled version. It keeps the ceiling model -- exact equality would abort when
the provider charges *less*, and an unconditional abort would strand a job that
`createJob` had already created on a run that spends nothing -- and folds in the
other draft's explanation of why an over-ceiling budget is refused.
`--allow-budget-mismatch` is dropped: one guard, one override.

## Verification

Format clean, `compile --force --warnings-as-errors` exit 0, `raxol_earn` 801
passed / 0 failures.

The gate is proven by mutation rather than assertion. Reintroducing exact
equality plus an unconditional abort reds 5 of 33 tests, covering the
under-ceiling, no-`--fund` and `--max-escrow` axes; reverting to WARN-only reds 2
more on the over-ceiling axis.

## Manual testing

- [ ] `mix raxol_earn.order --dry-run` prints the SPEND PLAN
- [ ] A resumed `--job-id` run prints the on-chain budget, not the flag defaults
- [ ] A provider budget above the ceiling aborts before anything is approved
