### PR TITLE
Drop the RATE matrix leg with no runner

### DIFF
--- a/.github/workflows/rate-selfhosted.yml
+++ b/.github/workflows/rate-selfhosted.yml
@@ -1,10 +1,23 @@
 name: RATE self-hosted
 
 # Builds the termbox2 NIF and exercises the tty-dependent suite on the homelab's
-# Nix-pinned self-hosted runners (aarch64-linux + x86_64-linux). GitHub-hosted CI
-# skips these via SKIP_TERMBOX2_TESTS; this workflow leaves it unset and runs the
-# NIF for real on both Linux architectures, plus a golden render comparison so the
-# aarch64-linux hash is checked against priv/rate/golden.refs.
+# Nix-pinned self-hosted runners. GitHub-hosted CI skips these via
+# SKIP_TERMBOX2_TESTS; this workflow leaves it unset and runs the NIF for real,
+# plus a golden render comparison so the aarch64-linux hash is checked against
+# priv/rate/golden.refs.
+#
+# aarch64 only, because that is the homelab: the Turing Pi nodes are ARM. This
+# matrix used to name X64 as well, which no registered runner could satisfy, so
+# that leg queued until the next nightly cancelled it through the concurrency
+# group -- eight consecutive daily runs reported `cancelled` while the aarch64
+# half was passing, which reads as CI flakiness and hides a real result.
+#
+# What that leaves uncovered on x86_64 is the tty-dependent work only -- the
+# termbox2 NIF suite and the :requires_terminal platform suite, both skipped by
+# SKIP_TERMBOX2_TESTS in GitHub-hosted CI. The golden render is untagged, so it
+# still runs there in the default suite. Closing the tty gap needs either an
+# x86_64 self-hosted runner or a nix-on-ubuntu-latest leg; naming an arch nobody
+# can run is not coverage.
 #
 # Security: raxol is a public repository, so these jobs must never run untrusted
 # code on the homelab. Triggers are limited to manual dispatch, pushes to master,
@@ -33,11 +46,7 @@ permissions:
 jobs:
   nif:
     if: github.repository_owner == 'DROOdotFOO'
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ARM64, X64]
-    runs-on: [self-hosted, linux, "${{ matrix.arch }}", raxol]
+    runs-on: [self-hosted, linux, ARM64, raxol]
     timeout-minutes: 45
     env:
       TERM: xterm-256color


### PR DESCRIPTION
The `RATE self-hosted` workflow has not reported success since at least
2026-08-11. Eight consecutive daily runs read `cancelled`.

It is not flakiness. The matrix named two architectures:

    matrix:
      arch: [ARM64, X64]
    runs-on: [self-hosted, linux, "${{ matrix.arch }}", raxol]

The homelab is a Turing Pi, so both registered runners are ARM64
(`turing-node-1-1`, `turing-node-3-1`). Nothing can satisfy the X64 leg. It
queued until the next nightly cancelled it through the concurrency group's
`cancel-in-progress`, and the run as a whole reported cancelled even though
`nif (ARM64)` passed every time.

The cost is not the wasted leg, it is the signal: a workflow that always reads
cancelled is one you learn to skip, so a real aarch64 regression would have
looked identical.

## What this does

Runs aarch64 only, which is what the hardware is, and records in the header
what that leaves uncovered rather than implying parity.

## What is genuinely uncovered

On x86_64, the tty-dependent suites: the termbox2 NIF suite and the
`:requires_terminal` platform suite, both skipped in GitHub-hosted CI via
`SKIP_TERMBOX2_TESTS`. That gap already existed -- the phantom matrix leg was
hiding it behind a permanently cancelled run rather than covering it.

The golden render is unaffected: `test/rate/golden_test.exs` carries no tags, so
it runs in the default suite on ubuntu-latest.

Closing the tty gap needs either an x86_64 self-hosted runner or a
nix-on-ubuntu-latest leg. Both are real options; neither is this PR.

## Manual testing

- [ ] `gh workflow run rate-selfhosted.yml` completes rather than stranding a job
- [ ] the run reports success, not cancelled
