### PR TITLE
Pin the precondition the mandatory pull_signature rests on

### DIFF
--- a/packages/raxol_earn/lib/raxol/earn/xochi/offering.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/offering.ex
@@ -117,6 +117,25 @@ defmodule Raxol.Earn.Xochi.Offering do
   the buyer no longer hand-carries (and cannot misstate) `src_chain_id`,
   `dst_chain_id`, `src_token`, `dst_token`, or `amount_atomic`. Those remain as
   optional audit hints; raxol derives and enforces the real values.
+
+  ## `pull_signature` is mandatory, which narrows this to pulling corridors
+
+  The bundle requires a `pull_signature` for every mode. That is deliberate, and
+  it means an ACP job can only ever be a corridor whose origin supports a gasless
+  pull -- an EVM leg signing ERC-3009 or Permit2.
+
+  A non-EVM origin (Tron, Solana) funds a `deposit_address` instead, so its buyer
+  has no pull to sign and nothing to put here. `Raxol.Payments` models that case
+  (`Protocols.Xochi.deposit_route_quote/3`, and a bundle whose `pull_signature`
+  is nil for non-pulling methods), but the seller stack does not: every corridor
+  in `Raxol.Earn.Xochi.CorridorAllowlist` is EVM, and `Raxol.Earn.Xochi.Settler`
+  settles only by relaying a signed pull through `execute_signed/2`. Accepting a
+  deposit-route job would therefore escrow a fee for work this stack cannot do.
+
+  So the narrowing costs nothing today, and a corridor_allowlist_test guard fails
+  if a non-pulling origin ever becomes quotable while this stays mandatory. At
+  that point make `pull_signature` required per-mode in `requirement_schema/1`
+  rather than in this shared base. See GitHub #665.
   """
   @spec requirement_schema() :: map()
   def requirement_schema do
@@ -496,6 +515,10 @@ defmodule Raxol.Earn.Xochi.Offering do
   authoritatively from Xochi by the intent id (see
   `Raxol.Earn.Xochi.IntentDeriver`). It does not verify the signature (Riddler
   does that against its persisted quote).
+
+  Requiring `pull_signature` restricts this to corridors whose origin can sign a
+  gasless pull; see `requirement_schema/0` for why that is safe while every
+  allowlisted corridor is EVM, and what to change when one is not.
   """
   @spec valid_requirement?(map()) :: boolean()
   def valid_requirement?(req) when is_map(req) do

--- a/packages/raxol_earn/test/raxol/earn/xochi/corridor_allowlist_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/corridor_allowlist_test.exs
@@ -121,6 +121,45 @@ defmodule Raxol.Earn.Xochi.CorridorAllowlistTest do
     end
   end
 
+  # `Offering.requirement_schema/0` hard-requires `pull_signature` on every
+  # signed_intent bundle, so an ACP job can only be a corridor whose ORIGIN can
+  # sign a gasless pull. A non-EVM origin (Tron, Solana) funds a deposit address
+  # instead and has no pull to sign, so such a buyer would be turned away at the
+  # shape gate as malformed rather than as an unsupported corridor.
+  #
+  # That narrowing costs nothing while no non-pulling origin is quotable at all,
+  # which is what this pins. If it fails, a corridor was added whose origin
+  # cannot pull: make `pull_signature` required per-mode in
+  # `requirement_schema/1` instead of in the shared base. See GitHub #665.
+  describe "pull-signature precondition" do
+    # Every chain reachable as a corridor ORIGIN today. All EVM, all able to sign
+    # ERC-3009 or Permit2.
+    @pulling_origins [1, 10, 137, 8453, 42_161, 4663]
+
+    test "every corridor origin can sign a gasless pull" do
+      origins =
+        CorridorAllowlist.corridors()
+        |> Enum.map(fn {_src, _dst, from, _to} -> from end)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert origins -- @pulling_origins == [],
+             "a corridor origin cannot sign a gasless pull, so its buyer has no " <>
+               "pull_signature -- but Offering.requirement_schema/0 still demands one"
+    end
+
+    test "a Tron origin is not quotable, so the mandatory pull_signature turns nobody away" do
+      # Tron mainnet, which Raxol.Payments.Assets knows (USDT/USDC TRC-20) and
+      # Riddler is actively building deposit routes for. It funds by deposit
+      # address, so it is the concrete corridor this precondition would break on.
+      tron = 728_126_428
+
+      for dst <- @pulling_origins, symbol <- ~w(USDC USDT) do
+        refute CorridorAllowlist.allowed?(symbol, symbol, tron, dst)
+      end
+    end
+  end
+
   describe "enabled?/0" do
     test "an explicit config boolean wins over the deployment default" do
       Application.put_env(:raxol_earn, :stablecoin_corridors_only, true)

--- a/packages/raxol_earn/test/raxol/earn/xochi/corridor_allowlist_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/corridor_allowlist_test.exs
@@ -3,6 +3,8 @@ defmodule Raxol.Earn.Xochi.CorridorAllowlistTest do
   use ExUnit.Case, async: false
 
   alias Raxol.Earn.Xochi.CorridorAllowlist
+  alias Raxol.Payments.Assets
+  alias Raxol.Payments.Relay.Schemas, as: RelaySchemas
 
   @usdc_chains [1, 10, 137, 8453, 42_161]
   @usdt_chains [1, 10, 137, 8453, 42_161]
@@ -132,30 +134,44 @@ defmodule Raxol.Earn.Xochi.CorridorAllowlistTest do
   # cannot pull: make `pull_signature` required per-mode in
   # `requirement_schema/1` instead of in the shared base. See GitHub #665.
   describe "pull-signature precondition" do
-    # Every chain reachable as a corridor ORIGIN today. All EVM, all able to sign
-    # ERC-3009 or Permit2.
-    @pulling_origins [1, 10, 137, 8453, 42_161, 4663]
+    # The property is "the origin can sign a gasless pull", i.e. it is an EVM leg
+    # signing ERC-3009 or Permit2. `Raxol.Payments.Assets` is the registry of EVM
+    # chains the payments stack prices gas for, so membership there IS that
+    # property. Restating the chain ids in this file instead would make any newly
+    # allowlisted EVM chain -- Linea, Scroll, which sign both just fine -- fail
+    # with a diagnosis that is simply false.
+    test "every corridor origin is an EVM chain whose buyer can sign a gasless pull" do
+      corridors = CorridorAllowlist.corridors()
+      assert corridors != []
 
-    test "every corridor origin can sign a gasless pull" do
-      origins =
-        CorridorAllowlist.corridors()
-        |> Enum.map(fn {_src, _dst, from, _to} -> from end)
-        |> Enum.uniq()
-        |> Enum.sort()
+      for {src, dst, from, to} <- corridors do
+        assert Assets.native_symbol(from),
+               "corridor #{src}->#{dst} (#{from}->#{to}) has origin chain #{from}, which " <>
+                 "Raxol.Payments.Assets does not know as an EVM chain. A non-EVM origin " <>
+                 "funds a deposit address and so has no pull to sign, while " <>
+                 "Offering.requirement_schema/0 demands a pull_signature from every " <>
+                 "bundle. Either register the chain, or make pull_signature required " <>
+                 "per-mode in requirement_schema/1. See GitHub #665."
 
-      assert origins -- @pulling_origins == [],
-             "a corridor origin cannot sign a gasless pull, so its buyer has no " <>
-               "pull_signature -- but Offering.requirement_schema/0 still demands one"
+        refute RelaySchemas.tron_chain?(from),
+               "Tron is quotable as a corridor origin (#{src}->#{dst}), but it funds by " <>
+                 "deposit address and its buyer has no pull_signature to send."
+      end
     end
 
-    test "a Tron origin is not quotable, so the mandatory pull_signature turns nobody away" do
-      # Tron mainnet, which Raxol.Payments.Assets knows (USDT/USDC TRC-20) and
-      # Riddler is actively building deposit routes for. It funds by deposit
-      # address, so it is the concrete corridor this precondition would break on.
-      tron = 728_126_428
+    test "Tron is quotable as neither origin nor destination" do
+      tron = RelaySchemas.tron_chain_id()
 
-      for dst <- @pulling_origins, symbol <- ~w(USDC USDT) do
-        refute CorridorAllowlist.allowed?(symbol, symbol, tron, dst)
+      # A positive control, because `allowed?/4` ends in a catch-all returning
+      # false: refutes alone would still pass if `tron` were a typo, or if the
+      # argument order here drifted. This proves the same call shape can be true.
+      assert CorridorAllowlist.allowed?("USDC", "USDC", 8453, 10)
+
+      # Derived from the corridor list rather than a hand-written pair list, so
+      # every symbol pairing is covered and a new one cannot slip past.
+      for {src, dst, from, to} <- CorridorAllowlist.corridors() do
+        refute CorridorAllowlist.allowed?(src, dst, tron, to)
+        refute CorridorAllowlist.allowed?(src, dst, from, tron)
       end
     end
   end


### PR DESCRIPTION
Closes #665.

The issue asks a question before it asks for code: *"Verify whether deposit-route
(non-EVM origin) transfers are meant to flow through the ACP offerings at all. If yes,
make `pull_signature` required only for the pulling corridors [...] If deposit routes were
never supported here, no code change; just document the intentional narrowing."*

## The answer is no, on three independent signals

- **`raxol_earn` has no deposit-route code.** Not one reference to `deposit_route`,
  `deposit_address`, or `deposit_attestation` anywhere in `lib/`.
- **Every corridor is EVM.** `CorridorAllowlist` is USDC and USDT across the five CCTP
  chains plus USDG on Robinhood Chain (4663). No Tron, no Solana.
- **The settle path cannot do anything else.** `Raxol.Earn.Xochi.Settler` settles by
  relaying the buyer's pre-signed intent through `Xochi.execute_signed/2`. A deposit route
  has no pull to relay — the buyer funds an address and the solver watches for it.

Accepting a deposit-route job would therefore escrow a fee for work this stack has no
mechanism to perform. Rejecting it is right.

The reason this reads as a defect is a genuine asymmetry between layers:
**`raxol_payments` does model the case** — `Protocols.Xochi.deposit_route_quote/3`,
`DepositAttestation`, and a bundle whose `pull_signature` is nil for non-pulling methods
("Optional: `pull_signature` (nil for non-pulling methods)"). `Raxol.Payments.Assets` even
knows Tron mainnet (`728126428`, USDT/USDC TRC-20). So the payer side is ready and the
seller side is not, which makes the shared schema look like an oversight when it is a
correct narrowing.

**No schema change**, per the issue's own instruction.

## What was actually missing

Nothing notices when the narrowing stops being correct. Add a corridor and a
deposit-route buyer starts getting rejected at the *shape* gate as a malformed
requirement, rather than honestly as an unsupported corridor — a confusing failure at the
worst moment.

So this does two things:

**Documents it where the requirement is declared** — `requirement_schema/0` now explains
why `pull_signature` is mandatory, what it forecloses, why that is free today, and what to
change when it is not (per-mode in `requirement_schema/1`, as the issue suggests).
`valid_requirement?/1` points at it.

**Pins the premise** in `corridor_allowlist_test.exs`:

- every corridor ORIGIN must be a chain that can sign a gasless pull
- Tron specifically must stay unquotable

## The guard was proven to fail

A guard nobody has seen fail is not a guard. I added Tron to `@usdt_chains`, confirmed
both tests go red with the intended diagnostic —

```
a corridor origin cannot sign a gasless pull, so its buyer has no pull_signature
-- but Offering.requirement_schema/0 still demands one
```

— then reverted. The diff is two files: a moduledoc and a test.

This is likelier to fire than it looks: Riddler opened three Tron deposit-route issues in
the last two days (axol-io/Riddler#846, #856, #857).

## Manual testing

- [x] Guard verified RED by adding Tron to `@usdt_chains`, then reverted (probe not in the diff)
- [x] `MIX_ENV=test mix test` in `packages/raxol_earn`: 888 passed
- [x] `MIX_ENV=test mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean at root and in the package
- [x] Traced `Settler` -> `execute_signed/2` and `CorridorAllowlist.corridors/0` to establish the three signals above

## Note

Stacked conceptually on #880 (also `raxol_earn`), but textually independent — different
files, no conflict either way.
