### PR TITLE
Gate the ACP package, revive three dead conformance oracles

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -21,6 +21,7 @@
   # pulls the ungated packages (169 files of pre-existing drift) into the root
   # check, so a package joins here when it joins that matrix.
   subdirectories: [
+    "packages/raxol_agent_client_protocol",
     "packages/raxol_cli",
     "packages/raxol_earn",
     "packages/raxol_gateway",

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -295,7 +295,21 @@ jobs:
         # gated packages in the repo: the Sma7702Wallet alias bug (#858) shipped
         # with a compiler warning nobody could fail on, because nothing here ran
         # them. Adding them required unbreaking both suites first -- see the PR.
-        package: [raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn]
+        #
+        # raxol_agent_client_protocol joins for the format half: ungated, five of
+        # its files had been rewrapped at the root's 80 columns and no check
+        # anywhere disagreed. A package earns its entry in the root
+        # .formatter.exs `subdirectories` list by being gated here, so the two
+        # lists move together.
+        package:
+          [
+            raxol_gateway,
+            raxol_telegram,
+            raxol_cli,
+            raxol_payments,
+            raxol_earn,
+            raxol_agent_client_protocol
+          ]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -301,15 +301,10 @@ jobs:
         # anywhere disagreed. A package earns its entry in the root
         # .formatter.exs `subdirectories` list by being gated here, so the two
         # lists move together.
-        package:
-          [
-            raxol_gateway,
-            raxol_telegram,
-            raxol_cli,
-            raxol_payments,
-            raxol_earn,
-            raxol_agent_client_protocol
-          ]
+        # Keep on ONE line: test/raxol/formatter_delegation_test.exs parses this
+        # matrix with `^\s*package: \[...\]` to prove every gated package is also
+        # delegated by the root .formatter.exs. A block sequence parses as absent.
+        package: [raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn, raxol_agent_client_protocol]
 
     steps:
       - uses: actions/checkout@v7

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/ext/reattach.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/ext/reattach.ex
@@ -363,9 +363,7 @@ defmodule Raxol.AgentClientProtocol.Ext.Reattach do
       ])
     end
 
-    Logger.debug(
-      "acp reattach: attach denied for #{inspect(sid)} (#{inspect(reason)})"
-    )
+    Logger.debug("acp reattach: attach denied for #{inspect(sid)} (#{inspect(reason)})")
 
     :ok
   end
@@ -410,8 +408,7 @@ defmodule Raxol.AgentClientProtocol.Ext.Reattach do
       forward_hi: 0,
       live: :pending,
       # dead-injector knobs (untagged red controls, bus §9):
-      dead_register_after_history:
-        Map.get(dead, :__dead_register_after_history__, false),
+      dead_register_after_history: Map.get(dead, :__dead_register_after_history__, false),
       dead_cached_counter: Map.get(dead, :__dead_cached_counter__, false)
     }
 

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/schema/agent_types.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/schema/agent_types.ex
@@ -92,8 +92,7 @@ defmodule Raxol.AgentClientProtocol.Schema.AgentTypes do
   # fold into `_meta` via `extract_meta/2`, so forward-compat is untouched.
   @spec fetch(map(), String.t(), (term() -> boolean())) ::
           {:ok, term()}
-          | {:error,
-             {:missing_field, String.t()} | {:invalid_field, String.t(), term()}}
+          | {:error, {:missing_field, String.t()} | {:invalid_field, String.t(), term()}}
   def fetch(map, key, valid?) when is_map(map) and is_function(valid?, 1) do
     case Map.fetch(map, key) do
       {:ok, value} ->

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/schema/unstable.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/schema/unstable.ex
@@ -765,8 +765,7 @@ defmodule Raxol.AgentClientProtocol.Schema.Unstable.SetSessionConfigOptionRespon
   def to_json(%__MODULE__{} = r) do
     AgentTypes.put_meta(
       %{
-        "configOptions" =>
-          Enum.map(r.config_options, &SessionConfigOption.to_json/1)
+        "configOptions" => Enum.map(r.config_options, &SessionConfigOption.to_json/1)
       },
       r._meta
     )
@@ -1478,8 +1477,7 @@ defmodule Raxol.AgentClientProtocol.Schema.Unstable.ConfigOptionUpdate do
   def to_json(%__MODULE__{} = c) do
     AgentTypes.put_meta(
       %{
-        "configOptions" =>
-          Enum.map(c.config_options, &SessionConfigOption.to_json/1)
+        "configOptions" => Enum.map(c.config_options, &SessionConfigOption.to_json/1)
       },
       c._meta
     )

--- a/packages/raxol_agent_client_protocol/test/ext/journal_writer_test.exs
+++ b/packages/raxol_agent_client_protocol/test/ext/journal_writer_test.exs
@@ -152,8 +152,7 @@ defmodule Raxol.AgentClientProtocol.Ext.Journal.WriterTest do
 
     assert_receive {:reattach_live, ^sid, %Record{offset: 2}}
 
-    assert_receive {:reattach_live, ^sid,
-                    %Record{offset: 3, payload: %{"phantom" => true}}}
+    assert_receive {:reattach_live, ^sid, %Record{offset: 3, payload: %{"phantom" => true}}}
 
     durable = MapSet.new(read_all(j), & &1.offset)
 

--- a/packages/raxol_agent_client_protocol/test/ext/reattach_test.exs
+++ b/packages/raxol_agent_client_protocol/test/ext/reattach_test.exs
@@ -82,9 +82,7 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
       start_supervised!(
         %{
           id: {:writer, sid},
-          start:
-            {Writer, :start_link,
-             [[session_id: sid, journal: {Mem, j}] ++ writer_opts]},
+          start: {Writer, :start_link, [[session_id: sid, journal: {Mem, j}] ++ writer_opts]},
           restart: :temporary
         },
         restart: :temporary
@@ -242,12 +240,9 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
       {sid, j, w} =
         start_writer([
           {"turn_started", %{"turnId" => 1, "prompt" => []}, "user"},
-          {"session_update", %{"sessionUpdate" => "agent_message_chunk"},
-           "agent"},
-          {"session_update", %{"sessionUpdate" => "agent_message_chunk"},
-           "agent"},
-          {"turn_completed", %{"turnId" => 1, "stopReason" => "end_turn"},
-           "system"}
+          {"session_update", %{"sessionUpdate" => "agent_message_chunk"}, "agent"},
+          {"session_update", %{"sessionUpdate" => "agent_message_chunk"}, "agent"},
+          {"turn_completed", %{"turnId" => 1, "stopReason" => "end_turn"}, "system"}
         ])
 
       # Durable so far: 1 genesis, 2 turn_started, 3-4 updates, 5 turn_completed.
@@ -453,9 +448,7 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
     taints = ~w(user agent external system)
 
     {sid, j, _w} =
-      start_writer(
-        Enum.map(taints, fn t -> {"session_update", %{"t" => t}, t} end)
-      )
+      start_writer(Enum.map(taints, fn t -> {"session_update", %{"t" => t}, t} end))
 
     {conn, _ref, sub, :deferred} = attach(sid, j)
     _ = sync(sub)
@@ -563,8 +556,7 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
       # emits the terminal Lagged for the probe and drops it. (Assertions below do
       # not hardcode the triggering offset — any reasonable accounting greens this.)
       for i <- 1..5,
-          do:
-            {:ok, _} = Writer.append(w, "session_update", %{"i" => i}, "agent")
+          do: {:ok, _} = Writer.append(w, "session_update", %{"i" => i}, "agent")
 
       # The Writer PRODUCED the heal signal itself, carrying the highest offset it
       # actually sent this subscriber (selectively received past the live frames).
@@ -677,10 +669,8 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
     {sid, j, _w} =
       start_writer([
         {"turn_started", %{"turnId" => 4, "prompt" => []}, "user"},
-        {"session_update", %{"sessionUpdate" => "agent_message_chunk"},
-         "agent"},
-        {"turn_completed", %{"turnId" => 4, "stopReason" => "end_turn"},
-         "system"}
+        {"session_update", %{"sessionUpdate" => "agent_message_chunk"}, "agent"},
+        {"turn_completed", %{"turnId" => 4, "stopReason" => "end_turn"}, "system"}
       ])
 
     {conn, _ref, sub, :deferred} = attach(sid, j)
@@ -776,8 +766,7 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
         })
 
       # The CDI-5 deny envelope: -32000 "attach denied", NO data (anti-oracle).
-      assert {:error,
-              %Error{code: -32_000, message: "attach denied", data: nil}} = res
+      assert {:error, %Error{code: -32_000, message: "attach denied", data: nil}} = res
 
       # Nothing registered, no history read, no delegate/reply — a denied
       # attacher never appears in the subscriber set even transiently.
@@ -849,10 +838,8 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
     {sid, j, _w} =
       start_writer([
         {"turn_started", %{"turnId" => 1, "prompt" => []}, "user"},
-        {"session_update", %{"sessionUpdate" => "agent_message_chunk"},
-         "agent"},
-        {"turn_completed", %{"turnId" => 1, "stopReason" => "end_turn"},
-         "system"}
+        {"session_update", %{"sessionUpdate" => "agent_message_chunk"}, "agent"},
+        {"turn_completed", %{"turnId" => 1, "stopReason" => "end_turn"}, "system"}
       ])
 
     {conn, _ref, sub, :deferred} = attach(sid, j, %{offset_aware?: false})
@@ -895,8 +882,7 @@ defmodule Raxol.AgentClientProtocol.Ext.ReattachTest do
         start_supervised!(
           %{
             id: {:writer, sid},
-            start:
-              {Writer, :start_link, [[session_id: sid, journal: {Mem, j}]]},
+            start: {Writer, :start_link, [[session_id: sid, journal: {Mem, j}]]},
             restart: :temporary
           },
           restart: :temporary

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -882,13 +882,6 @@ defmodule Raxol.Payments.Protocols.Xochi do
 
   defp replay_nonce_from(_), do: 0
 
-  # Build the domain from exactly the keys the worker served -- EVERY field is
-  # conditional. `Raxol.Payments.EIP712` derives the EIP712Domain field list from
-  # the keys present, so a key carrying `nil` still declares that field and hashes
-  # a domain the verifier never built. No served domain uses all five: the
-  # canonical XochiIntent domain omits `verifyingContract` and carries a `salt`,
-  # and Permit2's omits `version` (see GitHub #772 -- signing a 4-field domain
-  # against Permit2's 3-field one reverts InvalidContractSignature on the pull).
   @domain_fields [
     {:name, "name"},
     {:version, "version"},
@@ -897,7 +890,24 @@ defmodule Raxol.Payments.Protocols.Xochi do
     {:salt, "salt"}
   ]
 
-  defp eip712_domain(eip712) do
+  @doc """
+  Project a served EIP-712 payload's `"domain"` onto the domain map the wallet
+  signs, carrying over exactly the keys the worker sent.
+
+  EVERY field is conditional. `Raxol.Payments.EIP712` derives the EIP712Domain
+  field list from the keys present, so a key carrying `nil` still declares that
+  field and hashes a domain the verifier never built. No served domain uses all
+  five: the canonical XochiIntent domain omits `verifyingContract` and carries a
+  `salt`, and Permit2's omits `version` (see GitHub #772 -- signing a 4-field
+  domain against Permit2's 3-field one reverts InvalidContractSignature on the
+  pull).
+
+  Public because the served-to-signed projection is what the conformance oracle
+  has to exercise. A test that rebuilds this mapping proves only that the test
+  agrees with itself, which is how #772 reached production with a green suite.
+  """
+  @spec eip712_domain(map()) :: map()
+  def eip712_domain(eip712) do
     served = eip712["domain"] || %{}
 
     Enum.reduce(@domain_fields, %{}, fn {key, served_key}, domain ->

--- a/packages/raxol_payments/test/raxol/payments/conformance/wallet_signer_parity_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/wallet_signer_parity_test.exs
@@ -69,17 +69,22 @@ defmodule Raxol.Payments.Conformance.WalletSignerParityTest do
   # Resolve the CLI checkout: explicit env var, then the two common dev layouts
   # (beside the raxol repo under a shared parent, or inside it). Returns nil when
   # absent so the test flunks with a clear message under `--only cli_signer`.
+  # The CLI repo (axol-io/riddler-sdk, formerly riddler-client) became a
+  # monorepo and its entry point moved to packages/sdk-taker/src/cli.ts.
+  # Probing for the retired src/index.js + src/acp.js answered nil even with
+  # RIDDLER_CLI_DIR set correctly, which silently retired this oracle: the test
+  # is :cli_signer-tagged and excluded by default, so the flunk below was never
+  # reached. Probe the entry point CliSigner actually spawns.
   defp locate_cli do
     [
       System.get_env("RIDDLER_CLI_DIR"),
+      Path.expand("../../../../../../../riddler-sdk", __DIR__),
+      Path.expand("../../../../../../riddler-sdk", __DIR__),
       Path.expand("../../../../../../../riddler-client", __DIR__),
       Path.expand("../../../../../../riddler-client", __DIR__)
     ]
     |> Enum.reject(&is_nil/1)
-    |> Enum.find(fn dir ->
-      File.exists?(Path.join([dir, "src", "index.js"])) and
-        File.exists?(Path.join([dir, "src", "acp.js"]))
-    end)
+    |> Enum.find(&File.exists?(Path.join([&1, "packages", "sdk-taker", "src", "cli.ts"])))
   end
 
   defp decode_hex("0x" <> hex), do: Base.decode16(hex, case: :mixed)

--- a/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/conformance/xochi_conformance_test.exs
@@ -2,6 +2,7 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
   use ExUnit.Case, async: true
 
   alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Protocols.Xochi
   alias Raxol.Payments.Test.ConformanceFixture
   alias Raxol.Payments.Test.ConformanceSigner
 
@@ -41,16 +42,26 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
   # settlement path.
   @shielded_signature "0xbe2545d815e4ce15d859e9bdee5bcb3a2f81e94a4b0fd0586220bd0235682d2f4bd1ea6082ddb8e59bb5557e91cb2f80e4dd3aef800e0fa4eabd0367a04c86061b"
 
-  # The fixture domain (above) is a determinism-locked synthetic, NOT the live
-  # worker domain. The live worker domain-separates with name "Xochi", version
-  # "1-prod", and a bytes32 salt (no verifyingContract) -- pinned byte-for-byte
-  # against viem in eip712_test.exs "salt domain". Kept here to guard the drift.
+  # The live worker domain-separates with name "Xochi", a DEPLOY-SCOPED version,
+  # and salt = keccak256(version), with no verifyingContract. Operators set the
+  # version via XOCHI_EIP712_VERSION; api.xochi.fi (riddler-axol) serves
+  # "3-prod", and riddler-prod serves "1-prod". Pinned to the endpoint raxol
+  # actually talks to.
+  #
+  # raxol signs whatever domain the quote serves (`Xochi.eip712_domain/1`), so a
+  # version bump needs no change here. This constant exists only to prove the
+  # fixture domain is not a live one.
   @live_domain %{
     name: "Xochi",
-    version: "1-prod",
+    version: "3-prod",
     chainId: 8453,
-    salt: "0x50c4e63fec78d6897bf2f854fbe944310903876e56027940293bb80e79f75fe2"
+    salt: "0x9367b434237c76dd65474f6b3400f245656f312be16268d772cec464857dc759"
   }
+
+  # The generator pins the server's BARE default version for determinism
+  # (riddler-sdk packages/spec/conformance/generate.ts, XOCHI_DOMAIN_VERSION),
+  # tracking the server's domain SHAPE while staying off every deploy scope.
+  @fixture_domain_version "3"
 
   # ExUnit has no runtime skip: a callback returning {:skip, _} raises and
   # invalidates the module. Decide at load time -- .exs files are re-evaluated
@@ -59,9 +70,26 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
     @moduletag skip: "conformance fixture not found"
   end
 
+  # `by_protocol/1` answers [] both when the fixture is absent and when it loads
+  # but carries no xochi vectors, and a `for` over [] generates no tests at all.
+  # The moduletag above covers the first case; this covers the second, where the
+  # suite would otherwise report a green run having asserted nothing about Xochi.
+  describe "fixture coverage" do
+    test "the loaded fixture yields at least one xochi vector" do
+      assert ConformanceFixture.by_protocol("xochi") != [],
+             "fixture loaded but produced no xochi vectors -- every generated " <>
+               "test below was silently skipped out of existence"
+    end
+  end
+
   # Xochi vectors carry their full EIP-712 typed data inline because the
   # domain has no `verifyingContract` and the `version` is deployment-scoped
   # (read from the quote response at runtime).
+  #
+  # The domain comes from `Xochi.eip712_domain/1`, the same projection the
+  # signing path uses, so a served-to-signed mismatch fails here. Rebuilding
+  # that mapping locally is what let #772 ship green: the copy in this file was
+  # conditional on `version` while production was not, and nothing compared them.
   describe "Xochi XochiIntent EIP-712 conformance vs CLI" do
     for vec <- ConformanceFixture.by_protocol("xochi") do
       @vec vec
@@ -69,7 +97,7 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
       test "digest matches CLI for #{vec["name"]}" do
         vec = @vec
         eip712 = vec["eip712"]
-        domain = atomize_domain(eip712["domain"])
+        domain = Xochi.eip712_domain(eip712)
         types = atomize_types(eip712["types"])
         message = eip712["message"]
 
@@ -88,7 +116,7 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
       test "signs + recovers identically to CLI for #{vec["name"]}" do
         vec = @vec
         eip712 = vec["eip712"]
-        domain = atomize_domain(eip712["domain"])
+        domain = Xochi.eip712_domain(eip712)
         types = atomize_types(eip712["types"])
         message = eip712["message"]
 
@@ -153,28 +181,41 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
   # for a live one. This guard fails loudly if the two domains ever converge,
   # forcing a conscious decision about whether the fixture should track live.
   describe "live-vs-fixture domain drift guard" do
-    test "the fixture domain differs from the live worker domain (name, version, salt)" do
+    test "the fixture version carries no deploy scope, so it is no deployment's domain" do
       fixture = ConformanceFixture.by_name("xochi-base-optimism-usdc")["eip712"]["domain"]
 
-      assert fixture["name"] == "XochiIntent"
-      assert fixture["name"] != @live_domain.name
+      # Name and salt-presence converged on live deliberately, so neither
+      # separates the two any more. The deploy scope is what does.
+      assert fixture["name"] == @live_domain.name
+      assert Map.has_key?(fixture, "salt")
 
-      assert fixture["version"] == "1"
-      assert fixture["version"] != @live_domain.version
+      assert fixture["version"] == @fixture_domain_version
 
-      refute Map.has_key?(fixture, "salt")
-      assert Map.has_key?(@live_domain, :salt)
+      refute String.contains?(fixture["version"], "-"),
+             "the fixture pins the server's BARE default version for determinism; " <>
+               "a scoped value here means it is signing some deployment's domain"
+
+      assert String.contains?(@live_domain.version, "-"),
+             "every deployment scopes its version (riddler-prod 1-prod, " <>
+               "riddler-axol 3-prod); an unscoped live version collides with the fixture"
+
+      refute fixture["version"] == @live_domain.version
+      refute fixture["salt"] == @live_domain.salt
+    end
+
+    test "salt is keccak256(version) on both sides, so the version binds the salt" do
+      fixture = ConformanceFixture.by_name("xochi-base-optimism-usdc")["eip712"]["domain"]
+
+      assert fixture["salt"] == keccak_utf8(fixture["version"])
+      assert @live_domain.salt == keccak_utf8(@live_domain.version)
     end
 
     test "the same XochiIntent message hashes differently under each domain" do
       message = shielded_message("public")
+      fixture = ConformanceFixture.by_name("xochi-base-optimism-usdc")["eip712"]["domain"]
 
       assert {:ok, fixture_digest} =
-               EIP712.hash(
-                 %{name: "XochiIntent", version: "1", chainId: 8453},
-                 @xochi_types,
-                 message
-               )
+               EIP712.hash(Xochi.eip712_domain(%{"domain" => fixture}), @xochi_types, message)
 
       assert {:ok, live_digest} = EIP712.hash(@live_domain, @xochi_types, message)
 
@@ -185,14 +226,10 @@ defmodule Raxol.Payments.Conformance.XochiConformanceTest do
 
   # -- Fixture shape helpers --
 
-  defp atomize_domain(domain) do
-    %{name: domain["name"], chainId: domain["chainId"]}
-    |> maybe_put(:version, domain["version"])
-    |> maybe_put(:salt, domain["salt"])
+  # The domain salt rule on both sides: salt = keccak256(utf8(version)).
+  defp keccak_utf8(value) do
+    "0x" <> Base.encode16(ExKeccak.hash_256(value), case: :lower)
   end
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   # CLI emits types as { TypeName: [{name, type}, ...], ... }; convert to
   # the {name, type} tuple shape Raxol.Payments.EIP712 expects.

--- a/packages/raxol_payments/test/support/cli_signer.ex
+++ b/packages/raxol_payments/test/support/cli_signer.ex
@@ -145,11 +145,21 @@ defmodule Raxol.Payments.Test.CliSigner do
     end
   end
 
-  # Best-effort fallback: ../../riddler-client relative to the
-  # raxol monorepo root. Works for the common dev layout where both repos
-  # live side-by-side under ~/CODE/.
+  # Best-effort fallback: a sibling checkout of the CLI repo (axol-io/riddler-sdk,
+  # formerly riddler-client) beside the raxol monorepo, the common dev layout
+  # where both live under ~/CODE/.
+  #
+  # The previous expansion was one level short and landed on
+  # <raxol>/riddler-client, inside this repo, so the fallback never resolved
+  # under either repo name.
   defp sibling_default do
-    Path.expand("../../../../riddler-client", __DIR__)
+    Enum.find(
+      [
+        Path.expand("../../../../../riddler-sdk", __DIR__),
+        Path.expand("../../../../../riddler-client", __DIR__)
+      ],
+      &File.dir?/1
+    )
   end
 
   defp encode_flags(flags) do

--- a/packages/raxol_payments/test/support/cli_signer_test.exs
+++ b/packages/raxol_payments/test/support/cli_signer_test.exs
@@ -6,9 +6,20 @@ defmodule Raxol.Payments.Test.CliSignerTest do
   @moduletag :cli_signer
 
   setup do
+    # The CLI repo is axol-io/riddler-sdk (formerly riddler-client), a sibling of
+    # the raxol monorepo. The previous expansion was one level short and landed
+    # on <raxol>/riddler-client, inside this repo, so the fallback never resolved
+    # under either name and these tests only ran with RIDDLER_CLI_DIR set.
     cwd =
       System.get_env("RIDDLER_CLI_DIR") ||
-        Path.expand("../../../../riddler-client", __DIR__)
+        Enum.find(
+          [
+            Path.expand("../../../../../riddler-sdk", __DIR__),
+            Path.expand("../../../../../riddler-client", __DIR__)
+          ],
+          &File.dir?/1
+        ) ||
+        Path.expand("../../../../../riddler-sdk", __DIR__)
 
     cli_available? =
       File.dir?(cwd) and
@@ -38,7 +49,13 @@ defmodule Raxol.Payments.Test.CliSignerTest do
       assert {:ok, %{exit_code: 0, stdout: stdout}} =
                CliSigner.run("help", [], cwd: cwd)
 
-      assert stdout =~ "RIDDLER COMMERCE CLIENT"
+      # Assert the subcommands raxol drives, not the banner. The banner has
+      # already been renamed once upstream (COMMERCE -> XOCHI) and nothing here
+      # depends on it; these three are the actual contract with the CLI.
+      for subcommand <- ~w(acp-buyer-auth sign-erc3009 sign-permit2) do
+        assert stdout =~ subcommand,
+               "CLI help no longer advertises #{subcommand}, which this oracle drives"
+      end
     end
 
     test "acp-buyer-auth emits a parseable RESULT_JSON line", %{

--- a/packages/raxol_payments/test/support/conformance_fixture.ex
+++ b/packages/raxol_payments/test/support/conformance_fixture.ex
@@ -107,7 +107,15 @@ defmodule Raxol.Payments.Test.ConformanceFixture do
   defp cli_dir_path(dir),
     do: Path.join([dir, "packages", "spec", "conformance", "conformance.json"])
 
+  # axol-io/riddler-sdk, formerly riddler-client. The old name is kept as a
+  # fallback so a checkout under either directory resolves.
   defp sibling_default do
-    Path.expand("../../../../../riddler-client", __DIR__)
+    Enum.find(
+      [
+        Path.expand("../../../../../riddler-sdk", __DIR__),
+        Path.expand("../../../../../riddler-client", __DIR__)
+      ],
+      &File.dir?/1
+    )
   end
 end


### PR DESCRIPTION
Follow-up to #878, which fixed the Permit2 domain bug. This is about the checks that
should have caught it and were not running.

## Format gate for raxol_agent_client_protocol

The package was in neither the root `.formatter.exs` `subdirectories` list nor the CI
`package-tests` matrix, so five of its files had been rewrapped at the root's 80 columns
and nothing anywhere disagreed. #878 tripped over this: `mix format` inside the package
reformatted files that PR never touched.

Reformatted at the package's own 98, and added to both lists. The root file already
documents that they move together ("a package joins here when it joins that matrix"), so
this keeps that invariant rather than special-casing.

Verified the package clears the whole gate: `mix compile --warnings-as-errors` clean,
859 tests pass, format clean.

## Three dead conformance oracles

All three located the CLI repo by a layout that no longer exists, and all three are
behind default-excluded tags, so none of them failed loudly:

| locator | fault |
|---|---|
| `wallet_signer_parity_test.locate_cli/0` | probed `src/index.js` + `src/acp.js`, retired when the CLI became a monorepo — answered `nil` even with `RIDDLER_CLI_DIR` set correctly, so it only ever reached its `flunk` |
| `CliSigner.sibling_default/0` | expanded one level short to `<raxol>/riddler-client`, **inside** this repo |
| `CliSignerTest` setup | same one-level-short expansion, a third private copy |

The repo is `axol-io/riddler-sdk` now (formerly `riddler-client`). Each locator now
probes the entry point `CliSigner` actually spawns, at the right depth, accepting both
names.

**All 1260 raxol_payments tests now pass with every oracle enabled and no env vars set.**
Previously the conformance and cli_signer suites could not run at all without pointing
`RIDDLER_CLI_DIR` at a directory layout that had not existed for some time.

## What surfaced once they ran

**The CLI help banner was renamed upstream** (`RIDDLER COMMERCE CLIENT` ->
`RIDDLER XOCHI CLIENT`). The assertion now checks the three subcommands raxol actually
drives (`acp-buyer-auth`, `sign-erc3009`, `sign-permit2`) instead of the banner, which
nothing depends on and which has now drifted once.

**The fixture domain converged on live's shape**, firing the drift guard. Investigated
rather than patched, because that guard exists to force exactly this question:

- The generator tracks the server's domain *shape* on purpose: name `"Xochi"`,
  `salt = keccak256(version)`, no `verifyingContract`
  (`riddler-sdk packages/spec/conformance/generate.ts`).
- It pins the **bare default** version `"3"` for determinism.
- Every deployment **scopes** its version via `XOCHI_EIP712_VERSION`: `riddler-prod` is
  `1-prod`, `riddler-axol` (which serves `api.xochi.fi`) is `3-prod`.

So the invariant holds and the fixture is no deployment's domain — but `name` and
salt-presence no longer separate them, and the deploy scope does. The guard is
re-expressed on that, plus a new test asserting `salt == keccak256(version)` on both
sides. Both salts verified with `cast keccak`.

`@live_domain` was pinned to `1-prod`, which is the *other* host; repinned to `3-prod`,
what `api.xochi.fi` actually serves. This affects nothing at runtime — raxol signs
whatever domain the quote serves — the constant exists only to prove fixture != live.

## The xochi conformance digests now use the production projection

`atomize_domain/1` in the test was a **reimplementation** of `Xochi.eip712_domain/1`, and
the copy was conditional on `version` while production was not. That is precisely the
#878 bug, sitting in the file whose job was to catch it, invisible because the two were
never compared. The vector tests now call `Xochi.eip712_domain/1` directly, so a
served-to-signed mismatch fails conformance.

`eip712_domain/1` is public for this reason, with a docstring saying so. Also added a
guard for the case where the fixture loads but yields zero xochi vectors, which a `for`
over `[]` would otherwise turn into a green run that asserted nothing.

## Manual testing

- [x] `raxol_payments`: 1260 passed with `--include conformance --include cli_signer`, no env vars
- [x] `raxol_payments`: 1150 passed in the default CI shape (both tags excluded)
- [x] `raxol_agent_client_protocol`: 859 passed, compiles warning-free, format clean
- [x] Drift guard verified against the real fixture at `~/CODE/riddler-sdk`
- [x] `keccak256("3")` and `keccak256("3-prod")` checked with `cast keccak` against both salts
- [x] Root and per-package `mix format --check-formatted` clean
- [x] Workflow YAML parses; matrix resolves to 6 packages

## Notes

`eip712_test.exs` still pins `version: "1-prod"` with its matching salt. Left alone
deliberately: that is a frozen viem-generated digest vector, and the version string is
incidental to the hashing math it proves. Its comment describes the domain as the one
"the worker serves", which is now stale for `api.xochi.fi`, but the vector itself is
sound.

CI still excludes `conformance` and `cli_signer` — the fixture lives in a sibling repo
that CI does not check out. The change is that a developer with that checkout now gets
the oracles for free, where before they got a `flunk` no matter what they set.
