### PR TITLE
Make the package format gate agree with the root config

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -11,6 +11,22 @@
     "test/fixtures"
   ],
   line_length: 80,
+  # Each package carries its own .formatter.exs and formats at the 98-column
+  # default. Without delegation, a root-cwd `mix format packages/...` -- what an
+  # editor save does in a monorepo workspace -- rewraps those files at 80 and
+  # reverts exactly what the per-package CI gate blessed.
+  #
+  # This list tracks the `package-tests` matrix in .github/workflows/ci-unified.yml,
+  # which is the only place a package is format-gated. Widening it to `packages/*`
+  # pulls the ungated packages (169 files of pre-existing drift) into the root
+  # check, so a package joins here when it joins that matrix.
+  subdirectories: [
+    "packages/raxol_cli",
+    "packages/raxol_earn",
+    "packages/raxol_gateway",
+    "packages/raxol_payments",
+    "packages/raxol_telegram"
+  ],
   locals_without_parens: [
     # Phoenix
     action_fallback: 1,

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -284,6 +284,10 @@ jobs:
     name: Package Tests (${{ matrix.package }})
     needs: setup
     runs-on: ubuntu-latest
+    # A backstop, not a budget: the suites finish in single-digit minutes. If a
+    # live test ever escapes its exclusion it blocks on a network call, and the
+    # default 6h job timeout would let it sit there.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -332,9 +336,30 @@ jobs:
           mix deps.get
           mix compile --warnings-as-errors
 
+      # The exclusions are stated here rather than left to each package's
+      # test_helper. raxol_payments computes its list from env-var PRESENCE, so a
+      # stray XOCHI_LIVE_URL anywhere in the workflow env drops :live_xochi and
+      # the live suite -- which compile-gates on the same one variable -- starts
+      # issuing requests on every PR, forks included. ExUnit unions these with
+      # the helper's list, so nothing here can un-exclude a tag.
       - name: Run package tests
         working-directory: packages/${{ matrix.package }}
-        run: mix test
+        run: |
+          mix test \
+            --exclude live_xochi \
+            --exclude live_xochi_matrix \
+            --exclude live_xochi_preflight \
+            --exclude live_xochi_order \
+            --exclude live_xochi_order_preflight \
+            --exclude live_xochi_order_settle \
+            --exclude live_relay \
+            --exclude live_property \
+            --exclude live_parity \
+            --exclude live_solver_fee \
+            --exclude live_chain \
+            --exclude live_bundler \
+            --exclude live_acp_dev \
+            --exclude cli_signer
 
   # The local terminal input path is BEAM/OTP-coupled: keystrokes arrive by
   # tracing prim_tty's reader (a private protocol). Every unit test fabricates

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -321,15 +321,6 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
 
-      # The root Format Check reads the root .formatter.exs, whose inputs cover
-      # only root lib/config/examples/test -- so before this step NO file under
-      # packages/ was format-checked anywhere in CI. Drift accumulated silently
-      # across formatter versions (25 files over three packages when this was
-      # added), and an unformatted file could pass a fully green run.
-      - name: Check formatting
-        working-directory: packages/${{ matrix.package }}
-        run: mix format --check-formatted
-
       - name: Compile package
         working-directory: packages/${{ matrix.package }}
         run: |
@@ -360,6 +351,16 @@ jobs:
             --exclude live_bundler \
             --exclude live_acp_dev \
             --exclude cli_signer
+
+      # Last, not first. The root Format Check reads the root .formatter.exs,
+      # whose inputs cover only root lib/config/examples/test, so before this
+      # step no file under packages/ was format-checked anywhere in CI (25 files
+      # over three packages had drifted). But this job is named "Package Tests"
+      # and two of its cells move real money: a red X here has to mean the tests
+      # ran, not that a line was two columns too wide before compile started.
+      - name: Check formatting
+        working-directory: packages/${{ matrix.package }}
+        run: mix format --check-formatted
 
   # The local terminal input path is BEAM/OTP-coupled: keystrokes arrive by
   # tracing prim_tty's reader (a private protocol). Every unit test fabricates

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -317,6 +317,15 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
 
+      # The root Format Check reads the root .formatter.exs, whose inputs cover
+      # only root lib/config/examples/test -- so before this step NO file under
+      # packages/ was format-checked anywhere in CI. Drift accumulated silently
+      # across formatter versions (25 files over three packages when this was
+      # added), and an unformatted file could pass a fully green run.
+      - name: Check formatting
+        working-directory: packages/${{ matrix.package }}
+        run: mix format --check-formatted
+
       - name: Compile package
         working-directory: packages/${{ matrix.package }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ mix credo                     # Style checks
 mix dialyzer                  # Type checking
 ```
 
+Packages format at their own line length (98), not the root's 80. The root
+`.formatter.exs` delegates to the packages CI format-gates (`:subdirectories`),
+so a root `mix format` handles those correctly. For any other package, format
+from inside it: `cd packages/<pkg> && mix format`.
+
 ### Running examples
 
 ```bash

--- a/lib/mix/tasks/raxol.check.ex
+++ b/lib/mix/tasks/raxol.check.ex
@@ -186,6 +186,9 @@ defmodule Mix.Tasks.Raxol.Check do
   defp run_check(:format) do
     Mix.shell().info(Colors.subsection_header("Code formatting"))
 
+    # Covers the format-gated packages too: the root .formatter.exs lists them
+    # under :subdirectories, so this one command sees every file CI checks, each
+    # at its own package config. CI hard-fails on a miss, so this must too.
     case Mix.shell().cmd("mix format --check-formatted") do
       0 ->
         Mix.shell().info(
@@ -195,12 +198,12 @@ defmodule Mix.Tasks.Raxol.Check do
         {:format, :ok}
 
       _ ->
-        Mix.shell().info(
-          "    " <> Colors.format_warning("Code formatting issues found")
+        Mix.shell().error(
+          "    " <> Colors.format_error("Code formatting issues found")
         )
 
         Mix.shell().info("    " <> Colors.format_fix("Fix", "mix format"))
-        {:format, :warning}
+        {:format, :error}
     end
   end
 

--- a/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket.ex
@@ -94,10 +94,8 @@ defmodule Raxol.Gateway.Adapter.Discord.GatewaySocket do
       transport: Keyword.get(opts, :transport, MintTransport),
       transport_opts: Keyword.get(opts, :transport_opts, []),
       parent: Keyword.get(opts, :parent),
-      reconnect_base_ms:
-        Keyword.get(opts, :reconnect_base_ms, @default_reconnect_base_ms),
-      reconnect_max_ms:
-        Keyword.get(opts, :reconnect_max_ms, @default_reconnect_max_ms),
+      reconnect_base_ms: Keyword.get(opts, :reconnect_base_ms, @default_reconnect_base_ms),
+      reconnect_max_ms: Keyword.get(opts, :reconnect_max_ms, @default_reconnect_max_ms),
       jitter_fn: Keyword.get(opts, :jitter_fn, &:rand.uniform/0),
       conn: nil,
       phase: :disconnected,

--- a/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket/mint_transport.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/adapter/discord/gateway_socket/mint_transport.ex
@@ -97,8 +97,7 @@ defmodule Raxol.Gateway.Adapter.Discord.GatewaySocket.MintTransport do
         {%{t | conn: conn, ws: ws}, [:upgraded | events]}
 
       {:error, conn, reason} ->
-        {%{t | conn: conn},
-         [{:transport_error, {:upgrade_failed, reason}} | events]}
+        {%{t | conn: conn}, [{:transport_error, {:upgrade_failed, reason}} | events]}
     end
   end
 

--- a/packages/raxol_payments/lib/mix/tasks/raxol.docs.tools.ex
+++ b/packages/raxol_payments/lib/mix/tasks/raxol.docs.tools.ex
@@ -54,14 +54,10 @@ defmodule Mix.Tasks.Raxol.Docs.Tools do
         Mix.shell().info("TOOL_CATALOG.md is up to date")
 
       {:ok, _stale} ->
-        Mix.raise(
-          "docs/reference/TOOL_CATALOG.md is stale. Run `mix raxol.docs.tools`."
-        )
+        Mix.raise("docs/reference/TOOL_CATALOG.md is stale. Run `mix raxol.docs.tools`.")
 
       {:error, _} ->
-        Mix.raise(
-          "docs/reference/TOOL_CATALOG.md is missing. Run `mix raxol.docs.tools`."
-        )
+        Mix.raise("docs/reference/TOOL_CATALOG.md is missing. Run `mix raxol.docs.tools`.")
     end
   end
 

--- a/packages/raxol_payments/lib/raxol/payments/accounting.ex
+++ b/packages/raxol_payments/lib/raxol/payments/accounting.ex
@@ -85,8 +85,6 @@ defmodule Raxol.Payments.Accounting do
 
   @spec price_source() :: atom()
   defp price_source do
-    String.to_atom(
-      System.get_env("RAXOL_PRICE_SOURCE") || @default_price_source
-    )
+    String.to_atom(System.get_env("RAXOL_PRICE_SOURCE") || @default_price_source)
   end
 end

--- a/packages/raxol_payments/lib/raxol/payments/echo_server.ex
+++ b/packages/raxol_payments/lib/raxol/payments/echo_server.ex
@@ -184,8 +184,7 @@ defmodule Raxol.Payments.EchoServer do
       "payTo" => Keyword.fetch!(opts, :pay_to),
       "asset" => Keyword.fetch!(opts, :asset),
       "network" => Keyword.fetch!(opts, :network),
-      "nonce" =>
-        "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
+      "nonce" => "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
       "validAfter" => 0,
       "validBefore" => System.system_time(:second) + 3600
     }
@@ -193,8 +192,7 @@ defmodule Raxol.Payments.EchoServer do
 
   defp build_receipt(payload) do
     %{
-      "transactionHash" =>
-        "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
+      "transactionHash" => "0x" <> Base.encode16(:crypto.strong_rand_bytes(32), case: :lower),
       "network" => payload["network"],
       "success" => true,
       "settledBy" => "echo_server"

--- a/packages/raxol_payments/lib/raxol/payments/eip191.ex
+++ b/packages/raxol_payments/lib/raxol/payments/eip191.ex
@@ -15,9 +15,7 @@ defmodule Raxol.Payments.Eip191 do
   """
   @spec digest(binary()) :: binary()
   def digest(message) when is_binary(message) do
-    ExKeccak.hash_256(
-      @prefix <> Integer.to_string(byte_size(message)) <> message
-    )
+    ExKeccak.hash_256(@prefix <> Integer.to_string(byte_size(message)) <> message)
   end
 
   @doc """

--- a/packages/raxol_payments/lib/raxol/payments/eip712.ex
+++ b/packages/raxol_payments/lib/raxol/payments/eip712.ex
@@ -63,10 +63,7 @@ defmodule Raxol.Payments.EIP712 do
     with {:ok, domain_separator} <-
            hash_struct("EIP712Domain", domain, eip712_domain_types(domain)),
          {:ok, message_hash} <- hash_struct(primary_type(types), message, types) do
-      {:ok,
-       ExKeccak.hash_256(
-         <<0x19, 0x01, domain_separator::binary, message_hash::binary>>
-       )}
+      {:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}
     end
   end
 
@@ -119,8 +116,7 @@ defmodule Raxol.Payments.EIP712 do
   # (an EIP-155 chain-encoded v, or a buggy signer) would silently pack a
   # non-recovering signature, so fail loud rather than emit one.
   defp canonical_v(v),
-    do:
-      raise(ArgumentError, "non-canonical secp256k1 recovery id: #{inspect(v)}")
+    do: raise(ArgumentError, "non-canonical secp256k1 recovery id: #{inspect(v)}")
 
   # EIP-712 defines exactly five domain fields, in this order: name, version,
   # chainId, verifyingContract, salt. Only the keys present in the domain map are

--- a/packages/raxol_payments/lib/raxol/payments/mandate/store.ex
+++ b/packages/raxol_payments/lib/raxol/payments/mandate/store.ex
@@ -145,6 +145,7 @@ defmodule Raxol.Payments.Mandate.Store do
   @impl Raxol.Core.Behaviours.BaseManager
   def init_manager(opts) do
     name = Naming.registered_name!(__MODULE__)
+
     tables = %{
       primary: primary_table(name),
       by_agent: by_agent_table(name),

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -197,9 +197,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
     signer =
       opts[:deposit_attestation_signer] ||
         Application.get_env(:raxol_payments, :xochi_deposit_attestation_signer) ||
-        Capabilities.deposit_attestation_signer(
-          deposit_capabilities(config, opts)
-        )
+        Capabilities.deposit_attestation_signer(deposit_capabilities(config, opts))
 
     case signer do
       s when is_binary(s) and s != "" -> {:ok, s}
@@ -615,7 +613,8 @@ defmodule Raxol.Payments.Protocols.Xochi do
   defp sign_pull_authorization(
          %QuoteResponse{pull_authorization: nil},
          _wallet
-       ), do: {:ok, nil}
+       ),
+       do: {:ok, nil}
 
   defp sign_pull_authorization(%QuoteResponse{pull_authorization: pull}, wallet) do
     domain = eip712_domain(pull)
@@ -691,11 +690,9 @@ defmodule Raxol.Payments.Protocols.Xochi do
     message = pull["message"] || %{}
 
     first_mismatch([
-      {:pull_type,
-       valid_envelope?(pull, @erc3009_primary_type, @erc3009_fields)},
+      {:pull_type, valid_envelope?(pull, @erc3009_primary_type, @erc3009_fields)},
       {:pull_from, addr_match?(message["from"], signer)},
-      {:pull_token,
-       addr_match?(domain["verifyingContract"], request.from_token)},
+      {:pull_token, addr_match?(domain["verifyingContract"], request.from_token)},
       {:pull_chain, int_match?(domain["chainId"], request.from_chain_id)},
       {:pull_value, int_within?(message["value"], request.from_amount)},
       {:pull_to, solver_allowed?(message["to"], :erc3009)},
@@ -716,8 +713,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
     permitted = message["permitted"] || %{}
 
     first_mismatch([
-      {:pull_type,
-       valid_envelope?(pull, @permit2_primary_type, @permit2_fields)},
+      {:pull_type, valid_envelope?(pull, @permit2_primary_type, @permit2_fields)},
       {:pull_token, addr_match?(permitted["token"], request.from_token)},
       {:pull_chain, int_match?(domain["chainId"], request.from_chain_id)},
       {:pull_value, int_within?(permitted["amount"], request.from_amount)},
@@ -788,9 +784,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
     do: Application.get_env(:raxol_payments, :pull_require_solver_pin, false)
 
   defp solver_allowlist do
-    normalize_solver_list(
-      Application.get_env(:raxol_payments, :pull_solver_allowlist, [])
-    )
+    normalize_solver_list(Application.get_env(:raxol_payments, :pull_solver_allowlist, []))
   end
 
   defp normalize_solver_list(list) do

--- a/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/agent_stream.ex
@@ -297,9 +297,7 @@ defmodule Raxol.Payments.Xochi.AgentStream do
   end
 
   defp handle_response({:error, reason}, config) do
-    Logger.warning(
-      "[agent-stream] announce transport error: #{inspect(reason)}"
-    )
+    Logger.warning("[agent-stream] announce transport error: #{inspect(reason)}")
 
     emit_dropped(config, reason)
     {:error, reason}

--- a/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
+++ b/packages/raxol_payments/lib/raxol/payments/xochi/client.ex
@@ -207,6 +207,7 @@ defmodule Raxol.Payments.Xochi.Client do
   # invite). A `Raxol.Payments.Secret`-wrapped token is revealed only here, so
   # the token stays redacted in any config/state that a crash report might dump.
   defp auth_mode(%{auth: auth}), do: auth
+
   defp auth_mode(%{auth_token: %Raxol.Payments.Secret{} = token}),
     do: {:member, Raxol.Payments.Secret.reveal(token)}
 

--- a/packages/raxol_payments/mix.exs
+++ b/packages/raxol_payments/mix.exs
@@ -82,7 +82,8 @@ defmodule RaxolPayments.MixProject do
       links: %{
         "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/raxol_payments",
-        "Changelog" => "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_payments/CHANGELOG.md",
+        "Changelog" =>
+          "https://github.com/DROOdotFOO/raxol/blob/master/packages/raxol_payments/CHANGELOG.md",
         "Website" => "https://raxol.io"
       },
       maintainers: ["Raxol Team"]

--- a/packages/raxol_payments/test/property/ledger_concurrent_property_test.exs
+++ b/packages/raxol_payments/test/property/ledger_concurrent_property_test.exs
@@ -64,9 +64,7 @@ defmodule Raxol.Payments.LedgerConcurrentPropertyTest do
             lifetime <- integer(50..200)
           ) do
       ledger =
-        case Ledger.start_link(
-               table_name: :"conc_ledger_#{:erlang.unique_integer([:positive])}"
-             ) do
+        case Ledger.start_link(table_name: :"conc_ledger_#{:erlang.unique_integer([:positive])}") do
           {:ok, pid} -> pid
           {:error, {:already_started, pid}} -> pid
         end
@@ -100,9 +98,7 @@ defmodule Raxol.Payments.LedgerConcurrentPropertyTest do
             amount <- integer(1..10)
           ) do
       ledger =
-        case Ledger.start_link(
-               table_name: :"frz_conc_#{:erlang.unique_integer([:positive])}"
-             ) do
+        case Ledger.start_link(table_name: :"frz_conc_#{:erlang.unique_integer([:positive])}") do
           {:ok, pid} -> pid
           {:error, {:already_started, pid}} -> pid
         end

--- a/packages/raxol_payments/test/property/ledger_model_property_test.exs
+++ b/packages/raxol_payments/test/property/ledger_model_property_test.exs
@@ -85,10 +85,7 @@ defmodule Raxol.Payments.LedgerModelPropertyTest do
   property "Ledger outcomes match the pure-Elixir reference model" do
     check all(cmds <- commands()) do
       ledger =
-        case Ledger.start_link(
-               table_name:
-                 :"model_ledger_#{:erlang.unique_integer([:positive])}"
-             ) do
+        case Ledger.start_link(table_name: :"model_ledger_#{:erlang.unique_integer([:positive])}") do
           {:ok, pid} -> pid
           {:error, {:already_started, pid}} -> pid
         end

--- a/packages/raxol_payments/test/property/policy_gate_property_test.exs
+++ b/packages/raxol_payments/test/property/policy_gate_property_test.exs
@@ -57,9 +57,7 @@ defmodule Raxol.Payments.PolicyGatePropertyTest do
       # Even with an always-:approve callback installed and an amount above
       # the threshold, an unapproved domain must deny on the domain reason.
       result =
-        PolicyGate.evaluate(policy, amount, attempted_host,
-          on_confirm: fn _, _ -> :approve end
-        )
+        PolicyGate.evaluate(policy, amount, attempted_host, on_confirm: fn _, _ -> :approve end)
 
       assert match?({:deny, {:domain_not_approved, _}}, result),
              "expected domain-deny for host #{attempted_host} not in #{approved_host}, got #{inspect(result)}"
@@ -85,9 +83,7 @@ defmodule Raxol.Payments.PolicyGatePropertyTest do
 
       assert match?(
                {:deny, {:domain_not_approved, _}},
-               PolicyGate.evaluate(policy, amount, attempted_host,
-                 on_confirm: canary
-               )
+               PolicyGate.evaluate(policy, amount, attempted_host, on_confirm: canary)
              )
     end
   end

--- a/packages/raxol_payments/test/raxol/payments/eip712_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/eip712_test.exs
@@ -223,8 +223,7 @@ defmodule Raxol.Payments.EIP712Test do
       "nonce" => 1,
       "deadline" => 1_900_000_000,
       "witness" => %{
-        "orderId" =>
-          "0xdeadbeef00000000000000000000000000000000000000000000000000000000"
+        "orderId" => "0xdeadbeef00000000000000000000000000000000000000000000000000000000"
       }
     }
 

--- a/packages/raxol_payments/test/raxol/payments/gate_parity_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/gate_parity_test.exs
@@ -106,9 +106,7 @@ defmodule Raxol.Payments.GateParityTest do
 
   defp hook_decision(%{policy: policy, amount: amount, host: host}) do
     {:ok, ledger} =
-      Ledger.start_link(
-        table_name: :"parity_hook_#{:erlang.unique_integer([:positive])}"
-      )
+      Ledger.start_link(table_name: :"parity_hook_#{:erlang.unique_integer([:positive])}")
 
     try do
       SpendingHook.set_config(%{ledger: ledger, policy: policy})
@@ -136,9 +134,7 @@ defmodule Raxol.Payments.GateParityTest do
 
   defp auto_pay_decision(%{policy: policy, amount: amount, host: host}) do
     {:ok, ledger} =
-      Ledger.start_link(
-        table_name: :"parity_auto_#{:erlang.unique_integer([:positive])}"
-      )
+      Ledger.start_link(table_name: :"parity_auto_#{:erlang.unique_integer([:positive])}")
 
     Process.put(:wallet_signal_target, self())
 

--- a/packages/raxol_payments/test/raxol/payments/ledger_subscribe_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/ledger_subscribe_test.exs
@@ -6,9 +6,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
   describe "freeze/unfreeze" do
     setup do
       {:ok, ledger} =
-        Ledger.start_link(
-          table_name: :"frz_ledger_#{:erlang.unique_integer([:positive])}"
-        )
+        Ledger.start_link(table_name: :"frz_ledger_#{:erlang.unique_integer([:positive])}")
 
       on_exit(fn ->
         try do
@@ -64,9 +62,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
   describe "telemetry events" do
     setup do
       {:ok, ledger} =
-        Ledger.start_link(
-          table_name: :"tel_ledger_#{:erlang.unique_integer([:positive])}"
-        )
+        Ledger.start_link(table_name: :"tel_ledger_#{:erlang.unique_integer([:positive])}")
 
       handler_id = :"telemetry_test_#{:erlang.unique_integer([:positive])}"
       parent = self()
@@ -103,8 +99,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
           %{protocol: "x402"}
         )
 
-      assert_receive {:telemetry, [:raxol, :payments, :spend], measurements,
-                      metadata}
+      assert_receive {:telemetry, [:raxol, :payments, :spend], measurements, metadata}
 
       assert Decimal.equal?(measurements.amount, Decimal.new("0.10"))
       assert metadata.agent_id == :tel_a
@@ -122,8 +117,7 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
       assert {:over_limit, :per_request} =
                Ledger.try_spend(ledger, :tel_b, Decimal.new("1.00"), policy)
 
-      assert_receive {:telemetry, [:raxol, :payments, :over_budget],
-                      measurements, metadata}
+      assert_receive {:telemetry, [:raxol, :payments, :over_budget], measurements, metadata}
 
       assert Decimal.equal?(measurements.amount, Decimal.new("1.00"))
       assert metadata.limit_type == :per_request
@@ -140,28 +134,23 @@ defmodule Raxol.Payments.LedgerSubscribeTest do
                  SpendingPolicy.unrestricted()
                )
 
-      assert_receive {:telemetry, [:raxol, :payments, :over_budget], _,
-                      %{limit_type: :frozen}}
+      assert_receive {:telemetry, [:raxol, :payments, :over_budget], _, %{limit_type: :frozen}}
     end
 
     test "emits :freeze event on freeze/unfreeze", %{ledger: ledger} do
       :ok = Ledger.freeze(ledger)
 
-      assert_receive {:telemetry, [:raxol, :payments, :freeze], _,
-                      %{frozen?: true}}
+      assert_receive {:telemetry, [:raxol, :payments, :freeze], _, %{frozen?: true}}
 
       :ok = Ledger.unfreeze(ledger)
 
-      assert_receive {:telemetry, [:raxol, :payments, :freeze], _,
-                      %{frozen?: false}}
+      assert_receive {:telemetry, [:raxol, :payments, :freeze], _, %{frozen?: false}}
     end
   end
 
   setup do
     {:ok, ledger} =
-      Ledger.start_link(
-        table_name: :"sub_ledger_#{:erlang.unique_integer([:positive])}"
-      )
+      Ledger.start_link(table_name: :"sub_ledger_#{:erlang.unique_integer([:positive])}")
 
     on_exit(fn ->
       try do

--- a/packages/raxol_payments/test/raxol/payments/policy_gate_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/policy_gate_test.exs
@@ -126,7 +126,9 @@ defmodule Raxol.Payments.PolicyGateTest do
                PolicyGate.evaluate(
                  policy,
                  Decimal.new("10.00"),
-                 "api.example.com", on_confirm: callback)
+                 "api.example.com",
+                 on_confirm: callback
+               )
 
       assert_received {:saw, %Decimal{} = amount, "api.example.com"}
       assert Decimal.equal?(amount, Decimal.new("10.00"))

--- a/packages/raxol_payments/test/raxol/payments/protocols/permit2_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/permit2_test.exs
@@ -157,7 +157,8 @@ defmodule Raxol.Payments.Protocols.Permit2Test do
     end
 
     test "missing required field returns an error" do
-      bad_quote = put_in(@canonical_quote["gasless"], Map.delete(@canonical_quote["gasless"], "orderId"))
+      bad_quote =
+        put_in(@canonical_quote["gasless"], Map.delete(@canonical_quote["gasless"], "orderId"))
 
       assert {:error, {:missing_quote_field, :orderId}} =
                Permit2.sign_quote(bad_quote, 8453, StaticWallet)

--- a/packages/raxol_payments/test/raxol/payments/relay/live_relay_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/relay/live_relay_test.exs
@@ -44,8 +44,7 @@ defmodule Raxol.Payments.Relay.LiveRelayTest do
       }
 
       request = %QuoteRequest{
-        transfer_id:
-          "live_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower),
+        transfer_id: "live_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower),
         from_chain_id: env_int("RELAY_LIVE_FROM_CHAIN", 8453),
         to_chain_id: env_int("RELAY_LIVE_TO_CHAIN", 728_126_428),
         from_token: System.get_env("RELAY_LIVE_FROM_TOKEN", @usdc_base),

--- a/packages/raxol_payments/test/raxol/payments/xochi/settlement_matrix_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/settlement_matrix_test.exs
@@ -47,18 +47,18 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
   @chains [1, 10, 137, 8453, 42_161, 4663]
   @symbols Enum.sort(Assets.symbols())
 
-  @endpoints (for chain <- @chains,
-                  symbol <- @symbols,
-                  {:ok, address} <- [Assets.address(chain, symbol)],
-                  do: {chain, symbol, address})
+  @endpoints for chain <- @chains,
+                 symbol <- @symbols,
+                 {:ok, address} <- [Assets.address(chain, symbol)],
+                 do: {chain, symbol, address}
 
   # Every cross-chain (chain, token) -> (chain, token) pair. Cross-asset when the
   # two symbols differ (the norm for any Robinhood corridor: USDG lives only on
   # 4663), same-asset when they match.
-  @corridors (for {fc, fs, fa} <- @endpoints,
-                  {tc, ts, ta} <- @endpoints,
-                  fc != tc,
-                  do: {fc, fs, fa, tc, ts, ta})
+  @corridors for {fc, fs, fa} <- @endpoints,
+                 {tc, ts, ta} <- @endpoints,
+                 fc != tc,
+                 do: {fc, fs, fa, tc, ts, ta}
 
   @pubkey_re ~r/^0x0[23][a-f0-9]{64}$/
 
@@ -187,7 +187,7 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
       assert length(@corridors) == 240
 
       # USDG lives only on Robinhood Chain, and shows up as both origin and dest.
-      assert (for {c, "USDG", _} <- @endpoints, do: c) == [4663]
+      assert for({c, "USDG", _} <- @endpoints, do: c) == [4663]
 
       assert Enum.any?(@corridors, fn {fc, fs, _, tc, _, _} ->
                {fc, fs} == {4663, "USDG"} and tc != 4663
@@ -245,7 +245,10 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
         assert body["settlement_preference"] == "stealth"
         assert body["from_chain_id"] == fc
         assert body["to_chain_id"] == tc
-        assert Regex.match?(@pubkey_re, body["stealth_spending_pub_key"]), "#{label}: spending key"
+
+        assert Regex.match?(@pubkey_re, body["stealth_spending_pub_key"]),
+               "#{label}: spending key"
+
         assert Regex.match?(@pubkey_re, body["stealth_viewing_pub_key"]), "#{label}: viewing key"
       end
 
@@ -294,7 +297,10 @@ defmodule Raxol.Payments.Xochi.SettlementMatrixTest do
       {:ok, to} = Assets.address(4663, "USDG")
 
       assert {:error, %Failure{reason: :delivery_below_floor}} =
-               run(ledger, 8453, from, 4663, to, "public", %{to_amount: "1", min_to_amount: "490000"})
+               run(ledger, 8453, from, 4663, to, "public", %{
+                 to_amount: "1",
+                 min_to_amount: "490000"
+               })
 
       refute_received :wallet_signed
 

--- a/packages/raxol_payments/test/raxol/payments/xochi/stealth_e2e_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/xochi/stealth_e2e_test.exs
@@ -70,7 +70,10 @@ defmodule Raxol.Payments.Xochi.StealthE2ETest do
 
       # Sign a message with the stealth private key
       message = ExKeccak.hash_256("claim:#{settlement.stealth_address}")
-      {:ok, {r, s, _recovery_id}} = ExSecp256k1.sign(message, Secret.reveal(payment.stealth_priv_key))
+
+      {:ok, {r, s, _recovery_id}} =
+        ExSecp256k1.sign(message, Secret.reveal(payment.stealth_priv_key))
+
       signature = r <> s
       assert byte_size(signature) == 64
 

--- a/packages/raxol_telegram/lib/raxol/telegram/update_poller.ex
+++ b/packages/raxol_telegram/lib/raxol/telegram/update_poller.ex
@@ -95,10 +95,8 @@ defmodule Raxol.Telegram.UpdatePoller do
     state = %{
       conn: Keyword.get(opts, :conn, []),
       on_update: Keyword.fetch!(opts, :on_update),
-      poll_timeout_s:
-        Keyword.get(opts, :poll_timeout_s, @default_poll_timeout_s),
-      allowed_updates:
-        Keyword.get(opts, :allowed_updates, @default_allowed_updates),
+      poll_timeout_s: Keyword.get(opts, :poll_timeout_s, @default_poll_timeout_s),
+      allowed_updates: Keyword.get(opts, :allowed_updates, @default_allowed_updates),
       offset: load_offset(dets),
       dets: dets,
       failures: 0,

--- a/packages/raxol_telegram/test/raxol/telegram/update_poller_test.exs
+++ b/packages/raxol_telegram/test/raxol/telegram/update_poller_test.exs
@@ -44,8 +44,7 @@ defmodule Raxol.Telegram.UpdatePollerTest do
   defp respond(pid, result) do
     send(
       pid,
-      {:respond,
-       {:ok, %{status: 200, body: %{"ok" => true, "result" => result}}}}
+      {:respond, {:ok, %{status: 200, body: %{"ok" => true, "result" => result}}}}
     )
   end
 

--- a/test/raxol/formatter_delegation_test.exs
+++ b/test/raxol/formatter_delegation_test.exs
@@ -1,0 +1,62 @@
+defmodule Raxol.FormatterDelegationTest do
+  @moduledoc """
+  The root formatter must resolve format-gated package files through the
+  package's own `.formatter.exs`.
+
+  Without that, a root-cwd `mix format packages/...` -- an editor save in a
+  monorepo workspace -- rewraps those files at the root's 80 columns, reverting
+  the 98-column shape the per-package CI cell enforces, and the two gates become
+  mutually unsatisfiable.
+  """
+
+  use ExUnit.Case, async: true
+
+  # 94 columns: legal at the package default of 98, split by the root's 80.
+  @wide_line "{:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}\n"
+
+  @gated_file "packages/raxol_payments/lib/raxol/payments/eip712.ex"
+  @workflow ".github/workflows/ci-unified.yml"
+
+  test "a gated package file keeps its own line length under the root formatter" do
+    {format, _opts} = Mix.Tasks.Format.formatter_for_file(@gated_file)
+
+    assert format.(@wide_line) == @wide_line
+  end
+
+  test "the root formatter still holds root files to 80 columns" do
+    {format, _opts} = Mix.Tasks.Format.formatter_for_file("lib/raxol.ex")
+
+    refute format.(@wide_line) == @wide_line
+  end
+
+  test "every format-gated package is delegated by the root formatter" do
+    delegated = Keyword.fetch!(root_formatter_opts(), :subdirectories)
+
+    for package <- gated_packages() do
+      assert "packages/#{package}" in delegated,
+             "#{package} is format-gated in #{@workflow} but the root " <>
+               ".formatter.exs does not delegate to it"
+    end
+  end
+
+  defp root_formatter_opts do
+    {opts, _bindings} = Code.eval_file(".formatter.exs")
+    opts
+  end
+
+  defp gated_packages do
+    matrix =
+      @workflow
+      |> File.read!()
+      |> String.split("\n")
+      |> Enum.find(&Regex.match?(~r/^\s*package: \[/, &1))
+
+    assert is_binary(matrix), "no package matrix found in #{@workflow}"
+
+    ~r/^\s*package: \[(?<packages>[^\]]+)\]/
+    |> Regex.named_captures(matrix)
+    |> Map.fetch!("packages")
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+  end
+end


### PR DESCRIPTION
Supersedes #865 (rebased onto master; the two commits already inside #862's
squash are dropped).

#865 adds a `mix format --check-formatted` step to the CI package cell. An
adversarial review found the gate is at war with the repo's own root formatter.

## The gate was self-defeating

The root `.formatter.exs` sets `line_length: 80` and declares no
`:subdirectories`; the package configs use the default 98. So a root-invoked
`mix format packages/raxol_payments/lib/raxol/payments/eip712.ex` -- which is
what an editor-on-save and a bare root `mix format` both do -- rewrote 23 of the
25 files this PR blesses back toward their pre-PR shape and re-redded the gate it
adds.

Fixed with `subdirectories:` in the root config. It names the five packages in
the CI matrix rather than globbing `packages/*`, because the other twelve carry
169 files of pre-existing drift at their own 98 -- measured -- and a glob would
red the root Format Check immediately and force a reformat out of scope here. A
new test parses the matrix out of the workflow YAML and fails if a format-gated
package is missing from the list, so the coupling cannot rot quietly.

## Three more

- `mix raxol.check` ran only the root check, was blind to `packages/`,
  downgraded a failure to a non-fatal `:warning`, and printed `Fix: mix format`
  -- advice that, applied from the root to a `packages/` file, caused the very
  failure it claimed to fix. It now fails, and the advice is correct.
- The cell's `mix test` stated no exclusions and inherited a per-package gate
  that fails open on env-var presence. It now passes 14 explicit `--exclude`
  flags, and the job gained `timeout-minutes: 20`. Enumerating the tags turned up
  two more instances of the same fail-open: `:live_xochi_matrix` and
  `:live_xochi_preflight` are in neither helper list, and `:live_parity` is in
  neither either.
- The format step was first in a job named "Package Tests", so a whitespace nit
  aborted the cell before compile and test ran -- a red X on a money package
  could mean the tests never executed. Moved last, keeping identical authority.

## Verification

From the repo root, `mix format --check-formatted
packages/raxol_payments/lib/raxol/payments/eip712.ex` went exit 1 to exit 0; the
bare root check still exits 0; a bare root `mix format` leaves the tree clean.
`mix raxol.check --only format` passes and was proven to fail on a deliberately
misformatted `packages/` file. The YAML parses and the step order ends with the
format check.

The workflow itself was not executed -- watch the first run for `timeout-minutes`
headroom on a cold cache.

## Manual testing

- [ ] All five package cells green with the format step visible last
- [ ] Deliberate drift in one package reds its cell
