### PR TITLE
Ignore Python bytecode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,12 @@ yarn-error.log
 # Elixir
 .elixir_ls/
 
+# Python bytecode. The repo's .py helpers are run in place, so the interpreter
+# drops __pycache__ next to them; committed bytecode is unreviewable.
+__pycache__/
+*.py[cod]
+*.pyo
+
 # VS Code Extension
 /extensions/vscode/out/
 


### PR DESCRIPTION
An external fork PR (#866) added four `__pycache__/*.pyc` binaries across the
repo. Nothing stops that today: `grep -nE 'pycache|\.pyc' .gitignore` returns
nothing.

Those particular files turned out to be inert here -- they are tagged
`cpython-314` while this repo runs Python 3.10, and their PEP 552 flags are `0`
(timestamp-validated) rather than the hash-based-unchecked variant that loads
without consulting the source. But committed bytecode is unreviewable by
definition, and the version tag and one flag byte are the only reasons it was
harmless.

Adds `__pycache__/`, `*.py[cod]` and `*.pyo` to the root `.gitignore`.

## Verification

No currently-tracked file becomes ignored, checked per pattern:

```
git ls-files | grep -cE '(^|/)__pycache__/'   -> 0
git ls-files | grep -cE '\.py[cod]$'          -> 0
git ls-files | grep -cE '\.pyo$'              -> 0
```

Negative control -- the four tracked Python sources are unaffected, since `.py`
does not match `.py[cod]` (the class requires a fourth character):

```
git ls-files | grep -cE '\.py$'               -> 4
```

They are `termbox2/demo/example.py`, `scripts/harness/t0/lib/read_reply.py`,
`test/fixtures/scripts/hello.py` and `test/support/harness/pty/pty_spawn.py` --
exactly the sources whose bytecode #866 tried to commit.

Rules confirmed to fire via `git check-ignore -v` against throwaway files, which
were then removed.

## Scope

Prevention only. `.gitignore` does not stop `git add -f`, and it does nothing
about a fork PR that already contains the files, since their side commits under
their own config. A hard gate needs a CI check rejecting bytecode paths -- worth
doing, but not this commit.

`*.pyo` is redundant with `*.py[cod]`; it is included for explicitness, matching
the file's existing style of overlapping rules (`.DS_Store` + `**/.DS_Store`).
Drop it if you prefer strict minimality; behaviour is identical.

## Manual testing

- [ ] A stray `__pycache__/` no longer shows in `git status`
