### PR TITLE
Gate raxol_console in per-PR CI

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -23,6 +23,7 @@
   subdirectories: [
     "packages/raxol_agent_client_protocol",
     "packages/raxol_cli",
+    "packages/raxol_console",
     "packages/raxol_earn",
     "packages/raxol_gateway",
     "packages/raxol_payments",

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -301,10 +301,15 @@ jobs:
         # anywhere disagreed. A package earns its entry in the root
         # .formatter.exs `subdirectories` list by being gated here, so the two
         # lists move together.
+        #
+        # raxol_console boots agent packages onto the gateway and was ungated for
+        # the same reason the others were: nothing in per-PR CI ran it. It joins
+        # already clean, so this adds a gate rather than fixing drift.
+        #
         # Keep on ONE line: test/raxol/formatter_delegation_test.exs parses this
         # matrix with `^\s*package: \[...\]` to prove every gated package is also
         # delegated by the root .formatter.exs. A block sequence parses as absent.
-        package: [raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn, raxol_agent_client_protocol]
+        package: [raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn, raxol_agent_client_protocol, raxol_console]
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Follow-up to #881, where I noted that `raxol_console`'s suites do not run in per-PR CI.

`raxol_console` boots agent packages onto the gateway and was in neither the CI
`package-tests` matrix nor the root `.formatter.exs` `subdirectories` list. Nothing in
per-PR CI ran it: no tests, no `--warnings-as-errors`, no format check.

Adds it to both, which the root `.formatter.exs` documents as moving together and
`test/raxol/formatter_delegation_test.exs` enforces.

## It joins clean

Unlike `raxol_agent_client_protocol` in #879, this is not repairing drift. Verified on
`master` before changing anything, running exactly what the gate runs:

- `mix format --check-formatted` — clean
- `mix compile --warnings-as-errors` — clean
- the workflow's full `mix test --exclude ...` line — 34 passed

So this adds a gate to a package that already satisfies it, and no source file changes.

## Verified after

- `test/raxol/formatter_delegation_test.exs` — 3 passed (this is the test that proves
  every gated package is delegated by the root formatter)
- root `mix format --check-formatted` — clean, now that it delegates to the package
- workflow YAML parses; matrix resolves to 7 packages

## Manual testing

- [x] All three gate commands run against `master` before the change
- [x] Delegation test passes after
- [x] Root format check passes with the new delegation in place
- [x] YAML parses and the matrix resolves

## Note

The matrix stays on one line. `formatter_delegation_test.exs` parses it with
`^\s*package: \[...\]`, so a YAML block sequence reads as *absent* and fails the guard
with "no package matrix found" — which is how I broke #879's first CI run. There is a
comment above the line saying so.
