### PR TITLE
Make a port's child actually die when we stop it

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -1,0 +1,160 @@
+defmodule Raxol.Symphony.PortReaper do
+  @moduledoc """
+  Stop the OS process behind a `Port`, and the descendants it spawned.
+
+  `Port.close/1` releases the BEAM-side port and signals NOTHING. What becomes
+  of the child is entirely the child's business: one that reads its stdin sees
+  EOF and usually exits, one that does not simply keeps running, and in BOTH
+  cases the subprocesses it spawned are untouched and outlive it. A caller that
+  needs the work actually stopped has to signal it.
+
+  Capture a target with `capture/1` while the port is still open, then either
+  `kill/1` (we have given up on the work) or `await_exit/2` (let it go quietly
+  first, then insist).
+
+  The remote counterpart is `Raxol.Symphony.Ssh.reap_on_disconnect/2`, which
+  does the same job on the far side of an ssh connection with `set -m` and a
+  group kill inside bash.
+  """
+
+  require Logger
+
+  @typedoc """
+  What may safely be signalled.
+
+  `{:group, pgid}` when the child leads its own process group, so its
+  descendants come with it. `{:pid, os_pid}` when it does not, in which case
+  only the child itself can be signalled. `:none` when the child is already
+  gone.
+  """
+  @type target :: {:group, pos_integer()} | {:pid, pos_integer()} | :none
+
+  @poll_ms 50
+
+  @doc """
+  Read the signal target off a live port.
+
+  Call this BEFORE closing the port. Once the child has exited, `ps` answers
+  nothing about it, and the process group its orphans are still in is no longer
+  recoverable -- a process group outlives its leader, which is exactly the case
+  worth reaping.
+  """
+  @spec capture(port()) :: target()
+  def capture(port) when is_port(port) do
+    case Port.info(port, :os_pid) do
+      nil -> :none
+      {:os_pid, os_pid} -> classify(os_pid)
+    end
+  end
+
+  @doc """
+  SIGKILL the target now.
+
+  For callers that have already stopped waiting, where a process that traps
+  SIGTERM must not get to keep running anyway.
+  """
+  @spec kill(target()) :: :ok
+  def kill(:none), do: :ok
+
+  def kill(target) do
+    case signal(target, "-KILL") do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "symphony.port_reaper.kill_failed target=#{inspect(target)} reason=#{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
+  Wait up to `grace_ms` for the target to exit on its own, then SIGKILL it.
+
+  For a clean shutdown, where closing the port has already delivered the EOF a
+  well-behaved stdio child treats as "shut down": that child should be allowed
+  to flush and exit on its own terms. The kill is the backstop for the two
+  cases EOF does not cover -- a child that never reads stdin, and the tool
+  subprocesses that outlive a parent which DID exit cleanly.
+  """
+  @spec await_exit(target(), non_neg_integer()) :: :ok
+  def await_exit(:none, _grace_ms), do: :ok
+
+  def await_exit(target, grace_ms) do
+    deadline = System.monotonic_time(:millisecond) + grace_ms
+    poll_until_gone(target, deadline)
+  end
+
+  defp poll_until_gone(target, deadline) do
+    cond do
+      not alive?(target) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        Logger.debug("symphony.port_reaper.grace_expired target=#{inspect(target)}")
+        kill(target)
+
+      true ->
+        Process.sleep(@poll_ms)
+        poll_until_gone(target, deadline)
+    end
+  end
+
+  # `kill -0` reports whether anything signallable is left. Against a GROUP that
+  # is the question worth asking: the leader can be gone while an orphaned tool
+  # subprocess keeps the group alive.
+  #
+  # A zombie answers "alive" here, since it still holds its pid. `erl_child_setup`
+  # reaps its own children promptly, so that resolves on its own rather than
+  # costing the full grace.
+  defp alive?(:none), do: false
+
+  defp alive?(target) do
+    match?({:ok, _}, signal(target, "-0"))
+  end
+
+  defp signal(target, flag) do
+    case System.find_executable("kill") do
+      nil ->
+        {:error, :no_kill_executable}
+
+      kill_path ->
+        case System.cmd(kill_path, [flag, signal_arg(target)], stderr_to_stdout: true) do
+          {output, 0} -> {:ok, output}
+          {output, status} -> {:error, {status, String.trim(output)}}
+        end
+    end
+  end
+
+  defp signal_arg({:group, pgid}), do: "-#{pgid}"
+  defp signal_arg({:pid, os_pid}), do: "#{os_pid}"
+
+  # Signal the process GROUP wherever it is safe to, because killing only the
+  # child leaves its descendants running: still doing work, and still holding
+  # the inherited stdout pipe, so a reader waiting on EOF blocks for the
+  # command's full natural runtime after the supposed kill.
+  #
+  # `erl_child_setup` gives a spawned port child a process group of its own, so
+  # `kill -KILL -PID` reaches its descendants and nothing else. That is CHECKED
+  # rather than assumed, because the failure mode is not subtle: a child that is
+  # not a group leader shares the BEAM's own group, and the group kill would
+  # take the VM down with it. The `{:pid, _}` fallback loses the descendants and
+  # keeps the VM.
+  defp classify(os_pid) do
+    if group_leader?(os_pid), do: {:group, os_pid}, else: {:pid, os_pid}
+  end
+
+  # A `ps` that is missing, fails, or answers something unparseable resolves the
+  # same conservative way, for the same reason.
+  defp group_leader?(os_pid) do
+    with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
+         {output, 0} <-
+           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true) do
+      String.trim(output) == "#{os_pid}"
+    else
+      _ -> false
+    end
+  end
+end

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -18,6 +18,7 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
 
   require Logger
 
+  alias Raxol.Symphony.PortReaper
   alias Raxol.Symphony.Runners.Codex.{Framing, Protocol}
   alias Raxol.Symphony.Ssh
   alias Raxol.Symphony.Worker.HostSpec
@@ -42,6 +43,12 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
 
   @port_line_bytes 1_048_576
   @default_turn_id 100
+
+  # How long a codex gets to act on the EOF `stop/1` delivers before it is
+  # killed. Long enough for a clean app-server shutdown, short enough that it
+  # cannot stall the orchestrator's `after` block -- and the ordinary case does
+  # not spend it, since polling stops the moment the process group drains.
+  @stop_grace_ms 2_000
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -117,11 +124,36 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   end
 
   @doc """
-  Closes the Port and drains any residual messages.
+  Closes the Port, reaps whatever the session left running, and drains any
+  residual messages.
+
+  Closing the port delivers the EOF a stdio server treats as "shut down", and a
+  codex that is reading its stdin exits on it. That covers the ordinary case and
+  only the ordinary case, so it is not the whole of stopping a session:
+
+    * a codex that is NOT reading stdin -- wedged, or busy inside a turn --
+      never sees the EOF and keeps running.
+    * the tool subprocesses codex spawned are not its stdin's business at all.
+      They survive a parent that exited perfectly cleanly, reparented to init,
+      still holding the workspace open. Measured: parent gone, orphan still
+      running.
+
+  So the EOF is given first and a group kill backs it up. The grace window is
+  what keeps a well-behaved codex on the clean path -- it gets to flush and exit
+  on its own terms, and the kill only reaches a session that would otherwise
+  have been left behind.
   """
   @spec stop(session() | port()) :: :ok
   def stop(%{port: port}), do: stop(port)
-  def stop(port) when is_port(port), do: close_port(port)
+
+  def stop(port) when is_port(port) do
+    # Captured while the port is still open: after the child exits, the process
+    # group its orphans are in can no longer be read back off anything.
+    reaper = PortReaper.capture(port)
+    close_port(port)
+    PortReaper.await_exit(reaper, @stop_grace_ms)
+  end
+
   def stop(_), do: :ok
 
   # ---------------------------------------------------------------------------

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -747,11 +747,103 @@ defmodule Raxol.Symphony.Workspace do
         {:error, {:exit, status, IO.iodata_to_binary(Enum.reverse(acc))}}
     after
       timeout_ms ->
-        # Port.close kills the OS process via SIGKILL when :exit_status was
-        # requested. Drain the message queue to avoid leaks.
-        Port.close(port)
+        kill_spawned_process(port)
+        close_port(port)
         flush_port_messages(port)
         {:error, :timeout}
+    end
+  end
+
+  # Giving up on a hook does not stop it.
+  #
+  # `Port.close/1` releases the BEAM-side port and signals nothing, so the hook
+  # runs on. `before_remove` is the sharp case: `remove/3` then `rm_rf`s the
+  # workspace out from under a hook still writing to it, and `after_create`'s
+  # failure path has the same shape. Past that, a hook that leaks a process per
+  # timeout leaks one per retry, and the orchestrator retries.
+  #
+  # This is the local half of the mistake the remote deadline in
+  # `Ssh.reap_on_disconnect/2` fixed on the host.
+  defp kill_spawned_process(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} -> kill_process_tree(os_pid)
+      # Exited between the timer firing and this call: nothing left to signal.
+      nil -> :ok
+    end
+  end
+
+  defp kill_process_tree(os_pid) do
+    case System.find_executable("kill") do
+      nil ->
+        Logger.warning(
+          "symphony.workspace.hook_kill_skipped os_pid=#{os_pid} reason=no_kill_executable"
+        )
+
+        :ok
+
+      kill_path ->
+        run_kill(kill_path, os_pid, signal_target(os_pid))
+    end
+  end
+
+  # SIGKILL, where the remote deadline sends SIGTERM. There the status is read
+  # back (`@killed_by_deadline`); here nothing reads it, we have already stopped
+  # waiting, and the workspace may be deleted next -- so a hook that traps TERM
+  # must not get to keep running.
+  defp run_kill(kill_path, os_pid, target) do
+    case System.cmd(kill_path, ["-KILL", target], stderr_to_stdout: true) do
+      {_output, 0} ->
+        :ok
+
+      {output, status} ->
+        Logger.warning(
+          "symphony.workspace.hook_kill_failed os_pid=#{os_pid} target=#{target} " <>
+            "status=#{status} output=#{truncate_for_log(output)}"
+        )
+
+        :ok
+    end
+  end
+
+  # Signal the process GROUP, for the reason the remote half does: killing only
+  # the hook leaves its children running, doing work past the timeout and still
+  # holding the inherited stdout pipe.
+  #
+  # `erl_child_setup` gives a spawned port child a process group of its own, so
+  # `kill -KILL -PID` reaches its descendants and nothing else. That is checked
+  # rather than assumed, because the failure mode is not subtle: a child that is
+  # NOT a group leader shares the BEAM's group, and the group kill would take
+  # down the orchestrator itself. The bare-pid fallback loses the hook's
+  # children and keeps the VM.
+  defp signal_target(os_pid) do
+    if group_leader?(os_pid), do: "-#{os_pid}", else: "#{os_pid}"
+  end
+
+  # A `ps` that is missing, fails, or answers something unparseable is treated
+  # as "not a leader" -- the conservative answer, for the same reason.
+  defp group_leader?(os_pid) do
+    with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
+         {output, 0} <-
+           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true) do
+      String.trim(output) == "#{os_pid}"
+    else
+      _ -> false
+    end
+  end
+
+  # The kill can land before this runs, and closing an already-closed port
+  # raises.
+  defp close_port(port) do
+    case :erlang.port_info(port) do
+      :undefined ->
+        :ok
+
+      _ ->
+        try do
+          Port.close(port)
+        rescue
+          ArgumentError -> :ok
+        end
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -42,7 +42,7 @@ defmodule Raxol.Symphony.Workspace do
 
   require Logger
 
-  alias Raxol.Symphony.{Config, PathSafety, Ssh}
+  alias Raxol.Symphony.{Config, PathSafety, PortReaper, Ssh}
   alias Raxol.Symphony.Worker.HostSpec
 
   # Distinctive enough that a login banner or profile chatter on the remote
@@ -747,87 +747,24 @@ defmodule Raxol.Symphony.Workspace do
         {:error, {:exit, status, IO.iodata_to_binary(Enum.reverse(acc))}}
     after
       timeout_ms ->
-        kill_spawned_process(port)
+        # Giving up on a hook does not stop it. `Port.close/1` signals nothing,
+        # so the hook runs on -- and `before_remove` is the sharp case, since
+        # `remove/3` then `rm_rf`s the workspace out from under a hook still
+        # writing to it. `after_create`'s failure path has the same shape. Past
+        # that, a hook that leaks a process per timeout leaks one per retry, and
+        # the orchestrator retries.
+        #
+        # Captured before the close, killed after it: `PortReaper.capture/1`
+        # needs a live child to read the target off.
+        #
+        # SIGKILL outright, where the remote deadline sends SIGTERM. There the
+        # status is read back (`@killed_by_deadline`); here nothing reads it, we
+        # have already stopped waiting, and the workspace may be deleted next.
+        reaper = PortReaper.capture(port)
         close_port(port)
+        PortReaper.kill(reaper)
         flush_port_messages(port)
         {:error, :timeout}
-    end
-  end
-
-  # Giving up on a hook does not stop it.
-  #
-  # `Port.close/1` releases the BEAM-side port and signals nothing, so the hook
-  # runs on. `before_remove` is the sharp case: `remove/3` then `rm_rf`s the
-  # workspace out from under a hook still writing to it, and `after_create`'s
-  # failure path has the same shape. Past that, a hook that leaks a process per
-  # timeout leaks one per retry, and the orchestrator retries.
-  #
-  # This is the local half of the mistake the remote deadline in
-  # `Ssh.reap_on_disconnect/2` fixed on the host.
-  defp kill_spawned_process(port) do
-    case Port.info(port, :os_pid) do
-      {:os_pid, os_pid} -> kill_process_tree(os_pid)
-      # Exited between the timer firing and this call: nothing left to signal.
-      nil -> :ok
-    end
-  end
-
-  defp kill_process_tree(os_pid) do
-    case System.find_executable("kill") do
-      nil ->
-        Logger.warning(
-          "symphony.workspace.hook_kill_skipped os_pid=#{os_pid} reason=no_kill_executable"
-        )
-
-        :ok
-
-      kill_path ->
-        run_kill(kill_path, os_pid, signal_target(os_pid))
-    end
-  end
-
-  # SIGKILL, where the remote deadline sends SIGTERM. There the status is read
-  # back (`@killed_by_deadline`); here nothing reads it, we have already stopped
-  # waiting, and the workspace may be deleted next -- so a hook that traps TERM
-  # must not get to keep running.
-  defp run_kill(kill_path, os_pid, target) do
-    case System.cmd(kill_path, ["-KILL", target], stderr_to_stdout: true) do
-      {_output, 0} ->
-        :ok
-
-      {output, status} ->
-        Logger.warning(
-          "symphony.workspace.hook_kill_failed os_pid=#{os_pid} target=#{target} " <>
-            "status=#{status} output=#{truncate_for_log(output)}"
-        )
-
-        :ok
-    end
-  end
-
-  # Signal the process GROUP, for the reason the remote half does: killing only
-  # the hook leaves its children running, doing work past the timeout and still
-  # holding the inherited stdout pipe.
-  #
-  # `erl_child_setup` gives a spawned port child a process group of its own, so
-  # `kill -KILL -PID` reaches its descendants and nothing else. That is checked
-  # rather than assumed, because the failure mode is not subtle: a child that is
-  # NOT a group leader shares the BEAM's group, and the group kill would take
-  # down the orchestrator itself. The bare-pid fallback loses the hook's
-  # children and keeps the VM.
-  defp signal_target(os_pid) do
-    if group_leader?(os_pid), do: "-#{os_pid}", else: "#{os_pid}"
-  end
-
-  # A `ps` that is missing, fails, or answers something unparseable is treated
-  # as "not a leader" -- the conservative answer, for the same reason.
-  defp group_leader?(os_pid) do
-    with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
-         {output, 0} <-
-           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true) do
-      String.trim(output) == "#{os_pid}"
-    else
-      _ -> false
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
@@ -1,0 +1,137 @@
+defmodule Raxol.Symphony.PortReaperTest do
+  @moduledoc """
+  `Port.close/1` signals nothing, so what a port's child does next is the
+  child's own business. These drive the three behaviours that fall out of that,
+  against real spawned processes:
+
+    * a child that reads stdin exits on the EOF a close delivers
+    * a child that does not read stdin ignores it entirely
+    * a tool subprocess survives a parent that exited cleanly
+
+  Liveness is asked of the OS (`kill -0`) rather than inferred from a witness
+  file, since the question is whether a process is still running, not whether it
+  got as far as some side effect.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.PortReaper
+
+  # Mirrors `Runners.Codex.Session.base_port_opts/0`: no `:in`, so stdin is a
+  # live pipe and closing the port is what delivers EOF.
+  defp open_child(script) do
+    port =
+      Port.open(
+        {:spawn_executable, System.find_executable("bash")},
+        [
+          :binary,
+          :exit_status,
+          :stderr_to_stdout,
+          :hide,
+          {:line, 1_048_576},
+          {:cd, System.tmp_dir!()},
+          {:args, ["-lc", script]}
+        ]
+      )
+
+    # Let bash get as far as spawning whatever the script spawns.
+    Process.sleep(300)
+    port
+  end
+
+  defp alive?(target) do
+    {_out, status} = System.cmd("/bin/kill", ["-0", target], stderr_to_stdout: true)
+    status == 0
+  end
+
+  defp close(port) do
+    Port.close(port)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  describe "capture/1" do
+    test "reports the child as its own process group leader" do
+      port = open_child("sleep 30")
+
+      assert {:group, pgid} = PortReaper.capture(port)
+      assert {:os_pid, ^pgid} = Port.info(port, :os_pid)
+
+      close(port)
+      PortReaper.kill({:group, pgid})
+    end
+
+    test "is :none once the port is closed" do
+      port = open_child("sleep 30")
+      target = PortReaper.capture(port)
+      close(port)
+      PortReaper.kill(target)
+
+      assert PortReaper.capture(port) == :none
+    end
+  end
+
+  describe "kill/1" do
+    test "kills a child that never reads stdin" do
+      port = open_child("sleep 30")
+      target = PortReaper.capture(port)
+      {:group, pgid} = target
+
+      close(port)
+      assert alive?("-#{pgid}"), "closing the port must not be what stops it"
+
+      assert :ok = PortReaper.kill(target)
+      Process.sleep(200)
+      refute alive?("-#{pgid}")
+    end
+
+    test "is a no-op for :none" do
+      assert :ok = PortReaper.kill(:none)
+    end
+  end
+
+  describe "await_exit/2" do
+    test "reaps a tool subprocess that outlived a cleanly exited parent" do
+      # The codex shape: the app-server exits on EOF, the tool it spawned does
+      # not, and the group outlives its leader.
+      port = open_child("( sleep 30 ) & cat > /dev/null")
+      {:group, pgid} = target = PortReaper.capture(port)
+
+      close(port)
+      Process.sleep(400)
+
+      refute alive?("#{pgid}"), "the parent should have exited on EOF"
+      assert alive?("-#{pgid}"), "the orphaned tool should still hold the group"
+
+      assert :ok = PortReaper.await_exit(target, 1_000)
+      refute alive?("-#{pgid}")
+    end
+
+    test "returns as soon as a well-behaved child exits, without spending the grace" do
+      port = open_child("cat > /dev/null")
+      {:group, pgid} = target = PortReaper.capture(port)
+
+      close(port)
+
+      elapsed =
+        wall_ms(fn ->
+          assert :ok = PortReaper.await_exit(target, 10_000)
+        end)
+
+      refute alive?("-#{pgid}")
+
+      # Bounded well under the grace: the point is that a clean exit is detected
+      # rather than waited out. Generous enough not to be a timing race.
+      assert elapsed < 5_000
+    end
+
+    test "is a no-op for :none" do
+      assert :ok = PortReaper.await_exit(:none, 10_000)
+    end
+  end
+
+  defp wall_ms(fun) do
+    started = System.monotonic_time(:millisecond)
+    fun.()
+    System.monotonic_time(:millisecond) - started
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
@@ -1,0 +1,67 @@
+defmodule Raxol.Symphony.Runners.Codex.SessionStopTest do
+  @moduledoc """
+  `Session.stop/1` runs in the `after` block of every codex run, so whatever it
+  fails to clean up is left behind once per run.
+
+  Closing the port delivers EOF, which stops a codex that is reading stdin and
+  nothing else. These drive the two cases it does not cover, against real
+  processes standing in for the app-server and the tools it spawns.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.Runners.Codex.Session
+
+  defp open_session_port(script) do
+    port =
+      Port.open(
+        {:spawn_executable, System.find_executable("bash")},
+        [
+          :binary,
+          :exit_status,
+          :stderr_to_stdout,
+          :hide,
+          {:line, 1_048_576},
+          {:cd, System.tmp_dir!()},
+          {:args, ["-lc", script]}
+        ]
+      )
+
+    Process.sleep(300)
+    {:os_pid, os_pid} = Port.info(port, :os_pid)
+    {port, os_pid}
+  end
+
+  defp alive?(target) do
+    {_out, status} = System.cmd("/bin/kill", ["-0", target], stderr_to_stdout: true)
+    status == 0
+  end
+
+  test "stops a session that is not reading stdin" do
+    # Wedged, or busy inside a turn: the EOF lands on a codex that never looks.
+    {port, os_pid} = open_session_port("sleep 30")
+
+    assert :ok = Session.stop(port)
+
+    refute alive?("-#{os_pid}")
+  end
+
+  test "reaps the tool subprocesses a cleanly exited codex left behind" do
+    {port, os_pid} = open_session_port("( sleep 30 ) & cat > /dev/null")
+
+    assert :ok = Session.stop(port)
+
+    refute alive?("-#{os_pid}"),
+           "the app-server exits on EOF, but its tool subprocess does not"
+  end
+
+  test "accepts a session map and a already-dead port" do
+    {port, os_pid} = open_session_port("sleep 30")
+
+    assert :ok = Session.stop(%{port: port})
+    refute alive?("-#{os_pid}")
+
+    # Stopping twice must not raise on the already-closed port.
+    assert :ok = Session.stop(port)
+    assert :ok = Session.stop(nil)
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
@@ -89,6 +89,37 @@ defmodule Raxol.Symphony.WorkspaceTest do
     end
   end
 
+  describe "run_hook/4 timeout" do
+    # A hook we have stopped waiting for has to actually be DEAD. `before_remove`
+    # is followed by an `rm_rf` of the very directory the hook is still writing
+    # to, and a hook that survives its timeout survives once per retry.
+    #
+    # The witnesses are what a survivor leaves behind, so the assertion is their
+    # ABSENCE once the hook's own natural runtime has elapsed. Only a survivor
+    # can create them, which is what keeps this from being a wall-clock race:
+    # slow machines cannot fail it, they can only stop proving anything.
+    @tag :tmp_dir
+    test "kills a timed-out hook and the children it spawned", %{tmp_dir: tmp_dir} do
+      hook_witness = Path.join(tmp_dir, "hook_finished")
+      child_witness = Path.join(tmp_dir, "child_finished")
+
+      script = """
+      ( sleep 2; touch #{child_witness} ) &
+      sleep 2
+      touch #{hook_witness}
+      """
+
+      config = build_config(tmp_dir, %{before_run: script, timeout_ms: 200})
+
+      assert {:error, :timeout} = Workspace.run_hook(config, :before_run, tmp_dir)
+
+      Process.sleep(2_400)
+
+      refute File.exists?(hook_witness)
+      refute File.exists?(child_witness)
+    end
+  end
+
   describe "run_before_run_hook/2" do
     @tag :tmp_dir
     test "noop when hook is not set", %{tmp_dir: tmp_dir} do


### PR DESCRIPTION
Closes #890, and fixes the same class of defect in `Runners.Codex.Session`.

`Port.close/1` releases the BEAM-side port and signals NOTHING. What becomes of
the child is the child's own business, and both call sites had assumed
otherwise.

## 1. Workspace hooks (#890)

`Workspace.collect_output/3` claimed in a comment that `Port.close` SIGKILLs the
child. It does not: a local hook exceeding `hooks.timeout_ms` kept running after
the orchestrator gave up on it. `before_remove` then `rm_rf`s the workspace out
from under a live hook, and a hook that leaks a process per timeout leaks one
per retry. Reproduced before fixing: the hook completed its work a full 3s after
it was declared timed out.

Killed outright, where the remote deadline sends SIGTERM -- nothing reads the
status here, and the workspace may be deleted next.

## 2. Codex sessions

`Session.stop/1` closed the port and stopped there. Closing delivers the EOF a
stdio server treats as "shut down", so a codex that is reading stdin *does*
exit. That is why this looked fine, and it is only the ordinary case. Measured,
two cases fall straight through it:

| child | after `Port.close` |
|---|---|
| reads stdin, exits on EOF | dead -- the clean path, works today |
| **not reading stdin** (wedged / mid-turn) | **alive** |
| **tool subprocess of a cleanly exited parent** | **alive**, reparented to init |

The second is the one that bites in practice: codex spawns tool subprocesses,
and they outlive a parent that exited perfectly cleanly. `stop/1` runs in the
`after` block of every codex run, so whatever it misses is left behind per run.

The EOF is still delivered first, and a group kill backs it up after a grace
window -- a well-behaved codex stays on the clean path and gets to flush and
exit on its own terms; the kill only reaches a session that would otherwise have
been abandoned. Polling stops as soon as the group drains, so the ordinary case
does not spend the grace.

## The shared guard

Both sites need the same safety-critical decision, so it is extracted into
`Raxol.Symphony.PortReaper` rather than copied.

Signal the process **group**: killing only the child leaves its descendants
running, still working and still holding the inherited stdout pipe. Measured on
this machine, `erl_child_setup` gives a spawned port child its own process group
(child pid 79195, pgid 79195) while the BEAM sits in a different group (pgid
79135), and the child's `sleep` shares the child's group -- so `kill -KILL -PID`
reaches the descendants and nothing else.

That is **checked, not assumed**. A child that is not a group leader shares the
BEAM's group, and the group kill would take the VM down with it. The
`{:pid, _}` fallback loses the descendants and keeps the VM; a `ps` that is
missing, fails, or answers something unparseable resolves the same way.

The target is captured **before** the close: a process group outlives its
leader, which is exactly what makes the orphan case reachable, and once the
child exits there is nothing left to read the group off.

## Verification

Every behavioural test here was proven RED against the unfixed code first.

Hook timeout:

```
1) test run_hook/4 timeout kills a timed-out hook and the children it spawned
   Expected false or nil, got true
   code: refute File.exists?(hook_witness)
```

Codex stop, against the old close-only `stop/1`:

```
1) test reaps the tool subprocesses a cleanly exited codex left behind
2) test accepts a session map and a already-dead port
3) test stops a session that is not reading stdin
3 tests, 3 failures
```

All GREEN with the fix. The hook test asserts the ABSENCE of witness files only
a survivor could create, so a slow machine cannot fail it -- it can only stop
proving anything. The reaper and session tests ask the OS for liveness
(`kill -0`) rather than inferring it from a side effect.

- `mix test` (raxol_symphony): 23 doctests, **937 tests, 0 failures**
- `mix format --check-formatted`: clean
- `mix compile --warnings-as-errors`: clean
- `mix credo --strict`: no new findings. The three hits in changed files are
  pre-existing and in untouched code (`workspace.ex:213` in `bracket/2`, two
  `opts ++ [...]` appends in `Session.launch_spec`; my hunks stop at line 148)

## Acceptance (from #890)

- [x] a local hook exceeding `hooks.timeout_ms` is dead afterwards, asserted by
      a witness file that must NOT appear
- [x] the hook's children die with it
- [x] `collect_output/3` still returns `{:error, :timeout}` promptly
- [x] the incorrect `Port.close` comment is gone

## Manual testing

- [ ] Configure a `before_remove` hook that outlives `hooks.timeout_ms`, run an
      issue to removal, confirm no orphan remains (`ps -o pid,ppid,pgid,command`)
- [ ] Confirm an in-budget hook still reports its real exit status
- [ ] Run a codex issue that shells out to a long-running tool, stop it, confirm
      the tool is gone and a clean session still shuts down without the grace
- [ ] Confirm a remote (`worker.ssh_hosts`) codex session still tears down --
      killing the local `ssh` client is what triggers `reap_on_disconnect` on
      the host, so this should be unchanged
