### PR TITLE
Gate Console inbound events on Pairing

### DIFF
--- a/packages/raxol_console/lib/raxol/console/application.ex
+++ b/packages/raxol_console/lib/raxol/console/application.ex
@@ -75,7 +75,8 @@ defmodule Raxol.Console.Application do
     :handler_mode,
     :app_template,
     :idle_timeout,
-    :max_sessions
+    :max_sessions,
+    :pairing
   ]
 
   @impl true

--- a/packages/raxol_console/lib/raxol/console/application.ex
+++ b/packages/raxol_console/lib/raxol/console/application.ex
@@ -37,13 +37,19 @@ defmodule Raxol.Console.Application do
         pairing: [allowed_users: ["12345"]]       # these ids, any platform
         pairing: [platform_users: [telegram: ["12345"]]]   # these ids, there
         pairing: :open                            # open, and say so on purpose
-        pairing: []                                # allowlist nobody
+        pairing: []                                # deny everyone; pair by hand
 
   The allowlist decides who may OPEN a chat, keyed on the sender. It says
   nothing about who can read the reply: an allowed user who adds the bot to a
   group gets the agent's output -- tool results included -- delivered to that
   group. Prefer `chat_type: :dm` channels for an agent with reachable
   credentials.
+
+  `pairing: []` denies everyone and there is no `/pair` command to escape it --
+  a denial is decided before a session exists, so pairing a newcomer is an out
+  of band call to `Raxol.Gateway.Pairing`. Seed `:allowed_users` instead unless
+  that is what you meant. Note also that `:allowed_users` and confirmed pairings
+  match on the id alone, across every connected platform.
 
   Inbound events are gated by `Raxol.Console.Inbound.route/3` and by the router
   itself, so a deployment's own feed loop cannot route around it. See

--- a/packages/raxol_console/lib/raxol/console/application.ex
+++ b/packages/raxol_console/lib/raxol/console/application.ex
@@ -23,6 +23,33 @@ defmodule Raxol.Console.Application do
         workspace: "/srv/agent/workspace",
         bundle_default_mcp: true
 
+  ## Who may talk to this agent
+
+  Nobody by default is NOT the default. With no `:pairing` key, every connected
+  platform is open to everyone, and anyone who can reach the bot can spend this
+  agent's LLM turns, its tools, and any credential they reach through. That is
+  the wrong default for a container that holds a wallet, so the boot logs a
+  warning and emits `[:raxol_console, :pairing, :open]` until a deployment says
+  what it wants:
+
+      config :raxol_console,
+        pairing: [allow_platforms: [:telegram]]   # anyone on Telegram
+        pairing: [allowed_users: ["12345"]]       # these ids, any platform
+        pairing: [platform_users: [telegram: ["12345"]]]   # these ids, there
+        pairing: :open                            # open, and say so on purpose
+        pairing: []                                # allowlist nobody
+
+  The allowlist decides who may OPEN a chat, keyed on the sender. It says
+  nothing about who can read the reply: an allowed user who adds the bot to a
+  group gets the agent's output -- tool results included -- delivered to that
+  group. Prefer `chat_type: :dm` channels for an agent with reachable
+  credentials.
+
+  Inbound events are gated by `Raxol.Console.Inbound.route/3` and by the router
+  itself, so a deployment's own feed loop cannot route around it. See
+  `Raxol.Console.RuntimeConfig.build/2` for the full option and
+  `Raxol.Gateway.Pairing` for the decision order.
+
   A chat turn runs the stateless agent loop by default. To run a full TEA app per
   chat instead, name a template registered in `Raxol.Console.AppRegistry`:
 
@@ -153,11 +180,14 @@ defmodule Raxol.Console.Application do
 
   defp to_app_result({:ok, report}) do
     Logger.info(
+      # The posture belongs on the line an operator actually reads. The boot
+      # warning fires once and is easy to lose in container startup noise,
+      # which left "open to everyone" visible nowhere at a glance.
       "[Raxol.Console] booted: " <>
         "jobs created=#{length(report.jobs.created)} updated=#{length(report.jobs.updated)} " <>
         "removed=#{length(report.jobs.removed)} failed=#{length(report.jobs.failed)}, " <>
         "mcp tools=#{report.mcp.tools}, skills=#{report.skills.count}, " <>
-        "channels=#{inspect(report.channels)}"
+        "channels=#{inspect(report.channels)}, pairing=#{report.pairing}"
     )
 
     {:ok, report.supervisor}

--- a/packages/raxol_console/lib/raxol/console/boot.ex
+++ b/packages/raxol_console/lib/raxol/console/boot.ex
@@ -84,51 +84,78 @@ defmodule Raxol.Console.Boot do
 
     case start_gateway(sup, runtime_config, adapters, actions, base, skills) do
       :ok ->
-        pairing = apply_pairing(runtime_config, adapters, base)
-        {:ok, report(sup, mcp_sup, mcp, adapters, skills, pairing, opts)}
+        posture = announce_posture(runtime_config, adapters, base)
+        {:ok, report(sup, mcp_sup, mcp, adapters, skills, posture, opts)}
 
       {:error, _} = error ->
         stop_supervisor(sup) && error
     end
   end
 
-  # Seed the running Pairing server from the deployment's posture. This runs
-  # after start_gateway/6 because Pairing's allowlists are runtime-mutable only
-  # -- `init_manager/1` starts every one of them empty and takes no seeds.
+  # The deployment's posture, as `Raxol.Gateway.Pairing` start opts. These are
+  # SEEDS, not calls against a running server: the Pairing server applies them in
+  # `init_manager/1`, so a supervisor restart rebuilds the same posture. Seeding
+  # a running server from here instead would mean one crash silently reverses the
+  # deployment -- an open Console starts denying everything, an enforcing one
+  # forgets its allowlist -- with the boot that announced the posture long past.
   #
-  # Open mode is expressed as allow_platform_all/2 over the CONNECTED platforms
-  # rather than as a flag the gate consults, so `Raxol.Console.Inbound` has one
-  # code path and the posture is inspectable in the Pairing server's own state.
-  # A platform the deployment never connected stays denied even when open.
-  #
-  # A headless runtime connects no channels, so start_gateway/6 starts no gateway
-  # subtree and there is no Pairing server to seed. It also has no inbound chat
-  # surface to authorize, so warning about an open one would be false.
-  defp apply_pairing(_rc, adapters, _base) when map_size(adapters) == 0, do: :none
+  # Open mode is expressed as `allow_platforms` over the CONNECTED platforms
+  # rather than as a flag the gate consults, so there is one code path in both
+  # postures and the truth is in the Pairing server's own state. A platform the
+  # deployment never connected stays denied even when open.
+  defp pairing_opts(%{pairing: nil}, adapters), do: [allow_platforms: Map.keys(adapters)]
 
-  defp apply_pairing(%{pairing: nil}, _adapters, _base), do: :open
+  defp pairing_opts(%{pairing: %{mode: :open}}, adapters),
+    do: [allow_platforms: Map.keys(adapters)]
 
-  defp apply_pairing(%{pairing: pairing}, adapters, base) do
-    server = name(base, "pairing")
-
-    case pairing.mode do
-      :open ->
-        Enum.each(Map.keys(adapters), &Pairing.allow_platform_all(server, &1))
-        announce_open(pairing, Map.keys(adapters), base)
-        :open
-
-      :enforce ->
-        seed_allowlists(server, pairing)
-        :enforce
-    end
+  defp pairing_opts(%{pairing: pairing}, _adapters) do
+    [
+      allow_platforms: pairing.allow_platforms,
+      allowed_users: pairing.allowed_users,
+      platform_users: pairing.platform_users
+    ]
   end
 
-  defp seed_allowlists(server, pairing) do
-    Enum.each(pairing.allow_platforms, &Pairing.allow_platform_all(server, &1))
-    Enum.each(pairing.allowed_users, &Pairing.allow(server, &1, :global))
+  # A headless runtime connects no channels, so start_gateway/6 starts no gateway
+  # subtree and there is no Pairing server at all. It also has no inbound chat
+  # surface to authorize, so warning about an open one would be false.
+  defp announce_posture(_rc, adapters, _base) when map_size(adapters) == 0, do: :none
 
-    for {platform, users} <- pairing.platform_users, user <- users do
-      Pairing.allow(server, user, {:platform, platform})
+  defp announce_posture(%{pairing: nil} = rc, adapters, base) do
+    announce_open(rc.pairing, Map.keys(adapters), base)
+    :open
+  end
+
+  defp announce_posture(%{pairing: %{mode: :open} = pairing}, adapters, base) do
+    announce_open(pairing, Map.keys(adapters), base)
+    :open
+  end
+
+  defp announce_posture(%{pairing: pairing}, adapters, base) do
+    warn_unconnected(pairing, adapters, base)
+    :enforce
+  end
+
+  # A platform atom that names no connected channel grants nothing, which reads
+  # exactly like a deliberate `pairing: []` -- the silent lockout `known_keys/1`
+  # already refuses to allow one level up, where a typo'd `allowed_user:` is
+  # rejected on these same grounds. The names are known here, so say so.
+  defp warn_unconnected(pairing, adapters, base) do
+    connected = Map.keys(adapters)
+    named = Enum.uniq(pairing.allow_platforms ++ Keyword.keys(pairing.platform_users))
+
+    case named -- connected do
+      [] ->
+        :ok
+
+      unknown ->
+        Logger.warning("""
+        #{base}: pairing names #{inspect(unknown)}, which no channel connected.
+
+        Connected: #{inspect(connected)}. Those entries grant nothing, so anyone
+        they were meant to admit is denied -- indistinguishable from configuring
+        no allowlist at all. Check the platform atoms against your :channels.
+        """)
     end
   end
 
@@ -292,6 +319,8 @@ defmodule Raxol.Console.Boot do
       |> Keyword.put(:actions, skill_actions(skills) ++ actions)
       |> put_skills_context(skills)
 
+    pairing_server = name(base, "pairing")
+
     [
       handler: RuntimeConfig.handler_spec(rc, agent_opts),
       deliver: fn route, rendered ->
@@ -299,7 +328,14 @@ defmodule Raxol.Console.Boot do
       end,
       name: name(base, "gateway"),
       router_name: name(base, "router"),
-      pairing_name: name(base, "pairing"),
+      pairing_name: pairing_server,
+      pairing: pairing_opts(rc, adapters),
+      # The router asks Pairing itself, so the gate holds for a feed loop that
+      # calls `SessionRouter.route/3` directly. `Raxol.Console.Inbound` is the
+      # documented door and answers a denial without a round trip through the
+      # router; this is what makes skipping it a difference in ergonomics rather
+      # than a difference in who gets served.
+      authorize: fn route -> Pairing.authorize(pairing_server, route) end,
       sessions_sup: name(base, "sessions")
     ]
     |> put_router_opts(rc)

--- a/packages/raxol_console/lib/raxol/console/boot.ex
+++ b/packages/raxol_console/lib/raxol/console/boot.ex
@@ -103,6 +103,9 @@ defmodule Raxol.Console.Boot do
   # rather than as a flag the gate consults, so there is one code path in both
   # postures and the truth is in the Pairing server's own state. A platform the
   # deployment never connected stays denied even when open.
+  # `RuntimeConfig.build/2` always resolves a posture map, so a nil is a struct
+  # someone built by hand rather than a fourth posture. It reads as unset, which
+  # is what an unset `:pairing` option means.
   defp pairing_opts(%{pairing: nil}, adapters), do: [allow_platforms: Map.keys(adapters)]
 
   defp pairing_opts(%{pairing: %{mode: :open}}, adapters),
@@ -182,8 +185,12 @@ defmodule Raxol.Console.Boot do
 
         config :raxol_console,
           pairing: [allow_platforms: [:telegram]]     # or allowed_users: [...]
-          pairing: []                                 # enforce; pair over DM only
+          pairing: []                                 # deny everyone; pair by hand
           pairing: :open                              # keep this, silence this warning
+
+    There is no /pair command: a denial is decided before a session exists, so
+    `pairing: []` admits nobody until an operator calls Raxol.Gateway.Pairing
+    out of band. Seed :allowed_users unless that is what you meant.
     """)
   end
 

--- a/packages/raxol_console/lib/raxol/console/boot.ex
+++ b/packages/raxol_console/lib/raxol/console/boot.ex
@@ -23,8 +23,11 @@ defmodule Raxol.Console.Boot do
   `Raxol.Console.RuntimeConfig.handler_spec/2`).
   """
 
+  require Logger
+
   alias Raxol.Agent.{McpBundle, Scheduler}
   alias Raxol.Console.RuntimeConfig
+  alias Raxol.Gateway.Pairing
 
   # Read-only skill access surfaced to the chat agent when the package ships
   # skills: the agent can list/view them on demand (skill authoring stays a
@@ -44,7 +47,8 @@ defmodule Raxol.Console.Boot do
           jobs: jobs_report(),
           mcp: %{tools: non_neg_integer(), failed: [{atom(), term()}]},
           channels: [atom()],
-          skills: %{store: atom() | nil, count: non_neg_integer()}
+          skills: %{store: atom() | nil, count: non_neg_integer()},
+          pairing: :open | :enforce | :none
         }
 
   @doc """
@@ -79,9 +83,81 @@ defmodule Raxol.Console.Boot do
     actions = Keyword.get(opts, :actions, []) ++ mcp.tools
 
     case start_gateway(sup, runtime_config, adapters, actions, base, skills) do
-      :ok -> {:ok, report(sup, mcp_sup, mcp, adapters, skills, opts)}
-      {:error, _} = error -> stop_supervisor(sup) && error
+      :ok ->
+        pairing = apply_pairing(runtime_config, adapters, base)
+        {:ok, report(sup, mcp_sup, mcp, adapters, skills, pairing, opts)}
+
+      {:error, _} = error ->
+        stop_supervisor(sup) && error
     end
+  end
+
+  # Seed the running Pairing server from the deployment's posture. This runs
+  # after start_gateway/6 because Pairing's allowlists are runtime-mutable only
+  # -- `init_manager/1` starts every one of them empty and takes no seeds.
+  #
+  # Open mode is expressed as allow_platform_all/2 over the CONNECTED platforms
+  # rather than as a flag the gate consults, so `Raxol.Console.Inbound` has one
+  # code path and the posture is inspectable in the Pairing server's own state.
+  # A platform the deployment never connected stays denied even when open.
+  #
+  # A headless runtime connects no channels, so start_gateway/6 starts no gateway
+  # subtree and there is no Pairing server to seed. It also has no inbound chat
+  # surface to authorize, so warning about an open one would be false.
+  defp apply_pairing(_rc, adapters, _base) when map_size(adapters) == 0, do: :none
+
+  defp apply_pairing(%{pairing: nil}, _adapters, _base), do: :open
+
+  defp apply_pairing(%{pairing: pairing}, adapters, base) do
+    server = name(base, "pairing")
+
+    case pairing.mode do
+      :open ->
+        Enum.each(Map.keys(adapters), &Pairing.allow_platform_all(server, &1))
+        announce_open(pairing, Map.keys(adapters), base)
+        :open
+
+      :enforce ->
+        seed_allowlists(server, pairing)
+        :enforce
+    end
+  end
+
+  defp seed_allowlists(server, pairing) do
+    Enum.each(pairing.allow_platforms, &Pairing.allow_platform_all(server, &1))
+    Enum.each(pairing.allowed_users, &Pairing.allow(server, &1, :global))
+
+    for {platform, users} <- pairing.platform_users, user <- users do
+      Pairing.allow(server, user, {:platform, platform})
+    end
+  end
+
+  # The whole point of defaulting to open is that it cannot be silent. An
+  # operator who wrote `pairing: :open` has already made this call and is not
+  # nagged; only silence is.
+  defp announce_open(%{declared?: true}, _platforms, _base), do: :ok
+
+  defp announce_open(_pairing, platforms, base) do
+    :telemetry.execute(
+      [:raxol_console, :pairing, :open],
+      %{system_time: System.system_time()},
+      %{console: base, platforms: platforms, declared?: false}
+    )
+
+    Logger.warning("""
+    #{base}: gateway authorization is OPEN and was not configured.
+
+    Anyone who can reach #{inspect(platforms)} can open a chat and spend this
+    agent's LLM turns and tools. No :pairing option was set, so every connected
+    platform was allowed for everyone.
+
+    Set one in your deployment config:
+
+        config :raxol_console,
+          pairing: [allow_platforms: [:telegram]]     # or allowed_users: [...]
+          pairing: []                                 # enforce; pair over DM only
+          pairing: :open                              # keep this, silence this warning
+    """)
   end
 
   # The core supervisor opts: everything the tree starts synchronously at init --
@@ -102,7 +178,7 @@ defmodule Raxol.Console.Boot do
   defp mcp_supervisor_pid(%{mcp_servers: []}, _mcp_name), do: nil
   defp mcp_supervisor_pid(_rc, mcp_name), do: Process.whereis(mcp_name)
 
-  defp report(sup, mcp_sup, mcp, adapters, skills, opts) do
+  defp report(sup, mcp_sup, mcp, adapters, skills, pairing, opts) do
     reconciler = Keyword.get(opts, :reconciler_name, Raxol.Console.Reconciler)
 
     %{
@@ -111,7 +187,8 @@ defmodule Raxol.Console.Boot do
       jobs: Raxol.Console.Reconciler.report(reconciler),
       mcp: %{tools: length(mcp.tools), failed: mcp.failed},
       channels: Map.keys(adapters),
-      skills: skills_report(skills)
+      skills: skills_report(skills),
+      pairing: pairing
     }
   end
 

--- a/packages/raxol_console/lib/raxol/console/inbound.ex
+++ b/packages/raxol_console/lib/raxol/console/inbound.ex
@@ -30,18 +30,26 @@ defmodule Raxol.Console.Inbound do
   and Console -- having no feed loop -- never got the call site. The server ran,
   denied nothing, and every inbound event got a session. See GitHub #884.
 
-  So the gate is a function you route THROUGH rather than a check you remember to
-  perform. The gateway still cannot force it (`SessionRouter.route/3` is public
-  and a deployment may call it), but the documented path no longer has a step in
-  it that is easy to skip.
+  ## This is not the only enforcement point
+
+  A gate that only works when you remember to call it is the bug above with a
+  new name, so `Raxol.Console.Boot` also hands the router an `:authorize`
+  function over the same Pairing server. A deployment that calls
+  `Raxol.Gateway.SessionRouter.route/3` directly gets the same decision.
+
+  What this adds is the answer without a round trip: a denial here never touches
+  the router, and it carries the console's own telemetry and log line. Skipping
+  it costs an extra `GenServer.call` per denied event and loses that signal --
+  it does not cost the check.
 
   ## Authorization posture
 
-  `route/3` always consults `Pairing`. An open Console is open because
-  `Raxol.Console.Boot` called `Pairing.allow_platform_all/2` for its connected
-  platforms, not because this module skipped a check -- so there is one code path
-  in both postures, and `:sys.get_state` on the Pairing server shows the truth.
-  See `Raxol.Console.RuntimeConfig.build/2` for configuring it.
+  `route/3` always consults `Pairing`. An open Console is open because its
+  Pairing server was seeded to allow the connected platforms, not because
+  anything skipped a check -- so there is one code path in both postures, and
+  `:sys.get_state` on the Pairing server shows the truth. The seeds are start
+  options, so the posture survives a Pairing restart; runtime DM pairings do
+  not. See `Raxol.Console.RuntimeConfig.build/2` for configuring it.
 
   ## Telemetry
 

--- a/packages/raxol_console/lib/raxol/console/inbound.ex
+++ b/packages/raxol_console/lib/raxol/console/inbound.ex
@@ -51,12 +51,37 @@ defmodule Raxol.Console.Inbound do
   options, so the posture survives a Pairing restart; runtime DM pairings do
   not. See `Raxol.Console.RuntimeConfig.build/2` for configuring it.
 
+  A `Pairing` that cannot answer -- crashed, or inside its own restart window --
+  denies. The alternative is a feed loop taking an uncaught exit from the
+  authorization call, which would drop or replay whatever batch it was pumping.
+
+  ## Admitting someone who is not on the allowlist
+
+  There is no `/pair` chat command, and there cannot be one at this layer: a
+  denial is decided before a session exists, so an unpaired sender has no way to
+  ask for a code through the chat itself. Pairing a newcomer means calling
+  `Raxol.Gateway.Pairing.request_code/2` and `confirm/2` out of band -- a remote
+  shell on the node, or whatever admin surface the deployment already has:
+
+      pairing = Raxol.Console.Inbound.pairing_name(MyConsole)
+      {:ok, code} = Raxol.Gateway.Pairing.request_code(pairing, "12345")
+      # deliver `code` to that user however you already reach them
+      {:ok, "12345"} = Raxol.Gateway.Pairing.confirm(pairing, code)
+
+  A deployment that wants a self-service lane builds it in its own feed loop with
+  `authorized?/2`: answer a denied sender with a code instead of dropping them,
+  and never hand the event to `route/3`. That stays the deployment's decision
+  because "what an unauthorized stranger is told" is a policy question, and the
+  safe default -- silence -- is the one that does not confirm the bot exists.
+
   ## Telemetry
 
     * `[:raxol_console, :inbound, :denied]` -- metadata `%{console, key, platform,
-      user_id}`. The only signal that someone was turned away; a denial is
-      otherwise invisible, since `route/3` returns to a feed loop that is free to
-      discard it.
+      user_id}`. The signal that someone was turned away; a denial is otherwise
+      invisible, since `route/3` returns to a feed loop that is free to discard
+      it. Telemetry rather than a log line, because the volume is set by whoever
+      is sending the denied traffic: a handler here can sample or aggregate, an
+      unconditional `Logger.info` per event cannot. The matching log is `debug`.
   """
 
   require Logger
@@ -73,7 +98,7 @@ defmodule Raxol.Console.Inbound do
   """
   @spec route(atom(), Route.t(), term()) :: :ok | {:error, term()}
   def route(base \\ Raxol.Console, %Route{} = route, event) do
-    case Pairing.authorize(pairing_name(base), route) do
+    case authorize(base, route) do
       :allow ->
         SessionRouter.route(router_name(base), route, event)
 
@@ -91,7 +116,20 @@ defmodule Raxol.Console.Inbound do
   """
   @spec authorized?(atom(), Route.t()) :: boolean()
   def authorized?(base \\ Raxol.Console, %Route{} = route),
-    do: Pairing.authorize(pairing_name(base), route) == :allow
+    do: authorize(base, route) == :allow
+
+  # The caller is the deployment's feed loop, pumping a batch it cannot replay.
+  # An uncaught exit here -- Pairing crashed, or is inside its own restart --
+  # would take that loop down mid-batch and lose or duplicate whatever it was
+  # holding, which is a large price for a question we already know the safe
+  # answer to. A gate that cannot answer denies.
+  defp authorize(base, route) do
+    Pairing.authorize(pairing_name(base), route)
+  catch
+    :exit, reason ->
+      Logger.warning("#{base}: pairing server unreachable, denying: #{inspect(reason)}")
+      :deny
+  end
 
   @doc "The Pairing server name for a Console booted under `base`."
   @spec pairing_name(atom()) :: atom()
@@ -113,6 +151,12 @@ defmodule Raxol.Console.Inbound do
       }
     )
 
-    Logger.info("#{base}: denied unauthorized #{route.platform} chat #{Route.key(route)}")
+    # `debug`, not `info`: the rate is chosen by whoever is sending the denied
+    # traffic, and this is the one path an unauthorized sender can reach at will
+    # -- `Pairing` rate-limits `request_code/2` and locks out `confirm/2`, but a
+    # denial costs nothing to provoke. At `info` a flood is unbounded log volume
+    # carrying third-party chat and user ids. The telemetry event above is the
+    # signal, and a handler can sample it.
+    Logger.debug("#{base}: denied unauthorized #{route.platform} chat #{Route.key(route)}")
   end
 end

--- a/packages/raxol_console/lib/raxol/console/inbound.ex
+++ b/packages/raxol_console/lib/raxol/console/inbound.ex
@@ -1,0 +1,110 @@
+defmodule Raxol.Console.Inbound do
+  @moduledoc """
+  The authorized entry point for inbound chat events.
+
+  A Console has no feed loop of its own. Adapters translate (`normalize_event/1`)
+  and `Raxol.Gateway.SessionRouter` routes, but something has to pump one into
+  the other, and that something belongs to the deployment: which transport it
+  polls, how it handles backpressure, and where it logs are all its business.
+
+  What is NOT its business is deciding who may open a session. `route/3` is that
+  decision plus the routing, in one call, so a deployment's feed cannot wire up
+  the second half and forget the first:
+
+      Raxol.Telegram.UpdatePoller.start_link(
+        conn: conn,
+        on_update: fn raw ->
+          with {:ok, route, event} <- Raxol.Telegram.GatewayAdapter.normalize_event(raw) do
+            Raxol.Console.Inbound.route(MyConsole, route, event)
+          end
+        end
+      )
+
+  `MyConsole` is the same `:name` the runtime booted under, which is what the
+  Pairing server and the router are named after.
+
+  ## Why this exists
+
+  `Raxol.Gateway.Pairing.authorize/2` was documented across five adapters as
+  something the feed loop calls before routing. It was never enforced anywhere,
+  and Console -- having no feed loop -- never got the call site. The server ran,
+  denied nothing, and every inbound event got a session. See GitHub #884.
+
+  So the gate is a function you route THROUGH rather than a check you remember to
+  perform. The gateway still cannot force it (`SessionRouter.route/3` is public
+  and a deployment may call it), but the documented path no longer has a step in
+  it that is easy to skip.
+
+  ## Authorization posture
+
+  `route/3` always consults `Pairing`. An open Console is open because
+  `Raxol.Console.Boot` called `Pairing.allow_platform_all/2` for its connected
+  platforms, not because this module skipped a check -- so there is one code path
+  in both postures, and `:sys.get_state` on the Pairing server shows the truth.
+  See `Raxol.Console.RuntimeConfig.build/2` for configuring it.
+
+  ## Telemetry
+
+    * `[:raxol_console, :inbound, :denied]` -- metadata `%{console, key, platform,
+      user_id}`. The only signal that someone was turned away; a denial is
+      otherwise invisible, since `route/3` returns to a feed loop that is free to
+      discard it.
+  """
+
+  require Logger
+
+  alias Raxol.Gateway.{Pairing, Route, SessionRouter}
+
+  @doc """
+  Authorize `route` and, if allowed, deliver `event` to its session.
+
+  Returns `SessionRouter.route/3`'s own result when allowed -- `:ok`, or
+  `{:error, :max_sessions | :rate_limited}` -- and `{:error, :unauthorized}` when
+  not. Note that `:ok` carries `route/3`'s meaning: the event was accepted for
+  delivery, not that it was served.
+  """
+  @spec route(atom(), Route.t(), term()) :: :ok | {:error, term()}
+  def route(base \\ Raxol.Console, %Route{} = route, event) do
+    case Pairing.authorize(pairing_name(base), route) do
+      :allow ->
+        SessionRouter.route(router_name(base), route, event)
+
+      :deny ->
+        deny(base, route)
+        {:error, :unauthorized}
+    end
+  end
+
+  @doc """
+  Whether `route` would be authorized, without routing anything.
+
+  For a feed that wants to answer an unpaired sender (with a pairing code, say)
+  rather than drop them silently.
+  """
+  @spec authorized?(atom(), Route.t()) :: boolean()
+  def authorized?(base \\ Raxol.Console, %Route{} = route),
+    do: Pairing.authorize(pairing_name(base), route) == :allow
+
+  @doc "The Pairing server name for a Console booted under `base`."
+  @spec pairing_name(atom()) :: atom()
+  def pairing_name(base \\ Raxol.Console), do: :"#{base}.pairing"
+
+  @doc "The `SessionRouter` name for a Console booted under `base`."
+  @spec router_name(atom()) :: atom()
+  def router_name(base \\ Raxol.Console), do: :"#{base}.router"
+
+  defp deny(base, route) do
+    :telemetry.execute(
+      [:raxol_console, :inbound, :denied],
+      %{system_time: System.system_time()},
+      %{
+        console: base,
+        key: Route.key(route),
+        platform: route.platform,
+        user_id: route.user_id
+      }
+    )
+
+    Logger.info("#{base}: denied unauthorized #{route.platform} chat #{Route.key(route)}")
+  end
+end

--- a/packages/raxol_console/lib/raxol/console/runtime_config.ex
+++ b/packages/raxol_console/lib/raxol/console/runtime_config.ex
@@ -44,6 +44,23 @@ defmodule Raxol.Console.RuntimeConfig do
   """
   @type handler_mode :: :chat | :app
 
+  @typedoc """
+  The resolved gateway authorization posture.
+
+    * `:open` -- every connected platform is allowed for everyone. `declared?`
+      distinguishes an operator who asked for this from one who said nothing;
+      only the latter is warned about at boot.
+    * `:enforce` -- `Raxol.Gateway.Pairing` decides, seeded from the three
+      allowlists and extended at runtime by the DM pairing flow.
+  """
+  @type pairing :: %{
+          mode: :open | :enforce,
+          declared?: boolean(),
+          allow_platforms: [atom()],
+          allowed_users: [String.t()],
+          platform_users: [{atom(), [String.t()]}]
+        }
+
   defstruct system_prompt: nil,
             persona_sha256: nil,
             scheduler_jobs: [],
@@ -54,7 +71,8 @@ defmodule Raxol.Console.RuntimeConfig do
             handler_mode: :chat,
             app_module: nil,
             idle_timeout: nil,
-            max_sessions: nil
+            max_sessions: nil,
+            pairing: nil
 
   @type t :: %__MODULE__{
           system_prompt: String.t(),
@@ -67,7 +85,8 @@ defmodule Raxol.Console.RuntimeConfig do
           handler_mode: handler_mode(),
           app_module: module() | nil,
           idle_timeout: pos_integer() | nil,
-          max_sessions: pos_integer() | nil
+          max_sessions: pos_integer() | nil,
+          pairing: pairing()
         }
 
   @doc """
@@ -91,10 +110,43 @@ defmodule Raxol.Console.RuntimeConfig do
       of the deployment's app rather than of the gateway.
     * `:max_sessions` -- concurrent chats the router will hold (gateway default
       1000); further chats are refused with `:max_sessions`.
+    * `:pairing` -- who may open a chat; see "Authorization" below.
 
   `:handler_mode` and `:app_template` are read from the DEPLOYMENT options, never
   from the package. The package is untrusted input, and choosing which module
   runs per chat is not a decision it gets to make.
+
+  ## Authorization
+
+  `:pairing` has three states, and the difference between two of them is only
+  whether the operator said anything:
+
+      # unset -- open, and warned about loudly at every boot
+      # explicitly open, no warning: the operator has made this call
+      pairing: :open
+
+      # enforced; Raxol.Gateway.Pairing decides
+      pairing: [
+        allow_platforms: [:telegram],          # everyone on these platforms
+        allowed_users: ["12345"],              # global allowlist
+        platform_users: [discord: ["9876"]]    # per-platform allowlist
+      ]
+
+  `pairing: []` is the useful empty case: enforced with nothing seeded, so the
+  only way in is the runtime DM pairing flow (`Pairing.request_code/2` ->
+  `confirm/2`).
+
+  Open is the default because enforcing by default would lock out every Console
+  running today -- `Pairing`'s allowlists boot empty, so an unconfigured enforce
+  denies everyone. That makes silence the permissive answer, which is the wrong
+  way round; `Raxol.Console.Boot` compensates by making silence loud rather than
+  by making it safe.
+
+  Open mode is not a bypass. It is applied by calling
+  `Pairing.allow_platform_all/2` for each CONNECTED platform, so the gate runs
+  identically in both modes and the posture is visible in the Pairing server's
+  own state. A route on a platform the deployment never connected is denied even
+  when open.
 
   ## Sizing an `:app` deployment
 
@@ -116,7 +168,8 @@ defmodule Raxol.Console.RuntimeConfig do
     with {:ok, persona} <- persona(pkg),
          {:ok, mode, app_module} <- handler(opts),
          {:ok, idle_timeout} <- pos_integer(opts, :idle_timeout, :invalid_idle_timeout),
-         {:ok, max_sessions} <- pos_integer(opts, :max_sessions, :invalid_max_sessions) do
+         {:ok, max_sessions} <- pos_integer(opts, :max_sessions, :invalid_max_sessions),
+         {:ok, pairing} <- pairing(opts) do
       {:ok,
        %__MODULE__{
          system_prompt: persona,
@@ -129,7 +182,8 @@ defmodule Raxol.Console.RuntimeConfig do
          handler_mode: mode,
          app_module: app_module,
          idle_timeout: idle_timeout,
-         max_sessions: max_sessions
+         max_sessions: max_sessions,
+         pairing: pairing
        }}
     end
   end
@@ -194,6 +248,93 @@ defmodule Raxol.Console.RuntimeConfig do
   defp resolve_app(name) do
     with {:ok, module} <- AppRegistry.fetch(name), do: {:ok, :app, module}
   end
+
+  # -- authorization ---------------------------------------------------------
+
+  @pairing_keys [:allow_platforms, :allowed_users, :platform_users]
+
+  defp pairing(opts) do
+    case Keyword.get(opts, :pairing) do
+      nil -> {:ok, open(false)}
+      :open -> {:ok, open(true)}
+      list when is_list(list) -> enforce(list)
+      other -> {:error, {:invalid_pairing, other}}
+    end
+  end
+
+  defp open(declared?) do
+    %{
+      mode: :open,
+      declared?: declared?,
+      allow_platforms: [],
+      allowed_users: [],
+      platform_users: []
+    }
+  end
+
+  # A keyword list is the enforcing form, including the empty one. Unknown keys
+  # are refused rather than ignored: a typo'd `allowed_user:` would otherwise
+  # seed nothing and read as a deliberate deny-all.
+  defp enforce(list) do
+    with :ok <- known_keys(list),
+         {:ok, platforms} <- atom_list(list, :allow_platforms),
+         {:ok, users} <- string_list(list, :allowed_users),
+         {:ok, platform_users} <- platform_users(list) do
+      {:ok,
+       %{
+         mode: :enforce,
+         declared?: true,
+         allow_platforms: platforms,
+         allowed_users: users,
+         platform_users: platform_users
+       }}
+    end
+  end
+
+  defp known_keys(list) do
+    case Enum.reject(Keyword.keys(list), &(&1 in @pairing_keys)) do
+      [] -> :ok
+      unknown -> {:error, {:unknown_pairing_keys, unknown}}
+    end
+  end
+
+  defp atom_list(list, key) do
+    values = Keyword.get(list, key, [])
+
+    if is_list(values) and Enum.all?(values, &is_atom/1),
+      do: {:ok, values},
+      else: {:error, {:invalid_pairing, {key, values}}}
+  end
+
+  # User ids are stringified here rather than at the Pairing call site, because
+  # `Pairing.allow/3` stringifies too and an integer Telegram id configured as an
+  # integer must land in the same set the route's stringified id is checked
+  # against.
+  defp string_list(list, key) do
+    values = Keyword.get(list, key, [])
+
+    if is_list(values) and Enum.all?(values, &scalar_id?/1),
+      do: {:ok, Enum.map(values, &to_string/1)},
+      else: {:error, {:invalid_pairing, {key, values}}}
+  end
+
+  defp platform_users(list) do
+    entries = Keyword.get(list, :platform_users, [])
+
+    if Keyword.keyword?(entries) do
+      Enum.reduce_while(entries, {:ok, []}, &reduce_platform_users/2)
+    else
+      {:error, {:invalid_pairing, {:platform_users, entries}}}
+    end
+  end
+
+  defp reduce_platform_users({platform, users}, {:ok, acc}) do
+    if is_list(users) and Enum.all?(users, &scalar_id?/1),
+      do: {:cont, {:ok, acc ++ [{platform, Enum.map(users, &to_string/1)}]}},
+      else: {:halt, {:error, {:invalid_pairing, {:platform_users, platform, users}}}}
+  end
+
+  defp scalar_id?(value), do: is_binary(value) or is_integer(value)
 
   # -- router bounds ---------------------------------------------------------
 

--- a/packages/raxol_console/lib/raxol/console/runtime_config.ex
+++ b/packages/raxol_console/lib/raxol/console/runtime_config.ex
@@ -132,9 +132,19 @@ defmodule Raxol.Console.RuntimeConfig do
         platform_users: [discord: ["9876"]]    # per-platform allowlist
       ]
 
-  `pairing: []` is the useful empty case: enforced with nothing seeded, so the
-  only way in is the runtime DM pairing flow (`Pairing.request_code/2` ->
-  `confirm/2`).
+  `pairing: []` is enforced with nothing seeded: it denies everyone, and it
+  admits nobody until an operator pairs them by hand. There is no `/pair` chat
+  command -- a denial is decided before a session exists, so an unpaired sender
+  cannot ask for a code through the chat. `Pairing.request_code/2` and
+  `confirm/2` are reachable only out of band (a remote shell, or the
+  deployment's own admin surface), and a self-service lane is something the feed
+  loop builds with `Raxol.Console.Inbound.authorized?/2`. Do not reach for
+  `pairing: []` expecting the pairing flow to be wired; seed `:allowed_users`
+  with whoever should already be in.
+
+  `:allowed_users` is NOT platform-scoped -- the id matches on every connected
+  platform, whose id namespaces are unrelated. Prefer `:platform_users` when a
+  deployment connects more than one. See `Raxol.Gateway.Pairing`.
 
   Open is the default because enforcing by default would lock out every Console
   running today -- `Pairing`'s allowlists boot empty, so an unconfigured enforce
@@ -142,11 +152,11 @@ defmodule Raxol.Console.RuntimeConfig do
   way round; `Raxol.Console.Boot` compensates by making silence loud rather than
   by making it safe.
 
-  Open mode is not a bypass. It is applied by calling
-  `Pairing.allow_platform_all/2` for each CONNECTED platform, so the gate runs
-  identically in both modes and the posture is visible in the Pairing server's
-  own state. A route on a platform the deployment never connected is denied even
-  when open.
+  Open mode is not a bypass. It is seeded into `Pairing`'s own start options as
+  `allow_platforms:` over the CONNECTED platforms, so the gate runs identically
+  in both modes, the posture is visible in the Pairing server's state, and a
+  restart rebuilds it. A route on a platform the deployment never connected is
+  denied even when open.
 
   ## Sizing an `:app` deployment
 
@@ -298,13 +308,19 @@ defmodule Raxol.Console.RuntimeConfig do
     end
   end
 
+  # `nil`, `true` and `false` are atoms, and a platform key holding one of them
+  # names no channel and grants nothing -- the silent-lockout shape `known_keys/1`
+  # refuses one level up. `platform: nil` is the likely way in, from a lookup that
+  # missed. Refuse it here rather than warning about it at boot.
   defp atom_list(list, key) do
     values = Keyword.get(list, key, [])
 
-    if is_list(values) and Enum.all?(values, &is_atom/1),
+    if is_list(values) and Enum.all?(values, &platform_atom?/1),
       do: {:ok, values},
       else: {:error, {:invalid_pairing, {key, values}}}
   end
+
+  defp platform_atom?(value), do: is_atom(value) and value not in [nil, true, false]
 
   # User ids are stringified here rather than at the Pairing call site, because
   # `Pairing.allow/3` stringifies too and an integer Telegram id configured as an
@@ -328,8 +344,11 @@ defmodule Raxol.Console.RuntimeConfig do
     end
   end
 
+  # Duplicate platform keys are carried through as written; `Pairing` unions them
+  # when it seeds, so naming a platform twice adds both sets rather than keeping
+  # only the last.
   defp reduce_platform_users({platform, users}, {:ok, acc}) do
-    if is_list(users) and Enum.all?(users, &scalar_id?/1),
+    if platform_atom?(platform) and is_list(users) and Enum.all?(users, &scalar_id?/1),
       do: {:cont, {:ok, acc ++ [{platform, Enum.map(users, &to_string/1)}]}},
       else: {:halt, {:error, {:invalid_pairing, {:platform_users, platform, users}}}}
   end

--- a/packages/raxol_console/test/raxol/console/application_test.exs
+++ b/packages/raxol_console/test/raxol/console/application_test.exs
@@ -73,6 +73,19 @@ defmodule Raxol.Console.ApplicationTest do
       assert opts[:handler_mode] == :app
       assert opts[:app_template] == "dashboard"
     end
+
+    # Same filter, same failure mode: a :pairing absent from @rc_keys is dropped
+    # in silence, and the deployment's authorization posture never reaches
+    # RuntimeConfig -- so the runtime boots open while its config says otherwise.
+    test "carries the pairing posture through" do
+      config = [
+        package_dir: "/srv/agent",
+        pairing: [allowed_users: ["alice"]]
+      ]
+
+      assert {:ok, _dir, opts} = Application.plan(config)
+      assert opts[:pairing] == [allowed_users: ["alice"]]
+    end
   end
 
   describe "boot/2" do

--- a/packages/raxol_console/test/raxol/console/inbound_test.exs
+++ b/packages/raxol_console/test/raxol/console/inbound_test.exs
@@ -1,0 +1,192 @@
+defmodule Raxol.Console.InboundTest do
+  # Not async: boots named Console runtimes.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Console.{Boot, Inbound, RuntimeConfig}
+  alias Raxol.Earn.Console.Package
+  alias Raxol.Gateway.{Adapter.InMemory, Pairing, Route, SessionRouter}
+
+  defp package do
+    %Package{runtime: :raxol, soul_md: "# Bot\n\nHi.", agents_md: nil, tasks: [], skills: []}
+  end
+
+  defp boot(name, pairing_opts) do
+    {:ok, rc} =
+      RuntimeConfig.build(
+        package(),
+        [
+          bundle_default_mcp: false,
+          channels: [%{platform: :in_memory, adapter: InMemory, config: %{sink: self()}}]
+        ] ++ pairing_opts
+      )
+
+    {:ok, report} =
+      Boot.start(rc, name: name, scheduler_name: :"#{name}_s", reconciler_name: :"#{name}_r")
+
+    on_exit(fn ->
+      try do
+        Supervisor.stop(name)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    report
+  end
+
+  defp route(user_id, platform \\ :in_memory) do
+    Route.new(%{
+      platform: platform,
+      chat_type: :dm,
+      chat_id: "c-#{user_id}",
+      user_id: user_id
+    })
+  end
+
+  describe "unconfigured deployments" do
+    # The decision on #884: silence means allow, because Pairing's allowlists
+    # boot empty and enforcing by default would deny every Console running
+    # today. What silence must NOT mean is quiet -- so the posture is announced.
+    test "allow, and say so loudly" do
+      handler_id = "open-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol_console, :pairing, :open],
+        fn _e, _m, meta, pid -> send(pid, {:telemetry, meta}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          report = boot(:inb_open, [])
+          assert report.pairing == :open
+        end)
+
+      assert log =~ "gateway authorization is OPEN and was not configured"
+      assert log =~ "pairing:"
+
+      assert_receive {:telemetry,
+                      %{console: :inb_open, declared?: false, platforms: [:in_memory]}}
+
+      assert :ok = Inbound.route(:inb_open, route("anyone"), %{text: "hi"})
+
+      # Open is a real Pairing state, not a branch that skips the gate -- which
+      # is what makes both postures share one code path through Inbound.route/3.
+      assert :allow = Pairing.authorize(Inbound.pairing_name(:inb_open), route("anyone"))
+
+      # ...and it is open only on a platform the deployment actually connected.
+      assert :deny = Pairing.authorize(Inbound.pairing_name(:inb_open), route("x", :telegram))
+      refute Inbound.authorized?(:inb_open, route("x", :telegram))
+    end
+
+    test "an explicit :open is not nagged about" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          report = boot(:inb_declared, pairing: :open)
+          assert report.pairing == :open
+        end)
+
+      refute log =~ "was not configured"
+      assert :ok = Inbound.route(:inb_declared, route("anyone"), %{text: "hi"})
+    end
+  end
+
+  describe "enforcing deployments" do
+    test "an empty list enforces with nothing seeded, so only DM pairing gets in" do
+      report = boot(:inb_empty, pairing: [])
+      assert report.pairing == :enforce
+
+      assert {:error, :unauthorized} = Inbound.route(:inb_empty, route("stranger"), %{text: "hi"})
+
+      # The runtime pairing flow is the way in, and it works on a live runtime.
+      pairing = Inbound.pairing_name(:inb_empty)
+      {:ok, code} = Pairing.request_code(pairing, "newcomer")
+      {:ok, "newcomer"} = Pairing.confirm(pairing, code)
+
+      assert :ok = Inbound.route(:inb_empty, route("newcomer"), %{text: "hi"})
+    end
+
+    # The bug in #884: the Pairing server ran, nothing consulted it, and an
+    # unauthorized sender got a session anyway. A denial must reach neither the
+    # router nor the operator's blind spot, so both are asserted here.
+    test "seeds a global allowlist, and a denial starts no session and is announced" do
+      boot(:inb_users, pairing: [allowed_users: ["alice"]])
+      router = Inbound.router_name(:inb_users)
+      handler_id = "denied-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:raxol_console, :inbound, :denied],
+        fn _e, _m, meta, pid -> send(pid, {:telemetry, meta}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert {:error, :unauthorized} = Inbound.route(:inb_users, route("mallory"), %{text: "hi"})
+      assert SessionRouter.session_count(router) == 0
+
+      assert_receive {:telemetry,
+                      %{console: :inb_users, platform: :in_memory, user_id: "mallory"}}
+
+      assert :ok = Inbound.route(:inb_users, route("alice"), %{text: "hi"})
+      assert SessionRouter.session_count(router) == 1
+    end
+
+    # Telegram ids are integers in the wire payload and stringified into the
+    # Route, so an integer in config has to land in the same set the check reads.
+    test "an integer user id configured as an integer still matches" do
+      boot(:inb_int, pairing: [allowed_users: [12_345]])
+
+      assert :ok = Inbound.route(:inb_int, route(12_345), %{text: "hi"})
+      assert :ok = Inbound.route(:inb_int, route("12345"), %{text: "hi"})
+      assert {:error, :unauthorized} = Inbound.route(:inb_int, route(999), %{text: "hi"})
+    end
+
+    test "seeds a per-platform allowlist that does not leak across platforms" do
+      boot(:inb_plat, pairing: [platform_users: [in_memory: ["bob"]]])
+
+      assert :ok = Inbound.route(:inb_plat, route("bob"), %{text: "hi"})
+      refute Inbound.authorized?(:inb_plat, route("bob", :telegram))
+    end
+
+    test "seeds allow-everyone for a named platform" do
+      boot(:inb_allplat, pairing: [allow_platforms: [:in_memory]])
+
+      assert :ok = Inbound.route(:inb_allplat, route("anyone"), %{text: "hi"})
+      refute Inbound.authorized?(:inb_allplat, route("anyone", :discord))
+    end
+  end
+
+  describe "headless runtimes" do
+    test "connect no channels, so there is no gateway to authorize and no warning" do
+      {:ok, rc} = RuntimeConfig.build(package(), bundle_default_mcp: false)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          {:ok, report} =
+            Boot.start(rc,
+              name: :inb_headless,
+              scheduler_name: :inb_headless_s,
+              reconciler_name: :inb_headless_r
+            )
+
+          assert report.pairing == :none
+          assert report.channels == []
+        end)
+
+      on_exit(fn ->
+        try do
+          Supervisor.stop(:inb_headless)
+        catch
+          :exit, _ -> :ok
+        end
+      end)
+
+      refute log =~ "was not configured"
+    end
+  end
+end

--- a/packages/raxol_console/test/raxol/console/inbound_test.exs
+++ b/packages/raxol_console/test/raxol/console/inbound_test.exs
@@ -159,6 +159,94 @@ defmodule Raxol.Console.InboundTest do
       assert :ok = Inbound.route(:inb_allplat, route("anyone"), %{text: "hi"})
       refute Inbound.authorized?(:inb_allplat, route("anyone", :discord))
     end
+
+    # A platform atom naming no connected channel grants nothing, which reads
+    # exactly like configuring no allowlist at all. `known_keys/1` already
+    # refuses that ambiguity one level up, where a typo'd `allowed_user:` is
+    # rejected on the same grounds.
+    test "a platform atom that matches no channel is named in the log" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          report = boot(:inb_typo, pairing: [allow_platforms: [:in_memry]])
+          assert report.pairing == :enforce
+        end)
+
+      assert log =~ "pairing names [:in_memry]"
+      assert log =~ "Connected: [:in_memory]"
+    end
+
+    test "a correctly named platform warns about nothing" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          boot(:inb_no_typo, pairing: [allow_platforms: [:in_memory]])
+        end)
+
+      refute log =~ "pairing names"
+    end
+  end
+
+  # The gate is only a gate if it cannot be walked around. `route/3` is the
+  # documented door; these prove the walls.
+  describe "enforcement outside Inbound.route/3" do
+    test "the router refuses a feed that calls SessionRouter directly" do
+      boot(:inb_bypass, pairing: [allowed_users: ["alice"]])
+      router = Inbound.router_name(:inb_bypass)
+
+      assert {:error, :unauthorized} =
+               SessionRouter.route(router, route("mallory"), %{text: "hi"})
+
+      assert SessionRouter.session_count(router) == 0
+
+      assert :ok = SessionRouter.route(router, route("alice"), %{text: "hi"})
+      assert SessionRouter.session_count(router) == 1
+    end
+
+    # The posture is seeded into Pairing's own init, so a crash restores it.
+    # Seeded by calls against the running server it would not: an :open Console
+    # would start denying every message forever, and an enforcing one would
+    # forget its allowlist -- both silently, both with report.pairing still
+    # claiming the posture the boot announced.
+    test "an open Console is still open after its Pairing server crashes" do
+      boot(:inb_crash_open, [])
+      assert Inbound.authorized?(:inb_crash_open, route("anyone"))
+
+      restart_pairing(:inb_crash_open)
+
+      assert Inbound.authorized?(:inb_crash_open, route("anyone"))
+    end
+
+    test "an enforcing Console keeps its allowlist after a Pairing crash" do
+      boot(:inb_crash_enforce, pairing: [allowed_users: ["alice"]])
+      assert Inbound.authorized?(:inb_crash_enforce, route("alice"))
+
+      restart_pairing(:inb_crash_enforce)
+
+      assert Inbound.authorized?(:inb_crash_enforce, route("alice"))
+      refute Inbound.authorized?(:inb_crash_enforce, route("mallory"))
+    end
+  end
+
+  defp restart_pairing(console) do
+    name = Inbound.pairing_name(console)
+    pid = Process.whereis(name)
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+    wait_for(name)
+  end
+
+  defp wait_for(name, attempts \\ 200)
+  defp wait_for(name, 0), do: flunk("#{name} never came back")
+
+  defp wait_for(name, attempts) do
+    case Process.whereis(name) do
+      nil ->
+        Process.sleep(10)
+        wait_for(name, attempts - 1)
+
+      pid ->
+        pid
+    end
   end
 
   describe "headless runtimes" do

--- a/packages/raxol_console/test/raxol/console/inbound_test.exs
+++ b/packages/raxol_console/test/raxol/console/inbound_test.exs
@@ -224,6 +224,41 @@ defmodule Raxol.Console.InboundTest do
       assert Inbound.authorized?(:inb_crash_enforce, route("alice"))
       refute Inbound.authorized?(:inb_crash_enforce, route("mallory"))
     end
+
+    # The caller is the deployment's feed loop, pumping a batch it cannot replay.
+    # An uncaught exit from the authorization call would take that loop down
+    # mid-batch. A Pairing that cannot answer denies -- it does not raise, and it
+    # does not fall through to the router.
+    test "a Pairing server that cannot answer denies instead of exiting the caller" do
+      unbooted = :inb_no_such_console
+
+      assert Process.whereis(Inbound.pairing_name(unbooted)) == nil
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          refute Inbound.authorized?(unbooted, route("anyone"))
+
+          assert {:error, :unauthorized} =
+                   Inbound.route(unbooted, route("anyone"), %{text: "hi"})
+        end)
+
+      assert log =~ "pairing server unreachable, denying"
+    end
+
+    # A route the adapter built from wire input, which Route.new/1 does not
+    # validate. This used to crash the Pairing server -- and Pairing is the first
+    # :rest_for_one child, so it took every live session with it.
+    test "a malformed user id denies and leaves the runtime standing" do
+      boot(:inb_malformed, pairing: [allowed_users: ["alice"]])
+      pairing = Process.whereis(Inbound.pairing_name(:inb_malformed))
+
+      bad = Route.new(%{platform: :in_memory, chat_type: :dm, chat_id: "c", user_id: %{"a" => 1}})
+
+      assert {:error, :unauthorized} = Inbound.route(:inb_malformed, bad, %{text: "hi"})
+      assert Process.alive?(pairing)
+      assert SessionRouter.session_count(Inbound.router_name(:inb_malformed)) == 0
+      assert :ok = Inbound.route(:inb_malformed, route("alice"), %{text: "hi"})
+    end
   end
 
   defp restart_pairing(console) do

--- a/packages/raxol_console/test/raxol/console/runtime_config_test.exs
+++ b/packages/raxol_console/test/raxol/console/runtime_config_test.exs
@@ -279,6 +279,80 @@ defmodule Raxol.Console.RuntimeConfigTest do
     end
   end
 
+  # Who may open a chat. Unset means open, because Pairing's allowlists boot
+  # empty and enforcing by default would deny every Console running today --
+  # which makes silence the permissive answer, so Boot makes silence loud.
+  describe "pairing" do
+    test "unset is open and undeclared, which is what earns the boot warning" do
+      assert {:ok, cfg} = RuntimeConfig.build(package())
+      assert cfg.pairing.mode == :open
+      refute cfg.pairing.declared?
+    end
+
+    test "an explicit :open is open and declared" do
+      assert {:ok, cfg} = RuntimeConfig.build(package(), pairing: :open)
+      assert cfg.pairing.mode == :open
+      assert cfg.pairing.declared?
+    end
+
+    test "an empty list enforces with nothing seeded" do
+      assert {:ok, cfg} = RuntimeConfig.build(package(), pairing: [])
+      assert cfg.pairing.mode == :enforce
+      assert cfg.pairing.allow_platforms == []
+      assert cfg.pairing.allowed_users == []
+      assert cfg.pairing.platform_users == []
+    end
+
+    test "carries the three allowlists through" do
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(),
+                 pairing: [
+                   allow_platforms: [:telegram],
+                   allowed_users: ["alice"],
+                   platform_users: [discord: ["bob"]]
+                 ]
+               )
+
+      assert cfg.pairing.mode == :enforce
+      assert cfg.pairing.allow_platforms == [:telegram]
+      assert cfg.pairing.allowed_users == ["alice"]
+      assert cfg.pairing.platform_users == [discord: ["bob"]]
+    end
+
+    # Pairing stringifies on both allow/3 and the authorize check, so an integer
+    # Telegram id written as an integer has to normalize to the same thing.
+    test "stringifies integer user ids so they match the route's" do
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(),
+                 pairing: [allowed_users: [12_345], platform_users: [telegram: [678]]]
+               )
+
+      assert cfg.pairing.allowed_users == ["12345"]
+      assert cfg.pairing.platform_users == [telegram: ["678"]]
+    end
+
+    # A typo'd key would seed nothing and read as a deliberate deny-all, which is
+    # indistinguishable from `pairing: []` and locks the operator out silently.
+    test "refuses an unknown key rather than ignoring it" do
+      assert {:error, {:unknown_pairing_keys, [:allowed_user]}} =
+               RuntimeConfig.build(package(), pairing: [allowed_user: ["alice"]])
+    end
+
+    test "refuses a malformed posture" do
+      assert {:error, {:invalid_pairing, :everyone}} =
+               RuntimeConfig.build(package(), pairing: :everyone)
+
+      assert {:error, {:invalid_pairing, {:allow_platforms, ["telegram"]}}} =
+               RuntimeConfig.build(package(), pairing: [allow_platforms: ["telegram"]])
+
+      assert {:error, {:invalid_pairing, {:allowed_users, [%{}]}}} =
+               RuntimeConfig.build(package(), pairing: [allowed_users: [%{}]])
+
+      assert {:error, {:invalid_pairing, {:platform_users, :discord, "bob"}}} =
+               RuntimeConfig.build(package(), pairing: [platform_users: [discord: "bob"]])
+    end
+  end
+
   test "rejects a non-package" do
     assert {:error, {:not_a_package, %{}}} = RuntimeConfig.build(%{})
   end

--- a/packages/raxol_console/test/raxol/console/runtime_config_test.exs
+++ b/packages/raxol_console/test/raxol/console/runtime_config_test.exs
@@ -351,6 +351,31 @@ defmodule Raxol.Console.RuntimeConfigTest do
       assert {:error, {:invalid_pairing, {:platform_users, :discord, "bob"}}} =
                RuntimeConfig.build(package(), pairing: [platform_users: [discord: "bob"]])
     end
+
+    # `nil` is an atom, so a platform resolved from a lookup that missed would
+    # pass an `is_atom/1` check, name no channel, and grant nothing -- the same
+    # silent lockout an unknown key is refused for.
+    test "refuses nil and booleans as platform atoms" do
+      assert {:error, {:invalid_pairing, {:allow_platforms, [nil]}}} =
+               RuntimeConfig.build(package(), pairing: [allow_platforms: [nil]])
+
+      assert {:error, {:invalid_pairing, {:allow_platforms, [true]}}} =
+               RuntimeConfig.build(package(), pairing: [allow_platforms: [true]])
+
+      assert {:error, {:invalid_pairing, {:platform_users, nil, ["bob"]}}} =
+               RuntimeConfig.build(package(), pairing: [platform_users: [{nil, ["bob"]}]])
+    end
+
+    # A keyword list admits duplicates; Pairing unions them when it seeds, so
+    # both sets are carried through here rather than the last one winning.
+    test "carries a platform named twice through as written" do
+      assert {:ok, cfg} =
+               RuntimeConfig.build(package(),
+                 pairing: [platform_users: [telegram: ["a"], telegram: ["b"]]]
+               )
+
+      assert cfg.pairing.platform_users == [telegram: ["a"], telegram: ["b"]]
+    end
   end
 
   test "rejects a non-package" do

--- a/packages/raxol_console/test/test_helper.exs
+++ b/packages/raxol_console/test/test_helper.exs
@@ -1,1 +1,7 @@
-ExUnit.start()
+# Every test in this suite boots a Console runtime: a supervision tree with a
+# scheduler, a reconciler, a gateway (pairing + session supervisor + router) and
+# sometimes a per-chat TEA app. A "chat turn" assertion is therefore waiting on
+# a supervised agent turn, not on a message send, and ExUnit's 100ms default is
+# the wrong order of magnitude for it -- tight enough that merely adding test
+# cases to the suite made unrelated ones flake.
+ExUnit.start(assert_receive_timeout: 2_000)

--- a/packages/raxol_gateway/lib/raxol/gateway/pairing.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/pairing.ex
@@ -20,6 +20,23 @@ defmodule Raxol.Gateway.Pairing do
 
   `:code_ttl_ms` (1h), `:request_cooldown_ms` (30s), `:max_failures` (5),
   `:lockout_ms` (5m), `:code_length` (8).
+
+  ## Seeds, and why the configured posture is not runtime state
+
+  `:allow_platforms`, `:allowed_users` and `:platform_users` are applied at
+  `init_manager/1` on every start, including a supervisor RESTART. The
+  runtime-mutable calls (`allow/3`, `allow_platform_all/2`, `approve/2`) exist
+  alongside them and are lost on restart, which is what in-memory pairing means.
+
+  The split matters because the two failure modes are not symmetric. Losing a
+  DM pairing costs one user one re-pair. Losing the configured posture is total
+  and silent in BOTH directions: an `:open` deployment starts denying every
+  message forever, and an enforcing one revokes every allowlist entry it was
+  given. Neither re-announces itself, because the boot that announced it already
+  happened. Seeding from opts means a crash restores the deployment's intent
+  rather than an empty server that no caller can tell from a configured one.
+
+      {Raxol.Gateway.Pairing, name: :gw_pairing, allow_platforms: [:telegram]}
   """
 
   use Raxol.Core.Behaviours.BaseManager
@@ -89,13 +106,21 @@ defmodule Raxol.Gateway.Pairing do
        config: config,
        pending: %{},
        approved: MapSet.new(),
-       allow_global: MapSet.new(),
-       allow_platform: %{},
-       allow_all_platforms: MapSet.new(),
+       allow_global: MapSet.new(Enum.map(opt_list(opts, :allowed_users), &to_string/1)),
+       allow_platform: seed_platform_users(opts),
+       allow_all_platforms: MapSet.new(opt_list(opts, :allow_platforms)),
        last_request: %{},
        failures: 0,
        locked_until: nil
      }}
+  end
+
+  defp opt_list(opts, key), do: opts |> Keyword.get(key, []) |> List.wrap()
+
+  defp seed_platform_users(opts) do
+    for {platform, users} <- opt_list(opts, :platform_users), into: %{} do
+      {platform, MapSet.new(users, &to_string/1)}
+    end
   end
 
   @impl Raxol.Core.Behaviours.BaseManager

--- a/packages/raxol_gateway/lib/raxol/gateway/pairing.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/pairing.ex
@@ -16,6 +16,19 @@ defmodule Raxol.Gateway.Pairing do
   after `:code_ttl_ms`, and repeated invalid confirms lock confirmation for
   `:lockout_ms` after `:max_failures`. The lockout is global for this slice.
 
+  ## Pairings and the global allowlist are NOT platform-scoped
+
+  Steps 2 and 4 above match on the user id alone. A pairing confirmed over
+  Telegram, or an id in `:allowed_users`, admits that same id STRING on every
+  connected platform. Platform id namespaces are unrelated -- a Telegram integer
+  id, a Discord snowflake and an email address are drawn from different spaces --
+  so this is a deliberate convenience, not an identity guarantee, and it is only
+  safe while those spaces do not collide.
+
+  Use `:platform_users` (step 3) or `allow/3` with `{:platform, atom}` when the
+  grant should mean "this id, on this platform". A deployment connecting two
+  platforms whose ids could collide should prefer them for everything.
+
   ## Config keys (all optional)
 
   `:code_ttl_ms` (1h), `:request_cooldown_ms` (30s), `:max_failures` (5),
@@ -117,10 +130,16 @@ defmodule Raxol.Gateway.Pairing do
 
   defp opt_list(opts, key), do: opts |> Keyword.get(key, []) |> List.wrap()
 
+  # Repeated platform keys UNION rather than overwrite. A keyword list admits
+  # duplicates and `into: %{}` would keep only the last, silently dropping every
+  # id named earlier -- a lockout indistinguishable from never having configured
+  # them, which is the ambiguity the Console's `known_keys/1` refuses one level
+  # up for a typo'd key.
   defp seed_platform_users(opts) do
-    for {platform, users} <- opt_list(opts, :platform_users), into: %{} do
-      {platform, MapSet.new(users, &to_string/1)}
-    end
+    Enum.reduce(opt_list(opts, :platform_users), %{}, fn {platform, users}, acc ->
+      ids = MapSet.new(users, &to_string/1)
+      Map.update(acc, platform, ids, fn existing -> MapSet.union(existing, ids) end)
+    end)
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
@@ -202,10 +221,21 @@ defmodule Raxol.Gateway.Pairing do
   defp decide(%Route{platform: platform, user_id: user_id}, state) do
     cond do
       MapSet.member?(state.allow_all_platforms, platform) -> :allow
-      allowed_user?(state, platform, user_id && to_string(user_id)) -> :allow
+      allowed_user?(state, platform, scalar_id(user_id)) -> :allow
       true -> :deny
     end
   end
+
+  # `authorize/2` runs INSIDE this server on a route an adapter built from wire
+  # input, and `Route.new/1` validates nothing. A `to_string/1` over whatever the
+  # payload carried would raise here rather than at the caller, and this server is
+  # the first `:rest_for_one` child -- so one malformed id would take the session
+  # supervisor and the router down with it, on every retry, for every chat. An id
+  # that is not a scalar cannot match a seeded allowlist entry anyway, so treating
+  # it as absent is the same answer without the crash.
+  defp scalar_id(id) when is_binary(id), do: id
+  defp scalar_id(id) when is_integer(id), do: Integer.to_string(id)
+  defp scalar_id(_id), do: nil
 
   defp allowed_user?(_state, _platform, nil), do: false
 

--- a/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
@@ -18,7 +18,23 @@ defmodule Raxol.Gateway.SessionRouter do
     * `:handler_init_timeout` -- passed to each session; ms its handler's
       `init/2` may take before the session is killed (default 30 seconds)
     * `:cooldown_ms` -- minimum ms between starts for one key (default 5000)
+    * `:authorize` -- `(Route.t() -> :allow | :deny)`, consulted before a session
+      is started or an event delivered. Unset allows everything.
     * `:name` -- the router's registered name
+
+  ## Authorization
+
+  The router is the narrow point every session passes through, so the gate goes
+  here rather than in each caller. `:authorize` is a function and not a Pairing
+  server name because the router does not depend on how the decision is made --
+  `Raxol.Gateway.Pairing` is one implementation, and a deployment with its own
+  identity system should not have to route around the gate to use it.
+
+  Wiring it means no caller can skip it: `route/3` and `start_session/2` are
+  public, and a feed loop that calls them directly gets the same decision the
+  documented path gets. Leaving it unset is the open posture, which is why
+  `Raxol.Console.Boot` always sets it -- an open Console is open because its
+  Pairing server allows those platforms, not because nothing asked.
 
   ## Telemetry
 
@@ -36,7 +52,7 @@ defmodule Raxol.Gateway.SessionRouter do
       `:shutdown`. Metadata adds `:reason`.
     * `:stopped` -- `stop_session/2` was called. Metadata adds `reason: :explicit`.
     * `:rejected` -- no session was started. Metadata adds `:reason`, one of
-      `:max_sessions` or `:rate_limited`.
+      `:max_sessions`, `:rate_limited` or `:unauthorized`.
 
   A `:started` with no `:ready` behind it is a handler that failed or hung at
   startup. Since handler init is deferred (see `Raxol.Gateway.Session`), that
@@ -64,8 +80,8 @@ defmodule Raxol.Gateway.SessionRouter do
   session's handler initializes asynchronously (see `Raxol.Gateway.Session`), so
   a handler that fails or hangs at startup does so after this has replied;
   `[:raxol_gateway, :session, :ready]`, `:down` and `:init_timeout` are what
-  report that. An `{:error, _}` here is only ever a routing refusal --
-  `:max_sessions` or `:rate_limited`.
+  report that. An `{:error, _}` here is only ever a refusal to route --
+  `:unauthorized`, `:max_sessions` or `:rate_limited`.
   """
   @spec route(GenServer.server(), Route.t(), term()) :: :ok | {:error, term()}
   def route(server, %Route{} = route, event) do
@@ -114,6 +130,7 @@ defmodule Raxol.Gateway.SessionRouter do
        handler: Keyword.fetch!(opts, :handler),
        sessions_sup: Keyword.fetch!(opts, :sessions_sup),
        deliver: resolve_deliver(opts),
+       authorize: Keyword.get(opts, :authorize),
        log: Keyword.get(opts, :log),
        max_sessions: Keyword.get(opts, :max_sessions, @default_max_sessions),
        idle_timeout: Keyword.get(opts, :idle_timeout, @default_idle_timeout),
@@ -176,14 +193,27 @@ defmodule Raxol.Gateway.SessionRouter do
 
   # -- session lifecycle ------------------------------------------------------
 
+  # Authorization is checked on EVERY event, not only on the start that creates
+  # the session. A revoked user whose session is still within its idle timeout
+  # would otherwise keep being served from the grant they no longer hold.
   defp ensure_session(route, state) do
     key = Route.key(route)
 
-    case Map.get(state.sessions, key) do
-      nil -> start_guarded(key, route, state)
-      pid -> {:ok, pid, state}
+    cond do
+      not authorized?(route, state) ->
+        emit(:rejected, %{key: key, reason: :unauthorized})
+        {:error, :unauthorized}
+
+      pid = Map.get(state.sessions, key) ->
+        {:ok, pid, state}
+
+      true ->
+        start_guarded(key, route, state)
     end
   end
+
+  defp authorized?(_route, %{authorize: nil}), do: true
+  defp authorized?(route, %{authorize: fun}), do: fun.(route) == :allow
 
   defp start_guarded(key, route, state) do
     cond do
@@ -253,9 +283,22 @@ defmodule Raxol.Gateway.SessionRouter do
   # Start (or reuse) the destination session, carrying the source's
   # conversation_id so a configured log resumes the same history. A live
   # destination session keeps its own conversation_id (no mid-life rebind).
+  # A handoff creates a session on a route the source conversation named, so it
+  # is a session start like any other and the destination is authorized on its
+  # own terms. Otherwise "follow me to Discord" would be a way to open a chat
+  # the gate would have refused directly.
   defp rebind(conversation_id, to_route, state) do
     to_key = Route.key(to_route)
 
+    if authorized?(to_route, state) do
+      rebind_authorized(conversation_id, to_route, to_key, state)
+    else
+      emit(:rejected, %{key: to_key, reason: :unauthorized})
+      {:reply, {:error, :unauthorized}, state}
+    end
+  end
+
+  defp rebind_authorized(conversation_id, to_route, to_key, state) do
     case Map.get(state.sessions, to_key) do
       nil ->
         case do_start(to_key, to_route, conversation_id, state) do

--- a/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/session_router.ex
@@ -36,6 +36,11 @@ defmodule Raxol.Gateway.SessionRouter do
   `Raxol.Console.Boot` always sets it -- an open Console is open because its
   Pairing server allows those platforms, not because nothing asked.
 
+  The function runs inside the router's own call, so it should be cheap: every
+  event pays for it, including events for sessions that already exist. A function
+  that raises or exits is logged and DENIES rather than crashing the router --
+  a gate that cannot answer is not a reason to serve the chat.
+
   ## Telemetry
 
   Every event is `[:raxol_gateway, :session, event]`, measured
@@ -60,6 +65,8 @@ defmodule Raxol.Gateway.SessionRouter do
   """
 
   use Raxol.Core.Behaviours.BaseManager
+
+  require Logger
 
   alias Raxol.Gateway.Route
   alias Raxol.Gateway.Session
@@ -213,7 +220,26 @@ defmodule Raxol.Gateway.SessionRouter do
   end
 
   defp authorized?(_route, %{authorize: nil}), do: true
-  defp authorized?(route, %{authorize: fun}), do: fun.(route) == :allow
+
+  # The gate runs inside this server's own call, so a raising or exiting
+  # `:authorize` would take the router down and wipe every session it tracks
+  # while the session processes themselves live on, orphaned under the dynamic
+  # supervisor. The common cause is the decision living in another process --
+  # `Raxol.Gateway.Pairing` is one -- which is unreachable for the window of its
+  # own restart. Same treatment as `fetch_conversation_id/1`: absorb it here and
+  # answer. A gate that cannot answer denies; the alternative is serving a chat
+  # because the thing that would have refused it was briefly down.
+  defp authorized?(route, %{authorize: fun}) do
+    fun.(route) == :allow
+  rescue
+    error ->
+      Logger.warning("gateway :authorize raised, denying: #{Exception.message(error)}")
+      false
+  catch
+    :exit, reason ->
+      Logger.warning("gateway :authorize exited, denying: #{inspect(reason)}")
+      false
+  end
 
   defp start_guarded(key, route, state) do
     cond do

--- a/packages/raxol_gateway/lib/raxol/gateway/supervisor.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/supervisor.ex
@@ -21,10 +21,15 @@ defmodule Raxol.Gateway.Supervisor do
     * `:router` / `:pairing` -- extra opts merged into those children
 
   `:rest_for_one` also means a Pairing crash restarts the sessions and the
-  router behind it. That is deliberate: the router holds a closure over the
-  Pairing server, and sessions authorized under the pre-crash posture should not
-  outlive it. Pass the posture as `:pairing` seed opts rather than calling the
-  running server, so the restart rebuilds it -- see `Raxol.Gateway.Pairing`.
+  router behind it. That is deliberate: sessions authorized under the pre-crash
+  posture should not outlive it. (The router's `:authorize` closure captures a
+  NAME, so it would survive on its own -- the restart is about the sessions.)
+  Pass the posture as `:pairing` seed opts rather than calling the running
+  server, so the restart rebuilds it -- see `Raxol.Gateway.Pairing`.
+
+  The corollary is that Pairing sits on the hot path of every event with the
+  blast radius of every session behind it, so it must not crash on wire input.
+  `authorize/2` fails closed on a malformed route rather than raising.
   """
 
   use Supervisor

--- a/packages/raxol_gateway/lib/raxol/gateway/supervisor.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/supervisor.ex
@@ -15,7 +15,16 @@ defmodule Raxol.Gateway.Supervisor do
       `Raxol.Gateway.Pairing`)
     * `:sessions_sup` -- the session supervisor's name (default
       `Raxol.Gateway.SessionSup`)
+    * `:authorize` -- `(Route.t() -> :allow | :deny)` the router consults before
+      starting a session or delivering an event (see `SessionRouter`). Unset
+      allows everything.
     * `:router` / `:pairing` -- extra opts merged into those children
+
+  `:rest_for_one` also means a Pairing crash restarts the sessions and the
+  router behind it. That is deliberate: the router holds a closure over the
+  Pairing server, and sessions authorized under the pre-crash posture should not
+  outlive it. Pass the posture as `:pairing` seed opts rather than calling the
+  running server, so the restart rebuilds it -- see `Raxol.Gateway.Pairing`.
   """
 
   use Supervisor
@@ -37,6 +46,7 @@ defmodule Raxol.Gateway.Supervisor do
       ]
       |> put_if(:adapter, Keyword.get(opts, :adapter))
       |> put_if(:deliver, Keyword.get(opts, :deliver))
+      |> put_if(:authorize, Keyword.get(opts, :authorize))
       |> Keyword.merge(Keyword.get(opts, :router, []))
 
     pairing_opts =

--- a/packages/raxol_gateway/test/raxol/gateway/pairing_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/pairing_test.exs
@@ -119,6 +119,17 @@ defmodule Raxol.Gateway.PairingTest do
       assert :allow = Pairing.authorize(p, route(:telegram, "678"))
     end
 
+    # A keyword list admits duplicate keys, and collecting them `into: %{}` would
+    # keep only the last -- silently dropping every id named earlier. That is a
+    # lockout indistinguishable from never having configured them, which is the
+    # ambiguity `known_keys/1` refuses one level up for a typo'd key.
+    test "a platform named twice unions its ids rather than keeping the last" do
+      p = start_pairing(platform_users: [telegram: ["first"], telegram: ["second"]])
+
+      assert :allow = Pairing.authorize(p, route(:telegram, "first"))
+      assert :allow = Pairing.authorize(p, route(:telegram, "second"))
+    end
+
     test "the seeded posture survives a restart; a runtime pairing does not" do
       name = :"pairing_restart_#{System.unique_integer([:positive])}"
 
@@ -163,6 +174,33 @@ defmodule Raxol.Gateway.PairingTest do
         pid ->
           pid
       end
+    end
+  end
+
+  # `authorize/2` runs INSIDE this server, on a route an adapter built from wire
+  # input that `Route.new/1` does not validate. A `user_id` that is not a scalar
+  # used to raise `Protocol.UndefinedError` in `decide/2` -- and since Pairing is
+  # the first `:rest_for_one` child, that crash took the session supervisor and
+  # the router with it, on every retry, for every chat.
+  describe "a malformed route" do
+    test "denies rather than crashing the server" do
+      p = start_pairing(allowed_users: ["alice"])
+      pid = Process.whereis(p)
+
+      for bad <- [%{"a" => 1}, {:tuple, 1}, ["list"], self()] do
+        assert :deny = Pairing.authorize(p, route(:telegram, bad))
+      end
+
+      assert Process.alive?(pid)
+      assert :allow = Pairing.authorize(p, route(:telegram, "alice"))
+    end
+
+    # Normalizing with a bare `to_string/1` would turn a nil id into "", which an
+    # allowlist holding "" would then match.
+    test "a nil user id denies, and does not become the empty string" do
+      p = start_pairing(allowed_users: [""])
+
+      assert :deny = Pairing.authorize(p, route(:telegram, nil))
     end
   end
 end

--- a/packages/raxol_gateway/test/raxol/gateway/pairing_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/pairing_test.exs
@@ -90,4 +90,79 @@ defmodule Raxol.Gateway.PairingTest do
       assert :deny = Pairing.authorize(p, route(:telegram, nil))
     end
   end
+
+  # A crash must not silently reverse the deployment's posture. Seeded from
+  # opts, `init_manager/1` rebuilds it; seeded by calls against a running
+  # server, a restart leaves an empty server no caller can distinguish from a
+  # configured one -- open Consoles start denying everything, enforcing ones
+  # forget their allowlist, and the boot that announced the posture is long past.
+  describe "seeds" do
+    test "an allowlist given as start opts is applied at init" do
+      p =
+        start_pairing(
+          allow_platforms: [:telegram],
+          allowed_users: ["u-global"],
+          platform_users: [discord: ["u-discord"]]
+        )
+
+      assert :allow = Pairing.authorize(p, route(:telegram, "anyone"))
+      assert :allow = Pairing.authorize(p, route(:slack, "u-global"))
+      assert :allow = Pairing.authorize(p, route(:discord, "u-discord"))
+      assert :deny = Pairing.authorize(p, route(:slack, "u-discord"))
+      assert :deny = Pairing.authorize(p, route(:discord, "nobody"))
+    end
+
+    test "integer user ids seed the same as the strings a route carries" do
+      p = start_pairing(allowed_users: [12_345], platform_users: [telegram: [678]])
+
+      assert :allow = Pairing.authorize(p, route(:slack, "12345"))
+      assert :allow = Pairing.authorize(p, route(:telegram, "678"))
+    end
+
+    test "the seeded posture survives a restart; a runtime pairing does not" do
+      name = :"pairing_restart_#{System.unique_integer([:positive])}"
+
+      sup =
+        start_supervised!(%{
+          id: :sup_for_pairing_restart,
+          start:
+            {Supervisor, :start_link,
+             [
+               [{Pairing, [name: name, allow_platforms: [:telegram]]}],
+               [strategy: :one_for_one]
+             ]}
+        })
+
+      :ok = Pairing.approve(name, "u-runtime")
+      assert :allow = Pairing.authorize(name, route(:discord, "u-runtime"))
+      assert :allow = Pairing.authorize(name, route(:telegram, "anyone"))
+
+      ref = Process.monitor(Process.whereis(name))
+      Process.exit(Process.whereis(name), :kill)
+      assert_receive {:DOWN, ^ref, :process, _pid, :killed}
+      wait_for_restart(name)
+
+      # The configured posture is back.
+      assert :allow = Pairing.authorize(name, route(:telegram, "anyone"))
+      # The in-memory pairing is not, which is what in-memory means.
+      assert :deny = Pairing.authorize(name, route(:discord, "u-runtime"))
+
+      Supervisor.stop(sup)
+    end
+
+    defp wait_for_restart(name, attempts \\ 100)
+
+    defp wait_for_restart(name, 0), do: flunk("#{name} never restarted")
+
+    defp wait_for_restart(name, attempts) do
+      case Process.whereis(name) do
+        nil ->
+          Process.sleep(10)
+          wait_for_restart(name, attempts - 1)
+
+        pid ->
+          pid
+      end
+    end
+  end
 end

--- a/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
@@ -301,5 +301,100 @@ defmodule Raxol.Gateway.SessionRouterTest do
     assert {:error, :rate_limited} = SessionRouter.start_session(r, rt)
   end
 
+  # The router is the narrow point every session passes through, so a gate here
+  # holds for callers that never heard of the gate. Without it, authorization
+  # lives in whichever call site remembered it -- which is how #884 happened.
+  describe ":authorize" do
+    setup do
+      test_pid = self()
+      sup = :"sup_#{uid()}"
+      start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: sup})
+      router = :"gated_router_#{uid()}"
+
+      start_supervised!(%{
+        id: router,
+        start:
+          {SessionRouter, :start_link,
+           [
+             [
+               name: router,
+               handler: {EchoHandler, []},
+               sessions_sup: sup,
+               deliver: fn route, rendered -> send(test_pid, {:out, route, rendered}) end,
+               authorize: fn %Route{user_id: id} ->
+                 if id == "u1", do: :allow, else: :deny
+               end
+             ]
+           ]}
+      })
+
+      %{gated: router}
+    end
+
+    test "refuses an event for an unauthorized route, starting no session", %{gated: r} do
+      assert {:error, :unauthorized} = SessionRouter.route(r, route(2), {:say, "hi"})
+      assert SessionRouter.session_count(r) == 0
+      refute_receive {:out, _, _}, 50
+    end
+
+    test "refuses start_session/2, so the bypass is not one call over", %{gated: r} do
+      assert {:error, :unauthorized} = SessionRouter.start_session(r, route(2))
+      assert SessionRouter.session_count(r) == 0
+    end
+
+    test "serves an authorized route normally", %{gated: r} do
+      assert :ok = SessionRouter.route(r, route(1), {:say, "hi"})
+      assert_receive {:out, _route, "echo: hi"}
+    end
+
+    test "re-checks every event, so a revoked session stops being served" do
+      # A grant checked only at session start would keep serving a revoked user
+      # for the rest of the idle timeout.
+      test_pid = self()
+      sup = :"sup_#{uid()}"
+      start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: sup})
+      router = :"revoking_router_#{uid()}"
+      {:ok, allowed} = Agent.start_link(fn -> true end)
+
+      start_supervised!(%{
+        id: router,
+        start:
+          {SessionRouter, :start_link,
+           [
+             [
+               name: router,
+               handler: {EchoHandler, []},
+               sessions_sup: sup,
+               deliver: fn route, rendered -> send(test_pid, {:out, route, rendered}) end,
+               authorize: fn _route ->
+                 if Agent.get(allowed, & &1), do: :allow, else: :deny
+               end
+             ]
+           ]}
+      })
+
+      assert :ok = SessionRouter.route(router, route(1), {:say, "first"})
+      assert_receive {:out, _, "echo: first"}
+
+      Agent.update(allowed, fn _ -> false end)
+
+      assert {:error, :unauthorized} = SessionRouter.route(router, route(1), {:say, "second"})
+      refute_receive {:out, _, "echo: second"}, 50
+    end
+
+    test "refuses a handoff onto an unauthorized route", %{gated: r} do
+      from = route(1)
+      assert {:ok, _} = SessionRouter.start_session(r, from)
+
+      to = Route.new(%{platform: :discord, chat_type: :dm, chat_id: "d", user_id: "u9"})
+      assert {:error, :unauthorized} = SessionRouter.handoff(r, Route.key(from), to)
+    end
+
+    test "an unset :authorize allows everything, so the gateway stays usable bare", %{router: r} do
+      assert :ok = SessionRouter.route(r, route(7), {:say, "hi"})
+      assert_receive {:out, _route, "echo: hi"}
+    end
+  end
+
   defp uid, do: System.unique_integer([:positive])
 end

--- a/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/session_router_test.exs
@@ -394,6 +394,46 @@ defmodule Raxol.Gateway.SessionRouterTest do
       assert :ok = SessionRouter.route(r, route(7), {:say, "hi"})
       assert_receive {:out, _route, "echo: hi"}
     end
+
+    # The gate runs inside the router's own call. An uncaught raise or exit would
+    # kill the router and wipe its session map while the session processes lived
+    # on, orphaned under the dynamic supervisor. The usual cause is the decision
+    # living in another process (Pairing) that is inside its own restart window.
+    for {label, boom} <- [
+          {"raises", quote(do: raise("gate is broken"))},
+          {"exits", quote(do: exit({:noproc, {GenServer, :call, [:gone, :authorize]}}))}
+        ] do
+      test "an :authorize that #{label} denies, and the router survives it" do
+        test_pid = self()
+        sup = :"sup_#{uid()}"
+        start_supervised!({DynamicSupervisor, strategy: :one_for_one, name: sup})
+        router = :"broken_gate_router_#{uid()}"
+
+        start_supervised!(%{
+          id: router,
+          start:
+            {SessionRouter, :start_link,
+             [
+               [
+                 name: router,
+                 handler: {EchoHandler, []},
+                 sessions_sup: sup,
+                 deliver: fn route, rendered -> send(test_pid, {:out, route, rendered}) end,
+                 authorize: fn _route -> unquote(boom) end
+               ]
+             ]}
+        })
+
+        pid = Process.whereis(router)
+
+        assert {:error, :unauthorized} = SessionRouter.route(router, route(1), {:say, "hi"})
+        assert {:error, :unauthorized} = SessionRouter.start_session(router, route(1))
+
+        assert Process.whereis(router) == pid
+        assert SessionRouter.session_count(router) == 0
+        refute_receive {:out, _, _}, 50
+      end
+    end
   end
 
   defp uid, do: System.unique_integer([:positive])


### PR DESCRIPTION
`Raxol.Console.Boot` started a `Raxol.Gateway.Pairing` server and nothing ever
consulted it, so any inbound event that reached the router got a session.
`authorize/2` is documented across five adapters as the feed loop's job, but that
is guidance rather than an enforced seam -- and Console has no feed loop, so the
call site that was supposed to exist was never written.

Fixes #884. The gap predates #881 and affected `:chat` mode identically; #881
only raised the cost of an unauthorized session from a process plus a map to
roughly four processes and a screen buffer.

## The seam

`Raxol.Console.Inbound.route/3` is authorize-then-route in one call, so a
deployment's feed cannot wire the second half and forget the first:

```elixir
Raxol.Telegram.UpdatePoller.start_link(
  conn: conn,
  on_update: fn raw ->
    with {:ok, route, event} <- Raxol.Telegram.GatewayAdapter.normalize_event(raw) do
      Raxol.Console.Inbound.route(MyConsole, route, event)
    end
  end
)
```

Also `authorized?/2`, for a feed that would rather answer an unpaired sender than
drop them, and `pairing_name/1` / `router_name/1` so callers do not hand-build
`:"#{base}.pairing"`.

The gateway still cannot force this -- `SessionRouter.route/3` is public and a
deployment may call it -- but the documented path no longer has a step in it that
is easy to skip.

## Unconfigured deployments stay open, and are told so

Enforcing by default would deny every Console running today, because `Pairing`'s
allowlists boot empty. That makes silence the permissive answer, which is the
wrong way round. So silence is made loud rather than made safe: a multi-line
`Logger.warning` naming the connected platforms plus
`[:raxol_console, :pairing, :open]` telemetry, at every boot, unless the operator
wrote `pairing: :open` and has already made the call.

Open is applied by calling `Pairing.allow_platform_all/2` over the CONNECTED
platforms, not by branching around the gate. Both postures share one code path
through `Inbound.route/3`, and the posture is visible in the Pairing server's own
state. A platform the deployment never connected is denied even when open.

## Configuration

Through `@rc_keys`, validated in `RuntimeConfig.build/2`:

```elixir
config :raxol_console,
  pairing: [
    allow_platforms: [:telegram],          # everyone on these platforms
    allowed_users: ["12345"],              # global allowlist
    platform_users: [discord: ["9876"]]    # per-platform allowlist
  ]

  pairing: []      # enforce, nothing seeded -- DM pairing is the only way in
  pairing: :open   # keep today's behavior, silence the warning
```

`report.pairing` carries `:open | :enforce | :none`.

Three decisions not specified in the issue:

- **Unknown `:pairing` keys are refused, not ignored.** A typo'd `allowed_user:`
  would seed nothing and be indistinguishable from a deliberate `pairing: []` --
  a silent lockout.
- **Integer user ids are stringified at config time.** Telegram ids arrive as
  integers and `Pairing` stringifies on both `allow/3` and the check, so an
  integer in config has to normalize to the same thing.
- **Headless runtimes report `:none`.** No channels means `start_gateway/6`
  starts no gateway, so there is no Pairing server to seed and no inbound surface
  to warn about.

## Test-infra change worth a second look

`test/test_helper.exs` now sets `assert_receive_timeout: 2_000`.

Adding the new test file made two UNRELATED `boot_test` cases fail. That is not a
regression: both are bare `assert_receive` at ExUnit's 100ms default, waiting on
a full agent turn through a supervised gateway session, and the extra boots
pushed them over. #881 had already special-cased one assertion in that same file
at `5_000`. I raised the suite default rather than patch individual lines,
because every test here boots a supervision tree and 100ms is the wrong order of
magnitude for the whole file. Bisected against master to confirm the base passes
and the cause is load, not behavior.

## Manual testing

- [x] `MIX_ENV=test mix test` in `packages/raxol_console` -- 72 pass, seeds 0, 1, 42
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] End-to-end: an enforced Console answers `{:error, :unauthorized}` for a
      denied sender with `session_count == 0`, and `:ok` for an allowed one
- [x] Unconfigured boot emits the warning and the telemetry; `pairing: :open`
      emits neither
- [x] `pairing: []` denies a stranger, then admits them after
      `request_code/2` -> `confirm/2` on the live runtime
- [ ] Not covered: a real Telegram/Discord/email feed wired through
      `Inbound.route/3` against a live bot
