### PR TITLE
Refuse a solver fee that cannot be sized from the origin token

### DIFF
--- a/packages/raxol_earn/lib/raxol/earn/xochi/solver_agent.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/solver_agent.ex
@@ -56,6 +56,7 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
   alias Raxol.Earn.{Agent, HookClient, ProviderAdapter}
   alias Raxol.Earn.Transport.SSE.Parser
   alias Raxol.Earn.Xochi.{IntentDeriver, Offering}
+  alias Raxol.Payments.Assets
 
   # On-chain AgenticCommerceV3 JobStatus for a funded job. Verified on Base
   # mainnet (job 70759: `getJob().status == 1` once funded). The memoryless
@@ -526,15 +527,72 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
   # understate (`IntentDeriver`). Fails the job closed if the intent can't be
   # resolved rather than proposing a budget on an untrusted number.
   defp propose_budget(state, key, session, requirement) do
-    case IntentDeriver.resolve(state.xochi_config, requirement) do
-      {:ok, %{from_amount: transfer_atomic}} ->
-        set_budget(state, key, session, requirement, transfer_atomic)
-
+    with {:ok, %{intent: intent, from_amount: transfer_atomic}} <-
+           IntentDeriver.resolve(state.xochi_config, requirement),
+         :ok <- ensure_fee_base(intent, transfer_atomic, state.fee_bps) do
+      set_budget(state, key, session, requirement, transfer_atomic)
+    else
       {reject_or_error, reason} when reject_or_error in [:reject, :error] ->
         emit(state, key, :requirement_error, reason)
         put_session(state, key, %{session | status: :failed})
     end
   end
+
+  # The budget is `fee_bps` of the intent's `from_amount`, escrowed as the ACP
+  # payment token (USDC, 6dp). `from_amount` is denominated in the ORIGIN token's
+  # base units, so that arithmetic only means anything when the origin leg is
+  # itself a 6dp USD stablecoin.
+  #
+  # Rescaling by decimals cannot rescue a non-stablecoin: 1 WETH is 1e18 base
+  # units, and reading that as 1e6-scaled USDC understates the fee by roughly the
+  # ETH price. Sizing this correctly needs a price oracle, so until there is one
+  # the sound answer is to refuse the corridor rather than escrow a wrong number.
+  #
+  # An unregistered token is refused for the same reason: `Assets.decimals/2`
+  # answers 6 for anything it does not know, so an unlisted 18dp token would
+  # silently size a budget ~1e12 times too small.
+  #
+  # The USDC public offering gates both legs to USDC and is unaffected; this is
+  # the generic `xochi_cross_chain_transfer` path, which gates nothing. See #666.
+  @fee_base_symbols ~w(USDC USDT USDG)
+
+  defp ensure_fee_base(intent, transfer_atomic, fee_bps) do
+    with :ok <- ensure_stable_origin(intent) do
+      ensure_fee_floor(budget_for(transfer_atomic, fee_bps), fee_bps)
+    end
+  end
+
+  defp ensure_stable_origin(%{from_chain_id: chain, from_token: token}) do
+    case Assets.symbol_for(chain, token) do
+      symbol when symbol in @fee_base_symbols -> :ok
+      _ -> {:reject, {:unsupported_fee_base, chain, token}}
+    end
+  end
+
+  defp ensure_stable_origin(_intent), do: {:reject, {:unsupported_fee_base, nil, nil}}
+
+  # `budget_for/2` truncates through `div/2`, so a small enough transfer rounds
+  # the fee to zero. A zero budget is an escrow that can never pay, and the
+  # generic path has no order-size band of its own (the USDC public offering
+  # carries a 1 USDC floor), so reject rather than propose it.
+  #
+  # Two different zeros: a storefront configured with `fee_bps: 0` is charging
+  # nothing deliberately and its zero budget is the intended outcome. The floor
+  # is for the other one, where a fee was meant to be charged and truncated away.
+  @default_min_fee_atomic 1
+
+  defp ensure_fee_floor(_budget_atomic, 0), do: :ok
+
+  defp ensure_fee_floor(budget_atomic, _fee_bps) do
+    min = min_fee_atomic()
+
+    if budget_atomic >= min,
+      do: :ok,
+      else: {:reject, {:fee_below_min, budget_atomic, min}}
+  end
+
+  defp min_fee_atomic,
+    do: Application.get_env(:raxol_earn, :solver_min_fee_atomic, @default_min_fee_atomic)
 
   defp set_budget(state, key, session, requirement, transfer_atomic) do
     budget_atomic = budget_for(transfer_atomic, state.fee_bps)

--- a/packages/raxol_earn/lib/raxol/earn/xochi/solver_agent.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/solver_agent.ex
@@ -63,6 +63,11 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
   # reattach path settles only at exactly this status.
   @onchain_status_funded 1
 
+  # The smallest fee worth escrowing, in the ACP payment token's base units.
+  # `budget_for/2` truncates through `div/2`, so below this a fee that was meant
+  # to be charged has rounded away to an escrow that can never pay.
+  @default_min_fee_atomic 1
+
   @type session_status ::
           :awaiting_requirement
           | :budget_proposed
@@ -93,6 +98,7 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
           chain_id: pos_integer(),
           acp_core_address: String.t(),
           fee_bps: non_neg_integer(),
+          min_fee_atomic: non_neg_integer(),
           settle_fn: fun(),
           history_fn:
             (Raxol.Earn.Transport.job_key() ->
@@ -113,6 +119,7 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
     settle_fn: nil,
     history_fn: nil,
     fee_bps: 8,
+    min_fee_atomic: 1,
     sessions: %{}
   ]
 
@@ -142,6 +149,19 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
 
   @impl GenServer
   def init(opts) do
+    case validate_min_fee(configured_min_fee(opts)) do
+      {:ok, min_fee_atomic} -> start_solver(opts, min_fee_atomic)
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  defp configured_min_fee(opts) do
+    Keyword.get_lazy(opts, :min_fee_atomic, fn ->
+      Application.get_env(:raxol_earn, :solver_min_fee_atomic, @default_min_fee_atomic)
+    end)
+  end
+
+  defp start_solver(opts, min_fee_atomic) do
     state = %__MODULE__{
       agent: Keyword.fetch!(opts, :agent),
       provider: Keyword.fetch!(opts, :provider),
@@ -150,6 +170,7 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
       chain_id: Keyword.fetch!(opts, :chain_id),
       acp_core_address: Keyword.fetch!(opts, :acp_core_address),
       fee_bps: Keyword.get(opts, :fee_bps, 8),
+      min_fee_atomic: min_fee_atomic,
       settle_fn: Keyword.get(opts, :settle_fn, &default_settle/1),
       history_fn: Keyword.get(opts, :history_fn),
       xochi_config: Keyword.get(opts, :xochi_config, %{})
@@ -529,8 +550,8 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
   defp propose_budget(state, key, session, requirement) do
     with {:ok, %{intent: intent, from_amount: transfer_atomic}} <-
            IntentDeriver.resolve(state.xochi_config, requirement),
-         :ok <- ensure_fee_base(intent, transfer_atomic, state.fee_bps) do
-      set_budget(state, key, session, requirement, transfer_atomic)
+         {:ok, budget_atomic} <- fee_budget(state, intent, transfer_atomic) do
+      set_budget(state, key, session, requirement, transfer_atomic, budget_atomic)
     else
       {reject_or_error, reason} when reject_or_error in [:reject, :error] ->
         emit(state, key, :requirement_error, reason)
@@ -556,16 +577,38 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
   # the generic `xochi_cross_chain_transfer` path, which gates nothing. See #666.
   @fee_base_symbols ~w(USDC USDT USDG)
 
-  defp ensure_fee_base(intent, transfer_atomic, fee_bps) do
-    with :ok <- ensure_stable_origin(intent) do
-      ensure_fee_floor(budget_for(transfer_atomic, fee_bps), fee_bps)
+  # The scale the fee arithmetic assumes, asserted rather than trusted. Every
+  # registered @fee_base_symbols token is 6dp on every corridor chain today, so
+  # the symbol check alone happens to be right -- but the argument above is about
+  # DECIMALS, and a symbol is only a proxy for them. Registering an 18dp variant
+  # under one of these symbols would pass a symbol-only gate and size a budget
+  # ~1e12 too small. The symbol check still has to come first: `Assets.decimals/2`
+  # answers 6 for tokens it does not know, so on its own it would wave through
+  # every unregistered token.
+  @fee_base_decimals 6
+
+  # Returns the budget it validated, so the number that was checked is the
+  # number that gets escrowed. Recomputing it in `set_budget/6` would leave the
+  # gate guarding a value nothing downstream is bound to.
+  defp fee_budget(state, intent, transfer_atomic) do
+    budget_atomic = budget_for(transfer_atomic, state.fee_bps)
+
+    with :ok <- ensure_stable_origin(intent),
+         :ok <- ensure_fee_floor(budget_atomic, state.fee_bps, state.min_fee_atomic) do
+      {:ok, budget_atomic}
     end
   end
 
   defp ensure_stable_origin(%{from_chain_id: chain, from_token: token}) do
-    case Assets.symbol_for(chain, token) do
-      symbol when symbol in @fee_base_symbols -> :ok
-      _ -> {:reject, {:unsupported_fee_base, chain, token}}
+    with symbol when symbol in @fee_base_symbols <- Assets.symbol_for(chain, token),
+         @fee_base_decimals <- Assets.decimals(chain, token) do
+      :ok
+    else
+      decimals when is_integer(decimals) ->
+        {:reject, {:unsupported_fee_base_decimals, chain, token, decimals}}
+
+      _ ->
+        {:reject, {:unsupported_fee_base, chain, token}}
     end
   end
 
@@ -579,24 +622,24 @@ defmodule Raxol.Earn.Xochi.SolverAgent do
   # Two different zeros: a storefront configured with `fee_bps: 0` is charging
   # nothing deliberately and its zero budget is the intended outcome. The floor
   # is for the other one, where a fee was meant to be charged and truncated away.
-  @default_min_fee_atomic 1
+  defp ensure_fee_floor(_budget_atomic, 0, _min), do: :ok
 
-  defp ensure_fee_floor(_budget_atomic, 0), do: :ok
-
-  defp ensure_fee_floor(budget_atomic, _fee_bps) do
-    min = min_fee_atomic()
-
+  defp ensure_fee_floor(budget_atomic, _fee_bps, min) do
     if budget_atomic >= min,
       do: :ok,
       else: {:reject, {:fee_below_min, budget_atomic, min}}
   end
 
-  defp min_fee_atomic,
-    do: Application.get_env(:raxol_earn, :solver_min_fee_atomic, @default_min_fee_atomic)
+  # Read and checked once, at start_link, rather than per job. `>=` against a
+  # non-integer does not raise -- Erlang term order puts every number below every
+  # atom and binary, so `5000 >= "1"` and `5000 >= :infinity` are both false. A
+  # mistyped value would silently reject every job on this path, which is the
+  # worst way for a storefront to be down. Refusing to start says so instead.
+  @spec validate_min_fee(term()) :: {:ok, non_neg_integer()} | {:error, term()}
+  defp validate_min_fee(n) when is_integer(n) and n >= 0, do: {:ok, n}
+  defp validate_min_fee(other), do: {:error, {:invalid_solver_min_fee_atomic, other}}
 
-  defp set_budget(state, key, session, requirement, transfer_atomic) do
-    budget_atomic = budget_for(transfer_atomic, state.fee_bps)
-
+  defp set_budget(state, key, session, requirement, transfer_atomic, budget_atomic) do
     case HookClient.set_budget(
            state.provider,
            state.chain_id,

--- a/packages/raxol_earn/test/raxol/earn/xochi/solver_agent_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/solver_agent_test.exs
@@ -3,6 +3,7 @@ defmodule Raxol.Earn.Xochi.SolverAgentTest do
 
   alias Raxol.Earn.{Agent, ProviderAdapter, Transport, JobApi, JobSession}
   alias Raxol.Earn.Xochi.SolverAgent
+  alias Raxol.Payments.Assets
 
   @solver_wallet "0xfeedfacefeedfacefeedfacefeedfacefeedface"
   @evaluator "0x" <> String.duplicate("ed", 20)
@@ -217,6 +218,75 @@ defmodule Raxol.Earn.Xochi.SolverAgentTest do
 
       assert %{{8453, "42"} => %{status: :budget_proposed, budget_atomic: 5_000}} =
                SolverAgent.sessions(solver)
+    end
+  end
+
+  # The gate reads a SYMBOL, but the arithmetic it protects is about DECIMALS,
+  # and a symbol is only a proxy for them. `ensure_stable_origin/1` now asserts
+  # the scale directly, which is defence the day the proxy stops holding. This is
+  # the early warning for the same drift: `Raxol.Payments.Assets` is compiled
+  # from module attributes with no runtime seam, so registering an 18dp token
+  # under a stablecoin symbol is a source change, and this is the test it breaks.
+  describe "fee-base scale invariant" do
+    @fee_base_symbols ~w(USDC USDT USDG)
+    @corridor_chains [1, 10, 137, 8453, 42_161, 4663]
+
+    test "every stablecoin the fee can be sized from is 6dp on every corridor chain" do
+      registered =
+        for chain <- @corridor_chains,
+            symbol <- @fee_base_symbols,
+            {:ok, address} <- [Assets.address(chain, symbol)] do
+          {chain, symbol, address, Assets.decimals(chain, address)}
+        end
+
+      # Guards the guard: a comprehension that silently matched nothing would
+      # assert nothing. Assets.address/2 returns {:ok, _} | :error, and reading
+      # it as a bare address is exactly how this test could go hollow.
+      assert length(registered) >= 11
+
+      for {chain, symbol, address, decimals} <- registered do
+        assert decimals == 6,
+               "#{symbol} on chain #{chain} (#{address}) is #{decimals}dp, but " <>
+                 "SolverAgent sizes the ACP fee by reading an origin amount in " <>
+                 "this token's base units as 6dp USDC. Either drop it from " <>
+                 "@fee_base_symbols or size the fee through a price oracle."
+      end
+    end
+  end
+
+  # `>=` against a non-integer does not raise: Erlang term order puts every
+  # number below every atom and binary, so `5000 >= "1"` is false. An unvalidated
+  # value would silently reject every job on this path -- a storefront that is
+  # down and says nothing. Refusing to start says it instead.
+  describe "min fee config validation" do
+    test "refuses to start on a min fee that is not a non-negative integer", ctx do
+      Process.flag(:trap_exit, true)
+
+      for bad <- ["1", :infinity, 1.0, -1] do
+        assert {:error, {:invalid_solver_min_fee_atomic, ^bad}} =
+                 start_solver([min_fee_atomic: bad], ctx)
+      end
+    end
+
+    test "refuses to start on a bad :solver_min_fee_atomic from application config", ctx do
+      Process.flag(:trap_exit, true)
+      Application.put_env(:raxol_earn, :solver_min_fee_atomic, "1000")
+      on_exit(fn -> Application.delete_env(:raxol_earn, :solver_min_fee_atomic) end)
+
+      assert {:error, {:invalid_solver_min_fee_atomic, "1000"}} = start_solver([], ctx)
+    end
+
+    test "a valid min fee is honoured over the default", ctx do
+      # 50 bps of 1_000_000 is 5_000, which clears the default floor of 1 but not
+      # a floor of 10_000.
+      {:ok, solver} = start_solver([fee_bps: 50, min_fee_atomic: 10_000], ctx)
+
+      Agent.start_stream(ctx.agent)
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{status: :failed}} = SolverAgent.sessions(solver)
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/xochi/solver_agent_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/solver_agent_test.exs
@@ -8,6 +8,10 @@ defmodule Raxol.Earn.Xochi.SolverAgentTest do
   @evaluator "0x" <> String.duplicate("ed", 20)
   @acp_core "0x238E541BfefD82238730D00a2208E5497F1832E0"
 
+  # Real Base addresses, from Raxol.Payments.Assets: USDC is 6dp, WETH 18dp.
+  @base_usdc "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+  @base_weth "0x4200000000000000000000000000000000000006"
+
   setup do
     for {_, pid, _, _} <- DynamicSupervisor.which_children(JobSession.Supervisor),
         is_pid(pid) do
@@ -52,14 +56,18 @@ defmodule Raxol.Earn.Xochi.SolverAgentTest do
   # In-process Xochi stub for accept-time intent derivation: GET /api/intent/:id
   # returns a `:quoted` intent carrying the authoritative `from_amount`. The
   # budget is sized on THIS, never the requirement's declared `amount_atomic`.
-  defp xochi_stub(from_amount \\ "1000000", status \\ "quoted") do
+  #
+  # `from_token` defaults to real Base USDC: the fee is charged in USDC and
+  # derived 1:1 from the origin amount, so the origin leg has to actually be a
+  # 6dp USD stablecoin for that arithmetic to mean anything.
+  defp xochi_stub(from_amount \\ "1000000", status \\ "quoted", opts \\ []) do
     plug = fn conn ->
       body = %{
         "id" => "xi_1",
         "status" => status,
         "from_chain_id" => 8453,
         "to_chain_id" => 10,
-        "from_token" => "0x" <> String.duplicate("11", 20),
+        "from_token" => Keyword.get(opts, :from_token, @base_usdc),
         "to_token" => "0x" <> String.duplicate("22", 20),
         "from_amount" => from_amount,
         "to_amount" => from_amount,
@@ -140,6 +148,75 @@ defmodule Raxol.Earn.Xochi.SolverAgentTest do
       Process.sleep(40)
 
       assert SolverAgent.sessions(solver) |> map_size() == 1
+    end
+  end
+
+  # The budget is `fee_bps` of the intent's `from_amount`, escrowed as the ACP
+  # payment token (USDC, 6dp). `from_amount` is in the ORIGIN token's base units,
+  # so that arithmetic only holds when the origin token is itself a 6dp USD
+  # stablecoin. Rescaling decimals cannot rescue an 18dp token either: 1 WETH is
+  # 1e18 base units, and reading that as 1e6-scaled USDC understates by roughly
+  # the ETH price. Without a price oracle the only sound answer is to refuse.
+  describe "budget proposal fee-base gate" do
+    test "refuses to size a budget from an 18dp origin token", ctx do
+      {:ok, solver} =
+        start_solver(
+          [fee_bps: 50, xochi_config: xochi_stub("1000000", "quoted", from_token: @base_weth)],
+          ctx
+        )
+
+      Agent.start_stream(ctx.agent)
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{status: :failed}} = SolverAgent.sessions(solver)
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "refuses an unregistered origin token rather than assuming 6dp", ctx do
+      unknown = "0x" <> String.duplicate("11", 20)
+
+      {:ok, solver} =
+        start_solver(
+          [fee_bps: 50, xochi_config: xochi_stub("1000000", "quoted", from_token: unknown)],
+          ctx
+        )
+
+      Agent.start_stream(ctx.agent)
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{status: :failed}} = SolverAgent.sessions(solver)
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "refuses a transfer so small the fee truncates to zero", ctx do
+      # 50 bps of 100 base units truncates to 0 through `div/2`. A zero budget is
+      # an escrow that can never pay, so the job fails closed instead.
+      {:ok, solver} =
+        start_solver([fee_bps: 50, xochi_config: xochi_stub("100")], ctx)
+
+      Agent.start_stream(ctx.agent)
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{status: :failed}} = SolverAgent.sessions(solver)
+      assert ProviderAdapter.Mock.sent_calls(ctx.provider) == []
+    end
+
+    test "a 6dp stablecoin origin still proposes a budget", ctx do
+      {:ok, solver} = start_solver([fee_bps: 50], ctx)
+
+      Agent.start_stream(ctx.agent)
+      Transport.Mock.deliver(ctx.transport, job_created_entry())
+      Transport.Mock.deliver(ctx.transport, requirement_message())
+      Process.sleep(60)
+
+      assert %{{8453, "42"} => %{status: :budget_proposed, budget_atomic: 5_000}} =
+               SolverAgent.sessions(solver)
     end
   end
 


### PR DESCRIPTION
Closes #666.

## The defect

`SolverAgent` sizes the ACP job budget as `fee_bps` of the intent's `from_amount` and
escrows it as the ACP payment token (USDC, 6dp). But `from_amount` is denominated in the
**origin token's** base units, so that arithmetic only means anything when the origin leg
is itself a 6dp USD stablecoin.

The generic `xochi_cross_chain_transfer` path gates nothing. Two ways it went wrong:

- **18dp origin.** 1 WETH is `1e18` base units; read as 6dp USDC that is a budget roughly
  `1e12` times too small.
- **Unregistered token.** Worse, because it is silent: `Assets.decimals/2` answers 6 for
  anything it does not know, and its own docstring names the hazard — *"An unregistered
  token resolves to 6 decimals, which is wrong for an 18-decimal token."*

## Why not option (b) from the issue

The issue offered "(a) gate to 6dp stablecoins, or (b) scale the fee by the transfer
token's decimals". **(b) does not work as stated.** Rescaling decimals converts 1 WETH
(`1e18`) into `1e6` — "1.0 USDC" — which understates the fee by roughly the ETH price.
Converting a non-stablecoin origin amount into a USDC fee needs a *price* oracle, not a
decimals table. Until there is one, the sound answer is to refuse the corridor rather
than escrow a number known to be wrong.

So this takes (a), via `Assets.symbol_for/2` against `USDC`/`USDT`/`USDG` — the symbol,
not a bare decimals check, because the real precondition is "6dp USD stablecoin". A 6dp
token that is not a dollar would pass a decimals test and still be mis-sized.

## The fee floor

Also from the issue: `budget_for/2` truncates through `div/2`, so a small enough transfer
rounds the fee away entirely and proposes an escrow that can never pay. The generic path
has no order-size band of its own (the USDC public offering carries a 1 USDC floor).

There are two different zeros here, and only one is a bug:

- `fee_bps: 0` — the storefront is charging nothing deliberately. Zero budget stands.
- `fee_bps > 0` truncating to 0 — a fee was meant to be charged and got lost. Rejected.

The floor is `:solver_min_fee_atomic`, defaulting to 1 base unit. An existing test
(`zero fee_bps yields a zero budget`) pinned the first case and caught my first attempt
at this, which was too blunt.

## The USDC offering really is unaffected

The issue asserts "No launch impact"; I verified it rather than taking it. It is less
obvious than it looks, because `resolve_accept/2` sizes the budget **before**
`handle_request/2` runs the `usdc_only` gate. The reason it is still safe:

1. `resolve_accept/2` returns `derive_corridor(req, intent)` — the buyer-declared corridor
   replaced by the authoritative one from the intent.
2. `Queue` threads that **derived** request into `Provider.accept_request/3`.
3. `usdc_only/1` therefore checks the authoritative token, not the buyer's claim.
4. `setBudget` is written only on `{:accept, _}`; a reject makes no on-chain change.

So a WETH intent relayed through the USDC offering is rejected on the authoritative
corridor before any write. The gap really is only the generic SolverAgent path.

## Tests

Four new tests in a `budget proposal fee-base gate` block, written RED first (3 failed
against the old code, the 6dp control passed):

- an 18dp origin token fails closed, no on-chain call
- an unregistered origin token fails closed rather than assuming 6dp
- a transfer whose fee truncates to zero fails closed
- a 6dp stablecoin origin still proposes its budget

**The test fixture was itself carrying the bug.** `xochi_stub` returned
`from_token: "0x1111…"`, an unregistered address — exactly the case `Assets` would
silently call 6dp. It now defaults to real Base USDC, so the happy path exercises a token
that genuinely is what the fee math assumes.

## Manual testing

- [x] New tests RED on the parent commit, GREEN with the fix
- [x] `MIX_ENV=test mix test` in `packages/raxol_earn`: 890 passed
- [x] Re-run under a second seed to rule out ordering effects: 890 passed
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean at root and in the package
- [x] Traced `resolve_accept` -> `Queue` -> `usdc_only` -> `setBudget` to confirm the USDC offering is unaffected

## Note

One unrelated flake surfaced on the first full run,
`Seller.Backend.WebSocketTest handshake auth payload is delivered to the server`. It
passed on both re-runs including a different seed, and touches nothing in this change.
