### PR TITLE
Dispatch the run hooks nothing was calling

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -615,36 +615,27 @@ defmodule Raxol.Symphony.Orchestrator do
          workspace_path,
          host
        ) do
-    parent = self()
     config = state.config
+
+    # One map rather than a widening positional list. `:ssh` joined it when the
+    # worker task took over running the workspace hooks -- a remote hook needs
+    # the same transport options `Workspace.ensure/3` was given -- and every
+    # field here is read by both payload clauses.
+    dispatch = %{
+      parent: self(),
+      attempt: attempt,
+      workspace_path: workspace_path,
+      host: host,
+      ssh: state.ssh
+    }
 
     Task.Supervisor.async_nolink(
       task_supervisor(state),
-      fn ->
-        run_worker_payload(
-          config.workflow_mode,
-          config,
-          runner_mod,
-          issue,
-          attempt,
-          workspace_path,
-          host,
-          parent
-        )
-      end
+      fn -> run_worker_payload(config.workflow_mode, config, runner_mod, issue, dispatch) end
     )
   end
 
-  defp run_worker_payload(
-         :graph,
-         config,
-         runner_mod,
-         issue,
-         attempt,
-         workspace_path,
-         host,
-         parent
-       ) do
+  defp run_worker_payload(:graph, config, runner_mod, %Issue{} = issue, dispatch) do
     case GraphAdapter.from_workflow([]) do
       {:ok, compiled} ->
         state =
@@ -653,10 +644,11 @@ defmodule Raxol.Symphony.Orchestrator do
             runner_module: runner_mod,
             candidates: [issue],
             candidate: issue,
-            parent_pid: parent,
-            attempt: attempt,
-            workspace_path: workspace_path,
-            host: host
+            parent_pid: dispatch.parent,
+            attempt: dispatch.attempt,
+            workspace_path: dispatch.workspace_path,
+            host: dispatch.host,
+            ssh: dispatch.ssh
           )
 
         graph_outcome(WorkflowCompiled.invoke(compiled, state))
@@ -666,28 +658,42 @@ defmodule Raxol.Symphony.Orchestrator do
     end
   end
 
-  defp run_worker_payload(
-         _mode,
-         config,
-         runner_mod,
-         issue,
-         attempt,
-         workspace_path,
-         host,
-         parent
-       ) do
+  defp run_worker_payload(_mode, config, runner_mod, %Issue{} = issue, dispatch) do
     runner_opts = [
-      parent: parent,
-      attempt: attempt,
-      workspace_path: workspace_path,
-      host: host
+      parent: dispatch.parent,
+      attempt: dispatch.attempt,
+      workspace_path: dispatch.workspace_path,
+      host: dispatch.host
     ]
 
-    run_runner(runner_mod, issue, config, runner_opts)
+    run_runner(runner_mod, issue, config, runner_opts,
+      host: dispatch.host,
+      ssh: dispatch.ssh
+    )
   end
 
-  defp run_runner(runner_mod, %Issue{} = issue, config, runner_opts) do
-    case runner_mod.run(issue, config, runner_opts) do
+  # SPEC s9.4: a `before_run` failure is fatal to this run ATTEMPT. Exiting is
+  # how that is said here -- the task's exit is what schedules the failure
+  # retry, so the hook fails the attempt exactly the way a failing runner does,
+  # and the workspace itself survives for the retry to reuse.
+  #
+  # Both hooks run INSIDE the worker task rather than in the orchestrator. They
+  # carry `hooks.timeout_ms` and shell out (over SSH for a remote worker), so
+  # running them in the GenServer would block every other issue's dispatch for
+  # the duration.
+  defp run_runner(runner_mod, %Issue{} = issue, config, runner_opts, hook_opts) do
+    workspace = Keyword.fetch!(runner_opts, :workspace_path)
+
+    case Workspace.around_run(config, workspace, hook_opts, fn ->
+           runner_mod.run(issue, config, runner_opts)
+         end) do
+      {:error, reason} -> exit(reason)
+      {:ok, result} -> interpret_runner_result(result, issue, runner_opts)
+    end
+  end
+
+  defp interpret_runner_result(result, %Issue{} = issue, runner_opts) do
+    case result do
       :ok ->
         :ok
 
@@ -1344,6 +1350,7 @@ defmodule Raxol.Symphony.Orchestrator do
        ) do
     parent = self()
     config = state.config
+    ssh = state.ssh
 
     Task.Supervisor.async_nolink(
       task_supervisor(state),
@@ -1359,7 +1366,13 @@ defmodule Raxol.Symphony.Orchestrator do
           host: host
         ]
 
-        run_runner(runner_mod, issue, config, runner_opts)
+        # `before_run` runs again on a resume, and `after_run` did not run when
+        # this attempt paused. That keeps the pair balanced across a pause: one
+        # `before_run` per stretch of actual running, one `after_run` when the
+        # run finally ends. A `before_run` that is not idempotent would see the
+        # second call, but a resumed run genuinely is starting again -- on a
+        # remote worker, possibly after the host rebooted.
+        run_runner(runner_mod, issue, config, runner_opts, host: host, ssh: ssh)
       end
     )
   end

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -1377,11 +1377,13 @@ defmodule Raxol.Symphony.Orchestrator do
         ]
 
         # `before_run` runs again on a resume, and `after_run` did not run when
-        # this attempt paused. That keeps the pair balanced across a pause: one
-        # `before_run` per stretch of actual running, one `after_run` when the
-        # run finally ends. A `before_run` that is not idempotent would see the
-        # second call, but a resumed run genuinely is starting again -- on a
-        # remote worker, possibly after the host rebooted.
+        # this attempt paused. So the two are NOT matched one-for-one: a run
+        # that pauses N times gets N+1 `before_run`s and a single `after_run`
+        # when it finally ends. One `before_run` per stretch of actual running
+        # is the intent -- a resumed run genuinely is starting again, on a
+        # remote worker possibly after the host rebooted -- but it makes
+        # idempotence a REQUIREMENT of `before_run` rather than a nicety. A pair
+        # that starts a container has to tolerate being asked twice.
         run_runner(runner_mod, issue, config, runner_opts, host: host, ssh: ssh)
       end
     )

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -878,6 +878,7 @@ defmodule Raxol.Symphony.Orchestrator do
     parent = self()
     config = state.config
     max_candidates = length(issues)
+    ssh = state.ssh
 
     Task.Supervisor.async_nolink(
       task_supervisor(state),
@@ -889,12 +890,19 @@ defmodule Raxol.Symphony.Orchestrator do
           workspaces,
           hosts,
           max_candidates,
-          parent
+          parent,
+          ssh
         )
       end
     )
   end
 
+  # `ssh` is carried in for the same reason the single-issue graph payload
+  # carries it: the slots now bracket their runner with `before_run`/`after_run`,
+  # and on a remote worker those shell out over the transport. Left out, every
+  # parallel slot ran its hooks with DEFAULT transport options while the other
+  # two modes used the orchestrator's -- and the mode test could not see it,
+  # because all three modes run with `host: nil` unless a pool is configured.
   defp run_parallel_batch_payload(
          config,
          runner_mod,
@@ -902,7 +910,8 @@ defmodule Raxol.Symphony.Orchestrator do
          workspaces,
          hosts,
          max_candidates,
-         parent
+         parent,
+         ssh
        ) do
     case GraphAdapter.from_workflow_parallel(max_candidates: max_candidates) do
       {:ok, compiled} ->
@@ -913,7 +922,8 @@ defmodule Raxol.Symphony.Orchestrator do
             candidates: issues,
             workspaces: workspaces,
             hosts: hosts,
-            parent_pid: parent
+            parent_pid: parent,
+            ssh: ssh
           )
 
         results =

--- a/packages/raxol_symphony/lib/raxol/symphony/workflow/graph_adapter.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workflow/graph_adapter.ex
@@ -76,6 +76,7 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
   alias Raxol.Symphony.Issue
   alias Raxol.Symphony.Runner
   alias Raxol.Symphony.Tracker
+  alias Raxol.Symphony.Workspace
   alias Raxol.Workflow.Compiled
   alias Raxol.Workflow.Graph
 
@@ -258,33 +259,37 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
 
     fn state ->
       case Map.get(state, candidate_key) do
-        nil ->
-          {:ok, Map.put(state, result_key, nil)}
-
-        %Issue{} = issue ->
-          runner_opts = if state.runner_module, do: [runner_module: state.runner_module], else: []
-          parent = Map.get(state, :parent_pid, self())
-          attempt = Map.get(state, :attempt) || 1
-          workspace = Map.get(state, workspace_key) || Map.get(state, :workspace_path, "")
-          host = slot_host(state, slot)
-
-          with {:ok, runner_module} <- Runner.resolve(state.config, runner_opts) do
-            result =
-              runner_module.run(issue, state.config,
-                parent: parent,
-                attempt: attempt,
-                workspace_path: workspace,
-                host: host
-              )
-
-            # A branch pause is recorded verbatim as the slot result and
-            # surfaced through the aggregate; sibling branches run to
-            # completion. The graph run itself does NOT interrupt (unlike
-            # `from_workflow/1`) — the orchestrator parks the pause token
-            # and re-dispatches the paused issue on resume.
-            {:ok, Map.put(state, result_key, result)}
-          end
+        nil -> {:ok, Map.put(state, result_key, nil)}
+        %Issue{} = issue -> dispatch_slot(state, issue, slot, workspace_key, result_key)
       end
+    end
+  end
+
+  defp dispatch_slot(state, %Issue{} = issue, slot, workspace_key, result_key) do
+    runner_opts = if state.runner_module, do: [runner_module: state.runner_module], else: []
+    workspace = Map.get(state, workspace_key) || Map.get(state, :workspace_path, "")
+    host = slot_host(state, slot)
+
+    run_opts = base_run_opts(state, workspace, host)
+
+    with {:ok, runner_module} <- Runner.resolve(state.config, runner_opts) do
+      # Bracketed per SLOT, not per batch: each slot has its own issue, its own
+      # workspace and (in a host pool) its own machine, so one `before_run`
+      # covering all of them would run the wrong hook in the wrong place. A slot
+      # whose `before_run` fails records the failure as ITS result and leaves
+      # its siblings running -- the same shape as a branch pause, and the reason
+      # this does not abort the whole graph.
+      #
+      # A branch pause is recorded verbatim as the slot result and surfaced
+      # through the aggregate. The graph run itself does NOT interrupt (unlike
+      # `from_workflow/1`) -- the orchestrator parks the pause token and
+      # re-dispatches the paused issue on resume.
+      outcome =
+        Workspace.around_run(state.config, workspace, hook_opts(state, host), fn ->
+          runner_module.run(issue, state.config, run_opts)
+        end)
+
+      {:ok, Map.put(state, result_key, slot_result(outcome))}
     end
   end
 
@@ -372,7 +377,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
     |> maybe_put(:attempt, Keyword.get(opts, :attempt))
     |> maybe_put(:workspace_path, Keyword.get(opts, :workspace_path))
     |> maybe_put(:host, Keyword.get(opts, :host))
+    |> maybe_put(:ssh, Keyword.get(opts, :ssh))
   end
+
+  # The workspace run hooks a runner node brackets its runner with. `:host` is
+  # per-slot in a parallel graph and shared otherwise; `:ssh` is the transport
+  # the orchestrator was configured with, identical for every slot.
+  defp hook_opts(state, host), do: [host: host, ssh: Map.get(state, :ssh, [])]
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
@@ -419,21 +430,44 @@ defmodule Raxol.Symphony.Workflow.GraphAdapter do
     runner_opts =
       if state.runner_module, do: [runner_module: state.runner_module], else: []
 
-    parent = Map.get(state, :parent_pid, self())
-    attempt = Map.get(state, :attempt) || 1
     workspace = Map.get(state, :workspace_path, "")
     host = Map.get(state, :host)
-
     {resume_token, resume_value, state} = consume_pending_resume(state)
 
-    base_opts = [parent: parent, attempt: attempt, workspace_path: workspace, host: host]
-    run_opts = maybe_put_resume_opts(base_opts, resume_token, resume_value)
+    run_opts =
+      maybe_put_resume_opts(base_run_opts(state, workspace, host), resume_token, resume_value)
 
     with {:ok, runner_module} <- Runner.resolve(config, runner_opts) do
-      result = runner_module.run(issue, config, run_opts)
-      {:ok, store_runner_result(state, result)}
+      config
+      |> Workspace.around_run(workspace, hook_opts(state, host), fn ->
+        runner_module.run(issue, config, run_opts)
+      end)
+      |> store_bracketed_result(state)
     end
   end
+
+  # What every runner invocation is handed, however it was reached: the pid to
+  # report events to, which attempt this is, and where (and on what machine) to
+  # run. The parallel slots build the same list from their own per-slot values.
+  defp base_run_opts(state, workspace, host) do
+    [
+      parent: Map.get(state, :parent_pid, self()),
+      attempt: Map.get(state, :attempt) || 1,
+      workspace_path: workspace,
+      host: host
+    ]
+  end
+
+  # SPEC s9.4: a `before_run` failure is fatal to this run attempt. A node error
+  # is how the graph says that, and `graph_outcome/1` turns it into the same
+  # failure retry a runner error gets.
+  defp store_bracketed_result({:error, reason}, _state), do: {:error, reason}
+  defp store_bracketed_result({:ok, result}, state), do: {:ok, store_runner_result(state, result)}
+
+  # A `before_run` that failed is this slot's result, in the shape the
+  # aggregate already understands, so one slot cannot fail the batch.
+  defp slot_result({:ok, result}), do: result
+  defp slot_result({:error, reason}), do: {:error, reason}
 
   defp maybe_put_resume_opts(opts, nil, nil), do: opts
 

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -149,24 +149,40 @@ defmodule Raxol.Symphony.Workspace do
 
   ## When `after_run` fires
 
-  On any terminal outcome, including a runner that returned an error or raised.
-  `after_run` is the counterpart to `before_run`, so a run that started a dev
-  server or a container in `before_run` must get its teardown even when --
-  especially when -- the run went badly. Skipping it on failure leaks exactly
-  the resources it exists to reclaim.
+  On any outcome the worker task RETURNS FROM, including a runner that returned
+  an error or raised. `after_run` is the counterpart to `before_run`, so a run
+  that started a dev server or a container in `before_run` must get its teardown
+  even when -- especially when -- the run went badly. Skipping it on failure
+  leaks exactly the resources it exists to reclaim.
 
   It does NOT fire on `{:pause, _, _}`. A paused run is not over: the
   orchestrator parks the token, holds the workspace and the host slot, and
   re-dispatches later. Tearing down there would run the teardown mid-run and
   then run `before_run` a second time on resume.
 
+  It also cannot fire when the worker task is KILLED rather than returning --
+  `terminate_running/4` and the stall reconcile both `Process.exit(pid, :kill)`,
+  which no `after` or `catch` can intercept. So a run torn down by the
+  orchestrator leaves whatever `before_run` started, and the thing that reclaims
+  it is `before_remove` on the eventual `remove/3`. Worth knowing when writing
+  the pair: `after_run` is the normal teardown, not a guaranteed one.
+
   Its own failure is logged and ignored, per s9.4, so it cannot turn a
   successful run into a failed one.
+
+  A blank `path` is refused before `before_run` runs, so a hook can never land
+  in whatever directory the shell happened to start in. See
+  `execute_hook_script/4`.
   """
+  # `opts` carries no default on purpose. A default before a required argument
+  # is legal but reads as optional, and `around_run(config, path, opts)` would
+  # then silently bind `opts` to `fun` and die on the guard instead of saying
+  # what was left out. All four seams pass both.
   @spec around_run(Config.t(), Path.t(), keyword(), (-> result)) ::
           {:ok, result} | {:error, term()}
         when result: term()
-  def around_run(%Config{} = config, path, opts \\ [], fun) when is_function(fun, 0) do
+  def around_run(%Config{} = config, path, opts, fun)
+      when is_list(opts) and is_function(fun, 0) do
     case run_before_run_hook(config, path, opts) do
       {:error, reason} ->
         {:error, reason}
@@ -510,7 +526,36 @@ defmodule Raxol.Symphony.Workspace do
     :ok
   end
 
+  # A hook needs a directory to run IN, and a blank path is not one.
+  #
+  # `bash`'s `cd ''` SUCCEEDS and changes nothing, so the `cd WS && { … }` guard
+  # that carries SPEC s9.5 Invariant 1 across the network passes for an empty
+  # workspace and the hook runs in the login shell's home -- exactly the escape
+  # the group was built to prevent. Locally it is the same shape: `cd: ""` names
+  # no directory either.
+  #
+  # `GraphAdapter` defaults a missing workspace to `""` in two places
+  # (`slot_workspace/2` and `runner_dispatch_node/1`), which is unreachable on
+  # today's call paths and is a fail-OPEN default one off-by-one away from being
+  # reachable. Refusing here is fail-closed and costs a run attempt, not a
+  # workspace: it lands as a `before_run` failure, which SPEC s9.4 already makes
+  # fatal to the attempt.
+  #
+  # Checked here rather than in `run_hook/4` so a workspace with no hooks
+  # configured is unaffected -- `:no_hook` never reaches this.
+  defp execute_hook_script(_script, path, _timeout_ms, _opts)
+       when not is_binary(path),
+       do: {:error, {:invalid_workspace, path}}
+
   defp execute_hook_script(script, path, timeout_ms, opts) do
+    if String.trim(path) == "" do
+      {:error, {:invalid_workspace, path}}
+    else
+      do_execute_hook_script(script, path, timeout_ms, opts)
+    end
+  end
+
+  defp do_execute_hook_script(script, path, timeout_ms, opts) do
     case host_opt(opts) do
       nil ->
         execute_script(script, path, timeout_ms)

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -134,6 +134,65 @@ defmodule Raxol.Symphony.Workspace do
   end
 
   @doc """
+  Runs `fun` bracketed by the `before_run` and `after_run` hooks.
+
+  Returns `{:ok, result}` with whatever `fun` returned, or `{:error, reason}`
+  when `before_run` failed -- in which case `fun` never ran. The caller decides
+  what a `before_run` failure means in its own terms (SPEC s9.4 makes it fatal
+  to the run ATTEMPT, not to the workspace), which is why this reports rather
+  than exits.
+
+  The three seams that invoke a runner share this so the bracket cannot drift
+  between workflow modes: a hook that fires under `:default` and not under
+  `:graph_parallel` is worse than one that never fires, because only one of
+  those is visible.
+
+  ## When `after_run` fires
+
+  On any terminal outcome, including a runner that returned an error or raised.
+  `after_run` is the counterpart to `before_run`, so a run that started a dev
+  server or a container in `before_run` must get its teardown even when --
+  especially when -- the run went badly. Skipping it on failure leaks exactly
+  the resources it exists to reclaim.
+
+  It does NOT fire on `{:pause, _, _}`. A paused run is not over: the
+  orchestrator parks the token, holds the workspace and the host slot, and
+  re-dispatches later. Tearing down there would run the teardown mid-run and
+  then run `before_run` a second time on resume.
+
+  Its own failure is logged and ignored, per s9.4, so it cannot turn a
+  successful run into a failed one.
+  """
+  @spec around_run(Config.t(), Path.t(), keyword(), (-> result)) ::
+          {:ok, result} | {:error, term()}
+        when result: term()
+  def around_run(%Config{} = config, path, opts \\ [], fun) when is_function(fun, 0) do
+    case run_before_run_hook(config, path, opts) do
+      {:error, reason} ->
+        {:error, reason}
+
+      :ok ->
+        try do
+          fun.()
+        catch
+          # An exit is how a runner reports failure to its task, so this is a
+          # terminal outcome like any other. Re-raised verbatim afterwards: the
+          # teardown is not license to swallow the reason the run died.
+          kind, reason ->
+            run_after_run_hook(config, path, opts)
+            :erlang.raise(kind, reason, __STACKTRACE__)
+        else
+          result ->
+            unless paused?(result), do: run_after_run_hook(config, path, opts)
+            {:ok, result}
+        end
+    end
+  end
+
+  defp paused?({:pause, _reason, _token}), do: true
+  defp paused?(_result), do: false
+
+  @doc """
   Removes a workspace, running `before_remove` first (best-effort).
 
   With a `:host` the containment check is measured against that host's remote

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -170,9 +170,10 @@ defmodule Raxol.Symphony.Workspace do
   Its own failure is logged and ignored, per s9.4, so it cannot turn a
   successful run into a failed one.
 
-  A blank `path` is refused before `before_run` runs, so a hook can never land
-  in whatever directory the shell happened to start in. See
-  `execute_hook_script/4`.
+  A blank `path` is refused before `before_run` runs AND before `fun` does, so
+  neither a hook nor the runner it brackets can land in whatever directory the
+  shell happened to start in. It reports as a `before_run` failure would, which
+  s9.4 already makes fatal to the attempt and retryable.
   """
   # `opts` carries no default on purpose. A default before a required argument
   # is legal but reads as optional, and `around_run(config, path, opts)` would
@@ -183,29 +184,60 @@ defmodule Raxol.Symphony.Workspace do
         when result: term()
   def around_run(%Config{} = config, path, opts, fun)
       when is_list(opts) and is_function(fun, 0) do
-    case run_before_run_hook(config, path, opts) do
-      {:error, reason} ->
-        {:error, reason}
-
-      :ok ->
-        try do
-          fun.()
-        catch
-          # An exit is how a runner reports failure to its task, so this is a
-          # terminal outcome like any other. Re-raised verbatim afterwards: the
-          # teardown is not license to swallow the reason the run died.
-          kind, reason ->
-            run_after_run_hook(config, path, opts)
-            :erlang.raise(kind, reason, __STACKTRACE__)
-        else
-          result ->
-            unless paused?(result), do: run_after_run_hook(config, path, opts)
-            {:ok, result}
-        end
+    with :ok <- runnable_workspace(path),
+         :ok <- run_before_run_hook(config, path, opts) do
+      bracket(config, path, opts, fun)
     end
   end
 
-  defp paused?({:pause, _reason, _token}), do: true
+  # The RUNNER needs a real directory as much as the hooks do, so the refusal
+  # belongs here rather than only in `execute_hook_script/4`.
+  #
+  # Guarding the hook alone left the fail-open default in place for the thing
+  # the hook brackets: `GraphAdapter` defaults a missing workspace to `""` in
+  # two places (`slot_workspace/2`, `runner_dispatch_node/1`), and with no hooks
+  # configured `:no_hook` short-circuits before any check, so the runner was
+  # dispatched into an empty path anyway. `bash`'s `cd ''` succeeds and changes
+  # nothing, so SPEC s9.5 Invariant 1's `cd WS && { … }` guard passes and the
+  # work lands in whatever directory the shell started in.
+  #
+  # Costs a run ATTEMPT, not a workspace: it lands where a `before_run` failure
+  # lands, which s9.4 already makes fatal to the attempt and retryable.
+  defp runnable_workspace(path) when is_binary(path) do
+    if String.trim(path) == "", do: {:error, {:invalid_workspace, path}}, else: :ok
+  end
+
+  defp runnable_workspace(path), do: {:error, {:invalid_workspace, path}}
+
+  defp bracket(config, path, opts, fun) do
+    try do
+      fun.()
+    catch
+      # An exit is how a runner reports failure to its task, so this is a
+      # terminal outcome like any other. Re-raised verbatim afterwards: the
+      # teardown is not license to swallow the reason the run died.
+      kind, reason ->
+        run_after_run_hook(config, path, opts)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    else
+      result ->
+        unless paused?(result), do: run_after_run_hook(config, path, opts)
+        {:ok, result}
+    end
+  end
+
+  # `is_atom(reason)` matches every other reader of this shape, and the match
+  # has to be exact for the same reason the bracket is shared: a run the
+  # orchestrator treats as OVER must get its teardown.
+  #
+  # `Runner.result/0` is `{:pause, atom(), term()}`, and each consumer guards on
+  # it -- `Orchestrator.interpret_runner_result/3` (`exit({:runner_bad_return,
+  # _})`), `apply_batch_issue_result/3` (continuation retry) and
+  # `GraphAdapter.store_runner_result/2`. Unguarded here, a `{:pause, "string",
+  # token}` was the one shape read as paused by this and as terminated by all
+  # three: the run was retried and `after_run` never fired, so whatever
+  # `before_run` started was never reclaimed.
+  defp paused?({:pause, reason, _token}) when is_atom(reason), do: true
   defp paused?(_result), do: false
 
   @doc """

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_run_hooks_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_run_hooks_test.exs
@@ -1,0 +1,192 @@
+defmodule Raxol.Symphony.OrchestratorRunHooksTest do
+  @moduledoc """
+  `hooks.before_run` and `hooks.after_run` are dispatched (issue #744 follow-up).
+
+  Both were implemented in `Raxol.Symphony.Workspace` and covered by tests that
+  called them directly, but nothing in the orchestrator ever invoked them. A
+  deployment that configured either in `WORKFLOW.md` got silence: the hook was
+  accepted by config validation, reported in the snapshot, and never run.
+
+  These tests drive the real dispatch path and assert on side effects the hooks
+  themselves leave in the workspace, so they fail if the wiring is removed.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Config, Issue, Orchestrator}
+  alias Raxol.Symphony.Test.FakeSsh
+  alias Raxol.Symphony.Trackers.Memory
+
+  # Records the workspace contents AT RUN TIME, which is the only way to tell a
+  # `before_run` that ran before the runner from one that ran after it.
+  defmodule WitnessRunner do
+    @behaviour Raxol.Symphony.Runner
+
+    @impl true
+    def run(_issue, %Config{runner: %{agent: agent}}, opts) do
+      workspace = Keyword.get(opts, :workspace_path)
+      pid = Map.get(agent, :report_to)
+      seen = workspace |> Path.join("before_run_ran") |> File.exists?()
+
+      if is_pid(pid), do: send(pid, {:ran, workspace, seen})
+
+      case Map.get(agent, :outcome, :ok) do
+        :ok -> :ok
+        :error -> {:error, :deliberate}
+        :pause -> {:pause, :awaiting_review, "rt"}
+        :raise -> raise "deliberate"
+      end
+    end
+  end
+
+  setup do
+    start_supervised!({Task.Supervisor, name: Raxol.Symphony.TaskSupervisor})
+    start_supervised!({Memory, []})
+    Memory.put_issue(%Issue{id: "a", identifier: "RH-1", title: "T", state: "Todo"})
+
+    root = Path.join(System.tmp_dir!(), "sym_hooks_#{:erlang.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf(root) end)
+
+    %{root: root, workspace: Path.join(root, "RH-1")}
+  end
+
+  defp config(root, hooks, agent_extra \\ %{}, mode \\ "default") do
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{kind: "memory", active_states: ["Todo"], terminal_states: ["Done"]},
+        polling: %{interval_ms: 60_000},
+        agent: %{max_concurrent_agents: 10, max_retry_backoff_ms: 60_000},
+        runner: %{kind: "noop", agent: Map.merge(%{report_to: self()}, agent_extra)},
+        workspace: %{root: root},
+        workflow_mode: mode,
+        hooks: Map.merge(%{timeout_ms: 5_000}, hooks)
+      },
+      prompt_template: ""
+    })
+  end
+
+  defp start_orchestrator(config) do
+    {:ok, pid} =
+      start_supervised(
+        {Orchestrator,
+         config: config,
+         runner_module: WitnessRunner,
+         auto_start_tick: false,
+         name: nil,
+         ssh: FakeSsh.opts()},
+        id: {Orchestrator, make_ref()}
+      )
+
+    pid
+  end
+
+  defp eventually(fun, timeout_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_eventually(fun, deadline)
+  end
+
+  defp do_eventually(fun, deadline) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("condition not met before timeout")
+
+      true ->
+        Process.sleep(10)
+        do_eventually(fun, deadline)
+    end
+  end
+
+  describe "before_run" do
+    test "runs in the workspace before the runner does", %{root: root, workspace: ws} do
+      config(root, %{before_run: "touch before_run_ran"})
+      |> start_orchestrator()
+      |> Orchestrator.tick_now()
+
+      # `seen` is read by the runner itself, so this asserts ORDER, not just
+      # that the hook ran at some point.
+      assert_receive {:ran, ^ws, true}, 2_000
+    end
+
+    # SPEC s9.4: fatal to the run attempt.
+    test "a failure stops the runner from running at all", %{root: root} do
+      config(root, %{before_run: "exit 4"})
+      |> start_orchestrator()
+      |> Orchestrator.tick_now()
+
+      refute_receive {:ran, _, _}, 500
+    end
+  end
+
+  describe "after_run" do
+    test "runs after a successful run", %{root: root, workspace: ws} do
+      config(root, %{after_run: "touch after_run_ran"})
+      |> start_orchestrator()
+      |> Orchestrator.tick_now()
+
+      assert_receive {:ran, ^ws, _}, 2_000
+      eventually(fn -> File.exists?(Path.join(ws, "after_run_ran")) end)
+    end
+
+    # after_run is the counterpart to before_run, so a run that started
+    # something in before_run needs its teardown most when the run went badly.
+    test "runs when the runner returned an error", %{root: root, workspace: ws} do
+      config(root, %{after_run: "touch after_run_ran"}, %{outcome: :error})
+      |> start_orchestrator()
+      |> Orchestrator.tick_now()
+
+      assert_receive {:ran, ^ws, _}, 2_000
+      eventually(fn -> File.exists?(Path.join(ws, "after_run_ran")) end)
+    end
+
+    test "runs when the runner raised", %{root: root, workspace: ws} do
+      config(root, %{after_run: "touch after_run_ran"}, %{outcome: :raise})
+      |> start_orchestrator()
+      |> Orchestrator.tick_now()
+
+      assert_receive {:ran, ^ws, _}, 2_000
+      eventually(fn -> File.exists?(Path.join(ws, "after_run_ran")) end)
+    end
+
+    # A paused run is not over: the orchestrator parks the token, holds the
+    # workspace and the host slot, and re-dispatches later. Tearing down here
+    # would run the teardown mid-run.
+    test "does NOT run when the run merely paused", %{root: root, workspace: ws} do
+      config(root, %{after_run: "touch after_run_ran"}, %{outcome: :pause})
+      |> start_orchestrator()
+      |> Orchestrator.tick_now()
+
+      assert_receive {:ran, ^ws, _}, 2_000
+      Process.sleep(300)
+      refute File.exists?(Path.join(ws, "after_run_ran"))
+    end
+
+    # s9.4: logged and ignored, so it cannot turn a good run into a failed one.
+    test "its own failure does not fail the run", %{root: root, workspace: ws} do
+      pid = start_orchestrator(config(root, %{after_run: "exit 9"}))
+      :ok = Orchestrator.tick_now(pid)
+
+      assert_receive {:ran, ^ws, _}, 2_000
+      eventually(fn -> Orchestrator.snapshot(pid).counts.running == 0 end)
+      assert Orchestrator.snapshot(pid).counts.paused == 0
+    end
+  end
+
+  # The bracket lives in one shared place precisely so it cannot fire under one
+  # workflow_mode and not another -- a hook that runs for some issues and not
+  # others is worse than one that never runs, because only one of those is
+  # visible.
+  describe "every workflow mode dispatches the pair" do
+    for mode <- ["default", "graph", "graph_parallel"] do
+      test "#{mode} mode runs before_run in the workspace", %{root: root, workspace: ws} do
+        config(root, %{before_run: "touch before_run_ran"}, %{}, unquote(mode))
+        |> start_orchestrator()
+        |> Orchestrator.tick_now()
+
+        assert_receive {:ran, ^ws, true}, 2_000
+      end
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_run_hooks_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_run_hooks_test.exs
@@ -188,5 +188,68 @@ defmodule Raxol.Symphony.OrchestratorRunHooksTest do
         assert_receive {:ran, ^ws, true}, 2_000
       end
     end
+
+    # The three tests above all run with `host: nil`, so they exercise the local
+    # hook path in every mode and the TRANSPORT in none of them. That is what
+    # hid `graph_parallel` building its graph state without `:ssh`: its slots
+    # ran their hooks with default transport options while the other two modes
+    # used the orchestrator's configured ones.
+    #
+    # Asserting on the transport rather than on a file is the point -- a hook
+    # that ran, but over the wrong transport, leaves the same file behind.
+    #
+    # A marker only the hook script carries, so the mkdir and rm round trips
+    # that cross the same transport cannot be mistaken for it.
+    @hook_marker "__rx_hook_marker__"
+
+    for mode <- ["default", "graph", "graph_parallel"] do
+      test "#{mode} mode runs a remote hook over the CONFIGURED transport", %{root: root} do
+        me = self()
+        tag = unquote(mode)
+
+        recording = [
+          exec_fn: fn ssh, argv, opts ->
+            command = List.last(argv)
+            if String.contains?(command, @hook_marker), do: send(me, {:hook_via_transport, tag})
+            FakeSsh.exec_fn([]).(ssh, argv, opts)
+          end,
+          executable: "/usr/bin/ssh"
+        ]
+
+        config(root, %{before_run: "echo #{@hook_marker}"}, %{}, tag)
+        |> start_remote_orchestrator(root, recording)
+        |> Orchestrator.tick_now()
+
+        # Only the injected exec_fn can deliver this, and it IS the configured
+        # transport. A mode that built its graph state without `:ssh` falls back
+        # to the default `System.cmd` against a real `ssh`, and never sends.
+        # The marker keeps the mkdir and rm round trips off this channel.
+        assert_receive {:hook_via_transport, ^tag}, 5_000
+      end
+    end
+  end
+
+  # A host pool of one, so every dispatch is remote and the hooks have to go
+  # through the transport. `workspace_root` points at the same tmp root the
+  # local assertions use, since the "host" is this machine.
+  defp start_remote_orchestrator(config, root, ssh_opts) do
+    config = %{config | worker: %{config.worker | ssh_hosts: [remote_host(root)]}}
+
+    {:ok, pid} =
+      start_supervised(
+        {Orchestrator,
+         config: config,
+         runner_module: WitnessRunner,
+         auto_start_tick: false,
+         name: nil,
+         ssh: ssh_opts},
+        id: {Orchestrator, make_ref()}
+      )
+
+    pid
+  end
+
+  defp remote_host(root) do
+    %Raxol.Symphony.Worker.HostSpec{host: "build-1", user: "ci", workspace_root: root}
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_run_hooks_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_run_hooks_test.exs
@@ -33,6 +33,9 @@ defmodule Raxol.Symphony.OrchestratorRunHooksTest do
         :ok -> :ok
         :error -> {:error, :deliberate}
         :pause -> {:pause, :awaiting_review, "rt"}
+        # Outside `Runner.result/0`: every reader but one treats this as a
+        # terminated run, so the teardown owes it an `after_run`.
+        :bad_pause -> {:pause, "not-an-atom", "rt"}
         :raise -> raise "deliberate"
       end
     end
@@ -161,6 +164,24 @@ defmodule Raxol.Symphony.OrchestratorRunHooksTest do
       assert_receive {:ran, ^ws, _}, 2_000
       Process.sleep(300)
       refute File.exists?(Path.join(ws, "after_run_ran"))
+    end
+
+    # `Runner.result/0` is `{:pause, atom(), term()}`, and a non-atom reason is
+    # outside it. Every other reader guards `is_atom(reason)` and treats such a
+    # value as a terminated run: `interpret_runner_result/3` exits
+    # `{:runner_bad_return, _}`, the batch path falls to a continuation retry.
+    # Unguarded, `Workspace.paused?/1` was the ONLY reader that called it a
+    # pause -- so the run was retried and its teardown never fired.
+    test "a pause reason outside the runner contract still gets its teardown", %{
+      root: root,
+      workspace: ws
+    } do
+      config(root, %{after_run: "touch after_run_ran"}, %{outcome: :bad_pause})
+      |> start_orchestrator()
+      |> Orchestrator.tick_now()
+
+      assert_receive {:ran, ^ws, _}, 2_000
+      eventually(fn -> File.exists?(Path.join(ws, "after_run_ran")) end)
     end
 
     # s9.4: logged and ignored, so it cannot turn a good run into a failed one.

--- a/packages/raxol_symphony/test/raxol/symphony/workflow/graph_adapter_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workflow/graph_adapter_test.exs
@@ -29,7 +29,15 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
         prompt_template: ""
       })
 
-    %{config: config}
+    # A runner dispatch needs a real directory to run in (SPEC s9.5 Invariant 1),
+    # and `Workspace.around_run/4` refuses a blank one for the runner as well as
+    # for the hooks. These tests build graph state by hand, so they have to
+    # supply what the orchestrator supplies from `Workspace.ensure/3`.
+    workspace = Path.join(System.tmp_dir!(), "sym_ga_#{:erlang.unique_integer([:positive])}")
+    File.mkdir_p!(workspace)
+    on_exit(fn -> File.rm_rf(workspace) end)
+
+    %{config: config, workspace: workspace}
   end
 
   defp issue(id, identifier, state) do
@@ -69,7 +77,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       Noop.Director.set("MT-1", {:succeed_after, 0})
 
       {:ok, compiled} = GraphAdapter.from_workflow([])
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       assert {:ok, final, meta} = Compiled.invoke(compiled, state)
 
@@ -85,7 +99,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
     test "graceful handling when tracker returns no issues", ctx do
       # No issue seeded in Memory tracker.
       {:ok, compiled} = GraphAdapter.from_workflow([])
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       assert {:ok, final, meta} = Compiled.invoke(compiled, state)
       assert meta.nodes_executed == 5
@@ -101,7 +121,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       Noop.Director.set("MT-2", {:fail_after, 0, :simulated})
 
       {:ok, compiled} = GraphAdapter.from_workflow([])
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       assert {:ok, final, _meta} = Compiled.invoke(compiled, state)
 
@@ -123,7 +149,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       saver = {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: table}}
 
       {:ok, compiled} = GraphAdapter.from_workflow(saver: saver)
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       # First invoke: runner pauses, runner_wait interrupts.
       assert {:interrupted, run_id, paused_state, interrupt_value} =
@@ -157,7 +189,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       saver = {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: table}}
 
       {:ok, compiled} = GraphAdapter.from_workflow(saver: saver)
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       {:ok, _final, meta} = Compiled.invoke(compiled, state)
 
@@ -206,7 +244,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       Noop.Director.set("PAR-2", {:succeed_after, 0})
 
       {:ok, compiled} = GraphAdapter.from_workflow_parallel(max_candidates: 2)
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       assert {:ok, final, _meta} = Compiled.invoke(compiled, state)
 
@@ -226,7 +270,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       Noop.Director.set("PAR-3", {:succeed_after, 0})
 
       {:ok, compiled} = GraphAdapter.from_workflow_parallel(max_candidates: 3)
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       assert {:ok, final, _meta} = Compiled.invoke(compiled, state)
 
@@ -242,7 +292,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       Noop.Director.set("PAR-5", {:fail_after, 0, :boom})
 
       {:ok, compiled} = GraphAdapter.from_workflow_parallel(max_candidates: 2)
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       assert {:ok, final, _meta} = Compiled.invoke(compiled, state)
 
@@ -256,7 +312,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       Noop.Director.set("PAR-6", {:pause, :awaiting_review, %{token: 1}})
 
       {:ok, compiled} = GraphAdapter.from_workflow_parallel(max_candidates: 1)
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       # The run COMPLETES (no interrupt); the pause rides through aggregate.
       assert {:ok, final, _meta} = Compiled.invoke(compiled, state)
@@ -274,7 +336,13 @@ defmodule Raxol.Symphony.Workflow.GraphAdapterTest do
       Noop.Director.set("PAR-8", {:pause, :awaiting_review, %{token: 2}})
 
       {:ok, compiled} = GraphAdapter.from_workflow_parallel(max_candidates: 2)
-      state = GraphAdapter.initial_state(config: ctx.config, runner_module: Noop)
+
+      state =
+        GraphAdapter.initial_state(
+          config: ctx.config,
+          runner_module: Noop,
+          workspace_path: ctx.workspace
+        )
 
       assert {:ok, final, _meta} = Compiled.invoke(compiled, state)
 

--- a/packages/raxol_symphony/test/raxol/symphony/workspace_remote_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workspace_remote_test.exs
@@ -272,6 +272,37 @@ defmodule Raxol.Symphony.WorkspaceRemoteTest do
       refute File.exists?(escaped), "the hook ran outside its workspace"
     end
 
+    # `bash`'s `cd ''` SUCCEEDS and changes nothing, so the `cd WS && { … }`
+    # guard that carries Invariant 1 across the network passes for an empty
+    # workspace and the hook lands in the login shell's home. `GraphAdapter`
+    # defaults a missing workspace to `""` in two places, which makes this a
+    # fail-OPEN default guarding the one invariant the group exists for.
+    test "a blank workspace is refused rather than resolving to the shell's home", %{
+      local_root: local_root,
+      host_root: host_root
+    } do
+      escaped = Path.join(host_root, "hook_ran_in_home")
+      config = build_config(local_root, %{before_run: "touch #{escaped}"})
+      opts = [host: host(host_root), ssh: FakeSsh.opts(home: host_root)]
+
+      for blank <- ["", "   ", nil] do
+        assert {:error, {:before_run_hook_failed, {:invalid_workspace, ^blank}}} =
+                 Workspace.run_before_run_hook(config, blank, opts)
+      end
+
+      refute File.exists?(escaped), "the hook ran with no workspace to run in"
+    end
+
+    # The guard is on the hook, not on the workspace: a run with no hooks
+    # configured is unaffected by it, because `:no_hook` never reaches the
+    # check.
+    test "a blank workspace with no hook configured is still a no-op", %{local_root: local_root} do
+      config = build_config(local_root)
+
+      assert :ok = Workspace.run_before_run_hook(config, "", host: nil)
+      assert :ok = Workspace.run_after_run_hook(config, "", host: nil)
+    end
+
     test "before_run runs against the remote workspace", %{
       local_root: local_root,
       host_root: host_root

--- a/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
@@ -174,4 +174,41 @@ defmodule Raxol.Symphony.WorkspaceTest do
       refute File.dir?("/tmp/some/other/place_should_not_exist_anyway")
     end
   end
+
+  # SPEC s9.5 Invariant 1 depends on the workspace being a real directory.
+  # `bash`'s `cd ''` SUCCEEDS and changes nothing, so a blank path sails through
+  # the `cd WS && { … }` guard and the work lands in whatever directory the
+  # shell started in. `GraphAdapter` defaults a missing workspace to `""` in two
+  # places, so this is fail-closed for a default that is one off-by-one from
+  # being reachable.
+  describe "around_run/4 with no workspace to run in" do
+    @tag :tmp_dir
+    test "refuses before the hooks AND before the runner", %{tmp_dir: tmp_dir} do
+      config = build_config(tmp_dir, %{before_run: "true", after_run: "true"})
+
+      for blank <- ["", "   ", nil, :none] do
+        assert {:error, {:invalid_workspace, ^blank}} =
+                 Workspace.around_run(config, blank, [], fn -> flunk("runner should not run") end)
+      end
+    end
+
+    # The case guarding the hook alone did not cover: with nothing configured,
+    # `:no_hook` short-circuits before any check, so the runner was dispatched
+    # into an empty path anyway.
+    @tag :tmp_dir
+    test "refuses even when no hooks are configured", %{tmp_dir: tmp_dir} do
+      config = build_config(tmp_dir)
+
+      assert {:error, {:invalid_workspace, ""}} =
+               Workspace.around_run(config, "", [], fn -> flunk("runner should not run") end)
+    end
+
+    @tag :tmp_dir
+    test "a real workspace still runs, and gets its result back", %{tmp_dir: tmp_dir} do
+      config = build_config(tmp_dir)
+      {:ok, %{path: path}} = Workspace.ensure(config, "MT-1")
+
+      assert {:ok, :ran} = Workspace.around_run(config, path, [], fn -> :ran end)
+    end
+  end
 end


### PR DESCRIPTION
Stacked on #888 — review that first; this diff is against its tip.

`hooks.before_run` and `hooks.after_run` have never run. Both are implemented
in `Raxol.Symphony.Workspace`, both are covered by tests that call them
directly, and nothing in the orchestrator has ever invoked either. Config
validation accepts them, the snapshot reports them, and a deployment that
writes either into `WORKFLOW.md` gets silence.

#888 noted this as a pre-existing gap and left it alone, correctly: it is
orthogonal to making the hooks host-aware. It is also why #888's acceptance
criterion "hooks execute against the remote workspace root" was ticked for
`before_run` on the strength of a test calling a function production never
calls.

## Why this is not part of #888

Wiring these changes LOCAL dispatch too — every deployment with a hook
configured starts running it. #888 asserts the opposite as an acceptance
criterion ("local (`host == nil`) workspace behaviour unchanged"), so folding
this in would have made that criterion false.

## Where the bracket goes

Four seams invoke a runner, and all four now go through one
`Workspace.around_run/4`:

| Seam | Mode |
| --- | --- |
| `Orchestrator.run_worker_payload/5` | `:default` |
| `Orchestrator.spawn_resume_worker_task/8` | resume, any mode |
| `GraphAdapter.runner_dispatch_node/1` | `:graph` |
| `GraphAdapter.dispatch_slot/5` | `:graph_parallel` |

One shared function rather than four copies, because a hook that fires under
`:default` and not under `:graph_parallel` is worse than one that never fires:
only one of those is visible. A test asserts all three modes dispatch it.

Both hooks run INSIDE the worker task, never in the orchestrator. They carry
`hooks.timeout_ms` and shell out — over SSH for a remote worker — so running
them in the GenServer would stall every other issue's dispatch for the
duration.

## Failure semantics

**`before_run` failing is fatal to the run ATTEMPT** (SPEC s9.4). The task
exits, so the hook fails the attempt exactly the way a failing runner does,
and the workspace survives for the retry to reuse. A parallel slot records it
as THAT slot's result instead, leaving its siblings running — the same shape
a branch pause already has, and the reason one slot cannot fail a batch.

**`after_run` fires on any terminal outcome**, including a runner that returned
an error or raised. It is the counterpart to `before_run`, so a run that
started a dev server or a container needs its teardown most when — especially
when — the run went badly. Skipping it on failure leaks exactly what it exists
to reclaim.

**It does not fire on a pause.** A paused run is not over: the orchestrator
parks the token, holds the workspace and the host slot, and re-dispatches
later. Tearing down there would run the teardown mid-run. `before_run` then
runs again on resume, which keeps the pair balanced across a pause — one
`before_run` per stretch of actual running, one `after_run` when the run
finally ends.

Its own failure stays logged and ignored, per s9.4, so it cannot turn a
successful run into a failed one.

No SPEC document is checked in, so the `after_run`-on-failure and
not-on-pause choices are argued from the pairing above rather than quoted.
Say so if the intended semantics differ.

## Testing

`orchestrator_run_hooks_test.exs` drives the real dispatch path and asserts on
side effects the hooks leave in the workspace, so it fails if the wiring is
removed. Verified: **7 of 9 red** against the pre-fix tree (the two that stay
green are negative assertions — "does not fire on pause", "its own failure
does not fail the run" — which pass trivially when nothing fires at all).

Ordering is asserted rather than assumed: the runner itself reports whether it
could see `before_run`'s marker, so a hook that ran at the wrong time fails
the test rather than passing it.

One defect this caught in its own harness: the first `eventually/2` helper
short-circuited on `Process.sleep/1`'s `:ok` return and polled once, which made
all five `after_run` assertions vacuous. The red-check is what surfaced it.

## Acceptance criteria

- [x] `before_run` runs in the workspace, before the runner, at every seam
- [x] a `before_run` failure stops the runner from running at all
- [x] `after_run` runs on success, on runner error, and on a raise
- [x] `after_run` does NOT run on a pause
- [x] an `after_run` failure does not fail the run
- [x] all three `workflow_mode`s dispatch the pair

## Manual testing

- [x] `MIX_ENV=test mix test` in raxol_symphony: 926 pass, 6 excluded (916 before)
- [x] Three consecutive full-suite runs green
- [x] `mix compile --warnings-as-errors` clean, formatted
- [x] `mix credo --strict` on the three touched files: net **-1** finding vs the base (one pre-existing `build_slot_dispatch` complexity resolved, none introduced)
- [ ] Against a real deployment with hooks configured

## Notes

- **Operator-visible:** any deployment already carrying `before_run`/`after_run`
  in `WORKFLOW.md` starts executing them on the next dispatch, having never run
  them before. Worth checking what is configured before rolling out.
- `run_worker_payload/9` became `/5` — the parameters it accumulated are now one
  `dispatch` map. `:ssh` had to join them (a remote hook needs the same
  transport options `Workspace.ensure/3` was given) and nine positional
  arguments was over Credo's limit.

Refs #744
