### PR TITLE
Ask the chain if the pull signature will verify

### DIFF
--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -53,8 +53,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   Every run, `--dry-run` included, ends the signing step by asking the origin
   pull's verifying contract for its own `DOMAIN_SEPARATOR()` and asking the buyer
-  whether the signature just produced covers the digest that yields. Three
-  `eth_call`s, no writes.
+  whether the signature just produced covers the digest that yields. Four
+  read-only calls (`eth_chainId`, `eth_getCode`, and one `eth_call` each), no
+  writes.
 
   A real run proceeds only when that check PASSES. A rejection means the pull
   would revert on settlement; an inconclusive result means nobody knows, and the
@@ -161,6 +162,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   alias Raxol.Earn.Xochi.OriginPull
   alias Raxol.Earn.Xochi.PullPreflight
   alias Raxol.Payments.Assets
+  alias Raxol.Payments.Protocols.Permit2
   alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
   alias Raxol.Payments.Xochi.{PullContracts, Schemas.QuoteRequest}
 
@@ -764,7 +766,7 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # `check_origin_pull/3` decides the pull's SHAPE is safe to sign. This asks
   # whether the signature just produced will actually be accepted, which is a
   # different question and the one every funded attempt on GitHub #772 has lost:
-  # the shape passed each time, and the digest was wrong. The two `eth_call`s
+  # the shape passed each time, and the digest was wrong. Four read-only calls
   # cost nothing and happen before any write.
   #
   # A real run proceeds on `{:ok, _}` and nothing else. Continuing on anything
@@ -773,37 +775,66 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # and expired. Under `--dry-run` it only reports -- rehearsing the failure is
   # the reason that mode exists.
   #
-  # An inconclusive check blocks too, and the asymmetry that would make it not
-  # block does not exist: this reads `cfg.rpc`, the same endpoint the funding
-  # writes go to moments later, so a node too unwell to answer two `eth_call`s is
-  # not about to mine a `createJob`. Refusing costs a re-run; proceeding costs an
-  # escrow. What an inconclusive result must not do is claim the SIGNATURE is
-  # bad, and `PullPreflight.describe/1` keeps those separate in the log.
-  defp preflight_pull(_cfg, %{pull_authorization: nil}, _bundle, _opts), do: :ok
+  # An inconclusive check blocks too. Refusing costs a re-run; proceeding costs
+  # an escrow, and there is no reading of "nobody could answer" that makes the
+  # escrow the better bet. Note this reads `cfg.rpc`, the ORIGIN chain's
+  # endpoint, which is NOT where `createJob` and `fund` go -- those go to
+  # `cfg.acp_rpc` on Base, and the two are the same endpoint only when the origin
+  # IS Base or `ORDER_RPC_<from>` is unset. So an inconclusive result says
+  # nothing about whether the funding writes would land; it says the question
+  # this gate exists to answer went unanswered, which is reason enough on its
+  # own. What it must not do is claim the SIGNATURE is bad, and
+  # `PullPreflight.describe/1` keeps those separate in the log.
+  # Public, like `decide_preflight/2`, only so the money decision can be tested.
+  # A missing signature aborts `--dry-run` too: it is not a preflight VERDICT to
+  # rehearse, it is a bundle with nothing in it to check, and a dry run whose
+  # purpose is to rehearse the real thing should say so.
+  @doc false
+  def preflight_pull(_cfg, %{pull_authorization: nil}, _bundle, _opts), do: :ok
 
-  defp preflight_pull(cfg, quote_resp, bundle, opts) do
-    case bundle[:pull_signature] || bundle["pull_signature"] do
-      nil ->
-        :ok
+  def preflight_pull(cfg, quote_resp, bundle, opts) do
+    with {:ok, signature} <- pull_signature(bundle) do
+      outcome =
+        PullPreflight.verify(
+          quote_resp.pull_authorization,
+          signature,
+          cfg.buyer,
+          rpc: RPC.client(url: cfg.rpc),
+          expect_verifier: expected_verifier(quote_resp.payment_method, cfg)
+        )
 
-      signature ->
-        outcome =
-          PullPreflight.verify(
-            quote_resp.pull_authorization,
-            signature,
-            cfg.buyer,
-            rpc: RPC.client(url: cfg.rpc)
-          )
-
-        log(PullPreflight.describe(outcome))
-        decide_preflight(outcome, Keyword.get(opts, :dry_run, false))
+      log(PullPreflight.describe(outcome))
+      decide_preflight(outcome, Keyword.get(opts, :dry_run, false))
     end
   end
 
+  # The quote served a pull authorization, so the bundle must carry a signature
+  # over it. Reading a missing one as "nothing to check" would turn the gate off
+  # for exactly the payload it was built to gate -- the fail-open shape
+  # `PullPreflight` refuses to offer its callers, one level up.
+  defp pull_signature(bundle) do
+    case Map.get(bundle, :pull_signature) do
+      sig when is_binary(sig) -> {:ok, sig}
+      other -> {:error, {:pull_signature_missing, other}}
+    end
+  end
+
+  # WHO will check this signature, decided from the rail we asked for rather than
+  # from the payload under audit. `PullPreflight` reads `DOMAIN_SEPARATOR()` from
+  # this address, so leaving it to the served `verifyingContract` would let a
+  # hostile quote nominate its own oracle. Permit2 is one address on every chain;
+  # the ERC-3009 verifier is the origin token itself.
+  defp expected_verifier("permit2", _cfg), do: Permit2.verifying_contract()
+  defp expected_verifier("erc3009", cfg), do: cfg.src_token
+  defp expected_verifier(_method, _cfg), do: nil
+
   @doc false
   # Public only so the money decision itself can be tested. Every clause is
-  # explicit: there is no catch-all, so a new `PullPreflight` outcome is a
-  # compile-time gap here rather than a silent funded run.
+  # explicit and there is no catch-all: a `PullPreflight` outcome nobody named
+  # here raises `FunctionClauseError` inside `sign_intent/2`, which aborts the run
+  # before any write. Elixir will not tell you at compile time -- `mix dialyzer`
+  # is what catches the spec going stale -- but the runtime failure is the safe
+  # one, which is the property that matters.
   @spec decide_preflight(PullPreflight.outcome(), boolean()) :: :ok | {:error, atom()}
   def decide_preflight({:ok, _details}, _dry_run?), do: :ok
   def decide_preflight({:rejected, _details}, true = _dry_run?), do: :ok
@@ -1360,12 +1391,30 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     anything, because the most common cause is ORDER_RPC_<from-chain> being unset
     and falling back to the Base endpoint, which answers for the wrong chain.
 
-    This is not a claim that the signature is bad. It is a refusal to escrow a
-    fee on a question nobody answered: the same RPC serves the createJob and
-    fund writes that would come next, so a node that cannot answer two eth_calls
-    would not have carried the run much further anyway.
+    This is not a claim that the signature is bad, and it is not a claim about
+    the endpoint the funding writes go to: those go to ORDER_RPC_8453, while this
+    check reads ORDER_RPC_<from-chain>. It is a refusal to escrow a fee on a
+    question nobody answered. Fix the ORIGIN chain's endpoint, not Base's.
 
     Re-run once the endpoint answers, or with --dry-run to rehearse for free.
+    """
+  end
+
+  # The quote served a pull to sign and the bundle came back without a signature
+  # over it. Nothing is wrong on chain; the signing path did not produce what the
+  # settlement needs, and the gate cannot check a signature that is not there.
+  defp sign_intent_error({:pull_signature_missing, got}) do
+    """
+    the quote served an origin pull, but the signed bundle carries no
+    pull_signature (got #{inspect(got)}).
+
+    Nothing was written and nothing was escrowed. The solver will be asked to
+    pull funds on the origin chain and will have no authorization to do it with,
+    so this would strand a funded job exactly the way a bad signature does.
+
+    This is a defect in the signing path rather than in the quote or the chain:
+    Protocols.Xochi.sign_intent/4 attaches :pull_signature whenever the quote
+    carries a pull_authorization. Capture the bundle it returned.
     """
   end
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -62,10 +62,14 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   way the run stops before escrowing a fee it cannot earn, and the log line
   distinguishes the two so the next move is clear.
 
-  A rejection also fails `--dry-run`, non-zero, because the rehearsal is what CI
-  scores. An inconclusive check stays soft there: it says nothing about the
-  payload, and the usual cause is an origin-chain endpoint the rehearsing machine
-  was never given.
+  A rejection also fails `--dry-run`, non-zero: a rehearsal that reports the
+  defect and exits 0 is not rehearsing the real thing. An inconclusive check
+  stays soft there, because it says nothing about the payload and the usual
+  cause is an `ORDER_RPC_8453` the rehearsing machine cannot reach.
+
+  Note this is the MANUAL path. `scripts/run_live_gates.sh` does not invoke this
+  task; its `acp` cells drive the `:live_xochi_order_preflight` gate, which runs
+  the same `PullPreflight.verify/4` and applies the same rule there.
 
   A quote that served a pull with no signature in the signed bundle aborts BOTH
   modes. That is not a preflight verdict to rehearse -- it is a bundle with
@@ -780,20 +784,18 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # A real run proceeds on `{:ok, _}` and nothing else. Continuing on anything
   # weaker would `createJob` and escrow a fee for a settlement nobody has
   # confirmed can execute, which is how job 74047 ended up funded, unsettleable,
-  # and expired. A REJECTION fails `--dry-run` too, with a non-zero exit: the
-  # rehearsal is what CI runs, so a mode that reports the defect and exits 0
-  # scores the cell PASS and leaves the finding to whoever reads the log.
+  # and expired. A REJECTION fails `--dry-run` too, with a non-zero exit,
+  # because a rehearsal that reports the defect and exits 0 is reporting it, not
+  # rehearsing it.
   #
   # An inconclusive check blocks too. Refusing costs a re-run; proceeding costs
   # an escrow, and there is no reading of "nobody could answer" that makes the
-  # escrow the better bet. Note this reads `cfg.rpc`, the ORIGIN chain's
-  # endpoint, which is NOT where `createJob` and `fund` go -- those go to
-  # `cfg.acp_rpc` on Base, and the two are the same endpoint only when the origin
-  # IS Base or `ORDER_RPC_<from>` is unset. So an inconclusive result says
-  # nothing about whether the funding writes would land; it says the question
-  # this gate exists to answer went unanswered, which is reason enough on its
-  # own. What it must not do is claim the SIGNATURE is bad, and
-  # `PullPreflight.describe/1` keeps those separate in the log.
+  # escrow the better bet. This reads `cfg.rpc`, which `assert_acp_origin!/1`
+  # constrains to the ACP core's own chain -- so for this task it resolves to the
+  # SAME `ORDER_RPC_8453` the `createJob` and `fund` writes go to, and an
+  # inconclusive result here does mean those writes are in doubt as well. What it
+  # must not do is claim the SIGNATURE is bad, and `PullPreflight.describe/1`
+  # keeps those separate in the log.
   # Public, like `decide_preflight/2`, only so the money decision can be tested.
   # A missing signature aborts `--dry-run` too: it is not a preflight VERDICT to
   # rehearse, it is a bundle with nothing in it to check, and a dry run whose
@@ -851,20 +853,20 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   @spec decide_preflight(PullPreflight.outcome(), boolean()) :: :ok | {:error, atom()}
   def decide_preflight({:ok, _details}, _dry_run?), do: :ok
 
-  # A rejection fails BOTH modes, and the exit code is the point. `--dry-run` is
-  # what CI runs -- `scripts/run_live_gates.sh --dry-run` scores every cell on
-  # this task's exit status -- so returning `:ok` here made the rehearsal PASS on
-  # the one defect the rehearsal exists to find, leaving it as a single log line
-  # in a matrix of ninety. Rehearsing a failure means reproducing it without
-  # spending, not reporting it without failing.
+  # A rejection fails BOTH modes, and the exit code is the point. Returning `:ok`
+  # here made the rehearsal PASS on the one defect the rehearsal exists to find,
+  # leaving it as a single log line. Rehearsing a failure means reproducing it
+  # without spending, not reporting it without failing. The live-gate path
+  # applies the same rule at its own layer (`live_order_test.exs` fails the
+  # preflight cell on a REJECTED verdict); this task is the manual entry point.
   def decide_preflight({:rejected, _details}, _dry_run?),
     do: {:error, :pull_signature_rejected}
 
   # An inconclusive check stays soft under `--dry-run`. It is not a verdict on
-  # the payload, and the usual cause is an unset `ORDER_RPC_<from>` on a machine
-  # that was never meant to reach the origin chain -- failing a rehearsal for
-  # that trains an operator to ignore the exit code, which costs more than the
-  # signal is worth. A funded run still refuses.
+  # the payload, and the usual cause is an `ORDER_RPC_8453` the rehearsing
+  # machine cannot reach -- failing a rehearsal for that trains an operator to
+  # ignore the exit code, which costs more than the signal is worth. A funded run
+  # still refuses.
   def decide_preflight({:inconclusive, _reason}, true = _dry_run?), do: :ok
 
   def decide_preflight({:inconclusive, _reason}, false),
@@ -1401,8 +1403,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     attempts. Capture the served pull_authorization and compare its domain to the
     verifying contract's own DOMAIN_SEPARATOR() before re-running.
 
-    --dry-run reproduces this for free, and fails the same way: the rehearsal
-    is scored on this exit code.
+    --dry-run reproduces this for free, and fails the same way: a rehearsal that
+    printed this and exited 0 would not be rehearsing it.
     """
   end
 
@@ -1415,15 +1417,15 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
     Nothing was written and nothing was escrowed. The preflight line above says
     what stopped the check and what to do about it -- read it before changing
-    anything, because the most common cause is ORDER_RPC_<from-chain> being unset
-    and falling back to the Base endpoint, which answers for the wrong chain.
+    anything.
 
-    This is not a claim that the signature is bad, and it is not a claim about
-    the endpoint the funding writes go to: those go to ORDER_RPC_8453, while this
-    check reads ORDER_RPC_<from-chain>. It is a refusal to escrow a fee on a
-    question nobody answered. Fix the ORIGIN chain's endpoint, not Base's.
+    This is not a claim that the signature is bad. It is a refusal to escrow a
+    fee on a question nobody answered -- and since --corridor's origin is pinned
+    to the ACP core's own chain, the endpoint that could not answer is the SAME
+    ORDER_RPC_8453 the createJob and fund writes go to, so those are in doubt as
+    well.
 
-    Re-run once the endpoint answers, or with --dry-run to rehearse for free.
+    Re-run once ORDER_RPC_8453 answers, or with --dry-run to rehearse for free.
     """
   end
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -51,6 +51,14 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   `--dry-run` stops after signing and spends nothing.
 
+  Every run, `--dry-run` included, ends the signing step by asking the origin
+  pull's verifying contract for its own `DOMAIN_SEPARATOR()` and asking the buyer
+  whether the signature just produced covers the digest that yields. Two
+  `eth_call`s, no writes. A rejection means the pull would revert on settlement,
+  so a real run stops there rather than escrowing a fee it cannot earn; a
+  `--dry-run` reports it and carries on. See `Raxol.Earn.Xochi.PullPreflight` and
+  GitHub #772.
+
   ## Origin pull: the `--solver` pin
 
   The signed intent carries an origin-pull authorization letting the solver collect
@@ -145,7 +153,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     Transport
   }
 
+  alias Raxol.Earn.Onchain.RPC
   alias Raxol.Earn.Xochi.OriginPull
+  alias Raxol.Earn.Xochi.PullPreflight
   alias Raxol.Payments.Assets
   alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
   alias Raxol.Payments.Xochi.{PullContracts, Schemas.QuoteRequest}
@@ -741,10 +751,52 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
     with {:ok, quote_resp} <- XochiProtocol.get_quote(cfg.xochi_config, request),
          {:ok, pull} <- check_origin_pull(cfg, quote_resp, opts),
-         {:ok, bundle} <- XochiProtocol.sign_intent(quote_resp, cfg.intent_wallet, request) do
+         {:ok, bundle} <- XochiProtocol.sign_intent(quote_resp, cfg.intent_wallet, request),
+         :ok <- preflight_pull(cfg, quote_resp, bundle, opts) do
       {:ok, {bundle, pull}}
     end
   end
+
+  # `check_origin_pull/3` decides the pull's SHAPE is safe to sign. This asks
+  # whether the signature just produced will actually be accepted, which is a
+  # different question and the one every funded attempt on GitHub #772 has lost:
+  # the shape passed each time, and the digest was wrong. The two `eth_call`s
+  # cost nothing and happen before any write.
+  #
+  # A rejection aborts a real run. Continuing would `createJob` and escrow a fee
+  # for a settlement that provably cannot execute, which is how job 74047 ended
+  # up funded, unsettleable, and expired. Under `--dry-run` it only reports --
+  # rehearsing the failure is the reason that mode exists.
+  #
+  # An inconclusive check never blocks: an unreachable RPC is not evidence about
+  # a signature, and treating it as one would send the next debugging round after
+  # the wrong thing.
+  defp preflight_pull(_cfg, %{pull_authorization: nil}, _bundle, _opts), do: :ok
+
+  defp preflight_pull(cfg, quote_resp, bundle, opts) do
+    case bundle[:pull_signature] || bundle["pull_signature"] do
+      nil ->
+        :ok
+
+      signature ->
+        outcome =
+          PullPreflight.verify(
+            quote_resp.pull_authorization,
+            signature,
+            cfg.buyer,
+            rpc: RPC.client(url: cfg.rpc)
+          )
+
+        log(PullPreflight.describe(outcome))
+        decide_preflight(outcome, Keyword.get(opts, :dry_run, false))
+    end
+  end
+
+  defp decide_preflight({:error, {:signature_rejected, _}}, false = _dry_run?) do
+    {:error, :pull_signature_rejected}
+  end
+
+  defp decide_preflight(_outcome, _dry_run?), do: :ok
 
   # The Permit2 rail pulls through a standing ERC-20 allowance. Refusing an
   # unpinned or mismatched spender happens HERE, before the signature -- an
@@ -1256,6 +1308,28 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
     Do not widen the pin to whatever the quote served -- checking that value is
     the entire point of it.
+    """
+  end
+
+  # The signature exists and is well-formed; the contract that will verify it
+  # rebuilds a different digest. Settling is impossible, so the run stops here
+  # rather than at the far side of an escrow.
+  defp sign_intent_error(:pull_signature_rejected) do
+    """
+    the origin pull's signature will not verify on chain.
+
+    Nothing was written and nothing was escrowed. The preflight line above shows
+    which contract was asked and what it answered: the digest it rebuilds is not
+    the one this signature covers, so the pull would revert and the job would sit
+    funded and unsettleable until it expired.
+
+    That is a defect in what was signed, not a configuration you can retry
+    around. The domain the quote serves and the domain the verifier declares have
+    diverged -- see GitHub #772, where an extra `version` field cost four funded
+    attempts. Capture the served pull_authorization and compare its domain to the
+    verifying contract's own DOMAIN_SEPARATOR() before re-running.
+
+    Re-run with --dry-run to reproduce this for free.
     """
   end
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -60,8 +60,12 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   A real run proceeds only when that check PASSES. A rejection means the pull
   would revert on settlement; an inconclusive result means nobody knows. Either
   way the run stops before escrowing a fee it cannot earn, and the log line
-  distinguishes the two so the next move is clear. `--dry-run` reports both and
-  carries on, since it spends nothing.
+  distinguishes the two so the next move is clear.
+
+  A rejection also fails `--dry-run`, non-zero, because the rehearsal is what CI
+  scores. An inconclusive check stays soft there: it says nothing about the
+  payload, and the usual cause is an origin-chain endpoint the rehearsing machine
+  was never given.
 
   A quote that served a pull with no signature in the signed bundle aborts BOTH
   modes. That is not a preflight verdict to rehearse -- it is a bundle with
@@ -776,8 +780,9 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # A real run proceeds on `{:ok, _}` and nothing else. Continuing on anything
   # weaker would `createJob` and escrow a fee for a settlement nobody has
   # confirmed can execute, which is how job 74047 ended up funded, unsettleable,
-  # and expired. Under `--dry-run` it only reports -- rehearsing the failure is
-  # the reason that mode exists.
+  # and expired. A REJECTION fails `--dry-run` too, with a non-zero exit: the
+  # rehearsal is what CI runs, so a mode that reports the defect and exits 0
+  # scores the cell PASS and leaves the finding to whoever reads the log.
   #
   # An inconclusive check blocks too. Refusing costs a re-run; proceeding costs
   # an escrow, and there is no reading of "nobody could answer" that makes the
@@ -845,8 +850,21 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # one, which is the property that matters.
   @spec decide_preflight(PullPreflight.outcome(), boolean()) :: :ok | {:error, atom()}
   def decide_preflight({:ok, _details}, _dry_run?), do: :ok
-  def decide_preflight({:rejected, _details}, true = _dry_run?), do: :ok
-  def decide_preflight({:rejected, _details}, false), do: {:error, :pull_signature_rejected}
+
+  # A rejection fails BOTH modes, and the exit code is the point. `--dry-run` is
+  # what CI runs -- `scripts/run_live_gates.sh --dry-run` scores every cell on
+  # this task's exit status -- so returning `:ok` here made the rehearsal PASS on
+  # the one defect the rehearsal exists to find, leaving it as a single log line
+  # in a matrix of ninety. Rehearsing a failure means reproducing it without
+  # spending, not reporting it without failing.
+  def decide_preflight({:rejected, _details}, _dry_run?),
+    do: {:error, :pull_signature_rejected}
+
+  # An inconclusive check stays soft under `--dry-run`. It is not a verdict on
+  # the payload, and the usual cause is an unset `ORDER_RPC_<from>` on a machine
+  # that was never meant to reach the origin chain -- failing a rehearsal for
+  # that trains an operator to ignore the exit code, which costs more than the
+  # signal is worth. A funded run still refuses.
   def decide_preflight({:inconclusive, _reason}, true = _dry_run?), do: :ok
 
   def decide_preflight({:inconclusive, _reason}, false),
@@ -1383,7 +1401,8 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     attempts. Capture the served pull_authorization and compare its domain to the
     verifying contract's own DOMAIN_SEPARATOR() before re-running.
 
-    Re-run with --dry-run to reproduce this for free.
+    --dry-run reproduces this for free, and fails the same way: the rehearsal
+    is scored on this exit code.
     """
   end
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -53,11 +53,15 @@ defmodule Mix.Tasks.RaxolEarn.Order do
 
   Every run, `--dry-run` included, ends the signing step by asking the origin
   pull's verifying contract for its own `DOMAIN_SEPARATOR()` and asking the buyer
-  whether the signature just produced covers the digest that yields. Two
-  `eth_call`s, no writes. A rejection means the pull would revert on settlement,
-  so a real run stops there rather than escrowing a fee it cannot earn; a
-  `--dry-run` reports it and carries on. See `Raxol.Earn.Xochi.PullPreflight` and
-  GitHub #772.
+  whether the signature just produced covers the digest that yields. Three
+  `eth_call`s, no writes.
+
+  A real run proceeds only when that check PASSES. A rejection means the pull
+  would revert on settlement; an inconclusive result means nobody knows, and the
+  endpoint that could not say is the one the `createJob` and `fund` writes go to
+  next. Either way the run stops before escrowing a fee it cannot earn, and the
+  log line distinguishes the two so the next move is clear. `--dry-run` reports
+  and carries on. See `Raxol.Earn.Xochi.PullPreflight` and GitHub #772.
 
   ## Origin pull: the `--solver` pin
 
@@ -763,14 +767,18 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # the shape passed each time, and the digest was wrong. The two `eth_call`s
   # cost nothing and happen before any write.
   #
-  # A rejection aborts a real run. Continuing would `createJob` and escrow a fee
-  # for a settlement that provably cannot execute, which is how job 74047 ended
-  # up funded, unsettleable, and expired. Under `--dry-run` it only reports --
-  # rehearsing the failure is the reason that mode exists.
+  # A real run proceeds on `{:ok, _}` and nothing else. Continuing on anything
+  # weaker would `createJob` and escrow a fee for a settlement nobody has
+  # confirmed can execute, which is how job 74047 ended up funded, unsettleable,
+  # and expired. Under `--dry-run` it only reports -- rehearsing the failure is
+  # the reason that mode exists.
   #
-  # An inconclusive check never blocks: an unreachable RPC is not evidence about
-  # a signature, and treating it as one would send the next debugging round after
-  # the wrong thing.
+  # An inconclusive check blocks too, and the asymmetry that would make it not
+  # block does not exist: this reads `cfg.rpc`, the same endpoint the funding
+  # writes go to moments later, so a node too unwell to answer two `eth_call`s is
+  # not about to mine a `createJob`. Refusing costs a re-run; proceeding costs an
+  # escrow. What an inconclusive result must not do is claim the SIGNATURE is
+  # bad, and `PullPreflight.describe/1` keeps those separate in the log.
   defp preflight_pull(_cfg, %{pull_authorization: nil}, _bundle, _opts), do: :ok
 
   defp preflight_pull(cfg, quote_resp, bundle, opts) do
@@ -792,11 +800,18 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     end
   end
 
-  defp decide_preflight({:error, {:signature_rejected, _}}, false = _dry_run?) do
-    {:error, :pull_signature_rejected}
-  end
+  @doc false
+  # Public only so the money decision itself can be tested. Every clause is
+  # explicit: there is no catch-all, so a new `PullPreflight` outcome is a
+  # compile-time gap here rather than a silent funded run.
+  @spec decide_preflight(PullPreflight.outcome(), boolean()) :: :ok | {:error, atom()}
+  def decide_preflight({:ok, _details}, _dry_run?), do: :ok
+  def decide_preflight({:rejected, _details}, true = _dry_run?), do: :ok
+  def decide_preflight({:rejected, _details}, false), do: {:error, :pull_signature_rejected}
+  def decide_preflight({:inconclusive, _reason}, true = _dry_run?), do: :ok
 
-  defp decide_preflight(_outcome, _dry_run?), do: :ok
+  def decide_preflight({:inconclusive, _reason}, false),
+    do: {:error, :pull_preflight_inconclusive}
 
   # The Permit2 rail pulls through a standing ERC-20 allowance. Refusing an
   # unpinned or mismatched spender happens HERE, before the signature -- an
@@ -1330,6 +1345,27 @@ defmodule Mix.Tasks.RaxolEarn.Order do
     verifying contract's own DOMAIN_SEPARATOR() before re-running.
 
     Re-run with --dry-run to reproduce this for free.
+    """
+  end
+
+  # The check could not be completed, which is NOT a verdict on the signature.
+  # It still stops the run: an unanswered question is not permission to escrow,
+  # and the endpoint that could not answer it is the one the funding writes go to.
+  defp sign_intent_error(:pull_preflight_inconclusive) do
+    """
+    the origin pull's signature could not be checked against the chain.
+
+    Nothing was written and nothing was escrowed. The preflight line above says
+    what stopped the check and what to do about it -- read it before changing
+    anything, because the most common cause is ORDER_RPC_<from-chain> being unset
+    and falling back to the Base endpoint, which answers for the wrong chain.
+
+    This is not a claim that the signature is bad. It is a refusal to escrow a
+    fee on a question nobody answered: the same RPC serves the createJob and
+    fund writes that would come next, so a node that cannot answer two eth_calls
+    would not have carried the run much further anyway.
+
+    Re-run once the endpoint answers, or with --dry-run to rehearse for free.
     """
   end
 

--- a/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
+++ b/packages/raxol_earn/lib/mix/tasks/raxol_earn.order.ex
@@ -58,11 +58,15 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   writes.
 
   A real run proceeds only when that check PASSES. A rejection means the pull
-  would revert on settlement; an inconclusive result means nobody knows, and the
-  endpoint that could not say is the one the `createJob` and `fund` writes go to
-  next. Either way the run stops before escrowing a fee it cannot earn, and the
-  log line distinguishes the two so the next move is clear. `--dry-run` reports
-  and carries on. See `Raxol.Earn.Xochi.PullPreflight` and GitHub #772.
+  would revert on settlement; an inconclusive result means nobody knows. Either
+  way the run stops before escrowing a fee it cannot earn, and the log line
+  distinguishes the two so the next move is clear. `--dry-run` reports both and
+  carries on, since it spends nothing.
+
+  A quote that served a pull with no signature in the signed bundle aborts BOTH
+  modes. That is not a preflight verdict to rehearse -- it is a bundle with
+  nothing in it to check, so there is no version of the run worth continuing.
+  See `Raxol.Earn.Xochi.PullPreflight` and GitHub #772.
 
   ## Origin pull: the `--solver` pin
 
@@ -824,9 +828,13 @@ defmodule Mix.Tasks.RaxolEarn.Order do
   # this address, so leaving it to the served `verifyingContract` would let a
   # hostile quote nominate its own oracle. Permit2 is one address on every chain;
   # the ERC-3009 verifier is the origin token itself.
+  # Two clauses, no catch-all. `validate_pull/3` refused every other
+  # payment_method before this quote was signed, so a third value here is an
+  # impossibility rather than a case to handle -- and a FunctionClauseError says
+  # that, before any write, where a `nil` fallback would instead hand
+  # `PullPreflight` a missing pin.
   defp expected_verifier("permit2", _cfg), do: Permit2.verifying_contract()
   defp expected_verifier("erc3009", cfg), do: cfg.src_token
-  defp expected_verifier(_method, _cfg), do: nil
 
   @doc false
   # Public only so the money decision itself can be tested. Every clause is

--- a/packages/raxol_earn/lib/raxol/earn/onchain/permit2_approver.ex
+++ b/packages/raxol_earn/lib/raxol/earn/onchain/permit2_approver.ex
@@ -54,10 +54,20 @@ defmodule Raxol.Earn.Onchain.Permit2Approver do
   """
 
   alias Raxol.Earn.{ABI, ProviderAdapter}
+  alias Raxol.Payments.Protocols.Permit2
 
-  # Universal Permit2, identical on every EVM chain. Matches
-  # `Raxol.Payments.Protocols.Permit2.verifying_contract/0`.
-  @permit2_address "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  # Universal Permit2, identical on every EVM chain, and taken from the module
+  # that owns it rather than restated here.
+  #
+  # This address now decides three things: the spender an approve grants to
+  # (below), the `verifyingContract` a served pull must declare
+  # (`Protocols.Xochi.validate_permit2_pull/2`), and the contract
+  # `Raxol.Earn.Xochi.PullPreflight` reads `DOMAIN_SEPARATOR()` from. A second
+  # copy agreeing with the first by comment is exactly the shape of defect the
+  # preflight exists to catch -- and if the two ever drifted, the allowance
+  # would be granted at one address while the digest was vouched for at
+  # another, with nothing failing until settlement.
+  @permit2_address Permit2.verifying_contract()
   @approve_signature "approve(address,uint256)"
   @allowance_signature "allowance(address,address)"
   @max_uint256 Integer.pow(2, 256) - 1

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -1,0 +1,300 @@
+defmodule Raxol.Earn.Xochi.PullPreflight do
+  @moduledoc """
+  Read-only check that the origin pull a buyer just signed will actually be
+  accepted on chain, before anything is escrowed or funded.
+
+  The pull is the step that has failed every funded attempt on GitHub #772. It
+  fails at the far end of a long sequence -- quote, sign, `createJob`, fund,
+  provider `setBudget`, solver relay -- and reports back as a status string with
+  no detail (`validation_failed`, or a bare `pull_failed`), so each attempt cost
+  a job, an escrow, and a round trip through two other repositories to learn one
+  bit. This asks the two contracts involved the same question directly, for the
+  price of two `eth_call`s.
+
+  ## What it proves
+
+      separator  = VerifyingContract.DOMAIN_SEPARATOR()      -- read from chain
+      structHash = hashStruct(served types, served message)
+      digest     = keccak256(0x1901 || separator || structHash)
+      magic      = Account.isValidSignature(digest, pull_signature)
+
+  A `0x1626ba7e` means the account vouches for that signature over that digest,
+  and the digest was built on the separator the verifier itself will rebuild. So
+  the pull's signature check passes.
+
+  The separator being READ rather than computed is the whole point. Checking our
+  own signature against a digest from our own `domain` projection is circular:
+  both sides of the comparison carry the same mistake and agree. #772 was exactly
+  that -- a `version` field we inserted and Permit2 never declared, which every
+  test agreed with because every test rebuilt the domain the same way we did.
+  Sourcing the domain half from the contract breaks the loop.
+
+  The struct half is still encoded by `Raxol.Payments.EIP712`, which the Permit2
+  and ERC-3009 conformance suites pin against ethers-generated vectors.
+
+  ## What it does not prove
+
+  Only the signature check. A pull can still revert on allowance, balance,
+  an expired deadline, or a spent nonce, and this deliberately does not read
+  those: they are properties of funding time, not signing time, and the order
+  task reports the allowance separately. A pass here means the signature is not
+  the reason the next attempt fails.
+
+  It also needs a `verifyingContract` to ask, so it covers the pull (Permit2 or
+  the ERC-3009 token) and not the Xochi intent signature, whose domain is keyed
+  by `salt` with no contract behind it.
+
+  One blind spot is worth naming, because it is the same shape as the bug this
+  exists to catch. Permit2 builds its `PermitWitnessTransferFrom` typehash by
+  concatenating a fixed stub with the caller's witness type string, where EIP-712
+  sorts referenced types alphabetically. For `OriginPullWitness` the two agree --
+  `OriginPullWitness` sorts before `TokenPermissions` -- so the struct hash here
+  matches Permit2's. A witness type renamed to sort after `TokenPermissions`
+  would diverge, and this check would not see it: it would encode the struct the
+  same wrong way the signer did, and both would agree. Only the domain half is
+  sourced from the chain. Pinning the witness type string is the guard for that,
+  not this.
+  """
+
+  alias Raxol.Earn.ABI
+  alias Raxol.Earn.Onchain.RPC
+  alias Raxol.Payments.EIP712
+
+  # ERC-1271: bytes4(keccak256("isValidSignature(bytes32,bytes)"))
+  @erc1271_magic <<0x16, 0x26, 0xBA, 0x7E>>
+
+  @type outcome ::
+          {:ok,
+           %{
+             digest: binary(),
+             separator: binary(),
+             verifying_contract: String.t(),
+             signer_kind: :contract | :eoa
+           }}
+          | {:error, term()}
+
+  @doc """
+  Verify `signature` against `account` over the digest the pull's verifying
+  contract will build from `served`.
+
+  `served` is the quote's `pull_authorization` verbatim -- its `"domain"`,
+  `"types"` and `"message"` as the worker sent them.
+
+  ## Options
+
+  - `:rpc` -- an `Raxol.Earn.Onchain.RPC` client. Built from application config
+    when absent.
+
+  Returns `{:ok, details}` when the account answers with the ERC-1271 magic
+  value, `{:error, {:signature_rejected, details}}` when it answers anything
+  else, and `{:error, reason}` when the check could not be completed -- which is
+  NOT a verdict on the signature and must not be reported as one.
+  """
+  @spec verify(map(), String.t(), String.t(), keyword()) :: outcome()
+  def verify(served, signature, account, opts \\ []) when is_map(served) do
+    client = Keyword.get_lazy(opts, :rpc, fn -> RPC.client() end)
+
+    with {:ok, sig_bytes} <- decode_hex(signature, :signature),
+         {:ok, details} <- describe_target(client, served, account) do
+      details.signer_kind
+      |> check(client, account, details.digest, sig_bytes)
+      |> verdict(details)
+    end
+  end
+
+  # Everything the verdict is about, resolved before the signature is looked at:
+  # which contract verifies, the separator it rebuilds, the digest that yields,
+  # and whether the buyer is asked by ERC-1271 or by recovery.
+  defp describe_target(client, served, account) do
+    with {:ok, verifying_contract} <- verifying_contract(served),
+         {:ok, separator} <- domain_separator(client, verifying_contract),
+         {:ok, digest} <- digest(separator, served),
+         {:ok, kind} <- signer_kind(client, account) do
+      {:ok,
+       %{
+         digest: digest,
+         separator: separator,
+         verifying_contract: verifying_contract,
+         signer_kind: kind
+       }}
+    end
+  end
+
+  defp verdict(:ok, details), do: {:ok, details}
+
+  defp verdict({:rejected, returned}, details),
+    do: {:error, {:signature_rejected, Map.put(details, :returned, returned)}}
+
+  defp verdict({:error, _} = err, _details), do: err
+
+  @doc """
+  One line describing the outcome, for the order task's log.
+  """
+  @spec describe(outcome()) :: String.t()
+  def describe({:ok, %{verifying_contract: vc, digest: digest, signer_kind: kind}}) do
+    "pull preflight: OK -- the signature covers the digest #{short(vc)} will rebuild " <>
+      "(#{short_hex(digest)}), verified #{via(kind)}"
+  end
+
+  def describe({:error, {:signature_rejected, details}}) do
+    %{verifying_contract: vc, returned: returned, signer_kind: kind} = details
+
+    "pull preflight: REJECTED -- #{short(vc)} rebuilds a digest this signature does not " <>
+      "cover (#{via(kind)} answered #{describe_returned(kind, returned)}). The pull would " <>
+      "revert, so funding this order would escrow a fee for a settlement that cannot happen."
+  end
+
+  def describe({:error, reason}) do
+    "pull preflight: INCONCLUSIVE (#{inspect(reason)}) -- this is not a verdict on the " <>
+      "signature; the check itself could not run."
+  end
+
+  # -- Internal --
+
+  defp verifying_contract(served) do
+    case get_in(served, ["domain", "verifyingContract"]) do
+      "0x" <> _ = address -> {:ok, address}
+      nil -> {:error, :no_verifying_contract}
+      other -> {:error, {:invalid_verifying_contract, other}}
+    end
+  end
+
+  # The separator the contract itself rebuilds. Every domain we pull against
+  # -- Permit2 and the ERC-3009 tokens -- exposes it as an immutable public
+  # getter, so this is a cache-free read of the exact 32 bytes the on-chain
+  # verification will use.
+  defp domain_separator(client, verifying_contract) do
+    call = %{to: verifying_contract, data: selector()}
+
+    with {:ok, hex} <- RPC.eth_call(client, call),
+         {:ok, bytes} <- decode_hex(hex, :domain_separator) do
+      case bytes do
+        <<separator::binary-size(32)>> ->
+          {:ok, separator}
+
+        other ->
+          {:error, {:domain_separator_length, byte_size(other)}}
+      end
+    else
+      {:error, reason} -> {:error, {:domain_separator_unavailable, verifying_contract, reason}}
+    end
+  end
+
+  defp selector, do: ABI.function_selector("DOMAIN_SEPARATOR()")
+
+  defp digest(separator, served) do
+    types = types(served)
+    message = served["message"] || %{}
+
+    case EIP712.hash_with_separator(separator, types, message) do
+      {:ok, digest} -> {:ok, digest}
+      {:error, reason} -> {:error, {:digest_failed, reason}}
+    end
+  end
+
+  # Drop the served EIP712Domain declaration: the separator it describes is the
+  # one being read from chain instead, and leaving it in would make it a second
+  # root type and the primary type ambiguous.
+  defp types(served) do
+    (served["types"] || %{})
+    |> Map.drop(["EIP712Domain"])
+    |> Map.new(fn {name, fields} ->
+      {name, Enum.map(fields, fn f -> {f["name"], f["type"]} end)}
+    end)
+  end
+
+  # Permit2 and the ERC-3009 tokens branch on whether the owner has code: a
+  # contract account is asked via ERC-1271, an EOA is recovered with ecrecover.
+  # Checking the wrong one would answer a question the pull never asks -- an EOA
+  # has no `isValidSignature` to call, and a 7702 account's wrapped envelope
+  # cannot recover. A 7702 delegation designator IS code, so this splits them.
+  defp signer_kind(client, account) do
+    case RPC.deployed?(client, account) do
+      {:ok, true} -> {:ok, :contract}
+      {:ok, false} -> {:ok, :eoa}
+      {:error, reason} -> {:error, {:signer_kind_unavailable, account, reason}}
+    end
+  end
+
+  defp check(:contract, client, account, digest, sig_bytes) do
+    case call_erc1271(client, account, digest, sig_bytes) do
+      {:ok, @erc1271_magic} -> :ok
+      {:ok, returned} -> {:rejected, returned}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp check(:eoa, _client, account, digest, sig_bytes) do
+    case recover(digest, sig_bytes) do
+      {:ok, recovered} ->
+        if EIP712.normalize_address(recovered) == EIP712.normalize_address(account) do
+          :ok
+        else
+          {:rejected, recovered}
+        end
+
+      {:error, reason} ->
+        {:error, {:recover_failed, reason}}
+    end
+  end
+
+  defp recover(digest, <<r::binary-size(32), s::binary-size(32), v::8>>) when v in [27, 28] do
+    case ExSecp256k1.recover(digest, r, s, v - 27) do
+      {:ok, pubkey} -> {:ok, EIP712.address_from_pubkey(pubkey)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # An EOA pull carries a canonical 65-byte signature. Anything else is a
+  # wrapped envelope on an account with no code to unwrap it, which the pull
+  # would reject.
+  defp recover(_digest, sig), do: {:error, {:not_a_canonical_signature, byte_size(sig)}}
+
+  defp call_erc1271(client, account, digest, sig_bytes) do
+    data =
+      ABI.encode_call("isValidSignature(bytes32,bytes)", [
+        {"bytes32", "0x" <> Base.encode16(digest, case: :lower)},
+        {"bytes", sig_bytes}
+      ])
+
+    # `:data` is handed over as raw bytes: RPC.eth_call/3 hex-encodes it.
+    call = %{to: account, data: data}
+
+    with {:ok, hex} <- RPC.eth_call(client, call),
+         {:ok, bytes} <- decode_hex(hex, :magic_value) do
+      # A bytes4 return is left-aligned in its 32-byte word. An account that
+      # reverts rather than returning a value surfaces as an RPC error above.
+      {:ok, binary_part(bytes, 0, min(4, byte_size(bytes)))}
+    else
+      {:error, reason} -> {:error, {:erc1271_call_failed, account, reason}}
+    end
+  end
+
+  defp decode_hex("0x" <> hex, label), do: decode_hex(hex, label)
+
+  defp decode_hex(hex, label) when is_binary(hex) do
+    case Base.decode16(hex, case: :mixed) do
+      {:ok, bytes} -> {:ok, bytes}
+      :error -> {:error, {:invalid_hex, label}}
+    end
+  end
+
+  defp decode_hex(other, label), do: {:error, {:invalid_hex, label, other}}
+
+  defp short("0x" <> hex) when byte_size(hex) > 10 do
+    "0x" <> binary_part(hex, 0, 6) <> ".." <> binary_part(hex, byte_size(hex) - 4, 4)
+  end
+
+  defp short(other), do: to_string(other)
+
+  defp short_hex(bytes) when is_binary(bytes),
+    do: short("0x" <> Base.encode16(bytes, case: :lower))
+
+  defp via(:contract), do: "on-chain via ERC-1271 isValidSignature"
+  defp via(:eoa), do: "by ecrecover against the buyer address"
+
+  # An ERC-1271 refusal is a 4-byte magic value; an EOA mismatch is the address
+  # the signature actually recovers to, which says far more than "not equal".
+  defp describe_returned(:eoa, address), do: "recovered #{short(address)}"
+  defp describe_returned(:contract, magic), do: short_hex(magic)
+end

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -269,9 +269,16 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     end
   end
 
+  # The CALLER's address is what gets dialed, not the served one that just
+  # matched it. `normalize_address/1` trims and downcases, so the two can match
+  # while differing byte-for-byte -- a served `"0x…BA3 "` passes the pin and then
+  # goes to `eth_call` verbatim as `to:`, where the node refuses it and every
+  # funded run stops INCONCLUSIVE blaming an endpoint that is fine. Comparing
+  # against the pin and then asking the payload's copy of it also contradicts
+  # the rule this function exists to enforce.
   defp pinned_verifier(expected, address) do
     if EIP712.normalize_address(address) == EIP712.normalize_address(expected) do
-      {:ok, address}
+      {:ok, expected}
     else
       {:rejected_because, {:verifier_mismatch, address, expected}}
     end

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -292,15 +292,28 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   # broken when their RPC url is. `ORDER_RPC_<from>` falls back to the Base
   # endpoint when unset, so this is the DEFAULT path for any non-Base origin.
   defp same_chain(client, served) do
-    declared = to_uint(get_in(served, ["domain", "chainId"]))
+    served_chain_id = get_in(served, ["domain", "chainId"])
 
-    case {declared, RPC.eth_chain_id(client)} do
-      {nil, _} -> {:rejected_because, :no_chain_id}
-      {chain, {:ok, chain}} -> :ok
-      {chain, {:ok, other}} -> {:inconclusive, {:wrong_chain, declared: chain, node: other}}
-      {_chain, {:error, reason}} -> {:inconclusive, {:chain_id_unavailable, reason}}
+    case to_uint(served_chain_id) do
+      nil -> {:rejected_because, chain_id_defect(served_chain_id)}
+      declared -> compare_chain_id(client, declared)
     end
   end
+
+  defp compare_chain_id(client, declared) do
+    case RPC.eth_chain_id(client) do
+      {:ok, ^declared} -> :ok
+      {:ok, other} -> {:inconclusive, {:wrong_chain, declared: declared, node: other}}
+      {:error, reason} -> {:inconclusive, {:chain_id_unavailable, reason}}
+    end
+  end
+
+  # A payload that declares a chainId this module cannot read is a different
+  # defect from one that declares none, and reporting a negative or non-numeric
+  # value as "declares no domain.chainId" sends the operator looking for a field
+  # that is right there in the payload they captured.
+  defp chain_id_defect(nil), do: :no_chain_id
+  defp chain_id_defect(other), do: {:invalid_chain_id, other}
 
   defp to_uint(n) when is_integer(n) and n >= 0, do: n
 
@@ -486,6 +499,11 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
   defp describe_defect(:no_chain_id),
     do: "the served pull declares no domain.chainId, so it names no chain to settle on"
+
+  defp describe_defect({:invalid_chain_id, other}),
+    do:
+      "the served domain.chainId is not a chain id (#{inspect(other)}), so the separator it " <>
+        "commits to names no chain this can read"
 
   defp describe_defect({:invalid_verifying_contract, other}),
     do: "the served domain.verifyingContract is not an address (#{inspect(other)})"

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -83,13 +83,10 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   alias Raxol.Earn.ABI
   alias Raxol.Earn.Onchain.RPC
   alias Raxol.Payments.EIP712
-  alias Raxol.Payments.Protocols.Permit2
   alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
 
   # ERC-1271: bytes4(keccak256("isValidSignature(bytes32,bytes)"))
   @erc1271_magic <<0x16, 0x26, 0xBA, 0x7E>>
-
-  @permit2_primary_type "PermitWitnessTransferFrom"
 
   @type details :: %{
           optional(:digest) => binary(),
@@ -116,12 +113,17 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
   - `:rpc` -- an `Raxol.Earn.Onchain.RPC` client. Built from application config
     when absent.
-  - `:expect_verifier` -- the address the caller's rail says will verify this
-    signature (the canonical Permit2, or the origin token for ERC-3009). The
-    served `domain.verifyingContract` must match it or the pull is rejected.
-    PASS THIS. It is what stops the party who served the payload from also
-    choosing the contract this module asks about it; without it the fallback pin
-    keys off the served `primaryType`, which that party also controls.
+  - `:expect_verifier` (REQUIRED) -- the address the caller's rail says will
+    verify this signature: the canonical Permit2, or the origin token for
+    ERC-3009. The served `domain.verifyingContract` must match it or the pull is
+    rejected.
+
+    Required rather than defaulted, because every default available here is
+    drawn from the served payload, and the payload is the thing under audit.
+    A caller that does not name the verifier is asking the party who wrote the
+    envelope which contract to ask about the envelope. There is no safe value to
+    fall back to, so there is no fallback: omitting it raises rather than
+    quietly checking something weaker.
 
   Returns:
 
@@ -137,7 +139,7 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   @spec verify(map(), String.t(), String.t(), keyword()) :: outcome()
   def verify(served, signature, account, opts \\ []) when is_map(served) do
     client = Keyword.get_lazy(opts, :rpc, fn -> RPC.client() end)
-    expected = Keyword.get(opts, :expect_verifier)
+    expected = expected_verifier!(opts)
 
     with {:ok, sig_bytes} <- signature_bytes(signature),
          {:ok, details} <- describe_target(client, served, account, expected) do
@@ -213,21 +215,36 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
   # -- Internal --
 
+  # The caller's answer to "who checks this signature", validated at the door so
+  # a bad one stops at the call site rather than travelling in as a FunctionClause
+  # from somewhere three functions deeper. Naming the verifier is a decision the
+  # caller has already made by choosing a rail; getting it wrong is a bug there.
+  defp expected_verifier!(opts) do
+    case Keyword.fetch(opts, :expect_verifier) do
+      {:ok, "0x" <> _ = address} ->
+        address
+
+      {:ok, other} ->
+        raise ArgumentError,
+              ":expect_verifier must be a 0x address, got #{inspect(other)}"
+
+      :error ->
+        raise ArgumentError,
+              ":expect_verifier is required -- name the contract your rail pulls " <>
+                "through (Permit2, or the origin token for ERC-3009). There is no " <>
+                "default: every candidate comes from the payload under audit."
+    end
+  end
+
   # A served `verifyingContract` is a claim about WHO will check the signature,
   # made by the same party whose payload is under audit. Reading a separator from
   # an address the quote chose would let a hostile worker nominate a contract
   # whose DOMAIN_SEPARATOR() it controls, and the check would agree with the
-  # payload exactly the way #772's tests agreed with #772.
-  #
-  # `:expect_verifier` is how a caller breaks that: it names the verifier from
-  # the rail the caller ASKED for, so the oracle is not drawn from served data at
-  # all. Without it the only pin available keys off `served["primaryType"]` --
-  # also served, also chosen by the same party -- so a payload declaring some
-  # other primary type skips the pin. That floor makes a bare call no worse than
-  # nothing; it is not a substitute for passing the option.
+  # payload exactly the way #772's tests agreed with #772. So the served address
+  # is never the pin -- it is only ever checked AGAINST one.
   defp verifying_contract(served, expected) do
     with {:ok, address} <- declared_verifier(served) do
-      pinned_verifier(expected, served["primaryType"], address)
+      pinned_verifier(expected, address)
     end
   end
 
@@ -239,25 +256,13 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     end
   end
 
-  defp pinned_verifier(expected, _primary_type, address) when is_binary(expected) do
+  defp pinned_verifier(expected, address) do
     if EIP712.normalize_address(address) == EIP712.normalize_address(expected) do
       {:ok, address}
     else
       {:rejected_because, {:verifier_mismatch, address, expected}}
     end
   end
-
-  defp pinned_verifier(nil, @permit2_primary_type, address) do
-    canonical = Permit2.verifying_contract()
-
-    if EIP712.normalize_address(address) == EIP712.normalize_address(canonical) do
-      {:ok, address}
-    else
-      {:rejected_because, {:verifier_not_permit2, address, canonical}}
-    end
-  end
-
-  defp pinned_verifier(nil, _primary_type, address), do: {:ok, address}
 
   # Permit2's separator commits to the chain id, and Permit2 is deployed at the
   # SAME address everywhere -- so a node for the wrong chain answers this call
@@ -461,12 +466,6 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
       "the served domain.verifyingContract is #{short(served)}, not #{short(expected)}, which " <>
         "is what this rail pulls through. Asking the served address about the signature would " <>
         "be asking the party that chose it, so the check stops here"
-
-  defp describe_defect({:verifier_not_permit2, served, canonical}),
-    do:
-      "the served domain.verifyingContract is #{short(served)}, not the canonical Permit2 " <>
-        "at #{short(canonical)}. The allowance this pull spends was granted to Permit2, so " <>
-        "whatever that address says about the signature is not what will run"
 
   defp describe_defect({:digest_failed, reason}),
     do: "the served types and message cannot be EIP-712 encoded (#{inspect(reason)})"

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -46,8 +46,21 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   Only the signature check. A pull can still revert on allowance, balance,
   an expired deadline, or a spent nonce, and this deliberately does not read
   those: they are properties of funding time, not signing time, and the order
-  task reports the allowance separately. A pass here means the signature is not
-  the reason the next attempt fails.
+  task reports the allowance separately.
+
+  Two narrower limits are worth stating rather than leaving to be discovered.
+
+  The EOA branch checks what `ecrecover` checks: a canonical 65 bytes, `v` of 27
+  or 28, and a recovered address equal to the buyer's. Any acceptance policy the
+  verifier layers ON TOP of that -- signature malleability rules, for instance --
+  is the verifier's and is not modelled here, so a pass is a statement about
+  recovery rather than about every rule the contract may apply.
+
+  Both branches also read chain state at preflight time, and the pull happens
+  later. `signer_kind` in particular is a snapshot: a 7702 delegation set or
+  revoked between here and settlement moves the buyer between the ERC-1271 and
+  ecrecover branches, and the verdict was for the branch that was live when the
+  question was asked.
 
   It also needs a `verifyingContract` to ask, so it covers the pull (Permit2 or
   the ERC-3009 token) and not the Xochi intent signature, whose domain is keyed
@@ -388,6 +401,15 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     end
   end
 
+  # A 65-byte signature whose `v` is neither 27 nor 28 is a DIFFERENT defect
+  # from one of the wrong length, and reporting it by length alone produced
+  # "this signature is 65 bytes rather than a canonical 65" -- which says
+  # nothing, and then sent the operator after a 7702 delegation that is not the
+  # problem. Solidity's `ecrecover` yields the zero address for any other `v`,
+  # so the pull rejects this too; it just rejects it for the reason named here.
+  defp recover(_digest, <<_r::binary-size(32), _s::binary-size(32), v::8>>),
+    do: {:error, {:non_canonical_v, v}}
+
   # An EOA pull carries a canonical 65-byte signature. Anything else is a
   # wrapped envelope on an account with no code to unwrap it, which the pull
   # would reject.
@@ -475,6 +497,12 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
       "the buyer has no code on this chain, so the pull recovers with ecrecover, and this " <>
         "signature is #{size} bytes rather than a canonical 65. A wrapped envelope needs an " <>
         "account that can unwrap it -- check whether the 7702 delegation is actually set"
+
+  defp describe_defect({:recover_failed, {:non_canonical_v, v}}),
+    do:
+      "the signature is a canonical 65 bytes but its recovery id is #{v}, not 27 or 28, so " <>
+        "ecrecover yields the zero address and the pull rejects it. This is the signer's " <>
+        "packing rather than the buyer's account -- capture what produced the signature"
 
   defp describe_defect({:recover_failed, reason}),
     do: "this signature does not recover to any address (#{inspect(reason)})"

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -9,7 +9,10 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   no detail (`validation_failed`, or a bare `pull_failed`), so each attempt cost
   a job, an escrow, and a round trip through two other repositories to learn one
   bit. This asks the two contracts involved the same question directly, for the
-  price of two `eth_call`s.
+  price of four read-only calls: `eth_chainId` (which chain the node speaks for),
+  `eth_getCode` (which branch the pull will take), and one `eth_call` each for
+  the separator and the signature check. An EOA buyer costs three -- there is no
+  `isValidSignature` to call.
 
   ## What it proves
 
@@ -106,6 +109,12 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
   - `:rpc` -- an `Raxol.Earn.Onchain.RPC` client. Built from application config
     when absent.
+  - `:expect_verifier` -- the address the caller's rail says will verify this
+    signature (the canonical Permit2, or the origin token for ERC-3009). The
+    served `domain.verifyingContract` must match it or the pull is rejected.
+    PASS THIS. It is what stops the party who served the payload from also
+    choosing the contract this module asks about it; without it the fallback pin
+    keys off the served `primaryType`, which that party also controls.
 
   Returns:
 
@@ -121,9 +130,10 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   @spec verify(map(), String.t(), String.t(), keyword()) :: outcome()
   def verify(served, signature, account, opts \\ []) when is_map(served) do
     client = Keyword.get_lazy(opts, :rpc, fn -> RPC.client() end)
+    expected = Keyword.get(opts, :expect_verifier)
 
     with {:ok, sig_bytes} <- signature_bytes(signature),
-         {:ok, details} <- describe_target(client, served, account) do
+         {:ok, details} <- describe_target(client, served, account, expected) do
       details.signer_kind
       |> check(client, account, details.digest, sig_bytes)
       |> verdict(details)
@@ -139,9 +149,9 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   # that the node speaks for the chain the domain names, which contract verifies,
   # the separator it rebuilds, the digest that yields, and whether the buyer is
   # asked by ERC-1271 or by recovery.
-  defp describe_target(client, served, account) do
+  defp describe_target(client, served, account, expected) do
     with :ok <- same_chain(client, served),
-         {:ok, verifying_contract} <- verifying_contract(served),
+         {:ok, verifying_contract} <- verifying_contract(served, expected),
          {:ok, separator} <- domain_separator(client, verifying_contract),
          {:ok, digest} <- digest(separator, served),
          {:ok, kind} <- signer_kind(client, account) do
@@ -196,17 +206,21 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
   # -- Internal --
 
-  # Permit2 lives at one address on every chain, so a served `verifyingContract`
-  # is a claim about WHO will check the signature, made by the same party whose
-  # payload is under audit. Reading a separator from an address the quote chose
-  # would let a hostile worker nominate a contract whose DOMAIN_SEPARATOR() it
-  # controls, and the check would agree with the payload exactly the way #772's
-  # tests agreed with #772. The ERC-3009 rail needs no pin here: its verifier is
-  # the token, which `Protocols.Xochi` already binds to the request's origin
-  # token before anything is signed.
-  defp verifying_contract(served) do
+  # A served `verifyingContract` is a claim about WHO will check the signature,
+  # made by the same party whose payload is under audit. Reading a separator from
+  # an address the quote chose would let a hostile worker nominate a contract
+  # whose DOMAIN_SEPARATOR() it controls, and the check would agree with the
+  # payload exactly the way #772's tests agreed with #772.
+  #
+  # `:expect_verifier` is how a caller breaks that: it names the verifier from
+  # the rail the caller ASKED for, so the oracle is not drawn from served data at
+  # all. Without it the only pin available keys off `served["primaryType"]` --
+  # also served, also chosen by the same party -- so a payload declaring some
+  # other primary type skips the pin. That floor makes a bare call no worse than
+  # nothing; it is not a substitute for passing the option.
+  defp verifying_contract(served, expected) do
     with {:ok, address} <- declared_verifier(served) do
-      pinned_verifier(served["primaryType"], address)
+      pinned_verifier(expected, served["primaryType"], address)
     end
   end
 
@@ -218,7 +232,15 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     end
   end
 
-  defp pinned_verifier(@permit2_primary_type, address) do
+  defp pinned_verifier(expected, _primary_type, address) when is_binary(expected) do
+    if EIP712.normalize_address(address) == EIP712.normalize_address(expected) do
+      {:ok, address}
+    else
+      {:rejected_because, {:verifier_mismatch, address, expected}}
+    end
+  end
+
+  defp pinned_verifier(nil, @permit2_primary_type, address) do
     canonical = Permit2.verifying_contract()
 
     if EIP712.normalize_address(address) == EIP712.normalize_address(canonical) do
@@ -228,7 +250,7 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     end
   end
 
-  defp pinned_verifier(_primary_type, address), do: {:ok, address}
+  defp pinned_verifier(nil, _primary_type, address), do: {:ok, address}
 
   # Permit2's separator commits to the chain id, and Permit2 is deployed at the
   # SAME address everywhere -- so a node for the wrong chain answers this call
@@ -250,8 +272,13 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
   defp to_uint(n) when is_integer(n) and n >= 0, do: n
 
+  # Trimmed, to agree with `Protocols.Xochi`'s parser of the same field. Nothing
+  # reaching here can currently differ -- `EIP712` refuses a padded uint256 at
+  # signing, several steps earlier -- but two parsers of one field disagreeing is
+  # a bug waiting for a caller, and the disagreement here would surface as a hard
+  # rejection reading "declares no domain.chainId" for a payload that declares one.
   defp to_uint(s) when is_binary(s) do
-    case Integer.parse(s) do
+    case Integer.parse(String.trim(s)) do
       {n, ""} when n >= 0 -> n
       _ -> nil
     end
@@ -370,7 +397,9 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     with {:ok, hex} <- RPC.eth_call(client, call),
          {:ok, bytes} <- decode_hex(hex, :magic_value) do
       # A bytes4 return is left-aligned in its 32-byte word. An account that
-      # reverts rather than returning a value surfaces as an RPC error above.
+      # REVERTS rather than returning a value surfaces as an RPC error above and
+      # is classified `:inconclusive` -- indistinguishable here from a node that
+      # dropped the call, and both block, so the safe reading wins.
       {:ok, binary_part(bytes, 0, min(4, byte_size(bytes)))}
     else
       {:error, reason} -> {:inconclusive, {:erc1271_call_failed, account, reason}}
@@ -423,6 +452,12 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   defp describe_defect({:invalid_verifying_contract, other}),
     do: "the served domain.verifyingContract is not an address (#{inspect(other)})"
 
+  defp describe_defect({:verifier_mismatch, served, expected}),
+    do:
+      "the served domain.verifyingContract is #{short(served)}, not #{short(expected)}, which " <>
+        "is what this rail pulls through. Asking the served address about the signature would " <>
+        "be asking the party that chose it, so the check stops here"
+
   defp describe_defect({:verifier_not_permit2, served, canonical}),
     do:
       "the served domain.verifyingContract is #{short(served)}, not the canonical Permit2 " <>
@@ -468,8 +503,15 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   defp describe_gap({:signer_kind_unavailable, account, _}),
     do: "eth_getCode did not answer for #{short(account)}, so the pull's own branch is unknown"
 
+  # A revert lands here rather than in a rejection, because this cannot tell a
+  # reverting `isValidSignature` (which IS a verdict -- the pull reverts too)
+  # from a node that dropped the call. Erring toward "retry" is the safe
+  # direction for a check that blocks either way, but say what a repeat means so
+  # the operator is not sent after the RPC forever.
   defp describe_gap({:erc1271_call_failed, account, _}),
-    do: "#{short(account)} did not answer isValidSignature"
+    do:
+      "#{short(account)} did not answer isValidSignature. If it answers other calls, this is " <>
+        "the account REVERTING rather than the node failing, and the signature is the suspect"
 
   defp describe_gap(_other), do: "the check itself could not run"
 

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -32,8 +32,14 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   test agreed with because every test rebuilt the domain the same way we did.
   Sourcing the domain half from the contract breaks the loop.
 
-  The struct half is still encoded by `Raxol.Payments.EIP712`, which the Permit2
-  and ERC-3009 conformance suites pin against ethers-generated vectors.
+  The struct half is not chain-sourced. It is encoded by `Raxol.Payments.EIP712`,
+  which the Permit2 and ERC-3009 conformance suites pin against ethers-generated
+  vectors, and projected into that encoder by
+  `Raxol.Payments.Protocols.Xochi.eip712_types/1` -- the SIGNER's own function,
+  called rather than mirrored. Those are two different guarantees and only the
+  first is a vector pin: what the shared call buys is that this module and the
+  signer cannot drift into rebuilding different struct hashes, which would
+  surface as a REJECTED verdict on a signature that was fine.
 
   ## What it does not prove
 
@@ -78,6 +84,7 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   alias Raxol.Earn.Onchain.RPC
   alias Raxol.Payments.EIP712
   alias Raxol.Payments.Protocols.Permit2
+  alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
 
   # ERC-1271: bytes4(keccak256("isValidSignature(bytes32,bytes)"))
   @erc1271_magic <<0x16, 0x26, 0xBA, 0x7E>>
@@ -313,25 +320,22 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   # A served envelope this module cannot encode is one no signature can cover:
   # the signer encoded SOMETHING, and it was not this. That is a defect in the
   # payload, not a gap in the check.
+  # The struct half is projected by the SIGNER's own function, not a copy of it.
+  # A copy would agree with itself and diverge from production the moment either
+  # side changed -- and it would report that divergence as the signature being
+  # bad, which is the false verdict this module exists to avoid. It also does not
+  # make the check circular in any way the moduledoc does not already own: the
+  # domain half is what is sourced from the chain, and this step has no judgment
+  # in it beyond dropping EIP712Domain, which both sides must do identically or
+  # neither is encoding EIP-712.
   defp digest(separator, served) do
-    types = types(served)
+    types = XochiProtocol.eip712_types(served)
     message = served["message"] || %{}
 
     case EIP712.hash_with_separator(separator, types, message) do
       {:ok, digest} -> {:ok, digest}
       {:error, reason} -> {:rejected_because, {:digest_failed, reason}}
     end
-  end
-
-  # Drop the served EIP712Domain declaration: the separator it describes is the
-  # one being read from chain instead, and leaving it in would make it a second
-  # root type and the primary type ambiguous.
-  defp types(served) do
-    (served["types"] || %{})
-    |> Map.drop(["EIP712Domain"])
-    |> Map.new(fn {name, fields} ->
-      {name, Enum.map(fields, fn f -> {f["name"], f["type"]} end)}
-    end)
   end
 
   # Permit2 and the ERC-3009 tokens branch on whether the owner has code: a

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -54,24 +54,46 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   same wrong way the signer did, and both would agree. Only the domain half is
   sourced from the chain. Pinning the witness type string is the guard for that,
   not this.
+
+  ## Three outcomes, and which of them may spend money
+
+  `verify/4` answers `{:ok, _}`, `{:rejected, _}` or `{:inconclusive, _}`, and
+  the three are separate constructors rather than shades of `{:error, _}` on
+  purpose. A caller that funds on anything but `{:ok, _}` is spending money on an
+  unanswered question, and an `{:error, _}` catch-all is precisely how that
+  happens: every reason not yet enumerated lands in it silently, so the set of
+  ways to fund an unverifiable pull grows every time a new failure mode is added
+  here. With three constructors the caller must name what it does about each, and
+  a new reason joins an existing constructor rather than inventing a fourth path.
+
+  The split between `:rejected` and `:inconclusive` carries no safety weight --
+  neither may fund. It exists so the operator learns whether to fix the payload
+  or the environment.
   """
 
   alias Raxol.Earn.ABI
   alias Raxol.Earn.Onchain.RPC
   alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Protocols.Permit2
 
   # ERC-1271: bytes4(keccak256("isValidSignature(bytes32,bytes)"))
   @erc1271_magic <<0x16, 0x26, 0xBA, 0x7E>>
 
+  @permit2_primary_type "PermitWitnessTransferFrom"
+
+  @type details :: %{
+          optional(:digest) => binary(),
+          optional(:separator) => binary(),
+          optional(:verifying_contract) => String.t(),
+          optional(:signer_kind) => :contract | :eoa,
+          optional(:returned) => term(),
+          optional(:reason) => term()
+        }
+
   @type outcome ::
-          {:ok,
-           %{
-             digest: binary(),
-             separator: binary(),
-             verifying_contract: String.t(),
-             signer_kind: :contract | :eoa
-           }}
-          | {:error, term()}
+          {:ok, details()}
+          | {:rejected, details()}
+          | {:inconclusive, term()}
 
   @doc """
   Verify `signature` against `account` over the digest the pull's verifying
@@ -85,28 +107,41 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   - `:rpc` -- an `Raxol.Earn.Onchain.RPC` client. Built from application config
     when absent.
 
-  Returns `{:ok, details}` when the account answers with the ERC-1271 magic
-  value, `{:error, {:signature_rejected, details}}` when it answers anything
-  else, and `{:error, reason}` when the check could not be completed -- which is
-  NOT a verdict on the signature and must not be reported as one.
+  Returns:
+
+  - `{:ok, details}` -- the verifier vouches for this signature over the digest
+    it will rebuild. This is the ONLY outcome a funded run may proceed on.
+  - `{:rejected, details}` -- the signature provably will not verify, either
+    because the verifier said so or because the payload cannot produce a
+    verifiable signature at all. `details.reason` says which.
+  - `{:inconclusive, reason}` -- the check could not be completed, so this is NOT
+    a verdict on the signature and must not be reported as one. It is still not
+    permission to fund.
   """
   @spec verify(map(), String.t(), String.t(), keyword()) :: outcome()
   def verify(served, signature, account, opts \\ []) when is_map(served) do
     client = Keyword.get_lazy(opts, :rpc, fn -> RPC.client() end)
 
-    with {:ok, sig_bytes} <- decode_hex(signature, :signature),
+    with {:ok, sig_bytes} <- signature_bytes(signature),
          {:ok, details} <- describe_target(client, served, account) do
       details.signer_kind
       |> check(client, account, details.digest, sig_bytes)
       |> verdict(details)
+    else
+      # A defect found before the target resolved has no digest or separator to
+      # report alongside it, only the reason it stopped there.
+      {:rejected_because, reason} -> {:rejected, %{reason: reason}}
+      {:inconclusive, _} = out -> out
     end
   end
 
   # Everything the verdict is about, resolved before the signature is looked at:
-  # which contract verifies, the separator it rebuilds, the digest that yields,
-  # and whether the buyer is asked by ERC-1271 or by recovery.
+  # that the node speaks for the chain the domain names, which contract verifies,
+  # the separator it rebuilds, the digest that yields, and whether the buyer is
+  # asked by ERC-1271 or by recovery.
   defp describe_target(client, served, account) do
-    with {:ok, verifying_contract} <- verifying_contract(served),
+    with :ok <- same_chain(client, served),
+         {:ok, verifying_contract} <- verifying_contract(served),
          {:ok, separator} <- domain_separator(client, verifying_contract),
          {:ok, digest} <- digest(separator, served),
          {:ok, kind} <- signer_kind(client, account) do
@@ -123,9 +158,12 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   defp verdict(:ok, details), do: {:ok, details}
 
   defp verdict({:rejected, returned}, details),
-    do: {:error, {:signature_rejected, Map.put(details, :returned, returned)}}
+    do: {:rejected, details |> Map.put(:returned, returned) |> Map.put(:reason, :answered)}
 
-  defp verdict({:error, _} = err, _details), do: err
+  defp verdict({:rejected_because, reason}, details),
+    do: {:rejected, Map.put(details, :reason, reason)}
+
+  defp verdict({:inconclusive, _} = out, _details), do: out
 
   @doc """
   One line describing the outcome, for the order task's log.
@@ -136,7 +174,7 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
       "(#{short_hex(digest)}), verified #{via(kind)}"
   end
 
-  def describe({:error, {:signature_rejected, details}}) do
+  def describe({:rejected, %{reason: :answered} = details}) do
     %{verifying_contract: vc, returned: returned, signer_kind: kind} = details
 
     "pull preflight: REJECTED -- #{short(vc)} rebuilds a digest this signature does not " <>
@@ -144,20 +182,82 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
       "revert, so funding this order would escrow a fee for a settlement that cannot happen."
   end
 
-  def describe({:error, reason}) do
+  def describe({:rejected, %{reason: reason}}) do
+    "pull preflight: REJECTED -- #{describe_defect(reason)}. No signature over this " <>
+      "authorization can verify, so funding this order would escrow a fee for a settlement " <>
+      "that cannot happen."
+  end
+
+  def describe({:inconclusive, reason}) do
     "pull preflight: INCONCLUSIVE (#{inspect(reason)}) -- this is not a verdict on the " <>
-      "signature; the check itself could not run."
+      "signature; #{describe_gap(reason)}. Funding is refused either way: an unanswered " <>
+      "check is not permission to escrow."
   end
 
   # -- Internal --
 
+  # Permit2 lives at one address on every chain, so a served `verifyingContract`
+  # is a claim about WHO will check the signature, made by the same party whose
+  # payload is under audit. Reading a separator from an address the quote chose
+  # would let a hostile worker nominate a contract whose DOMAIN_SEPARATOR() it
+  # controls, and the check would agree with the payload exactly the way #772's
+  # tests agreed with #772. The ERC-3009 rail needs no pin here: its verifier is
+  # the token, which `Protocols.Xochi` already binds to the request's origin
+  # token before anything is signed.
   defp verifying_contract(served) do
-    case get_in(served, ["domain", "verifyingContract"]) do
-      "0x" <> _ = address -> {:ok, address}
-      nil -> {:error, :no_verifying_contract}
-      other -> {:error, {:invalid_verifying_contract, other}}
+    with {:ok, address} <- declared_verifier(served) do
+      pinned_verifier(served["primaryType"], address)
     end
   end
+
+  defp declared_verifier(served) do
+    case get_in(served, ["domain", "verifyingContract"]) do
+      "0x" <> _ = address -> {:ok, address}
+      nil -> {:rejected_because, :no_verifying_contract}
+      other -> {:rejected_because, {:invalid_verifying_contract, other}}
+    end
+  end
+
+  defp pinned_verifier(@permit2_primary_type, address) do
+    canonical = Permit2.verifying_contract()
+
+    if EIP712.normalize_address(address) == EIP712.normalize_address(canonical) do
+      {:ok, address}
+    else
+      {:rejected_because, {:verifier_not_permit2, address, canonical}}
+    end
+  end
+
+  defp pinned_verifier(_primary_type, address), do: {:ok, address}
+
+  # Permit2's separator commits to the chain id, and Permit2 is deployed at the
+  # SAME address everywhere -- so a node for the wrong chain answers this call
+  # happily with 32 valid-looking bytes that belong to a different domain. The
+  # digest then differs for a reason that has nothing to do with the signature,
+  # and reporting it as a rejection would tell the operator their signing is
+  # broken when their RPC url is. `ORDER_RPC_<from>` falls back to the Base
+  # endpoint when unset, so this is the DEFAULT path for any non-Base origin.
+  defp same_chain(client, served) do
+    declared = to_uint(get_in(served, ["domain", "chainId"]))
+
+    case {declared, RPC.eth_chain_id(client)} do
+      {nil, _} -> {:rejected_because, :no_chain_id}
+      {chain, {:ok, chain}} -> :ok
+      {chain, {:ok, other}} -> {:inconclusive, {:wrong_chain, declared: chain, node: other}}
+      {_chain, {:error, reason}} -> {:inconclusive, {:chain_id_unavailable, reason}}
+    end
+  end
+
+  defp to_uint(n) when is_integer(n) and n >= 0, do: n
+
+  defp to_uint(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {n, ""} when n >= 0 -> n
+      _ -> nil
+    end
+  end
+
+  defp to_uint(_), do: nil
 
   # The separator the contract itself rebuilds. Every domain we pull against
   # -- Permit2 and the ERC-3009 tokens -- exposes it as an immutable public
@@ -173,22 +273,26 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
           {:ok, separator}
 
         other ->
-          {:error, {:domain_separator_length, byte_size(other)}}
+          {:inconclusive, {:domain_separator_length, byte_size(other)}}
       end
     else
-      {:error, reason} -> {:error, {:domain_separator_unavailable, verifying_contract, reason}}
+      {:error, reason} ->
+        {:inconclusive, {:domain_separator_unavailable, verifying_contract, reason}}
     end
   end
 
   defp selector, do: ABI.function_selector("DOMAIN_SEPARATOR()")
 
+  # A served envelope this module cannot encode is one no signature can cover:
+  # the signer encoded SOMETHING, and it was not this. That is a defect in the
+  # payload, not a gap in the check.
   defp digest(separator, served) do
     types = types(served)
     message = served["message"] || %{}
 
     case EIP712.hash_with_separator(separator, types, message) do
       {:ok, digest} -> {:ok, digest}
-      {:error, reason} -> {:error, {:digest_failed, reason}}
+      {:error, reason} -> {:rejected_because, {:digest_failed, reason}}
     end
   end
 
@@ -212,7 +316,7 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     case RPC.deployed?(client, account) do
       {:ok, true} -> {:ok, :contract}
       {:ok, false} -> {:ok, :eoa}
-      {:error, reason} -> {:error, {:signer_kind_unavailable, account, reason}}
+      {:error, reason} -> {:inconclusive, {:signer_kind_unavailable, account, reason}}
     end
   end
 
@@ -220,7 +324,7 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     case call_erc1271(client, account, digest, sig_bytes) do
       {:ok, @erc1271_magic} -> :ok
       {:ok, returned} -> {:rejected, returned}
-      {:error, _} = err -> err
+      {:inconclusive, _} = out -> out
     end
   end
 
@@ -233,8 +337,11 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
           {:rejected, recovered}
         end
 
+      # Permit2 and the ERC-3009 tokens run this same recovery against this same
+      # account. A signature that cannot be recovered here cannot be recovered
+      # there either, which makes this a verdict and not a gap.
       {:error, reason} ->
-        {:error, {:recover_failed, reason}}
+        {:rejected_because, {:recover_failed, reason}}
     end
   end
 
@@ -266,7 +373,16 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
       # reverts rather than returning a value surfaces as an RPC error above.
       {:ok, binary_part(bytes, 0, min(4, byte_size(bytes)))}
     else
-      {:error, reason} -> {:error, {:erc1271_call_failed, account, reason}}
+      {:error, reason} -> {:inconclusive, {:erc1271_call_failed, account, reason}}
+    end
+  end
+
+  # A signature that is not hex is not a signature. The pull is handed these same
+  # bytes, so there is nothing here for a working RPC to resolve later.
+  defp signature_bytes(signature) do
+    case decode_hex(signature, :signature) do
+      {:ok, bytes} -> {:ok, bytes}
+      {:error, reason} -> {:rejected_because, reason}
     end
   end
 
@@ -292,6 +408,70 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
   defp via(:contract), do: "on-chain via ERC-1271 isValidSignature"
   defp via(:eoa), do: "by ecrecover against the buyer address"
+
+  # What is wrong with the payload, in the operator's terms. These are all
+  # defects in what the quote served or what was signed over it, so each one
+  # names the artifact to capture rather than a knob to turn.
+  defp describe_defect(:no_verifying_contract),
+    do:
+      "the served pull declares no domain.verifyingContract, so nothing on chain " <>
+        "claims to verify it"
+
+  defp describe_defect(:no_chain_id),
+    do: "the served pull declares no domain.chainId, so it names no chain to settle on"
+
+  defp describe_defect({:invalid_verifying_contract, other}),
+    do: "the served domain.verifyingContract is not an address (#{inspect(other)})"
+
+  defp describe_defect({:verifier_not_permit2, served, canonical}),
+    do:
+      "the served domain.verifyingContract is #{short(served)}, not the canonical Permit2 " <>
+        "at #{short(canonical)}. The allowance this pull spends was granted to Permit2, so " <>
+        "whatever that address says about the signature is not what will run"
+
+  defp describe_defect({:digest_failed, reason}),
+    do: "the served types and message cannot be EIP-712 encoded (#{inspect(reason)})"
+
+  defp describe_defect({:recover_failed, {:not_a_canonical_signature, size}}),
+    do:
+      "the buyer has no code on this chain, so the pull recovers with ecrecover, and this " <>
+        "signature is #{size} bytes rather than a canonical 65. A wrapped envelope needs an " <>
+        "account that can unwrap it -- check whether the 7702 delegation is actually set"
+
+  defp describe_defect({:recover_failed, reason}),
+    do: "this signature does not recover to any address (#{inspect(reason)})"
+
+  defp describe_defect({:invalid_hex, :signature}),
+    do: "the signature is not hex"
+
+  defp describe_defect(other), do: inspect(other)
+
+  # What stopped the check, and what the operator does about it. Every one of
+  # these is environmental, so every one of them is worth a retry -- unlike the
+  # defects above.
+  defp describe_gap({:wrong_chain, declared: declared, node: node}),
+    do:
+      "the RPC answers for chain #{node} while the pull is for chain #{declared}, so the " <>
+        "separator read back belongs to a different domain. Permit2 is at one address on " <>
+        "every chain, which is why this reads as a mismatch rather than an error. Set " <>
+        "ORDER_RPC_#{declared} -- it falls back to the Base endpoint when unset"
+
+  defp describe_gap({:chain_id_unavailable, _}),
+    do: "the RPC did not answer eth_chainId, so which chain it speaks for is unknown"
+
+  defp describe_gap({:domain_separator_unavailable, vc, _}),
+    do: "#{short(vc)} did not answer DOMAIN_SEPARATOR()"
+
+  defp describe_gap({:domain_separator_length, n}),
+    do: "DOMAIN_SEPARATOR() answered #{n} bytes rather than 32"
+
+  defp describe_gap({:signer_kind_unavailable, account, _}),
+    do: "eth_getCode did not answer for #{short(account)}, so the pull's own branch is unknown"
+
+  defp describe_gap({:erc1271_call_failed, account, _}),
+    do: "#{short(account)} did not answer isValidSignature"
+
+  defp describe_gap(_other), do: "the check itself could not run"
 
   # An ERC-1271 refusal is a 4-byte magic value; an EOA mismatch is the address
   # the signature actually recovers to, which says far more than "not equal".

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -381,13 +381,25 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   # Checking the wrong one would answer a question the pull never asks -- an EOA
   # has no `isValidSignature` to call, and a 7702 account's wrapped envelope
   # cannot recover. A 7702 delegation designator IS code, so this splits them.
-  defp signer_kind(client, account) do
+  #
+  # `RPC.get_code/3` head-matches `"0x" <> _`, so an account without the prefix
+  # would raise a FunctionClauseError out of a function that documents exactly
+  # three outcomes. The buyer address is the caller's, so getting it wrong is a
+  # bug there rather than a fact about the chain -- but it must still leave by
+  # one of the three doors.
+  defp signer_kind(_client, account) when not is_binary(account),
+    do: {:rejected_because, {:invalid_account, account}}
+
+  defp signer_kind(client, "0x" <> _ = account) do
     case RPC.deployed?(client, account) do
       {:ok, true} -> {:ok, :contract}
       {:ok, false} -> {:ok, :eoa}
       {:error, reason} -> {:inconclusive, {:signer_kind_unavailable, account, reason}}
     end
   end
+
+  defp signer_kind(_client, account),
+    do: {:rejected_because, {:invalid_account, account}}
 
   defp check(:contract, client, account, digest, sig_bytes) do
     case call_erc1271(client, account, digest, sig_bytes) do
@@ -419,6 +431,18 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
       {:ok, pubkey} -> {:ok, EIP712.address_from_pubkey(pubkey)}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  # EIP-2098 compact form: `r || vs`, where `vs` is `s` with the recovery bit
+  # occupying its top position. Permit2's `SignatureVerification` accepts this
+  # alongside the 65-byte form, and the ERC-3009 tokens go through the same
+  # library, so refusing it here would be a false REJECTED on a signature the
+  # pull would take -- and the message would send the operator after a 7702
+  # delegation that is not the problem. Widened to what the verifier accepts
+  # rather than to what we happen to emit: `EIP712.pack_signature/1` is 65
+  # bytes, but the signature under audit was not necessarily produced by it.
+  defp recover(digest, <<r::binary-size(32), y_parity::1, s::bitstring-size(255)>>) do
+    recover(digest, <<r::binary, 0::1, s::bitstring, 27 + y_parity>>)
   end
 
   # A 65-byte signature whose `v` is neither 27 nor 28 is a DIFFERENT defect
@@ -520,8 +544,15 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   defp describe_defect({:recover_failed, {:not_a_canonical_signature, size}}),
     do:
       "the buyer has no code on this chain, so the pull recovers with ecrecover, and this " <>
-        "signature is #{size} bytes rather than a canonical 65. A wrapped envelope needs an " <>
-        "account that can unwrap it -- check whether the 7702 delegation is actually set"
+        "signature is #{size} bytes rather than the 65 or the compact 64 the verifier accepts. " <>
+        "A wrapped envelope needs an account that can unwrap it -- check whether the 7702 " <>
+        "delegation is actually set"
+
+  defp describe_defect({:invalid_account, account}),
+    do:
+      "the buyer address this was asked about is not an 0x address (#{inspect(account)}), so " <>
+        "there is no account to check the signature against. That is a defect in what called " <>
+        "this, not in the quote or the chain"
 
   defp describe_defect({:recover_failed, {:non_canonical_v, v}}),
     do:
@@ -540,12 +571,19 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   # What stopped the check, and what the operator does about it. Every one of
   # these is environmental, so every one of them is worth a retry -- unlike the
   # defects above.
+  # Deliberately names no environment variable. Two callers reach this with
+  # different ones -- `mix raxol_earn.order` reads `ORDER_RPC_<chain>`, the live
+  # gate reads `XOCHI_ORDER_RPC_<chain>` -- so a name hardcoded here is wrong in
+  # one of them, and pointing an operator at a variable that does not exist is
+  # the failure this whole module was built to stop doing. Each caller names its
+  # own knob in its own error text; this says which chain the endpoint must
+  # answer for.
   defp describe_gap({:wrong_chain, declared: declared, node: node}),
     do:
       "the RPC answers for chain #{node} while the pull is for chain #{declared}, so the " <>
         "separator read back belongs to a different domain. Permit2 is at one address on " <>
-        "every chain, which is why this reads as a mismatch rather than an error. Set " <>
-        "ORDER_RPC_#{declared} -- it falls back to the Base endpoint when unset"
+        "every chain, which is why this reads as a mismatch rather than an error. Point this " <>
+        "run's ORIGIN-chain endpoint at chain #{declared}"
 
   defp describe_gap({:chain_id_unavailable, _}),
     do: "the RPC did not answer eth_chainId, so which chain it speaks for is unknown"

--- a/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
+++ b/packages/raxol_earn/lib/raxol/earn/xochi/pull_preflight.ex
@@ -48,7 +48,15 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   those: they are properties of funding time, not signing time, and the order
   task reports the allowance separately.
 
-  Two narrower limits are worth stating rather than leaving to be discovered.
+  It does not bind the pull to the corridor the OPERATOR asked for. `same_chain/2`
+  compares the served `domain.chainId` against the node, never against a
+  requested origin -- so a pull for the wrong chain, checked against a node that
+  speaks for that wrong chain, passes here. That binding is
+  `Protocols.Xochi.validate_pull/3`'s `:pull_chain` check, which runs before
+  signing and is a precondition of using this module rather than a duplicate of
+  it. A caller reaching for `verify/4` on its own owes itself that check.
+
+  Three narrower limits are worth stating rather than leaving to be discovered.
 
   The EOA branch checks what `ecrecover` checks: a canonical 65 bytes, `v` of 27
   or 28, and a recovered address equal to the buyer's. Any acceptance policy the
@@ -289,8 +297,14 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   # happily with 32 valid-looking bytes that belong to a different domain. The
   # digest then differs for a reason that has nothing to do with the signature,
   # and reporting it as a rejection would tell the operator their signing is
-  # broken when their RPC url is. `ORDER_RPC_<from>` falls back to the Base
-  # endpoint when unset, so this is the DEFAULT path for any non-Base origin.
+  # broken when their RPC url is.
+  #
+  # Both callers can reach it. The live gate reads `XOCHI_ORDER_RPC_<chain>` per
+  # corridor, so a mesh run points at whichever endpoint that names. `mix
+  # raxol_earn.order` falls `ORDER_RPC_<from>` back to `ORDER_RPC_8453` -- which
+  # today is the same chain, since `assert_acp_origin!/1` pins the origin to the
+  # ACP core's, but the fallback is what would surface a non-Base origin here
+  # rather than as a bad signature the moment that pin widens.
   defp same_chain(client, served) do
     served_chain_id = get_in(served, ["domain", "chainId"])
 
@@ -338,18 +352,23 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   defp domain_separator(client, verifying_contract) do
     call = %{to: verifying_contract, data: selector()}
 
-    with {:ok, hex} <- RPC.eth_call(client, call),
-         {:ok, bytes} <- decode_hex(hex, :domain_separator) do
-      case bytes do
-        <<separator::binary-size(32)>> ->
-          {:ok, separator}
-
-        other ->
-          {:inconclusive, {:domain_separator_length, byte_size(other)}}
-      end
+    with {:ok, hex} <- RPC.eth_call(client, call) do
+      interpret_separator(hex)
     else
       {:error, reason} ->
         {:inconclusive, {:domain_separator_unavailable, verifying_contract, reason}}
+    end
+  end
+
+  # A separator that came back but is not 32 bytes of hex is a different gap
+  # from one that never came back, and folding the two reported a node returning
+  # garbage as a node that was down -- which sends an operator to check
+  # connectivity that is fine.
+  defp interpret_separator(hex) do
+    case decode_hex(hex, :domain_separator) do
+      {:ok, <<separator::binary-size(32)>>} -> {:ok, separator}
+      {:ok, other} -> {:inconclusive, {:domain_separator_length, byte_size(other)}}
+      {:error, _} -> {:inconclusive, {:domain_separator_malformed, hex}}
     end
   end
 
@@ -366,14 +385,30 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   # domain half is what is sourced from the chain, and this step has no judgment
   # in it beyond dropping EIP712Domain, which both sides must do identically or
   # neither is encoding EIP-712.
+  #
+  # Wrapped because the encoder can RAISE on a served payload, not only return
+  # an error: `EIP712`'s primary-type detection raises `ArgumentError` when the
+  # types map has more than one unreferenced root, and `served` comes off the
+  # wire. In `mix raxol_earn.order` that is pre-empted -- signing runs the same
+  # encoder first and would have raised there -- but the live gate calls
+  # `verify/4` once per cell with no rescue, so one malformed payload took down
+  # a ninety-cell matrix instead of failing its own cell. A payload this module
+  # cannot encode is a rejection either way; the shape of the failure should not
+  # decide whether the other eighty-nine cells run.
   defp digest(separator, served) do
-    types = XochiProtocol.eip712_types(served)
-    message = served["message"] || %{}
-
-    case EIP712.hash_with_separator(separator, types, message) do
+    case encode_digest(separator, served) do
       {:ok, digest} -> {:ok, digest}
       {:error, reason} -> {:rejected_because, {:digest_failed, reason}}
     end
+  end
+
+  defp encode_digest(separator, served) do
+    types = XochiProtocol.eip712_types(served)
+    message = served["message"] || %{}
+
+    EIP712.hash_with_separator(separator, types, message)
+  rescue
+    error -> {:error, {:unencodable_types, Exception.message(error)}}
   end
 
   # Permit2 and the ERC-3009 tokens branch on whether the owner has code: a
@@ -405,6 +440,7 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
     case call_erc1271(client, account, digest, sig_bytes) do
       {:ok, @erc1271_magic} -> :ok
       {:ok, returned} -> {:rejected, returned}
+      {:rejected_because, _} = out -> out
       {:inconclusive, _} = out -> out
     end
   end
@@ -471,15 +507,65 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
 
     with {:ok, hex} <- RPC.eth_call(client, call),
          {:ok, bytes} <- decode_hex(hex, :magic_value) do
-      # A bytes4 return is left-aligned in its 32-byte word. An account that
-      # REVERTS rather than returning a value surfaces as an RPC error above and
-      # is classified `:inconclusive` -- indistinguishable here from a node that
-      # dropped the call, and both block, so the safe reading wins.
+      # A bytes4 return is left-aligned in its 32-byte word.
       {:ok, binary_part(bytes, 0, min(4, byte_size(bytes)))}
     else
-      {:error, reason} -> {:inconclusive, {:erc1271_call_failed, account, reason}}
+      {:error, reason} -> classify_erc1271_failure(account, reason)
     end
   end
+
+  # An account that REVERTS rather than returning a value is a VERDICT, not a
+  # gap. This used to read every `eth_call` failure as `:inconclusive` on the
+  # grounds that a revert is indistinguishable from a node that dropped the
+  # call. It is not: `RPC.request/3` reports a node that answered with a
+  # JSON-RPC error separately from one that could not be reached
+  # (`{:transport, _}`), and by the time this runs the same client has already
+  # answered `eth_chainId`, `eth_getCode` and `DOMAIN_SEPARATOR()`.
+  #
+  # Collapsing the two mattered because it is the DEFAULT shape for the account
+  # this module was built for. Plenty of ERC-1271 implementations -- including
+  # smart accounts on the 7702 path of GitHub #772 -- revert on a bad signature
+  # instead of returning `0xffffffff`. Read as inconclusive, that stays soft
+  # under `--dry-run` and soft in the live gate, so the rehearsal scored PASS on
+  # exactly the defect it exists to find, and the funded run was left as the
+  # only thing catching it.
+  #
+  # Only an EXECUTION revert converts. A rate limit, a method the node does not
+  # serve, an internal error -- all still `{:rpc_error, _}`, none of them a
+  # statement about the signature -- stay inconclusive, because a false REJECTED
+  # sends an operator after a signing defect that is not there.
+  defp classify_erc1271_failure(account, {:rpc_error, error} = reason) do
+    if execution_revert?(error) do
+      {:rejected_because, {:erc1271_reverted, error_detail(error)}}
+    else
+      {:inconclusive, {:erc1271_call_failed, account, reason}}
+    end
+  end
+
+  defp classify_erc1271_failure(account, reason),
+    do: {:inconclusive, {:erc1271_call_failed, account, reason}}
+
+  # What the EVM executing and reverting looks like on the wire. Geth and its
+  # descendants answer code `3` and carry the revert data; the -32000 range is
+  # server-defined, so there the message is what says which kind of failure it
+  # was. Anything this does not recognize is treated as not-a-revert, since the
+  # cost of that mistake is a re-run and the cost of the opposite is chasing a
+  # signature that was fine.
+  defp execution_revert?(%{code: 3}), do: true
+
+  defp execution_revert?(%{code: code, message: message})
+       when is_integer(code) and code <= -32_000 and code >= -32_099 and is_binary(message) do
+    String.contains?(String.downcase(message), "revert")
+  end
+
+  defp execution_revert?(%{message: message}) when is_binary(message) do
+    String.contains?(String.downcase(message), "execution reverted")
+  end
+
+  defp execution_revert?(_error), do: false
+
+  defp error_detail(%{message: message}) when is_binary(message), do: message
+  defp error_detail(error), do: inspect(error)
 
   # A signature that is not hex is not a signature. The pull is handed these same
   # bytes, so there is nothing here for a working RPC to resolve later.
@@ -563,6 +649,13 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   defp describe_defect({:recover_failed, reason}),
     do: "this signature does not recover to any address (#{inspect(reason)})"
 
+  defp describe_defect({:erc1271_reverted, detail}),
+    do:
+      "the buyer's isValidSignature REVERTED on this digest (#{detail}). A revert is the " <>
+        "account refusing the signature, and the pull calls it the same way, so the pull " <>
+        "reverts too. Capture the served pull_authorization and the signature: this is the " <>
+        "payload, not the endpoint"
+
   defp describe_defect({:invalid_hex, :signature}),
     do: "the signature is not hex"
 
@@ -594,18 +687,23 @@ defmodule Raxol.Earn.Xochi.PullPreflight do
   defp describe_gap({:domain_separator_length, n}),
     do: "DOMAIN_SEPARATOR() answered #{n} bytes rather than 32"
 
+  defp describe_gap({:domain_separator_malformed, _hex}),
+    do:
+      "DOMAIN_SEPARATOR() answered something that is not hex, so the endpoint is answering " <>
+        "but not with a separator"
+
   defp describe_gap({:signer_kind_unavailable, account, _}),
     do: "eth_getCode did not answer for #{short(account)}, so the pull's own branch is unknown"
 
-  # A revert lands here rather than in a rejection, because this cannot tell a
-  # reverting `isValidSignature` (which IS a verdict -- the pull reverts too)
-  # from a node that dropped the call. Erring toward "retry" is the safe
-  # direction for a check that blocks either way, but say what a repeat means so
-  # the operator is not sent after the RPC forever.
+  # An execution revert no longer lands here -- `classify_erc1271_failure/2`
+  # converts it to a rejection. What is left is the node failing to answer, or
+  # answering with an error that says nothing about the signature (a rate limit,
+  # an unserved method). Neither is a verdict, so neither may fund.
   defp describe_gap({:erc1271_call_failed, account, _}),
     do:
-      "#{short(account)} did not answer isValidSignature. If it answers other calls, this is " <>
-        "the account REVERTING rather than the node failing, and the signature is the suspect"
+      "#{short(account)} did not answer isValidSignature, and the answer was not an " <>
+        "execution revert -- so this says nothing about the signature. Check the endpoint's " <>
+        "rate limits and that it serves eth_call for #{short(account)}"
 
   defp describe_gap(_other), do: "the check itself could not run"
 

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -350,8 +350,18 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
                {:error, :pull_preflight_inconclusive}
     end
 
-    test "a dry run reports every outcome and carries on, since it spends nothing" do
-      assert Order.decide_preflight({:rejected, %{reason: :no_verifying_contract}}, true) == :ok
+    # `scripts/run_live_gates.sh --dry-run` scores every cell on this task's exit
+    # status, so a rejection that returned :ok here scored the rehearsal PASS on
+    # the single defect the rehearsal exists to find.
+    test "a dry run FAILS on a rejection, since the rehearsal is what CI scores" do
+      assert Order.decide_preflight({:rejected, %{reason: :no_verifying_contract}}, true) ==
+               {:error, :pull_signature_rejected}
+    end
+
+    # Not a verdict on the payload, and the usual cause is an origin-chain
+    # endpoint the rehearsing machine was never given. Failing on it trains an
+    # operator to ignore the exit code.
+    test "a dry run carries on when the check could not run" do
       assert Order.decide_preflight({:inconclusive, :whatever}, true) == :ok
     end
   end

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -329,4 +329,30 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
       assert message =~ "is not a USDC amount"
     end
   end
+
+  # The preflight's own suite proves it classifies outcomes correctly. This
+  # proves the run SPENDS on that classification -- a distinct claim, and the one
+  # that was untested while a catch-all funded every outcome but one.
+  describe "what a preflight outcome authorizes" do
+    test "a funded run proceeds only on a pass" do
+      assert Order.decide_preflight({:ok, %{}}, false) == :ok
+    end
+
+    test "a funded run stops on a rejection" do
+      assert Order.decide_preflight({:rejected, %{reason: :no_verifying_contract}}, false) ==
+               {:error, :pull_signature_rejected}
+    end
+
+    test "a funded run stops on an inconclusive check too" do
+      # An unanswered question is not permission to escrow. The RPC that could
+      # not answer it is the same one the createJob and fund writes go to.
+      assert Order.decide_preflight({:inconclusive, {:chain_id_unavailable, :timeout}}, false) ==
+               {:error, :pull_preflight_inconclusive}
+    end
+
+    test "a dry run reports every outcome and carries on, since it spends nothing" do
+      assert Order.decide_preflight({:rejected, %{reason: :no_verifying_contract}}, true) == :ok
+      assert Order.decide_preflight({:inconclusive, :whatever}, true) == :ok
+    end
+  end
 end

--- a/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
+++ b/packages/raxol_earn/test/mix/tasks/raxol_earn.order_test.exs
@@ -355,4 +355,27 @@ defmodule Mix.Tasks.RaxolEarn.OrderTest do
       assert Order.decide_preflight({:inconclusive, :whatever}, true) == :ok
     end
   end
+
+  # The gate can only check a signature it is handed. Reading a missing one as
+  # "nothing to check" would switch the gate off for exactly the payload it was
+  # built to gate, which is the fail-open shape PullPreflight refuses to offer
+  # its callers one level down.
+  describe "a bundle with no pull signature" do
+    test "aborts rather than funding an unchecked pull" do
+      quote_resp = %{pull_authorization: %{"domain" => %{}}}
+      cfg = %{buyer: "0x0", rpc: "http://stub.invalid", src_token: "0x0"}
+
+      assert {:error, {:pull_signature_missing, nil}} =
+               Order.preflight_pull(cfg, quote_resp, %{signature: "0xabc"}, [])
+
+      assert {:error, {:pull_signature_missing, nil}} =
+               Order.preflight_pull(cfg, quote_resp, %{}, dry_run: true)
+    end
+
+    test "a quote that served no pull has nothing to check and is not blocked" do
+      cfg = %{buyer: "0x0", rpc: "http://stub.invalid", src_token: "0x0"}
+
+      assert :ok = Order.preflight_pull(cfg, %{pull_authorization: nil}, %{}, [])
+    end
+  end
 end

--- a/packages/raxol_earn/test/raxol/earn/onchain/permit2_approver_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/onchain/permit2_approver_test.exs
@@ -14,9 +14,19 @@ defmodule Raxol.Earn.Onchain.Permit2ApproverTest do
   defp zero_word, do: "0x" <> String.duplicate("0", 64)
 
   describe "permit2_address/0" do
-    test "matches the universal Permit2 address the payments protocol signs against" do
+    test "is taken from the payments protocol rather than restated" do
       assert Permit2Approver.permit2_address() ==
                Raxol.Payments.Protocols.Permit2.verifying_contract()
+    end
+
+    test "is the universal Permit2 deployment" do
+      # This address decides three things at once: the spender an approve grants
+      # to, the `verifyingContract` a served pull must declare, and the contract
+      # `PullPreflight` reads DOMAIN_SEPARATOR() from. Pinning the external fact
+      # belongs in a test; a second copy in production code is what the
+      # preflight exists to catch.
+      assert Permit2Approver.permit2_address() ==
+               "0x000000000022D473030F116dDEE9F6B43aC78BA3"
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -313,10 +313,16 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     # Reported, never asserted. A cell that cannot reach an RPC has no verdict to
     # give, and this test's contract is that it moves no funds and fails only on
     # a solver-pin mismatch.
+    #
+    # The RPC is resolved FIRST, before `sign_intent`. A pull authorization is a
+    # bearer instrument -- bounded by the pinned spender, but live and in-window
+    # -- and minting one with the funded key for a check that cannot run is a
+    # side effect this gate has no reason to have. With the mesh corridor set
+    # that is ninety of them, signed and dropped.
     defp preflight_pull_signature(%{quote: quote, request: request}, from) do
-      with {:ok, served} <- served_pull(quote),
-           {:ok, bundle} <- XochiProtocol.sign_intent(quote, LiveWallet, request),
-           {:ok, url} <- rpc_url(from) do
+      with {:ok, url} <- rpc_url(from),
+           {:ok, served} <- served_pull(quote),
+           {:ok, bundle} <- XochiProtocol.sign_intent(quote, LiveWallet, request) do
         signature = bundle[:pull_signature] || bundle["pull_signature"]
 
         served

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -326,7 +326,13 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
         signature = bundle[:pull_signature] || bundle["pull_signature"]
 
         served
-        |> PullPreflight.verify(signature, LiveWallet.address(), rpc: RPC.client(url: url))
+        |> PullPreflight.verify(signature, LiveWallet.address(),
+          rpc: RPC.client(url: url),
+          # Named from the rail we asked for, never from the served payload: the
+          # party that chose `verifyingContract` must not also choose the
+          # contract we ask about its own signature.
+          expect_verifier: expected_verifier(quote.payment_method, request)
+        )
         |> PullPreflight.describe()
       else
         {:error, reason} -> "pull preflight: skipped (#{inspect(reason)})"
@@ -335,6 +341,12 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
 
     defp served_pull(%{pull_authorization: nil}), do: {:error, :no_pull_authorization}
     defp served_pull(%{pull_authorization: pull}), do: {:ok, pull}
+
+    defp expected_verifier("permit2", _request),
+      do: Raxol.Payments.Protocols.Permit2.verifying_contract()
+
+    defp expected_verifier("erc3009", request), do: request.from_token
+    defp expected_verifier(_method, _request), do: nil
 
     defp rpc_url(chain) do
       case System.get_env("XOCHI_ORDER_RPC_#{chain}") do

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -121,6 +121,24 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
 
       assert failures == [],
              "preflight failed for #{length(failures)} cell(s), no funds moved: #{inspect(failures)}"
+
+      # A REJECTED pull signature is a PROVEN defect: the verifying contract
+      # rebuilds a digest this signature does not cover, so the pull would revert
+      # and an order on this cell would escrow a fee for a settlement that cannot
+      # execute. That fails the rehearsal, for the same reason
+      # `Mix.Tasks.RaxolEarn.Order.decide_preflight/2` fails a funded run --
+      # this gate is what `scripts/run_live_gates.sh` scores, so a rejection that
+      # only printed itself would score the cell PASS on the single defect the
+      # rehearsal exists to find.
+      #
+      # INCONCLUSIVE does NOT fail: it is not a verdict on the payload, and the
+      # usual cause is an origin-chain endpoint this machine was never given.
+      rejected = for {cell, {:ok, %{pull: {:rejected, line}}}} <- results, do: {cell, line}
+
+      assert rejected == [],
+             "#{length(rejected)} cell(s) served a pull whose signature will not verify on " <>
+               "chain, so ordering them would strand an escrow (no funds moved): " <>
+               "#{inspect(rejected)}"
     end
 
     @tag :live_xochi_order_settle
@@ -310,9 +328,18 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     # checks the pull's SHAPE; this checks its DIGEST, which is what four funded
     # attempts on GitHub #772 died on while every shape check passed.
     #
-    # Reported, never asserted. A cell that cannot reach an RPC has no verdict to
-    # give, and this test's contract is that it moves no funds and fails only on
-    # a solver-pin mismatch.
+    # Returns `{verdict, line}`. A REJECTED verdict fails the cell (see the
+    # assertion in the preflight test); INCONCLUSIVE and skipped are reported and
+    # nothing more. That split is the same one
+    # `Mix.Tasks.RaxolEarn.Order.decide_preflight/2` makes, and it has to be made
+    # HERE as well, because this gate -- not that task -- is what
+    # `scripts/run_live_gates.sh` runs. A rejection that only printed itself
+    # would score the cell PASS on the one defect the rehearsal exists to find.
+    #
+    # It still moves no funds and still cannot fail on an unreachable endpoint,
+    # so the test's contract is unchanged: what it adds is a hard failure on a
+    # PROVEN defect, which was never covered by "fails only on a solver-pin
+    # mismatch".
     #
     # The RPC is resolved FIRST, before `sign_intent`. A pull authorization is a
     # bearer instrument -- bounded by the pinned spender, but live and in-window
@@ -324,17 +351,18 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
            {:ok, served} <- served_pull(quote),
            {:ok, bundle} <- XochiProtocol.sign_intent(quote, LiveWallet, request),
            {:ok, signature} <- pull_signature(bundle) do
-        served
-        |> PullPreflight.verify(signature, LiveWallet.address(),
-          rpc: RPC.client(url: url),
-          # Named from the rail we asked for, never from the served payload: the
-          # party that chose `verifyingContract` must not also choose the
-          # contract we ask about its own signature.
-          expect_verifier: expected_verifier(quote.payment_method, request)
-        )
-        |> PullPreflight.describe()
+        outcome =
+          PullPreflight.verify(served, signature, LiveWallet.address(),
+            rpc: RPC.client(url: url),
+            # Named from the rail we asked for, never from the served payload:
+            # the party that chose `verifyingContract` must not also choose the
+            # contract we ask about its own signature.
+            expect_verifier: expected_verifier(quote.payment_method, request)
+          )
+
+        {elem(outcome, 0), PullPreflight.describe(outcome)}
       else
-        {:error, reason} -> "pull preflight: skipped (#{inspect(reason)})"
+        {:error, reason} -> {:skipped, "pull preflight: skipped (#{inspect(reason)})"}
       end
     end
 
@@ -358,9 +386,12 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
 
     defp expected_verifier("erc3009", request), do: request.from_token
 
+    # Names the variable rather than the chain, because the skip is only
+    # actionable if the operator can see which knob was missing --
+    # `scripts/run_live_gates.sh` sets these from `GATE_RPC_<chain>`.
     defp rpc_url(chain) do
       case System.get_env("XOCHI_ORDER_RPC_#{chain}") do
-        nil -> {:error, {:no_rpc_for_chain, chain}}
+        nil -> {:error, {:unset, "XOCHI_ORDER_RPC_#{chain}"}}
         url -> {:ok, url}
       end
     end
@@ -553,7 +584,7 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
       )
 
       case outcome do
-        {:ok, %{pull: line}} when is_binary(line) -> log("  #{line}")
+        {:ok, %{pull: {_verdict, line}}} -> log("  #{line}")
         _ -> :ok
       end
     end

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -48,7 +48,9 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     alias Raxol.Earn.Offering.Registry, as: OfferingRegistry
     alias Raxol.Earn.ProviderAdapter
     alias Raxol.Earn.ProviderAdapter.JSONRPC
+    alias Raxol.Earn.Onchain.RPC
     alias Raxol.Earn.Xochi.OriginPull
+    alias Raxol.Earn.Xochi.PullPreflight
     alias Raxol.Earn.Xochi.StablePublicOffering
     alias Raxol.Payments.Assets
     alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
@@ -286,14 +288,52 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     # failure like a solver-pin mismatch (hard).
     defp preflight_cell(cfg, from, to, token) do
       case preflight_quote(cfg, from, to, token) do
-        {:ok, %{quote: quote}} ->
-          {:ok, %{method: quote.payment_method, to_amount: quote.to_amount}}
+        {:ok, %{quote: quote} = checked} ->
+          {:ok,
+           %{
+             method: quote.payment_method,
+             to_amount: quote.to_amount,
+             pull: preflight_pull_signature(checked, from)
+           }}
 
         {:error, :cannot_solve} ->
           {:soft, :cannot_solve}
 
         {:error, reason} ->
           {:error, reason}
+      end
+    end
+
+    # Signing is free and local, so the read-only gate can sign the served pull
+    # and ask the verifying contract whether that signature would be accepted --
+    # the question `validate_pull/3` above does not answer. `validate_pull`
+    # checks the pull's SHAPE; this checks its DIGEST, which is what four funded
+    # attempts on GitHub #772 died on while every shape check passed.
+    #
+    # Reported, never asserted. A cell that cannot reach an RPC has no verdict to
+    # give, and this test's contract is that it moves no funds and fails only on
+    # a solver-pin mismatch.
+    defp preflight_pull_signature(%{quote: quote, request: request}, from) do
+      with {:ok, served} <- served_pull(quote),
+           {:ok, bundle} <- XochiProtocol.sign_intent(quote, LiveWallet, request),
+           {:ok, url} <- rpc_url(from) do
+        signature = bundle[:pull_signature] || bundle["pull_signature"]
+
+        served
+        |> PullPreflight.verify(signature, LiveWallet.address(), rpc: RPC.client(url: url))
+        |> PullPreflight.describe()
+      else
+        {:error, reason} -> "pull preflight: skipped (#{inspect(reason)})"
+      end
+    end
+
+    defp served_pull(%{pull_authorization: nil}), do: {:error, :no_pull_authorization}
+    defp served_pull(%{pull_authorization: pull}), do: {:ok, pull}
+
+    defp rpc_url(chain) do
+      case System.get_env("XOCHI_ORDER_RPC_#{chain}") do
+        nil -> {:error, {:no_rpc_for_chain, chain}}
+        url -> {:ok, url}
       end
     end
 
@@ -483,6 +523,11 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
           {:error, reason} -> "FAIL #{cell}: #{inspect(reason)}"
         end
       )
+
+      case outcome do
+        {:ok, %{pull: line}} when is_binary(line) -> log("  #{line}")
+        _ -> :ok
+      end
     end
 
     # Render the corridor's asset pairing: "USDC" same-asset, "USDC->USDG" when a

--- a/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/live_order_test.exs
@@ -322,9 +322,8 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     defp preflight_pull_signature(%{quote: quote, request: request}, from) do
       with {:ok, url} <- rpc_url(from),
            {:ok, served} <- served_pull(quote),
-           {:ok, bundle} <- XochiProtocol.sign_intent(quote, LiveWallet, request) do
-        signature = bundle[:pull_signature] || bundle["pull_signature"]
-
+           {:ok, bundle} <- XochiProtocol.sign_intent(quote, LiveWallet, request),
+           {:ok, signature} <- pull_signature(bundle) do
         served
         |> PullPreflight.verify(signature, LiveWallet.address(),
           rpc: RPC.client(url: url),
@@ -342,11 +341,22 @@ defmodule Raxol.Earn.Xochi.LiveOrderTest do
     defp served_pull(%{pull_authorization: nil}), do: {:error, :no_pull_authorization}
     defp served_pull(%{pull_authorization: pull}), do: {:ok, pull}
 
+    # A quote served a pull, so the bundle owes a signature over it. Handing a
+    # nil to `verify/4` would report "REJECTED -- not hex", which reads as a
+    # verdict on a signature that was never produced.
+    defp pull_signature(bundle) do
+      case Map.get(bundle, :pull_signature) do
+        sig when is_binary(sig) -> {:ok, sig}
+        _ -> {:error, :pull_signature_missing}
+      end
+    end
+
+    # No catch-all: `sign_intent/3` above refused any other payment_method, so a
+    # third value cannot reach here.
     defp expected_verifier("permit2", _request),
       do: Raxol.Payments.Protocols.Permit2.verifying_contract()
 
     defp expected_verifier("erc3009", request), do: request.from_token
-    defp expected_verifier(_method, _request), do: nil
 
     defp rpc_url(chain) do
       case System.get_env("XOCHI_ORDER_RPC_#{chain}") do

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -607,7 +607,11 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       end
     end
 
-    test "a separator that cannot be read is inconclusive" do
+    # A node that ANSWERS with something that is not a separator is a different
+    # gap from one that never answered, and folding the two reported garbage on
+    # the wire as an endpoint that was down -- sending the operator to check
+    # connectivity that is fine.
+    test "a separator that comes back unreadable is inconclusive, and says so" do
       plug = fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
         req = Jason.decode!(body)
@@ -625,8 +629,167 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       client = RPC.client(url: "http://stub.invalid/rpc", plug: plug)
       served = served_pull()
 
+      assert {:inconclusive, {:domain_separator_malformed, _}} =
+               verify(served, current_signature(served), @account, rpc: client)
+    end
+
+    test "a separator the endpoint never answers for is its own gap" do
+      plug = fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        req = Jason.decode!(body)
+
+        payload =
+          if req["method"] == "eth_chainId" do
+            %{"result" => "0x2105"}
+          else
+            %{"error" => %{"code" => -32_603, "message" => "internal error"}}
+          end
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(Map.merge(%{"jsonrpc" => "2.0", "id" => req["id"]}, payload))
+        )
+      end
+
+      client = RPC.client(url: "http://stub.invalid/rpc", plug: plug)
+      served = served_pull()
+
       assert {:inconclusive, {:domain_separator_unavailable, _vc, _reason}} =
                verify(served, current_signature(served), @account, rpc: client)
+    end
+  end
+
+  # The default shape for the account this module was built for. A smart account
+  # that REVERTS on a bad signature rather than returning 0xffffffff was read as
+  # "the check could not run" -- which stays soft under `--dry-run` and soft in
+  # the live gate, so the rehearsal scored PASS on exactly the defect it exists
+  # to find. A revert is the account refusing the signature, and the pull calls
+  # it the same way, so the pull reverts too.
+  describe "an isValidSignature that reverts" do
+    # `eth_call` erroring rather than returning: what a reverting contract
+    # actually looks like on the wire.
+    defp erc1271_error_chain(error) do
+      plug = fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        req = Jason.decode!(body)
+
+        payload =
+          case req["method"] do
+            "eth_chainId" ->
+              %{"result" => "0x2105"}
+
+            "eth_getCode" ->
+              %{"result" => "0xef0100" <> String.duplicate("11", 20)}
+
+            "eth_call" ->
+              [%{"to" => to} | _] = req["params"]
+
+              if String.downcase(to) == String.downcase(@account) do
+                %{"error" => error}
+              else
+                %{"result" => "0x" <> Base.encode16(@permit2_separator, case: :lower)}
+              end
+          end
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(Map.merge(%{"jsonrpc" => "2.0", "id" => req["id"]}, payload))
+        )
+      end
+
+      RPC.client(url: "http://stub.invalid/rpc", plug: plug)
+    end
+
+    test "is a REJECTION, so the rehearsal fails on it" do
+      served = served_pull()
+
+      chain =
+        erc1271_error_chain(%{"code" => 3, "message" => "execution reverted", "data" => "0x"})
+
+      assert {:rejected, %{reason: {:erc1271_reverted, _detail}}} =
+               verify(served, current_signature(served), @account, rpc: chain)
+    end
+
+    # The -32000 range is server-defined, so the message is what says which kind
+    # of failure it was.
+    test "is recognized in the server-defined error range too" do
+      served = served_pull()
+
+      chain =
+        erc1271_error_chain(%{
+          "code" => -32_000,
+          "message" => "execution reverted: InvalidContractSignature()"
+        })
+
+      assert {:rejected, %{reason: {:erc1271_reverted, _}}} =
+               verify(served, current_signature(served), @account, rpc: chain)
+    end
+
+    # The other direction, and the reason this converts only an execution
+    # revert. A rate limit is still an RPC error and still says nothing about
+    # the signature; a false REJECTED there sends an operator after a signing
+    # defect that is not present.
+    test "but a rate limit is not a verdict and stays inconclusive" do
+      served = served_pull()
+
+      chain =
+        erc1271_error_chain(%{"code" => -32_005, "message" => "rate limit exceeded"})
+
+      assert {:inconclusive, {:erc1271_call_failed, _account, _reason}} =
+               verify(served, current_signature(served), @account, rpc: chain)
+    end
+
+    test "and a node that cannot be reached at all stays inconclusive" do
+      served = served_pull()
+
+      plug = fn conn -> Plug.Conn.send_resp(conn, 503, "upstream down") end
+
+      assert {:inconclusive, _} =
+               verify(served, current_signature(served), @account,
+                 rpc: RPC.client(url: "http://stub.invalid/rpc", plug: plug)
+               )
+    end
+
+    test "the rejection line names the payload, not the endpoint" do
+      line =
+        PullPreflight.describe({:rejected, %{reason: {:erc1271_reverted, "execution reverted"}}})
+
+      assert line =~ "REJECTED"
+      assert line =~ "REVERTED"
+      assert line =~ "this is the payload, not the endpoint"
+    end
+  end
+
+  # `verify/4` documents exactly three outcomes, and a served payload could
+  # break that by RAISING: `EIP712`'s primary-type detection raises when the
+  # types map has more than one unreferenced root. The order task never saw it
+  # (signing runs the same encoder first), but the live gate calls this once per
+  # cell with no rescue, so one malformed payload took down a ninety-cell matrix
+  # instead of failing its own cell.
+  describe "a served types map the encoder cannot handle" do
+    test "leaves by one of the three doors rather than raising" do
+      served =
+        update_in(served_pull(), ["types"], fn types ->
+          Map.put(types, "Orphan", [%{"name" => "x", "type" => "uint256"}])
+        end)
+
+      assert {:rejected, %{reason: {:digest_failed, {:unencodable_types, _}}}} =
+               verify(served, current_signature(served_pull()), @account, rpc: chain())
+    end
+
+    test "and the other eighty-nine cells could still run" do
+      # Same payload, called twice: the point is that it returns rather than
+      # unwinding the caller, so a sibling cell is unaffected.
+      served = update_in(served_pull(), ["types"], &Map.put(&1, "Orphan", []))
+
+      assert {:rejected, _} = verify(served, "0x00", @account, rpc: chain())
+
+      assert {:ok, _} =
+               verify(served_pull(), current_signature(served_pull()), @account, rpc: chain())
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -4,6 +4,8 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
   alias Raxol.Earn.Onchain.RPC
   alias Raxol.Earn.Xochi.PullPreflight
   alias Raxol.Payments.EIP712
+  alias Raxol.Payments.Protocols.Xochi, as: XochiProtocol
+  alias Raxol.Payments.Xochi.Schemas.{QuoteRequest, QuoteResponse}
 
   # Permit2's live Base DOMAIN_SEPARATOR, and the universal deployment it is
   # read from. Hardcoding the real value is what makes the fake chain below an
@@ -166,14 +168,6 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
     )
   end
 
-  defp types_for(served) do
-    served["types"]
-    |> Map.drop(["EIP712Domain"])
-    |> Map.new(fn {name, fields} ->
-      {name, Enum.map(fields, fn f -> {f["name"], f["type"]} end)}
-    end)
-  end
-
   defp sign_over(digest) do
     {:ok, raw} = ExSecp256k1.sign(digest, @key)
     "0x" <> Base.encode16(EIP712.pack_signature(raw), case: :lower)
@@ -183,7 +177,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
   # for this payload is exactly the three fields Permit2 declares.
   defp current_signature(served) do
     domain = Raxol.Payments.Protocols.Xochi.eip712_domain(served)
-    {:ok, digest} = EIP712.hash(domain, types_for(served), served["message"])
+    {:ok, digest} = EIP712.hash(domain, XochiProtocol.eip712_types(served), served["message"])
     sign_over(digest)
   end
 
@@ -204,7 +198,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       verifyingContract: d["verifyingContract"]
     }
 
-    {:ok, digest} = EIP712.hash(domain, types_for(served), served["message"])
+    {:ok, digest} = EIP712.hash(domain, XochiProtocol.eip712_types(served), served["message"])
     sign_over(digest)
   end
 
@@ -412,6 +406,104 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
 
       assert {:inconclusive, {:domain_separator_unavailable, _vc, _reason}} =
                PullPreflight.verify(served, current_signature(served), @account, rpc: client)
+    end
+  end
+
+  # Every other test in this file signs with a digest the test builds. That is
+  # fine for proving the checker distinguishes two digests, and useless for
+  # proving it agrees with the thing that will actually sign in production --
+  # which is the property #772 lost. Here the bundle comes out of
+  # `Xochi.sign_intent/3` itself, so a divergence anywhere in the real signing
+  # path (domain projection, types projection, pull selection) fails this.
+  describe "against a bundle the production signer produced" do
+    defmodule ProdWallet do
+      @moduledoc false
+      use Raxol.Payments.Wallets.Env, env_var: "RAXOL_PULL_PREFLIGHT_TEST_KEY"
+    end
+
+    setup do
+      System.put_env(
+        "RAXOL_PULL_PREFLIGHT_TEST_KEY",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+      )
+
+      Application.put_env(:raxol_payments, :pull_solver_allowlist, [@spender])
+
+      on_exit(fn ->
+        System.delete_env("RAXOL_PULL_PREFLIGHT_TEST_KEY")
+        Application.delete_env(:raxol_payments, :pull_solver_allowlist)
+      end)
+
+      :ok
+    end
+
+    test "accepts the pull signature sign_intent/3 actually emits" do
+      served = live_pull()
+
+      {:ok, bundle} =
+        XochiProtocol.sign_intent(quote_response(served), ProdWallet, quote_request())
+
+      assert {:ok, details} =
+               PullPreflight.verify(served, bundle[:pull_signature], @owner,
+                 rpc: chain(code: "0x"),
+                 expect_verifier: @permit2_address
+               )
+
+      assert details.separator == @permit2_separator
+      assert details.signer_kind == :eoa
+    end
+
+    # The same bundle, checked against a separator that is not Permit2's. If this
+    # passed, the one above would be proving nothing about the domain.
+    test "and rejects it against a verifier that rebuilds a different domain" do
+      served = live_pull()
+
+      {:ok, bundle} =
+        XochiProtocol.sign_intent(quote_response(served), ProdWallet, quote_request())
+
+      other = %{served["domain"] | "chainId" => 8453, "name" => "NotPermit2"}
+
+      assert {:rejected, _} =
+               PullPreflight.verify(served, bundle[:pull_signature], @owner,
+                 rpc: chain(code: "0x", foreign_separator: separator_for(other)),
+                 expect_verifier: @hostile
+               )
+    end
+
+    # The fixture's fixed deadline is months out and would silently start failing
+    # `valid_window?` on its own schedule. Only this describe block signs through
+    # the validator, so only this block needs a live one.
+    defp live_pull do
+      deadline = Integer.to_string(System.system_time(:second) + 3600)
+      update_in(served_pull(), ["message"], &Map.put(&1, "deadline", deadline))
+    end
+
+    defp quote_response(served) do
+      %QuoteResponse{
+        intent_id: "xi_prod",
+        quote_id: "xq_prod",
+        can_solve: true,
+        payment_method: "permit2",
+        eip712_data: %{
+          "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+          "primaryType" => "XochiIntent",
+          "types" => %{"XochiIntent" => [%{"name" => "intentId", "type" => "string"}]},
+          "message" => %{"intentId" => "xi_prod"}
+        },
+        pull_authorization: served
+      }
+    end
+
+    defp quote_request do
+      %QuoteRequest{
+        wallet: @owner,
+        from_chain_id: 8453,
+        to_chain_id: 42_161,
+        from_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        to_token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        from_amount: "3000000",
+        settlement_preference: "public"
+      }
     end
   end
 

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -405,6 +405,25 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       assert Agent.get(asked, & &1) == [@permit2_address]
     end
 
+    # A chainId that is present but unreadable is a different defect from one
+    # that is absent, and describing it as absent sends the operator looking for
+    # a field that is right there in the payload they captured.
+    test "a chainId that is present but unreadable is its own rejection" do
+      for bad <- [-1, "not-a-chain", 1.5, %{}] do
+        served = update_in(served_pull(), ["domain"], &Map.put(&1, "chainId", bad))
+
+        assert {:rejected, %{reason: {:invalid_chain_id, ^bad}}} =
+                 verify(served, "0x00", @account, rpc: chain())
+      end
+    end
+
+    test "a chainId that is absent is still reported as absent" do
+      served = update_in(served_pull(), ["domain"], &Map.delete(&1, "chainId"))
+
+      assert {:rejected, %{reason: :no_chain_id}} =
+               verify(served, "0x00", @account, rpc: chain())
+    end
+
     # This module and `Protocols.Xochi` both parse domain.chainId, and they now
     # agree on what a value is. Nothing reaches here that they disagree about --
     # `EIP712` refuses a padded uint256 at signing, several steps earlier -- so
@@ -616,6 +635,14 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       assert line =~ "REJECTED"
       assert line =~ "declares no domain.verifyingContract"
       refute line =~ "could not run"
+    end
+
+    test "an unreadable chainId is not described as a missing one" do
+      line = PullPreflight.describe({:rejected, %{reason: {:invalid_chain_id, -1}}})
+
+      assert line =~ "REJECTED"
+      assert line =~ "domain.chainId is not a chain id"
+      refute line =~ "declares no domain.chainId"
     end
 
     test "a bad recovery id is not described as a length problem" do

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -168,6 +168,18 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
     )
   end
 
+  # Every call needs the pin now, and these tests are about the other arguments.
+  # `put_new` so a test that IS about the pin can still name its own. The two
+  # tests about the requirement itself call `PullPreflight.verify/4` directly.
+  defp verify(served, signature, account, opts \\ []) do
+    PullPreflight.verify(
+      served,
+      signature,
+      account,
+      Keyword.put_new(opts, :expect_verifier, @permit2_address)
+    )
+  end
+
   defp sign_over(digest) do
     {:ok, raw} = ExSecp256k1.sign(digest, @key)
     "0x" <> Base.encode16(EIP712.pack_signature(raw), case: :lower)
@@ -207,7 +219,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:ok, details} =
-               PullPreflight.verify(served, current_signature(served), @account, rpc: chain())
+               verify(served, current_signature(served), @account, rpc: chain())
 
       assert details.separator == @permit2_separator
       assert details.verifying_contract == @permit2_address
@@ -220,9 +232,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:ok, details} =
-               PullPreflight.verify(served, current_signature(served), @owner,
-                 rpc: chain(code: "0x")
-               )
+               verify(served, current_signature(served), @owner, rpc: chain(code: "0x"))
 
       assert details.signer_kind == :eoa
     end
@@ -231,9 +241,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:rejected, details} =
-               PullPreflight.verify(served, current_signature(served), @account,
-                 rpc: chain(code: "0x")
-               )
+               verify(served, current_signature(served), @account, rpc: chain(code: "0x"))
 
       assert details.signer_kind == :eoa
       assert details.returned == @owner
@@ -246,9 +254,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:rejected, details} =
-               PullPreflight.verify(served, pre_878_signature(served), @owner,
-                 rpc: chain(code: "0x")
-               )
+               verify(served, pre_878_signature(served), @owner, rpc: chain(code: "0x"))
 
       assert details.signer_kind == :eoa
       refute details.returned == @owner
@@ -263,7 +269,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:rejected, details} =
-               PullPreflight.verify(served, pre_878_signature(served), @account, rpc: chain())
+               verify(served, pre_878_signature(served), @account, rpc: chain())
 
       assert details.returned == <<0xFF, 0xFF, 0xFF, 0xFF>>
       assert details.separator == @permit2_separator
@@ -281,7 +287,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = Map.put(served_pull(), "domain", %{"name" => "Xochi", "chainId" => 8453})
 
       assert {:rejected, %{reason: :no_verifying_contract}} =
-               PullPreflight.verify(served, "0x00", @account, rpc: chain())
+               verify(served, "0x00", @account, rpc: chain())
     end
 
     test "a permit2 pull is refused when the quote nominates its own verifier" do
@@ -294,27 +300,43 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served =
         update_in(served_pull(), ["domain"], &Map.put(&1, "verifyingContract", hostile))
 
-      assert {:rejected, %{reason: {:verifier_not_permit2, ^hostile, _canonical}}} =
-               PullPreflight.verify(served, current_signature(served), @account, rpc: chain())
+      assert {:rejected, %{reason: {:verifier_mismatch, ^hostile, _expected}}} =
+               verify(served, current_signature(served), @account, rpc: chain())
     end
 
-    # The primaryType-keyed fallback is a floor, not the control: it reads a
-    # field the same party served. A payload declaring some other primary type
-    # skips it, the quote picks the contract we ask about its own signature, and
-    # the check PASSES -- the #772 shape, one layer out. Documented so the option
-    # below reads as load-bearing rather than belt-and-braces.
-    test "without :expect_verifier a non-permit2 primaryType gets its own oracle to agree" do
+    # Every default available here would be drawn from the payload under audit,
+    # so there is no default. Omitting the pin used to fall back to one keyed on
+    # the served `primaryType` -- also chosen by the party that served it -- and
+    # a payload declaring some other primary type walked straight past it.
+    test "refuses to run at all without :expect_verifier" do
       {served, chain} = hostile_verifier()
 
-      assert {:ok, %{verifying_contract: @hostile}} =
-               PullPreflight.verify(served, current_signature(served), @account, rpc: chain)
+      assert_raise ArgumentError, ~r/:expect_verifier is required/, fn ->
+        PullPreflight.verify(served, current_signature(served), @account, rpc: chain)
+      end
     end
 
+    test "refuses an :expect_verifier that is not an address" do
+      {served, chain} = hostile_verifier()
+
+      for bad <- [:permit2, nil, 42, "permit2"] do
+        assert_raise ArgumentError, ~r/must be a 0x address/, fn ->
+          PullPreflight.verify(served, current_signature(served), @account,
+            rpc: chain,
+            expect_verifier: bad
+          )
+        end
+      end
+    end
+
+    # The whole payload is internally consistent -- the signature really does
+    # cover the digest that address really will rebuild. Only the caller's pin
+    # tells the two apart.
     test ":expect_verifier pins the oracle regardless of what the payload declares" do
       {served, chain} = hostile_verifier()
 
       assert {:rejected, %{reason: {:verifier_mismatch, @hostile, @permit2_address}}} =
-               PullPreflight.verify(served, current_signature(served), @account,
+               verify(served, current_signature(served), @account,
                  rpc: chain,
                  expect_verifier: @permit2_address
                )
@@ -324,7 +346,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:ok, _details} =
-               PullPreflight.verify(served, current_signature(served), @account,
+               verify(served, current_signature(served), @account,
                  rpc: chain(),
                  expect_verifier: String.downcase(@permit2_address)
                )
@@ -338,7 +360,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = update_in(served_pull(), ["domain"], &Map.put(&1, "chainId", "8453"))
 
       assert {:ok, _details} =
-               PullPreflight.verify(served, current_signature(served), @account, rpc: chain())
+               verify(served, current_signature(served), @account, rpc: chain())
     end
 
     test "an unrecoverable signature on a codeless account is a rejection" do
@@ -350,14 +372,14 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       wrapped = "0x" <> String.duplicate("ab", 72)
 
       assert {:rejected, %{reason: {:recover_failed, {:not_a_canonical_signature, 72}}}} =
-               PullPreflight.verify(served, wrapped, @owner, rpc: chain(code: "0x"))
+               verify(served, wrapped, @owner, rpc: chain(code: "0x"))
     end
 
     test "a signature that is not hex is a rejection, not a gap" do
       served = served_pull()
 
       assert {:rejected, %{reason: {:invalid_hex, :signature}}} =
-               PullPreflight.verify(served, "0xnothex", @account, rpc: chain())
+               verify(served, "0xnothex", @account, rpc: chain())
     end
 
     test "an RPC answering for the wrong chain is inconclusive, never a rejection" do
@@ -369,9 +391,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:inconclusive, {:wrong_chain, declared: 8453, node: 42_161}} =
-               PullPreflight.verify(served, current_signature(served), @account,
-                 rpc: chain(chain_id: 42_161)
-               )
+               verify(served, current_signature(served), @account, rpc: chain(chain_id: 42_161))
     end
 
     test "an unreachable RPC is inconclusive, not a rejection" do
@@ -383,7 +403,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:inconclusive, {:chain_id_unavailable, _reason}} =
-               PullPreflight.verify(served, current_signature(served), @account, rpc: client)
+               verify(served, current_signature(served), @account, rpc: client)
     end
 
     test "a separator that cannot be read is inconclusive" do
@@ -405,7 +425,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       served = served_pull()
 
       assert {:inconclusive, {:domain_separator_unavailable, _vc, _reason}} =
-               PullPreflight.verify(served, current_signature(served), @account, rpc: client)
+               verify(served, current_signature(served), @account, rpc: client)
     end
   end
 
@@ -444,7 +464,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
         XochiProtocol.sign_intent(quote_response(served), ProdWallet, quote_request())
 
       assert {:ok, details} =
-               PullPreflight.verify(served, bundle[:pull_signature], @owner,
+               verify(served, bundle[:pull_signature], @owner,
                  rpc: chain(code: "0x"),
                  expect_verifier: @permit2_address
                )
@@ -464,7 +484,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       other = %{served["domain"] | "chainId" => 8453, "name" => "NotPermit2"}
 
       assert {:rejected, _} =
-               PullPreflight.verify(served, bundle[:pull_signature], @owner,
+               verify(served, bundle[:pull_signature], @owner,
                  rpc: chain(code: "0x", foreign_separator: separator_for(other)),
                  expect_verifier: @hostile
                )
@@ -513,7 +533,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
 
       line =
         served
-        |> PullPreflight.verify(pre_878_signature(served), @account, rpc: chain())
+        |> verify(pre_878_signature(served), @account, rpc: chain())
         |> PullPreflight.describe()
 
       assert line =~ "REJECTED"

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -34,6 +34,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
   defp chain(opts \\ []) do
     code = Keyword.get(opts, :code, "0xef0100" <> String.duplicate("11", 20))
     chain_id = Keyword.get(opts, :chain_id, 8453)
+    foreign = Keyword.get(opts, :foreign_separator, @permit2_separator)
 
     plug = fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
@@ -53,7 +54,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
 
           "eth_call" ->
             [%{"to" => to, "data" => data} | _] = req["params"]
-            dispatch(String.downcase(to), data)
+            dispatch(String.downcase(to), data, foreign)
         end
 
       conn
@@ -67,11 +68,19 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
     RPC.client(url: "http://stub.invalid/rpc", plug: plug)
   end
 
-  defp dispatch(to, _data) when to == "0x000000000022d473030f116ddee9f6b43ac78ba3" do
+  defp dispatch(to, _data, _foreign) when to == "0x000000000022d473030f116ddee9f6b43ac78ba3" do
     "0x" <> Base.encode16(@permit2_separator, case: :lower)
   end
 
-  defp dispatch(to, data) when to == @account do
+  # Any other contract answers DOMAIN_SEPARATOR() with whatever 32 bytes it
+  # likes. A verifier nominated by the party under audit answers with the
+  # separator for the domain that party SERVED, which is what makes the check
+  # agree with the payload instead of testing it.
+  defp dispatch(to, "0x3644e515", foreign) when to != @account do
+    "0x" <> Base.encode16(foreign, case: :lower)
+  end
+
+  defp dispatch(to, data, _foreign) when to == @account do
     <<_selector::binary-size(4), digest::binary-size(32), _offset::binary-size(32),
       len::unsigned-big-256, rest::binary>> = decode!(data)
 
@@ -125,6 +134,36 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
         "witness" => %{"orderId" => "0x" <> String.duplicate("11", 32)}
       }
     }
+  end
+
+  @hostile "0x00000000000000000000000000000000000badc0"
+
+  # A pull whose domain nominates a verifier the worker controls, paired with a
+  # chain where that verifier answers DOMAIN_SEPARATOR() with the separator for
+  # the domain it served. Nothing in the payload is inconsistent -- that is the
+  # point. The signature really does cover the digest that address really will
+  # rebuild, so every question this module asks the chain comes back clean while
+  # the pull runs somewhere else entirely.
+  defp hostile_verifier do
+    served =
+      served_pull()
+      |> Map.put("primaryType", "PermitWitnessTransferFromV2")
+      |> update_in(["domain"], &Map.put(&1, "verifyingContract", @hostile))
+
+    {served, chain(foreign_separator: separator_for(served["domain"]))}
+  end
+
+  # EIP712Domain(string name,uint256 chainId,address verifyingContract), built
+  # the long way so the fake does not borrow the code under test to lie with.
+  defp separator_for(%{"name" => name, "chainId" => chain_id, "verifyingContract" => "0x" <> vc}) do
+    type = "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+
+    ExKeccak.hash_256(
+      ExKeccak.hash_256(type) <>
+        ExKeccak.hash_256(name) <>
+        <<chain_id::unsigned-big-256>> <>
+        <<0::size(96)>> <> Base.decode16!(vc, case: :mixed)
+    )
   end
 
   defp types_for(served) do
@@ -262,6 +301,49 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
         update_in(served_pull(), ["domain"], &Map.put(&1, "verifyingContract", hostile))
 
       assert {:rejected, %{reason: {:verifier_not_permit2, ^hostile, _canonical}}} =
+               PullPreflight.verify(served, current_signature(served), @account, rpc: chain())
+    end
+
+    # The primaryType-keyed fallback is a floor, not the control: it reads a
+    # field the same party served. A payload declaring some other primary type
+    # skips it, the quote picks the contract we ask about its own signature, and
+    # the check PASSES -- the #772 shape, one layer out. Documented so the option
+    # below reads as load-bearing rather than belt-and-braces.
+    test "without :expect_verifier a non-permit2 primaryType gets its own oracle to agree" do
+      {served, chain} = hostile_verifier()
+
+      assert {:ok, %{verifying_contract: @hostile}} =
+               PullPreflight.verify(served, current_signature(served), @account, rpc: chain)
+    end
+
+    test ":expect_verifier pins the oracle regardless of what the payload declares" do
+      {served, chain} = hostile_verifier()
+
+      assert {:rejected, %{reason: {:verifier_mismatch, @hostile, @permit2_address}}} =
+               PullPreflight.verify(served, current_signature(served), @account,
+                 rpc: chain,
+                 expect_verifier: @permit2_address
+               )
+    end
+
+    test ":expect_verifier accepts the address the rail actually pulls through" do
+      served = served_pull()
+
+      assert {:ok, _details} =
+               PullPreflight.verify(served, current_signature(served), @account,
+                 rpc: chain(),
+                 expect_verifier: String.downcase(@permit2_address)
+               )
+    end
+
+    # This module and `Protocols.Xochi` both parse domain.chainId, and they now
+    # agree on what a value is. Nothing reaches here that they disagree about --
+    # `EIP712` refuses a padded uint256 at signing, several steps earlier -- so
+    # this pins the agreement rather than a live divergence.
+    test "a chainId string parses the way the signing gate parses it" do
+      served = update_in(served_pull(), ["domain"], &Map.put(&1, "chainId", "8453"))
+
+      assert {:ok, _details} =
                PullPreflight.verify(served, current_signature(served), @account, rpc: chain())
     end
 

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -33,6 +33,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
   # the fake cannot accidentally agree with a wrong digest.
   defp chain(opts \\ []) do
     code = Keyword.get(opts, :code, "0xef0100" <> String.duplicate("11", 20))
+    chain_id = Keyword.get(opts, :chain_id, 8453)
 
     plug = fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
@@ -40,6 +41,12 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
 
       result =
         case req["method"] do
+          # Which chain the node speaks for. Permit2 is at one address on every
+          # chain with a DIFFERENT separator, so this is the only thing that
+          # distinguishes a correct read from a plausible wrong one.
+          "eth_chainId" ->
+            "0x" <> Integer.to_string(chain_id, 16)
+
           # A 7702 delegation designator is code; "0x" is a bare EOA.
           "eth_getCode" ->
             code
@@ -190,7 +197,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
     test "rejects an EOA signature that recovers to someone else, naming who" do
       served = served_pull()
 
-      assert {:error, {:signature_rejected, details}} =
+      assert {:rejected, details} =
                PullPreflight.verify(served, current_signature(served), @account,
                  rpc: chain(code: "0x")
                )
@@ -205,7 +212,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       # the Permit2 path at all.
       served = served_pull()
 
-      assert {:error, {:signature_rejected, details}} =
+      assert {:rejected, details} =
                PullPreflight.verify(served, pre_878_signature(served), @owner,
                  rpc: chain(code: "0x")
                )
@@ -222,7 +229,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       # the separator from the contract is what makes it visible here.
       served = served_pull()
 
-      assert {:error, {:signature_rejected, details}} =
+      assert {:rejected, details} =
                PullPreflight.verify(served, pre_878_signature(served), @account, rpc: chain())
 
       assert details.returned == <<0xFF, 0xFF, 0xFF, 0xFF>>
@@ -234,11 +241,61 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       refute current_signature(served) == pre_878_signature(served)
     end
 
-    test "a served domain with no verifyingContract has nothing to ask" do
+    test "a served domain with no verifyingContract is a rejection, not a gap" do
+      # Nothing on chain claims to verify this, so no signature over it can pass.
+      # Reporting that as inconclusive is what let #772's defect class through a
+      # gate built to catch it: the run read "could not check" and funded anyway.
       served = Map.put(served_pull(), "domain", %{"name" => "Xochi", "chainId" => 8453})
 
-      assert {:error, :no_verifying_contract} =
+      assert {:rejected, %{reason: :no_verifying_contract}} =
                PullPreflight.verify(served, "0x00", @account, rpc: chain())
+    end
+
+    test "a permit2 pull is refused when the quote nominates its own verifier" do
+      # The oracle must not be chosen by the party under audit. A hostile worker
+      # serving a contract it controls could answer DOMAIN_SEPARATOR() with
+      # whatever makes our own projection agree -- and the allowance being spent
+      # was granted to the canonical Permit2, which is where the pull runs.
+      hostile = "0x00000000000000000000000000000000000badc0"
+
+      served =
+        update_in(served_pull(), ["domain"], &Map.put(&1, "verifyingContract", hostile))
+
+      assert {:rejected, %{reason: {:verifier_not_permit2, ^hostile, _canonical}}} =
+               PullPreflight.verify(served, current_signature(served), @account, rpc: chain())
+    end
+
+    test "an unrecoverable signature on a codeless account is a rejection" do
+      # Permit2 recovers this same signature against this same account, so a
+      # signature that cannot be recovered here cannot be recovered there. This
+      # is the 7702 case: a wrapped envelope on an account whose delegation is
+      # not actually set has nothing to unwrap it.
+      served = served_pull()
+      wrapped = "0x" <> String.duplicate("ab", 72)
+
+      assert {:rejected, %{reason: {:recover_failed, {:not_a_canonical_signature, 72}}}} =
+               PullPreflight.verify(served, wrapped, @owner, rpc: chain(code: "0x"))
+    end
+
+    test "a signature that is not hex is a rejection, not a gap" do
+      served = served_pull()
+
+      assert {:rejected, %{reason: {:invalid_hex, :signature}}} =
+               PullPreflight.verify(served, "0xnothex", @account, rpc: chain())
+    end
+
+    test "an RPC answering for the wrong chain is inconclusive, never a rejection" do
+      # Permit2 lives at the same address on every chain with a different
+      # separator, so an RPC pointed at the wrong network returns 32 plausible
+      # bytes and a CORRECT signature fails to match them. Calling that a
+      # rejection would tell the operator their signing is broken when their
+      # ORDER_RPC_<chain> is -- and that env var falls back to Base when unset.
+      served = served_pull()
+
+      assert {:inconclusive, {:wrong_chain, declared: 8453, node: 42_161}} =
+               PullPreflight.verify(served, current_signature(served), @account,
+                 rpc: chain(chain_id: 42_161)
+               )
     end
 
     test "an unreachable RPC is inconclusive, not a rejection" do
@@ -249,7 +306,29 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       client = RPC.client(url: "http://stub.invalid/rpc", plug: plug)
       served = served_pull()
 
-      assert {:error, {:domain_separator_unavailable, _vc, _reason}} =
+      assert {:inconclusive, {:chain_id_unavailable, _reason}} =
+               PullPreflight.verify(served, current_signature(served), @account, rpc: client)
+    end
+
+    test "a separator that cannot be read is inconclusive" do
+      plug = fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        req = Jason.decode!(body)
+
+        result = if req["method"] == "eth_chainId", do: "0x2105", else: nil
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{"jsonrpc" => "2.0", "id" => req["id"], "result" => result})
+        )
+      end
+
+      client = RPC.client(url: "http://stub.invalid/rpc", plug: plug)
+      served = served_pull()
+
+      assert {:inconclusive, {:domain_separator_unavailable, _vc, _reason}} =
                PullPreflight.verify(served, current_signature(served), @account, rpc: client)
     end
   end
@@ -267,11 +346,28 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       assert line =~ "would revert"
     end
 
+    test "a payload defect reads as a rejection, not as a check that could not run" do
+      line = PullPreflight.describe({:rejected, %{reason: :no_verifying_contract}})
+
+      assert line =~ "REJECTED"
+      assert line =~ "declares no domain.verifyingContract"
+      refute line =~ "could not run"
+    end
+
     test "an inconclusive check does not claim the signature is bad" do
-      line = PullPreflight.describe({:error, {:domain_separator_unavailable, "0x0", :timeout}})
+      line =
+        PullPreflight.describe({:inconclusive, {:domain_separator_unavailable, "0x0", :timeout}})
 
       assert line =~ "INCONCLUSIVE"
       assert line =~ "not a verdict"
+    end
+
+    test "a wrong-chain RPC names the env var to set rather than blaming the signature" do
+      line = PullPreflight.describe({:inconclusive, {:wrong_chain, declared: 8453, node: 42_161}})
+
+      assert line =~ "INCONCLUSIVE"
+      assert line =~ "not a verdict"
+      assert line =~ "ORDER_RPC_8453"
     end
   end
 end

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -138,6 +138,59 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
     }
   end
 
+  @usdc_base "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+  @usdc_arbitrum "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+
+  # The ERC-3009 pull a quote serves for an EOA buyer. Two things differ from the
+  # Permit2 fixture and both matter: the verifying contract is the TOKEN rather
+  # than one universal address, and the domain carries a `version` -- so the
+  # `expect_verifier` pin comes from the caller's own token config, and the
+  # domain half has a field the Permit2 domain does not.
+  #
+  # This is the rail `mix raxol_earn.order --signer eoa` and the live ACP gate
+  # take. It had no coverage at all while the preflight was already blocking
+  # funded runs on it.
+  defp served_erc3009_pull do
+    %{
+      "domain" => %{
+        "name" => "USD Coin",
+        "version" => "2",
+        "chainId" => 8453,
+        "verifyingContract" => @usdc_base
+      },
+      "primaryType" => "ReceiveWithAuthorization",
+      "types" => %{
+        "EIP712Domain" => [
+          %{"name" => "name", "type" => "string"},
+          %{"name" => "version", "type" => "string"},
+          %{"name" => "chainId", "type" => "uint256"},
+          %{"name" => "verifyingContract", "type" => "address"}
+        ],
+        "ReceiveWithAuthorization" => [
+          %{"name" => "from", "type" => "address"},
+          %{"name" => "to", "type" => "address"},
+          %{"name" => "value", "type" => "uint256"},
+          %{"name" => "validAfter", "type" => "uint256"},
+          %{"name" => "validBefore", "type" => "uint256"},
+          %{"name" => "nonce", "type" => "bytes32"}
+        ]
+      },
+      "message" => %{
+        "from" => @owner,
+        "to" => @spender,
+        "value" => "3000000",
+        "validAfter" => "0",
+        "validBefore" => "1790000000",
+        "nonce" => "0x" <> String.duplicate("22", 32)
+      }
+    }
+  end
+
+  # A chain where the ERC-3009 token answers DOMAIN_SEPARATOR() with the
+  # separator for the domain it declares.
+  defp erc3009_chain(served),
+    do: chain(code: "0x", foreign_separator: separator_for(served["domain"]))
+
   @hostile "0x00000000000000000000000000000000000badc0"
 
   # A pull whose domain nominates a verifier the worker controls, paired with a
@@ -153,6 +206,23 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       |> update_in(["domain"], &Map.put(&1, "verifyingContract", @hostile))
 
     {served, chain(foreign_separator: separator_for(served["domain"]))}
+  end
+
+  # EIP712Domain(string name,string version,uint256 chainId,address
+  # verifyingContract) -- the four-field domain the ERC-3009 tokens declare.
+  # Must precede the three-field clause, which matches this map as well.
+  defp separator_for(%{"version" => version} = domain) do
+    %{"name" => name, "chainId" => chain_id, "verifyingContract" => "0x" <> vc} = domain
+
+    type = "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+
+    ExKeccak.hash_256(
+      ExKeccak.hash_256(type) <>
+        ExKeccak.hash_256(name) <>
+        ExKeccak.hash_256(version) <>
+        <<chain_id::unsigned-big-256>> <>
+        <<0::size(96)>> <> Base.decode16!(vc, case: :mixed)
+    )
   end
 
   # EIP712Domain(string name,uint256 chainId,address verifyingContract), built
@@ -171,7 +241,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
   # Every call needs the pin now, and these tests are about the other arguments.
   # `put_new` so a test that IS about the pin can still name its own. The two
   # tests about the requirement itself call `PullPreflight.verify/4` directly.
-  defp verify(served, signature, account, opts \\ []) do
+  defp verify(served, signature, account, opts) do
     PullPreflight.verify(
       served,
       signature,
@@ -495,6 +565,48 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
                verify(served, current_signature(served), @account, rpc: client)
     end
 
+    # EIP-2098: `r || vs`, with the recovery bit in the top position of `vs`.
+    # Permit2's SignatureVerification takes this alongside the 65-byte form and
+    # the ERC-3009 tokens go through the same library, so refusing it here would
+    # be a false REJECTED on a signature the pull would accept -- and the message
+    # would point at a 7702 delegation that is not the problem.
+    test "accepts a compact 64-byte signature, which the verifier also accepts" do
+      served = served_pull()
+
+      "0x" <> hex = current_signature(served)
+      <<r::binary-size(32), s::binary-size(32), v::8>> = Base.decode16!(hex, case: :lower)
+      <<0::1, s_rest::bitstring>> = s
+      compact = "0x" <> Base.encode16(<<r::binary, v - 27::1, s_rest::bitstring>>, case: :lower)
+
+      assert byte_size(Base.decode16!(String.trim_leading(compact, "0x"), case: :lower)) == 64
+
+      assert {:ok, details} = verify(served, compact, @owner, rpc: chain(code: "0x"))
+      assert details.signer_kind == :eoa
+    end
+
+    test "a compact signature over the WRONG digest is still rejected" do
+      served = served_pull()
+
+      "0x" <> hex = pre_878_signature(served)
+      <<r::binary-size(32), s::binary-size(32), v::8>> = Base.decode16!(hex, case: :lower)
+      <<0::1, s_rest::bitstring>> = s
+      compact = "0x" <> Base.encode16(<<r::binary, v - 27::1, s_rest::bitstring>>, case: :lower)
+
+      assert {:rejected, details} = verify(served, compact, @owner, rpc: chain(code: "0x"))
+      refute details.returned == @owner
+    end
+
+    # `RPC.get_code/3` head-matches `"0x" <> _`, so this used to leave `verify/4`
+    # as a FunctionClauseError out of a function that documents three outcomes.
+    test "a buyer address that is not an 0x address leaves by one of the three doors" do
+      served = served_pull()
+
+      for bad <- ["not-an-address", "", nil, :buyer] do
+        assert {:rejected, %{reason: {:invalid_account, ^bad}}} =
+                 verify(served, current_signature(served), bad, rpc: chain())
+      end
+    end
+
     test "a separator that cannot be read is inconclusive" do
       plug = fn conn ->
         {:ok, body, conn} = Plug.Conn.read_body(conn)
@@ -515,6 +627,85 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
 
       assert {:inconclusive, {:domain_separator_unavailable, _vc, _reason}} =
                verify(served, current_signature(served), @account, rpc: client)
+    end
+  end
+
+  # The other rail. `Mix.Tasks.RaxolEarn.Order.expected_verifier/2` pins this one
+  # to `cfg.src_token` rather than to a universal address, and the live ACP gate
+  # reaches it with a funded EOA -- so a gate that blocks funded runs on it had
+  # no test for it at all until these.
+  describe "the ERC-3009 rail" do
+    test "accepts a pull whose verifier is the origin token itself" do
+      served = served_erc3009_pull()
+
+      assert {:ok, details} =
+               verify(served, current_signature(served), @owner,
+                 rpc: erc3009_chain(served),
+                 expect_verifier: @usdc_base
+               )
+
+      assert details.verifying_contract == @usdc_base
+      assert details.signer_kind == :eoa
+    end
+
+    # The #772 defect on this rail, in the direction it would actually appear:
+    # the token declares a `version` and the signer drops it, so the separator
+    # the token rebuilds is not the one the signature covers. Nothing in the
+    # payload looks wrong -- only the chain-sourced separator tells them apart.
+    test "rejects a signature that dropped the version the token declares" do
+      served = served_erc3009_pull()
+
+      versionless =
+        served["domain"]
+        |> Map.delete("version")
+        |> then(
+          &%{name: &1["name"], chainId: &1["chainId"], verifyingContract: &1["verifyingContract"]}
+        )
+
+      {:ok, digest} =
+        EIP712.hash(versionless, XochiProtocol.eip712_types(served), served["message"])
+
+      assert {:rejected, details} =
+               verify(served, sign_over(digest), @owner,
+                 rpc: erc3009_chain(served),
+                 expect_verifier: @usdc_base
+               )
+
+      refute details.returned == @owner
+    end
+
+    # The pin is the destination token, not the origin one. Getting the leg
+    # backwards is a plausible caller bug, and it must not read as a signing
+    # defect: the served address is named, so the log says which is which.
+    test "refuses a pull pinned to the wrong side of the corridor" do
+      served = served_erc3009_pull()
+
+      assert {:rejected, %{reason: {:verifier_mismatch, @usdc_base, @usdc_arbitrum}}} =
+               verify(served, current_signature(served), @owner,
+                 rpc: erc3009_chain(served),
+                 expect_verifier: @usdc_arbitrum
+               )
+    end
+
+    # An ERC-3009 pull on a contract buyer goes through ERC-1271 exactly as the
+    # Permit2 one does -- the branch is decided by the ACCOUNT's code, never by
+    # the rail.
+    test "a contract buyer on this rail is asked via ERC-1271, not recovery" do
+      served = served_erc3009_pull()
+
+      chain =
+        chain(
+          code: "0xef0100" <> String.duplicate("11", 20),
+          foreign_separator: separator_for(served["domain"])
+        )
+
+      assert {:ok, details} =
+               verify(served, current_signature(served), @account,
+                 rpc: chain,
+                 expect_verifier: @usdc_base
+               )
+
+      assert details.signer_kind == :contract
     end
   end
 
@@ -653,7 +844,7 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       # The defect that DOES warrant the 7702 advice is the wrapped envelope,
       # and conflating the two sent operators after the wrong thing.
       refute line =~ "7702"
-      refute line =~ "rather than a canonical 65."
+      refute line =~ "bytes rather than"
     end
 
     test "a wrapped envelope still reads as a length problem worth checking 7702 for" do
@@ -662,8 +853,13 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
           {:rejected, %{reason: {:recover_failed, {:not_a_canonical_signature, 72}}}}
         )
 
-      assert line =~ "72 bytes rather than a canonical 65"
+      assert line =~ "72 bytes rather than"
       assert line =~ "7702"
+      # Both accepted lengths are named. Saying "a canonical 65" alone was wrong
+      # once the compact 64-byte form started being accepted, and an operator
+      # holding a 64-byte signature would have read it as confirmation.
+      assert line =~ "65"
+      assert line =~ "64"
     end
 
     test "an inconclusive check does not claim the signature is bad" do
@@ -674,12 +870,35 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       assert line =~ "not a verdict"
     end
 
-    test "a wrong-chain RPC names the env var to set rather than blaming the signature" do
+    test "a wrong-chain RPC names the CHAIN to fix rather than blaming the signature" do
       line = PullPreflight.describe({:inconclusive, {:wrong_chain, declared: 8453, node: 42_161}})
 
       assert line =~ "INCONCLUSIVE"
       assert line =~ "not a verdict"
-      assert line =~ "ORDER_RPC_8453"
+      assert line =~ "chain 8453"
+      assert line =~ "ORIGIN-chain endpoint"
+    end
+
+    # Two callers reach this with different variables -- `mix raxol_earn.order`
+    # reads ORDER_RPC_<chain>, the live gate reads XOCHI_ORDER_RPC_<chain> -- so
+    # a name hardcoded here is wrong in one of them. It named ORDER_RPC_<chain>,
+    # which is the one the live gate does NOT use, and pointing an operator at a
+    # variable that does not exist is the exact failure this module was built to
+    # stop. Each caller names its own knob in its own error text.
+    test "no gap message hardcodes a caller's environment variable" do
+      gaps = [
+        {:wrong_chain, declared: 8453, node: 42_161},
+        {:chain_id_unavailable, :timeout},
+        {:domain_separator_unavailable, "0x0", :timeout},
+        {:domain_separator_length, 8},
+        {:signer_kind_unavailable, "0x0", :timeout},
+        {:erc1271_call_failed, "0x0", :timeout}
+      ]
+
+      for gap <- gaps do
+        line = PullPreflight.describe({:inconclusive, gap})
+        refute line =~ "ORDER_RPC", "#{inspect(gap)} names an env var only one caller has"
+      end
     end
   end
 end

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -352,6 +352,59 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
                )
     end
 
+    # `normalize_address/1` trims and downcases, so a served verifyingContract
+    # can pass the pin while differing from it byte for byte. Carrying the
+    # SERVED spelling forward meant `eth_call` was asked about the payload's copy
+    # of the address -- and a served `"0x…BA3 "` reached the node as an invalid
+    # `to:`, stopping every funded run INCONCLUSIVE while blaming an endpoint
+    # that was fine. The pin is what gets dialed.
+    test "the pinned verifier is what gets dialed, not the served spelling of it" do
+      {:ok, asked} = Agent.start_link(fn -> [] end)
+
+      plug = fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        req = Jason.decode!(body)
+
+        result =
+          case req["method"] do
+            "eth_chainId" ->
+              "0x2105"
+
+            "eth_getCode" ->
+              "0x"
+
+            "eth_call" ->
+              [%{"to" => to} | _] = req["params"]
+              Agent.update(asked, &[to | &1])
+              "0x" <> Base.encode16(@permit2_separator, case: :lower)
+          end
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(
+          200,
+          Jason.encode!(%{"jsonrpc" => "2.0", "id" => req["id"], "result" => result})
+        )
+      end
+
+      # Same address, different spelling: passes the pin, is not the pin.
+      served =
+        update_in(
+          served_pull(),
+          ["domain"],
+          &Map.put(&1, "verifyingContract", String.downcase(@permit2_address))
+        )
+
+      assert {:ok, details} =
+               verify(served, current_signature(served), @owner,
+                 rpc: RPC.client(url: "http://stub.invalid/rpc", plug: plug),
+                 expect_verifier: @permit2_address
+               )
+
+      assert details.verifying_contract == @permit2_address
+      assert Agent.get(asked, & &1) == [@permit2_address]
+    end
+
     # This module and `Protocols.Xochi` both parse domain.chainId, and they now
     # agree on what a value is. Nothing reaches here that they disagree about --
     # `EIP712` refuses a padded uint256 at signing, several steps earlier -- so

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -375,6 +375,23 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
                verify(served, wrapped, @owner, rpc: chain(code: "0x"))
     end
 
+    test "a 65-byte signature with a non-canonical v is its own rejection reason" do
+      # Distinct from the wrapped-envelope case above, and reported separately:
+      # collapsing both into a byte count produced "this signature is 65 bytes
+      # rather than a canonical 65", which says nothing and then pointed the
+      # operator at a 7702 delegation that is not the problem. Solidity's
+      # ecrecover yields the zero address for any v outside 27/28, so the pull
+      # rejects this too -- for the reason named here.
+      served = served_pull()
+
+      "0x" <> hex = current_signature(served)
+      <<rs::binary-size(64), _v::8>> = Base.decode16!(hex, case: :lower)
+      bad_v = "0x" <> Base.encode16(rs <> <<1>>, case: :lower)
+
+      assert {:rejected, %{reason: {:recover_failed, {:non_canonical_v, 1}}}} =
+               verify(served, bad_v, @owner, rpc: chain(code: "0x"))
+    end
+
     test "a signature that is not hex is a rejection, not a gap" do
       served = served_pull()
 
@@ -546,6 +563,27 @@ defmodule Raxol.Earn.Xochi.PullPreflightTest do
       assert line =~ "REJECTED"
       assert line =~ "declares no domain.verifyingContract"
       refute line =~ "could not run"
+    end
+
+    test "a bad recovery id is not described as a length problem" do
+      line =
+        PullPreflight.describe({:rejected, %{reason: {:recover_failed, {:non_canonical_v, 1}}}})
+
+      assert line =~ "recovery id is 1"
+      # The defect that DOES warrant the 7702 advice is the wrapped envelope,
+      # and conflating the two sent operators after the wrong thing.
+      refute line =~ "7702"
+      refute line =~ "rather than a canonical 65."
+    end
+
+    test "a wrapped envelope still reads as a length problem worth checking 7702 for" do
+      line =
+        PullPreflight.describe(
+          {:rejected, %{reason: {:recover_failed, {:not_a_canonical_signature, 72}}}}
+        )
+
+      assert line =~ "72 bytes rather than a canonical 65"
+      assert line =~ "7702"
     end
 
     test "an inconclusive check does not claim the signature is bad" do

--- a/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs
@@ -1,0 +1,277 @@
+defmodule Raxol.Earn.Xochi.PullPreflightTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.Earn.Onchain.RPC
+  alias Raxol.Earn.Xochi.PullPreflight
+  alias Raxol.Payments.EIP712
+
+  # Permit2's live Base DOMAIN_SEPARATOR, and the universal deployment it is
+  # read from. Hardcoding the real value is what makes the fake chain below an
+  # ORACLE rather than a restatement: it is the 32 bytes the contract actually
+  # rebuilds, taken from chain, not from our own domain construction.
+  @permit2_separator Base.decode16!(
+                       "3b6f35e4fce979ef8eac3bcdc8c3fc38fe7911bb0c69c8fe72bf1fd1a17e6f07",
+                       case: :lower
+                     )
+  @permit2_address "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+  @spender "0x000000000000000000000000000000000000dEaD"
+
+  @key Base.decode16!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+         case: :lower
+       )
+  @owner "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+  @account "0x468aeae798b3a6548ac2401d276f83afdc172283"
+
+  @magic "0x1626ba7e" <> String.duplicate("00", 28)
+  @not_magic "0xffffffff" <> String.duplicate("00", 28)
+
+  # A chain that answers the two calls the preflight makes. `DOMAIN_SEPARATOR()`
+  # returns Permit2's real value; `isValidSignature` does what a 7702 account
+  # does -- recover the signer from the digest it was ASKED about and answer the
+  # magic value only if it is the authorized owner. Recovering for real is the
+  # point: a signature over a different digest recovers a different address, so
+  # the fake cannot accidentally agree with a wrong digest.
+  defp chain(opts \\ []) do
+    code = Keyword.get(opts, :code, "0xef0100" <> String.duplicate("11", 20))
+
+    plug = fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      req = Jason.decode!(body)
+
+      result =
+        case req["method"] do
+          # A 7702 delegation designator is code; "0x" is a bare EOA.
+          "eth_getCode" ->
+            code
+
+          "eth_call" ->
+            [%{"to" => to, "data" => data} | _] = req["params"]
+            dispatch(String.downcase(to), data)
+        end
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(
+        200,
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => req["id"], "result" => result})
+      )
+    end
+
+    RPC.client(url: "http://stub.invalid/rpc", plug: plug)
+  end
+
+  defp dispatch(to, _data) when to == "0x000000000022d473030f116ddee9f6b43ac78ba3" do
+    "0x" <> Base.encode16(@permit2_separator, case: :lower)
+  end
+
+  defp dispatch(to, data) when to == @account do
+    <<_selector::binary-size(4), digest::binary-size(32), _offset::binary-size(32),
+      len::unsigned-big-256, rest::binary>> = decode!(data)
+
+    <<sig::binary-size(^len), _padding::binary>> = rest
+    <<r::binary-size(32), s::binary-size(32), v::8>> = sig
+
+    {:ok, pubkey} = ExSecp256k1.recover(digest, r, s, v - 27)
+
+    if EIP712.address_from_pubkey(pubkey) == @owner, do: @magic, else: @not_magic
+  end
+
+  defp decode!("0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+
+  # The Permit2 pull a Xochi quote serves, with the domain Permit2 declares:
+  # name/chainId/verifyingContract, and NO version.
+  defp served_pull do
+    %{
+      "domain" => %{
+        "name" => "Permit2",
+        "chainId" => 8453,
+        "verifyingContract" => @permit2_address
+      },
+      "primaryType" => "PermitWitnessTransferFrom",
+      "types" => %{
+        "EIP712Domain" => [
+          %{"name" => "name", "type" => "string"},
+          %{"name" => "chainId", "type" => "uint256"},
+          %{"name" => "verifyingContract", "type" => "address"}
+        ],
+        "PermitWitnessTransferFrom" => [
+          %{"name" => "permitted", "type" => "TokenPermissions"},
+          %{"name" => "spender", "type" => "address"},
+          %{"name" => "nonce", "type" => "uint256"},
+          %{"name" => "deadline", "type" => "uint256"},
+          %{"name" => "witness", "type" => "OriginPullWitness"}
+        ],
+        "TokenPermissions" => [
+          %{"name" => "token", "type" => "address"},
+          %{"name" => "amount", "type" => "uint256"}
+        ],
+        "OriginPullWitness" => [%{"name" => "orderId", "type" => "bytes32"}]
+      },
+      "message" => %{
+        "permitted" => %{
+          "token" => "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+          "amount" => "3000000"
+        },
+        "spender" => @spender,
+        "nonce" => "1",
+        "deadline" => "1790000000",
+        "witness" => %{"orderId" => "0x" <> String.duplicate("11", 32)}
+      }
+    }
+  end
+
+  defp types_for(served) do
+    served["types"]
+    |> Map.drop(["EIP712Domain"])
+    |> Map.new(fn {name, fields} ->
+      {name, Enum.map(fields, fn f -> {f["name"], f["type"]} end)}
+    end)
+  end
+
+  defp sign_over(digest) do
+    {:ok, raw} = ExSecp256k1.sign(digest, @key)
+    "0x" <> Base.encode16(EIP712.pack_signature(raw), case: :lower)
+  end
+
+  # What the buyer emits today: the domain projected from the served map, which
+  # for this payload is exactly the three fields Permit2 declares.
+  defp current_signature(served) do
+    domain = Raxol.Payments.Protocols.Xochi.eip712_domain(served)
+    {:ok, digest} = EIP712.hash(domain, types_for(served), served["message"])
+    sign_over(digest)
+  end
+
+  # What the buyer emitted BEFORE #878: name/version/chainId/verifyingContract,
+  # with a version Permit2 never declared. This is the signature that reverted
+  # InvalidContractSignature() on Base and cost four funded attempts to find.
+  defp pre_878_signature(served) do
+    d = served["domain"]
+
+    # The key is present and holds nil, which is exactly what the old
+    # eip712_domain/1 produced: EIP712 derives the EIP712Domain field list with
+    # Map.has_key?, so this still declares `string version` and encodes it as
+    # the empty string.
+    domain = %{
+      name: d["name"],
+      version: nil,
+      chainId: d["chainId"],
+      verifyingContract: d["verifyingContract"]
+    }
+
+    {:ok, digest} = EIP712.hash(domain, types_for(served), served["message"])
+    sign_over(digest)
+  end
+
+  describe "verify/4" do
+    test "accepts a pull signed over Permit2's own domain separator" do
+      served = served_pull()
+
+      assert {:ok, details} =
+               PullPreflight.verify(served, current_signature(served), @account, rpc: chain())
+
+      assert details.separator == @permit2_separator
+      assert details.verifying_contract == @permit2_address
+      assert details.signer_kind == :contract
+    end
+
+    test "verifies an EOA buyer by recovery, since it has no isValidSignature to call" do
+      # The live ACP gate's buyer is a plain funded key, where Permit2 does
+      # ecrecover rather than an ERC-1271 call. Same digest, different check.
+      served = served_pull()
+
+      assert {:ok, details} =
+               PullPreflight.verify(served, current_signature(served), @owner,
+                 rpc: chain(code: "0x")
+               )
+
+      assert details.signer_kind == :eoa
+    end
+
+    test "rejects an EOA signature that recovers to someone else, naming who" do
+      served = served_pull()
+
+      assert {:error, {:signature_rejected, details}} =
+               PullPreflight.verify(served, current_signature(served), @account,
+                 rpc: chain(code: "0x")
+               )
+
+      assert details.signer_kind == :eoa
+      assert details.returned == @owner
+    end
+
+    test "rejects the pre-#878 signature for an EOA buyer too" do
+      # The domain defect was never specific to smart accounts. It only
+      # SURFACED there, because EOA buyers resolved to erc3009 and never took
+      # the Permit2 path at all.
+      served = served_pull()
+
+      assert {:error, {:signature_rejected, details}} =
+               PullPreflight.verify(served, pre_878_signature(served), @owner,
+                 rpc: chain(code: "0x")
+               )
+
+      assert details.signer_kind == :eoa
+      refute details.returned == @owner
+    end
+
+    test "rejects the pre-#878 signature that reverted InvalidContractSignature on Base" do
+      # The regression that matters. The old projection declared a `version`
+      # Permit2's domain does not carry, so the buyer signed a 4-field separator
+      # against Permit2's 3-field one. Nothing in the buyer's own suite could see
+      # it, because every check rebuilt the domain the same wrong way. Reading
+      # the separator from the contract is what makes it visible here.
+      served = served_pull()
+
+      assert {:error, {:signature_rejected, details}} =
+               PullPreflight.verify(served, pre_878_signature(served), @account, rpc: chain())
+
+      assert details.returned == <<0xFF, 0xFF, 0xFF, 0xFF>>
+      assert details.separator == @permit2_separator
+    end
+
+    test "the two signatures genuinely differ, so the pass above is not vacuous" do
+      served = served_pull()
+      refute current_signature(served) == pre_878_signature(served)
+    end
+
+    test "a served domain with no verifyingContract has nothing to ask" do
+      served = Map.put(served_pull(), "domain", %{"name" => "Xochi", "chainId" => 8453})
+
+      assert {:error, :no_verifying_contract} =
+               PullPreflight.verify(served, "0x00", @account, rpc: chain())
+    end
+
+    test "an unreachable RPC is inconclusive, not a rejection" do
+      # A failed check must never read as a verdict: reporting "signature bad"
+      # when the node was down would send the next debugging round after the
+      # wrong thing, which is how this issue lost two of its four attempts.
+      plug = fn conn -> Plug.Conn.send_resp(conn, 503, "upstream down") end
+      client = RPC.client(url: "http://stub.invalid/rpc", plug: plug)
+      served = served_pull()
+
+      assert {:error, {:domain_separator_unavailable, _vc, _reason}} =
+               PullPreflight.verify(served, current_signature(served), @account, rpc: client)
+    end
+  end
+
+  describe "describe/1" do
+    test "a rejection says the pull would revert and funding would strand a fee" do
+      served = served_pull()
+
+      line =
+        served
+        |> PullPreflight.verify(pre_878_signature(served), @account, rpc: chain())
+        |> PullPreflight.describe()
+
+      assert line =~ "REJECTED"
+      assert line =~ "would revert"
+    end
+
+    test "an inconclusive check does not claim the signature is bad" do
+      line = PullPreflight.describe({:error, {:domain_separator_unavailable, "0x0", :timeout}})
+
+      assert line =~ "INCONCLUSIVE"
+      assert line =~ "not a verdict"
+    end
+  end
+end

--- a/packages/raxol_payments/lib/raxol/payments/eip712.ex
+++ b/packages/raxol_payments/lib/raxol/payments/eip712.ex
@@ -84,7 +84,7 @@ defmodule Raxol.Payments.EIP712 do
   The struct half is still encoded here, and is covered against ethers-generated
   vectors by the Permit2 and ERC-3009 conformance suites.
   """
-  @spec hash_with_separator(binary(), map(), map()) :: {:ok, binary()} | {:error, term()}
+  @spec hash_with_separator(term(), map(), map()) :: {:ok, binary()} | {:error, term()}
   def hash_with_separator(<<domain_separator::binary-size(32)>>, types, message) do
     with {:ok, message_hash} <- hash_struct(primary_type(types), message, types) do
       {:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}
@@ -93,6 +93,14 @@ defmodule Raxol.Payments.EIP712 do
 
   def hash_with_separator(separator, _types, _message) when is_binary(separator) do
     {:error, {:invalid_domain_separator_length, byte_size(separator)}}
+  end
+
+  # The separator reaching this comes off the wire (an `eth_call` result a caller
+  # decoded), so a non-binary is a shape this function is asked about rather than
+  # a caller bug. Returning the error the spec already promises beats raising a
+  # FunctionClauseError out of a public function.
+  def hash_with_separator(separator, _types, _message) do
+    {:error, {:invalid_domain_separator, separator}}
   end
 
   @doc """

--- a/packages/raxol_payments/lib/raxol/payments/eip712.ex
+++ b/packages/raxol_payments/lib/raxol/payments/eip712.ex
@@ -68,6 +68,34 @@ defmodule Raxol.Payments.EIP712 do
   end
 
   @doc """
+  Hash a typed message against a domain separator obtained from somewhere other
+  than the `domain` map -- in practice the verifying contract's own
+  `DOMAIN_SEPARATOR()`, read from chain.
+
+  `hash/3` builds the separator from the fields present in `domain`, so a caller
+  checking our own signature with it asks the verifier about the very digest we
+  computed, and any disagreement over which fields the domain has cancels out on
+  both sides. Supplying the counterparty's separator removes that: the domain
+  half of the digest comes from the contract that will verify it, so a projection
+  that drops or invents a field is visible rather than self-consistent. See
+  GitHub #772, where a `version` we added and Permit2 never declared reverted the
+  origin pull.
+
+  The struct half is still encoded here, and is covered against ethers-generated
+  vectors by the Permit2 and ERC-3009 conformance suites.
+  """
+  @spec hash_with_separator(binary(), map(), map()) :: {:ok, binary()} | {:error, term()}
+  def hash_with_separator(<<domain_separator::binary-size(32)>>, types, message) do
+    with {:ok, message_hash} <- hash_struct(primary_type(types), message, types) do
+      {:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}
+    end
+  end
+
+  def hash_with_separator(separator, _types, _message) when is_binary(separator) do
+    {:error, {:invalid_domain_separator_length, byte_size(separator)}}
+  end
+
+  @doc """
   Pack an `ExSecp256k1.sign/2` result into Ethereum's canonical 65-byte
   signature `r || s || v`.
 

--- a/packages/raxol_payments/lib/raxol/payments/protocols/permit2.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/permit2.ex
@@ -128,7 +128,23 @@ defmodule Raxol.Payments.Protocols.Permit2 do
     end
   end
 
-  @doc "Return the universal Permit2 contract address."
+  @doc """
+  Return the universal Permit2 contract address.
+
+  One address on every chain, because Permit2 ships through the deterministic
+  CREATE2 deployer. That holds across every corridor raxol settles on, and it is
+  what lets three separate decisions share this constant: the spender an approve
+  grants to (`Raxol.Earn.Onchain.Permit2Approver`), the `verifyingContract` a
+  served pull must declare (`Raxol.Payments.Protocols.Xochi`), and the contract
+  `Raxol.Earn.Xochi.PullPreflight` reads `DOMAIN_SEPARATOR()` from.
+
+  It is not universal in the arithmetic sense. A chain whose CREATE2 derivation
+  differs -- zkSync Era is the one in production, at
+  `0x0000000000225e31d15943971f47ad3022f714fa` -- hosts Permit2 somewhere else.
+  Adding such a corridor turns this into a per-chain lookup; until then a single
+  constant is the honest shape, and the failure it produces is a refusal to
+  sign (`{:authorization_mismatch, :pull_verifier}`) rather than a bad signature.
+  """
   @spec verifying_contract() :: String.t()
   def verifying_contract, do: @permit2_address
 

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -928,7 +928,22 @@ defmodule Raxol.Payments.Protocols.Xochi do
     end)
   end
 
-  defp eip712_types(eip712) do
+  @doc """
+  The served `types` map, projected into the shape `Raxol.Payments.EIP712` encodes.
+
+  `EIP712Domain` is dropped: the domain is hashed from `eip712_domain/1` (or, for
+  a checker, read from the verifying contract), and leaving it here would make it
+  a second root type and the primary type ambiguous.
+
+  Public for the same reason `eip712_domain/1` is, and it is the same reason
+  twice: a second copy of this mapping agrees with itself. `EIP712.hash_struct/3`
+  is pinned against ethers-generated vectors, but the projection FEEDING it is
+  not, so a checker that re-derived this would rebuild a different struct hash
+  the moment either copy changed -- and would report that as the signature being
+  bad. `Raxol.Earn.Xochi.PullPreflight` calls this rather than mirroring it.
+  """
+  @spec eip712_types(map()) :: map()
+  def eip712_types(eip712) do
     (eip712["types"] || %{})
     |> Map.drop(["EIP712Domain"])
     |> Enum.into(%{}, fn {name, fields} ->

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -714,8 +714,9 @@ defmodule Raxol.Payments.Protocols.Xochi do
   # this signature. Leaving it to the quote lets the served payload nominate its
   # own verifier -- a contract whose `DOMAIN_SEPARATOR()` agrees with whatever it
   # served -- while the allowance being spent was granted to Permit2 and the pull
-  # runs there. Permit2 is deployed at one address on every chain, so this is a
-  # constant and not a per-corridor lookup.
+  # runs there. A constant rather than a per-corridor lookup because Permit2 is
+  # at one address on every chain raxol settles on; see
+  # `Permit2.verifying_contract/0` for the exception that would end that.
   defp validate_permit2_pull(pull, request) do
     domain = pull["domain"] || %{}
     message = pull["message"] || %{}

--- a/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
+++ b/packages/raxol_payments/lib/raxol/payments/protocols/xochi.ex
@@ -53,6 +53,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
   @behaviour Raxol.Payments.Protocol
 
   alias Raxol.Payments.Poll
+  alias Raxol.Payments.Protocols.Permit2
   alias Raxol.Payments.Xochi.{Capabilities, Client, DepositAttestation}
 
   alias Raxol.Payments.Xochi.Schemas.{
@@ -707,6 +708,14 @@ defmodule Raxol.Payments.Protocols.Xochi do
   # spender pin is ALWAYS required (fail-closed): with no allowlist configured a
   # permit2 pull is rejected before signing. The `OriginPullWitness` ties the
   # permit to one intent on-chain. See GitHub #333.
+  #
+  # `verifyingContract` is pinned to the canonical Permit2 for the same reason
+  # the ERC-3009 rail pins its own to the request's token: it decides WHO checks
+  # this signature. Leaving it to the quote lets the served payload nominate its
+  # own verifier -- a contract whose `DOMAIN_SEPARATOR()` agrees with whatever it
+  # served -- while the allowance being spent was granted to Permit2 and the pull
+  # runs there. Permit2 is deployed at one address on every chain, so this is a
+  # constant and not a per-corridor lookup.
   defp validate_permit2_pull(pull, request) do
     domain = pull["domain"] || %{}
     message = pull["message"] || %{}
@@ -715,6 +724,7 @@ defmodule Raxol.Payments.Protocols.Xochi do
     first_mismatch([
       {:pull_type, valid_envelope?(pull, @permit2_primary_type, @permit2_fields)},
       {:pull_token, addr_match?(permitted["token"], request.from_token)},
+      {:pull_verifier, addr_match?(domain["verifyingContract"], Permit2.verifying_contract())},
       {:pull_chain, int_match?(domain["chainId"], request.from_chain_id)},
       {:pull_value, int_within?(permitted["amount"], request.from_amount)},
       {:pull_spender, solver_allowed?(message["spender"], :permit2)},

--- a/packages/raxol_payments/test/raxol/payments/eip712_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/eip712_test.exs
@@ -368,6 +368,100 @@ defmodule Raxol.Payments.EIP712Test do
     end
   end
 
+  describe "hash_with_separator/3" do
+    @permit2 "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+    @separator_types %{"Thing" => [{"x", "uint256"}]}
+    @separator_message %{"x" => 42}
+
+    test "agrees with hash/3 when given the separator hash/3 would have built" do
+      # Supplying the same domain in a different form must not change the
+      # digest, or the two entry points would disagree about what was signed.
+      domain = %{name: "Permit2", chainId: 8453, verifyingContract: @permit2}
+
+      {:ok, computed} = EIP712.hash(domain, @separator_types, @separator_message)
+
+      {:ok, supplied} =
+        EIP712.hash_with_separator(
+          domain_separator(domain),
+          @separator_types,
+          @separator_message
+        )
+
+      assert supplied == computed
+    end
+
+    test "a different separator gives a different digest, so the domain is load-bearing" do
+      # The whole point of the arity-3 form: the domain half comes from the
+      # caller (in production, read from the verifying contract), so a domain
+      # this module would have built differently is visible rather than
+      # cancelled out on both sides. See GitHub #772.
+      three_field =
+        domain_separator(%{name: "Permit2", chainId: 8453, verifyingContract: @permit2})
+
+      four_field =
+        domain_separator(%{
+          name: "Permit2",
+          version: nil,
+          chainId: 8453,
+          verifyingContract: @permit2
+        })
+
+      refute three_field == four_field
+
+      {:ok, a} = EIP712.hash_with_separator(three_field, @separator_types, @separator_message)
+      {:ok, b} = EIP712.hash_with_separator(four_field, @separator_types, @separator_message)
+
+      refute a == b
+    end
+
+    test "refuses a separator that is not 32 bytes rather than padding it" do
+      assert {:error, {:invalid_domain_separator_length, 4}} =
+               EIP712.hash_with_separator(<<1, 2, 3, 4>>, @separator_types, @separator_message)
+    end
+
+    test "propagates an encoding error from the struct half" do
+      assert {:error, _} =
+               EIP712.hash_with_separator(
+                 :binary.copy(<<0>>, 32),
+                 %{"Thing" => [{"x", "address"}]},
+                 %{"x" => "not-an-address"}
+               )
+    end
+
+    # EIP712Domain separator built the long way, so the test does not lean on the
+    # function under test to produce its own oracle.
+    defp domain_separator(domain) do
+      fields =
+        [
+          {"name", "string", :name},
+          {"version", "string", :version},
+          {"chainId", "uint256", :chainId},
+          {"verifyingContract", "address", :verifyingContract},
+          {"salt", "bytes32", :salt}
+        ]
+        |> Enum.filter(fn {_n, _t, key} -> Map.has_key?(domain, key) end)
+
+      type_string =
+        "EIP712Domain(" <> Enum.map_join(fields, ",", fn {n, t, _} -> "#{t} #{n}" end) <> ")"
+
+      encoded =
+        Enum.map_join(fields, "", fn {_n, type, key} ->
+          encode_domain_field(type, Map.get(domain, key))
+        end)
+
+      ExKeccak.hash_256(ExKeccak.hash_256(type_string) <> encoded)
+    end
+
+    defp encode_domain_field("string", nil), do: ExKeccak.hash_256("")
+    defp encode_domain_field("string", v), do: ExKeccak.hash_256(v)
+    defp encode_domain_field("uint256", v), do: <<v::unsigned-big-256>>
+
+    defp encode_domain_field("address", "0x" <> hex),
+      do: <<0::size(96)>> <> Base.decode16!(hex, case: :mixed)
+
+    defp encode_domain_field("bytes32", "0x" <> hex), do: Base.decode16!(hex, case: :mixed)
+  end
+
   describe "pack_signature/1" do
     @r String.duplicate(<<0xAA>>, 32)
     @s String.duplicate(<<0xBB>>, 32)

--- a/packages/raxol_payments/test/raxol/payments/eip712_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/eip712_test.exs
@@ -419,6 +419,16 @@ defmodule Raxol.Payments.EIP712Test do
                EIP712.hash_with_separator(<<1, 2, 3, 4>>, @separator_types, @separator_message)
     end
 
+    # The separator comes off the wire -- an `eth_call` result a caller decoded --
+    # so a non-binary is a shape this is asked about, not a caller bug. Returning
+    # the error the spec promises beats raising out of a public function.
+    test "refuses a separator that is not a binary at all" do
+      for bad <- [nil, :error, 42, {:ok, <<0>>}] do
+        assert {:error, {:invalid_domain_separator, ^bad}} =
+                 EIP712.hash_with_separator(bad, @separator_types, @separator_message)
+      end
+    end
+
     test "propagates an encoding error from the struct half" do
       assert {:error, _} =
                EIP712.hash_with_separator(

--- a/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
+++ b/packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs
@@ -958,6 +958,88 @@ defmodule Raxol.Payments.Protocols.XochiTest do
       refute_received {:req, "POST", "/api/intent/execute", _h, _b}
     end
 
+    test "binds the permit2 verifyingContract to the canonical Permit2" do
+      # The served verifyingContract decides WHO checks this signature. Left to
+      # the quote, a hostile worker nominates a contract it controls -- one whose
+      # DOMAIN_SEPARATOR() agrees with whatever it served -- and every check that
+      # asks that address agrees with the payload. Meanwhile the allowance being
+      # spent was granted to the canonical Permit2, which is where the pull runs.
+      Application.put_env(:raxol_payments, :pull_solver_allowlist, [
+        "0x000000000000000000000000000000000000dEaD"
+      ])
+
+      on_exit(fn -> Application.delete_env(:raxol_payments, :pull_solver_allowlist) end)
+
+      request = %QuoteRequest{
+        wallet: @anvil_addr,
+        from_chain_id: 8453,
+        to_chain_id: 42_161,
+        from_token: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        to_token: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        from_amount: "1000000",
+        settlement_preference: "public"
+      }
+
+      config = %{
+        base_url: "https://api.xochi.fi",
+        auth: :none,
+        req_options: [plug: echo_plug(self())]
+      }
+
+      quote_for = fn pull ->
+        %QuoteResponse{
+          intent_id: "xi_vc",
+          quote_id: "xq_vc",
+          can_solve: true,
+          payment_method: "permit2",
+          eip712_data: %{
+            "domain" => %{"name" => "Xochi", "version" => "1", "chainId" => 8453},
+            "primaryType" => "XochiIntent",
+            "types" => %{"XochiIntent" => [%{"name" => "intentId", "type" => "string"}]},
+            "message" => %{"intentId" => "xi_vc"}
+          },
+          pull_authorization: pull
+        }
+      end
+
+      # The canonical address passes, served in any case.
+      canonical = Raxol.Payments.Protocols.Permit2.verifying_contract()
+
+      assert {:ok, _} =
+               Xochi.execute(
+                 config,
+                 quote_for.(
+                   canonical_permit2_pull(%{
+                     domain: %{"verifyingContract" => String.downcase(canonical)}
+                   })
+                 ),
+                 RealWallet,
+                 request
+               )
+
+      # A verifier of the worker's choosing aborts before anything is signed.
+      assert {:error, {:authorization_mismatch, :pull_verifier}} =
+               Xochi.execute(
+                 config,
+                 quote_for.(
+                   canonical_permit2_pull(%{
+                     domain: %{
+                       "verifyingContract" => "0x00000000000000000000000000000000000badc0"
+                     }
+                   })
+                 ),
+                 RealWallet,
+                 request
+               )
+
+      # So does omitting it, which is how a 2-field domain used to slip through.
+      no_verifier =
+        update_in(canonical_permit2_pull(), ["domain"], &Map.delete(&1, "verifyingContract"))
+
+      assert {:error, {:authorization_mismatch, :pull_verifier}} =
+               Xochi.execute(config, quote_for.(no_verifier), RealWallet, request)
+    end
+
     test "rejects a permit2 pull when no solver allowlist is configured (fail-closed)" do
       # Permit2 has NO on-chain recipient guard -- the spender picks where funds go
       # at call time -- so the pin is the only destination control and is always
@@ -1346,7 +1428,14 @@ defmodule Raxol.Payments.Protocols.XochiTest do
       )
 
     %{
-      "domain" => Map.merge(%{"chainId" => 8453}, Map.get(overrides, :domain, %{})),
+      "domain" =>
+        Map.merge(
+          %{
+            "chainId" => 8453,
+            "verifyingContract" => Raxol.Payments.Protocols.Permit2.verifying_contract()
+          },
+          Map.get(overrides, :domain, %{})
+        ),
       "primaryType" => Map.get(overrides, :primary_type, "PermitWitnessTransferFrom"),
       "types" =>
         Map.get(overrides, :types, %{

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -237,6 +237,37 @@ relay_cfg() {
 
 rpc_for() { local v="GATE_RPC_$1"; printf '%s' "${!v:-}"; }
 
+# The settleable EVM chains, matching @evm_chains in live_order_test.exs. A cell
+# originating on any of them needs an endpoint for the pull-signature preflight
+# to have anything to ask.
+ORDER_RPC_CHAINS="1 10 137 8453 42161 4663"
+
+# Hand every configured GATE_RPC_<chain> through as XOCHI_ORDER_RPC_<chain>, and
+# say out loud which chains have none. A cell whose origin has no endpoint
+# reports "pull preflight: skipped" -- which reads exactly like a check that
+# passed unless the absence is announced up front.
+export_order_rpcs() {
+  local asset="$1" c rpc found=false missing=""
+  for c in $ORDER_RPC_CHAINS; do
+    rpc="$(rpc_for "$c")"
+    if [[ -n "$rpc" ]]; then
+      export "XOCHI_ORDER_RPC_$c=$rpc"
+      found=true
+    else
+      missing="$missing $c"
+    fi
+  done
+
+  if [[ "$found" == false ]]; then
+    log "acp $asset: NOTE -- no GATE_RPC_<chain> is set, so the pull-signature"
+    log "             preflight SKIPS every cell and checks nothing. Set at least"
+    log "             GATE_RPC_8453 to have the rehearsal verify what it signs."
+  elif [[ -n "$missing" ]]; then
+    log "acp $asset: no endpoint for chain(s):$missing -- cells originating there"
+    log "             skip the pull-signature check."
+  fi
+}
+
 # --- secret loading (lazy: only what the selected routes need) ---
 need_xochi=false; need_relay=false
 for r in $ROUTE_LIST; do
@@ -334,6 +365,14 @@ run_acp() {
   # each asset's default corridor above is on the CorridorAllowlist.
   export XOCHI_ORDER_STABLECOIN_ALLOWLIST=true
 
+  # Origin-chain endpoints for the read-only pull-signature preflight. This used
+  # to be exported only for a Permit2 asset, where it was needed to broadcast the
+  # allowance -- so on USDC (p2=0, and the LIVE launch asset) no endpoint was
+  # ever set and the preflight reported "skipped" on every cell. The check needs
+  # an endpoint for whichever chain a cell ORIGINATES on, which is independent of
+  # the allowance question below.
+  export_order_rpcs "$asset"
+
   if [[ "$p2" == "1" ]]; then
     rpc="$(rpc_for "$p2chain")"
     if [[ -z "$rpc" && -z "$DRY_RUN" ]]; then
@@ -341,7 +380,6 @@ run_acp() {
       log "             broadcast the allowance. Set it, or run --dry-run."
       return 10
     fi
-    [[ -n "$rpc" ]] && export "XOCHI_ORDER_RPC_$p2chain=$rpc"
   fi
 
   cd "$ACP_DIR"

--- a/scripts/run_live_gates.sh
+++ b/scripts/run_live_gates.sh
@@ -237,18 +237,37 @@ relay_cfg() {
 
 rpc_for() { local v="GATE_RPC_$1"; printf '%s' "${!v:-}"; }
 
-# The settleable EVM chains, matching @evm_chains in live_order_test.exs. A cell
-# originating on any of them needs an endpoint for the pull-signature preflight
-# to have anything to ask.
+# The settleable EVM chains, matching @evm_chains in live_order_test.exs. This
+# is what `mesh`/`all` expands to there, so it is what this has to expand them
+# to here.
 ORDER_RPC_CHAINS="1 10 137 8453 42161 4663"
 
+# The ORIGIN chain of every corridor a run will actually drive. Derived from the
+# corridor spec rather than assumed, because `--corridors` accepts any pair: a
+# fixed list reported "all endpoints present" while the one corridor in play
+# originated on a chain nobody had set, and that cell then skipped silently.
+origin_chains_for() {
+  local spec="$1"
+  if [[ "$spec" == "mesh" || "$spec" == "all" ]]; then
+    printf '%s' "$ORDER_RPC_CHAINS"
+    return 0
+  fi
+  # `a>b,c>d` -> the `a` of each pair, deduplicated, order preserved. Spaces and
+  # tabs only: `[:space:]` would strip the newlines this splits on, folding
+  # every origin into one unusable token.
+  printf '%s' "$spec" | tr ',' '\n' | cut -d'>' -f1 | tr -d ' \t' \
+    | awk 'NF && !seen[$0]++' | tr '\n' ' '
+}
+
 # Hand every configured GATE_RPC_<chain> through as XOCHI_ORDER_RPC_<chain>, and
-# say out loud which chains have none. A cell whose origin has no endpoint
-# reports "pull preflight: skipped" -- which reads exactly like a check that
-# passed unless the absence is announced up front.
+# say out loud which of the chains THIS RUN originates on have none. A cell whose
+# origin has no endpoint reports "pull preflight: skipped" -- which reads exactly
+# like a check that passed unless the absence is announced up front.
 export_order_rpcs() {
-  local asset="$1" c rpc found=false missing=""
-  for c in $ORDER_RPC_CHAINS; do
+  local asset="$1" corridors="$2" c rpc origins found=false missing=""
+  origins="$(origin_chains_for "$corridors")"
+
+  for c in $origins; do
     rpc="$(rpc_for "$c")"
     if [[ -n "$rpc" ]]; then
       export "XOCHI_ORDER_RPC_$c=$rpc"
@@ -259,12 +278,13 @@ export_order_rpcs() {
   done
 
   if [[ "$found" == false ]]; then
-    log "acp $asset: NOTE -- no GATE_RPC_<chain> is set, so the pull-signature"
-    log "             preflight SKIPS every cell and checks nothing. Set at least"
-    log "             GATE_RPC_8453 to have the rehearsal verify what it signs."
+    log "acp $asset: NOTE -- no GATE_RPC_<chain> is set for any origin in"
+    log "             [$corridors], so the pull-signature preflight SKIPS every"
+    log "             cell and checks nothing. Set GATE_RPC_<origin> to have the"
+    log "             rehearsal verify what it signs."
   elif [[ -n "$missing" ]]; then
-    log "acp $asset: no endpoint for chain(s):$missing -- cells originating there"
-    log "             skip the pull-signature check."
+    log "acp $asset: no endpoint for origin chain(s):$missing -- those cells of"
+    log "             [$corridors] skip the pull-signature check."
   fi
 }
 
@@ -371,7 +391,7 @@ run_acp() {
   # ever set and the preflight reported "skipped" on every cell. The check needs
   # an endpoint for whichever chain a cell ORIGINATES on, which is independent of
   # the allowance question below.
-  export_order_rpcs "$asset"
+  export_order_rpcs "$asset" "$corridors"
 
   if [[ "$p2" == "1" ]]; then
     rpc="$(rpc_for "$p2chain")"


### PR DESCRIPTION
The origin pull is the step that has failed every funded attempt on #772. It
fails at the far end of a long sequence -- quote, sign, `createJob`, fund,
`setBudget`, solver relay -- and reports back as a status string with no detail
(`validation_failed`, then a bare `pull_failed`). Each attempt cost a job, an
escrow, and a round trip through two other repositories to learn one bit.

`Raxol.Earn.Xochi.PullPreflight` asks the two contracts involved directly, for
the price of two `eth_call`s:

```
separator  = VerifyingContract.DOMAIN_SEPARATOR()   <- read from chain
structHash = hashStruct(served types, served message)
digest     = keccak256(0x1901 || separator || structHash)
           -> isValidSignature(digest, sig)  for a contract account
           -> ecrecover(digest, sig)         for an EOA
```

## Why the separator is read, not computed

Checking our own signature against a digest built from our own `domain`
projection is circular: both sides of the comparison carry the same mistake and
agree. That is exactly how #772 reached production with a green suite -- every
test rebuilt the domain the same wrong way the signer did, so the extra
`version` field Permit2 never declared was invisible to all of them.

Sourcing the domain half from the contract that will verify it breaks the loop.

## The regression test has teeth

`pull_preflight_test.exs` signs the **pre-#878** way -- a `version` key holding
`nil`, which still declares `string version` because `EIP712` derives the
domain field list with `Map.has_key?` -- and asserts that signature is REJECTED
against Permit2's real Base `DOMAIN_SEPARATOR`. The current projection passes
the same check. Without the fix, the test fails.

Both signer kinds are covered, because the pull branches on code presence: the
ACP gate's buyer is a funded EOA, while the #772 buyer is a 7702 account whose
72-byte envelope cannot recover. Checking the wrong one answers a question the
pull never asks.

## Wiring

- **`mix raxol_earn.order`** -- runs after signing. A rejection aborts the run
  before `createJob`: continuing would escrow a fee for a settlement that
  provably cannot execute, which is how job 74047 ended up funded, unsettleable
  and expired.

  It aborts `--dry-run` too, non-zero. The rehearsal is what CI scores
  (`scripts/run_live_gates.sh --dry-run` reads this task's exit status per
  cell), so a mode that printed the defect and exited 0 would score the cell
  PASS on the one thing the rehearsal exists to find, leaving it as a single
  line in a matrix of ninety.

  An inconclusive check also blocks a funded run -- an unanswered question is
  not permission to escrow -- but stays soft under `--dry-run`. An unreachable
  RPC is not evidence about a signature, and the usual cause is an origin-chain
  endpoint the rehearsing machine was never given; failing on that teaches an
  operator to ignore the exit code.
- **the `:live_xochi_order_preflight` gate** -- which quoted and validated pull
  SHAPE (`validate_pull/3`) but never asked whether the signature would verify.
  Reported, not asserted, so it keeps its "moves no funds, fails only on a
  solver-pin mismatch" contract.

`EIP712.hash_with_separator/3` is the supporting primitive: `hash/3` with the
separator supplied rather than derived.

## Verified live, spending nothing

Against a real `api.xochi.fi` quote and the 7702 buyer
`0x468aeae7...172283`:

```
[order] origin pull: the standing Permit2 allowance already covers this intent's pull -- no approve sent
[order] pull preflight: OK -- the signature covers the digest 0x000000..8ba3 will rebuild
                            (0xed9eea..4dd8), verified on-chain via ERC-1271 isValidSignature
[order] signed Xochi intent: xi_e9ce76dbe415f2fb01ca83acce811fbe
```

That is the call which returned `0xffffffff` before #878, reverting the pull
with `InvalidContractSignature()` (`0xb0669cbc`). No writes, no escrow, no job.

Separately, reading Permit2's `DOMAIN_SEPARATOR()` through the real ABI/RPC path
on Base returns `0x3b6f35e4...6f07`, byte-identical to the constant recorded in
#772 -- so the oracle half is validated end to end.

## Known limit

Only the domain half is chain-sourced, and this is recorded in the moduledoc
rather than left implicit. Permit2 builds its `PermitWitnessTransferFrom`
typehash by concatenating a fixed stub with the caller's witness type string,
where EIP-712 sorts referenced types alphabetically. These agree for
`OriginPullWitness` (it sorts before `TokenPermissions`), but a witness type
renamed to sort after it would diverge, and this check would not see it -- it
would encode the struct the same wrong way the signer did. Pinning the witness
type string is the guard for that, not this.

## Fixes from an adversarial review pass

Five follow-up commits, each with its own regression test.

**The rehearsal could not fail.** `decide_preflight/2` returned `:ok` for a
rejection under `--dry-run`, and the `:live_xochi_order_preflight` gate reports
without asserting by design. So no unfunded surface could fail on a rejected
signature, and the only place the check could stop anything was the funded run
it exists to keep you away from. A rejection now fails both modes.

**The oracle was dialed from the payload.** `pinned_verifier/2` compared the
served `verifyingContract` against the caller's pin and then returned the
SERVED one -- which is the address `DOMAIN_SEPARATOR()` is read from.
`normalize_address/1` trims and downcases, so the two can match while differing
byte for byte: a served `"0x...BA3 "` passed the pin, reached `eth_call`
verbatim as `to:`, and the node refused it. One whitespace character in a quote
stopped every funded run INCONCLUSIVE while `describe_gap/1` blamed an endpoint
that was fine. The pin is what gets dialed now, which is also what the module
says it does.

**A chainId that is present but unreadable** was reported as one that is absent,
sending the operator to look for a field sitting in the payload they captured.
It gets its own reason.

**`EIP712.hash_with_separator/3`** raised `FunctionClauseError` on a non-binary
separator, out of a public function whose spec promises `{:error, _}`. The
separator comes off the wire, so a shape it does not recognise is a question it
was asked; it answers.

**Permit2's one address is not arithmetic.** `validate_permit2_pull/2` now pins
`verifyingContract` to that constant in a shared package, so where the
assumption ends is documented on `Permit2.verifying_contract/0` -- zkSync Era
hosts Permit2 elsewhere, and a corridor there turns this into a per-chain
lookup. No config seam, since nothing needs one and the failure is a refusal to
sign rather than a bad signature.

## Manual testing

- [x] `mix raxol_earn.order --amount 3.00 --dry-run --solver 0xE9B0...2f53` against
      live Xochi: preflight OK, nothing written
- [x] Refuses without a Permit2 spender pin (the fail-closed gate still fires first)
- [x] Permit2 `DOMAIN_SEPARATOR()` read from Base matches the #772 constant
- [x] raxol_earn 935 pass, raxol_payments 1156 pass
- [x] both packages `--warnings-as-errors` clean, formatted, no new credo findings
- [ ] Funded run end to end (settlement past the pull is still unproven)

Refs #772

