### PR TITLE
Sign only the EIP-712 domain fields the quote served

### DIFF
--- a/packages/raxol_agent_client_protocol/test/agent_test.exs
+++ b/packages/raxol_agent_client_protocol/test/agent_test.exs
@@ -11,7 +11,7 @@
 #      -> `session/prompt` (2 streamed updates + response) turn through
 #      `Connection`. `Connection`/`Session` are sibling-wave modules that
 #      may not have landed in this worktree yet; the `describe` block below
-#      skips (not fails) at runtime via `Code.ensure_loaded?/1` when they
+#      tags itself `:skip` at load time via `Code.ensure_loaded?/1` when they
 #      are absent, so the rest of the suite stays green either way.
 defmodule Raxol.AgentClientProtocol.AgentTest do
   use ExUnit.Case, async: true
@@ -233,12 +233,11 @@ defmodule Raxol.AgentClientProtocol.AgentTest do
   end
 
   describe "end-to-end smoke over Transport.Paired" do
-    setup do
-      if Code.ensure_loaded?(Raxol.AgentClientProtocol.Connection) do
-        :ok
-      else
-        {:skip, "Raxol.AgentClientProtocol.Connection has not landed in this worktree yet"}
-      end
+    # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+    # invalidates the module. Decide at load time instead.
+    if not Code.ensure_loaded?(Raxol.AgentClientProtocol.Connection) do
+      @describetag skip:
+                     "Raxol.AgentClientProtocol.Connection has not landed in this worktree yet"
     end
 
     test "initialize -> session/new -> session/prompt streams 2 updates then a response" do

--- a/packages/raxol_agent_client_protocol/test/capabilities_test.exs
+++ b/packages/raxol_agent_client_protocol/test/capabilities_test.exs
@@ -329,14 +329,12 @@ defmodule Raxol.AgentClientProtocol.CapabilitiesTest do
   # -- end-to-end over Transport.Paired -----------------------------------
 
   describe "Paired integration: agent terminal/create against a no-terminal client" do
-    setup do
-      if Code.ensure_loaded?(Raxol.AgentClientProtocol.Connection) and
-           Code.ensure_loaded?(Raxol.AgentClientProtocol.Agent) and
-           Code.ensure_loaded?(Raxol.AgentClientProtocol.Client) do
-        :ok
-      else
-        {:skip, "Connection/Agent/Client sibling-wave modules have not landed yet"}
-      end
+    # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+    # invalidates the module. Decide at load time instead.
+    if not (Code.ensure_loaded?(Raxol.AgentClientProtocol.Connection) and
+              Code.ensure_loaded?(Raxol.AgentClientProtocol.Agent) and
+              Code.ensure_loaded?(Raxol.AgentClientProtocol.Client)) do
+      @describetag skip: "Connection/Agent/Client sibling-wave modules have not landed yet"
     end
 
     defmodule GateAgent do

--- a/packages/raxol_agent_client_protocol/test/client_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_test.exs
@@ -240,12 +240,11 @@ defmodule Raxol.AgentClientProtocol.ClientTest do
   end
 
   describe "end-to-end smoke over Transport.Paired" do
-    setup do
-      if Code.ensure_loaded?(Raxol.AgentClientProtocol.Connection) do
-        :ok
-      else
-        {:skip, "Raxol.AgentClientProtocol.Connection has not landed in this worktree yet"}
-      end
+    # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+    # invalidates the module. Decide at load time instead.
+    if not Code.ensure_loaded?(Raxol.AgentClientProtocol.Connection) do
+      @describetag skip:
+                     "Raxol.AgentClientProtocol.Connection has not landed in this worktree yet"
     end
 
     test "client-side session_update/2 observes both streamed updates before the prompt response" do

--- a/packages/raxol_earn/test/raxol/earn/job_api/http_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/job_api/http_test.exs
@@ -12,26 +12,28 @@ defmodule Raxol.Earn.JobApi.HTTPTest do
 
   @moduletag :live_acp_dev
 
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks the credential. A skipped module never runs
+  # setup_all, so the key is present by the time it does.
+  if System.fetch_env("RAXOL_ACP_AGENT_PRIVATE_KEY") == :error do
+    @moduletag skip: "RAXOL_ACP_AGENT_PRIVATE_KEY not set -- live Virtuals dev API tests"
+  end
+
   setup_all do
-    case System.fetch_env("RAXOL_ACP_AGENT_PRIVATE_KEY") do
-      :error ->
-        {:skip, "RAXOL_ACP_AGENT_PRIVATE_KEY not set -- skipping live Virtuals dev API tests"}
+    pk = decode_pk(System.fetch_env!("RAXOL_ACP_AGENT_PRIVATE_KEY"))
 
-      {:ok, pk_hex} ->
-        pk = decode_pk(pk_hex)
+    server_url =
+      System.get_env("RAXOL_ACP_SERVER_URL", "https://api-dev.acp.virtuals.io")
 
-        server_url =
-          System.get_env("RAXOL_ACP_SERVER_URL", "https://api-dev.acp.virtuals.io")
+    rpc_url = System.get_env("RAXOL_ACP_RPC_URL", "https://mainnet.base.org")
 
-        rpc_url = System.get_env("RAXOL_ACP_RPC_URL", "https://mainnet.base.org")
+    provider = JSONRPC.new(chains: %{8453 => rpc_url}, private_key: pk)
 
-        provider = JSONRPC.new(chains: %{8453 => rpc_url}, private_key: pk)
+    {:ok, auth} = Auth.start_link(provider: provider, server_url: server_url, chain_id: 8453)
+    api = HTTP.new(auth: auth, server_url: server_url, chain_ids: [8453])
 
-        {:ok, auth} = Auth.start_link(provider: provider, server_url: server_url, chain_id: 8453)
-        api = HTTP.new(auth: auth, server_url: server_url, chain_ids: [8453])
-
-        {:ok, api: api, provider: provider}
-    end
+    {:ok, api: api, provider: provider}
   end
 
   describe "get_active_jobs/1" do

--- a/packages/raxol_earn/test/raxol/earn/transport/sse_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/transport/sse_test.exs
@@ -14,25 +14,27 @@ defmodule Raxol.Earn.Transport.SSETest do
 
   @moduletag :live_acp_dev
 
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks the credential. A skipped module never runs
+  # setup_all, so the key is present by the time it does.
+  if System.fetch_env("RAXOL_ACP_AGENT_PRIVATE_KEY") == :error do
+    @moduletag skip: "RAXOL_ACP_AGENT_PRIVATE_KEY not set -- live Virtuals dev API tests"
+  end
+
   setup_all do
-    case System.fetch_env("RAXOL_ACP_AGENT_PRIVATE_KEY") do
-      :error ->
-        {:skip, "RAXOL_ACP_AGENT_PRIVATE_KEY not set -- skipping live Virtuals dev API tests"}
+    pk = decode_pk(System.fetch_env!("RAXOL_ACP_AGENT_PRIVATE_KEY"))
 
-      {:ok, pk_hex} ->
-        pk = decode_pk(pk_hex)
+    server_url =
+      System.get_env("RAXOL_ACP_SERVER_URL", "https://api-dev.acp.virtuals.io")
 
-        server_url =
-          System.get_env("RAXOL_ACP_SERVER_URL", "https://api-dev.acp.virtuals.io")
+    rpc_url = System.get_env("RAXOL_ACP_RPC_URL", "https://mainnet.base.org")
 
-        rpc_url = System.get_env("RAXOL_ACP_RPC_URL", "https://mainnet.base.org")
+    provider = JSONRPC.new(chains: %{8453 => rpc_url}, private_key: pk)
 
-        provider = JSONRPC.new(chains: %{8453 => rpc_url}, private_key: pk)
+    {:ok, auth} = Auth.start_link(provider: provider, server_url: server_url, chain_id: 8453)
 
-        {:ok, auth} = Auth.start_link(provider: provider, server_url: server_url, chain_id: 8453)
-
-        {:ok, auth: auth, server_url: server_url, provider: provider}
-    end
+    {:ok, auth: auth, server_url: server_url, provider: provider}
   end
 
   setup ctx do

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -882,27 +882,31 @@ defmodule Raxol.Payments.Protocols.Xochi do
 
   defp replay_nonce_from(_), do: 0
 
-  # Build the domain from exactly the keys the worker served. `verifyingContract`
-  # and `salt` are only included when present: the canonical XochiIntent domain
-  # omits `verifyingContract` and carries a `salt`, so the included key set must
-  # mirror the served domain exactly -- dropping `salt` (or adding a nil
-  # verifyingContract) hashes a different EIP712Domain than the worker's and the
-  # signature does not recover.
+  # Build the domain from exactly the keys the worker served -- EVERY field is
+  # conditional. `Raxol.Payments.EIP712` derives the EIP712Domain field list from
+  # the keys present, so a key carrying `nil` still declares that field and hashes
+  # a domain the verifier never built. No served domain uses all five: the
+  # canonical XochiIntent domain omits `verifyingContract` and carries a `salt`,
+  # and Permit2's omits `version` (see GitHub #772 -- signing a 4-field domain
+  # against Permit2's 3-field one reverts InvalidContractSignature on the pull).
+  @domain_fields [
+    {:name, "name"},
+    {:version, "version"},
+    {:chainId, "chainId"},
+    {:verifyingContract, "verifyingContract"},
+    {:salt, "salt"}
+  ]
+
   defp eip712_domain(eip712) do
-    d = eip712["domain"] || %{}
+    served = eip712["domain"] || %{}
 
-    %{name: d["name"], version: d["version"], chainId: d["chainId"]}
-    |> maybe_put_verifying_contract(d["verifyingContract"])
-    |> maybe_put_salt(d["salt"])
+    Enum.reduce(@domain_fields, %{}, fn {key, served_key}, domain ->
+      case served[served_key] do
+        nil -> domain
+        value -> Map.put(domain, key, value)
+      end
+    end)
   end
-
-  defp maybe_put_verifying_contract(domain, nil), do: domain
-
-  defp maybe_put_verifying_contract(domain, vc),
-    do: Map.put(domain, :verifyingContract, vc)
-
-  defp maybe_put_salt(domain, nil), do: domain
-  defp maybe_put_salt(domain, salt), do: Map.put(domain, :salt, salt)
 
   defp eip712_types(eip712) do
     (eip712["types"] || %{})

--- a/packages/raxol_payments/test/raxol/payments/conformance/permit2_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/permit2_conformance_test.exs
@@ -7,11 +7,11 @@ defmodule Raxol.Payments.Conformance.Permit2ConformanceTest do
 
   @moduletag :conformance
 
-  setup_all do
-    case ConformanceFixture.locate() do
-      {:ok, _path} -> :ok
-      {:error, :not_found} -> {:skip, "conformance fixture not found"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether the fixture is present.
+  if match?({:error, :not_found}, ConformanceFixture.locate()) do
+    @moduletag skip: "conformance fixture not found"
   end
 
   # Signs with secp256k1 key 1 (the conformance fixture's key) through the same

--- a/packages/raxol_payments/test/raxol/payments/conformance/x402_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/x402_conformance_test.exs
@@ -8,11 +8,11 @@ defmodule Raxol.Payments.Conformance.X402ConformanceTest do
 
   @moduletag :conformance
 
-  setup_all do
-    case ConformanceFixture.locate() do
-      {:ok, _path} -> :ok
-      {:error, :not_found} -> {:skip, "conformance fixture not found"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether the fixture is present.
+  if match?({:error, :not_found}, ConformanceFixture.locate()) do
+    @moduletag skip: "conformance fixture not found"
   end
 
   # ERC-3009 vectors in the fixture exercise the x402 protocol's signing

--- a/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
@@ -52,11 +52,11 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
     salt: "0x50c4e63fec78d6897bf2f854fbe944310903876e56027940293bb80e79f75fe2"
   }
 
-  setup_all do
-    case ConformanceFixture.locate() do
-      {:ok, _path} -> :ok
-      {:error, :not_found} -> {:skip, "conformance fixture not found"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether the fixture is present.
+  if match?({:error, :not_found}, ConformanceFixture.locate()) do
+    @moduletag skip: "conformance fixture not found"
   end
 
   # Xochi vectors carry their full EIP-712 typed data inline because the

--- a/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
@@ -393,6 +393,11 @@ defmodule Raxol.Payments.Protocols.XochiTest do
     @anvil_key "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
     @anvil_addr "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
 
+    # The universal Permit2 deployment, and the solver spender a permit2 pull
+    # names (pinned via :pull_solver_allowlist, which is always required).
+    @permit2_address "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+    @permit2_spender "0x000000000000000000000000000000000000dEaD"
+
     defmodule RealWallet do
       @moduledoc false
       use Raxol.Payments.Wallets.Env, env_var: "RAXOL_XOCHI_DOMAIN_TEST_KEY"
@@ -632,6 +637,64 @@ defmodule Raxol.Payments.Protocols.XochiTest do
       assert body["pull_signature"] == "0x" <> Base.encode16(raw, case: :lower)
       # Distinct payload from the intent signature.
       assert body["pull_signature"] != body["signature"]
+    end
+
+    test "signs a permit2 pull over Permit2's own domain, which declares no version" do
+      # Permit2's EIP-712 domain is name/chainId/verifyingContract -- it carries NO
+      # `version`. A served domain that omits a field must not be signed as though
+      # that field were present and empty: doing so hashes a 4-field EIP712Domain
+      # against the 3-field one Permit2 rebuilds on-chain, so Permit2 asks
+      # `isValidSignature` about a digest the buyer never signed and the pull
+      # reverts InvalidContractSignature() (0xb0669cbc). See GitHub #772.
+      Application.put_env(:raxol_payments, :pull_solver_allowlist, [@permit2_spender])
+      on_exit(fn -> Application.delete_env(:raxol_payments, :pull_solver_allowlist) end)
+
+      pull =
+        canonical_permit2_pull(%{
+          domain: %{
+            "name" => "Permit2",
+            "chainId" => 8453,
+            "verifyingContract" => @permit2_address
+          },
+          message: %{"spender" => @permit2_spender}
+        })
+
+      quote_resp = %QuoteResponse{
+        intent_id: "xi_p2domain",
+        quote_id: "xq_p2domain",
+        can_solve: true,
+        payment_method: "permit2",
+        eip712_data: %{
+          "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+          "primaryType" => "XochiIntent",
+          "types" => %{"XochiIntent" => [%{"name" => "intentId", "type" => "string"}]},
+          "message" => %{"intentId" => "xi_p2domain"}
+        },
+        pull_authorization: pull
+      }
+
+      request = %QuoteRequest{
+        wallet: @anvil_addr,
+        from_chain_id: 8453,
+        to_chain_id: 42_161,
+        from_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        to_token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        from_amount: "1000000",
+        settlement_preference: "public"
+      }
+
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      assert {:ok, _} = Xochi.execute(config, quote_resp, RealWallet, request)
+      assert_receive {:req, "POST", "/api/intent/execute", _h, raw_body}
+      body = Jason.decode!(raw_body)
+
+      expected = permit2_reference_signature(pull)
+      assert body["pull_signature"] == "0x" <> Base.encode16(expected, case: :lower)
     end
 
     test "omits pull_signature when the quote carries no pull_authorization" do
@@ -1303,6 +1366,64 @@ defmodule Raxol.Payments.Protocols.XochiTest do
       "message" => message
     }
   end
+
+  # Permit2's DOMAIN_SEPARATOR() as deployed on Base (chain 8453), read from
+  # 0x000000000022D473030F116dDEE9F6B43aC78BA3. It is the 3-field
+  # EIP712Domain(string name,uint256 chainId,address verifyingContract): Permit2
+  # declares no `version`. Hard-coded so this test is an independent oracle
+  # rather than a second run of the code under test.
+  @permit2_domain_separator "3b6f35e4fce979ef8eac3bcdc8c3fc38fe7911bb0c69c8fe72bf1fd1a17e6f07"
+
+  # Permit2 builds the PermitWitnessTransferFrom typehash by concatenating a fixed
+  # stub with the caller's witness type string, not by EIP-712's alphabetical
+  # encodeType. Reproduce Permit2's construction so the expected digest is the one
+  # the contract computes. The witness string is XochiPullPermit2's.
+  @permit2_typehash_stub "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,"
+  @permit2_witness_type_string "OriginPullWitness witness)OriginPullWitness(bytes32 orderId)TokenPermissions(address token,uint256 amount)"
+
+  # The signature Permit2 will accept for `pull`: the anvil key over the digest
+  # Permit2 itself rebuilds on-chain.
+  defp permit2_reference_signature(pull) do
+    key = Base.decode16!(String.trim_leading(@anvil_key, "0x"), case: :mixed)
+    {:ok, signature} = ExSecp256k1.sign(permit2_reference_digest(pull), key)
+    Raxol.Payments.EIP712.pack_signature(signature)
+  end
+
+  defp permit2_reference_digest(pull) do
+    message = pull["message"]
+    permitted = message["permitted"]
+
+    token_permissions =
+      ExKeccak.hash_256(
+        ExKeccak.hash_256("TokenPermissions(address token,uint256 amount)") <>
+          address_word(permitted["token"]) <> uint_word(permitted["amount"])
+      )
+
+    witness =
+      ExKeccak.hash_256(
+        ExKeccak.hash_256("OriginPullWitness(bytes32 orderId)") <>
+          bytes32_word(message["witness"]["orderId"])
+      )
+
+    struct_hash =
+      ExKeccak.hash_256(
+        ExKeccak.hash_256(@permit2_typehash_stub <> @permit2_witness_type_string) <>
+          token_permissions <>
+          address_word(message["spender"]) <>
+          uint_word(message["nonce"]) <>
+          uint_word(message["deadline"]) <>
+          witness
+      )
+
+    ExKeccak.hash_256(
+      <<0x19, 0x01>> <>
+        Base.decode16!(@permit2_domain_separator, case: :lower) <> struct_hash
+    )
+  end
+
+  defp address_word("0x" <> hex), do: <<0::size(96)>> <> Base.decode16!(hex, case: :mixed)
+  defp uint_word(value), do: <<String.to_integer(value)::unsigned-big-256>>
+  defp bytes32_word("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
 
   describe "origin_pull_fail_open?/2" do
     test "an empty allowlist with the pin not required is fail-open" do

--- a/test/harness/editor_pty_test.exs
+++ b/test/harness/editor_pty_test.exs
@@ -28,12 +28,11 @@ defmodule Raxol.Harness.EditorPtyTest do
   @moduletag :skip_on_ci
   @moduletag timeout: 120_000
 
-  setup_all do
-    if PtyHarness.available?() do
-      :ok
-    else
-      {:skip, "python3 not found on PATH"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether python3 is on PATH.
+  if not PtyHarness.available?() do
+    @moduletag skip: "python3 not found on PATH"
   end
 
   # `stty -a` renders modes as bare tokens when set, minus-prefixed when

--- a/test/harness/ringb_iterm2_test.exs
+++ b/test/harness/ringb_iterm2_test.exs
@@ -27,21 +27,24 @@ defmodule Raxol.Harness.RingBIterm2Test do
 
   @probes_dir Path.expand("../../scripts/harness/t0/probes", __DIR__)
 
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide availability at load time. A spawn failure on
+  # an installed emulator is a real failure, so surface it as one.
+  if not Iterm2.available?() do
+    @moduletag skip: "iTerm2 not installed in this environment"
+  end
+
   setup do
-    if Iterm2.available?() do
-      case Iterm2.spawn_session([]) do
-        {:ok, session} ->
-          on_exit(fn ->
-            Guard.safe_teardown(Iterm2, session, "ringb-iterm2-test")
-          end)
+    case Iterm2.spawn_session([]) do
+      {:ok, session} ->
+        on_exit(fn ->
+          Guard.safe_teardown(Iterm2, session, "ringb-iterm2-test")
+        end)
 
-          [session: session]
+        [session: session]
 
-        {:error, reason} ->
-          {:skip, "iTerm2 spawn_session failed: #{inspect(reason)}"}
-      end
-    else
-      {:skip, "iTerm2 not installed in this environment"}
+      {:error, reason} ->
+        flunk("iTerm2 spawn_session failed: #{inspect(reason)}")
     end
   end
 

--- a/test/harness/ringb_kitty_test.exs
+++ b/test/harness/ringb_kitty_test.exs
@@ -22,22 +22,26 @@ defmodule Raxol.Harness.RingBKittyTest do
 
   @probes_dir Path.expand("../../scripts/harness/t0/probes", __DIR__)
 
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide availability at load time. A spawn failure on
+  # an installed emulator is a real failure, so surface it as one.
+  if not Kitty.available?() do
+    @moduletag skip: "kitty not installed in this environment"
+  end
+
   setup do
-    if Kitty.available?() do
-      case Kitty.spawn_session([]) do
-        {:ok, session} ->
-          on_exit(fn ->
-            Guard.safe_teardown(Kitty, session, "ringb-kitty-test")
-          end)
+    case Kitty.spawn_session([]) do
+      {:ok, session} ->
+        on_exit(fn ->
+          Guard.safe_teardown(Kitty, session, "ringb-kitty-test")
+        end)
 
-          [session: session]
+        [session: session]
 
-        {:error, reason} ->
-          {:skip,
-           "kitty spawn_session failed (best-effort driver): #{inspect(reason)}"}
-      end
-    else
-      {:skip, "kitty not installed in this environment"}
+      {:error, reason} ->
+        flunk(
+          "kitty spawn_session failed (best-effort driver): #{inspect(reason)}"
+        )
     end
   end
 

--- a/test/harness/ringb_terminal_app_test.exs
+++ b/test/harness/ringb_terminal_app_test.exs
@@ -26,21 +26,24 @@ defmodule Raxol.Harness.RingBTerminalAppTest do
 
   @probes_dir Path.expand("../../scripts/harness/t0/probes", __DIR__)
 
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide availability at load time. A spawn failure on
+  # an installed emulator is a real failure, so surface it as one.
+  if not TerminalApp.available?() do
+    @moduletag skip: "Terminal.app not available in this environment"
+  end
+
   setup do
-    if TerminalApp.available?() do
-      case TerminalApp.spawn_session([]) do
-        {:ok, session} ->
-          on_exit(fn ->
-            Guard.safe_teardown(TerminalApp, session, "ringb-apple-test")
-          end)
+    case TerminalApp.spawn_session([]) do
+      {:ok, session} ->
+        on_exit(fn ->
+          Guard.safe_teardown(TerminalApp, session, "ringb-apple-test")
+        end)
 
-          [session: session]
+        [session: session]
 
-        {:error, reason} ->
-          {:skip, "Terminal.app spawn_session failed: #{inspect(reason)}"}
-      end
-    else
-      {:skip, "Terminal.app not available in this environment"}
+      {:error, reason} ->
+        flunk("Terminal.app spawn_session failed: #{inspect(reason)}")
     end
   end
 

--- a/test/harness/ringb_wezterm_test.exs
+++ b/test/harness/ringb_wezterm_test.exs
@@ -22,21 +22,24 @@ defmodule Raxol.Harness.RingBWeztermTest do
 
   @probes_dir Path.expand("../../scripts/harness/t0/probes", __DIR__)
 
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide availability at load time. A spawn failure on
+  # an installed emulator is a real failure, so surface it as one.
+  if not Wezterm.available?() do
+    @moduletag skip: "wezterm not installed in this environment"
+  end
+
   setup do
-    if Wezterm.available?() do
-      case Wezterm.spawn_session([]) do
-        {:ok, session} ->
-          on_exit(fn ->
-            Guard.safe_teardown(Wezterm, session, "ringb-wezterm-test")
-          end)
+    case Wezterm.spawn_session([]) do
+      {:ok, session} ->
+        on_exit(fn ->
+          Guard.safe_teardown(Wezterm, session, "ringb-wezterm-test")
+        end)
 
-          [session: session]
+        [session: session]
 
-        {:error, reason} ->
-          {:skip, "wezterm spawn_session failed: #{inspect(reason)}"}
-      end
-    else
-      {:skip, "wezterm not installed in this environment"}
+      {:error, reason} ->
+        flunk("wezterm spawn_session failed: #{inspect(reason)}")
     end
   end
 

--- a/test/harness/t2a_scroll_region_test.exs
+++ b/test/harness/t2a_scroll_region_test.exs
@@ -338,12 +338,11 @@ defmodule Raxol.Harness.T2aScrollRegionTest do
   Process.sleep(:infinity)
   """
 
-  setup_all do
-    if PtyHarness.available?() do
-      :ok
-    else
-      {:skip, "python3 not found on PATH"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether python3 is on PATH.
+  if not PtyHarness.available?() do
+    @moduletag skip: "python3 not found on PATH"
   end
 
   defp start_mock_app_under_pty do

--- a/test/harness/t2d_teardown_negative_test.exs
+++ b/test/harness/t2d_teardown_negative_test.exs
@@ -84,12 +84,11 @@ defmodule Raxol.Harness.T2dTeardownNegativeTest do
   Process.sleep(:infinity)
   """
 
-  setup_all do
-    if PtyHarness.available?() do
-      :ok
-    else
-      {:skip, "python3 not found on PATH"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether python3 is on PATH.
+  if not PtyHarness.available?() do
+    @moduletag skip: "python3 not found on PATH"
   end
 
   defp start_mock_app_under_pty do

--- a/test/harness/t2d_teardown_positive_test.exs
+++ b/test/harness/t2d_teardown_positive_test.exs
@@ -291,12 +291,11 @@ defmodule Raxol.Harness.T2dTeardownPositiveTest do
   Process.sleep(:infinity)
   """
 
-  setup_all do
-    if PtyHarness.available?() do
-      :ok
-    else
-      {:skip, "python3 not found on PATH"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether python3 is on PATH.
+  if not PtyHarness.available?() do
+    @moduletag skip: "python3 not found on PATH"
   end
 
   defp start_mock_app_under_pty do

--- a/test/harness/tp_pty_test.exs
+++ b/test/harness/tp_pty_test.exs
@@ -37,12 +37,11 @@ defmodule Raxol.Harness.TpPtyTest do
   # bearing distinction here, not the exact exit code.
   @trap_script ~s(trap "echo CLEANUP" TERM; echo READY; sleep 30)
 
-  setup_all do
-    if PtyHarness.available?() do
-      :ok
-    else
-      {:skip, "python3 not found on PATH"}
-    end
+  # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
+  # invalidates the module. Decide at load time -- .exs files are re-evaluated
+  # every run, so this still tracks whether python3 is on PATH.
+  if not PtyHarness.available?() do
+    @moduletag skip: "python3 not found on PATH"
   end
 
   # Stops the wrapper (killing anything still running under it) and removes


### PR DESCRIPTION
Fixes the smart-account settlement blocker tracked in #772 and localised in
axol-io/Riddler#832.

## The defect

`Raxol.Payments.Protocols.Xochi.eip712_domain/1` built the signing domain from the
served typed data while inserting `name`, `version` and `chainId` unconditionally:

```elixir
%{name: d["name"], version: d["version"], chainId: d["chainId"]}
|> maybe_put_verifying_contract(d["verifyingContract"])
|> maybe_put_salt(d["salt"])
```

`Raxol.Payments.EIP712` derives the declared `EIP712Domain` field list with
`Map.has_key?`, so a `version` key holding `nil` still declares `string version` and
encodes it as the empty string.

Permit2's domain is name/chainId/verifyingContract with no `version`, so we hashed a
4-field separator against Permit2's 3-field one:

```
permit2 on-chain DOMAIN_SEPARATOR (Base): 0x3b6f35e4fce979ef8eac3bcdc8c3fc38fe7911bb0c69c8fe72bf1fd1a17e6f07
4-field separator we signed:              0xcbde02bf2da0fb4a7a18ecc6ce5035b2fc40a3699509e7cf3ff32d64305ac4cb
```

Permit2 then asks `isValidSignature` about a digest the buyer never signed, gets
`0xffffffff`, and reverts `InvalidContractSignature()` (`0xb0669cbc`). That is the
selector observed live. A funded ACP job reached `fund`, paid the fee escrow, and could
not settle.

The XochiIntent domain (name/version/chainId/salt) and USDC's ERC-3009 domain
(name/version/chainId/verifyingContract) carry every field we inserted, which is why the
intent signature verified through the same account, the same fallback envelope and the
same replay-safe wrapping minutes before the pull failed. Permit2 is the first
version-less domain we sign. EOA buyers resolve to `erc3009` and were unaffected.

## The change

Every domain field is now conditional, driven by a `@domain_fields` table, so the signed
domain mirrors the served one exactly. This is a class of bug rather than one field: a
served domain omitting `name` or `chainId` failed the same way.

Confirmed out of scope while diagnosing:

- The ma-v2 replay-safe wrapping in `Raxol.Earn.Wallet.SCA.ModularAccount.replay_safe_digest/3`
  matches `SemiModularAccountBase` byte for byte. Both typehashes verified with
  `cast keccak` against the on-chain constants.
- Witness typehash ordering. `OriginPullWitness` sorts before `TokenPermissions`, so
  EIP-712's alphabetical `encodeType` reproduces Permit2's stub concatenation.

## The test

`xochi_test.exs`, in the existing `execute/3 domain parity` block. It drives
`Xochi.execute/4` with a version-less Permit2 pull and asserts the emitted
`pull_signature` against a digest built from Permit2's own construction: its on-chain
Base `DOMAIN_SEPARATOR()` plus the `PermitWitnessTransferFrom` stub concatenated with
`XochiPullPermit2`'s witness type string. The oracle is Permit2's, so the test cannot
drift with the code under test.

Written RED first: it fails on the old `eip712_domain/1` with a well-formed but
divergent signature, and passes on the new one.

## Manual testing

- [x] New test is RED on the parent commit, GREEN with the fix
- [x] `MIX_ENV=test mix test` in `packages/raxol_payments` (1150 passed)
- [x] `MIX_ENV=test mix test` in `packages/raxol_earn` (886 passed, covers the Sma7702 order path)
- [x] `MIX_ENV=test mix test` in `packages/raxol_agent_client_protocol` (859 passed)
- [x] `MIX_ENV=test mix test` in main raxol (6709 passed, 1 skipped)
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean at the root and in each touched package
- [x] Permit2's Base `DOMAIN_SEPARATOR()` read on-chain and matched against the 3-field domain
- [ ] Funded live settlement through `--route acp` with a 7702 smart-account buyer

## Notes

The live gate is the remaining verification and needs funds, so it is left unchecked.
Riddler's `Executor.log_signed_digest/1` (axol-io/Riddler#833) emits the digest it hands
Permit2, which makes the next attempt decidable from logs.

The `cli_signer` tests still fail without the Riddler CLI. That is deliberate: they
`flunk` with "set RIDDLER_CLI_DIR or run with --exclude cli_signer", so opting in without
the CLI is meant to be loud. Left alone.

## Second commit: tag absent-dependency tests skip at load time

Found while checking that the conformance oracles above actually run. ExUnit callbacks
may return `:ok`, a keyword, or a map. A `{:skip, reason}` tuple falls through
`ExUnit.Callbacks.__merge__/4` to `raise_merge_failed!`, which raises and invalidates the
whole module. `setup` and `setup_all` share that path, so **none of these ever skipped**:
they failed, and reported the merge error rather than the reason they were written to
explain.

Only environments missing the dependency saw it. With python3, the fixture, an emulator
or a credential present, the `:ok` branch ran, so CI stayed quiet and every opt-in run on
a bare machine broke.

The fix decides at load time via the `:skip` tag. `.exs` test files are re-evaluated each
run, so the check still tracks the dependency, and a skipped module never runs its
callbacks. A spawn failure on an *installed* emulator has no load-time answer and is a
genuine failure, so it becomes a `flunk` carrying the same reason.

17 files across `raxol`, `raxol_payments`, `raxol_earn` and `raxol_agent_client_protocol`.
Verified: the payments conformance modules now report `4 skipped` where they reported
`4 invalid`.

This is a separate concern from the signing fix, and is a separate commit so review stays
tractable. It is bundled here because these parity oracles are the layer that would
otherwise have caught the Permit2 domain bug, and they were sitting in the same
green-by-absence state axol-io/Riddler#838 describes for its fork tests.

`test/harness/` also drops 3 unrelated `GitIntegrationPluginTest` failures on a machine
whose ssh-agent lacks the commit signing key: those tests shell out to real `git commit`
and inherit `commit.gpgsign=true`. Pre-existing, environment-only, and green with the
agent socket exported.
