### PR TITLE
Offer a per-chat TEA app as a Console handler mode

### DIFF
--- a/packages/raxol_console/lib/raxol/console/app_registry.ex
+++ b/packages/raxol_console/lib/raxol/console/app_registry.ex
@@ -18,37 +18,98 @@ defmodule Raxol.Console.AppRegistry do
         "trading-desk" => MyConsole.Apps.TradingDesk
       }
 
+  A keyword list resolves the same way, since that is the ordinary shape for
+  Elixir config: `[dashboard: MyConsole.Apps.Dashboard]`.
+
+  ## A registration is checked, not merely recorded
+
+  Being an atom is not evidence of being a bookable app, so `fetch/1` also
+  requires the module to LOAD and to export the TEA callbacks it will be driven
+  by. Deferring those checks to first use would mean a deployment that boots
+  green and then drops every chat: `Raxol.Console.RuntimeConfig.build/2` resolves
+  the name at boot, but nothing tries to START the app until a real chat arrives,
+  and by then the failure is a dead session behind a `Raxol.Gateway.SessionRouter`
+  that has already answered `:ok`. A typo in this map is a config error, and a
+  config error belongs at boot.
+
   See `Raxol.Console.RuntimeConfig.handler_spec/2` for what a resolved module is
   then booted into, and GitHub #763 for why the package format does not carry a
   TEA app of its own.
   """
 
+  # The minimum a `Raxol.Core.Runtime.Application` must export to be driven by
+  # `Raxol.Gateway.Handler.Lifecycle`: the model, the fold, and the frame.
+  # `subscriptions/1` is deliberately not required -- the Lifecycle tolerates its
+  # absence, and demanding it would reject an otherwise working app.
+  @tea_callbacks [init: 1, update: 2, view: 1]
+
   @type template_name :: String.t()
+
+  @typedoc "Why a registered name could not be resolved to a bookable app."
+  @type invalid_reason :: :module_not_loaded | {:missing_callbacks, keyword(arity())}
 
   @doc """
   The configured name -> module map. Empty when the deployment registered none.
+
+  Total: a malformed entry is dropped rather than raised on, so a bad config
+  shape surfaces through `fetch/1` as `{:unknown_app_template, name}` at boot
+  instead of as an `ArgumentError` from inside config reading.
   """
   @spec templates() :: %{optional(template_name()) => module()}
   def templates do
-    case Application.get_env(:raxol_console, :app_templates, %{}) do
-      map when is_map(map) -> map
-      list when is_list(list) -> Map.new(list)
-      _ -> %{}
-    end
+    :raxol_console
+    |> Application.get_env(:app_templates, %{})
+    |> normalize()
   end
 
   @doc """
   Resolve a template name to its registered module.
 
-  Fails closed on anything unregistered, including when nothing is registered.
+  Fails closed on anything unregistered, including when nothing is registered,
+  and on a registered name whose module cannot serve as a TEA app.
   """
-  @spec fetch(term()) :: {:ok, module()} | {:error, {:unknown_app_template, term()}}
+  @spec fetch(term()) ::
+          {:ok, module()}
+          | {:error, {:unknown_app_template, term()}}
+          | {:error, {:invalid_app_template, template_name(), module(), invalid_reason()}}
   def fetch(name) when is_binary(name) do
     case Map.fetch(templates(), name) do
-      {:ok, module} when is_atom(module) and not is_nil(module) -> {:ok, module}
-      _ -> {:error, {:unknown_app_template, name}}
+      {:ok, module} -> validate(name, module)
+      :error -> {:error, {:unknown_app_template, name}}
     end
   end
 
   def fetch(name), do: {:error, {:unknown_app_template, name}}
+
+  # -- private ---------------------------------------------------------------
+
+  defp normalize(entries) when is_map(entries) or is_list(entries),
+    do: entries |> Enum.flat_map(&entry/1) |> Map.new()
+
+  defp normalize(_), do: %{}
+
+  defp entry({name, module}) when is_binary(name) and is_atom(module) and not is_nil(module),
+    do: [{name, module}]
+
+  defp entry({name, module}) when is_atom(name) and not is_nil(name),
+    do: entry({Atom.to_string(name), module})
+
+  defp entry(_), do: []
+
+  defp validate(name, module) do
+    with :ok <- ensure_loaded(name, module), do: ensure_tea_app(name, module)
+  end
+
+  defp ensure_loaded(name, module) do
+    if Code.ensure_loaded?(module),
+      do: :ok,
+      else: {:error, {:invalid_app_template, name, module, :module_not_loaded}}
+  end
+
+  defp ensure_tea_app(name, module) do
+    case Enum.reject(@tea_callbacks, fn {fun, arity} -> function_exported?(module, fun, arity) end) do
+      [] -> {:ok, module}
+      missing -> {:error, {:invalid_app_template, name, module, {:missing_callbacks, missing}}}
+    end
+  end
 end

--- a/packages/raxol_console/lib/raxol/console/app_registry.ex
+++ b/packages/raxol_console/lib/raxol/console/app_registry.ex
@@ -1,0 +1,54 @@
+defmodule Raxol.Console.AppRegistry do
+  @moduledoc """
+  Allowlist of TEA app modules a Console runtime may boot in `:app` handler mode.
+
+  A Console package is untrusted input: it is authored elsewhere and loaded by
+  `Raxol.Earn.Console.Package`. Selecting a TEA app therefore goes through a
+  NAME, resolved against a map the deployment configures, rather than a module
+  the package could name directly. A name that is not in the map resolves to
+  nothing at all -- there is no `String.to_atom/1` on this path, so no input can
+  reach a module the operator did not list.
+
+  The map is also the capability gate. It is empty by default, so `:app` mode is
+  unavailable until an operator registers at least one template, and the default
+  Console runtime stays the stateless `Handler.Agent` chat loop.
+
+      config :raxol_console, :app_templates, %{
+        "dashboard" => MyConsole.Apps.Dashboard,
+        "trading-desk" => MyConsole.Apps.TradingDesk
+      }
+
+  See `Raxol.Console.RuntimeConfig.handler_spec/2` for what a resolved module is
+  then booted into, and GitHub #763 for why the package format does not carry a
+  TEA app of its own.
+  """
+
+  @type template_name :: String.t()
+
+  @doc """
+  The configured name -> module map. Empty when the deployment registered none.
+  """
+  @spec templates() :: %{optional(template_name()) => module()}
+  def templates do
+    case Application.get_env(:raxol_console, :app_templates, %{}) do
+      map when is_map(map) -> map
+      list when is_list(list) -> Map.new(list)
+      _ -> %{}
+    end
+  end
+
+  @doc """
+  Resolve a template name to its registered module.
+
+  Fails closed on anything unregistered, including when nothing is registered.
+  """
+  @spec fetch(term()) :: {:ok, module()} | {:error, {:unknown_app_template, term()}}
+  def fetch(name) when is_binary(name) do
+    case Map.fetch(templates(), name) do
+      {:ok, module} when is_atom(module) and not is_nil(module) -> {:ok, module}
+      _ -> {:error, {:unknown_app_template, name}}
+    end
+  end
+
+  def fetch(name), do: {:error, {:unknown_app_template, name}}
+end

--- a/packages/raxol_console/lib/raxol/console/application.ex
+++ b/packages/raxol_console/lib/raxol/console/application.ex
@@ -23,6 +23,21 @@ defmodule Raxol.Console.Application do
         workspace: "/srv/agent/workspace",
         bundle_default_mcp: true
 
+  A chat turn runs the stateless agent loop by default. To run a full TEA app per
+  chat instead, name a template registered in `Raxol.Console.AppRegistry`:
+
+      config :raxol_console, :app_templates, %{"dashboard" => MyConsole.Dashboard}
+
+      config :raxol_console,
+        handler_mode: :app,
+        app_template: "dashboard",
+        idle_timeout: :timer.hours(6)
+
+  A per-chat app holds its model in memory, and the session's idle timeout
+  discards it; `:idle_timeout` is how long a deployment's app is worth keeping
+  warm. Both other keys are deployment-owned. The package never selects the module that runs
+  per chat -- see `Raxol.Console.RuntimeConfig.build/2`.
+
   The package carries persona + behavior; the deployment supplies the rest. The
   three deployment-owned inputs the Console injects -- credentials (agent wallet,
   email, card, channel bot tokens), messaging channels, and inference -- arrive
@@ -44,7 +59,19 @@ defmodule Raxol.Console.Application do
   alias Raxol.Earn.Console.Package
   alias Raxol.Console.{Boot, RuntimeConfig}
 
-  @rc_keys [:channels, :agent_opts, :default_target, :workspace, :bundle_default_mcp]
+  # Every deployment option `RuntimeConfig.build/2` understands. Both takes below
+  # filter through this list, so a key missing here is silently dropped on the
+  # way in and its feature is unreachable from application config.
+  @rc_keys [
+    :channels,
+    :agent_opts,
+    :default_target,
+    :workspace,
+    :bundle_default_mcp,
+    :handler_mode,
+    :app_template,
+    :idle_timeout
+  ]
 
   @impl true
   def start(_type, _args) do

--- a/packages/raxol_console/lib/raxol/console/application.ex
+++ b/packages/raxol_console/lib/raxol/console/application.ex
@@ -31,12 +31,16 @@ defmodule Raxol.Console.Application do
       config :raxol_console,
         handler_mode: :app,
         app_template: "dashboard",
-        idle_timeout: :timer.hours(6)
+        idle_timeout: :timer.hours(6),
+        max_sessions: 200
 
   A per-chat app holds its model in memory, and the session's idle timeout
   discards it; `:idle_timeout` is how long a deployment's app is worth keeping
-  warm. Both other keys are deployment-owned. The package never selects the module that runs
-  per chat -- see `Raxol.Console.RuntimeConfig.build/2`.
+  warm. A running app is several processes rather than a message list, so a long
+  idle timeout wants a `:max_sessions` chosen for it -- see
+  `Raxol.Console.RuntimeConfig.build/2` for how the two multiply. All of these
+  keys are deployment-owned; the package never selects the module that runs per
+  chat.
 
   The package carries persona + behavior; the deployment supplies the rest. The
   three deployment-owned inputs the Console injects -- credentials (agent wallet,
@@ -70,7 +74,8 @@ defmodule Raxol.Console.Application do
     :bundle_default_mcp,
     :handler_mode,
     :app_template,
-    :idle_timeout
+    :idle_timeout,
+    :max_sessions
   ]
 
   @impl true

--- a/packages/raxol_console/lib/raxol/console/boot.ex
+++ b/packages/raxol_console/lib/raxol/console/boot.ex
@@ -17,8 +17,10 @@ defmodule Raxol.Console.Boot do
   own child, so it is torn down when the runtime stops and never leaks on the
   boot caller; a crashed server client is restarted by it rather than left
   dangling. Boot is two-phase: it starts the tree (with the empty MCP supervisor)
-  first, then loads the servers into it and starts the gateway last, so the chat
-  handler captures the resolved tools.
+  first, then loads the servers into it and starts the gateway last, so the
+  handler captures the resolved tools. Both handler modes receive them: the chat
+  loop as its turn options, a `:app` TEA app through `:lifecycle_opts` (see
+  `Raxol.Console.RuntimeConfig.handler_spec/2`).
   """
 
   alias Raxol.Agent.{McpBundle, Scheduler}
@@ -57,24 +59,28 @@ defmodule Raxol.Console.Boot do
   def start(runtime_config, opts \\ []) do
     base = Keyword.get(opts, :name, Raxol.Console)
     skills = resolve_skills(opts, base)
-    mcp_name = name(base, "mcp")
 
     with {:ok, adapters} <- connect_channels(runtime_config.channels),
-         core_opts = core_sup_opts(opts, runtime_config, adapters, skills, mcp_name),
+         core_opts = core_sup_opts(opts, runtime_config, adapters, skills, name(base, "mcp")),
          {:ok, sup} <- Raxol.Console.Supervisor.start_link(core_opts) do
-      # Phase two: the tree (incl. the empty MCP DynamicSupervisor, owned by the
-      # root supervisor so its lifecycle is the runtime's) is up. Load servers
-      # into that supervised MCP subtree, then start the gateway last, so its chat
-      # handler captures the resolved tools. A phase-two failure tears the tree
-      # (and the MCP subtree with it) down rather than leaving it half-booted.
-      mcp = load_mcp(runtime_config, opts, mcp_name)
-      mcp_sup = mcp_supervisor_pid(runtime_config, mcp_name)
-      actions = Keyword.get(opts, :actions, []) ++ mcp.tools
+      start_services(sup, runtime_config, adapters, skills, base, opts)
+    end
+  end
 
-      case start_gateway(sup, runtime_config, adapters, actions, base, skills) do
-        :ok -> {:ok, report(sup, mcp_sup, mcp, adapters, skills, opts)}
-        {:error, _} = error -> stop_supervisor(sup) && error
-      end
+  # Phase two: the tree (incl. the empty MCP DynamicSupervisor, owned by the root
+  # supervisor so its lifecycle is the runtime's) is up. Load servers into that
+  # supervised MCP subtree, then start the gateway last, so its handler captures
+  # the resolved tools. A phase-two failure tears the tree (and the MCP subtree
+  # with it) down rather than leaving it half-booted.
+  defp start_services(sup, runtime_config, adapters, skills, base, opts) do
+    mcp_name = name(base, "mcp")
+    mcp = load_mcp(runtime_config, opts, mcp_name)
+    mcp_sup = mcp_supervisor_pid(runtime_config, mcp_name)
+    actions = Keyword.get(opts, :actions, []) ++ mcp.tools
+
+    case start_gateway(sup, runtime_config, adapters, actions, base, skills) do
+      :ok -> {:ok, report(sup, mcp_sup, mcp, adapters, skills, opts)}
+      {:error, _} = error -> stop_supervisor(sup) && error
     end
   end
 
@@ -182,12 +188,13 @@ defmodule Raxol.Console.Boot do
 
   # Start the gateway subtree as the LAST child of the running tree, only when at
   # least one channel is connected; a headless (scheduler-only) runtime skips it.
-  # It is added dynamically (after MCP tools resolve) so the chat handler can
-  # carry the combined toolset. As the last-started child under `:rest_for_one`,
-  # this matches the ordering a static gateway child would have had. The chat
-  # handler runs the agent's persona + the combined toolset (read-only skill
-  # access + the skills store in context when the package ships skills), outbound
-  # through the same adapters map the scheduler delivers to.
+  # It is added dynamically (after MCP tools resolve) so the handler can carry
+  # the combined toolset. As the last-started child under `:rest_for_one`, this
+  # matches the ordering a static gateway child would have had. The handler runs
+  # the agent's persona + the combined toolset (read-only skill access + the
+  # skills store in context when the package ships skills), outbound through the
+  # same adapters map the scheduler delivers to. `RuntimeConfig.handler_spec/2`
+  # decides which handler that is; both modes are handed the same toolset.
   defp start_gateway(_sup, _rc, adapters, _actions, _base, _skills)
        when map_size(adapters) == 0,
        do: :ok
@@ -218,7 +225,16 @@ defmodule Raxol.Console.Boot do
       pairing_name: name(base, "pairing"),
       sessions_sup: name(base, "sessions")
     ]
+    |> put_router_opts(rc)
   end
+
+  # Only override the router's own defaults when the deployment asked to. An
+  # unset `:idle_timeout` leaves `Raxol.Gateway.SessionRouter` on its default
+  # rather than pinning a second copy of that number here.
+  defp put_router_opts(opts, %{idle_timeout: nil}), do: opts
+
+  defp put_router_opts(opts, %{idle_timeout: ms}),
+    do: Keyword.put(opts, :router, idle_timeout: ms)
 
   defp skill_actions(nil), do: []
   defp skill_actions(_), do: @skill_actions

--- a/packages/raxol_console/lib/raxol/console/boot.ex
+++ b/packages/raxol_console/lib/raxol/console/boot.ex
@@ -22,6 +22,7 @@ defmodule Raxol.Console.Boot do
   """
 
   alias Raxol.Agent.{McpBundle, Scheduler}
+  alias Raxol.Console.RuntimeConfig
 
   # Read-only skill access surfaced to the chat agent when the package ships
   # skills: the agent can list/view them on demand (skill authoring stays a
@@ -207,11 +208,8 @@ defmodule Raxol.Console.Boot do
       |> Keyword.put(:actions, skill_actions(skills) ++ actions)
       |> put_skills_context(skills)
 
-    handler =
-      {Raxol.Gateway.Handler.Agent, [system_prompt: rc.system_prompt, agent_opts: agent_opts]}
-
     [
-      handler: handler,
+      handler: RuntimeConfig.handler_spec(rc, agent_opts),
       deliver: fn route, rendered ->
         Raxol.Gateway.Delivery.deliver(adapters, {:direct, route}, rendered)
       end,

--- a/packages/raxol_console/lib/raxol/console/boot.ex
+++ b/packages/raxol_console/lib/raxol/console/boot.ex
@@ -229,12 +229,19 @@ defmodule Raxol.Console.Boot do
   end
 
   # Only override the router's own defaults when the deployment asked to. An
-  # unset `:idle_timeout` leaves `Raxol.Gateway.SessionRouter` on its default
-  # rather than pinning a second copy of that number here.
-  defp put_router_opts(opts, %{idle_timeout: nil}), do: opts
+  # unset bound leaves `Raxol.Gateway.SessionRouter` on its default rather than
+  # pinning a second copy of that number here. The two travel together because
+  # in `:app` mode they are one sizing decision -- see
+  # `Raxol.Console.RuntimeConfig.build/2`.
+  defp put_router_opts(opts, rc) do
+    case put_if([], :idle_timeout, rc.idle_timeout) |> put_if(:max_sessions, rc.max_sessions) do
+      [] -> opts
+      router -> Keyword.put(opts, :router, router)
+    end
+  end
 
-  defp put_router_opts(opts, %{idle_timeout: ms}),
-    do: Keyword.put(opts, :router, idle_timeout: ms)
+  defp put_if(kw, _key, nil), do: kw
+  defp put_if(kw, key, value), do: Keyword.put(kw, key, value)
 
   defp skill_actions(nil), do: []
   defp skill_actions(_), do: @skill_actions

--- a/packages/raxol_console/lib/raxol/console/runtime_config.ex
+++ b/packages/raxol_console/lib/raxol/console/runtime_config.ex
@@ -52,7 +52,8 @@ defmodule Raxol.Console.RuntimeConfig do
             channels: [],
             mcp_servers: [],
             handler_mode: :chat,
-            app_module: nil
+            app_module: nil,
+            idle_timeout: nil
 
   @type t :: %__MODULE__{
           system_prompt: String.t(),
@@ -63,7 +64,8 @@ defmodule Raxol.Console.RuntimeConfig do
           channels: [term()],
           mcp_servers: [McpBundle.server_spec()],
           handler_mode: handler_mode(),
-          app_module: module() | nil
+          app_module: module() | nil,
+          idle_timeout: pos_integer() | nil
         }
 
   @doc """
@@ -80,6 +82,11 @@ defmodule Raxol.Console.RuntimeConfig do
     * `:handler_mode` -- `:chat` (default) or `:app`; see `t:handler_mode/0`.
     * `:app_template` -- required in `:app` mode; a name resolved against
       `Raxol.Console.AppRegistry`.
+    * `:idle_timeout` -- ms a chat may sit idle before its session stops
+      (gateway default 10 minutes). A stopped session is rebuilt on the next
+      message, so for `:chat` this costs nothing. For `:app` it discards the
+      model the mode exists to persist, which makes the right value a property
+      of the deployment's app rather than of the gateway.
 
   `:handler_mode` and `:app_template` are read from the DEPLOYMENT options, never
   from the package. The package is untrusted input, and choosing which module
@@ -90,7 +97,8 @@ defmodule Raxol.Console.RuntimeConfig do
 
   def build(%Package{} = pkg, opts) do
     with {:ok, persona} <- persona(pkg),
-         {:ok, mode, app_module} <- handler(opts) do
+         {:ok, mode, app_module} <- handler(opts),
+         {:ok, idle_timeout} <- idle_timeout(opts) do
       {:ok,
        %__MODULE__{
          system_prompt: persona,
@@ -101,7 +109,8 @@ defmodule Raxol.Console.RuntimeConfig do
          channels: Keyword.get(opts, :channels, []),
          mcp_servers: mcp_servers(opts),
          handler_mode: mode,
-         app_module: app_module
+         app_module: app_module,
+         idle_timeout: idle_timeout
        }}
     end
   end
@@ -118,11 +127,20 @@ defmodule Raxol.Console.RuntimeConfig do
   `init(%{options: opts})`. That is the only seam a TEA app has for the persona:
   unlike the chat loop it weaves the system prompt into its own model and backend
   calls rather than getting it applied for free.
+
+  `agent_opts` rides the same seam. The boot resolves them either way -- bundled
+  MCP servers run as supervised subprocesses and the skills store is started
+  before the gateway -- so an `:app` runtime that dropped them would pay for a
+  toolset no chat could reach. A TEA app is free to ignore the key; it is not
+  free to have it silently withheld.
   """
   @spec handler_spec(t(), keyword()) :: {module(), keyword()}
-  def handler_spec(%__MODULE__{handler_mode: :app} = rc, _agent_opts) do
+  def handler_spec(%__MODULE__{handler_mode: :app} = rc, agent_opts) do
     {Raxol.Gateway.Handler.Lifecycle,
-     [app_module: rc.app_module, lifecycle_opts: [system_prompt: rc.system_prompt]]}
+     [
+       app_module: rc.app_module,
+       lifecycle_opts: [system_prompt: rc.system_prompt, agent_opts: agent_opts]
+     ]}
   end
 
   def handler_spec(%__MODULE__{} = rc, agent_opts) do
@@ -143,6 +161,20 @@ defmodule Raxol.Console.RuntimeConfig do
 
   defp resolve_app(name) do
     with {:ok, module} <- AppRegistry.fetch(name), do: {:ok, :app, module}
+  end
+
+  # -- idle timeout ----------------------------------------------------------
+
+  # Validated rather than defaulted: a timeout that is not a positive integer
+  # would otherwise reach the session's `Process.send_after/3` and fail there,
+  # or -- worse for a string -- compare as a term and never fire. `nil` is the
+  # honest "unset", leaving the gateway's own default in force.
+  defp idle_timeout(opts) do
+    case Keyword.get(opts, :idle_timeout) do
+      nil -> {:ok, nil}
+      ms when is_integer(ms) and ms > 0 -> {:ok, ms}
+      other -> {:error, {:invalid_idle_timeout, other}}
+    end
   end
 
   # -- persona ---------------------------------------------------------------

--- a/packages/raxol_console/lib/raxol/console/runtime_config.ex
+++ b/packages/raxol_console/lib/raxol/console/runtime_config.ex
@@ -53,7 +53,8 @@ defmodule Raxol.Console.RuntimeConfig do
             mcp_servers: [],
             handler_mode: :chat,
             app_module: nil,
-            idle_timeout: nil
+            idle_timeout: nil,
+            max_sessions: nil
 
   @type t :: %__MODULE__{
           system_prompt: String.t(),
@@ -65,7 +66,8 @@ defmodule Raxol.Console.RuntimeConfig do
           mcp_servers: [McpBundle.server_spec()],
           handler_mode: handler_mode(),
           app_module: module() | nil,
-          idle_timeout: pos_integer() | nil
+          idle_timeout: pos_integer() | nil,
+          max_sessions: pos_integer() | nil
         }
 
   @doc """
@@ -87,10 +89,25 @@ defmodule Raxol.Console.RuntimeConfig do
       message, so for `:chat` this costs nothing. For `:app` it discards the
       model the mode exists to persist, which makes the right value a property
       of the deployment's app rather than of the gateway.
+    * `:max_sessions` -- concurrent chats the router will hold (gateway default
+      1000); further chats are refused with `:max_sessions`.
 
   `:handler_mode` and `:app_template` are read from the DEPLOYMENT options, never
   from the package. The package is untrusted input, and choosing which module
   runs per chat is not a decision it gets to make.
+
+  ## Sizing an `:app` deployment
+
+  The two timeout/limit keys are one decision in `:app` mode, not two. A `:chat`
+  session is a process holding a message list; an `:app` session is a running
+  TEA app -- a Lifecycle, a dispatcher, an engine and a buffer, roughly four to
+  five processes plus the model. At the gateway's own defaults that is a ceiling
+  of ~5000 processes, and raising `:idle_timeout` to keep models warm raises how
+  many of them are live at once, because the two multiply: idle chats now hold
+  their apps instead of being rebuilt on the next message.
+
+  So a deployment that lengthens `:idle_timeout` for `:app` mode should size
+  `:max_sessions` deliberately rather than inherit 1000.
   """
   @spec build(Package.t(), keyword()) :: {:ok, t()} | {:error, term()}
   def build(package, opts \\ [])
@@ -98,7 +115,8 @@ defmodule Raxol.Console.RuntimeConfig do
   def build(%Package{} = pkg, opts) do
     with {:ok, persona} <- persona(pkg),
          {:ok, mode, app_module} <- handler(opts),
-         {:ok, idle_timeout} <- idle_timeout(opts) do
+         {:ok, idle_timeout} <- pos_integer(opts, :idle_timeout, :invalid_idle_timeout),
+         {:ok, max_sessions} <- pos_integer(opts, :max_sessions, :invalid_max_sessions) do
       {:ok,
        %__MODULE__{
          system_prompt: persona,
@@ -110,7 +128,8 @@ defmodule Raxol.Console.RuntimeConfig do
          mcp_servers: mcp_servers(opts),
          handler_mode: mode,
          app_module: app_module,
-         idle_timeout: idle_timeout
+         idle_timeout: idle_timeout,
+         max_sessions: max_sessions
        }}
     end
   end
@@ -133,6 +152,19 @@ defmodule Raxol.Console.RuntimeConfig do
   before the gateway -- so an `:app` runtime that dropped them would pay for a
   toolset no chat could reach. A TEA app is free to ignore the key; it is not
   free to have it silently withheld.
+
+  ## What an `:app` module is trusted with
+
+  Handing over `agent_opts` hands over capability, so it is worth stating plainly
+  what crosses. `:actions` is the fully resolved toolset, including the bundled
+  filesystem server scoped to `:workspace`, and `:context` carries the skills
+  store. In `:chat` mode those are reached only through `Raxol.Agent.Stream`,
+  which gates each call per turn. `:app` mode has no equivalent: the app receives
+  the list and whatever it does with it is unmediated.
+
+  That is why `Raxol.Console.AppRegistry` exists and why the package cannot name
+  a module. An `:app` template is operator-authored code running with the
+  runtime's own authority, and it should be read as such -- not as a sandbox.
   """
   @spec handler_spec(t(), keyword()) :: {module(), keyword()}
   def handler_spec(%__MODULE__{handler_mode: :app} = rc, agent_opts) do
@@ -163,17 +195,18 @@ defmodule Raxol.Console.RuntimeConfig do
     with {:ok, module} <- AppRegistry.fetch(name), do: {:ok, :app, module}
   end
 
-  # -- idle timeout ----------------------------------------------------------
+  # -- router bounds ---------------------------------------------------------
 
-  # Validated rather than defaulted: a timeout that is not a positive integer
+  # Validated rather than defaulted: a bound that is not a positive integer
   # would otherwise reach the session's `Process.send_after/3` and fail there,
-  # or -- worse for a string -- compare as a term and never fire. `nil` is the
-  # honest "unset", leaving the gateway's own default in force.
-  defp idle_timeout(opts) do
-    case Keyword.get(opts, :idle_timeout) do
+  # or -- worse for a string -- compare as a term and never fire the branch it
+  # feeds. `nil` is the honest "unset", leaving the gateway's own default in
+  # force rather than pinning a second copy of that number here.
+  defp pos_integer(opts, key, error_tag) do
+    case Keyword.get(opts, key) do
       nil -> {:ok, nil}
-      ms when is_integer(ms) and ms > 0 -> {:ok, ms}
-      other -> {:error, {:invalid_idle_timeout, other}}
+      n when is_integer(n) and n > 0 -> {:ok, n}
+      other -> {:error, {error_tag, other}}
     end
   end
 

--- a/packages/raxol_console/lib/raxol/console/runtime_config.ex
+++ b/packages/raxol_console/lib/raxol/console/runtime_config.ex
@@ -23,6 +23,7 @@ defmodule Raxol.Console.RuntimeConfig do
 
   alias Raxol.Earn.Console.Package
   alias Raxol.Agent.McpBundle
+  alias Raxol.Console.AppRegistry
 
   @type scheduler_job :: %{
           id: String.t(),
@@ -33,13 +34,25 @@ defmodule Raxol.Console.RuntimeConfig do
           enabled: boolean()
         }
 
+  @typedoc """
+  Which gateway handler a chat turn runs.
+
+    * `:chat` -- one `Raxol.Agent.Stream.run/2` per turn, persona applied
+      automatically. The default, and what every current Console template needs.
+    * `:app` -- a full TEA app per chat under `environment: :gateway`, so the
+      model persists across turns.
+  """
+  @type handler_mode :: :chat | :app
+
   defstruct system_prompt: nil,
             persona_sha256: nil,
             scheduler_jobs: [],
             skills: [],
             agent_opts: [],
             channels: [],
-            mcp_servers: []
+            mcp_servers: [],
+            handler_mode: :chat,
+            app_module: nil
 
   @type t :: %__MODULE__{
           system_prompt: String.t(),
@@ -48,7 +61,9 @@ defmodule Raxol.Console.RuntimeConfig do
           skills: [%{name: String.t(), skill_md: String.t()}],
           agent_opts: keyword(),
           channels: [term()],
-          mcp_servers: [McpBundle.server_spec()]
+          mcp_servers: [McpBundle.server_spec()],
+          handler_mode: handler_mode(),
+          app_module: module() | nil
         }
 
   @doc """
@@ -62,12 +77,20 @@ defmodule Raxol.Console.RuntimeConfig do
     * `:mcp_servers` -- override the bundled MCP server specs.
     * `:bundle_default_mcp` -- default `true`; bundle the standard server set.
     * `:workspace` -- scopes the bundled filesystem server (default `"."`).
+    * `:handler_mode` -- `:chat` (default) or `:app`; see `t:handler_mode/0`.
+    * `:app_template` -- required in `:app` mode; a name resolved against
+      `Raxol.Console.AppRegistry`.
+
+  `:handler_mode` and `:app_template` are read from the DEPLOYMENT options, never
+  from the package. The package is untrusted input, and choosing which module
+  runs per chat is not a decision it gets to make.
   """
   @spec build(Package.t(), keyword()) :: {:ok, t()} | {:error, term()}
   def build(package, opts \\ [])
 
   def build(%Package{} = pkg, opts) do
-    with {:ok, persona} <- persona(pkg) do
+    with {:ok, persona} <- persona(pkg),
+         {:ok, mode, app_module} <- handler(opts) do
       {:ok,
        %__MODULE__{
          system_prompt: persona,
@@ -76,12 +99,51 @@ defmodule Raxol.Console.RuntimeConfig do
          skills: pkg.skills,
          agent_opts: Keyword.get(opts, :agent_opts, []),
          channels: Keyword.get(opts, :channels, []),
-         mcp_servers: mcp_servers(opts)
+         mcp_servers: mcp_servers(opts),
+         handler_mode: mode,
+         app_module: app_module
        }}
     end
   end
 
   def build(other, _opts), do: {:error, {:not_a_package, other}}
+
+  @doc """
+  The `Raxol.Gateway` handler spec this runtime boots.
+
+  `:chat` runs the stateless agent loop with the resolved persona applied per
+  turn. `:app` runs a per-chat TEA app, and threads the persona through
+  `:lifecycle_opts` -- `Raxol.Gateway.Handler.Lifecycle` appends those to
+  `Raxol.Core.Runtime.Lifecycle.start_link/2`, which hands them to the app as
+  `init(%{options: opts})`. That is the only seam a TEA app has for the persona:
+  unlike the chat loop it weaves the system prompt into its own model and backend
+  calls rather than getting it applied for free.
+  """
+  @spec handler_spec(t(), keyword()) :: {module(), keyword()}
+  def handler_spec(%__MODULE__{handler_mode: :app} = rc, _agent_opts) do
+    {Raxol.Gateway.Handler.Lifecycle,
+     [app_module: rc.app_module, lifecycle_opts: [system_prompt: rc.system_prompt]]}
+  end
+
+  def handler_spec(%__MODULE__{} = rc, agent_opts) do
+    {Raxol.Gateway.Handler.Agent, [system_prompt: rc.system_prompt, agent_opts: agent_opts]}
+  end
+
+  # -- handler mode ----------------------------------------------------------
+
+  defp handler(opts) do
+    case Keyword.get(opts, :handler_mode, :chat) do
+      :chat -> {:ok, :chat, nil}
+      :app -> resolve_app(Keyword.get(opts, :app_template))
+      other -> {:error, {:unknown_handler_mode, other}}
+    end
+  end
+
+  defp resolve_app(nil), do: {:error, :missing_app_template}
+
+  defp resolve_app(name) do
+    with {:ok, module} <- AppRegistry.fetch(name), do: {:ok, :app, module}
+  end
 
   # -- persona ---------------------------------------------------------------
 

--- a/packages/raxol_console/test/raxol/console/application_test.exs
+++ b/packages/raxol_console/test/raxol/console/application_test.exs
@@ -56,6 +56,23 @@ defmodule Raxol.Console.ApplicationTest do
       assert opts[:agent_opts] == [backend: CaptureBackend]
       assert opts[:default_target] == "telegram:home"
     end
+
+    # `plan/1` filters config through `@rc_keys`, and `build/2` filters it again
+    # through the same list. A key absent from it is dropped in silence: the
+    # runtime boots `:chat` with no error, and the deployment's `:app` request
+    # never reaches `RuntimeConfig`. Tests that call `RuntimeConfig.build/2`
+    # directly cannot see that, because they never cross either take.
+    test "carries the handler mode and app template through" do
+      config = [
+        package_dir: "/srv/agent",
+        handler_mode: :app,
+        app_template: "dashboard"
+      ]
+
+      assert {:ok, _dir, opts} = Application.plan(config)
+      assert opts[:handler_mode] == :app
+      assert opts[:app_template] == "dashboard"
+    end
   end
 
   describe "boot/2" do

--- a/packages/raxol_console/test/raxol/console/boot_test.exs
+++ b/packages/raxol_console/test/raxol/console/boot_test.exs
@@ -1,5 +1,7 @@
 defmodule Raxol.Console.BootTest do
-  use ExUnit.Case, async: true
+  # Not async: the app-handler test sets and deletes `:app_templates`, which is
+  # global application env. RuntimeConfigTest writes the same key.
+  use ExUnit.Case, async: false
 
   alias Raxol.Earn.Console.Package
   alias Raxol.Agent.Action.Dynamic
@@ -291,6 +293,48 @@ defmodule Raxol.Console.BootTest do
 
       # The persona reached the app's init/1 through :lifecycle_opts.
       assert rendered =~ "persona: Be terse."
+    end
+
+    # `:idle_timeout` crosses four hops to reach the router: the deployment
+    # config, RuntimeConfig, gateway_opts' `:router` key, and Gateway.Supervisor's
+    # merge into the router child. A key dropped at any of them defaults in
+    # silence, which is exactly how `:handler_mode` came to be unreachable.
+    test "a configured idle timeout reaches the running router" do
+      pid = self()
+
+      pkg = %Package{
+        runtime: :raxol,
+        soul_md: "# Bot\n\nHi.",
+        agents_md: nil,
+        tasks: [],
+        skills: []
+      }
+
+      {:ok, rc} =
+        RuntimeConfig.build(pkg,
+          bundle_default_mcp: false,
+          idle_timeout: 1_234_000,
+          channels: [%{platform: :in_memory, adapter: InMemory, config: %{sink: pid}}]
+        )
+
+      assert rc.idle_timeout == 1_234_000
+
+      {:ok, _report} =
+        Boot.start(rc,
+          name: :console_idle,
+          scheduler_name: :console_idle_sched,
+          reconciler_name: :console_idle_recon
+        )
+
+      on_exit(fn ->
+        try do
+          Supervisor.stop(:console_idle)
+        catch
+          :exit, _ -> :ok
+        end
+      end)
+
+      assert :sys.get_state(:"console_idle.router").idle_timeout == 1_234_000
     end
   end
 

--- a/packages/raxol_console/test/raxol/console/boot_test.exs
+++ b/packages/raxol_console/test/raxol/console/boot_test.exs
@@ -8,6 +8,43 @@ defmodule Raxol.Console.BootTest do
   alias Raxol.Gateway.Adapter.InMemory
   alias Raxol.Gateway.SessionRouter
 
+  # A minimal per-chat TEA app for `:app` mode. Renders the last key it folded
+  # plus the persona it was handed at init, so one frame proves both that the
+  # model survived the turn and that the system prompt reached the app.
+  defmodule ProbeApp do
+    @moduledoc false
+    use Raxol.Core.Runtime.Application
+
+    @impl true
+    def init(context) do
+      persona = context |> Map.get(:options, []) |> Keyword.get(:system_prompt, "")
+      %{last: "ready", persona: String.trim(persona)}
+    end
+
+    @impl true
+    def update(message, model) do
+      case message do
+        %Raxol.Core.Events.Event{type: :paste, data: %{text: text}} ->
+          {%{model | last: text}, []}
+
+        %Raxol.Core.Events.Event{type: :key, data: %{key: :char, char: char}} ->
+          {%{model | last: char}, []}
+
+        _ ->
+          {model, []}
+      end
+    end
+
+    @impl true
+    def view(model) do
+      persona = model.persona |> String.split("\n", trim: true) |> List.last() || ""
+      Raxol.Core.Renderer.View.text("last: #{model.last} persona: #{persona}")
+    end
+
+    @impl true
+    def subscriptions(_model), do: []
+  end
+
   defp job(id, prompt, cron) do
     %{id: id, prompt: prompt, schedule: cron, skills: [], target: nil, enabled: true}
   end
@@ -187,6 +224,73 @@ defmodule Raxol.Console.BootTest do
       assert_receive {:tool_invoked, params}
       assert "hi" in Map.values(params)
       assert_receive {:gateway_sent, ^route, "final answer"}
+    end
+
+    # The same boot path in `:app` mode: the reply is a TEA app's rendered frame
+    # rather than an LLM turn, and the persona reaches the app through its own
+    # `init/1` instead of being applied for free. See GitHub #763.
+    test "app mode boots a per-chat TEA app and replies with its rendered frame" do
+      pid = self()
+
+      Application.put_env(:raxol_console, :app_templates, %{"probe" => ProbeApp})
+      on_exit(fn -> Application.delete_env(:raxol_console, :app_templates) end)
+
+      pkg = %Package{
+        runtime: :raxol,
+        soul_md: "# Bot\n\nBe terse.",
+        agents_md: nil,
+        tasks: [],
+        skills: []
+      }
+
+      {:ok, rc} =
+        RuntimeConfig.build(pkg,
+          bundle_default_mcp: false,
+          handler_mode: :app,
+          app_template: "probe",
+          channels: [%{platform: :in_memory, adapter: InMemory, config: %{sink: pid}}]
+        )
+
+      assert rc.app_module == ProbeApp
+
+      {:ok, report} =
+        Boot.start(rc,
+          name: :console_app,
+          scheduler_name: :console_app_sched,
+          reconciler_name: :console_app_recon
+        )
+
+      on_exit(fn ->
+        try do
+          Supervisor.stop(:console_app)
+        catch
+          :exit, _ -> :ok
+        end
+      end)
+
+      assert report.channels == [:in_memory]
+
+      raw = %{
+        platform: :in_memory,
+        chat_type: :dm,
+        chat_id: "c",
+        user_id: "u",
+        event: %{text: "z"}
+      }
+
+      {:ok, route, event} = InMemory.normalize_event(raw)
+      assert :ok = SessionRouter.route(:"console_app.router", route, event)
+
+      # Starting a per-chat Lifecycle and collecting its first frame is slower
+      # than a mocked chat turn, so this needs more than the 100ms default.
+      assert_receive {:gateway_sent, ^route, rendered}, 5_000
+
+      # The app folded the keypress into its own model and rendered it back,
+      # which no stateless chat turn would do.
+      assert rendered =~ "last: z"
+
+      # The persona reached the app's init/1 through :lifecycle_opts.
+      assert rendered =~ "persona: Be terse."
     end
   end
 

--- a/packages/raxol_console/test/raxol/console/boot_test.exs
+++ b/packages/raxol_console/test/raxol/console/boot_test.exs
@@ -295,11 +295,11 @@ defmodule Raxol.Console.BootTest do
       assert rendered =~ "persona: Be terse."
     end
 
-    # `:idle_timeout` crosses four hops to reach the router: the deployment
+    # Each router bound crosses four hops to reach the router: the deployment
     # config, RuntimeConfig, gateway_opts' `:router` key, and Gateway.Supervisor's
     # merge into the router child. A key dropped at any of them defaults in
     # silence, which is exactly how `:handler_mode` came to be unreachable.
-    test "a configured idle timeout reaches the running router" do
+    test "the configured router bounds reach the running router" do
       pid = self()
 
       pkg = %Package{
@@ -314,10 +314,12 @@ defmodule Raxol.Console.BootTest do
         RuntimeConfig.build(pkg,
           bundle_default_mcp: false,
           idle_timeout: 1_234_000,
+          max_sessions: 200,
           channels: [%{platform: :in_memory, adapter: InMemory, config: %{sink: pid}}]
         )
 
       assert rc.idle_timeout == 1_234_000
+      assert rc.max_sessions == 200
 
       {:ok, _report} =
         Boot.start(rc,
@@ -334,7 +336,13 @@ defmodule Raxol.Console.BootTest do
         end
       end)
 
-      assert :sys.get_state(:"console_idle.router").idle_timeout == 1_234_000
+      router = :sys.get_state(:"console_idle.router")
+      assert router.idle_timeout == 1_234_000
+
+      # In :app mode these are one sizing decision, so they cross the same four
+      # hops together; a deployment that lengthens the idle timeout without
+      # being able to reach max_sessions cannot act on the trade.
+      assert router.max_sessions == 200
     end
   end
 

--- a/packages/raxol_console/test/raxol/console/runtime_config_test.exs
+++ b/packages/raxol_console/test/raxol/console/runtime_config_test.exs
@@ -154,6 +154,83 @@ defmodule Raxol.Console.RuntimeConfigTest do
     end
   end
 
+  # Being an atom is not evidence of being a bookable app. Resolving on `is_atom`
+  # alone let a typo boot green and then drop every chat: the failure surfaced
+  # only per-chat, inside Handler.Lifecycle, behind a route/3 that had already
+  # answered :ok. A config error has to fail at boot, which is here.
+  describe "app template validation" do
+    defmodule NotATeaApp do
+      @moduledoc false
+      def init(_args), do: {:ok, %{}}
+    end
+
+    test "a registered module that does not exist is refused at build time" do
+      Application.put_env(:raxol_console, :app_templates, %{"typo" => MyConsole.Dashbaord})
+      on_exit(fn -> Application.delete_env(:raxol_console, :app_templates) end)
+
+      assert {:error, {:invalid_app_template, "typo", MyConsole.Dashbaord, :module_not_loaded}} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "typo")
+    end
+
+    test "a registered module missing the TEA callbacks is refused at build time" do
+      Application.put_env(:raxol_console, :app_templates, %{"wrong" => NotATeaApp})
+      on_exit(fn -> Application.delete_env(:raxol_console, :app_templates) end)
+
+      assert {:error, {:invalid_app_template, "wrong", NotATeaApp, {:missing_callbacks, missing}}} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "wrong")
+
+      assert missing == [update: 2, view: 1]
+    end
+  end
+
+  # `templates/0` is read at boot, so a malformed shape must produce a diagnosis
+  # rather than an exception from inside config reading -- and the keyword list
+  # is the shape an operator is most likely to actually write.
+  describe "app template config shapes" do
+    defmodule KeywordApp do
+      @moduledoc false
+      def init(_args), do: {:ok, %{}}
+      def update(_msg, model), do: model
+      def view(_model), do: nil
+    end
+
+    setup do
+      on_exit(fn -> Application.delete_env(:raxol_console, :app_templates) end)
+    end
+
+    test "a keyword list resolves the same as a map" do
+      Application.put_env(:raxol_console, :app_templates, dashboard: KeywordApp)
+
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "dashboard")
+
+      assert cfg.app_module == KeywordApp
+    end
+
+    test "a malformed list is a refusal, not an ArgumentError from Map.new/1" do
+      Application.put_env(:raxol_console, :app_templates, ["dashboard"])
+
+      assert {:error, {:unknown_app_template, "dashboard"}} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "dashboard")
+    end
+
+    test "a garbage entry is dropped without taking the well-formed ones with it" do
+      Application.put_env(:raxol_console, :app_templates, [
+        "junk",
+        {"dashboard", KeywordApp},
+        {"nil-module", nil}
+      ])
+
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "dashboard")
+
+      assert cfg.app_module == KeywordApp
+
+      assert {:error, {:unknown_app_template, "nil-module"}} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "nil-module")
+    end
+  end
+
   describe "idle timeout" do
     test "is unset by default, leaving the gateway's own default in force" do
       assert {:ok, cfg} = RuntimeConfig.build(package())
@@ -176,6 +253,29 @@ defmodule Raxol.Console.RuntimeConfigTest do
 
       assert {:error, {:invalid_idle_timeout, -1}} =
                RuntimeConfig.build(package(), idle_timeout: -1)
+    end
+  end
+
+  # In :app mode a session is a running TEA app rather than a message list, so
+  # the ceiling on concurrent chats is a sizing decision a deployment has to be
+  # able to make. It was unreachable while RuntimeConfig knew nothing about it.
+  describe "max sessions" do
+    test "is unset by default, leaving the gateway's own default in force" do
+      assert {:ok, cfg} = RuntimeConfig.build(package())
+      assert cfg.max_sessions == nil
+    end
+
+    test "carries a positive integer through" do
+      assert {:ok, cfg} = RuntimeConfig.build(package(), max_sessions: 200)
+      assert cfg.max_sessions == 200
+    end
+
+    test "refuses a value that is not a positive integer" do
+      assert {:error, {:invalid_max_sessions, "200"}} =
+               RuntimeConfig.build(package(), max_sessions: "200")
+
+      assert {:error, {:invalid_max_sessions, 0}} =
+               RuntimeConfig.build(package(), max_sessions: 0)
     end
   end
 

--- a/packages/raxol_console/test/raxol/console/runtime_config_test.exs
+++ b/packages/raxol_console/test/raxol/console/runtime_config_test.exs
@@ -1,5 +1,7 @@
 defmodule Raxol.Console.RuntimeConfigTest do
-  use ExUnit.Case, async: true
+  # Not async: the handler-mode tests set and delete `:app_templates`, which is
+  # global application env. BootTest writes the same key.
+  use ExUnit.Case, async: false
 
   alias Raxol.Earn.Console.Package
   alias Raxol.Console.RuntimeConfig
@@ -115,6 +117,20 @@ defmodule Raxol.Console.RuntimeConfigTest do
       assert opts[:lifecycle_opts][:system_prompt] == cfg.system_prompt
     end
 
+    # The boot resolves agent_opts either way -- bundled MCP servers are running
+    # subprocesses by this point. Dropping them in :app mode paid for a toolset
+    # nothing could reach.
+    test "app mode threads the resolved agent_opts to the app rather than dropping them" do
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "dashboard")
+
+      assert {Raxol.Gateway.Handler.Lifecycle, opts} =
+               RuntimeConfig.handler_spec(cfg, actions: [:tool_a], context: %{skills: :store})
+
+      assert opts[:lifecycle_opts][:agent_opts][:actions] == [:tool_a]
+      assert opts[:lifecycle_opts][:agent_opts][:context] == %{skills: :store}
+    end
+
     test "an unregistered template is refused rather than resolved to a module" do
       assert {:error, {:unknown_app_template, "not-a-template"}} =
                RuntimeConfig.build(package(), handler_mode: :app, app_template: "not-a-template")
@@ -135,6 +151,31 @@ defmodule Raxol.Console.RuntimeConfigTest do
     test "an unknown handler mode is refused" do
       assert {:error, {:unknown_handler_mode, :telepathy}} =
                RuntimeConfig.build(package(), handler_mode: :telepathy)
+    end
+  end
+
+  describe "idle timeout" do
+    test "is unset by default, leaving the gateway's own default in force" do
+      assert {:ok, cfg} = RuntimeConfig.build(package())
+      assert cfg.idle_timeout == nil
+    end
+
+    test "carries a positive integer through" do
+      assert {:ok, cfg} = RuntimeConfig.build(package(), idle_timeout: 3_600_000)
+      assert cfg.idle_timeout == 3_600_000
+    end
+
+    # A string compares against an integer by term order rather than raising, so
+    # an unvalidated one would arm a timer that never fires the branch it feeds.
+    test "refuses a value that is not a positive integer" do
+      assert {:error, {:invalid_idle_timeout, "3600000"}} =
+               RuntimeConfig.build(package(), idle_timeout: "3600000")
+
+      assert {:error, {:invalid_idle_timeout, 0}} =
+               RuntimeConfig.build(package(), idle_timeout: 0)
+
+      assert {:error, {:invalid_idle_timeout, -1}} =
+               RuntimeConfig.build(package(), idle_timeout: -1)
     end
   end
 

--- a/packages/raxol_console/test/raxol/console/runtime_config_test.exs
+++ b/packages/raxol_console/test/raxol/console/runtime_config_test.exs
@@ -71,6 +71,73 @@ defmodule Raxol.Console.RuntimeConfigTest do
     assert cfg.agent_opts == [executor: :x]
   end
 
+  describe "handler mode" do
+    defmodule DashboardApp do
+      @moduledoc false
+      def init(_args), do: {:ok, %{}}
+      def update(_msg, model), do: model
+      def view(_model), do: nil
+    end
+
+    setup do
+      Application.put_env(:raxol_console, :app_templates, %{"dashboard" => DashboardApp})
+      on_exit(fn -> Application.delete_env(:raxol_console, :app_templates) end)
+    end
+
+    test "defaults to the stateless chat loop" do
+      assert {:ok, cfg} = RuntimeConfig.build(package())
+      assert cfg.handler_mode == :chat
+      assert cfg.app_module == nil
+
+      assert {Raxol.Gateway.Handler.Agent, opts} = RuntimeConfig.handler_spec(cfg, foo: 1)
+      assert opts[:system_prompt] == cfg.system_prompt
+      assert opts[:agent_opts] == [foo: 1]
+    end
+
+    test "app mode resolves a registered template to its module" do
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "dashboard")
+
+      assert cfg.handler_mode == :app
+      assert cfg.app_module == DashboardApp
+    end
+
+    test "app mode boots Handler.Lifecycle with the persona threaded into init/1" do
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "dashboard")
+
+      assert {Raxol.Gateway.Handler.Lifecycle, opts} = RuntimeConfig.handler_spec(cfg, [])
+      assert opts[:app_module] == DashboardApp
+
+      # Lifecycle appends :lifecycle_opts to Lifecycle.start_link/2, and those
+      # options reach the app as `init(%{options: opts})`. That is the only seam
+      # a TEA app has for the persona, since it weaves it in itself.
+      assert opts[:lifecycle_opts][:system_prompt] == cfg.system_prompt
+    end
+
+    test "an unregistered template is refused rather than resolved to a module" do
+      assert {:error, {:unknown_app_template, "not-a-template"}} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "not-a-template")
+    end
+
+    test "app mode without a template is refused" do
+      assert {:error, :missing_app_template} =
+               RuntimeConfig.build(package(), handler_mode: :app)
+    end
+
+    test "app mode is refused when no templates are registered at all" do
+      Application.delete_env(:raxol_console, :app_templates)
+
+      assert {:error, {:unknown_app_template, "dashboard"}} =
+               RuntimeConfig.build(package(), handler_mode: :app, app_template: "dashboard")
+    end
+
+    test "an unknown handler mode is refused" do
+      assert {:error, {:unknown_handler_mode, :telepathy}} =
+               RuntimeConfig.build(package(), handler_mode: :telepathy)
+    end
+  end
+
   test "rejects a non-package" do
     assert {:error, {:not_a_package, %{}}} = RuntimeConfig.build(%{})
   end

--- a/packages/raxol_gateway/lib/raxol/gateway/session.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/session.ex
@@ -12,6 +12,20 @@ defmodule Raxol.Gateway.Session do
   across a platform handoff: the router can start a session on a new route with
   an existing `conversation_id`, so a configured `:log` resumes the same history.
 
+  ## Handler startup
+
+  `start_link/1` returns as soon as the process exists; the handler's `init/2`
+  runs in a `handle_continue` after it. This keeps an expensive handler (one
+  starting a per-chat TEA app, say) from blocking the router that started it,
+  which starts sessions synchronously inside its own `handle_call`.
+
+  Two consequences for callers. A handler that fails to initialize stops the
+  session *after* `start_link/1` has already returned `{:ok, pid}`, so the
+  failure arrives as a DOWN rather than a return value -- `SessionRouter` emits
+  `[:raxol_gateway, :session, :down]` for it. And "the handler has started" is
+  not implied by `start_link/1` returning: any `GenServer.call/3` to the session
+  is serialized behind the continue and can be used as the barrier.
+
   ## Options
 
     * `:route` (required) -- the `Raxol.Gateway.Route` this session serves
@@ -58,24 +72,42 @@ defmodule Raxol.Gateway.Session do
     # teardown at all.
     Process.flag(:trap_exit, true)
 
-    case handler_mod.init(route, handler_opts) do
+    state = %{
+      route: route,
+      handler_mod: handler_mod,
+      handler_state: nil,
+      handler_ready?: false,
+      deliver: Keyword.get(opts, :deliver, fn _route, _rendered -> :ok end),
+      idle_timeout: Keyword.get(opts, :idle_timeout, @default_idle_timeout),
+      conversation_id: Keyword.get(opts, :conversation_id) || Route.key(route),
+      log: Keyword.get(opts, :log),
+      timer: nil,
+      idle_ref: nil
+    }
+
+    {:ok, state, {:continue, {:init_handler, handler_opts}}}
+  end
+
+  # The handler is initialized here rather than in init/1 because the router
+  # starts sessions with a synchronous DynamicSupervisor.start_child inside its
+  # own handle_call: anything init/1 blocks on blocks the single router process,
+  # and with it every other chat's route/3. A handler whose init is a pure map
+  # (Handler.Agent) never made that visible; one that starts a per-chat TEA app
+  # and waits on its first render (Handler.Lifecycle) does.
+  #
+  # A continue is delivered before any queued message, so a cast that the router
+  # sends the instant start_child returns is still handled after this.
+  @impl true
+  def handle_continue({:init_handler, handler_opts}, state) do
+    case state.handler_mod.init(state.route, handler_opts) do
       {:ok, handler_state} ->
-        state = %{
-          route: route,
-          handler_mod: handler_mod,
-          handler_state: handler_state,
-          deliver: Keyword.get(opts, :deliver, fn _route, _rendered -> :ok end),
-          idle_timeout: Keyword.get(opts, :idle_timeout, @default_idle_timeout),
-          conversation_id: Keyword.get(opts, :conversation_id) || Route.key(route),
-          log: Keyword.get(opts, :log),
-          timer: nil,
-          idle_ref: nil
-        }
+        {:noreply, arm_timer(%{state | handler_state: handler_state, handler_ready?: true})}
 
-        {:ok, arm_timer(state)}
-
+      # Deferring init moved this failure off the caller's return value: route/3
+      # has already replied :ok. The router observes the DOWN and emits
+      # [:raxol_gateway, :session, :down] rather than the event vanishing.
       {:error, reason} ->
-        {:stop, reason}
+        {:stop, reason, state}
     end
   end
 
@@ -118,6 +150,12 @@ defmodule Raxol.Gateway.Session do
   # shutdown, explicit stop); only a brutal kill skips it. A handler owning
   # linked processes needs this: the session's :normal exit does not
   # propagate over links, so without teardown they would leak.
+  # `handler_ready?` gates this rather than a nil handler_state, because a
+  # handler is free to return `{:ok, nil}` as its own state. Tearing down a
+  # handler whose init never returned would hand it a state it never built.
+  @impl true
+  def terminate(_reason, %{handler_ready?: false}), do: :ok
+
   @impl true
   def terminate(reason, state) do
     if function_exported?(state.handler_mod, :terminate, 2) do

--- a/packages/raxol_gateway/lib/raxol/gateway/session.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/session.ex
@@ -26,12 +26,32 @@ defmodule Raxol.Gateway.Session do
   not implied by `start_link/1` returning: any `GenServer.call/3` to the session
   is serialized behind the continue and can be used as the barrier.
 
+  Because startup is no longer reported through a return value, it is reported
+  through telemetry instead: `[:raxol_gateway, :session, :ready]` once the
+  handler has initialized, and `[..., :init_timeout]` when it never does. A
+  `:started` from the router with no `:ready` behind it is a broken handler.
+
+  ## Handler init is bounded
+
+  A handler stuck in `init/2` parks the session inside its own continue, where
+  it can read no message -- not a queued event, and not the idle timer, which is
+  armed only once init succeeds. Nothing would ever reap it, while the router
+  goes on routing that chat to it. So `init/1` spawns a watchdog that kills the
+  session if the handler has not returned within `:handler_init_timeout`. The
+  kill has to be brutal (a wedged process cannot honour a graceful exit), which
+  is why the diagnosis is emitted as telemetry before it lands.
+
+  This matters most for a handler that starts a per-chat TEA app: `start_link`
+  on deployment-authored `init/1` code has no timeout of its own.
+
   ## Options
 
     * `:route` (required) -- the `Raxol.Gateway.Route` this session serves
     * `:handler` (required) -- `{module, opts}` implementing `Gateway.Handler`
     * `:deliver` -- `(Route.t(), rendered -> any())`, default a no-op
     * `:idle_timeout` -- ms before the session stops (default 10 minutes)
+    * `:handler_init_timeout` -- ms the handler's `init/2` may take before the
+      session is killed (default 30 seconds), or `:infinity` to wait forever
     * `:conversation_id` -- a stable id for this chat (default `Route.key/1`)
     * `:log` -- `{module, server}` whose `append(server, conversation_id, items)`
       records each inbound event and outbound reply (e.g.
@@ -43,6 +63,12 @@ defmodule Raxol.Gateway.Session do
   alias Raxol.Gateway.Route
 
   @default_idle_timeout 10 * 60 * 1000
+
+  # Well clear of the slowest legitimate init: Handler.Lifecycle boots a TEA app
+  # and then waits on a 5s :get_full_state call. Long enough that no working
+  # handler trips it, short enough that a wedged one does not hold a
+  # max_sessions slot for the life of the node.
+  @default_handler_init_timeout 30_000
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
@@ -72,6 +98,8 @@ defmodule Raxol.Gateway.Session do
     # teardown at all.
     Process.flag(:trap_exit, true)
 
+    init_timeout = Keyword.get(opts, :handler_init_timeout, @default_handler_init_timeout)
+
     state = %{
       route: route,
       handler_mod: handler_mod,
@@ -82,7 +110,8 @@ defmodule Raxol.Gateway.Session do
       conversation_id: Keyword.get(opts, :conversation_id) || Route.key(route),
       log: Keyword.get(opts, :log),
       timer: nil,
-      idle_ref: nil
+      idle_ref: nil,
+      watchdog: start_init_watchdog(route, handler_mod, init_timeout)
     }
 
     {:ok, state, {:continue, {:init_handler, handler_opts}}}
@@ -101,13 +130,17 @@ defmodule Raxol.Gateway.Session do
   def handle_continue({:init_handler, handler_opts}, state) do
     case state.handler_mod.init(state.route, handler_opts) do
       {:ok, handler_state} ->
-        {:noreply, arm_timer(%{state | handler_state: handler_state, handler_ready?: true})}
+        stop_init_watchdog(state.watchdog)
+        emit(:ready, state.route, %{handler: state.handler_mod})
+        ready = %{state | handler_state: handler_state, handler_ready?: true, watchdog: nil}
+        {:noreply, arm_timer(ready)}
 
       # Deferring init moved this failure off the caller's return value: route/3
       # has already replied :ok. The router observes the DOWN and emits
       # [:raxol_gateway, :session, :down] rather than the event vanishing.
       {:error, reason} ->
-        {:stop, reason, state}
+        stop_init_watchdog(state.watchdog)
+        {:stop, reason, %{state | watchdog: nil}}
     end
   end
 
@@ -180,5 +213,50 @@ defmodule Raxol.Gateway.Session do
     ref = make_ref()
     timer = Process.send_after(self(), {:idle_timeout, ref}, state.idle_timeout)
     %{state | timer: timer, idle_ref: ref}
+  end
+
+  # An unlinked process, so a legitimately slow init is not disturbed by it, and
+  # monitoring rather than linking so it retires when the session dies for any
+  # other reason. The kill is brutal because a process wedged in its own
+  # continue cannot honour a graceful exit -- which is also why the reason
+  # travels as telemetry: the DOWN the router sees can only say `:killed`.
+  defp start_init_watchdog(_route, _handler_mod, :infinity), do: nil
+
+  defp start_init_watchdog(route, handler_mod, timeout)
+       when is_integer(timeout) and timeout > 0 do
+    session = self()
+
+    spawn(fn ->
+      ref = Process.monitor(session)
+
+      receive do
+        {:handler_ready, ^session} -> :ok
+        {:DOWN, ^ref, :process, ^session, _reason} -> :ok
+      after
+        timeout ->
+          emit(:init_timeout, route, %{handler: handler_mod, timeout: timeout})
+          Process.exit(session, :kill)
+      end
+    end)
+  end
+
+  defp start_init_watchdog(_route, _handler_mod, other) do
+    raise ArgumentError,
+          ":handler_init_timeout must be a positive integer of milliseconds " <>
+            "or :infinity, got: #{inspect(other)}"
+  end
+
+  defp stop_init_watchdog(nil), do: :ok
+  defp stop_init_watchdog(pid), do: send(pid, {:handler_ready, self()})
+
+  # Same event prefix and shape as Raxol.Gateway.SessionRouter's: the namespace
+  # describes the session, not who observed the fact. The router owns routing
+  # facts (:started, :rejected, :down); the session owns handler-lifecycle ones.
+  defp emit(event, route, metadata) do
+    :telemetry.execute(
+      [:raxol_gateway, :session, event],
+      %{system_time: System.system_time()},
+      Map.put(metadata, :key, Route.key(route))
+    )
   end
 end

--- a/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
@@ -15,8 +15,32 @@ defmodule Raxol.Gateway.SessionRouter do
       `send_message/3`. Or pass `:deliver`, a `(Route.t(), rendered -> any())`.
     * `:max_sessions` (default 1000)
     * `:idle_timeout` ms (default 10 minutes)
+    * `:handler_init_timeout` -- passed to each session; ms its handler's
+      `init/2` may take before the session is killed (default 30 seconds)
     * `:cooldown_ms` -- minimum ms between starts for one key (default 5000)
     * `:name` -- the router's registered name
+
+  ## Telemetry
+
+  Every event is `[:raxol_gateway, :session, event]`, measured
+  `%{system_time: _}`, with the session's `:key` in metadata.
+
+    * `:started` -- a session PROCESS was spawned. Its handler has NOT
+      initialized yet, and `route/3` has already replied `:ok`.
+    * `:ready` -- the handler initialized and the chat can be served. Emitted by
+      `Raxol.Gateway.Session`; metadata adds `:handler`.
+    * `:init_timeout` -- the handler never returned from `init/2` and the session
+      was killed. Emitted by `Raxol.Gateway.Session`; metadata adds `:handler`
+      and `:timeout`.
+    * `:down` -- a session died for any reason other than `:normal` or
+      `:shutdown`. Metadata adds `:reason`.
+    * `:stopped` -- `stop_session/2` was called. Metadata adds `reason: :explicit`.
+    * `:rejected` -- no session was started. Metadata adds `:reason`, one of
+      `:max_sessions` or `:rate_limited`.
+
+  A `:started` with no `:ready` behind it is a handler that failed or hung at
+  startup. Since handler init is deferred (see `Raxol.Gateway.Session`), that
+  pair is the only signal of it -- `route/3` cannot report it.
   """
 
   use Raxol.Core.Behaviours.BaseManager
@@ -33,7 +57,16 @@ defmodule Raxol.Gateway.SessionRouter do
     GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
   end
 
-  @doc "Route an inbound event to the session for `route`, starting one if needed."
+  @doc """
+  Route an inbound event to the session for `route`, starting one if needed.
+
+  `:ok` means the event was ACCEPTED for delivery, not that it was served. A
+  session's handler initializes asynchronously (see `Raxol.Gateway.Session`), so
+  a handler that fails or hangs at startup does so after this has replied;
+  `[:raxol_gateway, :session, :ready]`, `:down` and `:init_timeout` are what
+  report that. An `{:error, _}` here is only ever a routing refusal --
+  `:max_sessions` or `:rate_limited`.
+  """
   @spec route(GenServer.server(), Route.t(), term()) :: :ok | {:error, term()}
   def route(server, %Route{} = route, event) do
     GenServer.call(server, {:route, route, event})
@@ -84,6 +117,9 @@ defmodule Raxol.Gateway.SessionRouter do
        log: Keyword.get(opts, :log),
        max_sessions: Keyword.get(opts, :max_sessions, @default_max_sessions),
        idle_timeout: Keyword.get(opts, :idle_timeout, @default_idle_timeout),
+       # Unset leaves Session on its own default rather than pinning a second
+       # copy of that number here.
+       handler_init_timeout: Keyword.get(opts, :handler_init_timeout),
        cooldown_ms: Keyword.get(opts, :cooldown_ms, @default_cooldown_ms),
        sessions: %{},
        monitors: %{},
@@ -181,6 +217,7 @@ defmodule Raxol.Gateway.SessionRouter do
       ]
       |> put_if(:conversation_id, conversation_id)
       |> put_if(:log, state.log)
+      |> put_if(:handler_init_timeout, state.handler_init_timeout)
 
     child = %{id: Session, start: {Session, :start_link, [session_opts]}, restart: :temporary}
 

--- a/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
@@ -132,8 +132,8 @@ defmodule Raxol.Gateway.SessionRouter do
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
-  def handle_manager_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    {:noreply, drop_pid(pid, state)}
+  def handle_manager_info({:DOWN, _ref, :process, pid, reason}, state) do
+    {:noreply, drop_pid(pid, reason, state)}
   end
 
   def handle_manager_info(_msg, state), do: {:noreply, state}
@@ -257,12 +257,24 @@ defmodule Raxol.Gateway.SessionRouter do
     end
   end
 
-  defp drop_pid(pid, state) do
+  defp drop_pid(pid, reason, state) do
     case Enum.find(state.sessions, fn {_key, p} -> p == pid end) do
-      {key, _pid} -> forget(key, state)
-      nil -> state
+      {key, _pid} ->
+        emit_down(key, reason)
+        forget(key, state)
+
+      nil ->
+        state
     end
   end
+
+  # A session dies abnormally on a handler crash mid-turn, and -- since handler
+  # init is deferred to a continue -- on a handler that failed to start at all.
+  # The latter no longer reaches the caller of route/3, which has already been
+  # told :ok, so this is the only signal that a chat was accepted and then
+  # dropped. Clean stops (idle timeout, explicit stop) are not failures.
+  defp emit_down(_key, reason) when reason in [:normal, :shutdown], do: :ok
+  defp emit_down(key, reason), do: emit(:down, %{key: key, reason: reason})
 
   defp demonitor(key, state) do
     case Map.get(state.monitors, key) do

--- a/packages/raxol_gateway/test/raxol/gateway/handler/lifecycle_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/handler/lifecycle_test.exs
@@ -153,6 +153,11 @@ defmodule Raxol.Gateway.Handler.LifecycleTest do
           handler: {Handler.Lifecycle, [app_module: EchoApp]}
         )
 
+      # The session initializes its handler in a continue, so start_link returns
+      # before the app Lifecycle exists. A call is serialized behind that
+      # continue, making it the barrier for "the handler has started".
+      _ = Raxol.Gateway.Session.route(session)
+
       {:links, links} = Process.info(session, :links)
       lifecycles = links -- [self()]
 

--- a/packages/raxol_gateway/test/raxol/gateway/handler_agent_react_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/handler_agent_react_test.exs
@@ -24,8 +24,7 @@ defmodule Raxol.Gateway.HandlerAgentReactTest do
       end
     }
 
-    {:ok, counter} = Agent.start_link(fn -> 0 end)
-    on_exit(fn -> if Process.alive?(counter), do: Agent.stop(counter) end)
+    counter = start_supervised!({Agent, fn -> 0 end})
 
     tool_calls_fn = fn ->
       n = Agent.get_and_update(counter, fn n -> {n, n + 1} end)

--- a/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
@@ -35,6 +35,23 @@ defmodule Raxol.Gateway.SessionRouterTest do
     def handle_event(_event, state), do: {:noreply, state}
   end
 
+  defmodule SlowInitHandler do
+    @behaviour Raxol.Gateway.Handler
+
+    @impl true
+    def init(_route, opts) do
+      send(Keyword.fetch!(opts, :caller), {:initializing, self()})
+
+      receive do
+        :release -> {:ok, %{}}
+      end
+    end
+
+    @impl true
+    def handle_event({:say, text}, state), do: {:reply, "echo: #{text}", state}
+    def handle_event(_event, state), do: {:noreply, state}
+  end
+
   setup ctx do
     test_pid = self()
     sup = :"sup_#{uid()}"
@@ -93,6 +110,45 @@ defmodule Raxol.Gateway.SessionRouterTest do
 
     refute SessionRouter.get_session(r, Route.key(route(1))) ==
              SessionRouter.get_session(r, Route.key(route(2)))
+  end
+
+  # The router starts sessions with a synchronous DynamicSupervisor.start_child
+  # inside its own handle_call. While a handler's init/2 ran there, it held the
+  # single router process, and every other chat's route/3 queued behind it until
+  # the caller's own call timeout fired. Handlers whose init is a pure map never
+  # showed this; one that starts a per-chat TEA app and waits on its first
+  # render does.
+  test "a handler blocked in init does not block the router for other chats" do
+    test_pid = self()
+    sup = :"sup_#{uid()}"
+    start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: sup})
+    router = :"router_#{uid()}"
+
+    start_supervised!(%{
+      id: router,
+      start:
+        {SessionRouter, :start_link,
+         [
+           [
+             name: router,
+             handler: {SlowInitHandler, [caller: test_pid]},
+             sessions_sup: sup,
+             deliver: fn route, rendered -> send(test_pid, {:out, route, rendered}) end
+           ]
+         ]}
+    })
+
+    rt = route(1)
+    assert :ok = SessionRouter.route(router, rt, {:say, "hi"})
+    assert_receive {:initializing, session}, 1_000
+
+    # Answered while that session is still stuck inside its handler's init.
+    assert SessionRouter.session_count(router) == 1
+
+    # And the event that started it was not lost: it was cast, so it waits
+    # behind the continue that finishes the handler rather than racing it.
+    send(session, :release)
+    assert_receive {:out, ^rt, "echo: hi"}, 1_000
   end
 
   test "a session crash is cleaned up from the router", %{router: r} do

--- a/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
@@ -151,6 +151,84 @@ defmodule Raxol.Gateway.SessionRouterTest do
     assert_receive {:out, ^rt, "echo: hi"}, 1_000
   end
 
+  # The other half of deferring init: a handler that never returns parks the
+  # session inside its own continue, where it can read neither the queued event
+  # nor the idle timer (which is armed only once init succeeds). Nothing reaped
+  # it, while the router went on routing that chat to it -- so every later
+  # message was accepted with :ok and queued into a mailbox nobody would read.
+  test "a handler that never returns from init is killed and its slot reclaimed" do
+    test_pid = self()
+    sup = :"sup_#{uid()}"
+    start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: sup})
+    router = :"router_#{uid()}"
+
+    handler_id = "init-timeout-#{uid()}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [[:raxol_gateway, :session, :init_timeout], [:raxol_gateway, :session, :down]],
+      fn event, _measure, meta, pid -> send(pid, {:telemetry, List.last(event), meta}) end,
+      test_pid
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    start_supervised!(%{
+      id: router,
+      start:
+        {SessionRouter, :start_link,
+         [
+           [
+             name: router,
+             handler: {SlowInitHandler, [caller: test_pid]},
+             sessions_sup: sup,
+             handler_init_timeout: 150,
+             deliver: fn route, rendered -> send(test_pid, {:out, route, rendered}) end
+           ]
+         ]}
+    })
+
+    assert :ok = SessionRouter.route(router, route(1), {:say, "hi"})
+    assert_receive {:initializing, session}, 1_000
+
+    # The kill has to be brutal, so the router's DOWN can only say :killed. The
+    # diagnosis rides its own event, emitted before the kill lands.
+    assert_receive {:telemetry, :init_timeout, meta}, 2_000
+    assert meta.key == Route.key(route(1))
+    assert meta.handler == SlowInitHandler
+    assert meta.timeout == 150
+
+    assert_receive {:telemetry, :down, %{reason: :killed}}, 1_000
+    refute Process.alive?(session)
+
+    # Reclaimed, so the chat recovers on a later message instead of routing
+    # forever into a dead mailbox.
+    assert SessionRouter.session_count(router) == 0
+  end
+
+  # A working handler must not be disturbed by the watchdog, and its readiness
+  # is the event an operator pairs against :started to spot a broken one.
+  test "a handler that initializes emits :ready and is left alone", %{router: r} do
+    handler_id = "ready-#{uid()}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [[:raxol_gateway, :session, :ready], [:raxol_gateway, :session, :init_timeout]],
+      fn event, _measure, meta, pid -> send(pid, {:telemetry, List.last(event), meta}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, pid} = SessionRouter.start_session(r, route(1))
+
+    assert_receive {:telemetry, :ready, meta}, 1_000
+    assert meta.key == Route.key(route(1))
+
+    refute_receive {:telemetry, :init_timeout, _}, 300
+    assert Process.alive?(pid)
+  end
+
   test "a session crash is cleaned up from the router", %{router: r} do
     {:ok, pid} = SessionRouter.start_session(r, route(1))
     ref = Process.monitor(pid)


### PR DESCRIPTION
Closes #763.

`Raxol.Gateway.Handler.Lifecycle` already runs a full TEA app per chat under
`environment: :gateway`. The Console had no way to select it. As the issue puts it, this
is "about optionally exposing it as a Console handler mode, not building it" -- and that
held up: no change was needed in `raxol` or `raxol_gateway`.

## Shape

- `RuntimeConfig` gains `handler_mode: :chat | :app` and `app_module`.
- `RuntimeConfig.handler_spec/2` maps a config to the gateway handler tuple.
- `Console.Boot` calls it instead of hardcoding `Handler.Agent`.
- New `Raxol.Console.AppRegistry`: the operator-configured name -> module allowlist.

`:chat` remains the default, so every current Console template is untouched.

## The package does not get to choose the module

A Console package is untrusted input -- authored elsewhere, loaded by
`Raxol.Earn.Console.Package`. So `:handler_mode` and `:app_template` are read from the
**deployment** options, never from the package, and the template is a **name** resolved
against a map the operator configures:

```elixir
config :raxol_console, :app_templates, %{"dashboard" => MyConsole.Apps.Dashboard}
```

There is no `String.to_atom/1` anywhere on that path, so no input can reach a module the
operator did not list. This is the issue's "avoid compiling untrusted package code"
constraint taken one step further: the package cannot even *name* a prebuilt one.

## One deliberate deviation from the suggested shape

The issue suggests "gate behind a capability flag so the default Console runtime stays
the stateless chat loop". **The registry is that gate**, rather than a second flag beside
it. It is empty by default, so `:app` mode is unavailable until an operator registers a
template.

Two gates that must agree can drift apart -- exactly the failure hit in #879, where the CI
matrix and the root formatter list were kept in sync by a test that then could not parse
one of them. One fail-closed gate has no such failure mode. If per-tenant control on top
of the global allowlist is wanted, `:handler_mode` already provides it: it is per-boot and
deployment-supplied.

## Persona threading needed no framework change

`Handler.Lifecycle` appends `:lifecycle_opts` to
`Raxol.Core.Runtime.Lifecycle.start_link/2`, and `Initializer.get_initial_model_args/1`
hands the whole option list to the app as `init(%{options: opts})`. So the persona rides
through as `lifecycle_opts: [system_prompt: ...]` and the app reads it in `init/1`.

That is the only seam available, and it matches the issue's "persona threading is manual"
caveat: a TEA app weaves the system prompt into its own model and backend calls rather
than getting it applied per turn for free.

## Why `handler_spec/2` lives in RuntimeConfig

That module's own docs describe it as the "pure mapping from a parsed Console package
plus deployment options into the config `Raxol.Console.Boot` starts a runtime from". A
handler spec is precisely that. It also makes the swap assertable without starting a
supervision tree, where the alternative was exposing a private `Boot` function purely for
tests.

## Tests

Seven unit tests on `RuntimeConfig` (written RED first -- all seven failed), covering the
`:chat` default, template resolution, both handler specs, and four fail-closed paths:
unregistered template, missing template, empty registry, unknown mode.

Plus one end-to-end test through the real boot path, adapted from the existing
`boots the gateway channel` test with its in-memory adapter. It boots `:app` mode, routes
a chat event, and asserts on the frame that comes back:

```elixir
assert rendered =~ "last: z"                 # the app folded the keypress into its model
assert rendered =~ "persona: Be terse."      # the persona reached the app's init/1
```

The first assertion is the thing a stateless chat turn cannot do; the second proves the
`:lifecycle_opts` seam end to end.

## Manual testing

- [x] The seven `RuntimeConfig` tests RED before the change, GREEN after
- [x] `MIX_ENV=test mix test` in `packages/raxol_console`: 42 passed
- [x] Re-run under a second seed (the end-to-end test starts a real Lifecycle): 42 passed
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean at root and in the package

## Notes

The end-to-end test needs a 5s `assert_receive` rather than the 100ms default, because
starting a per-chat Lifecycle and collecting its first frame is slower than the mocked
chat turn beside it. Called out in a comment so it does not read as a stray magic number.

Scope kept to the issue: no Console template ships with an actual app, since the issue is
explicit that the package format does not describe one. Registering a template is the
operator's step.

`raxol_console` is not in the CI `package-tests` matrix, so **these suites do not run in
per-PR CI** and every result above is local. It would pass the gate as it stands -- tests,
`--warnings-as-errors`, and format are all clean here -- so adding it is the same one-line
change #879 made for `raxol_agent_client_protocol`. Left out of this PR deliberately:
gating a package is its own concern, and bundling it here would hide a CI change inside a
feature.
