### PR TITLE
Make a pairing name a platform, not just an id

### DIFF
--- a/packages/raxol_console/lib/raxol/console/application.ex
+++ b/packages/raxol_console/lib/raxol/console/application.ex
@@ -34,8 +34,8 @@ defmodule Raxol.Console.Application do
 
       config :raxol_console,
         pairing: [allow_platforms: [:telegram]]   # anyone on Telegram
-        pairing: [allowed_users: ["12345"]]       # these ids, any platform
-        pairing: [platform_users: [telegram: ["12345"]]]   # these ids, there
+        pairing: [allowed_users: ["12345"]]       # these ids, EVERY platform
+        pairing: [platform_users: [telegram: ["12345"]]]   # these ids, only there
         pairing: :open                            # open, and say so on purpose
         pairing: []                                # deny everyone; pair by hand
 
@@ -47,9 +47,13 @@ defmodule Raxol.Console.Application do
 
   `pairing: []` denies everyone and there is no `/pair` command to escape it --
   a denial is decided before a session exists, so pairing a newcomer is an out
-  of band call to `Raxol.Gateway.Pairing`. Seed `:allowed_users` instead unless
-  that is what you meant. Note also that `:allowed_users` and confirmed pairings
-  match on the id alone, across every connected platform.
+  of band call to `Raxol.Gateway.Pairing`. Seed one of the allowlists instead
+  unless that is what you meant.
+
+  Prefer `:platform_users`: it grants an id on the platform it names, where
+  `:allowed_users` grants it on all of them. Two platforms number their users
+  independently, so one id there can be two people. The boot says so when a
+  deployment pairs `:allowed_users` with more than one channel.
 
   Inbound events are gated by `Raxol.Console.Inbound.route/3` and by the router
   itself, so a deployment's own feed loop cannot route around it. See

--- a/packages/raxol_console/lib/raxol/console/boot.ex
+++ b/packages/raxol_console/lib/raxol/console/boot.ex
@@ -136,8 +136,28 @@ defmodule Raxol.Console.Boot do
 
   defp announce_posture(%{pairing: pairing}, adapters, base) do
     warn_unconnected(pairing, adapters, base)
+    warn_cross_platform(pairing, adapters, base)
     :enforce
   end
+
+  # `:allowed_users` grants an id on EVERY connected platform, and platform id
+  # namespaces are unrelated. With one channel that is exactly what it looks
+  # like; with two it is a claim that a Telegram integer and a Discord snowflake
+  # cannot name different people, which is a claim and not a default.
+  defp warn_cross_platform(%{allowed_users: []}, _adapters, _base), do: :ok
+
+  defp warn_cross_platform(pairing, adapters, base) when map_size(adapters) > 1 do
+    Logger.warning("""
+    #{base}: :allowed_users grants #{length(pairing.allowed_users)} id(s) on ALL of
+    #{inspect(Map.keys(adapters))}.
+
+    Those platforms number their users independently, so one id can name a
+    different person on each. Move the entries under :platform_users to scope
+    them, or keep this if you know the id spaces cannot collide.
+    """)
+  end
+
+  defp warn_cross_platform(_pairing, _adapters, _base), do: :ok
 
   # A platform atom that names no connected channel grants nothing, which reads
   # exactly like a deliberate `pairing: []` -- the silent lockout `known_keys/1`

--- a/packages/raxol_console/lib/raxol/console/inbound.ex
+++ b/packages/raxol_console/lib/raxol/console/inbound.ex
@@ -60,13 +60,17 @@ defmodule Raxol.Console.Inbound do
   There is no `/pair` chat command, and there cannot be one at this layer: a
   denial is decided before a session exists, so an unpaired sender has no way to
   ask for a code through the chat itself. Pairing a newcomer means calling
-  `Raxol.Gateway.Pairing.request_code/2` and `confirm/2` out of band -- a remote
+  `Raxol.Gateway.Pairing.request_code/3` and `confirm/2` out of band -- a remote
   shell on the node, or whatever admin surface the deployment already has:
 
       pairing = Raxol.Console.Inbound.pairing_name(MyConsole)
-      {:ok, code} = Raxol.Gateway.Pairing.request_code(pairing, "12345")
+      {:ok, code} = Raxol.Gateway.Pairing.request_code(pairing, "12345", {:platform, :telegram})
       # deliver `code` to that user however you already reach them
       {:ok, "12345"} = Raxol.Gateway.Pairing.confirm(pairing, code)
+
+  The scope is required and bound to the CODE, so the grant admits that id on
+  the platform you minted it for. Pass `:global` only if you mean every
+  connected platform -- see `Raxol.Gateway.Pairing`.
 
   A deployment that wants a self-service lane builds it in its own feed loop with
   `authorized?/2`: answer a denied sender with a code instead of dropping them,

--- a/packages/raxol_console/lib/raxol/console/runtime_config.ex
+++ b/packages/raxol_console/lib/raxol/console/runtime_config.ex
@@ -135,16 +135,25 @@ defmodule Raxol.Console.RuntimeConfig do
   `pairing: []` is enforced with nothing seeded: it denies everyone, and it
   admits nobody until an operator pairs them by hand. There is no `/pair` chat
   command -- a denial is decided before a session exists, so an unpaired sender
-  cannot ask for a code through the chat. `Pairing.request_code/2` and
+  cannot ask for a code through the chat. `Pairing.request_code/3` and
   `confirm/2` are reachable only out of band (a remote shell, or the
   deployment's own admin surface), and a self-service lane is something the feed
   loop builds with `Raxol.Console.Inbound.authorized?/2`. Do not reach for
   `pairing: []` expecting the pairing flow to be wired; seed `:allowed_users`
   with whoever should already be in.
 
-  `:allowed_users` is NOT platform-scoped -- the id matches on every connected
-  platform, whose id namespaces are unrelated. Prefer `:platform_users` when a
-  deployment connects more than one. See `Raxol.Gateway.Pairing`.
+  The two user allowlists differ in SCOPE, not in convenience.
+  `:platform_users` grants an id on the platform it names and nowhere else;
+  `:allowed_users` grants it on every connected platform. Platform id namespaces
+  are unrelated -- a Telegram integer, a Discord snowflake and an email address
+  are drawn from different spaces -- so `:allowed_users` is only sound when you
+  know those spaces cannot collide, which a single-platform deployment gets for
+  free and anything else has to mean on purpose. `Raxol.Console.Boot` says so at
+  boot when a deployment uses it with more than one channel connected. Prefer
+  `:platform_users`. See `Raxol.Gateway.Pairing`.
+
+  `platform_users: [global: [...]]` is refused: a grant filed under "per
+  platform" must not turn out to admit every platform.
 
   Open is the default because enforcing by default would lock out every Console
   running today -- `Pairing`'s allowlists boot empty, so an unconfigured enforce
@@ -320,7 +329,10 @@ defmodule Raxol.Console.RuntimeConfig do
       else: {:error, {:invalid_pairing, {key, values}}}
   end
 
-  defp platform_atom?(value), do: is_atom(value) and value not in [nil, true, false]
+  # `:global` is `Raxol.Gateway.Pairing`'s key for the cross-platform bucket, so
+  # a platform of that name would file a scoped grant where every platform reads.
+  # `:allowed_users` is how you ask for that, out loud.
+  defp platform_atom?(value), do: is_atom(value) and value not in [:global, nil, true, false]
 
   # User ids are stringified here rather than at the Pairing call site, because
   # `Pairing.allow/3` stringifies too and an integer Telegram id configured as an

--- a/packages/raxol_console/test/raxol/console/inbound_test.exs
+++ b/packages/raxol_console/test/raxol/console/inbound_test.exs
@@ -10,13 +10,17 @@ defmodule Raxol.Console.InboundTest do
     %Package{runtime: :raxol, soul_md: "# Bot\n\nHi.", agents_md: nil, tasks: [], skills: []}
   end
 
-  defp boot(name, pairing_opts) do
+  defp channel(platform), do: %{platform: platform, adapter: InMemory, config: %{sink: self()}}
+
+  defp two_channels, do: [channel(:in_memory), channel(:in_memory_2)]
+
+  defp boot(name, pairing_opts, channels \\ nil) do
     {:ok, rc} =
       RuntimeConfig.build(
         package(),
         [
           bundle_default_mcp: false,
-          channels: [%{platform: :in_memory, adapter: InMemory, config: %{sink: self()}}]
+          channels: channels || [channel(:in_memory)]
         ] ++ pairing_opts
       )
 
@@ -102,11 +106,14 @@ defmodule Raxol.Console.InboundTest do
       assert {:error, :unauthorized} = Inbound.route(:inb_empty, route("stranger"), %{text: "hi"})
 
       # The runtime pairing flow is the way in, and it works on a live runtime.
+      # The scope is bound to the code, so the grant lands on the platform it
+      # was minted for and nowhere else.
       pairing = Inbound.pairing_name(:inb_empty)
-      {:ok, code} = Pairing.request_code(pairing, "newcomer")
+      {:ok, code} = Pairing.request_code(pairing, "newcomer", {:platform, :in_memory})
       {:ok, "newcomer"} = Pairing.confirm(pairing, code)
 
       assert :ok = Inbound.route(:inb_empty, route("newcomer"), %{text: "hi"})
+      refute Inbound.authorized?(:inb_empty, route("newcomer", :telegram))
     end
 
     # The bug in #884: the Pairing server ran, nothing consulted it, and an
@@ -151,6 +158,40 @@ defmodule Raxol.Console.InboundTest do
 
       assert :ok = Inbound.route(:inb_plat, route("bob"), %{text: "hi"})
       refute Inbound.authorized?(:inb_plat, route("bob", :telegram))
+    end
+
+    # :allowed_users grants on every connected platform, which is what a
+    # deployment with two channels has to mean on purpose rather than inherit.
+    test "warns when a cross-platform allowlist meets more than one channel" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          boot(:inb_multi, [pairing: [allowed_users: ["alice"]]], two_channels())
+        end)
+
+      assert log =~ ":allowed_users grants 1 id(s) on ALL of"
+      assert log =~ ":platform_users"
+    end
+
+    test "a single-channel deployment is not warned, since there is nothing to collide" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          boot(:inb_single, pairing: [allowed_users: ["alice"]])
+        end)
+
+      refute log =~ "grants 1 id(s) on ALL of"
+    end
+
+    test "a scoped allowlist is not warned about however many channels there are" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          boot(
+            :inb_multi_scoped,
+            [pairing: [platform_users: [in_memory: ["alice"]]]],
+            two_channels()
+          )
+        end)
+
+      refute log =~ "on ALL of"
     end
 
     test "seeds allow-everyone for a named platform" do

--- a/packages/raxol_console/test/raxol/console/runtime_config_test.exs
+++ b/packages/raxol_console/test/raxol/console/runtime_config_test.exs
@@ -366,6 +366,17 @@ defmodule Raxol.Console.RuntimeConfigTest do
                RuntimeConfig.build(package(), pairing: [platform_users: [{nil, ["bob"]}]])
     end
 
+    # `:global` is Pairing's key for the cross-platform bucket. Accepted here it
+    # would file ids written under "per platform" where every platform reads --
+    # a silent widening of the grant the scoping exists to narrow.
+    test "refuses :global as a platform, since :allowed_users is how you ask for that" do
+      assert {:error, {:invalid_pairing, {:platform_users, :global, ["bob"]}}} =
+               RuntimeConfig.build(package(), pairing: [platform_users: [global: ["bob"]]])
+
+      assert {:error, {:invalid_pairing, {:allow_platforms, [:global]}}} =
+               RuntimeConfig.build(package(), pairing: [allow_platforms: [:global]])
+    end
+
     # A keyword list admits duplicates; Pairing unions them when it seeds, so
     # both sets are carried through here rather than the last one winning.
     test "carries a platform named twice through as written" do

--- a/packages/raxol_gateway/lib/raxol/gateway/pairing.ex
+++ b/packages/raxol_gateway/lib/raxol/gateway/pairing.ex
@@ -7,27 +7,39 @@ defmodule Raxol.Gateway.Pairing do
   route is allowed, in this order:
 
     1. the route's platform is configured to allow everyone, or
-    2. the user is paired, or
-    3. the user is in the platform's allowlist, or
-    4. the user is in the global allowlist, otherwise
-    5. deny.
+    2. the user holds a PAIRING covering the route's platform, or
+    3. the user holds an ALLOWLIST entry covering the route's platform, otherwise
+    4. deny.
 
   Codes are 8 characters from an unambiguous alphabet (no `0/O/1/I/L`), expire
   after `:code_ttl_ms`, and repeated invalid confirms lock confirmation for
   `:lockout_ms` after `:max_failures`. The lockout is global for this slice.
 
-  ## Pairings and the global allowlist are NOT platform-scoped
+  ## Every grant carries a scope
 
-  Steps 2 and 4 above match on the user id alone. A pairing confirmed over
-  Telegram, or an id in `:allowed_users`, admits that same id STRING on every
-  connected platform. Platform id namespaces are unrelated -- a Telegram integer
-  id, a Discord snowflake and an email address are drawn from different spaces --
-  so this is a deliberate convenience, not an identity guarantee, and it is only
-  safe while those spaces do not collide.
+  A user id means nothing on its own. Telegram ids are integers, Discord ids are
+  snowflakes, email ids are addresses -- three unrelated namespaces, and no
+  authority reconciles them. "User 12345" is a different person on each, so a
+  grant that names only an id is a grant whose subject is undefined.
 
-  Use `:platform_users` (step 3) or `allow/3` with `{:platform, atom}` when the
-  grant should mean "this id, on this platform". A deployment connecting two
-  platforms whose ids could collide should prefer them for everything.
+  So a scope is an argument, never a default:
+
+      :global            # this id, on EVERY connected platform
+      {:platform, :telegram}   # this id, there, and nowhere else
+
+  `request_code/3`, `approve/3`, `revoke/3` and `allow/3` all require one.
+  `{:platform, _}` is the answer that means something; `:global` is the one you
+  have to type, and it is only safe when you know the connected platforms' id
+  spaces cannot collide -- which for a single-platform deployment is trivially
+  true and for any other is a claim worth making deliberately.
+
+  A pairing is scoped where the CODE was issued, not where it was confirmed: the
+  scope is bound into the pending entry by `request_code/3`, so a code minted for
+  Telegram cannot be redeemed into a Discord grant.
+
+  `{:platform, :global}` is refused rather than silently collapsing into the
+  cross-platform bucket, and so is a `:global` key in `:platform_users` -- a grant
+  filed under "per platform" must not turn out to admit every platform.
 
   ## Config keys (all optional)
 
@@ -38,8 +50,12 @@ defmodule Raxol.Gateway.Pairing do
 
   `:allow_platforms`, `:allowed_users` and `:platform_users` are applied at
   `init_manager/1` on every start, including a supervisor RESTART. The
-  runtime-mutable calls (`allow/3`, `allow_platform_all/2`, `approve/2`) exist
+  runtime-mutable calls (`allow/3`, `allow_platform_all/2`, `approve/3`) exist
   alongside them and are lost on restart, which is what in-memory pairing means.
+
+  `:allowed_users` seeds the `:global` scope and `:platform_users` seeds the
+  per-platform ones, so the config surface carries the same distinction the
+  runtime calls do.
 
   The split matters because the two failure modes are not symmetric. Losing a
   DM pairing costs one user one re-pair. Losing the configured posture is total
@@ -56,6 +72,18 @@ defmodule Raxol.Gateway.Pairing do
 
   alias Raxol.Gateway.Route
 
+  @typedoc """
+  Where a grant applies. `{:platform, atom}` admits the id on that platform
+  alone; `:global` admits it on every connected platform, which is only sound
+  when their id namespaces cannot collide.
+  """
+  @type scope :: :global | {:platform, atom()}
+
+  # `:global` is the cross-platform bucket's own key, so a platform of that name
+  # would file a scoped grant into it. nil/booleans are atoms too, and a platform
+  # resolved from a lookup that missed is the likely way one arrives.
+  defguardp is_platform(p) when is_atom(p) and p not in [:global, nil, true, false]
+
   @alphabet ~c"ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 
   @defaults %{
@@ -71,42 +99,80 @@ defmodule Raxol.Gateway.Pairing do
     GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
   end
 
-  @doc "Issue a pairing code for a user, or `{:error, :rate_limited}`."
-  @spec request_code(GenServer.server(), String.t()) ::
-          {:ok, String.t()} | {:error, :rate_limited}
-  def request_code(server, user_id),
-    do: GenServer.call(server, {:request_code, to_string(user_id)})
+  @doc """
+  Issue a pairing code granting `scope` when confirmed, or
+  `{:error, :rate_limited}`.
 
-  @doc "Confirm a code, pairing its user. Errors: `:invalid`, `:expired`, `:locked_out`."
+  The scope is bound HERE, not at `confirm/2`: the code is a bearer token, and
+  what it is worth has to be fixed by the party that minted it. Otherwise a code
+  issued to admit someone on Telegram could be redeemed for a grant somewhere
+  else entirely.
+  """
+  @spec request_code(GenServer.server(), String.t(), scope()) ::
+          {:ok, String.t()} | {:error, :rate_limited}
+  def request_code(server, user_id, scope),
+    do: GenServer.call(server, {:request_code, to_string(user_id), scope_key(scope)})
+
+  @doc """
+  Confirm a code, pairing its user in the scope the code was issued for.
+
+  Errors: `:invalid`, `:expired`, `:locked_out`.
+  """
   @spec confirm(GenServer.server(), String.t()) ::
           {:ok, String.t()} | {:error, :invalid | :expired | :locked_out}
   def confirm(server, code), do: GenServer.call(server, {:confirm, code})
 
-  @doc "Mark a user paired directly (admin path)."
-  @spec approve(GenServer.server(), String.t()) :: :ok
-  def approve(server, user_id), do: GenServer.call(server, {:approve, to_string(user_id)})
+  @doc "Mark a user paired in `scope` directly (admin path)."
+  @spec approve(GenServer.server(), String.t(), scope()) :: :ok
+  def approve(server, user_id, scope),
+    do: GenServer.call(server, {:approve, to_string(user_id), scope_key(scope)})
 
-  @doc "Remove a user's pairing."
-  @spec revoke(GenServer.server(), String.t()) :: :ok
-  def revoke(server, user_id), do: GenServer.call(server, {:revoke, to_string(user_id)})
+  @doc """
+  Remove a user's pairing in `scope`.
 
-  @doc "Add a user to the global allowlist, or a platform allowlist with `{:platform, atom}`."
-  @spec allow(GenServer.server(), String.t(), :global | {:platform, atom()}) :: :ok
-  def allow(server, user_id, scope \\ :global),
-    do: GenServer.call(server, {:allow, to_string(user_id), scope})
+  Scoped, so revoking a Telegram pairing leaves a Discord one standing. Revoking
+  `:global` removes only the cross-platform grant, not the per-platform ones --
+  each was granted separately and each has to go separately.
+  """
+  @spec revoke(GenServer.server(), String.t(), scope()) :: :ok
+  def revoke(server, user_id, scope),
+    do: GenServer.call(server, {:revoke, to_string(user_id), scope_key(scope)})
+
+  @doc "Add a user to the allowlist for `scope`."
+  @spec allow(GenServer.server(), String.t(), scope()) :: :ok
+  def allow(server, user_id, scope),
+    do: GenServer.call(server, {:allow, to_string(user_id), scope_key(scope)})
 
   @doc "Configure a platform to allow every user."
   @spec allow_platform_all(GenServer.server(), atom()) :: :ok
-  def allow_platform_all(server, platform),
+  def allow_platform_all(server, platform) when is_platform(platform),
     do: GenServer.call(server, {:allow_platform_all, platform})
 
   @doc "Decide whether a route is authorized."
   @spec authorize(GenServer.server(), Route.t()) :: :allow | :deny
   def authorize(server, %Route{} = route), do: GenServer.call(server, {:authorize, route})
 
-  @doc "Whether a user is paired."
-  @spec paired?(GenServer.server(), String.t()) :: boolean()
-  def paired?(server, user_id), do: GenServer.call(server, {:paired?, to_string(user_id)})
+  @doc """
+  Whether a pairing would admit `user_id` on `platform`.
+
+  True for a pairing scoped to that platform OR a `:global` one, which is the
+  same question `authorize/2` asks -- not "does a record exist somewhere".
+  """
+  @spec paired?(GenServer.server(), String.t(), atom()) :: boolean()
+  def paired?(server, user_id, platform) when is_platform(platform),
+    do: GenServer.call(server, {:paired?, to_string(user_id), platform})
+
+  # The scope, as the key its grants are filed under. Raises rather than
+  # returning an error tuple: these are the arguments of a caller who has decided
+  # who to admit, so a malformed one is a bug at that call site and should stop
+  # there rather than travel into the server as a grant nobody meant.
+  defp scope_key(:global), do: :global
+  defp scope_key({:platform, platform}) when is_platform(platform), do: platform
+
+  defp scope_key(other) do
+    raise ArgumentError,
+          "invalid pairing scope #{inspect(other)}; expected :global or {:platform, atom}"
+  end
 
   # -- BaseManager callbacks --------------------------------------------------
 
@@ -118,9 +184,12 @@ defmodule Raxol.Gateway.Pairing do
      %{
        config: config,
        pending: %{},
-       approved: MapSet.new(),
-       allow_global: MapSet.new(Enum.map(opt_list(opts, :allowed_users), &to_string/1)),
-       allow_platform: seed_platform_users(opts),
+       # Both are scope-keyed the same way -- `:global`, or a platform atom --
+       # and both are read by `in_scope?/3`. They stay separate because their
+       # lifetimes differ: `allowed` is rebuilt from opts on every restart,
+       # `paired` is not.
+       paired: %{},
+       allowed: seed_allowed(opts),
        allow_all_platforms: MapSet.new(opt_list(opts, :allow_platforms)),
        last_request: %{},
        failures: 0,
@@ -130,25 +199,49 @@ defmodule Raxol.Gateway.Pairing do
 
   defp opt_list(opts, key), do: opts |> Keyword.get(key, []) |> List.wrap()
 
+  # `:allowed_users` is the cross-platform bucket, `:platform_users` the scoped
+  # ones -- the same distinction the runtime calls make, so config and code are
+  # not two vocabularies for one decision.
+  defp seed_allowed(opts) do
+    global = MapSet.new(opt_list(opts, :allowed_users), &to_string/1)
+    seeded = if MapSet.size(global) == 0, do: %{}, else: %{global: global}
+
+    opts |> opt_list(:platform_users) |> Enum.reduce(seeded, &seed_platform/2)
+  end
+
   # Repeated platform keys UNION rather than overwrite. A keyword list admits
-  # duplicates and `into: %{}` would keep only the last, silently dropping every
-  # id named earlier -- a lockout indistinguishable from never having configured
-  # them, which is the ambiguity the Console's `known_keys/1` refuses one level
-  # up for a typo'd key.
-  defp seed_platform_users(opts) do
-    Enum.reduce(opt_list(opts, :platform_users), %{}, fn {platform, users}, acc ->
-      ids = MapSet.new(users, &to_string/1)
-      Map.update(acc, platform, ids, fn existing -> MapSet.union(existing, ids) end)
-    end)
+  # duplicates and collecting `into: %{}` would keep only the last, silently
+  # dropping every id named earlier -- a lockout indistinguishable from never
+  # having configured them, which is the ambiguity the Console's `known_keys/1`
+  # refuses one level up for a typo'd key.
+  #
+  # A `:global` key here is refused rather than merged: it would file ids written
+  # under "per platform" into the bucket that admits every platform, which is a
+  # silent widening of exactly the grant this scoping exists to narrow. Failing
+  # init is right -- a Pairing that will not start beats one that over-grants.
+  defp seed_platform({platform, users}, acc) when is_platform(platform) do
+    ids = MapSet.new(users, &to_string/1)
+    Map.update(acc, platform, ids, fn existing -> MapSet.union(existing, ids) end)
+  end
+
+  defp seed_platform({platform, _users}, _acc) do
+    raise ArgumentError,
+          ":platform_users cannot be keyed on #{inspect(platform)}; " <>
+            "use :allowed_users for a cross-platform grant"
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
-  def handle_manager_call({:request_code, user_id}, _from, state) do
+  def handle_manager_call({:request_code, user_id, scope_key}, _from, state) do
     if rate_limited?(user_id, state) do
       {:reply, {:error, :rate_limited}, state}
     else
       code = gen_code(state.config.code_length)
-      entry = %{user_id: user_id, expires_at: now() + state.config.code_ttl_ms}
+
+      entry = %{
+        user_id: user_id,
+        scope_key: scope_key,
+        expires_at: now() + state.config.code_ttl_ms
+      }
 
       state = %{
         state
@@ -166,21 +259,16 @@ defmodule Raxol.Gateway.Pairing do
       else: resolve_confirm(code, state)
   end
 
-  def handle_manager_call({:approve, user_id}, _from, state) do
-    {:reply, :ok, %{state | approved: MapSet.put(state.approved, user_id)}}
+  def handle_manager_call({:approve, user_id, scope_key}, _from, state) do
+    {:reply, :ok, %{state | paired: grant(state.paired, scope_key, user_id)}}
   end
 
-  def handle_manager_call({:revoke, user_id}, _from, state) do
-    {:reply, :ok, %{state | approved: MapSet.delete(state.approved, user_id)}}
+  def handle_manager_call({:revoke, user_id, scope_key}, _from, state) do
+    {:reply, :ok, %{state | paired: ungrant(state.paired, scope_key, user_id)}}
   end
 
-  def handle_manager_call({:allow, user_id, :global}, _from, state) do
-    {:reply, :ok, %{state | allow_global: MapSet.put(state.allow_global, user_id)}}
-  end
-
-  def handle_manager_call({:allow, user_id, {:platform, platform}}, _from, state) do
-    set = state.allow_platform |> Map.get(platform, MapSet.new()) |> MapSet.put(user_id)
-    {:reply, :ok, %{state | allow_platform: Map.put(state.allow_platform, platform, set)}}
+  def handle_manager_call({:allow, user_id, scope_key}, _from, state) do
+    {:reply, :ok, %{state | allowed: grant(state.allowed, scope_key, user_id)}}
   end
 
   def handle_manager_call({:allow_platform_all, platform}, _from, state) do
@@ -191,8 +279,35 @@ defmodule Raxol.Gateway.Pairing do
     {:reply, decide(route, state), state}
   end
 
-  def handle_manager_call({:paired?, user_id}, _from, state) do
-    {:reply, MapSet.member?(state.approved, user_id), state}
+  def handle_manager_call({:paired?, user_id, platform}, _from, state) do
+    {:reply, in_scope?(state.paired, platform, user_id), state}
+  end
+
+  # -- scoped grants ----------------------------------------------------------
+
+  defp grant(map, scope_key, user_id) do
+    Map.update(map, scope_key, MapSet.new([user_id]), &MapSet.put(&1, user_id))
+  end
+
+  defp ungrant(map, scope_key, user_id) do
+    case Map.get(map, scope_key) do
+      nil -> map
+      set -> Map.put(map, scope_key, MapSet.delete(set, user_id))
+    end
+  end
+
+  # A grant covers a route when it names that route's platform, or when it was
+  # deliberately made cross-platform. Nothing else matches, so an id granted on
+  # Telegram is not the same subject as the identical id arriving from Discord.
+  defp in_scope?(map, platform, user_id) do
+    member?(map, platform, user_id) or member?(map, :global, user_id)
+  end
+
+  defp member?(map, scope_key, user_id) do
+    case Map.get(map, scope_key) do
+      nil -> false
+      set -> MapSet.member?(set, user_id)
+    end
   end
 
   # -- confirm / authorize ----------------------------------------------------
@@ -206,9 +321,11 @@ defmodule Raxol.Gateway.Pairing do
         if now() >= entry.expires_at do
           {:reply, {:error, :expired}, drop_code(state, code)}
         else
+          # The scope comes off the pending entry, so redeeming a code cannot
+          # widen what the party who minted it decided to hand out.
           state = %{
             state
-            | approved: MapSet.put(state.approved, entry.user_id),
+            | paired: grant(state.paired, entry.scope_key, entry.user_id),
               pending: Map.delete(state.pending, code),
               failures: 0
           }
@@ -240,13 +357,8 @@ defmodule Raxol.Gateway.Pairing do
   defp allowed_user?(_state, _platform, nil), do: false
 
   defp allowed_user?(state, platform, user_id) do
-    MapSet.member?(state.approved, user_id) or
-      in_platform_allow?(state, platform, user_id) or
-      MapSet.member?(state.allow_global, user_id)
-  end
-
-  defp in_platform_allow?(state, platform, user_id) do
-    state.allow_platform |> Map.get(platform, MapSet.new()) |> MapSet.member?(user_id)
+    in_scope?(state.paired, platform, user_id) or
+      in_scope?(state.allowed, platform, user_id)
   end
 
   # -- failures / rate limiting -----------------------------------------------

--- a/packages/raxol_gateway/test/raxol/gateway/pairing_test.exs
+++ b/packages/raxol_gateway/test/raxol/gateway/pairing_test.exs
@@ -14,38 +14,40 @@ defmodule Raxol.Gateway.PairingTest do
     Route.new(%{platform: platform, chat_type: :dm, chat_id: 1, user_id: user_id})
   end
 
+  @telegram {:platform, :telegram}
+
   describe "pairing codes" do
     test "issues an 8-char code from the unambiguous alphabet" do
       p = start_pairing()
-      assert {:ok, code} = Pairing.request_code(p, "u1")
+      assert {:ok, code} = Pairing.request_code(p, "u1", @telegram)
       assert String.length(code) == 8
       assert code =~ ~r/^[A-HJ-NP-Z2-9]+$/
     end
 
     test "confirming a valid code pairs the user" do
       p = start_pairing()
-      {:ok, code} = Pairing.request_code(p, "u1")
+      {:ok, code} = Pairing.request_code(p, "u1", @telegram)
       assert {:ok, "u1"} = Pairing.confirm(p, code)
-      assert Pairing.paired?(p, "u1")
+      assert Pairing.paired?(p, "u1", :telegram)
     end
 
     test "a code is single-use" do
       p = start_pairing()
-      {:ok, code} = Pairing.request_code(p, "u1")
+      {:ok, code} = Pairing.request_code(p, "u1", @telegram)
       assert {:ok, "u1"} = Pairing.confirm(p, code)
       assert {:error, :invalid} = Pairing.confirm(p, code)
     end
 
     test "an expired code is rejected" do
       p = start_pairing(code_ttl_ms: 0)
-      {:ok, code} = Pairing.request_code(p, "u1")
+      {:ok, code} = Pairing.request_code(p, "u1", @telegram)
       assert {:error, :expired} = Pairing.confirm(p, code)
     end
 
     test "rate-limits repeated requests from one user" do
       p = start_pairing()
-      assert {:ok, _} = Pairing.request_code(p, "u1")
-      assert {:error, :rate_limited} = Pairing.request_code(p, "u1")
+      assert {:ok, _} = Pairing.request_code(p, "u1", @telegram)
+      assert {:error, :rate_limited} = Pairing.request_code(p, "u1", @telegram)
     end
 
     test "locks out confirmation after repeated failures" do
@@ -57,9 +59,9 @@ defmodule Raxol.Gateway.PairingTest do
   end
 
   describe "authorize/2 check order" do
-    test "paired users are allowed" do
+    test "paired users are allowed on the platform they paired on" do
       p = start_pairing()
-      Pairing.approve(p, "u1")
+      Pairing.approve(p, "u1", @telegram)
       assert :allow = Pairing.authorize(p, route(:telegram, "u1"))
     end
 
@@ -72,7 +74,7 @@ defmodule Raxol.Gateway.PairingTest do
 
     test "platform allowlist is scoped to that platform" do
       p = start_pairing()
-      Pairing.allow(p, "u2", {:platform, :telegram})
+      Pairing.allow(p, "u2", @telegram)
       assert :allow = Pairing.authorize(p, route(:telegram, "u2"))
       assert :deny = Pairing.authorize(p, route(:discord, "u2"))
     end
@@ -88,6 +90,75 @@ defmodule Raxol.Gateway.PairingTest do
       p = start_pairing()
       assert :deny = Pairing.authorize(p, route(:telegram, "nobody"))
       assert :deny = Pairing.authorize(p, route(:telegram, nil))
+    end
+  end
+
+  # A user id is only a subject once it is paired with a platform. Telegram ids
+  # are integers, Discord ids are snowflakes, email ids are addresses -- "12345"
+  # is a different person on each, and no authority reconciles them. A grant that
+  # named only an id used to admit all three.
+  describe "grant scoping" do
+    test "a pairing on one platform does not admit the same id on another" do
+      p = start_pairing()
+      Pairing.approve(p, "12345", @telegram)
+
+      assert :allow = Pairing.authorize(p, route(:telegram, "12345"))
+      assert :deny = Pairing.authorize(p, route(:discord, "12345"))
+      assert :deny = Pairing.authorize(p, route(:email, "12345"))
+      refute Pairing.paired?(p, "12345", :discord)
+    end
+
+    test "a code carries the scope it was ISSUED for, not the one it is redeemed in" do
+      # The code is a bearer token. If confirm/2 chose the scope, a code minted
+      # to admit someone on Telegram would be worth a grant anywhere.
+      p = start_pairing()
+      {:ok, code} = Pairing.request_code(p, "u1", @telegram)
+
+      assert {:ok, "u1"} = Pairing.confirm(p, code)
+      assert :allow = Pairing.authorize(p, route(:telegram, "u1"))
+      assert :deny = Pairing.authorize(p, route(:discord, "u1"))
+    end
+
+    test "a :global pairing admits everywhere, which is why it has to be typed" do
+      p = start_pairing()
+      Pairing.approve(p, "u1", :global)
+
+      assert :allow = Pairing.authorize(p, route(:telegram, "u1"))
+      assert :allow = Pairing.authorize(p, route(:discord, "u1"))
+    end
+
+    test "revoking one platform leaves the others standing" do
+      p = start_pairing()
+      Pairing.approve(p, "u1", @telegram)
+      Pairing.approve(p, "u1", {:platform, :discord})
+
+      Pairing.revoke(p, "u1", @telegram)
+
+      assert :deny = Pairing.authorize(p, route(:telegram, "u1"))
+      assert :allow = Pairing.authorize(p, route(:discord, "u1"))
+    end
+
+    test "revoking :global does not reach the per-platform grants" do
+      p = start_pairing()
+      Pairing.approve(p, "u1", :global)
+      Pairing.approve(p, "u1", @telegram)
+
+      Pairing.revoke(p, "u1", :global)
+
+      assert :allow = Pairing.authorize(p, route(:telegram, "u1"))
+      assert :deny = Pairing.authorize(p, route(:discord, "u1"))
+    end
+
+    # `:global` is the cross-platform bucket's own key, so a scope naming it
+    # would file a per-platform grant where every platform reads.
+    test "refuses a scope that is not one" do
+      p = start_pairing()
+
+      for bad <- [{:platform, :global}, {:platform, nil}, {:platform, "telegram"}, :everyone, nil] do
+        assert_raise ArgumentError, fn -> Pairing.approve(p, "u1", bad) end
+      end
+
+      assert :deny = Pairing.authorize(p, route(:telegram, "u1"))
     end
   end
 
@@ -130,6 +201,30 @@ defmodule Raxol.Gateway.PairingTest do
       assert :allow = Pairing.authorize(p, route(:telegram, "second"))
     end
 
+    # Filing ids written under "per platform" into the bucket that admits every
+    # platform is a silent widening of the grant this scoping exists to narrow.
+    # Refusing to start beats starting over-permissive.
+    test "refuses :platform_users keyed on :global rather than merging it" do
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {%ArgumentError{message: message}, _}} =
+               Pairing.start_link(
+                 name: :"pairing_bad_seed_#{System.unique_integer([:positive])}",
+                 platform_users: [global: ["everyone"]]
+               )
+
+      assert message =~ "cannot be keyed on :global"
+    end
+
+    test "the seeded scopes admit exactly where they were written" do
+      p = start_pairing(allowed_users: ["anywhere"], platform_users: [telegram: ["only-here"]])
+
+      assert :allow = Pairing.authorize(p, route(:telegram, "anywhere"))
+      assert :allow = Pairing.authorize(p, route(:discord, "anywhere"))
+      assert :allow = Pairing.authorize(p, route(:telegram, "only-here"))
+      assert :deny = Pairing.authorize(p, route(:discord, "only-here"))
+    end
+
     test "the seeded posture survives a restart; a runtime pairing does not" do
       name = :"pairing_restart_#{System.unique_integer([:positive])}"
 
@@ -144,7 +239,7 @@ defmodule Raxol.Gateway.PairingTest do
              ]}
         })
 
-      :ok = Pairing.approve(name, "u-runtime")
+      :ok = Pairing.approve(name, "u-runtime", {:platform, :discord})
       assert :allow = Pairing.authorize(name, route(:discord, "u-runtime"))
       assert :allow = Pairing.authorize(name, route(:telegram, "anyone"))
 


### PR DESCRIPTION
Stacked on #885, which this depends on: the seeding path, the `is_platform`
guard's siblings and the `scalar_id/1` fail-closed fix all land there.

A user id is not a subject. Telegram numbers its users, Discord numbers its
users, email addresses them, and no authority reconciles the three -- so
"12345" names a different person on each. A grant that carried only an id had
an undefined subject, and admitted all three.

## Every grant carries a scope, and none of them default to one

```elixir
Pairing.approve(p, "12345", {:platform, :telegram})   # there, and nowhere else
Pairing.approve(p, "12345", :global)                  # every connected platform
```

`approve/3`, `revoke/3`, `allow/3` and `request_code/3` all require one.
`allow/3` lost its `\\ :global` default, which was the same trap in miniature.

`:global` stays. A single-platform deployment gets namespace safety for free,
and `:allowed_users` is a documented, tested config key -- removing it would
break working deployments to prevent a hazard they do not have. What it no
longer is, is what you get by saying nothing.

## The code carries the scope, not the confirm

`request_code/3` binds the scope into the PENDING entry. The code is a bearer
token, so what it is worth has to be fixed by whoever minted it; letting
`confirm/2` choose would make a code issued to admit someone on Telegram
redeemable for a grant anywhere.

`paired?/3` takes a platform and answers the question `authorize/2` asks --
"would a pairing admit this user here" -- rather than "does a record exist
somewhere".

## State collapsed

Three overlapping MapSets (`approved`, `allow_global`, `allow_platform`), each
answering part of "is this user allowed", became two scope-keyed maps read by
one `in_scope?/3`: `paired` (runtime, lost on restart) and `allowed` (seeded,
rebuilt on restart). The split that survives is the one that means something --
lifetime, not provenance.

## Two key collisions found while writing it

`:global` is the cross-platform bucket's own key, so a *platform* of that name
files a scoped grant where every platform reads.

- `{:platform, :global}` raises at the call site.
- `platform_users: [global: [...]]` fails init. A Pairing that will not start
  beats one that silently over-grants. `RuntimeConfig` rejects it a level
  earlier, alongside `nil`/booleans.

## The one configuration where the collision is real

`:allowed_users` keeps its cross-platform meaning and now says so. `Boot` warns
only when a deployment pairs it with more than one connected channel:

```
:allowed_users grants 1 id(s) on ALL of [:telegram, :discord].

Those platforms number their users independently, so one id can name a
different person on each. Move the entries under :platform_users to scope
them, or keep this if you know the id spaces cannot collide.
```

One channel, or scoped entries: no warning. Same doctrine as the posture
warning in #885 -- make the ambiguous case loud rather than impossible.

## Breaking

This changes `Raxol.Gateway.Pairing`'s mutation surface: arities on `approve`,
`revoke`, `request_code` and `paired?`, plus the removed `allow/3` default.
Safe now -- the only callers were docs and tests, and raxol_gateway is
pre-alpha and unpublished -- but it is the kind of change that is cheap today
and expensive after a release.

## Manual testing

- [x] `MIX_ENV=test mix test` in `packages/raxol_gateway` -- 192 pass
- [x] `MIX_ENV=test mix test` in `packages/raxol_console` -- 85 pass
- [x] both `mix compile --warnings-as-errors` clean, both `mix format --check-formatted` clean
- [x] A pairing confirmed on one platform denies the identical id on two others
- [x] A code minted for `{:platform, :in_memory}` grants there and not on Telegram
- [x] `platform_users: [global: [...]]` refuses to start; `RuntimeConfig` refuses it first
- [ ] Not covered: a live two-platform deployment sharing one operator id
