### PR TITLE
Keep animation settings a map on every path

### DIFF
--- a/lib/raxol/animation/adaptation.ex
+++ b/lib/raxol/animation/adaptation.ex
@@ -45,11 +45,14 @@ defmodule Raxol.Animation.Adaptation do
     # Update StateManager settings
     settings = StateManager.get_settings()
 
-    new_settings = %{
-      settings
-      | reduced_motion: current_reduced_motion,
+    # Merge rather than update-in-place: the settings map is empty both before
+    # the framework is initialized and after `Framework.stop/0` clears it, and
+    # the update syntax demands the keys already exist.
+    new_settings =
+      Map.merge(settings, %{
+        reduced_motion: current_reduced_motion,
         cognitive_accessibility: current_cognitive_accessibility
-    }
+      })
 
     StateManager.init(new_settings)
 

--- a/lib/raxol/animation/framework.ex
+++ b/lib/raxol/animation/framework.ex
@@ -80,7 +80,15 @@ defmodule Raxol.Animation.Framework do
       iex> AnimationFramework.init(reduced_motion: true)
       :ok
   """
-  def init(opts \\ %{}, user_preferences_pid \\ nil) do
+  def init(opts \\ %{}, user_preferences_pid \\ nil)
+
+  # Every option below is read with `Map.get/3`, so the documented keyword form
+  # has to become a map before any of them are read.
+  def init(opts, user_preferences_pid) when is_list(opts) do
+    init(Map.new(opts), user_preferences_pid)
+  end
+
+  def init(opts, user_preferences_pid) when is_map(opts) do
     Raxol.Core.Runtime.Log.debug("Initializing animation framework...")
 
     # Read reduced_motion preference

--- a/lib/raxol/animation/state_server.ex
+++ b/lib/raxol/animation/state_server.ex
@@ -22,6 +22,10 @@ defmodule Raxol.Animation.StateServer do
   }
   ```
 
+  `settings` is a map on every path, including a server nobody has initialized.
+  Readers index it with `Map.get/3` and take their own defaults, so the empty
+  map means "no settings yet", never a different type.
+
   ## Performance Considerations
   This implementation uses ETS for read-heavy operations when performance
   is critical, while maintaining GenServer for write operations and
@@ -42,7 +46,7 @@ defmodule Raxol.Animation.StateServer do
   @doc """
   Initializes the animation state storage with the given settings.
   """
-  def init_state(server \\ __MODULE__, settings) do
+  def init_state(server \\ __MODULE__, settings) when is_map(settings) do
     GenServer.call(server, {:init_state, settings})
   end
 
@@ -56,7 +60,7 @@ defmodule Raxol.Animation.StateServer do
   @doc """
   Updates the animation framework settings.
   """
-  def update_settings(server \\ __MODULE__, settings) do
+  def update_settings(server \\ __MODULE__, settings) when is_map(settings) do
     GenServer.call(server, {:update_settings, settings})
   end
 
@@ -152,14 +156,8 @@ defmodule Raxol.Animation.StateServer do
   # GenServer Callbacks
 
   @impl Raxol.Core.Behaviours.BaseManager
-  def init_manager(settings) do
-    initial_state = %{
-      settings: settings,
-      animations: %{},
-      active_animations: %{}
-    }
-
-    {:ok, initial_state}
+  def init_manager(init_arg) do
+    {:ok, %{@default_state | settings: settings_from_init_arg(init_arg)}}
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -283,6 +281,26 @@ defmodule Raxol.Animation.StateServer do
   end
 
   # Private Helper Functions
+
+  # BaseManager splits the GenServer server options off and hands `init/1`
+  # whatever is left, so both a supervisor child spec and
+  # `StateManager.ensure_started/0` arrive here as `[name: __MODULE__]` minus
+  # the name, i.e. an empty keyword list. Every reader indexes the settings with
+  # `Map.get/3`, so storing that list verbatim turns the next read into a
+  # BadMapError. Settings are a map on every path.
+  defp settings_from_init_arg(settings) when is_map(settings), do: settings
+
+  defp settings_from_init_arg(opts) when is_list(opts) do
+    opts
+    |> Keyword.get(:settings, [])
+    |> Map.new()
+  end
+
+  defp settings_from_init_arg(other) do
+    raise ArgumentError,
+          "#{inspect(__MODULE__)} expects a settings map or keyword options, " <>
+            "got: #{inspect(other)}"
+  end
 
   defp do_remove_active_animation(state, element_id, animation_name) do
     element_animations = Map.get(state.active_animations, element_id, %{})

--- a/test/raxol/animation/state_settings_contract_test.exs
+++ b/test/raxol/animation/state_settings_contract_test.exs
@@ -1,0 +1,152 @@
+defmodule Raxol.Animation.StateSettingsContractTest do
+  @moduledoc """
+  The animation settings contract: `StateManager.get_settings/0` returns a map
+  on every path, including the one where the server was started by
+  `ensure_started/0` rather than by `Framework.init/2`.
+
+  That path is not hypothetical. `ensure_started/0` uses `start_link/1`, so the
+  server is linked to whichever process happened to start it. An ExUnit test
+  process exits with a non-normal reason, which kills the linked server, so the
+  next `StateManager` call anywhere -- including one inside a `Task` in the
+  middle of a later test -- starts a fresh server carrying no settings.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Raxol.Animation.Adaptation
+  alias Raxol.Animation.Framework
+  alias Raxol.Animation.StateManager
+  alias Raxol.Animation.StateServer
+  alias Raxol.Core.UserPreferences
+
+  setup do
+    prefs_name = __MODULE__.UserPreferences
+
+    {:ok, _pid} =
+      start_supervised({UserPreferences, [name: prefs_name, test_mode?: true]})
+
+    stop_state_server()
+    on_exit(&stop_state_server/0)
+
+    {:ok, %{prefs: prefs_name}}
+  end
+
+  defp stop_state_server do
+    case Process.whereis(StateServer) do
+      nil ->
+        :ok
+
+      pid ->
+        try do
+          GenServer.stop(pid, :normal, 1000)
+        catch
+          :exit, _ -> :ok
+        end
+    end
+  end
+
+  describe "settings shape" do
+    test "get_settings/0 returns a map when the server starts itself" do
+      settings = StateManager.get_settings()
+
+      assert is_map(settings), "expected a map, got: #{inspect(settings)}"
+    end
+
+    test "create_animation/2 falls back to the default duration" do
+      animation =
+        Framework.create_animation(:lazy_started, %{
+          type: :fade,
+          from: 0,
+          to: 1,
+          target_path: [:opacity]
+        })
+
+      assert animation.duration == Raxol.Core.Defaults.animation_duration_ms()
+    end
+
+    test "create_animation/2 survives the server dying under a live framework",
+         %{prefs: prefs} do
+      Framework.init(%{default_duration: 111}, prefs)
+      assert StateManager.get_settings().default_duration == 111
+
+      # Mimic the linked server dying with the process that started it.
+      stop_state_server()
+
+      animation =
+        Framework.create_animation(:after_restart, %{
+          type: :fade,
+          from: 0,
+          to: 1,
+          target_path: [:opacity]
+        })
+
+      assert animation.duration == Raxol.Core.Defaults.animation_duration_ms()
+    end
+
+    test "start_animation/2 reads accessibility flags off a self-started server" do
+      # `Lifecycle.do_start_animation/4` reads :reduced_motion,
+      # :cognitive_accessibility and :disable_all_animations off the same
+      # settings, so the whole create-then-start path has to survive a server
+      # nobody has initialized.
+      Framework.create_animation(:flags, %{
+        type: :fade,
+        duration: 10,
+        from: 0,
+        to: 1,
+        target_path: [:opacity]
+      })
+
+      assert :ok == Framework.start_animation(:flags, "element")
+    end
+
+    test "re_adapt_animations_if_needed/1 tolerates cleared settings", %{
+      prefs: prefs
+    } do
+      Framework.init(%{}, prefs)
+      # `Framework.stop/0` clears the settings back to an empty map.
+      Framework.stop()
+
+      assert [] == Adaptation.re_adapt_animations_if_needed(prefs)
+    end
+  end
+
+  describe "init options" do
+    test "init/2 accepts the documented keyword form", %{prefs: prefs} do
+      assert :ok ==
+               Framework.init(
+                 [reduced_motion: true, default_duration: 42],
+                 prefs
+               )
+
+      settings = StateManager.get_settings()
+      assert settings.reduced_motion == true
+      assert settings.default_duration == 42
+    end
+
+    test "init/2 still accepts a settings map", %{prefs: prefs} do
+      assert :ok == Framework.init(%{default_duration: 43}, prefs)
+      assert StateManager.get_settings().default_duration == 43
+    end
+  end
+
+  describe "state server contract" do
+    test "a supervisor-style child spec yields map settings" do
+      {:ok, pid} = StateServer.start_link(name: StateServer)
+
+      assert %{} == StateServer.get_settings(pid)
+    end
+
+    test "settings can be seeded through the :settings option" do
+      {:ok, pid} =
+        StateServer.start_link(name: StateServer, settings: %{frame_ms: 7})
+
+      assert %{frame_ms: 7} == StateServer.get_settings(pid)
+    end
+
+    test "storing non-map settings is rejected rather than corrupting state" do
+      assert_raise FunctionClauseError, fn ->
+        StateManager.init(reduced_motion: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #859.

The nightly build has been failing on the 1.19.0 / OTP 28.2 matrix cell, on both
ubuntu-latest and macos-latest:

```
1) test Animation Framework announces animations to screen readers when configured
   test/raxol/animation/framework_test.exs:366
   ** (BadMapError) expected a map, got:

       []

       (elixir 1.19.0) lib/map.ex:541: Map.get([], :default_duration, 300)
       (raxol 2.6.1) lib/raxol/animation/framework.ex:186: Framework.create_animation/2
```

## Root cause

Not a version quirk, and not primarily a race. It is an init-arg contract.

`use Raxol.Core.Behaviours.BaseManager` generates a `start_link/1` that splits
the GenServer server options off and hands `init/1` whatever is left
(`GenServerHelpers.split_server_opts/1`: `Keyword.take(opts, [:name, :timeout,
:debug, :spawn_opt])` and `Keyword.drop(opts, ...)`). For `[name: StateServer]`
the leftover is `[]`.

`Animation.StateServer.init_manager/1` named that parameter `settings` and stored
it verbatim, so `state.settings == []` -- an empty keyword list. Every reader
indexes settings with `Map.get/3`, so the next read raises.

Two paths reach it:

- deterministically, from `core_supervisor.ex:67` and `server_registry.ex:47`,
  which both declare the child as `{Raxol.Animation.StateServer, name: ...}`, so
  settings are `[]` at boot and after every supervisor restart;
- opportunistically in tests, because `StateManager.ensure_started/0` uses
  `start_link`, tying the singleton's lifetime to whichever process touched it
  first. When that process exits the server dies, and the next caller lazily
  recreates it with `settings: []`. The nightly stacktrace shows
  `Task.Supervised.invoke_mfa/2`, which is the `Task.async` inside
  `with_screen_reader_spy` -- whether `setup` wins that race is scheduling, which
  is why one matrix cell fails on both runners while another never does.

## The fix

`StateServer`'s `settings` is a map on every path, including a server nobody has
initialized. The empty map means "no settings yet", never a different type.
Readers keep taking their own defaults via `Map.get/3`.

- `init_manager/1` normalizes through `settings_from_init_arg/1`: a map passes
  through, a keyword list yields `Keyword.get(opts, :settings, []) |> Map.new()`,
  anything else raises `ArgumentError` rather than being silently coerced. This
  also makes `start_link(name: X, settings: %{...})` actually seed settings.
- `init_state/2` and `update_settings/2` gained `when is_map(settings)` guards,
  so a list cannot reach the state again -- it fails at the call site.

Two adjacent instances of the same defect family:

- `Framework.init/2` has always documented `init(reduced_motion: true)` while its
  body reads every option with `Map.get/3`, so the documented keyword form raised
  `BadMapError`. Now split into `is_list` and `is_map` clauses.
- `adaptation.ex` used `%{settings | ...}` update syntax, which requires the keys
  to pre-exist, so after `Framework.stop/0` clears settings it raised `KeyError`.
  Now `Map.merge/2`.

## Verification

New `test/raxol/animation/state_settings_contract_test.exs`, 10 tests, driving the
real code path rather than sleeping on the race.

Reverting only the three lib files to master and rerunning the identical test file
gives **1/10 passing**, reproducing the nightly failure exactly:

```
** (BadMapError) expected a map, got:
    []
    lib/map.ex:596: Map.get([], :default_duration, 300)
    (raxol 2.6.1) lib/raxol/animation/framework.ex:186: Framework.create_animation/2
```

With the fix: **10/10**, and `framework_test.exs` 8 passed / 3 excluded (11 with
`--include skip_on_ci`). The nightly-failing test at line 366 carries no
`skip_on_ci` tag, so it is in the running set, not the skipped one.

Also clean: `mix format --check-formatted`, `mix compile --warnings-as-errors`
(this additionally silences a pre-existing type warning about `Framework.init/1`),
and the animation neighbourhood at 112 passed.

## Not changed, deliberately

`StateManager.ensure_started/0` still uses `start_link`. That link is why the
singleton dies mid-suite at all. The crash is now impossible, but the underlying
state loss is not: if the server dies and is lazily recreated, settings revert to
framework defaults. Making it unlinked would also stop wiping animation state
between test files, which could surface latent cross-file contamination. That is a
separate change, not a nightly-breakage fix.

## Manual testing

- [ ] Nightly goes green on the 1.19.0 / OTP 28.2 cell
