### PR TITLE
Bound and pin the Permit2 origin pull

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -67,12 +67,12 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   (or `ORDER_SOLVER`) names the spender AND the quote served exactly it.
 
   When the pin holds, the run grants the Permit2 allowance first, as one extra
-  UserOp billed to the buyer in USDC. The approve is for exactly this intent's
-  authorized pull, not a standing max, so a later bad signature cannot reach more
-  of the origin balance than this run was already spending. It is idempotent: an
-  allowance that already covers the pull sends nothing. `--dry-run` reads the
-  allowance and reports whether a funded run would need the approve, without
-  sending it.
+  write: a USDC-gas UserOp under `privy`/`sca`, an ETH-gas tx under `eoa`. The
+  approve is for exactly this intent's authorized pull, not a standing max, so a
+  later bad signature cannot reach more of the origin balance than this run was
+  already spending. It is idempotent: an allowance that already covers the pull
+  sends nothing. `--dry-run` reads the allowance and reports whether a funded run
+  would need the approve, without sending it.
 
   ## Env
 
@@ -331,9 +331,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     ["SPEND PLAN -- buyer #{cfg.buyer} on chain #{cfg.from}, amounts in USDC"] ++
       escrow_lines(cfg, decimals, escrow_ceiling(cfg, opts), escrow) ++
       [
-        "  gas         charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH " <>
-          "and NOT free; priced per UserOp, known only from the receipt",
-        "             UserOps this run: #{userops(opts)}"
+        "  gas         #{gas_note(cfg.signer)}",
+        "             writes this run: #{writes(opts)}"
       ] ++
       permit2_lines(cfg, Keyword.get(opts, :dry_run, false)) ++
       [
@@ -342,25 +341,43 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       ] ++ plan_footer(opts)
   end
 
+  # `eoa` broadcasts plain EIP-1559 txs and pays ETH; the smart-account signers go
+  # through an ERC-20 paymaster that fronts the ETH and bills USDC. Saying "USDC
+  # gas" for all three would make the plan wrong for exactly the signer whose gas
+  # this task cannot see in its own USDC accounting.
+  defp gas_note("eoa"),
+    do:
+      "paid in ETH by the buyer EOA, NOT in USDC and NOT free; priced per tx, " <>
+        "known only from the receipt"
+
+  defp gas_note(_signer),
+    do:
+      "charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH " <>
+        "and NOT free; priced per UserOp, known only from the receipt"
+
   # The origin-pull rail is only known once the quote is served, so the approve is
-  # a conditional leg rather than a counted one. It is named anyway: a
-  # smart-account buyer pulls USDC via Permit2, and that costs the buyer one more
-  # USDC-billed UserOp than the ERC-3009 rail an EOA buyer takes.
+  # conditional -- but it can fire on ANY non-dry run, including one that neither
+  # creates nor funds a job, so it is counted as a leg rather than mentioned in
+  # passing.
   defp permit2_lines(cfg, false = _dry_run?) do
     [
-      "  permit2     +1 approve(Permit2) UserOp, USDC gas again, IF the quote's origin pull " <>
-        "is Permit2 and the buyer's allowance is short",
+      "  permit2     +1 approve(Permit2) #{write_noun(cfg.signer)}, gas again, IF the quote's " <>
+        "origin pull is Permit2 and the buyer's allowance is short",
+      "             approves exactly the intent's authorized pull, not a standing max",
       "             spender pin: #{spender_pin(cfg)}"
     ]
   end
 
   defp permit2_lines(cfg, true) do
     [
-      "  permit2     no approve(Permit2) UserOp is sent under --dry-run; the run reads the " <>
-        "allowance and reports whether a funded run would need one",
+      "  permit2     no approve(Permit2) #{write_noun(cfg.signer)} is sent under --dry-run; the " <>
+        "run reads the allowance and reports whether a funded run would need one",
       "             spender pin: #{spender_pin(cfg)}"
     ]
   end
+
+  defp write_noun("eoa"), do: "tx"
+  defp write_noun(_signer), do: "UserOp"
 
   defp spender_pin(%{solver: nil}),
     do:
@@ -399,20 +416,23 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     do:
       "refusing anything above #{Assets.to_human(ceiling, decimals)} (raise it with --max-escrow)"
 
-  defp userops(opts) do
-    legs =
-      [
-        if(Keyword.get(opts, :job_id), do: nil, else: "createJob"),
-        if(Keyword.get(opts, :fund, false), do: "approve+fund", else: nil)
-      ]
-      |> Enum.reject(&is_nil/1)
+  # Every leg that can broadcast, in the order it happens. The Permit2 approve is
+  # first because it is settled before the intent is signed, and it is counted
+  # even though the quote decides it: a leg that "usually" does not fire is still
+  # a write this run may make, and the plan exists so no write is unannounced.
+  defp writes(opts), do: describe_writes(Keyword.get(opts, :dry_run, false), opts)
 
-    describe_userops(Keyword.get(opts, :dry_run, false), legs)
+  defp describe_writes(true, _opts), do: "none (--dry-run writes nothing on-chain)"
+
+  defp describe_writes(false, opts) do
+    [
+      "approve(Permit2) if the pull needs it",
+      if(Keyword.get(opts, :job_id), do: nil, else: "createJob"),
+      if(Keyword.get(opts, :fund, false), do: "approve+fund", else: nil)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
   end
-
-  defp describe_userops(true, _legs), do: "none (--dry-run writes nothing on-chain)"
-  defp describe_userops(false, []), do: "none"
-  defp describe_userops(false, legs), do: Enum.join(legs, ", ")
 
   defp plan_footer(opts) do
     footer(
@@ -428,10 +448,13 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   defp footer(false, true, _resuming?), do: []
 
   defp footer(false, false, false),
-    do: ["  (no --fund: no escrow this run, but the createJob UserOp still costs USDC gas)"]
+    do: ["  (no --fund: no escrow this run, but the createJob write still costs gas)"]
 
   defp footer(false, false, true),
-    do: ["  (no --fund and no createJob: this run writes nothing on-chain)"]
+    do: [
+      "  (no --fund and no createJob: the only write this run can make is the " <>
+        "conditional approve(Permit2))"
+    ]
 
   defp expected_escrow(cfg), do: div(cfg.principal_atomic * cfg.fee_bps, 10_000)
 
@@ -828,6 +851,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       src_token: src_token,
       dst_token: dst_token,
       fee_bps: Keyword.get(opts, :fee_bps, 8),
+      signer: signer,
       rpc: rpc,
       core: Chain.mainnet().acp_core_address,
       server_url: Chain.mainnet().acp_server_url,

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -19,9 +19,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     5. Poll `getJob(jobId).budget` until the provider sets it, and assert it is
        `fee_bps` of the principal.
     6. With `--fund`: approve + `fund(jobId, budget)` so the provider is paid and
-       settlement proceeds. The provider writes that budget, so `--fund` refuses
-       anything above the `--fee-bps` take-rate unless `--max-escrow` raises the
-       ceiling.
+       settlement proceeds, carrying the origin-pull approve when the quote needs
+       one. The provider writes that budget, so `--fund` refuses anything above
+       the `--fee-bps` take-rate unless `--max-escrow` raises the ceiling.
 
   ## Signer backends (`--signer`)
 
@@ -66,13 +66,22 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   A Permit2 quote is therefore refused before signing unless `--solver`
   (or `ORDER_SOLVER`) names the spender AND the quote served exactly it.
 
-  When the pin holds, the run grants the Permit2 allowance first, as one extra
-  write: a USDC-gas UserOp under `privy`/`sca`, an ETH-gas tx under `eoa`. The
-  approve is for exactly this intent's authorized pull, not a standing max, so a
-  later bad signature cannot reach more of the origin balance than this run was
-  already spending. It is idempotent: an allowance that already covers the pull
-  sends nothing. `--dry-run` reads the allowance and reports whether a funded run
-  would need the approve, without sending it.
+  When the pin holds, the allowance is granted inside the `--fund` batch rather
+  than as a write of its own -- the Virtuals paymaster refuses a standalone
+  approve to a token contract, and the allowance is not needed until the solver
+  pulls, which happens at settlement, after funding. Batching it there costs no
+  extra write and leaves no window: the allowance lands in the same transaction
+  as the escrow, so it exists at the first block anyone can act on the funding.
+
+  The approve is for exactly this intent's authorized pull, not a standing max,
+  so a later bad signature cannot reach more of the origin balance than this run
+  was already spending. It is idempotent: an allowance that already covers the
+  pull adds nothing to the batch.
+
+  A run WITHOUT `--fund` (including `--dry-run`) therefore grants no allowance.
+  It still refuses an unpinned or mismatched Permit2 quote before signing, and it
+  says plainly that the pull it authorized cannot execute until a `--fund` run
+  grants the allowance.
 
   ## Env
 
@@ -171,11 +180,11 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     # the plan exists, so the costless mode must be the one that shows it.
     print_plan(cfg, opts)
 
-    # 1. Quote, settle the origin-pull allowance, then sign (all off-chain bar the
-    #    Permit2 approve).
-    bundle =
+    # 1. Quote, check the origin pull against the pin, then sign. All off-chain:
+    #    the allowance itself is granted later, inside the funding batch.
+    {bundle, pull} =
       case sign_intent(cfg, opts) do
-        {:ok, bundle} -> bundle
+        {:ok, signed} -> signed
         {:error, reason} -> Mix.raise(sign_intent_error(reason))
       end
 
@@ -185,7 +194,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     if opts[:dry_run] do
       log("--dry-run: signed only, no on-chain writes. requirement=#{inspect(requirement)}")
     else
-      place(cfg, requirement, opts)
+      place(cfg, requirement, opts, pull)
     end
   end
 
@@ -201,7 +210,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   # -- Orchestration --
 
-  defp place(cfg, requirement, opts) do
+  defp place(cfg, requirement, opts, pull) do
     {agent, resolver} = start_buyer(cfg)
 
     # 2. createJob on-chain (or resume an existing job with --job-id).
@@ -225,7 +234,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
     log("job #{job_id} is live -- view it at https://app.virtuals.io/acp")
 
-    if funding?, do: fund_job(cfg, job_id, budget)
+    if funding?, do: fund_job(cfg, job_id, budget, pull)
   end
 
   defp create_and_resolve(cfg, resolver) do
@@ -251,46 +260,74 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # approve (USDC) + fund (ACP Core) batched into ONE UserOp, per acp-node-v2. The
   # Virtuals paymaster refuses a standalone approve to a token contract; batched
   # with the ACP-core fund call it accepts the UserOp and bills the buyer in USDC.
-  defp fund_job(cfg, job_id, budget) do
-    log(funding_line(job_id))
+  #
+  # The origin-pull approve rides here for that same reason, and this is also when
+  # it is first needed: the solver pulls at SETTLEMENT, and the seller only
+  # settles from `:funded`. Granting the allowance in the very transaction that
+  # funds the job means it exists at the first block anyone can act on the
+  # funding, with no window and no leg that can land alone.
+  defp fund_job(cfg, job_id, budget, pull) do
+    label = batch_label(pull)
+    log(funding_line(job_id, pull))
 
-    calls = [
-      %{
-        to: cfg.src_token,
-        data:
-          Raxol.Earn.ABI.encode_call("approve(address,uint256)", [
-            {"address", cfg.core},
-            {"uint256", budget}
-          ]),
-        value: 0
-      },
-      %{
-        to: cfg.core,
-        data:
-          Raxol.Earn.ABI.encode_call("fund(uint256,uint256,bytes)", [
-            {"uint256", job_id},
-            {"uint256", budget},
-            {"bytes", <<>>}
-          ]),
-        value: 0
-      }
-    ]
-
-    case ProviderAdapter.send_calls(cfg.provider_adapter, cfg.from, calls) do
+    case ProviderAdapter.send_calls(
+           cfg.provider_adapter,
+           cfg.from,
+           funding_calls(cfg, job_id, budget, pull)
+         ) do
       {:ok, txs} ->
-        log("funded (approve+fund batched): #{inspect(txs)} -- provider will settle + deliver")
-        report_actuals(cfg, "approve+fund", txs)
+        log("funded (#{label} batched): #{inspect(txs)} -- provider will settle + deliver")
+        report_actuals(cfg, label, txs)
 
       err ->
         Mix.raise("fund failed: #{inspect(err)}")
     end
   end
 
+  defp batch_label({:short, _permit}), do: "approve(Permit2)+approve+fund"
+  defp batch_label(_pull), do: "approve+fund"
+
+  @doc false
+  # Public only so the batch can be inspected without a funded run. WHERE the
+  # origin-pull approve rides is the whole point of batching it, and it must not
+  # displace the ACP-core call that makes the paymaster accept the UserOp.
+  @spec funding_calls(map(), non_neg_integer(), non_neg_integer(), OriginPull.status()) ::
+          [ProviderAdapter.call()]
+  def funding_calls(cfg, job_id, budget, pull) do
+    OriginPull.approve_calls(pull) ++
+      [
+        %{
+          to: cfg.src_token,
+          data:
+            Raxol.Earn.ABI.encode_call("approve(address,uint256)", [
+              {"address", cfg.core},
+              {"uint256", budget}
+            ]),
+          value: 0
+        },
+        %{
+          to: cfg.core,
+          data:
+            Raxol.Earn.ABI.encode_call("fund(uint256,uint256,bytes)", [
+              {"uint256", job_id},
+              {"uint256", budget},
+              {"bytes", <<>>}
+            ]),
+          value: 0
+        }
+      ]
+  end
+
   @doc false
   # Public only so the wording can be tested: this line used to call the UserOp
   # sponsored, contradicting the plan printed a few lines earlier in the same run.
-  @spec funding_line(non_neg_integer()) :: String.t()
-  def funding_line(job_id),
+  @spec funding_line(non_neg_integer(), OriginPull.status()) :: String.t()
+  def funding_line(job_id, {:short, permit}),
+    do:
+      "funding escrow: batched approve(Permit2, #{permit.amount}) + approve + " <>
+        "fund(#{job_id}) in one UserOp -- gas billed to the buyer in USDC"
+
+  def funding_line(job_id, _pull),
     do:
       "funding escrow: batched approve + fund(#{job_id}) in one UserOp -- " <>
         "gas billed to the buyer in USDC"
@@ -336,7 +373,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
         "  gas         #{gas_note(cfg.signer)}",
         "             writes this run: #{writes(opts)}"
       ] ++
-      permit2_lines(cfg, Keyword.get(opts, :dry_run, false)) ++
+      permit2_lines(cfg, opts) ++
       [
         "  principal   #{cfg.amount} AUTHORIZED, not moved here -- the signed intent lets " <>
           "the solver pull up to that during settlement"
@@ -358,23 +395,36 @@ defmodule Mix.Tasks.RaxolEarn.Order do
         "and NOT free; priced per UserOp, known only from the receipt"
 
   # The origin-pull rail is only known once the quote is served, so the approve is
-  # conditional -- but it can fire on ANY non-dry run, including one that neither
-  # creates nor funds a job, so it is counted as a leg rather than mentioned in
-  # passing.
-  defp permit2_lines(cfg, false = _dry_run?) do
+  # conditional -- and it has no write of its own: it rides inside the --fund
+  # batch, since the Virtuals paymaster refuses a standalone approve to a token
+  # contract. Which makes --fund the thing that decides whether the allowance is
+  # granted at all, so the plan says that before the run signs anything.
+  defp permit2_lines(cfg, opts) do
+    pull_lines(cfg, Keyword.get(opts, :dry_run, false), Keyword.get(opts, :fund, false)) ++
+      ["             spender pin: #{spender_pin(cfg)}"]
+  end
+
+  defp pull_lines(cfg, true = _dry_run?, _funding?) do
     [
-      "  permit2     +1 approve(Permit2) #{write_noun(cfg.signer)}, gas again, IF the quote's " <>
-        "origin pull is Permit2 and the buyer's allowance is short",
-      "             approves exactly the intent's authorized pull, not a standing max",
-      "             spender pin: #{spender_pin(cfg)}"
+      "  permit2     no approve(Permit2) #{write_noun(cfg.signer)} is sent under --dry-run; the " <>
+        "run reads the allowance and reports whether a funded run would need one"
     ]
   end
 
-  defp permit2_lines(cfg, true) do
+  defp pull_lines(cfg, false, true = _funding?) do
     [
-      "  permit2     no approve(Permit2) #{write_noun(cfg.signer)} is sent under --dry-run; the " <>
-        "run reads the allowance and reports whether a funded run would need one",
-      "             spender pin: #{spender_pin(cfg)}"
+      "  permit2     the approve(Permit2) rides INSIDE the approve+fund " <>
+        "#{write_noun(cfg.signer)} -- no separate write, no extra gas -- IF the quote's " <>
+        "origin pull is Permit2 and the buyer's allowance is short",
+      "             approves exactly the intent's authorized pull, not a standing max"
+    ]
+  end
+
+  defp pull_lines(cfg, false, false) do
+    [
+      "  permit2     no approve(Permit2) #{write_noun(cfg.signer)} without --fund: the approve " <>
+        "rides in the funding batch, so a run that signs a Permit2 intent here leaves that " <>
+        "intent's pull unexecutable until a --fund run grants the allowance"
     ]
   end
 
@@ -419,22 +469,26 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       "refusing anything above #{Assets.to_human(ceiling, decimals)} (raise it with --max-escrow)"
 
   # Every leg that can broadcast, in the order it happens. The Permit2 approve is
-  # first because it is settled before the intent is signed, and it is counted
-  # even though the quote decides it: a leg that "usually" does not fire is still
-  # a write this run may make, and the plan exists so no write is unannounced.
+  # named inside the funding leg rather than beside it, because that is where it
+  # rides: counting it separately would promise a write this run cannot make on
+  # its own, and the plan exists so no write is either unannounced or invented.
   defp writes(opts), do: describe_writes(Keyword.get(opts, :dry_run, false), opts)
 
   defp describe_writes(true, _opts), do: "none (--dry-run writes nothing on-chain)"
 
   defp describe_writes(false, opts) do
     [
-      "approve(Permit2) if the pull needs it",
       if(Keyword.get(opts, :job_id), do: nil, else: "createJob"),
-      if(Keyword.get(opts, :fund, false), do: "approve+fund", else: nil)
+      if(Keyword.get(opts, :fund, false), do: fund_leg(), else: nil)
     ]
     |> Enum.reject(&is_nil/1)
-    |> Enum.join(", ")
+    |> join_writes()
   end
+
+  defp fund_leg, do: "approve+fund (carrying the approve(Permit2) if the pull needs it)"
+
+  defp join_writes([]), do: "none (without --fund and without createJob, this run only signs)"
+  defp join_writes(legs), do: Enum.join(legs, ", ")
 
   defp plan_footer(opts) do
     footer(
@@ -454,8 +508,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   defp footer(false, false, true),
     do: [
-      "  (no --fund and no createJob: the only write this run can make is the " <>
-        "conditional approve(Permit2))"
+      "  (no --fund and no createJob: this run signs an intent and broadcasts nothing, so " <>
+        "a Permit2 pull it authorizes stays unexecutable)"
     ]
 
   defp expected_escrow(cfg), do: div(cfg.principal_atomic * cfg.fee_bps, 10_000)
@@ -631,8 +685,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # -- Steps --
 
   # Quote first, so the origin-pull rail is read from what the solver actually
-  # served rather than assumed from the token, then hold the allowance that rail
-  # needs BEFORE releasing a signature over it.
+  # served rather than assumed from the token, then decide that rail's allowance
+  # BEFORE releasing a signature over it.
   defp sign_intent(cfg, opts) do
     request = %QuoteRequest{
       wallet: cfg.buyer,
@@ -646,42 +700,67 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     }
 
     with {:ok, quote_resp} <- XochiProtocol.get_quote(cfg.xochi_config, request),
-         :ok <- settle_origin_pull(cfg, quote_resp, opts) do
-      XochiProtocol.sign_intent(quote_resp, cfg.intent_wallet, request)
+         {:ok, pull} <- check_origin_pull(cfg, quote_resp, opts),
+         {:ok, bundle} <- XochiProtocol.sign_intent(quote_resp, cfg.intent_wallet, request) do
+      {:ok, {bundle, pull}}
     end
   end
 
-  # The Permit2 rail pulls through a standing ERC-20 allowance, which the buyer
-  # grants with one extra UserOp. Refusing an unpinned spender happens here,
-  # before the approve and before the signature -- an allowance towards an
-  # unverified spender is the failure this whole path exists to prevent.
-  defp settle_origin_pull(cfg, quote_resp, opts) do
+  # The Permit2 rail pulls through a standing ERC-20 allowance. Refusing an
+  # unpinned or mismatched spender happens HERE, before the signature -- an
+  # allowance towards an unverified spender is the failure this whole path exists
+  # to prevent, and refusing while nothing is signed yet is the point of it.
+  #
+  # Only the on-chain GRANT is deferred, to the funding batch: the allowance is
+  # not needed until the solver pulls, and the solver pulls at settlement, which
+  # the seller reaches only from `:funded`.
+  defp check_origin_pull(cfg, quote_resp, opts) do
     with {:ok, plan} <- OriginPull.allowance_plan(quote_resp, cfg.solver, origin_leg(cfg)),
-         {:ok, outcome} <- ensure_allowance(cfg, plan, opts) do
-      log(OriginPull.describe(outcome))
-      report_approve(cfg, outcome)
-      :ok
+         {:ok, status} <- OriginPull.allowance_status(plan, cfg.provider_adapter, cfg.buyer) do
+      Enum.each(origin_pull_lines(status, opts), &log/1)
+      {:ok, status}
     else
       {:error, reason} -> {:error, {:origin_pull, reason}}
     end
   end
+
+  @doc false
+  # Public only so the disclosure can be tested. A run that signs a Permit2 intent
+  # and then does not fund grants no allowance at all, so it must say the pull it
+  # just authorized cannot execute -- otherwise the run reads as a success and the
+  # settlement fails later with nothing pointing back at this.
+  @spec origin_pull_lines(OriginPull.status(), keyword()) :: [String.t()]
+  def origin_pull_lines(status, opts) do
+    [OriginPull.describe(status)] ++
+      grant_lines(status, Keyword.get(opts, :dry_run, false), Keyword.get(opts, :fund, false))
+  end
+
+  defp grant_lines({:short, _permit}, true, _funding?),
+    do: [
+      "origin pull: --dry-run sends no approve; a funded run grants it inside the " <>
+        "approve+fund batch"
+    ]
+
+  defp grant_lines({:short, _permit}, false, true),
+    do: [
+      "origin pull: that approve rides in the approve+fund batch, so the allowance lands " <>
+        "in the same transaction as the escrow"
+    ]
+
+  defp grant_lines({:short, _permit}, false, false),
+    do: [
+      "WARN: this run does not --fund, so no approve is sent. The intent is signed and its " <>
+        "pull authorized, but that pull CANNOT execute until the allowance exists -- " <>
+        "re-run with --job-id <id> --fund to grant it in the funding batch."
+    ]
+
+  defp grant_lines(_status, _dry_run?, _funding?), do: []
 
   # The transfer the operator asked for. The served permit is cross-checked
   # against it, so the allowance is granted on the chain and token this run named
   # and never exceeds the principal it was told to send.
   defp origin_leg(cfg),
     do: %{chain_id: cfg.from, token: cfg.src_token, amount: cfg.principal_atomic}
-
-  defp ensure_allowance(cfg, plan, opts) do
-    OriginPull.ensure_allowance(plan, cfg.provider_adapter, cfg.buyer,
-      dry_run: Keyword.get(opts, :dry_run, false)
-    )
-  end
-
-  defp report_approve(cfg, {:approved, _amount, tx}),
-    do: report_actuals(cfg, "permit2 approve", tx)
-
-  defp report_approve(_cfg, _outcome), do: :ok
 
   defp requirement(cfg, bundle) do
     %{

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -67,9 +67,12 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   (or `ORDER_SOLVER`) names the spender AND the quote served exactly it.
 
   When the pin holds, the run grants the Permit2 allowance first, as one extra
-  UserOp billed to the buyer in USDC. It is idempotent: a standing allowance
-  sends nothing. `--dry-run` reads the allowance and reports whether a funded run
-  would need the approve, without sending it.
+  UserOp billed to the buyer in USDC. The approve is for exactly this intent's
+  authorized pull, not a standing max, so a later bad signature cannot reach more
+  of the origin balance than this run was already spending. It is idempotent: an
+  allowance that already covers the pull sends nothing. `--dry-run` reads the
+  allowance and reports whether a funded run would need the approve, without
+  sending it.
 
   ## Env
 
@@ -628,7 +631,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # before the approve and before the signature -- an allowance towards an
   # unverified spender is the failure this whole path exists to prevent.
   defp settle_origin_pull(cfg, quote_resp, opts) do
-    with {:ok, plan} <- OriginPull.allowance_plan(quote_resp, cfg.solver),
+    with {:ok, plan} <- OriginPull.allowance_plan(quote_resp, cfg.solver, origin_leg(cfg)),
          {:ok, outcome} <- ensure_allowance(cfg, plan, opts) do
       log(OriginPull.describe(outcome))
       report_approve(cfg, outcome)
@@ -638,18 +641,21 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     end
   end
 
+  # The transfer the operator asked for. The served permit is cross-checked
+  # against it, so the allowance is granted on the chain and token this run named
+  # and never exceeds the principal it was told to send.
+  defp origin_leg(cfg),
+    do: %{chain_id: cfg.from, token: cfg.src_token, amount: cfg.principal_atomic}
+
   defp ensure_allowance(cfg, plan, opts) do
-    OriginPull.ensure_allowance(
-      plan,
-      cfg.provider_adapter,
-      cfg.from,
-      cfg.src_token,
-      cfg.buyer,
+    OriginPull.ensure_allowance(plan, cfg.provider_adapter, cfg.buyer,
       dry_run: Keyword.get(opts, :dry_run, false)
     )
   end
 
-  defp report_approve(cfg, {:approved, tx}), do: report_actuals(cfg, "permit2 approve", tx)
+  defp report_approve(cfg, {:approved, _amount, tx}),
+    do: report_actuals(cfg, "permit2 approve", tx)
+
   defp report_approve(_cfg, _outcome), do: :ok
 
   defp requirement(cfg, bundle) do

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -94,9 +94,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
       ORDER_KEY          session-key EOA (0x-hex): signs the intent, and -- under
                          sca/eoa -- the on-chain txs.
-      ORDER_RPC_8453     Base JSON-RPC (the ACP core lives on Base). Default: mainnet.
-      ORDER_RPC_<chain>  origin-chain JSON-RPC, when --corridor leaves another
-                         chain. Falls back to ORDER_RPC_8453.
+      ORDER_RPC_8453     Base JSON-RPC. Default: mainnet. This serves both roles --
+                         the ACP core read and the origin chain -- because the
+                         corridor's origin must BE Base (see --corridor).
       ORDER_XOCHI_TOKEN  Xochi Member token.  ORDER_XOCHI_URL default api.xochi.fi.
       ORDER_SOLVER       origin-pull spender to pin, when not passed as --solver.
 
@@ -111,7 +111,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       --signer B         privy (default) | sca | eoa
       --amount N         principal in USDC (default 3.00; the solver's dynamic gas
                          floor rejects sub-~$3 today).
-      --corridor F>T     origin>destination chain ids (default 8453>42161).
+      --corridor F>T     origin>destination chain ids (default 8453>42161). The
+                         ORIGIN must be the ACP core's chain (8453): the job and
+                         the origin-pull approve share one batch. Destination is free.
       --provider 0x..    the agent (seller) wallet to hire (default the raxol agent).
       --solver 0x..      the origin-pull spender to pin (or ORDER_SOLVER). REQUIRED
                          when the quote pulls via Permit2 -- see below.
@@ -946,12 +948,13 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   defp build_config(opts) do
     {from, to} = parse_corridor(Keyword.get(opts, :corridor, "8453>42161"))
+    assert_acp_origin!(from)
     amount = Keyword.get(opts, :amount, "3.00")
 
-    # Two chains, deliberately separate. `acp_rpc` reads the ACP core, which lives
-    # on Base whatever the corridor is; `rpc` is the ORIGIN chain the buyer signs
-    # UserOps and holds the Permit2 allowance on. They coincide on the default
-    # 8453 origin, which is why one hardcoded Base URL served both until now.
+    # Two names, deliberately separate. `acp_rpc` reads the ACP core; `rpc` is the
+    # ORIGIN chain the buyer signs UserOps and holds the Permit2 allowance on.
+    # `assert_acp_origin!/1` above is what makes them the same chain, so the split
+    # records which role each read plays rather than a divergence that can happen.
     acp_rpc = System.get_env("ORDER_RPC_8453", Chain.mainnet().rpc_url)
     rpc = System.get_env("ORDER_RPC_#{from}", acp_rpc)
 
@@ -1157,6 +1160,39 @@ defmodule Mix.Tasks.RaxolEarn.Order do
             "It pins the origin-pull spender, so a typo would either reject every quote " <>
             "or pin the wrong destination."
         )
+    end
+  end
+
+  # This task runs the whole ACP lifecycle on the corridor's ORIGIN chain --
+  # createJob, the budget read, and the approve+fund batch all go there -- while
+  # the ACP core is deployed only on Base. The funding batch is what makes that
+  # structural rather than incidental: it carries the origin-chain Permit2 approve
+  # in the SAME send_calls as the Base ACP fund, and one batch cannot span two
+  # chains.
+  #
+  # So a non-Base origin is refused here rather than half-executed. Left unchecked
+  # it reads as supported: createJob would be sent to the Base core address on the
+  # origin chain, where nothing is deployed, while the budget poll read Base and
+  # saw nothing -- and the 7702/SCA wallets sign for 8453 whatever the corridor
+  # says.
+  defp assert_acp_origin!(from) do
+    core_chain = Chain.mainnet().chain_id
+
+    case from do
+      ^core_chain ->
+        :ok
+
+      other ->
+        Mix.raise("""
+        --corridor origin #{other} is not the ACP core's chain (#{core_chain}).
+
+        This task creates and funds a real ACP job, and the ACP core is deployed
+        only on chain #{core_chain}. The origin-pull approve rides in the same
+        batch as that job's fund call, so the origin leg cannot be a different
+        chain than the job.
+
+        Order FROM #{core_chain} (the destination is free): --corridor #{core_chain}>#{other}
+        """)
     end
   end
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -78,6 +78,13 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   was already spending. It is idempotent: an allowance that already covers the
   pull adds nothing to the batch.
 
+  What the batch grants is decided by an allowance read taken when the batch is
+  BUILT, not by the one taken when the intent was signed. Minutes separate them --
+  createJob has to mine, the chat room has to appear, the provider has to write a
+  budget -- and an allowance can be spent down in between by an earlier intent's
+  own pull. Deciding on the older reading would escrow the fee and leave this
+  intent's pull short.
+
   A run WITHOUT `--fund` (including `--dry-run`) therefore grants no allowance.
   It still refuses an unpinned or mismatched Permit2 quote before signing, and it
   says plainly that the pull it authorized cannot execute until a `--fund` run
@@ -181,8 +188,10 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     print_plan(cfg, opts)
 
     # 1. Quote, check the origin pull against the pin, then sign. All off-chain:
-    #    the allowance itself is granted later, inside the funding batch.
-    {bundle, pull} =
+    #    the allowance itself is granted later, inside the funding batch. What
+    #    survives to that point is the PLAN -- the cross-checked permit -- not the
+    #    allowance reading taken here, which is stale by the time funding happens.
+    {bundle, plan} =
       case sign_intent(cfg, opts) do
         {:ok, signed} -> signed
         {:error, reason} -> Mix.raise(sign_intent_error(reason))
@@ -194,7 +203,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     if opts[:dry_run] do
       log("--dry-run: signed only, no on-chain writes. requirement=#{inspect(requirement)}")
     else
-      place(cfg, requirement, opts, pull)
+      place(cfg, requirement, opts, plan)
     end
   end
 
@@ -210,7 +219,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   # -- Orchestration --
 
-  defp place(cfg, requirement, opts, pull) do
+  defp place(cfg, requirement, opts, plan) do
     {agent, resolver} = start_buyer(cfg)
 
     # 2. createJob on-chain (or resume an existing job with --job-id).
@@ -234,7 +243,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
     log("job #{job_id} is live -- view it at https://app.virtuals.io/acp")
 
-    if funding?, do: fund_job(cfg, job_id, budget, pull)
+    if funding?, do: fund_job(cfg, job_id, budget, plan)
   end
 
   defp create_and_resolve(cfg, resolver) do
@@ -266,7 +275,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # settles from `:funded`. Granting the allowance in the very transaction that
   # funds the job means it exists at the first block anyone can act on the
   # funding, with no window and no leg that can land alone.
-  defp fund_job(cfg, job_id, budget, pull) do
+  defp fund_job(cfg, job_id, budget, plan) do
+    pull = fund_time_allowance(cfg, plan)
     label = batch_label(pull)
     log(funding_line(job_id, pull))
 
@@ -281,6 +291,34 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
       err ->
         Mix.raise("fund failed: #{inspect(err)}")
+    end
+  end
+
+  # The allowance read taken when the intent was signed is minutes old by now:
+  # createJob had to mine, the chat room had to appear, and the provider had to
+  # write a budget. An allowance that covered the pull back then can have been
+  # spent down since -- an earlier intent's own pull consumes it -- and a batch
+  # built on that reading would escrow the fee while leaving THIS intent's pull
+  # short, which is a fee paid for a transfer that cannot happen.
+  #
+  # So the batch is decided against a fresh read. The plan is what carries
+  # forward, because the plan is the cross-checked permit and cannot drift; only
+  # the allowance can. A read that fails aborts rather than funds: funding
+  # without the approve strands the escrow, which is the outcome being avoided.
+  @doc false
+  # Public only so the re-read can be proven. That the batch is built from a
+  # fund-time reading rather than the one taken at signing is the whole property,
+  # and it is invisible in `funding_calls/4`, which sees only the status it is
+  # handed.
+  @spec fund_time_allowance(map(), OriginPull.plan()) :: OriginPull.status()
+  def fund_time_allowance(cfg, plan) do
+    case OriginPull.allowance_status(plan, cfg.provider_adapter, cfg.buyer) do
+      {:ok, status} ->
+        log("at funding time -- " <> OriginPull.describe(status))
+        status
+
+      {:error, reason} ->
+        Mix.raise(OriginPull.explain(reason))
     end
   end
 
@@ -714,11 +752,15 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # Only the on-chain GRANT is deferred, to the funding batch: the allowance is
   # not needed until the solver pulls, and the solver pulls at settlement, which
   # the seller reaches only from `:funded`.
+  #
+  # The PLAN is what is returned, not the status read here. The status describes
+  # the allowance at signing time and is reported for that, but the funding batch
+  # re-reads rather than trusting it -- see `fund_time_allowance/2`.
   defp check_origin_pull(cfg, quote_resp, opts) do
     with {:ok, plan} <- OriginPull.allowance_plan(quote_resp, cfg.solver, origin_leg(cfg)),
          {:ok, status} <- OriginPull.allowance_status(plan, cfg.provider_adapter, cfg.buyer) do
       Enum.each(origin_pull_lines(status, opts), &log/1)
-      {:ok, status}
+      {:ok, plan}
     else
       {:error, reason} -> {:error, {:origin_pull, reason}}
     end

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -51,12 +51,33 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   `--dry-run` stops after signing and spends nothing.
 
+  ## Origin pull: the `--solver` pin
+
+  The signed intent carries an origin-pull authorization letting the solver collect
+  the principal at settlement. A smart-account buyer (the `privy`/`sca` signers)
+  pulls USDC through Permit2, where an EOA buyer pulls the same USDC through
+  ERC-3009 -- so the rail comes from the served quote's `payment_method`, never
+  from the token.
+
+  That distinction decides how much the destination is bounded. ERC-3009 names the
+  recipient inside the signed digest and the token enforces `msg.sender == to`;
+  Permit2 has no on-chain recipient guard at all, so the spender picks the
+  recipient at call time and the pinned spender is the ONLY destination control.
+  A Permit2 quote is therefore refused before signing unless `--solver`
+  (or `ORDER_SOLVER`) names the spender AND the quote served exactly it.
+
+  When the pin holds, the run grants the Permit2 allowance first, as one extra
+  UserOp billed to the buyer in USDC. It is idempotent: a standing allowance
+  sends nothing. `--dry-run` reads the allowance and reports whether a funded run
+  would need the approve, without sending it.
+
   ## Env
 
       ORDER_KEY          session-key EOA (0x-hex): signs the intent, and -- under
                          sca/eoa -- the on-chain txs.
       ORDER_RPC_8453     Base JSON-RPC (reads; eoa/sca broadcast). Default: mainnet.
       ORDER_XOCHI_TOKEN  Xochi Member token.  ORDER_XOCHI_URL default api.xochi.fi.
+      ORDER_SOLVER       origin-pull spender to pin, when not passed as --solver.
 
       # `privy` backend (delegated sidecar) -- from the agent's op item:
       RAXOL_ACP_WALLET_ADDRESS      the managed SCA agent (the buyer).
@@ -71,6 +92,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
                          floor rejects sub-~$3 today).
       --corridor F>T     origin>destination chain ids (default 8453>42161).
       --provider 0x..    the agent (seller) wallet to hire (default the raxol agent).
+      --solver 0x..      the origin-pull spender to pin (or ORDER_SOLVER). REQUIRED
+                         when the quote pulls via Permit2 -- see below.
       --fee-bps N        expected take-rate to assert (default 8).
       --max-escrow N     ceiling in USDC on what --fund will pay. Defaults to the
                          --fee-bps take-rate; a larger on-chain budget is refused.
@@ -99,6 +122,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     Transport
   }
 
+  alias Raxol.Earn.Xochi.OriginPull
   alias Raxol.Payments.Assets
   alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
   alias Raxol.Payments.Xochi.{PullContracts, Schemas.QuoteRequest}
@@ -116,6 +140,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     amount: :string,
     corridor: :string,
     provider: :string,
+    solver: :string,
     fee_bps: :integer,
     max_escrow: :string,
     fund: :boolean,
@@ -131,7 +156,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     Application.ensure_all_started(:raxol_earn)
 
     cfg = build_config(opts)
-    trust_pull_contracts()
+    pin_origin_pull(cfg.solver)
 
     log(
       "buyer=#{cfg.buyer}  provider=#{cfg.provider}  corridor=#{cfg.from}->#{cfg.to}  amount=#{cfg.amount} USDC"
@@ -141,9 +166,10 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     # the plan exists, so the costless mode must be the one that shows it.
     print_plan(cfg, opts)
 
-    # 1. Sign the Xochi intent (off-chain).
+    # 1. Quote, settle the origin-pull allowance, then sign (all off-chain bar the
+    #    Permit2 approve).
     bundle =
-      case sign_intent(cfg) do
+      case sign_intent(cfg, opts) do
         {:ok, bundle} -> bundle
         {:error, reason} -> Mix.raise(sign_intent_error(reason))
       end
@@ -304,11 +330,41 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       [
         "  gas         charged in USDC from the buyer by an ERC-20 paymaster, NOT in ETH " <>
           "and NOT free; priced per UserOp, known only from the receipt",
-        "             UserOps this run: #{userops(opts)}",
+        "             UserOps this run: #{userops(opts)}"
+      ] ++
+      permit2_lines(cfg, Keyword.get(opts, :dry_run, false)) ++
+      [
         "  principal   #{cfg.amount} AUTHORIZED, not moved here -- the signed intent lets " <>
           "the solver pull up to that during settlement"
       ] ++ plan_footer(opts)
   end
+
+  # The origin-pull rail is only known once the quote is served, so the approve is
+  # a conditional leg rather than a counted one. It is named anyway: a
+  # smart-account buyer pulls USDC via Permit2, and that costs the buyer one more
+  # USDC-billed UserOp than the ERC-3009 rail an EOA buyer takes.
+  defp permit2_lines(cfg, false = _dry_run?) do
+    [
+      "  permit2     +1 approve(Permit2) UserOp, USDC gas again, IF the quote's origin pull " <>
+        "is Permit2 and the buyer's allowance is short",
+      "             spender pin: #{spender_pin(cfg)}"
+    ]
+  end
+
+  defp permit2_lines(cfg, true) do
+    [
+      "  permit2     no approve(Permit2) UserOp is sent under --dry-run; the run reads the " <>
+        "allowance and reports whether a funded run would need one",
+      "             spender pin: #{spender_pin(cfg)}"
+    ]
+  end
+
+  defp spender_pin(%{solver: nil}),
+    do:
+      "NONE -- a Permit2 pull is refused before signing (pass --solver 0x.. / ORDER_SOLVER); " <>
+        "Permit2 has no on-chain recipient guard, so the pin is the only destination control"
+
+  defp spender_pin(%{solver: solver}), do: solver
 
   defp escrow_lines(cfg, decimals, ceiling, :new_job) do
     [
@@ -546,7 +602,10 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   # -- Steps --
 
-  defp sign_intent(cfg) do
+  # Quote first, so the origin-pull rail is read from what the solver actually
+  # served rather than assumed from the token, then hold the allowance that rail
+  # needs BEFORE releasing a signature over it.
+  defp sign_intent(cfg, opts) do
     request = %QuoteRequest{
       wallet: cfg.buyer,
       from_chain_id: cfg.from,
@@ -558,8 +617,40 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       slippage_bps: 50
     }
 
-    XochiProtocol.quote_and_sign(cfg.xochi_config, request, cfg.intent_wallet)
+    with {:ok, quote_resp} <- XochiProtocol.get_quote(cfg.xochi_config, request),
+         :ok <- settle_origin_pull(cfg, quote_resp, opts) do
+      XochiProtocol.sign_intent(quote_resp, cfg.intent_wallet, request)
+    end
   end
+
+  # The Permit2 rail pulls through a standing ERC-20 allowance, which the buyer
+  # grants with one extra UserOp. Refusing an unpinned spender happens here,
+  # before the approve and before the signature -- an allowance towards an
+  # unverified spender is the failure this whole path exists to prevent.
+  defp settle_origin_pull(cfg, quote_resp, opts) do
+    with {:ok, plan} <- OriginPull.allowance_plan(quote_resp, cfg.solver),
+         {:ok, outcome} <- ensure_allowance(cfg, plan, opts) do
+      log(OriginPull.describe(outcome))
+      report_approve(cfg, outcome)
+      :ok
+    else
+      {:error, reason} -> {:error, {:origin_pull, reason}}
+    end
+  end
+
+  defp ensure_allowance(cfg, plan, opts) do
+    OriginPull.ensure_allowance(
+      plan,
+      cfg.provider_adapter,
+      cfg.from,
+      cfg.src_token,
+      cfg.buyer,
+      dry_run: Keyword.get(opts, :dry_run, false)
+    )
+  end
+
+  defp report_approve(cfg, {:approved, tx}), do: report_actuals(cfg, "permit2 approve", tx)
+  defp report_approve(_cfg, _outcome), do: :ok
 
   defp requirement(cfg, bundle) do
     %{
@@ -710,6 +801,10 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     dst_token = usdc_address!(to, "destination")
     principal_atomic = Assets.to_atomic(Decimal.new(amount), Assets.decimals(from, src_token))
 
+    # Before build_signer, which boots the sidecar: a malformed pin should not
+    # cost a subprocess to discover.
+    solver = pinned_solver(opts)
+
     signer = Keyword.get(opts, :signer, "privy")
     {provider_adapter, buyer, intent_wallet} = build_signer(signer, from, rpc)
     log("signer backend: #{signer}")
@@ -719,6 +814,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       intent_wallet: intent_wallet,
       provider_adapter: provider_adapter,
       provider: Keyword.get(opts, :provider, @default_provider),
+      solver: solver,
       from: from,
       to: to,
       amount: amount,
@@ -856,10 +952,42 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   end
 
   # Trust the verified XochiPull contracts so the intent's origin-pull authorization
-  # passes the anti-drain pin (Riddler #591; same set config/runtime.exs uses).
-  defp trust_pull_contracts do
-    Application.put_env(:raxol_payments, :pull_solver_allowlist, PullContracts.pull_recipients())
+  # passes the anti-drain pin (Riddler #591; same set config/runtime.exs uses),
+  # plus the spender this run was told to expect. The mirrored contract set is a
+  # checked-in copy of a deployment record, so it is never widened silently: a
+  # rotated address has to be named on the command line.
+  defp pin_origin_pull(solver) do
+    Application.put_env(:raxol_payments, :pull_solver_allowlist, pull_allowlist(solver))
     Application.put_env(:raxol_payments, :pull_require_solver_pin, true)
+  end
+
+  defp pull_allowlist(nil), do: PullContracts.pull_recipients()
+  defp pull_allowlist(solver), do: Enum.uniq([solver | PullContracts.pull_recipients()])
+
+  # The pinned origin-pull spender: a flag, because it is a per-run counterparty
+  # address like --provider, and an env var, because the live-gate runner drives
+  # this task entirely through ORDER_*. The flag wins when both are set.
+  defp pinned_solver(opts) do
+    case Keyword.get(opts, :solver) || System.get_env("ORDER_SOLVER") do
+      nil -> nil
+      value -> solver_address!(String.trim(value))
+    end
+  end
+
+  defp solver_address!(""), do: nil
+
+  defp solver_address!(value) do
+    case Regex.match?(~r/\A0x[0-9a-fA-F]{40}\z/, value) do
+      true ->
+        value
+
+      false ->
+        Mix.raise(
+          "--solver / ORDER_SOLVER #{inspect(value)} is not a 0x-hex 20-byte address. " <>
+            "It pins the origin-pull spender, so a typo would either reject every quote " <>
+            "or pin the wrong destination."
+        )
+    end
   end
 
   defp parse_corridor(spec) do
@@ -900,6 +1028,28 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     cloudflare.com and other Cloudflare sites sit elsewhere and will pass while
     this one fails. Route around it with a VPN or an exit node in another
     country. Confirm from off-network before reporting an outage upstream.
+    """
+  end
+
+  defp sign_intent_error({:origin_pull, reason}), do: OriginPull.explain(reason)
+
+  # The pin rejected the served recipient/spender. The addresses it accepts are a
+  # checked-in mirror of Riddler's deployment record plus whatever --solver named,
+  # so a rotated pull contract lands here rather than anywhere more informative.
+  defp sign_intent_error({:authorization_mismatch, field})
+       when field in [:pull_to, :pull_spender] do
+    """
+    the quote's origin-pull recipient is not pinned (#{field}).
+
+    Nothing was signed. The accepted set is the verified XochiPull contracts this
+    repo mirrors, plus any --solver / ORDER_SOLVER address. A solver that has
+    redeployed its pull contract will fail exactly here: confirm the new address
+    against Riddler's XochiPull deployment record, then re-run with
+
+      --solver 0x<spender>
+
+    Do not widen the pin to whatever the quote served -- checking that value is
+    the entire point of it.
     """
   end
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -78,7 +78,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
       ORDER_KEY          session-key EOA (0x-hex): signs the intent, and -- under
                          sca/eoa -- the on-chain txs.
-      ORDER_RPC_8453     Base JSON-RPC (reads; eoa/sca broadcast). Default: mainnet.
+      ORDER_RPC_8453     Base JSON-RPC (the ACP core lives on Base). Default: mainnet.
+      ORDER_RPC_<chain>  origin-chain JSON-RPC, when --corridor leaves another
+                         chain. Falls back to ORDER_RPC_8453.
       ORDER_XOCHI_TOKEN  Xochi Member token.  ORDER_XOCHI_URL default api.xochi.fi.
       ORDER_SOLVER       origin-pull spender to pin, when not passed as --solver.
 
@@ -802,7 +804,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       params: [%{to: cfg.core, data: data}, "latest"]
     }
 
-    case Req.post(cfg.rpc, json: body) do
+    case Req.post(cfg.acp_rpc, json: body) do
       {:ok, %{status: 200, body: %{"result" => "0x" <> hex}}} when byte_size(hex) >= 8 * 64 ->
         raw = Base.decode16!(hex, case: :mixed)
 
@@ -822,9 +824,15 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # -- Config / helpers --
 
   defp build_config(opts) do
-    rpc = System.get_env("ORDER_RPC_8453", Chain.mainnet().rpc_url)
     {from, to} = parse_corridor(Keyword.get(opts, :corridor, "8453>42161"))
     amount = Keyword.get(opts, :amount, "3.00")
+
+    # Two chains, deliberately separate. `acp_rpc` reads the ACP core, which lives
+    # on Base whatever the corridor is; `rpc` is the ORIGIN chain the buyer signs
+    # UserOps and holds the Permit2 allowance on. They coincide on the default
+    # 8453 origin, which is why one hardcoded Base URL served both until now.
+    acp_rpc = System.get_env("ORDER_RPC_8453", Chain.mainnet().rpc_url)
+    rpc = System.get_env("ORDER_RPC_#{from}", acp_rpc)
 
     src_token = usdc_address!(from, "origin")
     dst_token = usdc_address!(to, "destination")
@@ -853,6 +861,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
       fee_bps: Keyword.get(opts, :fee_bps, 8),
       signer: signer,
       rpc: rpc,
+      acp_rpc: acp_rpc,
       core: Chain.mainnet().acp_core_address,
       server_url: Chain.mainnet().acp_server_url,
       xochi_config: %{

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -1006,14 +1006,24 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # The pinned origin-pull spender: a flag, because it is a per-run counterparty
   # address like --provider, and an env var, because the live-gate runner drives
   # this task entirely through ORDER_*. The flag wins when both are set.
+  # Trim BEFORE the fallback: `--solver ""` is truthy in Elixir, so an empty flag
+  # would otherwise suppress ORDER_SOLVER and leave the run unpinned rather than
+  # falling back to it.
   defp pinned_solver(opts) do
-    case Keyword.get(opts, :solver) || System.get_env("ORDER_SOLVER") do
+    case present(Keyword.get(opts, :solver)) || present(System.get_env("ORDER_SOLVER")) do
       nil -> nil
-      value -> solver_address!(String.trim(value))
+      value -> solver_address!(value)
     end
   end
 
-  defp solver_address!(""), do: nil
+  defp present(nil), do: nil
+
+  defp present(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
 
   defp solver_address!(value) do
     case Regex.match?(~r/\A0x[0-9a-fA-F]{40}\z/, value) do

--- a/packages/raxol_earn/lib/raxol/earn/onchain/permit2_approver.ex
+++ b/packages/raxol_earn/lib/raxol/earn/onchain/permit2_approver.ex
@@ -4,16 +4,20 @@ defmodule Raxol.Earn.Onchain.Permit2Approver do
   transaction stack.
 
   A Xochi cross-chain transfer whose origin pull is Permit2 collects the funds
-  through the universal Permit2 contract, which requires a standing ERC-20
-  allowance the origin wallet must grant once per token per chain. This module
-  reads the current allowance and, when it is short, broadcasts a max
-  `approve(Permit2, uint256.max)` so the pull lands.
+  through the universal Permit2 contract, which requires an ERC-20 allowance the
+  origin wallet grants beforehand. This module reads the current allowance and,
+  when it is short, broadcasts an `approve(Permit2, amount)` so the pull lands.
 
   Which transfers take that rail is a property of the quote, not of the token: an
   EOA buyer pulls USDC via ERC-3009 (no allowance), while a smart-account
   (ERC-1271) buyer pulls the same USDC via Permit2. Read the rail from the
   quote's `payment_method` -- `Raxol.Earn.Xochi.OriginPull` does that, and is the
   caller most orders should go through.
+
+  `:amount` defaults to `uint256.max`, the conventional standing Permit2 approval.
+  An agent ordering through `OriginPull` never takes that default: it passes the
+  one intent's authorized pull, so a bad signature cannot reach more of the
+  balance than the run was already spending.
 
   It lives in raxol_earn (not raxol_payments) for the same reason as
   `Raxol.Earn.Relay.OnchainBroadcaster`: this is where the proven EIP-1559 signing
@@ -68,13 +72,6 @@ defmodule Raxol.Earn.Onchain.Permit2Approver do
   @doc "The maximum uint256 value granted by a default approve."
   @spec max_uint256() :: non_neg_integer()
   def max_uint256, do: @max_uint256
-
-  @doc """
-  The default `:min_allowance` threshold. Exposed so a caller that only READS the
-  allowance (a rehearsal) judges it against the same number the funded path does.
-  """
-  @spec allowance_floor() :: non_neg_integer()
-  def allowance_floor, do: @allowance_floor
 
   @doc """
   Build the ERC-20 `approve(Permit2, amount)` call (selector `0x095ea7b3`).

--- a/packages/raxol_earn/lib/raxol/earn/onchain/permit2_approver.ex
+++ b/packages/raxol_earn/lib/raxol/earn/onchain/permit2_approver.ex
@@ -3,11 +3,17 @@ defmodule Raxol.Earn.Onchain.Permit2Approver do
   On-chain ERC-20 Permit2 allowance management, backed by raxol_earn's EVM
   transaction stack.
 
-  A Xochi cross-chain transfer of USDT or WETH pulls the origin funds through
-  the universal Permit2 contract, which requires a standing ERC-20 allowance the
-  origin wallet must grant once per token per chain. (USDC pulls via ERC-3009 and
-  needs no allowance.) This module reads the current allowance and, when it is
-  short, broadcasts a max `approve(Permit2, uint256.max)` so the pull lands.
+  A Xochi cross-chain transfer whose origin pull is Permit2 collects the funds
+  through the universal Permit2 contract, which requires a standing ERC-20
+  allowance the origin wallet must grant once per token per chain. This module
+  reads the current allowance and, when it is short, broadcasts a max
+  `approve(Permit2, uint256.max)` so the pull lands.
+
+  Which transfers take that rail is a property of the quote, not of the token: an
+  EOA buyer pulls USDC via ERC-3009 (no allowance), while a smart-account
+  (ERC-1271) buyer pulls the same USDC via Permit2. Read the rail from the
+  quote's `payment_method` -- `Raxol.Earn.Xochi.OriginPull` does that, and is the
+  caller most orders should go through.
 
   It lives in raxol_earn (not raxol_payments) for the same reason as
   `Raxol.Earn.Relay.OnchainBroadcaster`: this is where the proven EIP-1559 signing
@@ -30,11 +36,17 @@ defmodule Raxol.Earn.Onchain.Permit2Approver do
           Raxol.Earn.ProviderAdapter.get_address(provider)
         )
 
-  The EOA behind `provider` (the JSON-RPC `ProviderAdapter`) must be the origin
-  wallet that signs the Xochi Permit2 authorization, since that is the address
-  Permit2 pulls from. In the storefront model the BUYER signs and holds this
-  allowance (raxol relays the buyer's signed intent and never pulls), so pass the
-  buyer's wallet here -- not the storefront/ACP-provider wallet.
+  `provider` is any `Raxol.Earn.ProviderAdapter`: the allowance is read with
+  `read_contract/3` and granted with `send_calls/3`, both of which every adapter
+  implements. A smart-account provider therefore works and is the primary case --
+  `ProviderAdapter.Privy` grants the approval as a sponsored UserOp from the
+  managed 7702 account, no EOA involved.
+
+  Whatever the provider, its account must be the origin wallet that signs the
+  Xochi Permit2 authorization, since that is the address Permit2 pulls from. In
+  the storefront model the BUYER signs and holds this allowance (raxol relays the
+  buyer's signed intent and never pulls), so pass the buyer's wallet here -- not
+  the storefront/ACP-provider wallet.
   """
 
   alias Raxol.Earn.{ABI, ProviderAdapter}
@@ -56,6 +68,13 @@ defmodule Raxol.Earn.Onchain.Permit2Approver do
   @doc "The maximum uint256 value granted by a default approve."
   @spec max_uint256() :: non_neg_integer()
   def max_uint256, do: @max_uint256
+
+  @doc """
+  The default `:min_allowance` threshold. Exposed so a caller that only READS the
+  allowance (a rehearsal) judges it against the same number the funded path does.
+  """
+  @spec allowance_floor() :: non_neg_integer()
+  def allowance_floor, do: @allowance_floor
 
   @doc """
   Build the ERC-20 `approve(Permit2, amount)` call (selector `0x095ea7b3`).

--- a/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
@@ -18,88 +18,130 @@ defmodule Raxol.Earn.Xochi.OriginPull do
   EOA buyer of the same token pulls through ERC-3009.
 
   Because Permit2 has no on-chain recipient guard, the pinned spender is the only
-  destination control on that rail. `allowance_plan/2` therefore refuses a Permit2
+  destination control on that rail. `allowance_plan/3` therefore refuses a Permit2
   quote unless the operator named the spender they expect AND the quote served
   exactly that spender. Granting an allowance towards an unpinned spender is the
   one thing this module will not do.
+
+  ## The served permit decides nothing on its own
+
+  A quote is served by a remote solver, so every field the allowance depends on is
+  cross-checked against what the OPERATOR asked for before any of it is acted on:
+  the permit's `domain.chainId` and `permitted.token` must be the origin chain and
+  token of the transfer being ordered, and `permitted.amount` must not exceed the
+  origin amount the operator intended. A permit that disagrees is refused rather
+  than approved for, because the allowance is granted on the origin chain for the
+  origin token and would otherwise be sized by the counterparty.
+
+  ## The allowance is bounded, not a standing max
+
+  The conventional Permit2 pattern is one max ERC-20 approve per token, on the
+  reasoning that each `PermitWitnessTransferFrom` signature carries its own
+  spender/amount/deadline and is therefore the real bound. That reasoning assumes
+  a human reviews each signature. Here the signer is an agent's delegated
+  authority signing whatever a quote serves, so a standing max approve would turn
+  any single bad signature into a loss of the whole origin balance.
+
+  So the approve is for exactly this intent's authorized pull, which caps the
+  blast radius at the amount already being ordered. It costs one approve per run,
+  since the pull spends the allowance down to zero. An allowance that is already
+  large enough -- including a standing max granted out of band -- is left alone
+  and sends nothing, so an operator who prefers the conventional pattern is not
+  fought, only never given it by default.
   """
 
   alias Raxol.Earn.Onchain.Permit2Approver
   alias Raxol.Earn.ProviderAdapter
   alias Raxol.Payments.EIP712
 
+  @typedoc "The transfer the operator asked for, which the served permit must match."
+  @type origin :: %{
+          required(:chain_id) => pos_integer(),
+          required(:token) => String.t(),
+          required(:amount) => non_neg_integer() | String.t()
+        }
+
+  @typedoc "A cross-checked Permit2 pull: what to approve, where, and for how much."
+  @type permit :: %{
+          spender: String.t(),
+          chain_id: pos_integer(),
+          token: String.t(),
+          amount: non_neg_integer()
+        }
+
   @typedoc "What the origin pull needs before the intent is signed."
-  @type plan :: :not_needed | {:permit2, String.t()}
+  @type plan :: :not_needed | {:permit2, permit()}
 
   @typedoc "What ensuring the allowance did (or, under `:dry_run`, would do)."
   @type outcome ::
-          :not_needed | :standing | :would_approve | {:approved, String.t()}
+          :not_needed
+          | :standing
+          | {:would_approve, non_neg_integer()}
+          | {:approved, non_neg_integer(), String.t()}
 
   @doc """
-  Decide what allowance a served quote needs, given the operator's pinned spender.
+  Decide what allowance a served quote needs, given the operator's pinned spender
+  and the origin leg they intended.
 
   `{:ok, :not_needed}` for a non-pulling quote and for the ERC-3009 rail;
-  `{:ok, {:permit2, spender}}` when the quote's Permit2 spender matches the pin.
-  Fails closed otherwise -- an unpinned or mismatched spender never becomes an
-  allowance.
+  `{:ok, {:permit2, permit}}` when the quote's Permit2 spender matches the pin and
+  its chain, token and amount match `origin`. Fails closed otherwise -- an
+  unpinned, mismatched or oversized permit never becomes an allowance.
   """
-  @spec allowance_plan(map(), String.t() | nil) :: {:ok, plan()} | {:error, term()}
-  def allowance_plan(quote_resp, pinned_spender)
+  @spec allowance_plan(map(), String.t() | nil, origin()) :: {:ok, plan()} | {:error, term()}
+  def allowance_plan(quote_resp, pinned_spender, origin)
 
-  def allowance_plan(%{pull_authorization: nil}, _pinned), do: {:ok, :not_needed}
+  def allowance_plan(%{pull_authorization: nil}, _pinned, _origin), do: {:ok, :not_needed}
 
-  def allowance_plan(%{pull_authorization: pull, payment_method: "permit2"}, pinned),
-    do: permit2_plan(served_spender(pull), pinned)
+  def allowance_plan(%{pull_authorization: pull, payment_method: "permit2"}, pinned, origin),
+    do: permit2_plan(pull, pinned, origin)
 
-  def allowance_plan(%{payment_method: "erc3009"}, _pinned), do: {:ok, :not_needed}
+  def allowance_plan(%{payment_method: "erc3009"}, _pinned, _origin), do: {:ok, :not_needed}
 
-  def allowance_plan(%{payment_method: other}, _pinned),
+  def allowance_plan(%{payment_method: other}, _pinned, _origin),
     do: {:error, {:unsupported_pull_method, other}}
 
   @doc """
   Ensure the buyer holds the allowance `plan` calls for.
 
-  Idempotent: a standing allowance answers `{:ok, :standing}` and sends nothing.
-  With `dry_run: true` the allowance is only READ, so a rehearsal reports
-  `:would_approve` instead of broadcasting one. Remaining options are passed to
-  `Raxol.Earn.Onchain.Permit2Approver.ensure_allowance/5`.
+  The plan carries the chain, token and amount that were cross-checked against the
+  operator's intent, so this cannot act on a different leg than the one that was
+  decided. Idempotent: an allowance that already covers the pull answers
+  `{:ok, :standing}` and sends nothing. With `dry_run: true` the allowance is only
+  READ, so a rehearsal reports `{:would_approve, amount}` instead of broadcasting
+  one.
   """
-  @spec ensure_allowance(
-          plan(),
-          ProviderAdapter.adapter(),
-          pos_integer(),
-          String.t(),
-          String.t(),
-          keyword()
-        ) :: {:ok, outcome()} | {:error, term()}
-  def ensure_allowance(plan, provider, chain_id, token, owner, opts \\ [])
+  @spec ensure_allowance(plan(), ProviderAdapter.adapter(), String.t(), keyword()) ::
+          {:ok, outcome()} | {:error, term()}
+  def ensure_allowance(plan, provider, owner, opts \\ [])
 
-  def ensure_allowance(:not_needed, _provider, _chain_id, _token, _owner, _opts),
-    do: {:ok, :not_needed}
+  def ensure_allowance(:not_needed, _provider, _owner, _opts), do: {:ok, :not_needed}
 
-  def ensure_allowance({:permit2, _spender}, provider, chain_id, token, owner, opts) do
-    {dry_run?, approve_opts} = Keyword.pop(opts, :dry_run, false)
-    ensure(dry_run?, provider, chain_id, token, owner, approve_opts)
-  end
+  def ensure_allowance({:permit2, permit}, provider, owner, opts),
+    do: ensure(Keyword.get(opts, :dry_run, false), provider, permit, owner)
 
-  @doc "One log line describing what `ensure_allowance/6` did."
+  @doc "One log line describing what `ensure_allowance/4` did."
   @spec describe(outcome()) :: String.t()
   def describe(:not_needed),
     do: "origin pull: not a Permit2 pull -- no allowance to grant"
 
   def describe(:standing),
-    do: "origin pull: Permit2 allowance already standing -- no approve sent"
-
-  def describe(:would_approve),
     do:
-      "origin pull: Permit2 allowance is SHORT -- a funded run would send one " <>
-        "approve(Permit2) UserOp before signing"
+      "origin pull: the standing Permit2 allowance already covers this intent's pull " <>
+        "-- no approve sent"
 
-  def describe({:approved, hash}),
-    do: "origin pull: granted the Permit2 allowance, approve tx #{hash}"
+  def describe({:would_approve, amount}),
+    do:
+      "origin pull: Permit2 allowance is SHORT -- a funded run would approve exactly " <>
+        "#{amount} base units (this intent's authorized pull) before signing"
+
+  def describe({:approved, amount, hash}),
+    do:
+      "origin pull: approved exactly #{amount} base units for Permit2 " <>
+        "(this intent's authorized pull), approve tx #{hash}"
 
   @doc """
-  Operator-facing explanation of an `allowance_plan/2` refusal.
+  Operator-facing explanation of an `allowance_plan/3` refusal.
 
   Every message names the input the operator has to supply and where to confirm
   it, because a fail-closed run is only useful if it says what would unblock it.
@@ -128,6 +170,40 @@ defmodule Raxol.Earn.Xochi.OriginPull do
     pull contract -- confirm the new address against Riddler's XochiPull deployment
     record and re-run with `--solver #{served}` -- or this quote is not the one you
     meant to sign.
+    """
+  end
+
+  def explain({:pull_chain_mismatch, served, intended}) do
+    """
+    this quote's Permit2 permit is for chain #{inspect(served)}, but the transfer
+    being ordered leaves chain #{intended}.
+
+    Nothing was signed and no allowance was granted. The allowance is granted on
+    the origin chain, so a permit naming a different one either belongs to another
+    corridor or is not the quote you asked for. Check --corridor.
+    """
+  end
+
+  def explain({:pull_token_mismatch, served, intended}) do
+    """
+    this quote's Permit2 permit pulls #{inspect(served)}, but the transfer being
+    ordered sends #{intended}.
+
+    Nothing was signed and no allowance was granted. The allowance is granted for
+    the origin token, so approving for a token the operator never named would let
+    the pull reach a balance this run was not about.
+    """
+  end
+
+  def explain({:pull_amount_unbounded, served, intended}) do
+    """
+    this quote's Permit2 permit authorizes #{inspect(served)} base units, more than
+    the #{intended} being ordered.
+
+    Nothing was signed and no allowance was granted. The approve is sized by the
+    permit, so a permit larger than the intended origin amount would widen the
+    allowance past what this run is worth. Re-quote, or raise --amount if the
+    larger figure is really what you meant to send.
     """
   end
 
@@ -172,23 +248,81 @@ defmodule Raxol.Earn.Xochi.OriginPull do
 
   # -- Internal --
 
-  defp permit2_plan(_served, pinned) when pinned in [nil, ""],
+  defp permit2_plan(_pull, pinned, _origin) when pinned in [nil, ""],
     do: {:error, :unpinned_permit2_spender}
 
-  defp permit2_plan(served, pinned) do
+  defp permit2_plan(pull, pinned, origin) do
+    message = section(pull, "message")
+    permitted = section(message, "permitted")
+
+    with {:ok, spender} <- match_spender(message["spender"], pinned),
+         :ok <- match_chain(section(pull, "domain")["chainId"], origin.chain_id),
+         :ok <- match_token(permitted["token"], origin.token),
+         {:ok, amount} <- bounded_amount(permitted["amount"], origin.amount) do
+      {:ok,
+       {:permit2,
+        %{
+          spender: spender,
+          chain_id: origin.chain_id,
+          token: origin.token,
+          amount: amount
+        }}}
+    end
+  end
+
+  defp match_spender(served, pinned) do
     with {:ok, served_addr} <- address(served, :served),
          {:ok, pinned_addr} <- address(pinned, :pinned) do
       compare(served_addr, pinned_addr, served)
     end
   end
 
-  defp compare(addr, addr, served), do: {:ok, {:permit2, served}}
+  defp compare(addr, addr, served), do: {:ok, served}
 
   defp compare(served_addr, pinned_addr, _served),
     do: {:error, {:pull_spender_mismatch, "0x" <> served_addr, "0x" <> pinned_addr}}
 
-  defp served_spender(pull) when is_map(pull), do: get_in(pull, ["message", "spender"])
-  defp served_spender(_pull), do: nil
+  # The permit is signed for one chain and one token; the allowance is granted on
+  # the operator's origin leg. If those differ, the approve is for a leg nobody
+  # asked about.
+  defp match_chain(served, intended) do
+    case to_uint(served) do
+      ^intended -> :ok
+      _ -> {:error, {:pull_chain_mismatch, served, intended}}
+    end
+  end
+
+  defp match_token(served, intended) do
+    case addr_match?(served, intended) do
+      true -> :ok
+      false -> {:error, {:pull_token_mismatch, served, intended}}
+    end
+  end
+
+  # The approve is sized by the permit, so the permit must not be bigger than the
+  # transfer it belongs to. Same bound the payments-side `validate_permit2_pull/2`
+  # applies to the signature, applied here BEFORE the allowance rather than after.
+  defp bounded_amount(served, intended) do
+    case {to_uint(served), to_uint(intended)} do
+      {value, limit} when is_integer(value) and is_integer(limit) and value <= limit ->
+        {:ok, value}
+
+      _ ->
+        {:error, {:pull_amount_unbounded, served, intended}}
+    end
+  end
+
+  # The served envelope is remote JSON: any level of it may be absent or the wrong
+  # shape, and a malformed one must reach this module's own refusal rather than
+  # raise out of an Access call.
+  defp section(map, key) when is_map(map) do
+    case Map.get(map, key) do
+      nested when is_map(nested) -> nested
+      _ -> %{}
+    end
+  end
+
+  defp section(_map, _key), do: %{}
 
   # A canonical 20-byte hex address, matching what the payments-side pin compares.
   @address ~r/\A[0-9a-f]{40}\z/
@@ -204,26 +338,46 @@ defmodule Raxol.Earn.Xochi.OriginPull do
 
   defp address(value, role), do: {:error, {:invalid_spender, role, value}}
 
+  defp addr_match?(a, b) when is_binary(a) and is_binary(b) do
+    normalized = EIP712.normalize_address(a)
+    Regex.match?(@address, normalized) and normalized == EIP712.normalize_address(b)
+  end
+
+  defp addr_match?(_a, _b), do: false
+
+  defp to_uint(value) when is_integer(value) and value >= 0, do: value
+
+  defp to_uint(value) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {n, ""} when n >= 0 -> n
+      _ -> nil
+    end
+  end
+
+  defp to_uint(_value), do: nil
+
   # A rehearsal reads the allowance and answers with the same threshold the
   # funded path applies, so `--dry-run` cannot promise a different run.
-  defp ensure(true, provider, chain_id, token, owner, opts) do
-    min_required = Keyword.get(opts, :min_allowance, Permit2Approver.allowance_floor())
-
-    with {:ok, current} <- Permit2Approver.allowance(provider, chain_id, token, owner) do
-      {:ok, rehearsed(current >= min_required)}
+  defp ensure(true, provider, permit, owner) do
+    with {:ok, current} <-
+           Permit2Approver.allowance(provider, permit.chain_id, permit.token, owner) do
+      {:ok, rehearsed(current >= permit.amount, permit.amount)}
     end
   end
 
-  defp ensure(false, provider, chain_id, token, owner, opts) do
+  defp ensure(false, provider, permit, owner) do
     with {:ok, result} <-
-           Permit2Approver.ensure_allowance(provider, chain_id, token, owner, opts) do
-      {:ok, granted(result)}
+           Permit2Approver.ensure_allowance(provider, permit.chain_id, permit.token, owner,
+             min_allowance: permit.amount,
+             amount: permit.amount
+           ) do
+      {:ok, granted(result, permit.amount)}
     end
   end
 
-  defp rehearsed(true), do: :standing
-  defp rehearsed(false), do: :would_approve
+  defp rehearsed(true, _amount), do: :standing
+  defp rehearsed(false, amount), do: {:would_approve, amount}
 
-  defp granted(:sufficient), do: :standing
-  defp granted({:approved, hash}), do: {:approved, hash}
+  defp granted(:sufficient, _amount), do: :standing
+  defp granted({:approved, hash}, amount), do: {:approved, amount, hash}
 end

--- a/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
@@ -1,0 +1,229 @@
+defmodule Raxol.Earn.Xochi.OriginPull do
+  @moduledoc """
+  Decide, and grant, the origin-pull allowance a Xochi quote needs before the
+  buyer signs it.
+
+  Every pulling quote serves a `pull_authorization` the buyer signs so the solver
+  can collect the origin funds. Two rails, with different on-chain guarantees:
+
+    * `erc3009` -- the signed authorization names the recipient and the token
+      enforces `msg.sender == to`, so the chain bounds the destination. No
+      standing allowance exists to grant.
+    * `permit2` -- the buyer must already hold a standing ERC-20 allowance for
+      the universal Permit2 contract, and the `spender` named in the permit
+      chooses the recipient at call time. There is NO on-chain recipient guard.
+
+  The rail is read from the quote's `payment_method`, never guessed from the
+  token: a smart-account (ERC-1271) buyer pulls USDC through Permit2, where an
+  EOA buyer of the same token pulls through ERC-3009.
+
+  Because Permit2 has no on-chain recipient guard, the pinned spender is the only
+  destination control on that rail. `allowance_plan/2` therefore refuses a Permit2
+  quote unless the operator named the spender they expect AND the quote served
+  exactly that spender. Granting an allowance towards an unpinned spender is the
+  one thing this module will not do.
+  """
+
+  alias Raxol.Earn.Onchain.Permit2Approver
+  alias Raxol.Earn.ProviderAdapter
+  alias Raxol.Payments.EIP712
+
+  @typedoc "What the origin pull needs before the intent is signed."
+  @type plan :: :not_needed | {:permit2, String.t()}
+
+  @typedoc "What ensuring the allowance did (or, under `:dry_run`, would do)."
+  @type outcome ::
+          :not_needed | :standing | :would_approve | {:approved, String.t()}
+
+  @doc """
+  Decide what allowance a served quote needs, given the operator's pinned spender.
+
+  `{:ok, :not_needed}` for a non-pulling quote and for the ERC-3009 rail;
+  `{:ok, {:permit2, spender}}` when the quote's Permit2 spender matches the pin.
+  Fails closed otherwise -- an unpinned or mismatched spender never becomes an
+  allowance.
+  """
+  @spec allowance_plan(map(), String.t() | nil) :: {:ok, plan()} | {:error, term()}
+  def allowance_plan(quote_resp, pinned_spender)
+
+  def allowance_plan(%{pull_authorization: nil}, _pinned), do: {:ok, :not_needed}
+
+  def allowance_plan(%{pull_authorization: pull, payment_method: "permit2"}, pinned),
+    do: permit2_plan(served_spender(pull), pinned)
+
+  def allowance_plan(%{payment_method: "erc3009"}, _pinned), do: {:ok, :not_needed}
+
+  def allowance_plan(%{payment_method: other}, _pinned),
+    do: {:error, {:unsupported_pull_method, other}}
+
+  @doc """
+  Ensure the buyer holds the allowance `plan` calls for.
+
+  Idempotent: a standing allowance answers `{:ok, :standing}` and sends nothing.
+  With `dry_run: true` the allowance is only READ, so a rehearsal reports
+  `:would_approve` instead of broadcasting one. Remaining options are passed to
+  `Raxol.Earn.Onchain.Permit2Approver.ensure_allowance/5`.
+  """
+  @spec ensure_allowance(
+          plan(),
+          ProviderAdapter.adapter(),
+          pos_integer(),
+          String.t(),
+          String.t(),
+          keyword()
+        ) :: {:ok, outcome()} | {:error, term()}
+  def ensure_allowance(plan, provider, chain_id, token, owner, opts \\ [])
+
+  def ensure_allowance(:not_needed, _provider, _chain_id, _token, _owner, _opts),
+    do: {:ok, :not_needed}
+
+  def ensure_allowance({:permit2, _spender}, provider, chain_id, token, owner, opts) do
+    {dry_run?, approve_opts} = Keyword.pop(opts, :dry_run, false)
+    ensure(dry_run?, provider, chain_id, token, owner, approve_opts)
+  end
+
+  @doc "One log line describing what `ensure_allowance/6` did."
+  @spec describe(outcome()) :: String.t()
+  def describe(:not_needed),
+    do: "origin pull: ERC-3009 rail -- no Permit2 allowance to grant"
+
+  def describe(:standing),
+    do: "origin pull: Permit2 allowance already standing -- no approve sent"
+
+  def describe(:would_approve),
+    do:
+      "origin pull: Permit2 allowance is SHORT -- a funded run would send one " <>
+        "approve(Permit2) UserOp before signing"
+
+  def describe({:approved, hash}),
+    do: "origin pull: granted the Permit2 allowance, approve tx #{hash}"
+
+  @doc """
+  Operator-facing explanation of an `allowance_plan/2` refusal.
+
+  Every message names the input the operator has to supply and where to confirm
+  it, because a fail-closed run is only useful if it says what would unblock it.
+  """
+  @spec explain(term()) :: String.t()
+  def explain(:unpinned_permit2_spender) do
+    """
+    this quote's origin pull is Permit2, and no spender is pinned.
+
+    Permit2 has no on-chain recipient guard: the spender chooses where the pulled
+    funds go at call time, so the pinned spender is the ONLY destination control
+    on this rail. Name the spender you expect and re-run:
+
+      mix raxol_earn.order --solver 0x<spender> ...     (or ORDER_SOLVER=0x<spender>)
+
+    Take that address from Riddler's XochiPull deployment record, not from a quote
+    -- a served spender is exactly the value the pin exists to check.
+    """
+  end
+
+  def explain({:pull_spender_mismatch, served, pinned}) do
+    """
+    this quote's Permit2 spender is #{served}, but the pinned spender is #{pinned}.
+
+    Nothing was signed and no allowance was granted. Either the solver rotated its
+    pull contract -- confirm the new address against Riddler's XochiPull deployment
+    record and re-run with `--solver #{served}` -- or this quote is not the one you
+    meant to sign.
+    """
+  end
+
+  def explain({:invalid_spender, :pinned, value}) do
+    """
+    the pinned spender #{inspect(value)} is not a 20-byte 0x-hex address.
+
+    Pass the solver's Permit2 spender as `--solver 0x<40 hex chars>` (or
+    ORDER_SOLVER), taken from Riddler's XochiPull deployment record.
+    """
+  end
+
+  def explain({:invalid_spender, :served, value}) do
+    """
+    this quote's Permit2 authorization carries no usable spender (#{inspect(value)}).
+
+    Nothing was signed. A Permit2 permit with no spender cannot be checked against
+    the pin, so it is refused rather than signed blind.
+    """
+  end
+
+  def explain({:unsupported_pull_method, method}) do
+    """
+    this quote serves an origin pull on the unsupported rail #{inspect(method)}.
+
+    Only `erc3009` and `permit2` pulls are understood here, and an unknown rail's
+    destination controls are unknown too, so it is refused rather than signed.
+    """
+  end
+
+  # Reading the allowance, or granting it, can fail for reasons that belong to the
+  # chain rather than to this decision. Report those verbatim: a reason with no
+  # tailored message must still reach the operator.
+  def explain(reason) do
+    """
+    the origin-pull allowance could not be settled: #{inspect(reason)}
+
+    Nothing was signed. This is the allowance read or the approve itself failing,
+    so check the origin chain's RPC and whether the buyer can send a UserOp there.
+    """
+  end
+
+  # -- Internal --
+
+  defp permit2_plan(_served, pinned) when pinned in [nil, ""],
+    do: {:error, :unpinned_permit2_spender}
+
+  defp permit2_plan(served, pinned) do
+    with {:ok, served_addr} <- address(served, :served),
+         {:ok, pinned_addr} <- address(pinned, :pinned) do
+      compare(served_addr, pinned_addr, served)
+    end
+  end
+
+  defp compare(addr, addr, served), do: {:ok, {:permit2, served}}
+
+  defp compare(served_addr, pinned_addr, _served),
+    do: {:error, {:pull_spender_mismatch, "0x" <> served_addr, "0x" <> pinned_addr}}
+
+  defp served_spender(pull) when is_map(pull), do: get_in(pull, ["message", "spender"])
+  defp served_spender(_pull), do: nil
+
+  # A canonical 20-byte hex address, matching what the payments-side pin compares.
+  @address ~r/\A[0-9a-f]{40}\z/
+
+  defp address(value, role) when is_binary(value) do
+    normalized = EIP712.normalize_address(value)
+
+    case Regex.match?(@address, normalized) do
+      true -> {:ok, normalized}
+      false -> {:error, {:invalid_spender, role, value}}
+    end
+  end
+
+  defp address(value, role), do: {:error, {:invalid_spender, role, value}}
+
+  # A rehearsal reads the allowance and answers with the same threshold the
+  # funded path applies, so `--dry-run` cannot promise a different run.
+  defp ensure(true, provider, chain_id, token, owner, opts) do
+    min_required = Keyword.get(opts, :min_allowance, Permit2Approver.allowance_floor())
+
+    with {:ok, current} <- Permit2Approver.allowance(provider, chain_id, token, owner) do
+      {:ok, rehearsed(current >= min_required)}
+    end
+  end
+
+  defp ensure(false, provider, chain_id, token, owner, opts) do
+    with {:ok, result} <-
+           Permit2Approver.ensure_allowance(provider, chain_id, token, owner, opts) do
+      {:ok, granted(result)}
+    end
+  end
+
+  defp rehearsed(true), do: :standing
+  defp rehearsed(false), do: :would_approve
+
+  defp granted(:sufficient), do: :standing
+  defp granted({:approved, hash}), do: {:approved, hash}
+end

--- a/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
@@ -23,6 +23,24 @@ defmodule Raxol.Earn.Xochi.OriginPull do
   exactly that spender. Granting an allowance towards an unpinned spender is the
   one thing this module will not do.
 
+  ## That refusal binds this module's callers, and no one else
+
+  Read the sentence above as scoped, because the signing layer underneath applies
+  a WEAKER rule. `Raxol.Payments.Protocols.Xochi`'s `validate_permit2_pull/2` asks
+  only that the spender be in `:pull_solver_allowlist`, and both `config/runtime.exs`
+  and the live solver-fee gate populate that list from
+  `Raxol.Payments.Xochi.PullContracts.pull_recipients/0` -- the checked-in mirror,
+  which contains the Permit2 pull proxy. So `XochiProtocol.quote_and_sign/3`
+  called directly WILL sign a Permit2 pull naming that proxy with no operator
+  input at all.
+
+  That is deliberate at this stage and not something this module can close from
+  here: a mirror of a deployment record is a reasonable default for a server that
+  has no operator at the keyboard, and tightening it would stop existing
+  deployments settling. What it means for anyone adding a new caller is that the
+  operator pin arrives with THIS module and not with the signature. Route through
+  `allowance_plan/3` before signing, or the pin is simply absent.
+
   ## The served permit decides nothing on its own
 
   A quote is served by a remote solver, so every field the allowance depends on is

--- a/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
@@ -238,14 +238,21 @@ defmodule Raxol.Earn.Xochi.OriginPull do
     """
   end
 
+  # The served address is NAMED but never formatted as the fix. Printing
+  # `--solver <served>` here would hand back a ready-to-run command that grants a
+  # real allowance towards whatever the counterparty asked for, one paste after
+  # being told the pin exists to check exactly that value.
   def explain({:pull_spender_mismatch, served, pinned}) do
     """
     this quote's Permit2 spender is #{served}, but the pinned spender is #{pinned}.
 
-    Nothing was signed and no allowance was granted. Either the solver rotated its
-    pull contract -- confirm the new address against Riddler's XochiPull deployment
-    record and re-run with `--solver #{served}` -- or this quote is not the one you
-    meant to sign.
+    Nothing was signed and no allowance was granted.
+
+    Do NOT re-run with the served address because it appears above -- checking it
+    is the entire point of the pin. Either this quote is not the one you meant to
+    sign, or the solver rotated its pull contract. Only the second is a reason to
+    change the pin, and only after the new address matches Riddler's XochiPull
+    deployment record. Take the value from that record, not from this message.
     """
   end
 

--- a/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
@@ -48,6 +48,27 @@ defmodule Raxol.Earn.Xochi.OriginPull do
   large enough -- including a standing max granted out of band -- is left alone
   and sends nothing, so an operator who prefers the conventional pattern is not
   fought, only never given it by default.
+
+  ## The decision is early; the effect need not be
+
+  Refusing happens before the signature -- an allowance towards an unverified
+  spender is what this exists to prevent, so `allowance_plan/3` runs while there
+  is still nothing signed to regret. The GRANT is a separate question, because
+  the allowance is not needed until the solver pulls, which is at settlement.
+
+  Two effect shapes, for two kinds of caller:
+
+    * `ensure_allowance/4` broadcasts the approve on its own. Right for a buyer
+      that can simply send a transaction.
+    * `allowance_status/3` + `approve_calls/1` hand the approve back as calls to
+      batch into a write the caller was already making. Right for a sponsored
+      ERC-4337 buyer, whose paymaster refuses a standalone approve to a token
+      contract -- and better besides, since batching lands the allowance in the
+      same transaction rather than an earlier one that could be the only leg to
+      land.
+
+  Both are bounded by the same plan and both send nothing when the allowance
+  already covers the pull.
   """
 
   alias Raxol.Earn.Onchain.Permit2Approver
@@ -71,6 +92,9 @@ defmodule Raxol.Earn.Xochi.OriginPull do
 
   @typedoc "What the origin pull needs before the intent is signed."
   @type plan :: :not_needed | {:permit2, permit()}
+
+  @typedoc "What the pull still needs, read against the buyer's current allowance."
+  @type status :: :not_needed | :standing | {:short, permit()}
 
   @typedoc "What ensuring the allowance did (or, under `:dry_run`, would do)."
   @type outcome ::
@@ -102,7 +126,47 @@ defmodule Raxol.Earn.Xochi.OriginPull do
     do: {:error, {:unsupported_pull_method, other}}
 
   @doc """
-  Ensure the buyer holds the allowance `plan` calls for.
+  Read the buyer's current allowance and say what the pull still needs.
+
+  Never writes. The counterpart to `ensure_allowance/4` for a caller that grants
+  the allowance inside a write of its own: it decides whether an approve is
+  needed and at what bound, and `approve_calls/1` turns that into the calls to
+  batch. A read that fails is returned as an error rather than assumed short,
+  because approving on a guess is the one thing this module will not do.
+  """
+  @spec allowance_status(plan(), ProviderAdapter.adapter(), String.t()) ::
+          {:ok, status()} | {:error, term()}
+  def allowance_status(plan, provider, owner)
+
+  def allowance_status(:not_needed, _provider, _owner), do: {:ok, :not_needed}
+
+  def allowance_status({:permit2, permit}, provider, owner) do
+    with {:ok, current} <-
+           Permit2Approver.allowance(provider, permit.chain_id, permit.token, owner) do
+      {:ok, covered(current >= permit.amount, permit)}
+    end
+  end
+
+  defp covered(true, _permit), do: :standing
+  defp covered(false, permit), do: {:short, permit}
+
+  @doc """
+  The `approve` calls that close a `{:short, _}` status, for the caller to batch
+  into its own write. Empty for every other status, so an allowance that already
+  covers the pull still sends nothing.
+
+  The amount is the permit's, which `allowance_plan/3` already bounded to the
+  transfer the operator asked for -- batching moves WHERE the approve lands,
+  never how much it grants.
+  """
+  @spec approve_calls(status()) :: [ProviderAdapter.call()]
+  def approve_calls({:short, permit}),
+    do: [Permit2Approver.approve_call(permit.token, permit.amount)]
+
+  def approve_calls(status) when status in [:not_needed, :standing], do: []
+
+  @doc """
+  Ensure the buyer holds the allowance `plan` calls for, in a write of its own.
 
   The plan carries the chain, token and amount that were cross-checked against the
   operator's intent, so this cannot act on a different leg than the one that was
@@ -110,6 +174,11 @@ defmodule Raxol.Earn.Xochi.OriginPull do
   `{:ok, :standing}` and sends nothing. With `dry_run: true` the allowance is only
   READ, so a rehearsal reports `{:would_approve, amount}` instead of broadcasting
   one.
+
+  Use this only where a lone approve is broadcastable. A sponsored ERC-4337 buyer
+  should batch instead (`allowance_status/3` + `approve_calls/1`): the Virtuals
+  paymaster refuses a standalone approve to a token contract, so on that path the
+  approve has to ride in a UserOp that also carries a call the paymaster accepts.
   """
   @spec ensure_allowance(plan(), ProviderAdapter.adapter(), String.t(), keyword()) ::
           {:ok, outcome()} | {:error, term()}
@@ -120,8 +189,8 @@ defmodule Raxol.Earn.Xochi.OriginPull do
   def ensure_allowance({:permit2, permit}, provider, owner, opts),
     do: ensure(Keyword.get(opts, :dry_run, false), provider, permit, owner)
 
-  @doc "One log line describing what `ensure_allowance/4` did."
-  @spec describe(outcome()) :: String.t()
+  @doc "One log line describing an `allowance_status/3` or an `ensure_allowance/4` result."
+  @spec describe(status() | outcome()) :: String.t()
   def describe(:not_needed),
     do: "origin pull: not a Permit2 pull -- no allowance to grant"
 
@@ -129,6 +198,13 @@ defmodule Raxol.Earn.Xochi.OriginPull do
     do:
       "origin pull: the standing Permit2 allowance already covers this intent's pull " <>
         "-- no approve sent"
+
+  # Where the approve then lands is the caller's, since only it knows whether it
+  # has a write to batch into.
+  def describe({:short, permit}),
+    do:
+      "origin pull: Permit2 allowance is SHORT -- an approve for exactly #{permit.amount} " <>
+        "base units (this intent's authorized pull) is needed before the solver can pull"
 
   def describe({:would_approve, amount}),
     do:
@@ -356,12 +432,11 @@ defmodule Raxol.Earn.Xochi.OriginPull do
 
   defp to_uint(_value), do: nil
 
-  # A rehearsal reads the allowance and answers with the same threshold the
-  # funded path applies, so `--dry-run` cannot promise a different run.
+  # A rehearsal goes through the same read the batching path does, so there is one
+  # threshold and `--dry-run` cannot promise a different run.
   defp ensure(true, provider, permit, owner) do
-    with {:ok, current} <-
-           Permit2Approver.allowance(provider, permit.chain_id, permit.token, owner) do
-      {:ok, rehearsed(current >= permit.amount, permit.amount)}
+    with {:ok, status} <- allowance_status({:permit2, permit}, provider, owner) do
+      {:ok, rehearsed(status)}
     end
   end
 
@@ -375,8 +450,8 @@ defmodule Raxol.Earn.Xochi.OriginPull do
     end
   end
 
-  defp rehearsed(true, _amount), do: :standing
-  defp rehearsed(false, amount), do: {:would_approve, amount}
+  defp rehearsed(:standing), do: :standing
+  defp rehearsed({:short, permit}), do: {:would_approve, permit.amount}
 
   defp granted(:sufficient, _amount), do: :standing
   defp granted({:approved, hash}, amount), do: {:approved, amount, hash}

--- a/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/origin_pull.ex
@@ -85,7 +85,7 @@ defmodule Raxol.Earn.Xochi.OriginPull do
   @doc "One log line describing what `ensure_allowance/6` did."
   @spec describe(outcome()) :: String.t()
   def describe(:not_needed),
-    do: "origin pull: ERC-3009 rail -- no Permit2 allowance to grant"
+    do: "origin pull: not a Permit2 pull -- no allowance to grant"
 
   def describe(:standing),
     do: "origin pull: Permit2 allowance already standing -- no approve sent"

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -3,8 +3,10 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
   use ExUnit.Case, async: false
 
   alias Mix.Tasks.RaxolEarn.Order
+  alias Raxol.Earn.ProviderAdapter.Mock
 
   @spender "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+  @allowance_sig "allowance(address,address)"
 
   setup do
     shell = Mix.shell()
@@ -49,6 +51,64 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
 
   defp approve_args(%{data: <<_sel::binary-size(4), spender::binary-size(32), amount::256>>}),
     do: {"0x" <> Base.encode16(binary_part(spender, 12, 20), case: :lower), amount}
+
+  defp word(value), do: "0x" <> String.pad_leading(Integer.to_string(value, 16), 64, "0")
+
+  # A cfg carrying a provider, for the reads the funding leg makes on its own.
+  defp funding_cfg(adapter), do: Map.put(cfg(), :provider_adapter, adapter)
+
+  defp with_allowance(value) do
+    adapter = Mock.new()
+    :ok = Mock.set_contract_read(adapter, cfg().src_token, @allowance_sig, word(value))
+    funding_cfg(adapter)
+  end
+
+  # The gap between signing and funding is minutes of real time: createJob has to
+  # mine, the chat room has to appear, and the provider has to write a budget. An
+  # allowance covering the pull at signing can be spent down inside that window --
+  # an earlier intent's own pull consumes it -- so a batch built from the signing
+  # read would escrow the fee and leave THIS intent's pull short. Fee paid,
+  # transfer impossible.
+  describe "the allowance behind the funding batch" do
+    test "is read at funding time, not carried over from signing" do
+      # Signing saw a covering allowance; by now it is spent down to zero.
+      assert {:short, %{amount: 3_000_000}} =
+               Order.fund_time_allowance(with_allowance(0), {:permit2, permit()})
+    end
+
+    test "an allowance that still covers the pull adds nothing to the batch" do
+      assert :standing =
+               Order.fund_time_allowance(with_allowance(3_000_000), {:permit2, permit()})
+    end
+
+    test "a rail needing no allowance reads nothing and stays not_needed" do
+      adapter = Mock.new()
+
+      assert :not_needed = Order.fund_time_allowance(funding_cfg(adapter), :not_needed)
+      assert Mock.sent_calls(adapter) == []
+    end
+
+    test "the fresh reading is what decides the batch, so a spent-down one restores the approve" do
+      pull = Order.fund_time_allowance(with_allowance(0), {:permit2, permit()})
+
+      assert [permit2_approve, _core_approve, _fund] = calls(pull)
+      assert approve_args(permit2_approve) == {String.downcase(@permit2), 3_000_000}
+    end
+
+    # Funding without the approve is the outcome being avoided, so an unreadable
+    # allowance must not be treated as one that covers the pull.
+    test "a failed read at funding time aborts rather than funding short" do
+      adapter = Mock.new()
+
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn ->
+          Order.fund_time_allowance(funding_cfg(adapter), {:permit2, permit()})
+        end)
+
+      assert message =~ "origin-pull allowance could not be settled"
+      assert Mock.sent_calls(adapter) == []
+    end
+  end
 
   describe "--corridor validation" do
     test "an unsupported destination lists only the chains USDC actually exists on" do

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -31,6 +31,25 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
   # under test.
   defp gate(budget, argv), do: Order.enforce_budget!(cfg(), budget, Order.parse_argv(argv))
 
+  # The universal Permit2 contract -- the ERC-20 spender an origin-pull approve
+  # names. The permit's own spender is what the --solver pin bounds; the two are
+  # different addresses and confusing them is the failure this pins against.
+  @permit2 "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+
+  defp permit(amount \\ 3_000_000),
+    do: %{spender: @spender, chain_id: 8453, token: cfg().src_token, amount: amount}
+
+  defp calls(pull), do: Order.funding_calls(cfg(), 73_295, 2_400, pull)
+
+  defp selector(%{data: <<sel::binary-size(4), _rest::binary>>}),
+    do: Base.encode16(sel, case: :lower)
+
+  defp selector_of(signature),
+    do: Base.encode16(binary_part(ExKeccak.hash_256(signature), 0, 4), case: :lower)
+
+  defp approve_args(%{data: <<_sel::binary-size(4), spender::binary-size(32), amount::256>>}),
+    do: {"0x" <> Base.encode16(binary_part(spender, 12, 20), case: :lower), amount}
+
   describe "--corridor validation" do
     test "an unsupported destination lists only the chains USDC actually exists on" do
       %Mix.Error{message: message} =
@@ -106,6 +125,80 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
 
   defp restore_env(name, nil), do: System.delete_env(name)
   defp restore_env(name, value), do: System.put_env(name, value)
+
+  # The Virtuals paymaster refuses a STANDALONE approve to a token contract, so
+  # the Permit2 approve cannot be its own UserOp on the sponsored path this task
+  # defaults to. It rides in the approve+fund batch instead, which the paymaster
+  # already accepts -- and which lands the allowance in the very transaction that
+  # funds the job, so it exists at the first block the seller can observe
+  # `funded` and settle (the settlement is when the solver pulls).
+  describe "the funding batch" do
+    test "a short allowance rides in the batch rather than a standalone approve" do
+      assert [permit2_approve, core_approve, fund] = calls({:short, permit()})
+
+      assert selector(permit2_approve) == selector_of("approve(address,uint256)")
+      assert permit2_approve.to == cfg().src_token
+      assert approve_args(permit2_approve) == {String.downcase(@permit2), 3_000_000}
+
+      # The ACP-core call is what makes the paymaster accept the UserOp, so the
+      # batch the approve rides in must still carry it.
+      assert core_approve.to == cfg().src_token
+      assert approve_args(core_approve) == {String.downcase(cfg().core), 2_400}
+      assert fund.to == cfg().core
+      assert selector(fund) == selector_of("fund(uint256,uint256,bytes)")
+    end
+
+    test "the batched approve grants the permit's bound, never a standing max" do
+      assert [permit2_approve | _] = calls({:short, permit(1_500_000)})
+      assert {_spender, 1_500_000} = approve_args(permit2_approve)
+    end
+
+    test "a standing allowance adds nothing, so the batch is escrow only" do
+      for pull <- [:standing, :not_needed] do
+        assert [core_approve, fund] = calls(pull)
+        assert approve_args(core_approve) == {String.downcase(cfg().core), 2_400}
+        assert fund.to == cfg().core
+      end
+    end
+
+    test "the funding log line names the Permit2 approve when it rides along" do
+      assert Order.funding_line(73_295, {:short, permit()}) =~ "approve(Permit2"
+      assert Order.funding_line(73_295, {:short, permit()}) =~ "3000000"
+      refute Order.funding_line(73_295, :standing) =~ "Permit2"
+      refute Order.funding_line(73_295, :standing) =~ "sponsored"
+    end
+  end
+
+  describe "the origin-pull disclosure" do
+    test "a funded run says where the approve lands" do
+      text = Enum.join(Order.origin_pull_lines({:short, permit()}, fund: true), "\n")
+
+      assert text =~ "SHORT"
+      assert text =~ "approve+fund"
+      refute text =~ "CANNOT execute"
+    end
+
+    test "a run that signs but never funds says the pull it authorized cannot execute" do
+      text = Enum.join(Order.origin_pull_lines({:short, permit()}, []), "\n")
+
+      assert text =~ "does not --fund"
+      assert text =~ "CANNOT execute"
+      assert text =~ "--job-id"
+    end
+
+    test "a dry run says no approve is sent, without the unfunded warning" do
+      text = Enum.join(Order.origin_pull_lines({:short, permit()}, dry_run: true), "\n")
+
+      assert text =~ "--dry-run"
+      refute text =~ "CANNOT execute"
+    end
+
+    test "a covered or non-Permit2 pull adds no warning at all" do
+      for pull <- [:standing, :not_needed], opts <- [[], [fund: true]] do
+        assert [_one_line] = Order.origin_pull_lines(pull, opts)
+      end
+    end
+  end
 
   describe "the escrow ceiling gate" do
     test "a budget above the ceiling aborts a --fund run before anything is approved" do

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -126,12 +126,32 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
       end
     end
 
-    test "an unsupported origin is named as the origin" do
+    # This task runs the whole ACP lifecycle on the corridor's ORIGIN chain, and
+    # the ACP core is deployed only on Base. The funding batch is what makes that
+    # binding rather than incidental: it carries the origin-chain Permit2 approve
+    # in the same send_calls as the Base ACP fund, and one batch is one chain.
+    #
+    # Unchecked it looked supported -- createJob went to the Base core address on
+    # the origin chain, where nothing is deployed, while the budget poll read Base
+    # and saw nothing. The 7702/SCA wallets sign for 8453 regardless, so nothing
+    # downstream would have caught it either.
+    test "a non-Base origin is refused, not half-executed" do
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> Order.run(["--corridor", "42161>8453", "--dry-run"]) end)
+
+      assert message =~ "--corridor origin 42161 is not the ACP core's chain (8453)"
+      # The remedy names a corridor that actually works, keeping the destination.
+      assert message =~ "--corridor 8453>42161"
+    end
+
+    # The origin check fires before the token lookup, so an origin that fails both
+    # is reported on the ground that no token address could fix.
+    test "an origin with no USDC is refused as an origin, not as a token gap" do
       %Mix.Error{message: message} =
         assert_raise(Mix.Error, fn -> Order.run(["--corridor", "4663>8453", "--dry-run"]) end)
 
-      assert message =~ "no USDC address for the origin chain 4663"
-      refute message =~ "Robinhood Chain"
+      assert message =~ "is not the ACP core's chain"
+      refute message =~ "no USDC address"
     end
   end
 

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -73,8 +73,7 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
     end
 
     test "ORDER_SOLVER is read when the flag is absent, and validated the same way" do
-      System.put_env("ORDER_SOLVER", "not-an-address")
-      on_exit(fn -> System.delete_env("ORDER_SOLVER") end)
+      put_solver_env("not-an-address")
 
       %Mix.Error{message: message} =
         assert_raise(Mix.Error, fn -> Order.run(["--dry-run"]) end)
@@ -82,7 +81,31 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
       assert message =~ "ORDER_SOLVER"
       assert message =~ "is not a 0x-hex 20-byte address"
     end
+
+    test "an empty --solver falls back to ORDER_SOLVER instead of suppressing it" do
+      # `--solver ""` is truthy in Elixir, so an empty flag used to win the `||`
+      # and leave the run unpinned while ORDER_SOLVER sat there set.
+      put_solver_env("not-an-address")
+
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> Order.run(["--solver", "  ", "--dry-run"]) end)
+
+      # The env value is what got validated, so it is the value named back.
+      assert message =~ ~s|"not-an-address"|
+      assert message =~ "is not a 0x-hex 20-byte address"
+    end
   end
+
+  # The value is process-global, so a test that deletes it on the way out erases
+  # whatever the operator (or an outer gate run) had set.
+  defp put_solver_env(value) do
+    prior = System.get_env("ORDER_SOLVER")
+    System.put_env("ORDER_SOLVER", value)
+    on_exit(fn -> restore_env("ORDER_SOLVER", prior) end)
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
 
   describe "the escrow ceiling gate" do
     test "a budget above the ceiling aborts a --fund run before anything is approved" do

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -4,6 +4,8 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
 
   alias Mix.Tasks.RaxolEarn.Order
 
+  @spender "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+
   setup do
     shell = Mix.shell()
     Mix.shell(Mix.Shell.Process)
@@ -51,6 +53,34 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
 
       assert message =~ "no USDC address for the origin chain 4663"
       refute message =~ "Robinhood Chain"
+    end
+  end
+
+  describe "the --solver pin" do
+    test "is a real switch, not one OptionParser silently drops" do
+      # `strict:` routes an unregistered switch to `invalid` and parse_argv drops
+      # it, so an unregistered --solver would leave the pin unset while the
+      # operator watched themselves type it.
+      assert Order.parse_argv(["--solver", @spender]) == [solver: @spender]
+    end
+
+    test "a malformed address is refused before the signer sidecar boots" do
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> Order.run(["--solver", "0xnope", "--dry-run"]) end)
+
+      assert message =~ "is not a 0x-hex 20-byte address"
+      assert message =~ "pins the origin-pull spender"
+    end
+
+    test "ORDER_SOLVER is read when the flag is absent, and validated the same way" do
+      System.put_env("ORDER_SOLVER", "not-an-address")
+      on_exit(fn -> System.delete_env("ORDER_SOLVER") end)
+
+      %Mix.Error{message: message} =
+        assert_raise(Mix.Error, fn -> Order.run(["--dry-run"]) end)
+
+      assert message =~ "ORDER_SOLVER"
+      assert message =~ "is not a 0x-hex 20-byte address"
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
@@ -22,6 +22,8 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
   @core "0x238E541BfefD82238730D00a2208E5497F1832E0"
   @paymaster "0x5d74bdab1ce9ddadd7e2e333d1d173830860694a"
 
+  @spender "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+
   # 3.00 USDC on Base at the default 8 bps.
   defp cfg do
     %{
@@ -31,7 +33,8 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       core: @core,
       amount: "3.00",
       principal_atomic: 3_000_000,
-      fee_bps: 8
+      fee_bps: 8,
+      solver: nil
     }
   end
 
@@ -106,6 +109,38 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       assert text =~ "SPEND PLAN"
       assert text =~ "UserOps this run: none (--dry-run writes nothing on-chain)"
       assert text =~ "spends nothing"
+    end
+  end
+
+  describe "the Permit2 approve" do
+    test "is named as a possible extra UserOp, with what decides it" do
+      text = plan(fund: true)
+
+      assert text =~ "+1 approve(Permit2) UserOp"
+      assert text =~ "USDC gas again"
+      assert text =~ "the buyer's allowance is short"
+    end
+
+    test "names the pinned spender when one was supplied" do
+      lines = Order.spend_plan_lines(%{cfg() | solver: @spender}, [fund: true], :new_job)
+
+      assert Enum.join(lines, "\n") =~ "spender pin: #{@spender}"
+    end
+
+    test "says a Permit2 pull is refused when no spender is pinned" do
+      text = plan(fund: true)
+
+      assert text =~ "spender pin: NONE"
+      assert text =~ "refused before signing"
+      assert text =~ "--solver"
+      assert text =~ "no on-chain recipient guard"
+    end
+
+    test "a dry run promises no approve, only a report" do
+      text = plan(dry_run: true)
+
+      assert text =~ "no approve(Permit2) UserOp is sent under --dry-run"
+      refute text =~ "+1 approve(Permit2) UserOp"
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
@@ -91,7 +91,7 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
     end
 
     test "the funding log line does not contradict the plan" do
-      line = Order.funding_line(72_993)
+      line = Order.funding_line(72_993, :not_needed)
 
       refute line =~ "sponsored"
       assert line =~ "gas billed to the buyer in USDC"
@@ -99,32 +99,34 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
   end
 
   describe "legs" do
-    test "a funded run names every write, the conditional approve included" do
+    test "a funded run names every write, the carried approve included" do
       assert plan(fund: true) =~
-               "writes this run: approve(Permit2) if the pull needs it, createJob, approve+fund"
+               "writes this run: createJob, approve+fund " <>
+                 "(carrying the approve(Permit2) if the pull needs it)"
     end
 
     test "an unfunded run still warns that createJob costs gas" do
       text = plan([])
 
-      assert text =~ "writes this run: approve(Permit2) if the pull needs it, createJob"
+      assert text =~ "writes this run: createJob"
       assert text =~ "no --fund: no escrow this run"
       assert text =~ "still costs gas"
     end
 
     test "resuming an existing job drops the createJob leg" do
       assert plan([job_id: 73_295, fund: true], {:ok, 2_400}) =~
-               "writes this run: approve(Permit2) if the pull needs it, approve+fund"
+               "writes this run: approve+fund (carrying the approve(Permit2) if the pull needs it)"
     end
 
-    test "a resumed unfunded run counts the approve rather than claiming no writes" do
+    test "a resumed unfunded run claims no writes, because it can make none" do
       text = plan([job_id: 73_295], {:ok, 2_400})
 
-      # The run can still broadcast the Permit2 approve, so a plan saying it
-      # writes nothing is the contradiction the plan exists to prevent.
-      assert text =~ "writes this run: approve(Permit2) if the pull needs it"
-      assert text =~ "the only write this run can make is the conditional approve(Permit2)"
-      refute text =~ "writes nothing on-chain"
+      # The approve now rides in the funding batch, so without --fund and without
+      # createJob there is nothing left to broadcast. Naming the approve as a leg
+      # here would promise a write this run cannot make.
+      assert text =~ "writes this run: none (without --fund and without createJob"
+      assert text =~ "this run signs an intent and broadcasts nothing"
+      assert text =~ "stays unexecutable"
     end
 
     test "a dry run names no writes at all" do
@@ -137,11 +139,11 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
   end
 
   describe "the Permit2 approve" do
-    test "is named as a possible extra UserOp, with what decides it" do
+    test "is named as riding inside the funding write, not as one of its own" do
       text = plan(fund: true)
 
-      assert text =~ "+1 approve(Permit2) UserOp"
-      assert text =~ "gas again"
+      assert text =~ "rides INSIDE the approve+fund UserOp"
+      assert text =~ "no separate write, no extra gas"
       assert text =~ "the buyer's allowance is short"
     end
 
@@ -151,10 +153,20 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       assert text =~ "approves exactly the intent's authorized pull, not a standing max"
     end
 
+    test "an unfunded run says the allowance is not granted, and what that costs" do
+      text = plan([])
+
+      # --fund is what carries the approve, so without it a signed Permit2 intent
+      # is left with a pull that cannot execute. Saying nothing here is how that
+      # surfaces later as an unexplained settlement failure.
+      assert text =~ "no approve(Permit2) UserOp without --fund"
+      assert text =~ "unexecutable until a --fund run grants the allowance"
+    end
+
     test "is a tx, not a UserOp, under --signer eoa" do
       lines = Order.spend_plan_lines(%{cfg() | signer: "eoa"}, [fund: true], :new_job)
 
-      assert Enum.join(lines, "\n") =~ "+1 approve(Permit2) tx"
+      assert Enum.join(lines, "\n") =~ "rides INSIDE the approve+fund tx"
     end
 
     test "names the pinned spender when one was supplied" do
@@ -176,7 +188,7 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       text = plan(dry_run: true)
 
       assert text =~ "no approve(Permit2) UserOp is sent under --dry-run"
-      refute text =~ "+1 approve(Permit2) UserOp"
+      refute text =~ "rides INSIDE"
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/order_spend_plan_test.exs
@@ -24,7 +24,7 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
 
   @spender "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
 
-  # 3.00 USDC on Base at the default 8 bps.
+  # 3.00 USDC on Base at the default 8 bps, under the default managed-SCA signer.
   defp cfg do
     %{
       buyer: "0x468aeae798b3a6548ac2401d276f83afdc172283",
@@ -34,6 +34,7 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       amount: "3.00",
       principal_atomic: 3_000_000,
       fee_bps: 8,
+      signer: "privy",
       solver: nil
     }
   end
@@ -78,6 +79,17 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       refute text =~ "sponsored"
     end
 
+    test "an EOA run says ETH, since no paymaster bills it USDC" do
+      lines = Order.spend_plan_lines(%{cfg() | signer: "eoa"}, [fund: true], :new_job)
+      text = Enum.join(lines, "\n")
+
+      assert text =~ "paid in ETH by the buyer EOA"
+      assert text =~ "NOT in USDC"
+      # An EOA broadcasts plain transactions; calling them UserOps sends the
+      # operator looking for a paymaster charge that never appears.
+      refute text =~ "UserOp"
+    end
+
     test "the funding log line does not contradict the plan" do
       line = Order.funding_line(72_993)
 
@@ -87,27 +99,39 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
   end
 
   describe "legs" do
-    test "a funded run names both UserOps" do
-      assert plan(fund: true) =~ "UserOps this run: createJob, approve+fund"
+    test "a funded run names every write, the conditional approve included" do
+      assert plan(fund: true) =~
+               "writes this run: approve(Permit2) if the pull needs it, createJob, approve+fund"
     end
 
     test "an unfunded run still warns that createJob costs gas" do
       text = plan([])
 
-      assert text =~ "UserOps this run: createJob"
+      assert text =~ "writes this run: approve(Permit2) if the pull needs it, createJob"
       assert text =~ "no --fund: no escrow this run"
-      assert text =~ "still costs USDC gas"
+      assert text =~ "still costs gas"
     end
 
     test "resuming an existing job drops the createJob leg" do
-      assert plan([job_id: 73_295, fund: true], {:ok, 2_400}) =~ "UserOps this run: approve+fund"
+      assert plan([job_id: 73_295, fund: true], {:ok, 2_400}) =~
+               "writes this run: approve(Permit2) if the pull needs it, approve+fund"
     end
 
-    test "a dry run names no UserOps at all" do
+    test "a resumed unfunded run counts the approve rather than claiming no writes" do
+      text = plan([job_id: 73_295], {:ok, 2_400})
+
+      # The run can still broadcast the Permit2 approve, so a plan saying it
+      # writes nothing is the contradiction the plan exists to prevent.
+      assert text =~ "writes this run: approve(Permit2) if the pull needs it"
+      assert text =~ "the only write this run can make is the conditional approve(Permit2)"
+      refute text =~ "writes nothing on-chain"
+    end
+
+    test "a dry run names no writes at all" do
       text = plan(dry_run: true, fund: true)
 
       assert text =~ "SPEND PLAN"
-      assert text =~ "UserOps this run: none (--dry-run writes nothing on-chain)"
+      assert text =~ "writes this run: none (--dry-run writes nothing on-chain)"
       assert text =~ "spends nothing"
     end
   end
@@ -117,8 +141,20 @@ defmodule Raxol.Earn.OrderSpendPlanTest do
       text = plan(fund: true)
 
       assert text =~ "+1 approve(Permit2) UserOp"
-      assert text =~ "USDC gas again"
+      assert text =~ "gas again"
       assert text =~ "the buyer's allowance is short"
+    end
+
+    test "is disclosed as bounded, not as a standing max approval" do
+      text = plan(fund: true)
+
+      assert text =~ "approves exactly the intent's authorized pull, not a standing max"
+    end
+
+    test "is a tx, not a UserOp, under --signer eoa" do
+      lines = Order.spend_plan_lines(%{cfg() | signer: "eoa"}, [fund: true], :new_job)
+
+      assert Enum.join(lines, "\n") =~ "+1 approve(Permit2) tx"
     end
 
     test "names the pinned spender when one was supplied" do

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_pin_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_pin_test.exs
@@ -39,6 +39,21 @@ defmodule Raxol.Earn.Xochi.LiveOrderPinTest do
              "go through OriginPull"
   end
 
+  # The pin is checked against ONE served quote. Signing a different one throws
+  # the check away: a quote served `erc3009` passes the Permit2 branch trivially,
+  # and a second quote served `permit2` is then signed with no pin behind it,
+  # leaving only the solver allowlist -- which already contains the mirrored pull
+  # proxy, i.e. exactly what the pin exists to add to.
+  test "the intent signed is the quote that was checked, not a second one", %{source: source} do
+    refute source =~ "quote_and_sign(",
+           "quote_and_sign/3 fetches a FRESH quote and signs that one, so the spender pin " <>
+             "and the bounded allowance would be checked against a quote the gate never signs"
+
+    assert source =~ "XochiProtocol.sign_intent(",
+           "the gate must sign the quote preflight_quote/4 already checked and the " <>
+             "allowance was granted against"
+  end
+
   test "the pinned spender is operator-supplied, with no default", %{source: source} do
     assert source =~ ~s|System.get_env("XOCHI_ORDER_PULL_SPENDER")|,
            "the Permit2 allowance pin must come from XOCHI_ORDER_PULL_SPENDER"

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_pin_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_pin_test.exs
@@ -7,11 +7,19 @@ defmodule Raxol.Earn.Xochi.LiveOrderPinTest do
 
   The gate itself cannot be exercised here: it moves money, it is tag-excluded,
   and its module body only compiles when the live env is present. So its one
-  safety property is asserted against the source instead -- the gate must reach
-  the allowance through `Raxol.Earn.Xochi.OriginPull`, which fails closed on an
-  unpinned spender, and must not hold a second route to the approver that skips
-  it. Written after a review found the gate granting a max allowance keyed only on
-  the served quote, while `mix raxol_earn.order` had already been given the pin.
+  safety property is asserted against the gate's PARSED source instead -- the gate
+  must reach the allowance through `Raxol.Earn.Xochi.OriginPull`, which fails
+  closed on an unpinned spender, and must not hold a second route to the approver
+  that skips it. Written after a review found the gate granting a max allowance
+  keyed only on the served quote, while `mix raxol_earn.order` had already been
+  given the pin.
+
+  Parsed, not grepped. A text search answers the wrong question in both
+  directions: a commented-out call still reads as present, so the guard would
+  stay green over code that no longer runs; and merely explaining in prose why
+  the approver is off-limits reads as calling it, so documenting the rule would
+  break the build. `Code.string_to_quoted/1` discards comments and leaves
+  docstrings as inert literals, so what remains is what executes.
   """
 
   use ExUnit.Case, async: true
@@ -20,21 +28,21 @@ defmodule Raxol.Earn.Xochi.LiveOrderPinTest do
   @external_resource @gate
 
   setup do
-    {:ok, source: File.read!(@gate)}
+    {:ok, gate: analyze(File.read!(@gate))}
   end
 
-  test "the allowance is decided by the shared pin, not by the gate", %{source: source} do
-    assert source =~ "OriginPull.allowance_plan(",
+  test "the allowance is decided by the shared pin, not by the gate", %{gate: gate} do
+    assert {:OriginPull, :allowance_plan, 3} in gate.calls,
            "the live gate must decide the allowance through OriginPull, which refuses " <>
              "an unpinned or mismatched Permit2 spender"
 
-    assert source =~ "OriginPull.ensure_allowance(",
+    assert {:OriginPull, :ensure_allowance, 3} in gate.calls,
            "the live gate must grant the allowance through OriginPull, so it is bounded " <>
              "to the intent's authorized pull"
   end
 
-  test "no path reaches the approver around the pin", %{source: source} do
-    refute source =~ "Permit2Approver",
+  test "no path reaches the approver around the pin", %{gate: gate} do
+    refute :Permit2Approver in gate.modules,
            "calling the approver directly grants an allowance without the spender pin; " <>
              "go through OriginPull"
   end
@@ -44,22 +52,56 @@ defmodule Raxol.Earn.Xochi.LiveOrderPinTest do
   # and a second quote served `permit2` is then signed with no pin behind it,
   # leaving only the solver allowlist -- which already contains the mirrored pull
   # proxy, i.e. exactly what the pin exists to add to.
-  test "the intent signed is the quote that was checked, not a second one", %{source: source} do
-    refute source =~ "quote_and_sign(",
+  test "the intent signed is the quote that was checked, not a second one", %{gate: gate} do
+    refute Enum.any?(gate.calls, fn {_mod, fun, _arity} -> fun == :quote_and_sign end),
            "quote_and_sign/3 fetches a FRESH quote and signs that one, so the spender pin " <>
              "and the bounded allowance would be checked against a quote the gate never signs"
 
-    assert source =~ "XochiProtocol.sign_intent(",
+    assert {:XochiProtocol, :sign_intent, 3} in gate.calls,
            "the gate must sign the quote preflight_quote/4 already checked and the " <>
              "allowance was granted against"
   end
 
-  test "the pinned spender is operator-supplied, with no default", %{source: source} do
-    assert source =~ ~s|System.get_env("XOCHI_ORDER_PULL_SPENDER")|,
+  test "the pinned spender is operator-supplied, with no default", %{gate: gate} do
+    assert {"XOCHI_ORDER_PULL_SPENDER", 1} in gate.env,
            "the Permit2 allowance pin must come from XOCHI_ORDER_PULL_SPENDER"
 
-    refute source =~ ~s|System.get_env("XOCHI_ORDER_PULL_SPENDER",|,
+    refute Enum.any?(gate.env, fn {name, arity} ->
+             name == "XOCHI_ORDER_PULL_SPENDER" and arity > 1
+           end),
            "a default would make the gate grant an allowance towards an address nobody " <>
              "typed; unset must skip the cell instead"
+  end
+
+  # -- The gate's source, as calls rather than text --
+
+  # `calls` are {LastAliasSegment, function, arity} for qualified calls and
+  # {nil, function, arity} for local ones; `modules` is every alias segment named
+  # anywhere; `env` is each System.get_env with a literal name, carrying its arity
+  # so a defaulted lookup is distinguishable from an undefaulted one.
+  defp analyze(source) do
+    {:ok, ast} = Code.string_to_quoted(source)
+    empty = %{calls: MapSet.new(), modules: MapSet.new(), env: MapSet.new()}
+
+    {_ast, found} =
+      Macro.prewalk(ast, empty, fn
+        {{:., _, [{:__aliases__, _, [:System]}, :get_env]}, _, [name | rest]} = node, acc
+        when is_binary(name) ->
+          {node, %{acc | env: MapSet.put(acc.env, {name, length(rest) + 1})}}
+
+        {{:., _, [{:__aliases__, _, mods}, fun]}, _, args} = node, acc when is_list(args) ->
+          {node, %{acc | calls: MapSet.put(acc.calls, {List.last(mods), fun, length(args)})}}
+
+        {:__aliases__, _, mods} = node, acc ->
+          {node, %{acc | modules: MapSet.union(acc.modules, MapSet.new(mods))}}
+
+        {fun, _, args} = node, acc when is_atom(fun) and is_list(args) ->
+          {node, %{acc | calls: MapSet.put(acc.calls, {nil, fun, length(args)})}}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    found
   end
 end

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_pin_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_pin_test.exs
@@ -1,0 +1,50 @@
+defmodule Raxol.Earn.Xochi.LiveOrderPinTest do
+  @moduledoc """
+  The funded ACP live gate grants a REAL Permit2 allowance on the buyer's origin
+  wallet. Permit2 has no on-chain recipient guard, so that allowance is a standing
+  capability towards whatever spender the quote named, and the operator's pin is
+  the only thing bounding it.
+
+  The gate itself cannot be exercised here: it moves money, it is tag-excluded,
+  and its module body only compiles when the live env is present. So its one
+  safety property is asserted against the source instead -- the gate must reach
+  the allowance through `Raxol.Earn.Xochi.OriginPull`, which fails closed on an
+  unpinned spender, and must not hold a second route to the approver that skips
+  it. Written after a review found the gate granting a max allowance keyed only on
+  the served quote, while `mix raxol_earn.order` had already been given the pin.
+  """
+
+  use ExUnit.Case, async: true
+
+  @gate Path.join(__DIR__, "live_order_test.exs")
+  @external_resource @gate
+
+  setup do
+    {:ok, source: File.read!(@gate)}
+  end
+
+  test "the allowance is decided by the shared pin, not by the gate", %{source: source} do
+    assert source =~ "OriginPull.allowance_plan(",
+           "the live gate must decide the allowance through OriginPull, which refuses " <>
+             "an unpinned or mismatched Permit2 spender"
+
+    assert source =~ "OriginPull.ensure_allowance(",
+           "the live gate must grant the allowance through OriginPull, so it is bounded " <>
+             "to the intent's authorized pull"
+  end
+
+  test "no path reaches the approver around the pin", %{source: source} do
+    refute source =~ "Permit2Approver",
+           "calling the approver directly grants an allowance without the spender pin; " <>
+             "go through OriginPull"
+  end
+
+  test "the pinned spender is operator-supplied, with no default", %{source: source} do
+    assert source =~ ~s|System.get_env("XOCHI_ORDER_PULL_SPENDER")|,
+           "the Permit2 allowance pin must come from XOCHI_ORDER_PULL_SPENDER"
+
+    refute source =~ ~s|System.get_env("XOCHI_ORDER_PULL_SPENDER",|,
+           "a default would make the gate grant an allowance towards an address nobody " <>
+             "typed; unset must skip the cell instead"
+  end
+end

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -21,6 +21,14 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
       XOCHI_ORDER_RPC_8453=https://mainnet.base.org \\
         mix test --only live_xochi_order test/raxol/acp/xochi/live_order_test.exs
 
+  A cell whose quote pulls via Permit2 also needs `XOCHI_ORDER_PULL_SPENDER`: the
+  spender the operator expects the permit to name, taken from Riddler's XochiPull
+  deployment record. It has no default, because granting the allowance is what
+  makes that address able to move the buyer's origin balance and Permit2 carries
+  no on-chain recipient guard. Unset, a Permit2 cell is skipped, never guessed.
+  It is NOT `XOCHI_ORDER_SOLVER`: that pins the solver wallet for the signature
+  allowlist, where the permit's spender is the pull proxy.
+
   Runner + full env/corridor reference (USDC/ERC-3009 vs USDT/WETH/USDG Permit2,
   Robinhood cross-asset corridors, mesh, and all `XOCHI_ORDER_*` overrides): the
   unified gate at the repo root, `scripts/run_live_gates.sh --route acp`.
@@ -34,9 +42,9 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
   if System.get_env("XOCHI_ORDER_LIVE_URL") && System.get_env("XOCHI_ORDER_LIVE_KEY") do
     alias Raxol.Earn.{AssetToken, Chain, JobSession}
     alias Raxol.Earn.Offering.Registry, as: OfferingRegistry
-    alias Raxol.Earn.Onchain.Permit2Approver
     alias Raxol.Earn.ProviderAdapter
     alias Raxol.Earn.ProviderAdapter.JSONRPC
+    alias Raxol.Earn.Xochi.OriginPull
     alias Raxol.Earn.Xochi.StablePublicOffering
     alias Raxol.Payments.Assets
     alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
@@ -75,6 +83,11 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
       cfg = %{
         xochi_config: xochi_config,
         wallet_address: wallet_address,
+        # No default, deliberately. This pin is what a real Permit2 allowance is
+        # granted towards, and Permit2 has no on-chain recipient guard -- a
+        # checked-in address would make the gate grant a standing capability
+        # nobody typed. Unset means Permit2 cells are skipped, not guessed.
+        pull_spender: System.get_env("XOCHI_ORDER_PULL_SPENDER"),
         stable_amount: System.get_env("XOCHI_ORDER_AMOUNT", "1.10")
       }
 
@@ -138,10 +151,17 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     # subset.
     defp run_fillable_cell(cfg, from, to, token, label) do
       with {:ok, quote_resp} <- preflight_quote(cfg, from, to, token),
-           {:ok, _allowance} <- ensure_permit2(quote_resp, from, token, cfg.wallet_address) do
+           {:ok, _allowance} <- ensure_permit2(quote_resp, cfg, from, token) do
         order_cell(cfg, from, to, token, label)
       else
-        {:error, reason} -> log("SKIP #{label}: #{inspect(reason)}; no funds moved")
+        {:error, :unpinned_permit2_spender} ->
+          log(
+            "SKIP #{label}: the served quote pulls via Permit2 and XOCHI_ORDER_PULL_SPENDER " <>
+              "is unset; no allowance granted, no funds moved"
+          )
+
+        {:error, reason} ->
+          log("SKIP #{label}: #{inspect(reason)}; no funds moved")
       end
     end
 
@@ -283,17 +303,43 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     # through ERC-3009 and holds no allowance, while a smart-account (ERC-1271)
     # buyer pulls the same USDC through Permit2 and must. USDT, WETH and USDG take
     # Permit2 whoever the buyer is, and the quote says so either way.
-    defp ensure_permit2(%{payment_method: "permit2"}, from, token, owner) do
-      with {:ok, provider} <- provider_for(from),
-           {:ok, src_token} <- Assets.address(from, leg_symbol(from, token)) do
-        Permit2Approver.ensure_allowance(provider, from, src_token, owner)
-      else
-        :error -> {:error, {:unknown_token, token}}
-        {:error, _} = err -> err
+    #
+    # The decision is OriginPull's, not this file's: it is the same allowance
+    # `mix raxol_earn.order` grants, so it must refuse on the same terms. An
+    # unpinned or mismatched spender, a permit for another chain or token, or one
+    # authorizing more than the cell is ordering, all fail closed here.
+    defp ensure_permit2(quote_resp, cfg, from, token) do
+      with {:ok, src_token} <- token_address(from, token),
+           {:ok, plan} <-
+             OriginPull.allowance_plan(
+               quote_resp,
+               cfg.pull_spender,
+               %{
+                 chain_id: from,
+                 token: src_token,
+                 amount: amount_atomic(from, token, cfg.stable_amount)
+               }
+             ) do
+        settle_allowance(plan, cfg, from)
       end
     end
 
-    defp ensure_permit2(_quote_resp, _from, _token, _owner), do: {:ok, :not_needed}
+    # Only a Permit2 plan needs a broadcasting provider, so an ERC-3009 cell still
+    # runs without an origin-chain RPC configured.
+    defp settle_allowance(:not_needed, _cfg, _from), do: {:ok, :not_needed}
+
+    defp settle_allowance(plan, cfg, from) do
+      with {:ok, provider} <- provider_for(from) do
+        OriginPull.ensure_allowance(plan, provider, cfg.wallet_address)
+      end
+    end
+
+    defp token_address(from, token) do
+      case Assets.address(from, leg_symbol(from, token)) do
+        {:ok, address} -> {:ok, address}
+        :error -> {:error, {:unknown_token, token}}
+      end
+    end
 
     defp provider_for(chain) do
       case System.get_env("XOCHI_ORDER_RPC_#{chain}") do

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -3,8 +3,7 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
   Live gate: a buyer orders the `xochi_stable_public` ACP offering and the seller
   settles it for real through Xochi + the Riddler solver. Moves real funds.
 
-  The buyer quotes and signs a Xochi intent itself
-  (`Raxol.Payments.Protocols.Xochi.quote_and_sign/3`), embeds the signed bundle in
+  The buyer quotes and signs a Xochi intent itself, embeds the signed bundle in
   the job requirement's `signed_intent`, and the seller's `StablePublicOffering`
   relays it via `Raxol.Earn.Xochi.Settler` -> `execute_signed/2` (no re-signing) and
   polls.
@@ -12,6 +11,11 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
   hook writes); only the settlement moves funds. The funded `LiveWallet` plays every
   role -- buyer, provider, and recipient (the Xochi `QuoteRequest` has no separate
   recipient, so funds return to the funded key on the destination chain).
+
+  Each cell quotes ONCE. The solver pin, the served-permit cross-checks and the
+  Permit2 allowance are all decided against that one quote, and that same quote is
+  what `sign_intent/3` signs -- re-quoting between the check and the signature
+  would leave every check standing behind a quote this gate never signs.
 
   Tagged `:live_xochi_order` (settle) and `:live_xochi_order_preflight`
   (read-only); excluded by default, compiled only when the env is present.
@@ -150,9 +154,9 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     # cell or a missing RPC is a logged skip, not a failure: this is the fillable
     # subset.
     defp run_fillable_cell(cfg, from, to, token, label) do
-      with {:ok, quote_resp} <- preflight_quote(cfg, from, to, token),
-           {:ok, _allowance} <- ensure_permit2(quote_resp, cfg, from, token) do
-        order_cell(cfg, from, to, token, label)
+      with {:ok, checked} <- preflight_quote(cfg, from, to, token),
+           {:ok, _allowance} <- ensure_permit2(checked.quote, cfg, from, token) do
+        order_cell(cfg, checked, from, to, token, label)
       else
         {:error, :unpinned_permit2_spender} ->
           log(
@@ -167,12 +171,19 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
 
     # -- Order one cell through the ACP job lifecycle --
 
-    defp order_cell(cfg, from, to, token, label) do
-      # The BUYER quotes + signs the Xochi intent itself; the signed bundle rides
-      # in the requirement. raxol (the offering) relays it -- it never re-signs.
-      {:ok, request} = quote_request(cfg, from, to, token)
+    defp order_cell(cfg, checked, from, to, token, label) do
+      # The BUYER signs the Xochi intent itself; the signed bundle rides in the
+      # requirement. raxol (the offering) relays it -- it never re-signs.
+      #
+      # `checked` is the quote the solver pin, the served-permit cross-checks and
+      # the Permit2 allowance were all settled against, so signing it (rather than
+      # re-quoting) is what makes those checks bind the signature. A fresh quote
+      # can arrive on another rail -- erc3009 checked, permit2 signed -- and the
+      # allowlist alone already trusts the mirrored pull proxy, so it would not
+      # catch that.
+      %{request: request, quote: quote_resp} = checked
 
-      {:ok, bundle} = XochiProtocol.quote_and_sign(cfg.xochi_config, request, LiveWallet)
+      {:ok, bundle} = XochiProtocol.sign_intent(quote_resp, LiveWallet, request)
 
       requirement = requirement(cfg, from, to, token, bundle)
 
@@ -244,11 +255,14 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
 
     # -- Read-only quote (fillability + solver pin) --
 
+    # Returns the checked PAIR, not just the quote: the request is what the pull
+    # was validated against, so `sign_intent/3` has to re-validate against that
+    # same one rather than a freshly built lookalike.
     defp preflight_quote(cfg, from, to, token) do
       with {:ok, request} <- quote_request(cfg, from, to, token),
            {:ok, quote} <- solver_quote(cfg, request),
            :ok <- XochiProtocol.validate_pull(quote, request, LiveWallet) do
-        {:ok, quote}
+        {:ok, %{request: request, quote: quote}}
       end
     end
 
@@ -272,9 +286,14 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     # failure like a solver-pin mismatch (hard).
     defp preflight_cell(cfg, from, to, token) do
       case preflight_quote(cfg, from, to, token) do
-        {:ok, quote} -> {:ok, %{method: quote.payment_method, to_amount: quote.to_amount}}
-        {:error, :cannot_solve} -> {:soft, :cannot_solve}
-        {:error, reason} -> {:error, reason}
+        {:ok, %{quote: quote}} ->
+          {:ok, %{method: quote.payment_method, to_amount: quote.to_amount}}
+
+        {:error, :cannot_solve} ->
+          {:soft, :cannot_solve}
+
+        {:error, reason} ->
+          {:error, reason}
       end
     end
 

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -132,12 +132,13 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
       end
     end
 
-    # Only order a cell the solver can fill now, and (for USDT/WETH) only once the
-    # Permit2 allowance is in place. A non-fillable cell or a missing RPC is a
-    # logged skip, not a failure -- this is the fillable subset.
+    # Only order a cell the solver can fill now, and -- when the served quote
+    # pulls via Permit2 -- only once that allowance is in place. A non-fillable
+    # cell or a missing RPC is a logged skip, not a failure: this is the fillable
+    # subset.
     defp run_fillable_cell(cfg, from, to, token, label) do
-      with {:ok, _quote} <- preflight_quote(cfg, from, to, token),
-           {:ok, _allowance} <- ensure_permit2(from, token, cfg.wallet_address) do
+      with {:ok, quote_resp} <- preflight_quote(cfg, from, to, token),
+           {:ok, _allowance} <- ensure_permit2(quote_resp, from, token, cfg.wallet_address) do
         order_cell(cfg, from, to, token, label)
       else
         {:error, reason} -> log("SKIP #{label}: #{inspect(reason)}; no funds moved")
@@ -276,21 +277,23 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
       end
     end
 
-    # -- Permit2 allowance (USDT/WETH only) --
+    # -- Permit2 allowance --
 
-    defp ensure_permit2(from, token, owner) do
-      if permit2_origin?(from, token) do
-        with {:ok, provider} <- provider_for(from),
-             {:ok, src_token} <- Assets.address(from, leg_symbol(from, token)) do
-          Permit2Approver.ensure_allowance(provider, from, src_token, owner)
-        else
-          :error -> {:error, {:unknown_token, token}}
-          {:error, _} = err -> err
-        end
+    # Keyed on the SERVED quote's rail, not on the token: an EOA buyer pulls USDC
+    # through ERC-3009 and holds no allowance, while a smart-account (ERC-1271)
+    # buyer pulls the same USDC through Permit2 and must. USDT, WETH and USDG take
+    # Permit2 whoever the buyer is, and the quote says so either way.
+    defp ensure_permit2(%{payment_method: "permit2"}, from, token, owner) do
+      with {:ok, provider} <- provider_for(from),
+           {:ok, src_token} <- Assets.address(from, leg_symbol(from, token)) do
+        Permit2Approver.ensure_allowance(provider, from, src_token, owner)
       else
-        {:ok, :not_needed}
+        :error -> {:error, {:unknown_token, token}}
+        {:error, _} = err -> err
       end
     end
+
+    defp ensure_permit2(_quote_resp, _from, _token, _owner), do: {:ok, :not_needed}
 
     defp provider_for(chain) do
       case System.get_env("XOCHI_ORDER_RPC_#{chain}") do
@@ -361,12 +364,6 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
 
     defp amount_for("WETH", _stable), do: System.get_env("XOCHI_ORDER_WETH_AMOUNT", "0.001")
     defp amount_for(_token, stable), do: stable
-
-    # The origin pull rail: USDC pulls via ERC-3009, everything else (USDT, WETH,
-    # and Robinhood's USDG) via Permit2. Keyed on the ORIGIN leg's resolved token,
-    # so a Robinhood-origin corridor (USDG) needs a Permit2 allowance even when the
-    # logical corridor token is USDC.
-    defp permit2_origin?(from, token), do: String.upcase(leg_symbol(from, token)) != "USDC"
 
     # Robinhood Chain (4663) carries no USDC/USDT: its only stablecoin is USDG. A
     # stablecoin corridor touching 4663 is therefore cross-asset (USDG on the

--- a/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
@@ -1,0 +1,230 @@
+defmodule Raxol.Earn.Xochi.OriginPullTest do
+  @moduledoc """
+  The origin-pull allowance decision an order makes before it signs anything.
+
+  Two properties are load-bearing enough to be pinned here rather than left to a
+  funded run:
+
+    * Permit2 has no on-chain recipient guard -- the spender picks the recipient
+      at call time -- so an allowance is granted ONLY towards a spender the
+      operator pinned and the quote actually served. Every other combination
+      fails closed, before the approve and before the signature.
+    * The approve is idempotent. A standing allowance must send no transaction,
+      or every order pays for one it did not need.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Raxol.Earn.Onchain.Permit2Approver
+  alias Raxol.Earn.ProviderAdapter.Mock
+  alias Raxol.Earn.Xochi.OriginPull
+  alias Raxol.Payments.Xochi.Schemas.QuoteResponse
+
+  @spender "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
+  @other_spender "0x97D447561fDe10E959E782a29411D8F89586d80b"
+  @token "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+  @owner "0x468aeae798b3a6548ac2401d276f83afdc172283"
+  @allowance_sig "allowance(address,address)"
+  @approve_selector <<0x09, 0x5E, 0xA7, 0xB3>>
+
+  defp quote_resp(method, pull) do
+    %QuoteResponse{
+      intent_id: "int_1",
+      quote_id: "qte_1",
+      can_solve: true,
+      payment_method: method,
+      pull_authorization: pull
+    }
+  end
+
+  defp permit2_pull(spender) do
+    %{
+      "primaryType" => "PermitWitnessTransferFrom",
+      "domain" => %{"name" => "Permit2", "chainId" => 8453},
+      "message" => %{
+        "permitted" => %{"token" => @token, "amount" => "3000000"},
+        "spender" => spender,
+        "nonce" => "0x" <> String.duplicate("11", 32),
+        "deadline" => "1900000000"
+      }
+    }
+  end
+
+  defp erc3009_pull do
+    %{
+      "primaryType" => "ReceiveWithAuthorization",
+      "domain" => %{"chainId" => 8453, "verifyingContract" => @token},
+      "message" => %{"from" => @owner, "to" => @other_spender, "value" => "3000000"}
+    }
+  end
+
+  defp max_word, do: "0x" <> String.duplicate("f", 64)
+  defp zero_word, do: "0x" <> String.duplicate("0", 64)
+
+  describe "allowance_plan/2 -- rails" do
+    test "a quote with no origin pull needs no allowance" do
+      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote_resp("erc3009", nil), nil)
+    end
+
+    test "the ERC-3009 rail needs no allowance, pinned or not" do
+      quote = quote_resp("erc3009", erc3009_pull())
+
+      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote, nil)
+      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote, @spender)
+    end
+
+    test "the rail comes from the quote, not the token: USDC can be a Permit2 pull" do
+      # Same USDC address as the ERC-3009 case above -- only payment_method differs.
+      quote = quote_resp("permit2", permit2_pull(@spender))
+
+      assert {:ok, {:permit2, @spender}} = OriginPull.allowance_plan(quote, @spender)
+    end
+
+    test "an unknown rail is refused rather than signed" do
+      quote = quote_resp("teleport", permit2_pull(@spender))
+
+      assert {:error, {:unsupported_pull_method, "teleport"}} =
+               OriginPull.allowance_plan(quote, @spender)
+    end
+  end
+
+  describe "allowance_plan/2 -- the Permit2 spender pin" do
+    test "an unpinned Permit2 pull is refused" do
+      quote = quote_resp("permit2", permit2_pull(@spender))
+
+      assert {:error, :unpinned_permit2_spender} = OriginPull.allowance_plan(quote, nil)
+      assert {:error, :unpinned_permit2_spender} = OriginPull.allowance_plan(quote, "")
+    end
+
+    test "a served spender that is not the pinned one is refused, naming both" do
+      quote = quote_resp("permit2", permit2_pull(@other_spender))
+
+      assert {:error, {:pull_spender_mismatch, served, pinned}} =
+               OriginPull.allowance_plan(quote, @spender)
+
+      assert served == String.downcase(@other_spender)
+      assert pinned == String.downcase(@spender)
+    end
+
+    test "the match is on the address, not its checksum casing" do
+      quote = quote_resp("permit2", permit2_pull(String.downcase(@spender)))
+
+      assert {:ok, {:permit2, _}} = OriginPull.allowance_plan(quote, String.upcase(@spender))
+    end
+
+    test "a Permit2 authorization with no spender is refused" do
+      pull = put_in(permit2_pull(@spender), ["message", "spender"], nil)
+
+      assert {:error, {:invalid_spender, :served, nil}} =
+               OriginPull.allowance_plan(quote_resp("permit2", pull), @spender)
+    end
+
+    test "a malformed pin is refused as malformed, not silently mismatched" do
+      quote = quote_resp("permit2", permit2_pull(@spender))
+
+      assert {:error, {:invalid_spender, :pinned, "0xnope"}} =
+               OriginPull.allowance_plan(quote, "0xnope")
+    end
+  end
+
+  describe "ensure_allowance/6" do
+    test "sends nothing when the rail needs no allowance" do
+      adapter = Mock.new()
+
+      assert {:ok, :not_needed} =
+               OriginPull.ensure_allowance(:not_needed, adapter, 8453, @token, @owner)
+
+      assert Mock.sent_calls(adapter) == []
+    end
+
+    test "sends nothing when the allowance is already standing" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, max_word())
+
+      assert {:ok, :standing} =
+               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner)
+
+      assert Mock.sent_calls(adapter) == []
+    end
+
+    test "sends exactly one approve when the allowance is short" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, zero_word())
+
+      assert {:ok, {:approved, "0x" <> _}} =
+               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner)
+
+      assert [{8453, [call]}] = Mock.sent_calls(adapter)
+      assert call.to == @token
+      assert <<@approve_selector::binary, _rest::binary>> = call.data
+    end
+
+    test "a short allowance under --dry-run is reported, never sent" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, zero_word())
+
+      assert {:ok, :would_approve} =
+               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner,
+                 dry_run: true
+               )
+
+      assert Mock.sent_calls(adapter) == []
+    end
+
+    test "a rehearsal judges the allowance by the same threshold the funded run does" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, Permit2Approver.max_uint256())
+
+      assert {:ok, :standing} =
+               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner,
+                 dry_run: true
+               )
+    end
+
+    test "surfaces a failed allowance read instead of assuming an approval is needed" do
+      adapter = Mock.new()
+
+      assert {:error, {:no_canned_read, _, _}} =
+               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner)
+
+      assert Mock.sent_calls(adapter) == []
+    end
+  end
+
+  describe "describe/1" do
+    test "distinguishes a granted approval from a standing one" do
+      assert OriginPull.describe({:approved, "0xabc"}) =~ "approve tx 0xabc"
+      assert OriginPull.describe(:standing) =~ "no approve sent"
+      assert OriginPull.describe(:would_approve) =~ "SHORT"
+      assert OriginPull.describe(:not_needed) =~ "ERC-3009"
+    end
+  end
+
+  describe "explain/1" do
+    test "an unpinned Permit2 pull names the flag and the env var that unblock it" do
+      text = OriginPull.explain(:unpinned_permit2_spender)
+
+      assert text =~ "--solver 0x<spender>"
+      assert text =~ "ORDER_SOLVER"
+      assert text =~ "no on-chain recipient guard"
+      # The served spender is the value the pin exists to check, so the message
+      # must not read as an invitation to copy it back in.
+      assert text =~ "not from a quote"
+    end
+
+    test "a mismatch names both addresses and says nothing was signed" do
+      text = OriginPull.explain({:pull_spender_mismatch, "0xaaa", "0xbbb"})
+
+      assert text =~ "0xaaa"
+      assert text =~ "0xbbb"
+      assert text =~ "Nothing was signed"
+    end
+
+    test "an unrecognised reason is still reported, not swallowed" do
+      text = OriginPull.explain({:transport, :econnrefused})
+
+      assert text =~ "econnrefused"
+      assert text =~ "Nothing was signed"
+    end
+  end
+end

--- a/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
@@ -393,6 +393,17 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
       assert text =~ "Nothing was signed"
     end
 
+    # Naming the served address is disclosure; formatting it as `--solver <it>` is
+    # a remedy. Rendering the remedy hands back a ready-to-run command that grants
+    # a real allowance towards whatever the counterparty asked for, one paste
+    # after the operator is told the pin exists to check exactly that value.
+    test "a mismatch does not offer the served address as the fix" do
+      text = OriginPull.explain({:pull_spender_mismatch, "0xaaa", "0xbbb"})
+
+      refute text =~ "--solver 0xaaa"
+      assert text =~ "deployment record"
+    end
+
     test "every cross-check refusal says what was served and what was intended" do
       chain = OriginPull.explain({:pull_chain_mismatch, 42_161, 8453})
       token = OriginPull.explain({:pull_token_mismatch, @other_token, @token})

--- a/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
@@ -2,15 +2,20 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
   @moduledoc """
   The origin-pull allowance decision an order makes before it signs anything.
 
-  Two properties are load-bearing enough to be pinned here rather than left to a
+  Four properties are load-bearing enough to be pinned here rather than left to a
   funded run:
 
     * Permit2 has no on-chain recipient guard -- the spender picks the recipient
       at call time -- so an allowance is granted ONLY towards a spender the
       operator pinned and the quote actually served. Every other combination
       fails closed, before the approve and before the signature.
-    * The approve is idempotent. A standing allowance must send no transaction,
-      or every order pays for one it did not need.
+    * The permit is served by the counterparty, so its chain, token and amount are
+      checked against the transfer the OPERATOR asked for. Otherwise the quote
+      picks which balance the allowance opens, and how much of it.
+    * The approve is bounded to the one intent's authorized pull, so a later bad
+      signature cannot reach more of the balance than this run was spending.
+    * The approve is idempotent. An allowance that already covers the pull must
+      send no transaction, or every order pays for one it did not need.
   """
 
   use ExUnit.Case, async: true
@@ -23,9 +28,17 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
   @spender "0xE9B020941015e428876f60C1979B3fc2A38a2f53"
   @other_spender "0x97D447561fDe10E959E782a29411D8F89586d80b"
   @token "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+  @other_token "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2"
   @owner "0x468aeae798b3a6548ac2401d276f83afdc172283"
+  @amount 3_000_000
   @allowance_sig "allowance(address,address)"
   @approve_selector <<0x09, 0x5E, 0xA7, 0xB3>>
+
+  defp origin(overrides \\ %{}),
+    do: Map.merge(%{chain_id: 8453, token: @token, amount: @amount}, overrides)
+
+  defp permit(overrides \\ %{}),
+    do: Map.merge(%{spender: @spender, chain_id: 8453, token: @token, amount: @amount}, overrides)
 
   defp quote_resp(method, pull) do
     %QuoteResponse{
@@ -37,12 +50,15 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
     }
   end
 
-  defp permit2_pull(spender) do
+  defp permit2_pull(spender, opts \\ []) do
     %{
       "primaryType" => "PermitWitnessTransferFrom",
-      "domain" => %{"name" => "Permit2", "chainId" => 8453},
+      "domain" => %{"name" => "Permit2", "chainId" => Keyword.get(opts, :chain_id, 8453)},
       "message" => %{
-        "permitted" => %{"token" => @token, "amount" => "3000000"},
+        "permitted" => %{
+          "token" => Keyword.get(opts, :token, @token),
+          "amount" => Keyword.get(opts, :amount, "3000000")
+        },
         "spender" => spender,
         "nonce" => "0x" <> String.duplicate("11", 32),
         "deadline" => "1900000000"
@@ -60,47 +76,52 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
 
   defp max_word, do: "0x" <> String.duplicate("f", 64)
   defp zero_word, do: "0x" <> String.duplicate("0", 64)
+  defp word(value), do: "0x" <> String.pad_leading(Integer.to_string(value, 16), 64, "0")
 
-  describe "allowance_plan/2 -- rails" do
+  describe "allowance_plan/3 -- rails" do
     test "a quote with no origin pull needs no allowance" do
-      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote_resp("erc3009", nil), nil)
+      assert {:ok, :not_needed} =
+               OriginPull.allowance_plan(quote_resp("erc3009", nil), nil, origin())
     end
 
     test "the ERC-3009 rail needs no allowance, pinned or not" do
       quote = quote_resp("erc3009", erc3009_pull())
 
-      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote, nil)
-      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote, @spender)
+      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote, nil, origin())
+      assert {:ok, :not_needed} = OriginPull.allowance_plan(quote, @spender, origin())
     end
 
     test "the rail comes from the quote, not the token: USDC can be a Permit2 pull" do
       # Same USDC address as the ERC-3009 case above -- only payment_method differs.
       quote = quote_resp("permit2", permit2_pull(@spender))
 
-      assert {:ok, {:permit2, @spender}} = OriginPull.allowance_plan(quote, @spender)
+      assert {:ok, {:permit2, permit()}} ==
+               OriginPull.allowance_plan(quote, @spender, origin())
     end
 
     test "an unknown rail is refused rather than signed" do
       quote = quote_resp("teleport", permit2_pull(@spender))
 
       assert {:error, {:unsupported_pull_method, "teleport"}} =
-               OriginPull.allowance_plan(quote, @spender)
+               OriginPull.allowance_plan(quote, @spender, origin())
     end
   end
 
-  describe "allowance_plan/2 -- the Permit2 spender pin" do
+  describe "allowance_plan/3 -- the Permit2 spender pin" do
     test "an unpinned Permit2 pull is refused" do
       quote = quote_resp("permit2", permit2_pull(@spender))
 
-      assert {:error, :unpinned_permit2_spender} = OriginPull.allowance_plan(quote, nil)
-      assert {:error, :unpinned_permit2_spender} = OriginPull.allowance_plan(quote, "")
+      assert {:error, :unpinned_permit2_spender} =
+               OriginPull.allowance_plan(quote, nil, origin())
+
+      assert {:error, :unpinned_permit2_spender} = OriginPull.allowance_plan(quote, "", origin())
     end
 
     test "a served spender that is not the pinned one is refused, naming both" do
       quote = quote_resp("permit2", permit2_pull(@other_spender))
 
       assert {:error, {:pull_spender_mismatch, served, pinned}} =
-               OriginPull.allowance_plan(quote, @spender)
+               OriginPull.allowance_plan(quote, @spender, origin())
 
       assert served == String.downcase(@other_spender)
       assert pinned == String.downcase(@spender)
@@ -109,93 +130,182 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
     test "the match is on the address, not its checksum casing" do
       quote = quote_resp("permit2", permit2_pull(String.downcase(@spender)))
 
-      assert {:ok, {:permit2, _}} = OriginPull.allowance_plan(quote, String.upcase(@spender))
+      assert {:ok, {:permit2, _}} =
+               OriginPull.allowance_plan(quote, String.upcase(@spender), origin())
     end
 
     test "a Permit2 authorization with no spender is refused" do
       pull = put_in(permit2_pull(@spender), ["message", "spender"], nil)
 
       assert {:error, {:invalid_spender, :served, nil}} =
-               OriginPull.allowance_plan(quote_resp("permit2", pull), @spender)
+               OriginPull.allowance_plan(quote_resp("permit2", pull), @spender, origin())
     end
 
     test "a malformed pin is refused as malformed, not silently mismatched" do
       quote = quote_resp("permit2", permit2_pull(@spender))
 
       assert {:error, {:invalid_spender, :pinned, "0xnope"}} =
-               OriginPull.allowance_plan(quote, "0xnope")
+               OriginPull.allowance_plan(quote, "0xnope", origin())
+    end
+
+    test "a malformed envelope reaches this module's refusal, not an Access error" do
+      quote = quote_resp("permit2", %{"message" => "not-a-map"})
+
+      assert {:error, {:invalid_spender, :served, nil}} =
+               OriginPull.allowance_plan(quote, @spender, origin())
     end
   end
 
-  describe "ensure_allowance/6" do
+  describe "allowance_plan/3 -- the served permit against the operator's intent" do
+    test "a permit for another chain is refused" do
+      quote = quote_resp("permit2", permit2_pull(@spender, chain_id: 42_161))
+
+      assert {:error, {:pull_chain_mismatch, 42_161, 8453}} =
+               OriginPull.allowance_plan(quote, @spender, origin())
+    end
+
+    test "a permit for another token is refused" do
+      quote = quote_resp("permit2", permit2_pull(@spender, token: @other_token))
+
+      assert {:error, {:pull_token_mismatch, @other_token, @token}} =
+               OriginPull.allowance_plan(quote, @spender, origin())
+    end
+
+    test "a permit authorizing more than the transfer being ordered is refused" do
+      quote = quote_resp("permit2", permit2_pull(@spender, amount: "3000001"))
+
+      assert {:error, {:pull_amount_unbounded, "3000001", @amount}} =
+               OriginPull.allowance_plan(quote, @spender, origin())
+    end
+
+    test "a permit for less than the ordered amount is allowed, and bounds the approve" do
+      quote = quote_resp("permit2", permit2_pull(@spender, amount: "1500000"))
+
+      assert {:ok, {:permit2, %{amount: 1_500_000}}} =
+               OriginPull.allowance_plan(quote, @spender, origin())
+    end
+
+    test "a missing or unparseable chain, token or amount is refused, never defaulted" do
+      for pull <- [
+            permit2_pull(@spender, chain_id: nil),
+            permit2_pull(@spender, token: nil),
+            permit2_pull(@spender, amount: "lots")
+          ] do
+        assert {:error, _reason} =
+                 OriginPull.allowance_plan(quote_resp("permit2", pull), @spender, origin())
+      end
+    end
+
+    test "the plan carries the operator's leg, so the effect cannot act on the served one" do
+      quote = quote_resp("permit2", permit2_pull(@spender))
+
+      assert {:ok, {:permit2, %{chain_id: 8453, token: @token}}} =
+               OriginPull.allowance_plan(quote, @spender, origin())
+    end
+  end
+
+  describe "ensure_allowance/4" do
     test "sends nothing when the rail needs no allowance" do
       adapter = Mock.new()
 
-      assert {:ok, :not_needed} =
-               OriginPull.ensure_allowance(:not_needed, adapter, 8453, @token, @owner)
+      assert {:ok, :not_needed} = OriginPull.ensure_allowance(:not_needed, adapter, @owner)
 
       assert Mock.sent_calls(adapter) == []
     end
 
-    test "sends nothing when the allowance is already standing" do
+    test "sends nothing when the allowance already covers the pull" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, word(@amount))
+
+      assert {:ok, :standing} =
+               OriginPull.ensure_allowance({:permit2, permit()}, adapter, @owner)
+
+      assert Mock.sent_calls(adapter) == []
+    end
+
+    test "leaves a standing max approval alone rather than replacing it" do
       adapter = Mock.new()
       :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, max_word())
 
       assert {:ok, :standing} =
-               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner)
+               OriginPull.ensure_allowance({:permit2, permit()}, adapter, @owner)
 
       assert Mock.sent_calls(adapter) == []
     end
 
-    test "sends exactly one approve when the allowance is short" do
+    test "approves exactly the intent's authorized pull, never uint256.max" do
       adapter = Mock.new()
       :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, zero_word())
 
-      assert {:ok, {:approved, "0x" <> _}} =
-               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner)
+      assert {:ok, {:approved, @amount, "0x" <> _}} =
+               OriginPull.ensure_allowance({:permit2, permit()}, adapter, @owner)
 
       assert [{8453, [call]}] = Mock.sent_calls(adapter)
       assert call.to == @token
-      assert <<@approve_selector::binary, _rest::binary>> = call.data
+      assert <<@approve_selector::binary, args::binary>> = call.data
+
+      # approve(address spender, uint256 amount): the amount is the second word.
+      assert <<_spender::binary-size(32), granted::unsigned-big-integer-size(256)>> = args
+      assert granted == @amount
+      refute granted == Permit2Approver.max_uint256()
     end
 
-    test "a short allowance under --dry-run is reported, never sent" do
+    test "an allowance short of the pull is topped up to the pull, not beyond" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, word(@amount - 1))
+
+      assert {:ok, {:approved, @amount, _hash}} =
+               OriginPull.ensure_allowance({:permit2, permit()}, adapter, @owner)
+    end
+
+    test "a short allowance under --dry-run is reported with its bound, never sent" do
       adapter = Mock.new()
       :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, zero_word())
 
-      assert {:ok, :would_approve} =
-               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner,
-                 dry_run: true
-               )
+      assert {:ok, {:would_approve, @amount}} =
+               OriginPull.ensure_allowance({:permit2, permit()}, adapter, @owner, dry_run: true)
 
       assert Mock.sent_calls(adapter) == []
     end
 
     test "a rehearsal judges the allowance by the same threshold the funded run does" do
       adapter = Mock.new()
-      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, Permit2Approver.max_uint256())
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, word(@amount))
 
       assert {:ok, :standing} =
-               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner,
-                 dry_run: true
-               )
+               OriginPull.ensure_allowance({:permit2, permit()}, adapter, @owner, dry_run: true)
+    end
+
+    test "the plan's chain and token decide where the allowance is read and granted" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @other_token, @allowance_sig, zero_word())
+
+      plan = {:permit2, permit(%{chain_id: 42_161, token: @other_token})}
+
+      assert {:ok, {:approved, @amount, _hash}} =
+               OriginPull.ensure_allowance(plan, adapter, @owner)
+
+      assert [{42_161, [call]}] = Mock.sent_calls(adapter)
+      assert call.to == @other_token
     end
 
     test "surfaces a failed allowance read instead of assuming an approval is needed" do
       adapter = Mock.new()
 
       assert {:error, {:no_canned_read, _, _}} =
-               OriginPull.ensure_allowance({:permit2, @spender}, adapter, 8453, @token, @owner)
+               OriginPull.ensure_allowance({:permit2, permit()}, adapter, @owner)
 
       assert Mock.sent_calls(adapter) == []
     end
   end
 
   describe "describe/1" do
-    test "distinguishes a granted approval from a standing one" do
-      assert OriginPull.describe({:approved, "0xabc"}) =~ "approve tx 0xabc"
+    test "distinguishes a granted approval from a standing one, and names the bound" do
+      assert OriginPull.describe({:approved, 3_000_000, "0xabc"}) =~ "approve tx 0xabc"
+      assert OriginPull.describe({:approved, 3_000_000, "0xabc"}) =~ "exactly 3000000 base units"
       assert OriginPull.describe(:standing) =~ "no approve sent"
-      assert OriginPull.describe(:would_approve) =~ "SHORT"
+      assert OriginPull.describe({:would_approve, 3_000_000}) =~ "SHORT"
+      assert OriginPull.describe({:would_approve, 3_000_000}) =~ "exactly 3000000 base units"
       # True of a non-pulling quote as well as an ERC-3009 one, since both reach
       # this outcome.
       assert OriginPull.describe(:not_needed) =~ "not a Permit2 pull"
@@ -220,6 +330,21 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
       assert text =~ "0xaaa"
       assert text =~ "0xbbb"
       assert text =~ "Nothing was signed"
+    end
+
+    test "every cross-check refusal says what was served and what was intended" do
+      chain = OriginPull.explain({:pull_chain_mismatch, 42_161, 8453})
+      token = OriginPull.explain({:pull_token_mismatch, @other_token, @token})
+      amount = OriginPull.explain({:pull_amount_unbounded, "9000000", 3_000_000})
+
+      for {text, served} <- [{chain, "42161"}, {token, @other_token}, {amount, "9000000"}] do
+        assert text =~ served
+        assert text =~ "no allowance was granted"
+      end
+
+      assert chain =~ "8453"
+      assert token =~ @token
+      assert amount =~ "3000000"
     end
 
     test "an unrecognised reason is still reported, not swallowed" do

--- a/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
@@ -196,7 +196,9 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
       assert OriginPull.describe({:approved, "0xabc"}) =~ "approve tx 0xabc"
       assert OriginPull.describe(:standing) =~ "no approve sent"
       assert OriginPull.describe(:would_approve) =~ "SHORT"
-      assert OriginPull.describe(:not_needed) =~ "ERC-3009"
+      # True of a non-pulling quote as well as an ERC-3009 one, since both reach
+      # this outcome.
+      assert OriginPull.describe(:not_needed) =~ "not a Permit2 pull"
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/origin_pull_test.exs
@@ -299,6 +299,65 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
     end
   end
 
+  describe "allowance_status/3 and approve_calls/1" do
+    test "reading the allowance broadcasts nothing, whatever it says" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, zero_word())
+
+      assert {:ok, {:short, permit()}} ==
+               OriginPull.allowance_status({:permit2, permit()}, adapter, @owner)
+
+      assert Mock.sent_calls(adapter) == []
+    end
+
+    test "a rail needing no allowance is short of nothing and batches nothing" do
+      adapter = Mock.new()
+
+      assert {:ok, :not_needed} = OriginPull.allowance_status(:not_needed, adapter, @owner)
+      assert OriginPull.approve_calls(:not_needed) == []
+    end
+
+    test "an allowance already covering the pull batches nothing" do
+      adapter = Mock.new()
+      :ok = Mock.set_contract_read(adapter, @token, @allowance_sig, word(@amount))
+
+      assert {:ok, :standing} =
+               OriginPull.allowance_status({:permit2, permit()}, adapter, @owner)
+
+      assert OriginPull.approve_calls(:standing) == []
+    end
+
+    test "a short allowance batches one approve, bounded to the permit" do
+      assert [call] = OriginPull.approve_calls({:short, permit()})
+
+      assert call.to == @token
+      assert call.value == 0
+      assert <<@approve_selector::binary, args::binary>> = call.data
+
+      assert <<spender::binary-size(32), granted::unsigned-big-integer-size(256)>> = args
+      assert granted == @amount
+      refute granted == Permit2Approver.max_uint256()
+
+      # The ERC-20 approval spender is the universal Permit2 contract; the
+      # permit's own spender is bounded by the pin, not by this approve.
+      assert "0x" <> Base.encode16(binary_part(spender, 12, 20), case: :lower) ==
+               String.downcase(Permit2Approver.permit2_address())
+    end
+
+    test "the batched bound is the permit's, not the amount originally ordered" do
+      assert [call] = OriginPull.approve_calls({:short, permit(%{amount: 1_500_000})})
+      assert <<@approve_selector::binary, _spender::binary-size(32), granted::256>> = call.data
+      assert granted == 1_500_000
+    end
+
+    test "a failed allowance read is surfaced, never read as sufficient" do
+      adapter = Mock.new()
+
+      assert {:error, {:no_canned_read, _, _}} =
+               OriginPull.allowance_status({:permit2, permit()}, adapter, @owner)
+    end
+  end
+
   describe "describe/1" do
     test "distinguishes a granted approval from a standing one, and names the bound" do
       assert OriginPull.describe({:approved, 3_000_000, "0xabc"}) =~ "approve tx 0xabc"
@@ -306,6 +365,8 @@ defmodule Raxol.Earn.Xochi.OriginPullTest do
       assert OriginPull.describe(:standing) =~ "no approve sent"
       assert OriginPull.describe({:would_approve, 3_000_000}) =~ "SHORT"
       assert OriginPull.describe({:would_approve, 3_000_000}) =~ "exactly 3000000 base units"
+      assert OriginPull.describe({:short, %{amount: 3_000_000}}) =~ "SHORT"
+      assert OriginPull.describe({:short, %{amount: 3_000_000}}) =~ "exactly 3000000 base units"
       # True of a non-pulling quote as well as an ERC-3009 one, since both reach
       # this outcome.
       assert OriginPull.describe(:not_needed) =~ "not a Permit2 pull"

--- a/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/smart_account_wire_test.exs
@@ -1,49 +1,54 @@
 defmodule Raxol.Earn.Xochi.SmartAccountWireTest do
   @moduledoc """
-  Pins the wire shape of a SMART-ACCOUNT signature against the constraint that
-  currently rejects it downstream.
+  Pins the wire shape of a SMART-ACCOUNT signature: the 72-byte ma-v2 ERC-1271
+  envelope `mix raxol_earn.order --signer privy` releases.
 
   ## Why this exists
 
-  Every live gate that has ever passed used an EOA buyer. Nothing exercised an
+  Every live gate that had ever passed used an EOA buyer. Nothing exercised an
   ERC-1271 signature, and that gap let one assumption -- "a signature is 65
-  bytes" -- survive three layers into production:
+  bytes" -- survive three layers into production, each needing its own fix:
 
-    1. raxol built the wrong ERC-1271 replay-safe domain (fixed, #773)
+    1. raxol built the wrong ERC-1271 replay-safe domain (raxol#773)
     2. Xochi's ERC-1271 verification silently never ran, because no `RPC_URL_*`
        was set in production, so every smart-account signer got a bare 401
-       (fixed, xochi-fi/xochi#364, deployed 2026-08-15)
-    3. Riddler's request schema constrains the signature to exactly 65 bytes,
-       `~r/^0x[a-fA-F0-9]{130}$/` (open, axol-io/Riddler#802)
+       (xochi-fi/xochi#364, deployed 2026-08-15)
+    3. Riddler's request schema constrained the signature to exactly 65 bytes
+       (axol-io/Riddler#802, closed 2026-08-16)
 
-  Layer 3 is why a real funded order (job 73295) still fails today, at
-  `validation_failed: Request validation failed`.
+  All three are cleared. What is still worth pinning is OUR half of the contract:
+  three services were taught to accept this exact envelope, so changing it is
+  changing something they agreed on, and this fails the moment anyone does.
+
+  The 65-byte pattern below is kept as a HISTORICAL literal rather than a live
+  constraint. It is the shape the envelope had to outgrow, and holding it here
+  keeps the reason the envelope is 72 bytes executable instead of folkloric.
 
   ## What this test can and cannot do
 
-  It asserts OUR half: the ma-v2 envelope raxol produces is 72 bytes, and a
-  72-byte signature cannot match the 65-byte pattern the solver enforces. That
-  makes the incompatibility an executable fact rather than a note in an issue,
-  and it fails immediately if anyone changes the envelope.
+  It deliberately does NOT probe the live service, because there is no fund-free
+  way to reach the constraint. Xochi verifies the signature BEFORE forwarding to
+  Riddler: an intent signed with an unauthorized key is rejected at Xochi's
+  ERC-1271 check and never reaches the schema, while a validly signed one
+  executes the pull and moves the principal. A live probe would therefore either
+  test the wrong layer or spend real money.
 
-  It deliberately does NOT probe the live service, because there is no
-  fund-free way to reach the constraint. Xochi verifies the signature BEFORE
-  forwarding to Riddler: an intent signed with an unauthorized key is rejected
-  at Xochi's ERC-1271 check and never reaches the schema, while a validly
-  signed one executes the pull and moves the principal. A live probe would
-  therefore either test the wrong layer or spend real money.
+  Confirmation is one funded run, which a smart-account buyer now pulls through
+  Permit2 rather than ERC-3009, so it needs the spender pin (and, the first time,
+  the Permit2 approve):
 
-  When #802 lands, the confirmation is one funded run:
-  `mix raxol_earn.order --amount 3.00 --signer privy --fund` (~0.017 USDC).
+      mix raxol_earn.order --amount 3.00 --signer privy --solver 0x<spender> --fund
   """
 
   use ExUnit.Case, async: true
 
-  # Verbatim from Riddler `integrations/xochi/schemas/execute_request.ex:42`,
-  # duplicated in `web/openapi/schema.ex:92` and `claim_submit_request.ex:63`,
-  # and published in `packages/api/src/spec.json` as
-  # `CommerceOrderRequest.properties.signature`.
-  @riddler_signature_pattern ~r/^0x[a-fA-F0-9]{130}$/
+  # The signature pattern Riddler enforced before it accepted smart-account
+  # payments: verbatim from `integrations/xochi/schemas/execute_request.ex`,
+  # duplicated in `web/openapi/schema.ex` and `claim_submit_request.ex`, and
+  # published in `packages/api/src/spec.json` as
+  # `CommerceOrderRequest.properties.signature`. Kept as the historical shape the
+  # envelope had to outgrow, not as a constraint that still holds.
+  @legacy_65_byte_pattern ~r/^0x[a-fA-F0-9]{130}$/
 
   @account "0x468aeae798b3a6548ac2401d276f83afdc172283"
   @chain 8453
@@ -93,19 +98,19 @@ defmodule Raxol.Earn.Xochi.SmartAccountWireTest do
       assert inner == @raw_sig
     end
 
-    test "does not satisfy Riddler's 65-byte signature pattern (axol-io/Riddler#802)" do
+    test "outgrows the 65-byte pattern that used to reject it" do
       hex = "0x" <> Base.encode16(envelope(), case: :lower)
 
-      # 72 bytes = 144 hex chars; the pattern demands exactly 130.
+      # 72 bytes = 144 hex chars; the old pattern demanded exactly 130.
       assert String.length(hex) == 146
-      refute Regex.match?(@riddler_signature_pattern, hex)
+      refute Regex.match?(@legacy_65_byte_pattern, hex)
     end
 
-    test "a plain EOA signature does satisfy it -- the pattern is not simply broken" do
+    test "a plain EOA signature fits that pattern -- it was never simply broken" do
       hex = "0x" <> Base.encode16(@raw_sig, case: :lower)
 
       assert String.length(hex) == 132
-      assert Regex.match?(@riddler_signature_pattern, hex)
+      assert Regex.match?(@legacy_65_byte_pattern, hex)
     end
   end
 

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -54,6 +54,14 @@
 #                         asset (USDT needs GATE_RPC_42161; USDG needs GATE_RPC_4663)
 #                         on the acp route, and for the relay source chain.
 #   GATE_FROM_ADDRESS     EVM source address for the relay quote probe.
+#   GATE_PULL_SPENDER     the Permit2 spender the acp route may grant an origin
+#                         allowance to. REQUIRED to SETTLE a cell whose quote
+#                         pulls via Permit2; there is no default, because Permit2
+#                         has no on-chain recipient guard and the allowance is
+#                         what makes that address able to move the origin
+#                         balance. A Permit2 cell SKIPs without it. Take it from
+#                         Riddler's XochiPull deployment record -- it is the pull
+#                         proxy, not GATE_SOLVER's settlement wallet.
 #   GATE_TRON_ADDRESS     Tron recipient WALLET for the relay route. REQUIRED to
 #                         probe or settle relay; there is no default, because a
 #                         Tron settlement is final and the destination token
@@ -143,6 +151,7 @@ Usage: scripts/run_live_gates.sh --asset A[,A...] [--route R[,R...]] [options]
 
 Secrets via env: GATE_KEY, GATE_XOCHI_TOKEN, GATE_RELAY_TOKEN,
 GATE_RPC_<chainid> (e.g. GATE_RPC_42161), GATE_FROM_ADDRESS,
+GATE_PULL_SPENDER (Permit2 allowance pin; Permit2 cells SKIP without it),
 GATE_TRON_ADDRESS (relay recipient wallet; relay cells SKIP without it).
 EOF
 }
@@ -313,6 +322,14 @@ run_acp() {
   export XOCHI_ORDER_AMOUNT="$AMOUNT"
   export XOCHI_ORDER_CORRIDORS="$corridors" XOCHI_ORDER_TOKENS="$tok"
   export XOCHI_ORDER_SOLVER="${GATE_SOLVER:-$CANONICAL_SOLVER}"
+  # The Permit2 allowance pin is separate and deliberately undefaulted: it names
+  # the spender an ERC-20 approve would make able to pull the origin balance, and
+  # Permit2 bounds the destination nowhere on-chain. Unset, Permit2 cells SKIP.
+  if [[ -n "${GATE_PULL_SPENDER:-}" ]]; then
+    export XOCHI_ORDER_PULL_SPENDER="$GATE_PULL_SPENDER"
+  else
+    unset XOCHI_ORDER_PULL_SPENDER
+  fi
   # Order the launch offering (xochi_stable_public) under its real corridor scope:
   # each asset's default corridor above is on the CorridorAllowlist.
   export XOCHI_ORDER_STABLECOIN_ALLOWLIST=true


### PR DESCRIPTION
Unblocks #772's confirming funded run.

## Why now

All three layers of #772 are cleared upstream. Verified directly rather than from
the issue body, which is still the pre-correction text:

- raxol's ERC-1271 replay-safe domain -- fixed, #773
- Xochi's worker had no `RPC_URL_*`, so its ERC-1271 path never ran and every
  smart-account signer got a bare 401 -- xochi-fi/xochi#364, closed 2026-08-15
- Riddler's schema pinned the signature to exactly 65 bytes -- axol-io/Riddler#802,
  closed 2026-08-16 by merged PR axol-io/Riddler#810

**#810 did more than relax the regex: it steered smart-account USDC pulls from
ERC-3009 to Permit2.** That is what this PR accommodates.

## The safety problem Permit2 creates

Under ERC-3009 the signed authorization names the `to` address, so the chain
enforces the destination. Under Permit2 there is no on-chain recipient guard --
the spender picks the recipient at call time. The operator's spender pin is
therefore the only destination control on this rail.

So the pin is deliberately NOT satisfiable from the checked-in mirror.
`Raxol.Payments.Xochi.PullContracts` mirrors Riddler's deployment record and is
exactly in sync with it, but a copy of a deployment doc is not an operator's
assertion about this run. `--solver 0x..` (or `ORDER_SOLVER`) must name the
spender consciously, and a Permit2 quote without it is refused before anything is
signed or approved.

## What this adds

`Raxol.Earn.Xochi.OriginPull` splits the decision from the effect:
`allowance_plan/3` decides, `approve_calls/1` and `ensure_allowance/4` act,
`explain/1` produces the refusal text. Splitting them is what makes both callers
share one rule and lets the decision be tested with no live quote and no chain.

`allowance_plan/3` refuses unless the served permit agrees with the operator's
intent on all four axes: spender equals the pin, `domain.chainId` equals the
origin chain, `permitted.token` equals the origin token, and `permitted.amount`
is within the intended amount. The amount check is what makes the bounded approve
safe -- a hostile quote cannot request a large approve by serving a large permit.

`sign_intent/2` became quote -> check origin pull -> sign. Every refusal aborts
with nothing signed.

**The approve is bounded to the intent's authorized pull, not `uint256.max`.**
Permit2's own design puts the bound in the per-transfer signature, which is why a
standing max approve is conventional -- but that assumes a human reviews each
signature in a wallet UI. Here the signer is a delegated Privy sidecar signing
whatever the served quote contains, and the only human in the loop is the spender
pin, which bounds where funds go and not how much. A standing max would turn any
single bad signature into loss of the whole origin balance. An operator who
prefers the conventional pattern can still grant a max out of band; every
subsequent run then reads `:standing` and sends nothing.

**The approve rides inside the existing approve+fund batch.** The repo already
notes that the Virtuals paymaster refuses a standalone approve to a token
contract and accepts it batched with the ACP-core call. The allowance is not
needed at signature time -- it is needed when the solver pulls, which is at
settlement, strictly downstream of `fund` (traced through `JobSession.Provider`'s
`:funded` guard into `Xochi.Settler`). Batching also closes a window the
standalone approve had: the allowance now exists in the same transaction that
makes the job fundable.

## Verification

Four adversarial review rounds. Four safety properties confirmed by tracing on
the final tree: the TOCTOU is closed, the approve is resolved, **no path in this
task** grants an allowance or signs a Permit2 pull without an operator pin, and
the ERC-3009 / EOA path is unchanged.

That scope qualifier is load-bearing and is now written into `OriginPull`'s
moduledoc. The property belongs to this task, not to the signing layer:
`validate_permit2_pull/2` asks only that the spender be in
`:pull_solver_allowlist`, and `config/runtime.exs` populates that list from the
checked-in mirror -- so `XochiProtocol.quote_and_sign/3` called directly will
sign a Permit2 pull naming the mirrored proxy with no operator input. That is
pre-existing and deliberate (a server with no operator at the keyboard needs a
default), but it means the pin arrives with `OriginPull` and not with the
signature. A new caller that skips this module simply has no pin.

Fixed from the second round:
- the live gate pinned one quote then signed a second, freshly fetched one; it now
  signs the quote it checked
- the standalone approve is batched, as above

Fixed from the fourth round:
- **the funding batch re-reads the allowance.** It was built from the reading
  taken at signing time, minutes earlier -- across createJob mining, the chat
  room appearing, and the provider writing a budget. An allowance that covered
  the pull at signing can be spent down inside that window by an earlier intent's
  own pull, and the batch would then escrow the fee while leaving this intent's
  pull short: fee paid, transfer impossible. `fund_job/4` now carries the *plan*
  (which cannot drift) and reads the allowance again when it builds the batch. A
  read that fails aborts rather than funding short.
- a corridor whose origin is not the ACP core's chain is refused. The batch
  carries the origin-chain Permit2 approve in the same `send_calls` as the Base
  ACP fund, and one batch is one chain -- so a non-Base origin was sending
  createJob to the Base core address on the origin chain while the budget poll
  read Base. Nothing downstream caught it; the 7702/SCA wallets sign for 8453
  regardless.
- the spender-mismatch message no longer renders `--solver <served address>`.
  Naming the served value is disclosure; formatting it as the remedy handed back
  a ready-to-run command granting a real allowance towards whatever the
  counterparty asked for, one paste after saying the pin exists to check it.
- the live-gate guard test parses the gate instead of grepping it. As text it was
  wrong in both directions: a commented-out call still read as present, and
  documenting why the approver is off-limits would have broken the build.

`raxol_earn` 886 passed, `raxol_payments` 1149 passed, both clean on
`mix format --check-formatted` and `mix compile --warnings-as-errors`.
Each behavioural change has a red-then-green proof; the bounded approve is pinned
by decoding the emitted call's second ABI word.

No live or fund-moving test was run.

## Known limits

- The three-call batch (approve Permit2 + approve core + fund) is inferred to be
  paymaster-acceptable from the two-call precedent, not verified on-chain. The
  first funded run proves it; `--dry-run` cannot, since it only reads.
- The allowance is re-read when the batch is built, so the window is now the gap
  between that read and the UserOp landing rather than the minutes since signing.
  A third party can still spend the allowance down inside it; nothing short of an
  on-chain check-and-approve closes that, and the bounded approve caps what it
  could cost.
- The operator-pin requirement still lives in `OriginPull`, not in
  `validate_permit2_pull/2`. It is now documented as caller-scoped rather than
  absolute, but a new caller that skips this module has no pin. Pushing it down
  is the structural fix and is deliberately still out of scope here: it would
  stop existing deployments settling until they set `XOCHI_SOLVER_*`.
- `solver_fee_live_test.exs` still calls `quote_and_sign/3`, so it releases a pull
  signature with no spender pin. Excluded by default, worth its own change.
- The pin is not scoped per rail: `--solver` unions into the single flat
  `:pull_solver_allowlist`, which gates both rails, so pinning a Permit2 spender
  silently widens the ERC-3009 `to` set by the same address.

## Manual testing

- [ ] `mix raxol_earn.order --amount 3.00 --signer privy --dry-run --solver 0xE9B020941015e428876f60C1979B3fc2A38a2f53`
      reaches the plan and reports the allowance without sending anything
- [ ] Same without `--solver` on a Permit2 quote is refused before signing
- [ ] The funded run: `mix raxol_earn.order --amount 3.00 --signer privy --fund --solver 0x...`
      (moves the principal -- this is the #772 confirmation)
