### PR TITLE
Scope the JobCreated lookup to our own client

### DIFF
--- a/packages/raxol_earn/config/buyer.example.exs
+++ b/packages/raxol_earn/config/buyer.example.exs
@@ -82,7 +82,11 @@ config :raxol_earn,
   # An override is easy to get wrong and fails QUIETLY: a signature that does
   # not match the emitted event decodes to :pending, not an error, so the buyer
   # falls through to reconcile-by-tag instead of reporting a bad jobId. If you
-  # do override, take the signature from the core's verified ABI, not from here:
+  # do override, take the signature from the core's verified ABI, not from here.
+  #
+  # The `emitter` + `client` scoping (which pins the JobCreated log to the core
+  # we called and to our own buyer address) is filled in by the buyer itself, so
+  # an override here keeps it -- unless you spell either key out explicitly.
   #
   #     buyer_job_id_resolver:
   #       {Raxol.Earn.JobIdResolver.Receipt,

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -279,11 +279,16 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     Agent.subscribe(agent)
     Agent.start_stream(agent)
 
+    # `emitter` + `client` scope the JobCreated search to the job THIS buyer
+    # created: the sponsored path resolves against a bundle receipt that also
+    # carries other senders' JobCreated logs from this same core.
     resolver = %{
       adapter: JobIdResolver.Receipt,
       config: %{
         event_signature: "JobCreated(uint256,address,address,address,uint256,address)",
-        topic_index: 1
+        topic_index: 1,
+        emitter: cfg.core,
+        client: cfg.buyer
       }
     }
 

--- a/packages/raxol_earn/lib/raxol/earn/job_id_resolver.ex
+++ b/packages/raxol_earn/lib/raxol/earn/job_id_resolver.ex
@@ -26,9 +26,10 @@ defmodule Raxol.Earn.JobIdResolver do
   - `Raxol.Earn.JobIdResolver.Receipt` (default) -- reads the receipt via
     `ProviderAdapter.get_transaction_receipt` and decodes the `JobCreated` topic
     with `Raxol.Earn.Onchain.LogDecoder`; reconciles via `JobApi.get_active_jobs`.
-    The exact event signature, indexed position, and emitter address are config
-    with placeholders that **must be confirmed against the deployed
-    `AgenticCommerceV3` in the Sepolia dry-run** (see the module).
+    The event signature and indexed positions are verified against the deployed
+    `AgenticCommerceV3` and configurable, as are the emitter address and the
+    buyer address the log's indexed `client` must equal -- which is what keeps a
+    co-bundled UserOp's `JobCreated` from binding as ours (see the module).
   - `Raxol.Earn.JobIdResolver.Mock` -- canned tx->id and tag->id maps for tests.
   """
 

--- a/packages/raxol_earn/lib/raxol/earn/job_id_resolver/receipt.ex
+++ b/packages/raxol_earn/lib/raxol/earn/job_id_resolver/receipt.ex
@@ -13,16 +13,36 @@ defmodule Raxol.Earn.JobIdResolver.Receipt do
 
   The defaults below are verified against the deployed `AgenticCommerceV3`
   (Base `0x8e86FbEf...B77BC`, behind the ACP Core proxy): `JobCreated` carries
-  six params, with `jobId` the first indexed one, so topic 0 is
-  `keccak256("JobCreated(uint256,address,address,address,uint256,address)")`
-  and `jobId` is `topics[1]`. Override via the resolver config only if the core
-  is upgraded and the event changes:
+  six params, with `jobId`, `client` and `provider` the indexed ones, so topic 0
+  is `keccak256("JobCreated(uint256,address,address,address,uint256,address)")`,
+  `jobId` is `topics[1]` and `client` is `topics[2]`. Override via the resolver
+  config only if the core is upgraded and the event changes:
 
       %{adapter: Raxol.Earn.JobIdResolver.Receipt,
         config: %{
           event_signature: "JobCreated(uint256,address,address,address,uint256,address)",
-          topic_index: 1                            # 1-based; topic 0 is the hash
+          topic_index: 1,                           # 1-based; topic 0 is the hash
+          client_topic_index: 2,
+          emitter: "0x...",                         # the ACP core that must have emitted it
+          client: "0x..."                           # our buyer address
         }}
+
+  ## Scoping (why `:client` and `:emitter` matter)
+
+  The receipt read here is not always this buyer's own transaction's. On the
+  ERC-4337 path `Raxol.Earn.ProviderAdapter.SCA` reports the BUNDLE's
+  `transactionHash`, and that receipt's `logs` carry every co-bundled UserOp's
+  logs -- including another buyer's genuine `JobCreated` from the same ACP core,
+  which a topic-0-only search would take if it came first. `:client` is the
+  discriminator that actually separates them (the deployed event indexes it);
+  `:emitter` is defence in depth against a look-alike event from another
+  contract.
+
+  Both are unset by default here, which matches ANY log, because this is a
+  public injectable seam whose `resolve/4` contract is fail-soft. The buyer does
+  not opt in: `Raxol.Earn.JobSession.Client.new/1` fills both from the
+  `:acp_core_address` and `:buyer` it already holds. Pass either explicitly as
+  `nil` to opt back out.
 
   `reconcile/4`'s recovery path depends on `createJob`'s `description` string
   round-tripping on-chain and being readable back through `get_active_jobs`.
@@ -35,11 +55,13 @@ defmodule Raxol.Earn.JobIdResolver.Receipt do
   # Verified against the deployed AgenticCommerceV3 (see moduledoc).
   @default_event_signature "JobCreated(uint256,address,address,address,uint256,address)"
   @default_topic_index 1
+  @default_client_topic_index 2
 
   @impl Raxol.Earn.JobIdResolver
   def resolve(resolver, adapter, chain_id, tx_hash) do
     signature = cfg(resolver, :event_signature, @default_event_signature)
     topic_index = cfg(resolver, :topic_index, @default_topic_index)
+    match_opts = match_opts(resolver)
 
     case ProviderAdapter.get_transaction_receipt(adapter, chain_id, tx_hash) do
       # No receipt yet: the tx is not mined. Let the caller poll / reconcile.
@@ -47,7 +69,7 @@ defmodule Raxol.Earn.JobIdResolver.Receipt do
         :pending
 
       {:ok, receipt} ->
-        decode_from_logs(logs_of(receipt), signature, topic_index)
+        decode_from_logs(logs_of(receipt), signature, topic_index, match_opts)
 
       {:error, reason} ->
         {:error, reason}
@@ -69,13 +91,30 @@ defmodule Raxol.Earn.JobIdResolver.Receipt do
 
   # -- Internals --
 
+  # Narrow the search to the JobCreated this buyer caused: an ERC-4337 bundle
+  # receipt also carries the logs of every other UserOp in the bundle.
+  defp match_opts(resolver) do
+    client_topic_index = cfg(resolver, :client_topic_index, @default_client_topic_index)
+
+    [
+      emitter: cfg(resolver, :emitter, nil),
+      topics: client_topics(cfg(resolver, :client, nil), client_topic_index)
+    ]
+  end
+
+  # A configured-but-malformed client address raises out of LogDecoder rather
+  # than quietly matching nothing, which would be indistinguishable from an
+  # unmined receipt.
+  defp client_topics(nil, _index), do: %{}
+  defp client_topics(client, index), do: %{index => client}
+
   # An event that isn't present is treated as "not ready yet" (:pending) rather
   # than a hard error, so the crash-recovery caller can fall through to
-  # reconcile. A genuinely wrong signature therefore surfaces as a reconcile
-  # `:none` -- which the buyer turns into a visible error -- instead of a silent
-  # wrong id, honoring the fail-closed posture.
-  defp decode_from_logs(logs, signature, topic_index) do
-    case LogDecoder.extract(logs, signature, topic_index, :uint256) do
+  # reconcile. A genuinely wrong signature -- or a bundle that carries only
+  # other buyers' jobs -- therefore surfaces as a reconcile `:none`, which the
+  # buyer turns into a visible error, instead of a silent wrong id.
+  defp decode_from_logs(logs, signature, topic_index, match_opts) do
+    case LogDecoder.extract(logs, signature, topic_index, :uint256, match_opts) do
       {:ok, job_id} -> {:ok, job_id}
       {:error, {:event_not_found, _}} -> :pending
       {:error, {:topic_out_of_range, _}} -> :pending

--- a/packages/raxol_earn/lib/raxol/earn/job_session/client.ex
+++ b/packages/raxol_earn/lib/raxol/earn/job_session/client.ex
@@ -122,11 +122,26 @@ defmodule Raxol.Earn.JobSession.Client do
 
     %{
       c
-      | resolver: c.resolver || %{adapter: Raxol.Earn.JobIdResolver.Receipt},
+      | resolver: scope_resolver(c.resolver || %{adapter: Raxol.Earn.JobIdResolver.Receipt}, c),
         evaluator: c.evaluator || c.buyer,
         hook_address: c.hook_address || @zero_address,
         evaluate_fn: c.evaluate_fn || (&default_evaluate/2)
     }
+  end
+
+  # Tell the resolver WHICH JobCreated is ours. The receipt it decodes is the
+  # bundle's on the ERC-4337 path, so it holds every co-bundled UserOp's logs --
+  # another buyer's genuine JobCreated from this same core would otherwise win
+  # by being first, and a wrong job_id checkpoints as `bound` and sticks across
+  # restarts. An explicit config wins, so `client: nil` opts back out.
+  defp scope_resolver(resolver, c) do
+    config =
+      resolver
+      |> Map.get(:config, %{})
+      |> Map.put_new(:emitter, c.acp_core_address)
+      |> Map.put_new(:client, c.buyer)
+
+    Map.put(resolver, :config, config)
   end
 
   @doc """

--- a/packages/raxol_earn/lib/raxol/earn/onchain/log_decoder.ex
+++ b/packages/raxol_earn/lib/raxol/earn/onchain/log_decoder.ex
@@ -38,6 +38,23 @@ defmodule Raxol.Earn.Onchain.LogDecoder do
 
   @type log :: %{required(String.t()) => any()}
 
+  @typedoc """
+  Extra constraints a log must satisfy, beyond its `topics[0]`.
+
+  - `:emitter` -- the contract address the log must have been emitted by.
+  - `:topics` -- expected values for indexed parameters, keyed by 1-based topic
+    index. Each value is a 32-byte topic or a 20-byte address (left-padded to a
+    topic here).
+
+  An unset key constrains nothing. A log that does not CARRY a constrained key
+  never matches -- a log with no `address` cannot prove which contract emitted
+  it, so it cannot satisfy an `:emitter` constraint.
+  """
+  @type match_opts :: [
+          {:emitter, String.t() | nil}
+          | {:topics, %{optional(pos_integer()) => String.t()}}
+        ]
+
   # -- Topic computation --
 
   @doc """
@@ -56,31 +73,99 @@ defmodule Raxol.Earn.Onchain.LogDecoder do
   # -- Log lookup --
 
   @doc """
-  Find the first log in `logs` whose `topics[0]` matches `event`.
+  Find the first log in `logs` whose `topics[0]` matches `event` and which
+  satisfies every constraint in `opts`.
 
   Accepts either a precomputed topic hash (`"0x..."`) or a canonical event
   signature; the latter is hashed automatically.
 
-  Returns `{:ok, log}` or `:error` (no matching log).
+  A signature match alone is not identity: one receipt can hold many logs of the
+  same event from many senders (an ERC-4337 bundle receipt holds every
+  co-bundled UserOp's logs). Pass `:emitter` / `:topics` to pin the log down to
+  the one this caller caused.
+
+  Returns `{:ok, log}` or `:error` (no matching log). Raises `ArgumentError` on
+  a malformed expected topic value, since a mis-specified constraint that
+  silently matched nothing would read exactly like an absent event.
   """
-  @spec find_event([log()], String.t()) :: {:ok, log()} | :error
-  def find_event(logs, "0x" <> _ = topic) when is_list(logs) do
-    do_find(logs, normalize(topic))
+  @spec find_event([log()], String.t(), match_opts()) :: {:ok, log()} | :error
+  def find_event(logs, event, opts \\ [])
+
+  def find_event(logs, "0x" <> _ = topic, opts) when is_list(logs) and is_list(opts) do
+    do_find(logs, normalize(topic), constraints(opts))
   end
 
-  def find_event(logs, signature) when is_list(logs) and is_binary(signature) do
-    find_event(logs, event_topic(signature))
+  def find_event(logs, signature, opts)
+      when is_list(logs) and is_binary(signature) and is_list(opts) do
+    find_event(logs, event_topic(signature), opts)
   end
 
-  defp do_find([], _topic), do: :error
+  defp constraints(opts) do
+    %{
+      emitter: normalize_emitter(Keyword.get(opts, :emitter)),
+      topics:
+        opts
+        |> Keyword.get(:topics, %{})
+        |> Map.new(fn {index, value} -> {index, expected_topic(index, value)} end)
+    }
+  end
 
-  defp do_find([log | rest], topic) do
+  defp normalize_emitter(nil), do: nil
+  defp normalize_emitter(address) when is_binary(address), do: normalize(address)
+
+  defp expected_topic(_index, "0x" <> hex = value) when byte_size(hex) == 64, do: normalize(value)
+
+  defp expected_topic(_index, "0x" <> hex) when byte_size(hex) == 40,
+    do: "0x" <> String.duplicate("0", 24) <> String.downcase(hex)
+
+  defp expected_topic(index, value) do
+    raise ArgumentError,
+          "expected topic #{index} must be a 32-byte topic or a 20-byte address, " <>
+            "got: #{inspect(value)}"
+  end
+
+  defp do_find([], _topic, _constraints), do: :error
+
+  defp do_find([log | rest], topic, constraints) do
+    if matches?(log, topic, constraints) do
+      {:ok, log}
+    else
+      do_find(rest, topic, constraints)
+    end
+  end
+
+  defp matches?(log, topic, constraints) do
+    signature_matches?(log, topic) and emitted_by?(log, constraints.emitter) and
+      indexed_match?(log, constraints.topics)
+  end
+
+  defp signature_matches?(log, topic) do
     case Map.get(log, "topics", []) do
-      [first | _] ->
-        if normalize(first) == topic, do: {:ok, log}, else: do_find(rest, topic)
+      [first | _] when is_binary(first) -> normalize(first) == topic
+      _ -> false
+    end
+  end
 
-      _ ->
-        do_find(rest, topic)
+  defp emitted_by?(_log, nil), do: true
+
+  defp emitted_by?(log, emitter) do
+    case Map.get(log, "address") do
+      address when is_binary(address) -> normalize(address) == emitter
+      _ -> false
+    end
+  end
+
+  defp indexed_match?(_log, expected) when map_size(expected) == 0, do: true
+
+  defp indexed_match?(log, expected) do
+    topics = Map.get(log, "topics", [])
+    Enum.all?(expected, fn {index, value} -> topic_matches?(topics, index, value) end)
+  end
+
+  defp topic_matches?(topics, index, expected) do
+    case Enum.at(topics, index) do
+      raw when is_binary(raw) -> normalize(raw) == expected
+      _ -> false
     end
   end
 
@@ -129,26 +214,28 @@ defmodule Raxol.Earn.Onchain.LogDecoder do
   # -- Convenience: extract an indexed parameter --
 
   @doc """
-  Find a log matching `event` (canonical signature or topic hash) and decode the
-  parameter at `topic_index` (1-based; topic 0 is the event hash) as `type`.
+  Find a log matching `event` (canonical signature or topic hash) under `opts`
+  and decode the parameter at `topic_index` (1-based; topic 0 is the event hash)
+  as `type`.
 
   Returns `{:ok, value}` or `{:error, reason}`. Used by
   `Raxol.Earn.JobIdResolver.Receipt` to extract the new `jobId` from a
   `JobCreated` event without spelling out the find/decode steps every time.
   """
-  @spec extract([log()], String.t(), pos_integer(), :uint256 | :address) ::
+  @spec extract([log()], String.t(), pos_integer(), :uint256 | :address, match_opts()) ::
           {:ok, term()} | {:error, term()}
-  def extract(logs, event, topic_index, type)
-      when is_list(logs) and is_binary(event) and is_integer(topic_index) and topic_index > 0 do
-    with {:ok, log} <- find_or_error(logs, event),
+  def extract(logs, event, topic_index, type, opts \\ [])
+      when is_list(logs) and is_binary(event) and is_integer(topic_index) and topic_index > 0 and
+             is_list(opts) do
+    with {:ok, log} <- find_or_error(logs, event, opts),
          topics <- Map.get(log, "topics", []),
          {:ok, raw} <- nth_topic(topics, topic_index) do
       decode_one(raw, type)
     end
   end
 
-  defp find_or_error(logs, event) do
-    case find_event(logs, event) do
+  defp find_or_error(logs, event, opts) do
+    case find_event(logs, event, opts) do
       {:ok, log} -> {:ok, log}
       :error -> {:error, {:event_not_found, event}}
     end

--- a/packages/raxol_earn/test/raxol/earn/job_id_resolver_scope_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/job_id_resolver_scope_test.exs
@@ -1,0 +1,166 @@
+defmodule Raxol.Earn.JobIdResolverScopeTest do
+  @moduledoc """
+  The `createJob` receipt a buyer decodes is not always its own transaction's.
+  On the ERC-4337 path `ProviderAdapter.SCA` reports the BUNDLE's
+  `transactionHash`, so the receipt carries the logs of every UserOp the bundler
+  packed, including another buyer's genuine `JobCreated` from the same ACP core.
+  These cover the scoping that keeps a bundle-mate's jobId out of our binding.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Earn.AssetToken
+  alias Raxol.Earn.JobIdResolver
+  alias Raxol.Earn.JobIdResolver.Receipt
+  alias Raxol.Earn.JobSession.Client
+  alias Raxol.Earn.Onchain.LogDecoder
+  alias Raxol.Earn.ProviderAdapter.Mock, as: Adapter
+
+  @chain 84_532
+  @signature "JobCreated(uint256,address,address,address,uint256,address)"
+
+  @core "0x" <> String.duplicate("ce", 20)
+  @other_core "0x" <> String.duplicate("ff", 20)
+  @buyer "0x" <> String.duplicate("11", 20)
+  @stranger "0x" <> String.duplicate("99", 20)
+  @provider "0x" <> String.duplicate("22", 20)
+
+  describe "resolve/4 on a shared-bundle receipt" do
+    test "binds our jobId, not the bundle-mate's that precedes it" do
+      adapter = Adapter.new()
+
+      :ok =
+        Adapter.set_receipt(adapter, "0xbundle", %{
+          "logs" => [
+            job_created_log(@core, 7, @stranger),
+            job_created_log(@core, 42, @buyer)
+          ]
+        })
+
+      assert {:ok, 42} = JobIdResolver.resolve(scoped_resolver(), adapter, @chain, "0xbundle")
+    end
+
+    test "a bundle carrying only a stranger's job stays :pending" do
+      adapter = Adapter.new()
+
+      :ok =
+        Adapter.set_receipt(adapter, "0xbundle", %{
+          "logs" => [job_created_log(@core, 7, @stranger)]
+        })
+
+      assert :pending = JobIdResolver.resolve(scoped_resolver(), adapter, @chain, "0xbundle")
+    end
+
+    test "our client on a foreign emitter does not match" do
+      adapter = Adapter.new()
+
+      :ok =
+        Adapter.set_receipt(adapter, "0xbundle", %{
+          "logs" => [job_created_log(@other_core, 7, @buyer)]
+        })
+
+      assert :pending = JobIdResolver.resolve(scoped_resolver(), adapter, @chain, "0xbundle")
+    end
+
+    test "a log with no emitter cannot satisfy an emitter constraint" do
+      adapter = Adapter.new()
+      log = @core |> job_created_log(7, @buyer) |> Map.delete("address")
+
+      :ok = Adapter.set_receipt(adapter, "0xbundle", %{"logs" => [log]})
+
+      assert :pending = JobIdResolver.resolve(scoped_resolver(), adapter, @chain, "0xbundle")
+    end
+
+    test "an unscoped resolver still takes the first signature match" do
+      adapter = Adapter.new()
+
+      :ok =
+        Adapter.set_receipt(adapter, "0xbundle", %{
+          "logs" => [
+            job_created_log(@core, 7, @stranger),
+            job_created_log(@core, 42, @buyer)
+          ]
+        })
+
+      assert {:ok, 7} = JobIdResolver.resolve(%{adapter: Receipt}, adapter, @chain, "0xbundle")
+    end
+  end
+
+  describe "Client.new/1 scoping" do
+    test "fills the resolver emitter and client from the buyer it was built for" do
+      client = build_client(resolver: %{adapter: Receipt})
+
+      assert %{adapter: Receipt, config: %{emitter: @core, client: @buyer}} = client.resolver
+    end
+
+    test "defaults the resolver to a scoped Receipt when none is given" do
+      client = build_client([])
+
+      assert %{adapter: Receipt, config: %{emitter: @core, client: @buyer}} = client.resolver
+    end
+
+    test "an explicit config wins, including an explicit nil opt-out" do
+      client =
+        build_client(resolver: %{adapter: Receipt, config: %{emitter: @other_core, client: nil}})
+
+      assert %{config: %{emitter: @other_core, client: nil}} = client.resolver
+    end
+  end
+
+  describe "LogDecoder.find_event/3" do
+    test "rejects a malformed expected topic rather than silently not matching" do
+      logs = [job_created_log(@core, 42, @buyer)]
+
+      assert_raise ArgumentError, fn ->
+        LogDecoder.find_event(logs, @signature, topics: %{2 => "not-a-topic"})
+      end
+    end
+
+    test "a topic index past the log's topics does not match" do
+      logs = [job_created_log(@core, 42, @buyer)]
+
+      assert :error = LogDecoder.find_event(logs, @signature, topics: %{9 => @buyer})
+    end
+  end
+
+  # -- Fixtures --
+
+  defp scoped_resolver do
+    %{adapter: Receipt, config: %{emitter: @core, client: @buyer}}
+  end
+
+  defp build_client(opts) do
+    Client.new(
+      Keyword.merge(
+        [
+          adapter: %{},
+          chain_id: @chain,
+          acp_core_address: @core,
+          buyer: @buyer,
+          provider: @provider,
+          amount: AssetToken.usdc_from_raw(1_000_000, @chain)
+        ],
+        opts
+      )
+    )
+  end
+
+  defp job_created_log(emitter, job_id, client) do
+    %{
+      "address" => emitter,
+      "topics" => [
+        LogDecoder.event_topic(@signature),
+        uint_topic(job_id),
+        address_topic(client),
+        address_topic(@provider)
+      ]
+    }
+  end
+
+  defp uint_topic(value) do
+    hex = Integer.to_string(value, 16)
+    "0x" <> String.duplicate("0", 64 - byte_size(hex)) <> String.downcase(hex)
+  end
+
+  defp address_topic("0x" <> hex), do: "0x" <> String.duplicate("0", 24) <> String.downcase(hex)
+end


### PR DESCRIPTION
Pre-existing on master. Surfaced while reviewing #861, but not introduced by it,
so it is on its own branch.

## The defect

`JobIdResolver.Receipt.resolve/4` finds the `JobCreated` log by matching
`topics[0]` only. It never reads `log["address"]` and never checks the indexed
client. On the ERC-4337 path that is wrong, because the receipt it reads is the
whole **bundle's**: `ProviderAdapter.SCA` returns the bundle transaction hash,
and `eth_getTransactionReceipt` on it yields the logs of every UserOp in the
bundle, from unrelated senders. `LogDecoder` returns the first topic0 match.

So the buyer can bind another sender's jobId, and it checkpoints that id as phase
`bound`, which is sticky across restarts.

The likely trigger is not an attacker. It is another ACP buyer's genuine
`JobCreated`, emitted by the same core, co-bundled ahead of ours by a shared
bundler -- which an emitter-address filter alone would not catch. The
discriminator that works is the indexed client at `topics[2]`.

## Impact is bounded, and worth stating precisely

The deployed `AgenticCommerceV3` gates `fund()` on `msg.sender != job.client ->
revert Unauthorized()` and `jobId == 0 || jobId > jobCounter -> revert
InvalidJob()`. A mis-bound id **cannot** move USDC into a stranger's escrow. The
damage is a wedged purchase: a sticky wrong jobId, a reverting fund, an orphaned
real job, a held reservation and burnt gas.

## The fix

`LogDecoder.find_event/3` gains `:emitter` and `:topics` constraints, where a log
missing a constrained key is non-matching -- a missing key can never read as a
pass. `Receipt.resolve/4` threads an emitter and the indexed client through, and
`JobSession.Client.new/1` fills both from `acp_core_address` and `buyer`, so the
production path is scoped without anyone opting in. The order task passes them
explicitly. An unset key still means match-anything, because the resolver is a
public injectable behaviour and turning an absent key into a raise would crash
third-party implementations; the fix does not depend on that opt-in.

`job_id_resolver.ex`'s moduledoc advertised a configurable emitter that `cfg/3`
never read. That is now true.

## Verification

RED then GREEN on a two-log bundle receipt -- a stranger's `JobCreated` for job 7
ahead of ours for job 42. Before: `{:ok, 7}`. After: `{:ok, 42}`.

Format clean, `compile --force --warnings-as-errors` exit 0, `raxol_earn` suite
green.

## Manual testing

- [ ] A real SCA order resolves its own jobId from a shared bundle
